### PR TITLE
draw: prevent random draw changes in pause screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed music triggers with partial masks killing the ambient track (#763)
 - fixed the text and bar scaling from being able to be set below the max and min  (#698)
 - fixed a data issue in Colosseum, which prevented a bat from triggering (#750)
+- fixed lightning and gun flash continuing to animate in the inventory, pause and statistics screens (#767)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 - removed the fix_pyramid_secret gameflow sequence (now handled by data injection) (#788)

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -126,6 +126,7 @@ bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
     g_CurrentLevel = level_num;
     g_GameInfo.current_level_type = level_type;
+    g_GameInfo.status = GMS_IN_GAME;
 
     switch (level_type) {
     case GFL_SAVED:

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -8,6 +8,7 @@
 #include "game/sound.h"
 #include "game/text.h"
 #include "global/types.h"
+#include "global/vars.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -149,6 +150,7 @@ bool Game_Pause(void)
     Music_Pause();
     Sound_StopAmbientSounds();
     Sound_StopAllSamples();
+    g_GameInfo.status = GMS_IN_PAUSE;
 
     Output_FadeToSemiBlack(true);
     int32_t select = Game_Pause_Loop();
@@ -157,5 +159,6 @@ bool Game_Pause(void)
     Music_Unpause();
     Requester_Remove(&m_PauseRequester);
     Game_Pause_RemoveText();
+    g_GameInfo.status = GMS_IN_GAME;
     return select < 0;
 }

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -46,6 +46,7 @@ static void Inv_Construct(void);
 static void Inv_SelectMeshes(INVENTORY_ITEM *inv_item);
 static bool Inv_AnimateItem(INVENTORY_ITEM *inv_item);
 static void Inv_DrawItem(INVENTORY_ITEM *inv_item);
+static int32_t Inv_ConstructAndDisplay(int inv_mode);
 
 static void Inv_Draw(RING_INFO *ring, IMOTION_INFO *imo)
 {
@@ -341,7 +342,7 @@ static void Inv_DrawItem(INVENTORY_ITEM *inv_item)
     Matrix_Pop();
 }
 
-int32_t Inv_Display(int inv_mode)
+static int32_t Inv_ConstructAndDisplay(int inv_mode)
 {
     RING_INFO ring;
     IMOTION_INFO imo;
@@ -996,4 +997,12 @@ int32_t Inv_Display(int inv_mode)
     }
 
     return GF_NOP;
+}
+
+int32_t Inv_Display(int inv_mode)
+{
+    g_GameInfo.status = GMS_IN_INVENTORY;
+    int32_t inv_result = Inv_ConstructAndDisplay(inv_mode);
+    g_GameInfo.status = GMS_IN_GAME;
+    return inv_result;
 }

--- a/src/game/objects/traps/lightning_emitter.c
+++ b/src/game/objects/traps/lightning_emitter.c
@@ -214,9 +214,11 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
     for (int i = 0; i < LIGHTNING_STEPS; i++) {
         PHD_VECTOR *pos = &l->wibble[i];
-        pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
-        pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
-        pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+        if (g_GameInfo.status == GMS_IN_GAME) {
+            pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+            pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+            pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+        }
         if (i == LIGHTNING_STEPS - 1) {
             pos->y = 0;
         }
@@ -266,9 +268,11 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
         for (j = 0; j < steps; j++) {
             PHD_VECTOR *pos = l->shoot[i];
-            pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
-            pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
-            pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+            if (g_GameInfo.status == GMS_IN_GAME) {
+                pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+                pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+                pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
+            }
             if (j == steps - 1) {
                 pos->y = 0;
             }

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -1,5 +1,7 @@
 #include "game/random.h"
 
+#include "global/types.h"
+#include "global/vars.h"
 #include "log.h"
 
 static int32_t m_RandControl = 0xD371F947;
@@ -25,6 +27,8 @@ void Random_SeedDraw(int32_t seed)
 
 int32_t Random_GetDraw(void)
 {
-    m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
+    if (g_GameInfo.status == GMS_IN_GAME) {
+        m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
+    }
     return (m_RandDraw >> 10) & 0x7FFF;
 }

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -271,6 +271,8 @@ void Stats_Show(int32_t level_num)
         return;
     }
 
+    g_GameInfo.status = GMS_IN_STATS;
+
     char buf[100];
     char time_str[100];
     TEXTSTRING *txt;
@@ -379,6 +381,7 @@ void Stats_Show(int32_t level_num)
     }
 
     Output_FadeReset();
+    g_GameInfo.status = GMS_IN_GAME;
 }
 
 void Stats_ShowTotal(const char *filename)

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1564,6 +1564,13 @@ typedef struct RESUME_INFO {
     GAME_STATS stats;
 } RESUME_INFO;
 
+typedef enum GAME_STATUS {
+    GMS_IN_GAME = 0,
+    GMS_IN_INVENTORY = 1,
+    GMS_IN_PAUSE = 2,
+    GMS_IN_STATS = 3,
+} GAME_STATUS;
+
 typedef struct GAME_INFO {
     RESUME_INFO *current;
     uint8_t bonus_flag;
@@ -1578,6 +1585,7 @@ typedef struct GAME_INFO {
     bool remove_scions;
     bool remove_ammo;
     bool remove_medipacks;
+    GAME_STATUS status;
 } GAME_INFO;
 
 typedef struct CREATURE_INFO {


### PR DESCRIPTION
Resolves #767.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes lightning and gun flash continuing to animate in the inventory, pause and statistics screens. Every other effect that calls `Random_GetDraw` for positioning has been tested and none is affected currently, nor impacted by the change.

- Bubbles
- Gunshot (ricochet)
- Splash
- Twinkle (Midas touch)
- Waterfall

As mentioned in the issue, the introduction of the status enum may be useful for naming the `g_OverlayFlag` values; this variable is only used in `game.c` so it can be removed as a global. My feeling is that this is best tackled in its own issue.