### PR TITLE
gun: fix Lara holster and back states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 - fixed the ingame timer being skewed upon inventory open (#1420, regression from 4.1)
 - fixed Lara able to reach triggers through closed doors (#1419, regression from 1.1.4)
 - fixed Lara voiding when loading the game on a closed door (#1419)
-- fixed underwater caustics not resumed smoothly when unpausing (#1423, regression 3.2)
+- fixed underwater caustics not resumed smoothly when unpausing (#1423, regression from 3.2)
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground (#606)
 - fixed an issue with a missing Spanish config tool translation for the target mode (#1439)
+- fixed carrying over unexpected guns in holsters to the next level under rare scenarios (#1437, regression from 2.4)
+- fixed item cheats not updating Lara holster and backpack meshes (#1437)
 - improved initial level load time by lazy-loading audio samples (LostArtefacts/TR2X#114)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1115,6 +1115,9 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             break;
 
         case GFS_LOOP_GAME:
+            if (level_type != GFL_SAVED) {
+                Lara_RevertToPistolsIfNeeded();
+            }
             Phase_Set(PHASE_GAME, NULL);
             ret = Phase_Run();
             if (ret.command != GF_PHASE_CONTINUE) {

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1115,7 +1115,8 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             break;
 
         case GFS_LOOP_GAME:
-            if (level_type != GFL_SAVED) {
+            if (level_type != GFL_SAVED
+                && level_num != g_GameFlow.first_level_num) {
                 Lara_RevertToPistolsIfNeeded();
             }
             Phase_Set(PHASE_GAME, NULL);

--- a/src/game/gameflow.c
+++ b/src/game/gameflow.c
@@ -1258,18 +1258,6 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                     (const GAMEFLOW_GIVE_ITEM_DATA *)seq->data;
                 Inv_AddItemNTimes(
                     give_item_data->object_num, give_item_data->quantity);
-                if (g_Lara.gun_type == LGT_UNARMED) {
-                    if (Inv_RequestItem(O_PISTOL_ITEM)) {
-                        g_GameInfo.current[level_num].gun_type = LGT_PISTOLS;
-                    } else if (Inv_RequestItem(O_SHOTGUN_ITEM)) {
-                        g_GameInfo.current[level_num].gun_type = LGT_SHOTGUN;
-                    } else if (Inv_RequestItem(O_MAGNUM_ITEM)) {
-                        g_GameInfo.current[level_num].gun_type = LGT_MAGNUMS;
-                    } else if (Inv_RequestItem(O_UZI_ITEM)) {
-                        g_GameInfo.current[level_num].gun_type = LGT_UZIS;
-                    }
-                    Lara_InitialiseMeshes(level_num);
-                }
             }
             break;
 

--- a/src/game/gun.h
+++ b/src/game/gun.h
@@ -14,5 +14,10 @@ int32_t Gun_FireWeapon(
 void Gun_HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int16_t damage);
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, int32_t clip);
 GAME_OBJECT_ID Gun_GetLaraAnim(LARA_GUN_TYPE gun_type);
-GAME_OBJECT_ID Gun_GetPistolsAnim(LARA_GUN_TYPE gun_type);
-GAME_OBJECT_ID Gun_GetRifleAnim(LARA_GUN_TYPE gun_type);
+GAME_OBJECT_ID Gun_GetWeaponAnim(LARA_GUN_TYPE gun_type);
+void Gun_UpdateLaraMeshes(GAME_OBJECT_ID object_id);
+void Gun_SetLaraBackMesh(LARA_GUN_TYPE weapon_type);
+void Gun_SetLaraHandLMesh(LARA_GUN_TYPE weapon_type);
+void Gun_SetLaraHandRMesh(LARA_GUN_TYPE weapon_type);
+void Gun_SetLaraHolsterLMesh(LARA_GUN_TYPE weapon_type);
+void Gun_SetLaraHolsterRMesh(LARA_GUN_TYPE weapon_type);

--- a/src/game/gun/gun.c
+++ b/src/game/gun/gun.c
@@ -4,6 +4,7 @@
 #include "game/gun/gun_rifle.h"
 #include "game/input.h"
 #include "game/inventory.h"
+#include "game/lara.h"
 #include "game/output.h"
 #include "game/random.h"
 #include "global/const.h"
@@ -105,8 +106,7 @@ void Gun_Control(void)
         break;
 
     case LGS_UNDRAW:
-        g_Lara.mesh_ptrs[LM_HEAD] =
-            g_Meshes[g_Objects[O_LARA].mesh_index + LM_HEAD];
+        Lara_SwapSingleMesh(LM_HEAD, O_LARA);
 
         switch (g_Lara.gun_type) {
         case LGT_PISTOLS:
@@ -125,14 +125,12 @@ void Gun_Control(void)
         break;
 
     case LGS_READY:
-        g_Lara.mesh_ptrs[LM_HEAD] =
-            g_Meshes[g_Objects[O_LARA].mesh_index + LM_HEAD];
+        Lara_SwapSingleMesh(LM_HEAD, O_LARA);
 
         switch (g_Lara.gun_type) {
         case LGT_PISTOLS:
             if (g_Lara.pistols.ammo && g_Input.action) {
-                g_Lara.mesh_ptrs[LM_HEAD] =
-                    g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_HEAD];
+                Lara_SwapSingleMesh(LM_HEAD, O_UZI_ANIM);
             }
             if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
                 g_Camera.type = CAM_COMBAT;
@@ -142,8 +140,7 @@ void Gun_Control(void)
 
         case LGT_MAGNUMS:
             if (g_Lara.magnums.ammo && g_Input.action) {
-                g_Lara.mesh_ptrs[LM_HEAD] =
-                    g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_HEAD];
+                Lara_SwapSingleMesh(LM_HEAD, O_UZI_ANIM);
             }
             if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
                 g_Camera.type = CAM_COMBAT;
@@ -153,8 +150,7 @@ void Gun_Control(void)
 
         case LGT_UZIS:
             if (g_Lara.uzis.ammo && g_Input.action) {
-                g_Lara.mesh_ptrs[LM_HEAD] =
-                    g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_HEAD];
+                Lara_SwapSingleMesh(LM_HEAD, O_UZI_ANIM);
             }
             if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
                 g_Camera.type = CAM_COMBAT;
@@ -164,8 +160,7 @@ void Gun_Control(void)
 
         case LGT_SHOTGUN:
             if (g_Lara.shotgun.ammo && g_Input.action) {
-                g_Lara.mesh_ptrs[LM_HEAD] =
-                    g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_HEAD];
+                Lara_SwapSingleMesh(LM_HEAD, O_UZI_ANIM);
             }
             if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
                 g_Camera.type = CAM_COMBAT;
@@ -312,8 +307,7 @@ void Gun_SetLaraHandLMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID object_id =
         weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
     assert(object_id != NO_OBJECT);
-    g_Lara.mesh_ptrs[LM_HAND_L] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_L];
+    Lara_SwapSingleMesh(LM_HAND_L, object_id);
 }
 
 void Gun_SetLaraHandRMesh(const LARA_GUN_TYPE weapon_type)
@@ -321,8 +315,7 @@ void Gun_SetLaraHandRMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID object_id =
         weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
     assert(object_id != NO_OBJECT);
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_R];
+    Lara_SwapSingleMesh(LM_HAND_R, object_id);
 }
 
 void Gun_SetLaraBackMesh(const LARA_GUN_TYPE weapon_type)
@@ -330,8 +323,7 @@ void Gun_SetLaraBackMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID object_id =
         weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
     assert(object_id != NO_OBJECT);
-    g_Lara.mesh_ptrs[LM_TORSO] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_TORSO];
+    Lara_SwapSingleMesh(LM_TORSO, object_id);
     g_Lara.back_gun_type = weapon_type;
 }
 
@@ -340,8 +332,7 @@ void Gun_SetLaraHolsterLMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID object_id =
         weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
     assert(object_id != NO_OBJECT);
-    g_Lara.mesh_ptrs[LM_THIGH_L] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_L];
+    Lara_SwapSingleMesh(LM_THIGH_L, object_id);
     g_Lara.holsters_gun_type = weapon_type;
 }
 
@@ -350,7 +341,6 @@ void Gun_SetLaraHolsterRMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID object_id =
         weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
     assert(object_id != NO_OBJECT);
-    g_Lara.mesh_ptrs[LM_THIGH_R] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_R];
+    Lara_SwapSingleMesh(LM_THIGH_R, object_id);
     g_Lara.holsters_gun_type = weapon_type;
 }

--- a/src/game/gun/gun.c
+++ b/src/game/gun/gun.c
@@ -10,6 +10,7 @@
 #include "global/vars.h"
 #include "math/matrix.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -73,6 +74,9 @@ void Gun_Control(void)
                 g_Lara.gun_status = LGS_UNDRAW;
             }
             break;
+
+        default:
+            break;
         }
     }
 
@@ -94,12 +98,16 @@ void Gun_Control(void)
             }
             Gun_Rifle_Draw(g_Lara.gun_type);
             break;
+
+        default:
+            break;
         }
         break;
 
     case LGS_UNDRAW:
         g_Lara.mesh_ptrs[LM_HEAD] =
             g_Meshes[g_Objects[O_LARA].mesh_index + LM_HEAD];
+
         switch (g_Lara.gun_type) {
         case LGT_PISTOLS:
         case LGT_MAGNUMS:
@@ -110,12 +118,16 @@ void Gun_Control(void)
         case LGT_SHOTGUN:
             Gun_Rifle_Undraw(g_Lara.gun_type);
             break;
+
+        default:
+            break;
         }
         break;
 
     case LGS_READY:
         g_Lara.mesh_ptrs[LM_HEAD] =
             g_Meshes[g_Objects[O_LARA].mesh_index + LM_HEAD];
+
         switch (g_Lara.gun_type) {
         case LGT_PISTOLS:
             if (g_Lara.pistols.ammo && g_Input.action) {
@@ -159,6 +171,9 @@ void Gun_Control(void)
                 g_Camera.type = CAM_COMBAT;
             }
             Gun_Rifle_Control(g_Lara.gun_type);
+            break;
+
+        default:
             break;
         }
         break;
@@ -208,7 +223,7 @@ GAME_OBJECT_ID Gun_GetLaraAnim(const LARA_GUN_TYPE gun_type)
     }
 }
 
-GAME_OBJECT_ID Gun_GetPistolsAnim(const LARA_GUN_TYPE gun_type)
+GAME_OBJECT_ID Gun_GetWeaponAnim(const LARA_GUN_TYPE gun_type)
 {
     switch (gun_type) {
     case LGT_PISTOLS:
@@ -217,14 +232,6 @@ GAME_OBJECT_ID Gun_GetPistolsAnim(const LARA_GUN_TYPE gun_type)
         return O_MAGNUM_ANIM;
     case LGT_UZIS:
         return O_UZI_ANIM;
-    default:
-        return NO_OBJECT;
-    }
-}
-
-GAME_OBJECT_ID Gun_GetRifleAnim(const LARA_GUN_TYPE gun_type)
-{
-    switch (gun_type) {
     case LGT_SHOTGUN:
         return O_SHOTGUN_ANIM;
     default:
@@ -270,4 +277,80 @@ void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, int32_t clip)
     if (g_Objects[O_GUN_FLASH].loaded) {
         Output_DrawPolygons(g_Meshes[g_Objects[O_GUN_FLASH].mesh_index], clip);
     }
+}
+
+void Gun_UpdateLaraMeshes(const GAME_OBJECT_ID object_id)
+{
+    const bool lara_has_pistols = Inv_RequestItem(O_PISTOL_ITEM)
+        || Inv_RequestItem(O_MAGNUM_ITEM) || Inv_RequestItem(O_UZI_ITEM);
+
+    LARA_GUN_TYPE back_gun_type = LGT_UNARMED;
+    LARA_GUN_TYPE holsters_gun_type = LGT_UNARMED;
+
+    if (!Inv_RequestItem(O_SHOTGUN_ITEM) && object_id == O_SHOTGUN_ITEM) {
+        back_gun_type = LGT_SHOTGUN;
+    } else if (!lara_has_pistols && object_id == O_PISTOL_ITEM) {
+        holsters_gun_type = LGT_PISTOLS;
+    } else if (!lara_has_pistols && object_id == O_MAGNUM_ITEM) {
+        holsters_gun_type = LGT_MAGNUMS;
+    } else if (!lara_has_pistols && object_id == O_UZI_ITEM) {
+        holsters_gun_type = LGT_UZIS;
+    }
+
+    if (back_gun_type != LGT_UNARMED) {
+        Gun_SetLaraBackMesh(back_gun_type);
+    }
+
+    if (holsters_gun_type != LGT_UNARMED) {
+        Gun_SetLaraHolsterLMesh(holsters_gun_type);
+        Gun_SetLaraHolsterRMesh(holsters_gun_type);
+    }
+}
+
+void Gun_SetLaraHandLMesh(const LARA_GUN_TYPE weapon_type)
+{
+    const GAME_OBJECT_ID object_id =
+        weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
+    assert(object_id != NO_OBJECT);
+    g_Lara.mesh_ptrs[LM_HAND_L] =
+        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_L];
+}
+
+void Gun_SetLaraHandRMesh(const LARA_GUN_TYPE weapon_type)
+{
+    const GAME_OBJECT_ID object_id =
+        weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
+    assert(object_id != NO_OBJECT);
+    g_Lara.mesh_ptrs[LM_HAND_R] =
+        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_R];
+}
+
+void Gun_SetLaraBackMesh(const LARA_GUN_TYPE weapon_type)
+{
+    const GAME_OBJECT_ID object_id =
+        weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
+    assert(object_id != NO_OBJECT);
+    g_Lara.mesh_ptrs[LM_TORSO] =
+        g_Meshes[g_Objects[object_id].mesh_index + LM_TORSO];
+    g_Lara.back_gun_type = weapon_type;
+}
+
+void Gun_SetLaraHolsterLMesh(const LARA_GUN_TYPE weapon_type)
+{
+    const GAME_OBJECT_ID object_id =
+        weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
+    assert(object_id != NO_OBJECT);
+    g_Lara.mesh_ptrs[LM_THIGH_L] =
+        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_L];
+    g_Lara.holsters_gun_type = weapon_type;
+}
+
+void Gun_SetLaraHolsterRMesh(const LARA_GUN_TYPE weapon_type)
+{
+    const GAME_OBJECT_ID object_id =
+        weapon_type == LGT_UNARMED ? O_LARA : Gun_GetWeaponAnim(weapon_type);
+    assert(object_id != NO_OBJECT);
+    g_Lara.mesh_ptrs[LM_THIGH_R] =
+        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_R];
+    g_Lara.holsters_gun_type = weapon_type;
 }

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -110,43 +110,23 @@ void Gun_Pistols_Ready(const LARA_GUN_TYPE weapon_type)
 
 void Gun_Pistols_DrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
-    const GAME_OBJECT_ID object_id = Gun_GetPistolsAnim(weapon_type);
-    if (object_id == NO_OBJECT) {
-        return;
-    }
-    g_Lara.mesh_ptrs[LM_HAND_L] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_L];
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_R];
-    g_Lara.mesh_ptrs[LM_THIGH_L] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_THIGH_L];
-    g_Lara.mesh_ptrs[LM_THIGH_R] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_THIGH_R];
+    Gun_SetLaraHandLMesh(weapon_type);
+    Gun_SetLaraHandRMesh(weapon_type);
+    Gun_SetLaraHolsterLMesh(LGT_UNARMED);
+    Gun_SetLaraHolsterRMesh(LGT_UNARMED);
 }
 
 void Gun_Pistols_UndrawMeshLeft(const LARA_GUN_TYPE weapon_type)
 {
-    const GAME_OBJECT_ID object_id = Gun_GetPistolsAnim(weapon_type);
-    if (object_id == NO_OBJECT) {
-        return;
-    }
-    g_Lara.mesh_ptrs[LM_THIGH_L] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_L];
-    g_Lara.mesh_ptrs[LM_HAND_L] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_HAND_L];
+    Gun_SetLaraHandLMesh(LGT_UNARMED);
+    Gun_SetLaraHolsterLMesh(weapon_type);
     Sound_Effect(SFX_LARA_HOLSTER, &g_LaraItem->pos, SPM_NORMAL);
 }
 
 void Gun_Pistols_UndrawMeshRight(const LARA_GUN_TYPE weapon_type)
 {
-    const GAME_OBJECT_ID object_id = Gun_GetPistolsAnim(weapon_type);
-    if (object_id == NO_OBJECT) {
-        return;
-    }
-    g_Lara.mesh_ptrs[LM_THIGH_R] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_THIGH_R];
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_HAND_R];
+    Gun_SetLaraHandRMesh(LGT_UNARMED);
+    Gun_SetLaraHolsterRMesh(weapon_type);
     Sound_Effect(SFX_LARA_HOLSTER, &g_LaraItem->pos, SPM_NORMAL);
 }
 

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -84,30 +84,16 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
 
 void Gun_Rifle_DrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
-    const GAME_OBJECT_ID object_id = Gun_GetRifleAnim(weapon_type);
-    if (object_id == NO_OBJECT) {
-        return;
-    }
-    g_Lara.mesh_ptrs[LM_HAND_L] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_L];
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_HAND_R];
-    g_Lara.mesh_ptrs[LM_TORSO] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_TORSO];
+    Gun_SetLaraHandLMesh(weapon_type);
+    Gun_SetLaraHandRMesh(weapon_type);
+    Gun_SetLaraBackMesh(LGT_UNARMED);
 }
 
 void Gun_Rifle_UndrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
-    const GAME_OBJECT_ID object_id = Gun_GetRifleAnim(weapon_type);
-    if (object_id == NO_OBJECT) {
-        return;
-    }
-    g_Lara.mesh_ptrs[LM_HAND_L] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_HAND_L];
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[O_LARA].mesh_index + LM_HAND_R];
-    g_Lara.mesh_ptrs[LM_TORSO] =
-        g_Meshes[g_Objects[object_id].mesh_index + LM_TORSO];
+    Gun_SetLaraHandLMesh(LGT_UNARMED);
+    Gun_SetLaraHandRMesh(LGT_UNARMED);
+    Gun_SetLaraBackMesh(weapon_type);
 }
 
 void Gun_Rifle_Ready(const LARA_GUN_TYPE weapon_type)

--- a/src/game/inventory/inventory_func.c
+++ b/src/game/inventory/inventory_func.c
@@ -1,3 +1,4 @@
+#include "game/gun.h"
 #include "game/inventory.h"
 #include "game/inventory/inventory_vars.h"
 #include "game/items.h"
@@ -11,6 +12,10 @@
 
 bool Inv_AddItem(const GAME_OBJECT_ID object_id)
 {
+    if (Object_IsObjectType(object_id, g_GunObjects)) {
+        Gun_UpdateLaraMeshes(object_id);
+    }
+
     const GAME_OBJECT_ID inv_object_id = Inv_GetItemOption(object_id);
     if (!g_Objects[inv_object_id].loaded) {
         return false;

--- a/src/game/lara.h
+++ b/src/game/lara.h
@@ -19,6 +19,7 @@ void Lara_InitialiseInventory(int32_t level_num);
 void Lara_InitialiseMeshes(int32_t level_num);
 
 void Lara_SwapMeshExtra(void);
+void Lara_SwapSingleMesh(LARA_MESH mesh, GAME_OBJECT_ID);
 bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);
 void Lara_UseItem(GAME_OBJECT_ID object_num);
 int16_t Lara_GetNearestEnemy(void);

--- a/src/game/lara.h
+++ b/src/game/lara.h
@@ -31,3 +31,5 @@ bool Lara_MovePosition(ITEM_INFO *item, XYZ_32 *vec);
 void Lara_Push(ITEM_INFO *item, COLL_INFO *coll, bool spaz_on, bool big_push);
 
 void Lara_TakeDamage(int16_t damage, bool hit_status);
+
+void Lara_RevertToPistolsIfNeeded(void);

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -210,9 +210,14 @@ void Lara_SwapMeshExtra(void)
     if (!g_Objects[O_LARA_EXTRA].loaded) {
         return;
     }
-    for (int i = 0; i < LM_NUMBER_OF; i++) {
-        g_Lara.mesh_ptrs[i] = g_Meshes[g_Objects[O_LARA_EXTRA].mesh_index + i];
+    for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
+        Lara_SwapSingleMesh(mesh, O_LARA_EXTRA);
     }
+}
+
+void Lara_SwapSingleMesh(const LARA_MESH mesh, const GAME_OBJECT_ID object_id)
+{
+    g_Lara.mesh_ptrs[mesh] = g_Meshes[g_Objects[object_id].mesh_index + mesh];
 }
 
 void Lara_Animate(ITEM_INFO *item)
@@ -610,17 +615,14 @@ void Lara_InitialiseMeshes(int32_t level_num)
     const RESUME_INFO *const resume = &g_GameInfo.current[level_num];
 
     if (resume->flags.costume) {
-        for (int32_t i = 0; i < LM_NUMBER_OF; i++) {
-            const bool use_orig_mesh = i == LM_HEAD;
-            g_Lara.mesh_ptrs[i] = g_Meshes
-                [g_Objects[use_orig_mesh ? O_LARA : O_LARA_EXTRA].mesh_index
-                 + i];
+        for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
+            Lara_SwapSingleMesh(mesh, mesh == LM_HEAD ? O_LARA : O_LARA_EXTRA);
         }
         return;
     }
 
-    for (int32_t i = 0; i < LM_NUMBER_OF; i++) {
-        g_Lara.mesh_ptrs[i] = g_Meshes[g_Objects[O_LARA].mesh_index + i];
+    for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
+        Lara_SwapSingleMesh(mesh, O_LARA);
     }
 
     LARA_GUN_TYPE holsters_gun_type = resume->holsters_gun_type;

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -611,7 +611,9 @@ void Lara_RevertToPistolsIfNeeded(void)
 
     g_Lara.gun_type = LGT_PISTOLS;
 
-    g_Lara.holsters_gun_type = LGT_UNARMED;
+    if (g_Lara.gun_status != LGS_ARMLESS) {
+        g_Lara.holsters_gun_type = LGT_UNARMED;
+    }
     if (Inv_RequestItem(O_SHOTGUN_ITEM)) {
         g_Lara.back_gun_type = LGT_SHOTGUN;
     } else {

--- a/src/game/lara/lara.c
+++ b/src/game/lara/lara.c
@@ -594,20 +594,33 @@ void Lara_InitialiseInventory(int32_t level_num)
     }
 
     g_Lara.gun_status = resume->gun_status;
-
-    if (g_Config.revert_to_pistols
-        && g_GameInfo.current[level_num].flags.got_pistols != 0) {
-        g_Lara.request_gun_type = LGT_PISTOLS;
-        g_Lara.gun_type = LGT_PISTOLS;
-    } else {
-        g_Lara.gun_type = resume->equipped_gun_type;
-        g_Lara.request_gun_type = resume->equipped_gun_type;
-    }
+    g_Lara.gun_type = resume->equipped_gun_type;
+    g_Lara.request_gun_type = resume->equipped_gun_type;
     g_Lara.holsters_gun_type = resume->holsters_gun_type;
     g_Lara.back_gun_type = resume->back_gun_type;
 
     Lara_InitialiseMeshes(level_num);
     Gun_InitialiseNewWeapon();
+}
+
+void Lara_RevertToPistolsIfNeeded(void)
+{
+    if (!g_Config.revert_to_pistols || !Inv_RequestItem(O_PISTOL_ITEM)) {
+        return;
+    }
+
+    g_Lara.gun_type = LGT_PISTOLS;
+
+    g_Lara.holsters_gun_type = LGT_UNARMED;
+    if (Inv_RequestItem(O_SHOTGUN_ITEM)) {
+        g_Lara.back_gun_type = LGT_SHOTGUN;
+    } else {
+        g_Lara.back_gun_type = LGT_UNARMED;
+    }
+    Gun_InitialiseNewWeapon();
+    Gun_SetLaraHolsterLMesh(g_Lara.holsters_gun_type);
+    Gun_SetLaraHolsterRMesh(g_Lara.holsters_gun_type);
+    Gun_SetLaraBackMesh(g_Lara.back_gun_type);
 }
 
 void Lara_InitialiseMeshes(int32_t level_num)

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "game/input.h"
 #include "game/items.h"
+#include "game/lara.h"
 #include "game/lara/lara_look.h"
 #include "game/objects/effects/twinkle.h"
 #include "game/room.h"
@@ -683,85 +684,70 @@ void Lara_State_DieMidas(ITEM_INFO *item, COLL_INFO *coll)
     case 5:
         g_Lara.mesh_effects |= (1 << LM_FOOT_L);
         g_Lara.mesh_effects |= (1 << LM_FOOT_R);
-        g_Lara.mesh_ptrs[LM_FOOT_L] =
-            g_Meshes[g_Objects[O_LARA_EXTRA].mesh_index + LM_FOOT_L];
-        g_Lara.mesh_ptrs[LM_FOOT_R] =
-            g_Meshes[g_Objects[O_LARA_EXTRA].mesh_index + LM_FOOT_R];
+        Lara_SwapSingleMesh(LM_FOOT_L, O_LARA_EXTRA);
+        Lara_SwapSingleMesh(LM_FOOT_R, O_LARA_EXTRA);
         break;
 
     case 70:
         g_Lara.mesh_effects |= (1 << LM_CALF_L);
-        g_Lara.mesh_ptrs[LM_CALF_L] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_CALF_L];
+        Lara_SwapSingleMesh(LM_CALF_L, O_LARA_EXTRA);
         break;
 
     case 90:
         g_Lara.mesh_effects |= (1 << LM_THIGH_L);
-        g_Lara.mesh_ptrs[LM_THIGH_L] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_THIGH_L];
+        Lara_SwapSingleMesh(LM_THIGH_L, O_LARA_EXTRA);
         break;
 
     case 100:
         g_Lara.mesh_effects |= (1 << LM_CALF_R);
-        g_Lara.mesh_ptrs[LM_CALF_R] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_CALF_R];
+        Lara_SwapSingleMesh(LM_CALF_R, O_LARA_EXTRA);
         break;
 
     case 120:
         g_Lara.mesh_effects |= (1 << LM_HIPS);
         g_Lara.mesh_effects |= (1 << LM_THIGH_R);
-        g_Lara.mesh_ptrs[LM_HIPS] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_HIPS];
-        g_Lara.mesh_ptrs[LM_THIGH_R] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_THIGH_R];
+        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
+        Lara_SwapSingleMesh(LM_THIGH_R, O_LARA_EXTRA);
         break;
 
     case 135:
         g_Lara.mesh_effects |= (1 << LM_TORSO);
-        g_Lara.mesh_ptrs[LM_TORSO] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_TORSO];
+        Lara_SwapSingleMesh(LM_TORSO, O_LARA_EXTRA);
         break;
 
     case 150:
         g_Lara.mesh_effects |= (1 << LM_UARM_L);
-        g_Lara.mesh_ptrs[LM_UARM_L] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_UARM_L];
+        Lara_SwapSingleMesh(LM_UARM_L, O_LARA_EXTRA);
         break;
 
     case 163:
         g_Lara.mesh_effects |= (1 << LM_LARM_L);
-        g_Lara.mesh_ptrs[LM_LARM_L] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_LARM_L];
+        Lara_SwapSingleMesh(LM_LARM_L, O_LARA_EXTRA);
         break;
 
     case 174:
         g_Lara.mesh_effects |= (1 << LM_HAND_L);
-        g_Lara.mesh_ptrs[LM_HAND_L] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_HAND_L];
+        Lara_SwapSingleMesh(LM_HAND_L, O_LARA_EXTRA);
         break;
 
     case 186:
         g_Lara.mesh_effects |= (1 << LM_UARM_R);
-        g_Lara.mesh_ptrs[LM_UARM_R] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_UARM_R];
+        Lara_SwapSingleMesh(LM_UARM_R, O_LARA_EXTRA);
         break;
 
     case 195:
         g_Lara.mesh_effects |= (1 << LM_LARM_R);
-        g_Lara.mesh_ptrs[LM_LARM_R] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_LARM_R];
+        Lara_SwapSingleMesh(LM_LARM_R, O_LARA_EXTRA);
         break;
 
     case 218:
         g_Lara.mesh_effects |= (1 << LM_HAND_R);
-        g_Lara.mesh_ptrs[LM_HAND_R] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_HAND_R];
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_EXTRA);
         break;
 
     case 225:
         g_Lara.mesh_effects |= (1 << LM_HEAD);
-        g_Lara.mesh_ptrs[LM_HEAD] =
-            g_Meshes[(&g_Objects[O_LARA_EXTRA])->mesh_index + LM_HEAD];
+        Lara_SwapSingleMesh(LM_HEAD, O_LARA_EXTRA);
         break;
     }
 

--- a/src/game/objects/creatures/bacon_lara.c
+++ b/src/game/objects/creatures/bacon_lara.c
@@ -138,14 +138,14 @@ void BaconLara_Draw(ITEM_INFO *item)
 
     int16_t *old_mesh_ptrs[LM_NUMBER_OF];
 
-    for (int i = 0; i < LM_NUMBER_OF; i++) {
-        old_mesh_ptrs[i] = g_Lara.mesh_ptrs[i];
-        g_Lara.mesh_ptrs[i] = g_Meshes[g_Objects[O_BACON_LARA].mesh_index + i];
+    for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
+        old_mesh_ptrs[mesh] = g_Lara.mesh_ptrs[mesh];
+        Lara_SwapSingleMesh(mesh, O_BACON_LARA);
     }
 
     Lara_Draw(item);
 
-    for (int i = 0; i < LM_NUMBER_OF; i++) {
-        g_Lara.mesh_ptrs[i] = old_mesh_ptrs[i];
+    for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
+        g_Lara.mesh_ptrs[mesh] = old_mesh_ptrs[mesh];
     }
 }

--- a/src/game/objects/general/pickup.c
+++ b/src/game/objects/general/pickup.c
@@ -1,6 +1,7 @@
 #include "game/objects/general/pickup.h"
 
 #include "config.h"
+#include "game/gun.h"
 #include "game/input.h"
 #include "game/inventory.h"
 #include "game/items.h"
@@ -49,45 +50,13 @@ static const OBJECT_BOUNDS m_PickUpBoundsUW = {
     },
 };
 
-static void PickUp_AddGunToMesh(
-    const GAME_OBJECT_ID obj_num, const ITEM_INFO *lara_item);
 static void PickUp_GetItem(
     int16_t item_num, ITEM_INFO *item, ITEM_INFO *lara_item);
 static void PickUp_GetAllAtLaraPos(ITEM_INFO *item, ITEM_INFO *lara_item);
 
-static void PickUp_AddGunToMesh(
-    const GAME_OBJECT_ID obj_num, const ITEM_INFO *const lara_item)
-{
-    const bool lara_has_pistols = Inv_RequestItem(O_PISTOL_ITEM)
-        || Inv_RequestItem(O_MAGNUM_ITEM) || Inv_RequestItem(O_UZI_ITEM);
-
-    if (!Inv_RequestItem(O_SHOTGUN_ITEM) && obj_num == O_SHOTGUN_ITEM) {
-        g_Lara.mesh_ptrs[LM_TORSO] =
-            g_Meshes[g_Objects[O_SHOTGUN_ANIM].mesh_index + LM_TORSO];
-    } else if (!lara_has_pistols && obj_num == O_PISTOL_ITEM) {
-        g_Lara.mesh_ptrs[LM_THIGH_L] =
-            g_Meshes[g_Objects[O_PISTOL_ANIM].mesh_index + LM_THIGH_L];
-        g_Lara.mesh_ptrs[LM_THIGH_R] =
-            g_Meshes[g_Objects[O_PISTOL_ANIM].mesh_index + LM_THIGH_R];
-    } else if (!lara_has_pistols && obj_num == O_MAGNUM_ITEM) {
-        g_Lara.mesh_ptrs[LM_THIGH_L] =
-            g_Meshes[g_Objects[O_MAGNUM_ANIM].mesh_index + LM_THIGH_L];
-        g_Lara.mesh_ptrs[LM_THIGH_R] =
-            g_Meshes[g_Objects[O_MAGNUM_ANIM].mesh_index + LM_THIGH_R];
-    } else if (!lara_has_pistols && obj_num == O_UZI_ITEM) {
-        g_Lara.mesh_ptrs[LM_THIGH_L] =
-            g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_THIGH_L];
-        g_Lara.mesh_ptrs[LM_THIGH_R] =
-            g_Meshes[g_Objects[O_UZI_ANIM].mesh_index + LM_THIGH_R];
-    }
-}
-
 static void PickUp_GetItem(
     int16_t item_num, ITEM_INFO *item, ITEM_INFO *lara_item)
 {
-    if (Object_IsObjectType(item->object_number, g_GunObjects)) {
-        PickUp_AddGunToMesh(item->object_number, lara_item);
-    }
     Overlay_AddPickup(item->object_number);
     Inv_AddItem(item->object_number);
     item->status = IS_INVISIBLE;

--- a/src/game/phase/phase_demo.c
+++ b/src/game/phase/phase_demo.c
@@ -142,7 +142,9 @@ static void Phase_Demo_Start(void *arg)
     resume_info->flags.got_pistols = 1;
     resume_info->pistol_ammo = 1000;
     resume_info->gun_status = LGS_ARMLESS;
-    resume_info->gun_type = LGT_PISTOLS;
+    resume_info->equipped_gun_type = LGT_PISTOLS;
+    resume_info->holsters_gun_type = LGT_PISTOLS;
+    resume_info->back_gun_type = LGT_UNARMED;
     resume_info->lara_hitpoints = LARA_MAX_HITPOINTS;
 
     Random_SeedDraw(0xD371F947);

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -283,6 +283,7 @@ void Savegame_ApplyLogicToCurrentInfo(int level_num)
         current->magnum_ammo = 1234;
         current->uzi_ammo = 1234;
         current->equipped_gun_type = LGT_UZIS;
+        current->holsters_gun_type = LGT_UZIS;
     }
 
     // Fallback logic to figure out holster and back gun items for versions 4.2

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -245,7 +245,12 @@ static bool Savegame_BSON_LoadResumeInfo(
             json_object_get_int(resume_obj, "num_big_medis", 0);
         resume->num_scions = json_object_get_int(resume_obj, "num_scions", 0);
         resume->gun_status = json_object_get_int(resume_obj, "gun_status", 0);
-        resume->gun_type = json_object_get_int(resume_obj, "gun_type", 0);
+        resume->equipped_gun_type =
+            json_object_get_int(resume_obj, "gun_type", LGT_UNARMED);
+        resume->holsters_gun_type =
+            json_object_get_int(resume_obj, "holsters_gun_type", LGT_UNKNOWN);
+        resume->back_gun_type =
+            json_object_get_int(resume_obj, "back_gun_type", LGT_UNKNOWN);
         resume->flags.available =
             json_object_get_bool(resume_obj, "available", 0);
         resume->flags.got_pistols =
@@ -314,7 +319,10 @@ static bool Savegame_BSON_LoadDiscontinuedStartInfo(
             json_object_get_int(start_obj, "num_big_medis", 0);
         start->num_scions = json_object_get_int(start_obj, "num_scions", 0);
         start->gun_status = json_object_get_int(start_obj, "gun_status", 0);
-        start->gun_type = json_object_get_int(start_obj, "gun_type", 0);
+        start->equipped_gun_type =
+            json_object_get_int(start_obj, "gun_type", LGT_UNARMED);
+        start->holsters_gun_type = LGT_UNKNOWN;
+        start->back_gun_type = LGT_UNKNOWN;
         start->flags.available =
             json_object_get_bool(start_obj, "available", 0);
         start->flags.got_pistols =
@@ -939,7 +947,12 @@ static struct json_array_s *Savegame_BSON_DumpResumeInfo(
             resume_obj, "num_big_medis", resume->num_big_medis);
         json_object_append_int(resume_obj, "num_scions", resume->num_scions);
         json_object_append_int(resume_obj, "gun_status", resume->gun_status);
-        json_object_append_int(resume_obj, "gun_type", resume->gun_type);
+        json_object_append_int(
+            resume_obj, "gun_type", resume->equipped_gun_type);
+        json_object_append_int(
+            resume_obj, "holsters_gun_type", resume->holsters_gun_type);
+        json_object_append_int(
+            resume_obj, "back_gun_type", resume->back_gun_type);
         json_object_append_bool(
             resume_obj, "available", resume->flags.available);
         json_object_append_bool(

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -428,7 +428,9 @@ static void Savegame_Legacy_ReadResumeInfo(MYFILE *fp, GAME_INFO *game_info)
         Savegame_Legacy_Read(&current->num_big_medis, sizeof(uint8_t));
         Savegame_Legacy_Read(&current->num_scions, sizeof(uint8_t));
         Savegame_Legacy_Read(&current->gun_status, sizeof(int8_t));
-        Savegame_Legacy_Read(&current->gun_type, sizeof(int8_t));
+        Savegame_Legacy_Read(&current->equipped_gun_type, sizeof(int8_t));
+        current->holsters_gun_type = LGT_UNKNOWN;
+        current->back_gun_type = LGT_UNKNOWN;
         uint16_t flags;
         Savegame_Legacy_Read(&flags, sizeof(uint16_t));
         current->flags.available = flags & 1 ? 1 : 0;
@@ -530,6 +532,8 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     Savegame_Legacy_Skip(sizeof(int32_t)); // save counter
 
     Savegame_Legacy_ReadResumeInfo(fp, game_info);
+    g_Lara.holsters_gun_type = LGT_UNKNOWN;
+    g_Lara.back_gun_type = LGT_UNKNOWN;
 
     Lara_InitialiseInventory(g_CurrentLevel);
     SAVEGAME_LEGACY_ITEM_STATS item_stats = { 0 };
@@ -688,7 +692,7 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         Savegame_Legacy_Write(&current->num_big_medis, sizeof(uint8_t));
         Savegame_Legacy_Write(&current->num_scions, sizeof(uint8_t));
         Savegame_Legacy_Write(&current->gun_status, sizeof(int8_t));
-        Savegame_Legacy_Write(&current->gun_type, sizeof(int8_t));
+        Savegame_Legacy_Write(&current->equipped_gun_type, sizeof(int8_t));
         uint16_t flags = 0;
         flags |= current->flags.available ? 1 : 0;
         flags |= current->flags.got_pistols ? 2 : 0;

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -732,6 +732,7 @@ typedef enum LARA_MESH {
     LM_LARM_L = 12,
     LM_HAND_L = 13,
     LM_HEAD = 14,
+    LM_FIRST = LM_HIPS,
     LM_NUMBER_OF = 15,
 } LARA_MESH;
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -707,6 +707,7 @@ typedef enum LARA_GUN_STATE {
 } LARA_GUN_STATE;
 
 typedef enum LARA_GUN_TYPE {
+    LGT_UNKNOWN = -1, // for legacy saves
     LGT_UNARMED = 0,
     LGT_PISTOLS = 1,
     LGT_MAGNUMS = 2,
@@ -1414,8 +1415,10 @@ typedef struct FX_INFO {
 typedef struct LARA_INFO {
     int16_t item_number;
     int16_t gun_status;
-    int16_t gun_type;
-    int16_t request_gun_type;
+    LARA_GUN_TYPE gun_type;
+    LARA_GUN_TYPE request_gun_type;
+    LARA_GUN_TYPE holsters_gun_type;
+    LARA_GUN_TYPE back_gun_type;
     int16_t calc_fall_speed;
     int16_t water_status;
     int16_t pose_count;
@@ -1477,7 +1480,9 @@ typedef struct RESUME_INFO {
     uint8_t num_big_medis;
     uint8_t num_scions;
     int8_t gun_status;
-    int8_t gun_type;
+    LARA_GUN_TYPE equipped_gun_type;
+    LARA_GUN_TYPE holsters_gun_type;
+    LARA_GUN_TYPE back_gun_type;
     union {
         uint16_t all;
         struct {


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1437.

It's impossible to determine which guns should go in Lara's holsters and on her back without saving this information in the save files. To address this, I've added this data to `RESUME_INFO`, which should work well with the Select Level and Restart Level features. For smoother state management, the current holsters and back gun types are now also included in `LARA_INFO` (although, in theory, this could be inferred from mesh comparisons). This addition requires extra record-keeping. Additionally, to accommodate saves lacking the new holsters and back gun types information (such as TombATI and anything pre-4.3), I've introduced a special `LARA_GUN_TYPE` member: `LGT_UNKNOWN`. Although not ideal, it's the only method I could devise to support these configurations. When this information is missing, `Savegame_ApplyLogicToCurrentInfo` makes educated guesses to fill in the gaps.

Because I hated seeing `mesh_ptrs` so often during this endeavor I've introduced `Lara_SwapSingleMesh` which compels `Lara_SwapMeshExtra`.

Important testing scenarios to consider that ideally should be combined with each other:

- Loading the game from a legacy save
- Loading the game from a 4.2 save
- Starting a new game
- Advancing to Natla's Mines (and losing guns)
- Using the Select Level feature
- Using the Restart Level feature
- Enabling and disabling `revert_to_pistols` config option
- Going from Natla's Mines to Atlantis with various configurations (this is extra difficult scenario, as it carries over the gun information across a cutscene, and in the middle of it, Lara is given guns)
    - This is handled differently if you start from a TombATI save
    - This is handled yet differently if you start from a TR1X save

Reference mesh matrix for gun combinations that make sense:

Hands object | Back object | Holsters object
------------ | ----------- | ---------------
Empty        | Empty       | Empty
Empty        | Empty       | Magnums
Empty        | Empty       | Pistols
Empty        | Empty       | Uzis
Empty        | Shotgun     | Empty
Empty        | Shotgun     | Magnums
Empty        | Shotgun     | Pistols
Empty        | Shotgun     | Uzis
Magnums      | Empty       | Empty
Magnums      | Empty       | Pistols
Magnums      | Empty       | Uzis
Magnums      | Shotgun     | Empty
Magnums      | Shotgun     | Pistols
Magnums      | Shotgun     | Uzis
Pistols      | Empty       | Empty
Pistols      | Empty       | Magnums
Pistols      | Empty       | Uzis
Pistols      | Shotgun     | Empty
Pistols      | Shotgun     | Magnums
Pistols      | Shotgun     | Uzis
Shotgun      | Empty       | Empty
Shotgun      | Empty       | Magnums
Shotgun      | Empty       | Pistols
Shotgun      | Empty       | Uzis
Uzis         | Empty       | Empty
Uzis         | Empty       | Magnums
Uzis         | Empty       | Pistols
Uzis         | Shotgun     | Empty
Uzis         | Shotgun     | Magnums
Uzis         | Shotgun     | Pistols
