### PR TITLE
overlay: change bars to better match PS1 and fix scaling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added Spanish localization to the config tool
 - added an option to launch Unfinished Business from the config tool (#739)
 - added dart emitters to the savegame (#774)
+- changed the health, air, and enemy bars to better match the PS1 version (#698)
 - fixed Larson's gun textures in Tomb of Qualopec to match the cutscene and Sanctuary of the Scion (#737)
 - fixed texture issues in the Cowboy, Kold and Skateboard Kid models (#744)
 - fixed the savegame requestor arrow's position with a large number of savegames and long level titles (#756)
@@ -10,6 +11,7 @@
 - fixed the animation of Lara's left arm when the shotgun is equipped (#771)
 - fixed Lara's braid not turning to gold during the Midas touch animation (#769)
 - fixed the equipped weapon's ammo showing on the inventory screen (#777)
+- fixed the health, air, and enemy bars from being affected by the text scaling option (#698)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 

--- a/src/config.c
+++ b/src/config.c
@@ -259,10 +259,10 @@ bool Config_ReadFromJSON(const char *cfg_data)
     CLAMP(g_Config.brightness, MIN_BRIGHTNESS, MAX_BRIGHTNESS);
 
     READ_FLOAT(ui.text_scale, DEFAULT_UI_SCALE);
-    CLAMP(g_Config.ui.text_scale, MIN_UI_SCALE, MAX_UI_SCALE);
+    CLAMP(g_Config.ui.text_scale, MIN_UI_SCALE, MAX_TEXT_SCALE);
 
     READ_FLOAT(ui.bar_scale, DEFAULT_UI_SCALE);
-    CLAMP(g_Config.ui.bar_scale, MIN_UI_SCALE, MAX_UI_SCALE);
+    CLAMP(g_Config.ui.bar_scale, MIN_UI_SCALE, MAX_BAR_SCALE);
 
     char layout_name[50];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;

--- a/src/config.c
+++ b/src/config.c
@@ -259,10 +259,10 @@ bool Config_ReadFromJSON(const char *cfg_data)
     CLAMP(g_Config.brightness, MIN_BRIGHTNESS, MAX_BRIGHTNESS);
 
     READ_FLOAT(ui.text_scale, DEFAULT_UI_SCALE);
-    CLAMP(g_Config.ui.text_scale, MIN_UI_SCALE, MAX_TEXT_SCALE);
+    CLAMP(g_Config.ui.text_scale, MIN_TEXT_SCALE, MAX_TEXT_SCALE);
 
     READ_FLOAT(ui.bar_scale, DEFAULT_UI_SCALE);
-    CLAMP(g_Config.ui.bar_scale, MIN_UI_SCALE, MAX_BAR_SCALE);
+    CLAMP(g_Config.ui.bar_scale, MIN_BAR_SCALE, MAX_BAR_SCALE);
 
     char layout_name[50];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;

--- a/src/game/option/option_control.c
+++ b/src/game/option/option_control.c
@@ -199,11 +199,11 @@ static void Option_ControlProgressBar(TEXTSTRING *txt, int32_t timer);
 static void Option_ControlInitMenu(void)
 {
     int32_t visible_lines = 0;
-    if (Screen_GetResHeightDownscaled() <= 240) {
+    if (Screen_GetResHeightDownscaledText() <= 240) {
         visible_lines = 6;
-    } else if (Screen_GetResHeightDownscaled() <= 384) {
+    } else if (Screen_GetResHeightDownscaledText() <= 384) {
         visible_lines = 8;
-    } else if (Screen_GetResHeightDownscaled() <= 480) {
+    } else if (Screen_GetResHeightDownscaledText() <= 480) {
         visible_lines = 12;
     } else {
         visible_lines = 18;
@@ -240,7 +240,7 @@ static void Option_ControlInitText(CONTROL_MODE mode, INPUT_LAYOUT layout_num)
         : CtrlTextPlacementNormal;
 
     const TEXT_COLUMN_PLACEMENT *col = cols;
-    const int16_t centre = Screen_GetResWidthDownscaled() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
     int16_t x_roles = centre - 150;
     int16_t box_width = 315;
     int16_t x_names = -centre + box_width / 2 - BORDER;
@@ -548,14 +548,14 @@ static void Option_ControlProgressBar(TEXTSTRING *txt, int32_t timer)
     int32_t y = txt->pos.y - TEXT_HEIGHT;
 
     if (txt->flags.centre_h) {
-        x += (Screen_GetResWidthDownscaled() - width) / 2;
+        x += (Screen_GetResWidthDownscaledText() - width) / 2;
     } else if (txt->flags.right) {
-        x += Screen_GetResWidthDownscaled() - width;
+        x += Screen_GetResWidthDownscaledText() - width;
     }
     if (txt->flags.centre_v) {
-        y += Screen_GetResHeightDownscaled() / 2;
+        y += Screen_GetResHeightDownscaledText() / 2;
     } else if (txt->flags.bottom) {
-        y += Screen_GetResHeightDownscaled();
+        y += Screen_GetResHeightDownscaledText();
     }
 
     int32_t percent = (timer * 100) / (FRAMES_PER_SECOND * BUTTON_HOLD_TIME);

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -178,11 +178,11 @@ static void Option_GraphicsUpdateArrows(void)
         break;
     case TEXT_UI_TEXT_SCALE:
         m_HideArrowLeft = g_Config.ui.text_scale <= MIN_UI_SCALE;
-        m_HideArrowRight = g_Config.ui.text_scale >= MAX_UI_SCALE;
+        m_HideArrowRight = g_Config.ui.text_scale >= MAX_TEXT_SCALE;
         break;
     case TEXT_UI_BAR_SCALE:
         m_HideArrowLeft = g_Config.ui.bar_scale <= MIN_UI_SCALE;
-        m_HideArrowRight = g_Config.ui.bar_scale >= MAX_UI_SCALE;
+        m_HideArrowRight = g_Config.ui.bar_scale >= MAX_BAR_SCALE;
         break;
     case TEXT_RESOLUTION:
         resolution_offset = 70;
@@ -354,14 +354,14 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_UI_TEXT_SCALE:
-            if (g_Config.ui.text_scale < MAX_UI_SCALE) {
+            if (g_Config.ui.text_scale < MAX_TEXT_SCALE) {
                 g_Config.ui.text_scale += 0.1;
                 reset = TEXT_UI_TEXT_SCALE;
             }
             break;
 
         case TEXT_UI_BAR_SCALE:
-            if (g_Config.ui.bar_scale < MAX_UI_SCALE) {
+            if (g_Config.ui.bar_scale < MAX_BAR_SCALE) {
                 g_Config.ui.bar_scale += 0.1;
                 reset = TEXT_UI_BAR_SCALE;
             }

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -130,7 +130,7 @@ static void Option_GraphicsInitText(void)
     m_HideArrowRight =
         g_Config.rendering.enable_perspective_filter ? true : false;
 
-    const int16_t centre = Screen_GetResWidthDownscaled() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
     m_Text[TEXT_ROW_SELECT] =
         Text_Create(centre - 3, TOP_Y + ROW_HEIGHT + BORDER * 2, " ");
     Text_CentreV(m_Text[TEXT_ROW_SELECT], 1);
@@ -208,7 +208,7 @@ static void Option_GraphicsUpdateArrows(void)
 
 static int16_t Option_GraphicsPlaceColumns(bool create)
 {
-    const int16_t centre = Screen_GetResWidthDownscaled() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
 
     int16_t max_y = 0;
     int16_t xs[2] = { centre - 142, centre + 30 };
@@ -277,7 +277,7 @@ static void Option_GraphicsChangeTextOption(int32_t option_num)
         Text_ChangeText(m_Text[TEXT_UI_TEXT_SCALE_TOGGLE], buf);
         Option_GraphicsPlaceColumns(false);
         Text_SetPos(
-            m_Text[TEXT_ROW_SELECT], Screen_GetResWidthDownscaled() / 2 - 3,
+            m_Text[TEXT_ROW_SELECT], Screen_GetResWidthDownscaledText() / 2 - 3,
             TOP_Y + ROW_HEIGHT + BORDER * 2);
         break;
 

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -177,11 +177,11 @@ static void Option_GraphicsUpdateArrows(void)
         m_HideArrowRight = g_Config.brightness >= MAX_BRIGHTNESS;
         break;
     case TEXT_UI_TEXT_SCALE:
-        m_HideArrowLeft = g_Config.ui.text_scale <= MIN_UI_SCALE;
+        m_HideArrowLeft = g_Config.ui.text_scale <= MIN_TEXT_SCALE;
         m_HideArrowRight = g_Config.ui.text_scale >= MAX_TEXT_SCALE;
         break;
     case TEXT_UI_BAR_SCALE:
-        m_HideArrowLeft = g_Config.ui.bar_scale <= MIN_UI_SCALE;
+        m_HideArrowLeft = g_Config.ui.bar_scale <= MIN_BAR_SCALE;
         m_HideArrowRight = g_Config.ui.bar_scale >= MAX_BAR_SCALE;
         break;
     case TEXT_RESOLUTION:
@@ -407,14 +407,14 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_UI_TEXT_SCALE:
-            if (g_Config.ui.text_scale > MIN_UI_SCALE) {
+            if (g_Config.ui.text_scale > MIN_TEXT_SCALE) {
                 g_Config.ui.text_scale -= 0.1;
                 reset = TEXT_UI_TEXT_SCALE;
             }
             break;
 
         case TEXT_UI_BAR_SCALE:
-            if (g_Config.ui.bar_scale > MIN_UI_SCALE) {
+            if (g_Config.ui.bar_scale > MIN_BAR_SCALE) {
                 g_Config.ui.bar_scale -= 0.1;
                 reset = TEXT_UI_BAR_SCALE;
             }

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -243,10 +243,10 @@ static void Option_PassportInitNewGameRequester(void)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaled() / 2.4)
+        req->y = (-Screen_GetResHeightDownscaledText() / 2.4)
             + (req->line_height * req->vis_lines + 1);
     } else {
-        req->y = (-Screen_GetResHeightDownscaled() / 2)
+        req->y = (-Screen_GetResHeightDownscaledText() / 2)
             + (req->line_height * req->vis_lines);
     }
 }
@@ -258,11 +258,11 @@ static void Option_PassportInitSelectLevelRequester(void)
     Requester_Init(req);
     Requester_SetHeading(req, g_GameFlow.strings[GS_PASSPORT_SELECT_LEVEL]);
 
-    if (Screen_GetResHeightDownscaled() <= 240) {
+    if (Screen_GetResHeightDownscaledText() <= 240) {
         req->vis_lines = 5;
-    } else if (Screen_GetResHeightDownscaled() <= 384) {
+    } else if (Screen_GetResHeightDownscaledText() <= 384) {
         req->vis_lines = 7;
-    } else if (Screen_GetResHeightDownscaled() <= 480) {
+    } else if (Screen_GetResHeightDownscaledText() <= 480) {
         req->vis_lines = 10;
     } else {
         req->vis_lines = 12;
@@ -270,10 +270,10 @@ static void Option_PassportInitSelectLevelRequester(void)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaled() / 2)
+        req->y = (-Screen_GetResHeightDownscaledText() / 2)
             + (req->line_height * req->vis_lines);
     } else {
-        req->y = (-Screen_GetResHeightDownscaled() / 1.73)
+        req->y = (-Screen_GetResHeightDownscaledText() / 1.73)
             + (req->line_height * req->vis_lines);
     }
 
@@ -290,11 +290,11 @@ static void Option_PassportInitSaveRequester(int16_t page_num)
             [page_num == PASSPORT_PAGE_1 ? GS_PASSPORT_LOAD_GAME
                                          : GS_PASSPORT_SAVE_GAME]);
 
-    if (Screen_GetResHeightDownscaled() <= 240) {
+    if (Screen_GetResHeightDownscaledText() <= 240) {
         req->vis_lines = 5;
-    } else if (Screen_GetResHeightDownscaled() <= 384) {
+    } else if (Screen_GetResHeightDownscaledText() <= 384) {
         req->vis_lines = 7;
-    } else if (Screen_GetResHeightDownscaled() <= 480) {
+    } else if (Screen_GetResHeightDownscaledText() <= 480) {
         req->vis_lines = 10;
     } else {
         req->vis_lines = 12;
@@ -302,10 +302,10 @@ static void Option_PassportInitSaveRequester(int16_t page_num)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaled() / 2)
+        req->y = (-Screen_GetResHeightDownscaledText() / 2)
             + (req->line_height * req->vis_lines);
     } else {
-        req->y = (-Screen_GetResHeightDownscaled() / 1.73)
+        req->y = (-Screen_GetResHeightDownscaledText() / 1.73)
             + (req->line_height * req->vis_lines);
     }
 

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -401,13 +401,7 @@ void Overlay_DrawAmmoInfo(void)
     const int32_t screen_margin_h = 24;
     const int32_t screen_margin_v = 18;
 
-    // Scale ammo string properly if text scaling used.
-    double scale_ammo_to_bar = g_Config.ui.bar_scale;
-    if (g_Config.ui.text_scale > 1) {
-        scale_ammo_to_bar /= g_Config.ui.text_scale;
-    } else if (g_Config.ui.text_scale < 1) {
-        scale_ammo_to_bar *= 1 / g_Config.ui.text_scale;
-    }
+    double scale_ammo_to_bar = g_Config.ui.bar_scale / g_Config.ui.text_scale;
 
     char ammostring[80] = "";
 

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -27,17 +27,17 @@ static int32_t m_OldGameTimer = 0;
 
 static RGBA8888 m_ColorBarMap[][COLOR_STEPS] = {
     // gold
-    { { 112, 92, 44, 255 },
-      { 164, 120, 72, 255 },
-      { 112, 92, 44, 255 },
-      { 88, 68, 0, 255 },
-      { 80, 48, 20, 255 } },
+    { { 124, 94, 37, 255 },
+      { 161, 131, 60, 255 },
+      { 124, 94, 37, 255 },
+      { 100, 70, 19, 255 },
+      { 76, 46, 2, 255 } },
     // blue
-    { { 100, 116, 100, 255 },
-      { 92, 160, 156, 255 },
-      { 100, 116, 100, 255 },
-      { 76, 80, 76, 255 },
-      { 48, 48, 48, 255 } },
+    { { 61, 113, 123, 255 },
+      { 101, 146, 154, 255 },
+      { 61, 113, 123, 255 },
+      { 31, 93, 107, 255 },
+      { 0, 74, 91, 255 } },
     // grey
     { { 88, 100, 88, 255 },
       { 116, 132, 116, 255 },
@@ -169,9 +169,9 @@ static void Overlay_BarBlink(BAR_INFO *bar_info)
 static void Overlay_BarGetLocation(
     BAR_INFO *bar_info, int32_t *width, int32_t *height, int32_t *x, int32_t *y)
 {
-    const int32_t screen_margin_h = 20;
+    const int32_t screen_margin_h = 25;
     const int32_t screen_margin_v = 18;
-    const int32_t bar_spacing = 8;
+    const int32_t bar_spacing = 16;
 
     if (bar_info->location == BL_CUSTOM) {
         *width = bar_info->custom_width;
@@ -187,18 +187,17 @@ static void Overlay_BarGetLocation(
     } else if (
         bar_info->location == BL_TOP_RIGHT
         || bar_info->location == BL_BOTTOM_RIGHT) {
-        *x = Screen_GetResWidthDownscaled() - *width * g_Config.ui.bar_scale
-            - screen_margin_h;
+        *x = Screen_GetResWidthDownscaledBar() - *width - screen_margin_h;
     } else {
-        *x = (Screen_GetResWidthDownscaled() - *width) / 2;
+        *x = (Screen_GetResWidthDownscaledBar() - *width) / 2;
     }
 
     if (bar_info->location == BL_TOP_LEFT || bar_info->location == BL_TOP_CENTER
         || bar_info->location == BL_TOP_RIGHT) {
         *y = screen_margin_v + m_BarOffsetY[bar_info->location];
     } else {
-        *y = Screen_GetResHeightDownscaled() - *height * g_Config.ui.bar_scale
-            - screen_margin_v - m_BarOffsetY[bar_info->location];
+        *y = Screen_GetResHeightDownscaledBar() - *height - screen_margin_v
+            - m_BarOffsetY[bar_info->location];
     }
 
     m_BarOffsetY[bar_info->location] += *height + bar_spacing;
@@ -207,30 +206,26 @@ static void Overlay_BarGetLocation(
 void Overlay_BarDraw(BAR_INFO *bar_info)
 {
     const RGBA8888 rgb_bgnd = { 0, 0, 0, 255 };
-    const RGBA8888 rgb_border_light = { 128, 128, 128, 255 };
-    const RGBA8888 rgb_border_dark = { 64, 64, 64, 255 };
+    const RGBA8888 rgb_border = { 53, 53, 53, 255 };
 
-    int32_t width = 100;
-    int32_t height = 5;
+    int32_t width = 200;
+    int32_t height = 10;
 
     int32_t x = 0;
     int32_t y = 0;
     Overlay_BarGetLocation(bar_info, &width, &height, &x, &y);
 
-    int32_t padding = Screen_GetResWidth() <= 800 ? 1 : 2;
-    int32_t border = 1;
-    int32_t sx = Screen_GetRenderScale(x) - padding;
-    int32_t sy = Screen_GetRenderScale(y) - padding;
-    int32_t sw =
-        Screen_GetRenderScale(width) * g_Config.ui.bar_scale + padding * 2;
-    int32_t sh =
-        Screen_GetRenderScale(height) * g_Config.ui.bar_scale + padding * 2;
+    int32_t padding = Screen_GetRenderScaleBar(2);
+    int32_t border = Screen_GetRenderScaleBar(2);
+
+    int32_t sx = Screen_GetRenderScaleBar(x) - padding;
+    int32_t sy = Screen_GetRenderScaleBar(y) - padding;
+    int32_t sw = Screen_GetRenderScaleBar(width) + padding * 2;
+    int32_t sh = Screen_GetRenderScaleBar(height) + padding * 2;
 
     // border
     Output_DrawScreenFlatQuad(
-        sx - border, sy - border, sw + border, sh + border, rgb_border_dark);
-    Output_DrawScreenFlatQuad(
-        sx, sy, sw + border, sh + border, rgb_border_light);
+        sx - border, sy - border, sw + 2 * border, sh + 2 * border, rgb_border);
 
     // background
     Output_DrawScreenFlatQuad(sx, sy, sw, sh, rgb_bgnd);
@@ -243,10 +238,10 @@ void Overlay_BarDraw(BAR_INFO *bar_info)
     if (percent && !bar_info->blink) {
         width = width * percent / 100;
 
-        sx = Screen_GetRenderScale(x);
-        sy = Screen_GetRenderScale(y);
-        sw = Screen_GetRenderScale(width) * g_Config.ui.bar_scale;
-        sh = Screen_GetRenderScale(height) * g_Config.ui.bar_scale;
+        sx = Screen_GetRenderScaleBar(x);
+        sy = Screen_GetRenderScaleBar(y);
+        sw = Screen_GetRenderScaleBar(width);
+        sh = Screen_GetRenderScaleBar(height);
 
         if (g_Config.enable_smooth_bars) {
             for (int i = 0; i < COLOR_STEPS - 1; i++) {
@@ -400,11 +395,19 @@ void Overlay_RemoveAmmoText(void)
 
 void Overlay_DrawAmmoInfo(void)
 {
-    const double scale = 0.8;
+    const double scale = 1.5;
     const int32_t text_height = 17 * scale;
     const int32_t text_offset_x = 3;
-    const int32_t screen_margin_h = 20;
+    const int32_t screen_margin_h = 24;
     const int32_t screen_margin_v = 18;
+
+    // Scale ammo string properly if text scaling used.
+    double scale_ammo_to_bar = g_Config.ui.bar_scale;
+    if (g_Config.ui.text_scale > 1) {
+        scale_ammo_to_bar /= g_Config.ui.text_scale;
+    } else if (g_Config.ui.text_scale < 1) {
+        scale_ammo_to_bar *= 1 / g_Config.ui.text_scale;
+    }
 
     char ammostring[80] = "";
 
@@ -443,8 +446,13 @@ void Overlay_DrawAmmoInfo(void)
         Text_AlignRight(m_AmmoText, 1);
     }
 
+    m_AmmoText->pos.x = m_BarOffsetY[BL_TOP_RIGHT]
+        ? (-screen_margin_h * scale_ammo_to_bar) - text_offset_x
+        : -screen_margin_h - text_offset_x;
+
     m_AmmoText->pos.y = m_BarOffsetY[BL_TOP_RIGHT]
-        ? text_height + screen_margin_v + m_BarOffsetY[BL_TOP_RIGHT]
+        ? text_height + (screen_margin_v * scale_ammo_to_bar)
+            + (m_BarOffsetY[BL_TOP_RIGHT] * scale_ammo_to_bar)
         : text_height + screen_margin_v;
 }
 

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -211,7 +211,7 @@ void Requester_AddItem(REQUEST_INFO *req, const char *string, uint16_t flag)
 void Requester_SetSize(REQUEST_INFO *req, int32_t max_lines, int16_t y)
 {
     req->y = y;
-    req->vis_lines = Screen_GetResHeightDownscaled() / 2 / MAX_REQLINES;
+    req->vis_lines = Screen_GetResHeightDownscaledText() / 2 / MAX_REQLINES;
     if (req->vis_lines > max_lines) {
         req->vis_lines = max_lines;
     }

--- a/src/game/screen.c
+++ b/src/game/screen.c
@@ -76,9 +76,19 @@ int32_t Screen_GetResWidthDownscaled(void)
     return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScale(PHD_ONE);
 }
 
+int32_t Screen_GetResWidthDownscaledBar(void)
+{
+    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
+}
+
 int32_t Screen_GetResHeightDownscaled(void)
 {
     return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScale(PHD_ONE);
+}
+
+int32_t Screen_GetResHeightDownscaledBar(void)
+{
+    return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
 }
 
 int32_t Screen_GetRenderScale(int32_t unit)
@@ -93,6 +103,21 @@ int32_t Screen_GetRenderScale(int32_t unit)
         ? ((double)Screen_GetResHeight() * unit * g_Config.ui.text_scale)
             / baseHeight
         : unit * g_Config.ui.text_scale;
+    return MIN(scale_x, scale_y);
+}
+
+int32_t Screen_GetRenderScaleBar(int32_t unit)
+{
+    int32_t baseWidth = 640;
+    int32_t baseHeight = 480;
+    int32_t scale_x = Screen_GetResWidth() > baseWidth
+        ? ((double)Screen_GetResWidth() * unit * g_Config.ui.bar_scale)
+            / baseWidth
+        : unit * g_Config.ui.bar_scale;
+    int32_t scale_y = Screen_GetResHeight() > baseHeight
+        ? ((double)Screen_GetResHeight() * unit * g_Config.ui.bar_scale)
+            / baseHeight
+        : unit * g_Config.ui.bar_scale;
     return MIN(scale_x, scale_y);
 }
 

--- a/src/game/screen.c
+++ b/src/game/screen.c
@@ -93,30 +93,30 @@ int32_t Screen_GetResHeightDownscaledBar(void)
 
 int32_t Screen_GetRenderScale(int32_t unit)
 {
-    int32_t baseWidth = 640;
-    int32_t baseHeight = 480;
-    int32_t scale_x = Screen_GetResWidth() > baseWidth
+    int32_t base_width = 640;
+    int32_t base_height = 480;
+    int32_t scale_x = Screen_GetResWidth() > base_width
         ? ((double)Screen_GetResWidth() * unit * g_Config.ui.text_scale)
-            / baseWidth
+            / base_width
         : unit * g_Config.ui.text_scale;
-    int32_t scale_y = Screen_GetResHeight() > baseHeight
+    int32_t scale_y = Screen_GetResHeight() > base_height
         ? ((double)Screen_GetResHeight() * unit * g_Config.ui.text_scale)
-            / baseHeight
+            / base_height
         : unit * g_Config.ui.text_scale;
     return MIN(scale_x, scale_y);
 }
 
 int32_t Screen_GetRenderScaleBar(int32_t unit)
 {
-    int32_t baseWidth = 640;
-    int32_t baseHeight = 480;
-    int32_t scale_x = Screen_GetResWidth() > baseWidth
+    int32_t base_width = 640;
+    int32_t base_height = 480;
+    int32_t scale_x = Screen_GetResWidth() > base_width
         ? ((double)Screen_GetResWidth() * unit * g_Config.ui.bar_scale)
-            / baseWidth
+            / base_width
         : unit * g_Config.ui.bar_scale;
-    int32_t scale_y = Screen_GetResHeight() > baseHeight
+    int32_t scale_y = Screen_GetResHeight() > base_height
         ? ((double)Screen_GetResHeight() * unit * g_Config.ui.bar_scale)
-            / baseHeight
+            / base_height
         : unit * g_Config.ui.bar_scale;
     return MIN(scale_x, scale_y);
 }

--- a/src/game/screen.c
+++ b/src/game/screen.c
@@ -71,9 +71,14 @@ int32_t Screen_GetPendingResHeight(void)
     return g_AvailableResolutions[m_PendingResolutionIdx].height;
 }
 
-int32_t Screen_GetResWidthDownscaled(void)
+int32_t Screen_GetResWidthDownscaledText(void)
 {
-    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScale(PHD_ONE);
+    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScaleText(PHD_ONE);
+}
+
+int32_t Screen_GetResHeightDownscaledText(void)
+{
+    return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScaleText(PHD_ONE);
 }
 
 int32_t Screen_GetResWidthDownscaledBar(void)
@@ -81,43 +86,30 @@ int32_t Screen_GetResWidthDownscaledBar(void)
     return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
 }
 
-int32_t Screen_GetResHeightDownscaled(void)
-{
-    return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScale(PHD_ONE);
-}
-
 int32_t Screen_GetResHeightDownscaledBar(void)
 {
     return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
 }
 
-int32_t Screen_GetRenderScale(int32_t unit)
+int32_t Screen_GetRenderScaleText(int32_t unit)
 {
-    int32_t base_width = 640;
-    int32_t base_height = 480;
-    int32_t scale_x = Screen_GetResWidth() > base_width
-        ? ((double)Screen_GetResWidth() * unit * g_Config.ui.text_scale)
-            / base_width
-        : unit * g_Config.ui.text_scale;
-    int32_t scale_y = Screen_GetResHeight() > base_height
-        ? ((double)Screen_GetResHeight() * unit * g_Config.ui.text_scale)
-            / base_height
-        : unit * g_Config.ui.text_scale;
-    return MIN(scale_x, scale_y);
+    return Screen_GetRenderScaleBase(unit, 640, 480, g_Config.ui.text_scale);
 }
 
 int32_t Screen_GetRenderScaleBar(int32_t unit)
 {
-    int32_t base_width = 640;
-    int32_t base_height = 480;
+    return Screen_GetRenderScaleBase(unit, 640, 480, g_Config.ui.bar_scale);
+}
+
+int32_t Screen_GetRenderScaleBase(
+    int32_t unit, int32_t base_width, int32_t base_height, double factor)
+{
     int32_t scale_x = Screen_GetResWidth() > base_width
-        ? ((double)Screen_GetResWidth() * unit * g_Config.ui.bar_scale)
-            / base_width
-        : unit * g_Config.ui.bar_scale;
+        ? ((double)Screen_GetResWidth() * unit * factor) / base_width
+        : unit * factor;
     int32_t scale_y = Screen_GetResHeight() > base_height
-        ? ((double)Screen_GetResHeight() * unit * g_Config.ui.bar_scale)
-            / base_height
-        : unit * g_Config.ui.bar_scale;
+        ? ((double)Screen_GetResHeight() * unit * factor) / base_height
+        : unit * factor;
     return MIN(scale_x, scale_y);
 }
 

--- a/src/game/screen.h
+++ b/src/game/screen.h
@@ -11,13 +11,16 @@ int32_t Screen_GetResIdx(void);
 int32_t Screen_GetResWidth(void);
 int32_t Screen_GetResHeight(void);
 int32_t Screen_GetResWidthDownscaled(void);
+int32_t Screen_GetResWidthDownscaledBar(void);
 int32_t Screen_GetResHeightDownscaled(void);
+int32_t Screen_GetResHeightDownscaledBar(void);
 
 int32_t Screen_GetPendingResIdx(void);
 int32_t Screen_GetPendingResWidth(void);
 int32_t Screen_GetPendingResHeight(void);
 
 int32_t Screen_GetRenderScale(int32_t unit);
+int32_t Screen_GetRenderScaleBar(int32_t unit);
 int32_t Screen_GetRenderScaleGLRage(int32_t unit);
 
 void Screen_ApplyResolution(void);

--- a/src/game/screen.h
+++ b/src/game/screen.h
@@ -10,17 +10,19 @@ bool Screen_SetNextRes(void);
 int32_t Screen_GetResIdx(void);
 int32_t Screen_GetResWidth(void);
 int32_t Screen_GetResHeight(void);
-int32_t Screen_GetResWidthDownscaled(void);
+int32_t Screen_GetResWidthDownscaledText(void);
+int32_t Screen_GetResHeightDownscaledText(void);
 int32_t Screen_GetResWidthDownscaledBar(void);
-int32_t Screen_GetResHeightDownscaled(void);
 int32_t Screen_GetResHeightDownscaledBar(void);
 
 int32_t Screen_GetPendingResIdx(void);
 int32_t Screen_GetPendingResWidth(void);
 int32_t Screen_GetPendingResHeight(void);
 
-int32_t Screen_GetRenderScale(int32_t unit);
+int32_t Screen_GetRenderScaleText(int32_t unit);
 int32_t Screen_GetRenderScaleBar(int32_t unit);
+int32_t Screen_GetRenderScaleBase(
+    int32_t unit, int32_t base_width, int32_t base_height, double factor);
 int32_t Screen_GetRenderScaleGLRage(int32_t unit);
 
 void Screen_ApplyResolution(void);

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -491,15 +491,15 @@ static void Text_DrawText(TEXTSTRING *textstring)
     int32_t textwidth = Text_GetWidth(textstring);
 
     if (textstring->flags.centre_h) {
-        x += (Screen_GetResWidthDownscaled() - textwidth) / 2;
+        x += (Screen_GetResWidthDownscaledText() - textwidth) / 2;
     } else if (textstring->flags.right) {
-        x += Screen_GetResWidthDownscaled() - textwidth;
+        x += Screen_GetResWidthDownscaledText() - textwidth;
     }
 
     if (textstring->flags.centre_v) {
-        y += Screen_GetResHeightDownscaled() / 2;
+        y += Screen_GetResHeightDownscaledText() / 2;
     } else if (textstring->flags.bottom) {
-        y += Screen_GetResHeightDownscaled();
+        y += Screen_GetResHeightDownscaledText();
     }
 
     int32_t bxpos = textstring->bgnd_off.x + x - TEXT_BOX_OFFSET;
@@ -519,10 +519,10 @@ static void Text_DrawText(TEXTSTRING *textstring)
         }
 
         uint8_t sprite_num = Text_MapLetterToSpriteNum(letter);
-        sx = Screen_GetRenderScale(x);
-        sy = Screen_GetRenderScale(y);
-        sh = Screen_GetRenderScale(textstring->scale.h);
-        sv = Screen_GetRenderScale(textstring->scale.v);
+        sx = Screen_GetRenderScaleText(x);
+        sy = Screen_GetRenderScaleText(y);
+        sh = Screen_GetRenderScaleText(textstring->scale.h);
+        sv = Screen_GetRenderScaleText(textstring->scale.v);
 
         Output_DrawScreenSprite2D(
             sx, sy, 0, sh, sv, g_Objects[O_ALPHABET].mesh_index + sprite_num,
@@ -555,10 +555,10 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.background) {
-        sx = Screen_GetRenderScale(bxpos);
-        sy = Screen_GetRenderScale(bypos);
-        sh = Screen_GetRenderScale(bwidth);
-        sv = Screen_GetRenderScale(bheight);
+        sx = Screen_GetRenderScaleText(bxpos);
+        sy = Screen_GetRenderScaleText(bypos);
+        sh = Screen_GetRenderScaleText(bwidth);
+        sv = Screen_GetRenderScaleText(bheight);
 
         Text_DrawTextBackground(
             g_Config.ui.menu_style, sx, sy, sh, sv,
@@ -570,10 +570,10 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.outline) {
-        sx = Screen_GetRenderScale(bxpos);
-        sy = Screen_GetRenderScale(bypos);
-        sh = Screen_GetRenderScale(bwidth);
-        sv = Screen_GetRenderScale(bheight);
+        sx = Screen_GetRenderScaleText(bxpos);
+        sy = Screen_GetRenderScaleText(bypos);
+        sh = Screen_GetRenderScaleText(bwidth);
+        sv = Screen_GetRenderScaleText(bheight);
 
         Text_DrawTextOutline(
             g_Config.ui.menu_style, sx, sy, sh, sv, textstring->outline.style);

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -10,10 +10,11 @@
 #define PHD_45 (PHD_ONE / 8) // = 8192 = 0x2000
 #define PHD_135 (PHD_45 * 3) // = 24576 = 0x6000
 
-#define MIN_UI_SCALE 0.5f
-#define MAX_TEXT_SCALE 2.0f
-#define MAX_BAR_SCALE 1.5f
-#define DEFAULT_UI_SCALE 1.0f
+#define MIN_TEXT_SCALE 0.5
+#define MAX_TEXT_SCALE 2.0
+#define MIN_BAR_SCALE 0.5
+#define MAX_BAR_SCALE 1.5
+#define DEFAULT_UI_SCALE 1.0
 
 #define MIN_BRIGHTNESS 0.1f
 #define MAX_BRIGHTNESS 2.0f

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -11,7 +11,8 @@
 #define PHD_135 (PHD_45 * 3) // = 24576 = 0x6000
 
 #define MIN_UI_SCALE 0.5f
-#define MAX_UI_SCALE 2.0f
+#define MAX_TEXT_SCALE 2.0f
+#define MAX_BAR_SCALE 1.5f
 #define DEFAULT_UI_SCALE 1.0f
 
 #define MIN_BRIGHTNESS 0.1f


### PR DESCRIPTION
Resolves #698.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Changed the health, air, and enemy bars to better match the PS1 version. Fixed the health, air, and enemy bars from being affected by the text scaling option,
...
