### PR TITLE
tr2/lara/state: fix surface to swim input check

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.6...develop) - ××××-××-××
 - added support for custom levels to enforce values for any config setting (#1846)
 - fixed depth problems when drawing certain rooms (#1853, regression from 0.6)
+- fixed being unable to go from surface swimming to underwater swimming without first stopping (#1863, regression from 0.6)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -909,7 +909,7 @@ void __cdecl Lara_State_SurfSwim(ITEM *item, COLL_INFO *coll)
     } else if (g_Input.right) {
         item->rot.y += LARA_SLOW_TURN;
     }
-    if (!g_Input.forward || g_Input.back) {
+    if (!g_Input.forward || g_Input.jump) {
         item->goal_anim_state = LS_SURF_TREAD;
     }
     item->fall_speed += 8;


### PR DESCRIPTION
Resolves #1863.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Before the input refactor in https://github.com/LostArtefacts/TRX/commit/d22d495e4690ba3300f49bcf4b7272c12601f780, the check was `!(g_Input & LS_RUN) || (g_Input & LS_BACK)` - but this should have been `!(g_Input & IN_FORWARD) || (g_Input & IN_JUMP)`. `LS_RUN` and `LS_BACK` are states, which happen to have the same values as 
`IN_FORWARD` and `IN_JUMP`. So in the refactor, `LS_BACK` was converted to `g_Input.back` rather than `g_Input.jump`.

https://github.com/LostArtefacts/TRX/commit/d22d495e4690ba3300f49bcf4b7272c12601f780#diff-f7b5cbdc56e281149ad2c9907db8c2f8dc2ef61171e00fe274f405e2e444ee73L914

This also introduced a bug where you could hold forward and backwards on the water surface, and Lara would gradually move forward, come to a stop, then continue, which isn't present in OG.

I've checked for other cases of potential `LS_` usage as inputs in the code before the input refactor and this was the only case.
