### PR TITLE
Fix TR2 screenshot issues

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed missing death tiles in Temple of Xian room 91 (#1920)
 - fixed broken final stats screen in software rendering mode (#1915, regression from 0.6)
 - fixed screenshots not capturing level stats (#1925, regression from 0.6)
+- fixed screenshots sometimes crashing in the windowed mode (regression from 0.6)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed being unable to use the drawbridge key in Tibetan Foothills after the flipmap (#1744)
 - fixed missing death tiles in Temple of Xian room 91 (#1920)
 - fixed broken final stats screen in software rendering mode (#1915, regression from 0.6)
+- fixed screenshots not capturing level stats (#1925, regression from 0.6)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -1934,7 +1934,6 @@ bool __cdecl D3DIsSupported(LPD3DDEVICEDESC_V2 desc)
 bool __cdecl D3DSetViewport(void)
 {
     D3DVIEWPORT2 viewPort = {
-
         .dwSize = sizeof(D3DVIEWPORT2),
         .dvClipX = 0.0,
         .dvClipY = 0.0,

--- a/src/tr2/decomp/stats.c
+++ b/src/tr2/decomp/stats.c
@@ -322,12 +322,12 @@ int32_t __cdecl LevelStats(const int32_t level_num)
     S_CopyScreenToBuffer();
 
     while (true) {
-        S_InitialisePolyList(0);
-        S_CopyBufferToScreen();
-
         Shell_ProcessEvents();
         Input_Update();
         Shell_ProcessInput();
+
+        S_InitialisePolyList(0);
+        S_CopyBufferToScreen();
 
         if (g_IsGameToExit) {
             break;
@@ -378,12 +378,12 @@ int32_t __cdecl GameStats(const int32_t level_num)
     }
 
     while (true) {
-        S_InitialisePolyList(0);
-        S_CopyBufferToScreen();
-
         Shell_ProcessEvents();
         Input_Update();
         Shell_ProcessInput();
+
+        S_InitialisePolyList(0);
+        S_CopyBufferToScreen();
 
         if (g_IsGameToExit) {
             break;

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -4449,17 +4449,17 @@ bool __cdecl Output_MakeScreenshot(const char *const path)
         return false;
     }
 
-    int32_t src_x = 0;
-    int32_t src_y = 0;
-    int32_t width = g_GameWindowWidth;
-    int32_t height = g_GameWindowHeight;
+    const int32_t src_x = 0;
+    const int32_t src_y = 0;
+    const int32_t width = g_GameVid_Width;
+    const int32_t height = g_GameVid_Height;
     IMAGE *const image = Image_Create(width, height);
 
     for (int32_t y = 0; y < height; y++) {
-        uint8_t *src = desc.lpSurface + desc.lPitch * (y + src_y);
+        const uint8_t *src = desc.lpSurface + desc.lPitch * (y + src_y);
         src += src_x * (desc.ddpfPixelFormat.dwRGBBitCount / 8);
-        IMAGE_PIXEL *dst = &image->data[width * y];
 
+        IMAGE_PIXEL *dst = &image->data[width * y];
         switch (desc.ddpfPixelFormat.dwRGBBitCount) {
         case 8:
             assert(desc.ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8);
@@ -4531,8 +4531,6 @@ bool __cdecl Output_MakeScreenshot(const char *const path)
                 }
             }
         }
-
-        src -= desc.lPitch;
     }
 
     const bool ret = Image_SaveToFile(image, path);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1925 and crashes with unaligned video buffer size in windowed mode.