### PR TITLE
libtrx/config: support enforced config settings

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the ability to pause during cutscenes (#1673)
 - added an option to enable responsive swim cancellation, similar to TR2+ (#1004)
 - added a special target, "pickup", to item-based console commands
+- added support for custom levels to enforce values for any config setting (#1846)
 - changed OpenGL backend to use version 3.3, with fallback to 2.1 if initialization fails (#1738)
 - changed text backend to accept named sequences. Currently supported sequences (limited by the sprites available in OG):
     - `\{umlaut}`

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -10,6 +10,7 @@ Jump to:
 - [Bonus levels](#bonus-levels)
 - [Item drops](#item-drops)
 - [Injections](#injections)
+- [User configuration](#user-configuration)
 
 ## Global properties
 The following properties are in the root of the gameflow document and control
@@ -1483,3 +1484,50 @@ provided with the game achieves.
     </td>
   </tr>
 </table>
+
+## User Configuration
+TRX ships with a configuration tool to allow users to adjust game settings to
+their taste. This tool writes to `cfg\TR1X.json5`. As a level builder, you may
+wish to enforce some settings to match how your level is designed.
+
+As an example, let's say you do not wish to add save crystals to your level, and
+as a result you wish to prevent the player from enabling that option in the
+config tool. To achieve this, open `cfg\TR1X.json5` in a suitable text editor
+and add the following.
+
+```json
+"enforced" : {
+  "enable_save_crystals" : false,
+}
+```
+
+This means that the game will enforce your chosen value for this particular
+config setting. If the player launches the config tool, the option to toggle
+save crystals will be greyed out.
+
+You can add as many settings within the `enforced` section as needed.
+
+Note that you do not need to ship a full `cfg\TR1X.json5` with your level, and
+indeed it is not recommended to do so if you have, for example, your own custom
+keyboard or controller layouts defined.
+
+If you do not have any requirement to enforce settings, you can omit the file
+altogether from your level - the game will provide defaults for all settings as
+standard when it is launched.
+
+You can also ship only the `enforced` settings. So, your _entire_ file may
+appear simply as follows, and this is perfectly valid.
+
+```json
+{
+  "enforced" : {
+    "enable_save_crystals" : false,
+    "disable_healing_between_levels" : true,
+    "enable_3d_pickups" : true,
+    "enable_wading" : true,
+  }
+}
+```
+
+These settings will be enforced; everything else will default, plus the player
+can customise the settings you have not defined as desired.

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.6...develop) - ××××-××-××
+- added support for custom levels to enforce values for any config setting (#1846)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/libtrx/include/libtrx/json.h
+++ b/src/libtrx/include/libtrx/json.h
@@ -5,6 +5,7 @@
 #define JSON_INVALID_NUMBER 0x7FFFFFFF
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -126,7 +127,9 @@ void JSON_ObjectAppendArray(JSON_OBJECT *obj, const char *key, JSON_ARRAY *arr);
 void JSON_ObjectAppendObject(
     JSON_OBJECT *obj, const char *key, JSON_OBJECT *obj2);
 
+bool JSON_ObjectContainsKey(JSON_OBJECT *obj, const char *key);
 void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key);
+void JSON_ObjectMerge(JSON_OBJECT *root, const JSON_OBJECT *obj);
 
 JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *obj, const char *key);
 int JSON_ObjectGetBool(JSON_OBJECT *obj, const char *key, int d);

--- a/src/libtrx/json/json_base.c
+++ b/src/libtrx/json/json_base.c
@@ -347,6 +347,20 @@ void JSON_ObjectAppendObject(
     JSON_ObjectAppend(obj, key, JSON_ValueFromObject(obj2));
 }
 
+bool JSON_ObjectContainsKey(JSON_OBJECT *const obj, const char *const key)
+{
+    JSON_OBJECT_ELEMENT *elem = obj->start;
+    while (elem != NULL) {
+        if (!strcmp(elem->name->string, key)) {
+            return true;
+        }
+
+        elem = elem->next;
+    }
+
+    return false;
+}
+
 void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key)
 {
     if (!obj) {
@@ -365,6 +379,16 @@ void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key)
             return;
         }
         prev = elem;
+        elem = elem->next;
+    }
+}
+
+void JSON_ObjectMerge(JSON_OBJECT *const root, const JSON_OBJECT *const obj)
+{
+    JSON_OBJECT_ELEMENT *elem = obj->start;
+    while (elem != NULL) {
+        JSON_ObjectEvictKey(root, elem->name->string);
+        JSON_ObjectAppend(root, elem->name->string, elem->value);
         elem = elem->next;
     }
 }

--- a/tools/config/TRX_ConfigToolLib/Controls/PropertyControl.xaml
+++ b/tools/config/TRX_ConfigToolLib/Controls/PropertyControl.xaml
@@ -6,15 +6,30 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="clr-namespace:TRX_ConfigToolLib.Controls"
     xmlns:models="clr-namespace:TRX_ConfigToolLib.Models"
+    xmlns:utils="clr-namespace:TRX_ConfigToolLib.Utils"
     mc:Ignorable="d"
     d:DesignHeight="450"
     d:DesignWidth="800">
 
     <UserControl.Resources>
-        <ResourceDictionary Source="/TRX_ConfigToolLib;component/Resources/styles.xaml" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/TRX_ConfigToolLib;component/Resources/styles.xaml" />
+                <ResourceDictionary>
+                    <utils:BoolToVisibilityConverter
+                        x:Key="BoolToCollapsedConverter"
+                        FalseValue="Collapsed"
+                        TrueValue="Visible"/>
+                    <utils:BoolToVisibilityConverter
+                        x:Key="InverseBoolToCollapsedConverter"
+                        FalseValue="Visible"
+                        TrueValue="Collapsed"/>
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel>
+    <StackPanel IsEnabled="{Binding IsEnabled}">
         <TextBlock
             Text="{Binding Title}"
             Style="{StaticResource PropertyTitleStyle}"/>
@@ -25,7 +40,8 @@
 
         <ContentControl
             Content="{Binding}"
-            HorizontalAlignment="Left">
+            HorizontalAlignment="Left"
+            Visibility="{Binding IsEnabled, Converter={StaticResource BoolToCollapsedConverter}}">
             <ContentControl.Resources>
                 <DataTemplate DataType="{x:Type models:BoolProperty}">
                     <CheckBox
@@ -52,5 +68,12 @@
                 </DataTemplate>
             </ContentControl.Resources>
         </ContentControl>
+
+        <TextBlock
+            Style="{StaticResource PropertyEnforcedStyle}"
+            Visibility="{Binding IsEnabled, Converter={StaticResource InverseBoolToCollapsedConverter}}">
+            <Run Text="{Binding DataContext.ViewText[label_enforced], RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"/>
+            <Run Text="{Binding EnforcedValue}"/>
+        </TextBlock>
     </StackPanel>
 </UserControl>

--- a/tools/config/TRX_ConfigToolLib/Controls/TRXConfigWindow.xaml
+++ b/tools/config/TRX_ConfigToolLib/Controls/TRXConfigWindow.xaml
@@ -136,11 +136,28 @@
         <Grid
             Margin="7">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
+            <Border
+                Visibility="{Binding HasReadOnlyItems, Converter={StaticResource BoolToCollapsedConverter}}"
+                BorderThickness="1"
+                BorderBrush="#666"
+                Margin="0,0,0,7"
+                Background="Orange">
+                <StackPanel>
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Margin="5"
+                        FontWeight="Bold"
+                        Text="{Binding ViewText[label_locked_properties]}"/>
+                </StackPanel>
+            </Border>
+
             <TabControl
+                Grid.Row="1"
                 Margin="0,0,0,7"
                 Padding="0"
                 IsEnabled="{Binding IsEditorActive}"
@@ -165,7 +182,7 @@
             </TabControl>
 
             <Grid
-                Grid.Row="1">
+                Grid.Row="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>

--- a/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
@@ -34,6 +34,7 @@ public class MainWindowViewModel : BaseLanguageViewModel
     {
         IsEditorDirty = _configuration.IsDataDirty();
         IsEditorDefault = _configuration.IsDataDefault();
+        HasReadOnlyItems = _configuration.HasReadOnlyItems();
     }
 
     public void Load()
@@ -75,6 +76,20 @@ public class MainWindowViewModel : BaseLanguageViewModel
             if (_isEditorDefault != value)
             {
                 _isEditorDefault = value;
+                NotifyPropertyChanged();
+            }
+        }
+    }
+
+    private bool _hasReadOnlyItems;
+    public bool HasReadOnlyItems
+    {
+        get => _hasReadOnlyItems;
+        set
+        {
+            if (_hasReadOnlyItems != value)
+            {
+                _hasReadOnlyItems = value;
                 NotifyPropertyChanged();
             }
         }

--- a/tools/config/TRX_ConfigToolLib/Models/Specification/BaseProperty.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/Specification/BaseProperty.cs
@@ -2,6 +2,8 @@
 
 public abstract class BaseProperty : BaseNotifyPropertyChanged
 {
+    private static readonly object _nullValue = new();
+
     public string Field { get; set; }
 
     public string Title
@@ -18,6 +20,23 @@ public abstract class BaseProperty : BaseNotifyPropertyChanged
     public abstract void LoadValue(string value);
     public abstract void SetToDefault();
     public abstract bool IsDefault { get; }
+
+    private object _enforcedValue = _nullValue;
+    public object EnforcedValue
+    {
+        get => _enforcedValue;
+        set
+        {
+            if (_enforcedValue != value)
+            {
+                _enforcedValue = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(IsEnabled));
+            }
+        }
+    }
+
+    public bool IsEnabled => _enforcedValue == _nullValue;
 
     public virtual void Initialise(Specification specification)
     {

--- a/tools/config/TRX_ConfigToolLib/Resources/Lang/en.json
+++ b/tools/config/TRX_ConfigToolLib/Resources/Lang/en.json
@@ -12,6 +12,8 @@
     "menu_help": "_Help",
     "command_github": "_GitHub",
     "command_about": "_About",
+    "label_locked_properties": "This configuration set contains some read-only values defined by the game author.",
+    "label_enforced": "Value enforced to:",
     "checkbox_enabled": "Enabled",
     "spinner_msg_invalid_number": "The input string is not a valid number",
     "spinner_msg_comparison_failed": "The input value must be between {0} and {1}",

--- a/tools/config/TRX_ConfigToolLib/Resources/Lang/es.json
+++ b/tools/config/TRX_ConfigToolLib/Resources/Lang/es.json
@@ -12,6 +12,8 @@
     "menu_help": "_Ayuda",
     "command_github": "_GitHub",
     "command_about": "_Acerca de",
+    "label_locked_properties": "Este conjunto de configuración contiene algunos valores de solo lectura definidos por el autor del juego.",
+    "label_enforced": "Valor aplicado a:",
     "checkbox_enabled": "Habilitado",
     "spinner_msg_invalid_number": "La cadena de entrada no es un número válido",
     "spinner_msg_comparison_failed": "El valor de entrada debe estar entre {0} y {1}",

--- a/tools/config/TRX_ConfigToolLib/Resources/Lang/fr.json
+++ b/tools/config/TRX_ConfigToolLib/Resources/Lang/fr.json
@@ -12,6 +12,8 @@
     "menu_help": "_Aide",
     "command_github": "_GitHub",
     "command_about": "_A propos",
+    "label_locked_properties": "Cet ensemble de configuration contient certaines valeurs en lecture seule définies par l'auteur du jeu.",
+    "label_enforced": "Valeur imposée à:",
     "checkbox_enabled": "Activé",
     "spinner_msg_invalid_number": "La valeur n'est pas un nombre valide",
     "spinner_msg_comparison_failed": "La valeur doit être entre {0} et {1}",

--- a/tools/config/TRX_ConfigToolLib/Resources/Lang/it.json
+++ b/tools/config/TRX_ConfigToolLib/Resources/Lang/it.json
@@ -12,6 +12,8 @@
     "menu_help": "_Aiuto",
     "command_github": "_GitHub",
     "command_about": "_Informazioni su",
+    "label_locked_properties": "Questo set di configurazione contiene alcuni valori di sola lettura definiti dall'autore del gioco.",
+    "label_enforced": "Valore applicato a:",
     "checkbox_enabled": "Abilitato",
     "spinner_msg_invalid_number": "Il valore immesso non è un numero valido",
     "spinner_msg_comparison_failed": "Il valore immesso deve essere compreso tra {0} e {1}",

--- a/tools/config/TRX_ConfigToolLib/Resources/styles.xaml
+++ b/tools/config/TRX_ConfigToolLib/Resources/styles.xaml
@@ -63,6 +63,11 @@
         <Setter
             Property="Margin"
             Value="0,0,0,2" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style
@@ -77,6 +82,25 @@
         <Setter
             Property="Margin"
             Value="0,0,0,10" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style
+        x:Key="PropertyEnforcedStyle"
+        TargetType="{x:Type TextBlock}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="FontStyle" Value="Italic"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style
@@ -85,6 +109,11 @@
         <Setter
             Property="VerticalContentAlignment"
             Value="Center" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style
@@ -93,6 +122,11 @@
         <Setter
             Property="MinWidth"
             Value="150" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style
@@ -101,6 +135,11 @@
         <Setter
             Property="MinWidth"
             Value="100" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style


### PR DESCRIPTION
Resolves #1846.
Resolves #1847.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows an enforced object to be defined in the config file, within which any regular config setting can be defined, and the values from here will be enforced in the game. This applies to TR1 and TR2.

Example snippet for `TR1X.json5`:
```json
{
  "enable_uw_roll" : true,
  "enforced" : {
    "enable_uw_roll" : false
  }
}
```
Here the initial value is replaced by the one in the `enforced` object when the game loads. When the game writes back the config, both entries will be preserved, meaning if players want to remove these enforcements they can do so and their original settings will not need to be re-edited.

The config tool will grey out any enforced options, and display a message so the user knows why they cannot be edited.

I think we can remove `force_game_modes` and `force_save_crystals` from the gameflow and allow builders to implement it in the same way as above. But probably best handled in its own PR and after review/testing of this one.

Re #1847, this same approach can be used by builders to remove features available only with Lara's animation injection. The alternative to this is testing animation goals, which IMO would result in too many additional code checks.
