### PR TITLE
build: introduce meson subprojects option

### DIFF
--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -7,6 +7,7 @@ project(
   ],
 )
 
+subprojects = get_option('subprojects')
 staticdeps = get_option('staticdeps')
 tr_version = get_option('tr_version')
 
@@ -32,9 +33,28 @@ if host_machine.system() == 'darwin'
   staticdeps = false
 endif
 
-uthash = subproject('uthash', default_options: ['warning_level=0'])
-
 null_dep = dependency('', required: false)
+
+dep_uthash = null_dep
+if subprojects
+  # Use uthash bundled meson subproject
+  uthash = subproject('uthash', default_options: ['warning_level=0'])
+  dep_uthash = uthash.get_variable('uthash_dep')
+else
+  # Searching for uthash library header provided by OS package manager
+  incdir = include_directories('/usr/include')
+  uthash_version = c_compiler.get_define('UTHASH_VERSION',
+    include_directories: incdir,
+    prefix: '#include "uthash.h"')
+
+  # make sure we found the right version
+  if uthash_version.version_compare('>=2.3.0')
+    message('Found uthash library header version: ' + uthash_version)
+  else
+    error('Found wrong uthash library header version: ' + uthash_version)
+  endif
+endif
+
 dep_avcodec = dependency('libavcodec', static: staticdeps)
 dep_avformat = dependency('libavformat', static: staticdeps)
 dep_avutil = dependency('libavutil', static: staticdeps)
@@ -151,7 +171,7 @@ dependencies = [
   dep_swscale,
   dep_zlib,
   dep_opengl,
-  uthash.get_variable('uthash_dep'),
+  dep_uthash,
 ]
 
 if dep_backtrace.found() and host_machine.system() == 'linux'

--- a/src/libtrx/meson.options
+++ b/src/libtrx/meson.options
@@ -1,4 +1,12 @@
 option(
+  'subprojects',
+  type: 'boolean',
+  value: true,
+  description: 'Use bundled dependencies through meson subprojects. default: true.' +
+    'If false, try to find them on the OS.'
+)
+
+option(
   'staticdeps',
   type: 'boolean',
   value: true,

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -8,10 +8,12 @@ project(
 )
 
 staticdeps = get_option('staticdeps')
+subprojects = get_option('subprojects')
 
 trx = subproject('libtrx', default_options: {
   'tr_version': '1',
   'staticdeps': staticdeps,
+  'subprojects': subprojects,
 })
 c_compiler = meson.get_compiler('c')
 

--- a/src/tr1/meson.options
+++ b/src/tr1/meson.options
@@ -1,1 +1,14 @@
-option('staticdeps', type: 'boolean', value: true, description: 'Try to build against static dependencies. default: true')
+option(
+  'subprojects',
+  type: 'boolean',
+  value: true,
+  description: 'Use bundled dependencies through meson subprojects. default: true.' +
+    'If false, try to find them on the OS.'
+)
+
+option(
+  'staticdeps',
+  type: 'boolean',
+  value: true,
+  description: 'Try to build against static dependencies. default: true'
+)

--- a/src/tr2/meson.build
+++ b/src/tr2/meson.build
@@ -6,10 +6,12 @@ project('TR2X', ['c'],
 )
 
 staticdeps = get_option('staticdeps')
+subprojects = get_option('subprojects')
 
 trx = subproject('libtrx', default_options: {
   'tr_version': '2',
   'staticdeps': staticdeps,
+  'subprojects': subprojects,
 })
 c_compiler = meson.get_compiler('c')
 

--- a/src/tr2/meson.options
+++ b/src/tr2/meson.options
@@ -1,1 +1,14 @@
-option('staticdeps', type: 'boolean', value: true, description: 'Try to build against static dependencies. default: true')
+option(
+  'subprojects',
+  type: 'boolean',
+  value: true,
+  description: 'Use bundled dependencies through meson subprojects. default: true.' +
+    'If false, try to find them on the OS.'
+)
+
+option(
+  'staticdeps',
+  type: 'boolean',
+  value: true,
+  description: 'Try to build against static dependencies. default: true'
+)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

On Gentoo Linux, downloading external dependencies via subprojects concept is forbidden (meson setup --wrap-mode nodownload).

Then, when trying to package TRX, meson is failing with the following error on libtrx configuration while it tries to download/unpack the uthash library :
> Executing subproject libtrx
>
> libtrx| Project name: libtrx
> libtrx| Project version: undefined
> libtrx| C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 13.3.1 "x86_64-pc-linux-gnu-gcc (Gentoo 13.3.1_p20241025 p1) 13.3.1 20241024")
> libtrx| C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.42
> libtrx| Using subprojects/libtrx/subprojects/uthash.wrap
>
> src/tr1/subprojects/libtrx/meson.build:35:9: ERROR: Automatic wrap-based subproject downloading is disabled

On Gentoo, the uthash library is distributed by the package manager and installed in /usr/include.

This commit introduces a new boolean meson option (subprojects), defaulting to true.

With subprojects == true, meson is using the bundled uthash subproject library as usual.

With subprojects == false, meson is trying to find the uthash.h header on the system (in /usr/include). It also checks for the right library version (currently 2.3.0).

Partial meson output with -Dsubprojects=false when the header was found :
> Executing subproject libtrx
>
> libtrx| Project name: libtrx
> libtrx| Project version: undefined
> libtrx| C compiler for the host machine: ccache cc (gcc 13.3.1 "cc
> (Gentoo 13.3.1_p20241025 p1) 13.3.1 20241024")
> libtrx| C linker for the host machine: cc ld.bfd 2.42
> libtrx| Fetching value of define "UTHASH_VERSION" : 2.3.0
> libtrx| Message: Found uthash library header version: 2.3.0

Same output with -Dsubprojects=false while the header was not found :
> Executing subproject libtrx
>
> libtrx| Project name: libtrx
> libtrx| Project version: undefined
> libtrx| C compiler for the host machine: ccache cc (gcc 13.3.1 "cc
> (Gentoo 13.3.1_p20241025 p1) 13.3.1 20241024")
> libtrx| C linker for the host machine: cc ld.bfd 2.42
> [...]/TRX/src/tr1/subprojects/libtrx/meson.build:46:30: ERROR: Could not get define 'UTHASH_VERSION'

Same output with -Dsubprojects=false while the header version mismatches :
> Executing subproject libtrx
>
> libtrx| Project name: libtrx
> libtrx| Project version: undefined
> libtrx| C compiler for the host machine: ccache cc (gcc 13.3.1 "cc
> (Gentoo 13.3.1_p20241025 p1) 13.3.1 20241024")
> libtrx| C linker for the host machine: cc ld.bfd 2.42
> [..]TRX/src/tr1/subprojects/libtrx/meson.build:54:4: ERROR: Problem encountered: Found wrong uthash library header version: 2.2.0
