### PR TITLE
config: move enable_game_modes to config and add gameflow override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed the camera in Natla's Mines when pulling the lever in room 67 (#352)
 - fixed flame emitter saving and loading which caused rare crashing (#947)
 - fixed new game plus not working if enable_game_modes was set to false (#960, regression from 2.8)
+- moved the enable_game_modes option from the gameflow to the config tool and added a gameflow option to override (#962)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -10,8 +10,8 @@
     "savegame_fmt_bson": "save_tr1_%02d.dat",
 
     // whether to allow user to select NG/NG+/etc. modes in the new game dialog
-    // overrides the config file option enable_game_modes
-    "override_game_modes": false,
+    // disables the config option enable_game_modes until a playthrough is completed
+    "disable_game_modes": false,
 
     // disables saving except in the locations near the crystals.
     "enable_save_crystals": false,

--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -10,7 +10,8 @@
     "savegame_fmt_bson": "save_tr1_%02d.dat",
 
     // whether to allow user to select NG/NG+/etc. modes in the new game dialog
-    "enable_game_modes": true,
+    // overrides the config file option enable_game_modes
+    "override_game_modes": false,
 
     // disables saving except in the locations near the crystals.
     "enable_save_crystals": false,

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -4,7 +4,7 @@
     "main_menu_picture": "data/titleh_ub.png",
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
-    "override_game_modes": false,
+    "disable_game_modes ": false,
     "enable_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -4,7 +4,7 @@
     "main_menu_picture": "data/titleh_ub.png",
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
-    "enable_game_modes": true,
+    "override_game_modes": false,
     "enable_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],

--- a/src/config.c
+++ b/src/config.c
@@ -235,6 +235,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(load_music_triggers, true);
     READ_BOOL(fix_item_rots, true);
     READ_BOOL(restore_ps1_enemies, false);
+    READ_BOOL(enable_game_modes, true);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -423,6 +424,7 @@ bool Config_Write(void)
     WRITE_BOOL(load_music_triggers);
     WRITE_BOOL(fix_item_rots);
     WRITE_BOOL(restore_ps1_enemies);
+    WRITE_BOOL(enable_game_modes);
 
     // User settings
     WRITE_BOOL(rendering.enable_bilinear_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -115,6 +115,7 @@ typedef struct {
     bool load_music_triggers;
     bool fix_item_rots;
     bool restore_ps1_enemies;
+    bool enable_game_modes;
 
     struct {
         int32_t layout;

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -228,8 +228,8 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     }
     g_GameFlow.demo_delay = tmp_d * FRAMES_PER_SECOND;
 
-    g_GameFlow.override_game_modes =
-        json_object_get_bool(obj, "override_game_modes", false);
+    g_GameFlow.disable_game_modes =
+        json_object_get_bool(obj, "disable_game_modes ", false);
 
     tmp_i =
         json_object_get_bool(obj, "enable_save_crystals", JSON_INVALID_BOOL);

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -228,12 +228,8 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     }
     g_GameFlow.demo_delay = tmp_d * FRAMES_PER_SECOND;
 
-    tmp_i = json_object_get_bool(obj, "enable_game_modes", JSON_INVALID_BOOL);
-    if (tmp_i == JSON_INVALID_BOOL) {
-        LOG_ERROR("'enable_game_modes' must be a boolean");
-        return false;
-    }
-    g_GameFlow.enable_game_modes = tmp_i;
+    g_GameFlow.override_game_modes =
+        json_object_get_bool(obj, "override_game_modes", false);
 
     tmp_i =
         json_object_get_bool(obj, "enable_save_crystals", JSON_INVALID_BOOL);

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -66,7 +66,7 @@ typedef struct GAMEFLOW {
     char *savegame_fmt_bson;
     int8_t has_demo;
     int32_t demo_delay;
-    int8_t enable_game_modes;
+    bool override_game_modes;
     int8_t enable_save_crystals;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -66,7 +66,7 @@ typedef struct GAMEFLOW {
     char *savegame_fmt_bson;
     int8_t has_demo;
     int32_t demo_delay;
-    bool override_game_modes;
+    bool disable_game_modes;
     int8_t enable_save_crystals;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -473,7 +473,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                 if (g_InvMode == INV_TITLE_MODE
                     || (g_CurrentLevel == g_GameFlow.gym_level_num
                         && g_InvMode != INV_DEATH_MODE)) {
-                    if (g_GameFlow.enable_game_modes) {
+                    if (g_Config.enable_game_modes
+                        && !g_GameFlow.override_game_modes) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
                         g_Input = (INPUT_STATE) { 0 };

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -474,7 +474,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                     || (g_CurrentLevel == g_GameFlow.gym_level_num
                         && g_InvMode != INV_DEATH_MODE)) {
                     if (g_Config.enable_game_modes
-                        && !g_GameFlow.override_game_modes) {
+                        && !g_GameFlow.disable_game_modes) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
                         g_Input = (INPUT_STATE) { 0 };

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -377,6 +377,7 @@ static bool Savegame_BSON_LoadMisc(
         return false;
     }
     game_info->bonus_flag = json_object_get_int(misc_obj, "bonus_flag", 0);
+    LOG_DEBUG("Load bonus_flag: %d", game_info->bonus_flag);
     return true;
 }
 
@@ -926,6 +927,7 @@ static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info)
     assert(game_info);
     struct json_object_s *misc_obj = json_object_new();
     json_object_append_int(misc_obj, "bonus_flag", game_info->bonus_flag);
+    LOG_DEBUG("Dump bonus_flag: %d", game_info->bonus_flag);
     return misc_obj;
 }
 

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -243,6 +243,10 @@
       "Title": "Restore PS1 enemies",
       "Description": "Adds the mummy that appears in the PlayStation version of City of Khamoon, room 25.\nChanging this option will require restarting the level."
     },
+    "enable_game_modes": {
+      "Title": "Enable game modes",
+      "Description": "Allows new game plus options to be selected from the new game passport menu.\n- New Game+: unlocks all weapons with infinite ammo; enemies have double the HP.\n- Japanese NG: weapons do double damage.\n- Japanese NG+: combination of New Game+ and Japanese NG."
+    },
     "enable_timer_in_inventory": {
       "Title": "Timer counts in inventory",
       "Description": "Makes the in-game timer work even while the game is showing the inventory."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -243,6 +243,10 @@
       "Title": "Restaure les ennemis PlayStation",
       "Description": "Remet la momie absente sur la version PC mais présente dans la version PlayStation (room 25).\nAttention, changer cette option sur une partie en cours nécessite de redémarrer le niveau, pour être prise en charge."
     },
+    "enable_game_modes": {
+      "Title": "Activer les différents modes de jeu",
+      "Description": "Permet de sélectionner de nouveaux modes de jeu dans le menu nouvelle partie du passeport au menu principal.\n- Nouvelle partie + : Déverrouille toutes les armes avec munitions infinies ; les ennemis ont le double de points de vie.\n- Version Japonaise : Les armes font le double de dégâts.\n- Version Japonaise + : Combine le mode Version Japonaise et le mode Nouvelle partie +."
+    },
     "enable_timer_in_inventory": {
       "Title": "Compteur de temps de jeu dans l'inventaire",
       "Description": "Fait fonctionner le conteur du jeu même en étant dans les menus de l'inventaire."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -272,6 +272,11 @@
           "DefaultValue": false
         },
         {
+          "Field": "enable_game_modes",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "enable_timer_in_inventory",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
Resolves #962.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Moved the `enable_game_modes` option from the gameflow to the config tool.
