### PR TITLE
libtrx/console: fix play_level command action

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed being able to shoot the scion multiple times if save/load is used while it blows up (#1819)
 - fixed certain erroneous `/play` invocations resulting in duplicated error messages
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)
+- fixed the `/play` console command resulting in Lara starting the target level without pistols (#1861, regression from 4.5)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)

--- a/src/libtrx/game/console/cmd/play_level.c
+++ b/src/libtrx/game/console/cmd/play_level.c
@@ -57,7 +57,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 matched:
     if (level_to_load >= 0 && level_to_load < Gameflow_GetLevelCount()) {
         Gameflow_OverrideCommand((GAMEFLOW_COMMAND) {
-            .action = GF_START_GAME,
+            .action = GF_SELECT_GAME,
             .param = level_to_load,
         });
         Console_Log(GS(OSD_PLAY_LEVEL), Gameflow_GetLevelTitle(level_to_load));

--- a/src/tr2/game/gameflow/gameflow_new.c
+++ b/src/tr2/game/gameflow/gameflow_new.c
@@ -241,6 +241,7 @@ void Gameflow_OverrideCommand(const GAMEFLOW_COMMAND command)
 {
     switch (command.action) {
     case GF_START_GAME:
+    case GF_SELECT_GAME:
         g_GF_OverrideDir = GFD_START_GAME | command.param;
         break;
     case GF_START_SAVED_GAME:


### PR DESCRIPTION
Resolves #1861.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This sets the action for `/play` commands to `GF_SELECT_GAME` rather than `GF_START_GAME`, so that resume info can be properly calculated. While TR2 wasn't affected, it should also be tested here as it's impacted by the change.
