### PR TITLE
tr2/savegame: test object IDs rather than function pointers

### DIFF
--- a/src/libtrx/include/libtrx/game/objects/vars.h
+++ b/src/libtrx/include/libtrx/game/objects/vars.h
@@ -9,6 +9,8 @@ extern const GAME_OBJECT_ID g_PickupObjects[];
 extern const GAME_OBJECT_ID g_AnimObjects[];
 extern const GAME_OBJECT_ID g_NullObjects[];
 extern const GAME_OBJECT_ID g_InvObjects[];
+extern const GAME_OBJECT_ID g_MovableBlockObjects[];
+extern const GAME_OBJECT_ID g_PuzzleHoleObjects[];
 
 extern const GAME_OBJECT_PAIR g_ItemToInvObjectMap[];
 extern const GAME_OBJECT_PAIR g_KeyItemToReceptacleMap[];

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -11,6 +11,7 @@
 #include "game/objects/general/movable_block.h"
 #include "game/objects/general/pickup.h"
 #include "game/objects/general/puzzle_hole.h"
+#include "game/objects/vars.h"
 #include "game/requester.h"
 #include "game/room.h"
 #include "game/shell.h"
@@ -92,7 +93,7 @@ static void M_ReadItems(void)
         ITEM *const item = Item_Get(item_num);
         OBJECT *const obj = &g_Objects[item->object_id];
 
-        if (obj->control == MovableBlock_Control) {
+        if (Object_IsObjectType(item->object_id, g_MovableBlockObjects)) {
             Room_AlterFloorHeight(item, WALL_L);
         }
 
@@ -179,13 +180,13 @@ static void M_ReadItems(void)
 
             item->flags &= 0xFF00;
 
-            if (obj->collision == PuzzleHole_Collision
+            if (Object_IsObjectType(item->object_id, g_PuzzleHoleObjects)
                 && (item->status == IS_DEACTIVATED
                     || item->status == IS_ACTIVE)) {
                 item->object_id += O_PUZZLE_DONE_1 - O_PUZZLE_HOLE_1;
             }
 
-            if (obj->collision == Pickup_Collision
+            if (Object_IsObjectType(item->object_id, g_PickupObjects)
                 && item->status == IS_DEACTIVATED) {
                 Item_RemoveDrawn(item_num);
             }
@@ -200,7 +201,7 @@ static void M_ReadItems(void)
             }
         }
 
-        if (obj->control == MovableBlock_Control
+        if (Object_IsObjectType(item->object_id, g_MovableBlockObjects)
             && item->status == IS_INACTIVE) {
             Room_AlterFloorHeight(item, -WALL_L);
         }

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -117,6 +117,26 @@ const GAME_OBJECT_ID g_TrapdoorObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_MovableBlockObjects[] = {
+    // clang-format off
+    O_MOVABLE_BLOCK_1,
+    O_MOVABLE_BLOCK_2,
+    O_MOVABLE_BLOCK_3,
+    O_MOVABLE_BLOCK_4,
+    NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_PuzzleHoleObjects[] = {
+    // clang-format off
+    O_PUZZLE_HOLE_1,
+    O_PUZZLE_HOLE_2,
+    O_PUZZLE_HOLE_3,
+    O_PUZZLE_HOLE_4,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_AnimObjects[] = {
     // clang-format off
     O_LARA_PISTOLS,


### PR DESCRIPTION
Resolves #1930.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

For some reason, the function pointer tests when loading a save were not passing in the debug build, so these have been changed to check the object IDs instead (pushblocks, puzzle slots and pickup items).

No changelog entry as it only affected debug.
