### PR TITLE
tr2/game: fix x2 turbo speed not working

### DIFF
--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -25,7 +25,9 @@
 #include <libtrx/log.h>
 #include <libtrx/utils.h>
 
-GAME_FLOW_DIR Game_Control(const int32_t num_frames, const bool demo_mode)
+static GAME_FLOW_DIR M_Control(bool demo_mode);
+
+static GAME_FLOW_DIR M_Control(const bool demo_mode)
 {
     if (!g_GameFlow.cheat_mode_check_disabled) {
         Lara_Cheat_CheckKeys();
@@ -116,15 +118,29 @@ GAME_FLOW_DIR Game_Control(const int32_t num_frames, const bool demo_mode)
     Sound_EndScene();
     ItemAction_RunActive();
 
-    g_Camera.num_frames = num_frames * TICKS_PER_FRAME;
-    Overlay_Animate(num_frames);
-    Output_AnimateTextures(g_Camera.num_frames);
-
     g_HealthBarTimer--;
     if (g_CurrentLevel || g_IsAssaultTimerActive) {
         Stats_UpdateTimer();
     }
+
     return (GAME_FLOW_DIR)-1;
+}
+
+GAME_FLOW_DIR Game_Control(const int32_t num_frames, const bool demo_mode)
+{
+    GAME_FLOW_DIR dir = (GAME_FLOW_DIR)-1;
+    for (int32_t i = 0; i < num_frames; i++) {
+        dir = M_Control(demo_mode);
+        if (dir != (GAME_FLOW_DIR)-1) {
+            break;
+        }
+    }
+
+    g_Camera.num_frames = num_frames * TICKS_PER_FRAME;
+    Overlay_Animate(num_frames);
+    Output_AnimateTextures(g_Camera.num_frames);
+
+    return dir;
 }
 
 void Game_Draw(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2173. Regression introduced in 807b789.