### PR TITLE
save_crystal: fix collision pushing Lara through walls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
 - added support for .ogg, .mp3 and .wav formats for audio tracks (#688)
+- fix save crystal collision pushing Lara through walls (#682)
 
 ## [2.12](https://github.com/rr-/Tomb1Main/compare/2.11...2.12) - 2022-12-23
 - added collision to save crystals (#654)

--- a/src/game/objects/general/save_crystal.c
+++ b/src/game/objects/general/save_crystal.c
@@ -5,10 +5,9 @@
 #include "game/inventory.h"
 #include "game/items.h"
 #include "game/lara.h"
+#include "game/objects/common.h"
 #include "global/const.h"
 #include "global/vars.h"
-
-#include <stdbool.h>
 
 static int16_t m_CrystalBounds[12] = {
     -256, +256, -100, +100, -256, +256, -10 * PHD_DEGREE, +10 * PHD_DEGREE,
@@ -44,9 +43,7 @@ void SaveCrystal_Collision(
 {
     ITEM_INFO *item = &g_Items[item_num];
 
-    if (coll->enable_baddie_push) {
-        Lara_Push(item, coll, false, true);
-    }
+    Object_Collision(item_num, lara_item, coll);
 
     if (!g_Input.action || g_Lara.gun_status != LGS_ARMLESS
         || lara_item->gravity_status) {


### PR DESCRIPTION
Resolves #682.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix save crystal collision pushing Lara through walls. Matches the PS1 implementation thanks to Troye's decompilation.
...
