### PR TITLE
tr2/input: allow holding up/down in menus

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added a level skip cheat key (#1640)
 - added the ability to skip end credits with the action and escape keys (#1800)
 - added the ability to skip FMVs with the action key (#1650)
+- added the ability to hold forward/back to move through menus more quickly (#1644)
 - changed the inputs backend from DirectX to SDL (#1695)
     - improved controller support to match TR1X
     - changed the number of custom layouts to 3

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -40,6 +40,9 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the dragon counting as more than one kill if allowed to revive
 - fixed enemies that are run over by the skidoo not being counted in the statistics
 
+#### Input
+- added the ability to hold forward/back to move through menus more quickly
+
 #### Visuals
 
 - fixed TGA screenshots crashing the game

--- a/src/tr2/game/clock.c
+++ b/src/tr2/game/clock.c
@@ -1,5 +1,7 @@
 #include "game/clock.h"
 
+#include <libtrx/game/const.h>
+
 #include <windows.h>
 
 double Clock_GetHighPrecisionCounter(void)
@@ -9,4 +11,9 @@ double Clock_GetHighPrecisionCounter(void)
     QueryPerformanceFrequency(&frequency);
     QueryPerformanceCounter(&counter);
     return counter.QuadPart * 1000.0 / frequency.QuadPart;
+}
+
+int32_t Clock_GetLogicalFrame(void)
+{
+    return Clock_GetHighPrecisionCounter() * LOGIC_FPS / 1000.0;
 }

--- a/src/tr2/game/clock.h
+++ b/src/tr2/game/clock.h
@@ -1,3 +1,6 @@
 #pragma once
 
+#include <stdint.h>
+
 double Clock_GetHighPrecisionCounter(void);
+int32_t Clock_GetLogicalFrame(void);


### PR DESCRIPTION
Resolves #1644.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This mimics the TR1X behaviour of allowing up/down to be held in menus such as save/load.
