### PR TITLE
installer: use existing installation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added unobtainable secrets stat support in the gameflow (#1379)
 - added a wireframe mode
 - changed console caret blinking rate (#1377)
+- changed the TR1X install source in the installer to suggest using the existing installation directory (#1350)
 - fixed config tool and installer missing icons (#1358, regression from 4.0)
 - fixed looking forward too far causing an upside down camera frame (#1338)
 - fixed the enemy bear behavior in demo mode (#1370, regression since 2.16)

--- a/tools/installer/Installer/Installers/BaseInstallSource.cs
+++ b/tools/installer/Installer/Installers/BaseInstallSource.cs
@@ -20,7 +20,7 @@ public abstract class BaseInstallSource : IInstallSource
     public abstract bool IsImportingSavesSupported { get; }
     public abstract string SourceName { get; }
 
-    public string SuggestedInstallationDirectory
+    public virtual string SuggestedInstallationDirectory
     {
         get
         {

--- a/tools/installer/Installer/Installers/InstallExecutor.cs
+++ b/tools/installer/Installer/Installers/InstallExecutor.cs
@@ -1,5 +1,4 @@
 using Installer.Models;
-using Microsoft.Win32;
 using System;
 using System.IO;
 using System.Linq;
@@ -66,8 +65,7 @@ public class InstallExecutor
 
     protected static async Task CopyTR1XFiles(string targetDirectory, IProgress<InstallProgress> progress)
     {
-        using var key = Registry.CurrentUser.CreateSubKey(@"Software\Tomb1Main");
-        key?.SetValue("InstallPath", targetDirectory);
+        InstallUtils.StoreInstallationPath(targetDirectory);
 
         progress.Report(new InstallProgress
         {

--- a/tools/installer/Installer/Installers/TR1XInstallSource.cs
+++ b/tools/installer/Installer/Installers/TR1XInstallSource.cs
@@ -13,20 +13,24 @@ public class TR1XInstallSource : BaseInstallSource
     {
         get
         {
-            using var key = Registry.CurrentUser.OpenSubKey(@"Software\Tomb1Main");
-            if (key is not null)
+            var previousPath = GetPreviousInstallationPath();
+            if (previousPath is not null)
             {
-                var value = key.GetValue("InstallPath")?.ToString();
-                if (value is not null)
-                {
-                    yield return value;
-                }
+                yield return previousPath;
             }
 
             foreach (var path in InstallUtils.GetDesktopShortcutDirectories())
             {
                 yield return path;
             }
+        }
+    }
+
+    public override string SuggestedInstallationDirectory
+    {
+        get
+        {
+            return GetPreviousInstallationPath() ?? base.SuggestedInstallationDirectory;
         }
     }
 
@@ -62,5 +66,11 @@ public class TR1XInstallSource : BaseInstallSource
     public override bool IsGameFound(string sourceDirectory)
     {
         return File.Exists(Path.Combine(sourceDirectory, "TR1X.exe")) || File.Exists(Path.Combine(sourceDirectory, "Tomb1Main.exe"));
+    }
+
+    private static string? GetPreviousInstallationPath()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(@"Software\Tomb1Main");
+        return key?.GetValue("InstallPath")?.ToString();
     }
 }

--- a/tools/installer/Installer/Installers/TR1XInstallSource.cs
+++ b/tools/installer/Installer/Installers/TR1XInstallSource.cs
@@ -1,4 +1,3 @@
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,7 +12,7 @@ public class TR1XInstallSource : BaseInstallSource
     {
         get
         {
-            var previousPath = GetPreviousInstallationPath();
+            var previousPath = InstallUtils.GetPreviousInstallationPath();
             if (previousPath is not null)
             {
                 yield return previousPath;
@@ -30,7 +29,7 @@ public class TR1XInstallSource : BaseInstallSource
     {
         get
         {
-            return GetPreviousInstallationPath() ?? base.SuggestedInstallationDirectory;
+            return InstallUtils.GetPreviousInstallationPath() ?? base.SuggestedInstallationDirectory;
         }
     }
 
@@ -66,11 +65,5 @@ public class TR1XInstallSource : BaseInstallSource
     public override bool IsGameFound(string sourceDirectory)
     {
         return File.Exists(Path.Combine(sourceDirectory, "TR1X.exe")) || File.Exists(Path.Combine(sourceDirectory, "Tomb1Main.exe"));
-    }
-
-    private static string? GetPreviousInstallationPath()
-    {
-        using var key = Registry.CurrentUser.OpenSubKey(@"Software\Tomb1Main");
-        return key?.GetValue("InstallPath")?.ToString();
     }
 }


### PR DESCRIPTION
Resolves #1350.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The existing installation path - if it exists - will be suggested when performing an upgrade by selecting the TR1X install source.

Should we just leave the reg key as `Tomb1Main`? It's out of sight as opposed to a folder name, so adding extra code for backwards compatibility seems like unnecessary overhead imo.
