### PR TITLE
build: pass staticdeps parameter to libtrx

### DIFF
--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -7,8 +7,11 @@ project(
   ],
 )
 
+staticdeps = get_option('staticdeps')
+
 trx = subproject('libtrx', default_options: {
   'tr_version': '1',
+  'staticdeps': staticdeps,
 })
 c_compiler = meson.get_compiler('c')
 
@@ -23,8 +26,6 @@ build_opts = [
 ] + trx.get_variable('defines')
 
 add_project_arguments(build_opts, language: 'c')
-
-staticdeps = get_option('staticdeps')
 
 # Always dynamically link on macOS
 if host_machine.system() == 'darwin'

--- a/src/tr2/meson.build
+++ b/src/tr2/meson.build
@@ -5,8 +5,11 @@ project('TR2X', ['c'],
   ],
 )
 
+staticdeps = get_option('staticdeps')
+
 trx = subproject('libtrx', default_options: {
   'tr_version': '2',
+  'staticdeps': staticdeps,
 })
 c_compiler = meson.get_compiler('c')
 
@@ -21,8 +24,6 @@ build_opts = [
 ] + trx.get_variable('defines')
 
 add_project_arguments(build_opts, language: 'c')
-
-staticdeps = get_option('staticdeps')
 
 null_dep = dependency('', required: false)
 dep_trx = trx.get_variable('dep_trx')


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

When trying to link dynamically to required dependencies with -Dstaticdeps=false parameter, meson produces 95 warnings.

To fix them, staticdeps parameter must be passed to libtrx subproject.

Current partial output :
> meson setup -Doptimization=2 -Db_asneeded=true
> --prefix=/var/tmp/devcxx/meson/TR1X/installdir
> /var/tmp/devcxx/meson/TR1X/builddir
> [...]/dev/projects/TRX/src/tr1 -Dstaticdeps=false
>
> [...]
>
>  TR1X undefined
>
>   Subprojects
>     libtrx      : YES 95 warnings
>     uthash      : YES (from libtrx)
>
>   User defined options
>     optimization: 2
>     prefix      : /var/tmp/devcxx/meson/TR1X/installdir
>     b_asneeded  : true
>     staticdeps  : false