### PR TITLE
Add animated interaction information to the savegame to fix save/load bug and fix long animated interaction time if pushed

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed Story So Far feature looping cutscenes forever (#1551, regression from 4.4)
 - fixed a rare crash related to the camera that could affect custom levels (#1671)
 - fixed a bug when saving and loading when picking up an item or using a switch with animated interactions enabled (#1546)
+- fixed a bug where Lara was stuck for a long time in an animated interactions if pushed (#1687)
 - improved object name matching in console commands to work like TR2X
 - improved vertex movement when looking through water portals even more (#1493)
 - improved console commands targeting creatures and pickups (#1667)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed `/endlevel` displaying a success message in the title screen
 - fixed Story So Far feature looping cutscenes forever (#1551, regression from 4.4)
 - fixed a rare crash related to the camera that could affect custom levels (#1671)
+- fixed a bug when saving and loading when picking up an item or using a switch with animated interactions enabled (#1546)
 - improved object name matching in console commands to work like TR2X
 - improved vertex movement when looking through water portals even more (#1493)
 - improved console commands targeting creatures and pickups (#1667)

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -28,6 +28,7 @@
 #include <stddef.h>
 
 #define LARA_MOVE_TIMEOUT 90
+#define LARA_PUSH_TIMEOUT 15
 #define LARA_MOVE_ANIM_VELOCITY 12
 #define LARA_MOVE_SPEED 16
 #define LARA_UW_DAMAGE 5
@@ -802,6 +803,12 @@ void Lara_Push(ITEM *item, COLL_INFO *coll, bool spaz_on, bool big_push)
             coll->old.y = lara_item->pos.y;
             coll->old.z = lara_item->pos.z;
             Item_UpdateRoom(item, -10);
+        }
+
+        if (g_Lara.interact_target.is_moving
+            && g_Lara.interact_target.move_count > LARA_PUSH_TIMEOUT) {
+            g_Lara.interact_target.is_moving = false;
+            g_Lara.gun_status = LGS_ARMLESS;
         }
     }
 }

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -164,6 +164,7 @@ void Switch_CollisionControlled(
                 g_Lara.torso_rot.x = 0;
                 g_Lara.torso_rot.y = 0;
                 g_Lara.interact_target.is_moving = false;
+                g_Lara.interact_target.item_num = NO_OBJECT;
                 g_Lara.gun_status = LGS_HANDS_BUSY;
                 Item_AddActive(item_num);
                 item->status = IS_ACTIVE;

--- a/src/tr1/game/savegame.h
+++ b/src/tr1/game/savegame.h
@@ -13,7 +13,7 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
-#define SAVEGAME_CURRENT_VERSION 5
+#define SAVEGAME_CURRENT_VERSION 6
 
 typedef enum {
     VERSION_LEGACY = -1,
@@ -23,6 +23,7 @@ typedef enum {
     VERSION_3 = 3,
     VERSION_4 = 4,
     VERSION_5 = 5,
+    VERSION_6 = 6,
 } SAVEGAME_VERSION;
 
 typedef enum {


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Includes two commits to solve two animated interaction issues. Increments the savegame version to add the animated interaction target information as in TR4+. Also adds in the proper animated interaction timeout from TR4+ so Lara doesn't get stuck trying to pull a switch for a very long time if pushed while trying to use the switch (ex- Tomb of Qualopec switch with raptors nearby).