### PR TITLE
tr1/objects/door: fix initialising doors

### DIFF
--- a/src/tr1/game/objects/general/door.c
+++ b/src/tr1/game/objects/general/door.c
@@ -181,6 +181,7 @@ void Door_Initialise(int16_t item_num)
     if (r->flipped_room == -1) {
         door->d2flip.sector = NULL;
     } else {
+        r = Room_Get(r->flipped_room);
         M_Initialise(r, item, 0, 0, &door->d2flip);
     }
 


### PR DESCRIPTION
Resolves #1797.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This fixes initialising doors in TR1 sitting on portals where the portal room has a flipped room.

The TR2 code looks fine in this regard, but I made a test level just to be sure as I couldn't think of anywhere in TR2 that has a similar setup to the start of Atlantis. Note the camera starts differently anyway in this scenario as in TR2 it will prefer to be to the side of Lara when a wall is behind her like this. You can test by trying to make Lara look through the door while the flipmap changes.

[wall.zip](https://github.com/user-attachments/files/17607230/wall.zip)
