### PR TITLE
shell: improve support for windowed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - moved the enable_game_modes option from the gameflow to the config tool and added a gameflow option to override (#962)
 - moved the enable_save_crystals option from the gameflow to the config tool (#962)
 - improved Spanish localization for the config tool
+- improved support for windowed mode (#896)
 
 ## [2.15.3](https://github.com/rr-/Tomb1Main/compare/2.15.2...2.15.3) - 2023-08-15
 - fixed Lara stuttering when performing certain animations (#901, regression from 2.14)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - added enemy health bars
 - added PS1 style UI
 - added fade effects to displayed images
+- improved support for windowed mode
 
 #### Gameplay
 - added ability to set user-defined FOV

--- a/src/config.c
+++ b/src/config.c
@@ -243,6 +243,12 @@ bool Config_ReadFromJSON(const char *cfg_data)
 
     // User settings
     READ_INTEGER(rendering.render_mode, GFX_RM_LEGACY);
+    READ_BOOL(rendering.enable_fullscreen, true);
+    READ_BOOL(rendering.enable_maximized, true);
+    READ_INTEGER(rendering.window_x, -1);
+    READ_INTEGER(rendering.window_y, -1);
+    READ_INTEGER(rendering.window_width, -1);
+    READ_INTEGER(rendering.window_height, -1);
     READ_BOOL(rendering.enable_bilinear_filter, true);
     READ_BOOL(rendering.enable_perspective_filter, true);
     READ_BOOL(rendering.enable_vsync, true);
@@ -316,6 +322,8 @@ bool Config_ReadFromJSON(const char *cfg_data)
     if (root) {
         json_value_free(root);
     }
+
+    g_Config.loaded = true;
     return result;
 }
 
@@ -430,8 +438,13 @@ bool Config_Write(void)
     WRITE_BOOL(enable_game_modes);
     WRITE_BOOL(enable_save_crystals);
 
-    // User settings
     WRITE_INTEGER(rendering.render_mode);
+    WRITE_BOOL(rendering.enable_fullscreen);
+    WRITE_BOOL(rendering.enable_maximized);
+    WRITE_INTEGER(rendering.window_x);
+    WRITE_INTEGER(rendering.window_y);
+    WRITE_INTEGER(rendering.window_width);
+    WRITE_INTEGER(rendering.window_height);
     WRITE_BOOL(rendering.enable_bilinear_filter);
     WRITE_BOOL(rendering.enable_perspective_filter);
     WRITE_BOOL(rendering.enable_vsync);

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,8 @@ typedef enum {
 } BAR_SHOW_MODE;
 
 typedef struct {
+    bool loaded;
+
     bool disable_healing_between_levels;
     bool disable_medpacks;
     bool disable_magnums;
@@ -127,6 +129,12 @@ typedef struct {
 
     struct {
         GFX_RENDER_MODE render_mode;
+        bool enable_fullscreen;
+        bool enable_maximized;
+        int32_t window_x;
+        int32_t window_y;
+        int32_t window_width;
+        int32_t window_height;
         bool enable_perspective_filter;
         bool enable_bilinear_filter;
         bool enable_vsync;

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -389,11 +389,6 @@ void Output_SetWindowSize(int width, int height)
     S_Output_SetWindowSize(width, height);
 }
 
-void Output_SetFullscreen(bool fullscreen)
-{
-    S_Output_SetFullscreen(fullscreen);
-}
-
 void Output_ApplyRenderSettings(void)
 {
     S_Output_ApplyRenderSettings();

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -9,7 +9,6 @@ bool Output_Init(void);
 void Output_Shutdown(void);
 
 void Output_SetWindowSize(int width, int height);
-void Output_SetFullscreen(bool fullscreen);
 void Output_ApplyRenderSettings(void);
 void Output_DownloadTextures(int page_count);
 

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -110,7 +110,7 @@ static char *Shell_GetScreenshotName(void)
 
 void Shell_Init(const char *gameflow_path)
 {
-    S_Shell_SeedRandom();
+    S_Shell_Init();
 
     if (!Output_Init()) {
         Shell_ExitSystem("Could not initialise video system");

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -20,7 +20,6 @@ typedef struct GFX_CONTEXT {
     int32_t window_width;
     int32_t window_height;
 
-    bool is_fullscreen; // fullscreen flag
     bool is_rendered; // rendering flag
     char *scheduled_screenshot_path;
     GFX_FBO_Renderer renderer_fbo;
@@ -178,16 +177,6 @@ void GFX_Context_Detach(void)
 void GFX_Context_SetVSync(bool vsync)
 {
     SDL_GL_SetSwapInterval(vsync);
-}
-
-bool GFX_Context_IsFullscreen(void)
-{
-    return m_Context.is_fullscreen;
-}
-
-void GFX_Context_SetFullscreen(bool fullscreen)
-{
-    m_Context.is_fullscreen = fullscreen;
 }
 
 void GFX_Context_SetWindowSize(int32_t width, int32_t height)

--- a/src/gfx/context.h
+++ b/src/gfx/context.h
@@ -17,8 +17,6 @@ typedef enum GFX_RENDER_MODE {
 void GFX_Context_Attach(void *window_handle);
 void GFX_Context_Detach(void);
 void GFX_Context_SetVSync(bool vsync);
-bool GFX_Context_IsFullscreen(void);
-void GFX_Context_SetFullscreen(bool fullscreen);
 void GFX_Context_SetWindowSize(int32_t width, int32_t height);
 void GFX_Context_SetDisplaySize(int32_t width, int32_t height);
 void GFX_Context_SetRenderingMode(GFX_RENDER_MODE target_mode);

--- a/src/specific/s_fmv.c
+++ b/src/specific/s_fmv.c
@@ -2240,11 +2240,12 @@ static void S_FMV_EventLoop(VideoState *is)
                 is->audio_volume = 0;
                 break;
 
-            case SDL_WINDOWEVENT_SIZE_CHANGED:
+            case SDL_WINDOWEVENT_MOVED:
+            case SDL_WINDOWEVENT_RESIZED:
                 is->width = event.window.data1;
                 is->height = event.window.data2;
                 is->force_refresh = true;
-                Output_SetWindowSize(event.window.data1, event.window.data2);
+                S_Shell_HandleWindowResize();
                 break;
 
             case SDL_WINDOWEVENT_EXPOSED:

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -966,11 +966,6 @@ void S_Output_SetWindowSize(int width, int height)
     GFX_Context_SetWindowSize(width, height);
 }
 
-void S_Output_SetFullscreen(bool fullscreen)
-{
-    GFX_Context_SetFullscreen(fullscreen);
-}
-
 bool S_Output_Init(void)
 {
     for (int i = 0; i < GFX_MAX_TEXTURES; i++) {

--- a/src/specific/s_output.h
+++ b/src/specific/s_output.h
@@ -22,7 +22,6 @@ void S_Output_ClearDepthBuffer(void);
 void S_Output_DrawEmpty(void);
 
 void S_Output_SetWindowSize(int width, int height);
-void S_Output_SetFullscreen(bool fullscreen);
 void S_Output_ApplyRenderSettings(void);
 
 void S_Output_SetPalette(RGB888 palette[256]);

--- a/src/specific/s_shell.h
+++ b/src/specific/s_shell.h
@@ -5,11 +5,12 @@
 
 void S_Shell_ShowFatalError(const char *message);
 
-void S_Shell_SeedRandom(void);
+void S_Shell_Init(void);
 void S_Shell_SpinMessageLoop(void);
 bool S_Shell_GetCommandLine(int *arg_count, char ***args);
 void *S_Shell_GetWindowHandle(void);
-void S_Shell_TerminateGame(int exit_code);
 void S_Shell_ToggleFullscreen(void);
+void S_Shell_HandleWindowResize(void);
+void S_Shell_TerminateGame(int exit_code);
 int S_Shell_GetCurrentDisplayWidth(void);
 int S_Shell_GetCurrentDisplayHeight(void);


### PR DESCRIPTION
Resolves #896.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fullscreen state, window size and position are now all saved across reboots. Window size and position are not updated when the game is in fullscreen state, which is intended to avoid window size resetting to desktop size upon alt-enter.

To avoid weird out-of-order config read/write sequences, I add a `loaded` flag to `g_Config` to ensure shell can only update it once it's done loading.