### PR TITLE
Fix support for 64-bit

### DIFF
--- a/src/game/level.c
+++ b/src/game/level.c
@@ -274,7 +274,23 @@ static bool Level_LoadObjects(MYFILE *fp)
     File_Read(&m_AnimCount, sizeof(int32_t), 1, fp);
     LOG_INFO("%d anims", m_AnimCount);
     g_Anims = GameBuf_Alloc(sizeof(ANIM_STRUCT) * m_AnimCount, GBUF_ANIMS);
-    File_Read(g_Anims, sizeof(ANIM_STRUCT), m_AnimCount, fp);
+    for (int i = 0; i < m_AnimCount; i++) {
+        ANIM_STRUCT *anim = g_Anims + i;
+
+        File_Read(&anim->frame_ofs, sizeof(uint32_t), 1, fp);
+        File_Read(&anim->interpolation, sizeof(int16_t), 1, fp);
+        File_Read(&anim->current_anim_state, sizeof(int16_t), 1, fp);
+        File_Read(&anim->velocity, sizeof(int32_t), 1, fp);
+        File_Read(&anim->acceleration, sizeof(int32_t), 1, fp);
+        File_Read(&anim->frame_base, sizeof(int16_t), 1, fp);
+        File_Read(&anim->frame_end, sizeof(int16_t), 1, fp);
+        File_Read(&anim->jump_anim_num, sizeof(int16_t), 1, fp);
+        File_Read(&anim->jump_frame_num, sizeof(int16_t), 1, fp);
+        File_Read(&anim->number_changes, sizeof(int16_t), 1, fp);
+        File_Read(&anim->change_index, sizeof(int16_t), 1, fp);
+        File_Read(&anim->number_commands, sizeof(int16_t), 1, fp);
+        File_Read(&anim->command_index, sizeof(int16_t), 1, fp);
+    }
 
     File_Read(&m_AnimChangeCount, sizeof(int32_t), 1, fp);
     LOG_INFO("%d anim changes", m_AnimChangeCount);
@@ -306,7 +322,7 @@ static bool Level_LoadObjects(MYFILE *fp)
         GameBuf_Alloc(sizeof(int16_t) * m_AnimFrameCount, GBUF_ANIM_FRAMES);
     File_Read(g_AnimFrames, sizeof(int16_t), m_AnimFrameCount, fp);
     for (int i = 0; i < m_AnimCount; i++) {
-        g_Anims[i].frame_ptr = &g_AnimFrames[(size_t)g_Anims[i].frame_ptr / 2];
+        g_Anims[i].frame_ptr = &g_AnimFrames[g_Anims[i].frame_ofs / 2];
     }
 
     File_Read(&m_ObjectCount, sizeof(int32_t), 1, fp);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1810,6 +1810,7 @@ typedef struct CAMERA_INFO {
 
 typedef struct ANIM_STRUCT {
     int16_t *frame_ptr;
+    uint32_t frame_ofs;
     int16_t interpolation;
     int16_t current_anim_state;
     int32_t velocity;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

When running Tomb1Main compiled as a 64-bit application, I got an error.
This happens because `ANIM_STRUCT` has a `frame_ptr` item which is a pointer and so it varies its size if it's compiled for an addressing depth larger than 32-bit. I fixed the issue by adding a `frame_ofs` item, used for indexing `g_AnimFrames[]`, and by filling all the items of `ANIM_STRUCT` by reading them one by one, in the same manner it has been already done into function `Level_LoadRooms()`.

I tested Tomb1Main with the demo levels (see issue #667) under Windows, compiled as i686 (32-bit) and x64 (64-bit) and the engine worked fine on both.
