### PR TITLE
tr2/lara: revert camera after extra anim unless heavy

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...develop) - ××××-××-××
 - fixed `/give` not working with weapons (regression from 0.5)
+- fixed the camera being cut off after using the gong hammer in Ice Palace (#1580)
 - improved switch object names
     - Switch Type 1 renamed to "Airlock Switch"
     - Switch Type 2 renamed to "Small Switch"

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -32,6 +32,7 @@ decompilation process. We recognize that there is much work to be done.
 #### Visuals
 
 - fixed TGA screenshots crashing the game
+- fixed the camera being cut off after using the gong hammer in Ice Palace
 
 #### Audio
 

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -700,7 +700,9 @@ void __cdecl Lara_State_Extra_Breath(ITEM *item, COLL_INFO *coll)
     item->current_anim_state = LS_STOP;
     g_Lara.extra_anim = 0;
     g_Lara.gun_status = LGS_ARMLESS;
-    g_Camera.type = CAM_CHASE;
+    if (g_Camera.type != CAM_HEAVY) {
+        g_Camera.type = CAM_CHASE;
+    }
     Output_AlterFOV(GAME_FOV * PHD_DEGREE);
 }
 


### PR DESCRIPTION
Resolves #1580.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The `Lara_State_Extra_Breath` function serves as a bridging animation between an extra animation and Lara returning to normal. This change will respect any heavy camera triggers set during the extra animation rather than blindly resetting to chase type. So as a result it fixes the gong camera in Ice Palace.

For testing, we can check WadTool where this could apply elsewhere. Any `Lara misc animation` that has the `next anim` set to `0` is relevant:

![image](https://github.com/user-attachments/assets/3df78e95-5a7b-4c91-8202-7bec51ce7ad4)

So this gives the following. The camera should return to normal after these animations.
- Bartoli detonator
- Offshore start
- Offshore wheel door
- Pulling the dagger (although slightly different, as Lara herself activates the exit door camera here)
- HSH start (same again, Lara triggers a camera after the start anim)
