### PR TITLE
lara: fix responsive jumping delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
 - fixed jump-twist animations at times being interrupted (#932, regression from 2.15.1)
 - fixed walk-run-jump at times breaking when TR2 jumping is enabled (OG bug in TR2+) (#934)
-- fixed Lara jumping late with TR2 jumping enabled, as compared to normal TR1 jumping and when entering the run animation initially (#975)
+- fixed Lara jumping late with TR2 jumping enabled, as compared to normal TR1 jumping when entering the run animation initially (#975)
 - fixed the reset and unbind progress bars in the controls menu for non-default bar scaling (#930)
 - fixed original data issues where music triggers are not set as one shot (#939)
 - fixed a missing enemy trigger in Tomb of Tihocan (#751)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed the incorrect starting animation on centaurs that spawn from statues (#926, regression from 2.15)
 - fixed jump-twist animations at times being interrupted (#932, regression from 2.15.1)
 - fixed walk-run-jump at times breaking when TR2 jumping is enabled (OG bug in TR2+) (#934)
+- fixed Lara jumping late with TR2 jumping enabled, as compared to normal TR1 jumping and when entering the run animation initially (#975)
 - fixed the reset and unbind progress bars in the controls menu for non-default bar scaling (#930)
 - fixed original data issues where music triggers are not set as one shot (#939)
 - fixed a missing enemy trigger in Tomb of Tihocan (#751)

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -123,7 +123,8 @@ void Lara_State_Run(ITEM_INFO *item, COLL_INFO *coll)
             item->anim_number - g_Objects[item->object_number].anim_index;
         if (anim == LA_RUN_START) {
             m_JumpPermitted = false;
-        } else if (anim != LA_RUN || item->frame_number == LF_JUMP_READY) {
+        } else if (
+            anim != LA_RUN || (item->frame_number + 1) == LF_JUMP_READY) {
             m_JumpPermitted = true;
         }
     }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -543,7 +543,7 @@ typedef enum MUSIC_TRACK_ID {
 } MUSIC_TRACK_ID;
 
 typedef enum LARA_ANIMATION_FRAME {
-    LF_JUMP_READY = 4,
+    LF_JUMP_READY = 3,
     LF_PICKUPSCION = 44,
     LF_STOPHANG = 448,
     LF_FASTFALL = 481,


### PR DESCRIPTION
Resolves #975.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

In normal TR1 jumping, Lara can jump on frame 3 of the running animation (animation 0), so this has now been restored rather than using frame 4 from TR2+. The problem was coupled with another issue - the frame number check in `Lara_State_Run` did not take into account the fact that the frame number is _about_ to be incremented in `lara_control.c`. Without the `+1` added in this fix, we were still testing the previous frame and so as a result, we were actually 2 frames out.

So the control order is:

* `Lara_HandleAboveWater`
  * `g_LaraStateRoutines[item->current_anim_state](item, coll);` ( => `Lara_State_Run`)
  * `Lara_Animate(item);`
    * `item->frame_number++;`

This shows the old responsive jumping state - Lara doesn't switch to the jumping animation until frame 4 of the running animation.
https://www.youtube.com/watch?v=WVIv_H74M4c

As well as the jump in Sabatu's report, this also affected some jumps in the original levels. Below is a before and after from Natla's Mines; a similar jump in The Great Pyramid was also affected.
https://www.youtube.com/watch?v=ZB0lPsy-zBA

And finally, here is a comparison video of the fix in detail showing that we now have like-for-like. Original TR1 jumping is on the left and responsive jumping on the right.
https://www.youtube.com/watch?v=DyowWoJr6YY

