### PR TITLE
tr2/gameflow: restore NG+ flag

### DIFF
--- a/src/tr2/game/gameflow.c
+++ b/src/tr2/game/gameflow.c
@@ -537,6 +537,7 @@ GAME_FLOW_DIR GF_InterpretSequence(const int16_t *ptr, GAMEFLOW_LEVEL_TYPE type)
         case GFE_GAME_COMPLETE:
             START_INFO *const start = &g_SaveGame.start[g_CurrentLevel];
             start->stats = g_SaveGame.current_stats;
+            g_SaveGame.bonus_flag = true;
             dir = DisplayCredits();
             ptr++;
             break;


### PR DESCRIPTION
Resolves #2152.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Restores the NG+ flag after completing the game.