### PR TITLE
flame: tie FX to Lara's room when on fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed bugs when trying to stack multiple movable blocks (#1079)
 - fixed Lara's meshes being swapped in the gym level when using the console to give guns (#1092)
 - fixed Midas's touch having unrestricted vertical range (#1094)
+- fixed flames not being drawn when Lara is on fire but leaves the room where she caught fire (#1106)
 
 ## [3.0.4](https://github.com/LostArtefacts/TR1X/compare/3.0.3...3.0.4) - 2023-12-08
 - fixed missiles damaging Lara when she is far beyond their damage range (#1090)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed counting the secret in The Great Pyramid
 - fixed running out of ammo forcing Lara to equip pistols even if she doesn't carry them
 - fixed a crash when Lara is on fire and goes too far away from where she caught fire
+- fixed flames not being drawn when Lara is on fire and leaves the room where she caught fire
 - fixed settings not being saved when exiting the game with Alt+F4
 - fixed settings not persisting chosen layout (default vs. user keys)
 - fixed the infamous Tihocan crocodile bug (integer overflow causing creatures to deal damage across the entire level)

--- a/src/game/objects/traps/flame.c
+++ b/src/game/objects/traps/flame.c
@@ -58,6 +58,9 @@ void Flame_Control(int16_t fx_num)
             Sound_StopEffect(SFX_FIRE, NULL);
             Effect_Kill(fx_num);
         } else {
+            if (fx->room_number != g_LaraItem->room_number) {
+                Effect_NewRoom(fx_num, g_LaraItem->room_number);
+            }
             Sound_Effect(SFX_FIRE, &fx->pos, SPM_NORMAL);
             Lara_TakeDamage(FLAME_ONFIRE_DAMAGE, true);
         }


### PR DESCRIPTION
Resolves #1106.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that if Lara enters a different room while on fire, that the flame FX are tied to that room so that they will always be drawn.
