### PR TITLE
Introduce phasers to TR2 (part 3)

### DIFF
--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -73,45 +73,7 @@ int16_t TitleSequence(void)
         Music_Play(g_GameFlow.title_track, MPM_LOOPED);
     }
 
-    GAME_FLOW_DIR dir = Inv_Display(INV_TITLE_MODE);
-    Output_UnloadBackground();
-    Music_Stop();
-
-    if (dir == GFD_OVERRIDE) {
-        dir = g_GF_OverrideDir;
-        g_GF_OverrideDir = (GAME_FLOW_DIR)-1;
-        return dir;
-    }
-
-    if (dir == GFD_START_DEMO) {
-        return GFD_START_DEMO | 0xFF;
-    }
-
-    if (g_Inv_Chosen == O_PHOTO_OPTION) {
-        return GFD_START_GAME | LV_GYM;
-    }
-
-    if (g_Inv_Chosen == O_PASSPORT_OPTION) {
-        const int32_t slot_num = g_Inv_ExtraData[1];
-
-        if (g_Inv_ExtraData[0] == 0) {
-            Inv_RemoveAllItems();
-            S_LoadGame(&g_SaveGame, sizeof(SAVEGAME_INFO), slot_num);
-            return GFD_START_SAVED_GAME | slot_num;
-        }
-
-        if (g_Inv_ExtraData[0] == 1) {
-            InitialiseStartInfo();
-            int32_t level_id = LV_FIRST;
-            if (g_GameFlow.play_any_level) {
-                level_id = LV_FIRST + slot_num;
-            }
-            return GFD_START_GAME | level_id;
-        }
-        return GFD_EXIT_GAME;
-    }
-
-    return GFD_EXIT_GAME;
+    return Inv_Display(INV_TITLE_MODE);
 }
 
 void Game_SetCutsceneTrack(const int32_t track)

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -143,15 +143,6 @@ void Game_Draw(void)
     Output_DrawPolyList();
 }
 
-GAME_FLOW_DIR Game_Start(
-    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
-{
-    PHASE *const phase = Phase_Game_Create(level_num, level_type);
-    const GAME_FLOW_DIR dir = PhaseExecutor_Run(phase);
-    Phase_Game_Destroy(phase);
-    return dir;
-}
-
 GAMEFLOW_LEVEL_TYPE Game_GetCurrentLevelType(void)
 {
     return g_GameInfo.current_level.type;

--- a/src/tr2/game/game.h
+++ b/src/tr2/game/game.h
@@ -2,10 +2,8 @@
 
 #include "global/types.h"
 
+GAME_FLOW_DIR Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 GAME_FLOW_DIR Game_Control(int32_t num_frames, bool demo_mode);
-GAME_FLOW_DIR Game_ControlRaw(int32_t num_frames, bool demo_mode);
-int32_t Game_Draw(void);
-int16_t Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
-GAME_FLOW_DIR Game_Loop(bool demo_mode);
+void Game_Draw(void);
 bool Game_IsPlayable(void);
 void Game_ProcessInput(void);

--- a/src/tr2/game/game.h
+++ b/src/tr2/game/game.h
@@ -2,7 +2,6 @@
 
 #include "global/types.h"
 
-GAME_FLOW_DIR Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
 GAME_FLOW_DIR Game_Control(int32_t num_frames, bool demo_mode);
 void Game_Draw(void);
 bool Game_IsPlayable(void);

--- a/src/tr2/game/gameflow.c
+++ b/src/tr2/game/gameflow.c
@@ -433,7 +433,7 @@ int32_t GF_InterpretSequence(
                 if (type == GFL_MID_STORY) {
                     return GFD_EXIT_TO_TITLE;
                 }
-                dir = Game_Start(ptr[1], type);
+                dir = GF_StartGame(ptr[1], type);
                 if (type == GFL_SAVED) {
                     type = GFL_NORMAL;
                 }
@@ -659,5 +659,14 @@ GAME_FLOW_DIR GF_StartDemo(const int32_t level_num)
     PHASE *const demo_phase = Phase_Demo_Create(level_num);
     const GAME_FLOW_DIR dir = PhaseExecutor_Run(demo_phase);
     Phase_Demo_Destroy(demo_phase);
+    return dir;
+}
+
+GAME_FLOW_DIR GF_StartGame(
+    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
+{
+    PHASE *const phase = Phase_Game_Create(level_num, level_type);
+    const GAME_FLOW_DIR dir = PhaseExecutor_Run(phase);
+    Phase_Game_Destroy(phase);
     return dir;
 }

--- a/src/tr2/game/gameflow.h
+++ b/src/tr2/game/gameflow.h
@@ -13,3 +13,4 @@ int32_t GF_InterpretSequence(
 void GF_ModifyInventory(int32_t level, int32_t type);
 
 GAME_FLOW_DIR GF_StartDemo(int32_t level_num);
+GAME_FLOW_DIR GF_StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);

--- a/src/tr2/game/phase.h
+++ b/src/tr2/game/phase.h
@@ -3,5 +3,6 @@
 #include "game/phase/executor.h"
 #include "game/phase/phase_cutscene.h"
 #include "game/phase/phase_demo.h"
+#include "game/phase/phase_game.h"
 #include "game/phase/phase_picture.h"
 #include "game/phase/phase_stats.h"

--- a/src/tr2/game/phase/executor.c
+++ b/src/tr2/game/phase/executor.c
@@ -57,10 +57,6 @@ GAME_FLOW_DIR PhaseExecutor_Run(PHASE *const phase)
         control = phase->start(phase);
         if (control.action == PHASE_ACTION_END) {
             return control.dir;
-        } else if (g_GF_OverrideDir != (GAME_FLOW_DIR)-1) {
-            const GAME_FLOW_DIR dir = g_GF_OverrideDir;
-            g_GF_OverrideDir = -1;
-            return dir;
         } else if (g_IsGameToExit) {
             return GFD_EXIT_GAME;
         }

--- a/src/tr2/game/phase/phase_demo.c
+++ b/src/tr2/game/phase/phase_demo.c
@@ -3,11 +3,8 @@
 #include "config.h"
 #include "decomp/decomp.h"
 #include "game/camera.h"
-#include "game/demo.h"
 #include "game/fader.h"
 #include "game/game.h"
-#include "game/gameflow.h"
-#include "game/input.h"
 #include "game/items.h"
 #include "game/lara/cheat.h"
 #include "game/music.h"
@@ -16,11 +13,8 @@
 #include "game/phase/priv.h"
 #include "game/random.h"
 #include "game/room.h"
-#include "game/room_draw.h"
-#include "game/shell.h"
 #include "game/sound.h"
 #include "game/stats.h"
-#include "game/text.h"
 #include "global/vars.h"
 
 #include <libtrx/log.h>
@@ -186,10 +180,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
     } else {
         Fader_Control(&p->exit_fader);
 
-        const GAME_FLOW_DIR dir = Game_ControlRaw(num_frames, true);
-        g_Camera.num_frames = num_frames * TICKS_PER_FRAME;
-        Overlay_Animate(num_frames);
-        Output_AnimateTextures(g_Camera.num_frames);
+        const GAME_FLOW_DIR dir = Game_Control(num_frames, true);
         if (dir != (GAME_FLOW_DIR)-1) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
@@ -203,11 +194,8 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
 static void M_Draw(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
-    Room_DrawAllRooms(g_Camera.pos.room_num);
-    Output_DrawPolyList();
-    Overlay_DrawGameInfo(true);
-    Output_DrawPolyList();
-    Output_DrawBlackRectangle(p->exit_fader.current.value);
+    Game_Draw();
+    Output_DrawBlackRectangle(Fader_GetCurrentValue(&p->exit_fader));
 }
 
 PHASE *Phase_Demo_Create(const int32_t level_num)

--- a/src/tr2/game/phase/phase_game.c
+++ b/src/tr2/game/phase/phase_game.c
@@ -1,0 +1,183 @@
+#include "game/phase/phase_game.h"
+
+#include "config.h"
+#include "decomp/decomp.h"
+#include "decomp/savegame.h"
+#include "game/camera.h"
+#include "game/fader.h"
+#include "game/game.h"
+#include "game/music.h"
+#include "game/output.h"
+#include "game/overlay.h"
+#include "game/phase/priv.h"
+#include "game/sound.h"
+#include "game/stats.h"
+#include "global/vars.h"
+
+#include <libtrx/memory.h>
+
+typedef struct {
+    bool exiting;
+    FADER exit_fader;
+    int32_t level_num;
+    GAMEFLOW_LEVEL_TYPE level_type;
+} M_PRIV;
+
+static PHASE_CONTROL M_Start(PHASE *phase);
+static void M_End(PHASE *phase);
+static PHASE_CONTROL M_Control(PHASE *phase, int32_t n_frames);
+static void M_Draw(PHASE *phase);
+
+static PHASE_CONTROL M_Start(PHASE *const phase)
+{
+    M_PRIV *const p = phase->priv;
+
+    if (p->level_type == GFL_NORMAL || p->level_type == GFL_SAVED
+        || p->level_type == GFL_DEMO) {
+        g_CurrentLevel = p->level_num;
+    }
+    if (p->level_type != GFL_SAVED) {
+        ModifyStartInfo(p->level_num);
+    }
+    g_IsTitleLoaded = false;
+    if (p->level_type != GFL_SAVED) {
+        InitialiseLevelFlags();
+    }
+    if (!Level_Initialise(p->level_num, p->level_type)) {
+        g_CurrentLevel = 0;
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END,
+            .dir = GFD_EXIT_GAME,
+        };
+    }
+
+    g_OverlayStatus = 1;
+    Camera_Initialise();
+    g_NoInputCounter = 0;
+    Stats_StartTimer();
+
+    return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
+}
+
+static void M_End(PHASE *const phase)
+{
+    M_PRIV *const p = phase->priv;
+    Overlay_HideGameInfo();
+    Sound_StopAllSamples();
+    Music_Stop();
+    Music_SetVolume(g_Config.audio.music_volume);
+}
+
+static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
+{
+    M_PRIV *const p = phase->priv;
+
+    GAME_FLOW_DIR dir;
+    if (g_IsGameToExit && !p->exiting) {
+        p->exiting = true;
+        Fader_InitAnyToBlack(&p->exit_fader, FRAMES_PER_SECOND / 3);
+    } else if (p->exiting && !Fader_IsActive(&p->exit_fader)) {
+        dir = GFD_EXIT_GAME;
+    } else {
+        Fader_Control(&p->exit_fader);
+        dir = Game_Control(num_frames, false);
+    }
+
+    if (dir != (GAME_FLOW_DIR)-1) {
+        if (dir == GFD_EXIT_TO_TITLE || dir == GFD_START_DEMO) {
+            return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
+        }
+
+        if (dir == GFD_EXIT_GAME) {
+            g_CurrentLevel = 0;
+            return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
+        }
+
+        if (g_LevelComplete) {
+            if (g_GameFlow.demo_version && g_GameFlow.single_level) {
+                return (PHASE_CONTROL) {
+                    .action = PHASE_ACTION_END,
+                    .dir = GFD_EXIT_TO_TITLE,
+                };
+            }
+
+            if (g_CurrentLevel == LV_GYM) {
+                // TODO: fade to black
+                return (PHASE_CONTROL) {
+                    .action = PHASE_ACTION_END,
+                    .dir = GFD_EXIT_TO_TITLE,
+                };
+            }
+
+            return (PHASE_CONTROL) {
+                .action = PHASE_ACTION_END,
+                .dir = GFD_LEVEL_COMPLETE | g_CurrentLevel,
+            };
+        }
+
+        // TODO: fade to black
+        if (!g_Inv_Chosen) {
+            return (PHASE_CONTROL) {
+                .action = PHASE_ACTION_END,
+                .dir = GFD_EXIT_TO_TITLE,
+            };
+        }
+
+        if (g_Inv_ExtraData[0] == 0) {
+            S_LoadGame(&g_SaveGame, sizeof(SAVEGAME_INFO), g_Inv_ExtraData[1]);
+            return (PHASE_CONTROL) {
+                .action = PHASE_ACTION_END,
+                .dir = GFD_START_SAVED_GAME | g_Inv_ExtraData[1],
+            };
+        }
+
+        if (g_Inv_ExtraData[0] != 1) {
+            return (PHASE_CONTROL) {
+                .action = PHASE_ACTION_END,
+                .dir = GFD_EXIT_TO_TITLE,
+            };
+        }
+
+        if (g_GameFlow.play_any_level) {
+            return (PHASE_CONTROL) {
+                .action = PHASE_ACTION_END,
+                .dir = g_Inv_ExtraData[1] + 1,
+            };
+        }
+
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END,
+            .dir = GFD_START_GAME | LV_FIRST,
+        };
+    }
+    return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
+}
+
+static void M_Draw(PHASE *const phase)
+{
+    M_PRIV *const p = phase->priv;
+    Game_Draw();
+    Output_DrawBlackRectangle(Fader_GetCurrentValue(&p->exit_fader));
+}
+
+PHASE *Phase_Game_Create(
+    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
+{
+    PHASE *const phase = Memory_Alloc(sizeof(PHASE));
+    M_PRIV *const p = Memory_Alloc(sizeof(M_PRIV));
+    p->level_num = level_num;
+    p->level_type = level_type;
+    phase->priv = p;
+    phase->start = M_Start;
+    phase->end = M_End;
+    phase->control = M_Control;
+    phase->draw = M_Draw;
+    return phase;
+}
+
+void Phase_Game_Destroy(PHASE *const phase)
+{
+    M_PRIV *const p = phase->priv;
+    Memory_Free(p);
+    Memory_Free(phase);
+}

--- a/src/tr2/game/phase/phase_game.c
+++ b/src/tr2/game/phase/phase_game.c
@@ -84,71 +84,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
     }
 
     if (dir != (GAME_FLOW_DIR)-1) {
-        if (dir == GFD_EXIT_TO_TITLE || dir == GFD_START_DEMO) {
-            return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
-        }
-
-        if (dir == GFD_EXIT_GAME) {
-            g_CurrentLevel = 0;
-            return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
-        }
-
-        if (g_LevelComplete) {
-            if (g_GameFlow.demo_version && g_GameFlow.single_level) {
-                return (PHASE_CONTROL) {
-                    .action = PHASE_ACTION_END,
-                    .dir = GFD_EXIT_TO_TITLE,
-                };
-            }
-
-            if (g_CurrentLevel == LV_GYM) {
-                // TODO: fade to black
-                return (PHASE_CONTROL) {
-                    .action = PHASE_ACTION_END,
-                    .dir = GFD_EXIT_TO_TITLE,
-                };
-            }
-
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .dir = GFD_LEVEL_COMPLETE | g_CurrentLevel,
-            };
-        }
-
-        // TODO: fade to black
-        if (!g_Inv_Chosen) {
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .dir = GFD_EXIT_TO_TITLE,
-            };
-        }
-
-        if (g_Inv_ExtraData[0] == 0) {
-            S_LoadGame(&g_SaveGame, sizeof(SAVEGAME_INFO), g_Inv_ExtraData[1]);
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .dir = GFD_START_SAVED_GAME | g_Inv_ExtraData[1],
-            };
-        }
-
-        if (g_Inv_ExtraData[0] != 1) {
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .dir = GFD_EXIT_TO_TITLE,
-            };
-        }
-
-        if (g_GameFlow.play_any_level) {
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .dir = g_Inv_ExtraData[1] + 1,
-            };
-        }
-
-        return (PHASE_CONTROL) {
-            .action = PHASE_ACTION_END,
-            .dir = GFD_START_GAME | LV_FIRST,
-        };
+        return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
     }
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }

--- a/src/tr2/game/phase/phase_game.h
+++ b/src/tr2/game/phase/phase_game.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "game/phase/common.h"
+#include "global/types.h"
+
+PHASE *Phase_Game_Create(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+void Phase_Game_Destroy(PHASE *phase);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -376,6 +376,11 @@ void Shell_Main(void)
         const int16_t gf_param = gf_option & 0x00FF;
 
         switch (gf_dir) {
+        case GFD_OVERRIDE:
+            gf_option = g_GF_OverrideDir;
+            g_GF_OverrideDir = -1;
+            break;
+
         case GFD_START_GAME:
             if (g_GameFlow.single_level >= 0) {
                 gf_option =

--- a/src/tr2/meson.build
+++ b/src/tr2/meson.build
@@ -252,6 +252,7 @@ sources = [
   'game/phase/executor.c',
   'game/phase/phase_cutscene.c',
   'game/phase/phase_demo.c',
+  'game/phase/phase_game.c',
   'game/phase/phase_picture.c',
   'game/phase/phase_stats.c',
   'game/random.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Continuing from #2126 and #2139, this PR converts the main game loop to use the phaser pattern. 
Also, it prepares the inventory code to consistently provide a valid and actionable `GAME_FLOW_DIR`, eliminating the need for `Inv_Display` call sites to handle post-processing of its output.