### PR TITLE
overlay: fix FPS counter overlapping the healthbar in demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - `/heal`
 - fixed config tool and installer missing icons (#1358, regression from 4.0)
 - fixed looking forward too far causing an upside down camera frame (#1338)
+- fixed the FPS counter overlapping the healthbar in demo mode (#1369)
 
 ## [4.1.2](https://github.com/LostArtefacts/TR1X/compare/4.1.1...4.1.2) - 2024-04-28
 - fixed pictures display time (#1349, regression from 4.1)

--- a/src/game/overlay.c
+++ b/src/game/overlay.c
@@ -749,7 +749,8 @@ void Overlay_DrawFPSInfo(void)
         bool inv_health_showable = Phase_Get() == PHASE_INVENTORY
             && g_GameInfo.inv_showing_medpack
             && m_HealthBar.location == BL_TOP_LEFT;
-        bool game_bar_showable = Phase_Get() == PHASE_GAME
+        bool game_bar_showable =
+            (Phase_Get() == PHASE_GAME || Phase_Get() == PHASE_DEMO)
             && (m_HealthBar.location == BL_TOP_LEFT
                 || m_AirBar.location == BL_TOP_LEFT
                 || m_EnemyBar.location == BL_TOP_LEFT);


### PR DESCRIPTION
Resolves #1369.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the FPS counter overlapping the healthbar in demo mode if the bar location is top left.