### PR TITLE
output: improve vertex movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - improved level load times
 - improved logs module names readability
 - improved crash debug information on Windows
+- improved vertex movement when looking through water portals (#1493)
 
 ## [4.3](https://github.com/LostArtefacts/TR1X/compare/4.2...4.3) - 2024-08-15
 - added deadly water feature from TR2+ for custom levels (#1404)

--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - **Temple of the Cat**: incorrect textures in rooms 50, 70, 71, 76, 78, 87 and 96, and a missing texture in 75
     - **Atlantean Stronghold**: incorrect textures in rooms 2, 6, 7 and 75, and missing textures in rooms 5, 13, 19, 63 and 74
     - **The Hive**: incorrect textures in room 8, 13 and 18
+- improved vertex movement when looking through water portals
 
 #### Audio
 - added music during the credits

--- a/src/game/inject.c
+++ b/src/game/inject.c
@@ -1447,6 +1447,7 @@ static void Inject_AlterRoomVertex(INJECTION *injection)
     *(data_ptr + 2) += y_change;
     *(data_ptr + 3) += z_change;
     *(data_ptr + 4) += shade_change;
+    CLAMPG(*(data_ptr + 4), MAX_LIGHTING);
 }
 
 static void Inject_RotateRoomFace(INJECTION *injection)

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -342,7 +342,7 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr)
         m_VBuf[i].xv = xv;
         m_VBuf[i].yv = yv;
         m_VBuf[i].zv = zv;
-        m_VBuf[i].g = obj_ptr[3];
+        m_VBuf[i].g = obj_ptr[3] & MAX_LIGHTING;
 
         if (zv < Output_GetNearZ()) {
             m_VBuf[i].clip = 0x8000;
@@ -350,21 +350,21 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr)
             int16_t clip_flags = 0;
             int32_t depth = zv_int >> W2V_SHIFT;
             if (depth > Output_GetDrawDistMax()) {
-                m_VBuf[i].g = 0x1FFF;
+                m_VBuf[i].g = MAX_LIGHTING;
                 if (!m_IsSkyboxEnabled) {
                     clip_flags |= 16;
                 }
             } else if (depth) {
                 m_VBuf[i].g += Output_CalcFogShade(depth);
                 if (!m_IsWaterEffect) {
-                    CLAMPG(m_VBuf[i].g, 0x1FFF);
+                    CLAMPG(m_VBuf[i].g, MAX_LIGHTING);
                 }
             }
 
             double persp = g_PhdPersp / zv;
             double xs = Viewport_GetCenterX() + xv * persp;
             double ys = Viewport_GetCenterY() + yv * persp;
-            if (m_IsWibbleEffect) {
+            if (m_IsWibbleEffect && !(obj_ptr[3] & NO_VERT_MOVE)) {
                 xs += m_WibbleTable[(m_WibbleOffset + (int)ys) & 0x1F];
                 ys += m_WibbleTable[(m_WibbleOffset + (int)xs) & 0x1F];
             }

--- a/src/global/const.h
+++ b/src/global/const.h
@@ -130,6 +130,8 @@
 #define WIBBLE_SIZE 32
 #define MAX_WIBBLE 2
 #define MAX_SHADE 0x300
+#define MAX_LIGHTING 0x1FFF
+#define NO_VERT_MOVE 0x2000
 #define MAX_EXPANSION 5
 #define NO_BOX (-1)
 #define BOX_NUMBER 0x7FFF


### PR DESCRIPTION
Resolves #1493.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows locking specific vertices such that they don't move when looked at through a water portal. We make use of an unused bit in vertex shading, and ensure shading is clamped to the max value.

This only covers vertices on water edges, as mentioned in #1493 there are other situations which would require a big undertaking of work to inject face/vertex/texture changes, and I don't think that it's feasible. This brings things into line with TR2 though, so it's a definite improvement.

I've tied this to the texture fix option in the config, but LMK if you think this deserves its own setting.
