### PR TITLE
overlay: fix demo text overlapping with bottom center enemy bar

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -56,6 +56,7 @@
 - fixed being able to shoot the scion multiple times if save/load is used while it blows up (#1819)
 - fixed certain erroneous `/play` invocations resulting in duplicated error messages
 - fixed the `/play` console command resulting in Lara starting the target level without pistols (#1861, regression from 4.5)
+- fixed the demo mode text overlapping with the enemy health bar if the health bar is located in the bottom centered (#1446)
 - improved enemy item drops by supporting the TR2+ approach of having drops defined in level data (#1713)
 - improved Italian localization for the Config Tool
 - improved the injection approach for Lara's responsive jumping (#1823)

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -139,6 +139,7 @@ static void M_ResetBarLocations(void);
 static void M_RemoveAmmoText(void);
 static void M_DrawAmmoInfo(void);
 static void M_DrawPickups(void);
+static double M_GetBarToTextScale(void);
 
 static void M_BarSetupHealth(void)
 {
@@ -237,17 +238,23 @@ static void M_BarGetLocation(
             - m_BarOffsetY[bar_info->location];
     }
 
-    if (Phase_Get() == PHASE_INVENTORY
+    if (Phase_Get() == PHASE_DEMO && bar_info->location == BL_BOTTOM_CENTER) {
+        *y -= M_GetBarToTextScale() * (TEXT_HEIGHT + bar_spacing);
+    } else if (
+        Phase_Get() == PHASE_INVENTORY
         && g_CurrentLevel == g_GameFlow.title_level_num
         && (bar_info->location == BL_TOP_CENTER
             || bar_info->location == BL_BOTTOM_CENTER)) {
-        double scale_bar_to_text =
-            g_Config.ui.text_scale / g_Config.ui.bar_scale;
         *y = screen_margin_v + m_BarOffsetY[bar_info->location]
-            + scale_bar_to_text * (TEXT_HEIGHT + bar_spacing);
+            + M_GetBarToTextScale() * (TEXT_HEIGHT + bar_spacing);
     }
 
     m_BarOffsetY[bar_info->location] += *height + bar_spacing;
+}
+
+static double M_GetBarToTextScale(void)
+{
+    return g_Config.ui.text_scale / g_Config.ui.bar_scale;
 }
 
 void Overlay_BarDraw(BAR_INFO *bar_info, RENDER_SCALE_REF scale_ref)


### PR DESCRIPTION
Resolves #1446.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Fixed the demo mode text overlapping with the enemy health bar if the health bar is located in the bottom centered. Fix courtesy of Lahm!