### PR TITLE
s/shell: Add support for older FFmpeg (support for Windows XP)

### DIFF
--- a/src/specific/s_shell.c
+++ b/src/specific/s_shell.c
@@ -9,6 +9,8 @@
 #include "log.h"
 #include "memory.h"
 
+#include <libavcodec/avcodec.h>
+
 #define SDL_MAIN_HANDLED
 
 #ifdef _WIN32
@@ -140,6 +142,10 @@ int main(int argc, char **argv)
     // necessary for SDL_OpenAudioDevice to work with WASAPI
     // https://www.mail-archive.com/ffmpeg-trac@avcodec.org/msg43300.html
     CoInitializeEx(NULL, COINIT_MULTITHREADED);
+#endif
+
+#if LIBAVCODEC_VERSION_MAJOR <= 57
+    av_register_all();
 #endif
 
     m_ArgCount = argc;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I have been able to run the engine also on Windows XP.
The last version of FFmpeg able to work on this OS is v3.4.12 "Cantor".
However, before version 4.x.x, FFmpeg required to call `av_register_all()` as first thing, otherwise it won't work anything. On newer versions, this function has been deprecated and no longer available. So, I would like to suggest to add this tiny fix, that calls `av_register_all()` if the selected libraries will need it.
