### PR TITLE
items: use relative frames for more anims

### DIFF
--- a/src/game/game/game_cutscene.c
+++ b/src/game/game/game_cutscene.c
@@ -105,9 +105,8 @@ void Game_Cutscene_InitialiseHair(int32_t level_num)
     Lara_Initialise(level_num);
     Lara_Hair_SetLaraType(lara_type);
 
-    g_LaraItem->anim_number = g_Objects[lara_type].anim_index;
+    Item_SwitchToObjAnim(g_LaraItem, 0, 0, lara_type);
     ANIM_STRUCT *cut_anim = &g_Anims[g_LaraItem->anim_number];
-    g_LaraItem->frame_number = cut_anim->frame_base;
     g_LaraItem->current_anim_state = g_LaraItem->goal_anim_state =
         g_LaraItem->required_anim_state = cut_anim->current_anim_state;
 }

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -524,7 +524,14 @@ bool Item_TestAnimEqual(ITEM_INFO *item, int16_t anim_index)
 
 void Item_SwitchToAnim(ITEM_INFO *item, int16_t anim_index, int16_t frame)
 {
-    item->anim_number = g_Objects[item->object_number].anim_index + anim_index;
+    Item_SwitchToObjAnim(item, anim_index, frame, item->object_number);
+}
+
+void Item_SwitchToObjAnim(
+    ITEM_INFO *item, int16_t anim_index, int16_t frame,
+    GAME_OBJECT_ID object_number)
+{
+    item->anim_number = g_Objects[object_number].anim_index + anim_index;
     item->frame_number = g_Anims[item->anim_number].frame_base + frame;
 }
 

--- a/src/game/items.h
+++ b/src/game/items.h
@@ -37,6 +37,9 @@ void Item_Translate(ITEM_INFO *item, int32_t x, int32_t y, int32_t z);
 
 bool Item_TestAnimEqual(ITEM_INFO *item, int16_t anim_index);
 void Item_SwitchToAnim(ITEM_INFO *item, int16_t anim_index, int16_t frame);
+void Item_SwitchToObjAnim(
+    ITEM_INFO *item, int16_t anim_index, int16_t frame,
+    GAME_OBJECT_ID object_number);
 void Item_Animate(ITEM_INFO *item);
 bool Item_GetAnimChange(ITEM_INFO *item, ANIM_STRUCT *anim);
 void Item_PlayAnimSFX(ITEM_INFO *item, int16_t *command, uint16_t flags);

--- a/src/game/objects/common.c
+++ b/src/game/objects/common.c
@@ -67,8 +67,7 @@ void Object_DrawPickupItem(ITEM_INFO *item)
     // Save the frame number.
     int16_t old_frame_number = item->frame_number;
     // Modify item to be the anim for inv item and animation 0.
-    item->anim_number = g_Objects[item_num_option].anim_index;
-    item->frame_number = g_Anims[item->anim_number].frame_base;
+    Item_SwitchToObjAnim(item, 0, 0, item_num_option);
 
     OBJECT_INFO *object = &g_Objects[item_num_option];
 

--- a/src/game/objects/creatures/bacon_lara.c
+++ b/src/game/objects/creatures/bacon_lara.c
@@ -79,8 +79,11 @@ void BaconLara_Control(int16_t item_num)
         int32_t lh = Room_GetHeight(
             floor, g_LaraItem->pos.x, g_LaraItem->pos.y, g_LaraItem->pos.z);
 
-        item->anim_number = g_LaraItem->anim_number;
-        item->frame_number = g_LaraItem->frame_number;
+        int16_t relative_anim = g_LaraItem->anim_number
+            - g_Objects[g_LaraItem->object_number].anim_index;
+        int16_t relative_frame = g_LaraItem->frame_number
+            - g_Anims[g_LaraItem->anim_number].frame_base;
+        Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
         item->pos.x = x;
         item->pos.y = y;
         item->pos.z = z;

--- a/src/game/objects/creatures/bat.c
+++ b/src/game/objects/creatures/bat.c
@@ -37,7 +37,7 @@ static void Bat_FixEmbeddedPosition(int16_t item_num)
     ITEM_INFO *item;
     FLOOR_INFO *floor;
     int32_t x, y, z;
-    int16_t room_number, ceiling, old_anim, old_frame, bat_height;
+    int16_t room_number, ceiling, bat_height;
     int16_t *bounds;
 
     item = &g_Items[item_num];
@@ -54,15 +54,16 @@ static void Bat_FixEmbeddedPosition(int16_t item_num)
         // The bats animation and frame have to be changed to the hanging
         // one to properly measure them. Save it so it can be restored
         // after.
-        old_anim = item->anim_number;
-        old_frame = item->frame_number;
+        int16_t old_anim =
+            item->anim_number - g_Objects[item->object_number].anim_index;
+        int16_t old_frame =
+            item->frame_number - g_Anims[item->anim_number].frame_base;
 
-        item->anim_number = g_Objects[item->object_number].anim_index;
-        item->frame_number = g_Anims[item->anim_number].frame_base;
+        Item_SwitchToAnim(item, 0, 0);
+
         bounds = Item_GetBoundsAccurate(item);
 
-        item->anim_number = old_anim;
-        item->frame_number = old_frame;
+        Item_SwitchToAnim(item, old_anim, old_frame);
 
         bat_height = ABS(bounds[FRAME_BOUND_MIN_Y]);
 

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -169,13 +169,15 @@ void SkateKid_Control(int16_t item_num)
 void SkateKid_Draw(ITEM_INFO *item)
 {
     Object_DrawAnimatingItem(item);
-    int16_t anim = item->anim_number;
-    int16_t frame = item->frame_number;
+
+    int16_t relative_anim =
+        item->anim_number - g_Objects[item->object_number].anim_index;
+    int16_t relative_frame =
+        item->frame_number - g_Anims[item->anim_number].frame_base;
     item->object_number = O_SKATEBOARD;
-    item->anim_number = anim + g_Objects[O_SKATEBOARD].anim_index
-        - g_Objects[O_SKATEKID].anim_index;
+    Item_SwitchToAnim(item, relative_anim, relative_frame);
     Object_DrawAnimatingItem(item);
-    item->anim_number = anim;
-    item->frame_number = frame;
+
     item->object_number = O_SKATEKID;
+    Item_SwitchToAnim(item, relative_anim, relative_frame);
 }

--- a/src/game/objects/creatures/torso.c
+++ b/src/game/objects/creatures/torso.c
@@ -15,6 +15,7 @@
 
 #include <stdbool.h>
 
+#define EXTRA_ANIM_TORSO_SLAM 0
 #define TORSO_TURN_L_ANIM 8
 #define TORSO_DIE_ANIM 13
 #define TORSO_TURN_R_ANIM 17
@@ -206,9 +207,8 @@ void Torso_Control(int16_t item_num)
                 || g_LaraItem->hit_points <= 0) {
                 item->goal_anim_state = TORSO_KILL;
 
-                g_LaraItem->anim_number = g_Objects[O_LARA_EXTRA].anim_index;
-                g_LaraItem->frame_number =
-                    g_Anims[g_LaraItem->anim_number].frame_base;
+                Item_SwitchToObjAnim(
+                    g_LaraItem, EXTRA_ANIM_TORSO_SLAM, 0, O_LARA_EXTRA);
                 g_LaraItem->current_anim_state = LS_SPECIAL;
                 g_LaraItem->goal_anim_state = LS_SPECIAL;
                 g_LaraItem->room_number = item->room_number;

--- a/src/game/objects/creatures/trex.c
+++ b/src/game/objects/creatures/trex.c
@@ -13,6 +13,7 @@
 
 #include <stdbool.h>
 
+#define EXTRA_ANIM_TREX_DEATH 1
 #define TREX_ATTACK_RANGE SQUARE(WALL_L * 4) // = 16777216
 #define TREX_BITE_DAMAGE 10000
 #define TREX_BITE_RANGE SQUARE(1500) // = 2250000
@@ -192,8 +193,7 @@ void TRex_LaraDeath(ITEM_INFO *item)
     g_LaraItem->gravity_status = 0;
     g_LaraItem->current_anim_state = LS_SPECIAL;
     g_LaraItem->goal_anim_state = LS_SPECIAL;
-    g_LaraItem->anim_number = g_Objects[O_LARA_EXTRA].anim_index + 1;
-    g_LaraItem->frame_number = g_Anims[g_LaraItem->anim_number].frame_base;
+    Item_SwitchToObjAnim(g_LaraItem, EXTRA_ANIM_TREX_DEATH, 0, O_LARA_EXTRA);
     Lara_SwapMeshExtra();
 
     g_LaraItem->hit_points = -1;

--- a/src/game/objects/general/scion.c
+++ b/src/game/objects/general/scion.c
@@ -16,6 +16,8 @@
 
 #include <stdbool.h>
 
+#define EXTRA_ANIM_PEDESTAL_SCION 0
+#define EXTRA_ANIM_HOLDER_SCION 0
 #define LF_PICKUPSCION 44
 
 static PHD_VECTOR m_Scion_Position = { 0, 640, -310 };
@@ -166,8 +168,8 @@ void Scion_Collision(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
         Lara_AlignPosition(item, &m_Scion_Position);
         lara_item->current_anim_state = LS_PICKUP;
         lara_item->goal_anim_state = LS_PICKUP;
-        lara_item->anim_number = g_Objects[O_LARA_EXTRA].anim_index;
-        lara_item->frame_number = g_Anims[lara_item->anim_number].frame_base;
+        Item_SwitchToObjAnim(
+            lara_item, EXTRA_ANIM_PEDESTAL_SCION, 0, O_LARA_EXTRA);
         g_Lara.gun_status = LGS_HANDS_BUSY;
         g_Camera.type = CAM_CINEMATIC;
         g_CineFrame = 0;
@@ -199,8 +201,8 @@ void Scion_Collision4(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
         Lara_AlignPosition(item, &m_Scion_Position4);
         lara_item->current_anim_state = LS_PICKUP;
         lara_item->goal_anim_state = LS_PICKUP;
-        lara_item->anim_number = g_Objects[O_LARA_EXTRA].anim_index;
-        lara_item->frame_number = g_Anims[lara_item->anim_number].frame_base;
+        Item_SwitchToObjAnim(
+            lara_item, EXTRA_ANIM_HOLDER_SCION, 0, O_LARA_EXTRA);
         g_Lara.gun_status = LGS_HANDS_BUSY;
         g_Camera.type = CAM_CINEMATIC;
         g_CineFrame = 0;

--- a/src/game/objects/traps/midas_touch.c
+++ b/src/game/objects/traps/midas_touch.c
@@ -8,6 +8,9 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#define EXTRA_ANIM_PLACE_BAR 0
+#define EXTRA_ANIM_DIE_GOLD 1
+
 static int16_t m_MidasBounds[12] = {
     -700,
     +700,
@@ -41,8 +44,7 @@ void MidasTouch_Collision(
         && lara_item->pos.z < item->pos.z + 512) {
         lara_item->current_anim_state = LS_DIE_MIDAS;
         lara_item->goal_anim_state = LS_DIE_MIDAS;
-        lara_item->anim_number = g_Objects[O_LARA_EXTRA].anim_index + 1;
-        lara_item->frame_number = g_Anims[lara_item->anim_number].frame_base;
+        Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_DIE_GOLD, 0, O_LARA_EXTRA);
         lara_item->hit_points = -1;
         lara_item->gravity_status = 0;
         g_Lara.air = -1;
@@ -89,8 +91,7 @@ void MidasTouch_Collision(
         Inv_AddItem(O_PUZZLE_ITEM1);
         lara_item->current_anim_state = LS_USE_MIDAS;
         lara_item->goal_anim_state = LS_USE_MIDAS;
-        lara_item->anim_number = g_Objects[O_LARA_EXTRA].anim_index;
-        lara_item->frame_number = g_Anims[item->anim_number].frame_base;
+        Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_PLACE_BAR, 0, O_LARA_EXTRA);
         g_Lara.gun_status = LGS_HANDS_BUSY;
     }
 }

--- a/src/game/objects/traps/thors_hammer.c
+++ b/src/game/objects/traps/thors_hammer.c
@@ -148,10 +148,11 @@ void ThorsHandle_Control(int16_t item_num)
     Item_Animate(item);
 
     ITEM_INFO *head_item = item->data;
-    int32_t anim = item->anim_number - g_Objects[O_THORS_HANDLE].anim_index;
-    int32_t frm = item->frame_number - g_Anims[item->anim_number].frame_base;
-    head_item->anim_number = g_Objects[O_THORS_HEAD].anim_index + anim;
-    head_item->frame_number = g_Anims[head_item->anim_number].frame_base + frm;
+    int16_t relative_anim =
+        item->anim_number - g_Objects[item->object_number].anim_index;
+    int16_t relative_frame =
+        item->frame_number - g_Anims[item->anim_number].frame_base;
+    Item_SwitchToAnim(head_item, relative_anim, relative_frame);
     head_item->current_anim_state = item->current_anim_state;
 }
 


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Use more relative animations and frames. Continuation of #1006.

Three remaining absolute `Item_SwitchToAnim` frame cases remain in `Item_Animate`, `Item_GetAnimChange`, and `Lara_Animate`. Two remaining absolute `Item_TestFrameEqual` checks remain in `Lara_Animate` and `Item_Animate`. These might require a more fundamental rework in which the link and jump data will contain relative offsets.