### PR TITLE
savegame: fix remember played music always being enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed a flipmap issue in Natla's Mines that could make the cabin appear stacked and prevent normal gameplay (#1052)
 - fixed several texture issues across the majority of levels (#1231)
 - fixed broken gorilla animations (#1244, regression since 2.15.3)
+- fixed the remember played music option always being enabled (#1249, regression since 2.16)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -900,6 +900,10 @@ static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
 static bool SaveGame_BSON_LoadMusicTrackFlags(
     struct json_array_s *music_track_arr)
 {
+    if (!g_Config.load_music_triggers) {
+        return true;
+    }
+
     if (!music_track_arr) {
         LOG_WARNING("Malformed save: invalid or missing music track array");
         return true;

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -338,7 +338,7 @@
     },
     "load_music_triggers": {
       "Title": "Remember played music",
-      "Description": "Loads previously triggered music so music tracks do not replay."
+      "Description": "Loads previously triggered, one shot music so one shot music tracks do not replay."
     },
     "enable_music_in_menu": {
       "Title": "Enable main menu music",


### PR DESCRIPTION
Resolves #1249.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the remember played music option always being enabled. Regression since 2.16.