### PR TITLE
interpolation: correct camera room number

### DIFF
--- a/src/game/game/game_draw.c
+++ b/src/game/game/game_draw.c
@@ -19,7 +19,7 @@ void Game_DrawScene(bool draw_overlay)
     Camera_Apply();
 
     if (g_Objects[O_LARA].loaded) {
-        Room_DrawAllRooms(g_Camera.interp.result.room_num);
+        Room_DrawAllRooms(g_Camera.interp.room_num);
         if (draw_overlay) {
             Overlay_DrawGameInfo();
         } else {

--- a/src/game/interpolation.c
+++ b/src/game/interpolation.c
@@ -70,11 +70,11 @@ void Interpolation_Commit(void)
         INTERPOLATE(&g_Camera, target.y, ratio, 512);
         INTERPOLATE(&g_Camera, target.z, ratio, 512);
 
-        g_Camera.interp.result.room_num = g_Camera.interp.prev.room_num;
+        g_Camera.interp.room_num = g_Camera.pos.room_number;
         Room_GetFloor(
             g_Camera.interp.result.pos.x,
             g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
-            g_Camera.interp.result.pos.z, &g_Camera.interp.result.room_num);
+            g_Camera.interp.result.pos.z, &g_Camera.interp.room_num);
     }
 
     INTERPOLATE_ROT(&g_Lara.left_arm, rot.x, ratio, PHD_45);
@@ -146,7 +146,6 @@ void Interpolation_Remember(void)
         REMEMBER(&g_Camera, target.x);
         REMEMBER(&g_Camera, target.y);
         REMEMBER(&g_Camera, target.z);
-        g_Camera.interp.prev.room_num = g_Camera.pos.room_number;
     }
 
     REMEMBER(&g_Lara.left_arm, rot.x);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1856,8 +1856,8 @@ typedef struct CAMERA_INFO {
             XYZ_32 target;
             XYZ_32 pos;
             int32_t shift;
-            int16_t room_num;
         } result, prev;
+        int16_t room_num;
     } interp;
 } CAMERA_INFO;
 


### PR DESCRIPTION
Resolves #1240.
Resolves #1241.
Resolves #1243.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

When `Room_GetFloor` is called, it will work out the relevant room number based on the interpolated position of the camera, so we need not track the previous room. We do still need a separate `room_num` for the interpolation because any slight change in `X Y Z` may yield a different number than the one stored in `g_Camera.pos.room_number`; I opted to move it from `result`/`prev` and put it directly into `interp`, but let me know if this would be better otherwise.

A little detail on the individual issues:
- In the Lost Valley demo example, although Lara had passed from room 0 to 1, the previous camera value was still 0 even though it was technically also in room 1.
- In Midas, the camera is initially set to Lara's room so this became the remembered value although the camera is far away in room 11. Because `Room_GetFloor` can't "fix" this (no matching portals at that position), we ended up with the camera at the correct position in room 11, but with a room value of 0, hence all the other rooms were culled and you would only see the tunnel.
- In Tihocan, when the camera returns to Lara after the fixed viewpoint, its number remains at the viewpoint for one frame so you see the adjoining Pierre room as a result (which just so happens to be directly above the switch).

This should also fix the other Midas problem @Richard-L mentioned on Discord (same idea as Lost Valley).

You can pause and use , and . to move through the frames here and check. You'll notice there are other issues remaining like the camera going into the wall in Lost Valley and going beyond the door in Tihocan, but these are part of #1034 and aren't new issues.
https://youtu.be/vDfNlQdwkqU