### PR TITLE
tr1/objects/door: define doors in opening rooms

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed the drawbridge in Obelisk of Khamoon not being angled correctly when open, which was resulting in embedded artefacts (#2006)
 - fixed incorrect positions on static meshes in Obelisk of Khamoon, Return to Egypt and Temple of the Cat (#2006)
 - fixed incorrect picture strides on certain hardware (#1979)
+- fixed doors at times disappearing if Lara is close to portals and the door's room is no longer visible (#2005)
 
 ## [4.6.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.6...tr1-4.6.1) - 2024-11-25
 - added ability to disable saves completely by setting the save slot to 0 (#1954)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -549,6 +549,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - **The Hive**: incorrect textures in room 8, 13 and 18
 - fixed transparent eyes on the wolf and bat models in Peru
 - fixed incorrect transparent pixels on some Egypt textures
+- fixed doors at times disappearing if Lara is close to portals and the door's room is no longer visible
 - improved vertex movement when looking through water portals
 
 #### Audio

--- a/src/tr1/game/objects/general/door.c
+++ b/src/tr1/game/objects/general/door.c
@@ -189,6 +189,10 @@ void Door_Initialise(int16_t item_num)
 
     M_Shut(&door->d2);
     M_Shut(&door->d2flip);
+
+    const int16_t prev_room = item->room_num;
+    Item_NewRoom(item_num, room_num);
+    item->room_num = prev_room;
 }
 
 void Door_Control(int16_t item_num)


### PR DESCRIPTION
Part of #2005.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This takes on the TR2 approach of having doors defined in the rooms they open into, so to resolve drawing issues when close to the portals.

I'll keep the issue open for ongoing investigation into how room bounds are calculated and how this can be improved.
