### PR TITLE
requestor: fix slight delay when moving up or down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed underwater bubbles not being animated in 60 FPS (#1314)
 - fixed compass needle being too fast in 60 FPS (#1316, regression from 4.0)
 - fixed black screen flickers that can occur in 60 FPS (#1295)
+- fixed a slight delay with the passport menu selector (#1334)
 - decreased initial flicker upon game launch (#1322)
 
 ## [4.0.3](https://github.com/LostArtefacts/TR1X/compare/4.0.2...4.0.3) - 2024-04-14

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -77,6 +77,26 @@ int32_t Requester_Display(REQUEST_INFO *req)
         Text_AddOutline(req->heading, true, TS_HEADING);
     }
 
+    if (g_InputDB.menu_down) {
+        if (req->requested < req->items - 1) {
+            req->requested++;
+        }
+        req->line_old_offset = req->line_offset;
+        if (req->requested > req->line_offset + req->vis_lines - 1) {
+            req->line_offset++;
+        }
+    }
+
+    if (g_InputDB.menu_up) {
+        if (req->requested) {
+            req->requested--;
+        }
+        req->line_old_offset = req->line_offset;
+        if (req->requested < req->line_offset) {
+            req->line_offset--;
+        }
+    }
+
     if (req->line_offset) {
         if (!req->moreup) {
             req->moreup =
@@ -130,28 +150,6 @@ int32_t Requester_Display(REQUEST_INFO *req)
                          [req->item_text_len * (req->line_offset + i)]);
             }
         }
-    }
-
-    if (g_InputDB.menu_down) {
-        if (req->requested < req->items - 1) {
-            req->requested++;
-        }
-        req->line_old_offset = req->line_offset;
-        if (req->requested > req->line_offset + req->vis_lines - 1) {
-            req->line_offset++;
-        }
-        return 0;
-    }
-
-    if (g_InputDB.menu_up) {
-        if (req->requested) {
-            req->requested--;
-        }
-        req->line_old_offset = req->line_offset;
-        if (req->requested < req->line_offset) {
-            req->line_offset--;
-        }
-        return 0;
     }
 
     if (g_InputDB.menu_confirm) {


### PR DESCRIPTION
Resolves #1334.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed a slight delay with the passport menu selector. I think this is technically an OG bug I think but is only noticeable because of the arrows added for the level select menu. This fixes those arrows moving a a frame earlier than the requestor's `requested`. Also fixes the delay with `moreup` and `moredown`.