### PR TITLE
tr2/objects/harpoon_bolt: test target item status

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -55,6 +55,7 @@
 - fixed grenades launched at too slow speeds (#1760, regression from 0.3)
 - fixed the dragon counting as more than one kill if allowed to revive (#1771)
 - fixed a crash when firing grenades at Xian guards in statue form (#1561)
+- fixed harpoon bolts damaging inactive enemies (#1804)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -34,6 +34,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the ammo counter being hidden while a demo plays in NG+
 - fixed the game hanging if exited during the level stats, credits, or final stats
 - fixed a crash when firing grenades at Xian guards in statue form
+- fixed harpoon bolts damaging inactive enemies
 
 #### Statistics
 - fixed the dragon counting as more than one kill if allowed to revive

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -84,7 +84,7 @@ void __cdecl HarpoonBolt_Control(const int16_t item_num)
         if (target_item->object_id == O_WINDOW_1) {
             SmashWindow(target_num);
         } else {
-            if (target_obj->intelligent) {
+            if (target_obj->intelligent && target_item->status == IS_ACTIVE) {
                 DoLotsOfBlood(
                     item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,
                     5);


### PR DESCRIPTION
Resolves #1804.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This tests that a target item for a harpoon bolt is a fully activated creature.
