### PR TITLE
tr2/output: do not subject console text to fade effects

### DIFF
--- a/src/libtrx/game/text.c
+++ b/src/libtrx/game/text.c
@@ -100,6 +100,14 @@ void Text_Shutdown(void)
     m_GlyphLookupKeyCap = 0;
 }
 
+void Text_DrawReset(void)
+{
+    for (int32_t i = 0; i < TEXT_MAX_STRINGS; i++) {
+        TEXTSTRING *const text = &m_TextStrings[i];
+        text->flags.drawn = 0;
+    }
+}
+
 void Text_Draw(void)
 {
     for (int32_t i = 0; i < TEXT_MAX_STRINGS; i++) {

--- a/src/libtrx/include/libtrx/game/text.h
+++ b/src/libtrx/include/libtrx/game/text.h
@@ -53,7 +53,9 @@ typedef struct {
             uint32_t outline : 1;
             uint32_t hide : 1;
             uint32_t multiline : 1;
+
             uint32_t manual_draw : 1;
+            uint32_t drawn : 1;
         };
     } flags;
 
@@ -129,4 +131,5 @@ void Text_SetMultiline(TEXTSTRING *text, bool enable);
 int32_t Text_GetWidth(const TEXTSTRING *text);
 int32_t Text_GetHeight(const TEXTSTRING *text);
 
+void Text_DrawReset(void);
 void Text_Draw(void);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -611,6 +611,7 @@ void Output_FlushTranslucentObjects(void)
 void Output_BeginScene(void)
 {
     Output_ApplyFOV();
+    Text_DrawReset();
 
     S_Output_RenderBegin();
     m_LightningCount = 0;

--- a/src/tr1/game/text.c
+++ b/src/tr1/game/text.c
@@ -113,6 +113,11 @@ RGBA_8888 Text_GetMenuColor(MENU_COLOR color)
 
 void Text_DrawText(TEXTSTRING *const text)
 {
+    if (text->flags.drawn) {
+        return;
+    }
+    text->flags.drawn = 1;
+
     if (text->flags.hide || text->glyphs == NULL) {
         return;
     }

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -436,10 +436,11 @@ void __cdecl DisplayCredits(void)
         while (Fader_Control(&fader)) {
             Output_BeginScene();
             Output_DrawBackground();
+            Output_DrawPolyList();
+            Output_DrawBlackRectangle(fader.current.value);
             Console_Draw();
             Text_Draw();
             Output_DrawPolyList();
-            Output_DrawBlackRectangle(fader.current.value);
             Output_EndScene();
         }
 
@@ -451,10 +452,11 @@ void __cdecl DisplayCredits(void)
         while (Fader_Control(&fader)) {
             Output_BeginScene();
             Output_DrawBackground();
+            Output_DrawPolyList();
+            Output_DrawBlackRectangle(fader.current.value);
             Console_Draw();
             Text_Draw();
             Output_DrawPolyList();
-            Output_DrawBlackRectangle(fader.current.value);
             Output_EndScene();
         }
 

--- a/src/tr2/decomp/stats.c
+++ b/src/tr2/decomp/stats.c
@@ -372,10 +372,12 @@ int32_t __cdecl GameStats(const int32_t level_num)
         Output_BeginScene();
         Output_DrawBackground();
         ShowEndStatsText();
-        Console_Draw();
         Text_Draw();
         Output_DrawPolyList();
         Output_DrawBlackRectangle(fader.current.value);
+        Console_Draw();
+        Text_Draw();
+        Output_DrawPolyList();
         Output_EndScene();
     }
 
@@ -394,6 +396,7 @@ int32_t __cdecl GameStats(const int32_t level_num)
         Output_BeginScene();
         Output_DrawBackground();
         ShowEndStatsText();
+        Output_DrawPolyList();
         Console_Draw();
         Text_Draw();
         Output_DrawPolyList();
@@ -411,10 +414,12 @@ int32_t __cdecl GameStats(const int32_t level_num)
         Output_BeginScene();
         Output_DrawBackground();
         ShowEndStatsText();
-        Console_Draw();
         Text_Draw();
         Output_DrawPolyList();
         Output_DrawBlackRectangle(fader.current.value);
+        Console_Draw();
+        Text_Draw();
+        Output_DrawPolyList();
         Output_EndScene();
     }
 

--- a/src/tr2/game/inventory/common.c
+++ b/src/tr2/game/inventory/common.c
@@ -461,11 +461,14 @@ static void M_Draw(
     }
 
     Overlay_DrawModeInfo();
-    Console_Draw();
     Text_Draw();
     Output_DrawPolyList();
 
     Output_DrawBlackRectangle(fader->current.value);
+    Console_Draw();
+    Text_Draw();
+    Output_DrawPolyList();
+
     const int32_t frames = Output_EndScene() * TICKS_PER_FRAME;
 
     Sound_EndScene();

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -609,6 +609,7 @@ bool __cdecl Output_MakeScreenshot(const char *const path)
 void Output_BeginScene(void)
 {
     g_MatrixPtr = g_MatrixStack;
+    Text_DrawReset();
     Render_BeginScene();
 }
 

--- a/src/tr2/game/text.c
+++ b/src/tr2/game/text.c
@@ -41,6 +41,11 @@ void __cdecl Text_DrawBorder(
 
 void __cdecl Text_DrawText(TEXTSTRING *const text)
 {
+    if (text->flags.drawn) {
+        return;
+    }
+    text->flags.drawn = 1;
+
     int32_t box_w = 0;
     int32_t box_h = 0;
     const int32_t scale_h = Text_GetScaleH(text->scale.h);


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This pull request updates the console text to always appear above the fade effects. This change is most noticeable on the final stats screen. To achieve this:

1. Each piece of text is drawn only once per frame.
2. The text drawing process is split into two stages:
   - First, we render ingame text before the fade rectangle.
   - Then, we render the console text.

TR1's fades mechanism works differently, so it shouldn't be affected, but the changes do touch the TR1 code, so it's good to run sanity tests around inventory and other texts.