### PR TITLE
room_draw: include camera target room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed console not retaining changed user settings across game relaunches (#1318)
 - fixed passport inventory item not being animated in 60 FPS (#1314)
 - fixed compass needle being too fast in 60 FPS (#1316, regression from 4.0)
+- fixed black screen flickers that can occur in 60 FPS (#1295)
 
 ## [4.0.3](https://github.com/LostArtefacts/TR1X/compare/4.0.2...4.0.3) - 2024-04-14
 - fixed flickering sprite pickups (#1298)

--- a/src/game/game/game_draw.c
+++ b/src/game/game/game_draw.c
@@ -19,7 +19,8 @@ void Game_DrawScene(bool draw_overlay)
     Camera_Apply();
 
     if (g_Objects[O_LARA].loaded) {
-        Room_DrawAllRooms(g_Camera.interp.room_num);
+        Room_DrawAllRooms(
+            g_Camera.interp.room_num, g_Camera.target.room_number);
         if (draw_overlay) {
             Overlay_DrawGameInfo();
         } else {

--- a/src/game/room_draw.h
+++ b/src/game/room_draw.h
@@ -7,5 +7,5 @@
 
 bool Room_SetBounds(int16_t *objptr, int16_t room_num, ROOM_INFO *parent);
 void Room_GetBounds(int16_t room_num);
-void Room_DrawAllRooms(int16_t room_num);
+void Room_DrawAllRooms(int16_t base_room, int16_t target_room);
 void Room_DrawSingleRoom(int16_t room_num);


### PR DESCRIPTION
Part of #1295.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This is a workaround for flickers in 60 FPS to ensure that the camera's target room is included in drawing checks. It does not solve _every_ issue, but the majority i.e. those where the visibility portal checks deem the target room to not be visible. What it doesn't solve is this:

![image](https://github.com/LostArtefacts/TR1X/assets/33758420/382ac18e-3806-4a9b-ae46-1566043de221)

This is all the same room, but the clipping is for some reason deciding to cull most of the left side.

To be clear too, this does not solve the OG issues detailed in #1034.

The camera going out of bounds is not a new phenomenon in TR1. This PR hopefully puts us in a situation that's no(t much) worse than OG/30 FPS until we get a better solution for the camera collision control in place.
