### PR TITLE
tr1/option_control: fix controls menu height

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed crash reports not working in certain circumstances (#1738)
 - fixed missing trapdoor triggers in City of Khamoon (#1744)
 - fixed being unable to rename the lead bar (#1774, regression from 4.5)
+- fixed the controls menu extending to the bottom of the screen with certain text scaling values (#1783, regression from 2.12)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - removed health cheat (we now have the `/hp` command)

--- a/src/tr1/game/option/option_control.c
+++ b/src/tr1/game/option/option_control.c
@@ -182,7 +182,7 @@ static void M_InitMenu(void)
         visible_lines = 6;
     } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 384) {
         visible_lines = 8;
-    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 480) {
+    } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 600) {
         visible_lines = 12;
     } else {
         visible_lines = 18;


### PR DESCRIPTION
Resolves #1783.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes the controls menu for text scales 0.8 and 0.9 such that the menu doesn't extend to the bottom of the screen or overlap the inventory "Controls" text.
