### PR TITLE
lara: fix automatic slope jump-twists

### DIFF
--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -484,7 +484,7 @@ void Lara_State_Slide(ITEM_INFO *item, COLL_INFO *coll)
 {
     g_Camera.flags = NO_CHUNKY;
     g_Camera.target_elevation = -45 * PHD_DEGREE;
-    if (g_Input.jump) {
+    if (g_Input.jump && (!g_Config.enable_jump_twists || !g_Input.back)) {
         item->goal_anim_state = LS_JUMP_FORWARD;
     }
 }
@@ -560,7 +560,7 @@ void Lara_State_HangRight(ITEM_INFO *item, COLL_INFO *coll)
 
 void Lara_State_SlideBack(ITEM_INFO *item, COLL_INFO *coll)
 {
-    if (g_Input.jump) {
+    if (g_Input.jump && (!g_Config.enable_jump_twists || !g_Input.forward)) {
         item->goal_anim_state = LS_JUMP_BACK;
     }
 }


### PR DESCRIPTION
Resolves #949.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This keeps jump-twist behaviour in line with TR2 on slopes - so if you want to jump-twist, you have to release the inputs and press them again at the right time. Comparison video below.

https://youtu.be/BvlHGnL4rJ8

I didn't add a changelog entry as the entry added from #935 covers it, and this doesn't affect the current release.
