### PR TITLE
console: use the new string functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed cameras with glide values sometimes moving in the wrong direction (#1451, regression from 4.3)
 - fixed `/give` console command giving duplicate items under some circumstances (#1463, regression from 3.0)
 - fixed `/give` console command confusing logging around mismatched items (#1463, regression from 3.0)
+- fixed `/flip` console command misreporting an already enabled flipmap as off (regression from 4.0)
 - fixed console commands causing improper ring shutdown with selected inventory item (#1460, regression from 3.0)
 - improved logs module names readability
 - improved crash debug information on Windows

--- a/src/game/console.c
+++ b/src/game/console.c
@@ -15,6 +15,7 @@
 #include <libtrx/log.h>
 
 #include <SDL2/SDL_keycode.h>
+#include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -74,7 +75,7 @@ static COMMAND_RESULT Console_Eval(const char *const cmdline)
     const CONSOLE_COMMAND *matching_cmd = NULL;
 
     for (CONSOLE_COMMAND *cur_cmd = &g_ConsoleCommands[0];
-         cur_cmd->proc != NULL; cur_cmd++) {
+         cur_cmd->prefix != NULL; cur_cmd++) {
         if (strstr(cmdline, cur_cmd->prefix) != cmdline) {
             continue;
         }
@@ -96,7 +97,9 @@ static COMMAND_RESULT Console_Eval(const char *const cmdline)
         return CR_BAD_INVOCATION;
     }
 
+    assert(matching_cmd->proc != NULL);
     const COMMAND_RESULT result = matching_cmd->proc(args);
+
     switch (result) {
     case CR_BAD_INVOCATION:
         Console_Log(GS(OSD_COMMAND_BAD_INVOCATION), cmdline);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A loose proposal how to refactor parsing the arguments of the console commands using https://github.com/LostArtefacts/libtrx/pull/19. I refactored a few commands to showcase how this works.

I'm not sure if I like this, honestly, and I'm eager to hear your opinion. It works great for boolean commands, but might make string handling more cumbersome. For instance, the `/play` command accepts a level name, but the new argument parsing requires spaces to be enclosed in quotes (e.g., `/play "great pyramid"`). The problem is, the console does not support all characters, and it's actually impossible to type this.