### PR TITLE
output: read vertex buffer size from level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed lightning rendering z-buffer issues (#1385, regression from 1.4)
 - fixed possible game crashes if more than 16 savegame slots are set (#1374)
 - fixed savegame slots higher than 64 not working (#1395)
+- fixed a crash in custom levels if a room had more than 1500 vertices (#1398)
 
 ## [4.1.2](https://github.com/LostArtefacts/TR1X/compare/4.1.1...4.1.2) - 2024-04-28
 - fixed pictures display time (#1349, regression from 4.1)

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - expanded moveable limit from 256 to 10240
 - expanded maximum textures from 2048 to 8192
 - expanded maximum texture pages from 32 to 128
+- expanded maximum vertices of a single drawable object from 1500 to unlimited
 - expanded the number of visible enemies from 8 to 32
 - ported audio decoding library to ffmpeg
 - ported video decoding library to ffmpeg

--- a/src/game/gamebuf.c
+++ b/src/game/gamebuf.c
@@ -50,6 +50,7 @@ static const char *GameBuf_GetBufferName(GAME_BUFFER buffer)
         case GBUF_SAMPLES:                  return "Samples";
         case GBUF_TRAP_DATA:                return "Trap data";
         case GBUF_CREATURE_DATA:            return "Creature data";
+        case GBUF_VERTEX_BUFFER:            return "Vertex buffer";
     }
     // clang-format on
     return "Unknown";

--- a/src/game/gamebuf.h
+++ b/src/game/gamebuf.h
@@ -44,6 +44,7 @@ typedef enum GAME_BUFFER {
     GBUF_SAMPLES,
     GBUF_TRAP_DATA,
     GBUF_CREATURE_DATA,
+    GBUF_VERTEX_BUFFER,
 } GAME_BUFFER;
 
 void GameBuf_Init(void);

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -891,7 +891,7 @@ static void Level_CompleteSetup(int32_t level_num)
     // Configure enemies who carry and drop items
     Carrier_InitialiseLevel(level_num);
 
-    size_t max_vertices = Level_CalculateMaxVertices();
+    const size_t max_vertices = Level_CalculateMaxVertices();
     LOG_INFO("Maximum vertices: %d", max_vertices);
     Output_ReserveVertexBuffer(max_vertices);
 

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -54,7 +54,7 @@ static bool Level_LoadTexturePages(MYFILE *fp);
 static bool Level_LoadFromFile(
     const char *filename, int32_t level_num, bool is_demo);
 static void Level_CompleteSetup(int32_t level_num);
-static void Level_CalculateMaxVertices(void);
+static size_t Level_CalculateMaxVertices(void);
 
 static bool Level_LoadFromFile(
     const char *filename, int32_t level_num, bool is_demo)
@@ -891,7 +891,9 @@ static void Level_CompleteSetup(int32_t level_num)
     // Configure enemies who carry and drop items
     Carrier_InitialiseLevel(level_num);
 
-    Level_CalculateMaxVertices();
+    size_t max_vertices = Level_CalculateMaxVertices();
+    LOG_INFO("Maximum vertices: %d", max_vertices);
+    Output_ReserveVertexBuffer(max_vertices);
 
     // Move the prepared texture pages into g_TexturePagePtrs.
     uint8_t *base = GameBuf_Alloc(
@@ -928,7 +930,7 @@ static void Level_CompleteSetup(int32_t level_num)
     Memory_FreePointer(&sample_sizes);
 }
 
-static void Level_CalculateMaxVertices(void)
+static size_t Level_CalculateMaxVertices(void)
 {
     size_t max_vertices = 0;
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
@@ -957,8 +959,7 @@ static void Level_CalculateMaxVertices(void)
         max_vertices = MAX(max_vertices, *g_RoomInfo[i].data);
     }
 
-    LOG_INFO("Maximum vertices: %d", max_vertices);
-    Output_ReserveVertexBuffer(max_vertices);
+    return max_vertices;
 }
 
 bool Level_Load(int level_num)

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -932,7 +932,7 @@ static void Level_CalculateMaxVertices(void)
 {
     size_t max_vertices = 0;
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
-        OBJECT_INFO *object_info = &g_Objects[i];
+        const OBJECT_INFO *object_info = &g_Objects[i];
         if (!object_info->loaded) {
             continue;
         }
@@ -944,7 +944,7 @@ static void Level_CalculateMaxVertices(void)
     }
 
     for (int32_t i = 0; i < STATIC_NUMBER_OF; i++) {
-        STATIC_INFO *static_info = &g_StaticObjects[i];
+        const STATIC_INFO *static_info = &g_StaticObjects[i];
         if (!static_info->loaded || static_info->nmeshes < 0) {
             continue;
         }

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "game/clock.h"
 #include "game/console.h"
+#include "game/gamebuf.h"
 #include "game/overlay.h"
 #include "game/phase/phase.h"
 #include "game/picture.h"
@@ -48,7 +49,7 @@ static int32_t m_WibbleTable[WIBBLE_SIZE] = { 0 };
 static int32_t m_ShadeTable[WIBBLE_SIZE] = { 0 };
 static int32_t m_RandTable[WIBBLE_SIZE] = { 0 };
 
-static PHD_VBUF m_VBuf[1500] = { 0 };
+static PHD_VBUF *m_VBuf = NULL;
 static int32_t m_DrawDistFade = 0;
 static int32_t m_DrawDistMax = 0;
 static RGB_F m_WaterColor = { 0 };
@@ -76,6 +77,11 @@ static const int16_t *Output_CalcVerticeLight(const int16_t *obj_ptr);
 static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr);
 static int32_t Output_CalcFogShade(int32_t depth);
 static void Output_CalcWibbleTable(void);
+
+void Output_ReserveVertexBuffer(const size_t size)
+{
+    m_VBuf = GameBuf_Alloc(size * sizeof(PHD_VBUF), GBUF_VERTEX_BUFFER);
+}
 
 static const int16_t *Output_DrawObjectG3(
     const int16_t *obj_ptr, int32_t number)

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -78,11 +78,6 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr);
 static int32_t Output_CalcFogShade(int32_t depth);
 static void Output_CalcWibbleTable(void);
 
-void Output_ReserveVertexBuffer(size_t size)
-{
-    m_VBuf = GameBuf_Alloc(size * sizeof(PHD_VBUF), GBUF_VERTEX_BUFFER);
-}
-
 static const int16_t *Output_DrawObjectG3(
     const int16_t *obj_ptr, int32_t number)
 {
@@ -406,6 +401,11 @@ void Output_Shutdown(void)
 {
     S_Output_Shutdown();
     Memory_FreePointer(&m_BackdropImagePath);
+}
+
+void Output_ReserveVertexBuffer(const size_t size)
+{
+    m_VBuf = GameBuf_Alloc(size * sizeof(PHD_VBUF), GBUF_VERTEX_BUFFER);
 }
 
 void Output_SetWindowSize(int width, int height)

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -78,7 +78,7 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr);
 static int32_t Output_CalcFogShade(int32_t depth);
 static void Output_CalcWibbleTable(void);
 
-void Output_ReserveVertexBuffer(const size_t size)
+void Output_ReserveVertexBuffer(size_t size)
 {
     m_VBuf = GameBuf_Alloc(size * sizeof(PHD_VBUF), GBUF_VERTEX_BUFFER);
 }

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -15,6 +15,7 @@ void Output_DownloadTextures(int page_count);
 RGBA_8888 Output_RGB2RGBA(const RGB_888 color);
 void Output_SetPalette(RGB_888 palette[256]);
 RGB_888 Output_GetPaletteColor(uint8_t idx);
+void Output_ReserveVertexBuffer(const size_t size);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -7,6 +7,7 @@
 
 bool Output_Init(void);
 void Output_Shutdown(void);
+void Output_ReserveVertexBuffer(size_t size);
 
 void Output_SetWindowSize(int width, int height);
 void Output_ApplyRenderSettings(void);
@@ -15,7 +16,6 @@ void Output_DownloadTextures(int page_count);
 RGBA_8888 Output_RGB2RGBA(const RGB_888 color);
 void Output_SetPalette(RGB_888 palette[256]);
 RGB_888 Output_GetPaletteColor(uint8_t idx);
-void Output_ReserveVertexBuffer(size_t size);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);

--- a/src/game/output.h
+++ b/src/game/output.h
@@ -15,7 +15,7 @@ void Output_DownloadTextures(int page_count);
 RGBA_8888 Output_RGB2RGBA(const RGB_888 color);
 void Output_SetPalette(RGB_888 palette[256]);
 RGB_888 Output_GetPaletteColor(uint8_t idx);
-void Output_ReserveVertexBuffer(const size_t size);
+void Output_ReserveVertexBuffer(size_t size);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);


### PR DESCRIPTION
Resolves #1398.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This replaces the fixed vertex buffer size of `1500` with a maximum value read from the level - so the "biggest" room, object or static mesh will determine the array size. In most cases it will be the biggest room, but this covers all bases. An alternative to doing the object/static check would be setting an initial value of `1500` and just iterating over the room meshes, so let me know if that's preferable.
