### PR TITLE
demo: fix hidden ammo counter while demo plays in NG+

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed Lara reloading the harpoon gun after every shot in NG+ (#1575)
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
 - fixed grenades counting as double kills in the game statistics (#1560)
+- fixed the ammo counter being hidden while a demo plays in NG+ (#1559)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -31,6 +31,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed Lara reloading the harpoon gun after every shot in NG+
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
 - fixed grenades counting as double kills in the game statistics
+- fixed the ammo counter being hidden while a demo plays in NG+
 
 #### Visuals
 

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -12,9 +12,27 @@
 #include "global/funcs.h"
 #include "global/vars.h"
 
+static struct {
+    bool bonus_flag;
+} m_OldConfig;
+
 static int32_t m_DemoLevel = 0;
 static int32_t m_DemoLevel2 = 0;
 static int32_t m_OldDemoInputDB = 0;
+
+static void M_PrepareConfig(void);
+static void M_RestoreConfig(void);
+
+static void M_PrepareConfig(void)
+{
+    m_OldConfig.bonus_flag = g_SaveGame.bonus_flag;
+    g_SaveGame.bonus_flag = false;
+}
+
+static void M_RestoreConfig(void)
+{
+    g_SaveGame.bonus_flag = m_OldConfig.bonus_flag;
+}
 
 int32_t __cdecl Demo_Control(int32_t level_num)
 {
@@ -40,6 +58,8 @@ int32_t __cdecl Demo_Start(int32_t level_num)
     if (level_num < 0 && !g_GameFlow.num_demos) {
         return GFD_EXIT_TO_TITLE;
     }
+
+    M_PrepareConfig();
 
     if (level_num >= 0) {
         m_DemoLevel2 = level_num;
@@ -90,6 +110,8 @@ int32_t __cdecl Demo_Start(int32_t level_num)
     g_Inv_DemoMode = false;
 
     Text_Remove(text);
+
+    M_RestoreConfig();
 
     *s = start;
     S_FadeToBlack();


### PR DESCRIPTION
Resolves #1559.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix the ammo counter being hidden while a demo plays in NG+. Institutes a similar groundwork as TR1X which stores and restores config options that can mess with demos.