### PR TITLE
lara: fix jump-twist interruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed some incorrectly rotated pickups when using the 3D pickups option (#253)
 - fixed dead centaurs exploding again after saving and reloading (#924)
 - fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
+- fixed jump-twist animations at times being interrupted (#932, regression from 2.15.1)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -195,17 +195,13 @@ void Lara_State_ForwardJump(ITEM_INFO *item, COLL_INFO *coll)
         || item->goal_anim_state == LS_REACH) {
         item->goal_anim_state = LS_JUMP_FORWARD;
     }
-    if (item->goal_anim_state != LS_DEATH && item->goal_anim_state != LS_STOP) {
+    if (item->goal_anim_state != LS_DEATH && item->goal_anim_state != LS_STOP
+        && item->goal_anim_state != LS_RUN) {
         if (g_Input.action && g_Lara.gun_status == LGS_ARMLESS) {
             item->goal_anim_state = LS_REACH;
         }
-        if (g_Config.enable_jump_twists) {
-            if (g_Input.roll && item->goal_anim_state != LS_RUN) {
-                item->goal_anim_state = LS_TWIST;
-            } else if (
-                item->goal_anim_state == LS_TWIST && !item->gravity_status) {
-                item->goal_anim_state = LS_STOP;
-            }
+        if (g_Config.enable_jump_twists && g_Input.roll) {
+            item->goal_anim_state = LS_TWIST;
         }
         if (g_Input.slow && g_Lara.gun_status == LGS_ARMLESS) {
             item->goal_anim_state = LS_SWAN_DIVE;
@@ -495,14 +491,12 @@ void Lara_State_BackJump(ITEM_INFO *item, COLL_INFO *coll)
     g_Camera.target_angle = PHD_DEGREE * 135;
     if (item->fall_speed > LARA_FASTFALL_SPEED) {
         item->goal_anim_state = LS_FAST_FALL;
-    }
-
-    if (g_Config.enable_jump_twists) {
-        if (g_Input.roll && item->goal_anim_state != LS_STOP) {
-            item->goal_anim_state = LS_TWIST;
-        } else if (item->goal_anim_state == LS_TWIST && !item->gravity_status) {
-            item->goal_anim_state = LS_STOP;
-        }
+    } else if (item->goal_anim_state == LS_RUN) {
+        item->goal_anim_state = LS_STOP;
+    } else if (
+        item->goal_anim_state != LS_STOP && g_Config.enable_jump_twists
+        && g_Input.roll) {
+        item->goal_anim_state = LS_TWIST;
     }
 }
 


### PR DESCRIPTION
Resolves #932.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The gravity check added as part of #890 was failing in some cases because there is a 4 frame window at the start of the jumping animation where gravity is zero, so if roll was pressed here the jump would be cancelled.

The changes here now reflect tomb3 (aside from the additional twist inputs, but that will be covered separately against #931).

@aredfan has done some additional animation testing with me on this build as follows to be thorough:

* The original T-pose softlock issue from #890 under low ceilings
* Running jump + action to grab a ledge
* Running jump into a swan dive
* Running jump off a ledge to enter fast fall
* Backward jump off a ledge to enter fast fall
* Normal backward jump into standing still state
* Backward jump off a higher ledge, but not high enough to kill Lara
