### PR TITLE
overlay: fix equipped weapon's ammo showing on inventory screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fixed a crash when taking a screenshot of an opening FMV (#445)
 - fixed the animation of Lara's left arm when the shotgun is equipped (#771)
 - fixed Lara's braid not turning to gold during the Midas touch animation (#769)
+- fixed the equipped weapon's ammo showing on the inventory screen (#777)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 

--- a/src/game/game/game_draw.c
+++ b/src/game/game/game_draw.c
@@ -20,12 +20,17 @@ int32_t Game_ProcessFrame(void)
     return g_Camera.number_frames;
 }
 
+#include "log.h"
+
 void Game_DrawScene(bool draw_overlay)
 {
     if (g_Objects[O_LARA].loaded) {
         Room_DrawAllRooms(g_Camera.pos.room_number);
+        LOG_DEBUG("draw_overlay: %d", draw_overlay);
         if (draw_overlay) {
             Overlay_DrawGameInfo();
+        } else {
+            Overlay_RemoveAmmoText();
         }
     } else {
         // cinematic scene

--- a/src/game/game/game_draw.c
+++ b/src/game/game/game_draw.c
@@ -20,13 +20,10 @@ int32_t Game_ProcessFrame(void)
     return g_Camera.number_frames;
 }
 
-#include "log.h"
-
 void Game_DrawScene(bool draw_overlay)
 {
     if (g_Objects[O_LARA].loaded) {
         Room_DrawAllRooms(g_Camera.pos.room_number);
-        LOG_DEBUG("draw_overlay: %d", draw_overlay);
         if (draw_overlay) {
             Overlay_DrawGameInfo();
         } else {

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -8,7 +8,6 @@
 #include "game/sound.h"
 #include "game/text.h"
 #include "global/types.h"
-#include "global/vars.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -144,9 +143,6 @@ bool Game_Pause(void)
 {
     g_OldInputDB = g_Input;
 
-    int old_overlay_flag = g_OverlayFlag;
-    g_OverlayFlag = -3;
-
     Text_RemoveAll();
     Output_SetupAboveWater(false);
 
@@ -161,6 +157,5 @@ bool Game_Pause(void)
     Music_Unpause();
     Requester_Remove(&m_PauseRequester);
     Game_Pause_RemoveText();
-    g_OverlayFlag = old_overlay_flag;
     return select < 0;
 }

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -390,6 +390,14 @@ void Overlay_BarDrawEnemy(void)
     Overlay_BarDraw(&m_EnemyBar);
 }
 
+void Overlay_RemoveAmmoText(void)
+{
+    if (m_AmmoText) {
+        Text_Remove(m_AmmoText);
+        m_AmmoText = NULL;
+    }
+}
+
 void Overlay_DrawAmmoInfo(void)
 {
     const double scale = 0.8;
@@ -400,12 +408,9 @@ void Overlay_DrawAmmoInfo(void)
 
     char ammostring[80] = "";
 
-    if (g_Lara.gun_status != LGS_READY || g_OverlayFlag <= 0
+    if (g_Lara.gun_status != LGS_READY
         || (g_GameInfo.bonus_flag & GBF_NGPLUS)) {
-        if (m_AmmoText) {
-            Text_Remove(m_AmmoText);
-            m_AmmoText = NULL;
-        }
+        Overlay_RemoveAmmoText();
         return;
     }
 
@@ -503,13 +508,10 @@ void Overlay_DrawFPSInfo(void)
 
 void Overlay_DrawGameInfo(void)
 {
-    if (g_OverlayFlag > 0) {
-        Overlay_BarDrawHealth();
-        Overlay_BarDrawAir();
-        Overlay_BarDrawEnemy();
-        Overlay_DrawPickups();
-    }
-
+    Overlay_BarDrawHealth();
+    Overlay_BarDrawAir();
+    Overlay_BarDrawEnemy();
+    Overlay_DrawPickups();
     Overlay_DrawAmmoInfo();
     Overlay_DrawFPSInfo();
 

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -14,6 +14,7 @@ void Overlay_BarDraw(struct BAR_INFO *bar_info);
 void Overlay_BarDrawHealth(void);
 void Overlay_BarDrawAir(void);
 void Overlay_BarDrawEnemy(void);
+void Overlay_RemoveAmmoText(void);
 void Overlay_DrawAmmoInfo(void);
 void Overlay_DrawPickups(void);
 void Overlay_DrawFPSInfo(void);


### PR DESCRIPTION
Resolves #777.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the equipped weapon's ammo showing on the inventory screen.

I removed some unused instances of `g_OverlayFlag` since that was just confusing things. That flag was no longer used for `Overlay_DrawGameInfo` because `Game_DrawScene(bool draw_overlay)` takes the `draw_overlay` flag to determine whether the overlay is drawn. The pause screen also is self contained in its own mini loop and doesn't need `g_OverlayFlag`.

Let me know if this is OK or if you want to fix it another way. `Overlay_DrawFPSInfo` isn't called every loop, so it can no longer be used to do the removal. Also `Overlay_OnAmmoTextRemoval` and `Overlay_OnFPSTextRemoval` seem redundant so let me know if we want to keep those. No other text seems to make use of `on_remove`. I couldn't tell from when exactly this is a regression. Seems to have happened during one of the refactors.
...
