### PR TITLE
data: allow failed injections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - added the current music track and timestamp to the savegame so they now persist on load (#419)
 - added the triggered music tracks to the savegame so one shot tracks don't replay on load (#371)
 - changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
-- changed the data injection system to warn when it detects invalid or missing files, rather than preventing levels from loading (#882)
+- changed the data injection system to warn when it detects invalid or missing files, rather than preventing levels from loading (#918)
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 - fixed the bear pat attack so it does not miss Lara (#450)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added the current music track and timestamp to the savegame so they now persist on load (#419)
 - added the triggered music tracks to the savegame so one shot tracks don't replay on load (#371)
 - changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
+- changed the data injection system to warn when it detects invalid or missing files, rather than preventing levels from loading (#882)
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 - fixed the bear pat attack so it does not miss Lara (#450)

--- a/src/game/inject.h
+++ b/src/game/inject.h
@@ -2,7 +2,6 @@
 
 #include "global/types.h"
 
-#include <stdbool.h>
 #include <stdint.h>
 
 typedef struct INJECTION_ROOM_MESH {
@@ -39,7 +38,8 @@ typedef struct INJECTION_INFO {
     int32_t item_rotation_count;
 } INJECTION_INFO;
 
-bool Inject_Init(
+void Inject_Init(
     int injection_count, char *filenames[], INJECTION_INFO *aggregate);
-bool Inject_AllInjections(LEVEL_INFO *level_info);
+void Inject_AllInjections(LEVEL_INFO *level_info);
+void Inject_Cleanup(void);
 uint32_t Inject_GetExtraRoomMeshSize(int32_t room_index);


### PR DESCRIPTION
Resolves #918.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Related to #882, this will allow levels to load in spite of injection failures. The overall flow for level loading is as follows:
* Initialise injections
* Read level file, using aggregated injection info
* Inject
* Complete level setup
* Cleanup injection resources

Previously, injection cleanup was only taking place if there was at least one valid injection file. Now this is pushed to the end of the flow to ensure that resources for invalid injections are released e.g. files that were opened, but where invalid data was detected at some point in the process.

I've tested the following cases.
* The gameflow points to an injection file that does not exist
* An injection file has invalid header magic
* An injection file has an unsupported version
* An injection type does not match any defined `INJECTION_TYPE`
