### PR TITLE
build: Fix macOS build workflow by mitigating bug in MacPorts' pyjson5 package

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -62,7 +62,8 @@ jobs:
           sudo port select --set pip3 pip312
 
           # Install the rest.
-          sudo port -N install create-dmg meson ninja pkgconfig py-json5
+          sudo port -N install create-dmg meson ninja pkgconfig
+          sudo pip3 install pyjson5
 
       - name: "Build dependencies: Compression libraries (universal)"
         run: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install and update MacPorts
         run: |
-          wget -O ${{ github.workspace }}/macports.pkg https://github.com/macports/macports-base/releases/download/v2.9.1/MacPorts-2.9.1-14-Sonoma.pkg
+          wget -O ${{ github.workspace }}/macports.pkg https://github.com/macports/macports-base/releases/download/v2.9.2/MacPorts-2.9.2-14-Sonoma.pkg
           sudo installer -pkg ${{ github.workspace }}/macports.pkg -target /
 
       - name: Install build and deployment tools


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Switches to installing pyjson5 via pip rather than MacPorts due to a temporary bug with the MacPorts package.

Also updates MacPorts to the latest release. MacPorts performs a self-update during install so we already had this, but updating the URL can slightly speed up the workflow as the self-update delta gets a little smaller.

...
