### PR TITLE
Fix path names to UNIX

### DIFF
--- a/src/game/music.c
+++ b/src/game/music.c
@@ -80,7 +80,7 @@ bool Music_Play(int16_t track)
     }
 
     char file_path[64];
-    sprintf(file_path, "music\\track%02d.flac", track);
+    sprintf(file_path, "music/track%02d.flac", track);
 
     Music_StopActiveStream();
     m_AudioStreamID = S_Audio_StreamSoundCreateFromFile(file_path);
@@ -111,7 +111,7 @@ bool Music_PlayLooped(int16_t track)
     }
 
     char file_path[64];
-    sprintf(file_path, "music\\track%02d.flac", track);
+    sprintf(file_path, "music/track%02d.flac", track);
 
     Music_StopActiveStream();
     m_AudioStreamID = S_Audio_StreamSoundCreateFromFile(file_path);

--- a/src/gfx/2d/2d_renderer.c
+++ b/src/gfx/2d/2d_renderer.c
@@ -32,9 +32,9 @@ void GFX_2D_Renderer_Init(GFX_2D_Renderer *renderer)
 
     GFX_GL_Program_Init(&renderer->program);
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_VERTEX_SHADER, "shaders\\2d.vsh");
+        &renderer->program, GL_VERTEX_SHADER, "shaders/2d.vsh");
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_FRAGMENT_SHADER, "shaders\\2d.fsh");
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/2d.fsh");
     GFX_GL_Program_Link(&renderer->program);
     GFX_GL_Program_FragmentData(&renderer->program, "fragColor");
 

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -45,9 +45,9 @@ void GFX_3D_Renderer_Init(GFX_3D_Renderer *renderer)
 
     GFX_GL_Program_Init(&renderer->program);
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_VERTEX_SHADER, "shaders\\3d.vsh");
+        &renderer->program, GL_VERTEX_SHADER, "shaders/3d.vsh");
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_FRAGMENT_SHADER, "shaders\\3d.fsh");
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/3d.fsh");
     GFX_GL_Program_Link(&renderer->program);
 
     renderer->loc_mat_projection =


### PR DESCRIPTION
This patch fixes some paths using MSDOS directory separator '\\' to UNIX separator '/'. Tested also on Windows and it worked fine.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This patch fixes some paths using MSDOS directory separator '\\' to UNIX separator '/'.
Tested also on Windows and it worked fine.
