### PR TITLE
tr2/inventory: fix fast spinout animation

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -62,6 +62,7 @@
 - fixed harpoon bolts damaging inactive enemies (#1804)
 - fixed enemies that are run over by the skidoo not being counted in the statistics (#1772)
 - fixed sound settings resuming the music (#1707)
+- fixed the inventory ring spinout animation sometimes running too fast (#1704, regression from 0.3)
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/src/libtrx/game/clock/common.c
+++ b/src/libtrx/game/clock/common.c
@@ -50,7 +50,12 @@ double Clock_GetHighPrecisionCounter(void)
         / (double)m_Frequency;
 }
 
-int32_t Clock_SyncTicks(void)
+void Clock_SyncTick(void)
+{
+    m_LastCounter = SDL_GetPerformanceCounter();
+}
+
+int32_t Clock_WaitTick(void)
 {
     const Uint64 counter = SDL_GetPerformanceCounter();
 
@@ -73,7 +78,7 @@ int32_t Clock_SyncTicks(void)
         elapsed_frames = 1;
     }
 
-    m_LastCounter = SDL_GetPerformanceCounter();
+    Clock_SyncTick();
 
     return elapsed_frames;
 }

--- a/src/libtrx/include/libtrx/game/clock/common.h
+++ b/src/libtrx/include/libtrx/game/clock/common.h
@@ -8,7 +8,8 @@
 
 void Clock_Init(void);
 
-int32_t Clock_SyncTicks(void);
+void Clock_SyncTick(void);
+int32_t Clock_WaitTick(void);
 
 size_t Clock_GetDateTime(char *buffer, size_t size);
 

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -27,7 +27,7 @@
         Input_Update();                                                        \
         Output_EndScene();                                                     \
         Output_AnimateFades();                                                 \
-        Clock_SyncTicks();                                                     \
+        Clock_WaitTick();                                                      \
     } while (g_Input.key);
 
 void Game_ProcessInput(void)

--- a/src/tr1/game/phase/phase.c
+++ b/src/tr1/game/phase/phase.c
@@ -109,7 +109,7 @@ static void M_SetUnconditionally(const PHASE phase, const void *args)
     // set it at the end, so that the start callbacks can retrieve the old phase
     m_Phase = phase;
 
-    Clock_SyncTicks();
+    Clock_WaitTick();
 }
 
 PHASE Phase_Get(void)
@@ -134,13 +134,13 @@ static int32_t M_Wait(void)
     if (m_Phaser && m_Phaser->wait) {
         return m_Phaser->wait();
     } else {
-        return Clock_SyncTicks();
+        return Clock_WaitTick();
     }
 }
 
 GAMEFLOW_COMMAND Phase_Run(void)
 {
-    int32_t nframes = Clock_SyncTicks();
+    int32_t nframes = Clock_WaitTick();
     PHASE_CONTROL control = { .end = false };
 
     m_Running = true;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -2791,7 +2791,7 @@ void __cdecl S_Wait(int32_t frames, const BOOL input_check)
             if (!g_Input.any) {
                 break;
             }
-            frames -= Clock_SyncTicks() * TICKS_PER_FRAME;
+            frames -= Clock_WaitTick() * TICKS_PER_FRAME;
 
             if (g_IsGameToExit) {
                 break;
@@ -2910,7 +2910,7 @@ void __cdecl DisplayCredits(void)
 
 DWORD __cdecl S_DumpScreen(void)
 {
-    const int32_t passed = Clock_SyncTicks();
+    const int32_t passed = Clock_WaitTick();
     ScreenPartialDump();
     return passed;
 }

--- a/src/tr2/game/inventory/common.c
+++ b/src/tr2/game/inventory/common.c
@@ -1,6 +1,7 @@
 #include "game/inventory/common.h"
 
 #include "decomp/decomp.h"
+#include "game/clock.h"
 #include "game/console/common.h"
 #include "game/demo.h"
 #include "game/game.h"
@@ -185,6 +186,7 @@ void __cdecl Inv_Construct(void)
 
 int32_t __cdecl Inv_Display(int32_t inventory_mode)
 {
+    Clock_SyncTick();
     Stats_StartTimer();
     RING_INFO ring = { 0 };
     IMOTION_INFO imo = { 0 };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1704.

This was especially evident with FMVs that don't depend on the clock - m_LastCounter held old time data, making the game try to make up for the perceived large difference, and skip ahead by many frames at once.