### PR TITLE
natla: move facing property to item scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed the camera in Natla's Mines when pulling the lever in room 67 (#352)
 - fixed flame emitter saving and loading which caused rare crashing (#947)
 - fixed new game plus not working if enable_game_modes was set to false (#960, regression from 2.8)
+- fixed Natla spinning in her semi-death and second phases when more than one is active in the level (#906)
 - moved the enable_game_modes option from the gameflow to the config tool and added a gameflow option to override (#962)
 - moved the enable_save_crystals option from the gameflow to the config tool (#962)
 - improved Spanish localization for the config tool

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -126,6 +126,7 @@ void Item_Initialise(int16_t item_num)
     item->mesh_bits = -1;
     item->touch_bits = 0;
     item->data = NULL;
+    item->priv = NULL;
 
     if (item->flags & IF_NOT_VISIBLE) {
         item->status = IS_INVISIBLE;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1394,6 +1394,7 @@ typedef struct ITEM_INFO {
     int16_t flags;
     int16_t shade;
     void *data;
+    void *priv;
     PHD_3DPOS pos;
     uint16_t active : 1;
     uint16_t status : 2;


### PR DESCRIPTION
Resolves #906.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Introduced a `priv` property on `ITEM_INFO`, and we make use of this to move Natla's `facing` property from module to item scope. This prevents multiple Natlas simultaneously changing the same variable, which was leading to the spinning effect in her semi-death and second phases.

Demo of the new state: https://www.youtube.com/watch?v=VGCbKsrCBBI
