### PR TITLE
gfx: make shaders compatible with GLSL 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the ability to unbind the sidestep left and sidestep right keys (#766)
 - added a cheat to explode Lara like in TR2 and TR3 (#793)
 - fixed sounds stopping instead of pausing if game sounds in inventory are disabled (#717)
+- changed shaders to use GLSL 1.20 which should fix most issues with OpenGL 2.1 (#327, #685)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/bin/shaders/2d.fsh
+++ b/bin/shaders/2d.fsh
@@ -1,7 +1,7 @@
 #version 120
 #extension GL_ARB_explicit_attrib_location: enable
 
-in vec2 vertTexCoords;
+varying vec2 vertTexCoords;
 
 layout(location = 0) out vec4 fragColor;
 

--- a/bin/shaders/2d.fsh
+++ b/bin/shaders/2d.fsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 #extension GL_ARB_explicit_attrib_location: enable
 
 in vec2 vertTexCoords;
@@ -8,5 +8,5 @@ layout(location = 0) out vec4 fragColor;
 uniform sampler2D tex0;
 
 void main(void) {
-    fragColor = texture(tex0, vertTexCoords);
+    fragColor = texture2D(tex0, vertTexCoords);
 }

--- a/bin/shaders/2d.fsh
+++ b/bin/shaders/2d.fsh
@@ -1,12 +1,9 @@
 #version 120
-#extension GL_ARB_explicit_attrib_location: enable
 
 varying vec2 vertTexCoords;
-
-layout(location = 0) out vec4 fragColor;
 
 uniform sampler2D tex0;
 
 void main(void) {
-    fragColor = texture2D(tex0, vertTexCoords);
+    gl_FragColor = texture2D(tex0, vertTexCoords);
 }

--- a/bin/shaders/2d.vsh
+++ b/bin/shaders/2d.vsh
@@ -3,7 +3,7 @@
 
 layout(location = 0) in vec2 inPosition;
 
-out vec2 vertTexCoords;
+varying vec2 vertTexCoords;
 
 void main(void) {
     vertTexCoords = inPosition;

--- a/bin/shaders/2d.vsh
+++ b/bin/shaders/2d.vsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 #extension GL_ARB_explicit_attrib_location: enable
 
 layout(location = 0) in vec2 inPosition;

--- a/bin/shaders/3d.fsh
+++ b/bin/shaders/3d.fsh
@@ -2,8 +2,8 @@
 #extension GL_ARB_explicit_attrib_location: enable
 #extension GL_EXT_gpu_shader4: enable
 
-in vec4 vertColor;
-in vec3 vertTexCoords;
+varying vec4 vertColor;
+varying vec3 vertTexCoords;
 
 layout(location = 0) out vec4 fragColor;
 

--- a/bin/shaders/3d.fsh
+++ b/bin/shaders/3d.fsh
@@ -1,18 +1,15 @@
 #version 120
-#extension GL_ARB_explicit_attrib_location: enable
 #extension GL_EXT_gpu_shader4: enable
 
 varying vec4 vertColor;
 varying vec3 vertTexCoords;
-
-layout(location = 0) out vec4 fragColor;
 
 uniform sampler2D tex0;
 uniform bool texturingEnabled;
 uniform bool smoothingEnabled;
 
 void main(void) {
-    fragColor = vertColor;
+    gl_FragColor = vertColor;
 
     if (texturingEnabled) {
 #ifdef GL_EXT_gpu_shader4
@@ -33,6 +30,6 @@ void main(void) {
             discard;
         }
 
-        fragColor = vec4(fragColor.rgb * texColor.rgb, texColor.a);
+        gl_FragColor = vec4(gl_FragColor.rgb * texColor.rgb, texColor.a);
     }
 }

--- a/bin/shaders/3d.fsh
+++ b/bin/shaders/3d.fsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 #extension GL_ARB_explicit_attrib_location: enable
 #extension GL_EXT_gpu_shader4: enable
 
@@ -15,18 +15,20 @@ void main(void) {
     fragColor = vertColor;
 
     if (texturingEnabled) {
+#ifdef GL_EXT_gpu_shader4
         if (smoothingEnabled) {
             // do not use smoothing for chroma key
             ivec2 size = textureSize2D(tex0, 0);
             int tx = int((vertTexCoords.x / vertTexCoords.z) * size.x) % size.x;
             int ty = int((vertTexCoords.y / vertTexCoords.z) * size.y) % size.y;
-            vec4 texel = texelFetch(tex0, ivec2(tx, ty), 0);
+            vec4 texel = texelFetch2D(tex0, ivec2(tx, ty), 0);
             if (texel.a == 0.0) {
                 discard;
             }
         }
+#endif
 
-        vec4 texColor = texture(tex0, vertTexCoords.xy / vertTexCoords.z);
+        vec4 texColor = texture2D(tex0, vertTexCoords.xy / vertTexCoords.z);
         if (texColor.a == 0.0) {
             discard;
         }

--- a/bin/shaders/3d.vsh
+++ b/bin/shaders/3d.vsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 #extension GL_ARB_explicit_attrib_location: enable
 
 layout(location = 0) in vec3 inPosition;

--- a/bin/shaders/3d.vsh
+++ b/bin/shaders/3d.vsh
@@ -8,8 +8,8 @@ layout(location = 2) in vec4 inColor;
 uniform mat4 matProjection;
 uniform mat4 matModelView;
 
-out vec4 vertColor;
-out vec3 vertTexCoords;
+varying vec4 vertColor;
+varying vec3 vertTexCoords;
 
 void main(void) {
     gl_Position = matProjection * matModelView * vec4(inPosition, 1);


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixed compatibility with OpenGL 2.1 shaders on my system.

P.S. I didn't add neither a changelog entry nor `fixes #issue` because it's not clear at this time if this will be enough. It can be added later if needed.
