### PR TITLE
misc: fix lead bar not having bounds resulting in a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- fixed trying to pick up a lead bar crashing the game (#1293, regression from 3.1.1)
 
 ## [4.0](https://github.com/LostArtefacts/TR1X/compare/3.1.1...4.0) - 2024-04-09
 - added experimental support for 60 FPS, available from the in-game graphics menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
-- fixed trying to pick up a lead bar crashing the game (#1293, regression from 3.1.1)
+- fixed trying to pick up a lead bar crashing the game (#1293, regression from 4.0)
 
 ## [4.0](https://github.com/LostArtefacts/TR1X/compare/3.1.1...4.0) - 2024-04-09
 - added experimental support for 60 FPS, available from the in-game graphics menu

--- a/src/game/objects/general/misc.c
+++ b/src/game/objects/general/misc.c
@@ -23,4 +23,5 @@ void LeadBar_Setup(OBJECT_INFO *obj)
     obj->draw_routine = Object_DrawPickupItem;
     obj->collision = Pickup_Collision;
     obj->save_flags = 1;
+    obj->bounds = Pickup_Bounds;
 }


### PR DESCRIPTION
Resolves #1293.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed trying to pick up a lead bar crashing the game. Will need a hotfix.
