### PR TITLE
Config refactor

### DIFF
--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -41,7 +41,6 @@ bool Config_Write(void)
     };
     const bool updated = ConfigFile_Write(&args);
     if (updated) {
-        Config_ApplyChanges();
         if (m_EventManager != NULL) {
             const EVENT event = {
                 .name = "write",
@@ -50,6 +49,7 @@ bool Config_Write(void)
             };
             EventManager_Fire(m_EventManager, &event);
         }
+        Config_ApplyChanges();
     }
     return updated;
 }


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Extracted from #1983.

Moves `Config_ApplyChanges` to be called *after* launching event listeners, enabling client games to detect changes to specific config properties. To facilitate this, clients should implement logic in their `ApplyChanges` method like this:

```c
CONFIG g_SavedConfig = { 0 };

void Config_ApplyChanges(CONFIG_CHANGE_TRIGGER trigger)
{
    g_SavedConfig = g_Config;
}
```

Then the event subscribers can test for individual properties by comparing `g_Config` and `g_SavedConfig`.