### PR TITLE
config: fix inconsistent wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the mummy to the level kill stats if Lara touches it and it falls (#701)
 - fix save crystal collision pushing Lara through walls (#682)
 - fixed passport animation when deselecting the passport (#703)
+- fixed inconsistent wording in config tool health and air color options (#705)
 
 ## [2.12](https://github.com/rr-/Tomb1Main/compare/2.11...2.12) - 2022-12-23
 - added collision to save crystals (#654)

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -53,10 +53,10 @@
       "png": "PNG"
     },
     "ui_color": {
-      "gold": "Gold (game default)",
+      "gold": "Gold (default for health)",
       "red": "Red",
       "grey": "Gray",
-      "blue": "Blue",
+      "blue": "Blue (default for air)",
       "silver": "Silver",
       "green": "Green",
       "gold2": "Gold (alternative)",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -53,14 +53,14 @@
       "png": "PNG"
     },
     "ui_color": {
-      "gold": "Or (par défaut dans le jeu original)",
+      "gold": "Or (par défaut pour la santé)",
       "red": "Rouge",
       "grey": "Gris",
-      "blue": "Bleu",
+      "blue": "Bleu (par défaut pour l'air)",
       "silver": "Argent",
       "green": "Vert",
-      "gold2": "Or (Alternatif)",
-      "blue2": "Bleu (Alternatif)",
+      "gold2": "Or (alternatif)",
+      "blue2": "Bleu (alternatif)",
       "pink": "Rose"
     },
     "ui_location": {


### PR DESCRIPTION
Resolves #705.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The UI colour options for air and health now explicitly show what "default" refers to, and a case issue in the French localization has been resolved.
