### PR TITLE
lara: improve braid control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed the savegame requestor arrow's position with a large number of savegames and long level titles (#756)
 - fixed empty holsters when starting a level with the shotgun equipped (#749)
 - fixed a crash when taking a screenshot of an opening FMV (#445)
+- improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 
 ## [2.13.2](https://github.com/rr-/Tomb1Main/compare/2.13.1...2.13.2)
 - fixed depth buffer size causing rendering issues on some hardware (#748, regression from 2.13)

--- a/src/math/matrix.c
+++ b/src/math/matrix.c
@@ -338,19 +338,32 @@ void Matrix_Interpolate(void)
     MATRIX *mptr = g_MatrixPtr;
     MATRIX *iptr = m_IMMatrixPtr;
 
-    if (m_IMRate == 2) {
-        mptr->_00 = (mptr->_00 + iptr->_00) / 2;
-        mptr->_01 = (mptr->_01 + iptr->_01) / 2;
-        mptr->_02 = (mptr->_02 + iptr->_02) / 2;
-        mptr->_03 = (mptr->_03 + iptr->_03) / 2;
-        mptr->_10 = (mptr->_10 + iptr->_10) / 2;
-        mptr->_11 = (mptr->_11 + iptr->_11) / 2;
-        mptr->_12 = (mptr->_12 + iptr->_12) / 2;
-        mptr->_13 = (mptr->_13 + iptr->_13) / 2;
-        mptr->_20 = (mptr->_20 + iptr->_20) / 2;
-        mptr->_21 = (mptr->_21 + iptr->_21) / 2;
-        mptr->_22 = (mptr->_22 + iptr->_22) / 2;
-        mptr->_23 = (mptr->_23 + iptr->_23) / 2;
+    if (m_IMRate == 2 || (m_IMFrac == 2 && m_IMRate == 4)) {
+        mptr->_00 += (iptr->_00 - mptr->_00) >> 1;
+        mptr->_01 += (iptr->_01 - mptr->_01) >> 1;
+        mptr->_02 += (iptr->_02 - mptr->_02) >> 1;
+        mptr->_03 += (iptr->_03 - mptr->_03) >> 1;
+        mptr->_10 += (iptr->_10 - mptr->_10) >> 1;
+        mptr->_11 += (iptr->_11 - mptr->_11) >> 1;
+        mptr->_12 += (iptr->_12 - mptr->_12) >> 1;
+        mptr->_13 += (iptr->_13 - mptr->_13) >> 1;
+        mptr->_20 += (iptr->_20 - mptr->_20) >> 1;
+        mptr->_21 += (iptr->_21 - mptr->_21) >> 1;
+        mptr->_22 += (iptr->_22 - mptr->_22) >> 1;
+        mptr->_23 += (iptr->_23 - mptr->_23) >> 1;
+    } else if (m_IMFrac == 1) {
+        mptr->_00 += (iptr->_00 - mptr->_00) >> 2;
+        mptr->_01 += (iptr->_01 - mptr->_01) >> 2;
+        mptr->_02 += (iptr->_02 - mptr->_02) >> 2;
+        mptr->_03 += (iptr->_03 - mptr->_03) >> 2;
+        mptr->_10 += (iptr->_10 - mptr->_10) >> 2;
+        mptr->_11 += (iptr->_11 - mptr->_11) >> 2;
+        mptr->_12 += (iptr->_12 - mptr->_12) >> 2;
+        mptr->_13 += (iptr->_13 - mptr->_13) >> 2;
+        mptr->_20 += (iptr->_20 - mptr->_20) >> 2;
+        mptr->_21 += (iptr->_21 - mptr->_21) >> 2;
+        mptr->_22 += (iptr->_22 - mptr->_22) >> 2;
+        mptr->_23 += (iptr->_23 - mptr->_23) >> 2;
     } else {
         mptr->_00 += ((iptr->_00 - mptr->_00) * m_IMFrac) / m_IMRate;
         mptr->_01 += ((iptr->_01 - mptr->_01) * m_IMFrac) / m_IMRate;


### PR DESCRIPTION
Resolves #761.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
These improvements have been translated from tomb3 (thanks to @Trxyebeep for assistance with this).

Animation comparison (before and after):
https://youtu.be/kVBBDyNjZ7w

Floor detection:
![image](https://user-images.githubusercontent.com/33758420/224975597-e74c21fe-414d-4434-9632-ebf7b21a0be2.png)

The change in `matrix.c` warranted extensive testing as this function is used by so many different animations. I completed a full run of the game, interacting with all moveable objects and checking their behaviour. Originally, I had copied the final `else` clause from [tomb3](https://github.com/Trxyebeep/tomb3/blob/master/tomb3/game/draw.cpp#L236), but this was causing issues with animations with higher framerates, such as Lara starting to push a block, or crocodiles swimming. Reverting to the original else clause here resolved each of these issues.

There is one outstanding issue with the braid as far as I can tell: when Lara turns to gold in Midas, the braid meshes do not. I will raise a separate issue for this as it's more data related, and it will need some thought on the best way to resolve it.
