### PR TITLE
option_graphics: clamp text & bar scaling to avoid rounding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed the equipped weapon's ammo showing on the inventory screen (#777)
 - fixed the health, air, and enemy bars from being affected by the text scaling option (#698)
 - fixed music triggers with partial masks killing the ambient track (#763)
+- fixed the text and bar scaling from being able to be set below the max and min  (#698)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -347,10 +347,9 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_BRIGHTNESS:
-            if (g_Config.brightness < MAX_BRIGHTNESS) {
-                g_Config.brightness += 0.1f;
-                reset = TEXT_BRIGHTNESS;
-            }
+            g_Config.brightness += 0.1f;
+            CLAMP(g_Config.brightness, MIN_BRIGHTNESS, MAX_BRIGHTNESS);
+            reset = TEXT_BRIGHTNESS;
             break;
 
         case TEXT_UI_TEXT_SCALE:
@@ -398,10 +397,9 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_BRIGHTNESS:
-            if (g_Config.brightness > MIN_BRIGHTNESS) {
-                g_Config.brightness -= 0.1f;
-                reset = TEXT_BRIGHTNESS;
-            }
+            g_Config.brightness -= 0.1f;
+            CLAMP(g_Config.brightness, MIN_BRIGHTNESS, MAX_BRIGHTNESS);
+            reset = TEXT_BRIGHTNESS;
             break;
 
         case TEXT_UI_TEXT_SCALE:

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -341,8 +341,8 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
         case TEXT_VSYNC:
             if (!g_Config.rendering.enable_vsync) {
                 g_Config.rendering.enable_vsync = true;
-                reset = TEXT_VSYNC;
                 GFX_Context_SetVSync(g_Config.rendering.enable_vsync);
+                reset = TEXT_VSYNC;
             }
             break;
 
@@ -391,8 +391,8 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
         case TEXT_VSYNC:
             if (g_Config.rendering.enable_vsync) {
                 g_Config.rendering.enable_vsync = false;
-                reset = TEXT_VSYNC;
                 GFX_Context_SetVSync(g_Config.rendering.enable_vsync);
+                reset = TEXT_VSYNC;
             }
             break;
 

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -354,17 +354,15 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_UI_TEXT_SCALE:
-            if (g_Config.ui.text_scale < MAX_TEXT_SCALE) {
-                g_Config.ui.text_scale += 0.1;
-                reset = TEXT_UI_TEXT_SCALE;
-            }
+            g_Config.ui.text_scale += 0.1;
+            CLAMP(g_Config.ui.text_scale, MIN_TEXT_SCALE, MAX_TEXT_SCALE);
+            reset = TEXT_UI_TEXT_SCALE;
             break;
 
         case TEXT_UI_BAR_SCALE:
-            if (g_Config.ui.bar_scale < MAX_BAR_SCALE) {
-                g_Config.ui.bar_scale += 0.1;
-                reset = TEXT_UI_BAR_SCALE;
-            }
+            g_Config.ui.bar_scale += 0.1;
+            CLAMP(g_Config.ui.bar_scale, MIN_BAR_SCALE, MAX_BAR_SCALE);
+            reset = TEXT_UI_BAR_SCALE;
             break;
 
         case TEXT_RESOLUTION:
@@ -407,17 +405,15 @@ void Option_Graphics(INVENTORY_ITEM *inv_item)
             break;
 
         case TEXT_UI_TEXT_SCALE:
-            if (g_Config.ui.text_scale > MIN_TEXT_SCALE) {
-                g_Config.ui.text_scale -= 0.1;
-                reset = TEXT_UI_TEXT_SCALE;
-            }
+            g_Config.ui.text_scale -= 0.1;
+            CLAMP(g_Config.ui.text_scale, MIN_TEXT_SCALE, MAX_TEXT_SCALE);
+            reset = TEXT_UI_TEXT_SCALE;
             break;
 
         case TEXT_UI_BAR_SCALE:
-            if (g_Config.ui.bar_scale > MIN_BAR_SCALE) {
-                g_Config.ui.bar_scale -= 0.1;
-                reset = TEXT_UI_BAR_SCALE;
-            }
+            g_Config.ui.bar_scale -= 0.1;
+            CLAMP(g_Config.ui.bar_scale, MIN_BAR_SCALE, MAX_BAR_SCALE);
+            reset = TEXT_UI_BAR_SCALE;
             break;
 
         case TEXT_RESOLUTION:


### PR DESCRIPTION
Resolves #781.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the text and bar scaling from being able to be set below the intended max and min values.
...
