### PR TITLE
rat: fix dead voles looking alive when a room's water drains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed save crystal collision pushing Lara through walls (#682)
 - fixed passport animation when deselecting the passport (#703)
 - fixed inconsistent wording in config tool health and air color options (#705)
+- fixed dead water rats looking alive when the room's water is drained (#687, regression from 0.12.2)
 
 ## [2.12.1](https://github.com/rr-/Tomb1Main/compare/2.12...2.12.1) - 2023-01-16
 - fixed crash when using enhanced saves in levels with flame emitters (#693)

--- a/src/game/objects/creatures/rat.c
+++ b/src/game/objects/creatures/rat.c
@@ -222,7 +222,7 @@ void Vole_Control(int16_t item_num)
             item->current_anim_state = RAT_DEATH;
             item->goal_anim_state = RAT_DEATH;
             item->anim_number = g_Objects[O_RAT].anim_index + RAT_DIE_ANIM;
-            item->frame_number = g_Anims[item->anim_number].frame_base;
+            item->frame_number = g_Anims[item->anim_number].frame_end;
             item->pos.y = item->floor;
         }
     } else {


### PR DESCRIPTION
Resolves #687.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed dead water rats looking alive when the room's water is drained. Broken since 2aa66a0ce3f54d298f89f2ae619089467fd01fff.

The game used to do a hard coded check for the level number. If it was Cistern, it would make the dead vole active again as a rat, so it would animate through it's death animation. With that removed, the vole becomes a rat but stays in its death animation's base frame which looks alive.

![image](https://user-images.githubusercontent.com/81546780/212818301-7ee941ac-c0f0-4df1-8140-65d79951bc88.png)

With this change, the hard coded check is still removed. But, the end frame is used so the rat looks dead.
![image](https://user-images.githubusercontent.com/81546780/212818363-e2740d93-a276-4b47-9b76-a0cdf17fd3f3.png)


This hard coded level check and animation was not used for the crocodile because it's death animation's base frame looks dead.

![image](https://user-images.githubusercontent.com/81546780/212818508-18bc51e6-8764-41d4-afe4-eb79c52a15aa.png)


Let me know what you think of this fix. (Btw something interesting I discovered is the dead vole uses `Item_Animate` while dead so the dead item isn't deactivated in `Creature_Animate`.)
...
