### PR TITLE
game: add an option to enable frame buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added the bonus level type for custom levels that unlocks if all main game secrets are found (#645)
 - added detection for animation commands to play SFX on land, water or both (#999)
 - added support for customizable enemy item drops via the gameflow (#967)
+- added an option to enable F-key and inventory frame buffering (#591)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - fixed Lara never using the step back down right animation (#1014)
 - improved frame scheduling to use less CPU (#985)

--- a/src/config.c
+++ b/src/config.c
@@ -238,6 +238,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enable_game_modes, true);
     READ_BOOL(enable_save_crystals, false);
     READ_BOOL(enable_uw_roll, true);
+    READ_BOOL(enable_buffering, false);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -441,6 +442,7 @@ bool Config_Write(void)
     WRITE_BOOL(enable_game_modes);
     WRITE_BOOL(enable_save_crystals);
     WRITE_BOOL(enable_uw_roll);
+    WRITE_BOOL(enable_buffering);
 
     WRITE_INTEGER(rendering.render_mode);
     WRITE_BOOL(rendering.enable_fullscreen);

--- a/src/config.h
+++ b/src/config.h
@@ -123,6 +123,7 @@ typedef struct {
     bool enable_game_modes;
     bool enable_save_crystals;
     bool enable_uw_roll;
+    bool enable_buffering;
 
     struct {
         int32_t layout;

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -12,6 +12,7 @@
 #include "game/lara/lara_hair.h"
 #include "game/level.h"
 #include "game/music.h"
+#include "game/output.h"
 #include "game/overlay.h"
 #include "game/savegame.h"
 #include "game/sound.h"
@@ -20,10 +21,18 @@
 #include "global/vars.h"
 #include "log.h"
 
+#define FRAME_BUFFER(key)                                                      \
+    do {                                                                       \
+        Game_DrawScene(true);                                                  \
+        Output_DumpScreen();                                                   \
+        Input_Update();                                                        \
+    } while (g_Input.key)
+
 static const int32_t m_AnimationRate = 0x8000;
 static int32_t m_FrameCount = 0;
 
 static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type);
+static void Game_UpdateInput(void);
 
 static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
 {
@@ -39,7 +48,7 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
             return GF_NOP_BREAK;
         }
 
-        Input_Update();
+        Game_UpdateInput();
 
         if (level_type == GFL_DEMO) {
             if (g_Input.any) {
@@ -68,8 +77,8 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
             }
         }
 
-        if ((g_InputDB.option || g_Input.save || g_Input.load
-             || g_OverlayFlag <= 0)
+        if (((g_Config.enable_buffering ? g_Input : g_InputDB).option
+             || g_Input.save || g_Input.load || g_OverlayFlag <= 0)
             && !g_Lara.death_timer) {
             if (g_Camera.type == CAM_CINEMATIC) {
                 g_OverlayFlag = 0;
@@ -120,6 +129,22 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
     }
 
     return GF_NOP;
+}
+
+static void Game_UpdateInput(void)
+{
+    Input_Update();
+    if (!g_Config.enable_buffering) {
+        return;
+    }
+
+    if (g_Input.toggle_fps_counter) {
+        FRAME_BUFFER(toggle_fps_counter);
+    } else if (g_Input.toggle_bilinear_filter) {
+        FRAME_BUFFER(toggle_bilinear_filter);
+    } else if (g_Input.toggle_perspective_filter) {
+        FRAME_BUFFER(toggle_perspective_filter);
+    }
 }
 
 bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -77,7 +77,7 @@ static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type)
             }
         }
 
-        if (((g_Config.enable_buffering ? g_Input : g_InputDB).option
+        if (((g_Config.enable_buffering ? g_Input.option : g_InputDB.option)
              || g_Input.save || g_Input.load || g_OverlayFlag <= 0)
             && !g_Lara.death_timer) {
             if (g_Camera.type == CAM_CINEMATIC) {

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -223,6 +223,10 @@
       "Title": "Enable FMVs",
       "Description": "Enables FMVs playing."
     },
+    "enable_buffering": {
+      "Title": "Enable buffering",
+      "Description": "Enables F-key (1-frame) and inventory (2-frame) buffering to achieve precise control of Lara's movement."
+    },
     "disable_trex_collision": {
       "Title": "Remove dead T-Rex collision",
       "Description": "Removes all collision with T-Rex upon death. This helps when the T-Rex's body blocks the passage out."

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -223,6 +223,10 @@
       "Title": "Activer les FMV",
       "Description": "Active les FMV en jeu."
     },
+    "enable_buffering": {
+      "Title": "Activer la mise en mémoire tampon",
+      "Description": "Permet la mise en mémoire tampon d'une saisie de mouvement grâce au passage dans l'inventaire (inventory buffering) ou image par image (frame buffering) pour obtenir un contrôle précis des mouvements de Lara."
+    },
     "disable_trex_collision": {
       "Title": "Supprimer la colision avec le cadavre du T-Rex",
       "Description": "Supprime toutes les collisions avec le cadavre T-Rex. Cela aide lorsque son cadavre bloque un passage."

--- a/tools/config/TR1X_ConfigTool/Resources/specification.json
+++ b/tools/config/TR1X_ConfigTool/Resources/specification.json
@@ -245,6 +245,11 @@
           "DefaultValue": true
         },
         {
+          "Field": "enable_buffering",
+          "DataType": "Bool",
+          "DefaultValue": false
+        },
+        {
           "Field": "disable_trex_collision",
           "DataType": "Bool",
           "DefaultValue": false


### PR DESCRIPTION
Resolves #591.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Continues on from #593 to allow buffering using the F2/F3/F4 keys (or whichever keys are mapped), and via the inventory. 

This remains optional, and is disabled by default, because of the noticeable delay when pressing F2/F3/F4 for their actual purpose, plus if you use the inventory key to cancel an FMV, the inventory will open immediately in-game.

The demo below shows the ability to accurately control inputs, and to test frame numbers. F2/F3/F4 allows for one-frame buffering, and inventory for two, which ties in with TombATI. _NB the animation and frame number shown in the demo are not part of this, only added here as a showcase._

https://youtu.be/jfopcpbYdU8
