### PR TITLE
tr2/boat: fix Lara's room number when on boat

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed the camera being cut off after using the gong hammer in Ice Palace (#1580)
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace (#1725)
 - fixed door cheat not working with drawbridges (#1748)
+- fixed Lara's underwater hue being retained when re-entering a boat (#1596)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -33,6 +33,7 @@ decompilation process. We recognize that there is much work to be done.
 
 - fixed TGA screenshots crashing the game
 - fixed the camera being cut off after using the gong hammer in Ice Palace
+- fixed Lara's underwater hue being retained when re-entering a boat
 
 #### Audio
 

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -635,7 +635,7 @@ void __cdecl Boat_Control(const int16_t item_num)
     const int32_t hfr = Boat_TestWaterHeight(boat, BOAT_FRONT, BOAT_SIDE, &fr);
 
     int16_t room_num = boat->room_num;
-    const SECTOR *const sector =
+    const SECTOR *sector =
         Room_GetSector(boat->pos.x, boat->pos.y, boat->pos.z, &room_num);
     int32_t height =
         Room_GetHeight(sector, boat->pos.x, boat->pos.y, boat->pos.z);
@@ -711,7 +711,6 @@ void __cdecl Boat_Control(const int16_t item_num)
 
         if (room_num != boat->room_num) {
             Item_NewRoom(item_num, room_num);
-            Item_NewRoom(g_Lara.item_num, room_num);
         }
 
         boat->rot.z += boat_data->tilt_angle;
@@ -721,6 +720,12 @@ void __cdecl Boat_Control(const int16_t item_num)
         lara->rot.x = boat->rot.x;
         lara->rot.y = boat->rot.y;
         lara->rot.z = boat->rot.z;
+
+        sector = Room_GetSector(
+            lara->pos.x, lara->pos.y - 5, lara->pos.z, &room_num);
+        if (room_num != g_LaraItem->room_num) {
+            Item_NewRoom(g_Lara.item_num, room_num);
+        }
 
         Item_Animate(lara);
 


### PR DESCRIPTION
Resolves #1596.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This tests Lara's position more accurately for cases when the boat's room number is the water room below, but we want Lara to be defined in the dry room above to remove her underwater hue.
