### PR TITLE
ai: add configurable item drop behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 - renamed the project from Tomb1Main to TR1X in an effort to establish our own unique identity, while respectfully disassociating from TR2Main.
 - added Linux builds and toolchain
 - added an option to allow Lara to roll while underwater, similar to TR2+ (#993)
-- fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - added the bonus level type for custom levels that unlocks if all main game secrets are found (#645)
 - added detection for animation commands to play SFX on land, water or both (#999)
+- added support for customizable enemy item drops via the gameflow (#967)
+- fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - improved frame scheduling to use less CPU (#985)
 
 ## [2.16](https://github.com/LostArtefacts/TR1X/compare/2.15.3...2.16) - 2023-09-20

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - you can change the main menu backdrop
     - you can specify the anchor room for Bacon Lara
     - you can add bonus levels that unlock if all main game secrets are found
+    - you can specify which enemies drop items, and the number and types of those items
 - added automatic calculation of secret counts (no longer having to fiddle with the .exe to get correct secret stats)
 - added save game crystals game mode (enabled via gameflow)
 - added per-level customizable water color (with customizable blue component)

--- a/bin/cfg/TR1X_gameflow.json5
+++ b/bin/cfg/TR1X_gameflow.json5
@@ -53,6 +53,11 @@
         "data/uzi_sfx.bin",
     ],
 
+    // When enabled and an enemy is configured to drop a gun, if Lara already has
+    // that gun, then the equivalent ammo will instead be dropped. Otherwise, the
+    // gun will always be dropped.
+    "convert_dropped_guns": false,
+
     // List of levels
     "levels": [
         // Level 0
@@ -305,6 +310,9 @@
                 "data/tihocan_itemrots.bin",
                 "data/tihocan_textures.bin",
             ],
+            "item_drops": [
+                {"enemy_num": 82, "object_ids": [86, 144, 129]},
+            ],
             "sequence": [
                 {"type": "start_game"},
                 {"type": "loop_game"},
@@ -406,6 +414,11 @@
                 "data/mines_itemrots.bin",
                 "data/mines_textures.bin",
                 "data/skateboardkid_textures.bin"
+            ],
+            "item_drops": [
+                {"enemy_num": 17, "object_ids": [86]},
+                {"enemy_num": 50, "object_ids": [87]},
+                {"enemy_num": 75, "object_ids": [85]},
             ],
             "sequence": [
                 {"type": "play_fmv", "fmv_path": "fmv/canyon.avi"},

--- a/bin/cfg/TR1X_gameflow_ub.json5
+++ b/bin/cfg/TR1X_gameflow_ub.json5
@@ -17,6 +17,7 @@
         "data/lara_jumping.bin",
         "data/uzi_sfx.bin",
     ],
+    "convert_dropped_guns": false,
 
     "levels": [
         // Level 0

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ sources = [
   'src/filesystem.c',
   'src/game/box.c',
   'src/game/camera.c',
+  'src/game/carrier.c',
   'src/game/clock.c',
   'src/game/collide.c',
   'src/game/creature.c',

--- a/src/game/carrier.c
+++ b/src/game/carrier.c
@@ -1,0 +1,213 @@
+#include "game/carrier.h"
+
+#include "game/gamebuf.h"
+#include "game/gameflow.h"
+#include "game/inventory.h"
+#include "game/items.h"
+#include "global/const.h"
+#include "global/types.h"
+#include "global/vars.h"
+#include "log.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define AMMO_OFFSET 4
+#define LEGACY_DROP_COUNT 4
+
+typedef struct LEGACY_DROP_TEST {
+    const GAME_OBJECT_ID object_id;
+    const GAME_OBJECT_ID drop_id;
+} LEGACY_DROP_TEST;
+
+static ITEM_INFO *Carrier_GetCarrier(int16_t item_num);
+static bool Carrier_IsObjectType(int16_t obj_num, const int16_t *test_arr);
+
+static const int16_t m_CarrierObjects[] = {
+    O_WOLF,   O_BEAR,   O_BAT,     O_LION,  O_LIONESS, O_PUMA,   O_APE,
+    O_TREX,   O_RAPTOR, O_CENTAUR, O_MUMMY, O_LARSON,  O_PIERRE, O_SKATEKID,
+    O_COWBOY, O_BALDY,  O_NATLA,   O_TORSO, NO_ITEM
+};
+
+static const int16_t m_PlaceholderObjects[] = { O_STATUE, O_PODS, O_BIG_POD,
+                                                NO_ITEM };
+
+static const int16_t m_DropObjects[] = {
+    O_GUN_ITEM,     O_SHOTGUN_ITEM,  O_MAGNUM_ITEM,   O_UZI_ITEM,
+    O_SG_AMMO_ITEM, O_MAG_AMMO_ITEM, O_UZI_AMMO_ITEM, O_MEDI_ITEM,
+    O_BIGMEDI_ITEM, O_PUZZLE_ITEM1,  O_PUZZLE_ITEM2,  O_PUZZLE_ITEM3,
+    O_PUZZLE_ITEM4, O_KEY_ITEM1,     O_KEY_ITEM2,     O_KEY_ITEM3,
+    O_KEY_ITEM4,    O_PICKUP_ITEM1,  O_PICKUP_ITEM2,  O_LEADBAR_ITEM,
+    O_SCION_ITEM2,  NO_ITEM
+};
+
+static const int16_t m_GunObjects[] = { O_SHOTGUN_ITEM, O_MAGNUM_ITEM,
+                                        O_UZI_ITEM, NO_ITEM };
+
+static const LEGACY_DROP_TEST m_LegacyMap[] = {
+    { O_PIERRE, O_SCION_ITEM2 },
+    { O_COWBOY, O_MAGNUM_ITEM },
+    { O_SKATEKID, O_UZI_ITEM },
+    { O_BALDY, O_SHOTGUN_ITEM },
+};
+
+void Carrier_InitialiseLevel(int32_t level_num)
+{
+    int32_t total_item_count = g_LevelItemCount;
+    GAMEFLOW_LEVEL level = g_GameFlow.levels[level_num];
+    for (int i = 0; i < level.item_drops.count; i++) {
+        GAMEFLOW_DROP_ITEM_DATA *data = &level.item_drops.data[i];
+
+        ITEM_INFO *item = Carrier_GetCarrier(data->enemy_num);
+        if (!item) {
+            LOG_WARNING("%d does not refer to a loaded item", data->enemy_num);
+            continue;
+        }
+
+        if (total_item_count + data->count > MAX_ITEMS) {
+            LOG_WARNING("Too many items being loaded");
+            return;
+        }
+
+        if (item->carried_item) {
+            LOG_WARNING("Item %d is already carrying", data->enemy_num);
+            continue;
+        }
+
+        if (!Carrier_IsObjectType(item->object_number, m_CarrierObjects)) {
+            LOG_WARNING(
+                "Item %d of type %d cannot carry items", data->enemy_num,
+                item->object_number);
+            continue;
+        }
+
+        bool valid_objects = true;
+        for (int i = 0; i < data->count; i++) {
+            if (!Carrier_IsObjectType(data->object_ids[i], m_DropObjects)) {
+                LOG_WARNING(
+                    "Items of type %d cannot be carried", data->object_ids[i]);
+                valid_objects = false;
+                break;
+            }
+        }
+
+        if (!valid_objects) {
+            continue;
+        }
+
+        item->carried_item =
+            GameBuf_Alloc(sizeof(CARRIED_ITEM) * data->count, GBUF_ITEMS);
+        CARRIED_ITEM *drop = item->carried_item;
+        for (int i = 0; i < data->count; i++) {
+            drop->object_id = data->object_ids[i];
+            drop->spawn_number = NO_ITEM;
+            drop->status = IS_NOT_ACTIVE;
+            total_item_count++;
+
+            if (i < data->count - 1) {
+                drop->next_item = drop + 1;
+                drop++;
+            } else {
+                drop->next_item = NULL;
+            }
+        }
+    }
+}
+
+static ITEM_INFO *Carrier_GetCarrier(int16_t item_num)
+{
+    if (item_num < 0 || item_num >= g_LevelItemCount) {
+        return NULL;
+    }
+
+    ITEM_INFO *item = &g_Items[item_num];
+    if (Carrier_IsObjectType(item->object_number, m_PlaceholderObjects)) {
+        int16_t child_item_num = *(int16_t *)item->data;
+        item = &g_Items[child_item_num];
+    }
+
+    if (!g_Objects[item->object_number].loaded) {
+        return NULL;
+    }
+
+    return item;
+}
+
+static bool Carrier_IsObjectType(int16_t object_id, const int16_t *test_arr)
+{
+    for (int i = 0; test_arr[i] != NO_ITEM; i++) {
+        if (test_arr[i] == object_id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int32_t Carrier_GetItemCount(int16_t item_num)
+{
+    ITEM_INFO *carrier = Carrier_GetCarrier(item_num);
+    if (!carrier) {
+        return 0;
+    }
+
+    CARRIED_ITEM *item = carrier->carried_item;
+    int32_t count = 0;
+    while (item) {
+        count++;
+        item = item->next_item;
+    }
+
+    return count;
+}
+
+void Carrier_TestItemDrops(int16_t item_num)
+{
+    ITEM_INFO *carrier = &g_Items[item_num];
+    CARRIED_ITEM *item = carrier->carried_item;
+    if (carrier->status != IS_DEACTIVATED || !item
+        || (carrier->object_number == O_PIERRE
+            && !(carrier->flags & IF_ONESHOT))) {
+        return;
+    }
+
+    do {
+        if (item->status == IS_INVISIBLE) {
+            continue;
+        }
+
+        int16_t object_id = item->object_id;
+        if (g_GameFlow.convert_dropped_guns
+            && Carrier_IsObjectType(object_id, m_GunObjects)
+            && Inv_RequestItem(object_id)) {
+            object_id += AMMO_OFFSET;
+        }
+
+        item->spawn_number = Item_Spawn(carrier, object_id);
+        item->status = IS_ACTIVE;
+    } while ((item = item->next_item));
+}
+
+void Carrier_TestLegacyDrops(int16_t item_num)
+{
+    ITEM_INFO *carrier = &g_Items[item_num];
+    if (carrier->status != IS_DEACTIVATED) {
+        return;
+    }
+
+    for (int i = 0; i < LEGACY_DROP_COUNT; i++) {
+        LEGACY_DROP_TEST legacy_test = m_LegacyMap[i];
+        if (carrier->object_number != legacy_test.object_id) {
+            continue;
+        }
+
+        if (!Inv_RequestItem(legacy_test.drop_id)) {
+            Carrier_TestItemDrops(item_num);
+        } else {
+            CARRIED_ITEM *item = carrier->carried_item;
+            while (item) {
+                item->status = IS_INVISIBLE;
+                item = item->next_item;
+            }
+        }
+    }
+}

--- a/src/game/carrier.h
+++ b/src/game/carrier.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+void Carrier_InitialiseLevel(int32_t level_num);
+int32_t Carrier_GetItemCount(int16_t item_num);
+void Carrier_TestItemDrops(int16_t item_num);
+void Carrier_TestLegacyDrops(int16_t item_num);

--- a/src/game/creature.c
+++ b/src/game/creature.c
@@ -1,6 +1,7 @@
 #include "game/creature.h"
 
 #include "game/box.h"
+#include "game/carrier.h"
 #include "game/collide.h"
 #include "game/effects.h"
 #include "game/effects/gunshot.h"
@@ -418,6 +419,7 @@ bool Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt)
         item->hit_points = DONT_TARGET;
         LOT_DisableBaddieAI(item_num);
         Item_RemoveActive(item_num);
+        Carrier_TestItemDrops(item_num);
         return false;
     }
 

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -15,6 +15,12 @@ typedef struct GAMEFLOW_SEQUENCE {
     void *data;
 } GAMEFLOW_SEQUENCE;
 
+typedef struct GAMEFLOW_DROP_ITEM_DATA {
+    int32_t enemy_num;
+    int32_t count;
+    int16_t *object_ids;
+} GAMEFLOW_DROP_ITEM_DATA;
+
 typedef struct GAMEFLOW_LEVEL {
     GAMEFLOW_LEVEL_TYPE level_type;
     int16_t music;
@@ -52,6 +58,10 @@ typedef struct GAMEFLOW_LEVEL {
         int length;
         char **data_paths;
     } injections;
+    struct {
+        int count;
+        GAMEFLOW_DROP_ITEM_DATA *data;
+    } item_drops;
     GAME_OBJECT_ID lara_type;
 } GAMEFLOW_LEVEL;
 
@@ -77,6 +87,7 @@ typedef struct GAMEFLOW {
         int length;
         char **data_paths;
     } injections;
+    bool convert_dropped_guns;
 } GAMEFLOW;
 
 extern GAMEFLOW g_GameFlow;

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -132,6 +132,7 @@ void Item_Initialise(int16_t item_num)
     item->touch_bits = 0;
     item->data = NULL;
     item->priv = NULL;
+    item->carried_item = NULL;
 
     if (item->flags & IF_NOT_VISIBLE) {
         item->status = IS_INVISIBLE;

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "filesystem.h"
+#include "game/carrier.h"
 #include "game/effects.h"
 #include "game/gamebuf.h"
 #include "game/gameflow.h"
@@ -48,7 +49,7 @@ static bool Level_LoadSamples(MYFILE *fp);
 static bool Level_LoadTexturePages(MYFILE *fp);
 
 static bool Level_LoadFromFile(const char *filename, int32_t level_num);
-static void Level_CompleteSetup(void);
+static void Level_CompleteSetup(int32_t level_num);
 
 static bool Level_LoadFromFile(const char *filename, int32_t level_num)
 {
@@ -659,7 +660,7 @@ static bool Level_LoadTexturePages(MYFILE *fp)
     return true;
 }
 
-static void Level_CompleteSetup(void)
+static void Level_CompleteSetup(int32_t level_num)
 {
     Inject_AllInjections(&m_LevelInfo);
 
@@ -674,6 +675,9 @@ static void Level_CompleteSetup(void)
     for (int i = 0; i < m_LevelInfo.item_count; i++) {
         Item_Initialise(i);
     }
+
+    // Configure enemies who carry and drop items
+    Carrier_InitialiseLevel(level_num);
 
     // Move the prepared texture pages into g_TexturePagePtrs.
     uint8_t *base = GameBuf_Alloc(
@@ -723,7 +727,7 @@ bool Level_Load(int level_num)
         Level_LoadFromFile(g_GameFlow.levels[level_num].level_file, level_num);
 
     if (ret) {
-        Level_CompleteSetup();
+        Level_CompleteSetup(level_num);
     }
 
     Inject_Cleanup();

--- a/src/game/objects/creatures/baldy.c
+++ b/src/game/objects/creatures/baldy.c
@@ -1,7 +1,6 @@
 #include "game/objects/creatures/baldy.h"
 
 #include "game/creature.h"
-#include "game/inventory.h"
 #include "game/items.h"
 #include "game/lot.h"
 #include "global/const.h"
@@ -77,11 +76,6 @@ void Baldy_Control(int16_t item_num)
         if (item->current_anim_state != BALDY_DEATH) {
             item->current_anim_state = BALDY_DEATH;
             Item_SwitchToAnim(item, BALDY_DIE_ANIM, 0);
-            if (Inv_RequestItem(O_SHOTGUN_ITEM)) {
-                Item_Spawn(item, O_SG_AMMO_ITEM);
-            } else {
-                Item_Spawn(item, O_SHOTGUN_ITEM);
-            }
         }
     } else {
         AI_INFO info;

--- a/src/game/objects/creatures/cowboy.c
+++ b/src/game/objects/creatures/cowboy.c
@@ -3,7 +3,6 @@
 #include "game/creature.h"
 #include "game/effects.h"
 #include "game/effects/gunshot.h"
-#include "game/inventory.h"
 #include "game/items.h"
 #include "game/lot.h"
 #include "global/const.h"
@@ -74,11 +73,6 @@ void Cowboy_Control(int16_t item_num)
         if (item->current_anim_state != COWBOY_DEATH) {
             item->current_anim_state = COWBOY_DEATH;
             Item_SwitchToAnim(item, COWBOY_DIE_ANIM, 0);
-            if (Inv_RequestItem(O_MAGNUM_ITEM)) {
-                Item_Spawn(item, O_MAG_AMMO_ITEM);
-            } else {
-                Item_Spawn(item, O_MAGNUM_ITEM);
-            }
         }
     } else {
         AI_INFO info;

--- a/src/game/objects/creatures/mummy.c
+++ b/src/game/objects/creatures/mummy.c
@@ -1,5 +1,6 @@
 #include "game/objects/creatures/mummy.h"
 
+#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/gamebuf.h"
 #include "game/items.h"
@@ -67,6 +68,9 @@ void Mummy_Control(int16_t item_num)
             g_GameInfo.current[g_CurrentLevel].stats.kill_count++;
         }
         Item_RemoveActive(item_num);
+        if (item->hit_points != DONT_TARGET) {
+            Carrier_TestItemDrops(item_num);
+        }
         item->hit_points = DONT_TARGET;
     }
 }

--- a/src/game/objects/creatures/pierre.c
+++ b/src/game/objects/creatures/pierre.c
@@ -2,7 +2,6 @@
 
 #include "config.h"
 #include "game/creature.h"
-#include "game/inventory.h"
 #include "game/items.h"
 #include "game/los.h"
 #include "game/lot.h"
@@ -114,13 +113,6 @@ void Pierre_Control(int16_t item_num)
         if (item->current_anim_state != PIERRE_DEATH) {
             item->current_anim_state = PIERRE_DEATH;
             Item_SwitchToAnim(item, PIERRE_DIE_ANIM, 0);
-            if (Inv_RequestItem(O_MAGNUM_ITEM)) {
-                Item_Spawn(item, O_MAG_AMMO_ITEM);
-            } else {
-                Item_Spawn(item, O_MAGNUM_ITEM);
-            }
-            Item_Spawn(item, O_SCION_ITEM2);
-            Item_Spawn(item, O_KEY_ITEM1);
         }
     } else {
         AI_INFO info;

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -1,7 +1,6 @@
 #include "game/objects/creatures/skate_kid.h"
 
 #include "game/creature.h"
-#include "game/inventory.h"
 #include "game/items.h"
 #include "game/lot.h"
 #include "game/music.h"
@@ -86,11 +85,6 @@ void SkateKid_Control(int16_t item_num)
         if (item->current_anim_state != SKATE_KID_DEATH) {
             item->current_anim_state = SKATE_KID_DEATH;
             Item_SwitchToAnim(item, SKATE_KID_DIE_ANIM, 0);
-            if (Inv_RequestItem(O_UZI_ITEM)) {
-                Item_Spawn(item, O_UZI_AMMO_ITEM);
-            } else {
-                Item_Spawn(item, O_UZI_ITEM);
-            }
         }
     } else {
         AI_INFO info;

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -126,31 +126,14 @@ static void Savegame_LoadPostprocess(void)
 
         if (item->object_number == O_PIERRE && item->hit_points <= 0
             && (item->flags & IF_ONESHOT)) {
-            if (Inv_RequestItem(O_SCION_ITEM) == 1) {
-                Item_Spawn(item, O_MAGNUM_ITEM);
-                Item_Spawn(item, O_SCION_ITEM2);
-                Item_Spawn(item, O_KEY_ITEM1);
-            }
             g_MusicTrackFlags[MX_PIERRE_SPEECH] |= IF_ONESHOT;
         }
 
-        if (item->object_number == O_SKATEKID && item->hit_points <= 0) {
-            if (!Inv_RequestItem(O_UZI_ITEM)) {
-                Item_Spawn(item, O_UZI_ITEM);
-            }
-        }
-
         if (item->object_number == O_COWBOY && item->hit_points <= 0) {
-            if (!Inv_RequestItem(O_MAGNUM_ITEM)) {
-                Item_Spawn(item, O_MAGNUM_ITEM);
-            }
             g_MusicTrackFlags[MX_COWBOY_SPEECH] |= IF_ONESHOT;
         }
 
         if (item->object_number == O_BALDY && item->hit_points <= 0) {
-            if (!Inv_RequestItem(O_SHOTGUN_ITEM)) {
-                Item_Spawn(item, O_SHOTGUN_ITEM);
-            }
             g_MusicTrackFlags[MX_BALDY_SPEECH] |= IF_ONESHOT;
         }
 

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -1,5 +1,6 @@
 #include "game/savegame/savegame_legacy.h"
 
+#include "game/carrier.h"
 #include "game/effects.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
@@ -600,6 +601,8 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
                 item->data = NULL;
             }
         }
+
+        Carrier_TestLegacyDrops(i);
     }
 
     Savegame_Legacy_ReadLara(&g_Lara);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1369,6 +1369,13 @@ typedef struct ROOM_INFO {
     uint16_t flags;
 } ROOM_INFO;
 
+typedef struct CARRIED_ITEM {
+    int16_t object_id;
+    int16_t spawn_number;
+    enum ITEM_STATUS status;
+    struct CARRIED_ITEM *next_item;
+} CARRIED_ITEM;
+
 typedef struct ITEM_INFO {
     int32_t floor;
     uint32_t touch_bits;
@@ -1391,6 +1398,7 @@ typedef struct ITEM_INFO {
     int16_t shade;
     void *data;
     void *priv;
+    CARRIED_ITEM *carried_item;
     PHD_3DPOS pos;
     uint16_t active : 1;
     uint16_t status : 2;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1370,7 +1370,7 @@ typedef struct ROOM_INFO {
 } ROOM_INFO;
 
 typedef struct CARRIED_ITEM {
-    int16_t object_id;
+    GAME_OBJECT_ID object_id;
     int16_t spawn_number;
     enum ITEM_STATUS status;
     struct CARRIED_ITEM *next_item;


### PR DESCRIPTION
Resolves #967.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This follows on from #1000, and allows all but a few enemies to carry and drop items for Lara to collect. The hardcoded drops have been removed and the gameflow is now responsible for the setup. The default gameflow is configured in line with OG behaviour/requirements.

`convert_dropped_guns` in the gameflow controls whether guns are converted to ammo when dropped and Lara already has that gun. This is `false` by default to avoid extra ammo pickups when killing Pierre, Cowboy and Kold in the original levels.

Enemies that are *not* capable of carrying and dropping are:
- `O_CROCODILE` `O_ALLIGATOR` `O_RAT` `O_VOLE`  - having items spawn in the water would be difficult to track with changing water levels I feel, and having floating pickups would not be in-keeping with normal experience.
- `O_WARRIOR1` `O_WARRIOR2` `O_WARRIOR3` - these explode in mid-air and don't follow the standard `Creature_Animate` routine on death. We could manually spawn the items in each object's control, and work out the floor height, but the item would appear out of nowhere if the creature were high above land when killed, so again it feels non-standard.

Pods and centaur statues can be referenced as carriers in the gameflow; the system will give the items to the enemies that actually spawn, provided those are suitable carriers (empty pods are excluded).

The statistics take into account carried items. I have added a function here for common behaviour when testing triggered killable items.

In terms of saving and loading, items will respawn accordingly if Lara hasn't picked them up yet and equally they will not if she has done so. For testing, I used legacy ATI saves, V3 of the TR1X save format (2.16) and the current V4. In each case, I tested Pierre, Cowboy, Skaterboy and Kold in six scenarios - the following with `convert_dropped_guns` set to `false` and then again with it set to `true`.
- Before killing the enemy
- After killing the enemy, but before collecting their item(s)
- After killing the enemy, and after collecting their item(s)

I also used a test level to ensure items allocated to every potential carrier type spawn as expected, and that items allocated to non-carriers are ignored.

I will follow-up this PR with a document update to create a gameflow MD file, so that builders have a go-to reference for this feature in detail, as well as other gameflow aspects.
