### PR TITLE
game: make game status modular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed incorrect usage reference URLs in the gameflow files (#1073)
+- fixed random number generation becoming stuck after entering and leaving the inventory, which affected effects and SFX (#1070, #1074)
 
 ## [3.0.1](https://github.com/LostArtefacts/TR1X/compare/3.0...3.0.1) - 2023-11-10
 - fixed installer not detecting old Tomb1Main installations (#1071)

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -5,6 +5,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+bool Game_HasStatus(GAME_STATUS status);
+void Game_SetStatus(GAME_STATUS status);
+void Game_AddStatus(GAME_STATUS status);
+void Game_RemoveStatus(GAME_STATUS status);
+void Game_RestoreStatus(void);
+
 bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 int32_t Game_Stop(void);
 int32_t Game_Loop(GAMEFLOW_LEVEL_TYPE level_type);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -5,11 +5,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool Game_HasStatus(GAME_STATUS status);
-void Game_SetStatus(GAME_STATUS status);
-void Game_AddStatus(GAME_STATUS status);
-void Game_RemoveStatus(GAME_STATUS status);
-void Game_RestoreStatus(void);
+GAME_STATUS Game_GetStatus(void);
+void Game_SetStatus(GAME_STATUS stauts);
 
 bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 int32_t Game_Stop(void);

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -31,8 +31,7 @@
 
 static const int32_t m_AnimationRate = 0x8000;
 static int32_t m_FrameCount = 0;
-static GAME_STATUS m_CurrentStatus = GMS_IN_GAME;
-static GAME_STATUS m_PreviousStatus = GMS_IN_GAME;
+static GAME_STATUS m_CurrentStatus = GS_INITIAL;
 
 static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type);
 
@@ -155,7 +154,7 @@ void Game_ProcessInput(void)
         Lara_UseItem(O_BIGMEDI_OPTION);
     }
 
-    if (g_Config.enable_buffering && Game_HasStatus(GMS_IN_GAME)) {
+    if (g_Config.enable_buffering && Game_GetStatus() == GS_IN_GAME) {
         if (g_Input.toggle_bilinear_filter) {
             FRAME_BUFFER(toggle_bilinear_filter);
         } else if (g_Input.toggle_perspective_filter) {
@@ -166,36 +165,20 @@ void Game_ProcessInput(void)
     }
 }
 
-bool Game_HasStatus(GAME_STATUS status)
+GAME_STATUS Game_GetStatus(void)
 {
-    return m_CurrentStatus & status;
+    return m_CurrentStatus;
 }
 
 void Game_SetStatus(GAME_STATUS status)
 {
-    m_PreviousStatus = m_CurrentStatus;
     m_CurrentStatus = status;
-}
-
-void Game_AddStatus(GAME_STATUS status)
-{
-    m_CurrentStatus |= status;
-}
-
-void Game_RemoveStatus(GAME_STATUS status)
-{
-    m_CurrentStatus &= ~status;
-}
-
-void Game_RestoreStatus(void)
-{
-    m_CurrentStatus = m_PreviousStatus;
 }
 
 bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
     g_GameInfo.current_level_type = level_type;
-    Game_SetStatus(GMS_IN_GAME);
+    Game_SetStatus(GS_IN_GAME);
 
     switch (level_type) {
     case GFL_SAVED:

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -31,6 +31,8 @@
 
 static const int32_t m_AnimationRate = 0x8000;
 static int32_t m_FrameCount = 0;
+static GAME_STATUS m_CurrentStatus = GMS_IN_GAME;
+static GAME_STATUS m_PreviousStatus = GMS_IN_GAME;
 
 static int32_t Game_Control(int32_t nframes, GAMEFLOW_LEVEL_TYPE level_type);
 
@@ -153,8 +155,7 @@ void Game_ProcessInput(void)
         Lara_UseItem(O_BIGMEDI_OPTION);
     }
 
-    if (g_Config.enable_buffering
-        && !(g_GameInfo.status & (GMS_IN_INVENTORY | GMS_IN_PAUSE))) {
+    if (g_Config.enable_buffering && Game_HasStatus(GMS_IN_GAME)) {
         if (g_Input.toggle_bilinear_filter) {
             FRAME_BUFFER(toggle_bilinear_filter);
         } else if (g_Input.toggle_perspective_filter) {
@@ -165,10 +166,36 @@ void Game_ProcessInput(void)
     }
 }
 
+bool Game_HasStatus(GAME_STATUS status)
+{
+    return m_CurrentStatus & status;
+}
+
+void Game_SetStatus(GAME_STATUS status)
+{
+    m_PreviousStatus = m_CurrentStatus;
+    m_CurrentStatus = status;
+}
+
+void Game_AddStatus(GAME_STATUS status)
+{
+    m_CurrentStatus |= status;
+}
+
+void Game_RemoveStatus(GAME_STATUS status)
+{
+    m_CurrentStatus &= ~status;
+}
+
+void Game_RestoreStatus(void)
+{
+    m_CurrentStatus = m_PreviousStatus;
+}
+
 bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 {
     g_GameInfo.current_level_type = level_type;
-    g_GameInfo.status = GMS_IN_GAME;
+    Game_SetStatus(GMS_IN_GAME);
 
     switch (level_type) {
     case GFL_SAVED:

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -152,7 +152,8 @@ bool Game_Pause(void)
 
     Music_Pause();
     Sound_PauseAll();
-    Game_SetStatus(GMS_IN_PAUSE);
+    const GAME_STATUS old_status = Game_GetStatus();
+    Game_SetStatus(GS_IN_PAUSE);
 
     Output_FadeToSemiBlack(true);
     int32_t select = Game_Pause_Loop();
@@ -162,6 +163,6 @@ bool Game_Pause(void)
     Sound_UnpauseAll();
     Requester_Remove(&m_PauseRequester);
     Game_Pause_RemoveText();
-    Game_RestoreStatus();
+    Game_SetStatus(old_status);
     return select < 0;
 }

--- a/src/game/game/game_pause.c
+++ b/src/game/game/game_pause.c
@@ -10,7 +10,6 @@
 #include "game/sound.h"
 #include "game/text.h"
 #include "global/types.h"
-#include "global/vars.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -153,7 +152,7 @@ bool Game_Pause(void)
 
     Music_Pause();
     Sound_PauseAll();
-    g_GameInfo.status |= GMS_IN_PAUSE;
+    Game_SetStatus(GMS_IN_PAUSE);
 
     Output_FadeToSemiBlack(true);
     int32_t select = Game_Pause_Loop();
@@ -163,6 +162,6 @@ bool Game_Pause(void)
     Sound_UnpauseAll();
     Requester_Remove(&m_PauseRequester);
     Game_Pause_RemoveText();
-    g_GameInfo.status &= ~GMS_IN_PAUSE;
+    Game_RestoreStatus();
     return select < 0;
 }

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1301,8 +1301,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                 break;
             }
 
-            if (level_type == GFL_TITLE && !Game_HasStatus(GMS_GAME_MENU_SHOWN)
-                && !g_Config.enable_eidos_logo) {
+            if (Game_GetStatus() == GS_INITIAL && !g_Config.enable_eidos_logo) {
                 break;
             }
 

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1301,8 +1301,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                 break;
             }
 
-            if (level_type == GFL_TITLE
-                && !(g_GameInfo.status & GMS_GAME_MENU_SHOWN)
+            if (level_type == GFL_TITLE && !Game_HasStatus(GMS_GAME_MENU_SHOWN)
                 && !g_Config.enable_eidos_logo) {
                 break;
             }

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -1011,11 +1011,10 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
 int32_t Inv_Display(int inv_mode)
 {
-    g_GameInfo.status |= GMS_GAME_MENU_SHOWN;
-    GAME_STATUS old_status = g_GameInfo.status;
-    g_GameInfo.status |= GMS_IN_INVENTORY;
+    Game_AddStatus(GMS_GAME_MENU_SHOWN);
+    Game_SetStatus(GMS_IN_INVENTORY);
     int32_t inv_result = Inv_ConstructAndDisplay(inv_mode);
-    g_GameInfo.status = old_status;
+    Game_RestoreStatus();
 
     if (g_Config.enable_buffering) {
         g_OldInputDB.any = 0;

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -1011,10 +1011,12 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
 int32_t Inv_Display(int inv_mode)
 {
-    Game_AddStatus(GMS_GAME_MENU_SHOWN);
-    Game_SetStatus(GMS_IN_INVENTORY);
+    const GAME_STATUS old_status = Game_GetStatus();
+    Game_SetStatus(
+        g_CurrentLevel == g_GameFlow.title_level_num ? GS_IN_MAIN_MENU
+                                                     : GS_IN_INVENTORY);
     int32_t inv_result = Inv_ConstructAndDisplay(inv_mode);
-    Game_RestoreStatus();
+    Game_SetStatus(old_status);
 
     if (g_Config.enable_buffering) {
         g_OldInputDB.any = 0;

--- a/src/game/inventory/inventory_ring.c
+++ b/src/game/inventory/inventory_ring.c
@@ -1,6 +1,7 @@
 #include "game/inventory/inventory_ring.h"
 
 #include "config.h"
+#include "game/game.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
@@ -298,13 +299,13 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
         } else if (g_Config.healthbar_location == BL_BOTTOM_RIGHT) {
             Text_Hide(m_InvDownArrow2, true);
         }
-        g_GameInfo.status |= GMS_IN_INVENTORY_HEALTH;
+        Game_AddStatus(GMS_IN_INVENTORY_HEALTH);
     } else {
         Text_Hide(m_InvUpArrow1, false);
         Text_Hide(m_InvUpArrow2, false);
         Text_Hide(m_InvDownArrow1, false);
         Text_Hide(m_InvDownArrow2, false);
-        g_GameInfo.status &= ~GMS_IN_INVENTORY_HEALTH;
+        Game_RemoveStatus(GMS_IN_INVENTORY_HEALTH);
     }
 }
 

--- a/src/game/inventory/inventory_ring.c
+++ b/src/game/inventory/inventory_ring.c
@@ -1,7 +1,6 @@
 #include "game/inventory/inventory_ring.h"
 
 #include "config.h"
-#include "game/game.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
@@ -299,13 +298,13 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
         } else if (g_Config.healthbar_location == BL_BOTTOM_RIGHT) {
             Text_Hide(m_InvDownArrow2, true);
         }
-        Game_AddStatus(GMS_IN_INVENTORY_HEALTH);
+        g_GameInfo.inv_showing_medpack = true;
     } else {
         Text_Hide(m_InvUpArrow1, false);
         Text_Hide(m_InvUpArrow2, false);
         Text_Hide(m_InvDownArrow1, false);
         Text_Hide(m_InvDownArrow2, false);
-        Game_RemoveStatus(GMS_IN_INVENTORY_HEALTH);
+        g_GameInfo.inv_showing_medpack = false;
     }
 }
 

--- a/src/game/objects/traps/lightning_emitter.c
+++ b/src/game/objects/traps/lightning_emitter.c
@@ -1,6 +1,7 @@
 #include "game/objects/traps/lightning_emitter.h"
 
 #include "game/collide.h"
+#include "game/game.h"
 #include "game/gamebuf.h"
 #include "game/items.h"
 #include "game/lara.h"
@@ -213,7 +214,7 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
     for (int i = 0; i < LIGHTNING_STEPS; i++) {
         PHD_VECTOR *pos = &l->wibble[i];
-        if (g_GameInfo.status == GMS_IN_GAME) {
+        if (Game_HasStatus(GMS_IN_GAME)) {
             pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
             pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
             pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
@@ -267,7 +268,7 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
         for (j = 0; j < steps; j++) {
             PHD_VECTOR *pos = l->shoot[i];
-            if (g_GameInfo.status == GMS_IN_GAME) {
+            if (Game_HasStatus(GMS_IN_GAME)) {
                 pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
                 pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
                 pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;

--- a/src/game/objects/traps/lightning_emitter.c
+++ b/src/game/objects/traps/lightning_emitter.c
@@ -214,7 +214,7 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
     for (int i = 0; i < LIGHTNING_STEPS; i++) {
         PHD_VECTOR *pos = &l->wibble[i];
-        if (Game_HasStatus(GMS_IN_GAME)) {
+        if (Game_GetStatus() == GS_IN_GAME) {
             pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
             pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
             pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
@@ -268,7 +268,7 @@ void LightningEmitter_Draw(ITEM_INFO *item)
 
         for (j = 0; j < steps; j++) {
             PHD_VECTOR *pos = l->shoot[i];
-            if (Game_HasStatus(GMS_IN_GAME)) {
+            if (Game_GetStatus() == GS_IN_GAME) {
                 pos->x += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
                 pos->y += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;
                 pos->z += (Random_GetDraw() - PHD_90) * LIGHTNING_RND;

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -229,7 +229,7 @@ static void Overlay_BarGetLocation(
             - m_BarOffsetY[bar_info->location];
     }
 
-    if (Game_HasStatus(GMS_IN_INVENTORY)
+    if (Game_GetStatus() == GS_IN_INVENTORY
         && (bar_info->location == BL_TOP_CENTER
             || bar_info->location == BL_BOTTOM_CENTER)) {
         double scale_bar_to_text =
@@ -727,9 +727,10 @@ void Overlay_DrawFPSInfo(void)
             elapsed = Clock_GetMS();
         }
 
-        bool inv_health_showable = Game_HasStatus(GMS_IN_INVENTORY_HEALTH)
+        bool inv_health_showable = Game_GetStatus() == GS_IN_INVENTORY
+            && g_GameInfo.inv_showing_medpack
             && m_HealthBar.location == BL_TOP_LEFT;
-        bool game_bar_showable = !Game_HasStatus(GMS_IN_INVENTORY)
+        bool game_bar_showable = Game_GetStatus() == GS_IN_GAME
             && (m_HealthBar.location == BL_TOP_LEFT
                 || m_AirBar.location == BL_TOP_LEFT
                 || m_EnemyBar.location == BL_TOP_LEFT);
@@ -739,7 +740,7 @@ void Overlay_DrawFPSInfo(void)
             y = text_height
                 + scale_fps_to_bar * (y + m_BarOffsetY[BL_TOP_LEFT]);
         } else if (
-            Game_HasStatus(GMS_IN_INVENTORY) && g_GameInfo.inv_ring_above) {
+            Game_GetStatus() == GS_IN_INVENTORY && g_GameInfo.inv_ring_above) {
             y += (text_height * 2) + text_inv_offset_y;
         } else {
             y += text_height;

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "game/clock.h"
+#include "game/game.h"
 #include "game/inventory.h"
 #include "game/output.h"
 #include "game/screen.h"
@@ -228,7 +229,7 @@ static void Overlay_BarGetLocation(
             - m_BarOffsetY[bar_info->location];
     }
 
-    if ((g_GameInfo.status & GMS_IN_INVENTORY)
+    if (Game_HasStatus(GMS_IN_INVENTORY)
         && (bar_info->location == BL_TOP_CENTER
             || bar_info->location == BL_BOTTOM_CENTER)) {
         double scale_bar_to_text =
@@ -726,9 +727,9 @@ void Overlay_DrawFPSInfo(void)
             elapsed = Clock_GetMS();
         }
 
-        bool inv_health_showable = (g_GameInfo.status & GMS_IN_INVENTORY_HEALTH)
+        bool inv_health_showable = Game_HasStatus(GMS_IN_INVENTORY_HEALTH)
             && m_HealthBar.location == BL_TOP_LEFT;
-        bool game_bar_showable = !(g_GameInfo.status & GMS_IN_INVENTORY)
+        bool game_bar_showable = !Game_HasStatus(GMS_IN_INVENTORY)
             && (m_HealthBar.location == BL_TOP_LEFT
                 || m_AirBar.location == BL_TOP_LEFT
                 || m_EnemyBar.location == BL_TOP_LEFT);
@@ -738,8 +739,7 @@ void Overlay_DrawFPSInfo(void)
             y = text_height
                 + scale_fps_to_bar * (y + m_BarOffsetY[BL_TOP_LEFT]);
         } else if (
-            (g_GameInfo.status & GMS_IN_INVENTORY)
-            && g_GameInfo.inv_ring_above) {
+            Game_HasStatus(GMS_IN_INVENTORY) && g_GameInfo.inv_ring_above) {
             y += (text_height * 2) + text_inv_offset_y;
         } else {
             y += text_height;

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -27,7 +27,7 @@ void Random_SeedDraw(int32_t seed)
 
 int32_t Random_GetDraw(void)
 {
-    if (Game_HasStatus(GMS_IN_GAME)) {
+    if (Game_GetStatus() == GS_IN_GAME) {
         m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
     }
     return (m_RandDraw >> 10) & 0x7FFF;

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -1,7 +1,7 @@
 #include "game/random.h"
 
+#include "game/game.h"
 #include "global/types.h"
-#include "global/vars.h"
 #include "log.h"
 
 static int32_t m_RandControl = 0xD371F947;
@@ -27,7 +27,7 @@ void Random_SeedDraw(int32_t seed)
 
 int32_t Random_GetDraw(void)
 {
-    if (g_GameInfo.status == GMS_IN_GAME) {
+    if (Game_HasStatus(GMS_IN_GAME)) {
         m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
     }
     return (m_RandDraw >> 10) & 0x7FFF;

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -307,7 +307,7 @@ void Stats_Show(int32_t level_num)
         return;
     }
 
-    g_GameInfo.status |= GMS_IN_STATS;
+    Game_SetStatus(GMS_IN_STATS);
 
     char buf[100];
     char time_str[100];
@@ -424,7 +424,7 @@ void Stats_Show(int32_t level_num)
     }
 
     Output_FadeReset();
-    g_GameInfo.status &= ~GMS_IN_STATS;
+    Game_RestoreStatus();
 
     for (int i = 0; i < MAX_TEXTSTRINGS; i++) {
         cur_txt = &all_txt[i];

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -307,7 +307,8 @@ void Stats_Show(int32_t level_num)
         return;
     }
 
-    Game_SetStatus(GMS_IN_STATS);
+    const GAME_STATUS old_status = Game_GetStatus();
+    Game_SetStatus(GS_IN_STATS);
 
     char buf[100];
     char time_str[100];
@@ -424,7 +425,7 @@ void Stats_Show(int32_t level_num)
     }
 
     Output_FadeReset();
-    Game_RestoreStatus();
+    Game_SetStatus(old_status);
 
     for (int i = 0; i < MAX_TEXTSTRINGS; i++) {
         cur_txt = &all_txt[i];

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1566,12 +1566,12 @@ typedef struct RESUME_INFO {
 } RESUME_INFO;
 
 typedef enum GAME_STATUS {
-    GMS_IN_GAME = 1 << 0,
-    GMS_IN_INVENTORY = 1 << 1,
-    GMS_IN_PAUSE = 1 << 2,
-    GMS_IN_STATS = 1 << 3,
-    GMS_IN_INVENTORY_HEALTH = 1 << 4,
-    GMS_GAME_MENU_SHOWN = 1 << 5,
+    GS_INITIAL = 0,
+    GS_IN_MAIN_MENU = 1,
+    GS_IN_GAME = 2,
+    GS_IN_INVENTORY = 3,
+    GS_IN_PAUSE = 4,
+    GS_IN_STATS = 5,
 } GAME_STATUS;
 
 typedef struct GAME_INFO {
@@ -1589,6 +1589,7 @@ typedef struct GAME_INFO {
     bool remove_scions;
     bool remove_ammo;
     bool remove_medipacks;
+    bool inv_showing_medpack;
     bool inv_ring_above;
 } GAME_INFO;
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1566,12 +1566,12 @@ typedef struct RESUME_INFO {
 } RESUME_INFO;
 
 typedef enum GAME_STATUS {
-    GMS_IN_GAME = 0,
-    GMS_IN_INVENTORY = 1 << 0,
-    GMS_IN_PAUSE = 1 << 1,
-    GMS_IN_STATS = 1 << 2,
-    GMS_IN_INVENTORY_HEALTH = 1 << 3,
-    GMS_GAME_MENU_SHOWN = 1 << 4,
+    GMS_IN_GAME = 1 << 0,
+    GMS_IN_INVENTORY = 1 << 1,
+    GMS_IN_PAUSE = 1 << 2,
+    GMS_IN_STATS = 1 << 3,
+    GMS_IN_INVENTORY_HEALTH = 1 << 4,
+    GMS_GAME_MENU_SHOWN = 1 << 5,
 } GAME_STATUS;
 
 typedef struct GAME_INFO {
@@ -1589,7 +1589,6 @@ typedef struct GAME_INFO {
     bool remove_scions;
     bool remove_ammo;
     bool remove_medipacks;
-    GAME_STATUS status;
     bool inv_ring_above;
 } GAME_INFO;
 


### PR DESCRIPTION
Resolves #1070.
Resolves #1074.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This removes the global game status and instead exposes functions for setting, adding, removing and reverting status. Callers still need to manage the call order, but it removes the various bitwise operations. Setting is done for main changes, like entering the inventory; adding/removing is intended for "sub" changes within that status (like `GMS_IN_INVENTORY_HEALTH`); restoring reverts back to a cached value created on the last `Game_SetStatus` call - so is intended for the likes of exiting the inventory.

The two linked issues themselves were caused by the inventory not reverting to `GMS_IN_GAME`. In `Random_GetDraw`, the check was looking for this value precisely (to indicate that the player was not in the inventory, pause or stats screen and hence to freeze effects).