### PR TITLE
tr1/option: fix crash on toggling bilinear filter

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -26,6 +26,7 @@
     Importantly, Asian and Arabic languages remain unsupported at the moment.
 - fixed invisible walls being present in front of some doors (#1948, regression from 4.6)
 - fixed missing FMVs causing the game to go silent (#1931, regression from 4.6)
+- fixed game crashing when toggling the bilinear filter in passport (#1942, regression from 4.5)
 
 ## [4.6](https://github.com/LostArtefacts/TRX/compare/tr1-4.5.1...tr1-4.6) - 2024-11-18
 - added support for wading, similar to TR2+ (#1537)

--- a/src/tr1/game/savegame.h
+++ b/src/tr1/game/savegame.h
@@ -2,6 +2,8 @@
 
 #include "global/types.h"
 
+#include <libtrx/game/savegame.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1942.