### PR TITLE
tr1/photo_mode: fix freeing the UI

### DIFF
--- a/src/tr1/game/ui/widgets/photo_mode.c
+++ b/src/tr1/game/ui/widgets/photo_mode.c
@@ -77,12 +77,12 @@ static void M_Free(UI_PHOTO_MODE *const self)
         self->right_labels[i]->free(self->right_labels[i]);
     }
     self->spacer->free(self->spacer);
-    self->spacer->free(self->title);
-    self->spacer->free(self->outer_stack);
-    self->spacer->free(self->inner_stack);
-    self->spacer->free(self->left_stack);
-    self->spacer->free(self->right_stack);
-    self->spacer->free(self->window);
+    self->title->free(self->title);
+    self->outer_stack->free(self->outer_stack);
+    self->inner_stack->free(self->inner_stack);
+    self->left_stack->free(self->left_stack);
+    self->right_stack->free(self->right_stack);
+    self->window->free(self->window);
     Memory_Free(self->left_labels);
     Memory_Free(self->right_labels);
     Memory_Free(self);


### PR DESCRIPTION
Resolves #1680.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes freeing the photo mode UI components. The resulting issue was that the title and window labels weren't causing the text count to decrease in `text.c` so it eventually hit the maximum and failed to create any further text.
