### PR TITLE
level: fix reading animated textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- fixed reading animated texture data in levels (#1346, regression from 4.1)
 
 ## [4.1](https://github.com/LostArtefacts/TR1X/compare/4.0.3...4.1) - 2024-04-26
 - added ability to show enemy healthbars only for bosses (#1300)


### PR DESCRIPTION
Resolves #1346.
Caused by #1303.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that we read to the end of the animated texture data, even if it does not contain accurate information that would otherwise be parsed into the relevant structure. Prior to 4.1, we would read `m_LevelInfo.anim_texture_range_count * sizeof(int16_t)` into `g_AnimTextureRanges`, so the new approach meant any extra data was not being consumed, and so subsequent reads from the file were starting at the wrong position.

For interest, the level in question seems to have a group of zeroes at the end of the data, so this appears to be a bug in whichever tool was used to compile it.

![image](https://github.com/LostArtefacts/TR1X/assets/33758420/fee28596-fbda-4aaf-923d-9adfa3f810fa)

