### PR TITLE
passport: fix new game and save game using wrong closing animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed Tihocan chain block sound (#433)
 - fixed passport menu with high UI scaling (#546, regression from 2.7)
 - fixed passport menu border being off by one pixel (#547)
+- fixed the new game and save game passport options using the wrong closing animation (#542, regression from 2.7)
 - removed XBox controller support
 
 ## [2.8.1](https://github.com/rr-/Tomb1Main/compare/2.8.1...2.8.2) - 2022-05-20

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -566,7 +566,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
 
     if (g_InputDB.select) {
         g_GameInfo.passport_page = page;
-        if (page == PASSPORT_PAGE_2) {
+        if (page == PASSPORT_PAGE_3) {
             inv_item->anim_direction = 1;
             inv_item->goal_frame = inv_item->frames_total - 1;
         } else {


### PR DESCRIPTION
Resolves #542.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the new game and save game passport options using the wrong closing animation.
...
