### PR TITLE
3.1 passport hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)
 - fixed a game crash when the quick load passport is deselected (#1136, regression from 3.1)
 - fixed not being able to save in an empty slot using quick save if the load game menu was opened before (#1140, regression from 3.1)
+- fixed the passport briefly flashing inaccessible page text (#1137, regression from 3.1)
 
 ## [3.1](https://github.com/LostArtefacts/TR1X/compare/3.0.5...3.1) - 2024-01-14
 - added the option to use "shell(s)" to give shotgun ammo in the developer console (#1096)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)
 - fixed a game crash when the quick load passport is deselected (#1136, regression from 3.1)
 - fixed not being able to save in an empty slot using quick save if the load game menu was opened before (#1140, regression from 3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- fixed a game crash when the quick load passport is deselected (#1136, regression from 3.1)
 
 ## [3.1](https://github.com/LostArtefacts/TR1X/compare/3.0.5...3.1) - 2024-01-14
 - added the option to use "shell(s)" to give shotgun ammo in the developer console (#1096)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed a game crash when the quick load passport is deselected (#1136, regression from 3.1)
+- fixed not being able to save in an empty slot using quick save if the load game menu was opened before (#1140, regression from 3.1)
 
 ## [3.1](https://github.com/LostArtefacts/TR1X/compare/3.0.5...3.1) - 2024-01-14
 - added the option to use "shell(s)" to give shotgun ammo in the developer console (#1096)

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -356,6 +356,8 @@ static void Option_PassportShowSaves(PASSPORT_MODE pending_mode)
         m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
         g_Input = (INPUT_STATE) { 0 };
         g_InputDB = (INPUT_STATE) { 0 };
+    } else {
+        m_PassportStatus.mode = PASSPORT_MODE_BROWSE;
     }
 }
 

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -389,10 +389,10 @@ static void Option_PassportLoadGame(void)
 {
     Text_ChangeText(
         m_Text[TEXT_PAGE_NAME], g_GameFlow.strings[GS_PASSPORT_LOAD_GAME]);
+    g_SavegameRequester.flags |= RIF_BLOCKABLE;
 
     if (m_PassportStatus.mode == PASSPORT_MODE_BROWSE) {
         if (g_InputDB.menu_confirm) {
-            g_SavegameRequester.flags |= RIF_BLOCKABLE;
             Option_PassportInitSaveRequester(m_PassportStatus.page);
             g_Input = (INPUT_STATE) { 0 };
             g_InputDB = (INPUT_STATE) { 0 };
@@ -472,10 +472,10 @@ static void Option_PassportSaveGame(void)
 {
     Text_ChangeText(
         m_Text[TEXT_PAGE_NAME], g_GameFlow.strings[GS_PASSPORT_SAVE_GAME]);
+    g_SavegameRequester.flags &= ~RIF_BLOCKABLE;
 
     if (m_PassportStatus.mode == PASSPORT_MODE_BROWSE) {
         if (g_InputDB.menu_confirm) {
-            g_SavegameRequester.flags &= ~RIF_BLOCKABLE;
             Option_PassportInitSaveRequester(m_PassportStatus.page);
             g_Input = (INPUT_STATE) { 0 };
             g_InputDB = (INPUT_STATE) { 0 };

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -191,7 +191,7 @@ static void Option_PassportDeterminePages(void)
 
     case INV_LOAD_MODE:
         m_PassportStatus.mode = PASSPORT_MODE_LOAD_GAME;
-        m_PassportStatus.page_available[PAGE_1] = g_SavedGamesCount > 0;
+        m_PassportStatus.page_available[PAGE_1] = true;
         m_PassportStatus.page_available[PAGE_2] = false;
         m_PassportStatus.page_available[PAGE_3] = false;
         m_PassportStatus.page_role[PAGE_1] = PASSPORT_MODE_LOAD_GAME;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1181,7 +1181,6 @@ typedef enum GAME_BONUS_FLAG {
 } GAME_BONUS_FLAG;
 
 typedef enum PASSPORT_PAGE {
-    PAGE_FLIPPING = -1,
     PAGE_1 = 0,
     PAGE_2 = 1,
     PAGE_3 = 2,


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Includes multiple passport fixes, a small refactor, and a change to quick load when there are no saves. Changes are best viewed on a commit by commit basis with their corresponding commit message and changelog entry. @aredfan tested the changes and had positive feedback. This will require a 3.1.1 hotfix since this fixes a game crash and a quick saving bug.