### PR TITLE
tr2/output: fix crash with z-buffer disabled

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances (#1572)
 - fixed grenades counting as double kills in the game statistics (#1560)
 - fixed the ammo counter being hidden while a demo plays in NG+ (#1559)
+- fixed the game crashing in large rooms with z-buffer disabled (#1761, regression from 0.2)
 - fixed the game hanging if exited during the level stats, credits, or final stats (#1585)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08

--- a/src/tr2/game/hwr.c
+++ b/src/tr2/game/hwr.c
@@ -269,9 +269,8 @@ void __cdecl HWR_GetPageHandles(void)
 
 bool __cdecl HWR_VertexBufferFull(void)
 {
-    const int32_t index =
-        (g_HWR_VertexPtr - g_HWR_VertexBuffer) / sizeof(D3DTLVERTEX);
-    return index >= MAX_VERTICES;
+    const int32_t index = g_HWR_VertexPtr - g_HWR_VertexBuffer;
+    return index >= MAX_VERTICES - 0x200;
 }
 
 bool __cdecl HWR_Init(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1761.