### PR TITLE
tr2/room: refactor floor data handling

### DIFF
--- a/docs/tr2/progress.svg
+++ b/docs/tr2/progress.svg
@@ -253,7 +253,7 @@
 <rect width="12" height="12" x="360" y="45" class="decompiled"><title>void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);</title></rect>
 <rect width="12" height="12" x="375" y="45" class="decompiled"><title>int32_t __cdecl Item_IsTriggerActive(ITEM *item);</title></rect>
 <rect width="12" height="12" x="390" y="45" class="decompiled"><title>int32_t __cdecl Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);</title></rect>
-<rect width="12" height="12" x="405" y="45" class="decompiled"><title>int16_t __cdecl Room_GetDoor(const SECTOR *sector);</title></rect>
+<rect width="12" height="12" x="405" y="45" class="decompiled"><title>int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *sector);</title></rect>
 <rect width="12" height="12" x="420" y="45" class="decompiled"><title>int32_t __cdecl LOS_Check(const GAME_VECTOR *start, GAME_VECTOR *target);</title></rect>
 <rect width="12" height="12" x="435" y="45" class="decompiled"><title>int32_t __cdecl LOS_CheckZ(const GAME_VECTOR *start, GAME_VECTOR *target);</title></rect>
 <rect width="12" height="12" x="450" y="45" class="decompiled"><title>int32_t __cdecl LOS_CheckX(const GAME_VECTOR *start, GAME_VECTOR *target);</title></rect>
@@ -2126,7 +2126,7 @@
 <rect width="4.94" height="5.26" x="624.52" y="337.03" class="decompiled"><title>void __cdecl LOT_DisableBaddieAI(int16_t item_num);</title></rect>
 <rect width="4.94" height="5.26" x="624.52" y="345.29" class="decompiled"><title>void __cdecl Trapdoor_Control(int16_t item_num);</title></rect>
 <rect width="4.94" height="5.15" x="624.52" y="353.54" class="decompiled"><title>void __cdecl Creature_Neck(ITEM *item, int16_t required);</title></rect>
-<rect width="4.94" height="5.15" x="624.52" y="361.70" class="decompiled"><title>int16_t __cdecl Room_GetDoor(const SECTOR *sector);</title></rect>
+<rect width="4.94" height="5.15" x="624.52" y="361.70" class="decompiled"><title>int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *sector);</title></rect>
 <rect width="4.94" height="5.15" x="624.52" y="369.85" class="decompiled"><title>void __cdecl Gun_Pistols_DrawMeshes(LARA_GUN_TYPE weapon_type);</title></rect>
 <rect width="4.97" height="5.12" x="632.45" y="252.89" class="decompiled"><title>int32_t __cdecl MovableBlock_TestDestination(ITEM *item, int32_t block_height);</title></rect>
 <rect width="4.97" height="5.12" x="640.42" y="252.89" class="known"><title>void __cdecl GunFlash_Control(int16_t fx_num);</title></rect>

--- a/docs/tr2/progress.svg
+++ b/docs/tr2/progress.svg
@@ -249,8 +249,8 @@
 <rect width="12" height="12" x="300" y="45" class="decompiled"><title>SECTOR *__cdecl Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);</title></rect>
 <rect width="12" height="12" x="315" y="45" class="decompiled"><title>int32_t __cdecl Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num);</title></rect>
 <rect width="12" height="12" x="330" y="45" class="decompiled"><title>int32_t __cdecl Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);</title></rect>
-<rect width="12" height="12" x="345" y="45" class="decompiled"><title>void __cdecl Camera_RefreshFromTrigger(int16_t type, const int16_t *data);</title></rect>
-<rect width="12" height="12" x="360" y="45" class="decompiled"><title>void __cdecl Room_TestTriggers(int16_t *data, int32_t heavy);</title></rect>
+<rect width="12" height="12" x="345" y="45" class="decompiled"><title>void __cdecl Camera_Legacy_RefreshFromTrigger(int16_t type, const int16_t *data);</title></rect>
+<rect width="12" height="12" x="360" y="45" class="decompiled"><title>void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);</title></rect>
 <rect width="12" height="12" x="375" y="45" class="decompiled"><title>int32_t __cdecl Item_IsTriggerActive(ITEM *item);</title></rect>
 <rect width="12" height="12" x="390" y="45" class="decompiled"><title>int32_t __cdecl Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);</title></rect>
 <rect width="12" height="12" x="405" y="45" class="decompiled"><title>int16_t __cdecl Room_GetDoor(const SECTOR *sector);</title></rect>
@@ -262,7 +262,7 @@
 <rect width="12" height="12" x="495" y="45" class="decompiled"><title>void __cdecl Room_FlipMap(void);</title></rect>
 <rect width="12" height="12" x="510" y="45" class="decompiled"><title>void __cdecl Room_RemoveFlipItems(ROOM *r);</title></rect>
 <rect width="12" height="12" x="525" y="45" class="decompiled"><title>void __cdecl Room_AddFlipItems(ROOM *r);</title></rect>
-<rect width="12" height="12" x="540" y="45" class="decompiled"><title>void __cdecl Room_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);</title></rect>
+<rect width="12" height="12" x="540" y="45" class="decompiled"><title>void __cdecl Room_Legacy_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);</title></rect>
 <rect width="12" height="12" x="555" y="45" class="decompiled"><title>void __cdecl Room_TriggerMusicTrackImpl(int16_t value, int16_t flags, int16_t type);</title></rect>
 <rect width="12" height="12" x="570" y="45" class="decompiled"><title>int32_t __cdecl Demo_Control(int32_t level_num);</title></rect>
 <rect width="12" height="12" x="585" y="45" class="decompiled"><title>int32_t __cdecl Demo_Start(int32_t level_num);</title></rect>
@@ -1352,7 +1352,7 @@
 <rect width="35.20" height="35.66" x="104.13" y="120.85" class="decompiled"><title>void __cdecl Option_Controls(INVENTORY_ITEM *item);</title></rect>
 <rect width="35.20" height="34.90" x="104.13" y="159.51" class="decompiled"><title>BOOL __cdecl GF_LoadFromFile(const char *file_name);</title></rect>
 <rect width="35.20" height="34.49" x="104.13" y="197.42" class="decompiled"><title>int32_t __cdecl Inv_AddItem(GAME_OBJECT_ID object_id);</title></rect>
-<rect width="35.20" height="33.49" x="104.13" y="234.91" class="decompiled"><title>void __cdecl Room_TestTriggers(int16_t *data, int32_t heavy);</title></rect>
+<rect width="35.20" height="33.49" x="104.13" y="234.91" class="decompiled"><title>void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);</title></rect>
 <rect width="35.20" height="33.06" x="104.13" y="271.40" class="decompiled"><title>void __cdecl Collide_GetCollisionInfo(COLL_INFO *coll, int32_t xpos, int32_t ypos, int32_t zpos, int16_t room_num, int32_t obj_height);</title></rect>
 <rect width="35.20" height="32.62" x="104.13" y="307.45" class="decompiled"><title>void __cdecl Lara_Control(int16_t item_num);</title></rect>
 <rect width="35.20" height="31.93" x="104.13" y="343.07" class="decompiled"><title>void __cdecl Option_Passport(INVENTORY_ITEM *item);</title></rect>
@@ -1720,7 +1720,7 @@
 <rect width="10.64" height="11.11" x="494.60" y="224.01" class="known"><title>void __cdecl Output_CalculateObjectLighting(const ITEM *item, const BOUNDS_16 *bounds);</title></rect>
 <rect width="10.64" height="11.11" x="494.60" y="238.12" class="decompiled"><title>BOOL __stdcall DInputEnumDevicesCallback(LPCDIDEVICEINSTANCE lpddi, LPVOID pvRef);</title></rect>
 <rect width="10.64" height="11.11" x="494.60" y="252.23" class="known"><title>void __cdecl CalculateWibbleTable(void);</title></rect>
-<rect width="10.64" height="11.05" x="494.60" y="266.34" class="decompiled"><title>void __cdecl Camera_RefreshFromTrigger(int16_t type, const int16_t *data);</title></rect>
+<rect width="10.64" height="11.05" x="494.60" y="266.34" class="decompiled"><title>void __cdecl Camera_Legacy_RefreshFromTrigger(int16_t type, const int16_t *data);</title></rect>
 <rect width="10.64" height="11.05" x="494.60" y="280.39" class="decompiled"><title>int32_t __cdecl Lara_TestWaterStepOut(ITEM *item, COLL_INFO *coll);</title></rect>
 <rect width="10.64" height="11.05" x="494.60" y="294.43" class="decompiled"><title>int32_t __cdecl S_Audio_Sample_Play(int32_t sample_id, int32_t volume, int32_t pitch, int32_t pan, int32_t flags);</title></rect>
 <rect width="10.64" height="10.99" x="494.60" y="308.48" class="decompiled"><title>void __cdecl Lara_TouchLava(ITEM *item);</title></rect>
@@ -2374,7 +2374,7 @@
 <rect width="2.47" height="2.62" x="687.21" y="372.38" class="decompiled"><title>HRESULT __cdecl WinVidBufferUnlock(LPDDS surface, LPDDSDESC desc);</title></rect>
 <rect width="2.88" height="2.22" x="692.67" y="320.63" class="known"><title>LPDIRECT3DTEXTURE2 __cdecl Create3DTexture(LPDDS surface);</title></rect>
 <rect width="2.88" height="2.22" x="698.55" y="320.63" class="known"><title>HRESULT __cdecl EnumerateTextureFormats(void);</title></rect>
-<rect width="2.72" height="2.22" x="704.43" y="320.63" class="decompiled"><title>void __cdecl Room_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);</title></rect>
+<rect width="2.72" height="2.22" x="704.43" y="320.63" class="decompiled"><title>void __cdecl Room_Legacy_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);</title></rect>
 <rect width="2.72" height="2.22" x="710.14" y="320.63" class="decompiled"><title>void __cdecl FX_AssaultStart(ITEM *item);</title></rect>
 <rect width="2.72" height="2.22" x="715.86" y="320.63" class="decompiled"><title>void __cdecl Inv_RemoveInventoryText(void);</title></rect>
 <rect width="2.72" height="2.22" x="721.58" y="320.63" class="decompiled"><title>void __cdecl Sound_Shutdown(void);</title></rect>

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -4513,7 +4513,7 @@ typedef enum {
 0x00526188  -       MATRIX *g_IMMatrixPtr;
 0x0052618C  -       ROOM *g_Rooms;
 0x00526240  -       int32_t g_FlipStatus;
-0x00526288  -       int16_t *g_TriggerIndex;
+0x00526288  -       int16_t *g_Legacy_TriggerIndex;
 0x005262A0  -       int32_t g_LOSRooms[20];
 0x005262F0  -       ITEM *g_Items;
 0x005262F6  -       int16_t g_NumCineFrames;

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -3085,7 +3085,7 @@ typedef enum {
 0x004151F0  0x0690  +       void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);
 0x004158D0  0x0055  +       int32_t __cdecl Item_IsTriggerActive(ITEM *item);
 0x00415930  0x023D  +       int32_t __cdecl Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-0x00415B90  0x004E  +       int16_t __cdecl Room_GetDoor(const SECTOR *sector);
+0x00415B90  0x004E  +       int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *sector);
 0x00415BE0  0x00A0  +       int32_t __cdecl LOS_Check(const GAME_VECTOR *start, GAME_VECTOR *target);
 0x00415C80  0x02EB  +       int32_t __cdecl LOS_CheckZ(const GAME_VECTOR *start, GAME_VECTOR *target);
 0x00415F70  0x02EC  +       int32_t __cdecl LOS_CheckX(const GAME_VECTOR *start, GAME_VECTOR *target);

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -2695,7 +2695,7 @@ typedef struct __unaligned {
     int16_t mesh_rots[];
 } FRAME_INFO;
 
-typedef enum {
+typedef enum { // decompiled
     TO_OBJECT      = 0,
     TO_CAMERA      = 1,
     TO_SINK        = 2,
@@ -2710,7 +2710,7 @@ typedef enum {
     TO_BODY_BAG    = 11,
 } TRIGGER_OBJECT;
 
-typedef enum {
+typedef enum { // decompiled
     TT_TRIGGER     = 0,
     TT_PAD         = 1,
     TT_SWITCH      = 2,
@@ -3081,8 +3081,8 @@ typedef enum {
 0x00414B70  0x0198  +       SECTOR *__cdecl Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
 0x00414D10  0x0168  +       int32_t __cdecl Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num);
 0x00414E80  0x0265  +       int32_t __cdecl Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-0x00415100  0x00E7  +       void __cdecl Camera_RefreshFromTrigger(int16_t type, const int16_t *data);
-0x004151F0  0x0690  +       void __cdecl Room_TestTriggers(int16_t *data, int32_t heavy);
+0x00415100  0x00E7  +       void __cdecl Camera_Legacy_RefreshFromTrigger(int16_t type, const int16_t *data);
+0x004151F0  0x0690  +       void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);
 0x004158D0  0x0055  +       int32_t __cdecl Item_IsTriggerActive(ITEM *item);
 0x00415930  0x023D  +       int32_t __cdecl Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 0x00415B90  0x004E  +       int16_t __cdecl Room_GetDoor(const SECTOR *sector);
@@ -3094,7 +3094,7 @@ typedef enum {
 0x00416640  0x00B3  +       void __cdecl Room_FlipMap(void);
 0x00416700  0x0096  +       void __cdecl Room_RemoveFlipItems(ROOM *r);
 0x004167A0  0x005C  +       void __cdecl Room_AddFlipItems(ROOM *r);
-0x00416800  0x0024  +       void __cdecl Room_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);
+0x00416800  0x0024  +       void __cdecl Room_Legacy_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);
 0x00416830  0x00DA  +       void __cdecl Room_TriggerMusicTrackImpl(int16_t value, int16_t flags, int16_t type);
 
 # game/demo.c

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -4593,7 +4593,7 @@ typedef enum {
 0x00466BDC  -       int32_t g_PaletteIndex;
 0x00519F78  -       int32_t g_HWR_TexturePageIndexes[32]; // MAX_TEXTURE_PAGES
 0x004D7790  -       int32_t g_HeightType;
-0x004D9D94  -       int16_t *g_FloorData;
+0x004D9D94  -       int16_t *g_Legacy_FloorData;
 0x00525B08  -       int16_t *g_AnimCommands;
 0x0052617C  -       ANIM_CHANGE *g_AnimChanges;
 0x00525B04  -       ANIM_RANGE *g_AnimRanges;

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -3,6 +3,8 @@
 #include "game/const.h"
 #include "utils.h"
 
+#include <stddef.h>
+
 void Item_TakeDamage(
     ITEM *const item, const int16_t damage, const bool hit_status)
 {
@@ -18,4 +20,16 @@ void Item_TakeDamage(
     if (hit_status) {
         item->hit_status = 1;
     }
+}
+
+ITEM *Item_Find(const GAME_OBJECT_ID object_id)
+{
+    for (int32_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
+        ITEM *const item = Item_Get(item_num);
+        if (item->object_id == object_id) {
+            return item;
+        }
+    }
+
+    return NULL;
 }

--- a/src/libtrx/include/libtrx/game/collision.h
+++ b/src/libtrx/include/libtrx/game/collision.h
@@ -63,7 +63,7 @@ typedef struct __PACKING {
     int16_t facing;
     int16_t quadrant;
     int16_t coll_type;
-    int16_t *trigger;
+    int16_t *trigger; // TODO: linked to g_TriggerIndex, so to be eliminated
     int8_t x_tilt;
     int8_t z_tilt;
     int8_t hit_by_baddie;

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 ITEM *Item_Get(int16_t num);
+ITEM *Item_Find(GAME_OBJECT_ID object_id);
 int32_t Item_GetTotalCount(void);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);

--- a/src/libtrx/include/libtrx/game/rooms/enum.h
+++ b/src/libtrx/include/libtrx/game/rooms/enum.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#if TR_VERSION == 1
 typedef enum {
     TO_OBJECT = 0,
     TO_CAMERA = 1,
@@ -13,6 +12,9 @@ typedef enum {
     TO_CD = 8,
     TO_FLIPEFFECT = 9,
     TO_SECRET = 10,
+#if TR_VERSION == 2
+    TO_BODY_BAG = 11,
+#endif
 } TRIGGER_OBJECT;
 
 typedef enum {
@@ -25,8 +27,10 @@ typedef enum {
     TT_ANTIPAD = 6,
     TT_COMBAT = 7,
     TT_DUMMY = 8,
-} TRIGGER_TYPE;
+#if TR_VERSION == 2
+    TT_ANTITRIGGER = 9,
 #endif
+} TRIGGER_TYPE;
 
 #if TR_VERSION == 2
 typedef enum {

--- a/src/libtrx/include/libtrx/game/rooms/enum.h
+++ b/src/libtrx/include/libtrx/game/rooms/enum.h
@@ -27,3 +27,13 @@ typedef enum {
     TT_DUMMY = 8,
 } TRIGGER_TYPE;
 #endif
+
+#if TR_VERSION == 2
+typedef enum {
+    LADDER_NONE = 0,
+    LADDER_NORTH = 1 << 0,
+    LADDER_EAST = 1 << 1,
+    LADDER_SOUTH = 1 << 2,
+    LADDER_WEST = 1 << 3,
+} LADDER_DIRECTION;
+#endif

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -60,8 +60,11 @@ typedef struct __PACKING {
 typedef struct __PACKING {
     uint16_t idx;
     int16_t box;
-    uint8_t pit_room;
-    uint8_t sky_room;
+    struct __PACKING {
+        uint8_t pit;
+        uint8_t sky;
+        int16_t wall;
+    } portal_room;
     struct __PACKING {
         int16_t height;
         int16_t tilt;

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -64,6 +64,7 @@ typedef struct __PACKING {
     uint8_t sky_room;
     struct __PACKING {
         int16_t height;
+        int16_t tilt;
     } floor, ceiling;
 } SECTOR;
 #endif

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -61,6 +61,7 @@ typedef struct __PACKING {
     uint16_t idx;
     int16_t box;
     bool is_death_sector;
+    LADDER_DIRECTION ladder;
     struct __PACKING {
         uint8_t pit;
         uint8_t sky;

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -61,9 +61,10 @@ typedef struct __PACKING {
     uint16_t idx;
     int16_t box;
     uint8_t pit_room;
-    int8_t floor;
     uint8_t sky_room;
-    int8_t ceiling;
+    struct __PACKING {
+        int16_t height;
+    } floor, ceiling;
 } SECTOR;
 #endif
 

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -38,28 +38,13 @@ typedef struct __PACKING {
     PORTAL portal[];
 } PORTALS;
 
-#if TR_VERSION == 1
 typedef struct __PACKING {
     uint16_t idx;
     int16_t box;
     bool is_death_sector;
-    TRIGGER *trigger;
-    struct __PACKING {
-        uint8_t pit;
-        uint8_t sky;
-        int16_t wall;
-    } portal_room;
-    struct __PACKING {
-        int16_t height;
-        int16_t tilt;
-    } floor, ceiling;
-} SECTOR;
-#elif TR_VERSION == 2
-typedef struct __PACKING {
-    uint16_t idx;
-    int16_t box;
-    bool is_death_sector;
+#if TR_VERSION == 2
     LADDER_DIRECTION ladder;
+#endif
     TRIGGER *trigger;
     struct __PACKING {
         uint8_t pit;
@@ -71,7 +56,6 @@ typedef struct __PACKING {
         int16_t tilt;
     } floor, ceiling;
 } SECTOR;
-#endif
 
 typedef struct __PACKING {
     XYZ_32 pos;

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -5,7 +5,6 @@
 
 #include <stdbool.h>
 
-#if TR_VERSION == 1
 typedef struct __PACKING {
     TRIGGER_OBJECT type;
     void *parameter;
@@ -27,7 +26,6 @@ typedef struct __PACKING {
     int32_t command_count;
     TRIGGER_CMD *commands;
 } TRIGGER;
-#endif
 
 typedef struct __PACKING {
     int16_t room_num;
@@ -62,6 +60,7 @@ typedef struct __PACKING {
     int16_t box;
     bool is_death_sector;
     LADDER_DIRECTION ladder;
+    TRIGGER *trigger;
     struct __PACKING {
         uint8_t pit;
         uint8_t sky;

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -60,6 +60,7 @@ typedef struct __PACKING {
 typedef struct __PACKING {
     uint16_t idx;
     int16_t box;
+    bool is_death_sector;
     struct __PACKING {
         uint8_t pit;
         uint8_t sky;

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -812,7 +812,7 @@ int32_t __cdecl Skidoo_Control(void)
         Room_GetSector(skidoo->pos.x, skidoo->pos.y, skidoo->pos.z, &room_num);
     int32_t height =
         Room_GetHeight(sector, skidoo->pos.x, skidoo->pos.y, skidoo->pos.z);
-    Room_TestTriggers(g_TriggerIndex, false);
+    Room_TestTriggers(g_LaraItem);
 
     bool dead = false;
     if (g_LaraItem->hit_points <= 0) {

--- a/src/tr2/game/camera.h
+++ b/src/tr2/game/camera.h
@@ -27,4 +27,7 @@ void __cdecl Camera_Fixed(void);
 void __cdecl Camera_Update(void);
 void __cdecl Camera_LoadCutsceneFrame(void);
 void __cdecl Camera_UpdateCutscene(void);
-void __cdecl Camera_RefreshFromTrigger(int16_t type, const int16_t *fd);
+void Camera_RefreshFromTrigger(const TRIGGER *trigger);
+
+// TODO: eliminate
+void __cdecl Camera_Legacy_RefreshFromTrigger(int16_t type, const int16_t *fd);

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -38,7 +38,6 @@ void __cdecl Collide_GetCollisionInfo(
     coll->side_mid.floor = height;
     coll->side_mid.ceiling = ceiling;
     coll->side_mid.type = g_HeightType;
-    coll->trigger = g_TriggerIndex;
 
     const int16_t tilt = Room_GetTiltType(sector, x, g_LaraItem->pos.y, z);
     coll->z_tilt = tilt >> 8;

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -121,8 +121,7 @@ void __cdecl Collide_GetCollisionInfo(
         coll->side_front.floor = 512;
     } else if (
         coll->lava_is_pit && coll->side_front.floor > 0
-        && g_TriggerIndex != NULL
-        && FLOORDATA_TYPE(g_TriggerIndex[0]) == FT_LAVA) {
+        && Room_GetPitSector(sector, x, z)->is_death_sector) {
         coll->side_front.floor = 512;
     }
 
@@ -149,8 +148,8 @@ void __cdecl Collide_GetCollisionInfo(
         && coll->side_left.floor > 0) {
         coll->side_left.floor = 512;
     } else if (
-        coll->lava_is_pit && coll->side_left.floor > 0 && g_TriggerIndex != NULL
-        && FLOORDATA_TYPE(g_TriggerIndex[0]) == FT_LAVA) {
+        coll->lava_is_pit && coll->side_left.floor > 0
+        && Room_GetPitSector(sector, x, z)->is_death_sector) {
         coll->side_left.floor = 512;
     }
 
@@ -178,8 +177,7 @@ void __cdecl Collide_GetCollisionInfo(
         coll->side_right.floor = 512;
     } else if (
         coll->lava_is_pit && coll->side_right.floor > 0
-        && g_TriggerIndex != NULL
-        && FLOORDATA_TYPE(g_TriggerIndex[0]) == FT_LAVA) {
+        && Room_GetPitSector(sector, x, z)->is_death_sector) {
         coll->side_right.floor = 512;
     }
 

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -155,7 +155,7 @@ void __cdecl Item_Initialise(const int16_t item_num)
     const int32_t dx = (item->pos.x - room->pos.x) >> WALL_SHIFT;
     const int32_t dz = (item->pos.z - room->pos.z) >> WALL_SHIFT;
     const SECTOR *const sector = &room->sectors[dx * room->size.z + dz];
-    item->floor = sector->floor << 8;
+    item->floor = sector->floor.height;
 
     if (g_SaveGame.bonus_flag && !g_IsDemoLevelType) {
         item->hit_points *= 2;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -92,7 +92,7 @@ void __cdecl Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
 
     Item_UpdateRoom(item, -LARA_HEIGHT / 2);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }
 
 void __cdecl Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
@@ -150,7 +150,7 @@ void __cdecl Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
 
     Item_UpdateRoom(item, 100);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }
 
 void __cdecl Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
@@ -239,7 +239,7 @@ void __cdecl Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
 
     Item_UpdateRoom(item, 0);
     Gun_Control();
-    Room_TestTriggers(coll->trigger, false);
+    Room_TestTriggers(item);
 }
 
 void __cdecl Lara_Control(const int16_t item_num)

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1573,17 +1573,16 @@ int32_t __cdecl Lara_GetWaterDepth(
         }
 
         sector = &r->sectors[z_sector + x_sector * r->size.z];
-        const int16_t data = Room_GetDoor(sector);
-        if (data == NO_ROOM) {
+        if (sector->portal_room.wall == NO_ROOM) {
             break;
         }
-        room_num = data;
+        room_num = sector->portal_room.wall;
         r = &g_Rooms[room_num];
     }
 
     if (r->flags & RF_UNDERWATER) {
-        while (sector->sky_room != NO_ROOM) {
-            r = &g_Rooms[sector->sky_room];
+        while (sector->portal_room.sky != NO_ROOM) {
+            r = &g_Rooms[sector->portal_room.sky];
             if (!(r->flags & RF_UNDERWATER)) {
                 const int32_t water_height = sector->ceiling.height;
                 sector = Room_GetSector(x, y, z, &room_num);
@@ -1596,8 +1595,8 @@ int32_t __cdecl Lara_GetWaterDepth(
         return 0x7FFF;
     }
 
-    while (sector->pit_room != NO_ROOM) {
-        r = &g_Rooms[sector->pit_room];
+    while (sector->portal_room.pit != NO_ROOM) {
+        r = &g_Rooms[sector->portal_room.pit];
         if (r->flags & RF_UNDERWATER) {
             const int32_t water_height = sector->floor.height;
             sector = Room_GetSector(x, y, z, &room_num);

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -824,13 +824,6 @@ int32_t __cdecl Lara_CheckForLetGo(ITEM *item, COLL_INFO *coll)
     item->gravity = 0;
     item->fall_speed = 0;
 
-    int16_t room_num = item->room_num;
-    int32_t x = item->pos.x;
-    int32_t y = item->pos.y;
-    int32_t z = item->pos.z;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    Room_GetHeight(sector, x, y, z);
-    coll->trigger = g_TriggerIndex;
     if (g_Input.action && item->hit_points > 0) {
         return 0;
     }

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -804,7 +804,7 @@ int32_t __cdecl Lara_LandedBad(ITEM *item, COLL_INFO *coll)
     item->pos.y = height;
     item->floor = height;
 
-    Room_TestTriggers(g_TriggerIndex, false);
+    Room_TestTriggers(item);
     int32_t land_speed = item->fall_speed - DAMAGE_START;
     item->pos.y = y;
     if (land_speed <= 0) {

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1585,7 +1585,7 @@ int32_t __cdecl Lara_GetWaterDepth(
         while (sector->sky_room != NO_ROOM) {
             r = &g_Rooms[sector->sky_room];
             if (!(r->flags & RF_UNDERWATER)) {
-                const int32_t water_height = sector->ceiling << 8;
+                const int32_t water_height = sector->ceiling.height;
                 sector = Room_GetSector(x, y, z, &room_num);
                 return Room_GetHeight(sector, x, y, z) - water_height;
             }
@@ -1599,7 +1599,7 @@ int32_t __cdecl Lara_GetWaterDepth(
     while (sector->pit_room != NO_ROOM) {
         r = &g_Rooms[sector->pit_room];
         if (r->flags & RF_UNDERWATER) {
-            const int32_t water_height = sector->floor << 8;
+            const int32_t water_height = sector->floor.height;
             sector = Room_GetSector(x, y, z, &room_num);
             return Room_GetHeight(sector, x, y, z) - water_height;
         }

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -772,21 +772,17 @@ void __cdecl Lara_State_Extra_PullDagger(ITEM *item, COLL_INFO *coll)
 
     if (item->frame_num == g_Anims[item->anim_num].frame_end) {
         item->rot.y += PHD_90;
-        int16_t room_num = item->room_num;
-        const SECTOR *sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        Room_TestTriggers(g_TriggerIndex, true);
+
+        const ITEM *const dragon_bones = Item_Find(O_DRAGON_BONES_2);
+        if (dragon_bones != NULL) {
+            Room_TestTriggers(dragon_bones);
+        }
     }
 }
 
 void __cdecl Lara_State_Extra_StartAnim(ITEM *item, COLL_INFO *coll)
 {
-    int16_t room_num = item->room_num;
-    const SECTOR *sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    Room_TestTriggers(g_TriggerIndex, false);
+    Room_TestTriggers(item);
 }
 
 void __cdecl Lara_State_Extra_StartHouse(ITEM *item, COLL_INFO *coll)

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -674,13 +674,6 @@ void __cdecl Lara_State_Zipline(ITEM *item, COLL_INFO *coll)
 {
     g_Camera.target_angle = CAM_ZIPLINE_ANGLE;
 
-    int16_t room_num = item->room_num;
-    const SECTOR *sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-
-    coll->trigger = g_TriggerIndex;
-
     if (!g_Input.action) {
         item->goal_anim_state = LS_FORWARD_JUMP;
         Lara_Animate(item);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -476,6 +476,7 @@ static void __cdecl M_LoadItems(VFILE *const file)
     const int32_t num_items = VFile_ReadS32(file);
     LOG_DEBUG("items: %d", num_items);
     if (!num_items) {
+        g_LevelItemCount = 0;
         goto finish;
     }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -148,9 +148,9 @@ static void __cdecl M_LoadRooms(VFILE *const file)
             SECTOR *const sector = &r->sectors[i];
             sector->idx = VFile_ReadU16(file);
             sector->box = VFile_ReadS16(file);
-            sector->pit_room = VFile_ReadU8(file);
+            sector->portal_room.pit = VFile_ReadU8(file);
             sector->floor.height = VFile_ReadS8(file) * STEP_L;
-            sector->sky_room = VFile_ReadU8(file);
+            sector->portal_room.sky = VFile_ReadU8(file);
             sector->ceiling.height = VFile_ReadS8(file) * STEP_L;
         }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -206,10 +206,12 @@ static void __cdecl M_LoadRooms(VFILE *const file)
         r->fx_num = NO_ITEM;
     }
 
+    // TODO: store this temporarily in a m_LevelInfo property similar to TR1 and
+    // release after parsing.
     const int32_t floor_data_size = VFile_ReadS32(file);
-    g_FloorData =
+    g_Legacy_FloorData =
         GameBuf_Alloc(sizeof(int16_t) * floor_data_size, GBUF_FLOOR_DATA);
-    VFile_Read(file, g_FloorData, sizeof(int16_t) * floor_data_size);
+    VFile_Read(file, g_Legacy_FloorData, sizeof(int16_t) * floor_data_size);
 
 finish:
     Benchmark_End(benchmark, NULL);
@@ -921,7 +923,7 @@ static void M_CompleteSetup(void)
     BENCHMARK *const benchmark = Benchmark_Start();
 
     // Expand raw floor data into sectors
-    Room_ParseFloorData(g_FloorData);
+    Room_ParseFloorData(g_Legacy_FloorData);
     // TODO: store raw FD temporarily, release here and eliminate g_FloorData
 
     // Must be called after Setup_AllObjects using the cached item

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -149,9 +149,9 @@ static void __cdecl M_LoadRooms(VFILE *const file)
             sector->idx = VFile_ReadU16(file);
             sector->box = VFile_ReadS16(file);
             sector->pit_room = VFile_ReadU8(file);
-            sector->floor = VFile_ReadS8(file);
+            sector->floor.height = VFile_ReadS8(file) * STEP_L;
             sector->sky_room = VFile_ReadU8(file);
-            sector->ceiling = VFile_ReadS8(file);
+            sector->ceiling.height = VFile_ReadS8(file) * STEP_L;
         }
 
         r->ambient_1 = VFile_ReadS16(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -4,6 +4,7 @@
 #include "game/hwr.h"
 #include "game/items.h"
 #include "game/objects/setup.h"
+#include "game/room.h"
 #include "game/shell.h"
 #include "global/const.h"
 #include "global/funcs.h"
@@ -918,6 +919,10 @@ static void M_LoadFromFile(const char *const file_name, const int32_t level_num)
 static void M_CompleteSetup(void)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+
+    // Expand raw floor data into sectors
+    Room_ParseFloorData(g_FloorData);
+    // TODO: store raw FD temporarily, release here and eliminate g_FloorData
 
     // Must be called after Setup_AllObjects using the cached item
     // count, as individual setups may increment g_LevelItemCount.

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -53,7 +53,7 @@ int32_t __cdecl Diver_GetWaterSurface(
         while (sector->sky_room != NO_ROOM) {
             r = Room_Get(sector->sky_room);
             if (!(r->flags & RF_UNDERWATER)) {
-                return sector->ceiling << 8;
+                return sector->ceiling.height;
             }
             sector = M_GetRelSector(r, x, z);
         }
@@ -61,7 +61,7 @@ int32_t __cdecl Diver_GetWaterSurface(
         while (sector->pit_room != NO_ROOM) {
             r = Room_Get(sector->pit_room);
             if ((r->flags & RF_UNDERWATER)) {
-                return sector->floor << 8;
+                return sector->floor.height;
             }
             sector = M_GetRelSector(r, x, z);
         }

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -50,16 +50,16 @@ int32_t __cdecl Diver_GetWaterSurface(
     const SECTOR *sector = M_GetRelSector(r, x, z);
 
     if ((r->flags & RF_UNDERWATER)) {
-        while (sector->sky_room != NO_ROOM) {
-            r = Room_Get(sector->sky_room);
+        while (sector->portal_room.sky != NO_ROOM) {
+            r = Room_Get(sector->portal_room.sky);
             if (!(r->flags & RF_UNDERWATER)) {
                 return sector->ceiling.height;
             }
             sector = M_GetRelSector(r, x, z);
         }
     } else {
-        while (sector->pit_room != NO_ROOM) {
-            r = Room_Get(sector->pit_room);
+        while (sector->portal_room.pit != NO_ROOM) {
+            r = Room_Get(sector->portal_room.pit);
             if ((r->flags & RF_UNDERWATER)) {
                 return sector->floor.height;
             }

--- a/src/tr2/game/objects/general/bell.c
+++ b/src/tr2/game/objects/general/bell.c
@@ -29,7 +29,7 @@ void __cdecl Bell_Control(const int16_t item_num)
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &item->room_num);
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    Room_TestTriggers(g_TriggerIndex, true);
+    Room_TestTriggers(item);
 
     Item_Animate(item);
 

--- a/src/tr2/game/objects/general/door.c
+++ b/src/tr2/game/objects/general/door.c
@@ -42,7 +42,7 @@ static void M_Initialise(
 
     const SECTOR *sector = door_pos->sector;
 
-    const int16_t room_num = Room_GetDoor(door_pos->sector);
+    const int16_t room_num = door_pos->sector->portal_room.wall;
     if (room_num != NO_ROOM) {
         sector =
             M_GetRoomRelSector(Room_Get(room_num), item, sector_dx, sector_dz);
@@ -67,8 +67,9 @@ void __cdecl Door_Shut(DOORPOS_DATA *const d)
     sector->box = NO_BOX;
     sector->ceiling.height = NO_HEIGHT;
     sector->floor.height = NO_HEIGHT;
-    sector->sky_room = NO_ROOM_NEG;
-    sector->pit_room = NO_ROOM_NEG;
+    sector->portal_room.sky = NO_ROOM_NEG;
+    sector->portal_room.pit = NO_ROOM_NEG;
+    sector->portal_room.wall = NO_ROOM;
 
     const int16_t box_num = d->block;
     if (box_num != NO_BOX) {
@@ -132,7 +133,7 @@ void __cdecl Door_Initialise(const int16_t item_num)
         M_Initialise(r, item, dx, dz, &door->d1flip);
     }
 
-    room_num = Room_GetDoor(door->d1.sector);
+    room_num = door->d1.sector->portal_room.wall;
     Door_Shut(&door->d1);
     Door_Shut(&door->d1flip);
 

--- a/src/tr2/game/objects/general/door.c
+++ b/src/tr2/game/objects/general/door.c
@@ -65,8 +65,8 @@ void __cdecl Door_Shut(DOORPOS_DATA *const d)
 
     sector->idx = 0;
     sector->box = NO_BOX;
-    sector->ceiling = NO_HEIGHT / STEP_L;
-    sector->floor = NO_HEIGHT / STEP_L;
+    sector->ceiling.height = NO_HEIGHT;
+    sector->floor.height = NO_HEIGHT;
     sector->sky_room = NO_ROOM_NEG;
     sector->pit_room = NO_ROOM_NEG;
 

--- a/src/tr2/game/objects/general/gong_bonger.c
+++ b/src/tr2/game/objects/general/gong_bonger.c
@@ -10,11 +10,7 @@ static void M_ActivateHeavyTriggers(int16_t item_num);
 static void M_ActivateHeavyTriggers(const int16_t item_num)
 {
     const ITEM *const item = Item_Get(item_num);
-    int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    Room_TestTriggers(g_TriggerIndex, true);
+    Room_TestTriggers(item);
     Item_Kill(item_num);
 }
 

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -210,12 +210,7 @@ void __cdecl MovableBlock_Control(const int16_t item_num)
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
         Room_AlterFloorHeight(item, -WALL_L);
-
-        int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
     }
 }
 

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -27,7 +27,7 @@ int32_t __cdecl MovableBlock_TestDestination(
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
 
-    const int16_t floor = sector->floor << 8;
+    const int16_t floor = sector->floor.height;
     return floor == NO_HEIGHT || (floor == item->pos.y - block_height);
 }
 
@@ -70,7 +70,7 @@ int32_t __cdecl MovableBlock_TestPush(
     }
 
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
-    if ((sector->floor << 8) != y) {
+    if (sector->floor.height != y) {
         return false;
     }
 
@@ -129,13 +129,13 @@ int32_t __cdecl MovableBlock_TestPull(
     }
 
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
-    if ((sector->floor << 8) != y) {
+    if (sector->floor.height != y) {
         return false;
     }
 
     const int32_t y_min = y - block_height;
     sector = Room_GetSector(x, y_min, z, &room_num);
-    if ((sector->ceiling << 8) > y_min) {
+    if (sector->ceiling.height > y_min) {
         return false;
     }
 
@@ -143,12 +143,12 @@ int32_t __cdecl MovableBlock_TestPull(
     z += z_add;
     room_num = item->room_num;
     sector = Room_GetSector(x, y, z, &room_num);
-    if ((sector->floor << 8) != y) {
+    if (sector->floor.height != y) {
         return false;
     }
 
     sector = Room_GetSector(x, y - LARA_HEIGHT, z, &room_num);
-    if ((sector->ceiling << 8) > y - LARA_HEIGHT) {
+    if (sector->ceiling.height > y - LARA_HEIGHT) {
         return false;
     }
 

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -51,11 +51,7 @@ static void M_DetonateAll(
     Item_Kill(boat_item_num);
     boat_item->object_id = O_BOAT;
 
-    const SECTOR *const sector = Room_GetSector(
-        mine_item->pos.x, mine_item->pos.y, mine_item->pos.z, &boat_room_num);
-    Room_GetHeight(
-        sector, mine_item->pos.x, mine_item->pos.y, mine_item->pos.z);
-    Room_TestTriggers(g_TriggerIndex, true);
+    Room_TestTriggers(mine_item);
 
     g_DetonateAllMines = true;
 }

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -62,7 +62,7 @@ void __cdecl RollingBall_Control(const int16_t item_num)
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(item);
 
         if (item->pos.y >= item->floor - STEP_L) {
             item->gravity = 0;

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -653,8 +653,8 @@ void __cdecl Boat_Control(const int16_t item_num)
     const int32_t ceiling =
         Room_GetCeiling(sector, boat->pos.x, boat->pos.y, boat->pos.z);
     if (g_Lara.skidoo == item_num) {
-        Room_TestTriggers(g_TriggerIndex, false);
-        Room_TestTriggers(g_TriggerIndex, true);
+        Room_TestTriggers(lara);
+        Room_TestTriggers(boat);
     }
 
     const int32_t water_height =

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -879,59 +879,9 @@ int32_t __cdecl Room_GetCeiling(
     return height;
 }
 
-int16_t __cdecl Room_GetDoor(const SECTOR *const sector)
+int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *const sector)
 {
-    if (!sector->idx) {
-        return NO_ROOM;
-    }
-
-    const int16_t *fd = &g_FloorData[sector->idx];
-    while (true) {
-        const int16_t fd_cmd = *fd++;
-
-        switch (FLOORDATA_TYPE(fd_cmd)) {
-        case FT_DOOR:
-            return *fd;
-
-        case FT_ROOF:
-        case FT_TILT:
-            fd++;
-            break;
-
-        case FT_TRIGGER:
-            fd++;
-
-            while (true) {
-                int16_t trigger = *fd++;
-                switch (TRIGGER_TYPE(trigger)) {
-                case TO_CAMERA:
-                    trigger = *fd++;
-                    break;
-
-                default:
-                    break;
-                }
-
-                if (TRIGGER_IS_END(trigger)) {
-                    break;
-                }
-            }
-            break;
-
-        case FT_LAVA:
-        case FT_CLIMB:
-            break;
-
-        default:
-            Shell_ExitSystem("GetDoor(): Unknown floordata type");
-            break;
-        }
-
-        if (FLOORDATA_IS_END(fd_cmd)) {
-            break;
-        }
-    }
-
+    assert(false);
     return NO_ROOM;
 }
 

--- a/src/tr2/game/room.h
+++ b/src/tr2/game/room.h
@@ -14,8 +14,12 @@ void __cdecl Room_GetNearbyRooms(
 void __cdecl Room_GetNewRoom(int32_t x, int32_t y, int32_t z, int16_t room_num);
 int16_t __cdecl Room_GetTiltType(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z);
+
+SECTOR *Room_GetPitSector(const SECTOR *sector, int32_t x, int32_t z);
+SECTOR *Room_GetSkySector(const SECTOR *sector, int32_t x, int32_t z);
 SECTOR *__cdecl Room_GetSector(
     int32_t x, int32_t y, int32_t z, int16_t *room_num);
+
 int32_t __cdecl Room_GetWaterHeight(
     int32_t x, int32_t y, int32_t z, int16_t room_num);
 int32_t __cdecl Room_GetHeight(

--- a/src/tr2/game/room.h
+++ b/src/tr2/game/room.h
@@ -26,7 +26,6 @@ int32_t __cdecl Room_GetHeight(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 int32_t __cdecl Room_GetCeiling(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-int16_t __cdecl Room_GetDoor(const SECTOR *sector);
 
 void Room_ParseFloorData(const int16_t *floor_data);
 void Room_PopulateSectorData(
@@ -40,6 +39,7 @@ void __cdecl Room_RemoveFlipItems(const ROOM *r);
 void __cdecl Room_AddFlipItems(const ROOM *r);
 
 // TODO: eliminate
+int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *sector);
 void __cdecl Room_Legacy_TestTriggers(const int16_t *fd, bool heavy);
 void __cdecl Room_Legacy_TriggerMusicTrack(
     int16_t value, int16_t flags, int16_t type);

--- a/src/tr2/game/room.h
+++ b/src/tr2/game/room.h
@@ -23,6 +23,12 @@ int32_t __cdecl Room_GetHeight(
 int32_t __cdecl Room_GetCeiling(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 int16_t __cdecl Room_GetDoor(const SECTOR *sector);
+
+void Room_ParseFloorData(const int16_t *floor_data);
+void Room_PopulateSectorData(
+    SECTOR *sector, const int16_t *floor_data, uint16_t start_index,
+    uint16_t null_index);
+
 void __cdecl Room_TestTriggers(const int16_t *fd, bool heavy);
 void __cdecl Room_AlterFloorHeight(const ITEM *item, int32_t height);
 void __cdecl Room_FlipMap(void);

--- a/src/tr2/game/room.h
+++ b/src/tr2/game/room.h
@@ -33,9 +33,13 @@ void Room_PopulateSectorData(
     SECTOR *sector, const int16_t *floor_data, uint16_t start_index,
     uint16_t null_index);
 
-void __cdecl Room_TestTriggers(const int16_t *fd, bool heavy);
+void Room_TestTriggers(const ITEM *item);
 void __cdecl Room_AlterFloorHeight(const ITEM *item, int32_t height);
 void __cdecl Room_FlipMap(void);
 void __cdecl Room_RemoveFlipItems(const ROOM *r);
 void __cdecl Room_AddFlipItems(const ROOM *r);
-void __cdecl Room_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);
+
+// TODO: eliminate
+void __cdecl Room_Legacy_TestTriggers(const int16_t *fd, bool heavy);
+void __cdecl Room_Legacy_TriggerMusicTrack(
+    int16_t value, int16_t flags, int16_t type);

--- a/src/tr2/global/types.h
+++ b/src/tr2/global/types.h
@@ -1522,34 +1522,6 @@ typedef struct __unaligned {
 } FRAME_INFO;
 
 typedef enum {
-    TO_OBJECT      = 0,
-    TO_CAMERA      = 1,
-    TO_SINK        = 2,
-    TO_FLIP_MAP    = 3,
-    TO_FLIP_ON     = 4,
-    TO_FLIP_OFF    = 5,
-    TO_TARGET      = 6,
-    TO_FINISH      = 7,
-    TO_CD          = 8,
-    TO_FLIP_EFFECT = 9,
-    TO_SECRET      = 10,
-    TO_BODY_BAG    = 11,
-} TRIGGER_OBJECT;
-
-typedef enum {
-    TT_TRIGGER     = 0,
-    TT_PAD         = 1,
-    TT_SWITCH      = 2,
-    TT_KEY         = 3,
-    TT_PICKUP      = 4,
-    TT_HEAVY       = 5,
-    TT_ANTIPAD     = 6,
-    TT_COMBAT      = 7,
-    TT_DUMMY       = 8,
-    TT_ANTITRIGGER = 9,
-} TRIGGER_TYPE;
-
-typedef enum {
     GF_S_PC_DETAIL_LEVELS      = 0,
     GF_S_PC_DEMO_MODE          = 1,
     GF_S_PC_SOUND              = 2,

--- a/src/tr2/global/vars_decomp.h
+++ b/src/tr2/global/vars_decomp.h
@@ -339,7 +339,7 @@
 #define g_LevelFileTexPagesOffset (*(int32_t*)0x004D9BF8)
 #define g_GF_LevelOffsets (*(int16_t(*)[200])0x004D9C00)
 #define g_MeshBase (*(int16_t **)0x004D9D90)
-#define g_FloorData (*(int16_t **)0x004D9D94)
+#define g_Legacy_FloorData (*(int16_t **)0x004D9D94)
 #define g_LevelFileName (*(char(*)[256])0x004D9D98)
 #define g_TextureInfoCount (*(int32_t*)0x004D9E98)
 #define g_LevelFileDepthQOffset (*(int32_t*)0x004D9E9C)

--- a/src/tr2/global/vars_decomp.h
+++ b/src/tr2/global/vars_decomp.h
@@ -494,7 +494,7 @@
 #define g_MusicTrackFlags (*(uint16_t(*)[64])0x005261C0)
 #define g_FlipStatus (*(int32_t*)0x00526240)
 #define g_FlipMaps (*(int32_t(*)[10])0x00526260)
-#define g_TriggerIndex (*(int16_t **)0x00526288)
+#define g_Legacy_TriggerIndex (*(int16_t **)0x00526288)
 #define g_LOSRooms (*(int32_t(*)[20])0x005262A0)
 #define g_Items (*(ITEM **)0x005262F0)
 #define g_CineLoaded (*(int16_t*)0x005262F4)

--- a/src/tr2/inject_exec.c
+++ b/src/tr2/inject_exec.c
@@ -414,7 +414,7 @@ static void M_Room(const bool enable)
     INJECT(enable, 0x00414D10, Room_GetWaterHeight);
     INJECT(enable, 0x00414E80, Room_GetHeight);
     INJECT(enable, 0x00415930, Room_GetCeiling);
-    INJECT(enable, 0x00415B90, Room_GetDoor);
+    INJECT(enable, 0x00415B90, Room_Legacy_GetDoor);
     INJECT(enable, 0x004151F0, Room_Legacy_TestTriggers);
     INJECT(enable, 0x004340B0, Room_AlterFloorHeight);
     INJECT(enable, 0x00416640, Room_FlipMap);

--- a/src/tr2/inject_exec.c
+++ b/src/tr2/inject_exec.c
@@ -386,7 +386,7 @@ static void M_Camera(const bool enable)
     INJECT(enable, 0x00411AA0, Camera_Update);
     INJECT(enable, 0x004126A0, Camera_LoadCutsceneFrame);
     INJECT(enable, 0x00412290, Camera_UpdateCutscene);
-    INJECT(enable, 0x00415100, Camera_RefreshFromTrigger);
+    INJECT(enable, 0x00415100, Camera_Legacy_RefreshFromTrigger);
 }
 
 static void M_Collide(const bool enable)
@@ -415,7 +415,7 @@ static void M_Room(const bool enable)
     INJECT(enable, 0x00414E80, Room_GetHeight);
     INJECT(enable, 0x00415930, Room_GetCeiling);
     INJECT(enable, 0x00415B90, Room_GetDoor);
-    INJECT(enable, 0x004151F0, Room_TestTriggers);
+    INJECT(enable, 0x004151F0, Room_Legacy_TestTriggers);
     INJECT(enable, 0x004340B0, Room_AlterFloorHeight);
     INJECT(enable, 0x00416640, Room_FlipMap);
     INJECT(enable, 0x00416700, Room_RemoveFlipItems);
@@ -426,7 +426,7 @@ static void M_Room(const bool enable)
     INJECT(enable, 0x004189D0, Room_DrawAllRooms);
     INJECT(enable, 0x004195B0, Room_DrawSingleRoomGeometry);
     INJECT(enable, 0x00419670, Room_DrawSingleRoomObjects);
-    INJECT(enable, 0x00416800, Room_TriggerMusicTrack);
+    INJECT(enable, 0x00416800, Room_Legacy_TriggerMusicTrack);
 }
 
 static void M_Matrix(const bool enable)


### PR DESCRIPTION
Resolves #1883.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This follows a similar approach as we did for TR1 in #941. Best viewed commit-by-commit to see the iterative changes.

As well as the main FD overhaul, there were a few snagging points that have been addressed here.
- `Item_Initialise` was previously called during `M_LoadItems` in `level.c` but this had to be shifted because there are floor data dependencies there. We now take a similar approach to TR1, so load the level data, then perform a "CompleteSetup"; this can be expanded later for things like injection processing.
- With the above, @aredfan found that if you start a level then go back to the title screen, it can crash. `g_LevelItemCount` wasn't being set to 0 here - not an issue originally because `Item_Initialise` (where the crash would occur) would have been skipped in that case.
- While the triggers that are meant to activate after pulling the dagger from the dragon are heavy, the call to test triggers came from Lara's extra anim routine. As we now pass the item, which determines the heavy state, this had to be amended to locate the dragon bones item and to pass that. The dragon control has already ended by the time the extra anim completes so we couldn't add the call anywhere there, and running it too early meant issues like the camera still being in cinematic mode while looking at the doors opening.

The dragon may need some extra checks based on where it lands e.g. if partially in the wall. I may change this to behave like the Torso in TR1, where it checks a range of surrounding sectors.

For testing, attached is a level with various trigger types, basic geometry, ladders, and death tiles. I didn't include a dragon for testing, that can be done in OG easily enough. For ceiling geometry, it's best to fly against it and hold down to see that Lara follows the structure properly.

[WALL.zip](https://github.com/user-attachments/files/17750165/WALL.zip)

There is a lot of scope now for sharing FD handling with TR1, but that can be tackled in the future. I may follow this up with some minor changes, like moving all FD macros to libtrx and renaming some enums, but I didn't want to touch TR1 at all in this PR.
