### PR TITLE
inventory_func: fix items not adding if sprite is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed flames not being drawn when Lara is on fire but leaves the room where she caught fire (#1106)
 - fixed being able to deselect the passport in quick save, quick load, save crystal, and death modes (#1108)
 - fixed inability to save in Unfinished Business in crystals mode as UB doesn't have crystals (#1102)
+- fixed items not being added to inventory if the sprite is missing from the level file (#1130)
 
 ## [3.0.5](https://github.com/LostArtefacts/TR1X/compare/3.0.4...3.0.5) - 2023-12-13
 - fixed crash when pressing certain keys and the console is disabled (#1116, regression since 3.0)

--- a/src/game/inventory/inventory_func.c
+++ b/src/game/inventory/inventory_func.c
@@ -11,7 +11,7 @@
 bool Inv_AddItem(int32_t item_num)
 {
     int32_t item_num_option = Inv_GetItemOption(item_num);
-    if (!g_Objects[item_num].loaded || !g_Objects[item_num_option].loaded) {
+    if (!g_Objects[item_num_option].loaded) {
         return false;
     }
 


### PR DESCRIPTION
Resolves #1130.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed items not being added to inventory if the sprite is missing from the level file. This only checks if the inventory 3D model is loaded since the sprite is only needed for pickups if 3D pickups aren't enabled.
