### PR TITLE
dragon: fix dragon reviving after the dagger is pulled

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace (#1725)
 - fixed door cheat not working with drawbridges (#1748)
 - fixed Lara's underwater hue being retained when re-entering a boat (#1596)
+- fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -28,6 +28,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed explosions sometimes being drawn too dark
 - fixed controls dialog remapping being too sensitive
 - fixed the distorted skybox in room 5 of Barkhang Monastery
+- fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
 
 #### Visuals
 

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -33,9 +33,6 @@
 #define DRAGON_LIVE_TIME 330
 #define DRAGON_HITPOINTS 300
 #define DRAGON_RADIUS (WALL_L / 3) // = 341
-#define DRAGON_ANIM_DIE 21
-#define DRAGON_ANIM_DEAD 22
-#define DRAGON_ANIM_RESURRECT 23
 
 typedef enum {
     // clang-format off
@@ -51,6 +48,9 @@ typedef enum {
     DRAGON_ANIM_SWIPE_LEFT  = 9,
     DRAGON_ANIM_SWIPE_RIGHT = 10,
     DRAGON_ANIM_DEATH       = 11,
+    DRAGON_ANIM_DIE         = 21,
+    DRAGON_ANIM_DEAD        = 22,
+    DRAGON_ANIM_RESURRECT   = 23,
     // clang-format on
 } DRAGON_ANIM;
 

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -33,6 +33,9 @@
 #define DRAGON_LIVE_TIME 330
 #define DRAGON_HITPOINTS 300
 #define DRAGON_RADIUS (WALL_L / 3) // = 341
+#define DRAGON_ANIM_DIE 21
+#define DRAGON_ANIM_DEAD 22
+#define DRAGON_ANIM_RESURRECT 23
 
 typedef enum {
     // clang-format off
@@ -48,9 +51,6 @@ typedef enum {
     DRAGON_ANIM_SWIPE_LEFT  = 9,
     DRAGON_ANIM_SWIPE_RIGHT = 10,
     DRAGON_ANIM_DEATH       = 11,
-    DRAGON_ANIM_DIE         = 21,
-    DRAGON_ANIM_DEAD        = 22,
-    DRAGON_ANIM_RESURRECT   = 23,
     // clang-format on
 } DRAGON_ANIM;
 
@@ -263,7 +263,7 @@ void __cdecl Dragon_Control(const int16_t item_num)
     if (dragon_front_item->hit_points <= 0) {
         if (dragon_front_item->current_anim_state != DRAGON_ANIM_DEATH) {
             dragon_front_item->anim_num =
-                g_Objects[O_DRAGON_FRONT].anim_idx + 21;
+                g_Objects[O_DRAGON_FRONT].anim_idx + DRAGON_ANIM_DIE;
             dragon_front_item->frame_num =
                 g_Anims[dragon_front_item->anim_num].frame_base;
             dragon_front_item->goal_anim_state = DRAGON_ANIM_DEATH;
@@ -275,7 +275,7 @@ void __cdecl Dragon_Control(const int16_t item_num)
             if (creature->flags == DRAGON_LIVE_TIME) {
                 dragon_front_item->goal_anim_state = DRAGON_ANIM_STOP;
             }
-            if (creature->flags >= DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) {
+            if (creature->flags > DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) {
                 dragon_front_item->hit_points =
                     g_Objects[O_DRAGON_FRONT].hit_points / 2;
             }


### PR DESCRIPTION
Resolves #1572.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the dragon reviving itself after Lara removes the dagger in a 1 frame window.

Explanation:
Dragon_Collision:
`item->frame_num - g_Anims[item->anim_num].frame_base <= DRAGON_ALMOST_LIVE // 100`

Dragon_Control:
```
creature->flags++;
if (creature->flags == DRAGON_LIVE_TIME) { // 330
    dragon_front_item->goal_anim_state = DRAGON_ANIM_STOP;
}

if (creature->flags >= DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) { // 330 + 100
    dragon_front_item->hit_points =
        g_Objects[O_DRAGON_FRONT].hit_points / 2;
}
```

So what was happening simultaneously was:
1. `Dragon_Control` runs and `creature->flags` increments to `430` which is `>= DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE` (330+100). 
2. `Dragon_Collision` runs the same frame and `item->frame_num - g_Anims[item->anim_num].frame_base` is `100` which is <=`DRAGON_ALMOST_LIVE` (100) so `M_PullDagger` runs .

So, `M_PullDagger` runs, but that really only prepares the dragon for death by setting `creature->flags = -1;`. However, in `Dragon_Control` already, the hit points were reset to `300/2` because the `creature->flags` hit `430`. So, the `else... then if (dragon_front_item->hit_points <= 0) {` block is no longer run which checks for` if (creature->flags > -20) {`  when the dragon has no HP and kills the dragon.

So, the fix is to change in `Dragon_Control`:
`if (creature->flags >= DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) { // 330 + 100`
to
`if (creature->flags > DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) { // 330 + 100`
that way we don't lose 1 frame in the window to pull the dagger and kill the dragon. I cannot screenshot or capture video of the old DirectX SW rendered window for some reason.