### PR TITLE
input: stop the default controls from functioning when unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed save crystals so they are single use (#654)
 - fixed demo mode if the do not heal on level finish option is used (#660)
 - removed the puzzle key sound effect when using save crystals (#654)
+- stopped the default controls from functioning when the user unbound them (#564)
 
 ## [2.11](https://github.com/rr-/Tomb1Main/compare/2.10.3...2.11) - 2022-10-19
 - added a .NET-based configuration tool (#633)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - fixed skipping credits working too fast
 - fixed not being able to close level stats with Escape
 - fixed Lara jumping forever when alt+tabbing out of the game
+- stopped the default controls from functioning when the user unbound them
 
 #### Statistics
 - added ability to keep timer on in inventory

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -18,7 +18,6 @@ INPUT_STATE g_InputDB = { 0 };
 INPUT_STATE g_OldInputDB = { 0 };
 
 static bool m_KeyConflictWithUser[INPUT_ROLE_NUMBER_OF] = { false };
-static bool m_KeyConflictWithDefault[INPUT_ROLE_NUMBER_OF] = { false };
 static int32_t m_HoldBack = 0;
 static int32_t m_HoldForward = 0;
 
@@ -51,10 +50,6 @@ static INPUT_STATE Input_GetDebounced(INPUT_STATE input)
 void Input_CheckConflicts(INPUT_LAYOUT layout_num)
 {
     for (INPUT_ROLE role1 = 0; role1 < INPUT_ROLE_NUMBER_OF; role1++) {
-        INPUT_SCANCODE scancode1_default =
-            Input_GetAssignedScancode(INPUT_LAYOUT_DEFAULT, role1);
-        m_KeyConflictWithDefault[role1] = false;
-
         INPUT_SCANCODE scancode1_user =
             Input_GetAssignedScancode(layout_num, role1);
         m_KeyConflictWithUser[role1] = false;
@@ -63,15 +58,10 @@ void Input_CheckConflicts(INPUT_LAYOUT layout_num)
             if (role1 == role2) {
                 continue;
             }
-
             INPUT_SCANCODE scancode2_user =
                 Input_GetAssignedScancode(layout_num, role2);
-
             if (scancode1_user == scancode2_user) {
                 m_KeyConflictWithUser[role1] = true;
-            }
-            if (scancode1_default == scancode2_user) {
-                m_KeyConflictWithDefault[role1] = true;
             }
         }
     }
@@ -164,11 +154,6 @@ void Input_Update(void)
 bool Input_IsKeyConflictedWithUser(INPUT_ROLE role)
 {
     return m_KeyConflictWithUser[role];
-}
-
-bool Input_IsKeyConflictedWithDefault(INPUT_ROLE role)
-{
-    return m_KeyConflictWithDefault[role];
 }
 
 INPUT_SCANCODE Input_GetAssignedScancode(

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -17,7 +17,7 @@ INPUT_STATE g_Input = { 0 };
 INPUT_STATE g_InputDB = { 0 };
 INPUT_STATE g_OldInputDB = { 0 };
 
-static bool m_KeyConflictWithUser[INPUT_ROLE_NUMBER_OF] = { false };
+static bool m_KeyConflict[INPUT_ROLE_NUMBER_OF] = { false };
 static int32_t m_HoldBack = 0;
 static int32_t m_HoldForward = 0;
 
@@ -50,18 +50,17 @@ static INPUT_STATE Input_GetDebounced(INPUT_STATE input)
 void Input_CheckConflicts(INPUT_LAYOUT layout_num)
 {
     for (INPUT_ROLE role1 = 0; role1 < INPUT_ROLE_NUMBER_OF; role1++) {
-        INPUT_SCANCODE scancode1_user =
-            Input_GetAssignedScancode(layout_num, role1);
-        m_KeyConflictWithUser[role1] = false;
+        INPUT_SCANCODE scancode1 = Input_GetAssignedScancode(layout_num, role1);
+        m_KeyConflict[role1] = false;
 
         for (INPUT_ROLE role2 = 0; role2 < INPUT_ROLE_NUMBER_OF; role2++) {
             if (role1 == role2) {
                 continue;
             }
-            INPUT_SCANCODE scancode2_user =
+            INPUT_SCANCODE scancode2 =
                 Input_GetAssignedScancode(layout_num, role2);
-            if (scancode1_user == scancode2_user) {
-                m_KeyConflictWithUser[role1] = true;
+            if (scancode1 == scancode2) {
+                m_KeyConflict[role1] = true;
             }
         }
     }
@@ -151,9 +150,9 @@ void Input_Update(void)
     }
 }
 
-bool Input_IsKeyConflictedWithUser(INPUT_ROLE role)
+bool Input_IsKeyConflicted(INPUT_ROLE role)
 {
-    return m_KeyConflictWithUser[role];
+    return m_KeyConflict[role];
 }
 
 INPUT_SCANCODE Input_GetAssignedScancode(

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -19,7 +19,7 @@ void Input_CheckConflicts(INPUT_LAYOUT layout_num);
 
 // Returns whether the key assigned to the given role is also used elsewhere
 // within the custom layout.
-bool Input_IsKeyConflictedWithUser(INPUT_ROLE role);
+bool Input_IsKeyConflicted(INPUT_ROLE role);
 
 // Assign a concrete scancode to the given layout and key role.
 void Input_AssignScancode(

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -21,10 +21,6 @@ void Input_CheckConflicts(INPUT_LAYOUT layout_num);
 // within the custom layout.
 bool Input_IsKeyConflictedWithUser(INPUT_ROLE role);
 
-// Returns whether the key assigned to the given role is conflicting with a
-// default key binding.
-bool Input_IsKeyConflictedWithDefault(INPUT_ROLE role);
-
 // Assign a concrete scancode to the given layout and key role.
 void Input_AssignScancode(
     INPUT_LAYOUT layout_num, INPUT_ROLE role, INPUT_SCANCODE scancode);

--- a/src/game/option/option_control.c
+++ b/src/game/option/option_control.c
@@ -465,7 +465,7 @@ static void Option_ControlFlashConflicts(void)
         Text_Flash(
             m_ControlMenu.key_texts[i],
             g_Config.input.layout != INPUT_LAYOUT_DEFAULT
-                && Input_IsKeyConflictedWithUser(col->role),
+                && Input_IsKeyConflicted(col->role),
             20);
         col++;
     }

--- a/src/specific/s_input.c
+++ b/src/specific/s_input.c
@@ -447,9 +447,7 @@ static bool S_Input_KbdKey(INPUT_ROLE role, INPUT_LAYOUT layout)
 
 static bool S_Input_Key(INPUT_ROLE role, INPUT_LAYOUT layout_num)
 {
-    return S_Input_KbdKey(role, layout_num)
-        || (!Input_IsKeyConflictedWithDefault(role)
-            && S_Input_KbdKey(role, INPUT_LAYOUT_DEFAULT));
+    return S_Input_KbdKey(role, layout_num);
 }
 
 static bool S_Input_JoyBtn(SDL_GameControllerButton button)


### PR DESCRIPTION
Resolves #564.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Stopped the default controls from functioning when the user unbound them.
...
