### PR TITLE
types: use better type for Lara's rotations

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -489,9 +489,9 @@ void Camera_Combat(ITEM_INFO *item)
         g_Camera.target_elevation = item->rot.x + g_Lara.target_angles[1];
     } else {
         g_Camera.target_angle =
-            item->rot.y + g_Lara.torso_y_rot + g_Lara.head_y_rot;
+            item->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
         g_Camera.target_elevation =
-            item->rot.x + g_Lara.torso_x_rot + g_Lara.head_x_rot;
+            item->rot.x + g_Lara.torso_rot.x + g_Lara.head_rot.x;
     }
 
     g_Camera.target_distance = COMBAT_DISTANCE;
@@ -525,9 +525,9 @@ void Camera_Look(ITEM_INFO *item)
     g_Camera.target.x = item->pos.x;
 
     g_Camera.target_angle =
-        item->rot.y + g_Lara.torso_y_rot + g_Lara.head_y_rot;
+        item->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
     g_Camera.target_elevation =
-        item->rot.x + g_Lara.torso_x_rot + g_Lara.head_x_rot;
+        item->rot.x + g_Lara.torso_rot.x + g_Lara.head_rot.x;
     g_Camera.target_distance = WALL_L * 3 / 2;
 
     int32_t distance =
@@ -648,26 +648,26 @@ void Camera_Update(void)
 
         if (angle > -MAX_HEAD_ROTATION && angle < MAX_HEAD_ROTATION
             && tilt > MIN_HEAD_TILT_CAM && tilt < MAX_HEAD_TILT_CAM) {
-            int16_t change = angle - g_Lara.head_y_rot;
+            int16_t change = angle - g_Lara.head_rot.y;
             if (change > HEAD_TURN) {
-                g_Lara.head_y_rot += HEAD_TURN;
+                g_Lara.head_rot.y += HEAD_TURN;
             } else if (change < -HEAD_TURN) {
-                g_Lara.head_y_rot -= HEAD_TURN;
+                g_Lara.head_rot.y -= HEAD_TURN;
             } else {
-                g_Lara.head_y_rot += change;
+                g_Lara.head_rot.y += change;
             }
 
-            change = tilt - g_Lara.head_x_rot;
+            change = tilt - g_Lara.head_rot.x;
             if (change > HEAD_TURN) {
-                g_Lara.head_x_rot += HEAD_TURN;
+                g_Lara.head_rot.x += HEAD_TURN;
             } else if (change < -HEAD_TURN) {
-                g_Lara.head_x_rot -= HEAD_TURN;
+                g_Lara.head_rot.x -= HEAD_TURN;
             } else {
-                g_Lara.head_x_rot += change;
+                g_Lara.head_rot.x += change;
             }
 
-            g_Lara.torso_y_rot = g_Lara.head_y_rot;
-            g_Lara.torso_x_rot = g_Lara.head_x_rot;
+            g_Lara.torso_rot.y = g_Lara.head_rot.y;
+            g_Lara.torso_rot.x = g_Lara.head_rot.x;
 
             g_Camera.type = CAM_LOOK;
             g_Camera.item->looked_at = 1;

--- a/src/game/gun/gun.c
+++ b/src/game/gun/gun.c
@@ -166,15 +166,15 @@ void Gun_Control(void)
 
 void Gun_InitialiseNewWeapon(void)
 {
-    g_Lara.left_arm.x_rot = 0;
-    g_Lara.left_arm.y_rot = 0;
-    g_Lara.left_arm.z_rot = 0;
+    g_Lara.left_arm.rot.x = 0;
+    g_Lara.left_arm.rot.y = 0;
+    g_Lara.left_arm.rot.z = 0;
     g_Lara.left_arm.lock = 0;
     g_Lara.left_arm.flash_gun = 0;
     g_Lara.left_arm.frame_number = LF_G_AIM_START;
-    g_Lara.right_arm.x_rot = 0;
-    g_Lara.right_arm.y_rot = 0;
-    g_Lara.right_arm.z_rot = 0;
+    g_Lara.right_arm.rot.x = 0;
+    g_Lara.right_arm.rot.y = 0;
+    g_Lara.right_arm.rot.z = 0;
     g_Lara.right_arm.lock = 0;
     g_Lara.right_arm.flash_gun = 0;
     g_Lara.right_arm.frame_number = LF_G_AIM_START;

--- a/src/game/gun/gun_misc.c
+++ b/src/game/gun/gun_misc.c
@@ -246,8 +246,8 @@ void Gun_GetNewTarget(WEAPON_INFO *winfo)
         PHD_ANGLE ang[2];
         Math_GetVectorAngles(
             target.x - src.x, target.y - src.y, target.z - src.z, ang);
-        ang[0] -= g_Lara.torso_y_rot + g_LaraItem->rot.y;
-        ang[1] -= g_Lara.torso_x_rot + g_LaraItem->rot.x;
+        ang[0] -= g_Lara.torso_rot.y + g_LaraItem->rot.y;
+        ang[1] -= g_Lara.torso_rot.x + g_LaraItem->rot.x;
         if (ang[0] >= winfo->lock_angles[0] && ang[0] <= winfo->lock_angles[1]
             && ang[1] >= winfo->lock_angles[2]
             && ang[1] <= winfo->lock_angles[3]) {
@@ -363,7 +363,7 @@ void Gun_AimWeapon(WEAPON_INFO *winfo, LARA_ARM *arm)
         desty = 0;
     }
 
-    curr = arm->y_rot;
+    curr = arm->rot.y;
     if (curr >= desty - speed && curr <= speed + desty) {
         curr = desty;
     } else if (curr < desty) {
@@ -371,9 +371,9 @@ void Gun_AimWeapon(WEAPON_INFO *winfo, LARA_ARM *arm)
     } else {
         curr -= speed;
     }
-    arm->y_rot = curr;
+    arm->rot.y = curr;
 
-    curr = arm->x_rot;
+    curr = arm->rot.x;
     if (curr >= destx - speed && curr <= speed + destx) {
         curr = destx;
     } else if (curr < destx) {
@@ -381,9 +381,9 @@ void Gun_AimWeapon(WEAPON_INFO *winfo, LARA_ARM *arm)
     } else {
         curr -= speed;
     }
-    arm->x_rot = curr;
+    arm->rot.x = curr;
 
-    arm->z_rot = 0;
+    arm->rot.z = 0;
 }
 
 int32_t Gun_FireWeapon(

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -35,13 +35,13 @@ void Gun_Pistols_Undraw(LARA_GUN_TYPE weapon_type)
     if (Anim_TestAbsFrameRange(anil, LF_G_RECOIL_START, LF_G_RECOIL_END)) {
         anil = LF_G_AIM_END;
     } else if (Anim_TestAbsFrameRange(anil, LF_G_AIM_BEND, LF_G_AIM_END)) {
-        g_Lara.left_arm.x_rot -= g_Lara.left_arm.x_rot / anil;
-        g_Lara.left_arm.y_rot -= g_Lara.left_arm.y_rot / anil;
+        g_Lara.left_arm.rot.x -= g_Lara.left_arm.rot.x / anil;
+        g_Lara.left_arm.rot.y -= g_Lara.left_arm.rot.y / anil;
         anil--;
     } else if (Anim_TestAbsFrameEqual(anil, LF_G_AIM_START)) {
-        g_Lara.left_arm.x_rot = 0;
-        g_Lara.left_arm.y_rot = 0;
-        g_Lara.left_arm.z_rot = 0;
+        g_Lara.left_arm.rot.x = 0;
+        g_Lara.left_arm.rot.y = 0;
+        g_Lara.left_arm.rot.z = 0;
         anil = LF_G_DRAW_END;
     } else if (Anim_TestAbsFrameRange(anil, LF_G_UNDRAW_BEND, LF_G_DRAW_END)) {
         anil--;
@@ -55,13 +55,13 @@ void Gun_Pistols_Undraw(LARA_GUN_TYPE weapon_type)
     if (Anim_TestAbsFrameRange(anir, LF_G_RECOIL_START, LF_G_RECOIL_END)) {
         anir = LF_G_AIM_END;
     } else if (Anim_TestAbsFrameRange(anir, LF_G_AIM_BEND, LF_G_AIM_END)) {
-        g_Lara.right_arm.x_rot -= g_Lara.right_arm.x_rot / anir;
-        g_Lara.right_arm.y_rot -= g_Lara.right_arm.y_rot / anir;
+        g_Lara.right_arm.rot.x -= g_Lara.right_arm.rot.x / anir;
+        g_Lara.right_arm.rot.y -= g_Lara.right_arm.rot.y / anir;
         anir--;
     } else if (Anim_TestAbsFrameEqual(anir, LF_G_AIM_START)) {
-        g_Lara.right_arm.x_rot = 0;
-        g_Lara.right_arm.y_rot = 0;
-        g_Lara.right_arm.z_rot = 0;
+        g_Lara.right_arm.rot.x = 0;
+        g_Lara.right_arm.rot.y = 0;
+        g_Lara.right_arm.rot.z = 0;
         anir = LF_G_DRAW_END;
     } else if (Anim_TestAbsFrameRange(anir, LF_G_UNDRAW_BEND, LF_G_DRAW_END)) {
         anir--;
@@ -81,27 +81,27 @@ void Gun_Pistols_Undraw(LARA_GUN_TYPE weapon_type)
         g_Lara.target = NULL;
     }
 
-    g_Lara.head_x_rot = (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
-    g_Lara.head_y_rot = (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
-    g_Lara.torso_x_rot = (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
-    g_Lara.torso_y_rot = (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
+    g_Lara.head_rot.x = (g_Lara.right_arm.rot.x + g_Lara.left_arm.rot.x) / 4;
+    g_Lara.head_rot.y = (g_Lara.right_arm.rot.y + g_Lara.left_arm.rot.y) / 4;
+    g_Lara.torso_rot.x = (g_Lara.right_arm.rot.x + g_Lara.left_arm.rot.x) / 4;
+    g_Lara.torso_rot.y = (g_Lara.right_arm.rot.y + g_Lara.left_arm.rot.y) / 4;
 }
 
 void Gun_Pistols_Ready(void)
 {
     g_Lara.gun_status = LGS_READY;
-    g_Lara.left_arm.x_rot = 0;
-    g_Lara.left_arm.y_rot = 0;
-    g_Lara.left_arm.z_rot = 0;
+    g_Lara.left_arm.rot.x = 0;
+    g_Lara.left_arm.rot.y = 0;
+    g_Lara.left_arm.rot.z = 0;
     g_Lara.left_arm.lock = 0;
-    g_Lara.right_arm.x_rot = 0;
-    g_Lara.right_arm.y_rot = 0;
-    g_Lara.right_arm.z_rot = 0;
+    g_Lara.right_arm.rot.x = 0;
+    g_Lara.right_arm.rot.y = 0;
+    g_Lara.right_arm.rot.z = 0;
     g_Lara.right_arm.lock = 0;
-    g_Lara.head_x_rot = 0;
-    g_Lara.head_y_rot = 0;
-    g_Lara.torso_x_rot = 0;
-    g_Lara.torso_y_rot = 0;
+    g_Lara.head_rot.x = 0;
+    g_Lara.head_rot.y = 0;
+    g_Lara.torso_rot.x = 0;
+    g_Lara.torso_rot.y = 0;
     g_Lara.target = NULL;
     g_Lara.right_arm.frame_base = g_Objects[O_PISTOLS].frame_base;
     g_Lara.left_arm.frame_base = g_Objects[O_PISTOLS].frame_base;
@@ -171,29 +171,29 @@ void Gun_Pistols_Control(LARA_GUN_TYPE weapon_type)
 
     if (g_Lara.left_arm.lock && !g_Lara.right_arm.lock) {
         if (g_Camera.type != CAM_LOOK) {
-            g_Lara.head_x_rot = g_Lara.left_arm.x_rot / 2;
-            g_Lara.head_y_rot = g_Lara.left_arm.y_rot / 2;
+            g_Lara.head_rot.x = g_Lara.left_arm.rot.x / 2;
+            g_Lara.head_rot.y = g_Lara.left_arm.rot.y / 2;
         }
-        g_Lara.torso_x_rot = g_Lara.left_arm.x_rot / 2;
-        g_Lara.torso_y_rot = g_Lara.left_arm.y_rot / 2;
+        g_Lara.torso_rot.x = g_Lara.left_arm.rot.x / 2;
+        g_Lara.torso_rot.y = g_Lara.left_arm.rot.y / 2;
     } else if (!g_Lara.left_arm.lock && g_Lara.right_arm.lock) {
         if (g_Camera.type != CAM_LOOK) {
-            g_Lara.head_x_rot = g_Lara.right_arm.x_rot / 2;
-            g_Lara.head_y_rot = g_Lara.right_arm.y_rot / 2;
+            g_Lara.head_rot.x = g_Lara.right_arm.rot.x / 2;
+            g_Lara.head_rot.y = g_Lara.right_arm.rot.y / 2;
         }
-        g_Lara.torso_x_rot = g_Lara.right_arm.x_rot / 2;
-        g_Lara.torso_y_rot = g_Lara.right_arm.y_rot / 2;
+        g_Lara.torso_rot.x = g_Lara.right_arm.rot.x / 2;
+        g_Lara.torso_rot.y = g_Lara.right_arm.rot.y / 2;
     } else if (g_Lara.left_arm.lock && g_Lara.right_arm.lock) {
         if (g_Camera.type != CAM_LOOK) {
-            g_Lara.head_x_rot =
-                (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
-            g_Lara.head_y_rot =
-                (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
+            g_Lara.head_rot.x =
+                (g_Lara.right_arm.rot.x + g_Lara.left_arm.rot.x) / 4;
+            g_Lara.head_rot.y =
+                (g_Lara.right_arm.rot.y + g_Lara.left_arm.rot.y) / 4;
         }
-        g_Lara.torso_x_rot =
-            (g_Lara.right_arm.x_rot + g_Lara.left_arm.x_rot) / 4;
-        g_Lara.torso_y_rot =
-            (g_Lara.right_arm.y_rot + g_Lara.left_arm.y_rot) / 4;
+        g_Lara.torso_rot.x =
+            (g_Lara.right_arm.rot.x + g_Lara.left_arm.rot.x) / 4;
+        g_Lara.torso_rot.y =
+            (g_Lara.right_arm.rot.y + g_Lara.left_arm.rot.y) / 4;
     }
 
     Gun_Pistols_Animate(weapon_type);
@@ -210,8 +210,8 @@ void Gun_Pistols_Animate(LARA_GUN_TYPE weapon_type)
             anir++;
         } else if (
             Anim_TestAbsFrameEqual(anir, LF_G_AIM_END) && g_Input.action) {
-            angles[0] = g_Lara.right_arm.y_rot + g_LaraItem->rot.y;
-            angles[1] = g_Lara.right_arm.x_rot;
+            angles[0] = g_Lara.right_arm.rot.y + g_LaraItem->rot.y;
+            angles[1] = g_Lara.right_arm.rot.x;
             if (Gun_FireWeapon(
                     weapon_type, g_Lara.target, g_LaraItem, angles)) {
                 g_Lara.right_arm.flash_gun = winfo->flash_time;
@@ -240,8 +240,8 @@ void Gun_Pistols_Animate(LARA_GUN_TYPE weapon_type)
             anil++;
         } else if (
             Anim_TestAbsFrameEqual(anil, LF_G_AIM_END) && g_Input.action) {
-            angles[0] = g_Lara.left_arm.y_rot + g_LaraItem->rot.y;
-            angles[1] = g_Lara.left_arm.x_rot;
+            angles[0] = g_Lara.left_arm.rot.y + g_LaraItem->rot.y;
+            angles[1] = g_Lara.left_arm.rot.x;
             if (Gun_FireWeapon(
                     weapon_type, g_Lara.target, g_LaraItem, angles)) {
                 g_Lara.left_arm.flash_gun = winfo->flash_time;

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -73,10 +73,10 @@ void Gun_Rifle_Undraw(void)
         }
     }
 
-    g_Lara.head_x_rot = 0;
-    g_Lara.head_y_rot = 0;
-    g_Lara.torso_x_rot += g_Lara.torso_x_rot / -2;
-    g_Lara.torso_y_rot += g_Lara.torso_y_rot / -2;
+    g_Lara.head_rot.x = 0;
+    g_Lara.head_rot.y = 0;
+    g_Lara.torso_rot.x += g_Lara.torso_rot.x / -2;
+    g_Lara.torso_rot.y += g_Lara.torso_rot.y / -2;
     g_Lara.right_arm.frame_number = ani;
     g_Lara.left_arm.frame_number = ani;
 }
@@ -104,18 +104,18 @@ void Gun_Rifle_UndrawMeshes(void)
 void Gun_Rifle_Ready(void)
 {
     g_Lara.gun_status = LGS_READY;
-    g_Lara.left_arm.x_rot = 0;
-    g_Lara.left_arm.y_rot = 0;
-    g_Lara.left_arm.z_rot = 0;
+    g_Lara.left_arm.rot.x = 0;
+    g_Lara.left_arm.rot.y = 0;
+    g_Lara.left_arm.rot.z = 0;
     g_Lara.left_arm.lock = 0;
-    g_Lara.right_arm.x_rot = 0;
-    g_Lara.right_arm.y_rot = 0;
-    g_Lara.right_arm.z_rot = 0;
+    g_Lara.right_arm.rot.x = 0;
+    g_Lara.right_arm.rot.y = 0;
+    g_Lara.right_arm.rot.z = 0;
     g_Lara.right_arm.lock = 0;
-    g_Lara.head_x_rot = 0;
-    g_Lara.head_y_rot = 0;
-    g_Lara.torso_x_rot = 0;
-    g_Lara.torso_y_rot = 0;
+    g_Lara.head_rot.x = 0;
+    g_Lara.head_rot.y = 0;
+    g_Lara.torso_rot.x = 0;
+    g_Lara.torso_rot.y = 0;
     g_Lara.target = NULL;
     g_Lara.right_arm.frame_base = g_Objects[O_SHOTGUN].frame_base;
     g_Lara.left_arm.frame_base = g_Objects[O_SHOTGUN].frame_base;
@@ -134,11 +134,11 @@ void Gun_Rifle_Control(LARA_GUN_TYPE weapon_type)
     Gun_AimWeapon(winfo, &g_Lara.left_arm);
 
     if (g_Lara.left_arm.lock) {
-        g_Lara.torso_y_rot = g_Lara.left_arm.y_rot / 2;
-        g_Lara.torso_x_rot = g_Lara.left_arm.x_rot / 2;
+        g_Lara.torso_rot.y = g_Lara.left_arm.rot.y / 2;
+        g_Lara.torso_rot.x = g_Lara.left_arm.rot.x / 2;
         if (g_Camera.type != CAM_LOOK) {
-            g_Lara.head_x_rot = 0;
-            g_Lara.head_y_rot = 0;
+            g_Lara.head_rot.x = 0;
+            g_Lara.head_rot.y = 0;
         }
     }
 
@@ -250,8 +250,8 @@ void Gun_Rifle_Fire(void)
     PHD_ANGLE angles[2];
     PHD_ANGLE dangles[2];
 
-    angles[0] = g_Lara.left_arm.y_rot + g_LaraItem->rot.y;
-    angles[1] = g_Lara.left_arm.x_rot;
+    angles[0] = g_Lara.left_arm.rot.y + g_LaraItem->rot.y;
+    angles[1] = g_Lara.left_arm.rot.x;
 
     for (int i = 0; i < SHOTGUN_AMMO_CLIP; i++) {
         dangles[0] = angles[0]

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -83,10 +83,10 @@ void Lara_Control(void)
             item->rot.x = -45 * PHD_DEGREE;
             item->fall_speed = (item->fall_speed * 3) / 2;
         }
-        g_Lara.head_x_rot = 0;
-        g_Lara.head_y_rot = 0;
-        g_Lara.torso_x_rot = 0;
-        g_Lara.torso_y_rot = 0;
+        g_Lara.head_rot.x = 0;
+        g_Lara.head_rot.y = 0;
+        g_Lara.torso_rot.x = 0;
+        g_Lara.torso_rot.y = 0;
         Splash_Spawn(item);
     } else if (g_Lara.water_status == LWS_UNDERWATER && !room_submerged) {
         int16_t wh = Room_GetWaterHeight(
@@ -101,10 +101,10 @@ void Lara_Control(void)
             item->pos.y = wh + 1;
             item->rot.x = 0;
             item->rot.z = 0;
-            g_Lara.head_x_rot = 0;
-            g_Lara.head_y_rot = 0;
-            g_Lara.torso_x_rot = 0;
-            g_Lara.torso_y_rot = 0;
+            g_Lara.head_rot.x = 0;
+            g_Lara.head_rot.y = 0;
+            g_Lara.torso_rot.x = 0;
+            g_Lara.torso_rot.y = 0;
             Item_UpdateRoom(item, -LARA_HEIGHT / 2);
             Sound_Effect(SFX_LARA_BREATH, &item->pos, SPM_ALWAYS);
         } else {
@@ -118,10 +118,10 @@ void Lara_Control(void)
             item->gravity_status = 1;
             item->rot.x = 0;
             item->rot.z = 0;
-            g_Lara.head_x_rot = 0;
-            g_Lara.head_y_rot = 0;
-            g_Lara.torso_x_rot = 0;
-            g_Lara.torso_y_rot = 0;
+            g_Lara.head_rot.x = 0;
+            g_Lara.head_rot.y = 0;
+            g_Lara.torso_rot.x = 0;
+            g_Lara.torso_rot.y = 0;
         }
     } else if (g_Lara.water_status == LWS_SURFACE && !room_submerged) {
         g_Lara.water_status = LWS_ABOVE_WATER;
@@ -134,10 +134,10 @@ void Lara_Control(void)
         item->gravity_status = 1;
         item->rot.x = 0;
         item->rot.z = 0;
-        g_Lara.head_x_rot = 0;
-        g_Lara.head_y_rot = 0;
-        g_Lara.torso_x_rot = 0;
-        g_Lara.torso_y_rot = 0;
+        g_Lara.head_rot.x = 0;
+        g_Lara.head_rot.y = 0;
+        g_Lara.torso_rot.x = 0;
+        g_Lara.torso_rot.y = 0;
     }
 
     if (item->hit_points <= 0) {
@@ -202,10 +202,10 @@ void Lara_Control(void)
                 g_Lara.water_status = LWS_ABOVE_WATER;
                 Item_SwitchToAnim(item, LA_STOP, 0);
                 item->rot.x = item->rot.z = 0;
-                g_Lara.head_x_rot = 0;
-                g_Lara.head_y_rot = 0;
-                g_Lara.torso_x_rot = 0;
-                g_Lara.torso_y_rot = 0;
+                g_Lara.head_rot.x = 0;
+                g_Lara.head_rot.y = 0;
+                g_Lara.torso_rot.x = 0;
+                g_Lara.torso_rot.y = 0;
             }
             g_Lara.gun_status = LGS_ARMLESS;
         }
@@ -425,12 +425,12 @@ void Lara_Initialise(int32_t level_num)
     }
 
     g_Lara.air = LARA_AIR;
-    g_Lara.torso_y_rot = 0;
-    g_Lara.torso_x_rot = 0;
-    g_Lara.torso_z_rot = 0;
-    g_Lara.head_y_rot = 0;
-    g_Lara.head_x_rot = 0;
-    g_Lara.head_z_rot = 0;
+    g_Lara.torso_rot.y = 0;
+    g_Lara.torso_rot.x = 0;
+    g_Lara.torso_rot.z = 0;
+    g_Lara.head_rot.y = 0;
+    g_Lara.head_rot.x = 0;
+    g_Lara.head_rot.z = 0;
     g_Lara.calc_fall_speed = 0;
     g_Lara.mesh_effects = 0;
     g_Lara.hit_frame = 0;

--- a/src/game/lara/lara_cheat.c
+++ b/src/game/lara/lara_cheat.c
@@ -128,10 +128,10 @@ void Lara_EnterFlyMode(void)
         item->gravity_status = 0;
         item->rot.x = 30 * PHD_DEGREE;
         item->fall_speed = 30;
-        g_Lara.head_x_rot = 0;
-        g_Lara.head_y_rot = 0;
-        g_Lara.torso_x_rot = 0;
-        g_Lara.torso_y_rot = 0;
+        g_Lara.head_rot.x = 0;
+        g_Lara.head_rot.y = 0;
+        g_Lara.torso_rot.x = 0;
+        g_Lara.torso_rot.y = 0;
     }
     g_Lara.water_status = LWS_CHEAT;
     g_Lara.spaz_effect_count = 0;

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -204,21 +204,21 @@ void Lara_HandleAboveWater(ITEM_INFO *item, COLL_INFO *coll)
     g_LaraStateRoutines[item->current_anim_state](item, coll);
 
     if (g_Camera.type != CAM_LOOK) {
-        if (g_Lara.head_x_rot > -HEAD_TURN / 2
-            && g_Lara.head_x_rot < HEAD_TURN / 2) {
-            g_Lara.head_x_rot = 0;
+        if (g_Lara.head_rot.x > -HEAD_TURN / 2
+            && g_Lara.head_rot.x < HEAD_TURN / 2) {
+            g_Lara.head_rot.x = 0;
         } else {
-            g_Lara.head_x_rot -= g_Lara.head_x_rot / 8;
+            g_Lara.head_rot.x -= g_Lara.head_rot.x / 8;
         }
-        g_Lara.torso_x_rot = g_Lara.head_x_rot;
+        g_Lara.torso_rot.x = g_Lara.head_rot.x;
 
-        if (g_Lara.head_y_rot > -HEAD_TURN / 2
-            && g_Lara.head_y_rot < HEAD_TURN / 2) {
-            g_Lara.head_y_rot = 0;
+        if (g_Lara.head_rot.y > -HEAD_TURN / 2
+            && g_Lara.head_rot.y < HEAD_TURN / 2) {
+            g_Lara.head_rot.y = 0;
         } else {
-            g_Lara.head_y_rot -= g_Lara.head_y_rot / 8;
+            g_Lara.head_rot.y -= g_Lara.head_rot.y / 8;
         }
-        g_Lara.torso_y_rot = g_Lara.head_y_rot;
+        g_Lara.torso_rot.y = g_Lara.head_rot.y;
     }
 
     if (item->rot.z >= -LARA_LEAN_UNDO && item->rot.z <= LARA_LEAN_UNDO) {
@@ -276,21 +276,21 @@ void Lara_HandleSurface(ITEM_INFO *item, COLL_INFO *coll)
     }
 
     if (g_Camera.type != CAM_LOOK) {
-        if (g_Lara.head_y_rot > -HEAD_TURN_SURF
-            && g_Lara.head_y_rot < HEAD_TURN_SURF) {
-            g_Lara.head_y_rot = 0;
+        if (g_Lara.head_rot.y > -HEAD_TURN_SURF
+            && g_Lara.head_rot.y < HEAD_TURN_SURF) {
+            g_Lara.head_rot.y = 0;
         } else {
-            g_Lara.head_y_rot -= g_Lara.head_y_rot / 8;
+            g_Lara.head_rot.y -= g_Lara.head_rot.y / 8;
         }
-        g_Lara.torso_y_rot = g_Lara.head_x_rot / 2;
+        g_Lara.torso_rot.y = g_Lara.head_rot.x / 2;
 
-        if (g_Lara.head_x_rot > -HEAD_TURN_SURF
-            && g_Lara.head_x_rot < HEAD_TURN_SURF) {
-            g_Lara.head_x_rot = 0;
+        if (g_Lara.head_rot.x > -HEAD_TURN_SURF
+            && g_Lara.head_rot.x < HEAD_TURN_SURF) {
+            g_Lara.head_rot.x = 0;
         } else {
-            g_Lara.head_x_rot -= g_Lara.head_x_rot / 8;
+            g_Lara.head_rot.x -= g_Lara.head_rot.x / 8;
         }
-        g_Lara.torso_x_rot = 0;
+        g_Lara.torso_rot.x = 0;
     }
 
     if (g_Lara.current_active && g_Lara.water_status != LWS_CHEAT) {

--- a/src/game/lara/lara_draw.c
+++ b/src/game/lara/lara_draw.c
@@ -126,14 +126,14 @@ void Lara_Draw(ITEM_INFO *item)
 
     Matrix_TranslateRel(bone[25], bone[26], bone[27]);
     Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
-    Matrix_RotYXZ(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
+    Matrix_RotYXZ(g_Lara.torso_rot.y, g_Lara.torso_rot.x, g_Lara.torso_rot.z);
     Output_DrawPolygons(g_Lara.mesh_ptrs[LM_TORSO], clip);
 
     Matrix_Push();
 
     Matrix_TranslateRel(bone[53], bone[54], bone[55]);
     Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
-    Matrix_RotYXZ(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
+    Matrix_RotYXZ(g_Lara.head_rot.y, g_Lara.head_rot.x, g_Lara.head_rot.z);
     Output_DrawPolygons(g_Lara.mesh_ptrs[LM_HEAD], clip);
 
     *g_MatrixPtr = saved_matrix;
@@ -204,8 +204,8 @@ void Lara_Draw(ITEM_INFO *item)
                                           * (object->nmeshes * 2 + FRAME_ROT)
                                       + 10);
         Matrix_RotYXZ(
-            g_Lara.right_arm.y_rot, g_Lara.right_arm.x_rot,
-            g_Lara.right_arm.z_rot);
+            g_Lara.right_arm.rot.y, g_Lara.right_arm.rot.x,
+            g_Lara.right_arm.rot.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
         Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -242,8 +242,8 @@ void Lara_Draw(ITEM_INFO *item)
                                           * (object->nmeshes * 2 + FRAME_ROT)
                                       + 10);
         Matrix_RotYXZ(
-            g_Lara.left_arm.y_rot, g_Lara.left_arm.x_rot,
-            g_Lara.left_arm.z_rot);
+            g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
+            g_Lara.left_arm.rot.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
         Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
@@ -405,14 +405,14 @@ void Lara_Draw_I(
 
     Matrix_TranslateRel_I(bone[25], bone[26], bone[27]);
     Matrix_RotYXZpack_I(packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
-    Matrix_RotYXZ_I(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
+    Matrix_RotYXZ_I(g_Lara.torso_rot.y, g_Lara.torso_rot.x, g_Lara.torso_rot.z);
     Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_TORSO], clip);
 
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[53], bone[54], bone[55]);
     Matrix_RotYXZpack_I(packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
-    Matrix_RotYXZ_I(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
+    Matrix_RotYXZ_I(g_Lara.head_rot.y, g_Lara.head_rot.x, g_Lara.head_rot.z);
     Output_DrawPolygons_I(g_Lara.mesh_ptrs[LM_HEAD], clip);
 
     *g_MatrixPtr = saved_matrix;
@@ -480,8 +480,8 @@ void Lara_Draw_I(
                                            * (object->nmeshes * 2 + FRAME_ROT)
                                        + 10);
         Matrix_RotYXZ(
-            g_Lara.right_arm.y_rot, g_Lara.right_arm.x_rot,
-            g_Lara.right_arm.z_rot);
+            g_Lara.right_arm.rot.y, g_Lara.right_arm.rot.x,
+            g_Lara.right_arm.rot.z);
         Matrix_RotYXZpack(packed_rotation1[LM_UARM_R]);
         Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -509,8 +509,8 @@ void Lara_Draw_I(
                                            * (object->nmeshes * 2 + FRAME_ROT)
                                        + 10);
         Matrix_RotYXZ(
-            g_Lara.left_arm.y_rot, g_Lara.left_arm.x_rot,
-            g_Lara.left_arm.z_rot);
+            g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
+            g_Lara.left_arm.rot.z);
         Matrix_RotYXZpack(packed_rotation1[LM_UARM_L]);
         Output_DrawPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 

--- a/src/game/lara/lara_hair.c
+++ b/src/game/lara/lara_hair.c
@@ -145,7 +145,7 @@ void Lara_Hair_Control(void)
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
         Matrix_RotYXZ_I(
-            g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
+            g_Lara.torso_rot.y, g_Lara.torso_rot.x, g_Lara.torso_rot.z);
         Matrix_Push_I();
         objptr = g_Meshes[object->mesh_index + LM_TORSO]; // ignore shotgun
         Matrix_TranslateRel_I(*objptr, *(objptr + 1), *(objptr + 2));
@@ -192,7 +192,7 @@ void Lara_Hair_Control(void)
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
         Matrix_RotYXZ_I(
-            g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
+            g_Lara.head_rot.y, g_Lara.head_rot.x, g_Lara.head_rot.z);
         Matrix_Push_I();
         objptr = mesh_base[LM_HEAD];
         Matrix_TranslateRel_I(*objptr, *(objptr + 1), *(objptr + 2));
@@ -227,7 +227,7 @@ void Lara_Hair_Control(void)
             *(bone + 1 + 24), *(bone + 2 + 24), *(bone + 3 + 24));
         Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
         Matrix_RotYXZ(
-            g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
+            g_Lara.torso_rot.y, g_Lara.torso_rot.x, g_Lara.torso_rot.z);
         Matrix_Push();
         objptr = g_Meshes[object->mesh_index + LM_TORSO]; // ignore shotgun
         Matrix_TranslateRel(*objptr, *(objptr + 1), *(objptr + 2));
@@ -267,7 +267,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             *(bone + 1 + 52), *(bone + 2 + 52), *(bone + 3 + 52));
         Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
-        Matrix_RotYXZ(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
+        Matrix_RotYXZ(g_Lara.head_rot.y, g_Lara.head_rot.x, g_Lara.head_rot.z);
         Matrix_Push();
         objptr = mesh_base[LM_HEAD];
         Matrix_TranslateRel(*objptr, *(objptr + 1), *(objptr + 2));

--- a/src/game/lara/lara_look.c
+++ b/src/game/lara/lara_look.c
@@ -17,17 +17,17 @@ static void Lara_LookLeftRightBase(int16_t max_head_rot, int16_t head_turn)
     g_Camera.type = CAM_LOOK;
     if (g_Input.left) {
         g_Input.left = 0;
-        if (g_Lara.head_y_rot > -max_head_rot) {
-            g_Lara.head_y_rot -= head_turn;
+        if (g_Lara.head_rot.y > -max_head_rot) {
+            g_Lara.head_rot.y -= head_turn;
         }
     } else if (g_Input.right) {
         g_Input.right = 0;
-        if (g_Lara.head_y_rot < max_head_rot) {
-            g_Lara.head_y_rot += head_turn;
+        if (g_Lara.head_rot.y < max_head_rot) {
+            g_Lara.head_rot.y += head_turn;
         }
     }
     if (g_Lara.gun_status != LGS_HANDS_BUSY) {
-        g_Lara.torso_y_rot = g_Lara.head_y_rot;
+        g_Lara.torso_rot.y = g_Lara.head_rot.y;
     }
 }
 
@@ -43,17 +43,17 @@ static void Lara_LookUpDownBase(
     g_Camera.type = CAM_LOOK;
     if (g_Input.forward) {
         g_Input.forward = 0;
-        if (g_Lara.head_x_rot > min_head_tilt) {
-            g_Lara.head_x_rot -= head_turn;
+        if (g_Lara.head_rot.x > min_head_tilt) {
+            g_Lara.head_rot.x -= head_turn;
         }
     } else if (g_Input.back) {
         g_Input.back = 0;
-        if (g_Lara.head_x_rot < max_head_tilt) {
-            g_Lara.head_x_rot += head_turn;
+        if (g_Lara.head_rot.x < max_head_tilt) {
+            g_Lara.head_rot.x += head_turn;
         }
     }
     if (g_Lara.gun_status != LGS_HANDS_BUSY) {
-        g_Lara.torso_x_rot = g_Lara.head_x_rot;
+        g_Lara.torso_rot.x = g_Lara.head_rot.x;
     }
 }
 
@@ -65,7 +65,7 @@ void Lara_LookLeftRight(void)
 void Lara_LookLeftRightSurf(void)
 {
     Lara_LookLeftRightBase(MAX_HEAD_ROTATION_SURF, HEAD_TURN_SURF);
-    g_Lara.torso_y_rot = g_Lara.head_y_rot / 2;
+    g_Lara.torso_rot.y = g_Lara.head_rot.y / 2;
 }
 
 void Lara_LookUpDown(void)
@@ -76,7 +76,7 @@ void Lara_LookUpDown(void)
 void Lara_LookUpDownSurf(void)
 {
     Lara_LookUpDownBase(MIN_HEAD_TILT_SURF, MAX_HEAD_TILT_SURF, HEAD_TURN_SURF);
-    g_Lara.torso_x_rot = 0;
+    g_Lara.torso_rot.x = 0;
 }
 
 void Lara_ResetLook(void)
@@ -84,19 +84,19 @@ void Lara_ResetLook(void)
     if (g_Camera.type == CAM_LOOK || g_Camera.last_item) {
         return;
     }
-    if (g_Lara.head_x_rot <= -HEAD_TURN / 2
-        || g_Lara.head_x_rot >= HEAD_TURN / 2) {
-        g_Lara.head_x_rot = g_Lara.head_x_rot / -8 + g_Lara.head_x_rot;
+    if (g_Lara.head_rot.x <= -HEAD_TURN / 2
+        || g_Lara.head_rot.x >= HEAD_TURN / 2) {
+        g_Lara.head_rot.x = g_Lara.head_rot.x / -8 + g_Lara.head_rot.x;
     } else {
-        g_Lara.head_x_rot = 0;
+        g_Lara.head_rot.x = 0;
     }
-    g_Lara.torso_x_rot = g_Lara.head_x_rot;
+    g_Lara.torso_rot.x = g_Lara.head_rot.x;
 
-    if (g_Lara.head_y_rot <= -HEAD_TURN / 2
-        || g_Lara.head_y_rot >= HEAD_TURN / 2) {
-        g_Lara.head_y_rot += g_Lara.head_y_rot / -8;
+    if (g_Lara.head_rot.y <= -HEAD_TURN / 2
+        || g_Lara.head_rot.y >= HEAD_TURN / 2) {
+        g_Lara.head_rot.y += g_Lara.head_rot.y / -8;
     } else {
-        g_Lara.head_y_rot = 0;
+        g_Lara.head_rot.y = 0;
     }
-    g_Lara.torso_y_rot = g_Lara.head_y_rot;
+    g_Lara.torso_rot.y = g_Lara.head_rot.y;
 }

--- a/src/game/objects/general/pickup.c
+++ b/src/game/objects/general/pickup.c
@@ -189,10 +189,10 @@ void Pickup_CollisionControlled(
                 g_Lara.gun_status = LGS_ARMLESS;
             }
             if (have_item) {
-                g_Lara.head_y_rot = 0;
-                g_Lara.head_x_rot = 0;
-                g_Lara.torso_y_rot = 0;
-                g_Lara.torso_x_rot = 0;
+                g_Lara.head_rot.y = 0;
+                g_Lara.head_rot.x = 0;
+                g_Lara.torso_rot.y = 0;
+                g_Lara.torso_rot.x = 0;
                 g_Lara.interact_target.is_moving = false;
                 g_Lara.gun_status = LGS_HANDS_BUSY;
             }

--- a/src/game/objects/general/switch.c
+++ b/src/game/objects/general/switch.c
@@ -144,10 +144,10 @@ void Switch_CollisionControlled(
                     lara_item->current_anim_state = LS_SWITCH_ON;
                     item->goal_anim_state = SWITCH_STATE_ON;
                 }
-                g_Lara.head_x_rot = 0;
-                g_Lara.head_y_rot = 0;
-                g_Lara.torso_x_rot = 0;
-                g_Lara.torso_y_rot = 0;
+                g_Lara.head_rot.x = 0;
+                g_Lara.head_rot.y = 0;
+                g_Lara.torso_rot.x = 0;
+                g_Lara.torso_rot.y = 0;
                 g_Lara.interact_target.is_moving = false;
                 g_Lara.gun_status = LGS_HANDS_BUSY;
                 Item_AddActive(item_num);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -699,9 +699,9 @@ static bool Savegame_BSON_LoadArm(struct json_object_s *arm_obj, LARA_ARM *arm)
     arm->frame_number =
         json_object_get_int(arm_obj, "frame_num", arm->frame_number);
     arm->lock = json_object_get_int(arm_obj, "lock", arm->lock);
-    arm->x_rot = json_object_get_int(arm_obj, "x_rot", arm->x_rot);
-    arm->y_rot = json_object_get_int(arm_obj, "y_rot", arm->y_rot);
-    arm->z_rot = json_object_get_int(arm_obj, "z_rot", arm->z_rot);
+    arm->rot.x = json_object_get_int(arm_obj, "x_rot", arm->rot.x);
+    arm->rot.y = json_object_get_int(arm_obj, "y_rot", arm->rot.y);
+    arm->rot.z = json_object_get_int(arm_obj, "z_rot", arm->rot.z);
     arm->flash_gun = json_object_get_int(arm_obj, "flash_gun", arm->flash_gun);
     return true;
 }
@@ -822,18 +822,18 @@ static bool Savegame_BSON_LoadLara(
         json_object_get_int(lara_obj, "turn_rate", lara->turn_rate);
     lara->move_angle =
         json_object_get_int(lara_obj, "move_angle", lara->move_angle);
-    lara->head_y_rot =
-        json_object_get_int(lara_obj, "head_y_rot", lara->head_y_rot);
-    lara->head_x_rot =
-        json_object_get_int(lara_obj, "head_x_rot", lara->head_x_rot);
-    lara->head_z_rot =
-        json_object_get_int(lara_obj, "head_z_rot", lara->head_z_rot);
-    lara->torso_y_rot =
-        json_object_get_int(lara_obj, "torso_y_rot", lara->torso_y_rot);
-    lara->torso_x_rot =
-        json_object_get_int(lara_obj, "torso_x_rot", lara->torso_x_rot);
-    lara->torso_z_rot =
-        json_object_get_int(lara_obj, "torso_z_rot", lara->torso_z_rot);
+    lara->head_rot.y =
+        json_object_get_int(lara_obj, "head_rot.y", lara->head_rot.y);
+    lara->head_rot.x =
+        json_object_get_int(lara_obj, "head_rot.x", lara->head_rot.x);
+    lara->head_rot.z =
+        json_object_get_int(lara_obj, "head_rot.z", lara->head_rot.z);
+    lara->torso_rot.y =
+        json_object_get_int(lara_obj, "torso_rot.y", lara->torso_rot.y);
+    lara->torso_rot.x =
+        json_object_get_int(lara_obj, "torso_rot.x", lara->torso_rot.x);
+    lara->torso_rot.z =
+        json_object_get_int(lara_obj, "torso_rot.z", lara->torso_rot.z);
 
     if (!Savegame_BSON_LoadArm(
             json_object_get_object(lara_obj, "left_arm"), &lara->left_arm)) {
@@ -1154,9 +1154,9 @@ static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm)
         arm_obj, "frame_base", arm->frame_base - g_AnimFrames);
     json_object_append_int(arm_obj, "frame_num", arm->frame_number);
     json_object_append_int(arm_obj, "lock", arm->lock);
-    json_object_append_int(arm_obj, "x_rot", arm->x_rot);
-    json_object_append_int(arm_obj, "y_rot", arm->y_rot);
-    json_object_append_int(arm_obj, "z_rot", arm->z_rot);
+    json_object_append_int(arm_obj, "x_rot", arm->rot.x);
+    json_object_append_int(arm_obj, "y_rot", arm->rot.y);
+    json_object_append_int(arm_obj, "z_rot", arm->rot.z);
     json_object_append_int(arm_obj, "flash_gun", arm->flash_gun);
     return arm_obj;
 }
@@ -1228,12 +1228,12 @@ static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara)
     json_object_append_int(lara_obj, "target_angle2", lara->target_angles[1]);
     json_object_append_int(lara_obj, "turn_rate", lara->turn_rate);
     json_object_append_int(lara_obj, "move_angle", lara->move_angle);
-    json_object_append_int(lara_obj, "head_y_rot", lara->head_y_rot);
-    json_object_append_int(lara_obj, "head_x_rot", lara->head_x_rot);
-    json_object_append_int(lara_obj, "head_z_rot", lara->head_z_rot);
-    json_object_append_int(lara_obj, "torso_y_rot", lara->torso_y_rot);
-    json_object_append_int(lara_obj, "torso_x_rot", lara->torso_x_rot);
-    json_object_append_int(lara_obj, "torso_z_rot", lara->torso_z_rot);
+    json_object_append_int(lara_obj, "head_rot.y", lara->head_rot.y);
+    json_object_append_int(lara_obj, "head_rot.x", lara->head_rot.x);
+    json_object_append_int(lara_obj, "head_rot.z", lara->head_rot.z);
+    json_object_append_int(lara_obj, "torso_rot.y", lara->torso_rot.y);
+    json_object_append_int(lara_obj, "torso_rot.x", lara->torso_rot.x);
+    json_object_append_int(lara_obj, "torso_rot.z", lara->torso_rot.z);
 
     json_object_append_object(
         lara_obj, "left_arm", Savegame_BSON_DumpArm(&lara->left_arm));

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -246,12 +246,12 @@ static void Savegame_Legacy_WriteLara(LARA_INFO *lara)
     Savegame_Legacy_Write(&lara->target_angles[1], sizeof(PHD_ANGLE));
     Savegame_Legacy_Write(&lara->turn_rate, sizeof(int16_t));
     Savegame_Legacy_Write(&lara->move_angle, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->head_y_rot, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->head_x_rot, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->head_z_rot, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->torso_y_rot, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->torso_x_rot, sizeof(int16_t));
-    Savegame_Legacy_Write(&lara->torso_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_rot.y, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_rot.x, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->head_rot.z, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_rot.y, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_rot.x, sizeof(int16_t));
+    Savegame_Legacy_Write(&lara->torso_rot.z, sizeof(int16_t));
 
     Savegame_Legacy_WriteArm(&lara->left_arm);
     Savegame_Legacy_WriteArm(&lara->right_arm);
@@ -276,9 +276,9 @@ static void Savegame_Legacy_WriteArm(LARA_ARM *arm)
     Savegame_Legacy_Write(&frame_base, sizeof(int32_t));
     Savegame_Legacy_Write(&arm->frame_number, sizeof(int16_t));
     Savegame_Legacy_Write(&arm->lock, sizeof(int16_t));
-    Savegame_Legacy_Write(&arm->y_rot, sizeof(PHD_ANGLE));
-    Savegame_Legacy_Write(&arm->x_rot, sizeof(PHD_ANGLE));
-    Savegame_Legacy_Write(&arm->z_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->rot.y, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->rot.x, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Write(&arm->rot.z, sizeof(PHD_ANGLE));
     Savegame_Legacy_Write(&arm->flash_gun, sizeof(int16_t));
 }
 
@@ -346,12 +346,12 @@ static void Savegame_Legacy_ReadLara(LARA_INFO *lara)
     Savegame_Legacy_Read(&lara->target_angles[1], sizeof(PHD_ANGLE));
     Savegame_Legacy_Read(&lara->turn_rate, sizeof(int16_t));
     Savegame_Legacy_Read(&lara->move_angle, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->head_y_rot, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->head_x_rot, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->head_z_rot, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->torso_y_rot, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->torso_x_rot, sizeof(int16_t));
-    Savegame_Legacy_Read(&lara->torso_z_rot, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_rot.y, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_rot.x, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->head_rot.z, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_rot.y, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_rot.x, sizeof(int16_t));
+    Savegame_Legacy_Read(&lara->torso_rot.z, sizeof(int16_t));
 
     Savegame_Legacy_ReadArm(&lara->left_arm);
     Savegame_Legacy_ReadArm(&lara->right_arm);
@@ -379,9 +379,9 @@ static void Savegame_Legacy_ReadArm(LARA_ARM *arm)
 
     Savegame_Legacy_Read(&arm->frame_number, sizeof(int16_t));
     Savegame_Legacy_Read(&arm->lock, sizeof(int16_t));
-    Savegame_Legacy_Read(&arm->y_rot, sizeof(PHD_ANGLE));
-    Savegame_Legacy_Read(&arm->x_rot, sizeof(PHD_ANGLE));
-    Savegame_Legacy_Read(&arm->z_rot, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->rot.y, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->rot.x, sizeof(PHD_ANGLE));
+    Savegame_Legacy_Read(&arm->rot.z, sizeof(PHD_ANGLE));
     Savegame_Legacy_Read(&arm->flash_gun, sizeof(int16_t));
 }
 

--- a/src/game/sound.c
+++ b/src/game/sound.c
@@ -157,7 +157,7 @@ static void Sound_UpdateSlotParams(SOUND_SLOT *slot)
 
     int16_t angle = Math_Atan(
         slot->pos->z - g_LaraItem->pos.z, slot->pos->x - g_LaraItem->pos.x);
-    angle -= g_LaraItem->rot.y + g_Lara.torso_y_rot + g_Lara.head_y_rot;
+    angle -= g_LaraItem->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
     slot->pan = angle;
 }
 
@@ -320,7 +320,7 @@ bool Sound_Effect(int32_t sfx_num, const XYZ_32 *pos, uint32_t flags)
     if (pan) {
         int16_t angle =
             Math_Atan(pos->z - g_LaraItem->pos.z, pos->x - g_LaraItem->pos.x);
-        angle -= g_LaraItem->rot.y + g_Lara.torso_y_rot + g_Lara.head_y_rot;
+        angle -= g_LaraItem->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
         pan = angle;
     }
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1450,9 +1450,7 @@ typedef struct LARA_ARM {
     int16_t *frame_base;
     int16_t frame_number;
     int16_t lock;
-    PHD_ANGLE y_rot;
-    PHD_ANGLE x_rot;
-    PHD_ANGLE z_rot;
+    XYZ_16 rot;
     uint16_t flash_gun;
 } LARA_ARM;
 
@@ -1521,12 +1519,8 @@ typedef struct LARA_INFO {
     PHD_ANGLE target_angles[2];
     int16_t turn_rate;
     int16_t move_angle;
-    int16_t head_y_rot;
-    int16_t head_x_rot;
-    int16_t head_z_rot;
-    int16_t torso_y_rot;
-    int16_t torso_x_rot;
-    int16_t torso_z_rot;
+    XYZ_16 head_rot;
+    XYZ_16 torso_rot;
     LARA_ARM left_arm;
     LARA_ARM right_arm;
     AMMO_INFO pistols;


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Breaking down 60 FPS into smaller PRs. It's an internal change to the types we use for storing Lara's rotations, so that we can later treat them with the same interpolation macros as ITEM_INFO pos and rot (among others). 