### PR TITLE
midas_touch: restrict vertical range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fixed bugs when trying to stack multiple movable blocks (#1079)
 - fixed missiles damaging Lara when she is far beyond their damage range (#1090)
 - fixed Lara's meshes being swapped in the gym level when using the console to give guns (#1092)
+- fixed Midas's touch having unrestricted vertical range (#1094)
 
 ## [3.0.3](https://github.com/LostArtefacts/TR1X/compare/3.0.2...3.0.3) - 2023-11-27
 - fixed underwater shadow effects rendering always in the same way rather than at random (#1081)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - **Atlantean Stronghold**: fixed poorly configured portals between rooms 74 and 12
 - fixed various bugs with falling movable blocks
 - fixed bugs when trying to stack multiple movable blocks
+- fixed Midas's touch having unrestricted vertical range
 
 #### Cheats
 - added a fly cheat

--- a/src/game/lara/lara_cheat.c
+++ b/src/game/lara/lara_cheat.c
@@ -6,6 +6,7 @@
 #include "game/items.h"
 #include "game/lara.h"
 #include "game/sound.h"
+#include "game/viewport.h"
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
@@ -141,4 +142,6 @@ void Lara_EnterFlyMode(void)
     g_Lara.death_timer = 0;
     g_Lara.mesh_effects = 0;
     Lara_InitialiseMeshes(g_CurrentLevel);
+    g_Camera.type = CAM_CHASE;
+    Viewport_SetFOV(Viewport_GetUserFOV());
 }

--- a/src/game/objects/traps/midas_touch.c
+++ b/src/game/objects/traps/midas_touch.c
@@ -12,6 +12,8 @@
 #define EXTRA_ANIM_PLACE_BAR 0
 #define EXTRA_ANIM_DIE_GOLD 1
 #define LF_PICKUP_GOLD_BAR 113
+#define MIDAS_RANGE_H (STEP_L * 2)
+#define MIDAS_RANGE_V (STEP_L * 3)
 
 static int16_t m_MidasBounds[12] = {
     -700,
@@ -47,10 +49,12 @@ void MidasTouch_Collision(
     }
 
     if (!lara_item->gravity_status && lara_item->current_anim_state == LS_STOP
-        && lara_item->pos.x > item->pos.x - 512
-        && lara_item->pos.x < item->pos.x + 512
-        && lara_item->pos.z > item->pos.z - 512
-        && lara_item->pos.z < item->pos.z + 512) {
+        && lara_item->pos.x > item->pos.x - MIDAS_RANGE_H
+        && lara_item->pos.x < item->pos.x + MIDAS_RANGE_H
+        && lara_item->pos.y > item->pos.y - MIDAS_RANGE_V
+        && lara_item->pos.y < item->pos.y + MIDAS_RANGE_V
+        && lara_item->pos.z > item->pos.z - MIDAS_RANGE_H
+        && lara_item->pos.z < item->pos.z + MIDAS_RANGE_H) {
         lara_item->current_anim_state = LS_DIE_MIDAS;
         lara_item->goal_anim_state = LS_DIE_MIDAS;
         Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_DIE_GOLD, 0, O_LARA_EXTRA);


### PR DESCRIPTION
Resolves #1094.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This restricts the Midas touch vertical range to 3 clicks in the context of turning Lara to gold. The fly cheat has also been updated to reset the camera and FOV e.g. to cancel turning to gold when testing.

Attached is a test level for this; the original Midas level works as expected.
[LEVEL1.zip](https://github.com/LostArtefacts/TR1X/files/13536927/LEVEL1.zip)