### PR TITLE
tr1/config-tool: small changes to the Italian translation

### DIFF
--- a/tools/tr1/config/TR1X_ConfigTool/Resources/Lang/it.json
+++ b/tools/tr1/config/TR1X_ConfigTool/Resources/Lang/it.json
@@ -102,7 +102,7 @@
     },
     "enable_tr2_swim_cancel": {
       "Title": "Annullamento reattivo del nuoto",
-      "Description": "Permette a Lara di fermarsi più reattivamente sott'acqua quando viene rilasciato il tasto per nuotare, similmente a TR2+."
+      "Description": "Permette a Lara di fermarsi in modo più istantaneo sott'acqua quando viene rilasciato il tasto per nuotare, simile a TR2+."
     },
     "enable_wading": {
       "Title": "Guadare",
@@ -118,11 +118,11 @@
     },
     "enable_lean_jumping": {
       "Title": "Salti inclinati",
-      "Description": "Permette a Lara di spostarsi ulteriormente in avanti o indietro quando esegue salti sul posto, tenendo premuto il relativo tasto (Avanti o Indietro), simile a TR2+."
+      "Description": "Permette a Lara di spostarsi ulteriormente in avanti o indietro quando esegue salti sul posto, tenendo premuto il relativo tasto (Avanti o Indietro), in modo simile a TR2+."
     },
     "enable_numeric_keys": {
       "Title": "Tasti numerici per uso rapido degli oggetti",
-      "Description": "Abilita i tasti numerici di scelta rapida per equipaggiare armi o usare kit medici.\n- 1: Equipaggia pistole\n- 2: Equipaggia fucile\n- 3: Equipaggia magnum\n- 4: Equipaggia Uzi\n- 8: Usa kit medico piccolo\n- 9: Usa kit medico grande"
+      "Description": "Abilita i tasti numerici di scelta rapida per equipaggiare armi o usare kit medici.\n- 1: Equipaggia pistole\n- 2: Equipaggia fucile a pompa\n- 3: Equipaggia magnum\n- 4: Equipaggia Uzi\n- 8: Usa kit medico piccolo\n- 9: Usa kit medico grande"
     },
     "enabled_inverted_look": {
       "Title": "Visuale invertita",
@@ -146,11 +146,11 @@
     },
     "fix_bridge_collision": {
       "Title": "Correggi la collisione dei ponti",
-      "Description": "Risolve il problema per cui Lara non è in grado di afferrare parti di alcuni ponti e muri invisibili ai bordi. Corregge anche i problemi di collisione con ponti levatoi, botole e ponti quando sono impilati l'uno sull'altro, su pendenze o vicino al suolo."
+      "Description": "Risolve il problema per cui Lara non è in grado di afferrare parti di alcuni ponti e muri invisibili ai bordi. Corregge anche i problemi di collisione con ponti levatoi, botole e ponti quando sono impilati l'uno sull'altro, su pendii o vicino al suolo."
     },
     "fix_floor_data_issues": {
       "Title": "Correggi i dati dei livelli",
-      "Description": "Risolve i problemi dei livelli originali relativi a dati/attivazioni, inclusi i seguenti.\n- Il pipistrello dormiente nel Colosseo.\n- Il segreto nella Grande Piramide che non viene registrato."
+      "Description": "Risolve i problemi dei livelli originali relativi a dati/eventi, inclusi i seguenti.\n- Il pipistrello dormiente nel Colosseo.\n- Il segreto nella Grande Piramide che non viene registrato."
     },
     "fix_texture_issues": {
       "Title": "Correggi i problemi delle texture",
@@ -182,7 +182,7 @@
     },
     "enable_cheats": {
       "Title": "Trucchi",
-      "Description": "Abilita vari trucchi:\n- L: termina immediatamente il livello.\n- I: dai a Lara tutte le armi; gran quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n     - tasto CAMMINA: disabilita DOZY.\n     - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi)."
+      "Description": "Abilita vari trucchi:\n- L: termina immediatamente il livello.\n- I: dai a Lara tutte le armi; maggior quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n     - tasto CAMMINA: disabilita il trucco DOZY.\n     - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi)."
     },
     "enable_console": {
       "Title": "Console",
@@ -202,14 +202,14 @@
     },
     "disable_shotgun": {
       "Title": "Rimuovi i fucili",
-      "Description": "Rimuove tutti i fucili e le cartucce per fucile dal gioco."
+      "Description": "Rimuove tutti i fucili a pompa e le cartucce per fucile dal gioco."
     },
     "disable_magnums": {
       "Title": "Rimuovi le magnum",
       "Description": "Rimuove tutte le magnum e le munizioni magnum dal gioco."
     },
     "disable_uzis": {
-      "Title": "Removi le Uzi",
+      "Title": "Rimuovi le Uzi",
       "Description": "Rimuove tutte le Uzi e le munizioni Uzi dal gioco."
     },
     "enable_save_crystals": {
@@ -238,7 +238,7 @@
     },
     "enable_detailed_stats": {
       "Title": "Mostra il numero totale di uccisioni e oggetti",
-      "Description": "Consente di mostrare il numero massimo di uccisioni e oggetti raccoglibili di ogni livello."
+      "Description": "Consente di mostrare il numero massimo di uccisioni e oggetti recuperabili di ogni livello."
     },
     "enable_cine": {
       "Title": "Abilita le scene di intermezzo",
@@ -258,7 +258,7 @@
     },
     "enable_loading_screens": {
       "Title": "Abilita le schermate di caricamento",
-      "Description": "Abilita le schermate di caricamento prima di ogni livello, in stile PS1."
+      "Description": "Abilita le schermate di caricamento in stile PS1 prima di ogni livello."
     },
     "enable_buffering": {
       "Title": "Abilita buffering",
@@ -270,7 +270,7 @@
     },
     "fix_shotgun_targeting": {
       "Title": "Mira con il fucile migliorata",
-      "Description": "Fa in modo che il fucile non spari più quando un bersaglio agganciato esce dal campo visivo di Lara, in modo simile alle altre armi."
+      "Description": "Fa in modo che il fucile a pompa non spari più quando un bersaglio agganciato esce dal campo visivo di Lara, in modo simile alle altre armi."
     },
     "revert_to_pistols": {
       "Title": "Pistole come arma primaria",
@@ -282,11 +282,11 @@
     },
     "enable_enhanced_saves": {
       "Title": "Salva informazioni aggiuntive sul gioco",
-      "Description": "Migliora il sistema di salvataggio in modo che effetti grafici, particellari delle cascate, emettitori di fiamme e altro vengano salvati invece di scomparire dopo il caricamento della partita."
+      "Description": "Migliora il sistema di salvataggio in modo che gli effetti grafici, la foschia delle cascate, gli emettitori di fiamme e altro vengano salvati invece di scomparire dopo il caricamento della partita."
     },
     "change_pierre_spawn": {
       "Title": "Cambia il comportamento di generazione di Pierre",
-      "Description": "Fa in modo che, alla sua generazione, un Pierre (sfuggente) sostituisca un altro Pierre (sfuggente) già esistente."
+      "Description": "Fa in modo che, alla sua generazione, un Pierre (in fuga) sostituisca un altro Pierre (in fuga) già esistente."
     },
     "restore_ps1_enemies": {
       "Title": "Ripristina i nemici PS1",
@@ -301,8 +301,8 @@
       "Description": "Fa in modo che il tempo di gioco scorra anche nel menu dell'inventario"
     },
     "enable_item_examining": {
-      "Title": "Esaminare oggetti",
-      "Description": "Per livelli custom: consente di visualizzare le descrizioni degli oggetti nell'inventario quando fornite dall'autore del livello."
+      "Title": "Esame degli oggetti",
+      "Description": "Per livelli personalizzati: consente di visualizzare le descrizioni degli oggetti nell'inventario quando fornite dall'autore del livello."
     },
     "anisotropy_filter": {
       "Title": "Filtro anisotropico",
@@ -310,7 +310,7 @@
     },
     "fov_value": {
       "Title": "Campo visivo",
-      "Description": "Il campo visivo desiderato in gradi, che sovrascrive l'impostazione predefinita codificata nel gioco. I valori predefiniti sono 80 (orizzontale) e 65 (verticale)."
+      "Description": "Campo visivo desiderato (in gradi), che sovrascrive l'impostazione predefinita codificata nel gioco. I valori predefiniti sono 80 (orizzontale) e 65 (verticale)."
     },
     "fov_vertical": {
       "Title": "Campo visivo verticale",
@@ -322,7 +322,7 @@
     },
     "resolution_height": {
       "Title": "Altezza risoluzione",
-      "Description": "Sovrascrive la risoluzione del gioco. Vedi le note dell'opzione 'Larghezza risoluzione'."
+      "Description": "Sovrascrive la risoluzione del gioco. Osserva le note dell'opzione 'Larghezza risoluzione'."
     },
     "enable_skybox": {
       "Title": "Cielo",
@@ -334,11 +334,11 @@
     },
     "enable_3d_pickups": {
       "Title": "Oggetti 3D",
-      "Description": "Sostituisce gli sprite 2D con i rispettivi modelli 3D per gli oggetti raccoglibili."
+      "Description": "Sostituisce gli oggetti recuperabili 2D con i rispettivi modelli 3D."
     },
     "enable_ps1_crystals": {
       "Title": "Abilita i cristalli di salvataggio PS1",
-      "Description": "I cristalli di salvataggio verranno resi viola, più simili a quelli PS1."
+      "Description": "I cristalli di salvataggio saranno di color viola, più simili a quelli PS1"
     },
     "enable_round_shadow": {
       "Title": "Ombre arrotondate",
@@ -346,11 +346,11 @@
     },
     "enable_shotgun_flash": {
       "Title": "Lampo dello sparo del fucile",
-      "Description": "Mostra il lampo dello sparo facendo fuoco con il fucile, come per le altre armi."
+      "Description": "Mostra il lampo dello sparo quando Lara fa fuoco con il fucile a pompa, come per le altre armi."
     },
     "screenshot_format": {
-      "Title": "Formato screenshot",
-      "Description": "Formato del file da utilizzare per gli screenshot."
+      "Title": "Formato istantanea dello schermo",
+      "Description": "Formato del file da utilizzare per le istantanee dello schermo."
     },
     "music_load_condition": {
       "Title": "Carica la traccia musicale",
@@ -358,7 +358,7 @@
     },
     "load_music_triggers": {
       "Title": "Ricorda la musica riprodotta",
-      "Description": "Registra le tracce musicali intese per attivarsi una singola volta nel file di salvataggio, impedendo che vengano riprodotte di nuovo dopo il caricamento della partita."
+      "Description": "Contrassegna le tracce musicali riprodotte nel file di salvataggio, in modo che le tracce legate ad eventi non vengano rieseguite dopo il caricamento della partita."
     },
     "enable_music_in_menu": {
       "Title": "Abilita la musica del menu principale",
@@ -430,7 +430,7 @@
     },
     "enable_smooth_bars": {
       "Title": "Barre sfumate",
-      "Description": "Fa in modo che la barra della salute e la barra dell'ossigeno transizionino armonicamente di colore."
+      "Description": "Fa in modo che la barra della salute e la barra dell'ossigeno utilizzino transizioni di colore uniformi."
     },
     "enable_fade_effects": {
       "Title": "Effetti di dissolvenza",


### PR DESCRIPTION
#### Checklist

- [ ] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Small changes to the Italian translation of TR1X ConfigTool.

I also updated the Italian translation of the game menus for TR1X 4.6.1: [TR1X4-6-1_TradITA.zip](https://github.com/user-attachments/files/18141438/TR1X4-6-1_TradITA.zip).
I hope someone starts working on the localization system and puts more emphasis on accessibility, because at the moment it is necessary to completely revise the scripts with each new version of TR1X, besides the fact that there are no subtitles for the in-game engine cutscenes (and it is not possible to add them).
