### PR TITLE
tr2/fmv: stop active FMV if game is exited

### DIFF
--- a/src/tr2/decomp/fmv.c
+++ b/src/tr2/decomp/fmv.c
@@ -364,7 +364,7 @@ void __cdecl WinPlayFMV(const char *const file_name, const bool is_playback)
 
         Input_Update();
         Shell_ProcessInput();
-        if (g_InputDB.menu_back || g_InputDB.menu_confirm) {
+        if (g_InputDB.menu_back || g_InputDB.menu_confirm || g_IsGameToExit) {
             Video_Stop(video);
             break;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1822.