### PR TITLE
tr1/objects/scion3: save scion hitpoints

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed being unable to rename the lead bar (#1774, regression from 4.5)
 - fixed the controls menu extending to the bottom of the screen with certain text scaling values (#1783, regression from 2.12)
 - fixed game stuck at remapping controller key if no controllers connected (#1788)
+- fixed being able to shoot the scion multiple times if save/load is used while it blows up (#1819)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - removed health cheat (we now have the `/hp` command)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -458,6 +458,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed the Scion being extremely difficult to shoot with the shotgun
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground
 - fixed a potential softlock when killing the Torso boss in Great Pyramid
+- fixed being able to shoot the scion multiple times if save/load is used while it blows up
 
 #### Cheats
 - added a fly cheat

--- a/src/tr1/game/objects/general/scion3.c
+++ b/src/tr1/game/objects/general/scion3.c
@@ -12,6 +12,7 @@ void Scion3_Setup(OBJECT *obj)
     obj->control = Scion3_Control;
     obj->hit_points = 5;
     obj->save_flags = 1;
+    obj->save_hitpoints = 1;
 }
 
 void Scion3_Control(int16_t item_num)

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -47,6 +47,7 @@ static char *m_SGBufPtr = NULL;
 
 static bool M_ItemHasSaveFlags(OBJECT *obj, ITEM *item);
 static bool M_ItemHasSaveAnim(const ITEM *item);
+static bool M_ItemHasHitPoints(const ITEM *item);
 static bool M_NeedsBaconLaraFix(char *buffer);
 
 static void M_Reset(char *buffer);
@@ -85,6 +86,12 @@ static bool M_ItemHasSaveAnim(const ITEM *const item)
 {
     const OBJECT *const obj = &g_Objects[item->object_id];
     return obj->save_anim && item->object_id != O_BACON_LARA;
+}
+
+static bool M_ItemHasHitPoints(const ITEM *const item)
+{
+    const OBJECT *const obj = &g_Objects[item->object_id];
+    return obj->save_hitpoints && item->object_id != O_SCION_ITEM_3;
 }
 
 static bool M_NeedsBaconLaraFix(char *buffer)
@@ -158,7 +165,7 @@ static bool M_NeedsBaconLaraFix(char *buffer)
             M_Read(&tmp_item.anim_num, sizeof(int16_t));
             M_Read(&tmp_item.frame_num, sizeof(int16_t));
         }
-        if (obj->save_hitpoints) {
+        if (M_ItemHasHitPoints(item)) {
             M_Read(&tmp_item.hit_points, sizeof(int16_t));
         }
         if (M_ItemHasSaveFlags(obj, item)) {
@@ -596,7 +603,7 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
             M_Read(&item->frame_num, sizeof(int16_t));
         }
 
-        if (obj->save_hitpoints) {
+        if (M_ItemHasHitPoints(item)) {
             M_Read(&item->hit_points, sizeof(int16_t));
         }
 
@@ -767,7 +774,7 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
             M_Write(&item->frame_num, sizeof(int16_t));
         }
 
-        if (obj->save_hitpoints) {
+        if (M_ItemHasHitPoints(item)) {
             M_Write(&item->hit_points, sizeof(int16_t));
         }
 


### PR DESCRIPTION
Resolves #1819.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures the shootable scion's hitpoints value is saved so if it's still active on reload, Lara can't continue to target it.
Existing saves would continue to have this bug, so it's a going-forward fix.
