### PR TITLE
tr1/option: fix overlapping text with 1.9 font scale

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -25,6 +25,7 @@
 
     Importantly, Asian and Arabic languages remain unsupported at the moment.
 - fixed invisible walls being present in front of some doors (#1948, regression from 4.6)
+- fixed big font scale causing text overlaps in the graphics options (#1946)
 - fixed missing FMVs causing the game to go silent (#1931, regression from 4.6)
 - fixed game crashing when toggling the bilinear filter in passport (#1942, regression from 4.5)
 

--- a/src/tr1/game/option/option_graphics.c
+++ b/src/tr1/game/option/option_graphics.c
@@ -129,7 +129,7 @@ static void M_InitMenu(void)
 static void M_UpdateMenuVisible(void)
 {
     int32_t visible_lines = 0;
-    if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 240) {
+    if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 260) {
         visible_lines = 8;
     } else if (Screen_GetResHeightDownscaled(RSR_TEXT) <= 384) {
         visible_lines = 9;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1946.

