### PR TITLE
tr1/carrier: fix initial sector selection for falling items

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...develop) - ××××-××-××
+- fixed falling pickup items not being drawn when they land in rare cases (#2088)
 
 ## [4.7](https://github.com/LostArtefacts/TRX/compare/tr1-4.6.1...tr1-4.7) - 2024-12-20
 - added support for Wayland in binary Linux builds (#1927)

--- a/src/tr1/game/carrier.c
+++ b/src/tr1/game/carrier.c
@@ -79,8 +79,11 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
 
     ITEM *const pickup = Item_Get(item->spawn_num);
     int16_t room_num = pickup->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(pickup->pos.x, pickup->pos.y, pickup->pos.z, &room_num);
+    // For cases where a flyer has dropped an item exactly on a portal, we need
+    // to ensure that the initial sector is in the room above, hence we test
+    // slightly above the initial y position.
+    const SECTOR *const sector = Room_GetSector(
+        pickup->pos.x, pickup->pos.y - 10, pickup->pos.z, &room_num);
     const int16_t height =
         Room_GetHeight(sector, pickup->pos.x, pickup->pos.y, pickup->pos.z);
     const bool in_water = g_RoomInfo[pickup->room_num].flags & RF_UNDERWATER;


### PR DESCRIPTION
Resolves #2088.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that if an item is dropped exactly at the height of a vertical portal, we get the room just above that portal first to ensure that later the item is placed in the correct room, and hence drawn there.

This is tricky to test, but I have confirmed the fix works by hard-coding a flyer's position to be exactly on a portal.
