### PR TITLE
Fix varargs for Log_Message()

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -21,19 +21,24 @@ void Log_Message(
     va_list va;
     va_start(va, fmt);
 
+    // print to log file
+    if (m_LogHandle) {
+        va_list vb;
+
+        va_copy(vb, va);
+        fprintf(m_LogHandle, "%s %d %s ", file, line, func);
+        vfprintf(m_LogHandle, fmt, vb);
+        fprintf(m_LogHandle, "\n");
+        fflush(m_LogHandle);
+
+        va_end(vb);
+    }
+
     // print to stdout
     printf("%s %d %s ", file, line, func);
     vprintf(fmt, va);
     printf("\n");
     fflush(stdout);
-
-    if (m_LogHandle) {
-        // now print the same to the log file
-        fprintf(m_LogHandle, "%s %d %s ", file, line, func);
-        vfprintf(m_LogHandle, fmt, va);
-        fprintf(m_LogHandle, "\n");
-        fflush(m_LogHandle);
-    }
 
     va_end(va);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

On Linux, the engine crashes when printing the log messages.
This happens because the current code re-uses the same `va_list` variable on two calls to `vprintf()` and `vfprintf()`.
Actually, this is not allowed.
For using the same information on multiple formatting functions, it is needed to create a copy of the primary `va_list` to a second one, by using `va_copy()`. After rewriting properly the `Log_Message()` function, the segmentation fault is gone.
Tested on both Linux and Windows builds.
