### PR TITLE
lara: improve jump-twist input detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
 - added the current music track and timestamp to the savegame so they now persist on load (#419)
 - added the triggered music tracks to the savegame so one shot tracks don't replay on load (#371)
+- added forward/backward input detection in line with TR2+ for jump-twists (#931)
 - changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
 - changed the data injection system to warn when it detects invalid or missing files, rather than preventing levels from loading (#918)
 - changed the gameflow to detect and skip over legacy sequence types, rather than preventing the game from starting (#882)

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -200,7 +200,7 @@ void Lara_State_ForwardJump(ITEM_INFO *item, COLL_INFO *coll)
         if (g_Input.action && g_Lara.gun_status == LGS_ARMLESS) {
             item->goal_anim_state = LS_REACH;
         }
-        if (g_Config.enable_jump_twists && g_Input.roll) {
+        if (g_Config.enable_jump_twists && (g_Input.roll || g_Input.back)) {
             item->goal_anim_state = LS_TWIST;
         }
         if (g_Input.slow && g_Lara.gun_status == LGS_ARMLESS) {
@@ -495,7 +495,7 @@ void Lara_State_BackJump(ITEM_INFO *item, COLL_INFO *coll)
         item->goal_anim_state = LS_STOP;
     } else if (
         item->goal_anim_state != LS_STOP && g_Config.enable_jump_twists
-        && g_Input.roll) {
+        && (g_Input.roll || g_Input.forward)) {
         item->goal_anim_state = LS_TWIST;
     }
 }


### PR DESCRIPTION
Resolves #931.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds a check for independent backward input detection during forward jumps, and forward input during backward jumps i.e. independent from backward and forward being treated as roll.

https://github.com/LostArtefacts/Tomb1Main/assets/33758420/88b8d51b-93ed-405d-ad2b-953e06fc656a
