### PR TITLE
tr2/overlay: fix assault digits scaling

### DIFF
--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -101,39 +101,49 @@ void Overlay_DrawAssaultTimer(void)
         buffer, "%d:%02d.%d", total_sec / 60, total_sec % 60,
         frame * 10 / FRAMES_PER_SECOND);
 
-    const int32_t scale_h = PHD_ONE;
-    const int32_t scale_v = PHD_ONE;
+    const int32_t scale_h = Scaler_Calc(PHD_ONE, SCALER_TARGET_ASSAULT_DIGITS);
+    const int32_t scale_v = Scaler_Calc(PHD_ONE, SCALER_TARGET_ASSAULT_DIGITS);
 
-    const int32_t dot_offset = -6;
-    const int32_t dot_width = 14;
-    const int32_t colon_offset = -6;
-    const int32_t colon_width = 14;
-    const int32_t digit_offset = 0;
-    const int32_t digit_width = 20;
+    typedef enum {
+        ASSAULT_GLYPH_DECIMAL_POINT,
+        ASSAULT_GLYPH_COLON,
+        ASSAULT_GLYPH_DIGIT,
+    } ASSAULT_GLYPH_TYPE;
 
-    const int32_t y = 36;
-    int32_t x = (g_PhdWinMaxX / 2) - 50;
+    struct {
+        int32_t offset;
+        int32_t width;
+    } glyph_info[] = {
+        [ASSAULT_GLYPH_DECIMAL_POINT] = { .offset = -6, .width = 14 },
+        [ASSAULT_GLYPH_COLON] = { .offset = -6, .width = 14 },
+        [ASSAULT_GLYPH_DIGIT] = { .offset = 0, .width = 20 },
+    };
+
+    const int32_t y = Scaler_Calc(36, SCALER_TARGET_ASSAULT_DIGITS);
+    int32_t x =
+        g_PhdWinWidth / 2 - Scaler_Calc(50, SCALER_TARGET_ASSAULT_DIGITS);
 
     for (char *c = buffer; *c != '\0'; c++) {
+        ASSAULT_GLYPH_TYPE glyph_type;
+        int32_t mesh_num;
         if (*c == ':') {
-            x += colon_offset;
-            Output_DrawScreenSprite2D(
-                x, y, 0, scale_h, scale_v,
-                g_Objects[O_ASSAULT_DIGITS].mesh_idx + 10, 0x1000, 0);
-            x += colon_width;
+            glyph_type = ASSAULT_GLYPH_COLON;
+            mesh_num = 10;
         } else if (*c == '.') {
-            x += dot_offset;
-            Output_DrawScreenSprite2D(
-                x, y, 0, scale_h, scale_v,
-                g_Objects[O_ASSAULT_DIGITS].mesh_idx + 11, 0x1000, 0);
-            x += dot_width;
+            glyph_type = ASSAULT_GLYPH_DECIMAL_POINT;
+            mesh_num = 11;
         } else {
-            x += digit_offset;
-            Output_DrawScreenSprite2D(
-                x, y, 0, scale_h, scale_v,
-                *c + g_Objects[O_ASSAULT_DIGITS].mesh_idx - '0', 0x1000, 0);
-            x += digit_width;
+            glyph_type = ASSAULT_GLYPH_DIGIT;
+            mesh_num = *c - '0';
         }
+
+        x += Scaler_Calc(
+            glyph_info[glyph_type].offset, SCALER_TARGET_ASSAULT_DIGITS);
+        Output_DrawScreenSprite2D(
+            x, y, 0, scale_h, scale_v,
+            g_Objects[O_ASSAULT_DIGITS].mesh_idx + mesh_num, 0x1000, 0);
+        x += Scaler_Calc(
+            glyph_info[glyph_type].width, SCALER_TARGET_ASSAULT_DIGITS);
     }
 }
 

--- a/src/tr2/game/scaler.c
+++ b/src/tr2/game/scaler.c
@@ -9,13 +9,14 @@
 static int32_t M_DoCalc(
     int32_t unit, int32_t base_width, int32_t base_height, double factor)
 {
-    int32_t scale_x = g_PhdWinWidth > base_width
-        ? ((double)g_PhdWinWidth * unit * factor) / base_width
-        : unit * factor;
-    int32_t scale_y = g_PhdWinHeight > base_height
-        ? ((double)g_PhdWinHeight * unit * factor) / base_height
-        : unit * factor;
-    return MIN(scale_x, scale_y);
+    const int32_t sign = unit < 0 ? -1 : 1;
+    const int32_t scale_x = g_PhdWinWidth > base_width
+        ? ((double)g_PhdWinWidth * ABS(unit) * factor) / base_width
+        : ABS(unit) * factor;
+    const int32_t scale_y = g_PhdWinHeight > base_height
+        ? ((double)g_PhdWinHeight * ABS(unit) * factor) / base_height
+        : ABS(unit) * factor;
+    return MIN(scale_x, scale_y) * sign;
 }
 
 double Scaler_GetScale(const SCALER_TARGET target)
@@ -24,6 +25,8 @@ double Scaler_GetScale(const SCALER_TARGET target)
     case SCALER_TARGET_BAR:
         return g_Config.ui.bar_scale;
     case SCALER_TARGET_TEXT:
+        return g_Config.ui.text_scale;
+    case SCALER_TARGET_ASSAULT_DIGITS:
         return g_Config.ui.text_scale;
     default:
         return 1.0;

--- a/src/tr2/game/scaler.h
+++ b/src/tr2/game/scaler.h
@@ -6,6 +6,7 @@ typedef enum {
     SCALER_TARGET_GENERIC,
     SCALER_TARGET_BAR,
     SCALER_TARGET_TEXT,
+    SCALER_TARGET_ASSAULT_DIGITS,
 } SCALER_TARGET;
 
 double Scaler_GetScale(const SCALER_TARGET target);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

We forgot to tackle assault course timer digits in #2158.
Also fixes the scaler to properly handle scaling negative numbers.