### PR TITLE
build: correct import name for python json5 module in meson build

### DIFF
--- a/tools/generate_init
+++ b/tools/generate_init
@@ -4,7 +4,7 @@ import io
 import json
 from pathlib import Path
 
-import pyjson5
+import json5
 
 REPO_DIR = Path(__file__).parent.parent
 BIN_DIR = REPO_DIR / "bin"
@@ -36,7 +36,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def get_init_c(version: str) -> str:
-    gameflow = pyjson5.loads(GAMEFLOW_PATH.read_text(encoding="utf-8"))
+    gameflow = json5.loads(GAMEFLOW_PATH.read_text(encoding="utf-8"))
     with io.StringIO() as handle:
         print(BODY_PREFIX.format(version=version).lstrip(), file=handle)
         for key, value in gameflow["strings"].items():


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Whilst the package name is _pyjson5_, the actual module name within python is _json5_.  Caused below build failure on my Gentoo distro. Ubuntu/Debian do not make any changes to the pyjson5 package so wonder if they patched a wildcard match elsewhere in Python. If someone could please test this works on docker.

```
[24/164] Generating fake_init with a custom command
FAILED: init.c
/usr/bin/python3 /srv/git/TR1X-test-pyjson5-failure/tools/generate_init --version-file version.txt -o init.c
Traceback (most recent call last):
  File "/srv/git/TR1X-test-pyjson5-failure/tools/generate_init", line 7, in <module>
    import pyjson5
ModuleNotFoundError: No module named 'pyjson5'
```