### PR TITLE
overlay: fix FPS, healthbar, and arrows from overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed the text and bar scaling from being able to be set below the max and min  (#698)
 - fixed a data issue in Colosseum, which prevented a bat from triggering (#750)
 - fixed lightning and gun flash continuing to animate in the inventory, pause and statistics screens (#767)
+- fixed the FPS, healthbar, and arrows from overlapping on the inventory screen (#787)
 - improved the control of Lara's braid to result in smoother animation and to detect floor collision (#761)
 - increased the number of effects from 100 to 1000 (#623)
 - removed the fix_pyramid_secret gameflow sequence (now handled by data injection) (#788)

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -150,7 +150,7 @@ bool Game_Pause(void)
     Music_Pause();
     Sound_StopAmbientSounds();
     Sound_StopAllSamples();
-    g_GameInfo.status = GMS_IN_PAUSE;
+    g_GameInfo.status |= GMS_IN_PAUSE;
 
     Output_FadeToSemiBlack(true);
     int32_t select = Game_Pause_Loop();
@@ -159,6 +159,6 @@ bool Game_Pause(void)
     Music_Unpause();
     Requester_Remove(&m_PauseRequester);
     Game_Pause_RemoveText();
-    g_GameInfo.status = GMS_IN_GAME;
+    g_GameInfo.status &= ~GMS_IN_PAUSE;
     return select < 0;
 }

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -476,7 +476,10 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
             Inv_Ring_NotActive();
         }
 
-        Overlay_DrawFPSInfo();
+        bool inv_ring_above = g_InvMode == INV_GAME_MODE
+            && ((ring.type == RT_MAIN && g_InvKeysObjects)
+                || (ring.type == RT_OPTION && g_InvMainObjects));
+        Overlay_DrawFPSInfo(inv_ring_above);
         Text_Draw();
 
         m_InvNFrames = Output_DumpScreen();
@@ -1001,8 +1004,8 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
 int32_t Inv_Display(int inv_mode)
 {
-    g_GameInfo.status = GMS_IN_INVENTORY;
+    g_GameInfo.status |= GMS_IN_INVENTORY;
     int32_t inv_result = Inv_ConstructAndDisplay(inv_mode);
-    g_GameInfo.status = GMS_IN_GAME;
+    g_GameInfo.status &= ~GMS_IN_INVENTORY;
     return inv_result;
 }

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -1004,8 +1004,9 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
 int32_t Inv_Display(int inv_mode)
 {
+    GAME_STATUS current_status = g_GameInfo.status;
     g_GameInfo.status |= GMS_IN_INVENTORY;
     int32_t inv_result = Inv_ConstructAndDisplay(inv_mode);
-    g_GameInfo.status &= ~GMS_IN_INVENTORY;
+    g_GameInfo.status = current_status;
     return inv_result;
 }

--- a/src/game/inventory/inventory_ring.c
+++ b/src/game/inventory/inventory_ring.c
@@ -1,5 +1,6 @@
 #include "game/inventory/inventory_ring.h"
 
+#include "config.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
@@ -11,6 +12,7 @@
 #include "global/vars.h"
 #include "math/math_misc.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -342,6 +344,26 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
 
     default:
         break;
+    }
+
+    if (inv_item->object_number == O_MEDI_OPTION
+        || inv_item->object_number == O_BIGMEDI_OPTION) {
+        if (g_Config.healthbar_location == BL_TOP_LEFT) {
+            Text_Hide(m_InvUpArrow1, true);
+        } else if (g_Config.healthbar_location == BL_TOP_RIGHT) {
+            Text_Hide(m_InvUpArrow2, true);
+        } else if (g_Config.healthbar_location == BL_BOTTOM_LEFT) {
+            Text_Hide(m_InvDownArrow1, true);
+        } else if (g_Config.healthbar_location == BL_BOTTOM_RIGHT) {
+            Text_Hide(m_InvDownArrow2, true);
+        }
+        g_GameInfo.status |= GMS_IN_INVENTORY_HEALTH;
+    } else {
+        Text_Hide(m_InvUpArrow1, false);
+        Text_Hide(m_InvUpArrow2, false);
+        Text_Hide(m_InvDownArrow1, false);
+        Text_Hide(m_InvDownArrow2, false);
+        g_GameInfo.status &= ~GMS_IN_INVENTORY_HEALTH;
     }
 }
 

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -2,6 +2,7 @@
 
 #include "global/types.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct BAR_INFO;
@@ -17,7 +18,7 @@ void Overlay_BarDrawEnemy(void);
 void Overlay_RemoveAmmoText(void);
 void Overlay_DrawAmmoInfo(void);
 void Overlay_DrawPickups(void);
-void Overlay_DrawFPSInfo(void);
+void Overlay_DrawFPSInfo(bool inv_ring_above);
 void Overlay_DrawGameInfo(void);
 
 void Overlay_AddPickup(int16_t object_num);

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -271,7 +271,7 @@ void Stats_Show(int32_t level_num)
         return;
     }
 
-    g_GameInfo.status = GMS_IN_STATS;
+    g_GameInfo.status |= GMS_IN_STATS;
 
     char buf[100];
     char time_str[100];
@@ -381,7 +381,7 @@ void Stats_Show(int32_t level_num)
     }
 
     Output_FadeReset();
-    g_GameInfo.status = GMS_IN_GAME;
+    g_GameInfo.status &= ~GMS_IN_STATS;
 }
 
 void Stats_ShowTotal(const char *filename)

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1566,9 +1566,10 @@ typedef struct RESUME_INFO {
 
 typedef enum GAME_STATUS {
     GMS_IN_GAME = 0,
-    GMS_IN_INVENTORY = 1,
-    GMS_IN_PAUSE = 2,
-    GMS_IN_STATS = 3,
+    GMS_IN_INVENTORY = 1 << 0,
+    GMS_IN_PAUSE = 1 << 1,
+    GMS_IN_STATS = 1 << 2,
+    GMS_IN_INVENTORY_HEALTH = 1 << 3,
 } GAME_STATUS;
 
 typedef struct GAME_INFO {


### PR DESCRIPTION
Resolves #787.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This builds on @walkawayy's commit in #796 to fix:
* the healthbar sitting behind the `INVENTORY` or `Small/Large Medi Pack` text if it's set to be centre-top or centre-bottom;
* the inventory ring up/down arrow not re-appearing if FPS is toggled off while a medipack is highlighted;
* the FPS Y position in normal game being off-screen when no bars are set to be top-left.

This also changes the `g_GameInfo.status` behaviour to allow flag combinations, so we can define specifics within overall statuses, so in this instance when we are in the inventory and have a medipack highlighted.
