### PR TITLE
audio: fix saved timestamp when load current music is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed a flipmap issue in Natla's Mines that could make the cabin appear stacked and prevent normal gameplay (#1052)
 - fixed several texture issues across the majority of levels (#1231)
 - fixed broken gorilla animations (#1244, regression since 2.15.3)
+- fixed saving and loading the music timestamp when the load current music option is enabled (#1237)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -286,9 +286,10 @@ static void S_Audio_StreamSoundClear(AUDIO_STREAM_SOUND *stream)
 {
     stream->is_used = false;
     stream->is_playing = false;
-    stream->is_looped = false;
     stream->is_read_done = true;
+    stream->is_looped = false;
     stream->volume = 0.0f;
+    stream->duration = 0.0;
     stream->timestamp = 0.0;
     stream->sdl.stream = NULL;
     stream->finish_callback = NULL;
@@ -540,18 +541,19 @@ double S_Audio_StreamGetTimestamp(int sound_id)
 {
     if (!g_AudioDeviceID || sound_id < 0
         || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
-        return -1;
+        return -1.0;
     }
 
-    if (m_StreamSounds[sound_id].is_playing) {
+    double timestamp = -1.0;
+    AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
+
+    if (stream->duration > 0.0) {
         SDL_LockAudioDevice(g_AudioDeviceID);
-        AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
-        double timestamp = stream->timestamp;
+        timestamp = stream->timestamp;
         SDL_UnlockAudioDevice(g_AudioDeviceID);
-        return timestamp;
     }
 
-    return -1.0;
+    return timestamp;
 }
 
 double S_Audio_StreamGetDuration(int sound_id)


### PR DESCRIPTION
Resolves #1237.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed saving and loading the music timestamp when the load current music option is enabled.