### PR TITLE
lara: fix drop-grab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 - fixed the bear pat attack so it does not miss Lara (#450)
+- fixed Lara not grabbing certain edges when the swing-cancel option is enabled (#911)
 
 ## [2.15.2](https://github.com/rr-/Tomb1Main/compare/2.15.1...2.15.2) - 2023-07-17
 - fixed Natla not leaving her semi-death state after Lara takes her down for the first time (#892, regression from 2.15.1)

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -522,7 +522,9 @@ void Lara_State_LeftJump(ITEM_INFO *item, COLL_INFO *coll)
 
 void Lara_State_UpJump(ITEM_INFO *item, COLL_INFO *coll)
 {
-    if (item->fall_speed > LARA_FASTFALL_SPEED) {
+    if (item->fall_speed
+        > (g_Config.enable_swing_cancel ? LARA_SWING_FASTFALL_SPEED
+                                        : LARA_FASTFALL_SPEED)) {
         item->goal_anim_state = LS_FAST_FALL;
     }
 }

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -56,6 +56,7 @@
 #define LARA_LEAN_MAX ((10 * PHD_DEGREE) + LARA_LEAN_UNDO) // = 2002
 #define LARA_LEAN_MAX_UW (LARA_LEAN_MAX * 2)
 #define LARA_FASTFALL_SPEED (FASTFALL_SPEED + 3) // = 131
+#define LARA_SWING_FASTFALL_SPEED (LARA_FASTFALL_SPEED + 2) // = 133
 #define LARA_RAD 100 // global radius of g_Lara
 #define LARA_HEIGHT 762 // global height of g_Lara - less than 3/4 block
 #define UW_MAXSPEED 200


### PR DESCRIPTION
Resolves #911.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The issue was that swing-cancel raises Lara briefly above a ledge when action is released, and so after falling 6 clicks plus this small distance, she was already in the `LS_FAST_FALL` animation. The fix increases the threshold by 2 to allow the same window as though swing-cancelling were not enabled. This was the minimum required to work.

As far as I know this is the only location like this in the game, but I may be wrong. Anything above 6 clicks does not allow grabbing lower ledges anyway - I've tested in TombEditor as follows with swing-cancel disabled. From left to right this is 6-click, 7-click and a 6-7 click slant. On the slanted drop, she can only grab the ledge below when at the far right.

![image](https://github.com/LostArtefacts/Tomb1Main/assets/33758420/357ef50f-fcb8-41ec-918a-5f2fef69821c)

