### PR TITLE
tr2/traps/rolling_ball: fix inactive boulder collision test

### DIFF
--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -144,7 +144,7 @@ void __cdecl RollingBall_Collision(
 {
     ITEM *const item = Item_Get(item_num);
     if (item->status != IS_ACTIVE) {
-        if (item->status != IS_INACTIVE) {
+        if (item->status != IS_INVISIBLE) {
             Object_Collision(item_num, lara_item, coll);
         }
         return;


### PR DESCRIPTION
Resolves #1910.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Check is in line with TR1, so no collision when invisible rather than inactive.
