### PR TITLE
build: improve pyjson5 module import

### DIFF
--- a/tools/generate_init
+++ b/tools/generate_init
@@ -4,7 +4,10 @@ import io
 import json
 from pathlib import Path
 
-import pyjson5
+try:
+    import pyjson5
+except ImportError:
+    import json5 as pyjson5
 
 REPO_DIR = Path(__file__).parent.parent
 BIN_DIR = REPO_DIR / "bin"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Trying to build on Gentoo Linux is failing with the following :
> Traceback (most recent call last):
>   File "[...]/TR1X/tools/generate_init", line 7, in <module>
>     import pyjson5
> ModuleNotFoundError: No module named 'pyjson5'

On Gentoo, pyjson5 module is installed as json5.
