### PR TITLE
tr1/lara: restore original non-standard water exit

### DIFF
--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -703,22 +703,20 @@ void Lara_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
     const int32_t water_depth =
         Lara_GetWaterDepth(item->pos.x, item->pos.y, item->pos.z, room_num);
 
-    if (water_depth == NO_HEIGHT) {
-        item->pos = coll->old;
-        item->fall_speed = 0;
-    } else if (water_depth <= STEP_L * 2) {
-        Item_SwitchToAnim(item, LA_UNDERWATER_TO_STAND, 0);
-        item->current_anim_state = LS_WATER_OUT;
-        item->goal_anim_state = LS_STOP;
-        item->rot.x = 0;
-        item->rot.z = 0;
-        item->gravity = 0;
-        item->speed = 0;
-        item->fall_speed = 0;
-        g_Lara.water_status = LWS_WADE;
-        item->pos.y =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    if (water_depth == NO_HEIGHT || water_depth > STEP_L * 2) {
+        return;
     }
+
+    Item_SwitchToAnim(item, LA_UNDERWATER_TO_STAND, 0);
+    item->current_anim_state = LS_WATER_OUT;
+    item->goal_anim_state = LS_STOP;
+    item->rot.x = 0;
+    item->rot.z = 0;
+    item->gravity = 0;
+    item->speed = 0;
+    item->fall_speed = 0;
+    g_Lara.water_status = LWS_WADE;
+    item->pos.y = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 }
 
 bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)


### PR DESCRIPTION
Resolves #1781.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Water depth testing was introduced with wading and so in OG, Lara could exit water in "non-standard" ways. This restores that ability while still maintaining wading support. Wading test level attached again, with additional rooms to try out this particular behaviour.

[level1.zip](https://github.com/user-attachments/files/17601536/level1.zip)

No changelog entry as this is unreleased.

Thanks to Mahetus for reporting this.
