### PR TITLE
tr1/ui/widgets/paginator: hide UI for empty text

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...develop) - ××××-××-××
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
+- changed the inventory examine UI to auto-hide if the item description is empty (#2097)
 - fixed falling pickup items not being drawn when they land in rare cases (#2088)
 
 ## [4.7](https://github.com/LostArtefacts/TRX/compare/tr1-4.6.1...tr1-4.7) - 2024-12-20

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -325,7 +325,8 @@ Following are each of the properties available within a level.
       Players can examine items in the inventory when this text has been
       defined. Use <code>\n</code> in the text to create new lines; you can also
       use <code>\f</code> to force a page break. Long text will be automatically
-      wrapped and paginated as necessary.
+      wrapped and paginated as necessary. If an empty string is defined, the UI
+      will not be shown and the inventory item simply focussed instead.
     </td>
   </tr>
   <tr valign="top">

--- a/src/tr1/game/ui/widgets/paginator.c
+++ b/src/tr1/game/ui/widgets/paginator.c
@@ -36,6 +36,7 @@ typedef struct {
     UI_WIDGET *page_label;
     int32_t current_page;
     VECTOR *page_content;
+    bool shown;
 } UI_PAGINATOR;
 
 static void M_DoLayout(UI_PAGINATOR *self);
@@ -107,7 +108,7 @@ static void M_Control(UI_PAGINATOR *const self)
 
 static void M_Draw(UI_PAGINATOR *const self)
 {
-    if (self->window->draw != NULL) {
+    if (self->shown && self->window->draw != NULL) {
         self->window->draw(self->window);
     }
 }
@@ -148,6 +149,8 @@ UI_WIDGET *UI_Paginator_Create(
         .set_position = (UI_WIDGET_SET_POSITION)M_SetPosition,
         .free = (UI_WIDGET_FREE)M_Free,
     };
+
+    self->shown = !String_IsEmpty(text);
 
     self->outer_stack = UI_Stack_Create(
         UI_STACK_LAYOUT_VERTICAL, UI_STACK_AUTO_SIZE, UI_STACK_AUTO_SIZE);


### PR DESCRIPTION
Resolves #2097.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This will automatically hide the paginator UI if the text content is empty. The level in https://github.com/LostArtefacts/TRX/pull/1872 can be used for testing, just change one of the gameflow string entries to be empty.
