### PR TITLE
passport: allow restart level in save crystal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - added the option to use "shell(s)" to give shotgun ammo in the developer console (#1096)
+- added the restart level option in save crystal mode if Lara dies (#1099)
 - fixed bugs when trying to stack multiple movable blocks (#1079)
 - fixed Lara's meshes being swapped in the gym level when using the console to give guns (#1092)
 - fixed Midas's touch having unrestricted vertical range (#1094)

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -306,21 +306,17 @@ int32_t Game_Stop(void)
         return GF_EXIT_TO_TITLE;
     }
 
-    if (g_GameInfo.passport_page == PASSPORT_PAGE_1) {
+    if (g_GameInfo.passport_selection == PASSPORT_MODE_LOAD_GAME) {
         return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
-    } else if (
-        g_GameInfo.passport_page == PASSPORT_PAGE_1
-        && g_GameInfo.passport_mode == PASSPORT_MODE_SELECT_LEVEL) {
+    } else if (g_GameInfo.passport_selection == PASSPORT_MODE_SELECT_LEVEL) {
         return GF_SELECT_GAME | g_GameInfo.select_level_num;
-    } else if (
-        g_GameInfo.passport_page == PASSPORT_PAGE_1
-        && g_GameInfo.passport_mode == PASSPORT_MODE_STORY_SO_FAR) {
-        // page 1: story so far
+    } else if (g_GameInfo.passport_selection == PASSPORT_MODE_STORY_SO_FAR) {
         return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
-    } else if (g_GameInfo.passport_page == PASSPORT_PAGE_2) {
-        return GF_START_GAME
-            | (g_InvMode == INV_DEATH_MODE ? g_CurrentLevel
-                                           : g_GameFlow.first_level_num);
+    } else if (g_GameInfo.passport_selection == PASSPORT_MODE_RESTART) {
+        return GF_RESTART_GAME | g_CurrentLevel;
+    } else if (g_GameInfo.passport_selection == PASSPORT_MODE_NEW_GAME) {
+        Savegame_InitCurrentInfo();
+        return GF_START_GAME | g_GameFlow.first_level_num;
     } else {
         return GF_EXIT_TO_TITLE;
     }

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -841,11 +841,13 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
                      && g_SavedGamesCount) /* f6 menu */
                     || g_InvMode == INV_DEATH_MODE /* Lara died */
                     || (g_InvMode == INV_GAME_MODE /* esc menu */
-                        && g_GameInfo.passport_page
-                            != PASSPORT_PAGE_2 /* but not the save page */
+                        && g_GameInfo.passport_selection
+                            != PASSPORT_MODE_SAVE_GAME /* but not save page */
                         )
                     || g_CurrentLevel == g_GameFlow.gym_level_num /* Gym */
-                    )) {
+                    || g_GameInfo.passport_selection
+                        == PASSPORT_MODE_RESTART)) {
+                LOG_DEBUG("Fade to black!");
                 Output_FadeToBlack(false);
             } else {
                 Output_FadeToTransparent(false);
@@ -900,81 +902,27 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
     switch (g_InvChosen) {
     case O_PASSPORT_OPTION:
-        if (g_InvMode == INV_TITLE_MODE) {
-            if (g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SHOW_SAVES) {
-                // page 1: load game
-                return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SELECT_LEVEL) {
-                // page 1: select level
-                return GF_SELECT_GAME | g_GameInfo.select_level_num;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_STORY_SO_FAR) {
-                // page 1: story so far
-                return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
-            } else if (g_GameInfo.passport_page == PASSPORT_PAGE_2) {
-                // page 2: new game
-                Savegame_InitCurrentInfo();
-                return GF_START_GAME | g_GameFlow.first_level_num;
-            } else {
-                // page 3: exit game
-                return GF_EXIT_GAME;
-            }
-        } else if (g_InvMode == INV_DEATH_MODE) {
-            if (g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SHOW_SAVES) {
-                // page 1: load game
-                return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SELECT_LEVEL) {
-                // page 1: select level
-                return GF_SELECT_GAME | g_GameInfo.select_level_num;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_STORY_SO_FAR) {
-                // page 1: story so far
-                return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
-            } else if (g_GameInfo.passport_page == PASSPORT_PAGE_2) {
-                // page 2: restart level
-                return GF_RESTART_GAME | g_CurrentLevel;
-            } else {
-                // page 3: exit game
-                return GF_EXIT_TO_TITLE;
-            }
+        if (g_GameInfo.passport_selection == PASSPORT_MODE_LOAD_GAME) {
+            return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
+        } else if (
+            g_GameInfo.passport_selection == PASSPORT_MODE_SELECT_LEVEL) {
+            return GF_SELECT_GAME | g_GameInfo.select_level_num;
+        } else if (
+            g_GameInfo.passport_selection == PASSPORT_MODE_STORY_SO_FAR) {
+            return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
+        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_NEW_GAME) {
+            Savegame_InitCurrentInfo();
+            return GF_START_GAME | g_GameFlow.first_level_num;
+        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_SAVE_GAME) {
+            Savegame_Save(g_GameInfo.current_save_slot, &g_GameInfo);
+            Config_Write();
+            return GF_NOP;
+        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_RESTART) {
+            return GF_RESTART_GAME | g_CurrentLevel;
+        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_EXIT_GAME) {
+            return GF_EXIT_GAME;
         } else {
-            if (g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SHOW_SAVES) {
-                // page 1: load game
-                return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_SELECT_LEVEL) {
-                // page 1: select level
-                return GF_SELECT_GAME | g_GameInfo.select_level_num;
-            } else if (
-                g_GameInfo.passport_page == PASSPORT_PAGE_1
-                && g_GameInfo.passport_mode == PASSPORT_MODE_STORY_SO_FAR) {
-                // page 1: story so far
-                return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
-            } else if (g_GameInfo.passport_page == PASSPORT_PAGE_2) {
-                if (g_CurrentLevel == g_GameFlow.gym_level_num) {
-                    // page 2: new game in gym
-                    Savegame_InitCurrentInfo();
-                    return GF_START_GAME | g_GameFlow.first_level_num;
-                } else {
-                    // page 2: save game
-                    Savegame_Save(g_GameInfo.current_save_slot, &g_GameInfo);
-                    Config_Write();
-                    return GF_NOP;
-                }
-            } else {
-                // page 3: exit to title
-                return GF_EXIT_TO_TITLE;
-            }
+            return GF_EXIT_TO_TITLE;
         }
 
     case O_PHOTO_OPTION:

--- a/src/game/inventory/inventory.c
+++ b/src/game/inventory/inventory.c
@@ -847,7 +847,6 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
                     || g_CurrentLevel == g_GameFlow.gym_level_num /* Gym */
                     || g_GameInfo.passport_selection
                         == PASSPORT_MODE_RESTART)) {
-                LOG_DEBUG("Fade to black!");
                 Output_FadeToBlack(false);
             } else {
                 Output_FadeToTransparent(false);
@@ -902,26 +901,30 @@ static int32_t Inv_ConstructAndDisplay(int inv_mode)
 
     switch (g_InvChosen) {
     case O_PASSPORT_OPTION:
-        if (g_GameInfo.passport_selection == PASSPORT_MODE_LOAD_GAME) {
+
+        switch (g_GameInfo.passport_selection) {
+        case PASSPORT_MODE_LOAD_GAME:
             return GF_START_SAVED_GAME | g_GameInfo.current_save_slot;
-        } else if (
-            g_GameInfo.passport_selection == PASSPORT_MODE_SELECT_LEVEL) {
+        case PASSPORT_MODE_SELECT_LEVEL:
             return GF_SELECT_GAME | g_GameInfo.select_level_num;
-        } else if (
-            g_GameInfo.passport_selection == PASSPORT_MODE_STORY_SO_FAR) {
+        case PASSPORT_MODE_STORY_SO_FAR:
             return GF_STORY_SO_FAR | g_GameInfo.current_save_slot;
-        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_NEW_GAME) {
+        case PASSPORT_MODE_NEW_GAME:
             Savegame_InitCurrentInfo();
             return GF_START_GAME | g_GameFlow.first_level_num;
-        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_SAVE_GAME) {
+        case PASSPORT_MODE_SAVE_GAME:
             Savegame_Save(g_GameInfo.current_save_slot, &g_GameInfo);
             Config_Write();
             return GF_NOP;
-        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_RESTART) {
+        case PASSPORT_MODE_RESTART:
             return GF_RESTART_GAME | g_CurrentLevel;
-        } else if (g_GameInfo.passport_selection == PASSPORT_MODE_EXIT_GAME) {
+        case PASSPORT_MODE_EXIT_TITLE:
             return GF_EXIT_GAME;
-        } else {
+        case PASSPORT_MODE_EXIT_GAME:
+            return GF_EXIT_TO_TITLE;
+        case PASSPORT_MODE_BROWSE:
+        case PASSPORT_MODE_UNAVAILABLE:
+        default:
             return GF_EXIT_TO_TITLE;
         }
 

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -520,7 +520,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
     bool pages_available[PASSPORT_PAGE_COUNT] = {
         g_SavedGamesCount > 0,
         g_InvMode == INV_TITLE_MODE || g_InvMode == INV_SAVE_CRYSTAL_MODE
-            || !g_Config.enable_save_crystals,
+            || !g_Config.enable_save_crystals || g_InvMode == INV_DEATH_MODE,
         true,
     };
 

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -17,8 +17,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "log.h"
-
 #define MAX_GAME_MODES 4
 #define MAX_GAME_MODE_LENGTH 20
 
@@ -571,11 +569,6 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
         Option_PassportInitText();
         m_IsTextInit = true;
         Option_PassportDeterminePages();
-        LOG_DEBUG(
-            "g_InvMode: %d; pages: (%d %d %d), modes: (%d %d %d)", g_InvMode,
-            m_PassportStatus.pages[PAGE_1], m_PassportStatus.pages[PAGE_2],
-            m_PassportStatus.pages[PAGE_3], m_PassportStatus.modes[PAGE_1],
-            m_PassportStatus.modes[PAGE_2], m_PassportStatus.modes[PAGE_3]);
     }
 
     m_PassportStatus.page = (inv_item->goal_frame - inv_item->open_frame) / 5;
@@ -583,7 +576,6 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
         m_PassportStatus.page = PAGE_FLIPPING;
     }
 
-    // TODO Out of bounds index?
     if (m_PassportStatus.mode == PASSPORT_MODE_BROWSE) {
         if (m_PassportStatus.page > PAGE_1
             && m_PassportStatus.pages[m_PassportStatus.page - 1]) {

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -32,8 +32,8 @@ typedef enum PASSPORT_TEXT {
 typedef struct PASSPORT_STATUS {
     PASSPORT_PAGE page;
     PASSPORT_MODE mode;
-    bool pages[PAGE_COUNT];
-    PASSPORT_MODE modes[PAGE_COUNT];
+    bool page_available[PAGE_COUNT];
+    PASSPORT_MODE page_role[PAGE_COUNT];
 } PASSPORT_STATUS;
 
 static PASSPORT_STATUS m_PassportStatus = {
@@ -165,92 +165,92 @@ static void Option_PassportDeterminePages(void)
     switch (g_InvMode) {
     case INV_TITLE_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
-        m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = true;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_NEW_GAME;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_GAME;
+        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = true;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_NEW_GAME;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_GAME;
         break;
 
     case INV_GAME_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
-        m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = true;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
+        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = true;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         if (g_CurrentLevel == g_GameFlow.gym_level_num) {
             m_PassportStatus.mode = PASSPORT_MODE_NEW_GAME;
-            m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_NEW_GAME;
+            m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_NEW_GAME;
         } else if (g_Config.enable_save_crystals) {
             m_PassportStatus.mode = PASSPORT_MODE_RESTART;
-            m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_RESTART;
-            m_PassportStatus.pages[PAGE_3] = true;
-            m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
+            m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_RESTART;
+            m_PassportStatus.page_available[PAGE_3] = true;
+            m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         }
         break;
 
     case INV_LOAD_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
-        m_PassportStatus.pages[PAGE_2] = false;
-        m_PassportStatus.pages[PAGE_3] = false;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_UNAVAILABLE;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_2] = false;
+        m_PassportStatus.page_available[PAGE_3] = false;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
         Option_PassportInitSaveRequester(PAGE_1);
         break;
 
     case INV_SAVE_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_SAVE_GAME;
-        m_PassportStatus.pages[PAGE_1] = false;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = false;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_UNAVAILABLE;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_available[PAGE_1] = false;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = false;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
         if (g_CurrentLevel == g_GameFlow.gym_level_num) {
             m_PassportStatus.mode = PASSPORT_MODE_NEW_GAME;
-            m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_NEW_GAME;
+            m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_NEW_GAME;
         } else if (g_Config.enable_save_crystals) {
             m_PassportStatus.mode = PASSPORT_MODE_RESTART;
-            m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_RESTART;
-            m_PassportStatus.pages[PAGE_3] = true;
-            m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
+            m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_RESTART;
+            m_PassportStatus.page_available[PAGE_3] = true;
+            m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         }
         Option_PassportInitSaveRequester(PAGE_2);
         break;
 
     case INV_SAVE_CRYSTAL_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_SAVE_GAME;
-        m_PassportStatus.pages[PAGE_1] = false;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = false;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_UNAVAILABLE;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_available[PAGE_1] = false;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = false;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_UNAVAILABLE;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_SAVE_GAME;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
         Option_PassportInitSaveRequester(PAGE_2);
         break;
     case INV_DEATH_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
-        m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = true;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_RESTART;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
+        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = true;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_RESTART;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         break;
 
     default:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
-        m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
-        m_PassportStatus.pages[PAGE_2] = true;
-        m_PassportStatus.pages[PAGE_3] = true;
-        m_PassportStatus.modes[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_NEW_GAME;
-        m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
+        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_2] = true;
+        m_PassportStatus.page_available[PAGE_3] = true;
+        m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;
+        m_PassportStatus.page_role[PAGE_2] = PASSPORT_MODE_NEW_GAME;
+        m_PassportStatus.page_role[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         break;
     }
 }
@@ -578,14 +578,14 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
 
     if (m_PassportStatus.mode == PASSPORT_MODE_BROWSE) {
         if (m_PassportStatus.page > PAGE_1
-            && m_PassportStatus.pages[m_PassportStatus.page - 1]) {
+            && m_PassportStatus.page_available[m_PassportStatus.page - 1]) {
             Text_Hide(m_Text[TEXT_LEFT_ARROW], false);
         } else {
             Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
         }
 
         if (m_PassportStatus.page < PAGE_3
-            && m_PassportStatus.pages[m_PassportStatus.page + 1]) {
+            && m_PassportStatus.page_available[m_PassportStatus.page + 1]) {
             Text_Hide(m_Text[TEXT_RIGHT_ARROW], false);
         } else {
             Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
@@ -595,7 +595,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
         Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
     }
 
-    switch (m_PassportStatus.modes[m_PassportStatus.page]) {
+    switch (m_PassportStatus.page_role[m_PassportStatus.page]) {
     case PASSPORT_MODE_LOAD_GAME:
         Option_PassportLoadGame();
         break;
@@ -638,12 +638,12 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
     }
 
     if (g_InputDB.menu_right
-        || !m_PassportStatus.pages[m_PassportStatus.page]) {
+        || !m_PassportStatus.page_available[m_PassportStatus.page]) {
         g_Input = (INPUT_STATE) { 0 };
         g_InputDB = (INPUT_STATE) { 0 };
 
         while (++m_PassportStatus.page < PAGE_COUNT) {
-            if (m_PassportStatus.pages[m_PassportStatus.page]) {
+            if (m_PassportStatus.page_available[m_PassportStatus.page]) {
                 break;
             }
         }
@@ -658,7 +658,7 @@ void Option_Passport(INVENTORY_ITEM *inv_item)
 
     if (g_InputDB.menu_left) {
         while (--m_PassportStatus.page >= PAGE_1) {
-            if (m_PassportStatus.pages[m_PassportStatus.page]) {
+            if (m_PassportStatus.page_available[m_PassportStatus.page]) {
                 break;
             }
         }

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -174,6 +174,7 @@ static void Option_PassportDeterminePages(void)
         m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_NEW_GAME;
         m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_GAME;
         break;
+
     case INV_GAME_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
         m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
@@ -192,6 +193,7 @@ static void Option_PassportDeterminePages(void)
             m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         }
         break;
+
     case INV_LOAD_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_LOAD_GAME;
         m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;
@@ -202,6 +204,7 @@ static void Option_PassportDeterminePages(void)
         m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_UNAVAILABLE;
         Option_PassportInitSaveRequester(PAGE_1);
         break;
+
     case INV_SAVE_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_SAVE_GAME;
         m_PassportStatus.pages[PAGE_1] = false;
@@ -221,6 +224,7 @@ static void Option_PassportDeterminePages(void)
         }
         Option_PassportInitSaveRequester(PAGE_2);
         break;
+
     case INV_SAVE_CRYSTAL_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_SAVE_GAME;
         m_PassportStatus.pages[PAGE_1] = false;
@@ -240,6 +244,7 @@ static void Option_PassportDeterminePages(void)
         m_PassportStatus.modes[PAGE_2] = PASSPORT_MODE_RESTART;
         m_PassportStatus.modes[PAGE_3] = PASSPORT_MODE_EXIT_TITLE;
         break;
+
     default:
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
         m_PassportStatus.pages[PAGE_1] = g_SavedGamesCount > 0;

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -139,7 +139,6 @@ int32_t Requester_Display(REQUEST_INFO *req)
         req->line_old_offset = req->line_offset;
         if (req->requested > req->line_offset + req->vis_lines - 1) {
             req->line_offset++;
-            return 0;
         }
         return 0;
     }
@@ -151,7 +150,6 @@ int32_t Requester_Display(REQUEST_INFO *req)
         req->line_old_offset = req->line_offset;
         if (req->requested < req->line_offset) {
             req->line_offset--;
-            return 0;
         }
         return 0;
     }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1181,19 +1181,24 @@ typedef enum GAME_BONUS_FLAG {
 } GAME_BONUS_FLAG;
 
 typedef enum PASSPORT_PAGE {
-    PASSPORT_PAGE_FLIPPING = -1,
-    PASSPORT_PAGE_1 = 0,
-    PASSPORT_PAGE_2 = 1,
-    PASSPORT_PAGE_3 = 2,
-    PASSPORT_PAGE_COUNT = 3,
+    PAGE_FLIPPING = -1,
+    PAGE_1 = 0,
+    PAGE_2 = 1,
+    PAGE_3 = 2,
+    PAGE_COUNT = 3,
 } PASSPORT_PAGE;
 
 typedef enum PASSPORT_MODE {
-    PASSPORT_MODE_FLIP = 0,
-    PASSPORT_MODE_SHOW_SAVES = 1,
-    PASSPORT_MODE_NEW_GAME = 2,
-    PASSPORT_MODE_SELECT_LEVEL = 3,
-    PASSPORT_MODE_STORY_SO_FAR = 4,
+    PASSPORT_MODE_BROWSE = 0,
+    PASSPORT_MODE_LOAD_GAME = 1,
+    PASSPORT_MODE_SELECT_LEVEL = 2,
+    PASSPORT_MODE_STORY_SO_FAR = 3,
+    PASSPORT_MODE_SAVE_GAME = 4,
+    PASSPORT_MODE_NEW_GAME = 5,
+    PASSPORT_MODE_RESTART = 6,
+    PASSPORT_MODE_EXIT_TITLE = 7,
+    PASSPORT_MODE_EXIT_GAME = 8,
+    PASSPORT_MODE_UNAVAILABLE = 9,
 } PASSPORT_MODE;
 
 #pragma pack(push, 1)
@@ -1581,8 +1586,7 @@ typedef struct GAME_INFO {
     bool bonus_level_unlock;
     int32_t current_save_slot;
     int16_t save_initial_version;
-    PASSPORT_PAGE passport_page;
-    PASSPORT_MODE passport_mode;
+    PASSPORT_MODE passport_selection;
     int32_t select_level_num;
     bool death_counter_supported;
     GAMEFLOW_LEVEL_TYPE current_level_type;


### PR DESCRIPTION
Resolves #1099.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added the restart level option in the passport at all times for save crystal mode. Refactored the passport code to be clearer.