### PR TITLE
types: refactor sector floor and ceiling properties

### DIFF
--- a/src/game/carrier.c
+++ b/src/game/carrier.c
@@ -261,7 +261,7 @@ static void Carrier_AnimateDrop(CARRIED_ITEM *item)
         pickup->rot.y += in_water ? DROP_SLOW_TURN : DROP_FAST_TURN;
 
         if (sector->pit_room != NO_ROOM
-            && pickup->pos.y > (sector->floor.height << 8)) {
+            && pickup->pos.y > sector->floor.height) {
             room_num = sector->pit_room;
         }
     }

--- a/src/game/carrier.c
+++ b/src/game/carrier.c
@@ -261,7 +261,7 @@ static void Carrier_AnimateDrop(CARRIED_ITEM *item)
         pickup->rot.y += in_water ? DROP_SLOW_TURN : DROP_FAST_TURN;
 
         if (sector->pit_room != NO_ROOM
-            && pickup->pos.y > (sector->floor << 8)) {
+            && pickup->pos.y > (sector->floor.height << 8)) {
             room_num = sector->pit_room;
         }
     }

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1370,15 +1370,15 @@ static void Inject_RoomShift(INJECTION *injection, int16_t room_num)
 
     // Update the sector floor and ceiling clicks to match.
     const int8_t click_shift = y_shift / STEP_L;
-    const int8_t wall_height = NO_HEIGHT / STEP_L;
     for (int i = 0; i < room->z_size * room->x_size; i++) {
         SECTOR_INFO *sector = &room->sectors[i];
-        if (sector->floor == wall_height || sector->ceiling == wall_height) {
+        if (sector->floor.height == WALL_CLICKS
+            || sector->ceiling.height == WALL_CLICKS) {
             continue;
         }
 
-        sector->floor += click_shift;
-        sector->ceiling += click_shift;
+        sector->floor.height += click_shift;
+        sector->ceiling.height += click_shift;
     }
 
     // Update vertex Y values to match; x and z are room-relative.

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1346,6 +1346,10 @@ static void Inject_RoomShift(INJECTION *injection, int16_t room_num)
     File_Read(&z_shift, sizeof(uint32_t), 1, fp);
     File_Read(&y_shift, sizeof(int32_t), 1, fp);
 
+    x_shift = ROUND_TO_SECTOR(x_shift);
+    y_shift = ROUND_TO_CLICK(y_shift);
+    z_shift = ROUND_TO_SECTOR(z_shift);
+
     ROOM_INFO *room = &g_RoomInfo[room_num];
     room->x += x_shift;
     room->z += z_shift;
@@ -1369,8 +1373,8 @@ static void Inject_RoomShift(INJECTION *injection, int16_t room_num)
     }
 
     // Update the sector floor and ceiling heights to match.
-    for (int i = 0; i < room->z_size * room->x_size; i++) {
-        SECTOR_INFO *sector = &room->sectors[i];
+    for (int32_t i = 0; i < room->z_size * room->x_size; i++) {
+        SECTOR_INFO *const sector = &room->sectors[i];
         if (sector->floor.height == NO_HEIGHT
             || sector->ceiling.height == NO_HEIGHT) {
             continue;

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1368,17 +1368,16 @@ static void Inject_RoomShift(INJECTION *injection, int16_t room_num)
         return;
     }
 
-    // Update the sector floor and ceiling clicks to match.
-    const int8_t click_shift = y_shift / STEP_L;
+    // Update the sector floor and ceiling heights to match.
     for (int i = 0; i < room->z_size * room->x_size; i++) {
         SECTOR_INFO *sector = &room->sectors[i];
-        if (sector->floor.height == WALL_CLICKS
-            || sector->ceiling.height == WALL_CLICKS) {
+        if (sector->floor.height == NO_HEIGHT
+            || sector->ceiling.height == NO_HEIGHT) {
             continue;
         }
 
-        sector->floor.height += click_shift;
-        sector->ceiling.height += click_shift;
+        sector->floor.height += y_shift;
+        sector->ceiling.height += y_shift;
     }
 
     // Update vertex Y values to match; x and z are room-relative.

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -173,7 +173,7 @@ void Item_Initialise(int16_t item_num)
     const int32_t x_sector = (item->pos.x - r->x) >> WALL_SHIFT;
     const SECTOR_INFO *const sector =
         &r->sectors[z_sector + x_sector * r->z_size];
-    item->floor = sector->floor.height << 8;
+    item->floor = sector->floor.height;
 
     if (g_GameInfo.bonus_flag & GBF_NGPLUS) {
         item->hit_points *= 2;

--- a/src/game/items.c
+++ b/src/game/items.c
@@ -173,7 +173,7 @@ void Item_Initialise(int16_t item_num)
     const int32_t x_sector = (item->pos.x - r->x) >> WALL_SHIFT;
     const SECTOR_INFO *const sector =
         &r->sectors[z_sector + x_sector * r->z_size];
-    item->floor = sector->floor << 8;
+    item->floor = sector->floor.height << 8;
 
     if (g_GameInfo.bonus_flag & GBF_NGPLUS) {
         item->hit_points *= 2;

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -217,9 +217,9 @@ static bool Level_LoadRooms(MYFILE *fp)
             File_Read(&sector->index, sizeof(uint16_t), 1, fp);
             File_Read(&sector->box, sizeof(int16_t), 1, fp);
             File_Read(&sector->pit_room, sizeof(uint8_t), 1, fp);
-            File_Read(&sector->floor, sizeof(int8_t), 1, fp);
+            File_Read(&sector->floor.height, sizeof(int8_t), 1, fp);
             File_Read(&sector->sky_room, sizeof(uint8_t), 1, fp);
-            File_Read(&sector->ceiling, sizeof(int8_t), 1, fp);
+            File_Read(&sector->ceiling.height, sizeof(int8_t), 1, fp);
         }
 
         // Room lights

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -214,12 +214,17 @@ static bool Level_LoadRooms(MYFILE *fp)
             GameBuf_Alloc(sizeof(SECTOR_INFO) * count4, GBUF_ROOM_SECTOR);
         for (int32_t j = 0; j < (signed)count4; j++) {
             SECTOR_INFO *const sector = &current_room_info->sectors[j];
+            int8_t floor_clicks;
+            int8_t ceiling_clicks;
             File_Read(&sector->index, sizeof(uint16_t), 1, fp);
             File_Read(&sector->box, sizeof(int16_t), 1, fp);
             File_Read(&sector->pit_room, sizeof(uint8_t), 1, fp);
-            File_Read(&sector->floor.height, sizeof(int8_t), 1, fp);
+            File_Read(&floor_clicks, sizeof(int8_t), 1, fp);
             File_Read(&sector->sky_room, sizeof(uint8_t), 1, fp);
-            File_Read(&sector->ceiling.height, sizeof(int8_t), 1, fp);
+            File_Read(&ceiling_clicks, sizeof(int8_t), 1, fp);
+
+            sector->floor.height = floor_clicks * STEP_L;
+            sector->ceiling.height = ceiling_clicks * STEP_L;
         }
 
         // Room lights

--- a/src/game/objects/general/bridge.c
+++ b/src/game/objects/general/bridge.c
@@ -123,22 +123,22 @@ static void Bridge_FixEmbeddedPosition(int16_t item_num)
 void Bridge_SetupFlat(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor = Bridge_FlatFloor;
-    obj->ceiling = Bridge_FlatCeiling;
+    obj->floor_height_routine = Bridge_AlterFlatFloorHeight;
+    obj->ceiling_height_routine = Bridge_AlterFlatCeilingHeight;
 }
 
 void Bridge_SetupTilt1(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor = Bridge_Tilt1Floor;
-    obj->ceiling = Bridge_Tilt1Ceiling;
+    obj->floor_height_routine = Bridge_AlterTilt1FloorHeight;
+    obj->ceiling_height_routine = Bridge_AlterTilt1CeilingHeight;
 }
 
 void Bridge_SetupTilt2(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor = Bridge_Tilt2Floor;
-    obj->ceiling = Bridge_Tilt2Ceiling;
+    obj->floor_height_routine = Bridge_AlterTilt2FloorHeight;
+    obj->ceiling_height_routine = Bridge_AlterTilt2CeilingHeight;
 }
 
 void Bridge_SetupDrawBridge(OBJECT_INFO *obj)
@@ -146,12 +146,12 @@ void Bridge_SetupDrawBridge(OBJECT_INFO *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->ceiling = Bridge_DrawBridgeCeiling;
+    obj->ceiling_height_routine = Bridge_DrawBridgeCeiling;
     obj->collision = Bridge_DrawBridgeCollision;
     obj->control = Cog_Control;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    obj->floor = Bridge_DrawBridgeFloor;
+    obj->floor_height_routine = Bridge_DrawBridgeFloor;
 }
 
 void Bridge_Initialise(int16_t item_num)
@@ -215,7 +215,7 @@ void Bridge_DrawBridgeCollision(
     }
 }
 
-void Bridge_FlatFloor(
+void Bridge_AlterFlatFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
@@ -233,7 +233,7 @@ void Bridge_FlatFloor(
     *height = item->pos.y;
 }
 
-void Bridge_FlatCeiling(
+void Bridge_AlterFlatCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
@@ -251,7 +251,7 @@ void Bridge_FlatCeiling(
     *height = item->pos.y + STEP_L;
 }
 
-void Bridge_Tilt1Floor(
+void Bridge_AlterTilt1FloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
@@ -271,7 +271,7 @@ void Bridge_Tilt1Floor(
     *height = offset_height;
 }
 
-void Bridge_Tilt1Ceiling(
+void Bridge_AlterTilt1CeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
@@ -291,7 +291,7 @@ void Bridge_Tilt1Ceiling(
     *height = offset_height + STEP_L;
 }
 
-void Bridge_Tilt2Floor(
+void Bridge_AlterTilt2FloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
@@ -311,7 +311,7 @@ void Bridge_Tilt2Floor(
     *height = offset_height;
 }
 
-void Bridge_Tilt2Ceiling(
+void Bridge_AlterTilt2CeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {

--- a/src/game/objects/general/bridge.c
+++ b/src/game/objects/general/bridge.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 
 static bool Bridge_IsSameSector(int32_t x, int32_t z, const ITEM_INFO *item);
-static bool Bridge_OnDrawBridge(ITEM_INFO *item, int32_t x, int32_t z);
+static bool Bridge_OnDrawBridge(const ITEM_INFO *item, int32_t x, int32_t z);
 static int32_t Bridge_GetOffset(
     const ITEM_INFO *item, int32_t x, int32_t y, int32_t z);
 static void Bridge_FixEmbeddedPosition(int16_t item_num);
@@ -27,7 +27,7 @@ static bool Bridge_IsSameSector(int32_t x, int32_t z, const ITEM_INFO *item)
     return sector_x == item_sector_x && sector_z == item_sector_z;
 }
 
-static bool Bridge_OnDrawBridge(ITEM_INFO *item, int32_t x, int32_t z)
+static bool Bridge_OnDrawBridge(const ITEM_INFO *item, int32_t x, int32_t z)
 {
     int32_t ix = item->pos.x >> WALL_SHIFT;
     int32_t iz = item->pos.z >> WALL_SHIFT;
@@ -123,22 +123,22 @@ static void Bridge_FixEmbeddedPosition(int16_t item_num)
 void Bridge_SetupFlat(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor_height_routine = Bridge_AlterFlatFloorHeight;
-    obj->ceiling_height_routine = Bridge_AlterFlatCeilingHeight;
+    obj->floor_height_func = Bridge_GetFlatFloorHeight;
+    obj->ceiling_height_func = Bridge_GetFlatCeilingHeight;
 }
 
 void Bridge_SetupTilt1(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor_height_routine = Bridge_AlterTilt1FloorHeight;
-    obj->ceiling_height_routine = Bridge_AlterTilt1CeilingHeight;
+    obj->floor_height_func = Bridge_GetTilt1FloorHeight;
+    obj->ceiling_height_func = Bridge_GetTilt1CeilingHeight;
 }
 
 void Bridge_SetupTilt2(OBJECT_INFO *obj)
 {
     obj->initialise = Bridge_Initialise;
-    obj->floor_height_routine = Bridge_AlterTilt2FloorHeight;
-    obj->ceiling_height_routine = Bridge_AlterTilt2CeilingHeight;
+    obj->floor_height_func = Bridge_GetTilt2FloorHeight;
+    obj->ceiling_height_func = Bridge_GetTilt2CeilingHeight;
 }
 
 void Bridge_SetupDrawBridge(OBJECT_INFO *obj)
@@ -146,12 +146,12 @@ void Bridge_SetupDrawBridge(OBJECT_INFO *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->ceiling_height_routine = Bridge_DrawBridgeCeiling;
+    obj->ceiling_height_func = Bridge_GetDrawBridgeCeilingHeight;
     obj->collision = Bridge_DrawBridgeCollision;
     obj->control = Cog_Control;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    obj->floor_height_routine = Bridge_DrawBridgeFloor;
+    obj->floor_height_func = Bridge_GetDrawBridgeFloorHeight;
 }
 
 void Bridge_Initialise(int16_t item_num)
@@ -162,48 +162,50 @@ void Bridge_Initialise(int16_t item_num)
     Bridge_FixEmbeddedPosition(item_num);
 }
 
-void Bridge_DrawBridgeFloor(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetDrawBridgeFloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (item->current_anim_state != DOOR_OPEN) {
-        return;
+        return height;
     }
 
     if (!Bridge_OnDrawBridge(item, x, z)) {
-        return;
+        return height;
     }
 
     if (y > item->pos.y) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y >= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y >= height) {
+        return height;
     }
 
-    *height = item->pos.y;
+    return item->pos.y;
 }
 
-void Bridge_DrawBridgeCeiling(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetDrawBridgeCeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (item->current_anim_state != DOOR_OPEN) {
-        return;
+        return height;
     }
 
     if (!Bridge_OnDrawBridge(item, x, z)) {
-        return;
+        return height;
     }
 
     if (y <= item->pos.y) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y <= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y <= height) {
+        return height;
     }
 
-    *height = item->pos.y + STEP_L;
+    return item->pos.y + STEP_L;
 }
 
 void Bridge_DrawBridgeCollision(
@@ -215,118 +217,124 @@ void Bridge_DrawBridgeCollision(
     }
 }
 
-void Bridge_AlterFlatFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetFlatFloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     if (y > item->pos.y) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y >= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y >= height) {
+        return height;
     }
 
-    *height = item->pos.y;
+    return item->pos.y;
 }
 
-void Bridge_AlterFlatCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetFlatCeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     if (y <= item->pos.y) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y <= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y <= height) {
+        return height;
     }
 
-    *height = item->pos.y + STEP_L;
+    return item->pos.y + STEP_L;
 }
 
-void Bridge_AlterTilt1FloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetTilt1FloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, y, z) / 4);
-    if (y > offset_height || item->pos.y >= *height) {
-        return;
+    if (y > offset_height || item->pos.y >= height) {
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y >= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y >= height) {
+        return height;
     }
 
-    *height = offset_height;
+    return offset_height;
 }
 
-void Bridge_AlterTilt1CeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetTilt1CeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, y, z) / 4);
     if (y <= offset_height) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y <= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y <= height) {
+        return height;
     }
 
-    *height = offset_height + STEP_L;
+    return offset_height + STEP_L;
 }
 
-void Bridge_AlterTilt2FloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetTilt2FloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, y, z) / 2);
     if (y > offset_height) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y >= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y >= height) {
+        return height;
     }
 
-    *height = offset_height;
+    return offset_height;
 }
 
-void Bridge_AlterTilt2CeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t Bridge_GetTilt2CeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (g_Config.fix_bridge_collision && !Bridge_IsSameSector(x, z, item)) {
-        return;
+        return height;
     }
 
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, y, z) / 2);
     if (y <= offset_height) {
-        return;
+        return height;
     }
 
-    if (g_Config.fix_bridge_collision && item->pos.y <= *height) {
-        return;
+    if (g_Config.fix_bridge_collision && item->pos.y <= height) {
+        return height;
     }
 
-    *height = offset_height + STEP_L;
+    return offset_height + STEP_L;
 }

--- a/src/game/objects/general/bridge.h
+++ b/src/game/objects/general/bridge.h
@@ -19,17 +19,17 @@ void Bridge_DrawBridgeCollision(
     int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
 void Bridge_DrawBridgeControl(int16_t item_num);
 
-void Bridge_FlatFloor(
+void Bridge_AlterFlatFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_FlatCeiling(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-
-void Bridge_Tilt1Floor(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_Tilt1Ceiling(
+void Bridge_AlterFlatCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
 
-void Bridge_Tilt2Floor(
+void Bridge_AlterTilt1FloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_Tilt2Ceiling(
+void Bridge_AlterTilt1CeilingHeight(
+    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+
+void Bridge_AlterTilt2FloorHeight(
+    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+void Bridge_AlterTilt2CeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);

--- a/src/game/objects/general/bridge.h
+++ b/src/game/objects/general/bridge.h
@@ -11,25 +11,25 @@ void Bridge_SetupDrawBridge(OBJECT_INFO *obj);
 
 void Bridge_Initialise(int16_t item_num);
 
-void Bridge_DrawBridgeFloor(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_DrawBridgeCeiling(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t Bridge_GetDrawBridgeFloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t Bridge_GetDrawBridgeCeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
 void Bridge_DrawBridgeCollision(
     int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
 void Bridge_DrawBridgeControl(int16_t item_num);
 
-void Bridge_AlterFlatFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_AlterFlatCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t Bridge_GetFlatFloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t Bridge_GetFlatCeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
 
-void Bridge_AlterTilt1FloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_AlterTilt1CeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t Bridge_GetTilt1FloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t Bridge_GetTilt1CeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
 
-void Bridge_AlterTilt2FloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void Bridge_AlterTilt2CeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t Bridge_GetTilt2FloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t Bridge_GetTilt2CeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -53,8 +53,8 @@ static void Door_Shut(DOORPOS_DATA *const d)
 
     sector->index = 0;
     sector->box = NO_BOX;
-    sector->floor.height = WALL_CLICKS;
-    sector->ceiling.height = WALL_CLICKS;
+    sector->floor.height = NO_HEIGHT;
+    sector->ceiling.height = NO_HEIGHT;
     sector->sky_room = NO_ROOM;
     sector->pit_room = NO_ROOM;
 

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -53,8 +53,8 @@ static void Door_Shut(DOORPOS_DATA *const d)
 
     sector->index = 0;
     sector->box = NO_BOX;
-    sector->floor = NO_HEIGHT / STEP_L;
-    sector->ceiling = NO_HEIGHT / STEP_L;
+    sector->floor.height = WALL_CLICKS;
+    sector->ceiling.height = WALL_CLICKS;
     sector->sky_room = NO_ROOM;
     sector->pit_room = NO_ROOM;
 

--- a/src/game/objects/general/trapdoor.c
+++ b/src/game/objects/general/trapdoor.c
@@ -29,8 +29,8 @@ static bool TrapDoor_StandingOn(ITEM_INFO *item, int32_t x, int32_t z)
 void TrapDoor_Setup(OBJECT_INFO *obj)
 {
     obj->control = TrapDoor_Control;
-    obj->floor = TrapDoor_Floor;
-    obj->ceiling = TrapDoor_Ceiling;
+    obj->floor_height_routine = TrapDoor_AlterFloorHeight;
+    obj->ceiling_height_routine = TrapDoor_AlterCeilingHeight;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }
@@ -48,7 +48,7 @@ void TrapDoor_Control(int16_t item_num)
     Item_Animate(item);
 }
 
-void TrapDoor_Floor(
+void TrapDoor_AlterFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (!TrapDoor_StandingOn(item, x, z)) {
@@ -63,7 +63,7 @@ void TrapDoor_Floor(
     *height = item->pos.y;
 }
 
-void TrapDoor_Ceiling(
+void TrapDoor_AlterCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (!TrapDoor_StandingOn(item, x, z)) {

--- a/src/game/objects/general/trapdoor.c
+++ b/src/game/objects/general/trapdoor.c
@@ -5,9 +5,9 @@
 
 #include <stdbool.h>
 
-static bool TrapDoor_StandingOn(ITEM_INFO *item, int32_t x, int32_t z);
+static bool TrapDoor_StandingOn(const ITEM_INFO *item, int32_t x, int32_t z);
 
-static bool TrapDoor_StandingOn(ITEM_INFO *item, int32_t x, int32_t z)
+static bool TrapDoor_StandingOn(const ITEM_INFO *item, int32_t x, int32_t z)
 {
     int32_t tx = item->pos.x >> WALL_SHIFT;
     int32_t tz = item->pos.z >> WALL_SHIFT;
@@ -29,8 +29,8 @@ static bool TrapDoor_StandingOn(ITEM_INFO *item, int32_t x, int32_t z)
 void TrapDoor_Setup(OBJECT_INFO *obj)
 {
     obj->control = TrapDoor_Control;
-    obj->floor_height_routine = TrapDoor_AlterFloorHeight;
-    obj->ceiling_height_routine = TrapDoor_AlterCeilingHeight;
+    obj->floor_height_func = TrapDoor_GetFloorHeight;
+    obj->ceiling_height_func = TrapDoor_GetCeilingHeight;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }
@@ -48,32 +48,34 @@ void TrapDoor_Control(int16_t item_num)
     Item_Animate(item);
 }
 
-void TrapDoor_AlterFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t TrapDoor_GetFloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (!TrapDoor_StandingOn(item, x, z)) {
-        return;
+        return height;
     }
 
     if (item->current_anim_state == DOOR_OPEN || y > item->pos.y
-        || item->pos.y >= *height) {
-        return;
+        || item->pos.y >= height) {
+        return height;
     }
 
-    *height = item->pos.y;
+    return item->pos.y;
 }
 
-void TrapDoor_AlterCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t TrapDoor_GetCeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (!TrapDoor_StandingOn(item, x, z)) {
-        return;
+        return height;
     }
 
     if (item->current_anim_state == DOOR_OPEN || y <= item->pos.y
-        || item->pos.y <= *height) {
-        return;
+        || item->pos.y <= height) {
+        return height;
     }
 
-    *height = item->pos.y + STEP_L;
+    return item->pos.y + STEP_L;
 }

--- a/src/game/objects/general/trapdoor.h
+++ b/src/game/objects/general/trapdoor.h
@@ -6,7 +6,7 @@
 
 void TrapDoor_Setup(OBJECT_INFO *obj);
 void TrapDoor_Control(int16_t item_num);
-void TrapDoor_AlterFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void TrapDoor_AlterCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t TrapDoor_GetFloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t TrapDoor_GetCeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);

--- a/src/game/objects/general/trapdoor.h
+++ b/src/game/objects/general/trapdoor.h
@@ -6,7 +6,7 @@
 
 void TrapDoor_Setup(OBJECT_INFO *obj);
 void TrapDoor_Control(int16_t item_num);
-void TrapDoor_Floor(
+void TrapDoor_AlterFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void TrapDoor_Ceiling(
+void TrapDoor_AlterCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);

--- a/src/game/objects/traps/falling_block.c
+++ b/src/game/objects/traps/falling_block.c
@@ -8,8 +8,8 @@
 void FallingBlock_Setup(OBJECT_INFO *obj)
 {
     obj->control = FallingBlock_Control;
-    obj->floor_height_routine = FallingBlock_AlterFloorHeight;
-    obj->ceiling_height_routine = FallingBlock_AlterCeilingHeight;
+    obj->floor_height_func = FallingBlock_GetFloorHeight;
+    obj->ceiling_height_func = FallingBlock_GetCeilingHeight;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
@@ -65,22 +65,28 @@ void FallingBlock_Control(int16_t item_num)
     }
 }
 
-void FallingBlock_AlterFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t FallingBlock_GetFloorHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (y <= item->pos.y - STEP_L * 2
         && (item->current_anim_state == TRAP_SET
             || item->current_anim_state == TRAP_ACTIVATE)) {
-        *height = item->pos.y - STEP_L * 2;
+        return item->pos.y - STEP_L * 2;
     }
+
+    return height;
 }
 
-void FallingBlock_AlterCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
+int16_t FallingBlock_GetCeilingHeight(
+    const ITEM_INFO *item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
     if (y > item->pos.y - STEP_L * 2
         && (item->current_anim_state == TRAP_SET
             || item->current_anim_state == TRAP_ACTIVATE)) {
-        *height = item->pos.y - STEP_L;
+        return item->pos.y - STEP_L;
     }
+
+    return height;
 }

--- a/src/game/objects/traps/falling_block.c
+++ b/src/game/objects/traps/falling_block.c
@@ -8,8 +8,8 @@
 void FallingBlock_Setup(OBJECT_INFO *obj)
 {
     obj->control = FallingBlock_Control;
-    obj->floor = FallingBlock_Floor;
-    obj->ceiling = FallingBlock_Ceiling;
+    obj->floor_height_routine = FallingBlock_AlterFloorHeight;
+    obj->ceiling_height_routine = FallingBlock_AlterCeilingHeight;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
@@ -65,7 +65,7 @@ void FallingBlock_Control(int16_t item_num)
     }
 }
 
-void FallingBlock_Floor(
+void FallingBlock_AlterFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (y <= item->pos.y - STEP_L * 2
@@ -75,7 +75,7 @@ void FallingBlock_Floor(
     }
 }
 
-void FallingBlock_Ceiling(
+void FallingBlock_AlterCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height)
 {
     if (y > item->pos.y - STEP_L * 2

--- a/src/game/objects/traps/falling_block.h
+++ b/src/game/objects/traps/falling_block.h
@@ -6,7 +6,7 @@
 
 void FallingBlock_Setup(OBJECT_INFO *obj);
 void FallingBlock_Control(int16_t item_num);
-void FallingBlock_Floor(
+void FallingBlock_AlterFloorHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void FallingBlock_Ceiling(
+void FallingBlock_AlterCeilingHeight(
     ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);

--- a/src/game/objects/traps/falling_block.h
+++ b/src/game/objects/traps/falling_block.h
@@ -6,7 +6,7 @@
 
 void FallingBlock_Setup(OBJECT_INFO *obj);
 void FallingBlock_Control(int16_t item_num);
-void FallingBlock_AlterFloorHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-void FallingBlock_AlterCeilingHeight(
-    ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+int16_t FallingBlock_GetFloorHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+int16_t FallingBlock_GetCeilingHeight(
+    const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -171,7 +171,7 @@ int16_t Room_GetTiltType(
                        + ((x - r->x) >> WALL_SHIFT) * r->z_size];
     }
 
-    if (y + 512 < ((int32_t)sector->floor << 8)) {
+    if (y + 512 < ((int32_t)sector->floor.height << 8)) {
         return 0;
     }
 
@@ -275,7 +275,7 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
         }
     } while (data != NO_ROOM);
 
-    if (y >= ((int32_t)sector->floor << 8)) {
+    if (y >= ((int32_t)sector->floor.height << 8)) {
         do {
             if (sector->pit_room == NO_ROOM) {
                 break;
@@ -287,8 +287,8 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
             const int32_t z_sector = (z - r->z) >> WALL_SHIFT;
             const int32_t x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
-        } while (y >= ((int32_t)sector->floor << 8));
-    } else if (y < ((int32_t)sector->ceiling << 8)) {
+        } while (y >= ((int32_t)sector->floor.height << 8));
+    } else if (y < ((int32_t)sector->ceiling.height << 8)) {
         do {
             if (sector->sky_room == NO_ROOM) {
                 break;
@@ -300,7 +300,7 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
             const int32_t z_sector = (z - r->z) >> WALL_SHIFT;
             const int32_t x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
-        } while (y < ((int32_t)sector->ceiling << 8));
+        } while (y < ((int32_t)sector->ceiling.height << 8));
     }
 
     return sector;
@@ -322,7 +322,7 @@ int16_t Room_GetCeiling(
         sky_sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sky_sector->ceiling << 8;
+    int16_t height = sky_sector->ceiling.height << 8;
 
     if (sky_sector->index) {
         data = &g_FloorData[sky_sector->index];
@@ -447,7 +447,7 @@ int16_t Room_GetHeight(
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sector->floor << 8;
+    int16_t height = sector->floor.height << 8;
 
     g_TriggerIndex = NULL;
 
@@ -583,12 +583,12 @@ int16_t Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num)
             x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
         }
-        return sector->ceiling << 8;
+        return sector->ceiling.height << 8;
     } else {
         while (sector->pit_room != NO_ROOM) {
             r = &g_RoomInfo[sector->pit_room];
             if (r->flags & RF_UNDERWATER) {
-                return sector->floor << 8;
+                return sector->floor.height << 8;
             }
             z_sector = (z - r->z) >> WALL_SHIFT;
             x_sector = (x - r->x) >> WALL_SHIFT;
@@ -661,13 +661,13 @@ void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height)
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    if (sector->floor != NO_HEIGHT / 256) {
-        sector->floor += height >> 8;
-        if (sector->floor == sky_sector->ceiling) {
-            sector->floor = NO_HEIGHT / 256;
+    if (sector->floor.height != WALL_CLICKS) {
+        sector->floor.height += height >> 8;
+        if (sector->floor.height == sky_sector->ceiling.height) {
+            sector->floor.height = WALL_CLICKS;
         }
     } else {
-        sector->floor = sky_sector->ceiling + (height >> 8);
+        sector->floor.height = sky_sector->ceiling.height + (height >> 8);
     }
 
     if (g_Boxes[sector->box].overlap_index & BLOCKABLE) {
@@ -993,7 +993,7 @@ bool Room_IsOnWalkable(
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sector->floor << 8;
+    int16_t height = sector->floor.height << 8;
     bool object_found = false;
 
     int16_t *floor_data = &g_FloorData[sector->index];

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -395,8 +395,9 @@ int16_t Room_GetCeiling(
                 } else {
                     ITEM_INFO *item = &g_Items[trigger & VALUE_BITS];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->ceiling_height_routine) {
-                        object->ceiling_height_routine(item, x, y, z, &height);
+                    if (object->ceiling_height_func) {
+                        height =
+                            object->ceiling_height_func(item, x, y, z, height);
                     }
                 }
             } while (!(trigger & END_BIT));
@@ -518,8 +519,9 @@ int16_t Room_GetHeight(
                 } else {
                     ITEM_INFO *item = &g_Items[trigger & VALUE_BITS];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->floor_height_routine) {
-                        object->floor_height_routine(item, x, y, z, &height);
+                    if (object->floor_height_func) {
+                        height =
+                            object->floor_height_func(item, x, y, z, height);
                     }
                 }
             } while (!(trigger & END_BIT));
@@ -1027,8 +1029,9 @@ bool Room_IsOnWalkable(
                     const int16_t item_num = trigger & VALUE_BITS;
                     ITEM_INFO *item = &g_Items[item_num];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->floor_height_routine) {
-                        object->floor_height_routine(item, x, y, z, &height);
+                    if (object->floor_height_func) {
+                        height =
+                            object->floor_height_func(item, x, y, z, height);
                         object_found = true;
                     }
                 } else if (TRIG_BITS(trigger) == TO_CAMERA) {

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -171,7 +171,7 @@ int16_t Room_GetTiltType(
                        + ((x - r->x) >> WALL_SHIFT) * r->z_size];
     }
 
-    if (y + 512 < ((int32_t)sector->floor.height << 8)) {
+    if ((y + 512) < sector->floor.height) {
         return 0;
     }
 
@@ -275,7 +275,7 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
         }
     } while (data != NO_ROOM);
 
-    if (y >= ((int32_t)sector->floor.height << 8)) {
+    if (y >= sector->floor.height) {
         do {
             if (sector->pit_room == NO_ROOM) {
                 break;
@@ -287,8 +287,8 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
             const int32_t z_sector = (z - r->z) >> WALL_SHIFT;
             const int32_t x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
-        } while (y >= ((int32_t)sector->floor.height << 8));
-    } else if (y < ((int32_t)sector->ceiling.height << 8)) {
+        } while (y >= sector->floor.height);
+    } else if (y < sector->ceiling.height) {
         do {
             if (sector->sky_room == NO_ROOM) {
                 break;
@@ -300,7 +300,7 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
             const int32_t z_sector = (z - r->z) >> WALL_SHIFT;
             const int32_t x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
-        } while (y < ((int32_t)sector->ceiling.height << 8));
+        } while (y < sector->ceiling.height);
     }
 
     return sector;
@@ -322,7 +322,7 @@ int16_t Room_GetCeiling(
         sky_sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sky_sector->ceiling.height << 8;
+    int16_t height = sky_sector->ceiling.height;
 
     if (sky_sector->index) {
         data = &g_FloorData[sky_sector->index];
@@ -447,7 +447,7 @@ int16_t Room_GetHeight(
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sector->floor.height << 8;
+    int16_t height = sector->floor.height;
 
     g_TriggerIndex = NULL;
 
@@ -583,12 +583,12 @@ int16_t Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num)
             x_sector = (x - r->x) >> WALL_SHIFT;
             sector = &r->sectors[z_sector + x_sector * r->z_size];
         }
-        return sector->ceiling.height << 8;
+        return sector->ceiling.height;
     } else {
         while (sector->pit_room != NO_ROOM) {
             r = &g_RoomInfo[sector->pit_room];
             if (r->flags & RF_UNDERWATER) {
-                return sector->floor.height << 8;
+                return sector->floor.height;
             }
             z_sector = (z - r->z) >> WALL_SHIFT;
             x_sector = (x - r->x) >> WALL_SHIFT;
@@ -661,13 +661,13 @@ void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height)
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    if (sector->floor.height != WALL_CLICKS) {
-        sector->floor.height += height >> 8;
+    if (sector->floor.height != NO_HEIGHT) {
+        sector->floor.height += height;
         if (sector->floor.height == sky_sector->ceiling.height) {
-            sector->floor.height = WALL_CLICKS;
+            sector->floor.height = NO_HEIGHT;
         }
     } else {
-        sector->floor.height = sky_sector->ceiling.height + (height >> 8);
+        sector->floor.height = sky_sector->ceiling.height + height;
     }
 
     if (g_Boxes[sector->box].overlap_index & BLOCKABLE) {
@@ -993,7 +993,7 @@ bool Room_IsOnWalkable(
         sector = &r->sectors[z_sector + x_sector * r->z_size];
     }
 
-    int16_t height = sector->floor.height << 8;
+    int16_t height = sector->floor.height;
     bool object_found = false;
 
     int16_t *floor_data = &g_FloorData[sector->index];

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -395,8 +395,8 @@ int16_t Room_GetCeiling(
                 } else {
                     ITEM_INFO *item = &g_Items[trigger & VALUE_BITS];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->ceiling) {
-                        object->ceiling(item, x, y, z, &height);
+                    if (object->ceiling_height_routine) {
+                        object->ceiling_height_routine(item, x, y, z, &height);
                     }
                 }
             } while (!(trigger & END_BIT));
@@ -518,8 +518,8 @@ int16_t Room_GetHeight(
                 } else {
                     ITEM_INFO *item = &g_Items[trigger & VALUE_BITS];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->floor) {
-                        object->floor(item, x, y, z, &height);
+                    if (object->floor_height_routine) {
+                        object->floor_height_routine(item, x, y, z, &height);
                     }
                 }
             } while (!(trigger & END_BIT));
@@ -1026,8 +1026,8 @@ bool Room_IsOnWalkable(
                     const int16_t item_num = trigger & VALUE_BITS;
                     ITEM_INFO *item = &g_Items[item_num];
                     OBJECT_INFO *object = &g_Objects[item->object_number];
-                    if (object->floor) {
-                        object->floor(item, x, y, z, &height);
+                    if (object->floor_height_routine) {
+                        object->floor_height_routine(item, x, y, z, &height);
                         object_found = true;
                     }
                 } else if (TRIG_BITS(trigger) == TO_CAMERA) {

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -662,12 +662,13 @@ void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height)
     }
 
     if (sector->floor.height != NO_HEIGHT) {
-        sector->floor.height += height;
+        sector->floor.height += ROUND_TO_CLICK(height);
         if (sector->floor.height == sky_sector->ceiling.height) {
             sector->floor.height = NO_HEIGHT;
         }
     } else {
-        sector->floor.height = sky_sector->ceiling.height + height;
+        sector->floor.height =
+            sky_sector->ceiling.height + ROUND_TO_CLICK(height);
     }
 
     if (g_Boxes[sector->box].overlap_index & BLOCKABLE) {

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -249,8 +249,8 @@ void Setup_AllObjects(void)
         obj->collision = NULL;
         obj->control = NULL;
         obj->draw_routine = Object_DrawAnimatingItem;
-        obj->ceiling = NULL;
-        obj->floor = NULL;
+        obj->ceiling_height_routine = NULL;
+        obj->floor_height_routine = NULL;
         obj->pivot_length = 0;
         obj->radius = DEFAULT_RADIUS;
         obj->shadow_size = 0;
@@ -268,15 +268,15 @@ void Setup_AllObjects(void)
         g_Objects[O_MEDI_ITEM].collision = NULL;
         g_Objects[O_MEDI_ITEM].control = NULL;
         g_Objects[O_MEDI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MEDI_ITEM].floor = NULL;
-        g_Objects[O_MEDI_ITEM].ceiling = NULL;
+        g_Objects[O_MEDI_ITEM].floor_height_routine = NULL;
+        g_Objects[O_MEDI_ITEM].ceiling_height_routine = NULL;
 
         g_Objects[O_BIGMEDI_ITEM].initialise = NULL;
         g_Objects[O_BIGMEDI_ITEM].collision = NULL;
         g_Objects[O_BIGMEDI_ITEM].control = NULL;
         g_Objects[O_BIGMEDI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_BIGMEDI_ITEM].floor = NULL;
-        g_Objects[O_BIGMEDI_ITEM].ceiling = NULL;
+        g_Objects[O_BIGMEDI_ITEM].floor_height_routine = NULL;
+        g_Objects[O_BIGMEDI_ITEM].ceiling_height_routine = NULL;
     }
 
     if (g_Config.disable_magnums) {
@@ -284,15 +284,15 @@ void Setup_AllObjects(void)
         g_Objects[O_MAGNUM_ITEM].collision = NULL;
         g_Objects[O_MAGNUM_ITEM].control = NULL;
         g_Objects[O_MAGNUM_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MAGNUM_ITEM].floor = NULL;
-        g_Objects[O_MAGNUM_ITEM].ceiling = NULL;
+        g_Objects[O_MAGNUM_ITEM].floor_height_routine = NULL;
+        g_Objects[O_MAGNUM_ITEM].ceiling_height_routine = NULL;
 
         g_Objects[O_MAG_AMMO_ITEM].initialise = NULL;
         g_Objects[O_MAG_AMMO_ITEM].collision = NULL;
         g_Objects[O_MAG_AMMO_ITEM].control = NULL;
         g_Objects[O_MAG_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MAG_AMMO_ITEM].floor = NULL;
-        g_Objects[O_MAG_AMMO_ITEM].ceiling = NULL;
+        g_Objects[O_MAG_AMMO_ITEM].floor_height_routine = NULL;
+        g_Objects[O_MAG_AMMO_ITEM].ceiling_height_routine = NULL;
     }
 
     if (g_Config.disable_uzis) {
@@ -300,15 +300,15 @@ void Setup_AllObjects(void)
         g_Objects[O_UZI_ITEM].collision = NULL;
         g_Objects[O_UZI_ITEM].control = NULL;
         g_Objects[O_UZI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_UZI_ITEM].floor = NULL;
-        g_Objects[O_UZI_ITEM].ceiling = NULL;
+        g_Objects[O_UZI_ITEM].floor_height_routine = NULL;
+        g_Objects[O_UZI_ITEM].ceiling_height_routine = NULL;
 
         g_Objects[O_UZI_AMMO_ITEM].initialise = NULL;
         g_Objects[O_UZI_AMMO_ITEM].collision = NULL;
         g_Objects[O_UZI_AMMO_ITEM].control = NULL;
         g_Objects[O_UZI_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_UZI_AMMO_ITEM].floor = NULL;
-        g_Objects[O_UZI_AMMO_ITEM].ceiling = NULL;
+        g_Objects[O_UZI_AMMO_ITEM].floor_height_routine = NULL;
+        g_Objects[O_UZI_AMMO_ITEM].ceiling_height_routine = NULL;
     }
 
     if (g_Config.disable_shotgun) {
@@ -316,14 +316,14 @@ void Setup_AllObjects(void)
         g_Objects[O_SHOTGUN_ITEM].collision = NULL;
         g_Objects[O_SHOTGUN_ITEM].control = NULL;
         g_Objects[O_SHOTGUN_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_SHOTGUN_ITEM].floor = NULL;
-        g_Objects[O_SHOTGUN_ITEM].ceiling = NULL;
+        g_Objects[O_SHOTGUN_ITEM].floor_height_routine = NULL;
+        g_Objects[O_SHOTGUN_ITEM].ceiling_height_routine = NULL;
 
         g_Objects[O_SG_AMMO_ITEM].initialise = NULL;
         g_Objects[O_SG_AMMO_ITEM].collision = NULL;
         g_Objects[O_SG_AMMO_ITEM].control = NULL;
         g_Objects[O_SG_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_SG_AMMO_ITEM].floor = NULL;
-        g_Objects[O_SG_AMMO_ITEM].ceiling = NULL;
+        g_Objects[O_SG_AMMO_ITEM].floor_height_routine = NULL;
+        g_Objects[O_SG_AMMO_ITEM].ceiling_height_routine = NULL;
     }
 }

--- a/src/game/setup.c
+++ b/src/game/setup.c
@@ -249,8 +249,8 @@ void Setup_AllObjects(void)
         obj->collision = NULL;
         obj->control = NULL;
         obj->draw_routine = Object_DrawAnimatingItem;
-        obj->ceiling_height_routine = NULL;
-        obj->floor_height_routine = NULL;
+        obj->ceiling_height_func = NULL;
+        obj->floor_height_func = NULL;
         obj->pivot_length = 0;
         obj->radius = DEFAULT_RADIUS;
         obj->shadow_size = 0;
@@ -268,15 +268,15 @@ void Setup_AllObjects(void)
         g_Objects[O_MEDI_ITEM].collision = NULL;
         g_Objects[O_MEDI_ITEM].control = NULL;
         g_Objects[O_MEDI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MEDI_ITEM].floor_height_routine = NULL;
-        g_Objects[O_MEDI_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_MEDI_ITEM].floor_height_func = NULL;
+        g_Objects[O_MEDI_ITEM].ceiling_height_func = NULL;
 
         g_Objects[O_BIGMEDI_ITEM].initialise = NULL;
         g_Objects[O_BIGMEDI_ITEM].collision = NULL;
         g_Objects[O_BIGMEDI_ITEM].control = NULL;
         g_Objects[O_BIGMEDI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_BIGMEDI_ITEM].floor_height_routine = NULL;
-        g_Objects[O_BIGMEDI_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_BIGMEDI_ITEM].floor_height_func = NULL;
+        g_Objects[O_BIGMEDI_ITEM].ceiling_height_func = NULL;
     }
 
     if (g_Config.disable_magnums) {
@@ -284,15 +284,15 @@ void Setup_AllObjects(void)
         g_Objects[O_MAGNUM_ITEM].collision = NULL;
         g_Objects[O_MAGNUM_ITEM].control = NULL;
         g_Objects[O_MAGNUM_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MAGNUM_ITEM].floor_height_routine = NULL;
-        g_Objects[O_MAGNUM_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_MAGNUM_ITEM].floor_height_func = NULL;
+        g_Objects[O_MAGNUM_ITEM].ceiling_height_func = NULL;
 
         g_Objects[O_MAG_AMMO_ITEM].initialise = NULL;
         g_Objects[O_MAG_AMMO_ITEM].collision = NULL;
         g_Objects[O_MAG_AMMO_ITEM].control = NULL;
         g_Objects[O_MAG_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_MAG_AMMO_ITEM].floor_height_routine = NULL;
-        g_Objects[O_MAG_AMMO_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_MAG_AMMO_ITEM].floor_height_func = NULL;
+        g_Objects[O_MAG_AMMO_ITEM].ceiling_height_func = NULL;
     }
 
     if (g_Config.disable_uzis) {
@@ -300,15 +300,15 @@ void Setup_AllObjects(void)
         g_Objects[O_UZI_ITEM].collision = NULL;
         g_Objects[O_UZI_ITEM].control = NULL;
         g_Objects[O_UZI_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_UZI_ITEM].floor_height_routine = NULL;
-        g_Objects[O_UZI_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_UZI_ITEM].floor_height_func = NULL;
+        g_Objects[O_UZI_ITEM].ceiling_height_func = NULL;
 
         g_Objects[O_UZI_AMMO_ITEM].initialise = NULL;
         g_Objects[O_UZI_AMMO_ITEM].collision = NULL;
         g_Objects[O_UZI_AMMO_ITEM].control = NULL;
         g_Objects[O_UZI_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_UZI_AMMO_ITEM].floor_height_routine = NULL;
-        g_Objects[O_UZI_AMMO_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_UZI_AMMO_ITEM].floor_height_func = NULL;
+        g_Objects[O_UZI_AMMO_ITEM].ceiling_height_func = NULL;
     }
 
     if (g_Config.disable_shotgun) {
@@ -316,14 +316,14 @@ void Setup_AllObjects(void)
         g_Objects[O_SHOTGUN_ITEM].collision = NULL;
         g_Objects[O_SHOTGUN_ITEM].control = NULL;
         g_Objects[O_SHOTGUN_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_SHOTGUN_ITEM].floor_height_routine = NULL;
-        g_Objects[O_SHOTGUN_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_SHOTGUN_ITEM].floor_height_func = NULL;
+        g_Objects[O_SHOTGUN_ITEM].ceiling_height_func = NULL;
 
         g_Objects[O_SG_AMMO_ITEM].initialise = NULL;
         g_Objects[O_SG_AMMO_ITEM].collision = NULL;
         g_Objects[O_SG_AMMO_ITEM].control = NULL;
         g_Objects[O_SG_AMMO_ITEM].draw_routine = Object_DrawDummyItem;
-        g_Objects[O_SG_AMMO_ITEM].floor_height_routine = NULL;
-        g_Objects[O_SG_AMMO_ITEM].ceiling_height_routine = NULL;
+        g_Objects[O_SG_AMMO_ITEM].floor_height_func = NULL;
+        g_Objects[O_SG_AMMO_ITEM].ceiling_height_func = NULL;
     }
 }

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -121,6 +121,7 @@
 #define DONT_TARGET (-16384)
 #define UNIT_SHADOW 256
 #define NO_HEIGHT (-32512)
+#define WALL_CLICKS (NO_HEIGHT / STEP_L)
 #define NO_BAD_POS (-NO_HEIGHT)
 #define NO_BAD_NEG NO_HEIGHT
 #define BAD_JUMP_CEILING ((STEP_L * 3) / 4) // = 192

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -121,7 +121,6 @@
 #define DONT_TARGET (-16384)
 #define UNIT_SHADOW 256
 #define NO_HEIGHT (-32512)
-#define WALL_CLICKS (NO_HEIGHT / STEP_L)
 #define NO_BAD_POS (-NO_HEIGHT)
 #define NO_BAD_NEG NO_HEIGHT
 #define BAD_JUMP_CEILING ((STEP_L * 3) / 4) // = 192

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -99,6 +99,8 @@
 #define WALL_L 1024
 #define WALL_SHIFT 10
 #define STEP_L 256
+#define ROUND_TO_CLICK(V) ((V) & ~(STEP_L - 1))
+#define ROUND_TO_SECTOR(V) ((V) & ~(WALL_L - 1))
 #define NO_ROOM 0xFF
 #define STEPUP_HEIGHT ((STEP_L * 3) / 2) // = 384
 #define FRONT_ARC PHD_90

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1644,9 +1644,9 @@ typedef struct OBJECT_INFO {
     FRAME_INFO *frame_base;
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);
-    void (*floor)(
+    void (*floor_height_routine)(
         ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-    void (*ceiling)(
+    void (*ceiling_height_routine)(
         ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
     void (*draw_routine)(ITEM_INFO *item);
     void (*collision)(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1166,7 +1166,7 @@ typedef struct SECTOR_INFO {
     uint8_t pit_room;
     uint8_t sky_room;
     struct {
-        int8_t height;
+        int16_t height;
     } floor, ceiling;
 } SECTOR_INFO;
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1164,9 +1164,10 @@ typedef struct SECTOR_INFO {
     uint16_t index;
     int16_t box;
     uint8_t pit_room;
-    int8_t floor;
     uint8_t sky_room;
-    int8_t ceiling;
+    struct {
+        int8_t height;
+    } floor, ceiling;
 } SECTOR_INFO;
 
 typedef struct DOORPOS_DATA {

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1644,10 +1644,10 @@ typedef struct OBJECT_INFO {
     FRAME_INFO *frame_base;
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);
-    void (*floor_height_routine)(
-        ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
-    void (*ceiling_height_routine)(
-        ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t *height);
+    int16_t (*floor_height_func)(
+        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
+    int16_t (*ceiling_height_func)(
+        const ITEM_INFO *item, int32_t x, int32_t y, int32_t z, int16_t height);
     void (*draw_routine)(ITEM_INFO *item);
     void (*collision)(int16_t item_num, ITEM_INFO *lara_item, COLL_INFO *coll);
     const OBJECT_BOUNDS *(*bounds)(void);


### PR DESCRIPTION
Part of #941.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This introduces a struct in `SECTOR_INFO` which currently stores the click height for the floor and ceiling values. The next phase will overhaul floor data parsing, and with that ,`tilt` will be added to this struct so that it's readily available. I've updated the issue itself with a task list for everything. I think perhaps just two more PRs after this one, all going well.

We have also replaced `height << 8` throughout with regard to sector clicks and instead store the height in world units in the sector.

Object floor and ceiling functions have been renamed to make clear what they do to the passed in height value.
