### PR TITLE
config: move enable_save_crystals to config; add override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed flame emitter saving and loading which caused rare crashing (#947)
 - fixed new game plus not working if enable_game_modes was set to false (#960, regression from 2.8)
 - moved the enable_game_modes option from the gameflow to the config tool and added a gameflow option to override (#962)
+- moved the enable_save_crystals option from the gameflow to the config tool (#962)
 - improve spanish localization and added translation for rotated pickups
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15

--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -15,7 +15,7 @@
 
     // forces whether save crystals are enabled or not
     // overrides the config option enable_save_crystals
-    "enable_save_crystals_option": true,
+    "force_enable_save_crystals": false,
 
     // seconds to pass in the main menu before playing the demo
     "demo_delay": 16,

--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -13,8 +13,9 @@
     // disables the config option enable_game_modes until a playthrough is completed
     "disable_game_modes": false,
 
-    // disables saving except in the locations near the crystals.
-    "enable_save_crystals": false,
+    // forces whether save crystals are enabled or not
+    // overrides the config option enable_save_crystals
+    "enable_save_crystals_option": true,
 
     // seconds to pass in the main menu before playing the demo
     "demo_delay": 16,

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -5,7 +5,7 @@
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
     "disable_game_modes ": false,
-    "enable_save_crystals": false,
+    "enable_save_crystals_option": true,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],
     "draw_distance_fade": 22,

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -5,7 +5,7 @@
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
     "disable_game_modes ": false,
-    "enable_save_crystals_option": true,
+    "force_enable_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],
     "draw_distance_fade": 22,

--- a/src/config.c
+++ b/src/config.c
@@ -236,6 +236,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(fix_item_rots, true);
     READ_BOOL(restore_ps1_enemies, false);
     READ_BOOL(enable_game_modes, true);
+    READ_BOOL(enable_save_crystals, false);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -425,6 +426,7 @@ bool Config_Write(void)
     WRITE_BOOL(fix_item_rots);
     WRITE_BOOL(restore_ps1_enemies);
     WRITE_BOOL(enable_game_modes);
+    WRITE_BOOL(enable_save_crystals);
 
     // User settings
     WRITE_BOOL(rendering.enable_bilinear_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -116,6 +116,7 @@ typedef struct {
     bool fix_item_rots;
     bool restore_ps1_enemies;
     bool enable_game_modes;
+    bool enable_save_crystals;
 
     struct {
         int32_t layout;

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -255,7 +255,7 @@ int32_t Game_Loop(GAMEFLOW_LEVEL_TYPE level_type)
     g_GameInfo.current[g_CurrentLevel].stats.max_secret_count =
         Stats_GetSecrets();
 
-    bool ask_for_save = g_GameFlow.enable_save_crystals
+    bool ask_for_save = g_Config.enable_save_crystals
         && level_type == GFL_NORMAL
         && g_CurrentLevel != g_GameFlow.first_level_num
         && g_CurrentLevel != g_GameFlow.gym_level_num;

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -231,14 +231,8 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     g_GameFlow.disable_game_modes =
         json_object_get_bool(obj, "disable_game_modes ", false);
 
-    g_GameFlow.enable_save_crystals_option =
-        json_object_get_bool(obj, "enable_save_crystals_option", false);
-    g_Config.enable_save_crystals &= g_GameFlow.enable_save_crystals_option;
-    LOG_DEBUG(
-        "g_GameFlow.enable_save_crystals_option: %d",
-        g_GameFlow.enable_save_crystals_option);
-    LOG_DEBUG(
-        "g_Config.enable_save_crystals: %d", g_Config.enable_save_crystals);
+    g_GameFlow.force_enable_save_crystals =
+        json_object_get_bool(obj, "force_enable_save_crystals", false);
 
     tmp_arr = json_object_get_array(obj, "water_color");
     g_GameFlow.water_color.r = 0.6;
@@ -1116,6 +1110,10 @@ bool GameFlow_LoadFromFile(const char *file_name)
     g_InvItemSound.string = g_GameFlow.strings[GS_INV_ITEM_SOUND];
     g_InvItemControls.string = g_GameFlow.strings[GS_INV_ITEM_CONTROLS];
     g_InvItemLarasHome.string = g_GameFlow.strings[GS_INV_ITEM_LARAS_HOME];
+
+    if (g_GameFlow.force_enable_save_crystals) {
+        g_Config.enable_save_crystals = true;
+    }
 
     return result;
 }

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -231,13 +231,14 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     g_GameFlow.disable_game_modes =
         json_object_get_bool(obj, "disable_game_modes ", false);
 
-    tmp_i =
-        json_object_get_bool(obj, "enable_save_crystals", JSON_INVALID_BOOL);
-    if (tmp_i == JSON_INVALID_BOOL) {
-        LOG_ERROR("'enable_save_crystals' must be a boolean");
-        return false;
-    }
-    g_GameFlow.enable_save_crystals = tmp_i;
+    g_GameFlow.enable_save_crystals_option =
+        json_object_get_bool(obj, "enable_save_crystals_option", false);
+    g_Config.enable_save_crystals &= g_GameFlow.enable_save_crystals_option;
+    LOG_DEBUG(
+        "g_GameFlow.enable_save_crystals_option: %d",
+        g_GameFlow.enable_save_crystals_option);
+    LOG_DEBUG(
+        "g_Config.enable_save_crystals: %d", g_Config.enable_save_crystals);
 
     tmp_arr = json_object_get_array(obj, "water_color");
     g_GameFlow.water_color.r = 0.6;

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -67,7 +67,7 @@ typedef struct GAMEFLOW {
     int8_t has_demo;
     int32_t demo_delay;
     bool disable_game_modes;
-    bool enable_save_crystals_option;
+    bool force_enable_save_crystals;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];
     RGBF water_color;

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -67,7 +67,7 @@ typedef struct GAMEFLOW {
     int8_t has_demo;
     int32_t demo_delay;
     bool disable_game_modes;
-    int8_t enable_save_crystals;
+    bool enable_save_crystals_option;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];
     RGBF water_color;

--- a/src/game/objects/general/save_crystal.c
+++ b/src/game/objects/general/save_crystal.c
@@ -1,6 +1,6 @@
 #include "game/objects/general/save_crystal.h"
 
-#include "game/gameflow.h"
+#include "config.h"
 #include "game/input.h"
 #include "game/inventory.h"
 #include "game/items.h"
@@ -17,7 +17,7 @@ static int16_t m_CrystalBounds[12] = {
 void SaveCrystal_Setup(OBJECT_INFO *obj)
 {
     obj->initialise = SaveCrystal_Initialise;
-    if (g_GameFlow.enable_save_crystals) {
+    if (g_Config.enable_save_crystals) {
         obj->control = SaveCrystal_Control;
         obj->collision = SaveCrystal_Collision;
         obj->save_flags = 1;
@@ -26,7 +26,7 @@ void SaveCrystal_Setup(OBJECT_INFO *obj)
 
 void SaveCrystal_Initialise(int16_t item_num)
 {
-    if (g_GameFlow.enable_save_crystals) {
+    if (g_Config.enable_save_crystals) {
         Item_AddActive(item_num);
     } else {
         g_Items[item_num].status = IS_INVISIBLE;

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -516,7 +516,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
     bool pages_available[PASSPORT_PAGE_COUNT] = {
         g_SavedGamesCount > 0,
         g_InvMode == INV_TITLE_MODE || g_InvMode == INV_SAVE_CRYSTAL_MODE
-            || !g_GameFlow.enable_save_crystals,
+            || !g_Config.enable_save_crystals,
         true,
     };
 

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -183,6 +183,10 @@
       "Title": "Remove Uzis",
       "Description": "Removes all Uzi guns and Uzi ammo pickups from the game."
     },
+    "enable_save_crystals": {
+      "Title": "Enable save crystals",
+      "Description": "Limits saving to the beginning of levels save crystals. Levels have limited, single use save crystals like the PS1 version. Changing this option will require restarting the level."
+    },
     "walk_to_items": {
       "Title": "Animated interactions",
       "Description": "Makes Lara walk to pickups and switches when nearby instead of teleporting to them."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -183,6 +183,10 @@
       "Title": "Supprimer les uzis",
       "Description": "Supprime tous les uzis et leurs munitions de tout le jeu."
     },
+    "enable_save_crystals": {
+      "Title": "Activer le mode de sauvegarde par cristaux",
+      "Description": "Active le système de sauvegarde de la version PlayStation par cristaux.  La sauvegarde se limite à chaque début de niveau et à chaque rencontre d’un cristal de sauvegarde à usage unique dans les niveaux. Changer cette option nécessitera de redémarrer le niveau."
+    },
     "walk_to_items": {
       "Title": "Interactions animées - Placement automatique",
       "Description": "Fait marcher Lara vers les collectibles et les interrupteurs à proximité, au lieu de se téléporter vers eux."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -195,6 +195,11 @@
       "Image": "Graphics/graphic4.jpg",
       "Properties": [
         {
+          "Field": "enable_save_crystals",
+          "DataType": "Bool",
+          "DefaultValue": false
+        },
+        {
           "Field": "walk_to_items",
           "DataType": "Bool",
           "DefaultValue": false


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Moved the enable_save_crystals option from the gameflow to the config tool. Added a gameflow option to force a mode for custom levels. Resolves #963. In a future PR, I will rename `disable_game_modes` to follow this naming convent (`enable_...`) and do an `&` with the gameflow and config option.