### PR TITLE
tr1/objects/door: fix flipmap door initialization

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -24,6 +24,7 @@
     Swedish, Turkish and possibly more.
 
     Importantly, Asian and Arabic languages remain unsupported at the moment.
+- fixed invisible walls being present in front of some doors (#1948, regression from 4.6)
 
 ## [4.6](https://github.com/LostArtefacts/TRX/compare/tr1-4.5.1...tr1-4.6) - 2024-11-18
 - added support for wading, similar to TR2+ (#1537)

--- a/src/tr1/game/objects/general/door.c
+++ b/src/tr1/game/objects/general/door.c
@@ -163,7 +163,7 @@ void Door_Initialise(int16_t item_num)
         door->d1flip.sector = NULL;
     } else {
         r = Room_Get(r->flipped_room);
-        M_Initialise(r, item, dz, dz, &door->d1flip);
+        M_Initialise(r, item, dx, dz, &door->d1flip);
     }
 
     room_num = door->d1.sector->portal_room.wall;


### PR DESCRIPTION
Resolves #1948.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Typo from https://github.com/LostArtefacts/TRX/commit/b41f4f2f42b64bb569982b3d1117e5bdac08f1d2.
