### PR TITLE
fixed underwater currents breaking in rare cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+- fixed underwater currents breaking in rare cases (#127)
 
 ## [2.10](https://github.com/rr-/Tomb1Main/compare/2.9.1...2.10) - 2022-07-26
 - added a .NET-based installer

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - fixed broken dart ricochet effect
 - fixed exploded mutant pods sometimes appearing unhatched on reload
 - fixed bridges at floor level appearing under the floor
+- fixed underwater currents breaking in rare cases
 
 #### Cheats
 - added a fly cheat

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -12,6 +12,7 @@
 #include "game/lara/lara_col.h"
 #include "game/lara/lara_look.h"
 #include "game/lara/lara_state.h"
+#include "game/lot.h"
 #include "game/objects/general/door.h"
 #include "game/room.h"
 #include "game/sound.h"
@@ -290,6 +291,8 @@ void Lara_HandleSurface(ITEM_INFO *item, COLL_INFO *coll)
 
     if (g_Lara.current_active && g_Lara.water_status != LWS_CHEAT) {
         Lara_WaterCurrent(coll);
+    } else {
+        LOT_ClearLOT(&g_Lara.LOT);
     }
 
     Lara_Animate(item);
@@ -356,6 +359,8 @@ void Lara_HandleUnderwater(ITEM_INFO *item, COLL_INFO *coll)
 
     if (g_Lara.current_active && g_Lara.water_status != LWS_CHEAT) {
         Lara_WaterCurrent(coll);
+    } else {
+        LOT_ClearLOT(&g_Lara.LOT);
     }
 
     Lara_Animate(item);

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -5,6 +5,7 @@
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/items.h"
+#include "game/lot.h"
 #include "game/objects/creatures/pod.h"
 #include "game/objects/general/pickup.h"
 #include "game/objects/general/puzzle_hole.h"
@@ -17,7 +18,6 @@
 #include "global/types.h"
 #include "global/vars.h"
 #include "memory.h"
-#include "game/lot.h"
 
 #include <assert.h>
 #include <stdbool.h>

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -17,6 +17,7 @@
 #include "global/types.h"
 #include "global/vars.h"
 #include "memory.h"
+#include "game/lot.h"
 
 #include <assert.h>
 #include <stdbool.h>
@@ -38,7 +39,6 @@ typedef struct SAVEGAME_STRATEGY {
     bool (*update_death_counters)(MYFILE *fp, GAME_INFO *game_info);
 } SAVEGAME_STRATEGY;
 
-static BOX_NODE *m_OldLaraLOTNode;
 static SAVEGAME_INFO *m_SavegameInfo = NULL;
 
 static const SAVEGAME_STRATEGY m_Strategies[] = {
@@ -72,8 +72,6 @@ static void Savegame_LoadPostprocess(void);
 
 static void Savegame_LoadPreprocess(void)
 {
-    m_OldLaraLOTNode = g_Lara.LOT.node;
-
     Savegame_InitCurrentInfo();
 }
 
@@ -155,9 +153,7 @@ static void Savegame_LoadPostprocess(void)
             g_MusicTrackFlags[MX_BALDY_SPEECH] |= IF_ONESHOT;
         }
     }
-
-    g_Lara.LOT.node = m_OldLaraLOTNode;
-    g_Lara.LOT.target_box = NO_BOX;
+    LOT_ClearLOT(&g_Lara.LOT);
 }
 
 void Savegame_Init(void)

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -339,7 +339,6 @@ static void Savegame_Legacy_ReadArm(LARA_ARM *arm)
 
 static void Savegame_Legacy_ReadLOT(LOT_INFO *lot)
 {
-    lot->node = NULL;
     Savegame_Legacy_Skip(sizeof(BOX_NODE *));
 
     Savegame_Legacy_Read(&lot->head, sizeof(int16_t));


### PR DESCRIPTION
Resolves #127.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed underwater currents breaking in rare cases. This solves two water current issues:
1. Saving and loading can break a current in rare situations. Can occur in all of the OG game's currents.
2. Lara entering a second water current before reaching the first current's target breaks the second water current. Doesn't occur in OG levels.

...
