### PR TITLE
tr2/lara/cheat: test zero or negative hit points when killing enemies

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fixed screenshots not capturing level stats (#1925, regression from 0.6)
 - fixed screenshots sometimes crashing in the windowed mode (regression from 0.6)
 - fixed creatures being able to swim/fly above the ceiling up to one tile (#1936, regression from 0.1)
+- fixed the `/kill all` command reporting an incorrect count in some levels (#1995, regression from 0.3)
 - removed unused detail level option
 
 ## [0.6](https://github.com/LostArtefacts/TRX/compare/tr2-0.5...tr2-0.6) - 2024-11-06

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -337,6 +337,7 @@ void __cdecl Creature_Die(const int16_t item_num, const bool explode)
         if (explode) {
             Effect_ExplodingDeath(item_num, -1, 0);
         }
+        item->hit_points = DONT_TARGET;
         const int16_t vehicle_item_num = (int16_t)(intptr_t)item->data;
         ITEM *const vehicle_item = &g_Items[vehicle_item_num];
         vehicle_item->hit_points = 0;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -431,8 +431,8 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
 
 bool Lara_Cheat_KillEnemy(const int16_t item_num)
 {
-    ITEM *const item = &g_Items[item_num];
-    if ((item->hit_points == DONT_TARGET && item->object_id != O_WINSTON)) {
+    ITEM *const item = Item_Get(item_num);
+    if (item->hit_points <= 0 && item->object_id != O_WINSTON) {
         return false;
     }
 


### PR DESCRIPTION
Resolves #1995.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This sets the skidoo driver's HP to `DONT_TARGET` after using the kill cheat (similar is done in `M_KillDriver`). Lara's test for which enemies to include now ignores anything with zero or negative HP, which resolves the issue of being able to cheat-kill the dragon multiple times.
