### PR TITLE
overlay: keep healthbar visible after resurrection

### DIFF
--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -187,6 +187,7 @@ static void Overlay_BarBlink(BAR_INFO *bar_info)
 
     const int32_t percent = Overlay_BarGetPercent(bar_info);
     if (percent > BLINK_THRESHOLD) {
+        bar_info->blink = false;
         return;
     }
 


### PR DESCRIPTION

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resurrecting Lara with the fly cheat kept the healthbar black instead of restoring it to full health. It's a rendering regression introduced in d327963fa75b879030580668ab3d97517f76cf33.