### PR TITLE
tr1/output: refactor object mesh lighting

### DIFF
--- a/src/tr1/game/inventory/inventory_ring.c
+++ b/src/tr1/game/inventory/inventory_ring.c
@@ -430,7 +430,7 @@ void Inv_Ring_GetView(RING_INFO *ring, XYZ_32 *view_pos, XYZ_16 *view_rot)
 void Inv_Ring_Light(RING_INFO *ring)
 {
     PHD_ANGLE angles[2];
-    g_LsDivider = 0x6000;
+    Output_SetLightDivider(0x6000);
     Math_GetVectorAngles(ring->light.x, ring->light.y, ring->light.z, angles);
     Output_RotateLight(angles[1], angles[0]);
 }

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -26,6 +26,9 @@ void Output_SetDrawDistFade(int32_t dist);
 void Output_SetDrawDistMax(int32_t dist);
 void Output_SetWaterColor(const RGB_F *color);
 
+void Output_SetLightAdder(int32_t adder);
+void Output_SetLightDivider(int32_t divider);
+
 void Output_FadeReset(void);
 void Output_FadeResetToBlack(void);
 void Output_FadeToBlack(bool allow_immediate);

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -390,8 +390,8 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     Matrix_RotYXZ(0, PHD_DEGREE * 15, 0);
     Matrix_RotYXZ(pu->rot_y, 0, 0);
 
-    g_LsDivider = 0x6000;
-    g_LsAdder = LOW_LIGHT;
+    Output_SetLightDivider(0x6000);
+    Output_SetLightAdder(LOW_LIGHT);
     Output_RotateLight(0, 0);
     Output_SetupAboveWater(false);
 

--- a/src/tr1/game/phase/phase_inventory.c
+++ b/src/tr1/game/phase/phase_inventory.c
@@ -459,10 +459,10 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
     const IMOTION_INFO *motion = &m_Motion;
 
     if (motion->status == RNG_DONE) {
-        g_LsAdder = LOW_LIGHT;
+        Output_SetLightAdder(LOW_LIGHT);
     } else if (inv_item == ring->list[ring->current_object]) {
         if (ring->rotating) {
-            g_LsAdder = LOW_LIGHT;
+            Output_SetLightAdder(LOW_LIGHT);
             for (int j = 0; j < frames; j++) {
                 if (inv_item->y_rot < 0) {
                     inv_item->y_rot += 512;
@@ -474,7 +474,7 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
             motion->status == RNG_SELECTED || motion->status == RNG_DESELECTING
             || motion->status == RNG_SELECTING || motion->status == RNG_DESELECT
             || motion->status == RNG_CLOSING_ITEM) {
-            g_LsAdder = HIGH_LIGHT;
+            Output_SetLightAdder(HIGH_LIGHT);
             for (int j = 0; j < frames; j++) {
                 if (inv_item->y_rot != inv_item->y_rot_sel) {
                     if (inv_item->y_rot_sel - inv_item->y_rot > 0
@@ -490,13 +490,13 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
             ring->number_of_objects == 1
             || (!g_Input.menu_left && !g_Input.menu_right)
             || !g_Input.menu_left) {
-            g_LsAdder = HIGH_LIGHT;
+            Output_SetLightAdder(HIGH_LIGHT);
             for (int j = 0; j < frames; j++) {
                 inv_item->y_rot += 256;
             }
         }
     } else {
-        g_LsAdder = LOW_LIGHT;
+        Output_SetLightAdder(LOW_LIGHT);
         for (int j = 0; j < frames; j++) {
             if (inv_item->y_rot < 0) {
                 inv_item->y_rot += 256;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -97,9 +97,6 @@ int16_t g_RoomsToDrawCount = 0;
 
 int16_t g_InvMode = INV_TITLE_MODE;
 
-int32_t g_LsAdder = 0;
-int32_t g_LsDivider = 0;
-
 #ifndef MESON_BUILD
 const char *g_TR1XVersion = "TR1X (non-Docker build)";
 #endif

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -22,9 +22,6 @@ extern PHD_TEXTURE g_PhdTextureInfo[MAX_TEXTURES];
 extern MATRIX *g_MatrixPtr;
 extern MATRIX g_W2VMatrix;
 
-extern int32_t g_LsAdder;
-extern int32_t g_LsDivider;
-
 extern bool g_IDelay;
 extern int32_t g_IDCount;
 extern int32_t g_OptionSelected;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This mainly covers a `TODO` from #1941 to refactor the object mesh lighting function to be a bit more readable. We check for static lighting on the mesh first, then fixed lighting, then dynamic lighting. Hopefully the flow is clearer.

I have also moved the global `g_LsAdder` and `g_LsDivider` variables to module scope in `output.c`, and provided relevant setter functions. I didn't add any getters as they're not required anywhere currently.
