### PR TITLE
GFX_GL: fix a copy-paste error.

### DIFF
--- a/src/gfx/gl/utils.h
+++ b/src/gfx/gl/utils.h
@@ -3,7 +3,7 @@
 #include "gfx/gl/gl_core_3_3.h"
 #include "log.h"
 
-#define GFX_GL_CheckError(void)                                                \
+#define GFX_GL_CheckError()                                                    \
     {                                                                          \
         for (GLenum err; (err = glGetError()) != GL_NO_ERROR;) {               \
             LOG_ERROR("glGetError: (%s)", GFX_GL_GetErrorString(err));         \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

MSVC complains the use of macro `GFX_GL_CheckError()`, saying that it needs a parameter. By looking its declaration into `src\gfx\gl\utils.h`, I have seen that it is declared with a `void` inside. Probably, in the past `GFX_GL_CheckError()` was a function and the `void` has been forgotten when it had been converted into a macro. GCC doesn't suffer much, but CL thinks instead that this is a required parameter. Hopefully, removing that thing made all compilers happy.

