### PR TITLE
room: fix invalid walkable detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed holstering pistols hiding the gun meshes 1 frame too early (#1449, regression from 0.6)
+- fixed Lara's sliding animation sometimes being interrupted by a stumble (#1452, regression from 4.3)
 - improved logs module names readability
 - improved crash debug information on Windows
 

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -1014,12 +1014,11 @@ bool Room_IsOnWalkable(
     const int32_t z, const int32_t room_height)
 {
     sector = Room_GetPitSector(sector, x, z);
-
-    int16_t height = sector->floor.height;
     if (sector->trigger == NULL) {
-        return room_height == height;
+        return false;
     }
 
+    int16_t height = sector->floor.height;
     bool object_found = false;
     for (int32_t i = 0; i < sector->trigger->command_count; i++) {
         const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];


### PR DESCRIPTION
Resolves #1452.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids testing the floor height for the on walkable check when the corresponding sector does not have a trigger. This is equivalent to not finding a walkable object.

Introduced in [da2353e](https://github.com/LostArtefacts/TR1X/commit/da2353e05f0f70660fa77f220dfec0da0307b6aa) and was originally fixed in [6c67520](https://github.com/LostArtefacts/TR1X/commit/6c6752014b0c20acaa0cbe6878bcfb5a4b1b6a3e). The FD refactor basically didn't implement the exit-early strategy properly.

Updated walkable test level attached with added slope room for checking against, if ever required again.
[LEVEL1.zip](https://github.com/user-attachments/files/16737232/LEVEL1.zip)
