### PR TITLE
tr2/overlay: support 3d pickup animations

### DIFF
--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -468,6 +468,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added a cheat to explode Lara like in TR2 and TR3
 
 #### Input
+- added ability to hold forward/back to move through menus more quickly
 - added ability to move camera around with W,A,S,D
 - added additional custom control schemes
 - added the ability to unbind unessential keys
@@ -606,6 +607,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - ported image decoding library to ffmpeg
 - ported audio output library to SDL
 - ported input method to SDL
+- changed screenshots to be put in the screenshots/ directory
 - changed saves to be put in the saves/ directory
 - fixed playing the secret sound in Tomb of Tihocan
 - fixed reading user settings not restoring the volume

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -500,6 +500,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 #### Visuals
 - added optional shotgun flash sprites
 - added optional rendering of pickups on the ground as 3D meshes
+- added optional rendering of pickups in the UI as 3D meshes
 - added Lara's braid to each level
 - added support for displaying more than 3 pickup sprites
 - added more control over when to show health bar and air bar

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added the ability to skip end credits with the action and escape keys (#1800)
 - added the ability to skip FMVs with the action key (#1650)
 - added the ability to hold forward/back to move through menus more quickly (#1644)
+- added 3d pickup animations (#1633)
 - changed the inputs backend from DirectX to SDL (#1695)
     - improved controller support to match TR1X
     - changed the number of custom layouts to 3

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -6,7 +6,7 @@
 - added the ability to skip end credits with the action and escape keys (#1800)
 - added the ability to skip FMVs with the action key (#1650)
 - added the ability to hold forward/back to move through menus more quickly (#1644)
-- added 3d pickup animations (#1633)
+- added optional rendering of pickups in the UI as 3D meshes (#1633)
 - changed the inputs backend from DirectX to SDL (#1695)
     - improved controller support to match TR1X
     - changed the number of custom layouts to 3

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -22,6 +22,7 @@ decompilation process. We recognize that there is much work to be done.
 #### Gameplay
 
 - added an option to fix M16 accuracy while running
+- added optional rendering of pickups in the UI as 3D meshes
 - fixed killing the T-Rex with a grenade launcher crashing the game
 - fixed secret rewards not displaying shotgun ammo
 - fixed numeric keys interfering with the demos

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -20,40 +20,69 @@ decompilation process. We recognize that there is much work to be done.
 ## Improvements over original game
 
 #### Gameplay
-
 - added an option to fix M16 accuracy while running
 - added optional rendering of pickups in the UI as 3D meshes
+- changed inventory to pause the music rather than muting it
 - fixed killing the T-Rex with a grenade launcher crashing the game
 - fixed secret rewards not displaying shotgun ammo
 - fixed numeric keys interfering with the demos
+- fixed the ammo counter being hidden while a demo plays in NG+
 - fixed explosions sometimes being drawn too dark
 - fixed controls dialog remapping being too sensitive
-- fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed Lara reloading the harpoon gun after every shot in NG+
 - fixed the dragon reviving itself after Lara removes the dagger in rare circumstances
 - fixed grenades counting as double kills in the game statistics
-- fixed the ammo counter being hidden while a demo plays in NG+
 - fixed the game hanging if exited during the level stats, credits, or final stats
 - fixed a crash when firing grenades at Xian guards in statue form
 - fixed harpoon bolts damaging inactive enemies
+- fixed the distorted skybox in room 5 of Barkhang Monastery
+
+#### Cheats
+- added a fly cheat
+- added a level skip cheat
+- added a door open cheat (while in fly mode)
+- added a cheat to increase the game speed
+- added a cheat to explode Lara like in TR2 and TR3
+
+#### Input
+- added additional custom control schemes
+- added customizable controller support
+- fixed setting user keys being very difficult
+- fixed skipping FMVs triggering inventory
+- fixed skipping credits working too fast
 
 #### Statistics
 - fixed the dragon counting as more than one kill if allowed to revive
 - fixed enemies that are run over by the skidoo not being counted in the statistics
 
 #### Input
-- added the ability to hold forward/back to move through menus more quickly
+- added ability to hold forward/back to move through menus more quickly
 
 #### Visuals
-
+- added support for HD FMVs
 - fixed TGA screenshots crashing the game
 - fixed the camera being cut off after using the gong hammer in Ice Palace
 - fixed Lara's underwater hue being retained when re-entering a boat
+- improved FMV mode behavior - stopped switching screen resolutions
+- improved vertex movement when looking through water portals
 
 #### Audio
-
 - fixed music not playing with certain game versions
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace
+- fixed sound settings resuming the music
+- fixed wrong default music volume (being very loud on some setups)
 
 #### Mods
 - added developer console (accessible with `/`, see [COMMANDS.md](COMMANDS.md) for details)
+
+#### Miscellaneous
+- added .jpeg/.png screenshots
+- added ability to skip FMVs with both the Action key
+- added ability to skip end credits with the Action and Escape keys
+- ported video decoding library to ffmpeg
+- ported audio output library to SDL
+- ported input method to SDL
+- fixed screenshots not working in windowed mode
+- fixed screenshots key not getting debounced
+- changed screenshots to be put in the screenshots/ directory
+- changed saves to be put in the saves/ directory

--- a/src/tr2/config.h
+++ b/src/tr2/config.h
@@ -14,6 +14,10 @@ typedef struct {
     } input;
 
     struct {
+        bool enable_3d_pickups;
+    } visuals;
+
+    struct {
         bool fix_m16_accuracy;
         bool enable_cheats;
     } gameplay;

--- a/src/tr2/config_map.def
+++ b/src/tr2/config_map.def
@@ -1,5 +1,6 @@
 CFG_BOOL(g_Config, gameplay.fix_m16_accuracy, true)
 CFG_BOOL(g_Config, gameplay.enable_cheats, false)
+CFG_BOOL(g_Config, visuals.enable_3d_pickups, true)
 CFG_ENUM(g_Config, rendering.screenshot_format, SCREENSHOT_FORMAT_JPEG, SCREENSHOT_FORMAT)
 CFG_INT32(g_Config, rendering.turbo_speed, 0)
 CFG_INT32(g_Config, input.keyboard_layout, INPUT_LAYOUT_DEFAULT)

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -183,8 +183,10 @@ int32_t __cdecl Game_Draw(void)
     Room_DrawAllRooms(g_Camera.pos.room_num);
     Overlay_DrawGameInfo(true);
     S_OutputPolyList();
-    g_Camera.num_frames = S_DumpScreen() * TICKS_PER_FRAME;
+    const int32_t frames = S_DumpScreen();
+    g_Camera.num_frames = frames * TICKS_PER_FRAME;
     Shell_ProcessEvents();
+    Overlay_Animate(frames);
     S_AnimateTextures(g_Camera.num_frames);
     return g_Camera.num_frames;
 }

--- a/src/tr2/game/inventory/common.c
+++ b/src/tr2/game/inventory/common.c
@@ -310,6 +310,7 @@ int32_t __cdecl Inv_Display(int32_t inventory_mode)
             Inv_DoInventoryBackground();
         }
         S_AnimateTextures(g_Inv_NFrames);
+        Overlay_Animate(g_Inv_NFrames / 2);
 
         PHD_3DPOS view;
         Inv_Ring_GetView(&ring, &view);
@@ -1184,7 +1185,7 @@ void __cdecl Inv_RingNotActive(const INVENTORY_ITEM *const inv_item)
     case O_SMALL_MEDIPACK_OPTION:
     case O_LARGE_MEDIPACK_OPTION:
         g_HealthBarTimer = 40;
-        Overlay_DrawHealthBar(Overlay_FlashCounter());
+        Overlay_DrawHealthBar();
         M_ShowItemQuantity("%d", qty);
         break;
 

--- a/src/tr2/game/matrix.c
+++ b/src/tr2/game/matrix.c
@@ -29,9 +29,9 @@ void __cdecl Matrix_PushUnit(void)
     mptr->_20 = 0;
     mptr->_21 = 0;
     mptr->_22 = (1 << W2V_SHIFT);
-    // mptr->_03 = 0;
-    // mptr->_13 = 0;
-    // mptr->_23 = 0;
+    mptr->_03 = 0;
+    mptr->_13 = 0;
+    mptr->_23 = 0;
 }
 
 void __cdecl Matrix_Pop(void)

--- a/src/tr2/game/matrix.c
+++ b/src/tr2/game/matrix.c
@@ -361,6 +361,14 @@ void __cdecl Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z)
     mptr->_23 = dx * mptr->_20 + dy * mptr->_21 + dz * mptr->_22;
 }
 
+void Matrix_TranslateSet(const int32_t x, const int32_t y, const int32_t z)
+{
+    MATRIX *const mptr = g_MatrixPtr;
+    mptr->_03 = x << W2V_SHIFT;
+    mptr->_13 = y << W2V_SHIFT;
+    mptr->_23 = z << W2V_SHIFT;
+}
+
 void __cdecl Matrix_InitInterpolate(int32_t frac, int32_t rate)
 {
     g_IMRate = rate;

--- a/src/tr2/game/matrix.h
+++ b/src/tr2/game/matrix.h
@@ -20,6 +20,7 @@ void __cdecl Matrix_RotYXZpack(uint32_t rpack);
 void __cdecl Matrix_RotYXZsuperpack(const int16_t **pprot, int32_t index);
 bool __cdecl Matrix_TranslateRel(int32_t x, int32_t y, int32_t z);
 void __cdecl Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z);
+void Matrix_TranslateSet(int32_t x, int32_t y, int32_t z);
 
 void __cdecl Matrix_InitInterpolate(int32_t frac, int32_t rate);
 void __cdecl Matrix_Interpolate(void);

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -403,13 +403,6 @@ void __cdecl Output_Init(
 
 void __cdecl Output_InsertPolygons(const int16_t *obj_ptr, const int32_t clip)
 {
-    g_FltWinLeft = g_PhdWinMinX;
-    g_FltWinTop = g_PhdWinMinY;
-    g_FltWinRight = (g_PhdWinMaxX + g_PhdWinMinX + 1);
-    g_FltWinBottom = (g_PhdWinMaxY + g_PhdWinMinY + 1);
-    g_FltWinCenterX = (g_PhdWinMinX + g_PhdWinCenterX);
-    g_FltWinCenterY = (g_PhdWinMinY + g_PhdWinCenterY);
-
     obj_ptr = Output_CalcObjectVertices(obj_ptr + 4);
     if (obj_ptr) {
         obj_ptr = Output_CalcVerticeLight(obj_ptr);
@@ -431,13 +424,6 @@ void __cdecl Output_InsertPolygons_I(
 
 void __cdecl Output_InsertRoom(const int16_t *obj_ptr, int32_t is_outside)
 {
-    g_FltWinLeft = (g_PhdWinMinX + g_PhdWinLeft);
-    g_FltWinTop = (g_PhdWinMinY + g_PhdWinTop);
-    g_FltWinRight = (g_PhdWinRight + g_PhdWinMinX + 1);
-    g_FltWinBottom = (g_PhdWinBottom + g_PhdWinMinY + 1);
-    g_FltWinCenterX = (g_PhdWinMinX + g_PhdWinCenterX);
-    g_FltWinCenterY = (g_PhdWinMinY + g_PhdWinCenterY);
-
     const int16_t *const old_obj_ptr = obj_ptr;
     obj_ptr = Output_CalcRoomVertices(obj_ptr, is_outside ? 0 : 16);
 
@@ -463,13 +449,6 @@ void __cdecl Output_InsertRoom(const int16_t *obj_ptr, int32_t is_outside)
 
 void __cdecl Output_InsertSkybox(const int16_t *obj_ptr)
 {
-    g_FltWinLeft = (g_PhdWinMinX + g_PhdWinLeft);
-    g_FltWinTop = (g_PhdWinMinY + g_PhdWinTop);
-    g_FltWinRight = (g_PhdWinRight + g_PhdWinMinX + 1);
-    g_FltWinBottom = (g_PhdWinBottom + g_PhdWinMinY + 1);
-    g_FltWinCenterX = (g_PhdWinMinX + g_PhdWinCenterX);
-    g_FltWinCenterY = (g_PhdWinMinY + g_PhdWinCenterY);
-
     obj_ptr = Output_CalcObjectVertices(obj_ptr + 4);
     if (obj_ptr) {
         if (g_SavedAppSettings.render_mode == RM_HARDWARE) {
@@ -4539,4 +4518,19 @@ bool __cdecl Output_MakeScreenshot(const char *const path)
     Image_Free(image);
     WinVidBufferUnlock(screen, &desc);
     return ret;
+}
+
+void Output_ClearDepthBuffer(void)
+{
+    if (g_SavedAppSettings.render_mode == RM_HARDWARE) {
+        DWORD d3dClearFlags = D3DCLEAR_ZBUFFER;
+
+        D3DRECT d3dRect;
+        d3dRect.x1 = g_PhdWinRect.left;
+        d3dRect.y1 = g_PhdWinRect.top;
+        d3dRect.x2 = g_PhdWinRect.right;
+        d3dRect.y2 = g_PhdWinRect.bottom;
+
+        g_D3DView->lpVtbl->Clear(g_D3DView, 1, &d3dRect, d3dClearFlags);
+    }
 }

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -23,8 +23,6 @@ void __cdecl Output_InitPolyList(void);
 void __cdecl Output_SortPolyList(void);
 void __cdecl Output_QuickSort(int32_t left, int32_t right);
 void __cdecl Output_PrintPolyList(uint8_t *surface_ptr);
-void __cdecl Output_SetNearZ(int32_t near_z);
-void __cdecl Output_SetFarZ(int32_t far_z);
 void __cdecl Output_AlterFOV(int16_t fov);
 
 void __cdecl Output_DrawPolyLine(const int16_t *obj_ptr);

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -170,4 +170,6 @@ void __cdecl Output_DrawScreenSprite(
 
 void __cdecl Output_DrawScaledSpriteC(const int16_t *obj_ptr);
 
+void Output_ClearDepthBuffer(void);
+
 bool __cdecl Output_MakeScreenshot(const char *path);

--- a/src/tr2/game/overlay.h
+++ b/src/tr2/game/overlay.h
@@ -2,11 +2,10 @@
 
 #include "global/types.h"
 
-bool __cdecl Overlay_FlashCounter(void);
 void __cdecl Overlay_DrawAssaultTimer(void);
 void __cdecl Overlay_DrawGameInfo(bool pickup_state);
-void __cdecl Overlay_DrawHealthBar(bool flash_state);
-void __cdecl Overlay_DrawAirBar(bool flash_state);
+void Overlay_DrawHealthBar(void);
+void Overlay_DrawAirBar(void);
 void Overlay_HideGameInfo(void);
 void __cdecl Overlay_MakeAmmoString(char *string);
 void __cdecl Overlay_DrawAmmoInfo(void);
@@ -14,4 +13,6 @@ void __cdecl Overlay_InitialisePickUpDisplay(void);
 void __cdecl Overlay_DrawPickups(bool pickup_state);
 void __cdecl Overlay_AddDisplayPickup(int16_t object_id);
 void __cdecl Overlay_DisplayModeInfo(const char *string);
+
 void __cdecl Overlay_DrawModeInfo(void);
+void Overlay_Animate(int32_t ticks);

--- a/src/tr2/game/viewport.c
+++ b/src/tr2/game/viewport.c
@@ -1,0 +1,114 @@
+#include "game/viewport.h"
+
+#include "config.h"
+#include "game/math.h"
+#include "game/output.h"
+#include "global/const.h"
+#include "global/vars.h"
+
+static VIEWPORT m_Viewport = { 0 };
+
+static void M_Apply(void);
+
+static void M_Apply(void)
+{
+    // TODO: remove most of these variables if possible
+    g_PhdWinMinX = m_Viewport.x;
+    g_PhdWinMinY = m_Viewport.y;
+    g_PhdWinMaxX = m_Viewport.width - 1;
+    g_PhdWinMaxY = m_Viewport.height - 1;
+    g_PhdWinWidth = m_Viewport.width;
+    g_PhdWinHeight = m_Viewport.height;
+
+    g_PhdWinCenterX = m_Viewport.width / 2;
+    g_PhdWinCenterY = m_Viewport.height / 2;
+    g_FltWinCenterX = m_Viewport.width / 2;
+    g_FltWinCenterY = m_Viewport.height / 2;
+
+    g_PhdWinLeft = 0;
+    g_PhdWinTop = 0;
+    g_PhdWinRight = g_PhdWinMaxX;
+    g_PhdWinBottom = g_PhdWinMaxY;
+
+    g_PhdWinRect.left = g_PhdWinMinX;
+    g_PhdWinRect.bottom = g_PhdWinMinY + g_PhdWinHeight;
+    g_PhdWinRect.top = g_PhdWinMinY;
+    g_PhdWinRect.right = g_PhdWinMinX + g_PhdWinWidth;
+
+    g_PhdNearZ = m_Viewport.near_z << W2V_SHIFT;
+    g_PhdFarZ = m_Viewport.far_z << W2V_SHIFT;
+
+    g_FltNearZ = g_PhdNearZ;
+    g_FltFarZ = g_PhdFarZ;
+
+    const double res_z =
+        0.99 * g_FltNearZ * g_FltFarZ / (g_FltFarZ - g_FltNearZ);
+    g_FltResZ = res_z;
+    g_FltResZORhw = res_z / g_RhwFactor;
+    g_FltResZBuf = 0.005 + res_z / g_FltNearZ;
+    g_FltRhwONearZ = g_RhwFactor / g_FltNearZ;
+    g_FltPerspONearZ = g_FltPersp / g_FltNearZ;
+    g_PhdViewDistance = m_Viewport.far_z;
+
+    Viewport_AlterFOV(m_Viewport.view_angle);
+
+    g_PhdScreenWidth = m_Viewport.screen_width;
+    g_PhdScreenHeight = m_Viewport.screen_height;
+}
+
+void Viewport_Init(
+    int16_t x, int16_t y, int32_t width, int32_t height, int32_t near_z,
+    int32_t far_z, int16_t view_angle, int32_t screen_width,
+    int32_t screen_height)
+{
+    m_Viewport.x = x;
+    m_Viewport.y = y;
+    m_Viewport.width = width;
+    m_Viewport.height = height;
+    m_Viewport.near_z = near_z;
+    m_Viewport.far_z = far_z;
+    m_Viewport.view_angle = view_angle;
+    m_Viewport.screen_width = screen_width;
+    m_Viewport.screen_height = screen_height;
+
+    M_Apply();
+}
+
+const VIEWPORT *Viewport_Get(void)
+{
+    return &m_Viewport;
+}
+
+void Viewport_AlterFOV(int16_t view_angle)
+{
+    m_Viewport.view_angle = view_angle;
+
+    view_angle /= 2;
+
+    g_PhdPersp =
+        g_PhdWinWidth / 2 * Math_Cos(view_angle) / Math_Sin(view_angle);
+
+    g_FltPersp = g_PhdPersp;
+    g_FltRhwOPersp = g_RhwFactor / g_FltPersp;
+    g_FltPerspONearZ = g_FltPersp / g_FltNearZ;
+
+    double window_aspect_ratio = 4.0 / 3.0;
+    if (!g_SavedAppSettings.fullscreen
+        && g_SavedAppSettings.aspect_mode == AM_16_9) {
+        window_aspect_ratio = 16.0 / 9.0;
+    }
+
+    g_ViewportAspectRatio =
+        window_aspect_ratio / ((double)g_PhdWinWidth / (double)g_PhdWinHeight);
+}
+
+int16_t Viewport_GetFOV(void)
+{
+    return m_Viewport.view_angle == -1 ? Viewport_GetUserFOV()
+                                       : m_Viewport.view_angle;
+}
+
+int16_t Viewport_GetUserFOV(void)
+{
+    return GAME_FOV * PHD_DEGREE;
+}

--- a/src/tr2/game/viewport.c
+++ b/src/tr2/game/viewport.c
@@ -38,6 +38,13 @@ static void M_Apply(void)
     g_PhdNearZ = m_Viewport.near_z << W2V_SHIFT;
     g_PhdFarZ = m_Viewport.far_z << W2V_SHIFT;
 
+    g_FltWinLeft = g_PhdWinMinX + g_PhdWinLeft;
+    g_FltWinTop = g_PhdWinMinY + g_PhdWinTop;
+    g_FltWinRight = g_PhdWinRight + g_PhdWinMinX + 1;
+    g_FltWinBottom = g_PhdWinBottom + g_PhdWinMinY + 1;
+    g_FltWinCenterX = g_PhdWinMinX + g_PhdWinCenterX;
+    g_FltWinCenterY = g_PhdWinMinY + g_PhdWinCenterY;
+
     g_FltNearZ = g_PhdNearZ;
     g_FltFarZ = g_PhdFarZ;
 

--- a/src/tr2/game/viewport.h
+++ b/src/tr2/game/viewport.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+    int32_t x;
+    int32_t y;
+    int32_t width;
+    int32_t height;
+    int32_t near_z;
+    int32_t far_z;
+    int16_t view_angle;
+    int32_t screen_width;
+    int32_t screen_height;
+} VIEWPORT;
+
+void Viewport_Init(
+    int16_t x, int16_t y, int32_t width, int32_t height, int32_t near_z,
+    int32_t far_z, int16_t view_angle, int32_t screen_width,
+    int32_t screen_height);
+
+void Viewport_AlterFOV(int16_t view_angle);
+
+const VIEWPORT *Viewport_Get(void);
+
+int16_t Viewport_GetFOV(void);
+int16_t Viewport_GetUserFOV(void);

--- a/src/tr2/global/const.h
+++ b/src/tr2/global/const.h
@@ -48,7 +48,6 @@
 #define MAX_STATIC_OBJECTS 50
 #define MAX_ITEMS 256
 #define MAX_EFFECTS 100
-#define MAX_PICKUPS 12
 #define MAX_LEVELS 24
 #define MAX_LEVEL_NAME_SIZE 50 // TODO: get rid of this limit
 #define MAX_DEMO_FILES MAX_LEVELS

--- a/src/tr2/inject_exec.c
+++ b/src/tr2/inject_exec.c
@@ -497,8 +497,6 @@ static void M_Output(const bool enable)
     INJECT(enable, 0x00402470, Output_QuickSort);
     INJECT(enable, 0x00402540, Output_PrintPolyList);
     INJECT(enable, 0x00402580, Output_AlterFOV);
-    INJECT(enable, 0x00402690, Output_SetNearZ);
-    INJECT(enable, 0x004026E0, Output_SetFarZ);
     INJECT(enable, 0x00402700, Output_Init);
     INJECT(enable, 0x00402970, Output_DrawPolyLine);
     INJECT(enable, 0x00402B10, Output_DrawPolyFlat);
@@ -601,11 +599,8 @@ static void M_Gameflow(bool enable)
 
 static void M_Overlay(const bool enable)
 {
-    INJECT(enable, 0x004219A0, Overlay_FlashCounter);
     INJECT(enable, 0x004219D0, Overlay_DrawAssaultTimer);
     INJECT(enable, 0x00421B20, Overlay_DrawGameInfo);
-    INJECT(enable, 0x00421B70, Overlay_DrawHealthBar);
-    INJECT(enable, 0x00421C20, Overlay_DrawAirBar);
     INJECT(enable, 0x00421CC0, Overlay_MakeAmmoString);
     INJECT(enable, 0x00421CF0, Overlay_DrawAmmoInfo);
     INJECT(enable, 0x00421E40, Overlay_InitialisePickUpDisplay);

--- a/src/tr2/meson.build
+++ b/src/tr2/meson.build
@@ -208,6 +208,7 @@ dll_sources = [
   'game/ui/widgets/controls_input_selector.c',
   'game/ui/widgets/controls_layout_editor.c',
   'game/ui/widgets/controls_layout_selector.c',
+  'game/viewport.c',
   'global/enum_map.c',
   'global/vars.c',
   'inject_exec.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1633. The dragon statuettes are kept as sprites for now.