### PR TITLE
creature: perform safer conversion of hybrids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed a potential softlock when killing the Torso boss in Great Pyramid (#1236)
 - fixed Bacon Lara re-spawning after saving and loading (#1500, regression from 0.7)
 - fixed config JSON not sanitizing some numeric values (#1515)
+- fixed potential crashes in custom levels if hybrid creature objects are not present in the level (#1444)
 - changed `/tp` console command to look for the closest place to teleport to when targeting items (#1484)
 - changed the door cheat to also target drawbridges
 - improved appearance of textures around edges when bilinear filter is off (#1483)

--- a/src/game/objects/creatures/skate_kid.c
+++ b/src/game/objects/creatures/skate_kid.c
@@ -9,6 +9,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/log.h>
 #include <libtrx/utils.h>
 
 #define SKATE_KID_STOP_SHOT_DAMAGE 50
@@ -57,6 +58,12 @@ void SkateKid_Setup(OBJECT_INFO *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
     g_AnimBones[obj->bone_index] |= BEB_ROT_Y;
+
+    if (!g_Objects[O_SKATEBOARD].loaded) {
+        LOG_WARNING(
+            "Skateboard object (%d) is not loaded and so will not be drawn.",
+            O_SKATEBOARD);
+    }
 }
 
 void SkateKid_Initialise(int16_t item_num)
@@ -168,6 +175,9 @@ void SkateKid_Control(int16_t item_num)
 void SkateKid_Draw(ITEM_INFO *item)
 {
     Object_DrawAnimatingItem(item);
+    if (!g_Objects[O_SKATEBOARD].loaded) {
+        return;
+    }
 
     int16_t relative_anim =
         item->anim_num - g_Objects[item->object_id].anim_index;


### PR DESCRIPTION
Resolves #1444.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A check will be performed before switching rats and crocodiles to ensure the target object is loaded. A similar check is done for skate kid's skateboard before trying to draw it.

Tidied up some `const`s too.

Attached is a couple of test levels, the first has the water models present and the land models not, the second vice-versa. There is a flipmap pad to test. Also, in the first, the skateboard is missing. 

[hybrids.zip](https://github.com/user-attachments/files/17002445/hybrids.zip)

