### PR TITLE
stats: fix mutating state in getters

### DIFF
--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -239,17 +239,18 @@ void Stats_CalculateStats(void)
 
     // Check triggers for special pickups / killables
     Stats_TraverseFloor();
+
+    m_LevelPickups -= g_GameFlow.levels[g_CurrentLevel].unobtainable.pickups;
+    m_LevelKillables -= g_GameFlow.levels[g_CurrentLevel].unobtainable.kills;
 }
 
 int32_t Stats_GetPickups(void)
 {
-    m_LevelPickups -= g_GameFlow.levels[g_CurrentLevel].unobtainable.pickups;
     return m_LevelPickups;
 }
 
 int32_t Stats_GetKillables(void)
 {
-    m_LevelKillables -= g_GameFlow.levels[g_CurrentLevel].unobtainable.kills;
     return m_LevelKillables;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Getters shouldn't be used to mutate the internal state.