### PR TITLE
midas: add pickup overlay for gold bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added detection for animation commands to play SFX on land, water or both (#999)
 - added support for customizable enemy item drops via the gameflow (#967)
 - added an option to enable F-key and inventory frame buffering (#591)
+- added a pickup overlay for the Midas gold bar when it changes from lead (#1010)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - fixed Lara never using the step back down right animation (#1014)
 - improved frame scheduling to use less CPU (#985)

--- a/src/game/objects/traps/midas_touch.c
+++ b/src/game/objects/traps/midas_touch.c
@@ -5,11 +5,13 @@
 #include "game/items.h"
 #include "game/lara.h"
 #include "game/objects/common.h"
+#include "game/overlay.h"
 #include "global/const.h"
 #include "global/vars.h"
 
 #define EXTRA_ANIM_PLACE_BAR 0
 #define EXTRA_ANIM_DIE_GOLD 1
+#define LF_PICKUP_GOLD_BAR 113
 
 static int16_t m_MidasBounds[12] = {
     -700,
@@ -36,6 +38,13 @@ void MidasTouch_Collision(
     int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll)
 {
     ITEM_INFO *item = &g_Items[item_num];
+
+    if (lara_item->current_anim_state == LS_USE_MIDAS) {
+        if (Item_TestFrameEqual(lara_item, LF_PICKUP_GOLD_BAR)) {
+            Overlay_AddPickup(O_PUZZLE_ITEM1);
+            Inv_AddItem(O_PUZZLE_ITEM1);
+        }
+    }
 
     if (!lara_item->gravity_status && lara_item->current_anim_state == LS_STOP
         && lara_item->pos.x > item->pos.x - 512
@@ -88,7 +97,6 @@ void MidasTouch_Collision(
 
     if (g_InvChosen == O_LEADBAR_OPTION) {
         Inv_RemoveItem(O_LEADBAR_OPTION);
-        Inv_AddItem(O_PUZZLE_ITEM1);
         lara_item->current_anim_state = LS_USE_MIDAS;
         lara_item->goal_anim_state = LS_USE_MIDAS;
         Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_PLACE_BAR, 0, O_LARA_EXTRA);


### PR DESCRIPTION
Resolves #1010.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added a pickup overlay for the Midas gold bar when it changes from lead.

https://github.com/LostArtefacts/TR1X/assets/81546780/54494ad7-66e1-4518-b098-21d1a37b927b