### PR TITLE
bacon_lara: save animation and custom status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed console commands causing improper ring shutdown with selected inventory item (#1460, regression from 3.0)
 - fixed console input immediately ending demo (#1480, regression from 4.1)
 - fixed a potential softlock when killing the Torso boss in Great Pyramid (#1236)
+- fixed Bacon Lara re-spawning after saving and loading (#1500, regression from 0.7)
 - changed `/tp` console command to look for the closest place to teleport to when targeting items (#1484)
 - improved appearance of textures around edges when bilinear filter is off (#1483)
   Since this removes the seams on pushblocks, this was made optional.

--- a/src/game/objects/creatures/bacon_lara.c
+++ b/src/game/objects/creatures/bacon_lara.c
@@ -28,6 +28,7 @@ void BaconLara_Setup(OBJECT_INFO *obj)
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void BaconLara_Initialise(int16_t item_num)

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -13,7 +13,7 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
-#define SAVEGAME_CURRENT_VERSION 4
+#define SAVEGAME_CURRENT_VERSION 5
 
 typedef enum SAVEGAME_VERSION {
     VERSION_LEGACY = -1,
@@ -22,6 +22,7 @@ typedef enum SAVEGAME_VERSION {
     VERSION_2 = 2,
     VERSION_3 = 3,
     VERSION_4 = 4,
+    VERSION_5 = 5,
 } SAVEGAME_VERSION;
 
 typedef enum SAVEGAME_FORMAT {

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -595,6 +595,13 @@ static bool Savegame_BSON_LoadItems(
                     item->data = (void *)(intptr_t)(fx_num + 1);
                 }
             }
+
+            if (header_version >= VERSION_5
+                && item->object_id == O_BACON_LARA) {
+                const int32_t status =
+                    json_object_get_int(item_obj, "bl_status", 0);
+                item->data = (void *)(intptr_t)status;
+            }
         }
 
         struct json_array_s *carried_items =
@@ -1101,6 +1108,11 @@ static struct json_array_s *Savegame_BSON_DumpItems(void)
                 int32_t fx_num = (int32_t)(intptr_t)item->data - 1;
                 fx_num = fx_order.id_map[fx_num];
                 json_object_append_int(item_obj, "fx_num", fx_num);
+            }
+
+            if (item->object_id == O_BACON_LARA && item->data) {
+                const int32_t status = (int32_t)(intptr_t)item->data;
+                json_object_append_int(item_obj, "bl_status", status);
             }
         }
 

--- a/src/game/savegame/savegame_legacy.c
+++ b/src/game/savegame/savegame_legacy.c
@@ -46,6 +46,7 @@ static int m_SGBufPos = 0;
 static char *m_SGBufPtr = NULL;
 
 static bool Savegame_Legacy_ItemHasSaveFlags(OBJECT_INFO *obj, ITEM_INFO *item);
+static bool Savegame_Legacy_ItemHasSaveAnim(const ITEM_INFO *item);
 static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer);
 
 static void Savegame_Legacy_Reset(char *buffer);
@@ -78,6 +79,12 @@ static bool Savegame_Legacy_ItemHasSaveFlags(OBJECT_INFO *obj, ITEM_INFO *item)
         && item->object_id != O_FLAME_EMITTER && item->object_id != O_WATERFALL
         && item->object_id != O_SCION_ITEM
         && item->object_id != O_DART_EMITTER);
+}
+
+static bool Savegame_Legacy_ItemHasSaveAnim(const ITEM_INFO *const item)
+{
+    const OBJECT_INFO *const obj = &g_Objects[item->object_id];
+    return obj->save_anim && item->object_id != O_BACON_LARA;
 }
 
 static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer)
@@ -144,7 +151,7 @@ static bool Savegame_Legacy_NeedsBaconLaraFix(char *buffer)
             Savegame_Legacy_Read(&tmp_item.speed, sizeof(int16_t));
             Savegame_Legacy_Read(&tmp_item.fall_speed, sizeof(int16_t));
         }
-        if (obj->save_anim) {
+        if (Savegame_Legacy_ItemHasSaveAnim(item)) {
             Savegame_Legacy_Read(&tmp_item.current_anim_state, sizeof(int16_t));
             Savegame_Legacy_Read(&tmp_item.goal_anim_state, sizeof(int16_t));
             Savegame_Legacy_Read(
@@ -585,7 +592,7 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
             }
         }
 
-        if (obj->save_anim) {
+        if (Savegame_Legacy_ItemHasSaveAnim(item)) {
             Savegame_Legacy_Read(&item->current_anim_state, sizeof(int16_t));
             Savegame_Legacy_Read(&item->goal_anim_state, sizeof(int16_t));
             Savegame_Legacy_Read(&item->required_anim_state, sizeof(int16_t));
@@ -760,7 +767,7 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
             Savegame_Legacy_Write(&item->fall_speed, sizeof(int16_t));
         }
 
-        if (obj->save_anim) {
+        if (Savegame_Legacy_ItemHasSaveAnim(item)) {
             Savegame_Legacy_Write(&item->current_anim_state, sizeof(int16_t));
             Savegame_Legacy_Write(&item->goal_anim_state, sizeof(int16_t));
             Savegame_Legacy_Write(&item->required_anim_state, sizeof(int16_t));


### PR DESCRIPTION
Resolves #1500.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures Bacon Lara's current animation and custom status will persist in saves. We save her animation now for the situation where she has started falling into the pit, or has "died". Saving the extra data flag ensures the correct control logic plays out on reload.

I haven't tackled a solution for existing saves as I can't think of a way to do this that would cover OG and custom levels. I think the only issue would be visual, as-in Bacon Lara might appear later in the level if the geometry allows such; with her re-spawning in OG, this should never be the case.
