### PR TITLE
tr1/output: fix lightnings not respecting scene depth

### DIFF
--- a/src/tr1/game/game/game_draw.c
+++ b/src/tr1/game/game/game_draw.c
@@ -34,6 +34,7 @@ void Game_DrawScene(bool draw_overlay)
         }
 
         Lara_Draw(g_LaraItem);
+        Output_FlushTranslucentObjects();
 
         if (draw_overlay) {
             Overlay_DrawGameInfo();
@@ -55,8 +56,8 @@ void Game_DrawScene(bool draw_overlay)
 
         Output_SetupAboveWater(false);
         Lara_Hair_Draw();
+        Output_FlushTranslucentObjects();
     }
 
-    Output_FlushTranslucentObjects();
     Output_DrawBackdropScreen();
 }

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -373,8 +373,6 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         return;
     }
 
-    Output_ClearDepthBuffer();
-
     // Reset the FOV and the W2V matrix in case they get changed by a cinematic
     // camera (when picking up the Scion). Move the viewport rather than
     // translating the object in order to avoid perspective distortion in the


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #2028.