### PR TITLE
skidoo: fix triggers being 1 frame late

### DIFF
--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -812,7 +812,6 @@ int32_t __cdecl Skidoo_Control(void)
         Room_GetSector(skidoo->pos.x, skidoo->pos.y, skidoo->pos.z, &room_num);
     int32_t height =
         Room_GetHeight(sector, skidoo->pos.x, skidoo->pos.y, skidoo->pos.z);
-    Room_TestTriggers(g_LaraItem);
 
     bool dead = false;
     if (g_LaraItem->hit_points <= 0) {
@@ -881,6 +880,7 @@ int32_t __cdecl Skidoo_Control(void)
     skidoo->rot.z += (z_rot - skidoo->rot.z) >> 1;
 
     if (skidoo->flags & IF_ONE_SHOT) {
+        Room_TestTriggers(g_LaraItem);
         if (room_num != skidoo->room_num) {
             Item_NewRoom(g_Lara.skidoo, room_num);
         }
@@ -912,6 +912,7 @@ int32_t __cdecl Skidoo_Control(void)
             g_LaraItem->rot.z = 0;
         }
     }
+    Room_TestTriggers(g_LaraItem);
 
     Item_Animate(g_LaraItem);
     if (!dead && drive >= 0 && M_IsArmed(skidoo_data)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1906.
The game code originally called the `Room_TestTriggers` function using `g_TriggerIndex`, which was determined by `Room_GetHeight`. This function was given the position of the skidoo with the `heavy` flag off. In commit f166dcb65afda2279a247641dc601bb9128c223f, we updated the code to automatically set the heavy flag if the item passed is not Lara. We used Lara's item instead, which was meant to match the skidoo's, with the trigger having the heavy flag off. However, Lara's position gets updated a little later, resulting in a 1-frame delay, causing the Tibet demo to become out of sync.
