### PR TITLE
fmv: fix music not stopping during fmv

### DIFF
--- a/src/game/fmv.c
+++ b/src/game/fmv.c
@@ -1,6 +1,8 @@
 #include "game/fmv.h"
 
 #include "filesystem.h"
+#include "game/music.h"
+#include "game/sound.h"
 #include "memory.h"
 #include "specific/s_fmv.h"
 
@@ -17,6 +19,9 @@ bool FMV_Init(void)
 
 bool FMV_Play(const char *path)
 {
+    Music_Stop();
+    Sound_StopAllSamples();
+
     char *final_path = File_GuessExtension(path, m_Extensions);
     bool ret = S_FMV_Play(final_path);
     Memory_FreePointer(&final_path);


### PR DESCRIPTION
Regression since recent phase refactors

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes the bug with Caves FMV playing the title music that's available only on develop.
(Stop routines no longer calls Music_Stop, instead it's mostly the responsibility of Start routines)