### PR TITLE
music: retain active track during enemy speeches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added an option to launch Unfinished Business from the config tool (#739)
 - added dart emitters to the savegame (#774)
 - added the ability for level builders to stop all music via triggers (#785)
+- added an option to prevent enemy speeches stopping the current music track (#762)
 - changed the health, air, and enemy bars to better match the PS1 version (#698)
 - fixed Larson's gun textures in Tomb of Qualopec to match the cutscene and Sanctuary of the Scion (#737)
 - fixed texture issues in the Cowboy, Kold and Skateboard Kid models (#744)

--- a/src/config.c
+++ b/src/config.c
@@ -189,6 +189,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(fix_tihocan_secret_sound, true);
     READ_BOOL(fix_pyramid_secret_trigger, true);
     READ_BOOL(fix_secrets_killing_music, true);
+    READ_BOOL(fix_speeches_killing_music, true);
     READ_BOOL(fix_descending_glitch, false);
     READ_BOOL(fix_wall_jump_glitch, false);
     READ_BOOL(fix_bridge_collision, true);
@@ -385,6 +386,7 @@ bool Config_Write(void)
     WRITE_BOOL(fix_tihocan_secret_sound);
     WRITE_BOOL(fix_pyramid_secret_trigger);
     WRITE_BOOL(fix_secrets_killing_music);
+    WRITE_BOOL(fix_speeches_killing_music);
     WRITE_BOOL(fix_descending_glitch);
     WRITE_BOOL(fix_wall_jump_glitch);
     WRITE_BOOL(fix_bridge_collision);

--- a/src/config.h
+++ b/src/config.h
@@ -76,6 +76,7 @@ typedef struct {
     bool fix_tihocan_secret_sound;
     bool fix_pyramid_secret_trigger;
     bool fix_secrets_killing_music;
+    bool fix_speeches_killing_music;
     bool fix_descending_glitch;
     bool fix_wall_jump_glitch;
     bool fix_bridge_collision;

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -82,6 +82,12 @@ bool Music_Play(int16_t track)
         return Sound_Effect(SFX_SECRET, NULL, SPM_ALWAYS);
     }
 
+    if (g_Config.fix_speeches_killing_music && track >= MX_BALDY_SPEECH
+        && track <= MX_SKATEKID_SPEECH) {
+        return Sound_Effect(
+            SFX_BALDY_SPEECH + track - MX_BALDY_SPEECH, NULL, SPM_ALWAYS);
+    }
+
     if (track == MX_CAVES_AMBIENT) {
         return false;
     }

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -23,6 +23,8 @@
 #define SKATE_KID_HITPOINTS 125
 #define SKATE_KID_RADIUS (WALL_L / 5) // = 204
 #define SKATE_KID_SMARTNESS 0x7FFF
+#define SKATE_KID_SPEECH_HITPOINTS 120
+#define SKATE_KID_SPEECH_STARTED 1
 
 typedef enum {
     SKATE_KID_STOP = 0,
@@ -90,8 +92,10 @@ void SkateKid_Control(int16_t item_num)
 
         angle = Creature_Turn(item, SKATE_KID_SKATE_TURN);
 
-        if (item->hit_points < 120 && Music_CurrentTrack() != 56) {
+        if (item->hit_points < SKATE_KID_SPEECH_HITPOINTS
+            && !(item->flags & SKATE_KID_SPEECH_STARTED)) {
             Music_Play(MX_SKATEKID_SPEECH);
+            item->flags |= SKATE_KID_SPEECH_STARTED;
         }
 
         switch (item->current_anim_state) {

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -265,7 +265,11 @@
     },
     "fix_secrets_killing_music": {
       "Title": "Do not stop music on secrets pick-ups",
-      "Description": "Fixes the sound of collecting a secret resetting the active music track."
+      "Description": "Fixes the sound of collecting a secret stopping the active music track."
+    },
+    "fix_speeches_killing_music": {
+      "Title": "Do not stop music when enemies speak",
+      "Description": "Fixes enemies stopping the active music track when they speak."
     },
     "enable_ps_uzi_sfx": {
       "Title": "Enable PS Uzi SFX",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
@@ -252,8 +252,12 @@
       "Title": "Solucione la falla de QWOP"
     },
     "fix_secrets_killing_music": {
-      "Description": "Corrige el sonido de recopilar un secreto que reinicia la pista de música activa.",
+      "Description": "Corrige el sonido de recopilar un secreto que detiene la pista de música activa.",
       "Title": "No pares de música en recogidas de secretos"
+    },
+    "fix_speeches_killing_music": {
+      "Title": "No parar la música cuando hablan los enemigos",
+      "Description": "Impide que los enemigos paren la pista de música cuando hablan."
     },
     "fix_shotgun_targeting": {
       "Description": "Hace que la escopeta ya no dispare cuando un objetivo bloqueado se mueve fuera de la vista de Lara, similar a otras armas.",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -267,6 +267,10 @@
       "Title": "Ne pas arrêter la musique au ramassage d'un secret",
       "Description": "Corrige le fait que les musiques et sons soient arrêtés net au déclenchement du son des secrets, lorsqu'ils sont ramassés"
     },
+    "fix_speeches_killing_music": {
+      "Title": "Ne pas arrêter la musique quand les ennemies parlent",
+      "Description": "Corrige le fait que les ennemis stoppent la musique lorsqu'ils se mettent à parler."
+    },
     "enable_ps_uzi_sfx": {
       "Title": "Activer les SFX PlayStation des uzis",
       "Description": "Change les effets sonores des uzis pour correspondre à ceux de la version PlayStation."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -319,6 +319,11 @@
           "DefaultValue": true
         },
         {
+          "Field": "fix_speeches_killing_music",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "enable_ps_uzi_sfx",
           "DataType": "Bool",
           "DefaultValue": false


### PR DESCRIPTION
Resolves #762.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Similar to the fix for secrets, enemy speeches will no longer stop the active track. Skateboard Kid needed a little extra work otherwise his speech plays endlessly. The flag implemented here isn't restored if you save after he has started his speech and then reload, but this is because of how the flags are reset on load.

https://github.com/LostArtefacts/Tomb1Main/blob/develop/src/game/savegame/savegame.c#L96

The situation is the same without this option enabled, as the standard music track would also be reset on load.

Short video of the feature in action:
https://www.youtube.com/watch?v=ODfV82X7jmo
