### PR TITLE
bacon_lara: prevent movement after death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added the ability to define the anchor room for Bacon Lara in the gameflow (#868)
 - changed screen resolution option to apply immediately (#114)
 - changed shaders to use GLSL 1.20 which should fix most issues with OpenGL 2.1 (#327, #685)
+- changed Bacon Lara to prevent movement after her death (#875)
 - fixed sounds stopping instead of pausing if game sounds in inventory are disabled (#717)
 - fixed skipping Eidos logo and end credits (#541)
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling (#323)

--- a/src/game/objects/creatures/bacon_lara.c
+++ b/src/game/objects/creatures/bacon_lara.c
@@ -3,6 +3,7 @@
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lara/lara_draw.h"
+#include "game/objects/common.h"
 #include "game/room.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -126,6 +127,11 @@ void BaconLara_Control(int16_t item_num)
 
 void BaconLara_Draw(ITEM_INFO *item)
 {
+    if (item->current_anim_state == LS_DEATH) {
+        Object_DrawAnimatingItem(item);
+        return;
+    }
+
     int16_t *old_mesh_ptrs[LM_NUMBER_OF];
 
     for (int i = 0; i < LM_NUMBER_OF; i++) {


### PR DESCRIPTION
Resolves #875.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Once Bacon Lara has died, she will be drawn as a regular object rather than continuing to inherit effects from Lara's draw routine.

![20230607_192012_Atlantis_4](https://github.com/LostArtefacts/Tomb1Main/assets/33758420/1ba7500a-34e9-4bce-95e6-16cef74fb1e8)
