### PR TITLE
tr2/creatures/dragon: count dragon kill only once

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed the game crashing in large rooms with z-buffer disabled (#1761, regression from 0.2)
 - fixed the game hanging if exited during the level stats, credits, or final stats (#1585)
 - fixed grenades launched at too slow speeds (#1760, regression from 0.3)
+- fixed the dragon counting as more than one kill if allowed to revive (#1771)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -34,6 +34,9 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the ammo counter being hidden while a demo plays in NG+
 - fixed the game hanging if exited during the level stats, credits, or final stats
 
+#### Statistics
+- fixed the dragon counting as more than one kill if allowed to revive
+
 #### Visuals
 
 - fixed TGA screenshots crashing the game

--- a/src/tr2/game/gun/gun_misc.c
+++ b/src/tr2/game/gun/gun_misc.c
@@ -312,7 +312,8 @@ void __cdecl Gun_FindTargetPoint(
 void __cdecl Gun_HitTarget(
     ITEM *const item, const GAME_VECTOR *const hit_pos, const int32_t damage)
 {
-    if (item->hit_points > 0 && item->hit_points <= damage) {
+    if (item->hit_points > 0 && item->hit_points <= damage
+        && item->object_id != O_DRAGON_FRONT) {
         g_SaveGame.statistics.kills++;
     }
     Item_TakeDamage(item, damage, true);

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -69,6 +69,7 @@ static void M_MarkDragonDead(const ITEM *const dragon_back_item)
     const ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
     CREATURE *const creature = dragon_front_item->data;
     creature->flags = -1;
+    g_SaveGame.statistics.kills++;
 }
 
 static void M_PushLaraAway(


### PR DESCRIPTION
Resolves #1771.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that the dragon kill is only counted in the statistics when it is finally defeated rather than after each time it is taken down.
