### PR TITLE
lara: fix revert_to_pistols ignoring gameflow's remove_guns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+-fix revert_to_pistols ignoring gameflow's remove_guns (#603)
 
 ## [2.10.1](https://github.com/rr-/Tomb1Main/compare/2.10...2.10.1) - 2022-07-27
 - fixed Lara being able to equip pistols in the gym level (#594)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- fix revert_to_pistols ignoring gameflow's remove_guns (#603)
+- fixed revert_to_pistols ignoring gameflow's remove_guns (#603)
 
 ## [2.10.1](https://github.com/rr-/Tomb1Main/compare/2.10...2.10.1) - 2022-07-27
 - fixed Lara being able to equip pistols in the gym level (#594)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
--fix revert_to_pistols ignoring gameflow's remove_guns (#603)
+- fix revert_to_pistols ignoring gameflow's remove_guns (#603)
 
 ## [2.10.1](https://github.com/rr-/Tomb1Main/compare/2.10...2.10.1) - 2022-07-27
 - fixed Lara being able to equip pistols in the gym level (#594)

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -567,7 +567,8 @@ void Lara_InitialiseInventory(int32_t level_num)
 
     g_Lara.gun_status = resume->gun_status;
 
-    if (g_Config.revert_to_pistols && level_num != g_GameFlow.gym_level_num) {
+    if (g_Config.revert_to_pistols
+        && g_GameInfo.current[level_num].flags.got_pistols != 0) {
         g_Lara.request_gun_type = LGT_PISTOLS;
         g_Lara.gun_type = LGT_PISTOLS;
     } else {


### PR DESCRIPTION
Resolves #603.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix revert_to_pistols ignoring gameflow's remove_guns.
...
