### PR TITLE
gun: add target changing and target lock mode options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- added the option to change weapon targets by tapping the look key like in TR4+ (#1145)
+- added three targeting lock options: full lock always keeps target lock (OG), semi lock loses target lock if the enemy dies, and no lock loses target lock if the enemey goes out of sight or dies (TR4+) (#1146)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed not being able to close level stats with Escape
 - fixed Lara jumping forever when alt+tabbing out of the game
 - stopped the default controls from functioning when the user unbound them
+- added the option to change weapon targets by tapping the look key like in TR4+
+- added three targeting lock options:
+  - full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1)
+  - semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies
+  - no lock: lose target lock if the enemey goes out of sight or dies (TR4+)
 
 #### Statistics
 - added ability to keep timer on in inventory

--- a/src/config.h
+++ b/src/config.h
@@ -51,7 +51,7 @@ typedef enum {
 typedef enum {
     TLM_FULL = 0,
     TLM_SEMI = 1,
-    TLM_NO = 2,
+    TLM_NONE = 2,
 } TARGET_LOCK_MODE;
 
 typedef struct {

--- a/src/config.h
+++ b/src/config.h
@@ -134,7 +134,7 @@ typedef struct {
     bool enable_buffering;
     bool enable_lean_jumping;
     bool enable_target_change;
-    int32_t target_lock_mode;
+    TARGET_LOCK_MODE target_mode;
 
     struct {
         int32_t layout;

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,12 @@ typedef enum {
     BSM_PS1 = 5,
 } BAR_SHOW_MODE;
 
+typedef enum {
+    TLM_FULL = 0,
+    TLM_SEMI = 1,
+    TLM_NO = 2,
+} TARGET_LOCK_MODE;
+
 typedef struct {
     bool loaded;
 
@@ -127,6 +133,8 @@ typedef struct {
     bool enable_uw_roll;
     bool enable_buffering;
     bool enable_lean_jumping;
+    bool enable_target_change;
+    int32_t target_lock_mode;
 
     struct {
         int32_t layout;

--- a/src/config_map.c
+++ b/src/config_map.c
@@ -115,7 +115,7 @@ const CONFIG_OPTION g_ConfigOptionMap[] = {
     { .name = "enemy_healthbar_color",          .type = COT_ENUM,   .target = &g_Config.enemy_healthbar_color,               .default_value = &(int32_t){BC_GREY},                 .param = m_BarColors},
     { .name = "screenshot_format",              .type = COT_ENUM,   .target = &g_Config.screenshot_format,                   .default_value = &(int32_t){SCREENSHOT_FORMAT_JPEG},  .param = m_ScreenshotFormats},
     { .name = "menu_style",                     .type = COT_ENUM,   .target = &g_Config.ui.menu_style,                       .default_value = &(int32_t){UI_STYLE_PC},             .param = m_UIStyles},
-    { .name = "target_lock_mode",               .type = COT_ENUM,   .target = &g_Config.target_lock_mode,                    .default_value = &(int32_t){TLM_FULL},                .param = m_TargetLockModes},
+    { .name = "target_mode",                    .type = COT_ENUM,   .target = &g_Config.target_mode,                         .default_value = &(TARGET_LOCK_MODE){TLM_FULL},       .param = m_TargetLockModes},
     { .name = "maximum_save_slots",             .type = COT_INT32,  .target = &g_Config.maximum_save_slots,                  .default_value = &(int32_t){25},                      0},
     { .name = "revert_to_pistols",              .type = COT_BOOL,   .target = &g_Config.revert_to_pistols,                   .default_value = &(bool){false},                      0},
     { .name = "enable_enhanced_saves",          .type = COT_BOOL,   .target = &g_Config.enable_enhanced_saves,               .default_value = &(bool){true},                       0},

--- a/src/config_map.c
+++ b/src/config_map.c
@@ -41,6 +41,13 @@ static const CONFIG_OPTION_ENUM_MAP m_BarColors[] = {
     { NULL, -1 },
 };
 
+static const CONFIG_OPTION_ENUM_MAP m_TargetLockModes[] = {
+    { "full-lock", TLM_FULL },
+    { "semi-lock", TLM_SEMI },
+    { "no-lock", TLM_NO },
+    { NULL, -1 },
+};
+
 static const CONFIG_OPTION_ENUM_MAP m_ScreenshotFormats[] = {
     { "jpg", SCREENSHOT_FORMAT_JPEG },
     { "jpeg", SCREENSHOT_FORMAT_JPEG },
@@ -108,6 +115,7 @@ const CONFIG_OPTION g_ConfigOptionMap[] = {
     { .name = "enemy_healthbar_color",          .type = COT_ENUM,   .target = &g_Config.enemy_healthbar_color,               .default_value = &(int32_t){BC_GREY},                 .param = m_BarColors},
     { .name = "screenshot_format",              .type = COT_ENUM,   .target = &g_Config.screenshot_format,                   .default_value = &(int32_t){SCREENSHOT_FORMAT_JPEG},  .param = m_ScreenshotFormats},
     { .name = "menu_style",                     .type = COT_ENUM,   .target = &g_Config.ui.menu_style,                       .default_value = &(int32_t){UI_STYLE_PC},             .param = m_UIStyles},
+    { .name = "target_lock_mode",               .type = COT_ENUM,   .target = &g_Config.target_lock_mode,                    .default_value = &(int32_t){TLM_FULL},                .param = m_TargetLockModes},
     { .name = "maximum_save_slots",             .type = COT_INT32,  .target = &g_Config.maximum_save_slots,                  .default_value = &(int32_t){25},                      0},
     { .name = "revert_to_pistols",              .type = COT_BOOL,   .target = &g_Config.revert_to_pistols,                   .default_value = &(bool){false},                      0},
     { .name = "enable_enhanced_saves",          .type = COT_BOOL,   .target = &g_Config.enable_enhanced_saves,               .default_value = &(bool){true},                       0},
@@ -128,6 +136,7 @@ const CONFIG_OPTION g_ConfigOptionMap[] = {
     { .name = "enable_uw_roll",                 .type = COT_BOOL,   .target = &g_Config.enable_uw_roll,                      .default_value = &(bool){true},                       0},
     { .name = "enable_buffering",               .type = COT_BOOL,   .target = &g_Config.enable_buffering,                    .default_value = &(bool){false},                      0},
     { .name = "enable_lean_jumping",            .type = COT_BOOL,   .target = &g_Config.enable_lean_jumping,                 .default_value = &(bool){false},                      0},
+    { .name = "enable_target_change",           .type = COT_BOOL,   .target = &g_Config.enable_target_change,                .default_value = &(bool){true},                       0},
     { .name = "render_mode",                    .type = COT_INT32,  .target = &g_Config.rendering.render_mode,               .default_value = &(int32_t){GFX_RM_LEGACY},           0},
     { .name = "enable_fullscreen",              .type = COT_BOOL,   .target = &g_Config.rendering.enable_fullscreen,         .default_value = &(bool){true},                       0},
     { .name = "enable_maximized",               .type = COT_BOOL,   .target = &g_Config.rendering.enable_maximized,          .default_value = &(bool){true},                       0},

--- a/src/config_map.c
+++ b/src/config_map.c
@@ -44,7 +44,7 @@ static const CONFIG_OPTION_ENUM_MAP m_BarColors[] = {
 static const CONFIG_OPTION_ENUM_MAP m_TargetLockModes[] = {
     { "full-lock", TLM_FULL },
     { "semi-lock", TLM_SEMI },
-    { "no-lock", TLM_NO },
+    { "no-lock", TLM_NONE },
     { NULL, -1 },
 };
 

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -199,6 +199,12 @@ void Gun_TargetInfo(WEAPON_INFO *winfo)
 
 void Gun_GetNewTarget(WEAPON_INFO *winfo)
 {
+    // Preserve OG targeting behavior.
+    if (g_Config.target_lock_mode == TLM_FULL && !g_Config.enable_target_change
+        && !g_Input.action) {
+        g_Lara.target = NULL;
+    }
+
     ITEM_INFO *best_target = NULL;
     int16_t best_yrot = 0x7FFF;
     int16_t num_targets = 0;
@@ -264,7 +270,11 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
     }
 
     if (num_targets > 0) {
-        for (int slot = 0; slot < num_targets; slot++) {
+        for (int slot = 0; slot < NUM_SLOTS; slot++) {
+            if (!m_TargetList[slot]) {
+                g_Lara.target = NULL;
+            }
+
             if (m_TargetList[slot] == g_Lara.target) {
                 break;
             }

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "game/collide.h"
 #include "game/effects/blood.h"
+#include "game/input.h"
 #include "game/inventory.h"
 #include "game/items.h"
 #include "game/los.h"
@@ -48,6 +49,9 @@
 #define SHOTGUN_RARM_YMAX (+80 * PHD_DEGREE)
 #define SHOTGUN_RARM_XMIN (-65 * PHD_DEGREE)
 #define SHOTGUN_RARM_XMAX (+65 * PHD_DEGREE)
+
+static ITEM_INFO *m_TargetList[NUM_SLOTS];
+static ITEM_INFO *m_LastTargetList[NUM_SLOTS];
 
 WEAPON_INFO g_Weapons[NUM_WEAPONS] = {
     // null
@@ -197,6 +201,7 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
 {
     ITEM_INFO *bestitem = NULL;
     int16_t bestyrot = 0x7FFF;
+    int16_t num_targets = 0;
 
     int32_t maxdist = winfo->target_dist;
     int32_t maxdist2 = maxdist * maxdist;
@@ -241,14 +246,86 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
             && ang[1] >= winfo->lock_angles[2]
             && ang[1] <= winfo->lock_angles[3]) {
             int16_t yrot = ABS(ang[0]);
+            m_TargetList[num_targets] = item;
+            num_targets++;
             if (yrot < bestyrot) {
                 bestyrot = yrot;
                 bestitem = item;
             }
         }
     }
+    m_TargetList[num_targets] = NULL;
 
-    g_Lara.target = bestitem;
+    if ((g_Config.target_lock_mode == TLM_FULL
+         || g_Config.target_lock_mode == TLM_SEMI)
+        && g_Input.action && g_Lara.target) {
+        Gun_TargetInfo(winfo);
+        return;
+    }
+
+    if (num_targets > 0) {
+        for (int slot = 0; slot < NUM_SLOTS; slot++) {
+            if (!m_TargetList[slot]) {
+                g_Lara.target = NULL;
+            }
+
+            if (m_TargetList[slot] == g_Lara.target) {
+                break;
+            }
+        }
+
+        if (!g_Lara.target) {
+            g_Lara.target = bestitem;
+            m_LastTargetList[0] = NULL;
+        }
+    } else {
+        g_Lara.target = NULL;
+    }
+
+    if (g_Lara.target != m_LastTargetList[0]) {
+        for (int slot = NUM_SLOTS - 1; slot > 0; slot--) {
+            m_LastTargetList[slot] = m_LastTargetList[slot - 1];
+        }
+        m_LastTargetList[0] = g_Lara.target;
+    }
+
+    Gun_TargetInfo(winfo);
+}
+
+void Gun_ChangeTarget(WEAPON_INFO *winfo)
+{
+    g_Lara.target = NULL;
+    bool found_new_target = false;
+
+    for (int new_target = 0; new_target < NUM_SLOTS; new_target++) {
+        if (!m_TargetList[new_target]) {
+            break;
+        }
+
+        for (int last_target = 0; last_target < NUM_SLOTS; last_target++) {
+            if (!m_LastTargetList[last_target]) {
+                found_new_target = true;
+                break;
+            }
+
+            if (m_LastTargetList[last_target] == m_TargetList[new_target]) {
+                break;
+            }
+        }
+
+        if (found_new_target == true) {
+            g_Lara.target = m_TargetList[new_target];
+            break;
+        }
+    }
+
+    if (g_Lara.target != m_LastTargetList[0]) {
+        for (int last_target = NUM_SLOTS - 1; last_target > 0; last_target--) {
+            m_LastTargetList[last_target] = m_LastTargetList[last_target - 1];
+        }
+        m_LastTargetList[0] = g_Lara.target;
+    }
+
     Gun_TargetInfo(winfo);
 }
 
@@ -409,6 +486,9 @@ void Gun_HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int16_t damage)
 {
     if (item->hit_points > 0 && item->hit_points <= damage) {
         g_GameInfo.current[g_CurrentLevel].stats.kill_count++;
+        if (g_Config.target_lock_mode == TLM_SEMI) {
+            g_Lara.target = NULL;
+        }
     }
     Item_TakeDamage(item, damage, true);
 

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -199,8 +199,8 @@ void Gun_TargetInfo(WEAPON_INFO *winfo)
 
 void Gun_GetNewTarget(WEAPON_INFO *winfo)
 {
-    ITEM_INFO *bestitem = NULL;
-    int16_t bestyrot = 0x7FFF;
+    ITEM_INFO *best_target = NULL;
+    int16_t best_yrot = 0x7FFF;
     int16_t num_targets = 0;
 
     int32_t maxdist = winfo->target_dist;
@@ -248,9 +248,9 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
             int16_t yrot = ABS(ang[0]);
             m_TargetList[num_targets] = item;
             num_targets++;
-            if (yrot < bestyrot) {
-                bestyrot = yrot;
-                bestitem = item;
+            if (yrot < best_yrot) {
+                best_yrot = yrot;
+                best_target = item;
             }
         }
     }
@@ -264,18 +264,14 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
     }
 
     if (num_targets > 0) {
-        for (int slot = 0; slot < NUM_SLOTS; slot++) {
-            if (!m_TargetList[slot]) {
-                g_Lara.target = NULL;
-            }
-
+        for (int slot = 0; slot < num_targets; slot++) {
             if (m_TargetList[slot] == g_Lara.target) {
                 break;
             }
         }
 
         if (!g_Lara.target) {
-            g_Lara.target = bestitem;
+            g_Lara.target = best_target;
             m_LastTargetList[0] = NULL;
         }
     } else {
@@ -313,7 +309,7 @@ void Gun_ChangeTarget(WEAPON_INFO *winfo)
             }
         }
 
-        if (found_new_target == true) {
+        if (found_new_target) {
             g_Lara.target = m_TargetList[new_target];
             break;
         }

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -200,7 +200,7 @@ void Gun_TargetInfo(WEAPON_INFO *winfo)
 void Gun_GetNewTarget(WEAPON_INFO *winfo)
 {
     // Preserve OG targeting behavior.
-    if (g_Config.target_lock_mode == TLM_FULL && !g_Config.enable_target_change
+    if (g_Config.target_mode == TLM_FULL && !g_Config.enable_target_change
         && !g_Input.action) {
         g_Lara.target = NULL;
     }
@@ -262,8 +262,7 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
     }
     m_TargetList[num_targets] = NULL;
 
-    if ((g_Config.target_lock_mode == TLM_FULL
-         || g_Config.target_lock_mode == TLM_SEMI)
+    if ((g_Config.target_mode == TLM_FULL || g_Config.target_mode == TLM_SEMI)
         && g_Input.action && g_Lara.target) {
         Gun_TargetInfo(winfo);
         return;
@@ -492,7 +491,7 @@ void Gun_HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int16_t damage)
 {
     if (item->hit_points > 0 && item->hit_points <= damage) {
         g_GameInfo.current[g_CurrentLevel].stats.kill_count++;
-        if (g_Config.target_lock_mode == TLM_SEMI) {
+        if (g_Config.target_mode == TLM_SEMI) {
             g_Lara.target = NULL;
         }
     }

--- a/src/game/gun/gun_misc.h
+++ b/src/game/gun/gun_misc.h
@@ -11,6 +11,7 @@ extern WEAPON_INFO g_Weapons[NUM_WEAPONS];
 
 void Gun_TargetInfo(WEAPON_INFO *winfo);
 void Gun_GetNewTarget(WEAPON_INFO *winfo);
+void Gun_ChangeTarget(WEAPON_INFO *winfo);
 void Gun_FindTargetPoint(ITEM_INFO *item, GAME_VECTOR *target);
 void Gun_AimWeapon(WEAPON_INFO *winfo, LARA_ARM *arm);
 int32_t Gun_FireWeapon(

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -1,5 +1,6 @@
 #include "game/gun/gun_pistols.h"
 
+#include "config.h"
 #include "game/anim.h"
 #include "game/gun/gun_misc.h"
 #include "game/input.h"
@@ -159,13 +160,10 @@ void Gun_Pistols_Control(LARA_GUN_TYPE weapon_type)
 {
     WEAPON_INFO *winfo = &g_Weapons[weapon_type];
 
-    if (g_Input.action) {
-        Gun_TargetInfo(winfo);
-    } else {
-        g_Lara.target = NULL;
-    }
-    if (!g_Lara.target) {
-        Gun_GetNewTarget(winfo);
+    Gun_GetNewTarget(winfo);
+
+    if (g_InputDB.change_target && g_Config.enable_target_change) {
+        Gun_ChangeTarget(winfo);
     }
 
     Gun_AimWeapon(winfo, &g_Lara.left_arm);

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -125,13 +125,10 @@ void Gun_Rifle_Control(LARA_GUN_TYPE weapon_type)
 {
     WEAPON_INFO *winfo = &g_Weapons[LGT_SHOTGUN];
 
-    if (g_Input.action) {
-        Gun_TargetInfo(winfo);
-    } else {
-        g_Lara.target = NULL;
-    }
-    if (!g_Lara.target) {
-        Gun_GetNewTarget(winfo);
+    Gun_GetNewTarget(winfo);
+
+    if (g_InputDB.change_target && g_Config.enable_target_change) {
+        Gun_ChangeTarget(winfo);
     }
 
     Gun_AimWeapon(winfo, &g_Lara.left_arm);

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -17,8 +17,31 @@ static bool m_KeyConflict[INPUT_ROLE_NUMBER_OF] = { false };
 static bool m_BtnConflict[INPUT_ROLE_NUMBER_OF] = { false };
 static int32_t m_HoldBack = 0;
 static int32_t m_HoldForward = 0;
+static int32_t m_HoldLook = 0;
 
+static void Input_CheckChangeTarget(INPUT_STATE *input);
 static INPUT_STATE Input_GetDebounced(INPUT_STATE input);
+
+static void Input_CheckChangeTarget(INPUT_STATE *input)
+{
+    if (g_Lara.gun_status != LGS_READY) {
+        return;
+    }
+
+    if (input->look) {
+        if (m_HoldLook >= 6)
+            m_HoldLook = 100;
+        else {
+            input->look = 0;
+            m_HoldLook++;
+        }
+    } else {
+        if (m_HoldLook && m_HoldLook != 100) {
+            input->change_target = 1;
+        }
+        m_HoldLook = 0;
+    }
+}
 
 static INPUT_STATE Input_GetDebounced(INPUT_STATE input)
 {
@@ -139,6 +162,10 @@ void Input_Update(void)
                 g_Input.step_right = 1;
             }
         }
+    }
+
+    if (g_Config.enable_target_change) {
+        Input_CheckChangeTarget(&g_Input);
     }
 
     g_InputDB = Input_GetDebounced(g_Input);

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -6,6 +6,8 @@
 
 #include <stdint.h>
 
+#define LOOK_HOLD_TIME 6
+#define LOOK_ENABLED 100
 #define DELAY_FRAMES 12
 #define HOLD_FRAMES 3
 
@@ -29,14 +31,14 @@ static void Input_CheckChangeTarget(INPUT_STATE *input)
     }
 
     if (input->look) {
-        if (m_HoldLook >= 6)
-            m_HoldLook = 100;
-        else {
+        if (m_HoldLook >= LOOK_HOLD_TIME) {
+            m_HoldLook = LOOK_ENABLED;
+        } else {
             input->look = 0;
             m_HoldLook++;
         }
     } else {
-        if (m_HoldLook && m_HoldLook != 100) {
+        if (m_HoldLook && m_HoldLook != LOOK_ENABLED) {
             input->change_target = 1;
         }
         m_HoldLook = 0;

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -165,7 +165,9 @@ void Natla_Control(int16_t item_num)
                 item->hit_points = NATLA_NEAR_DEATH;
                 Music_Play(MX_NATLA_SPEECH);
             } else {
-                g_Lara.target = NULL;
+                if (g_Config.target_lock_mode == TLM_SEMI || g_Config.target_lock_mode == TLM_NO) {
+                    g_Lara.target = NULL;
+                }
                 item->hit_points = DONT_TARGET;
             }
             break;

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -164,6 +164,7 @@ void Natla_Control(int16_t item_num)
                 item->hit_points = NATLA_NEAR_DEATH;
                 Music_Play(MX_NATLA_SPEECH);
             } else {
+                g_Lara.target = NULL;
                 item->hit_points = DONT_TARGET;
             }
             break;

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -14,6 +14,7 @@
 #include "math/math.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #define NATLA_SHOT_DAMAGE 100
 #define NATLA_NEAR_DEATH 200

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -165,7 +165,8 @@ void Natla_Control(int16_t item_num)
                 item->hit_points = NATLA_NEAR_DEATH;
                 Music_Play(MX_NATLA_SPEECH);
             } else {
-                if (g_Config.target_lock_mode == TLM_SEMI || g_Config.target_lock_mode == TLM_NONE) {
+                if (g_Config.target_mode == TLM_SEMI
+                    || g_Config.target_mode == TLM_NONE) {
                     g_Lara.target = NULL;
                 }
                 item->hit_points = DONT_TARGET;

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -165,7 +165,7 @@ void Natla_Control(int16_t item_num)
                 item->hit_points = NATLA_NEAR_DEATH;
                 Music_Play(MX_NATLA_SPEECH);
             } else {
-                if (g_Config.target_lock_mode == TLM_SEMI || g_Config.target_lock_mode == TLM_NO) {
+                if (g_Config.target_lock_mode == TLM_SEMI || g_Config.target_lock_mode == TLM_NONE) {
                     g_Lara.target = NULL;
                 }
                 item->hit_points = DONT_TARGET;

--- a/src/game/objects/creatures/natla.c
+++ b/src/game/objects/creatures/natla.c
@@ -1,5 +1,6 @@
 #include "game/objects/creatures/natla.h"
 
+#include "config.h"
 #include "game/creature.h"
 #include "game/effects.h"
 #include "game/effects/gun.h"

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -2073,6 +2073,7 @@ typedef union INPUT_STATE {
         uint64_t menu_right : 1;
         uint64_t menu_confirm : 1;
         uint64_t menu_back : 1;
+        uint64_t change_target : 1;
     };
 } INPUT_STATE;
 

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -71,6 +71,11 @@
       "bottom-left": "Bottom left",
       "bottom-center": "Bottom center",
       "bottom-right": "Bottom right"
+    },
+  "target_mode": {
+    "full-lock": "Full lock",
+    "semi-lock": "Semi lock",
+    "no-lock": "No lock"
     }
   },
   "Categories": {
@@ -106,6 +111,14 @@
     "enable_uw_roll": {
       "Title": "Underwater roll",
       "Description": "Allows Lara to roll while underwater, similar to TR2+."
+    },
+    "enable_target_change": {
+      "Title": "Target change",
+      "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
+    },
+    "target_lock_mode": {
+      "Title": "Weapon target lock mode",
+      "Description": "Changes the behavior of how weapons lock onto targets.\n- Full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1).\n- Semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies.\n- No lock: lose target lock if the enemey goes out of sight or dies (TR4+)."
     },
     "enable_lean_jumping": {
       "Title": "Lean jumping",

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -116,7 +116,7 @@
       "Title": "Target change",
       "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
     },
-    "target_lock_mode": {
+    "target_mode": {
       "Title": "Weapon target lock mode",
       "Description": "Changes the behavior of how weapons lock onto targets.\n- Full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1).\n- Semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies.\n- No lock: lose target lock if the enemey goes out of sight or dies (TR4+)."
     },

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
@@ -80,7 +80,12 @@
       "top-center": "Superior central",
       "top-left": "Superior izquierda",
       "top-right": "Superior derecha"
-    }
+    },
+    "target_mode": {
+      "full-lock": "Full lock",
+      "semi-lock": "Semi lock",
+      "no-lock": "No lock"
+      }
   },
   "Properties": {
     "airbar_color": {
@@ -222,6 +227,14 @@
     "enable_uw_roll": {
       "Title": "Giro en el agua",
       "Description": "Permite que Lara realice un giro mientras está bajo el agua, similar a TR2+."
+    },
+    "enable_target_change": {
+      "Title": "Target change",
+      "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
+    },
+    "target_lock_mode": {
+      "Title": "Weapon target lock mode",
+      "Description": "Changes the behavior of how weapons lock onto targets.\n- Full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1).\n- Semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies.\n- No lock: lose target lock if the enemy goes out of sight or dies (TR4+)."
     },
     "enable_lean_jumping": {
       "Title": "Saltos inclinados",

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
@@ -232,7 +232,7 @@
       "Title": "Target change",
       "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
     },
-    "target_lock_mode": {
+    "target_mode": {
       "Title": "Weapon target lock mode",
       "Description": "Changes the behavior of how weapons lock onto targets.\n- Full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1).\n- Semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies.\n- No lock: lose target lock if the enemy goes out of sight or dies (TR4+)."
     },

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -116,7 +116,7 @@
       "Title": "Changement de cible",
       "Description": "Permet de changer de cible en visant avec une arme. Appuyez sur la touche Regarder tout en visant pour changer de cible comme dans TR4+."
     },
-    "target_lock_mode": {
+    "target_mode": {
       "Title": "Mode de verrouillage des cibles",
       "Description": "Modifie le comportement de verrouillage des cibles.\n- Verrouillage complet : Garde toujours le verrouillage des cibles même si l'ennemi se déplace hors du champ de vision ou meurt (Comportement original de TR1).\n- Semi-verrouillage : Conserve le verrouillage des cibles si l'ennemi se déplace hors du champ de vision, mais perd le verrouillage si l'ennemi meurt.\n- Pas de verrouillage : Perd le verrouillage de la cible si l'ennemi disparaît de vue ou meurt (Comportemenent TR4+)."
     },

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -71,7 +71,12 @@
       "bottom-left": "En bas à gauche",
       "bottom-center": "En bas au centre",
       "bottom-right": "En bas à droite"
-    }
+    },
+    "target_mode": {
+      "full-lock": "Full lock",
+      "semi-lock": "Semi lock",
+      "no-lock": "No lock"
+      }
   },
   "Categories": {
     "controls": "Contrôles",
@@ -106,6 +111,14 @@
     "enable_uw_roll": {
       "Title": "Retourné sous-marin",
       "Description": "Permet à Lara de faire un demi tour immédiat, sous l'eau, similaire a TR2+."
+    },
+    "enable_target_change": {
+      "Title": "Weapon target changing",
+      "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
+    },
+    "target_lock_mode": {
+      "Title": "Mode de verrouillage des cibles",
+      "Description": "Modifie le comportement de verrouillage des cibles.\n- Verrouillage complet : Garde toujours le verrouillage des cibles même si l'ennemi se déplace hors du champ de vision ou meurt (Comportement original de TR1).\n- Semi-verrouillage : Conserve le verrouillage des cibles si l'ennemi se déplace hors du champ de vision, mais perd le verrouillage si l'ennemi meurt.\n- Pas de verrouillage : Perd le verrouillage de la cible si l'ennemi disparaît de vue ou meurt (Comportemenent TR4+)."
     },
     "enable_lean_jumping": {
       "Title": "Air controle du saut sur place",

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -113,8 +113,8 @@
       "Description": "Permet à Lara de faire un demi tour immédiat, sous l'eau, similaire a TR2+."
     },
     "enable_target_change": {
-      "Title": "Weapon target changing",
-      "Description": "Enables TR4+ target changing while aiming weapons. Press look while aiming to change targets."
+      "Title": "Changement de cible",
+      "Description": "Permet de changer de cible en visant avec une arme. Appuyez sur la touche Regarder tout en visant pour changer de cible comme dans TR4+."
     },
     "target_lock_mode": {
       "Title": "Mode de verrouillage des cibles",

--- a/tools/config/TR1X_ConfigTool/Resources/specification.json
+++ b/tools/config/TR1X_ConfigTool/Resources/specification.json
@@ -40,6 +40,11 @@
       "bottom-left",
       "bottom-center",
       "bottom-right"
+    ],
+    "target_mode": [
+      "full-lock",
+      "semi-lock",
+      "no-lock"
     ]
   },
   "CategorisedProperties": [
@@ -76,6 +81,17 @@
           "Field": "enable_uw_roll",
           "DataType": "Bool",
           "DefaultValue": true
+        },
+        {
+          "Field": "enable_target_change",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
+          "Field": "target_lock_mode",
+          "DataType": "Enum",
+          "EnumKey": "target_mode",
+          "DefaultValue": "full-lock"
         },
         {
           "Field": "enable_lean_jumping",

--- a/tools/config/TR1X_ConfigTool/Resources/specification.json
+++ b/tools/config/TR1X_ConfigTool/Resources/specification.json
@@ -88,7 +88,7 @@
           "DefaultValue": true
         },
         {
-          "Field": "target_lock_mode",
+          "Field": "target_mode",
           "DataType": "Enum",
           "EnumKey": "target_mode",
           "DefaultValue": "full-lock"


### PR DESCRIPTION
Resolves #1145 and #1146.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Decided to group these two issues since they have co-dependent features. 1 of 2 config options are translated in French with the second one pending. Requesting @ajtudela to translate the two for Spanish if possible. Thanks!

Added the option to change weapon targets by tapping the look key like in TR4+.
Added three targeting lock options:
  - full lock: always keep target lock even if the enemy moves out of sight or dies (OG TR1)
  - semi lock: keep target lock if the enemy moves out of sight but lose target lock if the enemy dies
  - no lock: lose target lock if the enemey goes out of sight or dies (TR4+)