### PR TITLE
missile: test range using components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed bugs when trying to stack multiple movable blocks (#1079)
+- fixed missiles damaging Lara when she is far beyond their damage range (#1090)
 
 ## [3.0.3](https://github.com/LostArtefacts/TR1X/compare/3.0.2...3.0.3) - 2023-11-27
 - fixed underwater shadow effects rendering always in the same way rather than at random (#1081)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed settings not being saved when exiting the game with Alt+F4
 - fixed settings not persisting chosen layout (default vs. user keys)
 - fixed the infamous Tihocan crocodile bug (integer overflow causing creatures to deal damage across the entire level)
+- fixed missiles damaging Lara when she is far beyond their damage range
 - fixed Lara not being able to grab parts of some bridges
 - fixed Lara voiding if a badly placed timed door closes on her (doesn't occur in OG levels)
 - fixed bats being positioned too high

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -355,6 +355,11 @@ bool Item_IsNearItem(ITEM_INFO *item, PHD_3DPOS *pos, int32_t distance)
     return false;
 }
 
+bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range)
+{
+    return ABS(x) < range && ABS(y) < range && ABS(z) < range;
+}
+
 bool Item_TestBoundsCollide(
     ITEM_INFO *src_item, ITEM_INFO *dst_item, int32_t radius)
 {

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -357,7 +357,8 @@ bool Item_IsNearItem(ITEM_INFO *item, PHD_3DPOS *pos, int32_t distance)
 
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range)
 {
-    return ABS(x) < range && ABS(y) < range && ABS(z) < range;
+    return ABS(x) < range && ABS(y) < range && ABS(z) < range
+        && (SQUARE(x) + SQUARE(y) + SQUARE(z) < SQUARE(range));
 }
 
 bool Item_TestBoundsCollide(

--- a/src/game/items.h
+++ b/src/game/items.h
@@ -24,6 +24,7 @@ int16_t Item_Spawn(ITEM_INFO *item, int16_t object_num);
 int32_t Item_GlobalReplace(int32_t src_object_num, int32_t dst_object_num);
 
 bool Item_IsNearItem(ITEM_INFO *item, PHD_3DPOS *pos, int32_t distance);
+bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
 bool Item_TestBoundsCollide(
     ITEM_INFO *src_item, ITEM_INFO *dst_item, int32_t radius);
 bool Item_TestPosition(

--- a/src/game/objects/effects/missile.c
+++ b/src/game/objects/effects/missile.c
@@ -1,6 +1,7 @@
 #include "game/objects/effects/missile.h"
 
 #include "game/effects.h"
+#include "game/items.h"
 #include "game/lara.h"
 #include "game/random.h"
 #include "game/room.h"
@@ -14,7 +15,8 @@
 
 #define SHARD_DAMAGE 30
 #define ROCKET_DAMAGE 100
-#define ROCKET_RANGE SQUARE(WALL_L) // = 1048576
+#define ROCKET_RANGE_BASE WALL_L
+#define ROCKET_RANGE SQUARE(ROCKET_RANGE_BASE) // = 1048576
 
 void Missile_Setup(OBJECT_INFO *obj)
 {
@@ -53,8 +55,8 @@ void Missile_Control(int16_t fx_num)
             int32_t x = fx->pos.x - g_LaraItem->pos.x;
             int32_t y = fx->pos.y - g_LaraItem->pos.y;
             int32_t z = fx->pos.z - g_LaraItem->pos.z;
-            int32_t range = SQUARE(x) + SQUARE(y) + SQUARE(z);
-            if (range >= 0 && range < ROCKET_RANGE) {
+            if (Item_Test3DRange(x, y, z, ROCKET_RANGE_BASE)) {
+                int32_t range = SQUARE(x) + SQUARE(y) + SQUARE(z);
                 Lara_TakeDamage(
                     ROCKET_DAMAGE * (ROCKET_RANGE - range) / ROCKET_RANGE,
                     true);


### PR DESCRIPTION
Resolves #1090.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This adjusts the missile damage range test to look at the individual components of the difference between Lara and the FX in question, rather than the Euclidean distance. There can be very large numbers involved and this was leading to overflow; this overflow itself was not detectable in release builds it seems, hence why the previous resolution in #872 only worked in debug.
