### PR TITLE
src/game/music.c: Unused Music_Stop call in Music_Play

### DIFF
--- a/src/game/music.c
+++ b/src/game/music.c
@@ -62,7 +62,7 @@ bool Music_Play(int16_t track)
         return false;
     }
 
-    if (track <= 1) {
+    if (track <= MX_UNUSED_1) {
         return false;
     }
 
@@ -70,12 +70,7 @@ bool Music_Play(int16_t track)
         return Sound_Effect(SFX_SECRET, NULL, SPM_ALWAYS);
     }
 
-    if (track == 0) {
-        Music_Stop();
-        return false;
-    }
-
-    if (track == 5) {
+    if (track == MX_CAVES_AMBIENT) {
         return false;
     }
 

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -159,7 +159,7 @@ void Natla_Control(int16_t item_num)
                 natla->flags = 0;
                 timer = 0;
                 item->hit_points = NATLA_NEAR_DEATH;
-                Music_Play(54);
+                Music_Play(MX_NATLA_SPEECH);
             } else {
                 item->hit_points = DONT_TARGET;
             }

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -91,7 +91,7 @@ void SkateKid_Control(int16_t item_num)
         angle = Creature_Turn(item, SKATE_KID_SKATE_TURN);
 
         if (item->hit_points < 120 && Music_CurrentTrack() != 56) {
-            Music_Play(56);
+            Music_Play(MX_SKATEKID_SPEECH);
         }
 
         switch (item->current_anim_state) {

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -893,7 +893,7 @@ void Room_TestTriggers(int16_t *data, bool heavy)
                 break;
             }
             g_GameInfo.current[g_CurrentLevel].stats.secret_flags |= 1 << value;
-            Music_Play(13);
+            Music_Play(MX_SECRET);
             break;
         }
     } while (!(trigger & END_BIT));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I run the engine with the demo files and some custom audio music tracks and I discovered a strange bug into `src/game/music.c`. Here:
https://github.com/rr-/Tomb1Main/blob/fcdf33adf0f634c10fdf3e768f7e11c0a5c1b9b9/src/game/music.c#L73 there is this piece of code:

```
    if (track == 0) {
        Music_Stop();
        return false;
    }
```

but it seems to be never called because previously at this line: https://github.com/rr-/Tomb1Main/blob/fcdf33adf0f634c10fdf3e768f7e11c0a5c1b9b9/src/game/music.c#L65 there is this code:

```
    if (track <= 1) {
        return false;
    }
```

which returns to the caller without doing anything. In my opinion, the block of code at line 65 must be deleted and line 73 should be changed as into this PR.
