### PR TITLE
phase_pause: add the ability to pause during cutscenes

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.5.1...develop) - ××××-××-××
 - added support for wading, similar to TR2+ (#1537)
+- added the ability to pause during cutscenes (#1673)
 - fixed missing pushblock SFX in Natla's Mines (#1714)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -391,6 +391,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added ability to wade, similar to TR2+
 - added Lara's exit-water-to-medium-height animation from TR2+
 - added a pause screen
+- added the ability to pause during cutscenes
 - added a choice whether to play NG or NG+ without having to play the entire game
 - added Japanese mode (guns deal twice the damage, inspired by JP release of TR3); available for both NG and NG+
 - added ability to restart level on death

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -391,7 +391,6 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added ability to wade, similar to TR2+
 - added Lara's exit-water-to-medium-height animation from TR2+
 - added a pause screen
-- added the ability to pause during cutscenes
 - added a choice whether to play NG or NG+ without having to play the entire game
 - added Japanese mode (guns deal twice the damage, inspired by JP release of TR3); available for both NG and NG+
 - added ability to restart level on death

--- a/src/tr1/game/phase/phase_cutscene.c
+++ b/src/tr1/game/phase/phase_cutscene.c
@@ -165,6 +165,19 @@ static PHASE_CONTROL M_Control(int32_t nframes)
             Phase_Set(PHASE_PHOTO_MODE, args);
             m_ExitingToPhotoMode = true;
             return (PHASE_CONTROL) { .end = false };
+        } else if (g_InputDB.pause) {
+            PHASE_CUTSCENE_ARGS *const cutscene_args =
+                Memory_Alloc(sizeof(PHASE_CUTSCENE_ARGS));
+            cutscene_args->resume_existing = true;
+            cutscene_args->level_num = g_CurrentLevel;
+
+            PHASE_PHOTO_MODE_ARGS *const args =
+                Memory_Alloc(sizeof(PHASE_PHOTO_MODE_ARGS));
+            args->phase_to_return_to = PHASE_CUTSCENE;
+            args->phase_arg = cutscene_args;
+            Phase_Set(PHASE_PAUSE, args);
+            m_ExitingToPhotoMode = true;
+            return (PHASE_CONTROL) { .end = false };
         }
     }
 

--- a/src/tr1/game/phase/phase_cutscene.c
+++ b/src/tr1/game/phase/phase_cutscene.c
@@ -12,6 +12,7 @@
 #include "game/level.h"
 #include "game/music.h"
 #include "game/output.h"
+#include "game/phase/phase_pause.h"
 #include "game/phase/phase_photo_mode.h"
 #include "game/shell.h"
 #include "game/sound.h"
@@ -25,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static bool m_ExitingToPhotoMode = false;
+static bool m_PauseCutscene = false;
 
 static void M_InitialiseHair(int32_t level_num);
 
@@ -69,7 +70,7 @@ static void M_InitialiseHair(int32_t level_num)
 
 static void M_Start(const PHASE_CUTSCENE_ARGS *const args)
 {
-    m_ExitingToPhotoMode = false;
+    m_PauseCutscene = false;
 
     // The cutscene is already playing and it's to be resumed.
     if (args->resume_existing) {
@@ -106,7 +107,7 @@ static void M_Start(const PHASE_CUTSCENE_ARGS *const args)
 
 static void M_End(void)
 {
-    if (m_ExitingToPhotoMode) {
+    if (m_PauseCutscene) {
         return;
     }
 
@@ -152,31 +153,27 @@ static PHASE_CONTROL M_Control(int32_t nframes)
 
         g_CineFrame++;
 
-        if (g_InputDB.toggle_photo_mode) {
+        if (g_InputDB.toggle_photo_mode || g_InputDB.pause) {
             PHASE_CUTSCENE_ARGS *const cutscene_args =
                 Memory_Alloc(sizeof(PHASE_CUTSCENE_ARGS));
             cutscene_args->resume_existing = true;
             cutscene_args->level_num = g_CurrentLevel;
 
-            PHASE_PHOTO_MODE_ARGS *const args =
-                Memory_Alloc(sizeof(PHASE_PHOTO_MODE_ARGS));
-            args->phase_to_return_to = PHASE_CUTSCENE;
-            args->phase_arg = cutscene_args;
-            Phase_Set(PHASE_PHOTO_MODE, args);
-            m_ExitingToPhotoMode = true;
-            return (PHASE_CONTROL) { .end = false };
-        } else if (g_InputDB.pause) {
-            PHASE_CUTSCENE_ARGS *const cutscene_args =
-                Memory_Alloc(sizeof(PHASE_CUTSCENE_ARGS));
-            cutscene_args->resume_existing = true;
-            cutscene_args->level_num = g_CurrentLevel;
+            if (g_InputDB.toggle_photo_mode) {
+                PHASE_PHOTO_MODE_ARGS *const args =
+                    Memory_Alloc(sizeof(PHASE_PHOTO_MODE_ARGS));
+                args->phase_to_return_to = PHASE_CUTSCENE;
+                args->phase_arg = cutscene_args;
+                Phase_Set(PHASE_PHOTO_MODE, args);
+            } else if (g_InputDB.pause) {
+                PHASE_PAUSE_ARGS *const args =
+                    Memory_Alloc(sizeof(PHASE_PAUSE_ARGS));
+                args->phase_to_return_to = PHASE_CUTSCENE;
+                args->phase_arg = cutscene_args;
+                Phase_Set(PHASE_PAUSE, args);
+            }
 
-            PHASE_PHOTO_MODE_ARGS *const args =
-                Memory_Alloc(sizeof(PHASE_PHOTO_MODE_ARGS));
-            args->phase_to_return_to = PHASE_CUTSCENE;
-            args->phase_arg = cutscene_args;
-            Phase_Set(PHASE_PAUSE, args);
-            m_ExitingToPhotoMode = true;
+            m_PauseCutscene = true;
             return (PHASE_CONTROL) { .end = false };
         }
     }

--- a/src/tr1/game/phase/phase_pause.c
+++ b/src/tr1/game/phase/phase_pause.c
@@ -7,6 +7,7 @@
 #include "game/music.h"
 #include "game/output.h"
 #include "game/overlay.h"
+#include "game/phase/phase_photo_mode.h"
 #include "game/requester.h"
 #include "game/shell.h"
 #include "game/sound.h"
@@ -31,7 +32,7 @@ typedef enum {
 
 static STATE m_PauseState = STATE_DEFAULT;
 static bool m_IsTextReady = false;
-
+static PHASE_PHOTO_MODE_ARGS m_Args;
 static TEXTSTRING *m_PausedText = NULL;
 
 static REQUEST_INFO m_PauseRequester = {
@@ -55,7 +56,7 @@ static void M_UpdateText(void);
 static int32_t M_DisplayRequester(
     const char *header, const char *option1, const char *option2,
     int16_t requested);
-static void M_Start(const void *args);
+static void M_Start(const PHASE_PHOTO_MODE_ARGS *args);
 static void M_End(void);
 static PHASE_CONTROL M_Control(int32_t nframes);
 static void M_Draw(void);
@@ -108,8 +109,15 @@ static int32_t M_DisplayRequester(
     return select;
 }
 
-static void M_Start(const void *const args)
+static void M_Start(const PHASE_PHOTO_MODE_ARGS *const args)
 {
+    if (args != NULL) {
+        m_Args = *args;
+    } else {
+        m_Args.phase_to_return_to = PHASE_GAME;
+        m_Args.phase_arg = NULL;
+    }
+
     g_OldInputDB = g_Input;
 
     Overlay_HideGameInfo();
@@ -145,7 +153,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         if (g_InputDB.pause) {
             Music_Unpause();
             Sound_UnpauseAll();
-            Phase_Set(PHASE_GAME, NULL);
+            Phase_Set(m_Args.phase_to_return_to, m_Args.phase_arg);
         } else if (g_InputDB.option) {
             m_PauseState = STATE_ASK;
         }
@@ -157,7 +165,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         if (choice == 1) {
             Music_Unpause();
             Sound_UnpauseAll();
-            Phase_Set(PHASE_GAME, NULL);
+            Phase_Set(m_Args.phase_to_return_to, m_Args.phase_arg);
         } else if (choice == 2) {
             m_PauseState = STATE_CONFIRM;
         }
@@ -175,7 +183,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         } else if (choice == 2) {
             Music_Unpause();
             Sound_UnpauseAll();
-            Phase_Set(PHASE_GAME, NULL);
+            Phase_Set(m_Args.phase_to_return_to, m_Args.phase_arg);
         }
         break;
     }
@@ -194,7 +202,7 @@ static void M_Draw(void)
 }
 
 PHASER g_PausePhaser = {
-    .start = M_Start,
+    .start = (PHASER_START)M_Start,
     .end = M_End,
     .control = M_Control,
     .draw = M_Draw,

--- a/src/tr1/game/phase/phase_pause.c
+++ b/src/tr1/game/phase/phase_pause.c
@@ -7,7 +7,6 @@
 #include "game/music.h"
 #include "game/output.h"
 #include "game/overlay.h"
-#include "game/phase/phase_photo_mode.h"
 #include "game/requester.h"
 #include "game/shell.h"
 #include "game/sound.h"
@@ -32,7 +31,7 @@ typedef enum {
 
 static STATE m_PauseState = STATE_DEFAULT;
 static bool m_IsTextReady = false;
-static PHASE_PHOTO_MODE_ARGS m_Args;
+static PHASE_PAUSE_ARGS m_Args;
 static TEXTSTRING *m_PausedText = NULL;
 
 static REQUEST_INFO m_PauseRequester = {
@@ -56,7 +55,7 @@ static void M_UpdateText(void);
 static int32_t M_DisplayRequester(
     const char *header, const char *option1, const char *option2,
     int16_t requested);
-static void M_Start(const PHASE_PHOTO_MODE_ARGS *args);
+static void M_Start(const PHASE_PAUSE_ARGS *args);
 static void M_End(void);
 static PHASE_CONTROL M_Control(int32_t nframes);
 static void M_Draw(void);
@@ -109,7 +108,7 @@ static int32_t M_DisplayRequester(
     return select;
 }
 
-static void M_Start(const PHASE_PHOTO_MODE_ARGS *const args)
+static void M_Start(const PHASE_PAUSE_ARGS *const args)
 {
     if (args != NULL) {
         m_Args = *args;

--- a/src/tr1/game/phase/phase_pause.h
+++ b/src/tr1/game/phase/phase_pause.h
@@ -2,4 +2,9 @@
 
 #include "game/phase/phase.h"
 
+typedef struct {
+    PHASE phase_to_return_to;
+    void *phase_arg;
+} PHASE_PAUSE_ARGS;
+
 extern PHASER g_PausePhaser;


### PR DESCRIPTION
Resolves #1673.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added the ability to pause during cutscenes.

This works as is, but I marked as a draft for now since it's kind of a proof of concept. It reuses the photo mode structures since that's already in place to resume cutscenes. But, I don't know if we want to rename the `PHASE_PHOTO_MODE_ARGS` struct to something more generic or possibly make a separate one for pausing. Lmk your thoughts.