### PR TITLE
effects: simplify linked lists management

### DIFF
--- a/src/game/effects.c
+++ b/src/game/effects.c
@@ -19,9 +19,11 @@ void Effect_InitialiseArray(void)
     g_NextFxActive = NO_ITEM;
     m_NextFxFree = 0;
     for (int i = 0; i < NUM_EFFECTS - 1; i++) {
-        g_Effects[i].next_fx = i + 1;
+        g_Effects[i].next_draw = i + 1;
+        g_Effects[i].next_free = i + 1;
     }
-    g_Effects[NUM_EFFECTS - 1].next_fx = NO_ITEM;
+    g_Effects[NUM_EFFECTS - 1].next_draw = NO_ITEM;
+    g_Effects[NUM_EFFECTS - 1].next_free = NO_ITEM;
 }
 
 void Effect_Control(void)
@@ -45,11 +47,11 @@ int16_t Effect_Create(int16_t room_num)
     }
 
     FX_INFO *fx = &g_Effects[fx_num];
-    m_NextFxFree = fx->next_fx;
+    m_NextFxFree = fx->next_free;
 
     ROOM_INFO *r = &g_RoomInfo[room_num];
     fx->room_number = room_num;
-    fx->next_fx = r->fx_number;
+    fx->next_draw = r->fx_number;
     r->fx_number = fx_num;
 
     fx->next_active = g_NextFxActive;
@@ -62,32 +64,35 @@ void Effect_Kill(int16_t fx_num)
 {
     FX_INFO *fx = &g_Effects[fx_num];
 
-    int16_t linknum = g_NextFxActive;
-    if (linknum == fx_num) {
+    if (g_NextFxActive == fx_num) {
         g_NextFxActive = fx->next_active;
     } else {
-        for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_active) {
-            if (g_Effects[linknum].next_active == fx_num) {
-                g_Effects[linknum].next_active = fx->next_active;
-                break;
+        int16_t linknum = g_NextFxActive;
+        while (linknum != NO_ITEM) {
+            FX_INFO *fx_link = &g_Effects[linknum];
+            if (fx_link->next_active == fx_num) {
+                fx_link->next_active = fx->next_active;
             }
+            linknum = fx_link->next_active;
         }
     }
 
     ROOM_INFO *r = &g_RoomInfo[fx->room_number];
-    linknum = r->fx_number;
-    if (linknum == fx_num) {
-        r->fx_number = fx->next_fx;
+    if (r->fx_number == fx_num) {
+        r->fx_number = fx->next_draw;
     } else {
-        for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_fx) {
-            if (g_Effects[linknum].next_fx == fx_num) {
-                g_Effects[linknum].next_fx = fx->next_fx;
+        int16_t linknum = r->fx_number;
+        while (linknum != NO_ITEM) {
+            FX_INFO *fx_link = &g_Effects[linknum];
+            if (fx_link->next_draw == fx_num) {
+                fx_link->next_draw = fx->next_draw;
                 break;
             }
+            linknum = fx_link->next_draw;
         }
     }
 
-    fx->next_fx = m_NextFxFree;
+    fx->next_free = m_NextFxFree;
     m_NextFxFree = fx_num;
 }
 
@@ -98,11 +103,11 @@ void Effect_NewRoom(int16_t fx_num, int16_t room_num)
 
     int16_t linknum = r->fx_number;
     if (linknum == fx_num) {
-        r->fx_number = fx->next_fx;
+        r->fx_number = fx->next_draw;
     } else {
-        for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_fx) {
-            if (g_Effects[linknum].next_fx == fx_num) {
-                g_Effects[linknum].next_fx = fx->next_fx;
+        for (; linknum != NO_ITEM; linknum = g_Effects[linknum].next_draw) {
+            if (g_Effects[linknum].next_draw == fx_num) {
+                g_Effects[linknum].next_draw = fx->next_draw;
                 break;
             }
         }
@@ -110,7 +115,7 @@ void Effect_NewRoom(int16_t fx_num, int16_t room_num)
 
     r = &g_RoomInfo[room_num];
     fx->room_number = room_num;
-    fx->next_fx = r->fx_number;
+    fx->next_draw = r->fx_number;
     r->fx_number = fx_num;
 }
 

--- a/src/game/room_draw.c
+++ b/src/game/room_draw.c
@@ -281,7 +281,7 @@ void Room_DrawSingleRoom(int16_t room_num)
         }
     }
 
-    for (int i = r->fx_number; i != NO_ITEM; i = g_Effects[i].next_fx) {
+    for (int i = r->fx_number; i != NO_ITEM; i = g_Effects[i].next_draw) {
         Effect_Draw(i);
     }
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1445,8 +1445,9 @@ typedef struct FX_INFO {
     PHD_3DPOS pos;
     int16_t room_number;
     GAME_OBJECT_ID object_number;
-    int16_t next_fx;
+    int16_t next_draw;
     int16_t next_active;
+    int16_t next_free;
     int16_t speed;
     int16_t fall_speed;
     int16_t frame_number;


### PR DESCRIPTION
The next_fx was split into a draw and a free pointer, which makes it easier to understand.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The next_fx was split into a draw and a free pointer, which makes it easier to understand. Originally I had thought this was an OG bug but actually it seems to be working fine, so it's just a cleanup PR.
