### PR TITLE
tr1/gameflow: read leadbar name from gameflow

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed missing pushblock SFX in Natla's Mines (#1714)
 - fixed crash reports not working in certain circumstances (#1738)
 - fixed missing trapdoor triggers in City of Khamoon (#1744)
+- fixed being unable to rename the lead bar (#1774, regression from 4.5)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -1482,6 +1482,8 @@ void GameFlow_LoadStrings(int32_t level_num)
         { O_PICKUP_OPTION_1,    GS(INV_ITEM_PICKUP1) },
         { O_PICKUP_ITEM_2,      GS(INV_ITEM_PICKUP2) },
         { O_PICKUP_OPTION_2,    GS(INV_ITEM_PICKUP2) },
+        { O_LEADBAR_ITEM,       GS(INV_ITEM_LEADBAR) },
+        { O_LEADBAR_OPTION,     GS(INV_ITEM_LEADBAR) },
         { O_SCION_ITEM_1,       GS(INV_ITEM_SCION) },
         { O_SCION_ITEM_2,       GS(INV_ITEM_SCION) },
         { O_SCION_ITEM_3,       GS(INV_ITEM_SCION) },


### PR DESCRIPTION
Resolves #1774.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This restores reading the leadbar name from the gameflow to allow it to be customised. Regression from 4.5.
