### PR TITLE
room: test sector range for Torso boss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed `/tp` console command reporting teleport fails as success (#1484, regression from 4.1)
 - fixed console commands causing improper ring shutdown with selected inventory item (#1460, regression from 3.0)
 - fixed console input immediately ending demo (#1480, regression from 4.1)
+- fixed a potential softlock when killing the Torso boss in Great Pyramid (#1236)
 - changed `/tp` console command to look for the closest place to teleport to when targeting items (#1484)
 - improved appearance of textures around edges when bilinear filter is off (#1483)
   Since this removes the seams on pushblocks, this was made optional.

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed looking forward too far causing an upside down camera frame
 - fixed the Scion being extremely difficult to shoot with the shotgun
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground
+- fixed a potential softlock when killing the Torso boss in Great Pyramid
 
 #### Cheats
 - added a fly cheat

--- a/src/game/room.c
+++ b/src/game/room.c
@@ -40,6 +40,8 @@ static int16_t Room_GetCeilingTiltHeight(
     const SECTOR_INFO *sector, const int32_t x, const int32_t z);
 static SECTOR_INFO *Room_GetSkySector(
     const SECTOR_INFO *sector, int32_t x, int32_t z);
+static void Room_TestSectorTrigger(
+    const ITEM_INFO *item, const SECTOR_INFO *sector);
 
 static void Room_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
 {
@@ -736,11 +738,34 @@ void Room_PopulateSectorData(
 
 void Room_TestTriggers(const ITEM_INFO *const item)
 {
-    const bool is_heavy = item->object_id != O_LARA;
     int16_t room_num = item->room_num;
-    const SECTOR_INFO *const sector =
+    const SECTOR_INFO *sector =
         Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
 
+    Room_TestSectorTrigger(item, sector);
+    if (item->object_id != O_TORSO) {
+        return;
+    }
+
+    for (int32_t dx = -1; dx < 2; dx++) {
+        for (int32_t dz = -1; dz < 2; dz++) {
+            if (!dx && !dz) {
+                continue;
+            }
+
+            room_num = item->room_num;
+            sector = Room_GetSector(
+                item->pos.x + dx * WALL_L, MAX_HEIGHT,
+                item->pos.z + dz * WALL_L, &room_num);
+            Room_TestSectorTrigger(item, sector);
+        }
+    }
+}
+
+static void Room_TestSectorTrigger(
+    const ITEM_INFO *const item, const SECTOR_INFO *const sector)
+{
+    const bool is_heavy = item->object_id != O_LARA;
     if (!is_heavy && sector->is_death_sector && Lava_TestFloor(item)) {
         Lava_Burn(g_LaraItem);
     }


### PR DESCRIPTION
Resolves #1236.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This provides an option to test a range of sectors around the one on which a large and heavy item dies. It ultimately resolves the potential softlock when killing Torso boss in Great Pyramid. For custom levels, it should be switched off in the gameflow as builders have full control of FD design (although it may have some uses, the freedom is there of course).

The only other solution to the softlock that I could see would involve item injection (a hidden boulder somewhere to trigger the camera/egg/music at the start) but this would break existing and TombATI saves, and I couldn't think of a way around that problem.

Other heavy trigger activators aren't affected here as they're all less than the 1.5 tile limit introduced here.

Just for testing - getting Adam to actually end up on the problematic tile is time-consuming, so attached is an exe that forces him here on death.
[TR1X.zip](https://github.com/user-attachments/files/16917520/TR1X.zip)

