### PR TITLE
libtrx/config: refactor enforced config approach

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -7,8 +7,6 @@
     "main_menu_picture": "data/images/title.webp",
     "savegame_fmt_legacy": "saveati.%d",
     "savegame_fmt_bson": "save_tr1_%02d.dat",
-    "force_game_modes": null,
-    "force_save_crystals": null,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],
     "draw_distance_fade": 22.0,

--- a/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
@@ -8,9 +8,6 @@
     // path to the savegame file
     "savegame_fmt_legacy": "save_demo_pc.%d",
     "savegame_fmt_bson": "save_demo_pc_%02d.dat",
-
-    "force_game_modes": null,
-    "force_save_crystals": null,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],
     "draw_distance_fade": 22.0,

--- a/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
@@ -7,8 +7,6 @@
     "main_menu_picture": "data/images/title_ub.webp",
     "savegame_fmt_legacy": "saveuba.%d",
     "savegame_fmt_bson": "save_trub_%02d.dat",
-    "force_game_modes": null,
-    "force_save_crystals": false,
     "demo_delay": 16,
     "water_color": [0.45, 1.0, 1.0],
     "draw_distance_fade": 22,
@@ -22,6 +20,10 @@
     ],
     "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
+
+    "enforced_config": {
+        "enable_save_crystals": false,
+    },
 
     "levels": [
         // Level 0

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -57,6 +57,7 @@
 - improved the injection approach for Lara's responsive jumping (#1823)
 - removed health cheat (we now have the `/hp` command)
 - removed background for the "Reset" and "Unbind" labels in the controls dialog
+- removed `force_game_modes` and `force_save_crystals` from the gameflow - see GAMEFLOW.md for details on how to enforce these settings (#1857)
 
 ## [4.5.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.5...tr1-4.5.1) - 2024-10-14
 - fixed mac builds missing embedded resources (#1710, regression from 4.5)

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -23,8 +23,6 @@ various pieces of global behaviour.
 "main_menu_picture": "data/titleh.png",
 "savegame_fmt_legacy": "saveati.%d",
 "savegame_fmt_bson": "save_tr1_%02d.dat",
-"force_game_modes": null,
-"force_save_crystals": null,
 "demo_delay": 16,
 "water_color": [0.45, 1.0, 1.0],
 "draw_distance_fade": 22.0,
@@ -35,6 +33,9 @@ various pieces of global behaviour.
     // etc
 ],
 "convert_dropped_guns": false,
+"enforced_config": {
+    "enable_save_crystals": false,
+},
 "levels": [
     {
         "title": "Caves",
@@ -125,27 +126,14 @@ various pieces of global behaviour.
   </tr>
   <tr valign="top">
     <td>
-      <code>force_game_modes</code>
+      <a name="enforced-config"></a>
+      <code>enforced_config</code>
     </td>
-    <td>Optional Boolean</td>
+    <td>String-to-object map</td>
     <td>No</td>
     <td>
-      Forces game mode selection to be enabled if <code>true</code> or disabled
-      if <code>false</code>, so the user can't select NG+ modes until a
-      playthrough is completed. Overrides the config option
-      <code>enable_game_modes</code>. Has no action if <code>null</code>.
-    </td>
-  </tr>
-  <tr valign="top">
-    <td>
-      <code>force_save_crystals</code>
-    </td>
-    <td>Optional Boolean</td>
-    <td>No</td>
-    <td>
-      Forces save crystals to be enabled if <code>true</code> or disabled if
-      <code>false</code>. Overrides the config option
-      <code>enable_save_crystals</code>. Has no action if <code>null</code>.
+      This allows <em>any</em> regular game config setting to be overriden. See
+      <a href="#user-configuration">User configuration</a> for full details.
     </td>
   </tr>
   <tr valign="top">
@@ -1488,15 +1476,15 @@ provided with the game achieves.
 ## User Configuration
 TRX ships with a configuration tool to allow users to adjust game settings to
 their taste. This tool writes to `cfg\TR1X.json5`. As a level builder, you may
-wish to enforce some settings to match how your level is designed.
+however wish to enforce some settings to match how your level is designed.
 
 As an example, let's say you do not wish to add save crystals to your level, and
 as a result you wish to prevent the player from enabling that option in the
-config tool. To achieve this, open `cfg\TR1X.json5` in a suitable text editor
-and add the following.
+config tool. To achieve this, open `cfg\TR1X_gameflow.json5` in a suitable text
+editor and add the following.
 
 ```json
-"enforced" : {
+"enforced_config" : {
   "enable_save_crystals" : false,
 }
 ```
@@ -1505,29 +1493,12 @@ This means that the game will enforce your chosen value for this particular
 config setting. If the player launches the config tool, the option to toggle
 save crystals will be greyed out.
 
-You can add as many settings within the `enforced` section as needed.
+You can add as many settings within the `enforced_config` section as needed.
+Refer to the key names within `cfg\TR1X.json5` for reference.
 
 Note that you do not need to ship a full `cfg\TR1X.json5` with your level, and
 indeed it is not recommended to do so if you have, for example, your own custom
 keyboard or controller layouts defined.
 
-If you do not have any requirement to enforce settings, you can omit the file
-altogether from your level - the game will provide defaults for all settings as
-standard when it is launched.
-
-You can also ship only the `enforced` settings. So, your _entire_ file may
-appear simply as follows, and this is perfectly valid.
-
-```json
-{
-  "enforced" : {
-    "enable_save_crystals" : false,
-    "disable_healing_between_levels" : true,
-    "enable_3d_pickups" : true,
-    "enable_wading" : true,
-  }
-}
-```
-
-These settings will be enforced; everything else will default, plus the player
-can customise the settings you have not defined as desired.
+If you do not have any requirement to enforce settings, you can omit the 
+`enforced_config` section from your gameflow.

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -19,7 +19,12 @@ void Config_Shutdown(void)
 
 bool Config_Read(void)
 {
-    const bool result = ConfigFile_Read(Config_GetPath(), &Config_LoadFromJSON);
+    const CONFIG_IO_ARGS args = {
+        .default_path = Config_GetPath(CFT_DEFAULT),
+        .enforced_path = Config_GetPath(CFT_ENFORCED),
+        .action = &Config_LoadFromJSON,
+    };
+    const bool result = ConfigFile_Read(&args);
     if (result) {
         Config_Sanitize();
         Config_ApplyChanges();
@@ -30,7 +35,12 @@ bool Config_Read(void)
 bool Config_Write(void)
 {
     Config_Sanitize();
-    const bool updated = ConfigFile_Write(Config_GetPath(), &Config_DumpToJSON);
+    const CONFIG_IO_ARGS args = {
+        .default_path = Config_GetPath(CFT_DEFAULT),
+        .enforced_path = Config_GetPath(CFT_ENFORCED),
+        .action = &Config_DumpToJSON,
+    };
+    const bool updated = ConfigFile_Write(&args);
     if (updated) {
         Config_ApplyChanges();
         if (m_EventManager != NULL) {

--- a/src/libtrx/game/console/history.c
+++ b/src/libtrx/game/console/history.c
@@ -46,13 +46,21 @@ void M_DumpToJSON(JSON_OBJECT *const root_obj)
 void Console_History_Init(void)
 {
     m_History = Vector_Create(sizeof(char *));
-    ConfigFile_Read(m_Path, &M_LoadFromJSON);
+    ConfigFile_Read(&(CONFIG_IO_ARGS) {
+        .default_path = m_Path,
+        .enforced_path = NULL,
+        .action = &M_LoadFromJSON,
+    });
 }
 
 void Console_History_Shutdown(void)
 {
     if (m_History != NULL) {
-        ConfigFile_Write(m_Path, &M_DumpToJSON);
+        ConfigFile_Write(&(CONFIG_IO_ARGS) {
+            .default_path = m_Path,
+            .enforced_path = NULL,
+            .action = &M_DumpToJSON,
+        });
         for (int32_t i = m_History->count - 1; i >= 0; i--) {
             char *const prompt = *(char **)Vector_Get(m_History, i);
             Memory_Free(prompt);

--- a/src/libtrx/include/libtrx/config/common.h
+++ b/src/libtrx/include/libtrx/config/common.h
@@ -7,6 +7,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+typedef enum {
+    CFT_DEFAULT = 0,
+    CFT_ENFORCED = 1,
+} CONFIG_FILE_TYPE;
+
 void Config_Init(void);
 void Config_Shutdown(void);
 
@@ -16,7 +21,7 @@ bool Config_Write(void);
 int32_t Config_SubscribeChanges(EVENT_LISTENER listener, void *user_data);
 void Config_UnsubscribeChanges(int32_t listener_id);
 
-extern const char *Config_GetPath(void);
+extern const char *Config_GetPath(CONFIG_FILE_TYPE file_type);
 
 extern void Config_Sanitize(void);
 extern void Config_ApplyChanges(void);

--- a/src/libtrx/include/libtrx/config/file.h
+++ b/src/libtrx/include/libtrx/config/file.h
@@ -7,8 +7,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool ConfigFile_Read(const char *path, void (*load)(JSON_OBJECT *root_obj));
-bool ConfigFile_Write(const char *path, void (*dump)(JSON_OBJECT *root_obj));
+typedef struct {
+    const char *default_path;
+    const char *enforced_path;
+    void (*action)(JSON_OBJECT *root_obj);
+} CONFIG_IO_ARGS;
+
+bool ConfigFile_Read(const CONFIG_IO_ARGS *control);
+bool ConfigFile_Write(const CONFIG_IO_ARGS *control);
 
 void ConfigFile_LoadOptions(
     JSON_OBJECT *root_obj, const CONFIG_OPTION *options);

--- a/src/tr1/config.c
+++ b/src/tr1/config.c
@@ -6,6 +6,7 @@
 #include "game/music.h"
 #include "game/output.h"
 #include "game/requester.h"
+#include "game/shell.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
@@ -160,9 +161,9 @@ static void M_DumpControllerLayout(
     }
 }
 
-const char *Config_GetPath(void)
+const char *Config_GetPath(const CONFIG_FILE_TYPE file_type)
 {
-    return m_ConfigPath;
+    return file_type == CFT_ENFORCED ? Shell_GetGameflowPath() : m_ConfigPath;
 }
 
 void Config_LoadFromJSON(JSON_OBJECT *root_obj)

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -58,7 +58,6 @@ static bool M_LoadScriptGameStrings(JSON_OBJECT *obj);
 static bool M_IsLegacySequence(const char *type_str);
 static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num);
 static bool M_LoadScriptLevels(JSON_OBJECT *obj);
-static bool M_LoadFromFileImpl(const char *file_name);
 static void M_StringTableShutdown(GAMEFLOW_STRING_ENTRY *dest);
 static bool M_LoadObjectNames(
     JSON_OBJECT *root_obj, GAMEFLOW_STRING_ENTRY **dest);
@@ -163,19 +162,6 @@ static bool M_LoadScriptMeta(JSON_OBJECT *obj)
         return false;
     }
     g_GameFlow.demo_delay = tmp_d;
-
-    g_GameFlow.force_game_modes = M_ReadTristateBool(obj, "force_game_modes");
-    if (JSON_ObjectGetBool(obj, "force_disable_game_modes", false)) {
-        // backwards compatibility
-        g_GameFlow.force_game_modes = TB_OFF;
-    }
-
-    g_GameFlow.force_save_crystals =
-        M_ReadTristateBool(obj, "force_save_crystals");
-    if (JSON_ObjectGetBool(obj, "force_enable_save_crystals", false)) {
-        // backwards compatibility
-        g_GameFlow.force_save_crystals = TB_ON;
-    }
 
     tmp_arr = JSON_ObjectGetArray(obj, "water_color");
     g_GameFlow.water_color.r = 0.6;
@@ -879,7 +865,7 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
     return true;
 }
 
-static bool M_LoadFromFileImpl(const char *file_name)
+bool GameFlow_LoadFromFile(const char *file_name)
 {
     GameFlow_Shutdown();
     bool result = false;
@@ -999,25 +985,6 @@ void GameFlow_Shutdown(void)
         }
         Memory_FreePointer(&g_GameFlow.levels);
     }
-}
-
-bool GameFlow_LoadFromFile(const char *file_name)
-{
-    bool result = M_LoadFromFileImpl(file_name);
-
-    if (g_GameFlow.force_save_crystals == TB_ON) {
-        g_Config.enable_save_crystals = true;
-    } else if (g_GameFlow.force_save_crystals == TB_OFF) {
-        g_Config.enable_save_crystals = false;
-    }
-
-    if (g_GameFlow.force_game_modes == TB_ON) {
-        g_Config.enable_game_modes = true;
-    } else if (g_GameFlow.force_game_modes == TB_OFF) {
-        g_Config.enable_game_modes = false;
-    }
-
-    return result;
 }
 
 GAMEFLOW_COMMAND

--- a/src/tr1/game/gameflow.h
+++ b/src/tr1/game/gameflow.h
@@ -68,8 +68,6 @@ typedef struct {
     char *savegame_fmt_bson;
     int8_t has_demo;
     double demo_delay;
-    TRISTATE_BOOL force_game_modes;
-    TRISTATE_BOOL force_save_crystals;
     GAMEFLOW_LEVEL *levels;
     RGB_F water_color;
     float draw_distance_fade;

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -40,6 +40,8 @@ static const char m_TR1XGameflowPath[] = "cfg/TR1X_gameflow.json5";
 static const char m_TR1XGameflowGoldPath[] = "cfg/TR1X_gameflow_ub.json5";
 static const char m_TR1XGameflowDemoPath[] = "cfg/TR1X_gameflow_demo_pc.json5";
 
+static const char *m_CurrentGameflowPath;
+
 void Shell_Init(const char *gameflow_path)
 {
     Text_Init();
@@ -89,23 +91,24 @@ void Shell_Shutdown(void)
     Log_Shutdown();
 }
 
+const char *Shell_GetGameflowPath(void)
+{
+    return m_CurrentGameflowPath;
+}
+
 void Shell_Main(void)
 {
-    GameString_Init();
-    EnumMap_Init();
-    Config_Init();
-
-    const char *gameflow_path = m_TR1XGameflowPath;
+    m_CurrentGameflowPath = m_TR1XGameflowPath;
 
     char **args = NULL;
     int arg_count = 0;
     S_Shell_GetCommandLine(&arg_count, &args);
     for (int i = 0; i < arg_count; i++) {
         if (!strcmp(args[i], "-gold")) {
-            gameflow_path = m_TR1XGameflowGoldPath;
+            m_CurrentGameflowPath = m_TR1XGameflowGoldPath;
         }
         if (!strcmp(args[i], "-demo_pc")) {
-            gameflow_path = m_TR1XGameflowDemoPath;
+            m_CurrentGameflowPath = m_TR1XGameflowDemoPath;
         }
     }
     for (int i = 0; i < arg_count; i++) {
@@ -113,7 +116,11 @@ void Shell_Main(void)
     }
     Memory_FreePointer(&args);
 
-    Shell_Init(gameflow_path);
+    GameString_Init();
+    EnumMap_Init();
+    Config_Init();
+
+    Shell_Init(m_CurrentGameflowPath);
 
     GAMEFLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
     bool intro_played = false;

--- a/src/tr1/game/shell.h
+++ b/src/tr1/game/shell.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 void Shell_Init(const char *gameflow_path);
+const char *Shell_GetGameflowPath(void);
 void Shell_ProcessInput(void);
 void Shell_Shutdown(void);
 void Shell_Main(void);

--- a/src/tr2/config.c
+++ b/src/tr2/config.c
@@ -3,6 +3,7 @@
 #include "config_map.h"
 #include "game/clock.h"
 #include "game/input.h"
+#include "game/shell.h"
 
 #include <libtrx/config/file.h>
 
@@ -101,9 +102,9 @@ static void M_DumpInputLayout(
     }
 }
 
-const char *Config_GetPath(void)
+const char *Config_GetPath(const CONFIG_FILE_TYPE file_type)
 {
-    return m_ConfigPath;
+    return file_type == CFT_DEFAULT ? m_ConfigPath : Shell_GetGameflowPath();
 }
 
 void Config_LoadFromJSON(JSON_OBJECT *root_obj)

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -28,6 +28,8 @@
 
 #define GAMEBUF_MEM_CAP 0x380000
 
+static const char *m_CurrentGameflowPath = "cfg/TR2X_gameflow.json5";
+
 // TODO: refactor the hell out of me
 void __cdecl Shell_Main(void)
 {
@@ -58,7 +60,7 @@ void __cdecl Shell_Main(void)
         return;
     }
 
-    if (!GF_N_Load("cfg/TR2X_gameflow.json5")) {
+    if (!GF_N_Load(m_CurrentGameflowPath)) {
         Shell_ExitSystem("GameMain: could not load new script file");
         return;
     }
@@ -209,6 +211,11 @@ void __cdecl Shell_ExitSystemFmt(const char *fmt, ...)
     Shell_ExitSystem(message);
 
     Memory_FreePointer(&message);
+}
+
+const char *Shell_GetGameflowPath(void)
+{
+    return m_CurrentGameflowPath;
 }
 
 // TODO: try to call this function in a single place after introducing phasers.

--- a/src/tr2/game/shell/common.h
+++ b/src/tr2/game/shell/common.h
@@ -7,4 +7,5 @@ void __cdecl Shell_Shutdown(void);
 void __cdecl Shell_ExitSystem(const char *message);
 void __cdecl Shell_ExitSystemFmt(const char *fmt, ...);
 
+const char *Shell_GetGameflowPath(void);
 void Shell_ProcessEvents(void);

--- a/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
@@ -146,7 +146,7 @@ public class MainWindowViewModel : BaseLanguageViewModel
     {
         try
         {
-            _configuration.Read(filePath);
+            _configuration.Read(filePath, TRXConstants.Instance.GameflowName);
             SelectedFile = filePath;
             IsEditorDirty = false;
             IsEditorDefault = _configuration.IsDataDefault();

--- a/tools/config/TRX_ConfigToolLib/Models/Specification/Configuration.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/Specification/Configuration.cs
@@ -7,7 +7,7 @@ namespace TRX_ConfigToolLib.Models;
 
 public class Configuration
 {
-    private static readonly string _enforcedKey = "enforced";
+    private static readonly string _enforcedKey = "enforced_config";
     private static readonly string _specificationPath = "Resources.specification.json";
     private static readonly JsonSerializerSettings _serializerSettings = new()
     {
@@ -76,16 +76,22 @@ public class Configuration
         return Properties.Any(p => !p.IsEnabled);
     }
 
-    public void Read(string jsonPath)
+    public void Read(string jsonPath, string enforcedDataName)
     {
         JObject externalData = File.Exists(jsonPath)
             ? JObject.Parse(File.ReadAllText(jsonPath))
             : new();
         JObject activeData = new();
 
-        JObject enforcedData = externalData.ContainsKey(_enforcedKey)
-            ? externalData[_enforcedKey].ToObject<JObject>()
-            : null;
+        string enforcedPath = Path.Combine(Path.GetDirectoryName(jsonPath), enforcedDataName);
+        JObject enforcedData = null;
+        if (File.Exists(enforcedPath))
+        {
+            JObject extraData = JObject.Parse(File.ReadAllText(enforcedPath));
+            enforcedData = extraData.ContainsKey(_enforcedKey)
+                ? extraData[_enforcedKey].ToObject<JObject>()
+                : null;
+        }
 
         foreach (BaseProperty property in Properties)
         {

--- a/tools/config/TRX_ConfigToolLib/Models/TRXConstants.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/TRXConstants.cs
@@ -16,6 +16,7 @@ public class TRXConstants
     public string AppImage { get; set; }
     public string ConfigFilterExtension { get; set; }
     public string ConfigPath { get; set; }
+    public string GameflowName { get; set; }
     public string ExecutableName { get; set; }
     public bool GoldSupported { get; set; }
     public string GoldArgs { get; set; }

--- a/tools/tr1/config/TR1X_ConfigTool/Resources/const.json
+++ b/tools/tr1/config/TR1X_ConfigTool/Resources/const.json
@@ -1,6 +1,7 @@
 {
   "AppImage": "TR1X.png",
   "ConfigPath": "cfg\\TR1X.json5",
+  "GameflowName": "TR1X_gameflow.json5",
   "ExecutableName": "TR1X.exe",
   "GoldSupported": true,
   "GitHubURL": "https://github.com/LostArtefacts/TRX"

--- a/tools/tr2/config/TR2X_ConfigTool/Resources/const.json
+++ b/tools/tr2/config/TR2X_ConfigTool/Resources/const.json
@@ -1,6 +1,7 @@
 {
   "AppImage": "TR2X.png",
   "ConfigPath": "cfg\\TR2X.json5",
+  "GameflowName": "TR2X_gameflow.json5",
   "ExecutableName": "TR2X.exe",
   "GoldSupported": false,
   "GitHubURL": "https://github.com/LostArtefacts/TRX"


### PR DESCRIPTION
Resolves #1857.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

~~This removes the dedicated enforced game modes and save crystals settings from the gameflow files, as these can now be controlled by builders in the main config file. The only exception is the UB gameflow, as we need to continue enforcing save crystals to be disabled there, and this can't be done through the config file. As a result, backwards compatibility is in place as standard with this, while the documentation points to the correct procedure for enforcing settings.~~

~~LMK if you think we can remove backwards compatibility for `force_game_modes`, I'm inclined to perhaps leave it for a while.~~

This refactors the enforced config control from #1854 into the gameflow and removes the legacy settings for enforcing game modes and save crystals.
