### PR TITLE
items: avoid changing const hitpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
+- fixed Natla not leaving her semi-death state after Lara takes her down for the first time (#892, regression from 2.15.1)
 
 ## [2.15.1](https://github.com/rr-/Tomb1Main/compare/2.15...2.15.1) - 2023-07-14
 - fixed the ape not performing the vault animation when climbing (#880)

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -721,8 +721,12 @@ int32_t Item_GetFrames(ITEM_INFO *item, int16_t *frmptr[], int32_t *rate)
 
 void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status)
 {
+    if (item->hit_points == DONT_TARGET) {
+        return;
+    }
+
     item->hit_points -= damage;
-    CLAMPL(item->hit_points, DONT_TARGET + 1);
+    CLAMPL(item->hit_points, 0);
 
     if (hit_status) {
         item->hit_status = 1;


### PR DESCRIPTION
Resolves #892.
Regression from #888.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The previous clamping method was setting hitpoints to -16383, so the condition below was passing and hence Natla's control was treating her as already dead instead of initiating the semi-death countdown timer.

https://github.com/LostArtefacts/Tomb1Main/blob/develop/src/game/objects/creatures/natla.c#L86

To avoid further issues, if an item's hitpoints value is `DONT_TARGET` no further changes will be made to it. For normal cases, we clamp to 0. I've tested each enemy's death, Lara's own death, shooting the scion and the mummy in Qualopec.