### PR TITLE
tr2/flares: fix flare effects in shallow water

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,8 @@
 - fixed software renderer not applying underwater tint (#2066, regression from 0.7)
 - fixed some enemies not looking at Lara (#2080, regression from 0.6)
 - fixed the camera getting stuck at the start of Home Sweet Home (#2129, regression from 0.7)
+- fixed bubbles spawning from flares if Lara is in shallow water (#1590)
+- fixed flare sound effects not always playing when Lara is in shallow water (#1590)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17
 - fixed a crash when selecting the sound option (#2057, regression from 0.6)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -101,6 +101,7 @@ game with new enhancements and features.
 - fixed Lara's underwater hue being retained when re-entering a boat
 - fixed distant rooms sometimes not appearing, causing the skybox to be visible when it shouldn't
 - fixed rendering problems on certain Intel GPUs
+- fixed bubbles spawning from flares if Lara is in shallow water
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios
@@ -110,6 +111,7 @@ game with new enhancements and features.
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace
 - fixed sound settings resuming the music
 - fixed wrong default music volume (being very loud on some setups)
+- fixed flare sound effects not always playing when Lara is in shallow water
 
 #### Mods
 - added developer console (accessible with `/`, see [COMMANDS.md](COMMANDS.md) for details)


### PR DESCRIPTION
Resolves #1590.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures we test water height at a flare's exact position rather than using Lara's general room number, so to determine if bubbles should spawn and how to play sound effects.
