### PR TITLE
tr1/carrier: add support for TR2-style item drops

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -22,6 +22,7 @@
         "data/injections/uzi_sfx.bin",
         "data/injections/explosion.bin",
     ],
+    "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
 
     "levels": [

--- a/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
@@ -23,6 +23,7 @@
         "data/injections/uzi_sfx.bin",
         "data/injections/explosion.bin",
     ],
+    "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
 
     "levels": [

--- a/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
@@ -21,6 +21,7 @@
         "data/injections/uzi_sfx.bin",
         "data/injections/explosion.bin",
     ],
+    "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
 
     "levels": [

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.5.1...develop) - ××××-××-××
 - fixed missing pushblock SFX in Natla's Mines (#1714)
+- improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 
 ## [4.5.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.5...tr1-4.5.1) - 2024-10-14
 - fixed mac builds missing embedded resources (#1710, regression from 4.5)

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -111,6 +111,19 @@ various pieces of global behaviour.
   </tr>
   <tr valign="top">
     <td>
+      <a name="enable-tr2-item-drops"></a>
+      <code>enable_tr2_item_drops</code>
+    </td>
+    <td>Boolean</td>
+    <td>No</td>
+    <td>
+      Forces enemies who are placed in the same position as pickup items to
+      carry those items and drop them when killed, similar to TR2+. See
+      <a href="#item-drops">Item drops</a> for full details.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td>
       <code>force_game_modes</code>
     </td>
     <td>Optional Boolean</td>
@@ -997,10 +1010,15 @@ to allow the _majority_ of enemy types to carry and drop items. Note that this
 also means by default that the original enemies who did drop items will not do
 so unless the gameflow has been configured as such.
 
-Item drops are defined in the `item_drops` section of a level's definition by
-creating objects with the following parameter structure. You can define at most
-one entry per enemy, but that definition can have as many drop items as
-necessary (within the engine's overall item limit).
+Item drops can be defined in two ways. If `enable_tr2_item_drops` is `true`,
+then custom level builders can add items directly to the level file, setting
+their position to be the same as the enemies who should drop them.
+
+For the original levels, `enable_tr2_item_drops` is `false`. Item drops are
+instead defined in the `item_drops` section of a level's definition by creating
+objects with the following parameter structure. You can define at most one entry
+per enemy, but that definition can have as many drop items as necessary (within
+the engine's overall item limit).
 
 <details>
 <summary>Show example setup</summary>

--- a/src/tr1/game/carrier.c
+++ b/src/tr1/game/carrier.c
@@ -25,6 +25,7 @@
 static int16_t m_AnimatingCount = 0;
 
 static ITEM *M_GetCarrier(int16_t item_num);
+static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *carrier);
 static void M_AnimateDrop(CARRIED_ITEM *item);
 static void M_InitialiseDataDrops(void);
 static void M_InitialiseGameflowDrops(int32_t level_num);
@@ -55,6 +56,19 @@ static ITEM *M_GetCarrier(const int16_t item_num)
     }
 
     return item;
+}
+
+static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *const carrier)
+{
+    if (carrier->hit_points > 0 && carrier->object_id != O_MUMMY) {
+        return NULL;
+    }
+
+    if (carrier->object_id == O_PIERRE && !(carrier->flags & IF_ONE_SHOT)) {
+        return NULL;
+    }
+
+    return carrier->carried_item;
 }
 
 static void M_AnimateDrop(CARRIED_ITEM *const item)
@@ -265,10 +279,8 @@ DROP_STATUS Carrier_GetSaveStatus(const CARRIED_ITEM *item)
 void Carrier_TestItemDrops(const int16_t item_num)
 {
     const ITEM *const carrier = Item_Get(item_num);
-    CARRIED_ITEM *item = carrier->carried_item;
-    if (carrier->hit_points > 0 || item == NULL
-        || (carrier->object_id == O_PIERRE
-            && !(carrier->flags & IF_ONE_SHOT))) {
+    CARRIED_ITEM *item = M_GetFirstDropItem(carrier);
+    if (item == NULL) {
         return;
     }
 

--- a/src/tr1/game/carrier.h
+++ b/src/tr1/game/carrier.h
@@ -6,6 +6,7 @@
 
 void Carrier_InitialiseLevel(int32_t level_num);
 int32_t Carrier_GetItemCount(int16_t item_num);
+bool Carrier_IsItemCarried(int16_t item_num);
 void Carrier_TestItemDrops(int16_t item_num);
 void Carrier_TestLegacyDrops(int16_t item_num);
 DROP_STATUS Carrier_GetSaveStatus(const CARRIED_ITEM *item);

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -228,6 +228,8 @@ static bool M_LoadScriptMeta(JSON_OBJECT *obj)
         g_GameFlow.injections.length = 0;
     }
 
+    g_GameFlow.enable_tr2_item_drops =
+        JSON_ObjectGetBool(obj, "enable_tr2_item_drops", false);
     g_GameFlow.convert_dropped_guns =
         JSON_ObjectGetBool(obj, "convert_dropped_guns", false);
 
@@ -808,7 +810,13 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
         cur->lara_type = (GAME_OBJECT_ID)tmp_i;
 
         tmp_arr = JSON_ObjectGetArray(jlvl_obj, "item_drops");
-        if (tmp_arr) {
+        cur->item_drops.count = 0;
+        if (tmp_arr && g_GameFlow.enable_tr2_item_drops) {
+            LOG_WARNING(
+                "TR2 item drops are enabled: gameflow-defined drops for level "
+                "%d will be ignored",
+                level_num);
+        } else if (tmp_arr) {
             cur->item_drops.count = (signed)tmp_arr->length;
             cur->item_drops.data = Memory_Alloc(
                 sizeof(GAMEFLOW_DROP_ITEM_DATA) * (signed)tmp_arr->length);
@@ -849,8 +857,6 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
                     data->object_ids[j] = (int16_t)id;
                 }
             }
-        } else {
-            cur->item_drops.count = 0;
         }
 
         if (!M_LoadLevelSequence(jlvl_obj, level_num)) {

--- a/src/tr1/game/gameflow.h
+++ b/src/tr1/game/gameflow.h
@@ -78,6 +78,7 @@ typedef struct {
         int length;
         char **data_paths;
     } injections;
+    bool enable_tr2_item_drops;
     bool convert_dropped_guns;
 } GAMEFLOW;
 

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -228,14 +228,16 @@ void Item_NewRoom(int16_t item_num, int16_t room_num)
     ITEM *item = &g_Items[item_num];
     ROOM *r = &g_RoomInfo[item->room_num];
 
-    int16_t linknum = r->item_num;
-    if (linknum == item_num) {
-        r->item_num = item->next_item;
-    } else {
-        for (; linknum != NO_ITEM; linknum = g_Items[linknum].next_item) {
-            if (g_Items[linknum].next_item == item_num) {
-                g_Items[linknum].next_item = item->next_item;
-                break;
+    if (item->room_num != NO_ROOM) {
+        int16_t linknum = r->item_num;
+        if (linknum == item_num) {
+            r->item_num = item->next_item;
+        } else {
+            for (; linknum != NO_ITEM; linknum = g_Items[linknum].next_item) {
+                if (g_Items[linknum].next_item == item_num) {
+                    g_Items[linknum].next_item = item->next_item;
+                    break;
+                }
             }
         }
     }

--- a/src/tr1/game/stats.c
+++ b/src/tr1/game/stats.c
@@ -193,7 +193,8 @@ void Stats_CalculateStats(void)
                 continue;
             }
 
-            if (Object_IsObjectType(item->object_id, g_PickupObjects)) {
+            if (Object_IsObjectType(item->object_id, g_PickupObjects)
+                && !Carrier_IsItemCarried(i)) {
                 m_LevelPickups++;
             }
         }

--- a/src/tr1/math/math_misc.c
+++ b/src/tr1/math/math_misc.c
@@ -60,3 +60,8 @@ int32_t XYZ_32_GetDistance(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
     );
     // clang-format on
 }
+
+bool XYZ_32_AreEquivalent(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
+{
+    return pos1->x == pos2->x && pos1->y == pos2->y && pos1->z == pos2->z;
+}

--- a/src/tr1/math/math_misc.h
+++ b/src/tr1/math/math_misc.h
@@ -6,3 +6,4 @@ void Math_GetVectorAngles(int32_t x, int32_t y, int32_t z, int16_t *dest);
 int32_t Math_AngleInCone(int32_t angle1, int32_t angle2, int32_t cone);
 int32_t Math_AngleMean(int32_t angle1, int32_t angle2, double ratio);
 int32_t XYZ_32_GetDistance(const XYZ_32 *pos1, const XYZ_32 *pos2);
+bool XYZ_32_AreEquivalent(const XYZ_32 *pos1, const XYZ_32 *pos2);


### PR DESCRIPTION
Resolves #1713.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows item drops to be defined in the level data in the same fashion as TR2, so any pickup item that is in the same position as an enemy will be carried by that enemy. The gameflow approach is retained for OG levels, and the provided gameflow setting will default to this.

For OG, Pierre in Tihocan and the enemies in Natla's Mines should continue to drop as normal. If the gameflow setting is enabled in OG, then they will not drop anything (and indeed the ape in room 82 of Tihocan will drop shotgun shells).

Attached is a custom level with every enemy type and some drops allocated to each. Similarly, if the gameflow setting is disabled here, then the items will appear normally (albeit some will float as they're positioned with the enemy).
[LEVEL1.zip](https://github.com/user-attachments/files/17383340/LEVEL1.zip)
