### PR TITLE
tr1/output: use item shade to light 3D pickups

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed camera positions in Return to Egypt and Temple of the Cat (#1317, regression from 4.1)
 - fixed being able to see the flipmap in Natla's Mines when moving the boat (#2019)
 - fixed an invisible wall in Temple of the Cat, due to a wrongly positioned door (#2021)
+- improved lighting on 3D pickups (#2017)
 
 ## [4.6.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.6...tr1-4.6.1) - 2024-11-25
 - added ability to disable saves completely by setting the save slot to 0 (#1954)

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -187,8 +187,7 @@ void Object_DrawPickupItem(ITEM *item)
         item->interp.result.rot.y, item->interp.result.rot.x,
         item->interp.result.rot.z);
 
-    Output_CalculateLight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    Output_CalculatePickupLight(item);
 
     frame = object->frame_base;
     int32_t clip = Output_GetObjectBounds(&frame->bounds);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -724,6 +724,20 @@ void Output_CalculateObjectLighting(
     Output_CalculateLight(offset.x, offset.y, offset.z, item->room_num);
 }
 
+void Output_CalculatePickupLight(const ITEM *const item)
+{
+    if (item->shade >= 0) {
+        m_LsAdder = item->shade;
+        m_LsDivider = 0;
+        const int32_t distance = g_MatrixPtr->_23 >> W2V_SHIFT;
+        m_LsAdder += M_CalcFogShade(distance);
+        CLAMPG(m_LsAdder, 0x1FFF);
+    } else {
+        Output_CalculateLight(
+            item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    }
+}
+
 void Output_DrawObjectMesh(const OBJECT_MESH *const mesh, const int32_t clip)
 {
     if (!M_CalcObjectVertices(mesh->vertices, mesh->num_vertices)) {

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -47,6 +47,7 @@ void Output_ClearDepthBuffer(void);
 void Output_CalculateLight(int32_t x, int32_t y, int32_t z, int16_t room_num);
 void Output_CalculateStaticLight(int16_t adder);
 void Output_CalculateObjectLighting(const ITEM *item, const BOUNDS_16 *bounds);
+void Output_CalculatePickupLight(const ITEM *item);
 
 void Output_DrawObjectMesh(const OBJECT_MESH *mesh, int32_t clip);
 void Output_DrawObjectMesh_I(const OBJECT_MESH *mesh, int32_t clip);


### PR DESCRIPTION
Part of #2017.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This uses the shade value on items to light 3D pickup objects, so they appear similarly lit to the sprite equivalent.

If this looks ok in TR1, we can apply similar to TR2 at a later date.
