### PR TITLE
mummy: add the mummy to the level kill stats if Lara touches it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
 - added support for .ogg, .mp3 and .wav formats for audio tracks (#688)
+- added the mummy to the level kill stats if Lara touches it and it falls (#701)
 - fix save crystal collision pushing Lara through walls (#682)
 
 ## [2.12](https://github.com/rr-/Tomb1Main/compare/2.11...2.12) - 2022-12-23

--- a/src/game/objects/creatures/mummy.c
+++ b/src/game/objects/creatures/mummy.c
@@ -62,6 +62,10 @@ void Mummy_Control(int16_t item_num)
     Item_Animate(item);
 
     if (item->status == IS_DEACTIVATED) {
+        // Count kill if Lara touches mummy and it falls.
+        if (item->hit_points > 0) {
+            g_GameInfo.current[g_CurrentLevel].stats.kill_count++;
+        }
         Item_RemoveActive(item_num);
         item->hit_points = DONT_TARGET;
     }


### PR DESCRIPTION
Resolves #701.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added the mummy to the level kill stats if Lara touches it and it falls. I made the check when the item is `IS_DEACTIVATED` because checking it in the `if (item->current_anim_state == MUMMY_STOP) {` block had a bug where the kill could be double counted because Lara could shoot it and touch it at the same time.
...
