### PR TITLE
tr2/camera: reset last camera on initialise

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs (#1989)
 - fixed software renderer not applying underwater tint (#2066, regression from 0.7)
 - fixed some enemies not looking at Lara (#2080, regression from 0.6)
+- fixed the camera getting stuck at the start of Home Sweet Home (#2129, regression from 0.7)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17
 - fixed a crash when selecting the sound option (#2057, regression from 0.6)

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -30,6 +30,7 @@
 
 void Camera_Initialise(void)
 {
+    g_Camera.last = NO_CAMERA;
     Camera_ResetPosition();
     Output_AlterFOV(GAME_FOV * PHD_DEGREE);
     Camera_Update();


### PR DESCRIPTION
Resolves #2129.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I *think* the actual issue was that `g_Camera.last` held garbage data in previous builds when loading straight in to HSH, and so the test [here](https://github.com/LostArtefacts/TRX/blob/develop/src/tr2/game/room.c#L319) was allowing the timer to subsequently be set and then everything would play out normally. In recent builds, `g_Camera.last` initialises to `0` but this is a valid camera number (and is the only one in HSH), so because the level starts with an in-game cutscene, `Camera_Update` does not set `g_Camera.last` as it would normally and hence we get the odd behaviour when jumping between levels. When going to Dragon's Lair, then HSH, Lair will have set it to `-1` already.

I think this is specific to this scenario e.g. special start anim followed by an immediate fixed camera, but it's safer all round to just reset the last camera with normal initialisation IMO.
