### PR TITLE
gameflow: rework game mode override to match save crystals

### DIFF
--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -11,7 +11,7 @@
 
     // whether to allow user to select NG/NG+/etc. modes in the new game dialog
     // disables the config option enable_game_modes until a playthrough is completed
-    "disable_game_modes": false,
+    "force_enable_game_modes": false,
 
     // forces whether save crystals are enabled or not
     // overrides the config option enable_save_crystals

--- a/bin/cfg/Tomb1Main_gameflow.json5
+++ b/bin/cfg/Tomb1Main_gameflow.json5
@@ -9,11 +9,11 @@
     "savegame_fmt_legacy": "saveati.%d",
     "savegame_fmt_bson": "save_tr1_%02d.dat",
 
-    // whether to allow user to select NG/NG+/etc. modes in the new game dialog
-    // disables the config option enable_game_modes until a playthrough is completed
-    "force_enable_game_modes": false,
+    // forces game mode selection to be disabled if true so the user can't select NG+ modes until a playthrough is completed
+    // overrides the config option enable_game_modes
+    "force_disable_game_modes": false,
 
-    // forces whether save crystals are enabled or not
+    // forces save crystals to be enabled if true
     // overrides the config option enable_save_crystals
     "force_enable_save_crystals": false,
 

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -4,7 +4,7 @@
     "main_menu_picture": "data/titleh_ub.png",
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
-    "force_enable_game_modes": false,
+    "force_disable_game_modes": false,
     "force_enable_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],

--- a/bin/cfg/Tomb1Main_gameflow_ub.json5
+++ b/bin/cfg/Tomb1Main_gameflow_ub.json5
@@ -4,7 +4,7 @@
     "main_menu_picture": "data/titleh_ub.png",
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
-    "disable_game_modes ": false,
+    "force_enable_game_modes": false,
     "force_enable_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -228,8 +228,8 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     }
     g_GameFlow.demo_delay = tmp_d * FRAMES_PER_SECOND;
 
-    g_GameFlow.disable_game_modes =
-        json_object_get_bool(obj, "disable_game_modes ", false);
+    g_GameFlow.force_enable_game_modes =
+        json_object_get_bool(obj, "force_enable_game_modes", false);
 
     g_GameFlow.force_enable_save_crystals =
         json_object_get_bool(obj, "force_enable_save_crystals", false);
@@ -1113,6 +1113,10 @@ bool GameFlow_LoadFromFile(const char *file_name)
 
     if (g_GameFlow.force_enable_save_crystals) {
         g_Config.enable_save_crystals = true;
+    }
+
+    if (g_GameFlow.force_enable_game_modes) {
+        g_Config.enable_game_modes = true;
     }
 
     return result;

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -228,8 +228,8 @@ static bool GameFlow_LoadScriptMeta(struct json_object_s *obj)
     }
     g_GameFlow.demo_delay = tmp_d * FRAMES_PER_SECOND;
 
-    g_GameFlow.force_enable_game_modes =
-        json_object_get_bool(obj, "force_enable_game_modes", false);
+    g_GameFlow.force_disable_game_modes =
+        json_object_get_bool(obj, "force_disable_game_modes", false);
 
     g_GameFlow.force_enable_save_crystals =
         json_object_get_bool(obj, "force_enable_save_crystals", false);
@@ -1115,7 +1115,7 @@ bool GameFlow_LoadFromFile(const char *file_name)
         g_Config.enable_save_crystals = true;
     }
 
-    if (g_GameFlow.force_enable_game_modes) {
+    if (g_GameFlow.force_disable_game_modes) {
         g_Config.enable_game_modes = true;
     }
 

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1116,7 +1116,7 @@ bool GameFlow_LoadFromFile(const char *file_name)
     }
 
     if (g_GameFlow.force_disable_game_modes) {
-        g_Config.enable_game_modes = true;
+        g_Config.enable_game_modes = false;
     }
 
     return result;

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -66,7 +66,7 @@ typedef struct GAMEFLOW {
     char *savegame_fmt_bson;
     int8_t has_demo;
     int32_t demo_delay;
-    bool force_enable_game_modes;
+    bool force_disable_game_modes;
     bool force_enable_save_crystals;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -66,7 +66,7 @@ typedef struct GAMEFLOW {
     char *savegame_fmt_bson;
     int8_t has_demo;
     int32_t demo_delay;
-    bool disable_game_modes;
+    bool force_enable_game_modes;
     bool force_enable_save_crystals;
     GAMEFLOW_LEVEL *levels;
     char *strings[GS_NUMBER_OF];

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -473,8 +473,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                 if (g_InvMode == INV_TITLE_MODE
                     || (g_CurrentLevel == g_GameFlow.gym_level_num
                         && g_InvMode != INV_DEATH_MODE)) {
-                    if (g_Config.enable_game_modes
-                        && !g_GameFlow.disable_game_modes) {
+                    if (g_Config.enable_game_modes) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
                         g_Input = (INPUT_STATE) { 0 };


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Renamed game modes override to `force_enable_game_modes` and matched save crystal override implementation. Mostly internal change since the gameflow override option was never officially released.