### PR TITLE
camera: improve underwater check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed broken gorilla animations (#1244, regression since 2.15.3)
 - fixed saving and loading the music timestamp when the load current music option is enabled (#1237)
 - fixed the remember played music option always being enabled (#1249, regression since 2.16)
+- fixed the underwater SFX playing for one frame at the start of Palace Midas (#1251)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -924,6 +924,6 @@ bool Level_Initialise(int32_t level_num)
     g_InvItemPickup1.string = g_GameFlow.levels[level_num].pickup1;
     g_InvItemPickup2.string = g_GameFlow.levels[level_num].pickup2;
 
-    g_Camera.underwater = 0;
+    g_Camera.underwater = false;
     return true;
 }

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1833,7 +1833,7 @@ typedef struct CAMERA_INFO {
     int32_t flags;
     int32_t fixed_camera;
     int32_t bounce;
-    int32_t underwater;
+    bool underwater;
     int32_t target_distance;
     int32_t target_square;
     int16_t target_angle;


### PR DESCRIPTION
Resolves #1251.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This delays the camera being marked as being underwater, and hence the SFX, until the very last moment for better accuracy in room position. As a result, the `Camera_Initialise` call no longer triggers the SFX via `Camera_Update` before the level actually begins, and we don't get the Midas issue. I did try removing `Camera_Update` from `Camera_Initialise` but this crashes Great Pyramid at the start, and so I think otherwise shuffling the general order of calls will cause further problems.

I've also changed the underwater flag in `CAMERA_INFO` to a `bool` for clarity as it's only used as such.