### PR TITLE
gameflow: fix displaying Eidos logo

### DIFF
--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1344,7 +1344,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                 break;
             }
 
-            if (Phase_Get() == PHASE_NULL && !g_Config.enable_eidos_logo) {
+            if (g_CurrentLevel == -1 && !g_Config.enable_eidos_logo) {
                 break;
             }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes EIDOS logo disabling also credit images.