### PR TITLE
door: fix checking for Lara position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed adjacent Midas Touch objects potentially allowing gold bar duplication in custom levels (#1415)
 - fixed the excessive pitch and playback speed correction for music files with sampling rate other than 44100 Hz (#1417, regression from 2.0)
 - fixed the ingame timer being skewed upon inventory open (#1420, regression from 4.1)
+- fixed Lara able to reach triggers through closed doors (#1419, regression since 1.1.4)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed the excessive pitch and playback speed correction for music files with sampling rate other than 44100 Hz (#1417, regression from 2.0)
 - fixed the ingame timer being skewed upon inventory open (#1420, regression from 4.1)
 - fixed Lara able to reach triggers through closed doors (#1419, regression since 1.1.4)
+- fixed Lara voiding when loading the game on a closed door (#1419)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -15,30 +15,31 @@
 #include <stddef.h>
 
 static void Door_Open(DOORPOS_DATA *d);
-static void Door_Shut(DOORPOS_DATA *d, ITEM_INFO *item);
-static bool Door_LaraDoorCollision(ITEM_INFO *item);
+static void Door_Shut(DOORPOS_DATA *d, const ITEM_INFO *door);
+static bool Door_LaraDoorCollision(
+    const ITEM_INFO *door, const FLOOR_INFO *const floor);
 
-static bool Door_LaraDoorCollision(ITEM_INFO *item)
+static bool Door_LaraDoorCollision(
+    const ITEM_INFO *const door, const FLOOR_INFO *const floor)
 {
-    if (!g_LaraItem) {
+    if (g_LaraItem == NULL) {
         return false;
     }
-    int32_t max_dist = SQUARE((WALL_L * 2) >> 8);
-    int32_t dx = ABS(item->pos.x - g_LaraItem->pos.x) >> 8;
-    int32_t dy = ABS(item->pos.y - g_LaraItem->pos.y) >> 8;
-    int32_t dz = ABS(item->pos.z - g_LaraItem->pos.z) >> 8;
-    int32_t dist = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    return dist < max_dist;
+
+    int16_t room_num = g_LaraItem->room_number;
+    const FLOOR_INFO *const lara_floor = Room_GetFloor(
+        g_LaraItem->pos.x, g_LaraItem->pos.y, g_LaraItem->pos.z, &room_num);
+    return lara_floor == floor;
 }
 
-static void Door_Shut(DOORPOS_DATA *d, ITEM_INFO *item)
+static void Door_Shut(DOORPOS_DATA *const d, const ITEM_INFO *const door)
 {
     FLOOR_INFO *floor = d->floor;
     if (!floor) {
         return;
     }
 
-    if (item && Door_LaraDoorCollision(item)) {
+    if (door && Door_LaraDoorCollision(door, floor)) {
         return;
     }
 

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -16,11 +16,9 @@
 
 static void Door_Open(DOORPOS_DATA *d);
 static void Door_Shut(DOORPOS_DATA *d, const ITEM_INFO *door);
-static bool Door_LaraDoorCollision(
-    const ITEM_INFO *door, const FLOOR_INFO *const floor);
+static bool Door_LaraDoorCollision(const FLOOR_INFO *const floor);
 
-static bool Door_LaraDoorCollision(
-    const ITEM_INFO *const door, const FLOOR_INFO *const floor)
+static bool Door_LaraDoorCollision(const FLOOR_INFO *const floor)
 {
     if (g_LaraItem == NULL) {
         return false;
@@ -34,38 +32,38 @@ static bool Door_LaraDoorCollision(
 
 static void Door_Shut(DOORPOS_DATA *const d, const ITEM_INFO *const door)
 {
-    FLOOR_INFO *floor = d->floor;
+    FLOOR_INFO *const floor = d->floor;
     if (!floor) {
         return;
     }
 
-    if (door && Door_LaraDoorCollision(door, floor)) {
+    if (door && Door_LaraDoorCollision(floor)) {
         return;
     }
 
     floor->index = 0;
     floor->box = NO_BOX;
-    floor->floor = NO_HEIGHT / 256;
-    floor->ceiling = NO_HEIGHT / 256;
+    floor->floor = NO_HEIGHT / STEP_L;
+    floor->ceiling = NO_HEIGHT / STEP_L;
     floor->sky_room = NO_ROOM;
     floor->pit_room = NO_ROOM;
 
-    int16_t box_num = d->block;
+    const int16_t box_num = d->block;
     if (box_num != NO_BOX) {
         g_Boxes[box_num].overlap_index |= BLOCKED;
     }
 }
 
-static void Door_Open(DOORPOS_DATA *d)
+static void Door_Open(DOORPOS_DATA *const d)
 {
-    FLOOR_INFO *floor = d->floor;
+    FLOOR_INFO *const floor = d->floor;
     if (!floor) {
         return;
     }
 
     *floor = d->old_floor;
 
-    int16_t box_num = d->block;
+    const int16_t box_num = d->block;
     if (box_num != NO_BOX) {
         g_Boxes[box_num].overlap_index &= ~BLOCKED;
     }


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1419.

Removes the proximity test and instead checks if Lara is on the same tile where the ghost block will spawn.