### PR TITLE
config_tool: fix linter whitespace error

### DIFF
--- a/tools/config/TRX_ConfigToolLib/Controls/TRXConfigWindow.xaml
+++ b/tools/config/TRX_ConfigToolLib/Controls/TRXConfigWindow.xaml
@@ -111,7 +111,7 @@
                         Header="{Binding ViewText[command_about]}"/>
                 </MenuItem>
             </Menu>
-            
+
             <Grid
                 DockPanel.Dock="Right"
                 Margin="0,7,7,0"
@@ -151,7 +151,7 @@
                                 </Style>
                             </TextBox.Style>
                         </TextBox>
-                        
+
                         <TextBlock
                             IsHitTestVisible="False"
                             Text="{Binding ViewText[label_search]}"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Sorry about this, I forgot to run the linter locally in #1907.