### PR TITLE
libtrx/rooms/common: fix adjoining room array limit

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed wrongly positioned doors in Ice Palace and Floating Islands, which caused invisible walls (#1963)
 - fixed picking up the Gong Hammer in Ice Palace sometimes not opening the nearby door (#1716)
 - fixed room 98 in Wreck of the Maria Doria not having water (#1939)
+- fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms (#1987)
 - removed unused detail level option
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -40,6 +40,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed new saves not displaying the save count in the passport
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo
 - fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory
+- fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Wreck of the Maria Doria**: fixed room 98 not having water

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -167,6 +167,9 @@ int32_t Room_GetAdjoiningRooms(
     const PORTALS *const portals = Room_Get(init_room_num)->portals;
     if (portals != NULL) {
         for (int32_t i = 0; i < portals->count; i++) {
+            if (count >= max_room_num_count) {
+                break;
+            }
             const int16_t room_num = portals->portal[i].room_num;
             out_room_nums[count++] = room_num;
         }


### PR DESCRIPTION
Resolves #1987.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures we don't write beyond array bounds when scanning for a room's neighbours, and specifically prevents the skidoo causing a crash if in a room with many neighbours.

Test level:
[WALL.zip](https://github.com/user-attachments/files/18030310/WALL.zip)
