### PR TITLE
tr2/objects/final_level_counter: fix final cutscene issues

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed picking up the Gong Hammer in Ice Palace sometimes not opening the nearby door (#1716)
 - fixed room 98 in Wreck of the Maria Doria not having water (#1939)
 - fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms (#1987)
+- fixed a softlock in Home Sweet Home if the final cutscene is triggered while Lara is on water surface (#1701)
 - removed unused detail level option
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed room 98 in Wreck of the Maria Doria not having water (#1939)
 - fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms (#1987)
 - fixed a softlock in Home Sweet Home if the final cutscene is triggered while Lara is on water surface (#1701)
+- fixed Lara's left arm becoming stuck if a flare is drawn just before the final cutscene in Home Sweet Home (#1992)
 - removed unused detail level option
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -41,6 +41,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo
 - fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory
 - fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms
+- fixed a softlock in Home Sweet Home if the final cutscene is triggered while Lara is on water surface
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Wreck of the Maria Doria**: fixed room 98 not having water

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -42,6 +42,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory
 - fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms
 - fixed a softlock in Home Sweet Home if the final cutscene is triggered while Lara is on water surface
+- fixed Lara's left arm becoming stuck if a flare is drawn just before the final cutscene in Home Sweet Home
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Wreck of the Maria Doria**: fixed room 98 not having water

--- a/src/tr2/game/objects/general/final_level_counter.c
+++ b/src/tr2/game/objects/general/final_level_counter.c
@@ -63,6 +63,8 @@ static void __cdecl M_ActivateLastBoss(void)
 
 static void __cdecl M_PrepareCutscene(const int16_t item_num)
 {
+    g_Lara.water_status = LWS_ABOVE_WATER;
+
     ITEM *const item = &g_Items[item_num];
     Creature_Kill(item, 0, 0, LA_EXTRA_FINAL_ANIM);
 

--- a/src/tr2/game/objects/general/final_level_counter.c
+++ b/src/tr2/game/objects/general/final_level_counter.c
@@ -1,6 +1,8 @@
 #include "game/objects/general/final_level_counter.h"
 
+#include "decomp/flares.h"
 #include "game/creature.h"
+#include "game/gun/gun.h"
 #include "game/items.h"
 #include "game/los.h"
 #include "game/lot.h"
@@ -63,14 +65,20 @@ static void __cdecl M_ActivateLastBoss(void)
 
 static void __cdecl M_PrepareCutscene(const int16_t item_num)
 {
+    if (g_Lara.gun_type == LGT_FLARE) {
+        Flare_Undraw();
+        g_Lara.flare_control_left = false;
+        g_Lara.left_arm.lock = false;
+    }
+
+    Gun_SetLaraHandLMesh(LGT_UNARMED);
+    Gun_SetLaraHandRMesh(LGT_UNARMED);
     g_Lara.water_status = LWS_ABOVE_WATER;
 
     ITEM *const item = &g_Items[item_num];
     Creature_Kill(item, 0, 0, LA_EXTRA_FINAL_ANIM);
 
     g_Camera.type = CAM_CINEMATIC;
-    g_Lara.mesh_ptrs[LM_HAND_R] =
-        g_Meshes[g_Objects[O_LARA].mesh_idx + LM_HAND_R];
     g_CineFrameIdx = 428;
     g_CinePos.pos = item->pos;
     g_CinePos.rot = item->rot;


### PR DESCRIPTION
Resolves #1701.
Resolves #1992.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Fixes issues with flares before the final cutscene, and the softlock if Lara is on water surface. Separate commits, which I'll retain on merge rather than squashing - as the issues are semi-related, I thought it would be easier to do one PR.
