### PR TITLE
lara: add swing animation cancelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added forward/backward jumps while looking and looking up/down while hanging if enhanced look is enabled (#848)
 - added case insensitive directory and file detection (#845)
 - added controller detection during runtime (#850)
+- added an option to allow cancelling Lara's ledge-swinging animation (#856)
 - changed screen resolution option to apply immediately (#114)
 - changed shaders to use GLSL 1.20 which should fix most issues with OpenGL 2.1 (#327, #685)
 - fixed sounds stopping instead of pausing if game sounds in inventory are disabled (#717)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - added ability to look up and down while hanging
 - added ability to sidestep like in TR3
 - added ability to jump-twist and somersault like in TR2+
+- added ability to cancel ledge-swinging animation like in TR2+
 - added ability to automatically walk to items when nearby
 - added a pause screen
 - added a choice whether to play NG or NG+ without having to play the entire game

--- a/src/config.c
+++ b/src/config.c
@@ -228,6 +228,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enabled_inverted_look, false);
     READ_INTEGER(camera_speed, 5);
     READ_BOOL(fix_texture_issues, true);
+    READ_BOOL(enable_swing_cancel, true);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -409,6 +410,7 @@ bool Config_Write(void)
     WRITE_BOOL(enabled_inverted_look);
     WRITE_INTEGER(camera_speed);
     WRITE_BOOL(fix_texture_issues);
+    WRITE_BOOL(enable_swing_cancel);
 
     // User settings
     WRITE_BOOL(rendering.enable_bilinear_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,7 @@ typedef struct {
     bool enabled_inverted_look;
     int32_t camera_speed;
     bool fix_texture_issues;
+    bool enable_swing_cancel;
 
     struct {
         int32_t layout;

--- a/src/game/lara/lara_misc.c
+++ b/src/game/lara/lara_misc.c
@@ -1,5 +1,6 @@
 #include "game/lara/lara_misc.h"
 
+#include "config.h"
 #include "game/collide.h"
 #include "game/input.h"
 #include "game/items.h"
@@ -66,7 +67,11 @@ void Lara_HangTest(ITEM_INFO *item, COLL_INFO *coll)
         item->current_anim_state = LS_JUMP_UP;
         Item_SwitchToAnim(item, LA_STOP_HANG, LF_STOPHANG);
         bounds = Item_GetBoundsAccurate(item);
-        item->pos.y += coll->front_floor - bounds[FRAME_BOUND_MIN_Y] + 2;
+        if (g_Config.enable_swing_cancel && item->hit_points > 0) {
+            item->pos.y += bounds[FRAME_BOUND_MAX_Y];
+        } else {
+            item->pos.y += coll->front_floor - bounds[FRAME_BOUND_MIN_Y] + 2;
+        }
         item->pos.x += coll->shift.x;
         item->pos.z += coll->shift.z;
         item->gravity_status = 1;

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -95,6 +95,10 @@
       "Title": "Jump twists",
       "Description": "Enables TR2+ style jump twists and somersaults i.e. press roll during jump and swan dive animations."
     },
+    "enable_swing_cancel": {
+      "Title": "Swing cancels",
+      "Description": "Allows Lara's ledge-swinging animation to be cancelled by letting go and quickly grabbing again, similar to TR2+."
+    },
     "enable_numeric_keys": {
       "Title": "Numeric key quick item use",
       "Description": "Enables quick weapon draws and medipack usage.\n- 1: Draw pistols\n- 2: Draw shotgun\n- 3: Draw magnums\n- 4: Draw Uzis\n- 8: Use small medipack\n- 9: Use large medipack"

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
@@ -183,6 +183,10 @@
       "Title": "Giros al saltar",
       "Description": "Habilita los giros al saltar y saltos mortales al estilo TR2+, es decir, presione rodar durante las animaciones del salto y salto del cisne."
     },
+    "enable_swing_cancel": {
+      "Title": "Cancelación de balanceo",
+      "Description": "Permite que la animación de balanceo de la repisa de Lara se cancele soltándola y agarrándola rápidamente de nuevo, similar a TR2+."
+    },
     "enable_music_in_inventory": {
       "Description": "Permite que los sonidos del juego continúen sonando en la pantalla de inventario.",
       "Title": "Habilitar sonidos de juegos en el inventario"

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -95,6 +95,10 @@
       "Title": "Sauts retournés",
       "Description": "Activer les sauts retournés qui permettent à Lara de faire un demi-tour en l'air pendant un saut, et le saut de l'ange alternatif avec saut périlleux avant. Comme depuis TR2. Appuyer sur la touche roulade pendant un saut classique ou un saut de l'ange."
     },
+    "enable_swing_cancel": {
+      "Title": "Annulation du balancement",
+      "Description": "Permet d'annuler l'animation de balancement à un rebord de Lara en relâchant prise et en saisissant rapidement à nouveau, similaire à TR2+."
+    },
     "enable_numeric_keys": {
       "Title": "Touches rapide numériques",
       "Description": "Active les touches rapides numériques en haut du clavier, en raccourci d'équipement d'armes ou d'utilisation de soins.\n- 1: Pistolets\n- 2: Fusil à pompe\n- 3: Magnums\n- 4: Uzis\n- 8: Utiliser une petite trousse de soin\n- 9: Utiliser une grande trousse de soin"

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -63,6 +63,11 @@
           "DefaultValue": true
         },
         {
+          "Field": "enable_swing_cancel",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "enable_numeric_keys",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
Resolves #856.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Allows Lara to swing cancel on ledges by shifting her slightly up after releasing grab to give a window to re-grab, which is the same for TR2+. The only difference with TR2 is that we check for Lara's hitpoints as well otherwise if she dies on a ledge and you continue to hold action, she continues to grab cancel. For T1M, she will fall when she dies.

If the option is disabled, the normal behaviour takes place, so releasing action gives no window to re-grab.

Short demo with various ledge types: https://www.youtube.com/watch?v=2OgGoAf_Tpk

