### PR TITLE
tr2/objects/door: fix initialising doors

### DIFF
--- a/src/tr2/game/objects/general/door.c
+++ b/src/tr2/game/objects/general/door.c
@@ -140,11 +140,11 @@ void __cdecl Door_Initialise(const int16_t item_num)
 
         Door_Shut(&door->d2);
         Door_Shut(&door->d2flip);
-    }
 
-    const int16_t prev_room = item->room_num;
-    Item_NewRoom(item_num, room_num);
-    item->room_num = prev_room;
+        const int16_t prev_room = item->room_num;
+        Item_NewRoom(item_num, room_num);
+        item->room_num = prev_room;
+    }
 }
 
 void __cdecl Door_Control(const int16_t item_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves another recent regression in the door initialization, reported on Discord by Lahm:

![image](https://github.com/user-attachments/assets/0ef74e8b-d31d-439e-ade1-0149c1c3b28b)
![image](https://github.com/user-attachments/assets/29ad2d09-6f82-425b-b3bc-5feb05a42d02)
