### PR TITLE
tr1/effects/flame: fix killing effect twice in fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)
+- fixed the game hanging when Lara is on fire and enters the fly cheat on the same frame as reaching water (#2116, regression from 0.8)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21
 - changed the inventory examine UI to auto-hide if the item description is empty (#2097)

--- a/src/tr1/game/objects/effects/flame.c
+++ b/src/tr1/game/objects/effects/flame.c
@@ -30,6 +30,7 @@ void Flame_Control(int16_t effect_num)
             effect->counter = 0;
             Sound_StopEffect(SFX_FIRE, NULL);
             Effect_Kill(effect_num);
+            return;
         }
 
         effect->pos.x = 0;


### PR DESCRIPTION
Resolves #2116.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures we exit the flame control early if Lara is on fire but also in the fly cheat, so preventing potentially killing the effect again if she is also at water height on the same frame.

This is already handled in TR2.
