### PR TITLE
movable_block: fix stacking multiple blocks on room portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed underwater shadow effects rendering always in the same way rather than at random (#1081)
+- fixed bugs when trying to stack multiple movable blocks (#1079)
 
 ## [3.0.2](https://github.com/LostArtefacts/TR1X/compare/3.0.1...3.0.2) - 2023-11-11
 - fixed incorrect usage reference URLs in the gameflow files (#1073)

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - **Obelisk of Khamoon**: missing switch trigger type in room 66
     - **Atlantean Stronghold**: fixed poorly configured portals between rooms 74 and 12
 - fixed various bugs with falling movable blocks
+- fixed bugs when trying to stack multiple movable blocks
 
 #### Cheats
 - added a fly cheat

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -130,7 +130,7 @@ static bool MovableBlock_TestPush(
     }
 
     floor = Room_GetFloor(x, y - block_height, z, &room_num);
-    if (Room_GetCeiling(floor, x, y - STEP_L, z) > y - block_height) {
+    if (Room_GetCeiling(floor, x, y - block_height, z) > y - block_height) {
         return false;
     }
 
@@ -179,7 +179,7 @@ static bool MovableBlock_TestPull(
     }
 
     floor = Room_GetFloor(x, y - block_height, z, &room_num);
-    if (Room_GetCeiling(floor, x, y - STEP_L, z) > y - block_height) {
+    if (Room_GetCeiling(floor, x, y - block_height, z) > y - block_height) {
         return false;
     }
 

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -244,10 +244,10 @@ void MovableBlock_Control(int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_number;
-    FLOOR_INFO *floor =
-        Room_GetFloor(item->pos.x, item->pos.y - 128, item->pos.z, &room_num);
-    int32_t height =
-        Room_GetHeight(floor, item->pos.x, item->pos.y - 128, item->pos.z);
+    FLOOR_INFO *floor = Room_GetFloor(
+        item->pos.x, item->pos.y - STEP_L / 2, item->pos.z, &room_num);
+    int32_t height = Room_GetHeight(
+        floor, item->pos.x, item->pos.y - STEP_L / 2, item->pos.z);
 
     if (item->pos.y < height) {
         item->gravity_status = 1;

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -77,11 +77,13 @@ static bool MovableBlock_TestDestination(ITEM_INFO *item, int32_t block_height)
     int16_t room_num = item->room_number;
     FLOOR_INFO *floor =
         Room_GetFloor(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (floor->floor == NO_HEIGHT / 256) {
+    if (Room_GetHeight(floor, item->pos.x, item->pos.y, item->pos.z)
+        == NO_HEIGHT) {
         return true;
     }
 
-    if ((floor->floor << 8) != item->pos.y - block_height) {
+    if (Room_GetHeight(floor, item->pos.x, item->pos.y, item->pos.z)
+        != item->pos.y - block_height) {
         return false;
     }
 
@@ -123,12 +125,12 @@ static bool MovableBlock_TestPush(
         return false;
     }
 
-    if (((int32_t)floor->floor << 8) != y) {
+    if (Room_GetHeight(floor, x, y, z) != y) {
         return false;
     }
 
     floor = Room_GetFloor(x, y - block_height, z, &room_num);
-    if (((int32_t)floor->ceiling << 8) > y - block_height) {
+    if (Room_GetCeiling(floor, x, y - STEP_L, z) > y - block_height) {
         return false;
     }
 
@@ -172,12 +174,12 @@ static bool MovableBlock_TestPull(
         return false;
     }
 
-    if (((int32_t)floor->floor << 8) != y) {
+    if (Room_GetHeight(floor, x, y, z) != y) {
         return false;
     }
 
     floor = Room_GetFloor(x, y - block_height, z, &room_num);
-    if (((int32_t)floor->ceiling << 8) > y - block_height) {
+    if (Room_GetCeiling(floor, x, y - STEP_L, z) > y - block_height) {
         return false;
     }
 
@@ -186,12 +188,12 @@ static bool MovableBlock_TestPull(
     room_num = item->room_number;
     floor = Room_GetFloor(x, y, z, &room_num);
 
-    if (((int32_t)floor->floor << 8) != y) {
+    if (Room_GetHeight(floor, x, y, z) != y) {
         return false;
     }
 
     floor = Room_GetFloor(x, y - LARA_HEIGHT, z, &room_num);
-    if (((int32_t)floor->ceiling << 8) > y - LARA_HEIGHT) {
+    if (Room_GetCeiling(floor, x, y - LARA_HEIGHT, z) > y - LARA_HEIGHT) {
         return false;
     }
 
@@ -243,9 +245,9 @@ void MovableBlock_Control(int16_t item_num)
 
     int16_t room_num = item->room_number;
     FLOOR_INFO *floor =
-        Room_GetFloor(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        Room_GetFloor(item->pos.x, item->pos.y - 128, item->pos.z, &room_num);
     int32_t height =
-        Room_GetHeight(floor, item->pos.x, item->pos.y, item->pos.z);
+        Room_GetHeight(floor, item->pos.x, item->pos.y - 128, item->pos.z);
 
     if (item->pos.y < height) {
         item->gravity_status = 1;

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -640,13 +640,28 @@ void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height)
         }
     } while (data != NO_ROOM);
 
+    FLOOR_INFO *f = floor;
+    while (f->sky_room != NO_ROOM) {
+        ROOM_INFO *r = &g_RoomInfo[f->sky_room];
+        int32_t x_floor = (item->pos.z - r->z) >> WALL_SHIFT;
+        int32_t y_floor = (item->pos.x - r->x) >> WALL_SHIFT;
+        f = &r->floor[x_floor + y_floor * r->x_size];
+    }
+
+    while (floor->pit_room != NO_ROOM) {
+        ROOM_INFO *r = &g_RoomInfo[floor->pit_room];
+        int32_t x_floor = (item->pos.z - r->z) >> WALL_SHIFT;
+        int32_t y_floor = (item->pos.x - r->x) >> WALL_SHIFT;
+        floor = &r->floor[x_floor + y_floor * r->x_size];
+    }
+
     if (floor->floor != NO_HEIGHT / 256) {
         floor->floor += height >> 8;
-        if (floor->floor == floor->ceiling && floor->sky_room == NO_ROOM) {
+        if (floor->floor == f->ceiling) {
             floor->floor = NO_HEIGHT / 256;
         }
     } else {
-        floor->floor = floor->ceiling + (height >> 8);
+        floor->floor = f->ceiling + (height >> 8);
     }
 
     if (g_Boxes[floor->box].overlap_index & BLOCKABLE) {


### PR DESCRIPTION
Resolves #1079.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Credit goes to @asasas9500 for the changes! Fixed bugs when trying to stack multiple movable blocks. Tested Thor room, Rapora's test level, Lahm's test level. Could possibly use a bigger test level to make sure all push/pull scenarios work, but I think everything looks good from my testing so far.