### PR TITLE
camera: fix floor data parsing in trigger refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed incorrect trapdoor triggers in City of Khamoon and a switch trigger in Obelisk of Khamoon (#942)
 - fixed the setup of two music triggers in St. Francis' Folly (#865)
 - fixed data portal issues in Atlantean Stronghold that could result in a crash (#227)
+- fixed the camera in Natla's Mines when pulling the lever in room 67 (#352)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -817,7 +817,7 @@ void Camera_RefreshFromTrigger(int16_t type, int16_t *data)
 
         switch (TRIG_BITS(trigger)) {
         case TO_CAMERA:
-            data++;
+            trigger = *data++;
 
             if (value == g_Camera.last) {
                 g_Camera.number = value;


### PR DESCRIPTION
Resolves #352.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This corrects the parsing in the camera trigger refresh control. We now store the extra camera `int16_t` so that `trigger & END_BIT` can be properly tested. This is in line with `Room_TestTriggers`.

Demo video for Natla's Mines [here](https://github.com/LostArtefacts/Tomb1Main/issues/352#issuecomment-1697943283).

A perfect storm was needed for the issue itself. The parsing would reach index 5415 below and would then skip over the final value (the camera setup).

![image](https://github.com/LostArtefacts/Tomb1Main/assets/33758420/84edabbe-b9b2-492d-9e71-21ccc38cf896)

Because the end bit is stored on the camera setup and not the action item, control would continue into entry 5417.

![image](https://github.com/LostArtefacts/Tomb1Main/assets/33758420/a467c624-9fc9-4c73-8670-64ece33b59e3)

This plays out as follows:
`trigger = 34308; // 0x8604`
`value = 34308 & VALUE_BITS; // 34308 & 1023 => 516`
`switch(TRIG_BITS(trigger)) // (34308 & 15360) >> 10 => 1`

So control falls into `TO_CAMERA (1)` and because `value != g_Camera.last`, `target_ok` becomes `0` and so the camera returns to Lara.

Interestingly too, if the original trigger were setup as follows, this would never have been an issue because the end bit would be detected on the "look at entry". But the order of action items should not matter as a rule.

![image](https://github.com/LostArtefacts/Tomb1Main/assets/33758420/e7d97609-f2d6-4ea8-aacb-6e21b16c52ef)
