### PR TITLE
tr1/phase_demo: disable wading during demos

### DIFF
--- a/src/tr1/game/phase/phase_demo.c
+++ b/src/tr1/game/phase/phase_demo.c
@@ -44,6 +44,7 @@ static struct {
     bool enable_enhanced_look;
     bool enable_tr2_jumping;
     bool enable_tr2_swimming;
+    bool enable_wading;
     bool fix_bear_ai;
     TARGET_LOCK_MODE target_mode;
 } m_OldConfig;
@@ -158,11 +159,13 @@ static void M_PrepareConfig(void)
     m_OldConfig.enable_enhanced_look = g_Config.enable_enhanced_look;
     m_OldConfig.enable_tr2_jumping = g_Config.enable_tr2_jumping;
     m_OldConfig.enable_tr2_swimming = g_Config.enable_tr2_swimming;
+    m_OldConfig.enable_wading = g_Config.enable_wading;
     m_OldConfig.target_mode = g_Config.target_mode;
     m_OldConfig.fix_bear_ai = g_Config.fix_bear_ai;
     g_Config.enable_enhanced_look = false;
     g_Config.enable_tr2_jumping = false;
     g_Config.enable_tr2_swimming = false;
+    g_Config.enable_wading = false;
     g_Config.target_mode = TLM_FULL;
     g_Config.fix_bear_ai = false;
 }
@@ -173,6 +176,7 @@ static void M_RestoreConfig(void)
     g_Config.enable_enhanced_look = m_OldConfig.enable_enhanced_look;
     g_Config.enable_tr2_jumping = m_OldConfig.enable_tr2_jumping;
     g_Config.enable_tr2_swimming = m_OldConfig.enable_tr2_swimming;
+    g_Config.enable_wading = m_OldConfig.enable_wading;
     g_Config.fix_bear_ai = m_OldConfig.fix_bear_ai;
 }
 


### PR DESCRIPTION
Resolves #1778.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Missed this in #1728. No changelog entry as it's unreleased.
