### PR TITLE
Fix clock drifts in TR1 and TR2

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -25,6 +25,7 @@
 
     Importantly, Asian and Arabic languages remain unsupported at the moment.
 - added the ability for falling pushblocks to kill Lara outright if one lands directly on her (#2035)
+- fixed clock drift accumulating with time (#1935, regression from 4.0)
 - fixed a potential invisible wall issue in custom levels with non-portal doors and certain geometry (#1958, regression from 4.3)
 - fixed transparent eyes on the wolf and bat models in Peru (#1945)
 - fixed incorrect transparent pixels on some Egypt textures (#1975)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fixed exiting the game with Alt+F4 not immediately working in cutscenes
 - fixed game freezing when starting demo/credits/inventory offscreen
 - fixed problems when trying to launch the game with High DPI mode enabled (#1845)
+- fixed clock drift accumulating with time, causing audio desync in cutscenes (#1935, regression from 0.6)
 - fixed controllers dialog missing background in the software renderer mode (#1978, regression from 0.6)
 - fixed a crash relating to audio decoding (#1895, regression from 0.2)
 - fixed depth problems when drawing certain rooms (#1853, regression from 0.6)

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -4388,7 +4388,7 @@ typedef enum {
 0x004D6F78  -       int8_t g_IsShadeEffect;
 0x004D6F80  +       D3DTLVERTEX g_VBufferD3D[32];
 0x004D7380  -       PALETTEENTRY g_GamePalette16[256];
-0x004D7780  -       int32_t g_CineFrameCurrent;
+0x004D7780  +       int32_t g_CineFrameCurrent;
 0x004D778C  -       int32_t g_IsChunkyCamera;
 0x004D7794  -       int32_t g_NoInputCounter;
 0x004D7798  +       BOOL g_IsResetFlag;
@@ -4573,7 +4573,7 @@ typedef enum {
 0x005252B8  +       int32_t g_DrawRoomsCount;
 0x00525B20  +       int16_t g_DrawRoomsArray[100];
 0x00525BEC  -       int32_t g_DynamicLightCount;
-0x004D7784  -       int32_t g_CineTickCount;
+0x004D7784  +       int32_t g_CineTickCount;
 0x004D7788  -       int32_t g_OriginalRoom;
 0x00465518  -       INVENTORY_ITEM *g_Inv_MainList[];
 0x00465608  +       INVENTORY_ITEM *g_Inv_OptionList[];

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -696,6 +696,7 @@ bool Audio_Stream_SeekTimestamp(int32_t sound_id, double timestamp)
         av_seek_frame(
             stream->av.format_ctx, 0, timestamp / time_base_sec,
             AVSEEK_FLAG_ANY);
+        avcodec_flush_buffers(stream->av.codec_ctx);
         SDL_UnlockAudioDevice(g_AudioDeviceID);
         return true;
     }

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -133,46 +133,6 @@ void __cdecl Game_SetCutsceneTrack(const int32_t track)
     g_CineTrackID = track;
 }
 
-int32_t __cdecl Game_Cutscene_Start(const int32_t level_num)
-{
-    if (!Level_Initialise(level_num, GFL_CUTSCENE)) {
-        return 2;
-    }
-
-    Room_InitCinematic();
-    CutscenePlayer1_Initialise(g_Lara.item_num);
-    g_Camera.target_angle = g_CineTargetAngle;
-
-    const bool old_sound_active = g_SoundIsActive;
-    g_SoundIsActive = false;
-
-    g_CineFrameIdx = 0;
-
-    if (!Music_PlaySynced(g_CineTrackID)) {
-        return 1;
-    }
-
-    Music_SetVolume(10);
-    g_CineFrameCurrent = 0;
-
-    int32_t result;
-    do {
-        Game_DrawCinematic();
-        int32_t nticks =
-            g_CineFrameCurrent - TICKS_PER_FRAME * (g_CineFrameIdx - 4);
-        CLAMPL(nticks, TICKS_PER_FRAME);
-        result = Game_ControlCinematic(nticks);
-    } while (!result);
-
-    Music_SetVolume(g_Config.audio.music_volume);
-    Music_Stop();
-    g_SoundIsActive = old_sound_active;
-    Sound_StopAllSamples();
-
-    g_LevelComplete = true;
-    return result;
-}
-
 void __cdecl CutscenePlayer_Control(const int16_t item_num)
 {
     ITEM *const item = &g_Items[item_num];

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -24,6 +24,7 @@
 #include "global/funcs.h"
 #include "global/vars.h"
 
+#include <libtrx/log.h>
 #include <libtrx/utils.h>
 
 static int32_t m_FrameCount = 0;
@@ -189,6 +190,15 @@ int32_t __cdecl Game_Control(int32_t nframes, const bool demo_mode)
 int32_t __cdecl Game_ControlCinematic(void)
 {
     Fader_Control(&m_ExitFader);
+
+    const int32_t audio_cine_frame_idx =
+        Music_GetTimestamp() * FRAMES_PER_SECOND;
+    const int32_t game_cine_frame_idx = g_CineFrameIdx;
+    const int32_t audio_drift = ABS(audio_cine_frame_idx - game_cine_frame_idx);
+    if (audio_drift >= FRAMES_PER_SECOND * 0.2) {
+        LOG_DEBUG("Detected audio drift: %d frames", audio_drift);
+        Music_SeekTimestamp(game_cine_frame_idx / (double)FRAMES_PER_SECOND);
+    }
 
     if (g_GF_OverrideDir != (GAME_FLOW_DIR)-1) {
         return 4;

--- a/src/tr2/game/game.h
+++ b/src/tr2/game/game.h
@@ -3,7 +3,7 @@
 #include "global/types.h"
 
 int32_t __cdecl Game_Control(int32_t nframes, bool demo_mode);
-int32_t __cdecl Game_ControlCinematic(int32_t nframes);
+int32_t __cdecl Game_ControlCinematic(void);
 int32_t __cdecl Game_Draw(void);
 int32_t __cdecl Game_DrawCinematic(void);
 int16_t __cdecl Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);

--- a/src/tr2/game/music.h
+++ b/src/tr2/game/music.h
@@ -15,6 +15,7 @@ void Music_Play(MUSIC_TRACK_ID track_id, MUSIC_PLAY_MODE mode);
 void __cdecl Music_Stop(void);
 bool __cdecl Music_PlaySynced(int16_t track_id);
 double __cdecl Music_GetTimestamp(void);
+bool Music_SeekTimestamp(double timestamp);
 void __cdecl Music_SetVolume(int32_t volume);
 MUSIC_TRACK_ID Music_GetCurrentTrack(void);
 MUSIC_TRACK_ID Music_GetLastPlayedTrack(void);

--- a/src/tr2/game/music/music_main.c
+++ b/src/tr2/game/music/music_main.c
@@ -193,6 +193,14 @@ double __cdecl Music_GetTimestamp(void)
     return Audio_Stream_GetTimestamp(m_AudioStreamID);
 }
 
+bool Music_SeekTimestamp(double timestamp)
+{
+    if (m_AudioStreamID < 0) {
+        return false;
+    }
+    return Audio_Stream_SeekTimestamp(m_AudioStreamID, timestamp);
+}
+
 void __cdecl Music_SetVolume(int32_t volume)
 {
     m_MusicVolume = volume ? volume / 10.0f : 0.0f;

--- a/src/tr2/global/vars_decomp.h
+++ b/src/tr2/global/vars_decomp.h
@@ -160,8 +160,6 @@
 #define g_IsWaterEffect (*(int32_t*)0x004D6C14)
 #define g_IsShadeEffect (*(int8_t*)0x004D6F78)
 #define g_GamePalette16 (*(PALETTEENTRY(*)[256])0x004D7380)
-#define g_CineFrameCurrent (*(int32_t*)0x004D7780)
-#define g_CineTickCount (*(int32_t*)0x004D7784)
 #define g_OriginalRoom (*(int32_t*)0x004D7788)
 #define g_IsChunkyCamera (*(int32_t*)0x004D778C)
 #define g_HeightType (*(int32_t*)0x004D7790)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #1935, which surfaced a minor delay in each frame that slightly slowed the game in longer sessions. It lost about 0.8-1.2 seconds per minute of gameplay. Thankfully, to my knowledge no speedrunners have been using TR1X yet, so I'm glad to have fixed it before it affected anyone in that community.

When testing, it's important to focus on immediate timing-oriented regressions in TR1, checking various turbo speeds and 30/60 FPS. I didn't touch the overall structure of the clock module, or more nuanced frame-based counters in TR1, so there's no need to go too deeply and check every possible interpolation target.