### PR TITLE
gun: fix firing blanks indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added gameflow option remove_medipacks to remove all medi packs from the inventory on level start (#599)
 - improved the UI frame drawing, it will now look consistent across all resolutions and no longer have gaps between the lines
 - fixed bridge item in City of Khamoon being incorrectly raised (#627)
+- fixed Lara firing blanks indefinitely when she doesn't have pistols and is out of ammo on non-pistol weapons (#629) 
 
 ## [2.10.3](https://github.com/rr-/Tomb1Main/compare/2.10.2...2.10.3) - 2022-09-15
 - fixed save crystal mode always saving in the first slot (#607, regression from 2.8)

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -337,8 +337,7 @@ int32_t Gun_FireWeapon(
         Sound_Effect(SFX_LARA_EMPTY, &src->pos, SPM_NORMAL);
         if (Inv_RequestItem(O_GUN_ITEM)) {
             g_Lara.request_gun_type = LGT_PISTOLS;
-        }
-        else {
+        } else {
             g_Lara.gun_status = LGS_UNDRAW;
         }
         return 0;

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -338,6 +338,9 @@ int32_t Gun_FireWeapon(
         if (Inv_RequestItem(O_GUN_ITEM)) {
             g_Lara.request_gun_type = LGT_PISTOLS;
         }
+        else {
+            g_Lara.gun_status = LGS_UNDRAW;
+        }
         return 0;
     }
 


### PR DESCRIPTION
Resolves #629.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

If Lara does not have pistols in her inventory and runs out of ammo for whichever other gun she is currently using, she will now undraw that gun rather than firing blanks indefinitely. There are some videos of the behaviour before and after this change in the comments against #629.