### PR TITLE
savegame: fix flame emitter item data save and load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed the setup of two music triggers in St. Francis' Folly (#865)
 - fixed data portal issues in Atlantean Stronghold that could result in a crash (#227)
 - fixed the camera in Natla's Mines when pulling the lever in room 67 (#352)
+- fixed flame emitter saving and loading which caused rare crashing (#947)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15


### PR DESCRIPTION
Resolves #947

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Alternative implementation of #952. Rather than trying to rely on the order of loaded items, we reuse the calculated FX IDs and adjust `item->data` as necessary.