### PR TITLE
lara: enable lean jumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added support for customizable enemy item drops via the gameflow (#967)
 - added an option to enable F-key and inventory frame buffering (#591)
 - added a pickup overlay for the Midas gold bar when it changes from lead (#1010)
+- added an option to allow Lara to creep forwards or backwards further when performing neutral jumps, in line with TR2+ (#998)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - fixed Lara never using the step back down right animation (#1014)
 - fixed dead crocodiles floating in drained rooms (#1031)

--- a/src/config.c
+++ b/src/config.c
@@ -239,6 +239,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(enable_save_crystals, false);
     READ_BOOL(enable_uw_roll, true);
     READ_BOOL(enable_buffering, false);
+    READ_BOOL(enable_lean_jumping, false);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -443,6 +444,7 @@ bool Config_Write(void)
     WRITE_BOOL(enable_save_crystals);
     WRITE_BOOL(enable_uw_roll);
     WRITE_BOOL(enable_buffering);
+    WRITE_BOOL(enable_lean_jumping);
 
     WRITE_INTEGER(rendering.render_mode);
     WRITE_BOOL(rendering.enable_fullscreen);

--- a/src/config.h
+++ b/src/config.h
@@ -124,6 +124,7 @@ typedef struct {
     bool enable_save_crystals;
     bool enable_uw_roll;
     bool enable_buffering;
+    bool enable_lean_jumping;
 
     struct {
         int32_t layout;

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -107,6 +107,10 @@
       "Title": "Underwater roll",
       "Description": "Allows Lara to roll while underwater, similar to TR2+."
     },
+    "enable_lean_jumping": {
+      "Title": "Lean jumping",
+      "Description": "Allows Lara to creep forwards or backwards further when performing neutral jumps with the relevant input key pressed, similar to TR2+."
+    },
     "enable_numeric_keys": {
       "Title": "Numeric key quick item use",
       "Description": "Enables quick weapon draws and medipack usage.\n- 1: Draw pistols\n- 2: Draw shotgun\n- 3: Draw magnums\n- 4: Draw Uzis\n- 8: Use small medipack\n- 9: Use large medipack"

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -107,6 +107,10 @@
       "Title": "Retourné sous-marin",
       "Description": "Permet à Lara de faire un demi tour immédiat, sous l'eau, similaire a TR2+."
     },
+    "enable_lean_jumping": {
+      "Title": "Air controle du saut sur place",
+      "Description": "Permet à Lara d'avancer ou de reculer davantage lors de l'exécution de sauts sur place avec la touche d'entrée appropriée enfoncée (avancer ou reculer), similaire à TR2+."
+    },
     "enable_numeric_keys": {
       "Title": "Touches rapide numériques",
       "Description": "Active les touches rapides numériques en haut du clavier, en raccourci d'équipement d'armes ou d'utilisation de soins.\n- 1: Pistolets\n- 2: Fusil à pompe\n- 3: Magnums\n- 4: Uzis\n- 8: Utiliser une petite trousse de soin\n- 9: Utiliser une grande trousse de soin"

--- a/tools/config/TR1X_ConfigTool/Resources/specification.json
+++ b/tools/config/TR1X_ConfigTool/Resources/specification.json
@@ -78,6 +78,11 @@
           "DefaultValue": true
         },
         {
+          "Field": "enable_lean_jumping",
+          "DataType": "Bool",
+          "DefaultValue": false
+        },
+        {
           "Field": "enable_numeric_keys",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
Resolves #998.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows Lara to creep forwards further compared to normal, when performing a neutral jump and pressing the forward input. It also allows for the same with backward input - this was not handled at all in the original, so Lara would continue to nudge forwards in that case.

In the original, she nudges forward 72 units; in TR2 it's 171 units. I've made a comparison video below.

https://youtu.be/gGxD35TUqoM