### PR TITLE
Make UI and input not rely on FPS

### DIFF
--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -141,7 +141,6 @@ static void Overlay_BarSetupHealth(void)
     m_HealthBar.show_mode = g_Config.healthbar_showing_mode;
     m_HealthBar.show = false;
     m_HealthBar.blink = false;
-    m_HealthBar.blink_counter = 0;
     m_HealthBar.timer = 40;
     m_HealthBar.color = g_Config.healthbar_color;
     m_HealthBar.location = g_Config.healthbar_location;
@@ -155,7 +154,6 @@ static void Overlay_BarSetupAir(void)
     m_AirBar.show_mode = g_Config.airbar_showing_mode;
     m_AirBar.show = false;
     m_AirBar.blink = false;
-    m_AirBar.blink_counter = 0;
     m_AirBar.timer = 0;
     m_AirBar.color = g_Config.airbar_color;
     m_AirBar.location = g_Config.airbar_location;
@@ -169,7 +167,6 @@ static void Overlay_BarSetupEnemy(void)
     m_EnemyBar.show_mode = g_Config.healthbar_showing_mode;
     m_EnemyBar.show = g_Config.enable_enemy_healthbar;
     m_EnemyBar.blink = false;
-    m_EnemyBar.blink_counter = 0;
     m_EnemyBar.timer = 0;
     m_EnemyBar.color = g_Config.enemy_healthbar_color;
     m_EnemyBar.location = g_Config.enemy_healthbar_location;
@@ -188,12 +185,14 @@ static void Overlay_BarBlink(BAR_INFO *bar_info)
         return;
     }
 
-    int32_t percent = Overlay_BarGetPercent(bar_info);
-    const int32_t blink_interval = 20;
-    int32_t blink_time = bar_info->blink_counter++ % blink_interval;
+    const int32_t percent = Overlay_BarGetPercent(bar_info);
+    if (percent > BLINK_THRESHOLD) {
+        return;
+    }
 
-    bar_info->blink =
-        percent <= BLINK_THRESHOLD && blink_time > blink_interval / 2;
+    if (Clock_IsAtLogicalFrame(10)) {
+        bar_info->blink = !bar_info->blink;
+    }
 }
 
 static void Overlay_BarGetLocation(

--- a/src/game/text.c
+++ b/src/game/text.c
@@ -1,6 +1,7 @@
 #include "game/text.h"
 
 #include "config.h"
+#include "game/clock.h"
 #include "game/output.h"
 #include "game/overlay.h"
 #include "game/screen.h"
@@ -483,7 +484,7 @@ void Text_DrawText(TEXTSTRING *textstring)
     }
 
     if (textstring->flags.flash) {
-        textstring->flash.count -= (int16_t)g_Camera.number_frames;
+        textstring->flash.count -= Clock_GetFrameAdvance();
         if (textstring->flash.count <= -textstring->flash.rate) {
             textstring->flash.count = textstring->flash.rate;
         } else if (textstring->flash.count < 0) {

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1631,7 +1631,6 @@ typedef struct BAR_INFO {
     bool show;
     BAR_SHOW_MODE show_mode;
     bool blink;
-    int32_t blink_counter;
     int32_t timer;
     int32_t color;
     BAR_LOCATION location;


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Preparation for 60 FPS. Areas of interest:
- holding reset and unbind keys in the control settings
- holding look to switch target
- holding up/down in the UIs to navigate menus faster
- blinking text speed
- blinking bar speed