### PR TITLE
tr1/objects/movable_block: add trap feature to pushblocks

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -22,6 +22,7 @@
     ],
     "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
+    "enable_killer_pushblocks": true,
 
     "levels": [
         // Level 0

--- a/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_demo_pc.json5
@@ -22,6 +22,7 @@
     ],
     "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
+    "enable_killer_pushblocks": true,
 
     "levels": [
         // Level 2

--- a/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_ub.json5
@@ -21,6 +21,7 @@
     ],
     "enable_tr2_item_drops": false,
     "convert_dropped_guns": false,
+    "enable_killer_pushblocks": true,
 
     "enforced_config": {
         "enable_save_crystals": false,

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -24,6 +24,7 @@
     Swedish, Turkish and possibly more.
 
     Importantly, Asian and Arabic languages remain unsupported at the moment.
+- added the ability for falling pushblocks to kill Lara outright if one lands directly on her (#2035)
 - fixed a potential invisible wall issue in custom levels with non-portal doors and certain geometry (#1958, regression from 4.3)
 - fixed transparent eyes on the wolf and bat models in Peru (#1945)
 - fixed incorrect transparent pixels on some Egypt textures (#1975)

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -113,6 +113,19 @@ various pieces of global behaviour.
   </tr>
   <tr valign="top">
     <td>
+      <a name="enable-killer-pushblocks"></a>
+      <code>enable_killer_pushblocks</code>
+    </td>
+    <td>Boolean</td>
+    <td>No</td>
+    <td>
+      If enabled, when a pushblock falls from the air and lands on Lara, it will
+      kill her outright. Otherwise, Lara will clip on top of the block and
+      survive.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td>
       <a name="enable-tr2-item-drops"></a>
       <code>enable_tr2_item_drops</code>
     </td>

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -403,6 +403,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added options to quiet or mute music while underwater
 - added a photo mode feature
 - added optional automatic key/puzzle inventory item pre-selection
+- added the ability for falling pushblocks to kill Lara outright if one lands directly on her
 - changed weapon pickup behavior when unarmed to set any weapon as the default weapon, not just pistols
 - fixed keys and items not working when drawing guns immediately after using them
 - fixed counting the secret in The Great Pyramid

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -46,6 +46,7 @@ typedef struct __PACKING {
     void *data;
     void *priv;
     CARRIED_ITEM *carried_item;
+    bool enable_shadow;
 #elif TR_VERSION == 2
     int16_t shade_1;
     int16_t shade_2;

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -221,6 +221,8 @@ static bool M_LoadScriptMeta(JSON_OBJECT *obj)
         JSON_ObjectGetBool(obj, "enable_tr2_item_drops", false);
     g_GameFlow.convert_dropped_guns =
         JSON_ObjectGetBool(obj, "convert_dropped_guns", false);
+    g_GameFlow.enable_killer_pushblocks =
+        JSON_ObjectGetBool(obj, "enable_killer_pushblocks", true);
 
     return true;
 }

--- a/src/tr1/game/gameflow.h
+++ b/src/tr1/game/gameflow.h
@@ -79,6 +79,7 @@ typedef struct {
     } injections;
     bool enable_tr2_item_drops;
     bool convert_dropped_guns;
+    bool enable_killer_pushblocks;
 } GAMEFLOW;
 
 extern GAMEFLOW g_GameFlow;

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -130,6 +130,7 @@ void Item_Initialise(int16_t item_num)
     item->data = NULL;
     item->priv = NULL;
     item->carried_item = NULL;
+    item->enable_shadow = true;
 
     if (item->flags & IF_INVISIBLE) {
         item->status = IS_INVISIBLE;

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -162,6 +162,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.air = LARA_MAX_AIR;
     g_Lara.death_timer = 0;
     g_Lara.mesh_effects = 0;
+    g_LaraItem->enable_shadow = true;
     Lara_InitialiseMeshes(g_CurrentLevel);
     g_Camera.type = CAM_CHASE;
     Viewport_SetFOV(-1);

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -34,6 +34,8 @@
 #define LARA_MOVE_SPEED 16
 #define LARA_UW_DAMAGE 5
 
+static int16_t m_DeathCameraTarget = NO_ITEM;
+
 LARA_INFO *Lara_GetLaraInfo(void)
 {
     return &g_Lara;
@@ -42,6 +44,16 @@ LARA_INFO *Lara_GetLaraInfo(void)
 ITEM *Lara_GetItem(void)
 {
     return g_LaraItem;
+}
+
+ITEM *Lara_GetDeathCameraTarget(void)
+{
+    return m_DeathCameraTarget == -1 ? NULL : Item_Get(m_DeathCameraTarget);
+}
+
+void Lara_SetDeathCameraTarget(const int16_t item_num)
+{
+    m_DeathCameraTarget = item_num;
 }
 
 void Lara_Control(void)
@@ -581,6 +593,7 @@ void Lara_Initialise(int32_t level_num)
         g_LaraItem->hit_points = g_Config.start_lara_hitpoints;
     }
 
+    m_DeathCameraTarget = NO_ITEM;
     g_Lara.air = LARA_MAX_AIR;
     g_Lara.torso_rot.y = 0;
     g_Lara.torso_rot.x = 0;

--- a/src/tr1/game/lara/common.h
+++ b/src/tr1/game/lara/common.h
@@ -9,6 +9,9 @@
 
 void Lara_Control(void);
 
+ITEM *Lara_GetDeathCameraTarget(void);
+void Lara_SetDeathCameraTarget(int16_t item_num);
+
 void Lara_ControlExtra(int16_t item_num);
 void Lara_Animate(ITEM *item);
 void Lara_AnimateUntil(ITEM *lara_item, int32_t goal);

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -700,9 +700,19 @@ void Lara_State_Roll2(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Special(ITEM *item, COLL_INFO *coll)
 {
-    g_Camera.flags = FOLLOW_CENTRE;
-    g_Camera.target_angle = 170 * PHD_DEGREE;
-    g_Camera.target_elevation = -25 * PHD_DEGREE;
+    ITEM *const target_item = Lara_GetDeathCameraTarget();
+    if (target_item != NULL) {
+        g_Camera.item = target_item;
+        g_Camera.flags = CHASE_OBJECT;
+        g_Camera.type = CAM_FIXED;
+        g_Camera.target_angle = item->rot.y;
+        g_Camera.target_distance = WALL_L * 2;
+        g_Camera.target_elevation = -25 * PHD_DEGREE;
+    } else {
+        g_Camera.flags = FOLLOW_CENTRE;
+        g_Camera.target_angle = 170 * PHD_DEGREE;
+        g_Camera.target_elevation = -25 * PHD_DEGREE;
+    }
 }
 
 void Lara_State_UseMidas(ITEM *item, COLL_INFO *coll)

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -806,6 +806,10 @@ void Output_DrawRoom(const ROOM_MESH *const mesh)
 void Output_DrawShadow(
     const int16_t size, const BOUNDS_16 *const bounds, const ITEM *const item)
 {
+    if (!item->enable_shadow) {
+        return;
+    }
+
     SHADOW_INFO shadow = { 0 };
     shadow.vertex_count = g_Config.enable_round_shadow ? 32 : 8;
 


### PR DESCRIPTION
Resolves #2035.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This makes falling pushblocks more realistic if they land on top of Lara, killing her outright. We hide Lara's shadow to avoid it appearing on top of the pushblock, as the floor height change will continue to operate in case there are active enemies nearby. Additionally, a camera target item is spawned to prevent issues with the camera looking into the pushblock at Lara i.e. if we set the target to be the pushblock, the camera will push into the raised floor. This target also needs to be stored and continually set in the state routine as the camera is otherwise eager to return to normal.
