### PR TITLE
inject: fix item creation

### DIFF
--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1277,7 +1277,9 @@ static void Inject_TriggeredItem(INJECTION *injection, LEVEL_INFO *level_info)
         return;
     }
 
-    ITEM_INFO *item = &g_Items[g_LevelItemCount];
+    int16_t item_number = Item_Create();
+    ITEM_INFO *item = &g_Items[item_number];
+
     File_Read(&item->object_number, sizeof(int16_t), 1, fp);
     File_Read(&item->room_number, sizeof(int16_t), 1, fp);
     File_Read(&item->pos.x, sizeof(int32_t), 1, fp);


### PR DESCRIPTION
Resolves #1266.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This uses the correct approach to create an item on the fly. The issue itself was unreleased, and the change in [c279b4e](https://github.com/LostArtefacts/TR1X/commit/c279b4e7966928baaefbc2353c2223faf49cd0d5) brought the bug to light.

This is the only instance (currently) where we inject a new item into the level.