### PR TITLE
ai: extend item drop support to all enemies

### DIFF
--- a/GAMEFLOW.md
+++ b/GAMEFLOW.md
@@ -1049,19 +1049,34 @@ that Lara already has, it will be converted to the equivalent ammo. When
 
 ### Enemy validity
 
-The majority of enemies are permitted to carry and drop items. This includes
-regular enemy types as well as Atlantean pods (objects 163, 181) and centaur
-statues (object 161). For pods, this will only work if the enemy within is a
-centaur or Torso.
+All enemy types are permitted to carry and drop items. This includes regular
+enemies as well as Atlantean pods (objects 163, 181) and centaur statues
+(object 161). For pods, the items will be allocated to the creature within
+(obviously empty pods are excluded).
 
-Following is a list of those enemies that are *excluded* from dropping items.
-The gameflow will ignore drops for these enemies if they are defined, and a
-suitable warning message will be produced in the log file.
+Items dropped by flying or swimming creatures will fall to the ground.
+
+For clarity, following is a list of all TR1 enemy type IDs, which you can
+reference when building your gameflow. The gameflow will ignore drops for
+non-enemy type objects, and a suitable warning message will be produced in the
+log file.
 
 <table>
   <tr valign="top" align="left">
     <th>Object ID
     <th>Name</th>
+  </tr>
+  <tr>
+    <td>7</td>
+    <td>Wolf</td>
+  </tr>
+  <tr>
+    <td>8</td>
+    <td>Bear</td>
+  </tr>
+  <tr>
+    <td>9</td>
+    <td>Bat</td>
   </tr>
   <tr>
     <td>10</td>
@@ -1072,12 +1087,36 @@ suitable warning message will be produced in the log file.
     <td>Alligator</td>
   </tr>
   <tr>
+    <td>12</td>
+    <td>Lion</td>
+  </tr>
+  <tr>
+    <td>13</td>
+    <td>Lioness</td>
+  </tr>
+  <tr>
+    <td>14</td>
+    <td>Puma</td>
+  </tr>
+  <tr>
+    <td>15</td>
+    <td>Ape</td>
+  </tr>
+  <tr>
     <td>16</td>
     <td>Rat</td>
   </tr>
   <tr>
     <td>17</td>
     <td>Vole</td>
+  </tr>
+  <tr>
+    <td>18</td>
+    <td>T-rex</td>
+  </tr>
+  <tr>
+    <td>19</td>
+    <td>Raptor</td>
   </tr>
   <tr>
     <td>20</td>
@@ -1090,6 +1129,42 @@ suitable warning message will be produced in the log file.
   <tr>
     <td>22</td>
     <td>Grounded mutant (non-shooter)</td>
+  </tr>
+  <tr>
+    <td>23</td>
+    <td>Centaur</td>
+  </tr>
+  <tr>
+    <td>24</td>
+    <td>Mummy (Tomb of Qualopec)</td>
+  </tr>
+  <tr>
+    <td>27</td>
+    <td>Larson</td>
+  </tr>
+  <tr>
+    <td>28</td>
+    <td>Pierre (not runaway)</td>
+  </tr>
+  <tr>
+    <td>30</td>
+    <td>Skate kid</td>
+  </tr>
+  <tr>
+    <td>31</td>
+    <td>Cowboy</td>
+  </tr>
+  <tr>
+    <td>32</td>
+    <td>Kold</td>
+  </tr>
+  <tr>
+    <td>33</td>
+    <td>Natla (items drop after second phase)</td>
+  </tr>
+  <tr>
+    <td>34</td>
+    <td>Torso</td>
   </tr>
 </table>
 

--- a/src/game/carrier.h
+++ b/src/game/carrier.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "global/types.h"
+
 #include <stdint.h>
 
 void Carrier_InitialiseLevel(int32_t level_num);
 int32_t Carrier_GetItemCount(int16_t item_num);
 void Carrier_TestItemDrops(int16_t item_num);
 void Carrier_TestLegacyDrops(int16_t item_num);
+DROP_STATUS Carrier_GetSaveStatus(const CARRIED_ITEM *item);
+void Carrier_AnimateDrops(void);

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -1,6 +1,7 @@
 #include "game/items.h"
 
 #include "config.h"
+#include "game/carrier.h"
 #include "game/room.h"
 #include "game/shell.h"
 #include "game/sound.h"
@@ -54,6 +55,8 @@ void Item_Control(void)
         }
         item_num = item->next_active;
     }
+
+    Carrier_AnimateDrops();
 }
 
 void Item_Kill(int16_t item_num)

--- a/src/game/objects/creatures/crocodile.c
+++ b/src/game/objects/creatures/crocodile.c
@@ -1,6 +1,7 @@
 #include "game/objects/creatures/crocodile.h"
 
 #include "config.h"
+#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/effects/blood.h"
 #include "game/items.h"
@@ -241,6 +242,7 @@ void Alligator_Control(int16_t item_num)
             item->current_anim_state = ALLIGATOR_DEATH;
             Item_SwitchToAnim(item, ALLIGATOR_DIE_ANIM, 0);
             item->hit_points = DONT_TARGET;
+            Carrier_TestItemDrops(item_num);
         }
 
         wh = Room_GetWaterHeight(

--- a/src/game/objects/creatures/mutant.c
+++ b/src/game/objects/creatures/mutant.c
@@ -1,5 +1,6 @@
 #include "game/objects/creatures/mutant.h"
 
+#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/effects/blood.h"
 #include "game/effects/exploding_death.h"
@@ -122,6 +123,7 @@ void Mutant_FlyerControl(int16_t item_num)
             LOT_DisableBaddieAI(item_num);
             Item_Kill(item_num);
             item->status = IS_DEACTIVATED;
+            Carrier_TestItemDrops(item_num);
             return;
         }
     } else {

--- a/src/game/objects/creatures/rat.c
+++ b/src/game/objects/creatures/rat.c
@@ -1,5 +1,6 @@
 #include "game/objects/creatures/rat.h"
 
+#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/effects/blood.h"
 #include "game/items.h"
@@ -205,6 +206,7 @@ void Vole_Control(int16_t item_num)
         if (item->current_anim_state != VOLE_DEATH) {
             item->current_anim_state = VOLE_DEATH;
             Item_SwitchToAnim(item, VOLE_DIE_ANIM, 0);
+            Carrier_TestItemDrops(item_num);
         }
 
         Creature_Head(item, head);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -603,6 +603,18 @@ static bool Savegame_BSON_LoadItems(
 
                 carried_item->object_id = json_object_get_int(
                     carried_item_obj, "object_id", carried_item->object_id);
+                carried_item->pos.x = json_object_get_int(
+                    carried_item_obj, "x", carried_item->pos.x);
+                carried_item->pos.y = json_object_get_int(
+                    carried_item_obj, "y", carried_item->pos.y);
+                carried_item->pos.z = json_object_get_int(
+                    carried_item_obj, "z", carried_item->pos.z);
+                carried_item->pos.y_rot = json_object_get_int(
+                    carried_item_obj, "y_rot", carried_item->pos.y_rot);
+                carried_item->room_number = json_object_get_int(
+                    carried_item_obj, "room_num", carried_item->room_number);
+                carried_item->fall_speed = json_object_get_int(
+                    carried_item_obj, "fall_speed", carried_item->fall_speed);
                 carried_item->status = json_object_get_int(
                     carried_item_obj, "status", carried_item->status);
 
@@ -1079,18 +1091,20 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
 
         struct json_array_s *carried_items_arr = json_array_new();
 
-        CARRIED_ITEM *drop_item = item->carried_item;
+        const CARRIED_ITEM *drop_item = item->carried_item;
         while (drop_item) {
             struct json_object_s *drop_obj = json_object_new();
             json_object_append_int(drop_obj, "object_id", drop_item->object_id);
+            json_object_append_int(drop_obj, "x", drop_item->pos.x);
+            json_object_append_int(drop_obj, "y", drop_item->pos.y);
+            json_object_append_int(drop_obj, "z", drop_item->pos.z);
+            json_object_append_int(drop_obj, "y_rot", drop_item->pos.y_rot);
+            json_object_append_int(
+                drop_obj, "room_num", drop_item->room_number);
+            json_object_append_int(
+                drop_obj, "fall_speed", drop_item->fall_speed);
 
-            ITEM_STATUS status = drop_item->status;
-            if (status == IS_ACTIVE) {
-                ITEM_INFO *drop = &g_Items[drop_item->spawn_number];
-                if (drop->status == IS_INVISIBLE) {
-                    status = IS_INVISIBLE;
-                }
-            }
+            DROP_STATUS status = Carrier_GetSaveStatus(drop_item);
             json_object_append_int(drop_obj, "status", status);
 
             json_array_append_object(carried_items_arr, drop_obj);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1369,10 +1369,20 @@ typedef struct ROOM_INFO {
     uint16_t flags;
 } ROOM_INFO;
 
+typedef enum DROP_STATUS {
+    DS_CARRIED = 0,
+    DS_FALLING = 1,
+    DS_DROPPED = 2,
+    DS_COLLECTED = 3,
+} DROP_STATUS;
+
 typedef struct CARRIED_ITEM {
     GAME_OBJECT_ID object_id;
     int16_t spawn_number;
-    enum ITEM_STATUS status;
+    PHD_3DPOS pos;
+    int16_t room_number;
+    int16_t fall_speed;
+    DROP_STATUS status;
     struct CARRIED_ITEM *next_item;
 } CARRIED_ITEM;
 


### PR DESCRIPTION
Resolves #1029.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

All enemies are now capable of carrying and dropping items. Items spawned by flying or swimming creatures will fall to the ground for a more realistic effect, rather than the items appearing out of nowhere on the floor.

I added the new `DROP_STATUS` enum for clarity as there are a few different states, and this was easier than adapting `ITEM_STATUS` to fit. I've also moved a little logic out of the savegame for determining status of picked up items, as I felt that didn't belong there.

No additional changelog entry as already covered in #1012.
