### PR TITLE
inventory: kill SFX in inventory with disable_music_in_inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+- fixed some sound effects playing in the inventory when disable_music_in_inventory is true (#486)
 
 ## [2.10.1](https://github.com/rr-/Tomb1Main/compare/2.10...2.10.1) - 2022-07-27
 - fixed Lara being able to equip pistols in the gym level (#594)

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -371,6 +371,8 @@ int32_t Inv_Display(int inv_mode)
         Music_Pause();
         Sound_StopAmbientSounds();
         Sound_StopAllSamples();
+    } else {
+        Sound_UpdateEffects();
     }
 
     switch (g_InvMode) {
@@ -474,7 +476,6 @@ int32_t Inv_Display(int inv_mode)
             Inv_Ring_NotActive();
         }
 
-        Sound_UpdateEffects();
         Overlay_DrawFPSInfo();
         Text_Draw();
 


### PR DESCRIPTION
Resolves #486.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed some sound effects playing in the inventory when disable_music_in_inventory is true.
...
