### PR TITLE
tr2/phaser: sync clock at phase start/resume

### DIFF
--- a/src/tr2/game/phase/executor.c
+++ b/src/tr2/game/phase/executor.c
@@ -65,6 +65,7 @@ GAME_FLOW_DIR PhaseExecutor_Run(PHASE *const phase)
     m_PhaseStack[m_PhaseStackSize++] = phase;
 
     if (phase->start != NULL) {
+        Clock_SyncTick();
         const PHASE_CONTROL control = phase->start(phase);
         if (g_IsGameToExit) {
             result = GFD_EXIT_GAME;
@@ -100,6 +101,7 @@ finish:
         phase->end(phase);
     }
     if (prev_phase != NULL && prev_phase->resume != NULL) {
+        Clock_SyncTick();
         prev_phase->resume(phase);
     }
     m_PhaseStackSize--;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a bug found by Lahm where playing an FMV causes the clock to not update. This results in the next phase trying to catch up on frames it thinks were missed. Translated to a real world example, this means that playing the Great Wall FMV would cause the game to start with Lara already having descended the opening slopes. The solution is to reset the clock's last tick value at the start of a phase. I've also applied this reset to the resume operation, e.g. when returning from a nested phase to an outer phase (for example whenever the player closes the inventory and goes back to the game).