### PR TITLE
lara_col: fix not jumping off collapsing floors with descent fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added an option to fix original texture issues (#826)
 - fixed sounds stopping instead of pausing if game sounds in inventory are disabled (#717)
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling (#323)
+- fixed Lara not being able to jump off trapdoors or crumbling floors if the sidestep descent fix is enabled (#830)
 - changed shaders to use GLSL 1.20 which should fix most issues with OpenGL 2.1 (#327, #685)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -433,10 +433,6 @@ void Lara_Col_Compress(ITEM_INFO *item, COLL_INFO *coll)
     coll->bad_ceiling = 0;
     Lara_GetCollisionInfo(item, coll);
 
-    if (g_Config.fix_descending_glitch && Lara_Fallen(item, coll)) {
-        return;
-    }
-
     if (coll->mid_ceiling > -100) {
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;


### PR DESCRIPTION
Resolves #830.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed Lara not being able to jump off trapdoors or crumbling floors if the sidestep descent fix is enabled.
