### PR TITLE
stats: fix ingame timer not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - added deadly water feature from TR2+ for custom levels (#1404)
 - added skybox support, with a default option provided for Lost Valley, Colosseum and Obelisk of Khamoon (#94)
+- changed the turbo cheat to no longer affect the gameplay time (#1420)
 - fixed adjacent Midas Touch objects potentially allowing gold bar duplication in custom levels (#1415)
 - fixed the excessive pitch and playback speed correction for music files with sampling rate other than 44100 Hz (#1417, regression from 2.0)
+- fixed the ingame timer being skewed upon inventory open (#1420, regression from 4.1)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/src/game/phase/phase_demo.c
+++ b/src/game/phase/phase_demo.c
@@ -249,7 +249,6 @@ static GAMEFLOW_COMMAND Phase_Demo_Run(int32_t nframes)
         Sound_ResetAmbient();
         Effect_RunActiveFlipEffect();
         Sound_UpdateEffects();
-        g_GameInfo.current[g_CurrentLevel].stats.timer++;
         Overlay_BarHealthTimerTick();
 
         // Discard demo input; check for debounced real keypresses

--- a/src/game/phase/phase_game.c
+++ b/src/game/phase/phase_game.c
@@ -14,6 +14,7 @@
 #include "game/overlay.h"
 #include "game/shell.h"
 #include "game/sound.h"
+#include "game/stats.h"
 #include "game/text.h"
 #include "global/const.h"
 #include "global/types.h"
@@ -33,6 +34,7 @@ static void Phase_Game_Draw(void);
 static void Phase_Game_Start(void *arg)
 {
     Interpolation_Remember();
+    Stats_StartTimer();
     if (Phase_Get() != PHASE_PAUSE) {
         Output_FadeReset();
     }
@@ -45,6 +47,7 @@ static void Phase_Game_End(void)
 static GAMEFLOW_COMMAND Phase_Game_Control(int32_t nframes)
 {
     Interpolation_Remember();
+    Stats_UpdateTimer();
     CLAMPG(nframes, MAX_FRAMES);
 
     for (int32_t i = 0; i < nframes; i++) {
@@ -123,7 +126,6 @@ static GAMEFLOW_COMMAND Phase_Game_Control(int32_t nframes)
             Sound_ResetAmbient();
             Effect_RunActiveFlipEffect();
             Sound_UpdateEffects();
-            g_GameInfo.current[g_CurrentLevel].stats.timer++;
             Overlay_BarHealthTimerTick();
         }
     }

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -1,6 +1,7 @@
 #include "game/stats.h"
 
 #include "game/carrier.h"
+#include "game/clock.h"
 #include "game/gamebuf.h"
 #include "game/gameflow.h"
 #include "game/items.h"
@@ -24,6 +25,11 @@ static int32_t m_LevelSecrets = 0;
 static uint32_t m_SecretRoom = 0;
 static bool m_KillableItems[MAX_ITEMS] = { 0 };
 static bool m_IfKillable[O_NUMBER_OF] = { 0 };
+
+static struct {
+    double start_counter;
+    int32_t start_timer;
+} m_StatsTimer = { 0 };
 
 int16_t m_PickupObjs[] = { O_PICKUP_ITEM1,   O_PICKUP_ITEM2,  O_KEY_ITEM1,
                            O_KEY_ITEM2,      O_KEY_ITEM3,     O_KEY_ITEM4,
@@ -282,3 +288,20 @@ bool Stats_CheckAllSecretsCollected(GAMEFLOW_LEVEL_TYPE level_type)
     Stats_ComputeTotal(level_type, &total_stats);
     return total_stats.player_secret_count >= total_stats.total_secret_count;
 }
+
+void Stats_StartTimer(void)
+{
+    m_StatsTimer.start_counter = Clock_GetHighPrecisionCounter();
+    m_StatsTimer.start_timer = g_GameInfo.current[g_CurrentLevel].stats.timer;
+}
+
+void Stats_UpdateTimer(void)
+{
+    const double elapsed =
+        (Clock_GetHighPrecisionCounter() - m_StatsTimer.start_counter)
+        * LOGIC_FPS / 1000.0;
+    g_GameInfo.current[g_CurrentLevel].stats.timer =
+        m_StatsTimer.start_timer + elapsed;
+}
+
+void Stats_StopTimer(void);

--- a/src/game/stats.h
+++ b/src/game/stats.h
@@ -24,3 +24,7 @@ int32_t Stats_GetKillables(void);
 int32_t Stats_GetSecrets(void);
 void Stats_ComputeTotal(GAMEFLOW_LEVEL_TYPE level_type, TOTAL_STATS *stats);
 bool Stats_CheckAllSecretsCollected(GAMEFLOW_LEVEL_TYPE level_type);
+
+void Stats_StartTimer(void);
+void Stats_UpdateTimer(void);
+void Stats_StopTimer(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The timer would become inaccurate when opening the inventory due to the internal stats timer not being reset on launch. As a result, the previous value was meaningless, leading to incorrect elapsed time calculations on the opening frame.

Also, refactored for simpler usage.