### PR TITLE
gun: add ability to move look camera while targeting in combat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added support for macOS builds (for both Apple Silicon and Intel)
 - added optional support for OpenGL 3.3 Core Profile
 - added Italian localization to the config tool
+- added the ability to move the look camera while targeting an enemy in combat (#1187)
 - changed the way music timestamps are internally handled – resets music position in existing saves
 - changed vertex and fragment shaders into unified files that are runtime pre-processed for OpenGL versions 2.1 or 3.3
 - fixed a missing translation for the Spanish config tool for the Eidos logo skip option (#1151)

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added the ability to reset control schemes to default
 - added customizable controller support
 - added an inverted look camera option
+- added the ability to move the look camera while targeting an enemy in combat
 - fixed freeze when holding the Action key during end of level
 - fixed inability to switch Control keys when shimmying
 - fixed setting user keys being very difficult

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -170,20 +170,26 @@ void Gun_Pistols_Control(LARA_GUN_TYPE weapon_type)
     Gun_AimWeapon(winfo, &g_Lara.right_arm);
 
     if (g_Lara.left_arm.lock && !g_Lara.right_arm.lock) {
-        g_Lara.head_x_rot = g_Lara.left_arm.x_rot / 2;
-        g_Lara.head_y_rot = g_Lara.left_arm.y_rot / 2;
+        if (g_Camera.type != CAM_LOOK) {
+            g_Lara.head_x_rot = g_Lara.left_arm.x_rot / 2;
+            g_Lara.head_y_rot = g_Lara.left_arm.y_rot / 2;
+        }
         g_Lara.torso_x_rot = g_Lara.left_arm.x_rot / 2;
         g_Lara.torso_y_rot = g_Lara.left_arm.y_rot / 2;
     } else if (!g_Lara.left_arm.lock && g_Lara.right_arm.lock) {
-        g_Lara.head_x_rot = g_Lara.right_arm.x_rot / 2;
-        g_Lara.head_y_rot = g_Lara.right_arm.y_rot / 2;
+        if (g_Camera.type != CAM_LOOK) {
+            g_Lara.head_x_rot = g_Lara.right_arm.x_rot / 2;
+            g_Lara.head_y_rot = g_Lara.right_arm.y_rot / 2;
+        }
         g_Lara.torso_x_rot = g_Lara.right_arm.x_rot / 2;
         g_Lara.torso_y_rot = g_Lara.right_arm.y_rot / 2;
     } else if (g_Lara.left_arm.lock && g_Lara.right_arm.lock) {
-        g_Lara.head_x_rot =
-            (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
-        g_Lara.head_y_rot =
-            (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
+        if (g_Camera.type != CAM_LOOK) {
+            g_Lara.head_x_rot =
+                (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
+            g_Lara.head_y_rot =
+                (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
+        }
         g_Lara.torso_x_rot =
             (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
         g_Lara.torso_y_rot =

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -136,8 +136,10 @@ void Gun_Rifle_Control(LARA_GUN_TYPE weapon_type)
     if (g_Lara.left_arm.lock) {
         g_Lara.torso_y_rot = g_Lara.left_arm.y_rot / 2;
         g_Lara.torso_x_rot = g_Lara.left_arm.x_rot / 2;
-        g_Lara.head_x_rot = 0;
-        g_Lara.head_y_rot = 0;
+        if (g_Camera.type != CAM_LOOK) {
+            g_Lara.head_x_rot = 0;
+            g_Lara.head_y_rot = 0;
+        }
     }
 
     Gun_Rifle_Animate();


### PR DESCRIPTION
Resolves #1187.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added the ability to move the look camera while targeting an enemy in combat. Matches TR4's [implementation ](https://github.com/Trxyebeep/TOMB4/blob/455931881bc1efabe6a3a18ea13fc1fe7d94a701/TOMB4/game/lara2gun.cpp#L457C1-L457C38).