### PR TITLE
tr2/lara/cheat: reset hands in fly cheat

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed depth problems when drawing certain rooms (#1853, regression from 0.6)
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)
 - fixed being unable to go from surface swimming to underwater swimming without first stopping (#1863, regression from 0.6)
+- fixed pistols appearing in Lara's hands when entering the fly cheat during certain animations (#1874)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -121,6 +121,10 @@ bool Lara_Cheat_EnterFlyMode(void)
         M_ResetGunStatus();
     }
 
+    if (g_Lara.gun_status == LGS_HANDS_BUSY) {
+        g_Lara.gun_status = LGS_ARMLESS;
+    }
+
     Lara_GetOffVehicle();
 
     if (g_Lara.water_status != LWS_UNDERWATER || g_LaraItem->hit_points <= 0) {


### PR DESCRIPTION
Resolves #1874.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This resets Lara's hands when entering the fly cheat and they are currently busy, such as when grabbing a pushblock or climbing.
