### PR TITLE
mutant: fix explosion damage

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed certain erroneous `/play` invocations resulting in duplicated error messages
 - fixed the `/play` console command resulting in Lara starting the target level without pistols (#1861, regression from 4.5)
 - fixed the demo mode text overlapping with the enemy health bar if the health bar is located in the bottom centered (#1446)
+- fixed mutant explosions sometimes heavily damaging Lara even if they missed (#1758, regression since 4.5)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -61,6 +61,7 @@
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)
+- improved the exploding Lara input cheat to always use explosion sprites
 - removed health cheat (we now have the `/hp` command)
 - removed background for the "Reset" and "Unbind" labels in the controls dialog
 - removed `force_game_modes` and `force_save_crystals` from the gameflow - see GAMEFLOW.md for details on how to enforce these settings (#1857)

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -114,7 +114,7 @@ void Lara_Cheat_Control(void)
                 g_Lara.uzis.ammo = 5000;
                 Sound_Effect(SFX_LARA_HOLSTER, NULL, SPM_ALWAYS);
             } else if (as == LS_SWAN_DIVE) {
-                Effect_ExplodingDeath(g_Lara.item_num, -1, 0);
+                Effect_ExplodingDeath(g_Lara.item_num, -1, 1);
                 Sound_Effect(SFX_EXPLOSION_CHEAT, &g_LaraItem->pos, SPM_NORMAL);
                 g_LaraItem->hit_points = 0;
                 g_LaraItem->flags |= IF_INVISIBLE;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -123,16 +123,15 @@ void Mutant_FlyerControl(int16_t item_num)
     int16_t angle = 0;
 
     if (item->hit_points <= 0) {
-        if (Effect_ExplodingDeath(
-                item_num, -1,
-                m_EnableExplosions ? FLYER_SMARTNESS : -FLYER_PART_DAMAGE)) {
-            Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
-            LOT_DisableBaddieAI(item_num);
-            Item_Kill(item_num);
-            item->status = IS_DEACTIVATED;
-            Carrier_TestItemDrops(item_num);
-            return;
-        }
+        Effect_ExplodingDeath(
+            item_num, -1,
+            m_EnableExplosions ? FLYER_PART_DAMAGE : -FLYER_PART_DAMAGE);
+        Sound_Effect(SFX_ATLANTEAN_DEATH, &item->pos, SPM_NORMAL);
+        LOT_DisableBaddieAI(item_num);
+        Item_Kill(item_num);
+        item->status = IS_DEACTIVATED;
+        Carrier_TestItemDrops(item_num);
+        return;
     } else {
         flyer->lot.step = STEP_L;
         flyer->lot.drop = -STEP_L;


### PR DESCRIPTION
Resolves #1758.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed mutant explosions sometimes heavily damaging Lara even if they missed.