### PR TITLE
sound: do triggered flip effects even there is no sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed inconsistent wording in config tool health and air color options (#705)
 - fixed Scion 1 respawning on load (#707)
 - fixed dead water rats looking alive when a room's water is drained (#687, regression from 0.12.0)
+- fixed triggered flip effects not working if there are no sound devices (#583)
 
 ## [2.12.1](https://github.com/rr-/Tomb1Main/compare/2.12...2.12.1) - 2023-01-16
 - fixed crash when using enhanced saves in levels with flame emitters (#693)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - fixed Lara loading inside a movable block if she's on a stack near a room portal
 - fixed a game crash on shutdown if the action button is held down
 - fixed Scion 1 respawning on load
+- fixed triggered flip effects not working if there are no sound devices
 
 #### Cheats
 - added a fly cheat

--- a/src/game/effects.c
+++ b/src/game/effects.c
@@ -1,6 +1,7 @@
 #include "game/effects.h"
 
 #include "game/output.h"
+#include "game/room.h"
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
@@ -144,10 +145,10 @@ void Effect_Draw(int16_t fxnum)
     }
 }
 
-void Effect_DoRoutine(int32_t effect_num)
+void Effect_DoRoutine()
 {
     // XXX: Some of the FX routines rely on the item to be not null!
-    if (effect_num != -1) {
-        g_EffectRoutines[effect_num](NULL);
+    if (g_FlipEffect != -1) {
+        g_EffectRoutines[g_FlipEffect](NULL);
     }
 }

--- a/src/game/effects.c
+++ b/src/game/effects.c
@@ -143,3 +143,11 @@ void Effect_Draw(int16_t fxnum)
         Matrix_Pop();
     }
 }
+
+void Effect_DoRoutine(int32_t effect_num)
+{
+    // XXX: Some of the FX routines rely on the item to be not null!
+    if (effect_num != -1) {
+        g_EffectRoutines[effect_num](NULL);
+    }
+}

--- a/src/game/effects.c
+++ b/src/game/effects.c
@@ -145,7 +145,7 @@ void Effect_Draw(int16_t fxnum)
     }
 }
 
-void Effect_DoRoutine()
+void Effect_RunActiveFlipEffect()
 {
     // XXX: Some of the FX routines rely on the item to be not null!
     if (g_FlipEffect != -1) {

--- a/src/game/effects.c
+++ b/src/game/effects.c
@@ -145,7 +145,7 @@ void Effect_Draw(int16_t fxnum)
     }
 }
 
-void Effect_RunActiveFlipEffect()
+void Effect_RunActiveFlipEffect(void)
 {
     // XXX: Some of the FX routines rely on the item to be not null!
     if (g_FlipEffect != -1) {

--- a/src/game/effects.h
+++ b/src/game/effects.h
@@ -13,4 +13,4 @@ int16_t Effect_Create(int16_t room_num);
 void Effect_Kill(int16_t fx_num);
 void Effect_NewRoom(int16_t fx_num, int16_t room_num);
 void Effect_Draw(int16_t fxnum);
-void Effect_DoRoutine();
+void Effect_RunActiveFlipEffect();

--- a/src/game/effects.h
+++ b/src/game/effects.h
@@ -13,4 +13,4 @@ int16_t Effect_Create(int16_t room_num);
 void Effect_Kill(int16_t fx_num);
 void Effect_NewRoom(int16_t fx_num, int16_t room_num);
 void Effect_Draw(int16_t fxnum);
-void Effect_DoRoutine(int32_t effect_num);
+void Effect_DoRoutine();

--- a/src/game/effects.h
+++ b/src/game/effects.h
@@ -13,4 +13,4 @@ int16_t Effect_Create(int16_t room_num);
 void Effect_Kill(int16_t fx_num);
 void Effect_NewRoom(int16_t fx_num, int16_t room_num);
 void Effect_Draw(int16_t fxnum);
-void Effect_RunActiveFlipEffect();
+void Effect_RunActiveFlipEffect(void);

--- a/src/game/effects.h
+++ b/src/game/effects.h
@@ -13,3 +13,4 @@ int16_t Effect_Create(int16_t room_num);
 void Effect_Kill(int16_t fx_num);
 void Effect_NewRoom(int16_t fx_num, int16_t room_num);
 void Effect_Draw(int16_t fxnum);
+void Effect_DoRoutine(int32_t effect_num);

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -110,7 +110,7 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
         Lara_Hair_Control(false);
 
         Camera_Update();
-        Effect_DoRoutine();
+        Effect_RunActiveFlipEffect();
         Sound_UpdateEffects();
         g_GameInfo.current[g_CurrentLevel].stats.timer++;
         Overlay_BarHealthTimerTick();

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -13,6 +13,7 @@
 #include "game/level.h"
 #include "game/music.h"
 #include "game/overlay.h"
+#include "game/room.h"
 #include "game/savegame.h"
 #include "game/sound.h"
 #include "game/stats.h"
@@ -110,6 +111,7 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
         Lara_Hair_Control(false);
 
         Camera_Update();
+        Effect_DoRoutine(g_FlipEffect);
         Sound_UpdateEffects();
         g_GameInfo.current[g_CurrentLevel].stats.timer++;
         Overlay_BarHealthTimerTick();

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -13,7 +13,6 @@
 #include "game/level.h"
 #include "game/music.h"
 #include "game/overlay.h"
-#include "game/room.h"
 #include "game/savegame.h"
 #include "game/sound.h"
 #include "game/stats.h"
@@ -111,7 +110,7 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
         Lara_Hair_Control(false);
 
         Camera_Update();
-        Effect_DoRoutine(g_FlipEffect);
+        Effect_DoRoutine();
         Sound_UpdateEffects();
         g_GameInfo.current[g_CurrentLevel].stats.timer++;
         Overlay_BarHealthTimerTick();

--- a/src/game/sound.c
+++ b/src/game/sound.c
@@ -217,12 +217,6 @@ void Sound_UpdateEffects(void)
         }
     }
 
-    // XXX: Why are we firing this here? Some of the FX routines rely on the
-    // item to be not null!
-    if (g_FlipEffect != -1) {
-        g_EffectRoutines[g_FlipEffect](NULL);
-    }
-
     for (int i = 0; i < MAX_PLAYING_FX; i++) {
         SOUND_SLOT *slot = &m_SFXPlaying[i];
         if (!(slot->flags & SOUND_FLAG_USED)) {


### PR DESCRIPTION
Resolves #583.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed triggered flip effects not working if there are no sound devices.
...
