### PR TITLE
savegame: fix incorrect number of FX check during loading.

### DIFF
--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -556,10 +556,10 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
     }
 
     if ((signed)fx_arr->length >= NUM_EFFECTS) {
-        LOG_ERROR(
-            "Malformed save: expected a max of %d fx, got %d", NUM_EFFECTS - 1,
-            fx_arr->length);
-        return false;
+        LOG_WARNING(
+            "Malformed save: expected a max of %d fx, got %d. fx over the "
+            "maximum will not be created.",
+            NUM_EFFECTS - 1, fx_arr->length);
     }
 
     for (int i = 0; i < (signed)fx_arr->length; i++) {

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -555,7 +555,7 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
         return false;
     }
 
-    if ((signed)fx_arr->length > NUM_EFFECTS - 1) {
+    if ((signed)fx_arr->length >= NUM_EFFECTS) {
         LOG_ERROR(
             "Malformed save: expected a max of %d fx, got %d", NUM_EFFECTS - 1,
             fx_arr->length);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -555,7 +555,7 @@ static bool SaveGame_BSON_LoadFx(struct json_array_s *fx_arr)
         return false;
     }
 
-    if ((signed)fx_arr->length >= NUM_EFFECTS - 1) {
+    if ((signed)fx_arr->length > NUM_EFFECTS - 1) {
         LOG_ERROR(
             "Malformed save: expected a max of %d fx, got %d", NUM_EFFECTS - 1,
             fx_arr->length);


### PR DESCRIPTION
Resolves #620.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
No changelog because enhanced saves haven't been released yet. Fixes loading saves with max number of FX. Future idea: maybe the max number of FX can be raised from 100.
...
