### PR TITLE
room: fix ceiling height miscalculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added a camera speed option for the manual camera (#815)
 - added an option to fix original texture issues (#826)
 - fixed sounds stopping instead of pausing if game sounds in inventory are disabled (#717)
+- fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling (#323)
 - changed shaders to use GLSL 1.20 which should fix most issues with OpenGL 2.1 (#327, #685)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - fixed a game crash on shutdown if the action button is held down
 - fixed Scion 1 respawning on load
 - fixed triggered flip effects not working if there are no sound devices
+- fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling
 
 #### Cheats
 - added a fly cheat

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -306,6 +306,7 @@ int16_t Room_GetCeiling(FLOOR_INFO *floor, int32_t x, int32_t y, int32_t z)
 {
     int16_t *data;
     int16_t type;
+    int16_t ended;
     int16_t trigger;
 
     FLOOR_INFO *f = floor;
@@ -321,8 +322,9 @@ int16_t Room_GetCeiling(FLOOR_INFO *floor, int32_t x, int32_t y, int32_t z)
     if (f->index) {
         data = &g_FloorData[f->index];
         type = *data & DATA_TYPE;
+        ended = *data++ & END_BIT;
 
-        if (!(*data++ & END_BIT) && type == FT_TILT) {
+        if (!ended && type == FT_TILT) {
             data++;
             type = *data++ & DATA_TYPE;
         }

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -320,9 +320,9 @@ int16_t Room_GetCeiling(FLOOR_INFO *floor, int32_t x, int32_t y, int32_t z)
 
     if (f->index) {
         data = &g_FloorData[f->index];
-        type = *data++ & DATA_TYPE;
+        type = *data & DATA_TYPE;
 
-        if (type == FT_TILT) {
+        if (!(*data++ & END_BIT) && type == FT_TILT) {
             data++;
             type = *data++ & DATA_TYPE;
         }


### PR DESCRIPTION
Resolves #323.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents the ceiling height calculation reading unrelated floor data when there exists a floor tilt. I have tested the following scenarios and the height corresponds to the geometry in each case.
- Tilted floor + flat ceiling
- Flat floor + flat ceiling
- Flat floor + tilted ceiling
