### PR TITLE
grenade: fix kills counting as two kills

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed Lara's underwater hue being retained when re-entering a boat (#1596)
 - fixed Lara reloading the harpoon gun after every shot in NG+ (#1575)
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
+- fixed grenades counting as double hits and kills in the game statistics (#1560)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -14,7 +14,7 @@
 - fixed Lara's underwater hue being retained when re-entering a boat (#1596)
 - fixed Lara reloading the harpoon gun after every shot in NG+ (#1575)
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
-- fixed grenades counting as double hits and kills in the game statistics (#1560)
+- fixed grenades counting as double kills in the game statistics (#1560)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -30,7 +30,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed Lara reloading the harpoon gun after every shot in NG+
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
-- fixed grenades counting as double hits and kills in the game statistics
+- fixed grenades counting as double kills in the game statistics
 
 #### Visuals
 

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -30,6 +30,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed Lara reloading the harpoon gun after every shot in NG+
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
+- fixed grenades counting as double hits and kills in the game statistics
 
 #### Visuals
 

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -119,17 +119,7 @@ void __cdecl Grenade_Control(int16_t item_num)
         } else {
             // XXX: missing check if obj is intelligent?
             Gun_HitTarget(target_item, NULL, 30);
-
             explode = true;
-            g_SaveGame.statistics.hits++;
-
-            if (target_item->hit_points <= 0) {
-                g_SaveGame.statistics.kills++;
-                if (target_item->object_id != O_DRAGON_FRONT
-                    && target_item->object_id != O_GIANT_YETI) {
-                    Creature_Die(target_item_num, true);
-                }
-            }
         }
     }
 

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -119,7 +119,16 @@ void __cdecl Grenade_Control(int16_t item_num)
         } else {
             // XXX: missing check if obj is intelligent?
             Gun_HitTarget(target_item, NULL, 30);
+
             explode = true;
+            g_SaveGame.statistics.hits++;
+
+            if (target_item->hit_points <= 0) {
+                if (target_item->object_id != O_DRAGON_FRONT
+                    && target_item->object_id != O_GIANT_YETI) {
+                    Creature_Die(target_item_num, true);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #1560.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix grenades counting as double hits and kills in the game statistics.