### PR TITLE
bat: reset fallspeed on death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed the underwater SFX playing for one frame at the start of Palace Midas (#1251)
 - fixed an incorrect frame in Lara's underwater twist animation (OG bug in TR2 onwards) (#1242)
 - fixed Lara saying "no" when taking valid actions in front of a key item receptacle (#1268)
+- fixed flickering in bats' death animations and rapid shooting if Lara continues to fire when they are killed (#992)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19
 - changed quick load to show empty passport instead of opening the save game menu when there are no saves (#1141)

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed bugs when trying to stack multiple movable blocks
 - fixed Midas's touch having unrestricted vertical range
 - fixed Lara saying "no" when taking valid actions in front of a key item receptacle
+- fixed flickering in bats' death animations and rapid shooting if Lara continues to fire when they are killed
 
 #### Cheats
 - added a fly cheat

--- a/src/game/objects/creatures/bat.c
+++ b/src/game/objects/creatures/bat.c
@@ -108,6 +108,7 @@ void Bat_Control(int16_t item_num)
             item->speed = 0;
         } else {
             item->gravity_status = 0;
+            item->fall_speed = 0;
             item->goal_anim_state = BAT_DEATH;
             item->pos.y = item->floor;
         }


### PR DESCRIPTION
Resolves #992.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents conflicts in setting the bats' Y position during the death animation, which itself manages Y shift during the bounce.

https://youtu.be/xykp2ieTHZU