### PR TITLE
collide: set Lara hit direction only when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed .mpeg FMVs not working (#844)
 - fixed the restart level passport text incorrectly showing new game in Lara's Home (#851)
 - fixed quick load creating an invalid save if used when no saves are present (#853)
+- fixed Lara entering body hit animations when not appropriate to do so (#857)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -155,7 +155,7 @@ static void Lara_BaddieCollision(ITEM_INFO *lara_item, COLL_INFO *coll)
         }
     }
 
-    if (g_Lara.spaz_effect_count && g_Lara.spaz_effect) {
+    if (g_Lara.spaz_effect_count && g_Lara.spaz_effect && coll->enable_spaz) {
         int32_t x = g_Lara.spaz_effect->pos.x - lara_item->pos.x;
         int32_t z = g_Lara.spaz_effect->pos.z - lara_item->pos.z;
         PHD_ANGLE hitang = lara_item->pos.y_rot - (PHD_180 + Math_Atan(z, x));

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -799,6 +799,7 @@ void Lara_State_SurfSwim(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
     g_Lara.dive_timer = 0;
 
     if (!g_Config.enable_tr3_sidesteps || !g_Input.slow) {
@@ -829,6 +830,7 @@ void Lara_State_SurfBack(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
     g_Lara.dive_timer = 0;
 
     if (!g_Config.enable_tr3_sidesteps || !g_Input.slow) {
@@ -856,6 +858,7 @@ void Lara_State_SurfLeft(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
     g_Lara.dive_timer = 0;
 
     if (g_Config.enable_tr3_sidesteps && g_Input.slow && g_Input.left) {
@@ -889,6 +892,7 @@ void Lara_State_SurfRight(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
     g_Lara.dive_timer = 0;
 
     if (g_Config.enable_tr3_sidesteps && g_Input.slow && g_Input.right) {
@@ -926,6 +930,8 @@ void Lara_State_SurfTread(ITEM_INFO *item, COLL_INFO *coll)
         item->goal_anim_state = LS_UW_DEATH;
         return;
     }
+
+    coll->enable_spaz = 0;
 
     if (g_Input.look) {
         Lara_LookLeftRightSurf();
@@ -979,6 +985,8 @@ void Lara_State_Swim(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
+
     if (g_Input.forward) {
         item->pos.x_rot -= 2 * PHD_DEGREE;
     }
@@ -1013,6 +1021,8 @@ void Lara_State_Glide(ITEM_INFO *item, COLL_INFO *coll)
         item->goal_anim_state = LS_UW_DEATH;
         return;
     }
+
+    coll->enable_spaz = 0;
 
     if (g_Input.forward) {
         item->pos.x_rot -= 2 * PHD_DEGREE;
@@ -1053,6 +1063,8 @@ void Lara_State_Tread(ITEM_INFO *item, COLL_INFO *coll)
         return;
     }
 
+    coll->enable_spaz = 0;
+
     if (g_Input.forward) {
         item->pos.x_rot -= 2 * PHD_DEGREE;
     } else if (g_Input.back) {
@@ -1084,6 +1096,7 @@ void Lara_State_Dive(ITEM_INFO *item, COLL_INFO *coll)
 
 void Lara_State_UWDeath(ITEM_INFO *item, COLL_INFO *coll)
 {
+    coll->enable_spaz = 0;
     item->fall_speed -= 8;
     if (item->fall_speed <= 0) {
         item->fall_speed = 0;


### PR DESCRIPTION
Resolves #857.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures `Lara_BaddieCollision` respects the `enable_spaz` flag on the collision, and accordingly updates Lara's water state functions to ensure this flag is not set. Other states such as underwater pickups and pulling underwater levers use the same state functions as on land, and the flag is set to `0` on these already.

Short video here to show the result (explosion sprites disabled for clarity).
https://www.youtube.com/watch?v=v03-C7zUypQ
