### PR TITLE
boat/skidoo: fix Lara getting stuck in her hit animation

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -51,6 +51,7 @@
 - fixed game stuck at remapping controller key if no controllers connected (#1788)
 - fixed being able to shoot the scion multiple times if save/load is used while it blows up (#1819)
 - fixed certain erroneous `/play` invocations resulting in duplicated error messages
+- fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -37,6 +37,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed harpoon bolts damaging inactive enemies
 - fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed new saves not displaying the save count in the passport
+- fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo
 
 #### Cheats
 - added a fly cheat

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -230,6 +230,7 @@ void __cdecl Skidoo_Collision(
     lara_item->current_anim_state = LARA_STATE_SKIDOO_GET_ON;
     lara_item->frame_num = g_Anims[lara_item->anim_num].frame_base;
     g_Lara.gun_status = LGS_ARMLESS;
+    g_Lara.hit_direction = -1;
 
     ITEM *const item = &g_Items[item_num];
     lara_item->pos.x = item->pos.x;

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -183,6 +183,7 @@ void __cdecl Boat_Collision(
     }
 
     g_Lara.water_status = LWS_ABOVE_WATER;
+    g_Lara.hit_direction = -1;
 
     ITEM *const boat = &g_Items[item_num];
 


### PR DESCRIPTION
Resolves #1606.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo. This fix is the same as what TR3 does with the quad bike.
