### PR TITLE
trx/audio: fix invalid audio freeing

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -48,6 +48,7 @@
 - changed the `/tp` command to teleport to items in a round-robin fashion
   The first call will teleport Lara to the object that's the closest to her; repeated calls will cycle through all matching objects in the object placement order.
 - changed the music timestamp loading behaviour and config option to support ambient tracks (#1769)
+- fixed a crash relating to audio decoding (#1895)
 - fixed missing pushblock SFX in Natla's Mines (#1714)
 - fixed crash reports not working in certain circumstances (#1738)
 - fixed missing trapdoor triggers in City of Khamoon (#1744)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added an option to fix inventory item usage duplication (#1586)
 - added optional automatic key/puzzle inventory item pre-selection (#1884)
 - added a search feature to the config tool (#1889)
+- fixed a crash relating to audio decoding (#1895)
 - fixed depth problems when drawing certain rooms (#1853, regression from 0.6)
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)
 - fixed being unable to go from surface swimming to underwater swimming without first stopping (#1863, regression from 0.6)

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -208,7 +208,7 @@ static bool M_EnqueueFrame(AUDIO_STREAM_SOUND *stream)
                 m_DecodeBuffer =
                     Memory_Realloc(m_DecodeBuffer, m_DecodeBufferCapacity);
             }
-            if (out_buffer) {
+            if (m_DecodeBuffer != NULL && out_buffer != NULL) {
                 memcpy(
                     (uint8_t *)m_DecodeBuffer + out_pos, out_buffer,
                     out_buffer_size);
@@ -393,6 +393,7 @@ void Audio_Stream_Init(void)
 void Audio_Stream_Shutdown(void)
 {
     Memory_FreePointer(&m_DecodeBuffer);
+    m_DecodeBufferCapacity = 0;
     if (!g_AudioDeviceID) {
         return;
     }


### PR DESCRIPTION

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1895.
