### PR TITLE
s/audio: Get rid of lock/unlock after opening audio device

### DIFF
--- a/src/specific/s_audio.c
+++ b/src/specific/s_audio.c
@@ -60,15 +60,13 @@ bool S_Audio_Init(void)
         return false;
     }
 
-    SDL_PauseAudioDevice(g_AudioDeviceID, 0);
-
     m_WorkingSilence = desired.silence;
     m_WorkingBufferSize = desired.samples * desired.channels
         * SDL_AUDIO_BITSIZE(desired.format) / 8;
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
     m_WorkingBuffer = Memory_Alloc(m_WorkingBufferSize);
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+
+    SDL_PauseAudioDevice(g_AudioDeviceID, 0);
 
     return true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

According to:

https://wiki.libsdl.org/SDL2/SDL_OpenAudioDevice

a device is always in paused state after `SDL_OpenAudioDevice()`, so in my opinion it is safe to initialize `m_WorkingBuffer[]` and then start the playback. This will avoid the need to use lock/unlock stuff.
