### PR TITLE
tr2/savegame: fix initialization of armed skidoo

### DIFF
--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -222,8 +222,10 @@ static void M_ReadItems(void)
 
         if (item->object_id == O_SKIDOO_DRIVER
             && item->status == IS_DEACTIVATED) {
-            item->object_id = O_SKIDOO_ARMED;
-            Skidoo_Initialise((intptr_t)item->data);
+            const int16_t skidoo_num = (int16_t)(intptr_t)item->data;
+            ITEM *const skidoo = Item_Get(skidoo_num);
+            skidoo->object_id = O_SKIDOO_FAST;
+            Skidoo_Initialise(skidoo_num);
         }
 
         if (item->object_id == O_DRAGON_FRONT


### PR DESCRIPTION
Resolves #1940.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This restores the armed skidoo after loading a save similar to the logic in `M_MakeMountable` in `skidoo_driver.c` after the driver is killed.
