### PR TITLE
shell: option_init needs gameflow to be loaded first

### DIFF
--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -123,13 +123,13 @@ void Shell_Init(const char *gameflow_path)
     Music_Init();
     Input_Init();
     FMV_Init();
-    Option_Init();
 
     if (!GameFlow_LoadFromFile(gameflow_path)) {
         Shell_ExitSystem("MAIN: unable to load script file");
         return;
     }
 
+    Option_Init();
     Savegame_InitCurrentInfo();
     Savegame_ScanSavedGames();
     Settings_Read();


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
`Option_Init` is called before the gameflow loading. So `g_GameFlow.level_count` in `Option_PassportInit` is 0 which breaks this line `m_SelectLevelRequester.item_texts = Memory_Alloc((g_GameFlow.level_count + 1) * m_SelectLevelRequester.item_text_len);` This PR calls `Option_Init` after loading the gameflow.
...
