### PR TITLE
stats: added a background picture for the final stats

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added an option to fix inventory item usage duplication (#1586)
 - added optional automatic key/puzzle inventory item pre-selection (#1884)
 - added a search feature to the config tool (#1889)
+- added a final statistics background picture (#1584)
 - fixed a crash relating to audio decoding (#1895)
 - fixed depth problems when drawing certain rooms (#1853, regression from 0.6)
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo (#1606)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -59,6 +59,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed skipping credits working too fast
 
 #### Statistics
+- added a final statistics background picture
 - fixed the dragon counting as more than one kill if allowed to revive
 - fixed enemies that are run over by the skidoo not being counted in the statistics
 

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -2907,7 +2907,6 @@ void __cdecl DisplayCredits(void)
     }
 
     memcpy(g_GamePalette8, old_palette, sizeof(g_GamePalette8));
-    S_Wait(300, true);
     FadeToPal(30, g_GamePalette8);
     g_IsVidModeLock = false;
 }

--- a/src/tr2/decomp/stats.c
+++ b/src/tr2/decomp/stats.c
@@ -371,6 +371,17 @@ int32_t __cdecl GameStats(const int32_t level_num)
 
     Overlay_HideGameInfo();
 
+    S_FadeToBlack();
+    g_IsVidModeLock = true;
+    RGB_888 old_palette[256];
+    memcpy(old_palette, g_GamePalette8, sizeof(old_palette));
+    memset(g_GamePalette8, 0, sizeof(g_GamePalette8));
+
+    char file_name[60];
+    sprintf(file_name, "data/end.pcx");
+    FadeToPal(0, g_GamePalette8);
+    S_DisplayPicture(file_name, true);
+
     while (g_Input.any) {
         Shell_ProcessEvents();
         Input_Update();
@@ -412,7 +423,12 @@ int32_t __cdecl GameStats(const int32_t level_num)
     }
     g_SaveGame.current_level = LV_FIRST;
 
+    S_FadeToBlack();
     S_DontDisplayPicture();
+
+    memcpy(g_GamePalette8, old_palette, sizeof(g_GamePalette8));
+    FadeToPal(30, g_GamePalette8);
+    g_IsVidModeLock = true;
     return 0;
 }
 


### PR DESCRIPTION
Resolves #1584.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description
Added a final statistics background picture. Uses `end.pcx`. Temporary solution similar to credits pictures until we get a gameflow script like TR1X.

I marked this as draft since I can't get a picture to show up in SW render mode and could use some help. I get a black screen only. Maybe that's related to #1915?