### PR TITLE
build: fix mathlibrary build failure

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ dep_avcodec = dependency('libavcodec', static: staticdeps)
 dep_avformat = dependency('libavformat', static: staticdeps)
 dep_avutil = dependency('libavutil', static: staticdeps)
 dep_backtrace = c_compiler.find_library('backtrace', static: staticdeps, required: false)
+dep_mathlibrary = c_compiler.find_library('m', static: staticdeps, required : false)
 dep_swscale = dependency('libswscale', static: staticdeps)
 dep_swresample = dependency('libswresample', static: staticdeps)
 dep_sdl2 = dependency('SDL2', static: staticdeps)
@@ -296,6 +297,7 @@ dependencies = [
   dep_avcodec,
   dep_avformat,
   dep_avutil,
+  dep_mathlibrary,
   dep_opengl,
   dep_sdl2,
   dep_swresample,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Since 4de8c65c, build is failing with :
> [...]/x86_64-pc-linux-gnu/bin/ld: TR1X.p/src_game_screen.c.o: undefined reference to symbol 'round@@GLIBC_2.2.5'
> [...]/x86_64-pc-linux-gnu/bin/ld: /lib64/libm.so.6: error adding symbols: DSO missing from command line
> collect2: error: ld returned 1 exit status

math library is missing at linking step.

See also 6610320146f214b37376e302058cb3ba8916e6af
