### PR TITLE
lot: expand the number of visible enemies to 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - added the option to use "shell(s)" to give shotgun ammo in the developer console (#1096)
 - added the restart level option to the passport in save crystal mode (#1099)
+- added the ability to back out of menus with the circle and triangle buttons when using a gamepad (cross acts as confirm) (#1104)
 - changed `force_enable_save_crystals` to `force_save_crystals` for custom level authors to force enable or disable the save crystals setting (#1102)
 - changed `force_disable_game_modes` to `force_game_modes` for custom level authors to force enable or disable the game modes setting (#1102)
 - changed the Scion in The Great Pyramid from spawning blood when hit to a richochet effect if texture fixes enabled (#1121)
-- added the ability to back out of menus with the circle and triangle buttons when using a gamepad (cross acts as confirm) (#1104)
 - changed the gamepad control menu's 'reset all buttons' bind to held R1 (was held triangle) (#1104)
 - changed the number of visible enemies from 8 to 32 (#1122)
 - fixed FMVs always playing at 100% volume – now they'll play at the game sound volume (#1110)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - changed the Scion in The Great Pyramid from spawning blood when hit to a richochet effect if texture fixes enabled (#1121)
 - added the ability to back out of menus with the circle and triangle buttons when using a gamepad (cross acts as confirm) (#1104)
 - changed the gamepad control menu's 'reset all buttons' bind to held R1 (was held triangle) (#1104)
+- changed the number of visible enemies from 8 to 32 (#1122)
 - fixed FMVs always playing at 100% volume – now they'll play at the game sound volume (#1110)
 - fixed bugs when trying to stack multiple movable blocks (#1079)
 - fixed Lara's meshes being swapped in the gym level when using the console to give guns (#1092)

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - expanded moveable limit from 256 to 10240
 - expanded maximum textures from 2048 to 8192
 - expanded maximum texture pages from 32 to 128
+- expanded the number of visible enemies from 8 to 32
 - ported audio decoding library to ffmpeg
 - ported video decoding library to ffmpeg
 - ported image decoding library to ffmpeg

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -29,7 +29,7 @@
 #define MAX_REQLINES 18
 #define MAX_SAMPLES 256
 #define MAX_LEVEL_NAME_LENGTH 48
-#define NUM_SLOTS 8
+#define NUM_SLOTS 32
 #define MAX_FRAMES 10
 #define MAX_CD_TRACKS 64
 #define MAX_TEXTURES 8192


### PR DESCRIPTION
Resolves #1122.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Expanded the number of visible enemies from 8 to 32. Lmk if `visible` is the right word. Maybe it should be active, possible, or something else?
