### PR TITLE
tr1/phase_photo_mode: fix exit option on controllers

### DIFF
--- a/src/tr1/game/phase/phase_photo_mode.c
+++ b/src/tr1/game/phase/phase_photo_mode.c
@@ -90,7 +90,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
     Input_Update();
     Shell_ProcessInput();
 
-    if (g_InputDB.toggle_photo_mode || g_InputDB.menu_back) {
+    if (g_InputDB.toggle_photo_mode || g_InputDB.option) {
         Phase_Set(PHASE_GAME, NULL);
     } else if (g_InputDB.action) {
         m_Status = PS_ACTIVE;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Uses the `option` input rather than `menu_back` to avoid issues with controllers.
