### PR TITLE
lara: fix jump-twist state softlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
 - fixed the ape not performing the vault animation when climbing (#880)
 - fixed holding down up or down to scroll the passport faster (#883, regression from 2.14)
+- fixed Lara becoming stuck in a T-pose on rare occasions after performing a jump tiwst (#889)
 
 ## [2.15](https://github.com/rr-/Tomb1Main/compare/2.14...2.15) - 2023-06-08
 - added an option to enable TR2+ jump-twist and somersault animations (#88)

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -34,6 +34,7 @@ void (*g_LaraCollisionRoutines[])(ITEM_INFO *item, COLL_INFO *coll) = {
     Lara_Col_SurfLeft,    Lara_Col_SurfRight, Lara_Col_UseMidas,
     Lara_Col_DieMidas,    Lara_Col_SwanDive,  Lara_Col_FastDive,
     Lara_Col_Gymnast,     Lara_Col_WaterOut,  Lara_Col_Controlled,
+    Lara_Col_Twist,
 };
 
 static void Lara_Col_Default(ITEM_INFO *item, COLL_INFO *coll);
@@ -672,6 +673,11 @@ void Lara_Col_Pickup(ITEM_INFO *item, COLL_INFO *coll)
 }
 
 void Lara_Col_Controlled(ITEM_INFO *item, COLL_INFO *coll)
+{
+    Lara_Col_Default(item, coll);
+}
+
+void Lara_Col_Twist(ITEM_INFO *item, COLL_INFO *coll)
 {
     Lara_Col_Default(item, coll);
 }

--- a/src/game/lara/lara_col.h
+++ b/src/game/lara/lara_col.h
@@ -63,3 +63,4 @@ void Lara_Col_SwanDive(ITEM_INFO *item, COLL_INFO *coll);
 void Lara_Col_FastDive(ITEM_INFO *item, COLL_INFO *coll);
 void Lara_Col_Gymnast(ITEM_INFO *item, COLL_INFO *coll);
 void Lara_Col_WaterOut(ITEM_INFO *item, COLL_INFO *coll);
+void Lara_Col_Twist(ITEM_INFO *item, COLL_INFO *coll);

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -199,9 +199,13 @@ void Lara_State_ForwardJump(ITEM_INFO *item, COLL_INFO *coll)
         if (g_Input.action && g_Lara.gun_status == LGS_ARMLESS) {
             item->goal_anim_state = LS_REACH;
         }
-        if (g_Config.enable_jump_twists && g_Input.roll
-            && item->goal_anim_state != LS_RUN) {
-            item->goal_anim_state = LS_TWIST;
+        if (g_Config.enable_jump_twists) {
+            if (g_Input.roll && item->goal_anim_state != LS_RUN) {
+                item->goal_anim_state = LS_TWIST;
+            } else if (
+                item->goal_anim_state == LS_TWIST && !item->gravity_status) {
+                item->goal_anim_state = LS_STOP;
+            }
         }
         if (g_Input.slow && g_Lara.gun_status == LGS_ARMLESS) {
             item->goal_anim_state = LS_SWAN_DIVE;
@@ -493,9 +497,12 @@ void Lara_State_BackJump(ITEM_INFO *item, COLL_INFO *coll)
         item->goal_anim_state = LS_FAST_FALL;
     }
 
-    if (g_Config.enable_jump_twists && g_Input.roll
-        && item->goal_anim_state != LS_STOP) {
-        item->goal_anim_state = LS_TWIST;
+    if (g_Config.enable_jump_twists) {
+        if (g_Input.roll && item->goal_anim_state != LS_STOP) {
+            item->goal_anim_state = LS_TWIST;
+        } else if (item->goal_anim_state == LS_TWIST && !item->gravity_status) {
+            item->goal_anim_state = LS_STOP;
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #889.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I discovered I had missed the collision routine for twists in #802, so I _believe_ this bug was a result of unknown behaviour there. In addition to this, I have added guards to the post-twist animations to ensure that if Lara is on the floor, her goal state should no longer be twist. It is a very difficult bug to reproduce, but Eycore provided a save with the issue and this fix allows that save to be played from again, plus I have not been able to reproduce the bug again after testing several scenarios.

Thanks as well to @Trxyebeep for input on this issue.
