### PR TITLE
shell: fix a crash when taking a screenshot of an opening FMV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed texture issues in the Cowboy, Kold and Skateboard Kid models (#744)
 - fixed the savegame requestor arrow's position with a large number of savegames and long level titles (#756)
 - fixed empty holsters when starting a level with the shotgun equipped (#749)
+- fixed a crash when taking a screenshot of an opening FMV (#445)
 
 ## [2.13.2](https://github.com/rr-/Tomb1Main/compare/2.13.1...2.13.2)
 - fixed depth buffer size causing rendering issues on some hardware (#748, regression from 2.13)

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -42,9 +42,13 @@ static char *Shell_GetScreenshotName(void)
     // Get level title of unknown length
     char level_title[100];
 
-    strncpy(
-        level_title, g_GameFlow.levels[g_CurrentLevel].level_title,
-        LEVEL_TITLE_SIZE - 1);
+    if (g_CurrentLevel < 0) {
+        strncpy(level_title, "Intro", LEVEL_TITLE_SIZE - 1);
+    } else {
+        strncpy(
+            level_title, g_GameFlow.levels[g_CurrentLevel].level_title,
+            LEVEL_TITLE_SIZE - 1);
+    }
     level_title[LEVEL_TITLE_SIZE] = '\0';
 
     // Prepare level title for screenshot


### PR DESCRIPTION
Resolves #445.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed a crash when taking a screenshot of an opening FMV. If `g_CurrentLevel` isn't initialized yet, I just gave the level name for the screenshot as `Intro` like `20230313_160009_Intro.jpg`. FMVs don't have level names / titles like levels and cutscenes, so they use whatever `g_CurrentLevel` was set to previously. For example, the elevator FMV is called `20230313_152329_Cut_Scene_1.jpg` since the cutscene with Larson after Qualopec plays right before. If we want to use the correct FMV filenames in the screenshot names, there would need to be a larger rework, but I wanted to mention it just in case that's something we want.
...
