### PR TITLE
option_passport: fix restart level text in Lara's home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed Lara not being able to jump off trapdoors or crumbling floors if the sidestep descent fix is enabled (#830)
 - fixed walk to pickups feature (#834, regression from 2.8)
 - fixed .mpeg FMVs not working (#844)
+- fixed the restart level passport text incorrectly showing new game in Lara's Home (#851)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -444,7 +444,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
             }
 
             if (g_InvMode == INV_TITLE_MODE
-                || g_CurrentLevel == g_GameFlow.gym_level_num) {
+                || (g_CurrentLevel == g_GameFlow.gym_level_num
+                    && g_InvMode != INV_DEATH_MODE)) {
                 Text_ChangeText(
                     m_Text[TEXT_PAGE_NAME],
                     g_GameFlow.strings[GS_PASSPORT_NEW_GAME]);
@@ -465,11 +466,13 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
             }
 
             if (g_InputDB.menu_confirm || g_InvMode == INV_SAVE_MODE
-                || g_InvMode == INV_SAVE_CRYSTAL_MODE) {
+                || g_InvMode == INV_SAVE_CRYSTAL_MODE
+                || (g_InvMode == INV_LOAD_MODE && !g_SavedGamesCount)) {
                 Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
                 Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
                 if (g_InvMode == INV_TITLE_MODE
-                    || g_CurrentLevel == g_GameFlow.gym_level_num) {
+                    || (g_CurrentLevel == g_GameFlow.gym_level_num
+                        && g_InvMode != INV_DEATH_MODE)) {
                     if (g_GameFlow.enable_game_modes) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
@@ -483,7 +486,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                 } else if (
                     g_InvMode == INV_SAVE_MODE
                     || g_InvMode == INV_SAVE_CRYSTAL_MODE
-                    || g_InvMode == INV_GAME_MODE) {
+                    || g_InvMode == INV_GAME_MODE
+                    || (g_InvMode == INV_LOAD_MODE && !g_SavedGamesCount)) {
                     g_SavegameRequester.flags &= ~RIF_BLOCKABLE;
                     Option_PassportInitSaveRequester(page);
                     m_PassportMode = PASSPORT_MODE_SHOW_SAVES;


### PR DESCRIPTION
Resolves #851.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the restart level passport text incorrectly showing new game in Lara's Home.