### PR TITLE
passport: fix new game plus if enable_game_modes set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed data portal issues in Atlantean Stronghold that could result in a crash (#227)
 - fixed the camera in Natla's Mines when pulling the lever in room 67 (#352)
 - fixed flame emitter saving and loading which caused rare crashing (#947)
+- fixed new game plus not working if enable_game_modes was set to false (#960, regression from 2.8)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -481,7 +481,6 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                     } else {
                         g_GameInfo.save_initial_version =
                             SAVEGAME_CURRENT_VERSION;
-                        g_GameInfo.bonus_flag = 0;
                     }
                 } else if (
                     g_InvMode == INV_SAVE_MODE


### PR DESCRIPTION
Resolves #960.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed new game plus not working if enable_game_modes was set to false.
