### PR TITLE
savegame: initialise gym only when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
 - fixed Natla's gun moving while she is in her semi death state (#878)
+- fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 
 ## [2.15.2](https://github.com/rr-/Tomb1Main/compare/2.15.1...2.15.2) - 2023-07-17
 - fixed Natla not leaving her semi-death state after Lara takes her down for the first time (#892, regression from 2.15.1)

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -207,7 +207,9 @@ void Savegame_InitCurrentInfo(void)
         Savegame_ApplyLogicToCurrentInfo(i);
         g_GameInfo.current[i].flags.available = 0;
     }
-    g_GameInfo.current[g_GameFlow.gym_level_num].flags.available = 1;
+    if (g_GameFlow.gym_level_num != -1) {
+        g_GameInfo.current[g_GameFlow.gym_level_num].flags.available = 1;
+    }
     g_GameInfo.current[g_GameFlow.first_level_num].flags.available = 1;
 }
 


### PR DESCRIPTION
Resolves #899.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The error message stemmed from the following line when it was being called against the legacy "Current Position" level object. During shutdown, it had `injections.length` value of 1 despite this being 0 when the gameflow was initially loaded, so it was trying to free a null injection path.

https://github.com/LostArtefacts/Tomb1Main/blob/develop/src/game/gameflow.c#L1018

In `savegame.c`, the negative index in the initialisation just so happened to mean that the address of the length value above was being accessed, so it was changing from 0 to 1 here. This probably went unnoticed in pre-injection versions as it was most likely not changing anything that incurred memory management like we have in this situation.

This is the only place where `g_GameFlow.gym_level_num` is used as an array index.
