### PR TITLE
tr2/objects/switch: fix weird airlock interaction

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed Lara spawning air bubbles above water surfaces during the fly cheat (#2115, regression from 0.3)
 - fixed demos playing too eagerly (#2068, regression from 0.3)
 - fixed Lara sometimes being unable to use switches (#2184, regression from 0.6)
+- fixed Lara interacting with airlock switches in unexpected ways (#2186, regression from 0.6)
 - improved the animation of Lara's braid (#2094)
 
 ## [0.7.1](https://github.com/LostArtefacts/TRX/compare/tr2-0.7...tr2-0.7.1) - 2024-12-17

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -46,9 +46,6 @@ static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
 {
     switch (switch_item->object_id) {
     case O_SWITCH_TYPE_AIRLOCK:
-        if (switch_item->current_anim_state == SWITCH_STATE_ON) {
-            return;
-        }
         Item_AlignPosition(&m_AirlockPosition, switch_item, lara_item);
         break;
 
@@ -65,16 +62,16 @@ static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
 static void M_SwitchOn(ITEM *const switch_item, ITEM *const lara_item)
 {
     switch (switch_item->object_id) {
-    default:
-        lara_item->anim_num = g_Objects[O_LARA].anim_idx + LA_WALL_SWITCH_DOWN;
-        break;
-
     case O_SWITCH_TYPE_SMALL:
         lara_item->anim_num = g_Objects[O_LARA].anim_idx + LA_SWITCH_SMALL_DOWN;
         break;
 
     case O_SWITCH_TYPE_BUTTON:
         lara_item->anim_num = g_Objects[O_LARA].anim_idx + LA_BUTTON_PUSH;
+        break;
+
+    default:
+        lara_item->anim_num = g_Objects[O_LARA].anim_idx + LA_WALL_SWITCH_DOWN;
         break;
     }
 
@@ -123,15 +120,20 @@ void Switch_Setup(OBJECT *const obj, const bool underwater)
 void Switch_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
-    ITEM *const item = &g_Items[item_num];
+    ITEM *const item = Item_Get(item_num);
     if (!g_Input.action || item->status != IS_INACTIVE
         || g_Lara.gun_status != LGS_ARMLESS || lara_item->gravity
         || lara_item->current_anim_state != LS_STOP
-        || !Item_TestPosition(m_SwitchBounds, &g_Items[item_num], lara_item)) {
+        || !Item_TestPosition(m_SwitchBounds, item, lara_item)) {
         return;
     }
 
     lara_item->rot.y = item->rot.y;
+
+    if (item->object_id == O_SWITCH_TYPE_AIRLOCK
+        && item->current_anim_state == SWITCH_STATE_ON) {
+        return;
+    }
 
     M_AlignLara(lara_item, item);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2186.
The bug was initially hard to identify, but it's trivial once you see it. In the original code, `M_AlignLara` wasn’t a separate function; its logic was directly embedded within the `Switch_Collision` function. It did contain the `return;` statement, though, which would end the entire collision routine when the check for opened airlocks would pass. But after wrapping the logic inside `M_AlignLara`, it no longer terminated the routine as expected, leading to Lara being able to use it as a lever.