### PR TITLE
music: fix partial masked triggers killing the ambient track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed Lara's braid not turning to gold during the Midas touch animation (#769)
 - fixed the equipped weapon's ammo showing on the inventory screen (#777)
 - fixed the health, air, and enemy bars from being affected by the text scaling option (#698)
+- fixed music triggers with partial masks killing the ambient track (#763)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -145,6 +145,19 @@ void Music_Stop(void)
     Music_StopActiveStream();
 }
 
+void Music_StopTrack(int16_t track)
+{
+    if (track != Music_CurrentTrack()) {
+        return;
+    }
+
+    Music_StopActiveStream();
+
+    if (m_TrackLooped >= 0) {
+        Music_PlayLooped(m_TrackLooped);
+    }
+}
+
 void Music_SetVolume(int16_t volume)
 {
     m_MusicVolume = volume ? (25 * volume + 5) / 255.0f : 0.0f;

--- a/src/game/music.h
+++ b/src/game/music.h
@@ -23,6 +23,9 @@ bool Music_PlayLooped(int16_t track);
 // Stops any music, whether looped or active speech.
 void Music_Stop(void);
 
+// Stops the provided single track and restarts the looped track if applicable.
+void Music_StopTrack(int16_t track);
+
 // Sets the game volume. Value can be 0-255.
 void Music_SetVolume(int16_t volume);
 

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -99,7 +99,7 @@ static void Room_TriggerMusicTrack(int16_t track, int16_t flags, int16_t type)
         }
         Music_Play(track);
     } else {
-        Music_Stop();
+        Music_StopTrack(track);
     }
 }
 


### PR DESCRIPTION
Resolves #763.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This resolves the ambient track being stopped in three places in the original game. The areas in St. Francis' Folly and Temple of the Cat are detailed in the issue; the third area is in Tomb of Qualopec, when passing through room 25 heading back towards room 24.

![image](https://user-images.githubusercontent.com/33758420/227739436-a8644ebc-1692-470e-a99a-011073ea0306.png)

The antipad here is intended to stop track 17 from playing again on exit, but I believe this is actually redundant as there is handling already to avoid repeated tracks (no other track is triggered in this area); this should perhaps be addressed properly with floor data manipulation (#755), but for now at least the ambient track is restored on exiting this area.

A potential side effect of this could be in custom levels where it may be desirable to kill all music, including the ambient track, using a trigger. I'm not sure if we wish to retain a method to achieve this.
