### PR TITLE
midas_touch: prevent item duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - added deadly water feature from TR2+ for custom levels (#1404)
+- fixed adjacent Midas Touch objects potentially allowing gold bar duplication in custom levels (#1415)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/src/game/objects/traps/midas_touch.c
+++ b/src/game/objects/traps/midas_touch.c
@@ -62,11 +62,12 @@ void MidasTouch_Collision(
         break;
     }
 
-    if (lara_item->current_anim_state == LS_USE_MIDAS) {
-        if (Item_TestFrameEqual(lara_item, LF_PICKUP_GOLD_BAR)) {
-            Overlay_AddPickup(O_PUZZLE_ITEM1);
-            Inv_AddItem(O_PUZZLE_ITEM1);
-        }
+    if (lara_item->current_anim_state == LS_USE_MIDAS
+        && g_Lara.interact_target.item_num == item_num
+        && Item_TestFrameEqual(lara_item, LF_PICKUP_GOLD_BAR)) {
+        Overlay_AddPickup(O_PUZZLE_ITEM1);
+        Inv_AddItem(O_PUZZLE_ITEM1);
+        g_Lara.interact_target.item_num = NO_OBJECT;
     }
 
     if (!lara_item->gravity_status && lara_item->current_anim_state == LS_STOP
@@ -100,7 +101,6 @@ void MidasTouch_Collision(
         Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_PLACE_BAR, 0, O_LARA_EXTRA);
         g_Lara.gun_status = LGS_HANDS_BUSY;
         g_Lara.interact_target.is_moving = false;
-        g_Lara.interact_target.item_num = NO_OBJECT;
     }
 
     if (!g_Input.action || g_Lara.gun_status != LGS_ARMLESS


### PR DESCRIPTION
Resolves #1415.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This retains the Midas Touch item number that Lara is interacting with until the puzzle item is added to inventory, so to avoid adjacent objects triggering the pickup together.

Tested on the affected TRLE and in Midas itself.
