### PR TITLE
installer: overwrite all essential files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
 - added the current music track and timestamp to the savegame so they now persist on load (#419)
+- changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 - fixed the bear pat attack so it does not miss Lara (#450)

--- a/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
+++ b/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
@@ -127,8 +127,8 @@
                         Overwrite all existing files
                         <LineBreak />
                         <Run Style="{StaticResource small}">
-                            Overwrites any files such as level data, music files and existing user settings.
-                            If this option is off, only overwrites Tomb1Main.exe in order to update the game.
+                            Overwrites any files such as level data and music files. If this option is off, only
+                            overwrites Tomb1Main.exe and other essential files in order to update the game.
                         </Run>
                     </TextBlock>
                 </CheckBox>

--- a/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
+++ b/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
@@ -122,17 +122,6 @@
                     </TextBlock>
                 </CheckBox>
 
-                <CheckBox VerticalAlignment="Center" Margin="0,0,0,12" IsChecked="{Binding InstallSettings.OverwriteAllFiles}">
-                    <TextBlock TextWrapping="Wrap">
-                        Overwrite all existing files
-                        <LineBreak />
-                        <Run Style="{StaticResource small}">
-                            Overwrites any files such as level data and music files. If this option is off, only
-                            overwrites Tomb1Main.exe and other essential files in order to update the game.
-                        </Run>
-                    </TextBlock>
-                </CheckBox>
-
                 <CheckBox VerticalAlignment="Center" Margin="0,0,0,12" IsChecked="{Binding InstallSettings.CreateDesktopShortcut}">
                     Create desktop shortcut
                 </CheckBox>

--- a/tools/installer/Installer/Installers/BaseInstallSource.cs
+++ b/tools/installer/Installer/Installers/BaseInstallSource.cs
@@ -32,8 +32,7 @@ public abstract class BaseInstallSource : IInstallSource
         string sourceDirectory,
         string targetDirectory,
         IProgress<InstallProgress> progress,
-        bool importSaves,
-        bool overwrite
+        bool importSaves
     );
 
     public abstract bool IsDownloadingMusicNeeded(string sourceDirectory);

--- a/tools/installer/Installer/Installers/GOGInstallSource.cs
+++ b/tools/installer/Installer/Installers/GOGInstallSource.cs
@@ -38,8 +38,7 @@ public class GOGInstallSource : BaseInstallSource
         string sourceDirectory,
         string targetDirectory,
         IProgress<InstallProgress> progress,
-        bool importSaves,
-        bool overwrite
+        bool importSaves
     )
     {
         var cuePath = Path.Combine(sourceDirectory, "game.dat");
@@ -86,7 +85,7 @@ public class GOGInstallSource : BaseInstallSource
             foreach (var path in filesToExtract)
             {
                 var targetPath = Path.Combine(targetDirectory, path);
-                if (!File.Exists(targetPath) || overwrite)
+                if (!File.Exists(targetPath))
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
 

--- a/tools/installer/Installer/Installers/IInstallSource.cs
+++ b/tools/installer/Installer/Installers/IInstallSource.cs
@@ -18,8 +18,7 @@ public interface IInstallSource
         string sourceDirectory,
         string targetDirectory,
         IProgress<InstallProgress> progress,
-        bool importSaves,
-        bool overwrite
+        bool importSaves
     );
 
     bool IsDownloadingMusicNeeded(string sourceDirectory);

--- a/tools/installer/Installer/Installers/InstallExecutor.cs
+++ b/tools/installer/Installer/Installers/InstallExecutor.cs
@@ -87,7 +87,11 @@ public class InstallExecutor
 
         var alwaysOverwrite = new string[]
         {
-            "Tomb1Main.exe",
+            ".bin",
+            ".exe",
+            ".fsh",
+            ".json5",
+            ".vsh",
         };
 
         await InstallUtils.ExtractZip(
@@ -97,7 +101,7 @@ public class InstallExecutor
             overwriteCallback:
                 file =>
                     _settings.OverwriteAllFiles
-                    || alwaysOverwrite.Any(otherFile => string.Equals(Path.GetFileName(file), otherFile, StringComparison.CurrentCultureIgnoreCase))
+                    || alwaysOverwrite.Any(otherExt => string.Equals(Path.GetExtension(file), otherExt, StringComparison.CurrentCultureIgnoreCase))
         );
     }
 

--- a/tools/installer/Installer/Installers/InstallExecutor.cs
+++ b/tools/installer/Installer/Installers/InstallExecutor.cs
@@ -59,7 +59,7 @@ public class InstallExecutor
         {
             throw new NullReferenceException();
         }
-        await _settings.InstallSource.CopyOriginalGameFiles(sourceDirectory, targetDirectory, progress, _settings.ImportSaves, _settings.OverwriteAllFiles);
+        await _settings.InstallSource.CopyOriginalGameFiles(sourceDirectory, targetDirectory, progress, _settings.ImportSaves);
     }
 
     protected async Task CopyTomb1MainFiles(string targetDirectory, IProgress<InstallProgress> progress)
@@ -85,24 +85,7 @@ public class InstallExecutor
             throw new ApplicationException($"Could not open embedded ZIP.");
         }
 
-        var alwaysOverwrite = new string[]
-        {
-            ".bin",
-            ".exe",
-            ".fsh",
-            ".json5",
-            ".vsh",
-        };
-
-        await InstallUtils.ExtractZip(
-            stream,
-            targetDirectory,
-            progress,
-            overwriteCallback:
-                file =>
-                    _settings.OverwriteAllFiles
-                    || alwaysOverwrite.Any(otherExt => string.Equals(Path.GetExtension(file), otherExt, StringComparison.CurrentCultureIgnoreCase))
-        );
+        await InstallUtils.ExtractZip(stream, targetDirectory, progress, overwrite: true);
     }
 
     protected void CreateDesktopShortcut(string targetDirectory)

--- a/tools/installer/Installer/Installers/InstallUtils.cs
+++ b/tools/installer/Installer/Installers/InstallUtils.cs
@@ -89,13 +89,12 @@ public static class InstallUtils
     public static async Task DownloadZip(
         string url,
         string targetDirectory,
-        IProgress<InstallProgress> progress,
-        Func<string, bool>? overwriteCallback = null
+        IProgress<InstallProgress> progress
     )
     {
         var response = await DownloadFile(url, progress);
         using var stream = new MemoryStream(response);
-        await ExtractZip(stream, targetDirectory, progress, overwriteCallback);
+        await ExtractZip(stream, targetDirectory, progress);
     }
 
     public static async Task ExtractZip(
@@ -103,7 +102,7 @@ public static class InstallUtils
         string targetDirectory,
         IProgress<InstallProgress> progress,
         Func<string, bool>? filterCallback = null,
-        Func<string, bool>? overwriteCallback = null
+        bool overwrite = false
     )
     {
         try
@@ -129,7 +128,7 @@ public static class InstallUtils
                         targetDirectory,
                         new Regex(@"[\\/]").Replace(entry.FullName, Path.DirectorySeparatorChar.ToString()));
 
-                if (!File.Exists(targetPath) || (overwriteCallback is not null && overwriteCallback(entry.FullName)))
+                if (!File.Exists(targetPath) || overwrite)
                 {
                     progress.Report(new InstallProgress
                     {

--- a/tools/installer/Installer/Installers/Tomb1MainInstallSource.cs
+++ b/tools/installer/Installer/Installers/Tomb1MainInstallSource.cs
@@ -37,8 +37,7 @@ public class Tomb1MainInstallSource : BaseInstallSource
         string sourceDirectory,
         string targetDirectory,
         IProgress<InstallProgress> progress,
-        bool importSaves,
-        bool overwrite
+        bool importSaves
     )
     {
         var filterRegex = new Regex(importSaves ? @"(data|fmv|music|saves)[\\/]|save.*\.\d+" : @"(data|fmv|music)[\\/]", RegexOptions.IgnoreCase);
@@ -46,8 +45,7 @@ public class Tomb1MainInstallSource : BaseInstallSource
             sourceDirectory,
             targetDirectory,
             progress,
-            file => filterRegex.IsMatch(file),
-            file => overwrite
+            file => filterRegex.IsMatch(file)
         );
     }
 

--- a/tools/installer/Installer/Installers/TombATIInstallSource.cs
+++ b/tools/installer/Installer/Installers/TombATIInstallSource.cs
@@ -31,8 +31,7 @@ public class TombATIInstallSource : BaseInstallSource
         string sourceDirectory,
         string targetDirectory,
         IProgress<InstallProgress> progress,
-        bool importSaves,
-        bool overwrite
+        bool importSaves
     )
     {
         var filterRegex = new Regex(importSaves ? @"(data|fmv|music)[\\/]|save.*\.\d+\b" : @"(data|fmv|music)[\\/]", RegexOptions.IgnoreCase);
@@ -40,8 +39,7 @@ public class TombATIInstallSource : BaseInstallSource
             sourceDirectory,
             targetDirectory,
             progress,
-            file => filterRegex.IsMatch(file),
-            file => overwrite
+            file => filterRegex.IsMatch(file)
         );
     }
 

--- a/tools/installer/Installer/Models/InstallSettings.cs
+++ b/tools/installer/Installer/Models/InstallSettings.cs
@@ -89,19 +89,6 @@ public class InstallSettings : BaseNotifyPropertyChanged
         }
     }
 
-    public bool OverwriteAllFiles
-    {
-        get => _overwriteAllFiles;
-        set
-        {
-            if (value != _overwriteAllFiles)
-            {
-                _overwriteAllFiles = value;
-                NotifyPropertyChanged();
-            }
-        }
-    }
-
     public string? SourceDirectory
     {
         get => _sourceDirectory;
@@ -133,7 +120,6 @@ public class InstallSettings : BaseNotifyPropertyChanged
     private bool _downloadUnfinishedBusiness;
     private bool _importSaves;
     private IInstallSource? _installSource;
-    private bool _overwriteAllFiles = false;
     private string? _sourceDirectory;
     private string? _targetDirectory;
 }


### PR DESCRIPTION
Resolves #904.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Changed the overwrite check approach to look at extensions so to avoid listing each file (the bin files alone would make this unmanageable I think). It will only overwrite what's in the release zip anyway, so such things as `Tomb1Main.json5` will remain unaffected. I included the shaders too - do you think this is OK, or given previous shader issues should we leave these out?
