### PR TITLE
bridge: avoid moving bridges sitting on vertical portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added gameflow option remove_ammo to remove all shotgun, magnum and uzi ammo from the inventory on level start (#599)
 - added gameflow option remove_medipacks to remove all medi packs from the inventory on level start (#599)
 - improved the UI frame drawing, it will now look consistent across all resolutions and no longer have gaps between the lines
+- fixed bridge item in City of Khamoon being incorrectly raised (#627)
 
 ## [2.10.3](https://github.com/rr-/Tomb1Main/compare/2.10.2...2.10.3) - 2022-09-15
 - fixed save crystal mode always saving in the first slot (#607, regression from 2.8)

--- a/src/game/objects/general/bridge.c
+++ b/src/game/objects/general/bridge.c
@@ -85,17 +85,19 @@ static void Bridge_FixEmbeddedPosition(int16_t item_num)
     int32_t z = item->pos.z;
     int16_t room_num = item->room_number;
 
-    FLOOR_INFO *floor = Room_GetFloor(x, y, z, &room_num);
-    int16_t floor_height = Room_GetHeight(floor, x, y, z);
-
-    // Only move the bridge up if it's at floor level.
-    if (item->floor != floor_height) {
-        return;
-    }
-
     int16_t *bounds = Item_GetBoundsAccurate(item);
     int16_t bridge_height =
         ABS(bounds[FRAME_BOUND_MAX_Y]) - ABS(bounds[FRAME_BOUND_MIN_Y]);
+
+    FLOOR_INFO *floor = Room_GetFloor(x, y - bridge_height, z, &room_num);
+    int16_t floor_height = Room_GetHeight(floor, x, y, z);
+
+    // Only move the bridge up if it's at floor level and there
+    // isn't a room portal below.
+    if (item->floor != floor_height || floor->pit_room != NO_ROOM) {
+        return;
+    }
+
     item->pos.y = floor_height - bridge_height;
 }
 


### PR DESCRIPTION
Resolves #627.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The nature of `Room_GetFloor` means that if the `y` value is exactly that of the floor's `floor` value and there is a portal beneath, the function will move down into that room and find the floor sector from there (line 269 onwards in `room.c`). So when seeking the sector that matches a bridge's location, we now pass the `y` value of the *top* of the bridge so that `Room_GetFloor` will not traverse the portal, and so will return the sector from the same room.
An alternative would be to check if `room_num != item->room_number` after having called `Room_GetFloor`, but I decided against that as it may not work properly if items have been defined with incorrect room numbers (although as I understand the original issue was to target an OG bug in Lost Valley so this itself may not be relevant).
For testing, I added logging to `Bridge_FixEmbeddedPosition` before amending the code and then loaded each level. Only the 3 items in Lost Valley and 1 in Khamoon were targeted.
After the code change, I repeated the test and only the Lost Valley items were then targeted, and their resultant Y values remained consistent. I checked the positions in-game as well.

![image](https://user-images.githubusercontent.com/33758420/192023943-843106c6-95e7-430b-aa83-b947d225f1d2.png)
