### PR TITLE
tr1/phase/phase_demo: disable swim cancel during demos

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.7.1...develop) - ××××-××-××
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
+- fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21
 - changed the inventory examine UI to auto-hide if the item description is empty (#2097)

--- a/src/tr1/game/phase/phase_demo.c
+++ b/src/tr1/game/phase/phase_demo.c
@@ -45,6 +45,7 @@ static struct {
     bool enable_enhanced_look;
     bool enable_tr2_jumping;
     bool enable_tr2_swimming;
+    bool enable_tr2_swim_cancel;
     bool enable_wading;
     bool fix_bear_ai;
     TARGET_LOCK_MODE target_mode;
@@ -160,12 +161,14 @@ static void M_PrepareConfig(void)
     m_OldConfig.enable_enhanced_look = g_Config.enable_enhanced_look;
     m_OldConfig.enable_tr2_jumping = g_Config.enable_tr2_jumping;
     m_OldConfig.enable_tr2_swimming = g_Config.enable_tr2_swimming;
+    m_OldConfig.enable_tr2_swim_cancel = g_Config.enable_tr2_swim_cancel;
     m_OldConfig.enable_wading = g_Config.enable_wading;
     m_OldConfig.target_mode = g_Config.target_mode;
     m_OldConfig.fix_bear_ai = g_Config.fix_bear_ai;
     g_Config.enable_enhanced_look = false;
     g_Config.enable_tr2_jumping = false;
     g_Config.enable_tr2_swimming = false;
+    g_Config.enable_tr2_swim_cancel = false;
     g_Config.enable_wading = false;
     g_Config.target_mode = TLM_FULL;
     g_Config.fix_bear_ai = false;
@@ -177,6 +180,7 @@ static void M_RestoreConfig(void)
     g_Config.enable_enhanced_look = m_OldConfig.enable_enhanced_look;
     g_Config.enable_tr2_jumping = m_OldConfig.enable_tr2_jumping;
     g_Config.enable_tr2_swimming = m_OldConfig.enable_tr2_swimming;
+    g_Config.enable_tr2_swim_cancel = m_OldConfig.enable_tr2_swim_cancel;
     g_Config.enable_wading = m_OldConfig.enable_wading;
     g_Config.fix_bear_ai = m_OldConfig.fix_bear_ai;
 }


### PR DESCRIPTION
Resolves #2113.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Similar to disabling other enhanced movement options, we now disable responsive swim cancellation in demos to avoid desync issues.
