### PR TITLE
output: do not rely on FPS for textures

### DIFF
--- a/src/game/clock.c
+++ b/src/game/clock.c
@@ -48,6 +48,11 @@ double Clock_GetSpeedMultiplier(void)
     return m_TurboSpeeds[m_TurboSpeedIdx];
 }
 
+int32_t Clock_GetLogicalFrame(void)
+{
+    return Clock_GetMS() * LOGIC_FPS / 1000;
+}
+
 void Clock_GetDateTime(char *date_time)
 {
     time_t lt = time(0);
@@ -71,4 +76,11 @@ double Clock_GetFrameAdvanceAdjusted(void)
         frames /= 2.0;
     }
     return frames;
+}
+
+bool Clock_IsAtLogicalFrame(const int32_t how_often)
+{
+    const int32_t now = Clock_GetMS();
+    const int32_t elapsed_frames = now * LOGIC_FPS / 1000;
+    return elapsed_frames % how_often == 0;
 }

--- a/src/game/clock.h
+++ b/src/game/clock.h
@@ -13,6 +13,8 @@ int32_t Clock_GetTurboSpeed(void);
 double Clock_GetSpeedMultiplier(void);
 
 int32_t Clock_GetMS(void);
+int32_t Clock_GetLogicalFrame(void);
+bool Clock_IsAtLogicalFrame(int32_t how_often);
 void Clock_GetDateTime(char *date_time);
 
 int32_t Clock_GetFrameAdvance(void);

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -916,18 +916,15 @@ void Output_AnimateFades(void)
     }
 }
 
-void Output_AnimateTextures(int32_t ticks)
+void Output_AnimateTextures(void)
 {
-    m_WibbleOffset = (m_WibbleOffset + ticks / TICKS_PER_FRAME) % WIBBLE_SIZE;
-
-    static int32_t tick_comp = 0;
-    tick_comp += ticks;
+    m_WibbleOffset = Clock_GetLogicalFrame() % WIBBLE_SIZE;
 
     if (!g_AnimTextureRanges) {
         return;
     }
 
-    while (tick_comp > TICKS_PER_FRAME * 5) {
+    if (Clock_IsAtLogicalFrame(5)) {
         int16_t *ptr = g_AnimTextureRanges;
         int16_t i = *ptr++;
         while (i > 0) {
@@ -942,7 +939,6 @@ void Output_AnimateTextures(int32_t ticks)
             i--;
             ptr++;
         }
-        tick_comp -= TICKS_PER_FRAME * 5;
     }
 }
 

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -92,7 +92,7 @@ void Output_LoadBackdropImage(const char *filename);
 
 void Output_SetupBelowWater(bool underwater);
 void Output_SetupAboveWater(bool underwater);
-void Output_AnimateTextures(int32_t ticks);
+void Output_AnimateTextures(void);
 void Output_AnimateFades(void);
 void Output_RotateLight(int16_t pitch, int16_t yaw);
 

--- a/src/game/phase/phase_cutscene.c
+++ b/src/game/phase/phase_cutscene.c
@@ -133,7 +133,7 @@ static GAMEFLOW_OPTION Phase_Cutscene_Control(int32_t nframes)
 static void Phase_Cutscene_Draw(void)
 {
     Game_DrawScene(true);
-    Output_AnimateTextures(g_Camera.number_frames);
+    Output_AnimateTextures();
     Output_AnimateFades();
 }
 

--- a/src/game/phase/phase_game.c
+++ b/src/game/phase/phase_game.c
@@ -138,8 +138,8 @@ static GAMEFLOW_OPTION Phase_Game_Control(int32_t nframes)
 static void Phase_Game_Draw(void)
 {
     Game_DrawScene(true);
+    Output_AnimateTextures();
     Output_AnimateFades();
-    Output_AnimateTextures(g_Camera.number_frames);
     Text_Draw();
 }
 


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Internal changes to prepare for 60 FPS. Area of interest – animated textures (waterfalls, water surface etc.) https://nebula.wind.garden/serve/pub/TR1X%203.1.1-98-gb091e26-Windows.zip