### PR TITLE
savegame: highlight latest save at game start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
 - added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load (#418)
+- changed passport to highlight latest save at game start (#618)
 - fixed some sound effects playing in the inventory when disable_music_in_inventory is true (#486)
 - fixed underwater currents breaking in rare cases (#127)
 - fixed gameflow option remove_guns preventing weapon pickups in rare situations (#611)

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -54,6 +54,7 @@ bool Savegame_LoadOnlyResumeInfo(int32_t slot_num, GAME_INFO *game_info);
 
 void Savegame_ScanSavedGames(void);
 void Savegame_ScanAvailableLevels(REQUEST_INFO *req);
+uint16_t Savegame_GetNewestSlot();
 GAMEFLOW_OPTION Savegame_PlayAvailableStory(int32_t slot_num);
 bool Savegame_RestartAvailable(int32_t slot_num);
 

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -54,7 +54,7 @@ bool Savegame_LoadOnlyResumeInfo(int32_t slot_num, GAME_INFO *game_info);
 
 void Savegame_ScanSavedGames(void);
 void Savegame_ScanAvailableLevels(REQUEST_INFO *req);
-uint16_t Savegame_GetNewestSlot();
+void Savegame_HighlightNewestSlot(void);
 GAMEFLOW_OPTION Savegame_PlayAvailableStory(int32_t slot_num);
 bool Savegame_RestartAvailable(int32_t slot_num);
 

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -39,6 +39,7 @@ typedef struct SAVEGAME_STRATEGY {
     bool (*update_death_counters)(MYFILE *fp, GAME_INFO *game_info);
 } SAVEGAME_STRATEGY;
 
+static uint16_t m_NewestSlot = 0;
 static SAVEGAME_INFO *m_SavegameInfo = NULL;
 
 static const SAVEGAME_STRATEGY m_Strategies[] = {
@@ -419,8 +420,6 @@ bool Savegame_Save(int32_t slot_num, GAME_INFO *game_info)
         sprintf(
             &req->item_texts[req->item_text_len * slot_num], "%s %d",
             g_GameFlow.levels[g_CurrentLevel].level_title, g_SaveCounter);
-        g_SavedGamesCount++;
-        g_SaveCounter++;
     }
 
     Savegame_ScanSavedGames();
@@ -541,6 +540,10 @@ void Savegame_ScanSavedGames(void)
             sprintf(
                 &req->item_texts[req->items * req->item_text_len], "%s %d",
                 savegame_info->level_title, savegame_info->counter);
+
+            if (savegame_info->counter == g_SaveCounter) {
+                m_NewestSlot = i;
+            }
         } else {
             req->item_flags[req->items] |= RIF_BLOCKED;
             sprintf(
@@ -601,6 +604,11 @@ void Savegame_ScanAvailableLevels(REQUEST_INFO *req)
 
     req->requested = 0;
     req->line_offset = 0;
+}
+
+uint16_t Savegame_GetNewestSlot()
+{
+    return m_NewestSlot;
 }
 
 bool Savegame_RestartAvailable(int32_t slot_num)

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -606,9 +606,9 @@ void Savegame_ScanAvailableLevels(REQUEST_INFO *req)
     req->line_offset = 0;
 }
 
-uint16_t Savegame_GetNewestSlot()
+void Savegame_HighlightNewestSlot(void)
 {
-    return m_NewestSlot;
+    g_SavegameRequester.requested = m_NewestSlot;
 }
 
 bool Savegame_RestartAvailable(int32_t slot_num)

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -132,6 +132,7 @@ void Shell_Init(const char *gameflow_path)
     Option_Init();
     Savegame_InitCurrentInfo();
     Savegame_ScanSavedGames();
+    g_SavegameRequester.requested = Savegame_GetNewestSlot();
     Settings_Read();
 
     Screen_ApplyResolution();

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -132,7 +132,7 @@ void Shell_Init(const char *gameflow_path)
     Option_Init();
     Savegame_InitCurrentInfo();
     Savegame_ScanSavedGames();
-    g_SavegameRequester.requested = Savegame_GetNewestSlot();
+    Savegame_HighlightNewestSlot();
     Settings_Read();
 
     Screen_ApplyResolution();


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Changed passport to highlight latest save at game start.

Brings back [this code](https://github.com/rr-/Tomb1Main/pull/534/files) except stores it in a new variable to only use it at game start.
...
