### PR TITLE
tr2/lara/state: stop walking when killed

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)
 - fixed being unable to go from surface swimming to underwater swimming without first stopping (#1863, regression from 0.6)
 - fixed pistols appearing in Lara's hands when entering the fly cheat during certain animations (#1874)
+- fixed Lara continuing to walk after being killed if in that animation (#1880, regression from 0.1)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -38,6 +38,7 @@ void __cdecl Lara_State_Walk(ITEM *item, COLL_INFO *coll)
 {
     if (item->hit_points <= 0) {
         item->goal_anim_state = LS_STOP;
+        return;
     }
 
     if (g_Input.left) {


### PR DESCRIPTION
Resolves #1880.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This now matches TR1. I think the return statement was missed in decomp as it's not there in the TR2X history.
