### PR TITLE
room: fix tilt being disabled when not on a walkable

### DIFF
--- a/src/game/room.c
+++ b/src/game/room.c
@@ -994,6 +994,7 @@ bool Room_IsOnWalkable(
     }
 
     int16_t height = sector->floor << 8;
+    bool object_found = false;
 
     int16_t *floor_data = &g_FloorData[sector->index];
     int16_t type;
@@ -1027,6 +1028,7 @@ bool Room_IsOnWalkable(
                     OBJECT_INFO *object = &g_Objects[item->object_number];
                     if (object->floor) {
                         object->floor(item, x, y, z, &height);
+                        object_found = true;
                     }
                 } else if (TRIG_BITS(trigger) == TO_CAMERA) {
                     trigger = *floor_data++;
@@ -1036,9 +1038,7 @@ bool Room_IsOnWalkable(
         }
     } while (!(type & END_BIT));
 
-    if (room_height == height) {
-        return true;
-    }
+    return object_found && room_height == height;
 
     return false;
 }


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix tilt being disabled when not on a walkable. There is a chance that Lara is exactly at the edge of a tile, so height == room_height and so the function returns true regardless of whether or not it found a suitable trigger for a bridge, trapdoor etc.

No changelog because the bug was never released. Fix courtesy of @lahm86 thanks!