### PR TITLE
savegame: fix death counter breaking old saves with enhanced saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop)
-- fix crash when using enhanced saves in levels with flame emitters (#693)
+- fixed crash when using enhanced saves in levels with flame emitters (#693)
+- fixed the death counter from breaking old saves if enhanced saves are turned on (#699)
 
 ## [2.12](https://github.com/rr-/Tomb1Main/compare/2.11...2.12) - 2022-12-23
 - added collision to save crystals (#654)

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -34,10 +34,14 @@ typedef struct SAVEGAME_BSON_HEADER {
     int32_t uncompressed_size;
 } SAVEGAME_BSON_HEADER;
 
-static void SaveGame_BSON_SaveRaw(MYFILE *fp, struct json_value_s *root);
+static void SaveGame_BSON_SaveRaw(
+    MYFILE *fp, struct json_value_s *root, int32_t version);
 static bool Savegame_BSON_IsValidItemObject(
     int16_t saved_obj_num, int16_t current_obj_num);
-static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp);
+static struct json_value_s *Savegame_BSON_ParseFromBuffer(
+    const char *buffer, size_t buffer_size, int32_t *version_out);
+static struct json_value_s *Savegame_BSON_ParseFromFile(
+    MYFILE *fp, int32_t *version_out);
 static bool Savegame_BSON_LoadResumeInfo(
     struct json_array_s *levels_arr, RESUME_INFO *resume_info);
 static bool Savegame_BSON_LoadDiscontinuedStartInfo(
@@ -70,7 +74,8 @@ static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo);
 static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot);
 static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara);
 
-static void SaveGame_BSON_SaveRaw(MYFILE *fp, struct json_value_s *root)
+static void SaveGame_BSON_SaveRaw(
+    MYFILE *fp, struct json_value_s *root, int32_t version)
 {
     size_t uncompressed_size;
     char *uncompressed = bson_write(root, &uncompressed_size);
@@ -89,7 +94,7 @@ static void SaveGame_BSON_SaveRaw(MYFILE *fp, struct json_value_s *root)
     SAVEGAME_BSON_HEADER header = {
         .magic = SAVEGAME_BSON_MAGIC,
         .initial_version = g_GameInfo.save_initial_version,
-        .version = SAVEGAME_CURRENT_VERSION,
+        .version = version,
         .compressed_size = compressed_size,
         .uncompressed_size = uncompressed_size,
     };
@@ -131,12 +136,16 @@ static bool Savegame_BSON_IsValidItemObject(
 }
 
 static struct json_value_s *Savegame_BSON_ParseFromBuffer(
-    const char *buffer, size_t buffer_size)
+    const char *buffer, size_t buffer_size, int32_t *version_out)
 {
     SAVEGAME_BSON_HEADER *header = (SAVEGAME_BSON_HEADER *)buffer;
     if (header->magic != SAVEGAME_BSON_MAGIC) {
         LOG_ERROR("Invalid savegame magic");
         return NULL;
+    }
+
+    if (version_out) {
+        *version_out = header->version;
     }
 
     const char *compressed = buffer + sizeof(SAVEGAME_BSON_HEADER);
@@ -157,7 +166,8 @@ static struct json_value_s *Savegame_BSON_ParseFromBuffer(
     return root;
 }
 
-static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp)
+static struct json_value_s *Savegame_BSON_ParseFromFile(
+    MYFILE *fp, int32_t *version_out)
 {
     size_t buffer_size = File_Size(fp);
     char *buffer = Memory_Alloc(buffer_size);
@@ -165,7 +175,7 @@ static struct json_value_s *Savegame_BSON_ParseFromFile(MYFILE *fp)
     File_Read(buffer, sizeof(char), buffer_size, fp);
 
     struct json_value_s *ret =
-        Savegame_BSON_ParseFromBuffer(buffer, buffer_size);
+        Savegame_BSON_ParseFromBuffer(buffer, buffer_size, version_out);
     Memory_FreePointer(&buffer);
     return ret;
 }
@@ -1105,7 +1115,7 @@ char *Savegame_BSON_GetSaveFileName(int32_t slot)
 bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
 {
     bool ret = false;
-    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp, NULL);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (root_obj) {
         info->counter = json_object_get_int(root_obj, "save_counter", -1);
@@ -1141,7 +1151,7 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     File_Read(&header, sizeof(SAVEGAME_BSON_HEADER), 1, fp);
     File_Seek(fp, 0, FILE_SEEK_SET);
 
-    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp, NULL);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (!root_obj) {
         LOG_ERROR("Malformed save: cannot parse BSON data");
@@ -1219,7 +1229,7 @@ bool Savegame_BSON_LoadOnlyResumeInfo(MYFILE *fp, GAME_INFO *game_info)
     assert(game_info);
 
     bool ret = false;
-    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp, NULL);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (!root_obj) {
         LOG_ERROR("Malformed save: cannot parse BSON data");
@@ -1276,14 +1286,15 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         root_obj, "lara", Savegame_BSON_DumpLara(&g_Lara));
 
     struct json_value_s *root = json_value_from_object(root_obj);
-    SaveGame_BSON_SaveRaw(fp, root);
+    SaveGame_BSON_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);
     json_value_free(root);
 }
 
 bool Savegame_BSON_UpdateDeathCounters(MYFILE *fp, GAME_INFO *game_info)
 {
     bool ret = false;
-    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp);
+    int32_t version;
+    struct json_value_s *root = Savegame_BSON_ParseFromFile(fp, &version);
     struct json_object_s *root_obj = json_value_as_object(root);
     if (!root_obj) {
         LOG_ERROR("Cannot find the root object");
@@ -1317,7 +1328,7 @@ bool Savegame_BSON_UpdateDeathCounters(MYFILE *fp, GAME_INFO *game_info)
     }
 
     File_Seek(fp, 0, FILE_SEEK_SET);
-    SaveGame_BSON_SaveRaw(fp, root);
+    SaveGame_BSON_SaveRaw(fp, root, version);
     ret = true;
 
 cleanup:


### PR DESCRIPTION
Resolves #699.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the death counter from breaking old saves if enhanced saves are turned on.
...
