### PR TITLE
tr2/camera: use config setting for microphone position

### DIFF
--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -185,7 +185,7 @@ typedef struct __unaligned { // decompiled
     bool triple_buffering; // TODO: remove this option
     bool fullscreen;
     bool sound_enabled;
-    bool lara_mic;
+    bool lara_mic; // TODO: remove this option
     bool joystick_enabled;
     bool disable_16bit_textures;
     bool dont_sort_primitives;
@@ -1215,7 +1215,7 @@ typedef struct __unaligned {
     ITEM *item;
     ITEM *last_item;
     OBJECT_VECTOR *fixed;
-    int32_t is_lara_mic;
+    int32_t is_lara_mic; // TODO: remove this - now stored in g_Config
     XYZ_32 mic_pos;
 } CAMERA_INFO;
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -134,7 +134,7 @@ void __cdecl Camera_Move(const GAME_VECTOR *target, int32_t speed)
         g_Camera.pos.x, g_Camera.shift + g_Camera.pos.y, g_Camera.pos.z,
         g_Camera.target.x, g_Camera.target.y, g_Camera.target.z, 0);
 
-    if (g_Camera.is_lara_mic) {
+    if (g_Config.audio.enable_lara_mic) {
         g_Camera.actual_angle =
             g_Lara.torso_y_rot + g_Lara.head_y_rot + g_LaraItem->rot.y;
         g_Camera.mic_pos.x = g_LaraItem->pos.x;
@@ -835,7 +835,7 @@ void __cdecl Camera_LoadCutsceneFrame(void)
     Room_GetSector(
         g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
 
-    if (g_Camera.is_lara_mic) {
+    if (g_Config.audio.enable_lara_mic) {
         g_Camera.actual_angle =
             g_Lara.torso_y_rot + g_Lara.head_y_rot + g_LaraItem->rot.y;
         g_Camera.mic_pos.x = g_LaraItem->pos.x;

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -681,7 +681,7 @@ typedef struct __unaligned {
     ITEM *item;
     ITEM *last_item;
     OBJECT_VECTOR *fixed;
-    int32_t is_lara_mic;
+    int32_t is_lara_mic; // TODO: remove this - now stored in g_Config
     XYZ_32 mic_pos;
 } CAMERA_INFO;
 


### PR DESCRIPTION
Resolves #2024.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This links the JSON microphone position config setting to the related logic in the camera module. Can be tested with the following and depending on the setting, you will either hear the clock when the camera shifts or not.

```
/play 0
/tp 43 2 89
```

For info, this is also used in the [Temple of Xian glitched speedrun](https://youtu.be/ZbZ8TyX5PX4?si=lZXZ8OaMvMY5cMmO&t=2473) so that you can hear Lara when moving through the void.
