### PR TITLE
es.json: fix error with Eidos logo skip config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added an option to the installer to install from a CD drive (#1144)
 - added stack traces to logs for better crash debugging (#1165)
 - changed the way music timestamps are internally handled – resets music position in existing saves
+- fixed a missing translation for the Spanish config tool for the Eidos logo skip option (#1151)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
@@ -192,7 +192,7 @@
       "Title": "Habilitar FMV",
       "Description": "Habilita la reproducción de vídeos FMV."
     },
-    "enable_eidos": {
+    "enable_eidos_logo": {
       "Title": "Habilitar el logo de EIDOS",
       "Description": "Habilita el logo de EIDOS al comienzo del juego."
     },


### PR DESCRIPTION
Resolves #1151.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed an Eidos logo skip error when using the config tool in Spanish.