### PR TITLE
tr2/phase: draw only if not ending

### DIFF
--- a/src/tr2/game/phase/executor.c
+++ b/src/tr2/game/phase/executor.c
@@ -72,13 +72,13 @@ GAME_FLOW_DIR PhaseExecutor_Run(PHASE *const phase)
     while (true) {
         control = M_Control(phase, nframes);
 
-        M_Draw(phase);
         if (control.action == PHASE_ACTION_END) {
             break;
         } else if (control.action == PHASE_ACTION_NO_WAIT) {
             nframes = 0;
             continue;
         } else {
+            M_Draw(phase);
             nframes = M_Wait(phase);
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Resolves #2151.

I'm confident there should be no problems, as we just skip drawing the final frame that we wouldn't even wait for anyway, but the examples of affected places include:

- opening the inventory ring
- closing the inventory ring
- closing the title ring (× fades on/off)
- finishing playing a demo
- finishing showing a credit picture (× fades on/off)
- finishing showing level stats (× fades on/off)
- finishing final stats (× fades on/off)
- finishing a cutscene (including the final shower cutscene)
- closing the game through Alt-F4 (× fades on/off × all of the phases above)
- closing the game through `/exit` (× all of the phases above)
- issuing a phase switch command like `/play {level_num}` or `/demo` (× all of the phases above)