### PR TITLE
gameflow: add unobtainable secrets property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - `/hp`
     - `/hp [num]`
     - `/heal`
+- added unobtainable secrets stat support in the gameflow (#1379)
 - fixed config tool and installer missing icons (#1358, regression from 4.0)
 - fixed looking forward too far causing an upside down camera frame (#1338)
 - fixed the enemy bear behavior in demo mode (#1370, regression since 2.16)

--- a/GAMEFLOW.md
+++ b/GAMEFLOW.md
@@ -540,6 +540,16 @@ Following are each of the properties available within a level.
   </tr>
   <tr valign="top">
     <td>
+      <code>unobtainable_secrets</code>
+    </td>
+    <td>Integer</td>
+    <td>No</td>
+    <td colspan="2">
+      A count of secrets that will be excluded from secret statistics. Useful for level demos.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td>
       <code>water_color</code>
     </td>
     <td>Float array</td>

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added optional final statistics screen
 - added optional deaths counter
 - added optional total pickups and kills per level
-- added unobtainable pickups and kills stats support in the gameflow
+- added unobtainable pickups, kills, and secrets stats support in the gameflow
 
 #### Visuals
 - added optional shotgun flash sprites

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -668,6 +668,9 @@ static bool GameFlow_LoadScriptLevels(struct json_object_s *obj)
         cur->unobtainable.kills =
             json_object_get_int(jlvl_obj, "unobtainable_kills", 0);
 
+        cur->unobtainable.secrets =
+            json_object_get_int(jlvl_obj, "unobtainable_secrets", 0);
+
         struct json_object_s *jlbl_strings_obj =
             json_object_get_object(jlvl_obj, "strings");
         if (!jlbl_strings_obj) {

--- a/src/game/gameflow.h
+++ b/src/game/gameflow.h
@@ -48,6 +48,7 @@ typedef struct GAMEFLOW_LEVEL {
     struct {
         uint32_t pickups;
         uint32_t kills;
+        uint32_t secrets;
     } unobtainable;
     struct {
         int length;

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -258,6 +258,7 @@ void Stats_CalculateStats(void)
 
     m_LevelPickups -= g_GameFlow.levels[g_CurrentLevel].unobtainable.pickups;
     m_LevelKillables -= g_GameFlow.levels[g_CurrentLevel].unobtainable.kills;
+    m_LevelSecrets -= g_GameFlow.levels[g_CurrentLevel].unobtainable.secrets;
 }
 
 int32_t Stats_GetPickups(void)

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/en.json
@@ -239,7 +239,7 @@
     },
     "enable_detailed_stats": {
       "Title": "Show total kills and pickups",
-      "Description": "Enables showing the maximum pickup count and kill count on each level. This includes unobtainable items."
+      "Description": "Enables showing the maximum pickup count and kill count on each level."
     },
     "enable_cine": {
       "Title": "Enable cutscenes",


### PR DESCRIPTION
Resolves #1379.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added unobtainable secrets stat support in the gameflow. Useful for demo level support where a full level is provided, but it has an early level end trigger.
