### PR TITLE
inventory: fix Lara not saying "no" when using Scion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed the underwater SFX playing for one frame at the start of Palace Midas (#1251)
 - fixed an incorrect frame in Lara's underwater twist animation (OG bug in TR2 onwards) (#1242)
 - fixed Lara saying "no" when taking valid actions in front of a key item receptacle (#1268)
+- fixed Lara not saying "no" when using the Scion incorrectly (#1278)
 - fixed flickering in bats' death animations and rapid shooting if Lara continues to fire when they are killed (#992)
 
 ## [3.1.1](https://github.com/LostArtefacts/TR1X/compare/3.1...3.1.1) - 2024-01-19

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed bugs when trying to stack multiple movable blocks
 - fixed Midas's touch having unrestricted vertical range
 - fixed Lara saying "no" when taking valid actions in front of a key item receptacle
+- fixed Lara not saying "no" when using the Scion incorrectly
 - fixed flickering in bats' death animations and rapid shooting if Lara continues to fire when they are killed
 
 #### Cheats

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -425,7 +425,6 @@ void Lara_UseItem(GAME_OBJECT_ID object_num)
             Sound_Effect(SFX_LARA_NO, NULL, SPM_NORMAL);
             return;
         }
-        ITEM_INFO *item = &g_Items[receptacle_item_number];
         g_Lara.interact_target.item_num = receptacle_item_number;
         g_Lara.interact_target.is_moving = true;
         g_Lara.interact_target.move_count = 0;

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -414,7 +414,12 @@ void Lara_UseItem(GAME_OBJECT_ID object_num)
     case O_PUZZLE_ITEM4:
     case O_PUZZLE_OPTION4:
     case O_LEADBAR_ITEM:
-    case O_LEADBAR_OPTION: {
+    case O_LEADBAR_OPTION:
+    case O_SCION_ITEM:
+    case O_SCION_ITEM2:
+    case O_SCION_ITEM3:
+    case O_SCION_ITEM4:
+    case O_SCION_OPTION: {
         int16_t receptacle_item_number = Object_FindReceptacle(object_num);
         if (receptacle_item_number == NO_OBJECT) {
             Sound_Effect(SFX_LARA_NO, NULL, SPM_NORMAL);

--- a/src/game/phase/phase_inventory.c
+++ b/src/game/phase/phase_inventory.c
@@ -253,6 +253,7 @@ static GAMEFLOW_OPTION Inv_Close(GAME_OBJECT_ID inv_chosen)
     case O_PUZZLE_OPTION3:
     case O_PUZZLE_OPTION4:
     case O_LEADBAR_OPTION:
+    case O_SCION_OPTION:
         Lara_UseItem(inv_chosen);
         break;
 


### PR DESCRIPTION
Resolves #1278.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed Lara not saying "no" when using the Scion incorrectly. She will now say "no" when using the Scion on nothing, keyholes, puzzle holes, and Midas hands.