### PR TITLE
shell: use the return value of snprintf() to save an strlen()

### DIFF
--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -41,14 +41,11 @@ static char *Shell_GetScreenshotName(void)
 {
     // Get level title of unknown length
     char level_title[100];
-    snprintf(
-        level_title, LEVEL_TITLE_SIZE, "%s",
-        g_GameFlow.levels[g_CurrentLevel].level_title);
 
-    // Trim level titles that are too long
-    if (strlen(level_title) >= LEVEL_TITLE_SIZE) {
-        level_title[LEVEL_TITLE_SIZE] = '\0';
-    }
+    strncpy(
+        level_title, g_GameFlow.levels[g_CurrentLevel].level_title,
+        LEVEL_TITLE_SIZE - 1);
+    level_title[LEVEL_TITLE_SIZE] = '\0';
 
     // Prepare level title for screenshot
     char *check = level_title;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

While looking into issue #445, I noticed that it can be possible to avoid an `strlen()` by using the return value of the `snprintf()`. This patch implements this tiny improvement.