### PR TITLE
room_draw: refactor visibility portal usage

### DIFF
--- a/src/game/level.c
+++ b/src/game/level.c
@@ -181,13 +181,13 @@ static bool Level_LoadRooms(MYFILE *fp)
             for (int32_t j = 0; j < count2; j++) {
                 DOOR_INFO *door = &current_room_info->doors->door[j];
                 File_Read(&door->room_num, sizeof(int16_t), 1, fp);
-                File_Read(&door->pos.x, sizeof(int16_t), 1, fp);
-                File_Read(&door->pos.y, sizeof(int16_t), 1, fp);
-                File_Read(&door->pos.z, sizeof(int16_t), 1, fp);
+                File_Read(&door->normal.x, sizeof(int16_t), 1, fp);
+                File_Read(&door->normal.y, sizeof(int16_t), 1, fp);
+                File_Read(&door->normal.z, sizeof(int16_t), 1, fp);
                 for (int32_t k = 0; k < 4; k++) {
-                    File_Read(&door->vertex[k].x, sizeof(uint16_t), 1, fp);
-                    File_Read(&door->vertex[k].y, sizeof(uint16_t), 1, fp);
-                    File_Read(&door->vertex[k].z, sizeof(uint16_t), 1, fp);
+                    File_Read(&door->vertex[k].x, sizeof(int16_t), 1, fp);
+                    File_Read(&door->vertex[k].y, sizeof(int16_t), 1, fp);
+                    File_Read(&door->vertex[k].z, sizeof(int16_t), 1, fp);
                 }
             }
         }

--- a/src/game/room_draw.h
+++ b/src/game/room_draw.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include "global/types.h"
-
-#include <stdbool.h>
 #include <stdint.h>
 
-bool Room_SetBounds(int16_t *objptr, int16_t room_num, ROOM_INFO *parent);
-void Room_GetBounds(int16_t room_num);
 void Room_DrawAllRooms(int16_t base_room, int16_t target_room);
 void Room_DrawSingleRoom(int16_t room_num);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1150,16 +1150,8 @@ typedef struct TEXTURE_RANGE {
 
 typedef struct DOOR_INFO {
     int16_t room_num;
-    struct {
-        int16_t x;
-        int16_t y;
-        int16_t z;
-    } pos;
-    struct {
-        uint16_t x;
-        uint16_t y;
-        uint16_t z;
-    } vertex[4];
+    XYZ_16 normal;
+    XYZ_16 vertex[4];
 } DOOR_INFO;
 
 typedef struct DOOR_INFOS {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This removes the assumption of `DOOR_INFO`'s layout and makes the visibility portal checks more readable as a result. I've also made internal functions private. The vertices were also being stored unsigned from the level, but interpreted as signed, so that's now standardized too.