### PR TITLE
inventory: fix quick load creating an invalid save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed walk to pickups feature (#834, regression from 2.8)
 - fixed .mpeg FMVs not working (#844)
 - fixed the restart level passport text incorrectly showing new game in Lara's Home (#851)
+- fixed quick load creating an invalid save if used when no saves are present (#853)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -825,7 +825,8 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
             if (g_InvMode == INV_TITLE_MODE) {
             } else if (
                 g_InvChosen == O_PASSPORT_OPTION
-                && (g_InvMode == INV_LOAD_MODE /* f6 menu */
+                && ((g_InvMode == INV_LOAD_MODE
+                     && g_SavedGamesCount) /* f6 menu */
                     || g_InvMode == INV_DEATH_MODE /* Lara died */
                     || (g_InvMode == INV_GAME_MODE /* esc menu */
                         && g_GameInfo.passport_page


### PR DESCRIPTION
Resolves #853. Follow up to #851.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed quick load creating an invalid save if used when no saves are present. This PR fixes the screen fading to black bug as the passport portion of the fix was merged in accidentally in #854.
