### PR TITLE
music: allow triggers to kill all music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added Spanish localization to the config tool
 - added an option to launch Unfinished Business from the config tool (#739)
 - added dart emitters to the savegame (#774)
+- added the ability for level builders to stop all music via triggers (#785)
 - changed the health, air, and enemy bars to better match the PS1 version (#698)
 - fixed Larson's gun textures in Tomb of Qualopec to match the cutscene and Sanctuary of the Scion (#737)
 - fixed texture issues in the Cowboy, Kold and Skateboard Kid models (#744)

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -28,7 +28,12 @@ static void Room_RemoveFlipItems(ROOM_INFO *r);
 
 static void Room_TriggerMusicTrack(int16_t track, int16_t flags, int16_t type)
 {
-    if (track <= 1 || track >= MAX_CD_TRACKS) {
+    if (track == MX_UNUSED_0 && type == TT_ANTIPAD) {
+        Music_Stop();
+        return;
+    }
+
+    if (track <= MX_UNUSED_1 || track >= MAX_CD_TRACKS) {
         return;
     }
 


### PR DESCRIPTION
Resolves #785.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Antipads configured with music parameter 0 will now stop all current tracks - so a non-looped track if it's playing, plus the ambient track.

![image](https://user-images.githubusercontent.com/33758420/227771405-ff3bbb7e-33ef-4da2-813e-84712c0885b3.png)


