### PR TITLE
Pistol start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- ...
+- added the option to make Lara revert to pistols on new level start
 
 ## [2.9.1](https://github.com/rr-/Tomb1Main/compare/2.9...2.9.1) - 2022-06-03
 - fixed crash on centaur hatch (#579, regression from 2.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- added the option to make Lara revert to pistols on new level start
+- added the option to make Lara revert to pistols on new level start (#557)
 
 ## [2.9.1](https://github.com/rr-/Tomb1Main/compare/2.9...2.9.1) - 2022-06-03
 - fixed crash on centaur hatch (#579, regression from 2.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- ...
+- fixed lara not reverting to pistols on new level start
 
 ## [2.9.1](https://github.com/rr-/Tomb1Main/compare/2.9...2.9.1) - 2022-06-03
 - fixed crash on centaur hatch (#579, regression from 2.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- fixed lara not reverting to pistols on new level start
+- added the option to make lara revert to pistols on new level start
 
 ## [2.9.1](https://github.com/rr-/Tomb1Main/compare/2.9...2.9.1) - 2022-06-03
 - fixed crash on centaur hatch (#579, regression from 2.9)

--- a/bin/cfg/Tomb1Main.json5
+++ b/bin/cfg/Tomb1Main.json5
@@ -220,4 +220,7 @@
 
     // How many save slots are available.
     "maximum_save_slots": 25,
+
+    // Make Lara revert to pistols on new level start (inline with TombATI behaviour)
+    "revert_to_pistols": false,
 }

--- a/src/config.c
+++ b/src/config.c
@@ -181,6 +181,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_ENUM(enemy_healthbar_color, BC_GREY, m_BarColors);
     READ_ENUM(screenshot_format, SCREENSHOT_FORMAT_JPEG, m_ScreenshotFormats);
     READ_INTEGER(maximum_save_slots, 25);
+    READ_BOOL(revert_to_pistols, false);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);

--- a/src/config.h
+++ b/src/config.h
@@ -93,6 +93,7 @@ typedef struct {
     bool walk_to_items;
     bool disable_trex_collision;
     int32_t maximum_save_slots;
+    bool revert_to_pistols;
 
     struct {
         int32_t layout;

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -566,8 +566,14 @@ void Lara_InitialiseInventory(int32_t level_num)
     }
 
     g_Lara.gun_status = resume->gun_status;
-    g_Lara.request_gun_type = LGT_PISTOLS;
-    g_Lara.gun_type = LGT_PISTOLS;
+
+    if (g_Config.revert_to_pistols) {
+        g_Lara.request_gun_type = LGT_PISTOLS;
+        g_Lara.gun_type = LGT_PISTOLS;
+    } else {
+        g_Lara.gun_type = resume->gun_type;
+        g_Lara.request_gun_type = resume->gun_type;
+    }
 
     Lara_InitialiseMeshes(level_num);
     Gun_InitialiseNewWeapon();

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -566,8 +566,8 @@ void Lara_InitialiseInventory(int32_t level_num)
     }
 
     g_Lara.gun_status = resume->gun_status;
-    g_Lara.gun_type = resume->gun_type;
-    g_Lara.request_gun_type = resume->gun_type;
+    g_Lara.request_gun_type = LGT_PISTOLS;
+    g_Lara.gun_type = LGT_PISTOLS;
 
     Lara_InitialiseMeshes(level_num);
     Gun_InitialiseNewWeapon();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Relevant to #557. `g_GameInfo.current[level_num]`'s fields `request_gun_type` & `gun_type` were being used to set the corresponding fields on `g_Lara`; this has been changed so that `LGT_PISTOLS` is used instead.

I hope this is the correct approach, I couldn't find any immediate issues with it. I also added it as a config option, not too sure if this is appropriate either.