### PR TITLE
libtrx/rooms/common: use linked lists for trigger commands

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.7.1...develop) - ××××-××-××
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
+- fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21
 - changed the inventory examine UI to auto-hide if the item description is empty (#2097)

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -5,9 +5,10 @@
 
 #include <stdbool.h>
 
-typedef struct __PACKING {
+typedef struct __PACKING TRIGGER_CMD {
     TRIGGER_OBJECT type;
     void *parameter;
+    struct TRIGGER_CMD *next_cmd;
 } TRIGGER_CMD;
 
 typedef struct __PACKING {
@@ -23,8 +24,7 @@ typedef struct __PACKING {
     int16_t mask;
     bool one_shot;
     int16_t item_index;
-    int32_t command_count;
-    TRIGGER_CMD *commands;
+    TRIGGER_CMD *command;
 } TRIGGER;
 
 typedef struct __PACKING {

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -820,8 +820,8 @@ void Camera_UpdateCutscene(void)
 void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
 {
     int16_t target_ok = 2;
-    for (int32_t i = 0; i < trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &trigger->commands[i];
+    const TRIGGER_CMD *cmd = trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type == TO_CAMERA) {
             const TRIGGER_CAMERA_DATA *const cam_data =
                 (TRIGGER_CAMERA_DATA *)cmd->parameter;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -1139,8 +1139,8 @@ static void M_TriggerParameterChange(INJECTION *injection, SECTOR *sector)
     // If we can find an action item for the given sector that matches
     // the command type and old (current) parameter, change it to the
     // new parameter.
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != cmd_type) {
             continue;
         }
@@ -1167,8 +1167,8 @@ static void M_SetMusicOneShot(SECTOR *sector)
         return;
     }
 
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type == TO_CD) {
             sector->trigger->one_shot = true;
         }

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -334,8 +334,8 @@ int16_t Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z)
         return height;
     }
 
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != TO_OBJECT) {
             continue;
         }
@@ -361,8 +361,8 @@ int16_t Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z)
         return height;
     }
 
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != TO_OBJECT) {
             continue;
         }
@@ -749,9 +749,8 @@ static void M_TestSectorTrigger(
         }
     }
 
-    for (int32_t i = 0; i < trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &trigger->commands[i];
-
+    const TRIGGER_CMD *cmd = trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         switch (cmd->type) {
         case TO_OBJECT: {
             const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
@@ -959,8 +958,8 @@ bool Room_IsOnWalkable(
 
     int16_t height = sector->floor.height;
     bool object_found = false;
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != TO_OBJECT) {
             continue;
         }

--- a/src/tr1/game/stats.c
+++ b/src/tr1/game/stats.c
@@ -66,9 +66,8 @@ static void M_CheckTriggers(ROOM *r, int room_num, int z_sector, int x_sector)
         return;
     }
 
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
-
+    const TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type == TO_SECRET) {
             const int16_t secret_num = 1 << (int16_t)(intptr_t)cmd->parameter;
             if (!(m_SecretRoom & secret_num)) {

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -893,8 +893,8 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
 {
     int16_t target_ok = 2;
 
-    for (int32_t i = 0; i < trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &trigger->commands[i];
+    const TRIGGER_CMD *cmd = trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type == TO_CAMERA) {
             const TRIGGER_CAMERA_DATA *const cam_data =
                 (TRIGGER_CAMERA_DATA *)cmd->parameter;

--- a/src/tr2/game/inject.c
+++ b/src/tr2/game/inject.c
@@ -214,8 +214,8 @@ static void M_TriggerParameterChange(
     // If we can find an action item for the given sector that matches
     // the command type and old (current) parameter, change it to the
     // new parameter.
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != cmd_type) {
             continue;
         }
@@ -242,8 +242,8 @@ static void M_SetMusicOneShot(const SECTOR *const sector)
         return;
     }
 
-    for (int32_t i = 0; i < sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type == TO_CD) {
             sector->trigger->one_shot = true;
             break;

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -230,9 +230,8 @@ static void M_TestSectorTrigger(
         }
     }
 
-    for (int32_t i = 0; i < trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &trigger->commands[i];
-
+    const TRIGGER_CMD *cmd = trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         switch (cmd->type) {
         case TO_OBJECT: {
             const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
@@ -690,8 +689,8 @@ int32_t Room_GetHeight(
         return height;
     }
 
-    for (int32_t i = 0; i < pit_sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &pit_sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = pit_sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != TO_OBJECT) {
             continue;
         }
@@ -732,8 +731,8 @@ int32_t Room_GetCeiling(
         return height;
     }
 
-    for (int32_t i = 0; i < pit_sector->trigger->command_count; i++) {
-        const TRIGGER_CMD *const cmd = &pit_sector->trigger->commands[i];
+    const TRIGGER_CMD *cmd = pit_sector->trigger->command;
+    for (; cmd != NULL; cmd = cmd->next_cmd) {
         if (cmd->type != TO_OBJECT) {
             continue;
         }


### PR DESCRIPTION
Resolves #2114.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This switches trigger setup to use a linked list of commands rather than a fixed array. This resolves issues in old custom levels that have this kind of setup:

![image](https://github.com/user-attachments/assets/e26532c8-ef2c-412c-9b93-6836ab4f359e)

This would previously work in OG because of the differences between testing triggers and checking floor/ceiling heights. The latter would do a full FD parse on the sector, so consuming both trigger entries, whereas testing triggers would stop after scanning the commands. The issue we had was that we were asserting that the sector's trigger was not set before parsing it, so now we simply append any additional commands.

This is technically the incorrect way to write FD to a level but only seems to affect ones built with Dxtre3d. This can be tested with [Nordic Adventure](https://trcustoms.org/levels/3146), which is the screenshot above - gameflow attached.
[TR1X_gameflow.json5.txt](https://github.com/user-attachments/files/18252213/TR1X_gameflow.json5.txt)
