### PR TITLE
music: fix the main music playing at the wrong volume with certain sound options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed double "Fly mode enabled" message when using `/fly` console command (regression from 4.0)
 - fixed crash in the `/set` console command (regression from 4.4)
 - fixed toggling fullscreen not always saving (regression from 4.4)
+- fixed main menu music volume when exiting while underwater with certain music settings (#1540, regression from 4.4)
 
 ## [4.4](https://github.com/LostArtefacts/TR1X/compare/4.3-102-g458cd96...4.4) - 2024-09-20
 - added `/exit` command (#1462)

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -1149,6 +1149,7 @@ bool Level_Initialise(int32_t level_num)
     Overlay_BarSetHealthTimer(100);
 
     Music_Stop();
+    Music_SetVolume(g_Config.music_volume);
     Sound_ResetEffects();
 
     Viewport_SetFOV(Viewport_GetUserFOV());

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -1152,11 +1152,13 @@ bool Level_Initialise(int32_t level_num)
     Music_SetVolume(g_Config.music_volume);
     Sound_ResetEffects();
 
-    Viewport_SetFOV(Viewport_GetUserFOV());
-
-    if (g_GameFlow.levels[level_num].music) {
+    const bool disable_music = level_num == g_GameFlow.title_level_num
+        && !g_Config.enable_music_in_menu;
+    if (g_GameFlow.levels[level_num].music && !disable_music) {
         Music_PlayLooped(g_GameFlow.levels[level_num].music);
     }
+
+    Viewport_SetFOV(Viewport_GetUserFOV());
 
     g_InvItemPuzzle1.string = g_GameFlow.levels[level_num].puzzle1;
     g_InvItemPuzzle2.string = g_GameFlow.levels[level_num].puzzle2;

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -131,11 +131,6 @@ bool Music_PlayLooped(MUSIC_TRACK_ID track)
         return false;
     }
 
-    if (g_CurrentLevel == g_GameFlow.title_level_num
-        && !g_Config.enable_music_in_menu) {
-        return false;
-    }
-
     M_StopActiveStream();
 
     char *file_path = M_GetTrackFileName(track);


### PR DESCRIPTION
Fixed quiet or mute main menu music if a level was exited while underwater and the quiet, full but no ambient, quiet but no ambient, or none underwater music behavior option was set.

Resolves #1540.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the main menu music being quiet or mute if a level was exited while underwater and the quiet, full but no ambient, quiet but no ambient, or none underwater music behavior option was set (regression from 4.4). I tried to apply the fix to the volume in a logical place which is where the other config option to mute main menu music is. `M_EnsureEnvironment` couldn't be called because `Game_DrawScene` isn't called when in the title menu inventory so`Camera_Apply` is never called. Might need to be hotfixed though it's not a game breaking issue, and it should be a rare bug.