### PR TITLE
gfx/3d: split color key blend mode to separate uniforms

### DIFF
--- a/data/tr1/ship/shaders/3d.glsl
+++ b/data/tr1/ship/shaders/3d.glsl
@@ -28,7 +28,8 @@ void main(void) {
 uniform sampler2D tex0;
 uniform bool texturingEnabled;
 uniform bool smoothingEnabled;
-uniform bool colorKeyEnabled;
+uniform bool alphaPointDiscard;
+uniform float alphaThreshold;
 
 #ifdef OGL33C
     #define OUTCOLOR outColor
@@ -54,7 +55,7 @@ void main(void) {
 
     if (texturingEnabled) {
 #if defined(GL_EXT_gpu_shader4) || defined(OGL33C)
-        if (colorKeyEnabled && smoothingEnabled) {
+        if (alphaPointDiscard && smoothingEnabled) {
             // do not use smoothing for chroma key
             ivec2 size = TEXTURESIZE(tex0, 0);
             int tx = int((vertTexCoords.x / vertTexCoords.z) * size.x) % size.x;
@@ -67,7 +68,7 @@ void main(void) {
 #endif
 
         vec4 texColor = TEXTURE(tex0, vertTexCoords.xy / vertTexCoords.z);
-        if (colorKeyEnabled && texColor.a == 0.0) {
+        if (alphaThreshold >= 0.0 && texColor.a <= alphaThreshold) {
             discard;
         }
 

--- a/src/libtrx/include/libtrx/gfx/3d/3d_renderer.h
+++ b/src/libtrx/include/libtrx/gfx/3d/3d_renderer.h
@@ -19,7 +19,6 @@ typedef enum {
     GFX_BLEND_MODE_OFF,
     GFX_BLEND_MODE_NORMAL,
     GFX_BLEND_MODE_MULTIPLY,
-    GFX_BLEND_MODE_COLOR_KEY,
 } GFX_BLEND_MODE;
 
 typedef struct GFX_3D_RENDERER GFX_3D_RENDERER;
@@ -66,3 +65,6 @@ void GFX_3D_Renderer_SetTexturingEnabled(
     GFX_3D_RENDERER *renderer, bool is_enabled);
 void GFX_3D_Renderer_SetAnisotropyFilter(
     GFX_3D_RENDERER *renderer, float value);
+void GFX_3D_Renderer_SetAlphaPointDiscard(
+    GFX_3D_RENDERER *renderer, bool is_enabled);
+void GFX_3D_Renderer_SetAlphaThreshold(GFX_3D_RENDERER *renderer, float value);

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -451,7 +451,7 @@ void S_Output_RenderBegin(void)
     GFX_3D_Renderer_RenderBegin(m_Renderer3D);
     GFX_3D_Renderer_SetTextureFilter(
         m_Renderer3D, g_Config.rendering.texture_filter);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
 }
 
 void S_Output_RenderEnd(void)
@@ -622,7 +622,7 @@ void S_Output_Draw2DLine(
     S_Output_DisableTextureMode();
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_NORMAL);
     GFX_3D_Renderer_RenderPrimList(m_Renderer3D, vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
     GFX_3D_Renderer_SetPrimType(m_Renderer3D, GFX_3D_PRIM_TRI);
 }
 
@@ -668,7 +668,7 @@ void S_Output_Draw2DQuad(
     S_Output_DisableTextureMode();
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_NORMAL);
     M_DrawTriangleFan(vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
 }
 
 void S_Output_DrawLightningSegment(
@@ -757,7 +757,7 @@ void S_Output_DrawLightningSegment(
     if (vertex_count) {
         M_DrawTriangleFan(vertices, vertex_count);
     }
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
 }
 
 void S_Output_DrawShadow(PHD_VBUF *vbufs, int clip, int vertex_count)
@@ -790,7 +790,7 @@ void S_Output_DrawShadow(PHD_VBUF *vbufs, int clip, int vertex_count)
 
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_NORMAL);
     M_DrawTriangleFan(vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
 }
 
 void S_Output_ApplyRenderSettings(void)
@@ -856,6 +856,8 @@ bool S_Output_Init(void)
 
     S_Output_ApplyRenderSettings();
     GFX_3D_Renderer_SetPrimType(m_Renderer3D, GFX_3D_PRIM_TRI);
+    GFX_3D_Renderer_SetAlphaThreshold(m_Renderer3D, 0.0);
+    GFX_3D_Renderer_SetAlphaPointDiscard(m_Renderer3D, true);
 
     return true;
 }
@@ -1022,7 +1024,7 @@ void S_Output_DrawEnvMapTriangle(
     GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_EnvMapTexture);
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_MULTIPLY);
     M_DrawTriangleFan(vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
     m_SelectedTexture = -1;
 }
 
@@ -1082,7 +1084,7 @@ void S_Output_DrawEnvMapQuad(
     GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_EnvMapTexture);
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_MULTIPLY);
     GFX_3D_Renderer_RenderPrimStrip(m_Renderer3D, vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_COLOR_KEY);
+    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
     m_SelectedTexture = -1;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This grants us more freedom with how we want to proceed with transparent pixels, which is necessary for another bug found in #1983:

![20241212_123200_xau](https://github.com/user-attachments/assets/8373a775-ae15-4b54-baad-a19f4748fd3d)

In that branch, we first output all opaque quads, then sort translucent faces by depth using some heuristics, and output them with the z-buffer disabled. This approach has many pitfalls, as detailed by https://www.khronos.org/opengl/wiki/Transparency_Sorting#Depth_Sorting (recommended reading). I worked around the issue by re-enabling z-writes and discarding alpha pixels in the shader above a certain threshold, which I've yet to push. This PR updates the GFX 3D Renderer API and adjusts TR1 code as needed, to support this technique.

To see it in effect, here's how it looks in TR2 when we use 0.1 alpha threshold:
![20241212_113145_Laras_Home_resized](https://github.com/user-attachments/assets/6aaa6951-c027-4e90-9c6f-142e32cb2dda)

The downside is that the bilinear filter may face some issues, like weird transparent pixels, but only if there's one transparent quad in front of another. I think that's acceptable.
![20241212_113146_Laras_Home_resized](https://github.com/user-attachments/assets/6ca32fdb-7090-49c5-826b-11b298e1a3e9)

In terms of implementation, this PR introduces two new shader settings by removing the special color key blending mode. The existing `colorKeyEnabled` blending uniform is split into `alphaThreshold` and `alphaPointDiscard`.

- `alphaThreshold`: Determines the opacity level at which pixels are discarded.
- `alphaPointDiscard`: Controls separate modulo sampling when bilinear filtering is active.

Here’s a visual comparison – using a 0.5 alpha threshold for discarding, and point discard off:
![20241212_124900_Laras_Home_cropped](https://github.com/user-attachments/assets/bd5da7d0-6b8c-4380-8d8a-78a08bf78340)
And here's 0.0 alpha threshold (ignored in this scenario), and point discard on (compatible with the current develop):
![20241212_124914_Laras_Home_cropped](https://github.com/user-attachments/assets/c9781c96-01c1-4953-948f-0e10fbdb4d74)
