### PR TITLE
gfx: render using framebuffers (WIP)

### DIFF
--- a/bin/shaders/fbo.fsh
+++ b/bin/shaders/fbo.fsh
@@ -1,0 +1,9 @@
+#version 120
+
+varying vec2 vertTexCoords;
+
+uniform sampler2D tex0;
+
+void main(void) {
+    gl_FragColor = texture2D(tex0, vertTexCoords);
+}

--- a/bin/shaders/fbo.vsh
+++ b/bin/shaders/fbo.vsh
@@ -1,0 +1,11 @@
+#version 120
+#extension GL_ARB_explicit_attrib_location: enable
+
+layout(location = 0) in vec2 inPosition;
+
+varying vec2 vertTexCoords;
+
+void main(void) {
+    vertTexCoords = inPosition;
+    gl_Position = vec4(vertTexCoords * vec2(2.0, 2.0) + vec2(-1.0, -1.0), 0.0, 1.0);
+}

--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,7 @@ sources = [
   'src/game/stats.c',
   'src/game/text.c',
   'src/game/viewport.c',
+  'src/gfx/fbo/fbo_renderer.c',
   'src/gfx/2d/2d_renderer.c',
   'src/gfx/2d/2d_surface.c',
   'src/gfx/3d/3d_renderer.c',

--- a/src/gfx/2d/2d_renderer.c
+++ b/src/gfx/2d/2d_renderer.c
@@ -69,10 +69,12 @@ void GFX_2D_Renderer_Upload(
         glTexImage2D(
             GL_TEXTURE_2D, 0, GL_RGBA, renderer->width, renderer->height, 0,
             tex_format, tex_type, data);
+        GFX_GL_CheckError();
     } else {
         glTexSubImage2D(
             GL_TEXTURE_2D, 0, 0, 0, renderer->width, renderer->height,
             tex_format, tex_type, data);
+        GFX_GL_CheckError();
     }
 }
 
@@ -95,6 +97,7 @@ void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer)
     }
 
     glDrawArrays(GL_TRIANGLES, 0, 6);
+    GFX_GL_CheckError();
 
     if (blend) {
         glEnable(GL_BLEND);
@@ -103,6 +106,4 @@ void GFX_2D_Renderer_Render(GFX_2D_Renderer *renderer)
     if (depth_test) {
         glEnable(GL_DEPTH_TEST);
     }
-
-    GFX_GL_CheckError();
 }

--- a/src/gfx/2d/2d_surface.c
+++ b/src/gfx/2d/2d_surface.c
@@ -163,9 +163,6 @@ bool GFX_2D_Surface_Flip(GFX_2D_Surface *surface)
         GFX_Context_SwapBuffers();
     }
 
-    // update viewport in case the window size has changed
-    GFX_Context_SetupViewport();
-
     // render surface
     GFX_2D_Renderer_Render(surface->renderer);
 

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -96,6 +96,7 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer)
     if (renderer->wireframe) {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     }
+    GFX_GL_CheckError();
 
     GFX_GL_Program_Bind(&renderer->program);
     GFX_3D_VertexStream_Bind(&renderer->vertex_stream);
@@ -124,7 +125,6 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_Renderer *renderer)
     glDepthFunc(GL_LEQUAL);
     glDepthMask(GL_TRUE);
     glEnable(GL_DEPTH_TEST);
-
     GFX_GL_CheckError();
 }
 
@@ -143,6 +143,7 @@ void GFX_3D_Renderer_RenderEnd(GFX_3D_Renderer *renderer)
 void GFX_3D_Renderer_ClearDepth(GFX_3D_Renderer *renderer)
 {
     glClear(GL_DEPTH_BUFFER_BIT);
+    GFX_GL_CheckError();
 }
 
 int GFX_3D_Renderer_TextureReg(
@@ -151,8 +152,7 @@ int GFX_3D_Renderer_TextureReg(
     assert(renderer);
     assert(data);
     GFX_GL_Texture *texture = GFX_GL_Texture_Create(GL_TEXTURE_2D);
-    GFX_GL_Texture_Bind(texture);
-    GFX_GL_Texture_Load(texture, data, width, height);
+    GFX_GL_Texture_Load(texture, data, width, height, GL_RGBA, GL_BGRA);
 
     int texture_num = GFX_NO_TEXTURE;
     for (int i = 0; i < GFX_MAX_TEXTURES; i++) {

--- a/src/gfx/3d/vertex_stream.c
+++ b/src/gfx/3d/vertex_stream.c
@@ -154,7 +154,6 @@ void GFX_3D_VertexStream_RenderPending(GFX_3D_VertexStream *vertex_stream)
     glDrawArrays(
         GL_PRIM_MODES[vertex_stream->prim_type], 0,
         vertex_stream->pending_vertices.count);
-
     GFX_GL_CheckError();
 
     vertex_stream->pending_vertices.count = 0;

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -24,6 +24,7 @@ typedef struct GFX_Context {
     int32_t window_width;
     int32_t window_height;
     char *scheduled_screenshot_path;
+    GFX_FBO_Renderer renderer_fbo;
     GFX_2D_Renderer renderer_2d;
     GFX_3D_Renderer renderer_3d;
 } GFX_Context;
@@ -32,15 +33,20 @@ static GFX_Context m_Context = { 0 };
 
 static bool GFX_Context_IsExtensionSupported(const char *name);
 static void GFX_Context_CheckExtensionSupport(const char *name);
+static void GFX_Context_SwitchToWindowViewport(void);
+static void GFX_Context_SwitchToRenderViewport(void);
 
 static bool GFX_Context_IsExtensionSupported(const char *name)
 {
     int number_of_extensions;
 
     glGetIntegerv(GL_NUM_EXTENSIONS, &number_of_extensions);
+    GFX_GL_CheckError();
 
     for (int i = 0; i < number_of_extensions; i++) {
         const char *gl_ext = (const char *)glGetStringi(GL_EXTENSIONS, i);
+        GFX_GL_CheckError();
+
         if (gl_ext && !strcmp(gl_ext, name)) {
             return true;
         }
@@ -53,6 +59,40 @@ static void GFX_Context_CheckExtensionSupport(const char *name)
     LOG_INFO(
         "%s supported: %s", name,
         GFX_Context_IsExtensionSupported(name) ? "yes" : "no");
+}
+
+static void GFX_Context_SwitchToWindowViewport(void)
+{
+    int vp_width = m_Context.window_width;
+    int vp_height = m_Context.window_height;
+
+    // default to bottom left corner of the window
+    int vp_x = 0;
+    int vp_y = 0;
+
+    int hw = m_Context.display_height * vp_width;
+    int wh = m_Context.display_width * vp_height;
+
+    // create viewport offset if the window has a different
+    // aspect ratio than the current display mode
+    if (hw > wh) {
+        int max_w = wh / m_Context.display_height;
+        vp_x = (vp_width - max_w) / 2;
+        vp_width = max_w;
+    } else if (hw < wh) {
+        int max_h = hw / m_Context.display_width;
+        vp_y = (vp_height - max_h) / 2;
+        vp_height = max_h;
+    }
+
+    glViewport(vp_x, vp_y, vp_width, vp_height);
+    GFX_GL_CheckError();
+}
+
+static void GFX_Context_SwitchToRenderViewport(void)
+{
+    glViewport(0, 0, FBO_WIDTH, FBO_HEIGHT);
+    GFX_GL_CheckError();
 }
 
 void GFX_Context_Attach(void *window_handle)
@@ -100,10 +140,12 @@ void GFX_Context_Attach(void *window_handle)
 
     glClearColor(0, 0, 0, 0);
     glClearDepth(1);
+    GFX_GL_CheckError();
 
     // VSync defaults to on unless user disabled it in runtime json
     SDL_GL_SetSwapInterval(1);
 
+    GFX_FBO_Renderer_Init(&m_Context.renderer_fbo);
     GFX_2D_Renderer_Init(&m_Context.renderer_2d);
     GFX_3D_Renderer_Init(&m_Context.renderer_3d);
 }
@@ -187,37 +229,16 @@ int32_t GFX_Context_GetScreenHeight(void)
     return m_Context.screen_height;
 }
 
-void GFX_Context_SetupViewport(void)
-{
-    int vp_width = m_Context.window_width;
-    int vp_height = m_Context.window_height;
-
-    // default to bottom left corner of the window
-    int vp_x = 0;
-    int vp_y = 0;
-
-    int hw = m_Context.display_height * vp_width;
-    int wh = m_Context.display_width * vp_height;
-
-    // create viewport offset if the window has a different
-    // aspect ratio than the current display mode
-    if (hw > wh) {
-        int max_w = wh / m_Context.display_height;
-        vp_x = (vp_width - max_w) / 2;
-        vp_width = max_w;
-    } else if (hw < wh) {
-        int max_h = hw / m_Context.display_width;
-        vp_y = (vp_height - max_h) / 2;
-        vp_height = max_h;
-    }
-
-    glViewport(vp_x, vp_y, vp_width, vp_height);
-}
-
 void GFX_Context_SwapBuffers(void)
 {
     glFinish();
+    GFX_GL_CheckError();
 
+    GFX_Context_SwitchToWindowViewport();
+
+    GFX_FBO_Renderer_Render(&m_Context.renderer_fbo);
+
+    // TODO: check if this still works and doesn't crash
     if (m_Context.scheduled_screenshot_path) {
         GFX_Screenshot_CaptureToFile(m_Context.scheduled_screenshot_path);
         Memory_FreePointer(&m_Context.scheduled_screenshot_path);
@@ -225,8 +246,11 @@ void GFX_Context_SwapBuffers(void)
 
     SDL_GL_SwapWindow(m_Context.window_handle);
 
-    glDrawBuffer(GL_BACK);
+    GFX_Context_SwitchToRenderViewport();
+
+    // TODO: this doesn't work when changing the resolution
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    GFX_GL_CheckError();
 
     m_Context.is_rendered = false;
 }
@@ -254,4 +278,9 @@ GFX_2D_Renderer *GFX_Context_GetRenderer2D(void)
 GFX_3D_Renderer *GFX_Context_GetRenderer3D(void)
 {
     return &m_Context.renderer_3d;
+}
+
+GFX_FBO_Renderer *GFX_Context_GetRendererFBO(void)
+{
+    return &m_Context.renderer_fbo;
 }

--- a/src/gfx/context.h
+++ b/src/gfx/context.h
@@ -2,6 +2,7 @@
 
 #include "gfx/2d/2d_renderer.h"
 #include "gfx/3d/3d_renderer.h"
+#include "gfx/fbo/fbo_renderer.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -21,10 +22,10 @@ int32_t GFX_Context_GetWindowWidth(void);
 int32_t GFX_Context_GetWindowHeight(void);
 int32_t GFX_Context_GetScreenWidth(void);
 int32_t GFX_Context_GetScreenHeight(void);
-void GFX_Context_SetupViewport(void);
 void GFX_Context_SwapBuffers(void);
 void GFX_Context_SetRendered(void);
 bool GFX_Context_IsRendered(void);
 void GFX_Context_ScheduleScreenshot(const char *path);
 GFX_2D_Renderer *GFX_Context_GetRenderer2D(void);
 GFX_3D_Renderer *GFX_Context_GetRenderer3D(void);
+GFX_FBO_Renderer *GFX_Context_GetRendererFBO(void);

--- a/src/gfx/fbo/fbo_renderer.c
+++ b/src/gfx/fbo/fbo_renderer.c
@@ -1,0 +1,141 @@
+#include "gfx/fbo/fbo_renderer.h"
+
+#include "gfx/gl/utils.h"
+#include "log.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+void GFX_FBO_Renderer_Init(GFX_FBO_Renderer *renderer)
+{
+    assert(renderer);
+
+    GFX_GL_Buffer_Init(&renderer->buffer, GL_ARRAY_BUFFER);
+    GFX_GL_Buffer_Bind(&renderer->buffer);
+    GLfloat verts[] = { 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                        0.0, 1.0, 1.0, 0.0, 1.0, 1.0 };
+    GFX_GL_Buffer_Data(&renderer->buffer, sizeof(verts), verts, GL_STATIC_DRAW);
+
+    GFX_GL_VertexArray_Init(&renderer->vertex_array);
+    GFX_GL_VertexArray_Bind(&renderer->vertex_array);
+    GFX_GL_VertexArray_Attribute(
+        &renderer->vertex_array, 0, 2, GL_FLOAT, GL_FALSE, 0, 0);
+
+    GFX_GL_Texture_Init(&renderer->texture, GL_TEXTURE_2D);
+
+    GFX_GL_Sampler_Init(&renderer->sampler);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+
+    GFX_GL_Program_Init(&renderer->program);
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_VERTEX_SHADER, "shaders/fbo.vsh");
+    GFX_GL_Program_AttachShader(
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/fbo.fsh");
+    GFX_GL_Program_Link(&renderer->program);
+    GFX_GL_Program_FragmentData(&renderer->program, "fragColor");
+
+    glGenFramebuffers(1, &renderer->fbo);
+    GFX_GL_CheckError();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, renderer->fbo);
+    GFX_GL_CheckError();
+
+    GFX_GL_Texture_Load(
+        &renderer->texture, NULL, FBO_WIDTH, FBO_HEIGHT, GL_RGB, GL_RGB);
+
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+        renderer->texture.id, 0);
+    GFX_GL_CheckError();
+
+    glGenRenderbuffers(1, &renderer->rbo);
+    GFX_GL_CheckError();
+
+    glBindRenderbuffer(GL_RENDERBUFFER, renderer->rbo);
+    GFX_GL_CheckError();
+
+    glRenderbufferStorage(
+        GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, FBO_WIDTH, FBO_HEIGHT);
+    GFX_GL_CheckError();
+
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    GFX_GL_CheckError();
+
+    glFramebufferRenderbuffer(
+        GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER,
+        renderer->rbo);
+    GFX_GL_CheckError();
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_ERROR("framebuffer is not complete!");
+    }
+}
+
+void GFX_FBO_Renderer_Close(GFX_FBO_Renderer *renderer)
+{
+    assert(renderer);
+    GFX_GL_VertexArray_Close(&renderer->vertex_array);
+    GFX_GL_Buffer_Close(&renderer->buffer);
+    GFX_GL_Texture_Close(&renderer->texture);
+    GFX_GL_Sampler_Close(&renderer->sampler);
+    GFX_GL_Program_Close(&renderer->program);
+}
+
+void GFX_FBO_Renderer_Render(GFX_FBO_Renderer *renderer)
+{
+    assert(renderer);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    GFX_GL_CheckError();
+
+    GFX_GL_Program_Bind(&renderer->program);
+    GFX_GL_Buffer_Bind(&renderer->buffer);
+    GFX_GL_VertexArray_Bind(&renderer->vertex_array);
+    GFX_GL_Texture_Bind(&renderer->texture);
+    GFX_GL_Sampler_Bind(&renderer->sampler, 0);
+
+    GLboolean blend = glIsEnabled(GL_BLEND);
+    if (blend) {
+        glDisable(GL_BLEND);
+    }
+
+    GLboolean depth_test = glIsEnabled(GL_DEPTH_TEST);
+    if (depth_test) {
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    GFX_GL_CheckError();
+
+    if (blend) {
+        glEnable(GL_BLEND);
+    }
+
+    if (depth_test) {
+        glEnable(GL_DEPTH_TEST);
+    }
+    GFX_GL_CheckError();
+
+    glBindFramebuffer(GL_FRAMEBUFFER, renderer->fbo);
+    GFX_GL_CheckError();
+}
+
+void GFX_FBO_Renderer_SetSmoothingEnabled(
+    GFX_FBO_Renderer *renderer, bool is_enabled)
+{
+    assert(renderer);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MAG_FILTER,
+        is_enabled ? GL_LINEAR : GL_NEAREST);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_MIN_FILTER,
+        is_enabled ? GL_LINEAR : GL_NEAREST);
+}

--- a/src/gfx/fbo/fbo_renderer.h
+++ b/src/gfx/fbo/fbo_renderer.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "gfx/gl/buffer.h"
+#include "gfx/gl/gl_core_3_3.h"
+#include "gfx/gl/program.h"
+#include "gfx/gl/sampler.h"
+#include "gfx/gl/texture.h"
+#include "gfx/gl/vertex_array.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// TODO: make customizable
+// TODO: triple check the behavior for different aspect ratios
+#define FBO_WIDTH 800
+#define FBO_HEIGHT 600
+
+typedef struct GFX_FBO_Renderer {
+    GLuint fbo;
+    GLuint rbo;
+
+    GFX_GL_VertexArray vertex_array;
+    GFX_GL_Buffer buffer;
+    GFX_GL_Texture texture;
+    GFX_GL_Sampler sampler;
+    GFX_GL_Program program;
+} GFX_FBO_Renderer;
+
+void GFX_FBO_Renderer_Init(GFX_FBO_Renderer *renderer);
+void GFX_FBO_Renderer_Close(GFX_FBO_Renderer *renderer);
+void GFX_FBO_Renderer_Render(GFX_FBO_Renderer *renderer);
+void GFX_FBO_Renderer_SetSmoothingEnabled(
+    GFX_FBO_Renderer *renderer, bool is_enabled);

--- a/src/gfx/gl/buffer.c
+++ b/src/gfx/gl/buffer.c
@@ -1,5 +1,7 @@
 #include "gfx/gl/buffer.h"
 
+#include "gfx/gl/utils.h"
+
 #include <assert.h>
 
 void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target)
@@ -7,18 +9,21 @@ void GFX_GL_Buffer_Init(GFX_GL_Buffer *buf, GLenum target)
     assert(buf);
     buf->target = target;
     glGenBuffers(1, &buf->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Buffer_Close(GFX_GL_Buffer *buf)
 {
     assert(buf);
     glDeleteBuffers(1, &buf->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Buffer_Bind(GFX_GL_Buffer *buf)
 {
     assert(buf);
     glBindBuffer(buf->target, buf->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Buffer_Data(
@@ -26,6 +31,7 @@ void GFX_GL_Buffer_Data(
 {
     assert(buf);
     glBufferData(buf->target, size, data, usage);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Buffer_SubData(
@@ -33,18 +39,22 @@ void GFX_GL_Buffer_SubData(
 {
     assert(buf);
     glBufferSubData(buf->target, offset, size, data);
+    GFX_GL_CheckError();
 }
 
 void *GFX_GL_Buffer_Map(GFX_GL_Buffer *buf, GLenum access)
 {
     assert(buf);
-    return glMapBuffer(buf->target, access);
+    void *ret = glMapBuffer(buf->target, access);
+    GFX_GL_CheckError();
+    return ret;
 }
 
 void GFX_GL_Buffer_Unmap(GFX_GL_Buffer *buf)
 {
     assert(buf);
     glUnmapBuffer(buf->target);
+    GFX_GL_CheckError();
 }
 
 GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname)
@@ -52,5 +62,6 @@ GLint GFX_GL_Buffer_Parameter(GFX_GL_Buffer *buf, GLenum pname)
     assert(buf);
     GLint params = 0;
     glGetBufferParameteriv(buf->target, pname, &params);
+    GFX_GL_CheckError();
     return params;
 }

--- a/src/gfx/gl/program.c
+++ b/src/gfx/gl/program.c
@@ -2,6 +2,7 @@
 
 #include "filesystem.h"
 #include "game/shell.h"
+#include "gfx/gl/utils.h"
 #include "log.h"
 #include "memory.h"
 
@@ -12,6 +13,7 @@ bool GFX_GL_Program_Init(GFX_GL_Program *program)
 {
     assert(program);
     program->id = glCreateProgram();
+    GFX_GL_CheckError();
     if (!program->id) {
         LOG_ERROR("Can't create shader program");
         return false;
@@ -23,6 +25,7 @@ void GFX_GL_Program_Close(GFX_GL_Program *program)
 {
     if (program->id) {
         glDeleteProgram(program->id);
+        GFX_GL_CheckError();
         program->id = 0;
     }
 }
@@ -30,12 +33,14 @@ void GFX_GL_Program_Close(GFX_GL_Program *program)
 void GFX_GL_Program_Bind(GFX_GL_Program *program)
 {
     glUseProgram(program->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_AttachShader(
     GFX_GL_Program *program, GLenum type, const char *path)
 {
     GLuint shader_id = glCreateShader(type);
+    GFX_GL_CheckError();
     if (!shader_id) {
         Shell_ExitSystem("Failed to create shader");
     }
@@ -46,14 +51,21 @@ void GFX_GL_Program_AttachShader(
     }
 
     glShaderSource(shader_id, 1, (const char **)&content, NULL);
+
+    GFX_GL_CheckError();
     glCompileShader(shader_id);
+    GFX_GL_CheckError();
 
     int compile_status;
     glGetShaderiv(shader_id, GL_COMPILE_STATUS, &compile_status);
+    GFX_GL_CheckError();
+
     if (compile_status != GL_TRUE) {
         GLsizei info_log_size = 4096;
         char info_log[info_log_size];
         glGetShaderInfoLog(shader_id, info_log_size, &info_log_size, info_log);
+        GFX_GL_CheckError();
+
         if (info_log[0]) {
             Shell_ExitSystemFmt("Shader compilation failed:\n%s", info_log);
         } else {
@@ -62,21 +74,29 @@ void GFX_GL_Program_AttachShader(
     }
 
     Memory_FreePointer(&content);
+
     glAttachShader(program->id, shader_id);
+    GFX_GL_CheckError();
+
     glDeleteShader(shader_id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_Link(GFX_GL_Program *program)
 {
     glLinkProgram(program->id);
+    GFX_GL_CheckError();
 
     GLint linkStatus;
     glGetProgramiv(program->id, GL_LINK_STATUS, &linkStatus);
+    GFX_GL_CheckError();
+
     if (!linkStatus) {
         GLsizei info_log_size = 4096;
         char info_log[info_log_size];
         glGetProgramInfoLog(
             program->id, info_log_size, &info_log_size, info_log);
+        GFX_GL_CheckError();
         if (info_log[0]) {
             Shell_ExitSystemFmt("Shader linking failed:\n%s", info_log);
         } else {
@@ -88,11 +108,13 @@ void GFX_GL_Program_Link(GFX_GL_Program *program)
 void GFX_GL_Program_FragmentData(GFX_GL_Program *program, const char *name)
 {
     glBindFragDataLocation(program->id, 0, name);
+    GFX_GL_CheckError();
 }
 
 GLint GFX_GL_Program_UniformLocation(GFX_GL_Program *program, const char *name)
 {
     GLint location = glGetUniformLocation(program->id, name);
+    GFX_GL_CheckError();
     if (location == -1) {
         LOG_INFO("Shader uniform not found: %s", name);
     }
@@ -103,6 +125,7 @@ void GFX_GL_Program_Uniform3f(
     GFX_GL_Program *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
 {
     glUniform3f(loc, v0, v1, v2);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_Uniform4f(
@@ -110,11 +133,13 @@ void GFX_GL_Program_Uniform4f(
     GLfloat v3)
 {
     glUniform4f(loc, v0, v1, v2, v3);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_Uniform1i(GFX_GL_Program *program, GLint loc, GLint v0)
 {
     glUniform1i(loc, v0);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_UniformMatrix4fv(
@@ -122,4 +147,5 @@ void GFX_GL_Program_UniformMatrix4fv(
     const GLfloat *value)
 {
     glUniformMatrix4fv(loc, count, transpose, value);
+    GFX_GL_CheckError();
 }

--- a/src/gfx/gl/sampler.c
+++ b/src/gfx/gl/sampler.c
@@ -1,28 +1,35 @@
 #include "gfx/gl/sampler.h"
 
+#include "gfx/gl/utils.h"
+
 void GFX_GL_Sampler_Init(GFX_GL_Sampler *sampler)
 {
     glGenSamplers(1, &sampler->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Close(GFX_GL_Sampler *sampler)
 {
     glDeleteSamplers(1, &sampler->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Bind(GFX_GL_Sampler *sampler, GLuint unit)
 {
     glBindSampler(unit, sampler->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Parameteri(
     GFX_GL_Sampler *sampler, GLenum pname, GLint param)
 {
     glSamplerParameteri(sampler->id, pname, param);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Sampler_Parameterf(
     GFX_GL_Sampler *sampler, GLenum pname, GLfloat param)
 {
     glSamplerParameterf(sampler->id, pname, param);
+    GFX_GL_CheckError();
 }

--- a/src/gfx/gl/texture.c
+++ b/src/gfx/gl/texture.c
@@ -25,32 +25,36 @@ void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target)
     assert(texture);
     texture->target = target;
     glGenTextures(1, &texture->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Texture_Close(GFX_GL_Texture *texture)
 {
     assert(texture);
     glDeleteTextures(1, &texture->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Texture_Bind(GFX_GL_Texture *texture)
 {
     assert(texture);
     glBindTexture(texture->target, texture->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Texture_Load(
-    GFX_GL_Texture *texture, const void *data, int width, int height)
+    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GLint internal_format, GLint format)
 {
     assert(texture);
-    assert(data);
-
-    glTexImage2D(
-        GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_BGRA, GL_UNSIGNED_BYTE,
-        data);
 
     GFX_GL_Texture_Bind(texture);
-    glGenerateMipmap(GL_TEXTURE_2D);
 
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, internal_format, width, height, 0, format,
+        GL_UNSIGNED_BYTE, data);
+    GFX_GL_CheckError();
+
+    glGenerateMipmap(GL_TEXTURE_2D);
     GFX_GL_CheckError();
 }

--- a/src/gfx/gl/texture.h
+++ b/src/gfx/gl/texture.h
@@ -14,4 +14,5 @@ void GFX_GL_Texture_Init(GFX_GL_Texture *texture, GLenum target);
 void GFX_GL_Texture_Close(GFX_GL_Texture *texture);
 void GFX_GL_Texture_Bind(GFX_GL_Texture *texture);
 void GFX_GL_Texture_Load(
-    GFX_GL_Texture *texture, const void *data, int width, int height);
+    GFX_GL_Texture *texture, const void *data, int width, int height,
+    GLint internal_format, GLint format);

--- a/src/gfx/gl/vertex_array.c
+++ b/src/gfx/gl/vertex_array.c
@@ -1,23 +1,28 @@
 #include "gfx/gl/vertex_array.h"
 
+#include "gfx/gl/utils.h"
+
 #include <assert.h>
 
 void GFX_GL_VertexArray_Init(GFX_GL_VertexArray *array)
 {
     assert(array);
     glGenVertexArrays(1, &array->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_VertexArray_Close(GFX_GL_VertexArray *array)
 {
     assert(array);
     glDeleteVertexArrays(1, &array->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_VertexArray_Bind(GFX_GL_VertexArray *array)
 {
     assert(array);
     glBindVertexArray(array->id);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_VertexArray_Attribute(
@@ -26,6 +31,9 @@ void GFX_GL_VertexArray_Attribute(
 {
     assert(array);
     glEnableVertexAttribArray(index);
+    GFX_GL_CheckError();
+
     glVertexAttribPointer(
         index, size, type, normalized, stride, (void *)offset);
+    GFX_GL_CheckError();
 }

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -11,6 +11,7 @@
 #include "gfx/3d/vertex_stream.h"
 #include "gfx/blitter.h"
 #include "gfx/context.h"
+#include "gfx/fbo/fbo_renderer.h"
 #include "global/vars.h"
 #include "log.h"
 #include "specific/s_shell.h"
@@ -29,6 +30,8 @@
 
 static int m_TextureMap[GFX_MAX_TEXTURES] = { GFX_NO_TEXTURE };
 static RGB888 m_ColorPalette[256];
+
+static GFX_FBO_Renderer *m_RendererFBO = NULL;
 
 static GFX_3D_Renderer *m_Renderer3D = NULL;
 static bool m_IsPaletteActive = false;
@@ -78,6 +81,8 @@ static void S_Output_SetupRenderContextAndRender(void)
     S_Output_RenderBegin();
     GFX_3D_Renderer_SetSmoothingEnabled(
         m_Renderer3D, g_Config.rendering.enable_bilinear_filter);
+    GFX_FBO_Renderer_SetSmoothingEnabled(
+        m_RendererFBO, g_Config.rendering.enable_bilinear_filter);
     S_Output_RenderToggle();
 }
 
@@ -974,6 +979,7 @@ bool S_Output_Init(void)
 
     GFX_Context_Attach(S_Shell_GetWindowHandle());
     m_Renderer3D = GFX_Context_GetRenderer3D();
+    m_RendererFBO = GFX_Context_GetRendererFBO();
 
     S_Output_ApplyResolution();
 
@@ -988,6 +994,7 @@ void S_Output_Shutdown(void)
     S_Output_ReleaseSurfaces();
     GFX_Context_Detach();
     m_Renderer3D = NULL;
+    m_RendererFBO = NULL;
 }
 
 void S_Output_DrawFlatTriangle(


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- ~~[ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change~~ This is WIP

#### Description

This changes the rendering to render to a 800x600 buffer and addresses #114. I left a couple of TODOs, but this speeds the game up massively on my machine, even if the menu resolution option is set to "render" at 4k. IMO this is a good way forward – let the game "render" always at max resolution and repurpose the current game resolution setting to control this buffer size.