### PR TITLE
overlay: support boss-only enemy healthbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- added ability to show enemy healthbars only for bosses (#1300)
 - added ability to kill specific enemy types (#1313)
 - added ability to teleport to nearest specific object (#1312)
 - added `/give all` variant of the item cheat

--- a/src/config.c
+++ b/src/config.c
@@ -33,6 +33,7 @@ static void Config_ReadKeyboardLayout(
     struct json_object_s *parent_obj, INPUT_LAYOUT layout);
 static void Config_ReadControllerLayout(
     struct json_object_s *parent_obj, INPUT_LAYOUT layout);
+static void Config_ReadLegacyOptions(struct json_object_s *const parent_obj);
 static void Config_WriteKeyboardLayout(
     struct json_object_s *parent_obj, INPUT_LAYOUT layout);
 static void Config_WriteControllerLayout(
@@ -174,6 +175,20 @@ static void Config_ReadControllerLayout(
     }
 }
 
+static void Config_ReadLegacyOptions(struct json_object_s *const parent_obj)
+{
+    // 0.10..4.0.3: enable_enemy_healthbar
+    {
+        const struct json_value_s *const value =
+            json_object_get_value(parent_obj, "enable_enemy_healthbar");
+        if (json_value_is_true(value)) {
+            g_Config.enemy_healthbar_show_mode = BSM_ALWAYS;
+        } else if (json_value_is_false(value)) {
+            g_Config.enemy_healthbar_show_mode = BSM_NEVER;
+        }
+    }
+}
+
 static void Config_WriteKeyboardLayout(
     struct json_object_s *const parent_obj, const INPUT_LAYOUT layout)
 {
@@ -295,6 +310,8 @@ bool Config_ReadFromJSON(const char *cfg_data)
         Config_ReadKeyboardLayout(root_obj, layout);
         Config_ReadControllerLayout(root_obj, layout);
     }
+
+    Config_ReadLegacyOptions(root_obj);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);

--- a/src/config.h
+++ b/src/config.h
@@ -40,12 +40,13 @@ typedef enum {
 } BAR_COLOR;
 
 typedef enum {
-    BSM_DEFAULT = 0,
-    BSM_FLASHING_OR_DEFAULT = 1,
-    BSM_FLASHING_ONLY = 2,
-    BSM_ALWAYS = 3,
-    BSM_NEVER = 4,
-    BSM_PS1 = 5,
+    BSM_DEFAULT,
+    BSM_FLASHING_OR_DEFAULT,
+    BSM_FLASHING_ONLY,
+    BSM_ALWAYS,
+    BSM_NEVER,
+    BSM_PS1,
+    BSM_BOSS_ONLY,
 } BAR_SHOW_MODE;
 
 typedef enum {
@@ -63,7 +64,6 @@ typedef struct {
     bool disable_uzis;
     bool disable_shotgun;
     bool enable_deaths_counter;
-    bool enable_enemy_healthbar;
     bool enable_enhanced_look;
     bool enable_numeric_keys;
     bool enable_shotgun_flash;
@@ -77,14 +77,15 @@ typedef struct {
     bool enable_timer_in_inventory;
     bool enable_smooth_bars;
     bool enable_fade_effects;
-    int32_t healthbar_showing_mode;
-    int32_t healthbar_location;
-    int32_t healthbar_color;
-    int32_t airbar_showing_mode;
-    int32_t airbar_location;
-    int32_t airbar_color;
-    int32_t enemy_healthbar_location;
-    int32_t enemy_healthbar_color;
+    BAR_SHOW_MODE healthbar_show_mode;
+    BAR_LOCATION healthbar_location;
+    BAR_COLOR healthbar_color;
+    BAR_SHOW_MODE airbar_show_mode;
+    BAR_LOCATION airbar_location;
+    BAR_COLOR airbar_color;
+    BAR_SHOW_MODE enemy_healthbar_show_mode;
+    BAR_LOCATION enemy_healthbar_location;
+    BAR_COLOR enemy_healthbar_color;
     bool fix_tihocan_secret_sound;
     bool fix_floor_data_issues;
     bool fix_secrets_killing_music;

--- a/src/config_map.c
+++ b/src/config_map.c
@@ -14,13 +14,14 @@ static const CONFIG_OPTION_ENUM_MAP m_UIStyles[] = {
     { NULL, -1 },
 };
 
-static const CONFIG_OPTION_ENUM_MAP m_BarShowingModes[] = {
+static const CONFIG_OPTION_ENUM_MAP m_BarShowModes[] = {
     { "default", BSM_DEFAULT },
     { "flashing-or-default", BSM_FLASHING_OR_DEFAULT },
     { "flashing-only", BSM_FLASHING_ONLY },
     { "always", BSM_ALWAYS },
     { "never", BSM_NEVER },
     { "ps1", BSM_PS1 },
+    { "boss-only", BSM_BOSS_ONLY },
     { NULL, -1 },
 };
 
@@ -64,7 +65,6 @@ const CONFIG_OPTION g_ConfigOptionMap[] = {
     { .name = "disable_shotgun",                .type = COT_BOOL,   .target = &g_Config.disable_shotgun,                     .default_value = &(bool){false},                      0},
     { .name = "enable_detailed_stats",          .type = COT_BOOL,   .target = &g_Config.enable_detailed_stats,               .default_value = &(bool){true},                       0},
     { .name = "enable_deaths_counter",          .type = COT_BOOL,   .target = &g_Config.enable_deaths_counter,               .default_value = &(bool){true},                       0},
-    { .name = "enable_enemy_healthbar",         .type = COT_BOOL,   .target = &g_Config.enable_enemy_healthbar,              .default_value = &(bool){true},                       0},
     { .name = "enable_enhanced_look",           .type = COT_BOOL,   .target = &g_Config.enable_enhanced_look,                .default_value = &(bool){true},                       0},
     { .name = "enable_shotgun_flash",           .type = COT_BOOL,   .target = &g_Config.enable_shotgun_flash,                .default_value = &(bool){true},                       0},
     { .name = "fix_shotgun_targeting",          .type = COT_BOOL,   .target = &g_Config.fix_shotgun_targeting,               .default_value = &(bool){true},                       0},
@@ -107,8 +107,9 @@ const CONFIG_OPTION g_ConfigOptionMap[] = {
     { .name = "walk_to_items",                  .type = COT_BOOL,   .target = &g_Config.walk_to_items,                       .default_value = &(bool){false},                      0},
     { .name = "disable_trex_collision",         .type = COT_BOOL,   .target = &g_Config.disable_trex_collision,              .default_value = &(bool){false},                      0},
     { .name = "start_lara_hitpoints",           .type = COT_INT32,  .target = &g_Config.start_lara_hitpoints,                .default_value = &(int32_t){LARA_HITPOINTS},          0},
-    { .name = "healthbar_showing_mode",         .type = COT_ENUM,   .target = &g_Config.healthbar_showing_mode,              .default_value = &(int32_t){BSM_FLASHING_OR_DEFAULT}, .param = m_BarShowingModes},
-    { .name = "airbar_showing_mode",            .type = COT_ENUM,   .target = &g_Config.airbar_showing_mode,                 .default_value = &(int32_t){BSM_DEFAULT},             .param = m_BarShowingModes},
+    { .name = "healthbar_showing_mode",         .type = COT_ENUM,   .target = &g_Config.healthbar_show_mode,                 .default_value = &(int32_t){BSM_FLASHING_OR_DEFAULT}, .param = m_BarShowModes},
+    { .name = "airbar_showing_mode",            .type = COT_ENUM,   .target = &g_Config.airbar_show_mode,                    .default_value = &(int32_t){BSM_DEFAULT},             .param = m_BarShowModes},
+    { .name = "enemy_healthbar_showing_mode",   .type = COT_ENUM,   .target = &g_Config.enemy_healthbar_show_mode,           .default_value = &(int32_t){BSM_ALWAYS},              .param = m_BarShowModes},
     { .name = "healthbar_location",             .type = COT_ENUM,   .target = &g_Config.healthbar_location,                  .default_value = &(int32_t){BL_TOP_LEFT},             .param = m_BarLocations},
     { .name = "airbar_location",                .type = COT_ENUM,   .target = &g_Config.airbar_location,                     .default_value = &(int32_t){BL_TOP_RIGHT},            .param = m_BarLocations},
     { .name = "enemy_healthbar_location",       .type = COT_ENUM,   .target = &g_Config.enemy_healthbar_location,            .default_value = &(int32_t){BL_BOTTOM_LEFT},          .param = m_BarLocations},

--- a/src/game/creature.c
+++ b/src/game/creature.c
@@ -9,6 +9,7 @@
 #include "game/lara.h"
 #include "game/los.h"
 #include "game/lot.h"
+#include "game/objects/common.h"
 #include "game/random.h"
 #include "game/room.h"
 #include "global/vars.h"
@@ -722,6 +723,12 @@ bool Creature_EnsureHabitat(
     return item->object_number == info->land.id
         ? Creature_SwitchToWater(item_num, wh, info)
         : Creature_SwitchToLand(item_num, wh, info);
+}
+
+bool Creature_IsBoss(const int16_t item_num)
+{
+    const ITEM_INFO *const item = &g_Items[item_num];
+    return Object_IsObjectType(item->object_number, g_BossObjects);
 }
 
 static bool Creature_SwitchToWater(

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -44,3 +44,4 @@ bool Creature_ShootAtLara(
     int16_t damage);
 bool Creature_EnsureHabitat(
     int16_t item_num, int32_t *wh, const HYBRID_INFO *info);
+bool Creature_IsBoss(int16_t item_num);

--- a/src/game/objects/common.c
+++ b/src/game/objects/common.c
@@ -46,6 +46,20 @@ const GAME_OBJECT_ID g_EnemyObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_BossObjects[] = {
+    // clang-format off
+    O_TREX,
+    O_LARSON,
+    O_PIERRE,
+    O_SKATEKID,
+    O_COWBOY,
+    O_BALDY,
+    O_NATLA,
+    O_TORSO,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_PlaceholderObjects[] = {
     // clang-format off
     O_STATUE,

--- a/src/game/objects/common.h
+++ b/src/game/objects/common.h
@@ -13,6 +13,7 @@ typedef struct GAME_OBJECT_PAIR {
 } GAME_OBJECT_PAIR;
 
 extern const GAME_OBJECT_ID g_EnemyObjects[];
+extern const GAME_OBJECT_ID g_BossObjects[];
 extern const GAME_OBJECT_ID g_PlaceholderObjects[];
 extern const GAME_OBJECT_ID g_PickupObjects[];
 extern const GAME_OBJECT_ID g_GunObjects[];

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -2,8 +2,10 @@
 
 #include "config.h"
 #include "game/clock.h"
+#include "game/creature.h"
 #include "game/gameflow.h"
 #include "game/inventory.h"
+#include "game/items.h"
 #include "game/output.h"
 #include "game/phase/phase.h"
 #include "game/screen.h"
@@ -137,7 +139,7 @@ static void Overlay_BarSetupHealth(void)
     m_HealthBar.type = BT_LARA_HEALTH;
     m_HealthBar.value = 0;
     m_HealthBar.max_value = LARA_HITPOINTS;
-    m_HealthBar.show_mode = g_Config.healthbar_showing_mode;
+    m_HealthBar.show_mode = g_Config.healthbar_show_mode;
     m_HealthBar.show = false;
     m_HealthBar.blink = false;
     m_HealthBar.timer = 40;
@@ -150,7 +152,7 @@ static void Overlay_BarSetupAir(void)
     m_AirBar.type = BT_LARA_AIR;
     m_AirBar.value = LARA_AIR;
     m_AirBar.max_value = LARA_AIR;
-    m_AirBar.show_mode = g_Config.airbar_showing_mode;
+    m_AirBar.show_mode = g_Config.airbar_show_mode;
     m_AirBar.show = false;
     m_AirBar.blink = false;
     m_AirBar.timer = 0;
@@ -163,8 +165,8 @@ static void Overlay_BarSetupEnemy(void)
     m_EnemyBar.type = BT_ENEMY_HEALTH;
     m_EnemyBar.value = 0;
     m_EnemyBar.max_value = 0;
-    m_EnemyBar.show_mode = g_Config.healthbar_showing_mode;
-    m_EnemyBar.show = g_Config.enable_enemy_healthbar;
+    m_EnemyBar.show_mode = g_Config.enemy_healthbar_show_mode;
+    m_EnemyBar.show = false;
     m_EnemyBar.blink = false;
     m_EnemyBar.timer = 0;
     m_EnemyBar.color = g_Config.enemy_healthbar_color;
@@ -529,7 +531,29 @@ static void Overlay_BarDrawAir(void)
 
 static void Overlay_BarDrawEnemy(void)
 {
-    if (!m_EnemyBar.show || !g_Lara.target) {
+    if (!g_Lara.target) {
+        return;
+    }
+
+    switch (m_EnemyBar.show_mode) {
+    case BSM_DEFAULT:
+    case BSM_PS1:
+    case BSM_NEVER:
+        m_EnemyBar.show = false;
+        break;
+
+    case BSM_FLASHING_ONLY:
+    case BSM_FLASHING_OR_DEFAULT:
+    case BSM_ALWAYS:
+        m_EnemyBar.show = true;
+        break;
+
+    case BSM_BOSS_ONLY:
+        m_EnemyBar.show = Creature_IsBoss(g_Lara.target - g_Items);
+        break;
+    }
+
+    if (!m_EnemyBar.show) {
         return;
     }
 

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -45,6 +45,11 @@
       "never": "Never",
       "ps1": "PS1"
     },
+    "enemy_healthbar_mode": {
+      "never": "Never",
+      "always": "Always",
+      "boss-only": "Bosses only"
+    },
     "menu_style": {
       "pc": "PC",
       "ps1": "PS1"
@@ -396,8 +401,8 @@
       "Title": "Airbar color",
       "Description": "Color of the airbar."
     },
-    "enable_enemy_healthbar": {
-      "Title": "Show enemy Healthbars",
+    "enemy_healthbar_showing_mode": {
+      "Title": "Show enemy healthbars",
       "Description": "Enables showing a healthbar for the active enemy."
     },
     "enemy_healthbar_location": {

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
@@ -54,6 +54,11 @@
       "never": "Nunca",
       "ps1": "PS1"
     },
+    "enemy_healthbar_mode": {
+      "never": "Nunca",
+      "always": "Siempre",
+      "boss-only": "Solo jefes"
+    },
     "menu_style": {
       "pc": "PC",
       "ps1": "PS1"
@@ -172,7 +177,7 @@
       "Title": "Mostrar total de objetos y muertes",
       "Description": "Permite mostrar el recuento máximo de objetos recogidos y el recuento de muertes en cada nivel. Esto incluye objetos que no se pueden obtener."
     },
-    "enable_enemy_healthbar": {
+    "enemy_healthbar_showing_mode": {
       "Title": "Mostrar barra de salud enemiga",
       "Description": "Permite mostrar una barra de salud para el enemigo activo."
     },

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/fr.json
@@ -45,6 +45,11 @@
       "never": "Jamais",
       "ps1": "PS1"
     },
+    "enemy_healthbar_mode": {
+      "never": "Jamais",
+      "always": "Toujours",
+      "boss-only": "Seulement les boss"
+    },
     "menu_style": {
       "pc": "PC",
       "ps1": "PS1"
@@ -396,7 +401,7 @@
       "Title": "Couleur de la barre d'air",
       "Description": "Choisir la couleur de la barre d'air."
     },
-    "enable_enemy_healthbar": {
+    "enemy_healthbar_showing_mode": {
       "Title": "Afficher la barre de santé des ennemis",
       "Description": "Affiche la barre de santé de l'ennemi sur lequel Lara vise et tire"
     },

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/it.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/it.json
@@ -45,6 +45,11 @@
       "never": "Mai",
       "ps1": "PS1"
     },
+    "enemy_healthbar_mode": {
+      "never": "Mai",
+      "always": "Sempre",
+      "boss-only": "Solo i boss"
+    },
     "menu_style": {
       "pc": "PC",
       "ps1": "PS1"
@@ -396,7 +401,7 @@
       "Title": "Colore della barra dell'ossigeno",
       "Description": "Colore utilizzato per la barra dell'ossigeno."
     },
-    "enable_enemy_healthbar": {
+    "enemy_healthbar_showing_mode": {
       "Title": "Mostra la barra della salute dei nemici",
       "Description": "Abilita la visualizzazione della barra della salute per il nemico ingaggiato."
     },

--- a/tools/config/TR1X_ConfigTool/Resources/specification.json
+++ b/tools/config/TR1X_ConfigTool/Resources/specification.json
@@ -14,6 +14,11 @@
       "never",
       "ps1"
     ],
+    "enemy_healthbar_mode": [
+      "never",
+      "always",
+      "boss-only"
+    ],
     "menu_style": [
       "pc",
       "ps1"
@@ -495,9 +500,10 @@
           "DefaultValue": "blue"
         },
         {
-          "Field": "enable_enemy_healthbar",
-          "DataType": "Bool",
-          "DefaultValue": true
+          "Field": "enemy_healthbar_showing_mode",
+          "DataType": "Enum",
+          "EnumKey": "enemy_healthbar_mode",
+          "DefaultValue": "always"
         },
         {
           "Field": "enemy_healthbar_location",


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1300 – allows to only display enemy healthbars for bosses. I decided to use t-rex hit points as the reference value as to how to tell if the creature is a boss or not. However, in this scenario, centaurs are also categorized as bosses, which I disagree with. Additionally, Pierre and Larson each have fewer hitpoints than the t-rex and I believe they should be considered bosses. Therefore, I have manually set overrides for these three enemies.

Also introduces small refactor to the naming to make it more grammatically correct (I hope, I'm an ESL), as well as additional code in the config to ensure backwards compatibility of the new enum-based option with the previous bool solution.

The suggested boss table, along with each enemy's max hit points, is outlined below:

Enemy     | Hit points | Considered a boss?
---       | ---------- | ---
Torso     | 500        | ✅
Natla     | 400        | ✅
Baldy     | 200        | ✅
Cowboy    | 150        | ✅
Skate Kid | 125        | ✅
Centaur   | 120        | ❌ (manual override)
TRex      | 100        | ✅
Pierre    | 70         | ✅ (manual override)
Larson    | 50         | ✅ (manual override)
Flyer     | 50         | ❌
Puma      | 45         | ❌
Lion      | 30         | ❌
Lioness   | 25         | ❌
Ape       | 22         | ❌
Bear      | 20         | ❌
Crocodile | 20         | ❌
Alligator | 20         | ❌
Raptor    | 20         | ❌
Mummy     | 18         | ❌
Wolf      | 6          | ❌
Rat       | 5          | ❌
Scion     | 5          | ❌
Bat       | 1          | ❌