### PR TITLE
items: add Item_TestFrameRange function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added detection for animation commands to play SFX on land, water or both (#999)
 - added support for customizable enemy item drops via the gameflow (#967)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
+- fixed Lara never using the step back down right animation (#1014)
 - improved frame scheduling to use less CPU (#985)
 
 ## [2.16](https://github.com/LostArtefacts/TR1X/compare/2.15.3...2.16) - 2023-09-20

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -516,6 +516,12 @@ void Item_Translate(ITEM_INFO *item, int32_t x, int32_t y, int32_t z)
     item->pos.z += (c * z - s * x) >> W2V_SHIFT;
 }
 
+bool Item_TestAnimEqual(ITEM_INFO *item, int16_t anim_index)
+{
+    return item->anim_number
+        == g_Objects[item->object_number].anim_index + anim_index;
+}
+
 void Item_SwitchToAnim(ITEM_INFO *item, int16_t anim_index, int16_t frame)
 {
     item->anim_number = g_Objects[item->object_number].anim_index + anim_index;

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -765,7 +765,7 @@ void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status)
     }
 }
 
-bool Item_TestFrame(ITEM_INFO *item, int16_t frame)
+bool Item_TestFrameEqual(ITEM_INFO *item, int16_t frame)
 {
     return item->frame_number == g_Anims[item->anim_number].frame_base + frame;
 }

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -637,8 +637,12 @@ bool Item_GetAnimChange(ITEM_INFO *item, ANIM_STRUCT *anim)
         if (change->goal_anim_state == item->goal_anim_state) {
             ANIM_RANGE_STRUCT *range = &g_AnimRanges[change->range_index];
             for (int j = 0; j < change->number_ranges; j++, range++) {
-                if (item->frame_number >= range->start_frame
-                    && item->frame_number <= range->end_frame) {
+                if (Item_TestFrameRange(
+                        item,
+                        range->start_frame
+                            - g_Anims[item->anim_number].frame_base,
+                        range->end_frame
+                            - g_Anims[item->anim_number].frame_base)) {
                     item->anim_number = range->link_anim_num;
                     item->frame_number = range->link_frame_num;
                     return true;
@@ -768,4 +772,10 @@ void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status)
 bool Item_TestFrameEqual(ITEM_INFO *item, int16_t frame)
 {
     return item->frame_number == g_Anims[item->anim_number].frame_base + frame;
+}
+
+bool Item_TestFrameRange(ITEM_INFO *item, int16_t start, int16_t end)
+{
+    return item->frame_number >= g_Anims[item->anim_number].frame_base + start
+        && item->frame_number <= g_Anims[item->anim_number].frame_base + end;
 }

--- a/src/game/items.h
+++ b/src/game/items.h
@@ -47,4 +47,4 @@ int16_t *Item_GetBoundsAccurate(ITEM_INFO *item);
 int32_t Item_GetFrames(ITEM_INFO *item, int16_t *frmptr[], int32_t *rate);
 
 void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status);
-bool Item_TestFrame(ITEM_INFO *item, int16_t frame);
+bool Item_TestFrameEqual(ITEM_INFO *item, int16_t frame);

--- a/src/game/items.h
+++ b/src/game/items.h
@@ -35,6 +35,7 @@ bool Item_MovePosition(
 void Item_ShiftCol(ITEM_INFO *item, COLL_INFO *coll);
 void Item_Translate(ITEM_INFO *item, int32_t x, int32_t y, int32_t z);
 
+bool Item_TestAnimEqual(ITEM_INFO *item, int16_t anim_index);
 void Item_SwitchToAnim(ITEM_INFO *item, int16_t anim_index, int16_t frame);
 void Item_Animate(ITEM_INFO *item);
 bool Item_GetAnimChange(ITEM_INFO *item, ANIM_STRUCT *anim);

--- a/src/game/items.h
+++ b/src/game/items.h
@@ -48,3 +48,4 @@ int32_t Item_GetFrames(ITEM_INFO *item, int16_t *frmptr[], int32_t *rate);
 
 void Item_TakeDamage(ITEM_INFO *item, int16_t damage, bool hit_status);
 bool Item_TestFrameEqual(ITEM_INFO *item, int16_t frame);
+bool Item_TestFrameRange(ITEM_INFO *item, int16_t start, int16_t end);

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -113,14 +113,12 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (Lara_DeflectEdge(item, coll)) {
-        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
-                == item->anim_number
+        if (Item_TestAnimEqual(item, LA_WALK_FORWARD)
             && Item_TestFrameRange(
                 item, LF_WALK_STEP_R_START, LF_WALK_STEP_R_END)) {
             Item_SwitchToAnim(item, LA_STOP_RIGHT, 0);
         } else if (
-            g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
-                == item->anim_number
+            Item_TestAnimEqual(item, LA_WALK_FORWARD)
             && (Item_TestFrameRange(
                     item, LF_WALK_STEP_L_START, LF_WALK_STEP_L_END)
                 || Item_TestFrameRange(
@@ -136,8 +134,7 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor > STEP_L / 2) {
-        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
-                == item->anim_number
+        if (Item_TestAnimEqual(item, LA_WALK_FORWARD)
             && Item_TestFrameRange(
                 item, LF_WALK_STEP_L_END, LF_WALK_STEP_R_NEAR_END)) {
             Item_SwitchToAnim(item, LA_WALK_STEP_DOWN_RIGHT, 0);
@@ -147,8 +144,7 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor >= -STEPUP_HEIGHT && coll->mid_floor < -STEP_L / 2) {
-        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
-                == item->anim_number
+        if (Item_TestAnimEqual(item, LA_WALK_FORWARD)
             && Item_TestFrameRange(
                 item, LF_WALK_STEP_L_NEAR_END, LF_WALK_STEP_R_MID)) {
             Item_SwitchToAnim(item, LA_WALK_STEP_UP_RIGHT, 0);
@@ -191,14 +187,12 @@ void Lara_Col_Run(ITEM_INFO *item, COLL_INFO *coll)
         if (coll->front_type == HT_WALL
             && coll->front_floor < -(STEP_L * 5) / 2) {
             item->current_anim_state = LS_SPLAT;
-            if (g_Objects[item->object_number].anim_index + LA_RUN
-                    == item->anim_number
+            if (Item_TestAnimEqual(item, LA_RUN)
                 && Item_TestFrameRange(item, LF_RUN_L_START, LF_RUN_L_END)) {
                 Item_SwitchToAnim(item, LA_HIT_WALL_LEFT, 0);
                 return;
             }
-            if (g_Objects[item->object_number].anim_index + LA_RUN
-                    == item->anim_number
+            if (Item_TestAnimEqual(item, LA_RUN)
                 && Item_TestFrameRange(item, LF_RUN_R_START, LF_RUN_R_END)) {
                 Item_SwitchToAnim(item, LA_HIT_WALL_RIGHT, 0);
                 return;
@@ -212,8 +206,7 @@ void Lara_Col_Run(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor >= -STEPUP_HEIGHT && coll->mid_floor < -STEP_L / 2) {
-        if (g_Objects[item->object_number].anim_index + LA_RUN
-                == item->anim_number
+        if (Item_TestAnimEqual(item, LA_RUN)
             && Item_TestFrameRange(
                 item, LF_RUN_L_HEEL_GROUND, LF_RUN_R_FOOT_GROUND)) {
             Item_SwitchToAnim(item, LA_RUN_STEP_UP_LEFT, 0);
@@ -512,8 +505,7 @@ void Lara_Col_Back(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor > STEP_L / 2 && coll->mid_floor < (STEP_L * 3) / 2) {
-        if (g_Objects[item->object_number].anim_index + LA_WALK_BACK
-                == item->anim_number
+        if (Item_TestAnimEqual(item, LA_WALK_BACK)
             && Item_TestFrameRange(item, LF_BACK_R_START, LF_BACK_R_END)) {
             Item_SwitchToAnim(item, LA_BACK_STEP_DOWN_RIGHT, 0);
         } else {

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -14,6 +14,26 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define LF_WALK_STEP_L_START 0
+#define LF_WALK_STEP_L_NEAR_END 5
+#define LF_WALK_STEP_L_END 6
+#define LF_WALK_STEP_R_START 7
+#define LF_WALK_STEP_R_MID 22
+#define LF_WALK_STEP_R_NEAR_END 23
+#define LF_WALK_STEP_R_END 25
+#define LF_WALK_STEP_L_2_START 26
+#define LF_WALK_STEP_L_2_END 35
+
+#define LF_RUN_L_START 0
+#define LF_RUN_L_HEEL_GROUND 3
+#define LF_RUN_L_END 9
+#define LF_RUN_R_START 10
+#define LF_RUN_R_FOOT_GROUND 14
+#define LF_RUN_R_END 21
+
+#define LF_BACK_R_START 26
+#define LF_BACK_R_END 55
+
 void (*g_LaraCollisionRoutines[])(ITEM_INFO *item, COLL_INFO *coll) = {
     Lara_Col_Walk,        Lara_Col_Run,       Lara_Col_Stop,
     Lara_Col_ForwardJump, Lara_Col_Pose,      Lara_Col_FastBack,
@@ -93,11 +113,18 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (Lara_DeflectEdge(item, coll)) {
-        if (item->frame_number >= 29 && item->frame_number <= 47) {
+        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
+                == item->anim_number
+            && Item_TestFrameRange(
+                item, LF_WALK_STEP_R_START, LF_WALK_STEP_R_END)) {
             Item_SwitchToAnim(item, LA_STOP_RIGHT, 0);
         } else if (
-            (item->frame_number >= 22 && item->frame_number <= 28)
-            || (item->frame_number >= 48 && item->frame_number <= 57)) {
+            g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
+                == item->anim_number
+            && (Item_TestFrameRange(
+                    item, LF_WALK_STEP_L_START, LF_WALK_STEP_L_END)
+                || Item_TestFrameRange(
+                    item, LF_WALK_STEP_L_2_START, LF_WALK_STEP_L_2_END))) {
             Item_SwitchToAnim(item, LA_STOP_LEFT, 0);
         } else {
             Item_SwitchToAnim(item, LA_STOP, 0);
@@ -109,7 +136,10 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor > STEP_L / 2) {
-        if (item->frame_number >= 28 && item->frame_number <= 45) {
+        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
+                == item->anim_number
+            && Item_TestFrameRange(
+                item, LF_WALK_STEP_L_END, LF_WALK_STEP_R_NEAR_END)) {
             Item_SwitchToAnim(item, LA_WALK_STEP_DOWN_RIGHT, 0);
         } else {
             Item_SwitchToAnim(item, LA_WALK_STEP_DOWN_LEFT, 0);
@@ -117,7 +147,10 @@ void Lara_Col_Walk(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor >= -STEPUP_HEIGHT && coll->mid_floor < -STEP_L / 2) {
-        if (item->frame_number >= 27 && item->frame_number <= 44) {
+        if (g_Objects[item->object_number].anim_index + LA_WALK_FORWARD
+                == item->anim_number
+            && Item_TestFrameRange(
+                item, LF_WALK_STEP_L_NEAR_END, LF_WALK_STEP_R_MID)) {
             Item_SwitchToAnim(item, LA_WALK_STEP_UP_RIGHT, 0);
         } else {
             Item_SwitchToAnim(item, LA_WALK_STEP_UP_LEFT, 0);
@@ -158,11 +191,15 @@ void Lara_Col_Run(ITEM_INFO *item, COLL_INFO *coll)
         if (coll->front_type == HT_WALL
             && coll->front_floor < -(STEP_L * 5) / 2) {
             item->current_anim_state = LS_SPLAT;
-            if (item->frame_number >= 0 && item->frame_number <= 9) {
+            if (g_Objects[item->object_number].anim_index + LA_RUN
+                    == item->anim_number
+                && Item_TestFrameRange(item, LF_RUN_L_START, LF_RUN_L_END)) {
                 Item_SwitchToAnim(item, LA_HIT_WALL_LEFT, 0);
                 return;
             }
-            if (item->frame_number >= 10 && item->frame_number <= 21) {
+            if (g_Objects[item->object_number].anim_index + LA_RUN
+                    == item->anim_number
+                && Item_TestFrameRange(item, LF_RUN_R_START, LF_RUN_R_END)) {
                 Item_SwitchToAnim(item, LA_HIT_WALL_RIGHT, 0);
                 return;
             }
@@ -175,7 +212,10 @@ void Lara_Col_Run(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor >= -STEPUP_HEIGHT && coll->mid_floor < -STEP_L / 2) {
-        if (item->frame_number >= 3 && item->frame_number <= 14) {
+        if (g_Objects[item->object_number].anim_index + LA_RUN
+                == item->anim_number
+            && Item_TestFrameRange(
+                item, LF_RUN_L_HEEL_GROUND, LF_RUN_R_FOOT_GROUND)) {
             Item_SwitchToAnim(item, LA_RUN_STEP_UP_LEFT, 0);
         } else {
             Item_SwitchToAnim(item, LA_RUN_STEP_UP_RIGHT, 0);
@@ -472,7 +512,9 @@ void Lara_Col_Back(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (coll->mid_floor > STEP_L / 2 && coll->mid_floor < (STEP_L * 3) / 2) {
-        if (item->frame_number >= 964 && item->frame_number <= 993) {
+        if (g_Objects[item->object_number].anim_index + LA_WALK_BACK
+                == item->anim_number
+            && Item_TestFrameRange(item, LF_BACK_R_START, LF_BACK_R_END)) {
             Item_SwitchToAnim(item, LA_BACK_STEP_DOWN_RIGHT, 0);
         } else {
             Item_SwitchToAnim(item, LA_BACK_STEP_DOWN_LEFT, 0);

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -126,7 +126,8 @@ void Lara_State_Run(ITEM_INFO *item, COLL_INFO *coll)
             item->anim_number - g_Objects[item->object_number].anim_index;
         if (anim == LA_RUN_START) {
             m_JumpPermitted = false;
-        } else if (anim != LA_RUN || Item_TestFrameEqual(item, LF_JUMP_READY - 1)) {
+        } else if (
+            anim != LA_RUN || Item_TestFrameEqual(item, LF_JUMP_READY - 1)) {
             m_JumpPermitted = true;
         }
     }

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -126,7 +126,7 @@ void Lara_State_Run(ITEM_INFO *item, COLL_INFO *coll)
             item->anim_number - g_Objects[item->object_number].anim_index;
         if (anim == LA_RUN_START) {
             m_JumpPermitted = false;
-        } else if (anim != LA_RUN || Item_TestFrame(item, LF_JUMP_READY - 1)) {
+        } else if (anim != LA_RUN || Item_TestFrameEqual(item, LF_JUMP_READY - 1)) {
             m_JumpPermitted = true;
         }
     }

--- a/src/game/objects/creatures/torso.c
+++ b/src/game/objects/creatures/torso.c
@@ -15,7 +15,9 @@
 
 #include <stdbool.h>
 
+#define TORSO_TURN_L_ANIM 8
 #define TORSO_DIE_ANIM 13
+#define TORSO_TURN_R_ANIM 17
 #define TORSO_PART_DAMAGE 250
 #define TORSO_ATTACK_DAMAGE 500
 #define TORSO_TOUCH_DAMAGE 5
@@ -29,6 +31,10 @@
 #define TORSO_HITPOINTS 500
 #define TORSO_RADIUS (WALL_L / 3) // = 341
 #define TORSO_SMARTNESS 0x7FFF
+#define TORSO_FRAME_TURN_L_START 14
+#define TORSO_FRAME_TURN_L_END 22
+#define TORSO_FRAME_TURN_R_START 17
+#define TORSO_FRAME_TURN_R_END 22
 
 typedef enum {
     TORSO_EMPTY = 0,
@@ -155,8 +161,10 @@ void Torso_Control(int16_t item_num)
             if (!torso->flags) {
                 torso->flags = item->frame_number;
             } else if (
-                item->frame_number - torso->flags > 13
-                && item->frame_number - torso->flags < 23) {
+                g_Objects[item->object_number].anim_index + TORSO_TURN_L_ANIM
+                    == item->anim_number
+                && Item_TestFrameRange(
+                    item, TORSO_FRAME_TURN_L_START, TORSO_FRAME_TURN_L_END)) {
                 item->pos.y_rot -= PHD_DEGREE * 9;
             }
 
@@ -169,8 +177,10 @@ void Torso_Control(int16_t item_num)
             if (!torso->flags) {
                 torso->flags = item->frame_number;
             } else if (
-                item->frame_number - torso->flags > 16
-                && item->frame_number - torso->flags < 23) {
+                g_Objects[item->object_number].anim_index + TORSO_TURN_R_ANIM
+                    == item->anim_number
+                && Item_TestFrameRange(
+                    item, TORSO_FRAME_TURN_R_START, TORSO_FRAME_TURN_R_END)) {
                 item->pos.y_rot += PHD_DEGREE * 14;
             }
 

--- a/src/game/objects/creatures/torso.c
+++ b/src/game/objects/creatures/torso.c
@@ -161,8 +161,7 @@ void Torso_Control(int16_t item_num)
             if (!torso->flags) {
                 torso->flags = item->frame_number;
             } else if (
-                g_Objects[item->object_number].anim_index + TORSO_TURN_L_ANIM
-                    == item->anim_number
+                Item_TestAnimEqual(item, TORSO_TURN_L_ANIM)
                 && Item_TestFrameRange(
                     item, TORSO_FRAME_TURN_L_START, TORSO_FRAME_TURN_L_END)) {
                 item->pos.y_rot -= PHD_DEGREE * 9;
@@ -177,8 +176,7 @@ void Torso_Control(int16_t item_num)
             if (!torso->flags) {
                 torso->flags = item->frame_number;
             } else if (
-                g_Objects[item->object_number].anim_index + TORSO_TURN_R_ANIM
-                    == item->anim_number
+                Item_TestAnimEqual(item, TORSO_TURN_R_ANIM)
                 && Item_TestFrameRange(
                     item, TORSO_FRAME_TURN_R_START, TORSO_FRAME_TURN_R_END)) {
                 item->pos.y_rot += PHD_DEGREE * 14;

--- a/src/game/objects/general/pickup.c
+++ b/src/game/objects/general/pickup.c
@@ -102,7 +102,7 @@ void Pickup_Collision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
         }
 
         if (lara_item->current_anim_state == LS_PICKUP) {
-            if (!Item_TestFrame(lara_item, LF_PICKUP_ERASE)) {
+            if (!Item_TestFrameEqual(lara_item, LF_PICKUP_ERASE)) {
                 goto cleanup;
             }
             PickUp_GetAllAtLaraPos(item, lara_item);
@@ -125,7 +125,7 @@ void Pickup_Collision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
         }
 
         if (lara_item->current_anim_state == LS_PICKUP) {
-            if (!Item_TestFrame(lara_item, LF_PICKUP_UW)) {
+            if (!Item_TestFrameEqual(lara_item, LF_PICKUP_UW)) {
                 goto cleanup;
             }
             PickUp_GetAllAtLaraPos(item, lara_item);
@@ -199,7 +199,7 @@ void Pickup_CollisionControlled(
         } else if (
             g_Lara.interact_target.item_num == item_num
             && lara_item->current_anim_state == LS_PICKUP) {
-            if (Item_TestFrame(lara_item, LF_PICKUP_ERASE)) {
+            if (Item_TestFrameEqual(lara_item, LF_PICKUP_ERASE)) {
                 PickUp_GetAllAtLaraPos(item, lara_item);
             }
         }
@@ -231,7 +231,7 @@ void Pickup_CollisionControlled(
         } else if (
             g_Lara.interact_target.item_num == item_num
             && lara_item->current_anim_state == LS_PICKUP
-            && Item_TestFrame(lara_item, LF_PICKUP_UW)) {
+            && Item_TestFrameEqual(lara_item, LF_PICKUP_UW)) {
             PickUp_GetAllAtLaraPos(item, lara_item);
             g_Lara.gun_status = LGS_ARMLESS;
         }

--- a/src/game/objects/general/puzzle_hole.c
+++ b/src/game/objects/general/puzzle_hole.c
@@ -50,7 +50,7 @@ void PuzzleHole_Collision(
             return;
         }
 
-        if (Item_TestFrame(lara_item, LF_USEPUZZLE)) {
+        if (Item_TestFrameEqual(lara_item, LF_USEPUZZLE)) {
             switch (item->object_number) {
             case O_PUZZLE_HOLE1:
                 item->object_number = O_PUZZLE_DONE1;

--- a/src/game/objects/general/scion.c
+++ b/src/game/objects/general/scion.c
@@ -152,7 +152,7 @@ void Scion_Collision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
     }
 
     if (lara_item->current_anim_state == LS_PICKUP) {
-        if (Item_TestFrame(lara_item, LF_PICKUPSCION)) {
+        if (Item_TestFrameEqual(lara_item, LF_PICKUPSCION)) {
             Overlay_AddPickup(item->object_number);
             Inv_AddItem(item->object_number);
             item->status = IS_INVISIBLE;

--- a/src/game/objects/traps/dart.c
+++ b/src/game/objects/traps/dart.c
@@ -106,7 +106,7 @@ void DartEmitter_Control(int16_t item_num)
     }
 
     if (item->current_anim_state == DART_EMITTER_FIRE
-        && item->frame_number == g_Anims[item->anim_number].frame_base) {
+        && Item_TestFrameEqual(item, 0)) {
         int16_t dart_item_num = Item_Create();
         if (dart_item_num != NO_ITEM) {
             ITEM_INFO *dart = &g_Items[dart_item_num];

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -197,7 +197,7 @@ void MovableBlock_Collision(
             g_Lara.gun_status = LGS_HANDS_BUSY;
         }
     } else if (lara_item->current_anim_state == LS_PP_READY) {
-        if (!Item_TestFrame(lara_item, LF_PPREADY)) {
+        if (!Item_TestFrameEqual(lara_item, LF_PPREADY)) {
             return;
         }
 


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Adds a function to test if an item's frame number is in an inclusive range. This PR also renames `Item_TestFrame` to `Item_TestFrameEqual` in a separate commit in order to better differentiate the two functions.

As part of this refactor, I noticed there are some parts of the code like in `Item_GetAnimChange` where the `Item_SwitchToAnim` function is not used:
```
                    item->anim_number = range->link_anim_num;
                    item->frame_number = range->link_frame_num;
```
This is probably because `Item_SwitchToAnim` uses `frame_base`, but I wanted to note that there are still some areas of the code not using these helper functions which could affect variable FPS down the road if it's ever implemented.