### PR TITLE
build: fix failure with non-docker build

### DIFF
--- a/docker/game-linux/entrypoint.sh
+++ b/docker/game-linux/entrypoint.sh
@@ -2,7 +2,6 @@
 set -x
 set -e
 
-export CFLAGS=-DDOCKER_BUILD
 EXE_FILE=TR1X
 
 if [ ! -f /app/build/linux/build.ninja ]; then

--- a/docker/game-win/entrypoint.sh
+++ b/docker/game-win/entrypoint.sh
@@ -2,8 +2,6 @@
 set -x
 set -e
 
-export CFLAGS=-DDOCKER_BUILD
-
 if [ ! -f /app/build/win/build.ninja ]; then
     meson --buildtype "$TARGET" /app/build/win/ --cross /app/docker/game-win/meson_linux_mingw32.txt --pkg-config-path=$PKG_CONFIG_PATH
 fi

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ endif
 build_opts = [
   '-Wno-unused',
   '-D_GNU_SOURCE',
+  '-DMESON_BUILD',
 ]
 c_opts = []
 add_project_arguments(build_opts + c_opts, language: 'c')

--- a/src/global/vars.c
+++ b/src/global/vars.c
@@ -101,7 +101,7 @@ int32_t g_LsAdder = 0;
 int32_t g_LsDivider = 0;
 SHADOW_INFO g_ShadowInfo = { 0 };
 
-#ifndef DOCKER_BUILD
+#ifndef MESON_BUILD
 const char *g_TR1XVersion = "TR1X (non-Docker build)";
 GAMEFLOW_DEFAULT_STRING g_GameFlowDefaultStrings[] = {
     { 0, NULL },


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Building on Linux directly with meson (as docker unnecessary) failed with;

```
/usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: TR1X.p/src_global_vars.c.o:/srv/git/TR1X-build-meson/builddir/../src/global/vars.c:105: multiple definition of `g_TR1XVersion'; TR1X.p/meson-generated_.._init.c.o:/srv/git/TR1X-build-meson/builddir/init.c:6: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: TR1X.p/src_global_vars.c.o:/srv/git/TR1X-build-meson/builddir/../src/global/vars.c:106: multiple definition of `g_GameFlowDefaultStrings'; TR1X.p/meson-generated_.._init.c.o:/srv/git/TR1X-build-meson/builddir/init.c:8: first defined here
```

Looks like DOCKER_BUILD, as introduced in https://github.com/LostArtefacts/TR1X/commit/d87837d95169ffe96871f4bf555e1b5259dd4672, is unnecessary as meson.build always calls tools/generate_init which always generates an init.c with these two parameters. Deleting the ifndef DOCKER_BUILD section in src/global/vars.c allowed the build to complete. Left the define in entrypoint.sh files as may be useful in future.