### PR TITLE
tr2/output: fix drawing certain rooms

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.6...develop) - ××××-××-××
 - added support for custom levels to enforce values for any config setting (#1846)
+- fixed depth problems when drawing certain rooms (#1853, regression from 0.6)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -403,6 +403,13 @@ void __cdecl Output_Init(
 
 void __cdecl Output_InsertPolygons(const int16_t *obj_ptr, const int32_t clip)
 {
+    g_FltWinLeft = g_PhdWinMinX + g_PhdWinLeft;
+    g_FltWinTop = g_PhdWinMinY + g_PhdWinTop;
+    g_FltWinRight = g_PhdWinRight + g_PhdWinMinX + 1;
+    g_FltWinBottom = g_PhdWinBottom + g_PhdWinMinY + 1;
+    g_FltWinCenterX = g_PhdWinMinX + g_PhdWinCenterX;
+    g_FltWinCenterY = g_PhdWinMinY + g_PhdWinCenterY;
+
     obj_ptr = Output_CalcObjectVertices(obj_ptr + 4);
     if (obj_ptr) {
         obj_ptr = Output_CalcVerticeLight(obj_ptr);
@@ -424,6 +431,13 @@ void __cdecl Output_InsertPolygons_I(
 
 void __cdecl Output_InsertRoom(const int16_t *obj_ptr, int32_t is_outside)
 {
+    g_FltWinLeft = g_PhdWinMinX + g_PhdWinLeft;
+    g_FltWinTop = g_PhdWinMinY + g_PhdWinTop;
+    g_FltWinRight = g_PhdWinRight + g_PhdWinMinX + 1;
+    g_FltWinBottom = g_PhdWinBottom + g_PhdWinMinY + 1;
+    g_FltWinCenterX = g_PhdWinMinX + g_PhdWinCenterX;
+    g_FltWinCenterY = g_PhdWinMinY + g_PhdWinCenterY;
+
     const int16_t *const old_obj_ptr = obj_ptr;
     obj_ptr = Output_CalcRoomVertices(obj_ptr, is_outside ? 0 : 16);
 
@@ -449,6 +463,13 @@ void __cdecl Output_InsertRoom(const int16_t *obj_ptr, int32_t is_outside)
 
 void __cdecl Output_InsertSkybox(const int16_t *obj_ptr)
 {
+    g_FltWinLeft = g_PhdWinMinX + g_PhdWinLeft;
+    g_FltWinTop = g_PhdWinMinY + g_PhdWinTop;
+    g_FltWinRight = g_PhdWinRight + g_PhdWinMinX + 1;
+    g_FltWinBottom = g_PhdWinBottom + g_PhdWinMinY + 1;
+    g_FltWinCenterX = g_PhdWinMinX + g_PhdWinCenterX;
+    g_FltWinCenterY = g_PhdWinMinY + g_PhdWinCenterY;
+
     obj_ptr = Output_CalcObjectVertices(obj_ptr + 4);
     if (obj_ptr) {
         if (g_SavedAppSettings.render_mode == RM_HARDWARE) {

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -403,8 +403,8 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
     const int32_t vp_x = vp_src_x + (vp_dst_x - vp_src_x) * ease;
     const int32_t vp_y = vp_src_y + (vp_dst_y - vp_src_y) * ease;
 
-    g_FltWinCenterX = vp_x;
-    g_FltWinCenterY = vp_y;
+    g_PhdWinCenterX = vp_x;
+    g_PhdWinCenterY = vp_y;
 
     Matrix_PushUnit();
     Matrix_TranslateRel(0, 0, scale);

--- a/src/tr2/game/viewport.c
+++ b/src/tr2/game/viewport.c
@@ -19,11 +19,8 @@ static void M_Apply(void)
     g_PhdWinMaxY = m_Viewport.height - 1;
     g_PhdWinWidth = m_Viewport.width;
     g_PhdWinHeight = m_Viewport.height;
-
     g_PhdWinCenterX = m_Viewport.width / 2;
     g_PhdWinCenterY = m_Viewport.height / 2;
-    g_FltWinCenterX = m_Viewport.width / 2;
-    g_FltWinCenterY = m_Viewport.height / 2;
 
     g_PhdWinLeft = 0;
     g_PhdWinTop = 0;
@@ -37,13 +34,6 @@ static void M_Apply(void)
 
     g_PhdNearZ = m_Viewport.near_z << W2V_SHIFT;
     g_PhdFarZ = m_Viewport.far_z << W2V_SHIFT;
-
-    g_FltWinLeft = g_PhdWinMinX + g_PhdWinLeft;
-    g_FltWinTop = g_PhdWinMinY + g_PhdWinTop;
-    g_FltWinRight = g_PhdWinRight + g_PhdWinMinX + 1;
-    g_FltWinBottom = g_PhdWinBottom + g_PhdWinMinY + 1;
-    g_FltWinCenterX = g_PhdWinMinX + g_PhdWinCenterX;
-    g_FltWinCenterY = g_PhdWinMinY + g_PhdWinCenterY;
 
     g_FltNearZ = g_PhdNearZ;
     g_FltFarZ = g_PhdFarZ;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Regression from 6c36549, related to centering the 3d pickups in the UI. Resolves #1853.