### PR TITLE
config: remove obsolete enable_xbox_one_controller option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -205,7 +205,6 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enable_cine, true);
     READ_BOOL(enable_music_in_menu, true);
     READ_BOOL(enable_music_in_inventory, true);
-    READ_BOOL(enable_xbox_one_controller, false);
     READ_BOOL(enable_round_shadow, true);
     READ_BOOL(enable_3d_pickups, true);
     READ_FLOAT(rendering.anisotropy_filter, 16.0f);
@@ -407,7 +406,6 @@ bool Config_Write(void)
     WRITE_BOOL(enable_cine);
     WRITE_BOOL(enable_music_in_menu);
     WRITE_BOOL(enable_music_in_inventory);
-    WRITE_BOOL(enable_xbox_one_controller);
     WRITE_BOOL(enable_round_shadow);
     WRITE_BOOL(enable_3d_pickups);
     WRITE_FLOAT(rendering.anisotropy_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -92,7 +92,6 @@ typedef struct {
     bool enable_music_in_inventory;
     int32_t resolution_width;
     int32_t resolution_height;
-    bool enable_xbox_one_controller;
     float brightness;
     bool enable_round_shadow;
     bool enable_3d_pickups;


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Remove obsolete enable_xbox_one_controller option. Internal change so no Changelog entry.
...
