### PR TITLE
room: refactor lava and trigger interpretation

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -788,8 +788,10 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
     for (int32_t i = 0; i < trigger->command_count; i++) {
         const TRIGGER_CMD *const cmd = &trigger->commands[i];
         if (cmd->type == TO_CAMERA) {
-            if (cmd->parameter == g_Camera.last) {
-                g_Camera.number = cmd->parameter;
+            const TRIGGER_CAMERA_DATA *const cam_data =
+                (TRIGGER_CAMERA_DATA *)cmd->parameter;
+            if (cam_data->camera_num == g_Camera.last) {
+                g_Camera.number = cam_data->camera_num;
 
                 if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
                     || g_Camera.type == CAM_COMBAT) {
@@ -804,7 +806,7 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
             }
         } else if (cmd->type == TO_TARGET) {
             if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
-                g_Camera.item = &g_Items[cmd->parameter];
+                g_Camera.item = &g_Items[(int16_t)(intptr_t)cmd->parameter];
             }
         }
     }

--- a/src/game/camera.h
+++ b/src/game/camera.h
@@ -14,6 +14,6 @@ void Camera_Fixed(void);
 void Camera_Update(void);
 void Camera_UpdateCutscene(void);
 void Camera_OffsetReset(void);
-void Camera_RefreshFromTrigger(int16_t type, int16_t *data);
+void Camera_RefreshFromTrigger(const TRIGGER *trigger);
 void Camera_MoveManual(void);
 void Camera_Apply(void);

--- a/src/game/collide.c
+++ b/src/game/collide.c
@@ -41,7 +41,6 @@ void Collide_GetCollisionInfo(
     coll->mid_floor = height;
     coll->mid_ceiling = ceiling;
     coll->mid_type = g_HeightType;
-    coll->trigger = g_TriggerIndex;
 
     if (!g_Config.fix_bridge_collision
         || !Room_IsOnWalkable(sector, x, ytop, z, room_height)) {

--- a/src/game/collide.c
+++ b/src/game/collide.c
@@ -135,8 +135,8 @@ void Collide_GetCollisionInfo(
             && coll->front_floor > 0) {
             coll->front_floor = 512;
         } else if (
-            coll->lava_is_pit && coll->front_floor > 0 && g_TriggerIndex
-            && (g_TriggerIndex[0] & DATA_TYPE) == FT_LAVA) {
+            coll->lava_is_pit && coll->front_floor > 0
+            && Room_GetPitSector(sector, x, z)->is_death_sector) {
             coll->front_floor = 512;
         }
     }
@@ -170,8 +170,8 @@ void Collide_GetCollisionInfo(
             && coll->left_floor > 0) {
             coll->left_floor = 512;
         } else if (
-            coll->lava_is_pit && coll->left_floor > 0 && g_TriggerIndex
-            && (g_TriggerIndex[0] & DATA_TYPE) == FT_LAVA) {
+            coll->lava_is_pit && coll->left_floor > 0
+            && Room_GetPitSector(sector, x, z)->is_death_sector) {
             coll->left_floor = 512;
         }
     }
@@ -205,8 +205,8 @@ void Collide_GetCollisionInfo(
             && coll->right_floor > 0) {
             coll->right_floor = 512;
         } else if (
-            coll->lava_is_pit && coll->right_floor > 0 && g_TriggerIndex
-            && (g_TriggerIndex[0] & DATA_TYPE) == FT_LAVA) {
+            coll->lava_is_pit && coll->right_floor > 0
+            && Room_GetPitSector(sector, x, z)->is_death_sector) {
             coll->right_floor = 512;
         }
     }

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1169,6 +1169,10 @@ static void Inject_TriggerParameterChange(
     const int16_t old_param = File_ReadS16(fp);
     const int16_t new_param = File_ReadS16(fp);
 
+    if (sector == NULL || sector->trigger == NULL) {
+        return;
+    }
+
     // If we can find an action item for the given sector that matches
     // the command type and old (current) parameter, change it to the
     // new parameter.

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -19,7 +19,7 @@
 #include <stddef.h>
 
 #define INJECTION_MAGIC MKTAG('T', '1', 'M', 'J')
-#define INJECTION_CURRENT_VERSION 7
+#define INJECTION_CURRENT_VERSION 8
 #define NULL_FD_INDEX ((uint16_t)(-1))
 
 typedef enum INJECTION_VERSION {
@@ -30,6 +30,7 @@ typedef enum INJECTION_VERSION {
     INJ_VERSION_5 = 5,
     INJ_VERSION_6 = 6,
     INJ_VERSION_7 = 7,
+    INJ_VERSION_8 = 8,
 } INJECTION_VERSION;
 
 typedef enum INJECTION_TYPE {
@@ -268,7 +269,11 @@ static void Inject_LoadFromFile(INJECTION *injection, const char *filename)
     info->mesh_edit_count = File_ReadS32(fp);
     info->texture_overwrite_count = File_ReadS32(fp);
     info->floor_edit_count = File_ReadS32(fp);
-    info->floor_data_size = File_ReadS32(fp);
+
+    if (injection->version < INJ_VERSION_8) {
+        // Legacy value that stored the total injected floor data length.
+        File_Skip(fp, sizeof(int32_t));
+    }
 
     if (injection->version > INJ_VERSION_1) {
         // room_mesh_count is a summary of the change in mesh size,
@@ -360,7 +365,6 @@ static void Inject_LoadFromFile(INJECTION *injection, const char *filename)
     m_Aggregate->sfx_count += info->sfx_count;
     m_Aggregate->sfx_data_size += info->sfx_data_size;
     m_Aggregate->sample_count += info->sample_count;
-    m_Aggregate->floor_data_size += info->floor_data_size;
 
     LOG_INFO("%s queued for injection", filename);
 }

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1178,9 +1178,22 @@ static void Inject_TriggerParameterChange(
     // new parameter.
     for (int32_t i = 0; i < sector->trigger->command_count; i++) {
         TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
-        if (cmd->type == cmd_type && cmd->parameter == old_param) {
-            cmd->parameter = new_param;
-            break;
+        if (cmd->type != cmd_type) {
+            continue;
+        }
+
+        if (cmd->type == TO_CAMERA) {
+            TRIGGER_CAMERA_DATA *const cam_data =
+                (TRIGGER_CAMERA_DATA *)cmd->parameter;
+            if (cam_data->camera_num == old_param) {
+                cam_data->camera_num = new_param;
+                break;
+            }
+        } else {
+            if ((int16_t)(intptr_t)cmd->parameter == old_param) {
+                cmd->parameter = (void *)(intptr_t)new_param;
+                break;
+            }
         }
     }
 }

--- a/src/game/inject.h
+++ b/src/game/inject.h
@@ -31,7 +31,6 @@ typedef struct INJECTION_INFO {
     int32_t mesh_edit_count;
     int32_t texture_overwrite_count;
     int32_t floor_edit_count;
-    int32_t floor_data_size;
     int32_t room_mesh_count;
     INJECTION_ROOM_MESH *room_meshes;
     int32_t room_mesh_edit_count;

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -240,7 +240,7 @@ void Lara_HandleAboveWater(ITEM_INFO *item, COLL_INFO *coll)
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
     Item_UpdateRoom(item, -LARA_HEIGHT / 2);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }
 
 void Lara_HandleSurface(ITEM_INFO *item, COLL_INFO *coll)
@@ -307,7 +307,7 @@ void Lara_HandleSurface(ITEM_INFO *item, COLL_INFO *coll)
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
     Item_UpdateRoom(item, 100);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }
 
 void Lara_HandleUnderwater(ITEM_INFO *item, COLL_INFO *coll)
@@ -397,5 +397,5 @@ void Lara_HandleUnderwater(ITEM_INFO *item, COLL_INFO *coll)
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
     Item_UpdateRoom(item, 0);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -181,7 +181,6 @@ void Lara_HandleAboveWater(ITEM_INFO *item, COLL_INFO *coll)
     coll->old.y = item->pos.y;
     coll->old.z = item->pos.z;
     coll->radius = LARA_RAD;
-    coll->trigger = NULL;
 
     coll->lava_is_pit = 0;
     coll->slopes_are_walls = 0;
@@ -254,7 +253,6 @@ void Lara_HandleSurface(ITEM_INFO *item, COLL_INFO *coll)
     coll->old.y = item->pos.y;
     coll->old.z = item->pos.z;
     coll->radius = SURF_RADIUS;
-    coll->trigger = NULL;
     coll->slopes_are_walls = 0;
     coll->slopes_are_pits = 0;
     coll->lava_is_pit = 0;
@@ -319,7 +317,6 @@ void Lara_HandleUnderwater(ITEM_INFO *item, COLL_INFO *coll)
     coll->old.y = item->pos.y;
     coll->old.z = item->pos.z;
     coll->radius = UW_RADIUS;
-    coll->trigger = NULL;
     coll->slopes_are_walls = 0;
     coll->slopes_are_pits = 0;
     coll->lava_is_pit = 0;

--- a/src/game/lara/lara_misc.c
+++ b/src/game/lara/lara_misc.c
@@ -556,7 +556,7 @@ bool Lara_LandedBad(ITEM_INFO *item, COLL_INFO *coll)
 
     item->floor = height;
     item->pos.y = height;
-    Room_TestTriggers(g_TriggerIndex, false);
+    Room_TestTriggers(item);
     item->pos.y = old_y;
 
     int landspeed = item->fall_speed - DAMAGE_START;

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -851,12 +851,12 @@ static bool Level_LoadTexturePages(MYFILE *fp)
 
 static void Level_CompleteSetup(int32_t level_num)
 {
-    Inject_AllInjections(&m_LevelInfo);
-
     // Expand raw floor data into sectors
     Room_ParseFloorData(g_FloorData);
     // TODO: store raw FD temporarily in m_LevelInfo, release here and eliminate
     // g_FloorData
+
+    Inject_AllInjections(&m_LevelInfo);
 
     // Must be called post-injection to allow for floor data changes.
     Stats_ObserveRoomsLoad();

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -275,13 +275,9 @@ static bool Level_LoadRooms(MYFILE *fp)
         current_room_info->fx_number = NO_ITEM;
     }
 
-    m_LevelInfo.floor_data_size = File_ReadS32(fp);
-    g_FloorData = GameBuf_Alloc(
-        sizeof(int16_t)
-            * (m_LevelInfo.floor_data_size + m_InjectionInfo->floor_data_size),
-        GBUF_FLOOR_DATA);
-    File_ReadItems(
-        fp, g_FloorData, sizeof(int16_t), m_LevelInfo.floor_data_size);
+    const int32_t fd_length = File_ReadS32(fp);
+    m_LevelInfo.floor_data = Memory_Alloc(sizeof(int16_t) * fd_length);
+    File_ReadItems(fp, m_LevelInfo.floor_data, fd_length, sizeof(int16_t));
 
     return true;
 }
@@ -852,9 +848,8 @@ static bool Level_LoadTexturePages(MYFILE *fp)
 static void Level_CompleteSetup(int32_t level_num)
 {
     // Expand raw floor data into sectors
-    Room_ParseFloorData(g_FloorData);
-    // TODO: store raw FD temporarily in m_LevelInfo, release here and eliminate
-    // g_FloorData
+    Room_ParseFloorData(m_LevelInfo.floor_data);
+    Memory_FreePointer(&m_LevelInfo.floor_data);
 
     Inject_AllInjections(&m_LevelInfo);
 

--- a/src/game/objects/creatures/bacon_lara.c
+++ b/src/game/objects/creatures/bacon_lara.c
@@ -116,13 +116,11 @@ void BaconLara_Control(int16_t item_num)
         const int32_t h = Room_GetHeight(sector, x, y, z);
         item->floor = h;
 
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
         if (item->pos.y >= h) {
             item->floor = h;
             item->pos.y = h;
-            sector = Room_GetSector(x, h, z, &room_num);
-            Room_GetHeight(sector, x, h, z);
-            Room_TestTriggers(g_TriggerIndex, true);
+            Room_TestTriggers(item);
             item->gravity_status = 0;
             item->fall_speed = 0;
             item->goal_anim_state = LS_DEATH;

--- a/src/game/objects/creatures/torso.c
+++ b/src/game/objects/creatures/torso.c
@@ -255,10 +255,7 @@ void Torso_Control(int16_t item_num)
     if (item->status == IS_DEACTIVATED) {
         Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
         Effect_ExplodingDeath(item_num, -1, TORSO_PART_DAMAGE);
-        const SECTOR_INFO *const sector = Room_GetSector(
-            item->pos.x, item->pos.y, item->pos.z, &item->room_number);
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
 
         Item_Kill(item_num);
         item->status = IS_DEACTIVATED;

--- a/src/game/objects/general/door.c
+++ b/src/game/objects/general/door.c
@@ -51,12 +51,12 @@ static void Door_Shut(DOORPOS_DATA *const d)
         return;
     }
 
-    sector->index = 0;
     sector->box = NO_BOX;
     sector->floor.height = NO_HEIGHT;
     sector->ceiling.height = NO_HEIGHT;
     sector->portal_room.sky = NO_ROOM;
     sector->portal_room.pit = NO_ROOM;
+    sector->portal_room.wall = NO_ROOM;
 
     const int16_t box_num = d->block;
     if (box_num != NO_BOX) {

--- a/src/game/objects/general/scion.c
+++ b/src/game/objects/general/scion.c
@@ -116,11 +116,7 @@ void Scion_Control3(int16_t item_num)
     if (counter == 0) {
         item->status = IS_INVISIBLE;
         item->hit_points = DONT_TARGET;
-        int16_t room_num = item->room_number;
-        const SECTOR_INFO *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
         Item_RemoveDrawn(item_num);
     }
 

--- a/src/game/objects/traps/lava.c
+++ b/src/game/objects/traps/lava.c
@@ -14,7 +14,7 @@
 #define LAVA_EMBER_DAMAGE 10
 #define LAVA_WEDGE_SPEED 25
 
-bool Lava_TestFloor(ITEM_INFO *item)
+bool Lava_TestFloor(const ITEM_INFO *const item)
 {
     if (item->hit_points < 0 || g_Lara.water_status == LWS_CHEAT
         || (g_Lara.water_status == LWS_ABOVE_WATER
@@ -25,40 +25,11 @@ bool Lava_TestFloor(ITEM_INFO *item)
     // OG fix: check if floor index has lava
     int16_t room_num = item->room_number;
     const SECTOR_INFO *const sector =
-        Room_GetSector(item->pos.x, 32000, item->pos.z, &room_num);
-
-    int16_t *data = &g_FloorData[sector->index];
-    int16_t type;
-    do {
-        type = *data++;
-
-        switch (type & DATA_TYPE) {
-        case FT_TILT: {
-            data++;
-            break;
-        }
-
-        case FT_ROOF:
-        case FT_DOOR:
-            data++;
-            break;
-
-        case FT_LAVA:
-            return true;
-
-        case FT_TRIGGER:
-            data++;
-            break;
-
-        default:
-            break;
-        }
-    } while (!(type & END_BIT));
-
-    return false;
+        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    return sector->is_death_sector;
 }
 
-void Lava_Burn(ITEM_INFO *item)
+void Lava_Burn(ITEM_INFO *const item)
 {
     if (g_Lara.water_status == LWS_CHEAT) {
         return;
@@ -70,8 +41,9 @@ void Lava_Burn(ITEM_INFO *item)
 
     int16_t room_num = item->room_number;
     const SECTOR_INFO *const sector =
-        Room_GetSector(item->pos.x, 32000, item->pos.z, &room_num);
-    int16_t height = Room_GetHeight(sector, item->pos.x, 32000, item->pos.z);
+        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    const int16_t height =
+        Room_GetHeight(sector, item->pos.x, MAX_HEIGHT, item->pos.z);
 
     if (item->floor != height) {
         return;
@@ -84,7 +56,7 @@ void Lava_Burn(ITEM_INFO *item)
     }
 
     for (int i = 0; i < 10; i++) {
-        int16_t fx_num = Effect_Create(item->room_number);
+        const int16_t fx_num = Effect_Create(item->room_number);
         if (fx_num != NO_ITEM) {
             FX_INFO *fx = &g_Effects[fx_num];
             fx->object_number = O_FLAME;

--- a/src/game/objects/traps/lava.h
+++ b/src/game/objects/traps/lava.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool Lava_TestFloor(ITEM_INFO *item);
+bool Lava_TestFloor(const ITEM_INFO *item);
 void Lava_Burn(ITEM_INFO *item);
 
 void Lava_Setup(OBJECT_INFO *obj);

--- a/src/game/objects/traps/movable_block.c
+++ b/src/game/objects/traps/movable_block.c
@@ -276,12 +276,7 @@ void MovableBlock_Control(int16_t item_num)
         item->status = IS_NOT_ACTIVE;
         Item_RemoveActive(item_num);
         Room_AlterFloorHeight(item, -WALL_L);
-
-        room_num = item->room_number;
-        sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
     }
 }
 

--- a/src/game/objects/traps/rolling_ball.c
+++ b/src/game/objects/traps/rolling_ball.c
@@ -66,7 +66,7 @@ void RollingBall_Control(int16_t item_num)
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
 
         if (item->pos.y >= item->floor - STEP_L) {
             item->gravity_status = 0;

--- a/src/game/objects/traps/thors_hammer.c
+++ b/src/game/objects/traps/thors_hammer.c
@@ -113,11 +113,7 @@ void ThorsHandle_Control(int16_t item_num)
         int32_t old_x = x;
         int32_t old_z = z;
 
-        int16_t room_num = item->room_number;
-        const SECTOR_INFO *const sector =
-            Room_GetSector(x, item->pos.y, z, &room_num);
-        Room_GetHeight(sector, x, item->pos.y, z);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
 
         switch (item->rot.y) {
         case 0:

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -25,7 +25,6 @@
 #define NEG_TILT(T, H) ((T * (H & (WALL_L - 1))) >> 2)
 #define POS_TILT(T, H) ((T * ((WALL_L - 1 - H) & (WALL_L - 1))) >> 2)
 
-int16_t *g_TriggerIndex = NULL;
 int32_t g_FlipTimer = 0;
 int32_t g_FlipEffect = -1;
 int32_t g_FlipStatus = 0;

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -291,10 +291,6 @@ SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num)
         }
 
         sector = &r->sectors[z_sector + x_sector * r->z_size];
-        if (!sector->index) {
-            break;
-        }
-
         portal_room = sector->portal_room.wall;
         if (portal_room != NO_ROOM) {
             *room_num = portal_room;

--- a/src/game/room.h
+++ b/src/game/room.h
@@ -30,6 +30,9 @@ int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
 void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height);
 
 void Room_ParseFloorData(const int16_t *floor_data);
+void Room_PopulateSectorData(
+    SECTOR_INFO *sector, const int16_t *floor_data, uint16_t start_index,
+    uint16_t null_index);
 void Room_TestTriggers(const ITEM_INFO *item);
 void Room_FlipMap(void);
 bool Room_IsOnWalkable(

--- a/src/game/room.h
+++ b/src/game/room.h
@@ -19,6 +19,7 @@ void Room_GetNewRoom(int32_t x, int32_t y, int32_t z, int16_t room_num);
 void Room_GetNearByRooms(
     int32_t x, int32_t y, int32_t z, int32_t r, int32_t h, int16_t room_num);
 SECTOR_INFO *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
+SECTOR_INFO *Room_GetPitSector(const SECTOR_INFO *sector, int32_t x, int32_t z);
 int16_t Room_GetCeiling(
     const SECTOR_INFO *sector, int32_t x, int32_t y, int32_t z);
 int16_t Room_GetHeight(
@@ -29,7 +30,7 @@ int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
 void Room_AlterFloorHeight(ITEM_INFO *item, int32_t height);
 
 void Room_ParseFloorData(const int16_t *floor_data);
-void Room_TestTriggers(int16_t *data, bool heavy);
+void Room_TestTriggers(const ITEM_INFO *item);
 void Room_FlipMap(void);
 bool Room_IsOnWalkable(
     const SECTOR_INFO *sector, int32_t x, int32_t y, int32_t z,

--- a/src/game/room.h
+++ b/src/game/room.h
@@ -6,7 +6,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-extern int16_t *g_TriggerIndex;
 extern int32_t g_FlipTimer;
 extern int32_t g_FlipEffect;
 extern int32_t g_FlipStatus;

--- a/src/game/stats.c
+++ b/src/game/stats.c
@@ -91,13 +91,13 @@ static void Stats_CheckTriggers(
         const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
 
         if (cmd->type == TO_SECRET) {
-            const int16_t secret_num = 1 << cmd->parameter;
+            const int16_t secret_num = 1 << (int16_t)(intptr_t)cmd->parameter;
             if (!(m_SecretRoom & secret_num)) {
                 m_SecretRoom |= secret_num;
                 m_LevelSecrets++;
             }
         } else if (cmd->type == TO_OBJECT) {
-            const int16_t item_num = cmd->parameter;
+            const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
             if (m_KillableItems[item_num]) {
                 continue;
             }

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -123,6 +123,7 @@
 #define DONT_TARGET (-16384)
 #define UNIT_SHADOW 256
 #define NO_HEIGHT (-32512)
+#define MAX_HEIGHT 32000
 #define NO_BAD_POS (-NO_HEIGHT)
 #define NO_BAD_NEG NO_HEIGHT
 #define BAD_JUMP_CEILING ((STEP_L * 3) / 4) // = 192

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1162,13 +1162,15 @@ typedef struct DOOR_INFOS {
 
 typedef struct TRIGGER_CMD {
     TRIGGER_OBJECT type;
-    int16_t parameter;
-    struct {
-        int8_t timer;
-        int8_t glide;
-        bool one_shot;
-    } camera;
+    void *parameter;
 } TRIGGER_CMD;
+
+typedef struct TRIGGER_CAMERA_DATA {
+    int16_t camera_num;
+    int8_t timer;
+    int8_t glide;
+    bool one_shot;
+} TRIGGER_CAMERA_DATA;
 
 typedef struct TRIGGER {
     TRIGGER_TYPE type;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1160,9 +1160,31 @@ typedef struct DOOR_INFOS {
     DOOR_INFO door[];
 } DOOR_INFOS;
 
+typedef struct TRIGGER_CMD {
+    TRIGGER_OBJECT type;
+    int16_t parameter;
+    struct {
+        int8_t timer;
+        int8_t glide;
+        bool one_shot;
+    } camera;
+} TRIGGER_CMD;
+
+typedef struct TRIGGER {
+    TRIGGER_TYPE type;
+    int8_t timer;
+    int16_t mask;
+    bool one_shot;
+    int16_t item_index;
+    int32_t command_count;
+    TRIGGER_CMD *commands;
+} TRIGGER;
+
 typedef struct SECTOR_INFO {
     uint16_t index;
     int16_t box;
+    bool is_death_sector;
+    TRIGGER *trigger;
     struct {
         uint8_t pit;
         uint8_t sky;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1644,7 +1644,6 @@ typedef struct COLL_INFO {
     int16_t facing;
     DIRECTION quadrant;
     int16_t coll_type;
-    int16_t *trigger;
     int8_t tilt_x;
     int8_t tilt_z;
     int8_t hit_by_baddie;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -2095,7 +2095,7 @@ typedef struct LEVEL_INFO {
     int32_t texture_count;
     int32_t texture_page_count;
     uint8_t *texture_page_ptrs;
-    int32_t floor_data_size;
+    int16_t *floor_data;
     int32_t anim_texture_range_count;
     int32_t item_count;
     int32_t sprite_info_count;

--- a/src/global/vars.c
+++ b/src/global/vars.c
@@ -63,7 +63,6 @@ int32_t g_OverlayFlag = 0;
 int32_t g_HeightType = 0;
 
 ROOM_INFO *g_RoomInfo = NULL;
-int16_t *g_FloorData = NULL;
 int16_t *g_MeshBase = NULL;
 int16_t **g_Meshes = NULL;
 OBJECT_INFO g_Objects[O_NUMBER_OF] = { 0 };

--- a/src/global/vars.h
+++ b/src/global/vars.h
@@ -50,7 +50,6 @@ extern int32_t g_OverlayFlag;
 extern int32_t g_HeightType;
 
 extern ROOM_INFO *g_RoomInfo;
-extern int16_t *g_FloorData;
 extern int16_t *g_MeshBase;
 extern int16_t **g_Meshes;
 extern OBJECT_INFO g_Objects[O_NUMBER_OF];


### PR DESCRIPTION
Resolves #941.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This completes the floor data migration into properties in `SECTOR_INFO`. The raw `int16_t` array from the level files is now only used temporarily while the level is loaded; once all FD is parsed, it is discarded. This has allowed `g_FloorData` to be removed.

We do some forward lookup when reading `TRIGGER` data to know how many `TRIGGER_CMD`s are needed to be stored. The benefit is that in retrieving data later in the codebase, we just need simple `for` loops rather than re-interpreting FD values repeatedly.

`Room_TestTriggers` now expects the "triggerer" (`ITEM_INFO`) to be passed to it and it works out the sector, "heavy" state and suchlike from there. This greatly simplifies calls to it, as we don't need to have guaranteed that `g_TriggerIndex` has been set via `Room_GetHeight`. That global - and the related pointer in `COLL_INFO` - have also been removed as they are no longer required.

I did wonder if we could add function pointers to `TRIGGER_CMD` to tidy the switch statement in `Room_TestTriggers` e.g. when parsing, we allocate the function pointer based on the command type. But this probably needs some further refactoring, such as making a new module, plus we need to track flip status, flip effect and suchlike throughout the switch statement, so it maybe needs some further thought.

One other niggle is that `index` in `SECTOR_INFO` is only used in the initial parsing. I can't think of a good way to store these temporarily and then discard, but this is maybe OK for now.

For floor data injection, no `.bin` changes are needed, despite the version being updated. This is only so that subsequent updates don't need to have a global FD injection size. We no longer append to `g_FloorData` during injection; instead, because it now takes place after sector/FD parsing, we just update the existing properties or have `room.c` parse the provided injection data where new entries are needed.