### PR TITLE
movable_block: test animation index over state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed missiles damaging Lara when she is far beyond their damage range (#1090)
 - fixed Lara's meshes being swapped in the gym level when using the console to give guns (#1092)
 - fixed Midas's touch having unrestricted vertical range (#1094)
+- fixed pushblocks moving freely if Lara releases but tries to regrab during the release animation (#1101, regression from 3.0)
 
 ## [3.0.3](https://github.com/LostArtefacts/TR1X/compare/3.0.2...3.0.3) - 2023-11-27
 - fixed underwater shadow effects rendering always in the same way rather than at random (#1081)

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -352,7 +352,7 @@ void MovableBlock_Collision(
         if (lara_item->current_anim_state == LS_PP_READY) {
             g_Lara.gun_status = LGS_HANDS_BUSY;
         }
-    } else if (lara_item->current_anim_state == LS_PP_READY) {
+    } else if (Item_TestAnimEqual(lara_item, LA_PUSHABLE_GRAB)) {
         if (!Item_TestFrameEqual(lara_item, LF_PPREADY)) {
             return;
         }
@@ -362,13 +362,13 @@ void MovableBlock_Collision(
         }
 
         if (g_Input.forward) {
-            if (!MovableBlock_TestPush(item, 1024, quadrant)) {
+            if (!MovableBlock_TestPush(item, WALL_L, quadrant)) {
                 return;
             }
             item->goal_anim_state = MBS_PUSH;
             lara_item->goal_anim_state = LS_PUSH_BLOCK;
         } else if (g_Input.back) {
-            if (!MovableBlock_TestPull(item, 1024, quadrant)) {
+            if (!MovableBlock_TestPull(item, WALL_L, quadrant)) {
                 return;
             }
             item->goal_anim_state = MBS_PULL;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -617,6 +617,7 @@ typedef enum LARA_ANIMATION {
     LA_SURF_DIVE = 119,
     LA_SURF_CLIMB = 111,
     LA_JUMP_IN = 112,
+    LA_PUSHABLE_GRAB = 120,
     LA_ROLL = 146,
     LA_PICKUP_UW = 130,
     LA_PICKUP = 135,


### PR DESCRIPTION
Resolves #1101.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`LS_PP_READY` refers to Lara's animation state when grabbing OR releasing a pushblock. Prior to #1006, `LF_PPREADY` was an absolute frame index and so the check for this would only pass after the grabbing animation. With relative indexing, the check can pass in either animation, and so holding action and forwards/backwards after releasing a block would allow the test to pass and the block to move independently. We now test for the specific grab animation rather than release.

I've checked other cases where this could be an issue and this is the only one. The `Item_TestFrame` calls in the PR files below highlight the animation states - `LS_PICKUP` could have potentially been an issue, but there is already a guard of sorts around this by testing water/not water, plus the frame indices are different too. `LS_PP_READY`/`LF_PPREADY` was ultimately the perfect storm.

https://github.com/LostArtefacts/TR1X/pull/1006/files
https://github.com/LostArtefacts/TR1X/blob/develop/src/game/objects/general/pickup.c#L104

I've also replaced some remaining 1024 usage in `movable_block.c` with the `WALL_L` const.
