### PR TITLE
savegame: added FX, lava emitters, flame emitters, and waterfalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+- added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load (#418)
 
 ## [2.10.1](https://github.com/rr-/Tomb1Main/compare/2.10...2.10.1) - 2022-07-27
 - fixed Lara being able to equip pistols in the gym level (#594)

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Not all options are turned on by default. Refer to `Tomb1Main.json5` for details
 - added ability to restart level on death
 - added ability to restart the adventure from any level when loading a game
 - added the "Story so far..." option in the select level menu to view cutscenes and FMVs
+- added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load
 - fixed keys and items not working when drawing guns immediately after using them
 - fixed counting the secret in The Great Pyramid
 - fixed running out of ammo forcing Lara to equip pistols even if she doesn't carry them

--- a/bin/cfg/Tomb1Main.json5
+++ b/bin/cfg/Tomb1Main.json5
@@ -228,4 +228,8 @@
 
     // Make Lara revert to pistols on new level start (inline with TombATI behaviour)
     "revert_to_pistols": false,
+
+    // Enhances savegames so graphic effects, waterfall mist, flame emitters, and
+    // more are saved instead of disappearing on load.
+    "enable_enhanced_saves": true,
 }

--- a/src/config.c
+++ b/src/config.c
@@ -189,6 +189,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_ENUM(ui.menu_style, UI_STYLE_PC, m_UIStyles);
     READ_INTEGER(maximum_save_slots, 25);
     READ_BOOL(revert_to_pistols, false);
+    READ_BOOL(enable_enhanced_saves, true);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);

--- a/src/config.h
+++ b/src/config.h
@@ -99,6 +99,7 @@ typedef struct {
     bool disable_trex_collision;
     int32_t maximum_save_slots;
     bool revert_to_pistols;
+    bool enable_enhanced_saves;
 
     struct {
         int32_t layout;

--- a/src/game/objects/effects/waterfall.c
+++ b/src/game/objects/effects/waterfall.c
@@ -14,9 +14,7 @@ void Waterfall_Setup(OBJECT_INFO *obj)
 {
     g_Objects[O_WATERFALL].control = Waterfall_Control;
     g_Objects[O_WATERFALL].draw_routine = Object_DrawDummyItem;
-    if (g_Config.enable_enhanced_saves) {
-        obj->save_flags = 1;
-    }
+    obj->save_flags = 1;
 }
 
 void Waterfall_Control(int16_t item_num)

--- a/src/game/objects/effects/waterfall.c
+++ b/src/game/objects/effects/waterfall.c
@@ -1,5 +1,6 @@
 #include "game/objects/effects/waterfall.h"
 
+#include "config.h"
 #include "game/effects.h"
 #include "game/objects/common.h"
 #include "game/random.h"
@@ -13,7 +14,9 @@ void Waterfall_Setup(OBJECT_INFO *obj)
 {
     g_Objects[O_WATERFALL].control = Waterfall_Control;
     g_Objects[O_WATERFALL].draw_routine = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    if (g_Config.enable_enhanced_saves) {
+        obj->save_flags = 1;
+    }
 }
 
 void Waterfall_Control(int16_t item_num)

--- a/src/game/objects/effects/waterfall.c
+++ b/src/game/objects/effects/waterfall.c
@@ -1,6 +1,5 @@
 #include "game/objects/effects/waterfall.h"
 
-#include "config.h"
 #include "game/effects.h"
 #include "game/objects/common.h"
 #include "game/random.h"

--- a/src/game/objects/effects/waterfall.c
+++ b/src/game/objects/effects/waterfall.c
@@ -13,6 +13,7 @@ void Waterfall_Setup(OBJECT_INFO *obj)
 {
     g_Objects[O_WATERFALL].control = Waterfall_Control;
     g_Objects[O_WATERFALL].draw_routine = Object_DrawDummyItem;
+    obj->save_flags = 1;
 }
 
 void Waterfall_Control(int16_t item_num)

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -1,5 +1,6 @@
 #include "game/objects/traps/flame.h"
 
+#include "config.h"
 #include "game/collide.h"
 #include "game/effects.h"
 #include "game/items.h"
@@ -93,7 +94,9 @@ void FlameEmitter_Setup(OBJECT_INFO *obj)
 {
     obj->control = FlameEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    if (g_Config.enable_enhanced_saves) {
+        obj->save_flags = 1;
+    }
 }
 
 void FlameEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -94,9 +94,7 @@ void FlameEmitter_Setup(OBJECT_INFO *obj)
 {
     obj->control = FlameEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
-    if (g_Config.enable_enhanced_saves) {
-        obj->save_flags = 1;
-    }
+    obj->save_flags = 1;
 }
 
 void FlameEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -93,6 +93,7 @@ void FlameEmitter_Setup(OBJECT_INFO *obj)
 {
     obj->control = FlameEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
+    obj->save_flags = 1;
 }
 
 void FlameEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -1,6 +1,5 @@
 #include "game/objects/traps/flame.h"
 
-#include "config.h"
 #include "game/collide.h"
 #include "game/effects.h"
 #include "game/items.h"

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -1,5 +1,6 @@
 #include "game/objects/traps/lava.h"
 
+#include "config.h"
 #include "game/effects.h"
 #include "game/items.h"
 #include "game/lara.h"
@@ -126,7 +127,9 @@ void LavaEmitter_Setup(OBJECT_INFO *obj)
     obj->control = LavaEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
     obj->collision = Object_Collision;
-    obj->save_flags = 1;
+    if (g_Config.enable_enhanced_saves) {
+        obj->save_flags = 1;
+    }
 }
 
 void LavaEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -127,9 +127,7 @@ void LavaEmitter_Setup(OBJECT_INFO *obj)
     obj->control = LavaEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
     obj->collision = Object_Collision;
-    if (g_Config.enable_enhanced_saves) {
-        obj->save_flags = 1;
-    }
+    obj->save_flags = 1;
 }
 
 void LavaEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -126,6 +126,7 @@ void LavaEmitter_Setup(OBJECT_INFO *obj)
     obj->control = LavaEmitter_Control;
     obj->draw_routine = Object_DrawDummyItem;
     obj->collision = Object_Collision;
+    obj->save_flags = 1;
 }
 
 void LavaEmitter_Control(int16_t item_num)

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -1,6 +1,5 @@
 #include "game/objects/traps/lava.h"
 
-#include "config.h"
 #include "game/effects.h"
 #include "game/items.h"
 #include "game/lara.h"

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -13,12 +13,13 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
-#define SAVEGAME_CURRENT_VERSION 1
+#define SAVEGAME_CURRENT_VERSION 2
 
 typedef enum SAVEGAME_VERSION {
     VERSION_LEGACY = -1,
     VERSION_0 = 0,
     VERSION_1 = 1,
+    VERSION_2 = 2,
 } SAVEGAME_VERSION;
 
 typedef enum SAVEGAME_FORMAT {

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1,6 +1,7 @@
 #include "game/savegame/savegame_bson.h"
 
 #include "config.h"
+#include "game/effects.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/items.h"
@@ -49,6 +50,7 @@ static bool Savegame_BSON_LoadInventory(struct json_object_s *inv_obj);
 static bool Savegame_BSON_LoadFlipmaps(struct json_object_s *flipmap_obj);
 static bool Savegame_BSON_LoadCameras(struct json_array_s *cameras_arr);
 static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr);
+static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr);
 static bool Savegame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm);
 static bool Savegame_BSON_LoadAmmo(
     struct json_object_s *ammo_obj, AMMO_INFO *ammo);
@@ -62,6 +64,7 @@ static struct json_object_s *Savegame_BSON_DumpInventory(void);
 static struct json_object_s *Savegame_BSON_DumpFlipmaps(void);
 static struct json_array_s *Savegame_BSON_DumpCameras(void);
 static struct json_array_s *Savegame_BSON_DumpItems(void);
+static struct json_array_s *SaveGame_BSON_DumpFx(void);
 static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm);
 static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo);
 static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot);
@@ -534,6 +537,62 @@ static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
     return true;
 }
 
+static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
+{
+    if (!fx_arr) {
+        LOG_ERROR("Malformed save: invalid or missing fx array");
+        return false;
+    }
+
+    if ((signed)fx_arr->length >= NUM_EFFECTS - 1) {
+        LOG_ERROR(
+            "Malformed save: expected a max of %d fx, got %d", NUM_EFFECTS - 1,
+            fx_arr->length);
+        return false;
+    }
+
+    int16_t room_num = 0;
+    ROOM_INFO *r;
+
+    for (int i = 0; i < (signed)fx_arr->length; i++) {
+        struct json_object_s *fx_obj = json_array_get_object(fx_arr, i);
+        if (!fx_obj) {
+            LOG_ERROR("Malformed save: invalid fx data");
+            return false;
+        }
+
+        int32_t x = json_object_get_int(fx_obj, "x", x);
+        int32_t y = json_object_get_int(fx_obj, "y", y);
+        int32_t z = json_object_get_int(fx_obj, "z", z);
+        int16_t room_num = json_object_get_int(fx_obj, "room_number", room_num);
+        GAME_OBJECT_ID object_number =
+            json_object_get_int(fx_obj, "object_number", object_number);
+        int16_t speed = json_object_get_int(fx_obj, "speed", speed);
+        int16_t fall_speed =
+            json_object_get_int(fx_obj, "fall_speed", fall_speed);
+        int16_t frame_number =
+            json_object_get_int(fx_obj, "frame_number", frame_number);
+        int16_t counter = json_object_get_int(fx_obj, "counter", counter);
+        int16_t shade = json_object_get_int(fx_obj, "shade", shade);
+
+        int16_t fx_num = Effect_Create(room_num);
+        if (fx_num != NO_ITEM) {
+            FX_INFO *fx = &g_Effects[fx_num];
+            fx->pos.x = x;
+            fx->pos.y = y;
+            fx->pos.z = z;
+            fx->object_number = object_number;
+            fx->speed = speed;
+            fx->fall_speed = fall_speed;
+            fx->frame_number = frame_number;
+            fx->counter = counter;
+            fx->shade = shade;
+        }
+    }
+
+    return true;
+}
+
 static bool Savegame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm)
 {
     assert(arm);
@@ -883,6 +942,36 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
     return items_arr;
 }
 
+static struct json_array_s *SaveGame_BSON_DumpFx(void)
+{
+    struct json_array_s *fx_arr = json_array_new();
+
+    int16_t linknum = g_NextFxActive;
+    int16_t num_fx = 0;
+
+    for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_active) {
+        struct json_object_s *fx_obj = json_object_new();
+
+        FX_INFO *fx = &g_Effects[linknum];
+        json_object_append_int(fx_obj, "x", fx->pos.x);
+        json_object_append_int(fx_obj, "y", fx->pos.y);
+        json_object_append_int(fx_obj, "z", fx->pos.z);
+        json_object_append_int(fx_obj, "room_number", fx->room_number);
+        json_object_append_int(fx_obj, "object_number", fx->object_number);
+        json_object_append_int(fx_obj, "speed", fx->speed);
+        json_object_append_int(fx_obj, "fall_speed", fx->fall_speed);
+        json_object_append_int(fx_obj, "frame_number", fx->frame_number);
+        json_object_append_int(fx_obj, "counter", fx->counter);
+        json_object_append_int(fx_obj, "shade", fx->shade);
+
+        json_array_append_object(fx_arr, fx_obj);
+
+        num_fx++;
+    }
+
+    return fx_arr;
+}
+
 static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm)
 {
     assert(arm);
@@ -1030,6 +1119,13 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     assert(game_info);
 
     bool ret = false;
+
+    // Read savegame version
+    SAVEGAME_BSON_HEADER header;
+    File_Seek(fp, 0, FILE_SEEK_SET);
+    File_Read(&header, sizeof(SAVEGAME_BSON_HEADER), 1, fp);
+    File_Seek(fp, 0, FILE_SEEK_SET);
+
     struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (!root_obj) {
@@ -1083,6 +1179,12 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 
     if (!Savegame_BSON_LoadItems(json_object_get_array(root_obj, "items"))) {
         goto cleanup;
+    }
+
+    if (header.version >= VERSION_2) {
+        if (!SaveGame_BSON_LoadFx(json_object_get_array(root_obj, "fx"))) {
+            goto cleanup;
+        }
     }
 
     if (!Savegame_BSON_LoadLara(
@@ -1154,6 +1256,7 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         root_obj, "flipmap", Savegame_BSON_DumpFlipmaps());
     json_object_append_array(root_obj, "cameras", Savegame_BSON_DumpCameras());
     json_object_append_array(root_obj, "items", Savegame_BSON_DumpItems());
+    json_object_append_array(root_obj, "fx", SaveGame_BSON_DumpFx());
     json_object_append_object(
         root_obj, "lara", Savegame_BSON_DumpLara(&g_Lara));
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -951,7 +951,6 @@ static struct json_array_s *SaveGame_BSON_DumpFx(void)
     struct json_array_s *fx_arr = json_array_new();
 
     int16_t linknum = g_NextFxActive;
-    int16_t num_fx = 0;
 
     for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_active) {
         struct json_object_s *fx_obj = json_object_new();
@@ -969,8 +968,6 @@ static struct json_array_s *SaveGame_BSON_DumpFx(void)
         json_object_append_int(fx_obj, "shade", fx->shade);
 
         json_array_append_object(fx_arr, fx_obj);
-
-        num_fx++;
     }
 
     return fx_arr;

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -539,6 +539,10 @@ static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
 
 static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
 {
+    if (!g_Config.enable_enhanced_saves) {
+        return true;
+    }
+
     if (!fx_arr) {
         LOG_ERROR("Malformed save: invalid or missing fx array");
         return false;
@@ -575,20 +579,18 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
         int16_t counter = json_object_get_int(fx_obj, "counter", counter);
         int16_t shade = json_object_get_int(fx_obj, "shade", shade);
 
-        if (g_Config.enable_enhanced_saves) {
-            int16_t fx_num = Effect_Create(room_num);
-            if (fx_num != NO_ITEM) {
-                FX_INFO *fx = &g_Effects[fx_num];
-                fx->pos.x = x;
-                fx->pos.y = y;
-                fx->pos.z = z;
-                fx->object_number = object_number;
-                fx->speed = speed;
-                fx->fall_speed = fall_speed;
-                fx->frame_number = frame_number;
-                fx->counter = counter;
-                fx->shade = shade;
-            }
+        int16_t fx_num = Effect_Create(room_num);
+        if (fx_num != NO_ITEM) {
+            FX_INFO *fx = &g_Effects[fx_num];
+            fx->pos.x = x;
+            fx->pos.y = y;
+            fx->pos.z = z;
+            fx->object_number = object_number;
+            fx->speed = speed;
+            fx->fall_speed = fall_speed;
+            fx->frame_number = frame_number;
+            fx->counter = counter;
+            fx->shade = shade;
         }
     }
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -950,9 +950,8 @@ static struct json_array_s *SaveGame_BSON_DumpFx(void)
 {
     struct json_array_s *fx_arr = json_array_new();
 
-    int16_t linknum = g_NextFxActive;
-
-    for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_active) {
+    for (int16_t linknum = g_NextFxActive; linknum != NO_ITEM;
+         linknum = g_Effects[linknum].next_active) {
         struct json_object_s *fx_obj = json_object_new();
 
         FX_INFO *fx = &g_Effects[linknum];

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -575,18 +575,20 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
         int16_t counter = json_object_get_int(fx_obj, "counter", counter);
         int16_t shade = json_object_get_int(fx_obj, "shade", shade);
 
-        int16_t fx_num = Effect_Create(room_num);
-        if (fx_num != NO_ITEM) {
-            FX_INFO *fx = &g_Effects[fx_num];
-            fx->pos.x = x;
-            fx->pos.y = y;
-            fx->pos.z = z;
-            fx->object_number = object_number;
-            fx->speed = speed;
-            fx->fall_speed = fall_speed;
-            fx->frame_number = frame_number;
-            fx->counter = counter;
-            fx->shade = shade;
+        if (g_Config.enable_enhanced_saves) {
+            int16_t fx_num = Effect_Create(room_num);
+            if (fx_num != NO_ITEM) {
+                FX_INFO *fx = &g_Effects[fx_num];
+                fx->pos.x = x;
+                fx->pos.y = y;
+                fx->pos.z = z;
+                fx->object_number = object_number;
+                fx->speed = speed;
+                fx->fall_speed = fall_speed;
+                fx->frame_number = frame_number;
+                fx->counter = counter;
+                fx->shade = shade;
+            }
         }
     }
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -555,9 +555,6 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
         return false;
     }
 
-    int16_t room_num = 0;
-    ROOM_INFO *r;
-
     for (int i = 0; i < (signed)fx_arr->length; i++) {
         struct json_object_s *fx_obj = json_array_get_object(fx_arr, i);
         if (!fx_obj) {

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -126,10 +126,9 @@ static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer)
         if (obj->save_hitpoints) {
             Savegame_Legacy_Read(&tmp_item.hit_points, sizeof(int16_t));
         }
-        if (obj->save_flags
-            && (item->object_number != O_LAVA_EMITTER
-                && item->object_number != O_FLAME_EMITTER
-                && item->object_number != O_WATERFALL)) {
+        if (obj->save_flags && item->object_number != O_LAVA_EMITTER
+            && item->object_number != O_FLAME_EMITTER
+            && item->object_number != O_WATERFALL) {
             Savegame_Legacy_Read(&tmp_item.flags, sizeof(int16_t));
             Savegame_Legacy_Read(&tmp_item.timer, sizeof(int16_t));
             if (tmp_item.flags & SAVE_CREATURE) {
@@ -544,9 +543,9 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 
         if (obj->save_flags
             && (item->object_number != O_BACON_LARA || !skip_reading_bacon_lara)
-            && (item->object_number != O_LAVA_EMITTER
-                && item->object_number != O_FLAME_EMITTER
-                && item->object_number != O_WATERFALL)) {
+            && item->object_number != O_LAVA_EMITTER
+            && item->object_number != O_FLAME_EMITTER
+            && item->object_number != O_WATERFALL) {
             Savegame_Legacy_Read(&item->flags, sizeof(int16_t));
             Savegame_Legacy_Read(&item->timer, sizeof(int16_t));
 
@@ -711,10 +710,9 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
             Savegame_Legacy_Write(&item->hit_points, sizeof(int16_t));
         }
 
-        if (obj->save_flags
-            && (item->object_number != O_LAVA_EMITTER
-                && item->object_number != O_FLAME_EMITTER
-                && item->object_number != O_WATERFALL)) {
+        if (obj->save_flags && item->object_number != O_LAVA_EMITTER
+            && item->object_number != O_FLAME_EMITTER
+            && item->object_number != O_WATERFALL) {
             uint16_t flags = item->flags + item->active + (item->status << 1)
                 + (item->gravity_status << 3) + (item->collidable << 4);
             if (obj->intelligent && item->data) {

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -126,7 +126,10 @@ static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer)
         if (obj->save_hitpoints) {
             Savegame_Legacy_Read(&tmp_item.hit_points, sizeof(int16_t));
         }
-        if (obj->save_flags) {
+        if (obj->save_flags
+            && (item->object_number != O_LAVA_EMITTER
+                && item->object_number != O_FLAME_EMITTER
+                && item->object_number != O_WATERFALL)) {
             Savegame_Legacy_Read(&tmp_item.flags, sizeof(int16_t));
             Savegame_Legacy_Read(&tmp_item.timer, sizeof(int16_t));
             if (tmp_item.flags & SAVE_CREATURE) {
@@ -540,8 +543,10 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         }
 
         if (obj->save_flags
-            && (item->object_number != O_BACON_LARA
-                || !skip_reading_bacon_lara)) {
+            && (item->object_number != O_BACON_LARA || !skip_reading_bacon_lara)
+            && (item->object_number != O_LAVA_EMITTER
+                && item->object_number != O_FLAME_EMITTER
+                && item->object_number != O_WATERFALL)) {
             Savegame_Legacy_Read(&item->flags, sizeof(int16_t));
             Savegame_Legacy_Read(&item->timer, sizeof(int16_t));
 
@@ -706,7 +711,10 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
             Savegame_Legacy_Write(&item->hit_points, sizeof(int16_t));
         }
 
-        if (obj->save_flags) {
+        if (obj->save_flags
+            && (item->object_number != O_LAVA_EMITTER
+                && item->object_number != O_FLAME_EMITTER
+                && item->object_number != O_WATERFALL)) {
             uint16_t flags = item->flags + item->active + (item->status << 1)
                 + (item->gravity_status << 3) + (item->collidable << 4);
             if (obj->intelligent && item->data) {


### PR DESCRIPTION
Resolves #418.
Creates new savegame version.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load. Creates new savegame version 2. Everything seems to be working, but marking this as draft for now. All FX, emitters, and waterfalls now save, but I'm not sure if I missed any other items that should be saved too. I looked into adding darts, but they are above the `g_LevelItemCount` so they get killed. I also thought about incrementing and decrementing as darts are created and killed similar to the mutant pods. But, the number of darts fired changes depending on how far away the wall is from the emitter.
...
