### PR TITLE
Music refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added the option to change weapon targets by tapping the look key like in TR4+ (#1145)
 - added three targeting lock options: full lock always keeps target lock (OG), semi lock loses target lock if the enemy dies, and no lock loses target lock if the enemey goes out of sight or dies (TR4+) (#1146)
 - added an option to the installer to install from a CD drive (#1144)
+- changed the way music timestamps are internally handled – resets music position in existing saves
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -222,6 +222,11 @@ MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void)
     return m_TrackLooped;
 }
 
+MUSIC_TRACK_ID Music_GetCurrentPlayingTrack(void)
+{
+    return m_TrackCurrent == MX_INACTIVE ? m_TrackLooped : m_TrackCurrent;
+}
+
 double Music_GetDuration(void)
 {
     if (m_AudioStreamID < 0) {

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -222,15 +222,23 @@ MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void)
     return m_TrackLooped;
 }
 
-int64_t Music_GetTimestamp(void)
+double Music_GetDuration(void)
 {
     if (m_AudioStreamID < 0) {
-        return -1;
+        return -1.0;
+    }
+    return S_Audio_StreamGetDuration(m_AudioStreamID);
+}
+
+double Music_GetTimestamp(void)
+{
+    if (m_AudioStreamID < 0) {
+        return -1.0;
     }
     return S_Audio_StreamGetTimestamp(m_AudioStreamID);
 }
 
-bool Music_SeekTimestamp(int64_t timestamp)
+bool Music_SeekTimestamp(double timestamp)
 {
     if (m_AudioStreamID < 0) {
         return false;

--- a/src/game/music.h
+++ b/src/game/music.h
@@ -53,6 +53,9 @@ MUSIC_TRACK_ID Music_GetLastPlayedTrack(void);
 // Returns the looped track.
 MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void);
 
+// Returns the currently playing track. Includes looped music.
+MUSIC_TRACK_ID Music_GetCurrentPlayingTrack(void);
+
 // Get the duration of the current stream in seconds.
 double Music_GetDuration(void);
 

--- a/src/game/music.h
+++ b/src/game/music.h
@@ -53,8 +53,11 @@ MUSIC_TRACK_ID Music_GetLastPlayedTrack(void);
 // Returns the looped track.
 MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void);
 
-// Get timestamp of current stream.
-int64_t Music_GetTimestamp(void);
+// Get the duration of the current stream in seconds.
+double Music_GetDuration(void);
+
+// Get the current timestamp of the current stream in seconds.
+double Music_GetTimestamp(void);
 
 // Seek to timestamp of current stream.
-bool Music_SeekTimestamp(int64_t timestamp);
+bool Music_SeekTimestamp(double timestamp);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -883,7 +883,7 @@ static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
     }
 
     int16_t current_track = json_object_get_int(music_obj, "current_track", -1);
-    int64_t timestamp = json_object_get_int64(music_obj, "timestamp", -1);
+    double timestamp = json_object_get_double(music_obj, "timestamp", -1.0);
     if (current_track != MX_INACTIVE) {
         Music_Play(current_track);
         if (!Music_SeekTimestamp(timestamp)) {
@@ -1254,7 +1254,7 @@ static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void)
     struct json_object_s *current_music_obj = json_object_new();
     json_object_append_int(
         current_music_obj, "current_track", Music_GetCurrentTrack());
-    json_object_append_int64(
+    json_object_append_double(
         current_music_obj, "timestamp", Music_GetTimestamp());
 
     return current_music_obj;

--- a/src/specific/s_audio.h
+++ b/src/specific/s_audio.h
@@ -39,8 +39,9 @@ bool S_Audio_SampleSoundClose(int sound_id);
 bool S_Audio_SampleSoundCloseAll(void);
 bool S_Audio_SampleSoundSetPan(int sound_id, int pan);
 bool S_Audio_SampleSoundSetVolume(int sound_id, int volume);
-int64_t S_Audio_StreamGetTimestamp(int sound_id);
-bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp);
+double S_Audio_StreamGetTimestamp(int sound_id);
+double S_Audio_StreamGetDuration(int sound_id);
+bool S_Audio_StreamSeekTimestamp(int sound_id, double timestamp);
 
 #ifdef S_AUDIO_IMPL
     #include <libavformat/avformat.h>


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds a couple of useful music related routines and also switches the timestamps from using int64_t opaque integers towards more human-readable `double seconds`.

May break saved music triggers but that's a sacrifice I'm willing to make.