### PR TITLE
build: reorganize libtrx usage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,13 @@
-project('TR1X', 'c',
+project(
+  'TR1X',
+  'c',
   default_options: [
     'c_std=c11',
     'warning_level=2',
   ],
 )
 
-dep_trx = subproject('libtrx')
+trx = subproject('libtrx')
 c_compiler = meson.get_compiler('c')
 
 build_opts = [
@@ -32,6 +34,7 @@ else
   dep_opengl = dependency('GL')
 endif
 
+dep_trx = trx.get_variable('dep_trx')
 dep_avcodec = dependency('libavcodec', static: staticdeps)
 dep_avformat = dependency('libavformat', static: staticdeps)
 dep_avutil = dependency('libavutil', static: staticdeps)
@@ -279,6 +282,7 @@ sources = [
 ]
 
 dependencies = [
+  dep_trx,
   dep_avcodec,
   dep_avformat,
   dep_avutil,
@@ -306,9 +310,11 @@ configure_file(
 executable(
   'TR1X',
   sources,
-  include_directories: ['src/'],
+  include_directories: [
+    'src/',
+    include_directories('subprojects/libtrx/include', is_system: true),
+  ],
   dependencies: dependencies,
-  link_with: dep_trx.get_variable('libtrx'),
   link_args: link_args,
   gui_app: true,
   install: true,

--- a/src/config.c
+++ b/src/config.c
@@ -7,11 +7,12 @@
 #include "gfx/context.h"
 #include "global/const.h"
 #include "global/types.h"
-#include "shared/filesystem.h"
-#include "shared/json.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/json.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/game/carrier.c
+++ b/src/game/carrier.c
@@ -9,7 +9,8 @@
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/game/clock.c
+++ b/src/game/clock.c
@@ -5,7 +5,8 @@
 #include "game/game_string.h"
 #include "game/phase/phase.h"
 #include "global/vars.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <assert.h>
 #include <math.h>

--- a/src/game/console.c
+++ b/src/game/console.c
@@ -11,7 +11,8 @@
 #include "game/viewport.h"
 #include "global/const.h"
 #include "global/types.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <SDL2/SDL_keycode.h>
 #include <stdarg.h>

--- a/src/game/console_cmd.c
+++ b/src/game/console_cmd.c
@@ -22,9 +22,10 @@
 #include "global/types.h"
 #include "global/vars.h"
 #include "math/math.h"
-#include "shared/memory.h"
-#include "shared/strings.h"
 #include "util.h"
+
+#include <libtrx/memory.h>
+#include <libtrx/strings.h>
 
 #include <assert.h>
 #include <math.h>

--- a/src/game/fmv.c
+++ b/src/game/fmv.c
@@ -2,9 +2,10 @@
 
 #include "game/music.h"
 #include "game/sound.h"
-#include "shared/filesystem.h"
-#include "shared/memory.h"
 #include "specific/s_fmv.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/memory.h>
 
 #include <stddef.h>
 

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -16,7 +16,8 @@
 #include "game/sound.h"
 #include "game/stats.h"
 #include "global/vars.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #define FRAME_BUFFER(key)                                                      \
     do {                                                                       \

--- a/src/game/game_string.c
+++ b/src/game/game_string.c
@@ -1,6 +1,7 @@
 #include "game_string.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/game/gamebuf.c
+++ b/src/game/gamebuf.c
@@ -1,7 +1,8 @@
 #include "game/gamebuf.h"
 
 #include "game/shell.h"
-#include "shared/memory.h"
+
+#include <libtrx/memory.h>
 
 #include <stddef.h>
 

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -15,10 +15,11 @@
 #include "game/phase/phase_stats.h"
 #include "game/room.h"
 #include "global/vars.h"
-#include "shared/filesystem.h"
-#include "shared/json.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/json.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <string.h>
 

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -7,10 +7,11 @@
 #include "global/const.h"
 #include "global/vars.h"
 #include "items.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stdbool.h>

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -21,8 +21,9 @@
 #include "global/const.h"
 #include "global/vars.h"
 #include "math/math.h"
-#include "shared/log.h"
 #include "util.h"
+
+#include <libtrx/log.h>
 
 #include <stddef.h>
 

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -23,9 +23,10 @@
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -4,10 +4,11 @@
 #include "game/gameflow.h"
 #include "game/sound.h"
 #include "global/vars.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "specific/s_audio.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <stdio.h>
 

--- a/src/game/objects/names.c
+++ b/src/game/objects/names.c
@@ -3,8 +3,9 @@
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
 #include "game/objects/common.h"
-#include "shared/memory.h"
 #include "strings.h"
+
+#include <libtrx/memory.h>
 
 #include <string.h>
 

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -12,7 +12,8 @@
 #include "game/text.h"
 #include "global/const.h"
 #include "global/vars.h"
-#include "shared/memory.h"
+
+#include <libtrx/memory.h>
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -14,10 +14,11 @@
 #include "math/math.h"
 #include "math/math_misc.h"
 #include "math/matrix.h"
-#include "shared/memory.h"
 #include "specific/s_output.h"
 #include "specific/s_shell.h"
 #include "util.h"
+
+#include <libtrx/memory.h>
 
 #include <stddef.h>
 

--- a/src/game/packer.c
+++ b/src/game/packer.c
@@ -3,9 +3,10 @@
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <stddef.h>
 

--- a/src/game/phase/phase.c
+++ b/src/game/phase/phase.c
@@ -13,7 +13,8 @@
 #include "game/phase/phase_stats.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/game/picture.c
+++ b/src/game/picture.c
@@ -1,8 +1,9 @@
 #include "game/picture.h"
 
-#include "shared/filesystem.h"
-#include "shared/memory.h"
 #include "specific/s_picture.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 

--- a/src/game/random.c
+++ b/src/game/random.c
@@ -1,7 +1,8 @@
 #include "game/random.h"
 
 #include "game/phase/phase.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 static int32_t m_RandControl = 0xD371F947;
 static int32_t m_RandDraw = 0xD371F947;

--- a/src/game/room_draw.c
+++ b/src/game/room_draw.c
@@ -10,7 +10,8 @@
 #include "global/types.h"
 #include "global/vars.h"
 #include "math/matrix.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <stdbool.h>
 

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -19,8 +19,9 @@
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/filesystem.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stdbool.h>

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -13,10 +13,11 @@
 #include "game/shell.h"
 #include "global/const.h"
 #include "global/vars.h"
-#include "shared/json.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/bson.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <inttypes.h>

--- a/src/game/savegame/savegame_bson.h
+++ b/src/game/savegame/savegame_bson.h
@@ -2,7 +2,8 @@
 
 #include "game/savegame.h"
 #include "global/types.h"
-#include "shared/filesystem.h"
+
+#include <libtrx/filesystem.h>
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -12,9 +12,10 @@
 #include "game/shell.h"
 #include "global/const.h"
 #include "global/vars.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "util.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/src/game/savegame/savegame_legacy.h
+++ b/src/game/savegame/savegame_legacy.h
@@ -2,7 +2,8 @@
 
 #include "game/savegame.h"
 #include "global/types.h"
-#include "shared/filesystem.h"
+
+#include <libtrx/filesystem.h>
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/game/shell.c
+++ b/src/game/shell.c
@@ -21,10 +21,11 @@
 #include "gfx/common.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "specific/s_shell.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <stdarg.h>
 #include <stdint.h>

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -7,7 +7,8 @@
 #include "global/const.h"
 #include "global/types.h"
 #include "global/vars.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/gfx/2d/2d_renderer.c
+++ b/src/gfx/2d/2d_renderer.c
@@ -2,7 +2,8 @@
 
 #include "gfx/gl/gl_core_3_3.h"
 #include "gfx/gl/utils.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <assert.h>
 

--- a/src/gfx/2d/2d_surface.c
+++ b/src/gfx/2d/2d_surface.c
@@ -2,8 +2,9 @@
 
 #include "gfx/blitter.h"
 #include "gfx/context.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <string.h>
 

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -3,7 +3,8 @@
 #include "config.h"
 #include "gfx/context.h"
 #include "gfx/gl/utils.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/gfx/3d/vertex_stream.c
+++ b/src/gfx/3d/vertex_stream.c
@@ -2,8 +2,9 @@
 
 #include "gfx/gl/gl_core_3_3.h"
 #include "gfx/gl/utils.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 static const GLenum GL_PRIM_MODES[] = {
     GL_LINES, // GFX_3D_PRIM_LINE

--- a/src/gfx/context.c
+++ b/src/gfx/context.c
@@ -4,8 +4,9 @@
 #include "gfx/gl/gl_core_3_3.h"
 #include "gfx/gl/utils.h"
 #include "gfx/screenshot.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <SDL2/SDL_video.h>
 #include <string.h>

--- a/src/gfx/fbo/fbo_renderer.c
+++ b/src/gfx/fbo/fbo_renderer.c
@@ -2,7 +2,8 @@
 
 #include "gfx/context.h"
 #include "gfx/gl/utils.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/gfx/gl/program.c
+++ b/src/gfx/gl/program.c
@@ -2,9 +2,10 @@
 
 #include "game/shell.h"
 #include "gfx/gl/utils.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/gfx/gl/texture.c
+++ b/src/gfx/gl/texture.c
@@ -1,7 +1,8 @@
 #include "gfx/gl/texture.h"
 
 #include "gfx/gl/utils.h"
-#include "shared/memory.h"
+
+#include <libtrx/memory.h>
 
 #include <assert.h>
 

--- a/src/gfx/gl/utils.h
+++ b/src/gfx/gl/utils.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "gfx/gl/gl_core_3_3.h"
-#include "shared/log.h"
+
+#include <libtrx/log.h>
 
 #define GFX_GL_CheckError()                                                    \
     {                                                                          \

--- a/src/gfx/screenshot.c
+++ b/src/gfx/screenshot.c
@@ -2,7 +2,8 @@
 
 #include "game/picture.h"
 #include "global/types.h"
-#include "shared/memory.h"
+
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <string.h>

--- a/src/shared
+++ b/src/shared
@@ -1,1 +1,0 @@
-../subprojects/libtrx/src/

--- a/src/specific/s_audio.c
+++ b/src/specific/s_audio.c
@@ -1,8 +1,8 @@
 #define S_AUDIO_IMPL
 #include "specific/s_audio.h"
 
-#include "shared/log.h"
-#include "shared/memory.h"
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_error.h>

--- a/src/specific/s_audio_sample.c
+++ b/src/specific/s_audio_sample.c
@@ -2,8 +2,9 @@
 #include "specific/s_audio.h"
 
 #include "game/shell.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <SDL2/SDL_audio.h>
 #include <errno.h>

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -1,9 +1,9 @@
 #define S_AUDIO_IMPL
 #include "specific/s_audio.h"
 
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <SDL2/SDL_audio.h>
 #include <SDL2/SDL_error.h>

--- a/src/specific/s_fmv.c
+++ b/src/specific/s_fmv.c
@@ -31,12 +31,13 @@
 #include "gfx/2d/2d_surface.h"
 #include "gfx/context.h"
 #include "global/types.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
 #include "specific/s_audio.h"
 #include "specific/s_output.h"
 #include "specific/s_shell.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_audio.h>

--- a/src/specific/s_input.c
+++ b/src/specific/s_input.c
@@ -1,6 +1,6 @@
 #include "specific/s_input.h"
 
-#include "shared/log.h"
+#include <libtrx/log.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_error.h>

--- a/src/specific/s_output.c
+++ b/src/specific/s_output.c
@@ -13,8 +13,9 @@
 #include "gfx/context.h"
 #include "gfx/fbo/fbo_renderer.h"
 #include "global/vars.h"
-#include "shared/log.h"
 #include "specific/s_shell.h"
+
+#include <libtrx/log.h>
 
 #include <assert.h>
 #include <stddef.h>

--- a/src/specific/s_picture.c
+++ b/src/specific/s_picture.c
@@ -1,9 +1,10 @@
 #include "specific/s_picture.h"
 
 #include "game/picture.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #include <assert.h>
 #include <errno.h>

--- a/src/specific/s_shell.c
+++ b/src/specific/s_shell.c
@@ -8,9 +8,10 @@
 #include "game/random.h"
 #include "game/shell.h"
 #include "game/sound.h"
-#include "shared/filesystem.h"
-#include "shared/log.h"
-#include "shared/memory.h"
+
+#include <libtrx/filesystem.h>
+#include <libtrx/log.h>
+#include <libtrx/memory.h>
 
 #define SDL_MAIN_HANDLED
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1,6 +1,6 @@
 #include "strings.h"
 
-#include "shared/log.h"
+#include <libtrx/log.h>
 
 #include <ctype.h>
 #include <pcre2.h>

--- a/tools/sort_imports
+++ b/tools/sort_imports
@@ -64,17 +64,20 @@ def sort_imports(path: Path) -> None:
     def cb(match):
         includes = re.findall(r'#include (["<][^"<>]+[">])', match.group(0))
         groups = {
-            "own": set(),
-            "proj": set(),
-            "lib": set(),
+            "self": set(),
+            "local": set(),
+            "shared": set(),
+            "external": set(),
         }
         for include in includes:
             if include.strip('"') == own_include:
-                groups["own"].add(include)
+                groups["self"].add(include)
+            elif include.startswith("<libtrx"):
+                groups["shared"].add(include)
             elif include.startswith("<"):
-                groups["lib"].add(include)
-            else:
-                groups["proj"].add(include)
+                groups["external"].add(include)
+            elif include.startswith('"'):
+                groups["local"].add(include)
 
         groups = {key: value for key, value in groups.items() if value}
 


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Removes the need for `src/shared` symlink which not only is confusing but also most likely prevents the project from working on Windows. Changes the `#include` macros to have more idiomatic appearance, too.

Related: https://github.com/LostArtefacts/libtrx/pull/2
