### PR TITLE
option_passport: fix save crystal mode saving in the first slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load (#418)
 - fixed some sound effects playing in the inventory when disable_music_in_inventory is true (#486)
 - fixed underwater currents breaking in rare cases (#127)
+- fixed save crystal mode always saving in the first slot (#607, regression from 2.8)
 
 ## [2.10.2](https://github.com/rr-/Tomb1Main/compare/2.10.1...2.10.2) - 2022-08-03
 - fixed revert_to_pistols ignoring gameflow's remove_guns (#603)

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -476,7 +476,9 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                         g_GameInfo.bonus_flag = 0;
                     }
                 } else if (
-                    g_InvMode == INV_SAVE_MODE || g_InvMode == INV_GAME_MODE) {
+                    g_InvMode == INV_SAVE_MODE
+                    || g_InvMode == INV_SAVE_CRYSTAL_MODE
+                    || g_InvMode == INV_GAME_MODE) {
                     g_SavegameRequester.flags &= ~RIF_BLOCKABLE;
                     Option_PassportInitSaveRequester(page);
                     m_PassportMode = PASSPORT_MODE_SHOW_SAVES;


### PR DESCRIPTION
Resolves #607.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed save crystal mode always saving in the first slot.
...
