### PR TITLE
Add stddef.h to global/types.h (try 2)

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -10,7 +10,9 @@
 #include "global/vars.h"
 #include "math/math.h"
 #include "math/matrix.h"
+#include "util.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 
 static bool Camera_BadPosition(

--- a/src/game/collide.c
+++ b/src/game/collide.c
@@ -1,16 +1,13 @@
 #include "game/collide.h"
 
-#include "config.h"
 #include "game/items.h"
-#include "game/lara.h"
-#include "game/objects/general/door.h"
 #include "game/room.h"
-#include "game/sound.h"
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
 #include "math/math.h"
 #include "math/matrix.h"
+#include "util.h"
 
 void Collide_GetCollisionInfo(
     COLL_INFO *coll, int32_t xpos, int32_t ypos, int32_t zpos, int16_t room_num,

--- a/src/game/effect_routines/bubbles.c
+++ b/src/game/effect_routines/bubbles.c
@@ -2,10 +2,12 @@
 
 #include "game/collide.h"
 #include "game/effects.h"
-#include "game/objects/effects/bubble.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stdint.h>
 
 void FX_Bubbles(ITEM_INFO *item)
 {

--- a/src/game/effect_routines/chain_block.c
+++ b/src/game/effect_routines/chain_block.c
@@ -3,7 +3,8 @@
 #include "config.h"
 #include "game/room.h"
 #include "game/sound.h"
-#include "global/vars.h"
+
+#include <stddef.h>
 
 void FX_ChainBlock(ITEM_INFO *item)
 {

--- a/src/game/effect_routines/earthquake.c
+++ b/src/game/effect_routines/earthquake.c
@@ -4,6 +4,8 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
+#include <stddef.h>
+
 void FX_Earthquake(ITEM_INFO *item)
 {
     if (g_FlipTimer == 0) {

--- a/src/game/effect_routines/explosion.c
+++ b/src/game/effect_routines/explosion.c
@@ -4,6 +4,8 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
+#include <stddef.h>
+
 void FX_Explosion(ITEM_INFO *item)
 {
     Sound_Effect(SFX_EXPLOSION_FX, NULL, SPM_NORMAL);

--- a/src/game/effect_routines/flicker.c
+++ b/src/game/effect_routines/flicker.c
@@ -1,7 +1,6 @@
 #include "game/effect_routines/flicker.h"
 
 #include "game/room.h"
-#include "game/sound.h"
 
 void FX_Flicker(ITEM_INFO *item)
 {

--- a/src/game/effect_routines/flood.c
+++ b/src/game/effect_routines/flood.c
@@ -2,6 +2,7 @@
 
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 void FX_Flood(ITEM_INFO *item)

--- a/src/game/effect_routines/powerup.c
+++ b/src/game/effect_routines/powerup.c
@@ -2,6 +2,7 @@
 
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 void FX_PowerUp(ITEM_INFO *item)

--- a/src/game/effect_routines/raising_block.c
+++ b/src/game/effect_routines/raising_block.c
@@ -2,7 +2,8 @@
 
 #include "game/room.h"
 #include "game/sound.h"
-#include "global/vars.h"
+
+#include <stddef.h>
 
 void FX_RaisingBlock(ITEM_INFO *item)
 {

--- a/src/game/effect_routines/sand.c
+++ b/src/game/effect_routines/sand.c
@@ -2,7 +2,10 @@
 
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stddef.h>
 
 void FX_DropSand(ITEM_INFO *item)
 {

--- a/src/game/effect_routines/stairs2slope.c
+++ b/src/game/effect_routines/stairs2slope.c
@@ -2,7 +2,8 @@
 
 #include "game/room.h"
 #include "game/sound.h"
-#include "global/vars.h"
+
+#include <stddef.h>
 
 void FX_Stairs2Slope(ITEM_INFO *item)
 {

--- a/src/game/effects/gunshot.c
+++ b/src/game/effects/gunshot.c
@@ -6,6 +6,7 @@
 #include "game/objects/effects/ricochet.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 int16_t Effect_GunShot(

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -14,14 +14,11 @@
 #include "game/music.h"
 #include "game/overlay.h"
 #include "game/savegame.h"
-#include "game/shell.h"
 #include "game/sound.h"
 #include "game/stats.h"
 #include "global/const.h"
 #include "global/vars.h"
 #include "log.h"
-
-#include <stdio.h>
 
 static const int32_t m_AnimationRate = 0x8000;
 static int32_t m_FrameCount = 0;

--- a/src/game/game/game_cutscene.c
+++ b/src/game/game/game_cutscene.c
@@ -11,6 +11,7 @@
 #include "global/types.h"
 #include "global/vars.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 static const int32_t m_CinematicAnimationRate = 0x8000;

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -5,14 +5,14 @@
 #include "game/music.h"
 #include "game/output.h"
 #include "game/requester.h"
-#include "game/screen.h"
 #include "game/sound.h"
 #include "game/text.h"
-#include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define PAUSE_MAX_ITEMS 5
 #define PAUSE_MAX_TEXT_LENGTH 50

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -8,10 +8,14 @@
 #include "game/objects/effects/ricochet.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
 #include "math/math_misc.h"
 #include "math/matrix.h"
+#include "util.h"
+
+#include <stddef.h>
 
 #define PISTOL_LOCK_YMIN (-60 * PHD_DEGREE)
 #define PISTOL_LOCK_YMAX (+60 * PHD_DEGREE)

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -5,6 +5,9 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
+#include <stddef.h>
+#include <stdint.h>
+
 void Gun_Pistols_Draw(LARA_GUN_TYPE weapon_type)
 {
     int16_t ani = g_Lara.left_arm.frame_number;

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -5,7 +5,12 @@
 #include "game/input.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 void Gun_Rifle_Draw(void)
 {

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -21,6 +21,7 @@
 #include "global/vars.h"
 #include "math/matrix.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -3,7 +3,6 @@
 #include "config.h"
 #include "game/camera.h"
 #include "game/collide.h"
-#include "game/gameflow.h"
 #include "game/gun.h"
 #include "game/input.h"
 #include "game/inventory.h"
@@ -15,9 +14,13 @@
 #include "game/room.h"
 #include "game/savegame.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "log.h"
 #include "math/math.h"
+#include "util.h"
+
+#include <stddef.h>
 
 #define LARA_MOVE_TIMEOUT 90
 #define LARA_MOVE_ANIM_VELOCITY 12

--- a/src/game/lara/lara_cheat.c
+++ b/src/game/lara/lara_cheat.c
@@ -3,7 +3,12 @@
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/sound.h"
+#include "global/types.h"
 #include "global/vars.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 void Lara_CheckCheatMode(void)
 {

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -8,7 +8,11 @@
 #include "game/lara/lara_misc.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stddef.h>
+#include <stdint.h>
 
 void (*g_LaraCollisionRoutines[])(ITEM_INFO *item, COLL_INFO *coll) = {
     Lara_Col_Walk,        Lara_Col_Run,       Lara_Col_Stop,

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -16,8 +16,13 @@
 #include "game/objects/general/door.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #define MAX_BADDIE_COLLISION 12
 

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -2,13 +2,15 @@
 
 #include "config.h"
 #include "game/input.h"
-#include "game/lara.h"
 #include "game/lara/lara_look.h"
 #include "game/objects/effects/twinkle.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
+
+#include <stdint.h>
 
 void (*g_LaraStateRoutines[])(ITEM_INFO *item, COLL_INFO *coll) = {
     Lara_State_Walk,        Lara_State_Run,       Lara_State_Stop,

--- a/src/game/objects/creatures/centaur.c
+++ b/src/game/objects/creatures/centaur.c
@@ -9,7 +9,11 @@
 #include "game/lot.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
+
+#include <stdbool.h>
 
 #define CENTAUR_PART_DAMAGE 100
 #define CENTAUR_REAR_DAMAGE 200

--- a/src/game/objects/creatures/mutant.c
+++ b/src/game/objects/creatures/mutant.c
@@ -8,7 +8,11 @@
 #include "game/lot.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
+
+#include <stdbool.h>
 
 #define FLYER_CHARGE_DAMAGE 100
 #define FLYER_LUNGE_DAMAGE 150

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -9,8 +9,11 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
+
+#include <stdbool.h>
 
 #define NATLA_SHOT_DAMAGE 100
 #define NATLA_NEAR_DEATH 200

--- a/src/game/objects/creatures/pod.c
+++ b/src/game/objects/creatures/pod.c
@@ -5,8 +5,9 @@
 #include "game/items.h"
 #include "game/lot.h"
 #include "game/objects/common.h"
-#include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
 
 #define POD_EXPLODE_DIST (WALL_L * 4) // = 4096
 

--- a/src/game/objects/creatures/statue.c
+++ b/src/game/objects/creatures/statue.c
@@ -7,7 +7,9 @@
 #include "game/objects/common.h"
 #include "game/shell.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
 
 #define STATUE_EXPLODE_DIST (WALL_L * 7 / 2) // = 3584
 

--- a/src/game/objects/creatures/torso.c
+++ b/src/game/objects/creatures/torso.c
@@ -7,8 +7,12 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
+#include "util.h"
+
+#include <stdbool.h>
 
 #define TORSO_DIE_ANIM 13
 #define TORSO_PART_DAMAGE 250

--- a/src/game/objects/effects/body_part.c
+++ b/src/game/objects/effects/body_part.c
@@ -1,10 +1,10 @@
 #include "game/objects/effects/body_part.h"
 
 #include "game/effects.h"
-#include "game/items.h"
 #include "game/lara.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
 

--- a/src/game/objects/effects/earthquake.c
+++ b/src/game/objects/effects/earthquake.c
@@ -6,6 +6,8 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
+#include <stddef.h>
+
 void Earthquake_Setup(OBJECT_INFO *obj)
 {
     obj->control = Earthquake_Control;

--- a/src/game/objects/effects/missile.c
+++ b/src/game/objects/effects/missile.c
@@ -5,8 +5,10 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
+#include "util.h"
 
 #define SHARD_DAMAGE 30
 #define ROCKET_DAMAGE 100

--- a/src/game/objects/effects/ricochet.c
+++ b/src/game/objects/effects/ricochet.c
@@ -3,7 +3,7 @@
 #include "game/effects.h"
 #include "game/random.h"
 #include "game/sound.h"
-#include "global/vars.h"
+#include "global/const.h"
 
 void Ricochet_Setup(OBJECT_INFO *obj)
 {

--- a/src/game/objects/effects/splash.c
+++ b/src/game/objects/effects/splash.c
@@ -4,6 +4,7 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
 

--- a/src/game/objects/general/keyhole.c
+++ b/src/game/objects/general/keyhole.c
@@ -1,12 +1,12 @@
 #include "game/objects/general/keyhole.h"
 
-#include "config.h"
 #include "game/input.h"
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
 #include "game/items.h"
 #include "game/lara.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 PHD_VECTOR g_KeyHolePosition = { 0, 0, WALL_L / 2 - LARA_RAD - 50 };

--- a/src/game/objects/general/puzzle_hole.c
+++ b/src/game/objects/general/puzzle_hole.c
@@ -7,6 +7,7 @@
 #include "game/lara.h"
 #include "game/objects/general/keyhole.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 PHD_VECTOR g_PuzzleHolePosition = { 0, 0, WALL_L / 2 - LARA_RAD - 85 };

--- a/src/game/objects/general/save_crystal.c
+++ b/src/game/objects/general/save_crystal.c
@@ -1,16 +1,14 @@
 #include "game/objects/general/save_crystal.h"
 
-#include "config.h"
-#include "game/collide.h"
 #include "game/gameflow.h"
 #include "game/input.h"
 #include "game/inventory.h"
 #include "game/items.h"
 #include "game/lara.h"
-#include "game/objects/general/pickup.h"
-#include "game/savegame.h"
-#include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stdbool.h>
 
 static int16_t m_CrystalBounds[12] = {
     -256, +256, -100, +100, -256, +256, -10 * PHD_DEGREE, +10 * PHD_DEGREE,

--- a/src/game/objects/general/scion.c
+++ b/src/game/objects/general/scion.c
@@ -11,7 +11,10 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+
+#include <stdbool.h>
 
 static PHD_VECTOR m_Scion_Position = { 0, 640, -310 };
 static PHD_VECTOR m_Scion_Position4 = { 0, 280, -512 + 105 };

--- a/src/game/objects/traps/damocles_sword.c
+++ b/src/game/objects/traps/damocles_sword.c
@@ -5,7 +5,11 @@
 #include "game/lara.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
+
+#include <stdbool.h>
 
 #define DAMOCLES_SWORD_ACTIVATE_DIST ((WALL_L * 3) / 2)
 #define DAMOCLES_SWORD_DAMAGE 100

--- a/src/game/objects/traps/dart.c
+++ b/src/game/objects/traps/dart.c
@@ -7,6 +7,7 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 
 typedef enum {

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -7,7 +7,11 @@
 #include "game/objects/common.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
+
+#include <stddef.h>
 
 #define FLAME_ONFIRE_DAMAGE 5
 #define FLAME_TOONEAR_DAMAGE 3

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -7,6 +7,7 @@
 #include "game/random.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
 

--- a/src/game/objects/traps/lightning_emitter.c
+++ b/src/game/objects/traps/lightning_emitter.c
@@ -9,8 +9,11 @@
 #include "game/room.h"
 #include "game/sound.h"
 #include "game/viewport.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "math/matrix.h"
+
+#include <stdbool.h>
 
 #define LIGHTNING_DAMAGE 400
 #define LIGHTNING_STEPS 8

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -8,7 +8,9 @@
 #include "game/objects/common.h"
 #include "game/room.h"
 #include "game/sound.h"
+#include "global/const.h"
 #include "global/vars.h"
+#include "util.h"
 
 typedef enum {
     MBS_STILL = 1,

--- a/src/game/option/option_control.c
+++ b/src/game/option/option_control.c
@@ -3,10 +3,10 @@
 #include "config.h"
 #include "game/gameflow.h"
 #include "game/input.h"
-#include "game/output.h"
 #include "game/screen.h"
 #include "game/sound.h"
 #include "game/text.h"
+#include "global/const.h"
 #include "global/types.h"
 #include "util.h"
 

--- a/src/game/option/option_control_pick.c
+++ b/src/game/option/option_control_pick.c
@@ -1,12 +1,10 @@
-#include "config.h"
 #include "game/gameflow.h"
 #include "game/input.h"
-#include "game/music.h"
-#include "game/option/option_sound.h"
-#include "game/sound.h"
 #include "game/text.h"
+#include "global/types.h"
 #include "global/vars.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 
 typedef enum PICK_TEXT {

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -9,8 +9,13 @@
 #include "game/screen.h"
 #include "game/sound.h"
 #include "game/text.h"
+#include "global/const.h"
 #include "global/vars.h"
 #include "memory.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #define MAX_GAME_MODES 4
 #define MAX_GAME_MODE_LENGTH 20

--- a/src/game/option/option_sound.c
+++ b/src/game/option/option_sound.c
@@ -8,6 +8,7 @@
 #include "game/text.h"
 #include "global/vars.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #define MIN_VOLUME 0

--- a/src/game/picture.h
+++ b/src/game/picture.h
@@ -2,6 +2,8 @@
 
 #include "global/types.h"
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 PICTURE *Picture_Create(int width, int height);

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -1,12 +1,8 @@
 #include "game/setup.h"
 
 #include "config.h"
-#include "game/gamebuf.h"
-#include "game/gameflow.h"
-#include "game/inventory.h"
 #include "game/lara.h"
 #include "game/lara/lara_hair.h"
-#include "game/level.h"
 #include "game/objects/common.h"
 #include "game/objects/creatures/ape.h"
 #include "game/objects/creatures/bacon_lara.h"
@@ -70,9 +66,8 @@
 #include "game/objects/traps/spikes.h"
 #include "game/objects/traps/teeth_trap.h"
 #include "game/objects/traps/thors_hammer.h"
-#include "game/savegame.h"
-#include "game/sound.h"
 #include "global/const.h"
+#include "global/types.h"
 #include "global/vars.h"
 
 #include <stddef.h>

--- a/src/game/sound.h
+++ b/src/game/sound.h
@@ -3,6 +3,7 @@
 #include "global/types.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 bool Sound_Init(void);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -4,6 +4,7 @@
 #include "global/const.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef int16_t PHD_ANGLE;

--- a/src/specific/s_audio_sample.c
+++ b/src/specific/s_audio_sample.c
@@ -8,9 +8,6 @@
 #include <SDL2/SDL_audio.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/codec_par.h>
-#include <libavcodec/packet.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -10,9 +10,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/codec_par.h>
-#include <libavcodec/packet.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>

--- a/src/specific/s_fmv.c
+++ b/src/specific/s_fmv.c
@@ -53,10 +53,6 @@
 #include <SDL2/SDL_video.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/codec_id.h>
-#include <libavcodec/codec_par.h>
-#include <libavcodec/packet.h>
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/attributes.h>

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -5,16 +5,18 @@
 #include "game/screen.h"
 #include "game/shell.h"
 #include "game/viewport.h"
+#include "gfx/2d/2d_renderer.h"
 #include "gfx/2d/2d_surface.h"
 #include "gfx/3d/3d_renderer.h"
+#include "gfx/3d/vertex_stream.h"
+#include "gfx/blitter.h"
 #include "gfx/context.h"
-#include "gfx/screenshot.h"
 #include "global/vars.h"
 #include "log.h"
-#include "memory.h"
 #include "specific/s_shell.h"
 
 #include <assert.h>
+#include <stddef.h>
 
 #define CLIP_VERTCOUNT_SCALE 4
 

--- a/src/specific/s_output.h
+++ b/src/specific/s_output.h
@@ -3,6 +3,9 @@
 #include "game/picture.h"
 #include "global/types.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+
 bool S_Output_Init(void);
 void S_Output_Shutdown(void);
 

--- a/src/specific/s_picture.c
+++ b/src/specific/s_picture.c
@@ -8,10 +8,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <libavcodec/avcodec.h>
-#include <libavcodec/codec.h>
-#include <libavcodec/codec_id.h>
-#include <libavcodec/codec_par.h>
-#include <libavcodec/packet.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
 #include <libavutil/error.h>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

While compiling my UNIX port of Tomb1Main, I got some error messages like this one:

```
In file included from src/game/camera.c:7:
src/game/sound.h:19:5: error: unknown type name ‘size_t’
   19 |     size_t num_samples, const char **sample_pointers, size_t *sizes);
      |     ^~~~~~
src/game/sound.h:1:1: note: ‘size_t’ is defined in header ‘<stddef.h>’; did you forget to '#include <stddef.h>’?
  +++ |+#include <stddef.h>
```

I would like to suggest to add an `#include <stddef.h>` into `global/types.h`.
This fix required some adjustments to satisfy the linters.
