### PR TITLE
config: add new game plus unlock flag to the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the triggered music tracks to the savegame so one shot tracks don't replay on load (#371)
 - added forward/backward input detection in line with TR2+ for jump-twists (#931)
 - added an option to restore the mummy in City of Khamoon room 25, similar to the PS1 version (#886)
+- added a flag indicating if new game plus is unlocked to the player config which allows the player to select new game plus or not when making a new game (#966)
 - changed the installer to always overwrite all essential files such as the gameflow and injections (#904)
 - changed the data injection system to warn when it detects invalid or missing files, rather than preventing levels from loading (#918)
 - changed the gameflow to detect and skip over legacy sequence types, rather than preventing the game from starting (#882)

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - added the "Story so far..." option in the select level menu to view cutscenes and FMVs
 - added graphics effects, lava emitters, flame emitters, and waterfalls to the savegame so they now persist on load
 - added an option to restore the mummy in City of Khamoon room 25, similar to the PS version
+- added a flag indicating if new game plus is unlocked to the player config which allows the player to select new game plus or not when making a new game
 - fixed keys and items not working when drawing guns immediately after using them
 - fixed counting the secret in The Great Pyramid
 - fixed running out of ammo forcing Lara to equip pistols even if she doesn't carry them

--- a/src/config.c
+++ b/src/config.c
@@ -268,6 +268,8 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_FLOAT(ui.bar_scale, DEFAULT_UI_SCALE);
     CLAMP(g_Config.ui.bar_scale, MIN_BAR_SCALE, MAX_BAR_SCALE);
 
+    READ_BOOL(runtime.new_game_plus_unlock, false);
+
     char layout_name[50];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;
          layout < INPUT_LAYOUT_NUMBER_OF; layout++) {
@@ -440,6 +442,8 @@ bool Config_Write(void)
     WRITE_FLOAT(brightness);
     WRITE_FLOAT(ui.text_scale);
     WRITE_FLOAT(ui.bar_scale);
+
+    WRITE_BOOL(runtime.new_game_plus_unlock);
 
     char layout_name[20];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;

--- a/src/config.c
+++ b/src/config.c
@@ -268,7 +268,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_FLOAT(ui.bar_scale, DEFAULT_UI_SCALE);
     CLAMP(g_Config.ui.bar_scale, MIN_BAR_SCALE, MAX_BAR_SCALE);
 
-    READ_BOOL(runtime.new_game_plus_unlock, false);
+    READ_BOOL(profile.new_game_plus_unlock, false);
 
     char layout_name[50];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;
@@ -443,7 +443,7 @@ bool Config_Write(void)
     WRITE_FLOAT(ui.text_scale);
     WRITE_FLOAT(ui.bar_scale);
 
-    WRITE_BOOL(runtime.new_game_plus_unlock);
+    WRITE_BOOL(profile.new_game_plus_unlock);
 
     char layout_name[20];
     for (INPUT_LAYOUT layout = INPUT_LAYOUT_CUSTOM_1;

--- a/src/config.h
+++ b/src/config.h
@@ -46,6 +46,10 @@ typedef enum {
 } BAR_SHOW_MODE;
 
 typedef struct {
+    bool new_game_plus_unlock;
+} RUNTIME_SETTINGS;
+
+typedef struct {
     bool disable_healing_between_levels;
     bool disable_medpacks;
     bool disable_magnums;
@@ -141,6 +145,7 @@ typedef struct {
     int32_t music_volume;
 
     SCREENSHOT_FORMAT screenshot_format;
+    RUNTIME_SETTINGS runtime;
 } CONFIG;
 
 extern CONFIG g_Config;

--- a/src/config.h
+++ b/src/config.h
@@ -46,10 +46,6 @@ typedef enum {
 } BAR_SHOW_MODE;
 
 typedef struct {
-    bool new_game_plus_unlock;
-} RUNTIME_SETTINGS;
-
-typedef struct {
     bool disable_healing_between_levels;
     bool disable_medpacks;
     bool disable_magnums;
@@ -141,11 +137,14 @@ typedef struct {
         UI_STYLE menu_style;
     } ui;
 
+    typedef struct {
+        bool new_game_plus_unlock;
+    } profile;
+
     int32_t sound_volume;
     int32_t music_volume;
 
     SCREENSHOT_FORMAT screenshot_format;
-    RUNTIME_SETTINGS runtime;
 } CONFIG;
 
 extern CONFIG g_Config;

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -205,7 +205,7 @@ int32_t Game_Stop(void)
     Savegame_PersistGameToCurrentInfo(g_CurrentLevel);
 
     if (g_CurrentLevel == g_GameFlow.last_level_num) {
-        g_Config.runtime.new_game_plus_unlock = true;
+        g_Config.profile.new_game_plus_unlock = true;
         Config_Write();
     } else {
         Savegame_CarryCurrentInfoToNextLevel(

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -205,7 +205,8 @@ int32_t Game_Stop(void)
     Savegame_PersistGameToCurrentInfo(g_CurrentLevel);
 
     if (g_CurrentLevel == g_GameFlow.last_level_num) {
-        g_GameInfo.bonus_flag = GBF_NGPLUS;
+        g_Config.runtime.new_game_plus_unlock = true;
+        Config_Write();
     } else {
         Savegame_CarryCurrentInfoToNextLevel(
             g_CurrentLevel, g_CurrentLevel + 1);

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -474,7 +474,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                     || (g_CurrentLevel == g_GameFlow.gym_level_num
                         && g_InvMode != INV_DEATH_MODE)) {
                     if (g_Config.enable_game_modes
-                        || g_Config.runtime.new_game_plus_unlock) {
+                        || g_Config.profile.new_game_plus_unlock) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
                         g_Input = (INPUT_STATE) { 0 };

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -473,7 +473,8 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
                 if (g_InvMode == INV_TITLE_MODE
                     || (g_CurrentLevel == g_GameFlow.gym_level_num
                         && g_InvMode != INV_DEATH_MODE)) {
-                    if (g_Config.enable_game_modes) {
+                    if (g_Config.enable_game_modes
+                        || g_Config.runtime.new_game_plus_unlock) {
                         Option_PassportInitNewGameRequester();
                         m_PassportMode = PASSPORT_MODE_NEW_GAME;
                         g_Input = (INPUT_STATE) { 0 };

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -160,7 +160,7 @@ static void Savegame_LoadPostprocess(void)
     }
 
     if (g_GameInfo.bonus_flag) {
-        g_Config.runtime.new_game_plus_unlock = true;
+        g_Config.profile.new_game_plus_unlock = true;
     }
 
     LOT_ClearLOT(&g_Lara.LOT);

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -158,6 +158,11 @@ static void Savegame_LoadPostprocess(void)
             g_MusicTrackFlags[MX_BALDY_SPEECH] |= IF_ONESHOT;
         }
     }
+
+    if (g_GameInfo.bonus_flag) {
+        g_Config.runtime.new_game_plus_unlock = true;
+    }
+
     LOT_ClearLOT(&g_Lara.LOT);
 }
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -378,7 +378,6 @@ static bool Savegame_BSON_LoadMisc(
         return false;
     }
     game_info->bonus_flag = json_object_get_int(misc_obj, "bonus_flag", 0);
-    LOG_DEBUG("Load bonus_flag: %d", game_info->bonus_flag);
     return true;
 }
 
@@ -930,7 +929,6 @@ static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info)
     assert(game_info);
     struct json_object_s *misc_obj = json_object_new();
     json_object_append_int(misc_obj, "bonus_flag", game_info->bonus_flag);
-    LOG_DEBUG("Dump bonus_flag: %d", game_info->bonus_flag);
     return misc_obj;
 }
 


### PR DESCRIPTION
Resolves #966.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added a flag indicating if new game plus is unlocked to the player config which allows the player to select new game plus or not when making a new game even if the game modes option is disabled. The flag will be set if a save is loaded with the `bonus_flag` in order to set the flag for older saves. The only bug I noticed was the flag not saving to the config if the game was force exited, so I added `Config_Write();` to `Game_Stop` when the last level is completed. Let me know if you notice any other bugs.
