### PR TITLE
stats: respect turbo cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
 - added an optional demo number argument to the `/demo` command
 - changed demo to be interrupted only by esc or action keys
+- changed the turbo cheat to also affect ingame timer (#2167)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)
 - fixed the game hanging when Lara is on fire and enters the fly cheat on the same frame as reaching water (#2116, regression from 0.8)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added an option to set the bar scaling (no UI for it yet) (#1636)
 - added an option to set the text scaling (no UI for it yet) (#1636)
 - changed demo to be interrupted only by esc or action keys
+- changed the turbo cheat to also affect ingame timer (#2167)
 - fixed health bar and air bar scaling (#2149)
 - fixed text being stretched on non-4:3 aspect ratios (#2012)
 - fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs (#1989)

--- a/src/tr1/game/stats.c
+++ b/src/tr1/game/stats.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #define MAX_TEXTSTRINGS 10
+#define USE_REAL_CLOCK 0
 
 static int32_t m_CachedItemCount = 0;
 static SECTOR **m_CachedSectorArray = NULL;
@@ -28,10 +29,12 @@ static uint32_t m_SecretRoom = 0;
 static bool m_KillableItems[MAX_ITEMS] = { 0 };
 static bool m_IfKillable[O_NUMBER_OF] = { 0 };
 
+#if USE_REAL_CLOCK
 static struct {
     double start_counter;
     int32_t start_timer;
 } m_StatsTimer = { 0 };
+#endif
 
 static void M_TraverseFloor(void);
 static void M_CheckTriggers(ROOM *r, int room_num, int z_sector, int x_sector);
@@ -229,6 +232,7 @@ bool Stats_CheckAllSecretsCollected(GAMEFLOW_LEVEL_TYPE level_type)
     return total_stats.player_secret_count >= total_stats.total_secret_count;
 }
 
+#if USE_REAL_CLOCK
 void Stats_StartTimer(void)
 {
     m_StatsTimer.start_counter = Clock_GetHighPrecisionCounter();
@@ -243,3 +247,13 @@ void Stats_UpdateTimer(void)
     g_GameInfo.current[g_CurrentLevel].stats.timer =
         m_StatsTimer.start_timer + elapsed;
 }
+#else
+void Stats_StartTimer(void)
+{
+}
+
+void Stats_UpdateTimer(void)
+{
+    g_GameInfo.current[g_CurrentLevel].stats.timer++;
+}
+#endif

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -119,7 +119,7 @@ static GAME_FLOW_DIR M_Control(const bool demo_mode)
     ItemAction_RunActive();
 
     g_HealthBarTimer--;
-    if (g_CurrentLevel || g_IsAssaultTimerActive) {
+    if (g_CurrentLevel != LV_GYM || g_IsAssaultTimerActive) {
         Stats_UpdateTimer();
     }
 

--- a/src/tr2/game/phase/phase_inventory.c
+++ b/src/tr2/game/phase/phase_inventory.c
@@ -87,7 +87,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
         break;
 
     case STATE_RUN: {
-        const GAME_FLOW_DIR dir = InvRing_Control(p->ring, num_frames * 2);
+        const GAME_FLOW_DIR dir = InvRing_Control(p->ring, num_frames);
         if (dir != (GAME_FLOW_DIR)-1 || p->ring->motion.status == RNG_DONE) {
             p->dir = dir;
             M_FadeOut(p);

--- a/src/tr2/game/stats.c
+++ b/src/tr2/game/stats.c
@@ -3,6 +3,9 @@
 #include "game/clock.h"
 #include "global/vars.h"
 
+#define USE_REAL_CLOCK 0
+
+#if USE_REAL_CLOCK
 static double m_StartCounter = 0.0;
 static int32_t m_StartTimer = 0;
 
@@ -18,6 +21,16 @@ void Stats_UpdateTimer(void)
         (Clock_GetHighPrecisionCounter() - m_StartCounter) * LOGIC_FPS / 1000.0;
     g_SaveGame.current_stats.timer = m_StartTimer + elapsed;
 }
+#else
+void Stats_StartTimer(void)
+{
+}
+
+void Stats_UpdateTimer(void)
+{
+    g_SaveGame.current_stats.timer++;
+}
+#endif
 
 FINAL_STATS Stats_ComputeFinalStats(void)
 {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2167.

Now that 5785b0e65 has eliminated the clock drift problems, we can return to simple frame-based timer increments.
I've compared the current and proposed approaches for normal game speed. There are some initial differences of up to 4 frames due to loading times, but they remain stable and don't increase over time.
I kept the original code behind `#ifdef` but I think we maybe should remove it after all. I'd like to defer the final decision to @lahm86.