### PR TITLE
give_item: fix give command not checking if an object is loaded

### DIFF
--- a/src/libtrx/game/console/cmd/give_item.c
+++ b/src/libtrx/game/console/cmd/give_item.c
@@ -23,7 +23,8 @@ static bool M_CanTargetObjectPickup(const GAME_OBJECT_ID object_id)
     }
     const GAME_OBJECT_ID inv_object_id =
         Object_GetCognate(object_id, g_ItemToInvObjectMap);
-    return Object_GetObject(inv_object_id)->loaded;
+    return Object_GetObject(object_id)->loaded
+        && Object_GetObject(inv_object_id)->loaded;
 }
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)

--- a/src/libtrx/game/console/cmd/give_item.c
+++ b/src/libtrx/game/console/cmd/give_item.c
@@ -18,13 +18,11 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static bool M_CanTargetObjectPickup(const GAME_OBJECT_ID object_id)
 {
-    if (!Object_IsObjectType(object_id, g_PickupObjects)) {
-        return false;
-    }
-    const GAME_OBJECT_ID inv_object_id =
-        Object_GetCognate(object_id, g_ItemToInvObjectMap);
-    return Object_GetObject(object_id)->loaded
-        && Object_GetObject(inv_object_id)->loaded;
+    return Object_IsObjectType(object_id, g_InvObjects)
+        && Object_GetObject(object_id)->loaded
+        && Object_IsObjectType(
+               Object_GetCognateInverse(object_id, g_ItemToInvObjectMap),
+               g_PickupObjects);
 }
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)


### PR DESCRIPTION
Resolves #1850.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed `/give` not checking if the original object is loaded.

The reason you get 2 scions is because M_CanTargetObjectPickup does:
```
const GAME_OBJECT_ID inv_object_id =
    Object_GetCognate(object_id, g_ItemToInvObjectMap);
return Object_GetObject(inv_object_id)->loaded;
```

This function only tests if the cognate is loaded (the 3D inventory version). For example in Qualopec, only sprite `O_SCION_ITEM_1` `143` is in the .phd. But `O_SCION_ITEM_2` `144` also has the cognate of `O_SCION_OPTION` the 3D inventory version `150`. I have this weird feeling that it could break something regarding pickup ammo, custom levels, or something with the rando. So lmk your thoughts.