### PR TITLE
config: react to fov changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed double "Fly mode enabled" message when using `/fly` console command (regression from 4.0)
 - fixed crash in the `/set` console command (regression from 4.4)
 - fixed toggling fullscreen not always saving (regression from 4.4)
+- fixed altering fov with `/set` not being immediately respected (#1547)
 - fixed main menu music volume when exiting while underwater with certain music settings (#1540, regression from 4.4)
 
 ## [4.4](https://github.com/LostArtefacts/TR1X/compare/4.3-102-g458cd96...4.4) - 2024-09-20

--- a/src/config.c
+++ b/src/config.c
@@ -7,6 +7,7 @@
 #include "game/output.h"
 #include "game/requester.h"
 #include "game/sound.h"
+#include "game/viewport.h"
 #include "global/const.h"
 #include "global/enum_str.h"
 #include "global/types.h"
@@ -306,6 +307,7 @@ void Config_ApplyChanges(void)
     Requester_Shutdown(&g_SavegameRequester);
     Requester_Init(&g_SavegameRequester, g_Config.maximum_save_slots);
     Output_ApplyRenderSettings();
+    Viewport_SetFOV(Viewport_GetUserFOV());
 }
 
 const CONFIG_OPTION *Config_GetOptionMap(void)

--- a/src/game/viewport.c
+++ b/src/game/viewport.c
@@ -103,5 +103,9 @@ void Viewport_SetFOV(int16_t fov)
 
     int16_t c = Math_Cos(fov / 2);
     int16_t s = Math_Sin(fov / 2);
-    g_PhdPersp = ((Screen_GetResWidth() / 2) * c) / s;
+    g_PhdPersp = Screen_GetResWidth() / 2;
+    if (s != 0) {
+        g_PhdPersp *= c;
+        g_PhdPersp /= s;
+    }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1547.

For QA please note that certain animations, such as picking up the Scion from the pedestal or the Midas Hand death animation, use their own FOV values, and it's now possible to override that with the `/set` command.