### PR TITLE
types: fix camera data signedness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR1X/compare/stable...develop) - ××××-××-××
 - fixed holstering pistols hiding the gun meshes 1 frame too early (#1449, regression from 0.6)
 - fixed Lara's sliding animation sometimes being interrupted by a stumble (#1452, regression from 4.3)
+- fixed cameras with glide values sometimes moving in the wrong direction (#1451, regression from 4.3)
 - improved logs module names readability
 - improved crash debug information on Windows
 

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1177,8 +1177,8 @@ typedef struct TRIGGER_CMD {
 
 typedef struct TRIGGER_CAMERA_DATA {
     int16_t camera_num;
-    int8_t timer;
-    int8_t glide;
+    uint8_t timer;
+    uint8_t glide;
     bool one_shot;
 } TRIGGER_CAMERA_DATA;
 


### PR DESCRIPTION
Resolves #1451.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Timer and glide values are unsigned in data, they were wrongly allocated as signed in [da2353e](https://github.com/LostArtefacts/TR1X/commit/da2353e05f0f70660fa77f220dfec0da0307b6aa). This could have affected timed cameras with values > 127 but that isn't anywhere in the original levels.
