### PR TITLE
missile: test damage range for overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed quick load creating an invalid save if used when no saves are present (#853)
 - fixed Lara entering body hit animations when not appropriate to do so (#857)
 - fixed SkateKid causing a game crash when too many enemies are active (#866)
+- fixed missiles damaging Lara when she is far beyond their damage range (#871)
 
 ## [2.14](https://github.com/rr-/Tomb1Main/compare/2.13.2...2.14) - 2023-04-05
 - added Spanish localization to the config tool

--- a/src/game/objects/effects/missile.c
+++ b/src/game/objects/effects/missile.c
@@ -52,7 +52,7 @@ void Missile_Control(int16_t fx_num)
             int32_t y = fx->pos.y - g_LaraItem->pos.y;
             int32_t z = fx->pos.z - g_LaraItem->pos.z;
             int32_t range = SQUARE(x) + SQUARE(y) + SQUARE(z);
-            if (range < ROCKET_RANGE) {
+            if (range >= 0 && range < ROCKET_RANGE) {
                 g_LaraItem->hit_points -=
                     (int16_t)(ROCKET_DAMAGE * (ROCKET_RANGE - range) / ROCKET_RANGE);
                 g_LaraItem->hit_status = 1;


### PR DESCRIPTION
Resolves #871.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Ensures Lara can only be damaged if the missile range is positive.

An aside from this, I'm wondering if a global `Lara_TakeDamage(int16_t points)` function would be a good idea, which would clamp the value in all cases - probably best under its own issue? The missile check would still be needed to test the range, but this would at least avoid overflowing her hitpoints in any case.
