### PR TITLE
tr1|tr2/objects/door: reset sector tilt on closed doors

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -24,6 +24,7 @@
     Swedish, Turkish and possibly more.
 
     Importantly, Asian and Arabic languages remain unsupported at the moment.
+- fixed a potential invisible wall issue in custom levels with non-portal doors and certain geometry (#1958, regression from 4.3)
 
 ## [4.6.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.6...tr1-4.6.1) - 2024-11-25
 - added ability to disable saves completely by setting the save slot to 0 (#1954)

--- a/src/tr1/game/objects/general/door.c
+++ b/src/tr1/game/objects/general/door.c
@@ -97,6 +97,8 @@ static void M_Shut(DOORPOS_DATA *const d)
     sector->box = NO_BOX;
     sector->floor.height = NO_HEIGHT;
     sector->ceiling.height = NO_HEIGHT;
+    sector->floor.tilt = 0;
+    sector->ceiling.tilt = 0;
     sector->portal_room.sky = NO_ROOM;
     sector->portal_room.pit = NO_ROOM;
     sector->portal_room.wall = NO_ROOM;

--- a/src/tr2/game/objects/general/door.c
+++ b/src/tr2/game/objects/general/door.c
@@ -67,6 +67,8 @@ void __cdecl Door_Shut(DOORPOS_DATA *const d)
     sector->box = NO_BOX;
     sector->ceiling.height = NO_HEIGHT;
     sector->floor.height = NO_HEIGHT;
+    sector->floor.tilt = 0;
+    sector->ceiling.tilt = 0;
     sector->portal_room.sky = NO_ROOM_NEG;
     sector->portal_room.pit = NO_ROOM_NEG;
     sector->portal_room.wall = NO_ROOM;


### PR DESCRIPTION
Resolves #1958.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Before the FD refactor in both games, closing a door would reset the sector FD index to 0, and so that meant functions such as `Room_GetCeiling` would not interpret tilt values. I missed applying the equivalent reset in both #1433 and #1896 and so the result was that `NO_HEIGHT` values would be adjusted with tilt values, and hence produce something other than `NO_HEIGHT` and therefore potential invisible geometry.

Quite specific still for the issue itself: you need a door that's not on a portal sector in a room above, and there must be tilt geometry defined. This doesn't happen in OG TR1 AFAIK, so I've attached a test level.

[level1.zip](https://github.com/user-attachments/files/17924851/level1.zip)
