### PR TITLE
tr2/flares: fix flare throwing priority

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.7.1...develop) - ××××-××-××
 - added an option to use PS1 contrast levels, available under F8 (#1646)
+- fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs (#1989)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17
 - fixed a crash when selecting the sound option (#2057, regression from 0.6)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -46,6 +46,7 @@ decompilation process. We recognize that there is much work to be done.
 - fixed game freezing when starting demo/credits/inventory offscreen
 - fixed exiting the game with Alt+F4 not immediately working in cutscenes
 - fixed a crash when trying to draw too many rooms at once
+- fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Wreck of the Maria Doria**: fixed room 98 not having water

--- a/src/tr2/config.h
+++ b/src/tr2/config.h
@@ -26,6 +26,7 @@ typedef struct {
         bool fix_m16_accuracy;
         bool fix_item_duplication_glitch;
         bool fix_floor_data_issues;
+        bool fix_flare_throw_priority;
         bool enable_cheats;
         bool enable_auto_item_selection;
         int32_t turbo_speed;

--- a/src/tr2/config_map.def
+++ b/src/tr2/config_map.def
@@ -1,6 +1,7 @@
 CFG_BOOL(g_Config, gameplay.fix_m16_accuracy, true)
 CFG_BOOL(g_Config, gameplay.fix_item_duplication_glitch, false)
 CFG_BOOL(g_Config, gameplay.fix_floor_data_issues, true)
+CFG_BOOL(g_Config, gameplay.fix_flare_throw_priority, true)
 CFG_BOOL(g_Config, gameplay.enable_cheats, false)
 CFG_BOOL(g_Config, gameplay.enable_auto_item_selection, true)
 CFG_INT32(g_Config, gameplay.turbo_speed, 0)

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -1,7 +1,9 @@
 #include "decomp/flares.h"
 
+#include "config.h"
 #include "decomp/effects.h"
 #include "game/gun/gun.h"
+#include "game/input.h"
 #include "game/inventory/backpack.h"
 #include "game/lara/misc.h"
 #include "game/math.h"
@@ -20,6 +22,21 @@
 #define MAX_FLARE_AGE (60 * FRAMES_PER_SECOND) // = 1800
 #define FLARE_OLD_AGE (MAX_FLARE_AGE - 2 * FRAMES_PER_SECOND) // = 1740
 #define FLARE_YOUNG_AGE (FRAMES_PER_SECOND) // = 30
+
+static bool M_CanThrowFlare(void);
+
+static bool M_CanThrowFlare(void)
+{
+    if (g_Lara.gun_status != LGS_ARMLESS) {
+        return false;
+    }
+
+    return !g_Config.gameplay.fix_flare_throw_priority
+        || (!g_LaraItem->gravity && !g_Input.jump)
+        || g_LaraItem->current_anim_state == LS_FAST_FALL
+        || g_LaraItem->current_anim_state == LS_SWAN_DIVE
+        || g_LaraItem->current_anim_state == LS_FAST_DIVE;
+}
 
 int32_t __cdecl Flare_DoLight(const XYZ_32 *const pos, const int32_t flare_age)
 {
@@ -76,7 +93,7 @@ void __cdecl Flare_DoInHand(const int32_t flare_age)
         } else {
             Sound_Effect(SFX_LARA_FLARE_BURN, &g_LaraItem->pos, SPM_NORMAL);
         }
-    } else if (g_Lara.gun_status == LGS_ARMLESS) {
+    } else if (M_CanThrowFlare()) {
         g_Lara.gun_status = LGS_UNDRAW;
     }
 }

--- a/tools/tr2/config/TR2X_ConfigTool/Resources/Lang/en.json
+++ b/tools/tr2/config/TR2X_ConfigTool/Resources/Lang/en.json
@@ -34,6 +34,10 @@
       "Title": "Fix item duplication glitch",
       "Description": "Fixes the ability to duplicate usage of key items in the inventory."
     },
+    "fix_flare_throw_priority": {
+      "Title": "Fix flare throwing priority",
+      "Description": "Fixes Lara prioritising throwing a spent flare while in mid-air, which can lead to being unable to grab ledges."
+    },
     "fix_floor_data_issues": {
       "Title": "Fix floor data issues",
       "Description": "Fixes original issues with floor data/triggers."

--- a/tools/tr2/config/TR2X_ConfigTool/Resources/specification.json
+++ b/tools/tr2/config/TR2X_ConfigTool/Resources/specification.json
@@ -33,6 +33,11 @@
           "DefaultValue": false
         },
         {
+          "Field": "fix_flare_throw_priority",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "fix_floor_data_issues",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
Resolves #1989.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This performs stricter checks for when a flare should be automatically thrown away to avoid Lara being unable to grab ledges. So if Lara is mid-jump, or the player has jump input pressed, a spent flare will stay in her hand until she's otherwise safe to throw it. If however Lara is in fast fall state, or swan-diving, a spent flare will still be thrown because she cannot grab anyway in these states.

If the player actively discards a flare while mid-air, it will continue to be respected. The bug is in the automatic decision to throw it.

Something else I think we should consider is reverting flare input debouncing, which was introduced [here](https://github.com/LostArtefacts/TR2X/pull/161) as a workaround for the console key conflict. There may be input-sensitive gameplay where you want to tactically throw a flare at the right moment e.g. dropping off a ladder onto a slope before jumping off the slope somewhere else. This would be quite difficult with debouncing. We can raise this separately however.
