### PR TITLE
savegame: fix flame emitters in enhanced saves.

### DIFF
--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -536,7 +536,7 @@ static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
                 && g_Config.enable_enhanced_saves) {
                 int32_t flame_num =
                     json_object_get_int(item_obj, "flame_num", flame_num);
-                item->data = (void *)(flame_num);
+                item->data = (void *)flame_num;
             }
         }
     }
@@ -945,7 +945,7 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
             }
 
             if (item->object_number == O_FLAME_EMITTER) {
-                int32_t flame_num = ((int32_t)item->data);
+                int32_t flame_num = (int32_t)item->data;
                 json_object_append_int(item_obj, "flame_num", flame_num);
             }
         }

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -531,6 +531,13 @@ static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
             } else if (obj->intelligent) {
                 item->data = NULL;
             }
+
+            if (item->object_number == O_FLAME_EMITTER
+                && g_Config.enable_enhanced_saves) {
+                int16_t flame_num =
+                    json_object_get_int(item_obj, "flame_num", flame_num);
+                item->data = (void *)(flame_num + 0);
+            }
         }
     }
 
@@ -935,6 +942,11 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
                     item_obj, "creature_flags", creature->flags);
                 json_object_append_int(
                     item_obj, "creature_mood", creature->mood);
+            }
+
+            if (item->object_number == O_FLAME_EMITTER) {
+                int16_t flame_num = ((int16_t)(size_t)item->data);
+                json_object_append_int(item_obj, "flame_num", flame_num);
             }
         }
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -534,9 +534,9 @@ static bool Savegame_BSON_LoadItems(struct json_array_s *items_arr)
 
             if (item->object_number == O_FLAME_EMITTER
                 && g_Config.enable_enhanced_saves) {
-                int16_t flame_num =
+                int32_t flame_num =
                     json_object_get_int(item_obj, "flame_num", flame_num);
-                item->data = (void *)(flame_num + 0);
+                item->data = (void *)(flame_num);
             }
         }
     }
@@ -945,7 +945,7 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
             }
 
             if (item->object_number == O_FLAME_EMITTER) {
-                int16_t flame_num = ((int16_t)(size_t)item->data);
+                int32_t flame_num = ((int32_t)item->data);
                 json_object_append_int(item_obj, "flame_num", flame_num);
             }
         }


### PR DESCRIPTION
Resolves #616.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
No changelog entry since this fixes a bug with enhanced saves which aren't released yet. The issue is the flame emitter works by using item->data which is normally only saved and loaded for intelligent creatures which the flame emitter isn't. So basically on load, the flame emitter is working normally. But if you save while the flame is on, the restored flame FX is never killed so there's a constant flame always on (2 flames active basically with 1 never turning off). This PR saves the item->data and restores it in load.
...
