### PR TITLE
overlay: fix FPS, healthbar, and arrows from overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed the text and bar scaling from being able to be set below the max and min  (#698)
 - fixed a data issue in Colosseum, which prevented a bat from triggering (#750)
 - fixed lightning and gun flash continuing to animate in the inventory, pause and statistics screens (#767)
+- fixed the FPS, healthbar, and arrows from overlapping on the inventory screen (#787)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 - removed the fix_pyramid_secret gameflow sequence (now handled by data injection) (#788)

--- a/src/game/inventory/inventory_ring.c
+++ b/src/game/inventory/inventory_ring.c
@@ -21,6 +21,7 @@ static TEXTSTRING *m_InvDownArrow1 = NULL;
 static TEXTSTRING *m_InvDownArrow2 = NULL;
 static TEXTSTRING *m_InvUpArrow1 = NULL;
 static TEXTSTRING *m_InvUpArrow2 = NULL;
+BAR_LOCATION m_HealthBarLoc;
 
 void Inv_Ring_Init(
     RING_INFO *ring, int16_t type, INVENTORY_ITEM **list, int16_t qty,
@@ -137,6 +138,7 @@ void Inv_Ring_IsOpen(RING_INFO *ring)
             Text_AlignRight(m_InvDownArrow2, 1);
         }
     }
+    m_HealthBarLoc = Overlay_BarGetHealthLocation();
 }
 
 void Inv_Ring_IsNotOpen(RING_INFO *ring)
@@ -298,6 +300,18 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
     case O_MEDI_OPTION:
         Overlay_BarSetHealthTimer(40);
         Overlay_BarDrawHealth();
+        if (g_Config.rendering.enable_fps_counter) {
+            Overlay_SetFPSBarAware(true);
+        }
+        if (m_HealthBarLoc == BL_TOP_LEFT) {
+            Text_Hide(m_InvUpArrow1, true);
+        } else if (m_HealthBarLoc == BL_TOP_RIGHT) {
+            Text_Hide(m_InvUpArrow2, true);
+        } else if (m_HealthBarLoc == BL_BOTTOM_LEFT) {
+            Text_Hide(m_InvDownArrow1, true);
+        } else if (m_HealthBarLoc == BL_BOTTOM_RIGHT) {
+            Text_Hide(m_InvDownArrow2, true);
+        }
         if (!g_InvItemText[IT_QTY] && qty > 1) {
             sprintf(temp_text, "%d", qty);
             Overlay_MakeAmmoString(temp_text);
@@ -310,6 +324,18 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
     case O_BIGMEDI_OPTION:
         Overlay_BarSetHealthTimer(40);
         Overlay_BarDrawHealth();
+        if (g_Config.rendering.enable_fps_counter) {
+            Overlay_SetFPSBarAware(true);
+        }
+        if (m_HealthBarLoc == BL_TOP_LEFT) {
+            Text_Hide(m_InvUpArrow1, true);
+        } else if (m_HealthBarLoc == BL_TOP_RIGHT) {
+            Text_Hide(m_InvUpArrow2, true);
+        } else if (m_HealthBarLoc == BL_BOTTOM_LEFT) {
+            Text_Hide(m_InvDownArrow1, true);
+        } else if (m_HealthBarLoc == BL_BOTTOM_RIGHT) {
+            Text_Hide(m_InvDownArrow2, true);
+        }
         if (!g_InvItemText[IT_QTY] && qty > 1) {
             sprintf(temp_text, "%d", qty);
             Overlay_MakeAmmoString(temp_text);
@@ -342,6 +368,16 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
 
     default:
         break;
+    }
+
+    if (g_Config.rendering.enable_fps_counter
+        && inv_item->object_number != O_MEDI_OPTION
+        && inv_item->object_number != O_BIGMEDI_OPTION) {
+        Text_Hide(m_InvUpArrow1, false);
+        Text_Hide(m_InvUpArrow2, false);
+        Text_Hide(m_InvDownArrow1, false);
+        Text_Hide(m_InvDownArrow2, false);
+        Overlay_SetFPSBarAware(false);
     }
 }
 

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -11,15 +11,17 @@ void Overlay_Init(void);
 void Overlay_BarSetHealthTimer(int16_t health_bar_timer);
 void Overlay_BarHealthTimerTick(void);
 void Overlay_BarDraw(struct BAR_INFO *bar_info);
+BAR_LOCATION Overlay_BarGetHealthLocation();
 void Overlay_BarDrawHealth(void);
 void Overlay_BarDrawAir(void);
 void Overlay_BarDrawEnemy(void);
 void Overlay_RemoveAmmoText(void);
 void Overlay_DrawAmmoInfo(void);
 void Overlay_DrawPickups(void);
-void Overlay_DrawFPSInfo(void);
+void Overlay_DrawFPSInfo();
 void Overlay_DrawGameInfo(void);
 
 void Overlay_AddPickup(int16_t object_num);
 
 void Overlay_MakeAmmoString(char *string);
+void Overlay_SetFPSBarAware(bool medi_aware);


### PR DESCRIPTION
Resolves #787.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the FPS, healthbar, and arrows from overlapping on the inventory screen.
...
