### PR TITLE
tr2/objects/grenade: test target item intelligence and status

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -54,6 +54,7 @@
 - fixed the console not being drawn during credits (#1802)
 - fixed grenades launched at too slow speeds (#1760, regression from 0.3)
 - fixed the dragon counting as more than one kill if allowed to revive (#1771)
+- fixed a crash when firing grenades at Xian guards in statue form (#1561)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -33,6 +33,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed grenades counting as double kills in the game statistics
 - fixed the ammo counter being hidden while a demo plays in NG+
 - fixed the game hanging if exited during the level stats, credits, or final stats
+- fixed a crash when firing grenades at Xian guards in statue form
 
 #### Statistics
 - fixed the dragon counting as more than one kill if allowed to revive

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -117,10 +117,13 @@ void __cdecl Grenade_Control(int16_t item_num)
         if (target_item->object_id == O_WINDOW_1) {
             SmashWindow(target_item_num);
         } else {
-            // XXX: missing check if obj is intelligent?
-            Gun_HitTarget(target_item, NULL, 30);
-
             explode = true;
+
+            if (!target_obj->intelligent || target_item->status != IS_ACTIVE) {
+                continue;
+            }
+
+            Gun_HitTarget(target_item, NULL, 30);
             g_SaveGame.statistics.hits++;
 
             if (target_item->hit_points <= 0) {


### PR DESCRIPTION
Resolves #1561.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures grenades that hit inactive or unintelligent creatures have no effect on the item's hit points. We continue to explode the grenade in the creature's position though, as it's still a collidable entity.
