### PR TITLE
tr2/inventory_ring/control: hide up arrow on health items

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed looking forward too far causing an upside down camera frame (#1594)
 - fixed music not playing if triggered while the game is muted, but the volume is then increased (#2170)
 - fixed game FOV being interpreted as horizontal (#2002)
+- fixed the inventory up arrow at times overlapping the health bar (#2180)
 - fixed software renderer not applying underwater tint (#2066, regression from 0.7)
 - fixed some enemies not looking at Lara (#2080, regression from 0.6)
 - fixed the camera getting stuck at the start of Home Sweet Home (#2129, regression from 0.7)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -106,6 +106,7 @@ game with new enhancements and features.
 - fixed distant rooms sometimes not appearing, causing the skybox to be visible when it shouldn't
 - fixed rendering problems on certain Intel GPUs
 - fixed bubbles spawning from flares if Lara is in shallow water
+- fixed the inventory up arrow at times overlapping the health bar
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -743,6 +743,13 @@ static void M_RingNotActive(const INV_ITEM *const inv_item)
     default:
         break;
     }
+
+    if (inv_item->object_id == O_SMALL_MEDIPACK_OPTION
+        || inv_item->object_id == O_LARGE_MEDIPACK_OPTION) {
+        Text_Hide(m_UpArrow1, true);
+    } else {
+        Text_Hide(m_UpArrow1, false);
+    }
 }
 
 static void M_RingActive(void)

--- a/src/tr2/game/text.c
+++ b/src/tr2/game/text.c
@@ -53,6 +53,10 @@ void Text_DrawText(TEXTSTRING *const text)
     }
     text->flags.drawn = 1;
 
+    if (text->flags.hide || text->glyphs == NULL) {
+        return;
+    }
+
     int32_t box_w = 0;
     int32_t box_h = 0;
     const int32_t scale_h = M_Scale(text->scale.h);


### PR DESCRIPTION
Resolves #2180.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This hides the left up arrow when either medi pack type is selected in the inventory.
