### PR TITLE
Small console improvements

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -748,7 +748,7 @@
         "OSD_PERSPECTIVE_FILTER_ON": "Perspective filter enabled",
         "OSD_PHOTO_MODE_LAUNCHED": "Entering photo mode, press %s for help",
         "OSD_PLAY_LEVEL": "Loading %s",
-        "OSD_POS_GET": "Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
+        "OSD_POS_GET": "Level: %d (%s)  Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
         "OSD_POS_SET_ITEM": "Teleported to object: %s",
         "OSD_POS_SET_ITEM_FAIL": "Failed to teleport to object: %s",
         "OSD_POS_SET_POS": "Teleported to position: %.3f %.3f %.3f",

--- a/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
@@ -238,7 +238,7 @@
         "OSD_PERSPECTIVE_FILTER_ON": "Perspective filter enabled",
         "OSD_PHOTO_MODE_LAUNCHED": "Entering photo mode, press %s for help",
         "OSD_PLAY_LEVEL": "Loading %s",
-        "OSD_POS_GET": "Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
+        "OSD_POS_GET": "Level: %d (%s)  Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
         "OSD_POS_SET_ITEM": "Teleported to object: %s",
         "OSD_POS_SET_ITEM_FAIL": "Failed to teleport to object: %s",
         "OSD_POS_SET_POS": "Teleported to position: %.3f %.3f %.3f",

--- a/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
@@ -309,7 +309,7 @@
         "OSD_PERSPECTIVE_FILTER_ON": "Perspective filter enabled",
         "OSD_PHOTO_MODE_LAUNCHED": "Entering photo mode, press %s for help",
         "OSD_PLAY_LEVEL": "Loading %s",
-        "OSD_POS_GET": "Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
+        "OSD_POS_GET": "Level: %d (%s)  Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
         "OSD_POS_SET_ITEM": "Teleported to object: %s",
         "OSD_POS_SET_ITEM_FAIL": "Failed to teleport to object: %s",
         "OSD_POS_SET_POS": "Teleported to position: %.3f %.3f %.3f",

--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -419,7 +419,7 @@
         "OSD_LOAD_GAME_FAIL_UNAVAILABLE_SLOT": "Save slot %d is not available",
         "OSD_OBJECT_NOT_FOUND": "Object not found",
         "OSD_PLAY_LEVEL": "Loading %s",
-        "OSD_POS_GET": "Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
+        "OSD_POS_GET": "Level: %d (%s)  Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f",
         "OSD_POS_SET_ITEM": "Teleported to object: %s",
         "OSD_POS_SET_ITEM_FAIL": "Failed to teleport to object: %s",
         "OSD_POS_SET_POS": "Teleported to position: %.3f %.3f %.3f",

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fixed the controls menu extending to the bottom of the screen with certain text scaling values (#1783, regression from 2.12)
 - fixed game stuck at remapping controller key if no controllers connected (#1788)
 - fixed being able to shoot the scion multiple times if save/load is used while it blows up (#1819)
+- fixed certain erroneous `/play` invocations resulting in duplicated error messages
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -38,6 +38,7 @@
     - `\{ammo shotgun}`
     - `\{ammo magnums}`
     - `\{ammo uzis}`
+- changed the `/pos` command to include the level number and title
 - changed the music timestamp loading behaviour and config option to support ambient tracks (#1769)
 - fixed missing pushblock SFX in Natla's Mines (#1714)
 - fixed crash reports not working in certain circumstances (#1738)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -32,6 +32,7 @@
     - removed hardcoded cooldown of 15 frames for medipacks
 - changed text backend to accept named sequences (eg. "\{arrow up}" and similar)
 - changed inventory to pause the music rather than muting it (#1707)
+- changed the `/pos` command to include the level number and title
 - improved FMV mode appearance - removed black scanlines (#1729)
 - improved FMV mode behavior - stopped switching screen resolutions (#1729)
 - improved screenshots: now saved in the screenshots/ directory with level titles and timestamps as JPG or PNG, similar to TR1X (#1773)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed sound settings resuming the music (#1707)
 - fixed the inventory ring spinout animation sometimes running too fast (#1704, regression from 0.3)
 - fixed new saves not displaying the save count in the passport (#1591)
+- fixed certain erroneous `/play` invocations resulting in duplicated error messages
 
 ## [0.5](https://github.com/LostArtefacts/TRX/compare/afaf12a...tr2-0.5) - 2024-10-08
 - added `/sfx` command

--- a/src/libtrx/game/console/cmd/play_level.c
+++ b/src/libtrx/game/console/cmd/play_level.c
@@ -46,7 +46,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 
     if (matches->count == 0) {
         Console_Log(GS(OSD_INVALID_LEVEL));
-        result = CR_BAD_INVOCATION;
+        result = CR_FAILURE;
         goto cleanup;
     } else if (matches->count >= 1) {
         const STRING_FUZZY_MATCH *const match = Vector_Get(matches, 0);

--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -2,7 +2,9 @@
 
 #include "game/console/common.h"
 #include "game/const.h"
+#include "game/game.h"
 #include "game/game_string.h"
+#include "game/gameflow/common.h"
 #include "game/lara/common.h"
 #include "game/objects/common.h"
 #include "strings.h"
@@ -25,6 +27,8 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     // clang-format off
     Console_Log(
         GS(OSD_POS_GET),
+        Game_GetCurrentLevelNum(),
+        Gameflow_GetLevelTitle(Game_GetCurrentLevelNum()),
         lara_item->room_num,
         lara_item->pos.x / (float)WALL_L,
         lara_item->pos.y / (float)WALL_L,

--- a/src/libtrx/include/libtrx/game/game_string.def
+++ b/src/libtrx/include/libtrx/game/game_string.def
@@ -1,4 +1,4 @@
-GS_DEFINE(OSD_POS_GET, "Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f")
+GS_DEFINE(OSD_POS_GET, "Level: %d (%s)  Room: %d\nPosition: %.3f, %.3f, %.3f\nRotation: %.3f,%.3f,%.3f")
 GS_DEFINE(OSD_CURRENT_HEALTH_GET, "Current Lara's health: %d")
 GS_DEFINE(OSD_CURRENT_HEALTH_SET, "Lara's health set to %d")
 GS_DEFINE(OSD_CONFIG_OPTION_GET, "%s is currently set to %s")


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes duplicate warning about wrong `/level` invocation and adds the current level number / title to the `/pos` command.