### PR TITLE
output: improve anisotropic filter rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - improved logs module names readability
 - improved crash debug information on Windows
 - improved vertex movement when looking through water portals (#1493)
+- improved anisotropic filter rendering (#902, #1507)
 
 ## [4.3](https://github.com/LostArtefacts/TR1X/compare/4.2...4.3) - 2024-08-15
 - added deadly water feature from TR2+ for custom levels (#1404)

--- a/src/game/output.c
+++ b/src/game/output.c
@@ -432,16 +432,30 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr)
     int32_t vertex_count = *obj_ptr++;
 
     for (int i = 0; i < vertex_count; i++) {
-        double xv = g_MatrixPtr->_00 * obj_ptr[0]
-            + g_MatrixPtr->_01 * obj_ptr[1] + g_MatrixPtr->_02 * obj_ptr[2]
-            + g_MatrixPtr->_03;
-        double yv = g_MatrixPtr->_10 * obj_ptr[0]
-            + g_MatrixPtr->_11 * obj_ptr[1] + g_MatrixPtr->_12 * obj_ptr[2]
-            + g_MatrixPtr->_13;
-        int32_t zv_int = g_MatrixPtr->_20 * obj_ptr[0]
-            + g_MatrixPtr->_21 * obj_ptr[1] + g_MatrixPtr->_22 * obj_ptr[2]
-            + g_MatrixPtr->_23;
-        double zv = zv_int;
+        PHD_VBUF *const vbuf = &m_VBuf[i];
+
+        // clang-format off
+        const double xv = (
+            g_MatrixPtr->_00 * obj_ptr[0] +
+            g_MatrixPtr->_01 * obj_ptr[1] +
+            g_MatrixPtr->_02 * obj_ptr[2] +
+            g_MatrixPtr->_03
+        );
+        const double yv = (
+            g_MatrixPtr->_10 * obj_ptr[0] +
+            g_MatrixPtr->_11 * obj_ptr[1] +
+            g_MatrixPtr->_12 * obj_ptr[2] +
+            g_MatrixPtr->_13
+        );
+        const int32_t zv_int = (
+            g_MatrixPtr->_20 * obj_ptr[0] +
+            g_MatrixPtr->_21 * obj_ptr[1] +
+            g_MatrixPtr->_22 * obj_ptr[2] +
+            g_MatrixPtr->_23
+        );
+        const double zv = zv_int;
+        // clang-format on
+
         m_VBuf[i].xv = xv;
         m_VBuf[i].yv = yv;
         m_VBuf[i].zv = zv;
@@ -451,7 +465,7 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr)
             m_VBuf[i].clip = 0x8000;
         } else {
             int16_t clip_flags = 0;
-            int32_t depth = zv_int >> W2V_SHIFT;
+            const int32_t depth = zv_int >> W2V_SHIFT;
             if (depth > Output_GetDrawDistMax()) {
                 m_VBuf[i].g = MAX_LIGHTING;
                 if (!m_IsSkyboxEnabled) {
@@ -464,7 +478,7 @@ static const int16_t *Output_CalcRoomVertices(const int16_t *obj_ptr)
                 }
             }
 
-            double persp = g_PhdPersp / zv;
+            const double persp = g_PhdPersp / (double)zv;
             double xs = Viewport_GetCenterX() + xv * persp;
             double ys = Viewport_GetCenterY() + yv * persp;
             if (m_IsWibbleEffect && !(obj_ptr[3] & NO_VERT_MOVE)) {

--- a/src/gfx/3d/3d_renderer.c
+++ b/src/gfx/3d/3d_renderer.c
@@ -50,6 +50,10 @@ void GFX_3D_Renderer_Init(GFX_3D_Renderer *renderer)
     GFX_GL_Sampler_Parameterf(
         &renderer->sampler, GL_TEXTURE_MAX_ANISOTROPY_EXT,
         g_Config.rendering.anisotropy_filter);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    GFX_GL_Sampler_Parameteri(
+        &renderer->sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     GFX_GL_Program_Init(&renderer->program);
     GFX_GL_Program_AttachShader(

--- a/src/gfx/gl/texture.c
+++ b/src/gfx/gl/texture.c
@@ -52,6 +52,8 @@ void GFX_GL_Texture_Load(
 
     GFX_GL_Texture_Bind(texture);
 
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexImage2D(
         GL_TEXTURE_2D, 0, internal_format, width, height, 0, format,
         GL_UNSIGNED_BYTE, data);


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1507. Improves #902.

For a definite solution, we'd need to artifically add a border around each texture face inside texture atlases, hence I keep #902 as open for now.