### PR TITLE
camera: fix vibrations when teleporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - changed injection files to be placed in its own directory (#1306)
+- fixed camera vibrations when using the teleport command in 60 FPS (#1274)
 
 ## [4.0.3](https://github.com/LostArtefacts/TR1X/compare/4.0.2...4.0.3) - 2024-04-14
 - fixed flickering sprite pickups (#1298)

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -411,7 +411,7 @@ void Camera_Reset(void)
     g_Camera.pos.room_number = NO_ROOM;
 }
 
-void Camera_Initialise(void)
+void Camera_ResetPosition(void)
 {
     assert(g_LaraItem);
     g_Camera.shift = g_LaraItem->pos.y - WALL_L;
@@ -435,7 +435,11 @@ void Camera_Initialise(void)
     g_Camera.number = NO_CAMERA;
     g_Camera.additional_angle = 0;
     g_Camera.additional_elevation = 0;
+}
 
+void Camera_Initialise(void)
+{
+    Camera_ResetPosition();
     Camera_Update();
 }
 

--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -6,6 +6,7 @@
 
 void Camera_Initialise(void);
 void Camera_Reset(void);
+void Camera_ResetPosition(void);
 void Camera_Chase(ITEM_INFO *item);
 void Camera_Combat(ITEM_INFO *item);
 void Camera_Look(ITEM_INFO *item);

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "game/anim.h"
+#include "game/camera.h"
 #include "game/carrier.h"
 #include "game/clock.h"
 #include "game/interpolation.h"
@@ -281,6 +282,10 @@ bool Item_Teleport(ITEM_INFO *item, int32_t x, int32_t y, int32_t z)
         if (item->room_number != room_num) {
             const int16_t item_num = item - g_Items;
             Item_NewRoom(item_num, room_num);
+        }
+
+        if (item->object_number == O_LARA) {
+            Camera_ResetPosition();
         }
         return true;
     }


### PR DESCRIPTION
Resolves #1274.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This enforces a camera reset when Lara teleports to avoid large shifts in values between the camera positions.