### PR TITLE
tr1/fmv: fix initial playing flag

### DIFF
--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -21,7 +21,7 @@
 #include <stddef.h>
 
 static bool m_Muted = false;
-static bool m_IsPlaying = true;
+static bool m_IsPlaying = false;
 static const char *m_Extensions[] = {
     ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", NULL,
 };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1731.