### PR TITLE
Fix underwater tint for software renderer

### DIFF
--- a/data/tr1/ship/shaders/2d.glsl
+++ b/data/tr1/ship/shaders/2d.glsl
@@ -29,6 +29,8 @@ uniform sampler1D texPalette;
 uniform sampler2D texAlpha;
 uniform bool paletteEnabled;
 uniform bool alphaEnabled;
+uniform bool tintEnabled;
+uniform vec3 tintColor;
 uniform int effect;
 
 #ifdef OGL33C
@@ -63,6 +65,10 @@ void main(void) {
         OUTCOLOR = TEXTURE1D(texPalette, paletteIndex);
     } else {
         OUTCOLOR = TEXTURE2D(texMain, uv);
+    }
+
+    if (tintEnabled) {
+        OUTCOLOR.rgb *= tintColor.rgb;
     }
 
     if (effect == EFFECT_VIGNETTE) {

--- a/data/tr2/ship/shaders/2d.glsl
+++ b/data/tr2/ship/shaders/2d.glsl
@@ -29,6 +29,8 @@ uniform sampler1D texPalette;
 uniform sampler2D texAlpha;
 uniform bool paletteEnabled;
 uniform bool alphaEnabled;
+uniform bool tintEnabled;
+uniform vec3 tintColor;
 uniform int effect;
 
 #ifdef OGL33C
@@ -63,6 +65,10 @@ void main(void) {
         OUTCOLOR = TEXTURE1D(texPalette, paletteIndex);
     } else {
         OUTCOLOR = TEXTURE2D(texMain, uv);
+    }
+
+    if (tintEnabled) {
+        OUTCOLOR.rgb *= tintColor.rgb;
     }
 
     if (effect == EFFECT_VIGNETTE) {

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added an option to use PS1 contrast levels, available under F8 (#1646)
 - added an option to allow disabling the developer console (#2063)
 - fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs (#1989)
+- fixed software renderer not applying underwater tint (#2066, regression from 0.7)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17
 - fixed a crash when selecting the sound option (#2057, regression from 0.6)

--- a/docs/tr2/progress.txt
+++ b/docs/tr2/progress.txt
@@ -4657,7 +4657,7 @@ typedef enum {
 0x004D93F0  -       uint8_t g_LabTextureUVFlag[2048]; // MAX_TEXTURES
 0x005251B0  -       FRAME_INFO *g_AnimFrames;
 0x0051BC38  -       int32_t g_IsWet;
-0x0051B308  -       RGB_888 g_WaterPalette[256];
+0x0051B308  +       RGB_888 g_WaterPalette[256];
 0x004BF2D8  -       uint8_t g_DepthQIndex[256];
 0x004D7C74  -       int32_t g_NumCameras;
 0x0051B92C  -       int16_t *g_AnimTextureRanges;

--- a/src/libtrx/include/libtrx/gfx/2d/2d_renderer.h
+++ b/src/libtrx/include/libtrx/gfx/2d/2d_renderer.h
@@ -12,7 +12,7 @@
 
 typedef struct {
     uint8_t r, g, b;
-} GFX_PALETTE_ENTRY;
+} GFX_COLOR;
 
 typedef enum {
     GFX_2D_EFFECT_NONE = 0,
@@ -32,8 +32,9 @@ void GFX_2D_Renderer_Upload(
     GFX_2D_RENDERER *renderer, GFX_2D_SURFACE_DESC *desc, const uint8_t *data);
 
 void GFX_2D_Renderer_SetPalette(
-    GFX_2D_RENDERER *renderer, const GFX_PALETTE_ENTRY *palette);
+    GFX_2D_RENDERER *renderer, const GFX_COLOR *palette);
 void GFX_2D_Renderer_SetRepeat(GFX_2D_RENDERER *renderer, int32_t x, int32_t y);
 void GFX_2D_Renderer_SetEffect(GFX_2D_RENDERER *renderer, GFX_2D_EFFECT filter);
+void GFX_2D_Renderer_SetTint(GFX_2D_RENDERER *renderer, GFX_COLOR color);
 
 void GFX_2D_Renderer_Render(GFX_2D_RENDERER *renderer);

--- a/src/tr2/decomp/fmv.c
+++ b/src/tr2/decomp/fmv.c
@@ -113,9 +113,9 @@ static void M_Play(const char *const file_name)
 
     // Populate the palette with a palette corresponding to
     // AV_PIX_FMT_RGB8
-    GFX_PALETTE_ENTRY palette[256];
+    GFX_COLOR palette[256];
     for (int32_t i = 0; i < 256; i++) {
-        GFX_PALETTE_ENTRY *const col = &palette[i];
+        GFX_COLOR *const col = &palette[i];
         col->r = 0x24 * (i >> 5);
         col->g = 0x24 * ((i >> 2) & 7);
         col->b = 0x55 * (i & 3);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -510,13 +510,6 @@ static void M_LoadDepthQ(VFILE *const file)
         }
     }
 
-    g_IsWet = 0;
-    for (int32_t i = 0; i < 256; i++) {
-        g_WaterPalette[i].red = g_GamePalette8[i].red * 2 / 3;
-        g_WaterPalette[i].green = g_GamePalette8[i].green * 2 / 3;
-        g_WaterPalette[i].blue = g_GamePalette8[i].blue;
-    }
-
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -1126,6 +1126,7 @@ void __cdecl Output_LightRoom(ROOM *const room)
 void __cdecl Output_SetupBelowWater(const bool is_underwater)
 {
     g_IsWet = is_underwater;
+    Render_SetWet(is_underwater);
     g_IsWaterEffect = true;
     g_IsWibbleEffect = !is_underwater;
     g_IsShadeEffect = true;

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -364,3 +364,11 @@ void Render_InsertSprite(
         r->InsertSprite(r, z, x0, y0, x1, y1, sprite_idx, shade);
     }
 }
+
+void Render_SetWet(const bool is_wet)
+{
+    RENDERER *const r = M_GetRenderer();
+    if (r->SetWet != NULL) {
+        r->SetWet(r, is_wet);
+    }
+}

--- a/src/tr2/game/render/common.h
+++ b/src/tr2/game/render/common.h
@@ -46,6 +46,7 @@ void Render_DrawBlackRectangle(int32_t opacity);
 
 void Render_ClearZBuffer(void);
 void Render_EnableZBuffer(bool z_write_enable, bool z_test_enable);
+void Render_SetWet(bool is_wet);
 
 // TODO: there's too much repetition for these
 const int16_t *Render_InsertObjectG3(

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -890,7 +890,7 @@ static void M_InsertSprite_Sorted(
     }
 
     const bool old_shade = g_IsShadeEffect;
-    g_IsShadeEffect = 0;
+    g_IsShadeEffect = false;
     M_InsertPolyTextured(num_points, z, POLY_HWR_WGTMAP, sprite->tex_page);
     g_IsShadeEffect = old_shade;
 }

--- a/src/tr2/game/render/priv.h
+++ b/src/tr2/game/render/priv.h
@@ -24,6 +24,7 @@ typedef struct RENDERER {
     void (*ClearZBuffer)(struct RENDERER *);
     void (*EnableZBuffer)(struct RENDERER *, bool, bool);
     void (*DrawPolyList)(struct RENDERER *);
+    void (*SetWet)(struct RENDERER *, bool);
 
     const int16_t *(*InsertGT4)(
         struct RENDERER *renderer, const int16_t *obj_ptr, int32_t num,

--- a/src/tr2/game/render/swr.c
+++ b/src/tr2/game/render/swr.c
@@ -21,7 +21,7 @@ typedef struct {
     GFX_2D_RENDERER *renderer_2d;
     GFX_2D_SURFACE *surface;
     GFX_2D_SURFACE *surface_alpha;
-    GFX_PALETTE_ENTRY palette[256];
+    GFX_COLOR palette[256];
 } M_PRIV;
 
 static VERTEX_INFO m_VBuffer[32] = { 0 };
@@ -1401,6 +1401,18 @@ static void M_DrawPolyList(RENDERER *const renderer)
     GFX_2D_Renderer_Render(priv->renderer_2d);
 }
 
+static void M_SetWet(RENDERER *const renderer, const bool is_wet)
+{
+    M_PRIV *const priv = renderer->priv;
+    if (is_wet) {
+        GFX_2D_Renderer_SetTint(
+            priv->renderer_2d, (GFX_COLOR) { .r = 170, .g = 170, .b = 255 });
+    } else {
+        GFX_2D_Renderer_SetTint(
+            priv->renderer_2d, (GFX_COLOR) { .r = 255, .g = 255, .b = 255 });
+    }
+}
+
 static const int16_t *M_InsertObjectG3(
     RENDERER *const renderer, const int16_t *obj_ptr, const int32_t num,
     const SORT_TYPE sort_type)
@@ -2257,6 +2269,7 @@ void Renderer_SW_Prepare(RENDERER *const renderer)
     renderer->ResetPolyList = NULL;
     renderer->EnableZBuffer = NULL;
     renderer->ClearZBuffer = NULL;
+    renderer->SetWet = M_SetWet;
 
     renderer->InsertObjectG3 = M_InsertObjectG3;
     renderer->InsertObjectG4 = M_InsertObjectG4;

--- a/src/tr2/global/vars_decomp.h
+++ b/src/tr2/global/vars_decomp.h
@@ -268,7 +268,6 @@
 #define g_PassportMode (*(int32_t*)0x0051A2D0)
 #define g_SoundText (*(TEXTSTRING *(*)[4])0x0051A2F0)
 #define g_RoomLightTables (*(ROOM_LIGHT_TABLE(*)[32])0x0051A308)
-#define g_WaterPalette (*(RGB_888(*)[256])0x0051B308)
 #define g_PicturePalette (*(RGB_888(*)[256])0x0051B608)
 #define g_RoomLightShades (*(int32_t(*)[4])0x0051B908)
 #define g_AnimTextureRanges (*(int16_t **)0x0051B92C)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Builds on top of #2065. Resolves #2066.
The tint is applied through a new uniform in the 2D renderer's shader.