### PR TITLE
overlay: fix reset and unbind progress bars in controls menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
 - fixed jump-twist animations at times being interrupted (#932, regression from 2.15.1)
 - fixed walk-run-jump at times breaking when TR2 jumping is enabled (OG bug in TR2+) (#934)
+- fixed the reset and unbind progress bars in the controls menu for non-default bar scaling (#930)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/option/option_control.c
+++ b/src/game/option/option_control.c
@@ -552,6 +552,7 @@ static void Option_ControlProgressBar(TEXTSTRING *txt, int32_t timer)
     } else if (txt->flags.right) {
         x += Screen_GetResWidthDownscaledText() - width;
     }
+
     if (txt->flags.centre_v) {
         y += Screen_GetResHeightDownscaledText() / 2;
     } else if (txt->flags.bottom) {

--- a/src/game/option/option_control.c
+++ b/src/game/option/option_control.c
@@ -199,11 +199,11 @@ static void Option_ControlProgressBar(TEXTSTRING *txt, int32_t timer);
 static void Option_ControlInitMenu(void)
 {
     int32_t visible_lines = 0;
-    if (Screen_GetResHeightDownscaledText() <= 240) {
+    if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 240) {
         visible_lines = 6;
-    } else if (Screen_GetResHeightDownscaledText() <= 384) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 384) {
         visible_lines = 8;
-    } else if (Screen_GetResHeightDownscaledText() <= 480) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 480) {
         visible_lines = 12;
     } else {
         visible_lines = 18;
@@ -240,7 +240,7 @@ static void Option_ControlInitText(CONTROL_MODE mode, INPUT_LAYOUT layout_num)
         : CtrlTextPlacementNormal;
 
     const TEXT_COLUMN_PLACEMENT *col = cols;
-    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaled(RSR_TEXT) / 2;
     int16_t x_roles = centre - 150;
     int16_t box_width = 315;
     int16_t x_names = -centre + box_width / 2 - BORDER;
@@ -548,15 +548,15 @@ static void Option_ControlProgressBar(TEXTSTRING *txt, int32_t timer)
     int32_t y = txt->pos.y - TEXT_HEIGHT;
 
     if (txt->flags.centre_h) {
-        x += (Screen_GetResWidthDownscaledText() - width) / 2;
+        x += (Screen_GetResWidthDownscaled(RSR_TEXT) - width) / 2;
     } else if (txt->flags.right) {
-        x += Screen_GetResWidthDownscaledText() - width;
+        x += Screen_GetResWidthDownscaled(RSR_TEXT) - width;
     }
 
     if (txt->flags.centre_v) {
-        y += Screen_GetResHeightDownscaledText() / 2;
+        y += Screen_GetResHeightDownscaled(RSR_TEXT) / 2;
     } else if (txt->flags.bottom) {
-        y += Screen_GetResHeightDownscaledText();
+        y += Screen_GetResHeightDownscaled(RSR_TEXT);
     }
 
     int32_t percent = (timer * 100) / (FRAMES_PER_SECOND * BUTTON_HOLD_TIME);

--- a/src/game/option/option_graphics.c
+++ b/src/game/option/option_graphics.c
@@ -130,7 +130,7 @@ static void Option_GraphicsInitText(void)
     m_HideArrowRight =
         g_Config.rendering.enable_perspective_filter ? true : false;
 
-    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaled(RSR_TEXT) / 2;
     m_Text[TEXT_ROW_SELECT] =
         Text_Create(centre - 3, TOP_Y + ROW_HEIGHT + BORDER * 2, " ");
     Text_CentreV(m_Text[TEXT_ROW_SELECT], 1);
@@ -208,7 +208,7 @@ static void Option_GraphicsUpdateArrows(void)
 
 static int16_t Option_GraphicsPlaceColumns(bool create)
 {
-    const int16_t centre = Screen_GetResWidthDownscaledText() / 2;
+    const int16_t centre = Screen_GetResWidthDownscaled(RSR_TEXT) / 2;
 
     int16_t max_y = 0;
     int16_t xs[2] = { centre - 142, centre + 30 };
@@ -277,7 +277,8 @@ static void Option_GraphicsChangeTextOption(int32_t option_num)
         Text_ChangeText(m_Text[TEXT_UI_TEXT_SCALE_TOGGLE], buf);
         Option_GraphicsPlaceColumns(false);
         Text_SetPos(
-            m_Text[TEXT_ROW_SELECT], Screen_GetResWidthDownscaledText() / 2 - 3,
+            m_Text[TEXT_ROW_SELECT],
+            Screen_GetResWidthDownscaled(RSR_TEXT) / 2 - 3,
             TOP_Y + ROW_HEIGHT + BORDER * 2);
         break;
 

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -243,10 +243,10 @@ static void Option_PassportInitNewGameRequester(void)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaledText() / 2.4)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 2.4)
             + (req->line_height * req->vis_lines + 1);
     } else {
-        req->y = (-Screen_GetResHeightDownscaledText() / 2)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 2)
             + (req->line_height * req->vis_lines);
     }
 }
@@ -258,11 +258,11 @@ static void Option_PassportInitSelectLevelRequester(void)
     Requester_Init(req);
     Requester_SetHeading(req, g_GameFlow.strings[GS_PASSPORT_SELECT_LEVEL]);
 
-    if (Screen_GetResHeightDownscaledText() <= 240) {
+    if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 240) {
         req->vis_lines = 5;
-    } else if (Screen_GetResHeightDownscaledText() <= 384) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 384) {
         req->vis_lines = 7;
-    } else if (Screen_GetResHeightDownscaledText() <= 480) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 480) {
         req->vis_lines = 10;
     } else {
         req->vis_lines = 12;
@@ -270,10 +270,10 @@ static void Option_PassportInitSelectLevelRequester(void)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaledText() / 2)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 2)
             + (req->line_height * req->vis_lines);
     } else {
-        req->y = (-Screen_GetResHeightDownscaledText() / 1.73)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 1.73)
             + (req->line_height * req->vis_lines);
     }
 
@@ -290,11 +290,11 @@ static void Option_PassportInitSaveRequester(int16_t page_num)
             [page_num == PASSPORT_PAGE_1 ? GS_PASSPORT_LOAD_GAME
                                          : GS_PASSPORT_SAVE_GAME]);
 
-    if (Screen_GetResHeightDownscaledText() <= 240) {
+    if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 240) {
         req->vis_lines = 5;
-    } else if (Screen_GetResHeightDownscaledText() <= 384) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 384) {
         req->vis_lines = 7;
-    } else if (Screen_GetResHeightDownscaledText() <= 480) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 480) {
         req->vis_lines = 10;
     } else {
         req->vis_lines = 12;
@@ -302,10 +302,10 @@ static void Option_PassportInitSaveRequester(int16_t page_num)
 
     // Title screen passport is at a different pitch.
     if (g_InvMode == INV_TITLE_MODE) {
-        req->y = (-Screen_GetResHeightDownscaledText() / 2)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 2)
             + (req->line_height * req->vis_lines);
     } else {
-        req->y = (-Screen_GetResHeightDownscaledText() / 1.73)
+        req->y = (-Screen_GetResHeightDownscaled(RSR_TEXT) / 1.73)
             + (req->line_height * req->vis_lines);
     }
 

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -212,7 +212,7 @@ static void Overlay_BarGetLocation(
     m_BarOffsetY[bar_info->location] += *height + bar_spacing;
 }
 
-void Overlay_BarDraw(BAR_INFO *bar_info)
+void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func)
 {
     const RGBA8888 rgb_bgnd = { 0, 0, 0, 255 };
     const RGBA8888 rgb_border = { 53, 53, 53, 255 };
@@ -224,13 +224,13 @@ void Overlay_BarDraw(BAR_INFO *bar_info)
     int32_t y = 0;
     Overlay_BarGetLocation(bar_info, &width, &height, &x, &y);
 
-    int32_t padding = Screen_GetRenderScaleBar(2);
-    int32_t border = Screen_GetRenderScaleBar(2);
+    int32_t padding = scale_func(2);
+    int32_t border = scale_func(2);
 
-    int32_t sx = Screen_GetRenderScaleBar(x) - padding;
-    int32_t sy = Screen_GetRenderScaleBar(y) - padding;
-    int32_t sw = Screen_GetRenderScaleBar(width) + padding * 2;
-    int32_t sh = Screen_GetRenderScaleBar(height) + padding * 2;
+    int32_t sx = scale_func(x) - padding;
+    int32_t sy = scale_func(y) - padding;
+    int32_t sw = scale_func(width) + padding * 2;
+    int32_t sh = scale_func(height) + padding * 2;
 
     // border
     Output_DrawScreenFlatQuad(
@@ -247,69 +247,10 @@ void Overlay_BarDraw(BAR_INFO *bar_info)
     if (percent && !bar_info->blink) {
         width = width * percent / 100;
 
-        sx = Screen_GetRenderScaleBar(x);
-        sy = Screen_GetRenderScaleBar(y);
-        sw = Screen_GetRenderScaleBar(width);
-        sh = Screen_GetRenderScaleBar(height);
-
-        if (g_Config.enable_smooth_bars) {
-            for (int i = 0; i < COLOR_STEPS - 1; i++) {
-                RGBA8888 c1 = m_ColorBarMap[bar_info->color][i];
-                RGBA8888 c2 = m_ColorBarMap[bar_info->color][i + 1];
-                int32_t lsy = sy + i * sh / (COLOR_STEPS - 1);
-                int32_t lsh = sy + (i + 1) * sh / (COLOR_STEPS - 1) - lsy;
-                Output_DrawScreenGradientQuad(sx, lsy, sw, lsh, c1, c1, c2, c2);
-            }
-        } else {
-            for (int i = 0; i < COLOR_STEPS; i++) {
-                RGBA8888 color = m_ColorBarMap[bar_info->color][i];
-                int32_t lsy = sy + i * sh / COLOR_STEPS;
-                int32_t lsh = sy + (i + 1) * sh / COLOR_STEPS - lsy;
-                Output_DrawScreenFlatQuad(sx, lsy, sw, lsh, color);
-            }
-        }
-    }
-}
-
-void Overlay_BarDrawTextScaled(BAR_INFO *bar_info)
-{
-    const RGBA8888 rgb_bgnd = { 0, 0, 0, 255 };
-    const RGBA8888 rgb_border = { 53, 53, 53, 255 };
-
-    int32_t width = 200;
-    int32_t height = 10;
-
-    int32_t x = 0;
-    int32_t y = 0;
-    Overlay_BarGetLocation(bar_info, &width, &height, &x, &y);
-
-    int32_t padding = Screen_GetRenderScaleText(2);
-    int32_t border = Screen_GetRenderScaleText(2);
-
-    int32_t sx = Screen_GetRenderScaleText(x) - padding;
-    int32_t sy = Screen_GetRenderScaleText(y) - padding;
-    int32_t sw = Screen_GetRenderScaleText(width) + padding * 2;
-    int32_t sh = Screen_GetRenderScaleText(height) + padding * 2;
-
-    // border
-    Output_DrawScreenFlatQuad(
-        sx - border, sy - border, sw + 2 * border, sh + 2 * border, rgb_border);
-
-    // background
-    Output_DrawScreenFlatQuad(sx, sy, sw, sh, rgb_bgnd);
-
-    int32_t percent = Overlay_BarGetPercent(bar_info);
-
-    // Check if bar should flash or not
-    Overlay_BarBlink(bar_info);
-
-    if (percent && !bar_info->blink) {
-        width = width * percent / 100;
-
-        sx = Screen_GetRenderScaleText(x);
-        sy = Screen_GetRenderScaleText(y);
-        sw = Screen_GetRenderScaleText(width);
-        sh = Screen_GetRenderScaleText(height);
+        sx = scale_func(x);
+        sy = scale_func(y);
+        sw = scale_func(width);
+        sh = scale_func(height);
 
         if (g_Config.enable_smooth_bars) {
             for (int i = 0; i < COLOR_STEPS - 1; i++) {
@@ -402,7 +343,7 @@ void Overlay_BarDrawHealth(void)
         return;
     }
 
-    Overlay_BarDraw(&m_HealthBar);
+    Overlay_BarDraw(&m_HealthBar, Screen_GetRenderScaleBar);
 }
 
 void Overlay_BarDrawAir(void)
@@ -436,7 +377,7 @@ void Overlay_BarDrawAir(void)
         return;
     }
 
-    Overlay_BarDraw(&m_AirBar);
+    Overlay_BarDraw(&m_AirBar, Screen_GetRenderScaleBar);
 }
 
 void Overlay_BarDrawEnemy(void)
@@ -450,7 +391,7 @@ void Overlay_BarDrawEnemy(void)
         * ((g_GameInfo.bonus_flag & GBF_NGPLUS) ? 2 : 1);
     CLAMP(m_EnemyBar.value, 0, m_EnemyBar.max_value);
 
-    Overlay_BarDraw(&m_EnemyBar);
+    Overlay_BarDraw(&m_EnemyBar, Screen_GetRenderScaleBar);
 }
 
 void Overlay_RemoveAmmoText(void)

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -187,16 +187,16 @@ static void Overlay_BarGetLocation(
     } else if (
         bar_info->location == BL_TOP_RIGHT
         || bar_info->location == BL_BOTTOM_RIGHT) {
-        *x = Screen_GetResWidthDownscaledBar() - *width - screen_margin_h;
+        *x = Screen_GetResWidthDownscaled(RSR_BAR) - *width - screen_margin_h;
     } else {
-        *x = (Screen_GetResWidthDownscaledBar() - *width) / 2;
+        *x = (Screen_GetResWidthDownscaled(RSR_BAR) - *width) / 2;
     }
 
     if (bar_info->location == BL_TOP_LEFT || bar_info->location == BL_TOP_CENTER
         || bar_info->location == BL_TOP_RIGHT) {
         *y = screen_margin_v + m_BarOffsetY[bar_info->location];
     } else {
-        *y = Screen_GetResHeightDownscaledBar() - *height - screen_margin_v
+        *y = Screen_GetResHeightDownscaled(RSR_BAR) - *height - screen_margin_v
             - m_BarOffsetY[bar_info->location];
     }
 
@@ -212,7 +212,7 @@ static void Overlay_BarGetLocation(
     m_BarOffsetY[bar_info->location] += *height + bar_spacing;
 }
 
-void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func)
+void Overlay_BarDraw(BAR_INFO *bar_info, RENDER_SCALE_REF scale_ref)
 {
     const RGBA8888 rgb_bgnd = { 0, 0, 0, 255 };
     const RGBA8888 rgb_border = { 53, 53, 53, 255 };
@@ -224,13 +224,13 @@ void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func)
     int32_t y = 0;
     Overlay_BarGetLocation(bar_info, &width, &height, &x, &y);
 
-    int32_t padding = scale_func(2);
-    int32_t border = scale_func(2);
+    int32_t padding = Screen_GetRenderScale(2, scale_ref);
+    int32_t border = Screen_GetRenderScale(2, scale_ref);
 
-    int32_t sx = scale_func(x) - padding;
-    int32_t sy = scale_func(y) - padding;
-    int32_t sw = scale_func(width) + padding * 2;
-    int32_t sh = scale_func(height) + padding * 2;
+    int32_t sx = Screen_GetRenderScale(x, scale_ref) - padding;
+    int32_t sy = Screen_GetRenderScale(y, scale_ref) - padding;
+    int32_t sw = Screen_GetRenderScale(width, scale_ref) + padding * 2;
+    int32_t sh = Screen_GetRenderScale(height, scale_ref) + padding * 2;
 
     // border
     Output_DrawScreenFlatQuad(
@@ -247,10 +247,10 @@ void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func)
     if (percent && !bar_info->blink) {
         width = width * percent / 100;
 
-        sx = scale_func(x);
-        sy = scale_func(y);
-        sw = scale_func(width);
-        sh = scale_func(height);
+        sx = Screen_GetRenderScale(x, scale_ref);
+        sy = Screen_GetRenderScale(y, scale_ref);
+        sw = Screen_GetRenderScale(width, scale_ref);
+        sh = Screen_GetRenderScale(height, scale_ref);
 
         if (g_Config.enable_smooth_bars) {
             for (int i = 0; i < COLOR_STEPS - 1; i++) {
@@ -343,7 +343,7 @@ void Overlay_BarDrawHealth(void)
         return;
     }
 
-    Overlay_BarDraw(&m_HealthBar, Screen_GetRenderScaleBar);
+    Overlay_BarDraw(&m_HealthBar, RSR_BAR);
 }
 
 void Overlay_BarDrawAir(void)
@@ -377,7 +377,7 @@ void Overlay_BarDrawAir(void)
         return;
     }
 
-    Overlay_BarDraw(&m_AirBar, Screen_GetRenderScaleBar);
+    Overlay_BarDraw(&m_AirBar, RSR_BAR);
 }
 
 void Overlay_BarDrawEnemy(void)
@@ -391,7 +391,7 @@ void Overlay_BarDrawEnemy(void)
         * ((g_GameInfo.bonus_flag & GBF_NGPLUS) ? 2 : 1);
     CLAMP(m_EnemyBar.value, 0, m_EnemyBar.max_value);
 
-    Overlay_BarDraw(&m_EnemyBar, Screen_GetRenderScaleBar);
+    Overlay_BarDraw(&m_EnemyBar, RSR_BAR);
 }
 
 void Overlay_RemoveAmmoText(void)

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -12,6 +12,7 @@ void Overlay_Init(void);
 void Overlay_BarSetHealthTimer(int16_t health_bar_timer);
 void Overlay_BarHealthTimerTick(void);
 void Overlay_BarDraw(struct BAR_INFO *bar_info);
+void Overlay_BarDrawTextScaled(BAR_INFO *bar_info);
 void Overlay_BarDrawHealth(void);
 void Overlay_BarDrawAir(void);
 void Overlay_BarDrawEnemy(void);

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game/screen.h"
 #include "global/types.h"
 
 #include <stdbool.h>
@@ -11,8 +12,7 @@ void Overlay_Init(void);
 
 void Overlay_BarSetHealthTimer(int16_t health_bar_timer);
 void Overlay_BarHealthTimerTick(void);
-void Overlay_BarDraw(struct BAR_INFO *bar_info);
-void Overlay_BarDrawTextScaled(BAR_INFO *bar_info);
+void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func);
 void Overlay_BarDrawHealth(void);
 void Overlay_BarDrawAir(void);
 void Overlay_BarDrawEnemy(void);

--- a/src/game/overlay.h
+++ b/src/game/overlay.h
@@ -12,7 +12,7 @@ void Overlay_Init(void);
 
 void Overlay_BarSetHealthTimer(int16_t health_bar_timer);
 void Overlay_BarHealthTimerTick(void);
-void Overlay_BarDraw(BAR_INFO *bar_info, Screen_GetRenderScaleFunc scale_func);
+void Overlay_BarDraw(BAR_INFO *bar_info, RENDER_SCALE_REF scale_func);
 void Overlay_BarDrawHealth(void);
 void Overlay_BarDrawAir(void);
 void Overlay_BarDrawEnemy(void);

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -211,7 +211,7 @@ void Requester_AddItem(REQUEST_INFO *req, const char *string, uint16_t flag)
 void Requester_SetSize(REQUEST_INFO *req, int32_t max_lines, int16_t y)
 {
     req->y = y;
-    req->vis_lines = Screen_GetResHeightDownscaledText() / 2 / MAX_REQLINES;
+    req->vis_lines = Screen_GetResHeightDownscaled(RSR_TEXT) / 2 / MAX_REQLINES;
     if (req->vis_lines > max_lines) {
         req->vis_lines = max_lines;
     }

--- a/src/game/screen.c
+++ b/src/game/screen.c
@@ -97,34 +97,27 @@ int32_t Screen_GetResHeight(void)
     return m_Resolutions[m_ResolutionIdx].height;
 }
 
-int32_t Screen_GetResWidthDownscaledText(void)
+int32_t Screen_GetResWidthDownscaled(RENDER_SCALE_REF ref)
 {
-    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScaleText(PHD_ONE);
+    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScale(PHD_ONE, ref);
 }
 
-int32_t Screen_GetResHeightDownscaledText(void)
+int32_t Screen_GetResHeightDownscaled(RENDER_SCALE_REF ref)
 {
-    return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScaleText(PHD_ONE);
+    return Screen_GetResHeight() * PHD_ONE
+        / Screen_GetRenderScale(PHD_ONE, ref);
 }
 
-int32_t Screen_GetResWidthDownscaledBar(void)
+int32_t Screen_GetRenderScale(int32_t unit, RENDER_SCALE_REF ref)
 {
-    return Screen_GetResWidth() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
-}
-
-int32_t Screen_GetResHeightDownscaledBar(void)
-{
-    return Screen_GetResHeight() * PHD_ONE / Screen_GetRenderScaleBar(PHD_ONE);
-}
-
-int32_t Screen_GetRenderScaleText(int32_t unit)
-{
-    return Screen_GetRenderScaleBase(unit, 640, 480, g_Config.ui.text_scale);
-}
-
-int32_t Screen_GetRenderScaleBar(int32_t unit)
-{
-    return Screen_GetRenderScaleBase(unit, 640, 480, g_Config.ui.bar_scale);
+    if (ref == RSR_TEXT) {
+        return Screen_GetRenderScaleBase(
+            unit, 640, 480, g_Config.ui.text_scale);
+    } else if (ref == RSR_BAR) {
+        return Screen_GetRenderScaleBase(unit, 640, 480, g_Config.ui.bar_scale);
+    } else {
+        return Screen_GetRenderScaleBase(unit, 640, 480, 0);
+    }
 }
 
 int32_t Screen_GetRenderScaleBase(

--- a/src/game/screen.c
+++ b/src/game/screen.c
@@ -30,6 +30,8 @@ static RESOLUTION m_Resolutions[] = {
 };
 
 static void Screen_ApplyResolution(void);
+static int32_t Screen_GetRenderScaleBase(
+    int32_t unit, int32_t base_width, int32_t base_height, double factor);
 
 static void Screen_ApplyResolution(void)
 {
@@ -41,6 +43,18 @@ static void Screen_ApplyResolution(void)
 
     Matrix_ResetStack();
     Viewport_AlterFOV(g_Config.fov_value * PHD_DEGREE);
+}
+
+static int32_t Screen_GetRenderScaleBase(
+    int32_t unit, int32_t base_width, int32_t base_height, double factor)
+{
+    int32_t scale_x = Screen_GetResWidth() > base_width
+        ? ((double)Screen_GetResWidth() * unit * factor) / base_width
+        : unit * factor;
+    int32_t scale_y = Screen_GetResHeight() > base_height
+        ? ((double)Screen_GetResHeight() * unit * factor) / base_height
+        : unit * factor;
+    return MIN(scale_x, scale_y);
 }
 
 void Screen_Init(void)
@@ -118,18 +132,6 @@ int32_t Screen_GetRenderScale(int32_t unit, RENDER_SCALE_REF ref)
     } else {
         return Screen_GetRenderScaleBase(unit, 640, 480, 0);
     }
-}
-
-int32_t Screen_GetRenderScaleBase(
-    int32_t unit, int32_t base_width, int32_t base_height, double factor)
-{
-    int32_t scale_x = Screen_GetResWidth() > base_width
-        ? ((double)Screen_GetResWidth() * unit * factor) / base_width
-        : unit * factor;
-    int32_t scale_y = Screen_GetResHeight() > base_height
-        ? ((double)Screen_GetResHeight() * unit * factor) / base_height
-        : unit * factor;
-    return MIN(scale_x, scale_y);
 }
 
 int32_t Screen_GetRenderScaleGLRage(int32_t unit)

--- a/src/game/screen.h
+++ b/src/game/screen.h
@@ -15,8 +15,6 @@ int32_t Screen_GetResHeight(void);
 int32_t Screen_GetResWidthDownscaled(RENDER_SCALE_REF ref);
 int32_t Screen_GetResHeightDownscaled(RENDER_SCALE_REF ref);
 int32_t Screen_GetRenderScale(int32_t unit, RENDER_SCALE_REF ref);
-int32_t Screen_GetRenderScaleBase(
-    int32_t unit, int32_t base_width, int32_t base_height, double factor);
 int32_t Screen_GetRenderScaleGLRage(int32_t unit);
 
 bool Screen_CanSetPrevRes(void);

--- a/src/game/screen.h
+++ b/src/game/screen.h
@@ -17,6 +17,7 @@ int32_t Screen_GetRenderScaleBar(int32_t unit);
 int32_t Screen_GetRenderScaleBase(
     int32_t unit, int32_t base_width, int32_t base_height, double factor);
 int32_t Screen_GetRenderScaleGLRage(int32_t unit);
+typedef int32_t (*Screen_GetRenderScaleFunc)(int32_t);
 
 bool Screen_CanSetPrevRes(void);
 bool Screen_CanSetNextRes(void);

--- a/src/game/screen.h
+++ b/src/game/screen.h
@@ -3,21 +3,21 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+typedef enum RENDER_SCALE_REF {
+    RSR_TEXT = 0,
+    RSR_BAR = 1,
+} RENDER_SCALE_REF;
+
 void Screen_Init(void);
 
 int32_t Screen_GetResWidth(void);
 int32_t Screen_GetResHeight(void);
-int32_t Screen_GetResWidthDownscaledText(void);
-int32_t Screen_GetResHeightDownscaledText(void);
-int32_t Screen_GetResWidthDownscaledBar(void);
-int32_t Screen_GetResHeightDownscaledBar(void);
-
-int32_t Screen_GetRenderScaleText(int32_t unit);
-int32_t Screen_GetRenderScaleBar(int32_t unit);
+int32_t Screen_GetResWidthDownscaled(RENDER_SCALE_REF ref);
+int32_t Screen_GetResHeightDownscaled(RENDER_SCALE_REF ref);
+int32_t Screen_GetRenderScale(int32_t unit, RENDER_SCALE_REF ref);
 int32_t Screen_GetRenderScaleBase(
     int32_t unit, int32_t base_width, int32_t base_height, double factor);
 int32_t Screen_GetRenderScaleGLRage(int32_t unit);
-typedef int32_t (*Screen_GetRenderScaleFunc)(int32_t);
 
 bool Screen_CanSetPrevRes(void);
 bool Screen_CanSetNextRes(void);

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -566,7 +566,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.progress_bar && textstring->progress_bar.value) {
-        Overlay_BarDraw(&textstring->progress_bar);
+        Overlay_BarDrawTextScaled(&textstring->progress_bar);
     }
 
     if (textstring->flags.outline) {

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -566,7 +566,7 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.progress_bar && textstring->progress_bar.value) {
-        Overlay_BarDrawTextScaled(&textstring->progress_bar);
+        Overlay_BarDraw(&textstring->progress_bar, Screen_GetRenderScaleText);
     }
 
     if (textstring->flags.outline) {

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -491,15 +491,15 @@ static void Text_DrawText(TEXTSTRING *textstring)
     int32_t textwidth = Text_GetWidth(textstring);
 
     if (textstring->flags.centre_h) {
-        x += (Screen_GetResWidthDownscaledText() - textwidth) / 2;
+        x += (Screen_GetResWidthDownscaled(RSR_TEXT) - textwidth) / 2;
     } else if (textstring->flags.right) {
-        x += Screen_GetResWidthDownscaledText() - textwidth;
+        x += Screen_GetResWidthDownscaled(RSR_TEXT) - textwidth;
     }
 
     if (textstring->flags.centre_v) {
-        y += Screen_GetResHeightDownscaledText() / 2;
+        y += Screen_GetResHeightDownscaled(RSR_TEXT) / 2;
     } else if (textstring->flags.bottom) {
-        y += Screen_GetResHeightDownscaledText();
+        y += Screen_GetResHeightDownscaled(RSR_TEXT);
     }
 
     int32_t bxpos = textstring->bgnd_off.x + x - TEXT_BOX_OFFSET;
@@ -519,10 +519,10 @@ static void Text_DrawText(TEXTSTRING *textstring)
         }
 
         uint8_t sprite_num = Text_MapLetterToSpriteNum(letter);
-        sx = Screen_GetRenderScaleText(x);
-        sy = Screen_GetRenderScaleText(y);
-        sh = Screen_GetRenderScaleText(textstring->scale.h);
-        sv = Screen_GetRenderScaleText(textstring->scale.v);
+        sx = Screen_GetRenderScale(x, RSR_TEXT);
+        sy = Screen_GetRenderScale(y, RSR_TEXT);
+        sh = Screen_GetRenderScale(textstring->scale.h, RSR_TEXT);
+        sv = Screen_GetRenderScale(textstring->scale.v, RSR_TEXT);
 
         Output_DrawScreenSprite2D(
             sx, sy, 0, sh, sv, g_Objects[O_ALPHABET].mesh_index + sprite_num,
@@ -555,10 +555,10 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.background) {
-        sx = Screen_GetRenderScaleText(bxpos);
-        sy = Screen_GetRenderScaleText(bypos);
-        sh = Screen_GetRenderScaleText(bwidth);
-        sv = Screen_GetRenderScaleText(bheight);
+        sx = Screen_GetRenderScale(bxpos, RSR_TEXT);
+        sy = Screen_GetRenderScale(bypos, RSR_TEXT);
+        sh = Screen_GetRenderScale(bwidth, RSR_TEXT);
+        sv = Screen_GetRenderScale(bheight, RSR_TEXT);
 
         Text_DrawTextBackground(
             g_Config.ui.menu_style, sx, sy, sh, sv,
@@ -566,14 +566,14 @@ static void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.progress_bar && textstring->progress_bar.value) {
-        Overlay_BarDraw(&textstring->progress_bar, Screen_GetRenderScaleText);
+        Overlay_BarDraw(&textstring->progress_bar, RSR_TEXT);
     }
 
     if (textstring->flags.outline) {
-        sx = Screen_GetRenderScaleText(bxpos);
-        sy = Screen_GetRenderScaleText(bypos);
-        sh = Screen_GetRenderScaleText(bwidth);
-        sv = Screen_GetRenderScaleText(bheight);
+        sx = Screen_GetRenderScale(bxpos, RSR_TEXT);
+        sy = Screen_GetRenderScale(bypos, RSR_TEXT);
+        sh = Screen_GetRenderScale(bwidth, RSR_TEXT);
+        sv = Screen_GetRenderScale(bheight, RSR_TEXT);
 
         Text_DrawTextOutline(
             g_Config.ui.menu_style, sx, sy, sh, sv, textstring->outline.style);


### PR DESCRIPTION
Resolves #930.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the reset and unbind progress bars in the controls menu for non-default bar scaling. The progress bar needs to depend on text scaling instead of the bar scaling since it is positioned behind the reset and unbind text in the controls menu.