### PR TITLE
centaur: fix incorrect starting frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed the bear pat attack so it does not miss Lara (#450)
 - fixed some incorrectly rotated pickups when using the 3D pickups option (#253)
 - fixed dead centaurs exploding again after saving and reloading (#924)
+- fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/objects/creatures/statue.c
+++ b/src/game/objects/creatures/statue.c
@@ -13,7 +13,7 @@
 
 #define STATUE_EXPLODE_DIST (WALL_L * 7 / 2) // = 3584
 #define CENTAUR_REARING_ANIM 7
-#define CENTAUR_REARING_FRAME 36
+#define CENTAUR_REARING_FRAME 152
 
 void Statue_Setup(OBJECT_INFO *obj)
 {


### PR DESCRIPTION
Resolves #926.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The issue was in the call to `Item_SwitchToAnim` - in every other case, when a frame is passed to it, that frame is relative to the model's frame base (only used by Lara/Bacon Lara). For the centaur, the passed value was relative to the animation, so this was in turn setting the wrong frame (somewhere in centaur anim 5 instead of frame 36 in anim 7). This updates the constant to ensure we are passing relative to the model. Caused by #821.
