### PR TITLE
save_crystal: fixed to be single use and added collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed Lara loading inside a movable block if she's on a stack near a room portal (#619)
 - fixed a game crash on shutdown if the action button is held down (#646)
 - fixed the compass and new game menus at high text scaling (#648)
+- fixed save crystals so they are single use and added object collision (#654)
 
 ## [2.11](https://github.com/rr-/Tomb1Main/compare/2.10.3...2.11) - 2022-10-19
 - added a .NET-based configuration tool (#633)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
+- added collision to save crystals (#654)
 - added additional custom control schemes (#636)
 - fixed small cracks in the UI borders for PS1-style menus (#643)
 - fixed Lara loading inside a movable block if she's on a stack near a room portal (#619)
 - fixed a game crash on shutdown if the action button is held down (#646)
 - fixed the compass and new game menus at high text scaling (#648)
-- fixed save crystals so they are single use and added object collision (#654)
+- fixed save crystals so they are single use (#654)
+- removed the puzzle key sound effect when using save crystals (#654)
 
 ## [2.11](https://github.com/rr-/Tomb1Main/compare/2.10.3...2.11) - 2022-10-19
 - added a .NET-based configuration tool (#633)

--- a/src/game/objects/general/save_crystal.c
+++ b/src/game/objects/general/save_crystal.c
@@ -69,8 +69,7 @@ void SaveCrystal_Collision(
     item->status = IS_DEACTIVATED;
     int32_t old_save_count = g_SaveCounter;
     int32_t return_val = Inv_Display(INV_SAVE_CRYSTAL_MODE);
-    int32_t new_save_count = g_SaveCounter;
-    if (new_save_count > old_save_count) {
+    if (g_SaveCounter > old_save_count) {
         Item_RemoveDrawn(item_num);
     } else {
         item->status = IS_ACTIVE;

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -9,6 +9,7 @@
 #include "game/objects/creatures/pod.h"
 #include "game/objects/general/pickup.h"
 #include "game/objects/general/puzzle_hole.h"
+#include "game/objects/general/save_crystal.h"
 #include "game/objects/traps/movable_block.h"
 #include "game/objects/traps/rolling_block.h"
 #include "game/room.h"
@@ -105,6 +106,11 @@ static void Savegame_LoadPostprocess(void)
             }
 
             if (obj->collision == Pickup_Collision
+                && item->status == IS_DEACTIVATED) {
+                Item_RemoveDrawn(i);
+            }
+
+            if (obj->collision == SaveCrystal_Collision
                 && item->status == IS_DEACTIVATED) {
                 Item_RemoveDrawn(i);
             }


### PR DESCRIPTION
Resolves #654.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed save crystals so they are single use and added object collision.

Here's a video. The first interaction I deselected which is why the crystal stayed. I also check if the save counter increases because deselected without saving and saving both return `GF_NOP`, so the `Inv_Display` is not really usable. And I didn't want to introduce a new gameflow option and risk breaking other things. I also removed the puzzle key sound effect that was being used since the PS1 version has no sound effect.

https://streamable.com/v0cshe
...
