### PR TITLE
tr2: fix enemies not looking at Lara

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added an option to allow disabling the developer console (#2063)
 - fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs (#1989)
 - fixed software renderer not applying underwater tint (#2066, regression from 0.7)
+- fixed some enemies not looking at Lara (#2080, regression from 0.6)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17
 - fixed a crash when selecting the sound option (#2057, regression from 0.6)

--- a/src/tr2/game/objects/creatures/bandit.c
+++ b/src/tr2/game/objects/creatures/bandit.c
@@ -27,13 +27,13 @@ void Bandit1_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 32] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
 }
 
 void Bandit2_Setup(void)
@@ -52,13 +52,13 @@ void Bandit2_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 32] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
 }
 
 void Bandit2B_Setup(void)
@@ -82,11 +82,11 @@ void Bandit2B_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 32] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
 }

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -56,13 +56,13 @@ void Barracuda_Setup(void)
     obj->pivot_length = 200;
 
     obj->intelligent = 1;
-    obj->water_creature = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Barracuda_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -53,10 +53,10 @@ void BigEel_Setup(void)
 
     obj->hit_points = BIG_EEL_HITPOINTS;
 
-    obj->water_creature = 1;
     obj->save_hitpoints = 1;
-    obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
 }
 
 void __cdecl BigEel_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -50,10 +50,10 @@ void BigSpider_Setup(void)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void __cdecl BigSpider_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -56,10 +56,10 @@ void Bird_SetupEagle(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void Bird_SetupCrow(void)
@@ -73,16 +73,16 @@ void Bird_SetupCrow(void)
     obj->control = Bird_Control;
     obj->collision = Creature_Collision;
 
-    obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = CROW_HITPOINTS;
     obj->radius = BIRD_RADIUS;
+    obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void __cdecl Bird_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -66,10 +66,12 @@ void BirdGuardian_Setup(void)
     obj->radius = BIRD_GUARDIAN_RADIUS;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+
+    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl BirdGuardian_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist.c
+++ b/src/tr2/game/objects/creatures/cultist.c
@@ -30,10 +30,10 @@ void Cultist1_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
 }
@@ -59,10 +59,10 @@ void Cultist1A_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
 }
@@ -88,10 +88,10 @@ void Cultist1B_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
 }
@@ -112,13 +112,13 @@ void Cultist2_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 32] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
 }
 
 void Cultist3_Setup(void)
@@ -135,10 +135,11 @@ void Cultist3_Setup(void)
     obj->hit_points = CULTIST_3_HITPOINTS;
     obj->radius = CULTIST_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
+    obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -92,14 +92,14 @@ void Diver_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->water_creature = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
 
-    g_AnimBones[obj->bone_idx + 40] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 56] |= BF_ROT_Z;
+    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Z;
 }
 
 void __cdecl Diver_Control(int16_t item_num)

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -71,11 +71,13 @@ void Dog_Setup(void)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 300;
 
-    obj->save_anim = 1;
+    obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
-    obj->intelligent = 1;
+    obj->save_anim = 1;
+
+    g_AnimBones[obj->bone_idx + 19 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Dog_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -143,12 +143,12 @@ void Dragon_SetupFront(void)
     obj->pivot_length = 300;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 40] |= BF_ROT_Z;
+    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Z;
 }
 
 void Dragon_SetupBack(void)

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -53,10 +53,10 @@ void Eel_Setup(void)
 
     obj->hit_points = EEL_HITPOINTS;
 
-    obj->water_creature = 1;
     obj->save_hitpoints = 1;
-    obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
 }
 
 void __cdecl Eel_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -39,10 +39,11 @@ void Jelly_Setup(void)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
 }
 
 void __cdecl Jelly_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -25,12 +25,12 @@ void Monk1_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
 }
 
 void Monk2_Setup(void)
@@ -48,8 +48,10 @@ void Monk2_Setup(void)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
 }

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -58,10 +58,12 @@ void Mouse_Setup(void)
     obj->pivot_length = 50;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+
+    g_AnimBones[obj->bone_idx + 3 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Mouse_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -65,11 +65,13 @@ void Shark_Setup(void)
     obj->pivot_length = 200;
 
     obj->intelligent = 1;
-    obj->water_creature = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+    obj->water_creature = 1;
+
+    g_AnimBones[obj->bone_idx + 9 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Shark_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -180,8 +180,8 @@ void SkidooDriver_Setup(void)
     obj->hit_points = 1;
 
     obj->save_position = 1;
-    obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void __cdecl SkidooDriver_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -59,10 +59,10 @@ void Spider_Setup(void)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void __cdecl Spider_Leap(const int16_t item_num, const int16_t angle)

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -63,10 +63,12 @@ void Tiger_Setup(void)
     obj->pivot_length = 200;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
+
+    g_AnimBones[obj->bone_idx + 21 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Tiger_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -58,12 +58,13 @@ void TRex_Setup(void)
     obj->pivot_length = 1800;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 40] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 11 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl TRex_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -24,6 +24,6 @@ void Winston_Setup(void)
 
     obj->intelligent = 1;
     obj->save_position = 1;
-    obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/worker.c
+++ b/src/tr2/game/objects/creatures/worker.c
@@ -29,13 +29,13 @@ void Worker1_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 16] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 52] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
 }
 
 void Worker2_Setup(void)
@@ -54,13 +54,13 @@ void Worker2_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 16] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 52] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
 }
 
 void Worker3_Setup(void)
@@ -79,13 +79,13 @@ void Worker3_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 16] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
 }
 
 void Worker4_Setup(void)
@@ -104,13 +104,13 @@ void Worker4_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
     g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 16] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
 }
 
 void Worker5_Setup(void)
@@ -129,10 +129,11 @@ void Worker5_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 16] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
 }

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -31,10 +31,11 @@ void XianKnight_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 16 * 4] |= BF_ROT_Y;
 }

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -30,10 +30,11 @@ void XianSpearman_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 12 * 4] |= BF_ROT_Y;
 }

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -86,12 +86,13 @@ void Yeti_Setup(void)
     obj->pivot_length = 100;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Y;
 }
 
 void __cdecl Yeti_Control(const int16_t item_num)

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -26,10 +26,10 @@ void SkidooArmed_Setup(void)
     obj->pivot_length = 0;
 
     obj->intelligent = 1;
-    obj->save_anim = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
+    obj->save_anim = 1;
 }
 
 void __cdecl SkidooArmed_Push(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #2080. Regression made in d531d0b1.

List of affected enemies:

- bird guardian
- dobermans
- monks
- mice
- sharks
- tigers
- trex
- goons
- Xian swordmen
- Xian spearmen
- yetis
