### PR TITLE
camera: remove LOS check on fixed cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - changed injection files to be placed in its own directory (#1306)
 - fixed camera vibrations when using the teleport command in 60 FPS (#1274)
+- fixed the camera being thrown through doors for one frame when looked at from fixed camera positions (#954)
 
 ## [4.0.3](https://github.com/LostArtefacts/TR1X/compare/4.0.2...4.0.3) - 2024-04-14
 - fixed flickering sprite pickups (#1298)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed Scion 1 respawning on load
 - fixed triggered flip effects not working if there are no sound devices
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling
+- fixed the camera being thrown through doors for one frame when looked at from fixed camera positions
 - fixed the ape not performing the vault animation when climbing
 - fixed Natla's gun moving while she is in her semi death state
 - fixed the bear pat attack so it does not miss Lara

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -576,10 +576,6 @@ void Camera_Fixed(void)
     ideal.z = fixed->z;
     ideal.room_number = fixed->data;
 
-    if (!LOS_Check(&g_Camera.target, &ideal)) {
-        Camera_ShiftClamp(&ideal, STEP_L);
-    }
-
     g_Camera.fixed_camera = 1;
 
     Camera_Move(&ideal, g_Camera.speed);


### PR DESCRIPTION
Resolves #954.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

LOS checks are removed in TR3 onwards for fixed cameras, so implemented here to fix the camera being thrown through doors that are yet to open. This also improves other areas of the game, for example if Lara is jumping down a slope with a low-ceiling and a fixed camera like in Tihocan or The Great Pyramid, or if she begins a level on a fixed camera but is just out of sight like in [Natla's Mines](https://github.com/LostArtefacts/TR1X/issues/1034#issuecomment-2028661547).

The one thing this could affect is custom levels with fixed cameras where Lara can go behind geometry, but even so it still feels like an improvement rather than having a fixed camera moving all over the place. I checked all the fixed cameras in OG and TRUB and they behave well with this change. Let me know your thoughts though if this should be optional, my feeling is it shouldn't.

The following demo shows the result. I implemented a test command to toggle between old and new, so keep an eye on the console to see the current state.

https://youtu.be/9OTPPHdjbCc
