### PR TITLE
boat: fix triggers being 1 frame late

### DIFF
--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -652,10 +652,6 @@ void __cdecl Boat_Control(const int16_t item_num)
         Room_GetHeight(sector, boat->pos.x, boat->pos.y, boat->pos.z);
     const int32_t ceiling =
         Room_GetCeiling(sector, boat->pos.x, boat->pos.y, boat->pos.z);
-    if (g_Lara.skidoo == item_num) {
-        Room_TestTriggers(lara);
-        Room_TestTriggers(boat);
-    }
 
     const int32_t water_height =
         Room_GetWaterHeight(boat->pos.x, boat->pos.y, boat->pos.z, room_num);
@@ -731,6 +727,8 @@ void __cdecl Boat_Control(const int16_t item_num)
         lara->rot.x = boat->rot.x;
         lara->rot.y = boat->rot.y;
         lara->rot.z = boat->rot.z;
+        Room_TestTriggers(lara);
+        Room_TestTriggers(boat);
 
         sector = Room_GetSector(
             lara->pos.x, lara->pos.y - 5, lara->pos.z, &room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Similar to #1906 fixed in #2016, the boat triggers seem to be suffering from the same issue.