### PR TITLE
tr2/gun_rifle: fix harpoon recoil in NG+

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace (#1725)
 - fixed door cheat not working with drawbridges (#1748)
 - fixed Lara's underwater hue being retained when re-entering a boat (#1596)
+- fixed Lara reloading the harpoon gun after every shot in NG+ (#1575)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -28,6 +28,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed explosions sometimes being drawn too dark
 - fixed controls dialog remapping being too sensitive
 - fixed the distorted skybox in room 5 of Barkhang Monastery
+- fixed Lara reloading the harpoon gun after every shot in NG+
 
 #### Visuals
 

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -183,8 +183,10 @@ void __cdecl Gun_Rifle_FireHarpoon(void)
     item->speed = (HARPOON_BOLT_SPEED * Math_Cos(item->rot.x)) >> W2V_SHIFT;
     Item_AddActive(item_num);
 
-    if (!g_SaveGame.bonus_flag) {
-        g_Lara.harpoon_ammo.ammo--;
+    g_Lara.harpoon_ammo.ammo--;
+    if (g_SaveGame.bonus_flag
+        && (g_Lara.harpoon_ammo.ammo % HARPOON_RECOIL) == 0) {
+        g_Lara.harpoon_ammo.ammo += HARPOON_RECOIL;
     }
     g_SaveGame.statistics.shots++;
 }


### PR DESCRIPTION
Resolves #1575.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that harpoon ammo is decremented in NG+ so that the recoil check continues as normal after 4 rounds. The ammo is always incremented by 4 so that infinite ammo remains.
