### PR TITLE
random: advance RNG during game setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- fixed underwater shadow effects rendering always in the same way rather than at random (#1081)
 
 ## [3.0.2](https://github.com/LostArtefacts/TR1X/compare/3.0.1...3.0.2) - 2023-11-11
 - fixed incorrect usage reference URLs in the gameflow files (#1073)

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -27,7 +27,8 @@ void Random_SeedDraw(int32_t seed)
 
 int32_t Random_GetDraw(void)
 {
-    if (Game_GetStatus() == GS_IN_GAME) {
+    GAME_STATUS status = Game_GetStatus();
+    if (status == GS_INITIAL || status == GS_IN_GAME) {
         m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
     }
     return (m_RandDraw >> 10) & 0x7FFF;

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -27,6 +27,9 @@ void Random_SeedDraw(int32_t seed)
 
 int32_t Random_GetDraw(void)
 {
+    // Allow draw RNG to advance only during initial game setup (for such things
+    // as caustic initialisation) and normal game play. RNG should remain static
+    // when the game output is paused e.g. inventory, pause screen etc.
     GAME_STATUS status = Game_GetStatus();
     if (status == GS_INITIAL || status == GS_IN_GAME) {
         m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;


### PR DESCRIPTION
Resolves #1081.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows `m_RandTable` in `output.c` to be initialised properly during the game setup (`Output_CalcWibbleTable`). This is the only call to `Random_GetDraw` outside of regular game play. I missed this as part of #1075.

![image](https://github.com/LostArtefacts/TR1X/assets/33758420/a1a327d3-1186-47fd-92cc-3bd01a638cd2)
