### PR TITLE
tr1/camera: fix potential division by zero

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed Lara's head not matching the braid if in use when she is killed by the T-rex (#1549)
 - fixed `/endlevel` displaying a success message in the title screen
 - fixed Story So Far feature looping cutscenes forever (#1551, regression from 4.4)
+- fixed a rare crash related to the camera that could affect custom levels (#1671)
 - improved object name matching in console commands to work like TR2X
 - improved vertex movement when looking through water portals even more (#1493)
 - improved console commands targeting creatures and pickups (#1667)

--- a/src/tr1/game/camera.c
+++ b/src/tr1/game/camera.c
@@ -782,14 +782,21 @@ static void M_Clip(
     const int32_t target_y, const int32_t left, const int32_t top,
     const int32_t right, const int32_t bottom)
 {
+    const int32_t x_diff = *x - target_x;
+    const int32_t y_diff = *y - target_y;
+
     if ((right > left) != (target_x < left)) {
-        *y = target_y + (*y - target_y) * (left - target_x) / (*x - target_x);
+        if (x_diff) {
+            *y = target_y + (left - target_x) * y_diff / x_diff;
+        }
         *x = left;
     }
 
     if ((bottom > top && target_y > top && *y < top)
         || (bottom < top && target_y < top && (*y) > top)) {
-        *x = target_x + (*x - target_x) * (top - target_y) / (*y - target_y);
+        if (y_diff) {
+            *x = target_x + (top - target_y) * x_diff / y_diff;
+        }
         *y = top;
     }
 }


### PR DESCRIPTION
Resolves #1671.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids the crash in the custom level in the issue itself. The camera still shows the void briefly before returning to Lara but the check in place is clearly safer for this kind of situation.
