### PR TITLE
s/input: add SDL controller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+- added generic SDL-based controller support (#278)
 - added the ability to make freshly triggered (runaway) Pierre replace an already existing (runaway) Pierre (#532)
 - fixed Tihocan chain block sound (#433)
 - fixed passport menu with high UI scaling (#546, regression from 2.7)
 - fixed passport menu border being off by one pixel (#547)
 - fixed the new game and save game passport options using the wrong closing animation (#542, regression from 2.7)
 - fixed bridges at floor level appearing under the floor (#523)
-- removed XBox controller support
+- removed DInput-based XBox controller support
 
 ## [2.8.1](https://github.com/rr-/Tomb1Main/compare/2.8.1...2.8.2) - 2022-05-20
 - fixed Lara not picking up items near the edges of room portals (#563, regression from 2.8)

--- a/README.md
+++ b/README.md
@@ -232,20 +232,23 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - added save game crystals game mode (enabled via gameflow)
 - added pause screen
 - added movable camera on W,A,S,D
-- added Xbox One Controller support
-    - Per Axis Dead Zone
-    - Left Stick = movement
-    - A = Jump/Select
-    - B = Roll/Deselect
-    - X = Action/Select
-    - Y = Look/Select
-    - LB = Walk
-    - RB = Draw Weapons
-    - Dpad Up = Draw Weapons
-    - Back = Option
-    - Start = Pause
-    - Right Stick = Camera Movement
-    - R3 = Reset Camera
+- added controller support
+    | Xbox button | DualShock button   | Action          |
+    | ----------- | ------------------ | --------------- |
+    | Left Stick  | Left stick         | Movement        |
+    | A           | X                  | Action/select   |
+    | B           | Circle             | Roll/deselect   |
+    | X           | Square             | Jump            |
+    | Y           | Triangle           | Draw weapons    |
+    | LB          | L1                 | Look            |
+    | RB          | R1                 | Walk            |
+    | LT          | L2                 | Sidestep left   |
+    | RT          | R2                 | Sidestep right  |
+    | D-pad       | D-pad              | Movement        |
+    | Back        | Share/Touchpad     | Inventory       |
+    | Start       | Options            | Pause           |
+    | Right Stick | Right stick        | Camera movement |
+    | R3          | R3                 | Reset camera    |
 - added rounded shadows (instead of the default octagon)
 - added per-level customizable water color (with customizable blue component)
 - added per-level customizable fog distance


### PR DESCRIPTION
Resolves #278

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I kept Ozi's decision to switch the action and the jump button (I'm a bit conflicted whether to keep it).
I switched Draw Guns with Look to match PS1 controller layout.
I changed D-pad's function to movement. This was dictated by seeing people map D-pad for movement on streams, and Lara herself instructing the player to use the D-pad to move her around.

Tested on my DualShock 4 controller. I have no other devices. I am not a controller player so I'm clueless whether these feel OK.

I want the game to offer sane defaults. Customization comes way later (or perhaps never, or via third party software).