### PR TITLE
console_cmd: prevent teleporting to consumed crystals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed `/kill` console command not fully killing enemies (#1482, regression from 3.0)
 - fixed `/tp` console command not always picking the closest item (#1486, regression from 4.1)
 - fixed `/tp` console command reporting teleport fails as success (#1484, regression from 4.1)
+- fixed `/tp` console command allowing teleporting to consumed savegame crystals (#1518)
 - fixed `/set` console command not sanitizing numeric values (#1515)
 - fixed console commands causing improper ring shutdown with selected inventory item (#1460, regression from 3.0)
 - fixed console input immediately ending demo (#1480, regression from 4.1)

--- a/src/game/console_cmd.c
+++ b/src/game/console_cmd.c
@@ -184,9 +184,10 @@ static COMMAND_RESULT Console_Cmd_Teleport(const char *const args)
         for (int16_t item_num = 0; item_num < Item_GetTotalCount();
              item_num++) {
             const ITEM_INFO *const item = &g_Items[item_num];
-            const bool is_pickup =
-                Object_IsObjectType(item->object_id, g_PickupObjects);
-            if (is_pickup
+            const bool is_consumable =
+                Object_IsObjectType(item->object_id, g_PickupObjects)
+                || item->object_id == O_SAVEGAME_ITEM;
+            if (is_consumable
                 && (item->status == IS_INVISIBLE
                     || item->status == IS_DEACTIVATED)) {
                 continue;


### PR DESCRIPTION
Resolves #1518.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This prevents TP'ing to consumed savegame crystals, similar to picked-up pickups.
