### PR TITLE
tr2/objects/detonator: check for chosen inventory object

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed broken final stats screen in software rendering mode (#1915, regression from 0.6)
 - fixed screenshots not capturing level stats (#1925, regression from 0.6)
 - fixed screenshots sometimes crashing in the windowed mode (regression from 0.6)
+- fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory (#1887)
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06
 - added a fly cheat key (#1642)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -39,6 +39,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed new saves not displaying the save count in the passport
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo
+- fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Tibetan Foothills**: added missing triggers for the drawbridge in room 96 (after the flipmap)

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -87,7 +87,8 @@ void __cdecl Detonator_Collision(
     item->rot.y = lara_item->rot.y;
     item->rot.z = 0;
 
-    if (item->status == IS_DEACTIVATED || !g_Input.action
+    if (item->status == IS_DEACTIVATED
+        || (g_Inv_Chosen == NO_OBJECT && !g_Input.action)
         || g_Lara.gun_status != LGS_ARMLESS || lara_item->gravity
         || lara_item->current_anim_state != LS_STOP) {
         goto normal_collision;


### PR DESCRIPTION
Resolves #1887.

#### Checklist

- [ ] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows manually selecting the detonator key or gong hammer from the inventory when beside the corresponding item. A similar check is done in regular keyhole/puzzle collision.
