### PR TITLE
tr2/skidoo: use common approach to kill enemies

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -56,6 +56,7 @@
 - fixed the dragon counting as more than one kill if allowed to revive (#1771)
 - fixed a crash when firing grenades at Xian guards in statue form (#1561)
 - fixed harpoon bolts damaging inactive enemies (#1804)
+- fixed enemies that are run over by the skidoo not being counted in the statistics (#1772)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -38,6 +38,7 @@ decompilation process. We recognize that there is much work to be done.
 
 #### Statistics
 - fixed the dragon counting as more than one kill if allowed to revive
+- fixed enemies that are run over by the skidoo not being counted in the statistics
 
 #### Visuals
 

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -136,11 +136,11 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
         if (item->current_anim_state == TRAP_ACTIVATE) {
             Lara_TakeDamage(100, true);
         }
-    } else {
+    } else if (object->intelligent && item->status == IS_ACTIVE) {
         DoLotsOfBlood(
             item->pos.x, skidoo->pos.y - STEP_L, item->pos.z, skidoo->speed,
             skidoo->rot.y, item->room_num, 3);
-        item->hit_points = 0;
+        Gun_HitTarget(item, NULL, item->hit_points);
     }
     return true;
 }


### PR DESCRIPTION
Resolves #1772.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This treats killing enemies with the skidoo as though they were shot down, so that statistics can remain accurate. It also means that monks will become angry if one is run over (custom levels only).
