### PR TITLE
build: make prereleases use debug symbols

### DIFF
--- a/.github/workflows/job_build_tr1.yml
+++ b/.github/workflows/job_build_tr1.yml
@@ -2,7 +2,11 @@ name: Build TR1X and the installer
 
 on:
   workflow_call:
-  workflow_dispatch:
+    inputs:
+      target:
+        type: string
+        description: "Target to build for"
+        required: true
 
 jobs:
   build:
@@ -12,11 +16,11 @@ jobs:
       matrix:
         include:
           - platform: linux
-            just_target: tr1-package-linux
+            just_target: tr1-package-linux ${{ inputs.target }}
           - platform: win
-            just_target: tr1-package-win-all
+            just_target: tr1-package-win-all ${{ inputs.target }}
           - platform: win-installer
-            just_target: tr1-package-win-installer
+            just_target: tr1-package-win-installer ${{ inputs.target }}
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/job_build_tr1_macos.yml
+++ b/.github/workflows/job_build_tr1_macos.yml
@@ -3,6 +3,10 @@ name: Build TR1X and the installer (macOS)
 on:
   workflow_call:
     inputs:
+      target:
+        type: string
+        description: "Target to build for"
+        required: true
       let_mac_fail:
         type: boolean
         description: "Do not require Mac builds to pass"
@@ -226,14 +230,14 @@ jobs:
       - name: Build arm64 and create app bundle
         run: |
           BUILD_DIR=build-arm64
-          BUILD_OPTIONS="src/tr1 --prefix=/tmp/TR1X.app --bindir=Contents/MacOS"
+          BUILD_OPTIONS="src/tr1 --prefix=/tmp/TR1X.app --bindir=Contents/MacOS --buildtype ${{ inputs.target }}"
           meson setup $BUILD_DIR $BUILD_OPTIONS
           meson install -C $BUILD_DIR
 
       - name: Build x86-64
         run: |
           BUILD_DIR=build-x86-64
-          BUILD_OPTIONS="src/tr1 --prefix=/tmp/TR1X.app --bindir=Contents/MacOS --cross-file tools/tr1/mac/x86-64_cross_file.txt"
+          BUILD_OPTIONS="src/tr1 --prefix=/tmp/TR1X.app --bindir=Contents/MacOS --cross-file tools/tr1/mac/x86-64_cross_file.txt --buildtype ${{ inputs.target }}"
           meson setup $BUILD_DIR $BUILD_OPTIONS
           meson compile -C $BUILD_DIR
 

--- a/.github/workflows/job_build_tr2.yml
+++ b/.github/workflows/job_build_tr2.yml
@@ -2,7 +2,11 @@ name: Build TR2X
 
 on:
   workflow_call:
-  workflow_dispatch:
+    inputs:
+      target:
+        type: string
+        description: "Target to build for"
+        required: true
 
 jobs:
   build:
@@ -12,7 +16,7 @@ jobs:
       matrix:
         include:
           - platform: win
-            just_target: tr2-package-win-all
+            just_target: tr2-package-win-all ${{ inputs.target }}
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -14,6 +14,8 @@ jobs:
   package_tr1_multiplatform:
     name: Build TR1
     uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      target: 'debug'
     secrets: inherit
 
   package_tr1_mac:
@@ -21,10 +23,13 @@ jobs:
     if: vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1_macos.yml
     with:
+      target: 'debug'
       let_mac_fail: true
     secrets: inherit
 
   package_tr2_multiplatform:
     name: Build TR2
     uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      target: 'debug'
     secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,6 +13,8 @@ jobs:
     name: Build TR1
     if: vars.PRERELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      target: 'debug'
     secrets: inherit
 
   package_tr1_mac:
@@ -22,6 +24,7 @@ jobs:
       vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1_macos.yml
     with:
+      target: 'debug'
       let_mac_fail: true
     secrets: inherit
 
@@ -29,6 +32,8 @@ jobs:
     name: Build TR2
     if: vars.PRERELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      target: 'debug'
     secrets: inherit
 
   publish_prerelease:

--- a/.github/workflows/release_tr1.yml
+++ b/.github/workflows/release_tr1.yml
@@ -32,6 +32,8 @@ jobs:
     name: Build release assets
     if: vars.RELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      target: "release"
     secrets: inherit
 
   package_mac:
@@ -41,6 +43,7 @@ jobs:
       vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1_macos.yml
     with:
+      target: "release"
       let_mac_fail: ${{ inputs.let_mac_fail == true || inputs.let_mac_fail == 'true' }}
     secrets: inherit
 

--- a/.github/workflows/release_tr2.yml
+++ b/.github/workflows/release_tr2.yml
@@ -32,6 +32,8 @@ jobs:
     name: Build release assets
     if: vars.RELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      target: "release"
     secrets: inherit
 
   publish_release:

--- a/justfile
+++ b/justfile
@@ -54,10 +54,10 @@ tr1-build-win target='debug':      (tr1-image-win "0")           (_docker_run "-
 tr1-build-win-config:              (tr1-image-win-config "0")    (_docker_run "rrdash/tr1x-config")
 tr1-build-win-installer:           (tr1-image-win-installer "0") (_docker_run "rrdash/tr1x-installer")
 
-tr1-package-linux:                 (tr1-build-linux "release") (_docker_run "rrdash/tr1x-linux" "package")
-tr1-package-win:                   (tr1-build-win "release") (_docker_run "rrdash/tr1x" "package")
-tr1-package-win-all:               (tr1-build-win "release") (tr1-build-win-config) (_docker_run "rrdash/tr1x" "package")
-tr1-package-win-installer:         (tr1-build-win "release") (tr1-build-win-config) (_docker_run "rrdash/tr1x" "package" "-o" "tools/tr1/installer/Installer/Resources/release.zip") (tr1-build-win-installer)
+tr1-package-linux target='release': (tr1-build-linux target) (_docker_run "rrdash/tr1x-linux" "package")
+tr1-package-win target='release': (tr1-build-win target) (_docker_run "rrdash/tr1x" "package")
+tr1-package-win-all target='release': (tr1-build-win target) (tr1-build-win-config) (_docker_run "rrdash/tr1x" "package")
+tr1-package-win-installer target='release': (tr1-build-win target) (tr1-build-win-config) (_docker_run "rrdash/tr1x" "package" "-o" "tools/tr1/installer/Installer/Resources/release.zip") (tr1-build-win-installer)
     #!/bin/sh
     git checkout "tools/tr1/installer/Installer/Resources/release.zip"
     exe_name=TR1X-$(tools/get_version 1)-Installer.exe


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

To better debug crash issues, this disables symbol stripping and .exe compression in the non-release builds.