### PR TITLE
inventory: fix option header flashing

### DIFF
--- a/src/game/inventory/inventory_ring.c
+++ b/src/game/inventory/inventory_ring.c
@@ -75,17 +75,7 @@ void Inv_Ring_Init(
     ring->light.z = 1024;
 }
 
-void Inv_Ring_Shutdown(void)
-{
-    for (int i = 0; i < IT_NUMBER_OF; i++) {
-        if (g_InvItemText[i]) {
-            Text_Remove(g_InvItemText[i]);
-            g_InvItemText[i] = NULL;
-        }
-    }
-}
-
-void Inv_Ring_IsOpen(RING_INFO *ring)
+void Inv_Ring_InitHeader(RING_INFO *ring)
 {
     if (g_InvMode == INV_TITLE_MODE) {
         return;
@@ -141,7 +131,7 @@ void Inv_Ring_IsOpen(RING_INFO *ring)
     }
 }
 
-void Inv_Ring_IsNotOpen(RING_INFO *ring)
+void Inv_Ring_RemoveHeader(RING_INFO *ring)
 {
     if (!g_InvRingText) {
         return;
@@ -161,6 +151,16 @@ void Inv_Ring_IsNotOpen(RING_INFO *ring)
         Text_Remove(m_InvDownArrow2);
         m_InvDownArrow1 = NULL;
         m_InvDownArrow2 = NULL;
+    }
+}
+
+void Inv_Ring_RemoveAlText(void)
+{
+    for (int i = 0; i < IT_NUMBER_OF; i++) {
+        if (g_InvItemText[i]) {
+            Text_Remove(g_InvItemText[i]);
+            g_InvItemText[i] = NULL;
+        }
     }
 }
 
@@ -306,11 +306,6 @@ void Inv_Ring_Active(INVENTORY_ITEM *inv_item)
         Text_Hide(m_InvDownArrow2, false);
         g_GameInfo.inv_showing_medpack = false;
     }
-}
-
-void Inv_Ring_NotActive(void)
-{
-    Inv_Ring_Shutdown();
 }
 
 void Inv_Ring_GetView(RING_INFO *ring, XYZ_32 *view_pos, XYZ_16 *view_rot)

--- a/src/game/inventory/inventory_ring.h
+++ b/src/game/inventory/inventory_ring.h
@@ -7,12 +7,11 @@
 void Inv_Ring_Init(
     RING_INFO *ring, int16_t type, INVENTORY_ITEM **list, int16_t qty,
     int16_t current, IMOTION_INFO *imo);
-void Inv_Ring_Shutdown(void);
 
-void Inv_Ring_IsOpen(RING_INFO *ring);
-void Inv_Ring_IsNotOpen(RING_INFO *ring);
+void Inv_Ring_InitHeader(RING_INFO *ring);
+void Inv_Ring_RemoveHeader(RING_INFO *ring);
+void Inv_Ring_RemoveAlText(void);
 void Inv_Ring_Active(INVENTORY_ITEM *inv_item);
-void Inv_Ring_NotActive(void);
 
 void Inv_Ring_GetView(RING_INFO *ring, XYZ_32 *view_pos, XYZ_16 *view_rot);
 void Inv_Ring_Light(RING_INFO *ring);

--- a/src/game/phase/phase_inventory.c
+++ b/src/game/phase/phase_inventory.c
@@ -465,7 +465,7 @@ static GAMEFLOW_OPTION Phase_Inventory_Control(int32_t nframes)
             return GF_PHASE_CONTINUE;
         }
 
-        Inv_Ring_Shutdown();
+        Inv_Ring_RemoveAlText();
 
         if (m_VersionText) {
             Text_Remove(m_VersionText);
@@ -583,27 +583,6 @@ static GAMEFLOW_OPTION Phase_Inventory_Control(int32_t nframes)
     }
 
     ring->camera.pos.z = ring->radius + CAMERA_2_RING;
-
-    if (motion->status == RNG_OPEN || motion->status == RNG_SELECTING
-        || motion->status == RNG_SELECTED || motion->status == RNG_DESELECTING
-        || motion->status == RNG_DESELECT
-        || motion->status == RNG_CLOSING_ITEM) {
-        if (!ring->rotating && !g_Input.menu_left && !g_Input.menu_right) {
-            INVENTORY_ITEM *inv_item = ring->list[ring->current_object];
-            Inv_Ring_Active(inv_item);
-        }
-        Inv_Ring_IsOpen(ring);
-    } else {
-        Inv_Ring_IsNotOpen(ring);
-    }
-
-    if (!motion->status || motion->status == RNG_CLOSING
-        || motion->status == RNG_MAIN2OPTION
-        || motion->status == RNG_OPTION2MAIN
-        || motion->status == RNG_EXITING_INVENTORY || motion->status == RNG_DONE
-        || ring->rotating) {
-        Inv_Ring_NotActive();
-    }
 
     g_GameInfo.inv_ring_above = g_InvMode == INV_GAME_MODE
         && ((ring->type == RT_MAIN && g_InvKeysObjects)
@@ -973,6 +952,27 @@ static GAMEFLOW_OPTION Phase_Inventory_Control(int32_t nframes)
                 ring, CLOSE_ROTATION, ring->ringpos.rot.y - CLOSE_ROTATION);
         }
         break;
+    }
+
+    if (motion->status == RNG_OPEN || motion->status == RNG_SELECTING
+        || motion->status == RNG_SELECTED || motion->status == RNG_DESELECTING
+        || motion->status == RNG_DESELECT
+        || motion->status == RNG_CLOSING_ITEM) {
+        if (!ring->rotating && !g_Input.menu_left && !g_Input.menu_right) {
+            INVENTORY_ITEM *inv_item = ring->list[ring->current_object];
+            Inv_Ring_Active(inv_item);
+        }
+        Inv_Ring_InitHeader(ring);
+    } else {
+        Inv_Ring_RemoveHeader(ring);
+    }
+
+    if (!motion->status || motion->status == RNG_CLOSING
+        || motion->status == RNG_MAIN2OPTION
+        || motion->status == RNG_OPTION2MAIN
+        || motion->status == RNG_EXITING_INVENTORY || motion->status == RNG_DONE
+        || ring->rotating) {
+        Inv_Ring_RemoveAlText();
     }
 
     return GF_PHASE_CONTINUE;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes the `OPTION` text header disappearing for a frame or two when the player opens the passport inside the game. It's a regression from 9aaf5d29 that was not yet officially released.