### PR TITLE
savegame: add triggered music tracks to the savegame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
 - added the current music track and timestamp to the savegame so they now persist on load (#419)
+- added the triggered music tracks to the savegame so one shot tracks don't replay on load (#371)
 - changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - added an option to turn off sound effect pitching
 - added an option to use the PlayStation Uzi sound effects
 - added the current music track and timestamp to the savegame so they now persist on load
+- added the triggered music tracks to the savegame so one shot tracks don't replay on load
 - fixed the sound of collecting a secret killing the music
 - fixed audio mixer stopping playing sounds on big explosions
 - fixed game audio not muting when game is minimized

--- a/src/config.c
+++ b/src/config.c
@@ -232,6 +232,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enable_swing_cancel, true);
     READ_BOOL(enable_tr2_jumping, false);
     READ_BOOL(load_current_music, true);
+    READ_BOOL(load_music_triggers, true);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -417,6 +418,7 @@ bool Config_Write(void)
     WRITE_BOOL(enable_swing_cancel);
     WRITE_BOOL(enable_tr2_jumping);
     WRITE_BOOL(load_current_music);
+    WRITE_BOOL(load_music_triggers);
 
     // User settings
     WRITE_BOOL(rendering.enable_bilinear_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -112,6 +112,7 @@ typedef struct {
     bool enable_swing_cancel;
     bool enable_tr2_jumping;
     bool load_current_music;
+    bool load_music_triggers;
 
     struct {
         int32_t layout;

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1297,9 +1297,7 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
                 json_object_get_object(root_obj, "music"))) {
             goto cleanup;
         }
-    }
 
-    if (header.version >= VERSION_3) {
         if (!SaveGame_BSON_LoadMusicTrackFlags(
                 json_object_get_array(root_obj, "music_track_flags"))) {
             goto cleanup;

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -63,6 +63,8 @@ static bool Savegame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot);
 static bool Savegame_BSON_LoadLara(
     struct json_object_s *lara_obj, LARA_INFO *lara);
 static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj);
+static bool SaveGame_BSON_LoadMusicTrackFlags(
+    struct json_array_s *music_track_arr);
 static struct json_array_s *Savegame_BSON_DumpResumeInfo(
     RESUME_INFO *game_info);
 static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info);
@@ -76,6 +78,7 @@ static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo);
 static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot);
 static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara);
 static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void);
+static struct json_array_s *SaveGame_BSON_DumpMusicTrackFlags(void);
 
 static void SaveGame_BSON_SaveRaw(
     MYFILE *fp, struct json_value_s *root, int32_t version)
@@ -822,6 +825,27 @@ static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
                 current_track, timestamp);
         }
     }
+    return true;
+}
+
+static bool SaveGame_BSON_LoadMusicTrackFlags(
+    struct json_array_s *music_track_arr)
+{
+    if (!music_track_arr) {
+        LOG_WARNING("Malformed save: invalid or missing music track array");
+        return true;
+    }
+
+    if ((signed)music_track_arr->length != MAX_CD_TRACKS) {
+        LOG_WARNING(
+            "Malformed save: expected %d music track flags, got %d",
+            MAX_CD_TRACKS, music_track_arr->length);
+        return true;
+    }
+
+    for (int i = 0; i < (signed)music_track_arr->length; i++) {
+        g_MusicTrackFlags[i] = json_array_get_int(music_track_arr, i, 0);
+    }
 
     return true;
 }
@@ -1146,6 +1170,15 @@ static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void)
     return current_music_obj;
 }
 
+static struct json_array_s *SaveGame_BSON_DumpMusicTrackFlags(void)
+{
+    struct json_array_s *music_track_arr = json_array_new();
+    for (int i = 0; i < MAX_CD_TRACKS; i++) {
+        json_array_append_int(music_track_arr, g_MusicTrackFlags[i]);
+    }
+    return music_track_arr;
+}
+
 char *Savegame_BSON_GetSaveFileName(int32_t slot)
 {
     size_t out_size = snprintf(NULL, 0, g_GameFlow.savegame_fmt_bson, slot) + 1;
@@ -1266,6 +1299,13 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         }
     }
 
+    if (header.version >= VERSION_3) {
+        if (!SaveGame_BSON_LoadMusicTrackFlags(
+                json_object_get_array(root_obj, "music_track_flags"))) {
+            goto cleanup;
+        }
+    }
+
     ret = true;
 
 cleanup:
@@ -1335,6 +1375,8 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         root_obj, "lara", Savegame_BSON_DumpLara(&g_Lara));
     json_object_append_object(
         root_obj, "music", SaveGame_BSON_DumpCurrentMusic());
+    json_object_append_array(
+        root_obj, "music_track_flags", SaveGame_BSON_DumpMusicTrackFlags());
 
     struct json_value_s *root = json_value_from_object(root_obj);
     SaveGame_BSON_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -283,6 +283,10 @@
       "Title": "Load music track",
       "Description": "Loads the music track that was playing when the game was saved."
     },
+    "load_music_triggers": {
+      "Title": "Remember played music",
+      "Description": "Loads previously triggered music so music tracks do not replay."
+    },
     "enable_music_in_menu": {
       "Title": "Enable main menu music",
       "Description": "Plays music in the main menu."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
@@ -199,13 +199,13 @@
       "Title": "Cargar pista de música",
       "Description": "Carga la pista de música que se estaba reproduciendo cuando se guardó el juego."
     },
-    "enable_music_in_menu": {
-      "Title": "Habilitar música en menú principal",
-      "Description": "Reproduce música en el menú principal."
-    },
     "load_music_triggers": {
       "Title": "Recordar la música reproducida",
       "Description": "Carga música activada previamente para que las pistas de música no se reproduzcan."
+    },
+    "enable_music_in_menu": {
+      "Title": "Habilitar música en menú principal",
+      "Description": "Reproduce música en el menú principal."
     },
     "enable_numeric_keys": {
       "Title": "Uso rápido de teclas numéricas",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -283,6 +283,10 @@
       "Title": "Load music track",
       "Description": "Charge la musique qui était en cours de lecture lors de la sauvegarde."
     },
+    "load_music_triggers": {
+      "Title": "Garder en mémoire les musiques jouées",
+      "Description": "Garde en mémoire les musiques précédement déclenchées, pour que les pistes ne puissent pas se répéter à un rechargement de partie."
+    },
     "enable_music_in_menu": {
       "Title": "Activer la musique dans le menu principal",
       "Description": "Chosir d'activer ou non la musique dans le menu principal."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -341,6 +341,11 @@
           "DefaultValue": true
         },
         {
+          "Field": "load_music_triggers",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "enable_music_in_menu",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
Resolves #371.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added the triggered music tracks to the savegame so one shot tracks don't replay on load. I'm afk this weekend. But I wanted some feedback on the naming, behavior, etc of this. This saves off `g_MusicTrackFlags` for new save format saves. The original game only did this for Pierre, Cowboy, Baldy, and Larson (which for some reason uses `MX_BALDY_SPEECH` which could be a T1M bug, but I haven't looked into it yet). The implementation means the game behaves similar to how a level plays out if the player never reloads. Each `MUSIC_TRACK_ID` can only be played once in a level unless it's marked as one shot. This could be limiting to custom levels potentially, but it's also how the OG game behaves now. And custom levels do get 60 music slots to work with. Below are some examples of how it behaves and how it depends on level files.

This one shot Colosseum trigger doesn't play again on reload:
![image](https://github.com/LostArtefacts/Tomb1Main/assets/81546780/339a1677-5fda-4df9-bf48-34e44ef2be77)

But this **non** one shot St Francis Folly music trigger will always play:
![image](https://github.com/LostArtefacts/Tomb1Main/assets/81546780/66938673-37a9-4d40-b187-e9f784d96f78)
