### PR TITLE
Fix wibble effect seams in level geometry

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed `/endlevel` displaying a success message in the title screen
 - fixed Story So Far feature looping cutscenes forever (#1551, regression from 4.4)
 - improved object name matching in console commands to work like TR2X
+- improved vertex movement when looking through water portals even more (#1493)
 
 ## [4.4](https://github.com/LostArtefacts/TRX/compare/tr1-4.3...tr1-4.4) - 2024-09-20
 - added `/exit` command (#1462)

--- a/src/libtrx/event_manager.c
+++ b/src/libtrx/event_manager.c
@@ -29,6 +29,9 @@ EVENT_MANAGER *EventManager_Create(void)
 
 void EventManager_Free(EVENT_MANAGER *const manager)
 {
+    if (manager == NULL) {
+        return;
+    }
     Vector_Free(manager->listeners);
     Memory_Free(manager);
 }

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -320,6 +320,18 @@ void GFX_3D_Renderer_SetTextureFilter(
         filter == GFX_TF_BILINEAR);
 }
 
+void GFX_3D_Renderer_SetDepthWritesEnabled(
+    GFX_3D_RENDERER *const renderer, const bool is_enabled)
+{
+    assert(renderer);
+    GFX_3D_VertexStream_RenderPending(&renderer->vertex_stream);
+    if (is_enabled) {
+        glDepthMask(GL_TRUE);
+    } else {
+        glDepthMask(GL_FALSE);
+    }
+}
+
 void GFX_3D_Renderer_SetDepthTestEnabled(
     GFX_3D_RENDERER *renderer, bool is_enabled)
 {

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -111,6 +111,8 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_RENDERER *renderer)
         renderer->config->enable_wireframe ? GL_LINE : GL_FILL);
     GFX_GL_CheckError();
 
+    renderer->vertex_stream.rendered_count = 0;
+
     GFX_GL_Program_Bind(&renderer->program);
     GFX_3D_VertexStream_Bind(&renderer->vertex_stream);
     GFX_GL_Sampler_Bind(&renderer->sampler, 0);

--- a/src/libtrx/gfx/3d/vertex_stream.c
+++ b/src/libtrx/gfx/3d/vertex_stream.c
@@ -35,6 +35,7 @@ void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *vertex_stream)
     vertex_stream->pending_vertices.data = NULL;
     vertex_stream->pending_vertices.count = 0;
     vertex_stream->pending_vertices.capacity = 0;
+    vertex_stream->rendered_count = 0;
 
     GFX_GL_Buffer_Init(&vertex_stream->buffer, GL_ARRAY_BUFFER);
     GFX_GL_Buffer_Bind(&vertex_stream->buffer);
@@ -156,5 +157,6 @@ void GFX_3D_VertexStream_RenderPending(GFX_3D_VERTEX_STREAM *vertex_stream)
         vertex_stream->pending_vertices.count);
     GFX_GL_CheckError();
 
+    vertex_stream->rendered_count += vertex_stream->pending_vertices.count;
     vertex_stream->pending_vertices.count = 0;
 }

--- a/src/libtrx/include/libtrx/gfx/3d/3d_renderer.h
+++ b/src/libtrx/include/libtrx/gfx/3d/3d_renderer.h
@@ -70,6 +70,8 @@ void GFX_3D_Renderer_SetPrimType(
     GFX_3D_RENDERER *renderer, GFX_3D_PRIM_TYPE value);
 void GFX_3D_Renderer_SetTextureFilter(
     GFX_3D_RENDERER *renderer, GFX_TEXTURE_FILTER filter);
+void GFX_3D_Renderer_SetDepthWritesEnabled(
+    GFX_3D_RENDERER *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetDepthTestEnabled(
     GFX_3D_RENDERER *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetBlendingMode(

--- a/src/libtrx/include/libtrx/gfx/3d/vertex_stream.h
+++ b/src/libtrx/include/libtrx/gfx/3d/vertex_stream.h
@@ -27,6 +27,7 @@ typedef struct {
         size_t count;
         size_t capacity;
     } pending_vertices;
+    size_t rendered_count;
 } GFX_3D_VERTEX_STREAM;
 
 void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *vertex_stream);

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -424,6 +424,16 @@ void S_Output_DisableTextureMode(void)
     GFX_3D_Renderer_SetTexturingEnabled(m_Renderer3D, m_IsTextureMode);
 }
 
+void S_Output_EnableDepthWrites(void)
+{
+    GFX_3D_Renderer_SetDepthWritesEnabled(m_Renderer3D, true);
+}
+
+void S_Output_DisableDepthWrites(void)
+{
+    GFX_3D_Renderer_SetDepthWritesEnabled(m_Renderer3D, false);
+}
+
 void S_Output_EnableDepthTest(void)
 {
     GFX_3D_Renderer_SetDepthTestEnabled(m_Renderer3D, true);

--- a/src/tr1/specific/s_output.h
+++ b/src/tr1/specific/s_output.h
@@ -12,6 +12,8 @@ void S_Output_Shutdown(void);
 
 void S_Output_EnableTextureMode(void);
 void S_Output_DisableTextureMode(void);
+void S_Output_EnableDepthWrites(void);
+void S_Output_DisableDepthWrites(void);
 void S_Output_EnableDepthTest(void);
 void S_Output_DisableDepthTest(void);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

#1493

Uses double rendering of underwater rooms with the wibble effect disabled (and Z-buffer writes off, to avoid depth races) to provide sensible pixels in the seams.

This has a chance of affecting performance in pools.