### PR TITLE
config: fix missing Spanish translation option for target lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed Lara voiding when loading the game on a closed door (#1419)
 - fixed underwater caustics not resumed smoothly when unpausing (#1423, regression 3.2)
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground (#606)
+- fixed an issue with a missing Spanish config tool translation for the target mode (#1439)
 - improved initial level load time by lazy-loading audio samples (LostArtefacts/TR2X#114)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14

--- a/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/TR1X_ConfigTool/Resources/Lang/es.json
@@ -249,7 +249,7 @@
       "Title": "Cambio de objetivo",
       "Description": "Permite cambiar de objetivo como en TR4+ mientras apuntas con armas. Presiona mirar mientras apuntas para cambiar de objetivo."
     },
-    "target_lock_mode": {
+    "target_mode": {
       "Title": "Modo de bloqueo del objetivo del arma",
       "Description": "Cambia el comportamiento de cómo las armas se fijan en los objetivos.\n- Bloqueo total: siempre mantiene el objetivo bloqueado incluso si se pierde de vista al enemigo o muere (TR1 original).\n- Semibloqueo: mantiene el objetivo bloqueado si se pierde de vista al enemigo pero pierde el objetivo fijado si el enemigo muere.\n- Sin bloqueo: pierde el objetivo fijado si se pierde de vista al enemigo o muere (TR4+)."
     },


### PR DESCRIPTION
Resolves #1439.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed an issue with a missing Spanish config tool translation for the target mode.