### PR TITLE
gameflow: add remove_ammo and remove_medipacks options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fixed gameflow option remove_scions causing Lara to equip weapons even if she has none (#605)
 - fixed save crystal mode always saving in the first slot (#607, regression from 2.8)
 - added gameflow option remove_ammo to remove all shotgun, magnum and uzi ammo from the inventory on level start (#599)
-- added gameflow option remove_medpacks to remove all small and large medpacks from the inventory on level start (#599)
+- added gameflow option remove_medipacks to remove all medi packs from the inventory on level start (#599)
 
 ## [2.10.2](https://github.com/rr-/Tomb1Main/compare/2.10.1...2.10.2) - 2022-08-03
 - fixed revert_to_pistols ignoring gameflow's remove_guns (#603)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - fixed gameflow option remove_guns preventing weapon pickups in rare situations (#611)
 - fixed gameflow option remove_scions causing Lara to equip weapons even if she has none (#605)
 - fixed save crystal mode always saving in the first slot (#607, regression from 2.8)
+- added gameflow option remove_ammo to remove all shotgun, magnum and uzi ammo from the inventory on level start (#599)
+- added gameflow option remove_medpacks to remove all small and large medpacks from the inventory on level start (#599)
 
 ## [2.10.2](https://github.com/rr-/Tomb1Main/compare/2.10.1...2.10.2) - 2022-08-03
 - fixed revert_to_pistols ignoring gameflow's remove_guns (#603)

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -508,6 +508,12 @@ static bool GameFlow_LoadLevelSequence(
         } else if (!strcmp(type_str, "remove_scions")) {
             seq->type = GFS_REMOVE_SCIONS;
 
+        } else if (!strcmp(type_str, "remove_ammo")) {
+            seq->type = GFS_REMOVE_AMMO;
+
+        } else if (!strcmp(type_str, "remove_medpacks")) {
+            seq->type = GFS_REMOVE_MEDPACKS;
+
         } else if (!strcmp(type_str, "give_item")) {
             seq->type = GFS_GIVE_ITEM;
 
@@ -945,6 +951,8 @@ void GameFlow_Shutdown(void)
                     case GFS_REMOVE_SCIONS:
                     case GFS_PLAY_SYNCED_AUDIO:
                     case GFS_FIX_PYRAMID_SECRET_TRIGGER:
+                    case GFS_REMOVE_AMMO:
+                    case GFS_REMOVE_MEDPACKS:
                         break;
                     }
                     seq++;
@@ -1074,6 +1082,8 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
     g_GameInfo.remove_guns = false;
     g_GameInfo.remove_scions = false;
+    g_GameInfo.remove_ammo = false;
+    g_GameInfo.remove_medpacks = false;
 
     GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
     GAMEFLOW_OPTION ret = GF_EXIT_TO_TITLE;
@@ -1262,6 +1272,19 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             }
             break;
 
+        case GFS_REMOVE_AMMO:
+            if (level_type != GFL_SAVED
+                && !(g_GameInfo.bonus_flag & GBF_NGPLUS)) {
+                g_GameInfo.remove_ammo = true;
+            }
+            break;
+
+        case GFS_REMOVE_MEDPACKS:
+            if (level_type != GFL_SAVED) {
+                g_GameInfo.remove_medpacks = true;
+            }
+            break;
+
         case GFS_MESH_SWAP: {
             GAMEFLOW_MESH_SWAP_DATA *swap_data = seq->data;
             int16_t *temp;
@@ -1316,6 +1339,8 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
         case GFS_REMOVE_GUNS:
         case GFS_REMOVE_SCIONS:
         case GFS_FIX_PYRAMID_SECRET_TRIGGER:
+        case GFS_REMOVE_AMMO:
+        case GFS_REMOVE_MEDPACKS:
             break;
 
         case GFS_START_GAME:

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -511,8 +511,8 @@ static bool GameFlow_LoadLevelSequence(
         } else if (!strcmp(type_str, "remove_ammo")) {
             seq->type = GFS_REMOVE_AMMO;
 
-        } else if (!strcmp(type_str, "remove_medpacks")) {
-            seq->type = GFS_REMOVE_MEDPACKS;
+        } else if (!strcmp(type_str, "remove_medipacks")) {
+            seq->type = GFS_REMOVE_MEDIPACKS;
 
         } else if (!strcmp(type_str, "give_item")) {
             seq->type = GFS_GIVE_ITEM;
@@ -952,7 +952,7 @@ void GameFlow_Shutdown(void)
                     case GFS_PLAY_SYNCED_AUDIO:
                     case GFS_FIX_PYRAMID_SECRET_TRIGGER:
                     case GFS_REMOVE_AMMO:
-                    case GFS_REMOVE_MEDPACKS:
+                    case GFS_REMOVE_MEDIPACKS:
                         break;
                     }
                     seq++;
@@ -1083,7 +1083,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     g_GameInfo.remove_guns = false;
     g_GameInfo.remove_scions = false;
     g_GameInfo.remove_ammo = false;
-    g_GameInfo.remove_medpacks = false;
+    g_GameInfo.remove_medipacks = false;
 
     GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
     GAMEFLOW_OPTION ret = GF_EXIT_TO_TITLE;
@@ -1279,9 +1279,9 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             }
             break;
 
-        case GFS_REMOVE_MEDPACKS:
+        case GFS_REMOVE_MEDIPACKS:
             if (level_type != GFL_SAVED) {
-                g_GameInfo.remove_medpacks = true;
+                g_GameInfo.remove_medipacks = true;
             }
             break;
 
@@ -1340,7 +1340,7 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
         case GFS_REMOVE_SCIONS:
         case GFS_FIX_PYRAMID_SECRET_TRIGGER:
         case GFS_REMOVE_AMMO:
-        case GFS_REMOVE_MEDPACKS:
+        case GFS_REMOVE_MEDIPACKS:
             break;
 
         case GFS_START_GAME:

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -533,7 +533,7 @@ void Lara_InitialiseInventory(int32_t level_num)
         resume->uzi_ammo = 0;
     }
 
-    if (g_GameInfo.remove_medpacks) {
+    if (g_GameInfo.remove_medipacks) {
         resume->num_medis = 0;
         resume->num_big_medis = 0;
     }

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -527,6 +527,17 @@ void Lara_InitialiseInventory(int32_t level_num)
         resume->num_scions = 0;
     }
 
+    if (g_GameInfo.remove_ammo) {
+        resume->shotgun_ammo = 0;
+        resume->magnum_ammo = 0;
+        resume->uzi_ammo = 0;
+    }
+
+    if (g_GameInfo.remove_medpacks) {
+        resume->num_medis = 0;
+        resume->num_big_medis = 0;
+    }
+
     if (resume->flags.got_pistols) {
         Inv_AddItem(O_GUN_ITEM);
     }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1023,6 +1023,8 @@ typedef enum GAMEFLOW_SEQUENCE_TYPE {
     GFS_PLAY_SYNCED_AUDIO,
     GFS_MESH_SWAP,
     GFS_FIX_PYRAMID_SECRET_TRIGGER,
+    GFS_REMOVE_AMMO,
+    GFS_REMOVE_MEDPACKS,
 } GAMEFLOW_SEQUENCE_TYPE;
 
 typedef enum GAME_STRING_ID {
@@ -1547,6 +1549,8 @@ typedef struct GAME_INFO {
     GAMEFLOW_LEVEL_TYPE current_level_type;
     bool remove_guns;
     bool remove_scions;
+    bool remove_ammo;
+    bool remove_medpacks;
 } GAME_INFO;
 
 typedef struct CREATURE_INFO {

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1024,7 +1024,7 @@ typedef enum GAMEFLOW_SEQUENCE_TYPE {
     GFS_MESH_SWAP,
     GFS_FIX_PYRAMID_SECRET_TRIGGER,
     GFS_REMOVE_AMMO,
-    GFS_REMOVE_MEDPACKS,
+    GFS_REMOVE_MEDIPACKS,
 } GAMEFLOW_SEQUENCE_TYPE;
 
 typedef enum GAME_STRING_ID {
@@ -1550,7 +1550,7 @@ typedef struct GAME_INFO {
     bool remove_guns;
     bool remove_scions;
     bool remove_ammo;
-    bool remove_medpacks;
+    bool remove_medipacks;
 } GAME_INFO;
 
 typedef struct CREATURE_INFO {


### PR DESCRIPTION
Resolves #599.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Added two new gameflow options to affect the inventory at the start of the level in which they are used:
- `remove_ammo` to remove all shotgun, magnum and uzi ammo; and
- `remove_medipacks` to remove all small and large medpacks.