### PR TITLE
lara: fix shotgun arm animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed the savegame requestor arrow's position with a large number of savegames and long level titles (#756)
 - fixed empty holsters when starting a level with the shotgun equipped (#749)
 - fixed a crash when taking a screenshot of an opening FMV (#445)
+- fixed the animation of Lara's left arm when the shotgun is equipped (#771)
 - fixed Lara's braid not turning to gold during the Midas touch animation (#769)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - fixed underwater caustics animating at 2x speed
 - fixed incorrect ceiling textures in Colosseum 
 - fixed inconsistencies in some enemy textures
+- fixed the animation of Lara's left arm when the shotgun is equipped
 
 #### Audio
 - added music during the credits

--- a/src/game/lara/lara_draw.c
+++ b/src/game/lara/lara_draw.c
@@ -526,45 +526,52 @@ void Lara_Draw_I(
 
     case LGT_SHOTGUN:
         Matrix_Push_I();
-        Matrix_Interpolate();
 
         packed_rotation1 =
             (int32_t
                  *)(g_Lara.right_arm.frame_base + g_Lara.right_arm.frame_number * (object->nmeshes * 2 + FRAME_ROT) + 10);
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
-        Matrix_RotYXZpack(packed_rotation1[LM_UARM_R]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
+        packed_rotation2 = packed_rotation1;
+        Matrix_TranslateRel_I(bone[29], bone[30], bone[31]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
-        Matrix_RotYXZpack(packed_rotation1[LM_LARM_R]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_LARM_R], clip);
+        Matrix_TranslateRel_I(bone[33], bone[34], bone[35]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_LARM_R], packed_rotation2[LM_LARM_R]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_LARM_R], clip);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
-        Matrix_RotYXZpack(packed_rotation1[LM_HAND_R]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_HAND_R], clip);
+        Matrix_TranslateRel_I(bone[37], bone[38], bone[39]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_HAND_R], packed_rotation2[LM_HAND_R]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_HAND_R], clip);
 
         if (g_Lara.right_arm.flash_gun) {
             saved_matrix = *g_MatrixPtr;
         }
 
-        Matrix_Pop();
+        Matrix_Pop_I();
 
-        Matrix_Push();
+        Matrix_Push_I();
 
         packed_rotation1 =
             (int32_t
                  *)(g_Lara.left_arm.frame_base + g_Lara.left_arm.frame_number * (object->nmeshes * 2 + FRAME_ROT) + 10);
-        Matrix_TranslateRel(bone[41], bone[42], bone[43]);
-        Matrix_RotYXZpack(packed_rotation1[LM_UARM_L]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
+        packed_rotation2 = packed_rotation1;
+        Matrix_TranslateRel_I(bone[41], bone[42], bone[43]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
-        Matrix_RotYXZpack(packed_rotation1[LM_LARM_L]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_LARM_L], clip);
+        Matrix_TranslateRel_I(bone[45], bone[46], bone[47]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_LARM_L], packed_rotation2[LM_LARM_L]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_LARM_L], clip);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
-        Matrix_RotYXZpack(packed_rotation1[LM_HAND_L]);
-        Output_DrawPolygons(g_Lara.mesh_ptrs[LM_HAND_L], clip);
+        Matrix_TranslateRel_I(bone[49], bone[50], bone[51]);
+        Matrix_RotYXZpack_I(
+            packed_rotation1[LM_HAND_L], packed_rotation2[LM_HAND_L]);
+        Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_HAND_L], clip);
 
         if (g_Lara.right_arm.flash_gun) {
             *g_MatrixPtr = saved_matrix;


### PR DESCRIPTION
Resolves #771.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This update ensures the drawing of Lara's arms respects interpolation when the shotgun is equipped. Thanks to @Trxyebeep for assisting with this; the code now largely reflects [tomb3](https://github.com/Trxyebeep/tomb3/blob/master/tomb3/game/draw.cpp#L1176).

Comparison video (OG bug is in the first half, and the fix in the second half).
https://www.youtube.com/watch?v=ic-gbeL3DJk

These screenshots of the same frame also highlight the issue and the fix:

![image](https://user-images.githubusercontent.com/33758420/226099059-4771af0d-b28a-4b52-abfa-3653d445e342.png)
![image](https://user-images.githubusercontent.com/33758420/226099061-4b989d73-1709-4c9e-ba53-cebca690a581.png)
