### PR TITLE
lara: fix TR2 style walk-run-jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed dead centaurs exploding again after saving and reloading (#924)
 - fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
 - fixed jump-twist animations at times being interrupted (#932, regression from 2.15.1)
+- fixed walk-run-jump at times breaking when TR2 jumping is enabled (OG bug in TR2+) (#934)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -76,6 +76,9 @@ void Lara_State_Walk(ITEM_INFO *item, COLL_INFO *coll)
 
     if (g_Input.forward) {
         item->goal_anim_state = g_Input.slow ? LS_WALK : LS_RUN;
+        if (g_Config.enable_tr2_jumping && !g_Input.slow) {
+            m_JumpPermitted = true;
+        }
     } else {
         item->goal_anim_state = LS_STOP;
     }


### PR DESCRIPTION
Resolves #934.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This is the specific sequence to break walk-jun-jump.

1. Enter `Lara_State_Run`; `m_JumpPermitted` is set to `false`
2. Interrupt `LA_RUN (anim 0)` by rolling, for example; `m_JumpPermitted` is still false
3. Enter `Lara_State_Walk` and release walk. The state changes here will link to `WALK_TO_RUN_RIGHT (anim 4)` or `WALK_TO_RUN_LEFT (anim 5)`, depending on the frame.
4. These interim animations link directly to `LA_RUN (0)`, but link to frame 8 or 19. Their state IDs are the same as walk, so control remains in `Lara_State_Walk` until the state change is processed.
5. `m_JumpPermitted` will remain `false` until the frame cycles round again to `LF_JUMP_READY (4)` - so 18 frames have to play out for `WALK_TO_RUN_RIGHT` or 7 frames for `WALK_TO_RUN_LEFT`.

The fix is to set `m_JumpPermitted` to `true` at step 3 above when walk is released. For any other situation, Lara will enter `LA_RUN` again from scratch, so the normal lock check will play out.