### PR TITLE
creature: fix dead water creature placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added a pickup overlay for the Midas gold bar when it changes from lead (#1010)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - fixed Lara never using the step back down right animation (#1014)
+- fixed dead crocodiles floating in drained rooms (#1031)
 - improved frame scheduling to use less CPU (#985)
 - improved and expanded gameflow documentation (#1018)
 - rotated the Scion in Tomb of Qualopec to face the the main gate and Qualopec (#1007)

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -10,6 +10,19 @@
 #define CREATURE_SHOOT_RANGE SQUARE(WALL_L * 7) // = 51380224
 #define CREATURE_MISS_CHANCE 0x2000
 
+typedef struct HYBRID_INFO {
+    struct {
+        GAME_OBJECT_ID id;
+        int16_t active_anim;
+        int16_t death_anim;
+        int16_t death_state;
+    } land;
+    struct {
+        GAME_OBJECT_ID id;
+        int16_t active_anim;
+    } water;
+} HYBRID_INFO;
+
 void Creature_Initialise(int16_t item_num);
 void Creature_AIInfo(ITEM_INFO *item, AI_INFO *info);
 void Creature_Mood(ITEM_INFO *item, AI_INFO *info, bool violent);
@@ -29,3 +42,5 @@ bool Creature_CanTargetEnemy(ITEM_INFO *item, AI_INFO *info);
 bool Creature_ShootAtLara(
     ITEM_INFO *item, int32_t distance, BITE_INFO *gun, int16_t extra_rotation,
     int16_t damage);
+bool Creature_TestHybridState(
+    int16_t item_num, int32_t *wh, const HYBRID_INFO *info);

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -42,5 +42,5 @@ bool Creature_CanTargetEnemy(ITEM_INFO *item, AI_INFO *info);
 bool Creature_ShootAtLara(
     ITEM_INFO *item, int32_t distance, BITE_INFO *gun, int16_t extra_rotation,
     int16_t damage);
-bool Creature_TestHybridState(
+bool Creature_EnsureHabitat(
     int16_t item_num, int32_t *wh, const HYBRID_INFO *info);

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -535,7 +535,11 @@ void Item_SwitchToObjAnim(
     GAME_OBJECT_ID object_number)
 {
     item->anim_number = g_Objects[object_number].anim_index + anim_index;
-    item->frame_number = g_Anims[item->anim_number].frame_base + frame;
+    if (frame < 0) {
+        item->frame_number = g_Anims[item->anim_number].frame_end + frame + 1;
+    } else {
+        item->frame_number = g_Anims[item->anim_number].frame_base + frame;
+    }
 }
 
 void Item_Animate(ITEM_INFO *item)

--- a/src/game/objects/creatures/crocodile.c
+++ b/src/game/objects/creatures/crocodile.c
@@ -61,7 +61,7 @@ static const HYBRID_INFO m_CrocodileInfo = {
     .land.death_anim = CROCODILE_DIE_ANIM,
     .land.death_state = CROCODILE_DEATH,
     .water.id = O_ALLIGATOR,
-    .water.active_anim = ALLIGATOR_EMPTY
+    .water.active_anim = ALLIGATOR_EMPTY,
 };
 
 void Croc_Setup(OBJECT_INFO *obj)
@@ -189,7 +189,7 @@ void Croc_Control(int16_t item_num)
 
     // Test conversion to alligator and set relevant pathfinding values.
     int32_t wh;
-    if (Creature_TestHybridState(item_num, &wh, &m_CrocodileInfo) && croc) {
+    if (Creature_EnsureHabitat(item_num, &wh, &m_CrocodileInfo) && croc) {
         croc->LOT.step = WALL_L * 20;
         croc->LOT.drop = -WALL_L * 20;
         croc->LOT.fly = STEP_L / 16;
@@ -251,7 +251,7 @@ void Alligator_Control(int16_t item_num)
 
         // Test if we should convert to a crocodile. If not, control the death
         // pose of the alligator in the water.
-        if (!Creature_TestHybridState(item_num, &wh, &m_CrocodileInfo)) {
+        if (!Creature_EnsureHabitat(item_num, &wh, &m_CrocodileInfo)) {
             if (item->pos.y > wh + ALLIGATOR_FLOAT_SPEED) {
                 item->pos.y -= ALLIGATOR_FLOAT_SPEED;
             } else if (item->pos.y < wh) {
@@ -320,7 +320,7 @@ void Alligator_Control(int16_t item_num)
     Creature_Head(item, head);
 
     // Test alive conversion to crocodile and set relevant pathfinding values.
-    if (Creature_TestHybridState(item_num, &wh, &m_CrocodileInfo)) {
+    if (Creature_EnsureHabitat(item_num, &wh, &m_CrocodileInfo)) {
         gator->LOT.step = STEP_L;
         gator->LOT.drop = -STEP_L;
         gator->LOT.fly = 0;

--- a/src/game/objects/creatures/rat.c
+++ b/src/game/objects/creatures/rat.c
@@ -49,6 +49,13 @@ typedef enum {
 
 static BITE_INFO m_RatBite = { 0, -11, 108, 3 };
 
+static const HYBRID_INFO m_RatInfo = { .land.id = O_RAT,
+                                       .land.active_anim = RAT_EMPTY,
+                                       .land.death_anim = RAT_DIE_ANIM,
+                                       .land.death_state = RAT_DEATH,
+                                       .water.id = O_VOLE,
+                                       .water.active_anim = VOLE_EMPTY };
+
 void Rat_Setup(OBJECT_INFO *obj)
 {
     if (!obj->loaded) {
@@ -153,16 +160,8 @@ void Rat_Control(int16_t item_num)
 
     Creature_Head(item, head);
 
-    int32_t wh = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_number);
-    if (wh != NO_HEIGHT) {
-        item->object_number = O_VOLE;
-        Item_SwitchToAnim(item, VOLE_EMPTY, 0);
-        item->current_anim_state =
-            g_Anims[item->anim_number].current_anim_state;
-        item->goal_anim_state = item->current_anim_state;
-        item->pos.y = wh;
-    }
+    int32_t wh;
+    Creature_TestHybridState(item_num, &wh, &m_RatInfo);
 
     Creature_Animate(item_num, angle, 0);
 }
@@ -219,8 +218,7 @@ void Vole_Control(int16_t item_num)
             item->object_number = O_RAT;
             item->current_anim_state = RAT_DEATH;
             item->goal_anim_state = RAT_DEATH;
-            Item_SwitchToAnim(item, RAT_DIE_ANIM, 0);
-            item->frame_number = g_Anims[item->anim_number].frame_end;
+            Item_SwitchToAnim(item, RAT_DIE_ANIM, -1);
             item->pos.y = item->floor;
         }
     } else {
@@ -255,15 +253,8 @@ void Vole_Control(int16_t item_num)
 
         Creature_Head(item, head);
 
-        int32_t wh = Room_GetWaterHeight(
-            item->pos.x, item->pos.y, item->pos.z, item->room_number);
-        if (wh == NO_HEIGHT) {
-            item->object_number = O_RAT;
-            Item_SwitchToAnim(item, RAT_EMPTY, 0);
-            item->current_anim_state =
-                g_Anims[item->anim_number].current_anim_state;
-            item->goal_anim_state = item->current_anim_state;
-        }
+        int32_t wh;
+        Creature_TestHybridState(item_num, &wh, &m_RatInfo);
 
         int32_t height = item->pos.y;
         item->pos.y = item->floor;

--- a/src/game/objects/creatures/rat.c
+++ b/src/game/objects/creatures/rat.c
@@ -49,12 +49,14 @@ typedef enum {
 
 static BITE_INFO m_RatBite = { 0, -11, 108, 3 };
 
-static const HYBRID_INFO m_RatInfo = { .land.id = O_RAT,
-                                       .land.active_anim = RAT_EMPTY,
-                                       .land.death_anim = RAT_DIE_ANIM,
-                                       .land.death_state = RAT_DEATH,
-                                       .water.id = O_VOLE,
-                                       .water.active_anim = VOLE_EMPTY };
+static const HYBRID_INFO m_RatInfo = {
+    .land.id = O_RAT,
+    .land.active_anim = RAT_EMPTY,
+    .land.death_anim = RAT_DIE_ANIM,
+    .land.death_state = RAT_DEATH,
+    .water.id = O_VOLE,
+    .water.active_anim = VOLE_EMPTY,
+};
 
 void Rat_Setup(OBJECT_INFO *obj)
 {
@@ -161,7 +163,7 @@ void Rat_Control(int16_t item_num)
     Creature_Head(item, head);
 
     int32_t wh;
-    Creature_TestHybridState(item_num, &wh, &m_RatInfo);
+    Creature_EnsureHabitat(item_num, &wh, &m_RatInfo);
 
     Creature_Animate(item_num, angle, 0);
 }
@@ -254,7 +256,7 @@ void Vole_Control(int16_t item_num)
         Creature_Head(item, head);
 
         int32_t wh;
-        Creature_TestHybridState(item_num, &wh, &m_RatInfo);
+        Creature_EnsureHabitat(item_num, &wh, &m_RatInfo);
 
         int32_t height = item->pos.y;
         item->pos.y = item->floor;


### PR DESCRIPTION
Resolves #1031.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This moves the logic for shifting dead rats and crocodiles into shared functions in `creature.c` to resolve inconsistencies between the two and to cover all scenarios. Once a dead hybrid creature has been converted to its land type, it will remain in that state permanently.

I've also introduced an idiom in `Item_SwitchToObjAnim` that if you pass a negative frame number, this will be inferred as meaning the frame should be relative from the end of the animation.

