### PR TITLE
libtrx/anims/types: introduce frame size for animations

### DIFF
--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -52,7 +52,8 @@ typedef struct __PACKING {
 #elif TR_VERSION == 2
     int16_t *frame_ptr;
 #endif
-    int16_t interpolation;
+    uint8_t interpolation;
+    uint8_t frame_size;
     int16_t current_anim_state;
     int32_t velocity;
     int32_t acceleration;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -589,7 +589,10 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
         ANIM *anim = &g_Anims[level_info->anim_count + i];
 
         anim->frame_ofs = VFile_ReadU32(fp);
-        anim->interpolation = VFile_ReadS16(fp);
+        const int16_t interpolation = VFile_ReadS16(fp);
+        ASSERT(interpolation <= 0xFF);
+        anim->interpolation = interpolation & 0xFF;
+        anim->frame_size = 0;
         anim->current_anim_state = VFile_ReadS16(fp);
         anim->velocity = VFile_ReadS32(fp);
         anim->acceleration = VFile_ReadS32(fp);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -302,7 +302,10 @@ static void M_LoadAnims(VFILE *file)
         ANIM *anim = g_Anims + i;
 
         anim->frame_ofs = VFile_ReadU32(file);
-        anim->interpolation = VFile_ReadS16(file);
+        const int16_t interpolation = VFile_ReadS16(file);
+        ASSERT(interpolation <= 0xFF);
+        anim->interpolation = interpolation & 0xFF;
+        anim->frame_size = 0;
         anim->current_anim_state = VFile_ReadS16(file);
         anim->velocity = VFile_ReadS32(file);
         anim->acceleration = VFile_ReadS32(file);

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -104,9 +104,9 @@ static void M_DrawItem(
         }
     }
 
-    ANIM_FRAME *frame_ptr = (ANIM_FRAME *)&obj->frame_base
-                                [inv_item->current_frame
-                                 * (g_Anims[obj->anim_idx].interpolation >> 8)];
+    ANIM_FRAME *frame_ptr =
+        (ANIM_FRAME *)&obj->frame_base
+            [inv_item->current_frame * g_Anims[obj->anim_idx].frame_size];
 
     Matrix_Push();
     const int32_t clip = Output_GetObjectBounds(&frame_ptr->bounds);

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -669,8 +669,8 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
 {
     const ANIM *const anim = &g_Anims[item->anim_num];
     const int32_t cur_frame_num = item->frame_num - anim->frame_base;
-    const int32_t size = anim->interpolation >> 8;
-    const int32_t key_frame_span = anim->interpolation & 0xFF;
+    const int32_t size = anim->frame_size;
+    const int32_t key_frame_span = anim->interpolation;
     const int32_t key_frame_shift = cur_frame_num % key_frame_span;
     const int32_t first_key_frame_num = cur_frame_num / key_frame_span * size;
     const int32_t second_key_frame_num = first_key_frame_num + size;

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -69,8 +69,7 @@ void Lara_Draw(const ITEM *const item)
         }
         // clang-format on
         frame = (ANIM_FRAME *)(g_Anims[anim].frame_ptr
-                               + g_Lara.hit_frame
-                                   * (g_Anims[anim].interpolation >> 8));
+                               + g_Lara.hit_frame * g_Anims[anim].frame_size);
     }
 
     if (g_Lara.skidoo == NO_ITEM) {
@@ -117,11 +116,10 @@ void Lara_Draw(const ITEM *const item)
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots = &g_Lara.right_arm.frame_base
+                         [g_Lara.right_arm.frame_num
+                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                          + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
@@ -175,7 +173,7 @@ void Lara_Draw(const ITEM *const item)
         if (g_Lara.flare_control_left) {
             mesh_rots =
                 &g_Lara.left_arm.frame_base
-                     [(g_Anims[g_Lara.left_arm.anim_num].interpolation >> 8)
+                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
                           * (g_Lara.left_arm.frame_num
                              - g_Anims[g_Lara.left_arm.anim_num].frame_base)
                       + FBBOX_ROT];
@@ -214,7 +212,7 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.right_arm.rot.z);
         mesh_rots =
             &g_Lara.right_arm.frame_base
-                 [(g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
+                 [g_Anims[g_Lara.right_arm.anim_num].frame_size
                       * (g_Lara.right_arm.frame_num
                          - g_Anims[g_Lara.right_arm.anim_num].frame_base)
                   + FBBOX_ROT];
@@ -244,7 +242,7 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
             g_Lara.left_arm.rot.z);
         mesh_rots = &g_Lara.left_arm.frame_base
-                         [(g_Anims[g_Lara.left_arm.anim_num].interpolation >> 8)
+                         [g_Anims[g_Lara.left_arm.anim_num].frame_size
                               * (g_Lara.left_arm.frame_num
                                  - g_Anims[g_Lara.left_arm.anim_num].frame_base)
                           + FBBOX_ROT];
@@ -271,11 +269,10 @@ void Lara_Draw(const ITEM *const item)
     case LGT_HARPOON:
         Matrix_Push();
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots = &g_Lara.right_arm.frame_base
+                         [g_Lara.right_arm.frame_num
+                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                          + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -371,11 +368,10 @@ void Lara_Draw_I(
         && ((g_Items[g_Lara.weapon_item].current_anim_state) == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots_2 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots_2 = &g_Lara.right_arm.frame_base
+                           [g_Lara.right_arm.frame_num
+                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                            + FBBOX_ROT];
         mesh_rots_1 = mesh_rots_2;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -432,14 +428,14 @@ void Lara_Draw_I(
         if (g_Lara.flare_control_left) {
             mesh_rots_1 =
                 &g_Lara.left_arm.frame_base
-                     [(g_Anims[g_Lara.left_arm.anim_num].interpolation >> 8)
+                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
                           * (g_Lara.left_arm.frame_num
                              - g_Anims[g_Lara.left_arm.anim_num].frame_base)
                       + FBBOX_ROT];
 
             mesh_rots_2 =
                 &g_Lara.left_arm.frame_base
-                     [(g_Anims[g_Lara.left_arm.anim_num].interpolation >> 8)
+                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
                           * (g_Lara.left_arm.frame_num
                              - g_Anims[g_Lara.left_arm.anim_num].frame_base)
                       + FBBOX_ROT];
@@ -474,7 +470,7 @@ void Lara_Draw_I(
             g_Lara.right_arm.rot.z);
         mesh_rots_1 =
             &g_Lara.right_arm.frame_base
-                 [(g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
+                 [g_Anims[g_Lara.right_arm.anim_num].frame_size
                       * (g_Lara.right_arm.frame_num
                          - g_Anims[g_Lara.right_arm.anim_num].frame_base)
                   + FBBOX_ROT];
@@ -497,7 +493,7 @@ void Lara_Draw_I(
             g_Lara.left_arm.rot.z);
         mesh_rots_1 =
             &g_Lara.left_arm.frame_base
-                 [(g_Anims[g_Lara.left_arm.anim_num].interpolation >> 8)
+                 [g_Anims[g_Lara.left_arm.anim_num].frame_size
                       * (g_Lara.left_arm.frame_num
                          - g_Anims[g_Lara.left_arm.anim_num].frame_base)
                   + FBBOX_ROT];
@@ -523,16 +519,14 @@ void Lara_Draw_I(
     case LGT_HARPOON:
         Matrix_Push_I();
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        mesh_rots_1 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
-        mesh_rots_2 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots_1 = &g_Lara.right_arm.frame_base
+                           [g_Lara.right_arm.frame_num
+                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                            + FBBOX_ROT];
+        mesh_rots_2 = &g_Lara.right_arm.frame_base
+                           [g_Lara.right_arm.frame_num
+                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                            + FBBOX_ROT];
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 8);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -49,11 +49,10 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots = &g_Lara.right_arm.frame_base
+                         [g_Lara.right_arm.frame_num
+                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                          + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 6);
@@ -135,11 +134,10 @@ static void M_CalculateSpheres_I(
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots_1 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * (g_Anims[g_Lara.right_arm.anim_num].interpolation >> 8)
-                  + FBBOX_ROT];
+        mesh_rots_1 = &g_Lara.right_arm.frame_base
+                           [g_Lara.right_arm.frame_num
+                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
+                            + FBBOX_ROT];
         mesh_rots_2 = mesh_rots_1;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -251,9 +249,8 @@ void Lara_Hair_Control(const bool in_cutscene)
         }
 
         const int16_t *const frame_ptr = g_Anims[lara_anim].frame_ptr;
-        const int32_t interpolation = g_Anims[lara_anim].interpolation;
-        frame_1 =
-            (ANIM_FRAME *)&frame_ptr[g_Lara.hit_frame * (interpolation >> 8)];
+        const int32_t frame_size = g_Anims[lara_anim].frame_size;
+        frame_1 = (ANIM_FRAME *)&frame_ptr[g_Lara.hit_frame * frame_size];
         frac = 0;
     }
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -871,10 +871,10 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             break;
         }
         const ANIM *anim = &g_Anims[anim_num];
-        int32_t interpolation = anim->interpolation;
-        frame_ptr = (const ANIM_FRAME *)(anim->frame_ptr
-                                         + (int32_t)(g_Lara.hit_frame
-                                                     * (interpolation >> 8)));
+        const int32_t frame_size = anim->frame_size;
+        frame_ptr =
+            (const ANIM_FRAME *)(anim->frame_ptr
+                                 + (int32_t)(g_Lara.hit_frame * frame_size));
     } else {
         frame_ptr = frmptr[0];
     }
@@ -908,8 +908,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             const LARA_ARM *arm = &g_Lara.left_arm;
             const ANIM *anim = &g_Anims[arm->anim_num];
             rot = &arm->frame_base
-                       [(anim->interpolation >> 8)
-                            * (arm->frame_num - anim->frame_base)
+                       [anim->frame_size * (arm->frame_num - anim->frame_base)
                         + FBBOX_ROT];
         } else {
             rot = frame_ptr->mesh_rots;
@@ -926,8 +925,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
 
         const LARA_ARM *arm = &g_Lara.right_arm;
         const ANIM *anim = &g_Anims[arm->anim_num];
-        rot = &arm->frame_base
-                   [arm->frame_num * (anim->interpolation >> 8) + FBBOX_ROT];
+        rot = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot, 8);
 
         Matrix_TranslateRel(bone[33], bone[34], bone[35]);
@@ -983,8 +981,7 @@ void Lara_GetJointAbsPosition_I(
             const LARA_ARM *arm = &g_Lara.left_arm;
             const ANIM *anim = &g_Anims[arm->anim_num];
             rot1 = &arm->frame_base
-                        [(anim->interpolation >> 8)
-                             * (arm->frame_num - anim->frame_base)
+                        [anim->frame_size * (arm->frame_num - anim->frame_base)
                          + FBBOX_ROT];
         } else {
             rot1 = frame1->mesh_rots;
@@ -1002,8 +999,7 @@ void Lara_GetJointAbsPosition_I(
 
         const LARA_ARM *arm = &g_Lara.right_arm;
         const ANIM *anim = &g_Anims[arm->anim_num];
-        rot1 = &arm->frame_base
-                    [arm->frame_num * (anim->interpolation >> 8) + FBBOX_ROT];
+        rot1 = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot1, 8);
 
         Matrix_TranslateRel(bone[33], bone[34], bone[35]);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -245,7 +245,8 @@ static int32_t M_LoadAnims(VFILE *const file, int32_t **frame_pointers)
             (*frame_pointers)[i] = frame_idx;
         }
         anim->frame_ptr = NULL; // filled later by the animation frame loader
-        anim->interpolation = VFile_ReadS16(file);
+        anim->interpolation = VFile_ReadU8(file);
+        anim->frame_size = VFile_ReadU8(file);
         anim->current_anim_state = VFile_ReadS16(file);
         anim->velocity = VFile_ReadS32(file);
         anim->acceleration = VFile_ReadS32(file);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reduces repeated shifts on the interpolation property by introducing a frame size property on the anim struct. This only applies to TR2.

Bones refactor after this PR.
