### PR TITLE
inventory: set any weapon to default on pickup if unarmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added weapons to Lara's empty holsters on pickup (#1291)
 - added options to quiet or mute music while underwater (#528)
 - changed the turbo cheat to no longer affect the gameplay time (#1420)
+- changed weapon pickup behavior when unarmed to set any weapon as the default weapon, not just pistols (#1443)
 - fixed adjacent Midas Touch objects potentially allowing gold bar duplication in custom levels (#1415)
 - fixed the excessive pitch and playback speed correction for music files with sampling rate other than 44100 Hz (#1417, regression from 2.0)
 - fixed the ingame timer being skewed upon inventory open (#1420, regression from 4.1)
@@ -16,7 +17,6 @@
 - fixed carrying over unexpected guns in holsters to the next level under rare scenarios (#1437, regression from 2.4)
 - fixed item cheats not updating Lara holster and backpack meshes (#1437)
 - improved initial level load time by lazy-loading audio samples (LostArtefacts/TR2X#114)
-- set Lara's default weapon to any weapon she picks up when unarmed, not just pistols (#1443)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed carrying over unexpected guns in holsters to the next level under rare scenarios (#1437, regression from 2.4)
 - fixed item cheats not updating Lara holster and backpack meshes (#1437)
 - improved initial level load time by lazy-loading audio samples (LostArtefacts/TR2X#114)
+- set Lara's default weapon to any weapon she picks up when unarmed, not just pistols (#1443)
 
 ## [4.2](https://github.com/LostArtefacts/TR1X/compare/4.1.2...4.2) - 2024-07-14
 - added creating minidump files on crashes

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed looking forward too far causing an upside down camera frame
 - fixed the Scion being extremely difficult to shoot with the shotgun
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground
+- set Lara's default weapon to any weapon she picks up when unarmed, not just pistols
 
 #### Cheats
 - added a fly cheat

--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added a flag indicating if new game plus is unlocked to the player config which allows the player to select new game plus or not when making a new game
 - added weapons to Lara's empty holsters on pickup
 - added options to quiet or mute music while underwater
+- changed weapon pickup behavior when unarmed to set any weapon as the default weapon, not just pistols
 - fixed keys and items not working when drawing guns immediately after using them
 - fixed counting the secret in The Great Pyramid
 - fixed running out of ammo forcing Lara to equip pistols even if she doesn't carry them
@@ -515,7 +516,6 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed looking forward too far causing an upside down camera frame
 - fixed the Scion being extremely difficult to shoot with the shotgun
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground
-- set Lara's default weapon to any weapon she picks up when unarmed, not just pistols
 
 #### Cheats
 - added a fly cheat

--- a/src/game/gun.h
+++ b/src/game/gun.h
@@ -15,6 +15,7 @@ void Gun_HitTarget(ITEM_INFO *item, GAME_VECTOR *hitpos, int16_t damage);
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, int32_t clip);
 GAME_OBJECT_ID Gun_GetLaraAnim(LARA_GUN_TYPE gun_type);
 GAME_OBJECT_ID Gun_GetWeaponAnim(LARA_GUN_TYPE gun_type);
+LARA_GUN_TYPE Gun_GetType(GAME_OBJECT_ID object_id);
 void Gun_UpdateLaraMeshes(GAME_OBJECT_ID object_id);
 void Gun_SetLaraBackMesh(LARA_GUN_TYPE weapon_type);
 void Gun_SetLaraHandLMesh(LARA_GUN_TYPE weapon_type);

--- a/src/game/gun/gun.c
+++ b/src/game/gun/gun.c
@@ -234,6 +234,22 @@ GAME_OBJECT_ID Gun_GetWeaponAnim(const LARA_GUN_TYPE gun_type)
     }
 }
 
+LARA_GUN_TYPE Gun_GetType(const GAME_OBJECT_ID object_id)
+{
+    switch (object_id) {
+    case O_PISTOL_ITEM:
+        return LGT_PISTOLS;
+    case O_MAGNUM_ITEM:
+        return LGT_MAGNUMS;
+    case O_UZI_ITEM:
+        return LGT_UZIS;
+    case O_SHOTGUN_ITEM:
+        return LGT_SHOTGUN;
+    default:
+        return LGT_UNARMED;
+    }
+}
+
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, int32_t clip)
 {
     int32_t light;

--- a/src/game/inventory/inventory_func.c
+++ b/src/game/inventory/inventory_func.c
@@ -14,6 +14,11 @@ bool Inv_AddItem(const GAME_OBJECT_ID object_id)
 {
     if (Object_IsObjectType(object_id, g_GunObjects)) {
         Gun_UpdateLaraMeshes(object_id);
+        if (g_Lara.gun_type == LGT_UNARMED) {
+            g_Lara.gun_type = Gun_GetType(object_id);
+            g_Lara.gun_status = LGS_ARMLESS;
+            Gun_InitialiseNewWeapon();
+        }
     }
 
     const GAME_OBJECT_ID inv_object_id = Inv_GetItemOption(object_id);


### PR DESCRIPTION
Resolves #1443.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Set Lara's default weapon to any weapon she picks up when unarmed, not just pistols.

If you want to move this to 4.4 that's fine, but it seems like it's easy to implement and related to the other gun fixes. I thought we could maybe squeeze it in if there's no bugs.  I attached a build for @aredfan to test.

[default_weapon_v1 TR1X-4.2-47-g49b582f-Windows.zip](https://github.com/user-attachments/files/16621456/default_weapon_v1.TR1X-4.2-47-g49b582f-Windows.zip)