### PR TITLE
tr2/objects/switch: fix switch collision test

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed assault course timer not paused in the inventory (#2153, regression from 0.6)
 - fixed Lara spawning air bubbles above water surfaces during the fly cheat (#2115, regression from 0.3)
 - fixed demos playing too eagerly (#2068, regression from 0.3)
+- fixed Lara sometimes being unable to use switches (#2184, regression from 0.6)
 - improved the animation of Lara's braid (#2094)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -125,7 +125,7 @@ void Switch_Collision(
 {
     ITEM *const item = &g_Items[item_num];
     if (!g_Input.action || item->status != IS_INACTIVE
-        || g_Lara.gun_status != LGS_ARMLESS || lara_item->status
+        || g_Lara.gun_status != LGS_ARMLESS || lara_item->gravity
         || lara_item->current_anim_state != LS_STOP
         || !Item_TestPosition(m_SwitchBounds, &g_Items[item_num], lara_item)) {
         return;


### PR DESCRIPTION
Resolves #2184.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The collision test for switches was referencing Lara's status rather than her gravity status, as is done in TR1. Save attached in the issue for Diving Area.
