### PR TITLE
game: fix new saves not having the save count in the passport

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed enemies that are run over by the skidoo not being counted in the statistics (#1772)
 - fixed sound settings resuming the music (#1707)
 - fixed the inventory ring spinout animation sometimes running too fast (#1704, regression from 0.3)
+- fixed new saves not displaying the save count in the passport (#1591)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -36,6 +36,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed a crash when firing grenades at Xian guards in statue form
 - fixed harpoon bolts damaging inactive enemies
 - fixed the distorted skybox in room 5 of Barkhang Monastery
+- fixed new saves not displaying the save count in the passport
 
 #### Cheats
 - added a fly cheat

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -123,9 +123,15 @@ int32_t __cdecl Game_Control(int32_t nframes, const bool demo_mode)
                             return GFD_START_GAME | LV_FIRST;
                         }
                         CreateSaveGameInfo();
+                        const int16_t slot_num = g_Inv_ExtraData[1];
                         S_SaveGame(
-                            &g_SaveGame, sizeof(SAVEGAME_INFO),
-                            g_Inv_ExtraData[1]);
+                            &g_SaveGame, sizeof(SAVEGAME_INFO), slot_num);
+                        // TODO: move me inside S_SaveGame
+                        g_SaveGameReqFlags1[slot_num] =
+                            g_RequesterFlags1[slot_num];
+                        g_SaveGameReqFlags2[slot_num] =
+                            g_RequesterFlags2[slot_num];
+
                         S_SaveSettings();
                     } else {
                         return dir;

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -17,7 +17,11 @@ bool Savegame_IsSlotFree(const int32_t slot_idx)
 bool Savegame_Save(const int32_t slot_idx)
 {
     CreateSaveGameInfo();
+    const int16_t slot_num = g_Inv_ExtraData[1];
     S_SaveGame(&g_SaveGame, sizeof(SAVEGAME_INFO), slot_idx);
+    // TODO: move me inside S_SaveGame
+    g_SaveGameReqFlags1[slot_num] = g_RequesterFlags1[slot_num];
+    g_SaveGameReqFlags2[slot_num] = g_RequesterFlags2[slot_num];
     GetSavedGamesList(&g_LoadGameRequester);
     return true;
 }

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -17,11 +17,10 @@ bool Savegame_IsSlotFree(const int32_t slot_idx)
 bool Savegame_Save(const int32_t slot_idx)
 {
     CreateSaveGameInfo();
-    const int16_t slot_num = g_Inv_ExtraData[1];
     S_SaveGame(&g_SaveGame, sizeof(SAVEGAME_INFO), slot_idx);
     // TODO: move me inside S_SaveGame
-    g_SaveGameReqFlags1[slot_num] = g_RequesterFlags1[slot_num];
-    g_SaveGameReqFlags2[slot_num] = g_RequesterFlags2[slot_num];
+    g_SaveGameReqFlags1[slot_idx] = g_RequesterFlags1[slot_idx];
+    g_SaveGameReqFlags2[slot_idx] = g_RequesterFlags2[slot_idx];
     GetSavedGamesList(&g_LoadGameRequester);
     return true;
 }


### PR DESCRIPTION
Resolves #1591.

Eventually this fix will be moved to S_SaveGame.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed new saves not displaying the save count in the passport. Will eventually move to the savegame functions once those are decompiled. Fix courtesy of rr.
