### PR TITLE
stats: fix the game hanging if exited during the level stats, credits, or final stats

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
 - fixed grenades counting as double kills in the game statistics (#1560)
 - fixed the ammo counter being hidden while a demo plays in NG+ (#1559)
+- fixed the game hanging if exited during the level stats, credits, or final stats (#1585)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -32,6 +32,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
 - fixed grenades counting as double kills in the game statistics
 - fixed the ammo counter being hidden while a demo plays in NG+
+- fixed the game hanging if exited during the level stats, credits, or final stats
 
 #### Visuals
 

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -2816,6 +2816,10 @@ void __cdecl S_Wait(int32_t frames, const BOOL input_check)
                 passed = Sync();
             } while (!passed);
             frames -= passed;
+
+            if (g_IsGameToExit) {
+                break;
+            }
         }
     }
 
@@ -2830,6 +2834,10 @@ void __cdecl S_Wait(int32_t frames, const BOOL input_check)
             passed = Sync();
         } while (!passed);
         frames -= passed;
+
+        if (g_IsGameToExit) {
+            break;
+        }
     }
 }
 

--- a/src/tr2/decomp/stats.c
+++ b/src/tr2/decomp/stats.c
@@ -323,6 +323,10 @@ int32_t __cdecl LevelStats(const int32_t level_num)
 
         Input_Update();
 
+        if (g_IsGameToExit) {
+            break;
+        }
+
         if (g_GF_OverrideDir != (GAME_FLOW_DIR)-1) {
             break;
         }
@@ -368,6 +372,10 @@ int32_t __cdecl GameStats(const int32_t level_num)
         S_CopyBufferToScreen();
 
         Input_Update();
+
+        if (g_IsGameToExit) {
+            break;
+        }
 
         if (g_GF_OverrideDir != (GAME_FLOW_DIR)-1) {
             break;

--- a/src/tr2/game/shell.c
+++ b/src/tr2/game/shell.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "decomp/decomp.h"
+#include "game/background.h"
 #include "game/console/common.h"
 #include "game/demo.h"
 #include "game/game_string.h"
@@ -169,7 +170,8 @@ void __cdecl Shell_Shutdown(void)
     GameString_Shutdown();
     Console_Shutdown();
     WinInFinish();
-    RenderFinish(true);
+    BGND_Free();
+    RenderFinish(false);
     WinVidFinish();
     WinVidHideGameWindow();
     Text_Shutdown();


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fix the game hanging if exited during the level stats, credits, or final stats.

The only caveat to this PR is that if you exit during the credit images (not the final stats), the game has to wait until the current credits picture timer ends before it will exit. I think this is due to the credit pictures being unskippable which is a separate issue. I hate to bug @rr-, but if we could get `DisplayCredits` decompiled, I think we could solve this delayed exit and unskippable credits in another PR. There is no rush on this though, so I don't mind marking this PR as draft until we have to time to decompile `DisplayCredits`.