### PR TITLE
skatekid: check AI status before executing control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed the restart level passport text incorrectly showing new game in Lara's Home (#851)
 - fixed quick load creating an invalid save if used when no saves are present (#853)
 - fixed Lara entering body hit animations when not appropriate to do so (#857)
+- fixed SkateKid causing a game crash when too many enemies are active (#866)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -2,6 +2,7 @@
 
 #include "game/creature.h"
 #include "game/items.h"
+#include "game/lot.h"
 #include "game/music.h"
 #include "game/objects/common.h"
 #include "game/random.h"
@@ -68,6 +69,14 @@ void SkateKid_Initialise(int16_t item_num)
 void SkateKid_Control(int16_t item_num)
 {
     ITEM_INFO *item = &g_Items[item_num];
+
+    if (item->status == IS_INVISIBLE) {
+        if (!LOT_EnableBaddieAI(item_num, 0)) {
+            return;
+        }
+        item->status = IS_ACTIVE;
+    }
+
     CREATURE_INFO *kid = item->data;
     int16_t head = 0;
     int16_t angle = 0;


### PR DESCRIPTION
Resolves #866.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that SkateKid's AI status is checked before executing his control routine. Every other enemy uses this idiom, so it seems it was simply missed in this instance in OG. `CREATURE_INFO *kid = item->data;` could be `NULL`, so accessing it further down in the routine caused the crashing.
