### PR TITLE
lara: prevent look reset on target triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed being able to deselect the passport in quick save, quick load, save crystal, and death modes (#1108)
 - fixed inability to save in Unfinished Business in crystals mode as UB doesn't have crystals (#1102)
 - fixed items not being added to inventory if the sprite is missing from the level file (#1130)
+- fixed differences when looking at items from triggers that do not use fixed cameras when the enhanced look option is enabled (#1026)
 
 ## [3.0.5](https://github.com/LostArtefacts/TR1X/compare/3.0.4...3.0.5) - 2023-12-13
 - fixed crash when pressing certain keys and the console is disabled (#1116, regression since 3.0)

--- a/src/game/lara/lara_look.c
+++ b/src/game/lara/lara_look.c
@@ -81,7 +81,7 @@ void Lara_LookUpDownSurf(void)
 
 void Lara_ResetLook(void)
 {
-    if (g_Camera.type == CAM_LOOK) {
+    if (g_Camera.type == CAM_LOOK || g_Camera.last_item) {
         return;
     }
     if (g_Lara.head_x_rot <= -HEAD_TURN / 2


### PR DESCRIPTION
Resolves #1026.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that if Lara remains on a trigger with a `TO_TARGET` entry but no fixed camera, that she continues to look at the correct position of said target. The camera's type and item is reset on each frame, but the main camera update routine occurs after Lara's control routines, hence we need to refer to the cached `last_item` of the camera.

Tested the areas described in the issue itself, plus Natla's Mines room 94. I've also checked regular camera triggers and it seems fine to me.

~~We believe this is a bug in the later games too, it's just that there isn't a dosbox/ati equivalent for those so it's gone unnoticed.~~
