### PR TITLE
fmv: fix a missing delimiter for .mpeg FMVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling (#323)
 - fixed Lara not being able to jump off trapdoors or crumbling floors if the sidestep descent fix is enabled (#830)
 - fixed walk to pickups feature (#834, regression from 2.8)
+- fixed .mpeg FMVs not working (#844)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/fmv.c
+++ b/src/game/fmv.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 
 static const char *m_Extensions[] = {
-    ".mp4", ".mkv", "mpeg", ".avi", ".webm", ".rpl", NULL,
+    ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", NULL,
 };
 
 bool FMV_Init(void)


### PR DESCRIPTION
Resolves #844.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed .mpeg FMVs not working because of a missing delimiter.
...
