### PR TITLE
tr2/music/music_main: play tracks regardless of volume

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed bubbles spawning from flares if Lara is in shallow water (#1590)
 - fixed flare sound effects not always playing when Lara is in shallow water (#1590)
 - fixed looking forward too far causing an upside down camera frame (#1594)
+- fixed music not playing if triggered while the game is muted, but the volume is then increased (#2170)
 - fixed software renderer not applying underwater tint (#2066, regression from 0.7)
 - fixed some enemies not looking at Lara (#2080, regression from 0.6)
 - fixed the camera getting stuck at the start of Home Sweet Home (#2129, regression from 0.7)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -116,6 +116,7 @@ game with new enhancements and features.
 - fixed sound settings resuming the music
 - fixed wrong default music volume (being very loud on some setups)
 - fixed flare sound effects not always playing when Lara is in shallow water
+- fixed music not playing if triggered while the game is muted, but the volume is then increased
 
 #### Mods
 - added developer console (accessible with `/`, see [COMMANDS.md](COMMANDS.md) for details)

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -533,7 +533,7 @@ GAME_FLOW_DIR InvRing_Close(INV_RING *const ring)
     } else if (demo_needed) {
         return GFD_START_DEMO | 0xFF;
     } else if (g_Inv_Chosen == NO_OBJECT) {
-        if (mode != INV_TITLE_MODE && g_Config.audio.music_volume != 0) {
+        if (mode != INV_TITLE_MODE) {
             Music_Unpause();
         }
     } else {
@@ -546,7 +546,7 @@ GAME_FLOW_DIR InvRing_Close(INV_RING *const ring)
 
         switch (g_Inv_Chosen) {
         case O_PASSPORT_OPTION:
-            if (g_Inv_ExtraData[0] == 1 && g_Config.audio.music_volume != 0) {
+            if (g_Inv_ExtraData[0] == 1) {
                 Music_Unpause();
             }
 

--- a/src/tr2/game/music/music_main.c
+++ b/src/tr2/game/music/music_main.c
@@ -131,11 +131,6 @@ void Music_Play(const MUSIC_TRACK_ID track_id, const MUSIC_PLAY_MODE mode)
 
     M_StopActiveStream();
 
-    if (g_Config.audio.music_volume == 0) {
-        LOG_DEBUG("Not playing track %d because the game is silent", track_id);
-        goto finish;
-    }
-
     if (m_Backend == NULL) {
         LOG_DEBUG(
             "Not playing track %d because no backend is available", track_id);


### PR DESCRIPTION
Resolves #2170.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures tracks will always be played even if the game is muted - similar to TR1.
