### PR TITLE
output: fix rendering lightnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed the enemy bear behavior in demo mode (#1370, regression since 2.16)
 - fixed the FPS counter overlapping the healthbar in demo mode (#1369)
 - fixed the Scion being extremely difficult to shoot with the shotgun (#1381)
+- fixed lightning rendering z-buffer issues (#1385, regression from 1.4)
 
 ## [4.1.2](https://github.com/LostArtefacts/TR1X/compare/4.1.1...4.1.2) - 2024-04-28
 - fixed pictures display time (#1349, regression from 4.1)

--- a/src/game/game/game_draw.c
+++ b/src/game/game/game_draw.c
@@ -42,5 +42,6 @@ void Game_DrawScene(bool draw_overlay)
         Lara_Hair_Draw();
     }
 
+    Output_FlushTranslucentObjects();
     Output_DrawBackdropScreen();
 }

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -54,6 +54,7 @@ void Output_DrawShadow(
 void Output_DrawLightningSegment(
     int32_t x1, int32_t y1, int32_t z1, int32_t x2, int32_t y2, int32_t z2,
     int32_t width);
+void Output_FlushTranslucentObjects(void);
 
 void Output_DrawScreenFlatQuad(
     int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA_8888 color);


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes #1385. Restores the ATI3DCIF-era hardcoded hack of putting the lightnings last in the rendering pipeline. In the future, we will most likely need to introduce polygon sorting.

