### PR TITLE
sdl_gl: remove SDL_syswm.h from includes.

### DIFF
--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -9,7 +9,6 @@
 #include "memory.h"
 
 #include <SDL2/SDL.h>
-#include <SDL2/SDL_syswm.h>
 #include <string.h>
 
 typedef struct GFX_Context {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

After committing #680 for supporting SDL_GL and not using `SDL_GetWindowWMInfo()` anymore, including `SDL_syswm.h` (which is a Windows-only include file) is no longer needed. This bit had been forgotten in the previous PR.
