### PR TITLE
room: refactor tilt and portal interpretation

### DIFF
--- a/src/game/carrier.c
+++ b/src/game/carrier.c
@@ -248,7 +248,7 @@ static void Carrier_AnimateDrop(CARRIED_ITEM *item)
         Room_GetHeight(sector, pickup->pos.x, pickup->pos.y, pickup->pos.z);
     const bool in_water = g_RoomInfo[pickup->room_number].flags & RF_UNDERWATER;
 
-    if (sector->pit_room == NO_ROOM && pickup->pos.y >= height) {
+    if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {
         item->status = DS_DROPPED;
         pickup->pos.y = height;
         pickup->fall_speed = 0;
@@ -260,9 +260,9 @@ static void Carrier_AnimateDrop(CARRIED_ITEM *item)
         pickup->pos.y += pickup->fall_speed;
         pickup->rot.y += in_water ? DROP_SLOW_TURN : DROP_FAST_TURN;
 
-        if (sector->pit_room != NO_ROOM
+        if (sector->portal_room.pit != NO_ROOM
             && pickup->pos.y > sector->floor.height) {
-            room_num = sector->pit_room;
+            room_num = sector->portal_room.pit;
         }
     }
 

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -212,9 +212,9 @@ static bool Level_LoadRooms(MYFILE *fp)
             SECTOR_INFO *const sector = &current_room_info->sectors[j];
             sector->index = File_ReadU16(fp);
             sector->box = File_ReadS16(fp);
-            sector->pit_room = File_ReadU8(fp);
+            sector->portal_room.pit = File_ReadU8(fp);
             const int8_t floor_clicks = File_ReadS8(fp);
-            sector->sky_room = File_ReadU8(fp);
+            sector->portal_room.sky = File_ReadU8(fp);
             const int8_t ceiling_clicks = File_ReadS8(fp);
 
             sector->floor.height = floor_clicks * STEP_L;

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -853,6 +853,11 @@ static void Level_CompleteSetup(int32_t level_num)
 {
     Inject_AllInjections(&m_LevelInfo);
 
+    // Expand raw floor data into sectors
+    Room_ParseFloorData(g_FloorData);
+    // TODO: store raw FD temporarily in m_LevelInfo, release here and eliminate
+    // g_FloorData
+
     // Must be called post-injection to allow for floor data changes.
     Stats_ObserveRoomsLoad();
 

--- a/src/game/objects/general/bridge.c
+++ b/src/game/objects/general/bridge.c
@@ -113,7 +113,7 @@ static void Bridge_FixEmbeddedPosition(int16_t item_num)
 
     // Only move the bridge up if it's at floor level and there
     // isn't a room portal below.
-    if (item->floor != floor_height || sector->pit_room != NO_ROOM) {
+    if (item->floor != floor_height || sector->portal_room.pit != NO_ROOM) {
         return;
     }
 

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -55,8 +55,8 @@ static void Door_Shut(DOORPOS_DATA *const d)
     sector->box = NO_BOX;
     sector->floor.height = NO_HEIGHT;
     sector->ceiling.height = NO_HEIGHT;
-    sector->sky_room = NO_ROOM;
-    sector->pit_room = NO_ROOM;
+    sector->portal_room.sky = NO_ROOM;
+    sector->portal_room.pit = NO_ROOM;
 
     const int16_t box_num = d->block;
     if (box_num != NO_BOX) {
@@ -119,7 +119,7 @@ void Door_Initialise(int16_t item_num)
     z_sector = ((item->pos.z - r->z) >> WALL_SHIFT) + dx;
     x_sector = ((item->pos.x - r->x) >> WALL_SHIFT) + dy;
     door->d1.sector = &r->sectors[z_sector + x_sector * r->z_size];
-    room_num = Room_GetDoor(door->d1.sector);
+    room_num = door->d1.sector->portal_room.wall;
     if (room_num == NO_ROOM) {
         box_num = door->d1.sector->box;
     } else {
@@ -139,7 +139,7 @@ void Door_Initialise(int16_t item_num)
         z_sector = ((item->pos.z - r->z) >> WALL_SHIFT) + dx;
         x_sector = ((item->pos.x - r->x) >> WALL_SHIFT) + dy;
         door->d1flip.sector = &r->sectors[z_sector + x_sector * r->z_size];
-        room_num = Room_GetDoor(door->d1flip.sector);
+        room_num = door->d1flip.sector->portal_room.wall;
         if (room_num == NO_ROOM) {
             box_num = door->d1flip.sector->box;
         } else {
@@ -157,7 +157,7 @@ void Door_Initialise(int16_t item_num)
         door->d1flip.sector = NULL;
     }
 
-    room_num = Room_GetDoor(door->d1.sector);
+    room_num = door->d1.sector->portal_room.wall;
     Door_Shut(&door->d1);
     Door_Shut(&door->d1flip);
 
@@ -171,7 +171,7 @@ void Door_Initialise(int16_t item_num)
     z_sector = (item->pos.z - r->z) >> WALL_SHIFT;
     x_sector = (item->pos.x - r->x) >> WALL_SHIFT;
     door->d2.sector = &r->sectors[z_sector + x_sector * r->z_size];
-    room_num = Room_GetDoor(door->d2.sector);
+    room_num = door->d2.sector->portal_room.wall;
     if (room_num == NO_ROOM) {
         box_num = door->d2.sector->box;
     } else {
@@ -191,7 +191,7 @@ void Door_Initialise(int16_t item_num)
         z_sector = (item->pos.z - r->z) >> WALL_SHIFT;
         x_sector = (item->pos.x - r->x) >> WALL_SHIFT;
         door->d2flip.sector = &r->sectors[z_sector + x_sector * r->z_size];
-        room_num = Room_GetDoor(door->d2flip.sector);
+        room_num = door->d2flip.sector->portal_room.wall;
         if (room_num == NO_ROOM) {
             box_num = door->d2flip.sector->box;
         } else {

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -461,27 +461,27 @@ static int16_t Room_GetFloorTiltHeight(
         return height;
     }
 
-    const int32_t zoff = sector->floor.tilt >> 8;
-    const int32_t xoff = (int8_t)sector->floor.tilt;
+    const int32_t z_off = sector->floor.tilt >> 8;
+    const int32_t x_off = (int8_t)sector->floor.tilt;
 
     const HEIGHT_TYPE slope_type =
-        (ABS(zoff) > 2 || ABS(xoff) > 2) ? HT_BIG_SLOPE : HT_SMALL_SLOPE;
+        (ABS(z_off) > 2 || ABS(x_off) > 2) ? HT_BIG_SLOPE : HT_SMALL_SLOPE;
     if (g_ChunkyFlag && slope_type == HT_BIG_SLOPE) {
         return height;
     }
 
     g_HeightType = slope_type;
 
-    if (zoff < 0) {
-        height -= (int16_t)NEG_TILT(zoff, z);
+    if (z_off < 0) {
+        height -= (int16_t)NEG_TILT(z_off, z);
     } else {
-        height += (int16_t)POS_TILT(zoff, z);
+        height += (int16_t)POS_TILT(z_off, z);
     }
 
-    if (xoff < 0) {
-        height -= (int16_t)NEG_TILT(xoff, x);
+    if (x_off < 0) {
+        height -= (int16_t)NEG_TILT(x_off, x);
     } else {
-        height += (int16_t)POS_TILT(xoff, x);
+        height += (int16_t)POS_TILT(x_off, x);
     }
 
     return height;
@@ -495,23 +495,23 @@ static int16_t Room_GetCeilingTiltHeight(
         return height;
     }
 
-    const int32_t zoff = sector->ceiling.tilt >> 8;
-    const int32_t xoff = (int8_t)sector->ceiling.tilt;
+    const int32_t z_off = sector->ceiling.tilt >> 8;
+    const int32_t x_off = (int8_t)sector->ceiling.tilt;
 
-    if (g_ChunkyFlag && (ABS(zoff) > 2 || ABS(xoff) > 2)) {
+    if (g_ChunkyFlag && (ABS(z_off) > 2 || ABS(x_off) > 2)) {
         return height;
     }
 
-    if (zoff < 0) {
-        height += (int16_t)NEG_TILT(zoff, z);
+    if (z_off < 0) {
+        height += (int16_t)NEG_TILT(z_off, z);
     } else {
-        height -= (int16_t)POS_TILT(zoff, z);
+        height -= (int16_t)POS_TILT(z_off, z);
     }
 
-    if (xoff < 0) {
-        height += (int16_t)POS_TILT(xoff, x);
+    if (x_off < 0) {
+        height += (int16_t)POS_TILT(x_off, x);
     } else {
-        height -= (int16_t)NEG_TILT(xoff, x);
+        height -= (int16_t)NEG_TILT(x_off, x);
     }
 
     return height;

--- a/src/game/room.h
+++ b/src/game/room.h
@@ -21,7 +21,6 @@ void Room_GetNearByRooms(
 SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
 int16_t Room_GetCeiling(
     const SECTOR_INFO *sector, int32_t x, int32_t y, int32_t z);
-int16_t Room_GetDoor(const SECTOR_INFO *sector);
 int16_t Room_GetHeight(
     const SECTOR_INFO *sector, int32_t x, int32_t y, int32_t z);
 int16_t Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num);

--- a/src/game/room.h
+++ b/src/game/room.h
@@ -29,6 +29,7 @@ int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
 
 void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height);
 
+void Room_ParseFloorData(const int16_t *floor_data);
 void Room_TestTriggers(int16_t *data, bool heavy);
 void Room_FlipMap(void);
 bool Room_IsOnWalkable(

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1163,8 +1163,11 @@ typedef struct DOOR_INFOS {
 typedef struct SECTOR_INFO {
     uint16_t index;
     int16_t box;
-    uint8_t pit_room;
-    uint8_t sky_room;
+    struct {
+        uint8_t pit;
+        uint8_t sky;
+        int16_t wall;
+    } portal_room;
     struct {
         int16_t height;
         int16_t tilt;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1167,6 +1167,7 @@ typedef struct SECTOR_INFO {
     uint8_t sky_room;
     struct {
         int16_t height;
+        int16_t tilt;
     } floor, ceiling;
 } SECTOR_INFO;
 


### PR DESCRIPTION
Part of #941

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This moves floor and ceiling tilts directly into sectors to avoid repeated floor data loops to retrieve their values. It also introduces some additional functions to make traversing up/down to get a relevant sector easier, and so removes more repeated logic there.

For portals, sectors now have a struct with `pit`, `sky` and `wall` values. `pit` and `sky` are taken from the original data layout, while `wall` is now retrieved from the floor data once (and is initialised to `NO_ROOM` by default). This allows us to eliminate `Room_GetDoor` for horizontal portals.

There are some `TODO`s left related to the parsing: the next PR will move lava and trigger FD into sectors too, and we can then eliminate the FD globals.

I had one gotcha with the signs in `Room_GetCeilingTiltHeight` in relation to the new `NEG_TILT`/`POS_TILT` macros, where the tilts were inverted in-game. Perhaps these could be better named (and of course open to renaming anything else here). For testing ceilings I used the fly cheat and pushed Lara to the roof then swam and kept holding down to make sure she followed the geometry.