### PR TITLE
tr1/s_output: fix shutdown call order

### DIFF
--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -866,7 +866,7 @@ void S_Output_Shutdown(void)
 {
     M_ReleaseTextures();
     M_ReleaseSurfaces();
-    GFX_Context_Detach();
+
     if (m_Renderer2D != NULL) {
         GFX_2D_Renderer_Destroy(m_Renderer2D);
         m_Renderer2D = NULL;
@@ -875,6 +875,7 @@ void S_Output_Shutdown(void)
         GFX_3D_Renderer_Destroy(m_Renderer3D);
         m_Renderer3D = NULL;
     }
+    GFX_Context_Detach();
 }
 
 void S_Output_DrawFlatTriangle(


### PR DESCRIPTION
Resolves #2033.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This shifts the call to detach the graphics context after we have destroyed the renderers, which resolves an infinite loop when exiting the game and FMVs are enabled.
