### PR TITLE
lava: add deadly water feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
+- added deadly water feature from TR2+ for custom levels (#1404)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added save game crystals game mode (enabled via gameflow)
 - added per-level customizable water color (with customizable blue component)
 - added per-level customizable fog distance
+- added deadly water feature from TR2+
 
 #### Miscellaneous
 - added Linux builds

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -16,15 +16,13 @@
 
 bool Lava_TestFloor(ITEM_INFO *item)
 {
+    if (item->hit_points < 0 || g_Lara.water_status == LWS_CHEAT
+        || (g_Lara.water_status == LWS_ABOVE_WATER
+            && item->pos.y != item->floor)) {
+        return false;
+    }
+
     // OG fix: check if floor index has lava
-    if (g_Lara.water_status == LWS_CHEAT) {
-        return false;
-    }
-
-    if (item->hit_points < 0) {
-        return false;
-    }
-
     int16_t room_num = item->room_number;
     FLOOR_INFO *floor =
         Room_GetFloor(item->pos.x, 32000, item->pos.z, &room_num);
@@ -81,6 +79,10 @@ void Lava_Burn(ITEM_INFO *item)
 
     item->hit_points = -1;
     item->hit_status = 1;
+    if (g_Lara.water_status != LWS_ABOVE_WATER) {
+        return;
+    }
+
     for (int i = 0; i < 10; i++) {
         int16_t fx_num = Effect_Create(item->room_number);
         if (fx_num != NO_ITEM) {

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -712,10 +712,8 @@ void Room_TestTriggers(int16_t *data, bool heavy)
     }
 
     if ((*data & DATA_TYPE) == FT_LAVA) {
-        if (!heavy && g_LaraItem->pos.y == g_LaraItem->floor) {
-            if (Lava_TestFloor(g_LaraItem)) {
-                Lava_Burn(g_LaraItem);
-            }
+        if (!heavy && Lava_TestFloor(g_LaraItem)) {
+            Lava_Burn(g_LaraItem);
         }
 
         if (*data & END_BIT) {


### PR DESCRIPTION
Resolves #1404.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows death tiles in water rooms to be acknowledged, similar to TR2+. There is nowhere in the original levels where this will have an impact, and I did consider adding a gameflow option for custom levels but decided against that. The only scenario I could think of would be an unflipped room with water where the builder would want Lara to be safe, but then the flipped/drained room would have death tiles; altogether, in that case the death tiles need only be defined in the flipped room.

One difference with TR2+ is that we exit early from `Lava_Burn` if Lara is underwater, which avoids flames appearing for a couple of frames as Lara enters the water, which IMO looks odd.

Test level attached for reference.

[LEVEL1.zip](https://github.com/user-attachments/files/16247096/LEVEL1.zip)
