### PR TITLE
installer: add UB pack option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added an option to enable F-key and inventory frame buffering (#591)
 - added a pickup overlay for the Midas gold bar when it changes from lead (#1010)
 - added an option to allow Lara to creep forwards or backwards further when performing neutral jumps, in line with TR2+ (#998)
+- added an option to the installer to choose between the original and fan-made Unfinished Business level sets (#1019)
 - fixed baddies dropping duplicate guns (only affects mods) (#1000)
 - fixed Lara never using the step back down right animation (#1014)
 - fixed dead crocodiles floating in drained rooms (#1031)

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ We hope that eventually these alerts will go away as the popularity of the proje
 
        Optionally you can also install the Unfinished Business expansion pack files.
        - Either one of these these variants:
-         - https://lostartefacts.dev/aux/tr1x/trub-music.zip (includes music triggers)
-         - https://lostartefacts.dev/aux/tr1x/trub-vanilla.zip (does not include music triggers)
+         - https://lostartefacts.dev/aux/tr1x/trub-music.zip (fan-made patch to include music triggers)
+         - https://lostartefacts.dev/aux/tr1x/trub-vanilla.zip (original level files, which do not include music triggers)
        - Or the more manual link: https://archive.org/details/tomb-raider-i-unfinished-business-pc-eng-full-version_20201225
    2. For TombATI users this means copying the `data`, `fmv` and `music` directories.
 5. To play the game, run `TR1X.exe`.

--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ We hope that eventually these alerts will go away as the popularity of the proje
     1. For Steam and GOG users, extract the original `GAME.BIN` file using a tool such as UltraISO to your target directory.
        Note that neither the GOG nor the Steam releases ship the music files. You have a few options here:
        - You can download the music files from the link below.  
-         https://tmp.sakuya.pl/tr1x/music.zip
+         https://lostartefacts.dev/aux/tr1x/music.zip
          The legality of this approach is disputable.
        - Rip the assets yourself from a physical PlayStation/SegaSaturn disk.
 
        Optionally you can also install the Unfinished Business expansion pack files.
-       - Either this variant: https://tmp.sakuya.pl/tr1x/unfinished_business.zip
+       - Either one of these these variants:
+         - https://lostartefacts.dev/aux/tr1x/trub-music.zip (includes music triggers)
+         - https://lostartefacts.dev/aux/tr1x/trub-vanilla.zip (does not include music triggers)
        - Or the more manual link: https://archive.org/details/tomb-raider-i-unfinished-business-pc-eng-full-version_20201225
    2. For TombATI users this means copying the `data`, `fmv` and `music` directories.
 5. To play the game, run `TR1X.exe`.

--- a/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
+++ b/tools/installer/Installer/Controls/InstallSettingsStepControl.xaml
@@ -101,15 +101,24 @@
                     </TextBlock>
                 </CheckBox>
 
-                <CheckBox VerticalAlignment="Center" Margin="0,0,0,12" IsChecked="{Binding InstallSettings.DownloadUnfinishedBusiness}" IsEnabled="{Binding InstallSettings.IsDownloadingUnfinishedBusinessNeeded}">
-                    <TextBlock TextWrapping="Wrap">
-                        Download Unfinished Business expansion pack
-                        <Run Foreground="ForestGreen" Text="{Binding InstallSettings.IsDownloadingUnfinishedBusinessNeeded, Converter={utils:ConditionalMarkupConverter TrueValue='', FalseValue='(already found)'}, Mode=OneWay}" />
-                        <LineBreak />
-                        <Run Style="{StaticResource small}">
-                        The Unfinished Business expansion pack was made freeware. However, the Steam and GOG versions do not ship it. This option lets you download the expansion files automatically (6 MB).
-                        </Run>
-                    </TextBlock>
+                <CheckBox VerticalAlignment="Center" Margin="0,0,0,6" IsChecked="{Binding InstallSettings.DownloadUnfinishedBusiness}" IsEnabled="{Binding InstallSettings.IsDownloadingUnfinishedBusinessNeeded}">
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel.Resources>
+                            <utils:ComparisonConverter x:Key="ComparisonConverter" />
+                        </StackPanel.Resources>
+                        <TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
+                            Download Unfinished Business expansion pack
+                            <Run Foreground="ForestGreen" Text="{Binding InstallSettings.IsDownloadingUnfinishedBusinessNeeded, Converter={utils:ConditionalMarkupConverter TrueValue='', FalseValue='(already found)'}, Mode=OneWay}" />
+                            <LineBreak />
+                            <Run Style="{StaticResource small}">
+                            The Unfinished Business expansion pack was made freeware. However, the Steam and GOG versions do not ship it. This option lets you download the expansion files automatically (6 MB).
+                            </Run>
+                        </TextBlock>
+                        <RadioButton IsEnabled="{Binding InstallSettings.DownloadUnfinishedBusiness}" Style="{StaticResource small}" Margin="0,0,0,6" Content="Fan-made edition (includes music triggers)"
+                                     IsChecked="{Binding Path=InstallSettings.UnfinishedBusinessType, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static models:UBPackType.Music}}"/>
+                        <RadioButton IsEnabled="{Binding InstallSettings.DownloadUnfinishedBusiness}" Style="{StaticResource small}" Margin="0,0,0,6" Content="Original edition (does not include music triggers)"
+                                     IsChecked="{Binding Path=InstallSettings.UnfinishedBusinessType, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static models:UBPackType.Vanilla}}"/>
+                    </StackPanel>
                 </CheckBox>
 
                 <CheckBox VerticalAlignment="Center" Margin="0,0,0,12" IsChecked="{Binding InstallSettings.ImportSaves}" IsEnabled="{Binding InstallSettings.InstallSource.IsImportingSavesSupported}">

--- a/tools/installer/Installer/Installers/InstallExecutor.cs
+++ b/tools/installer/Installer/Installers/InstallExecutor.cs
@@ -10,6 +10,8 @@ namespace Installer.Installers;
 
 public class InstallExecutor
 {
+    private static readonly string _resourceBaseURL = "https://lostartefacts.dev/aux/tr1x";
+
     public InstallExecutor(InstallSettings settings)
     {
         _settings = settings;
@@ -43,7 +45,7 @@ public class InstallExecutor
 
         if (_settings.DownloadUnfinishedBusiness)
         {
-            await DownloadUnfinishedBusinessFiles(_settings.TargetDirectory, progress);
+            await DownloadUnfinishedBusinessFiles(_settings.TargetDirectory, _settings.UnfinishedBusinessType, progress);
         }
         if (_settings.CreateDesktopShortcut)
         {
@@ -92,12 +94,14 @@ public class InstallExecutor
 
     protected static async Task DownloadMusicFiles(string targetDirectory, IProgress<InstallProgress> progress)
     {
-        await InstallUtils.DownloadZip("https://tmp.sakuya.pl/tr1x/music.zip", targetDirectory, progress);
+        await InstallUtils.DownloadZip($"{_resourceBaseURL}/music.zip", targetDirectory, progress);
     }
 
-    protected static async Task DownloadUnfinishedBusinessFiles(string targetDirectory, IProgress<InstallProgress> progress)
+    protected static async Task DownloadUnfinishedBusinessFiles(string targetDirectory, UBPackType type, IProgress<InstallProgress> progress)
     {
-        await InstallUtils.DownloadZip("https://tmp.sakuya.pl/tr1x/unfinished_business.zip", targetDirectory, progress);
+        await InstallUtils.DownloadZip(
+            $"{_resourceBaseURL}/trub-{type.ToString().ToLower()}.zip",
+            targetDirectory, progress);
     }
 
     private readonly InstallSettings _settings;

--- a/tools/installer/Installer/Models/InstallSettings.cs
+++ b/tools/installer/Installer/Models/InstallSettings.cs
@@ -43,6 +43,19 @@ public class InstallSettings : BaseNotifyPropertyChanged
         }
     }
 
+    public UBPackType UnfinishedBusinessType
+    {
+        get => _unfinishedBusinessType;
+        set
+        {
+            if (value != _unfinishedBusinessType)
+            {
+                _unfinishedBusinessType = value;
+                NotifyPropertyChanged();
+            }
+        }
+    }
+
     public bool ImportSaves
     {
         get => _importSaves;
@@ -118,6 +131,7 @@ public class InstallSettings : BaseNotifyPropertyChanged
     private bool _createDesktopShortcut = true;
     private bool _downloadMusic;
     private bool _downloadUnfinishedBusiness;
+    private UBPackType _unfinishedBusinessType;
     private bool _importSaves;
     private IInstallSource? _installSource;
     private string? _sourceDirectory;

--- a/tools/installer/Installer/Models/UBPackType.cs
+++ b/tools/installer/Installer/Models/UBPackType.cs
@@ -1,0 +1,7 @@
+﻿namespace Installer.Models;
+
+public enum UBPackType
+{
+    Music,
+    Vanilla,
+}

--- a/tools/installer/Installer/Utils/ComparisonConverter.cs
+++ b/tools/installer/Installer/Utils/ComparisonConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Installer.Utils;
+
+public class ComparisonConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value.Equals(parameter);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return (bool)value ? parameter : Binding.DoNothing;
+    }
+}


### PR DESCRIPTION
Resolves #1019.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds an option to the installer to allow choosing between the original Unfinished Business level files or the fan-made ones that include music triggers.