### PR TITLE
tr1|tr2: refactor anim bone interpretation

### DIFF
--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -15,7 +15,6 @@ typedef struct __PACKING {
     int16_t link_frame_num;
 } ANIM_RANGE;
 
-#if TR_VERSION > 1
 typedef struct {
     union {
         int32_t flags;
@@ -32,7 +31,6 @@ typedef struct {
     };
     XYZ_32 pos;
 } ANIM_BONE;
-#endif
 
 typedef struct __PACKING {
     BOUNDS_16 bounds;

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -867,7 +867,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     int32_t *packed_rotation = frame->mesh_rots;
     Matrix_RotYXZpack(*packed_rotation++);
 
-    int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
 #if 0
     // XXX: present in OG, removed by GLrage on the grounds that it sometimes
     // crashes.
@@ -899,29 +899,26 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     }
 
     for (int i = 1; i < obj->nmeshes; i++) {
-        int32_t bone_extra_flags = *bone++;
-        if (bone_extra_flags & BF_MATRIX_POP) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
-        if (bone_extra_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[0], bone[1], bone[2]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZpack(*packed_rotation++);
 
 #if 0
     if (extra_rotation) {
-        if (bone_extra_flags & (BF_ROT_X | BF_ROT_Y | BF_ROT_Z)) {
-            if (bone_extra_flags & BF_ROT_Y) {
-                Matrix_RotY(*extra_rotation++);
-            }
-            if (bone_extra_flags & BF_ROT_X) {
-                Matrix_RotX(*extra_rotation++);
-            }
-            if (bone_extra_flags & BF_ROT_Z) {
-                Matrix_RotZ(*extra_rotation++);
-            }
+        if (bone->rot_y) {
+            Matrix_RotY(*extra_rotation++);
+        }
+        if (bone->rot_x) {
+            Matrix_RotX(*extra_rotation++);
+        }
+        if (bone->rot_z) {
+            Matrix_RotZ(*extra_rotation++);
         }
     }
 #endif
@@ -950,7 +947,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
             item->mesh_bits -= bit;
         }
 
-        bone += 3;
+        bone++;
     }
 
     Matrix_Pop();

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -98,7 +98,7 @@ void Lara_Draw(ITEM *item)
 
     Output_CalculateObjectLighting(item, &frame->bounds);
 
-    int32_t *bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     int32_t *packed_rotation = frame->mesh_rots;
 
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
@@ -107,15 +107,15 @@ void Lara_Draw(ITEM *item)
 
     Matrix_Push();
 
-    Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+    Matrix_TranslateRel(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, false);
 
-    Matrix_TranslateRel(bone[5], bone[6], bone[7]);
+    Matrix_TranslateRel(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, false);
 
-    Matrix_TranslateRel(bone[9], bone[10], bone[11]);
+    Matrix_TranslateRel(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, false);
 
@@ -123,21 +123,21 @@ void Lara_Draw(ITEM *item)
 
     Matrix_Push();
 
-    Matrix_TranslateRel(bone[13], bone[14], bone[15]);
+    Matrix_TranslateRel(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, false);
 
-    Matrix_TranslateRel(bone[17], bone[18], bone[19]);
+    Matrix_TranslateRel(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, false);
 
-    Matrix_TranslateRel(bone[21], bone[22], bone[23]);
+    Matrix_TranslateRel(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, false);
 
     Matrix_Pop();
 
-    Matrix_TranslateRel(bone[25], bone[26], bone[27]);
+    Matrix_TranslateRel(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
     Matrix_RotYXZ(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
@@ -146,7 +146,7 @@ void Lara_Draw(ITEM *item)
 
     Matrix_Push();
 
-    Matrix_TranslateRel(bone[53], bone[54], bone[55]);
+    Matrix_TranslateRel(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
     Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
     Matrix_RotYXZ(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
@@ -168,15 +168,15 @@ void Lara_Draw(ITEM *item)
     case LGT_UNARMED:
         Matrix_Push();
 
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
@@ -184,15 +184,15 @@ void Lara_Draw(ITEM *item)
 
         Matrix_Push();
 
-        Matrix_TranslateRel(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
@@ -204,7 +204,7 @@ void Lara_Draw(ITEM *item)
     case LGT_UZIS:
         Matrix_Push();
 
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
 
         g_MatrixPtr->_00 = g_MatrixPtr[-2]._00;
         g_MatrixPtr->_01 = g_MatrixPtr[-2]._01;
@@ -225,11 +225,11 @@ void Lara_Draw(ITEM *item)
         Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
@@ -241,7 +241,7 @@ void Lara_Draw(ITEM *item)
 
         Matrix_Push();
 
-        Matrix_TranslateRel(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
 
         g_MatrixPtr->_00 = g_MatrixPtr[-2]._00;
         g_MatrixPtr->_01 = g_MatrixPtr[-2]._01;
@@ -262,11 +262,11 @@ void Lara_Draw(ITEM *item)
         Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
@@ -286,15 +286,15 @@ void Lara_Draw(ITEM *item)
 
         packed_rotation =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
@@ -308,15 +308,15 @@ void Lara_Draw(ITEM *item)
 
         packed_rotation =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
-        Matrix_TranslateRel(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
@@ -370,7 +370,7 @@ void Lara_Draw_I(
 
     Output_CalculateObjectLighting(item, &frame1->bounds);
 
-    int32_t *bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     int32_t *packed_rotation1 = frame1->mesh_rots;
     int32_t *packed_rotation2 = frame2->mesh_rots;
 
@@ -385,17 +385,17 @@ void Lara_Draw_I(
 
     Matrix_Push_I();
 
-    Matrix_TranslateRel_I(bone[1], bone[2], bone[3]);
+    Matrix_TranslateRel_I(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_THIGH_L], packed_rotation2[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, true);
 
-    Matrix_TranslateRel_I(bone[5], bone[6], bone[7]);
+    Matrix_TranslateRel_I(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_CALF_L], packed_rotation2[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, true);
 
-    Matrix_TranslateRel_I(bone[9], bone[10], bone[11]);
+    Matrix_TranslateRel_I(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_FOOT_L], packed_rotation2[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, true);
@@ -404,24 +404,24 @@ void Lara_Draw_I(
 
     Matrix_Push_I();
 
-    Matrix_TranslateRel_I(bone[13], bone[14], bone[15]);
+    Matrix_TranslateRel_I(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_THIGH_R], packed_rotation2[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, true);
 
-    Matrix_TranslateRel_I(bone[17], bone[18], bone[19]);
+    Matrix_TranslateRel_I(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_CALF_R], packed_rotation2[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, true);
 
-    Matrix_TranslateRel_I(bone[21], bone[22], bone[23]);
+    Matrix_TranslateRel_I(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
     Matrix_RotYXZpack_I(
         packed_rotation1[LM_FOOT_R], packed_rotation2[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, true);
 
     Matrix_Pop_I();
 
-    Matrix_TranslateRel_I(bone[25], bone[26], bone[27]);
+    Matrix_TranslateRel_I(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
     Matrix_RotYXZpack_I(packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
@@ -430,7 +430,7 @@ void Lara_Draw_I(
 
     Matrix_Push_I();
 
-    Matrix_TranslateRel_I(bone[53], bone[54], bone[55]);
+    Matrix_TranslateRel_I(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
     Matrix_RotYXZpack_I(packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
@@ -452,17 +452,17 @@ void Lara_Draw_I(
     case LGT_UNARMED:
         Matrix_Push_I();
 
-        Matrix_TranslateRel_I(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
-        Matrix_TranslateRel_I(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_LARM_R], packed_rotation2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
-        Matrix_TranslateRel_I(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HAND_R], packed_rotation2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
@@ -471,17 +471,17 @@ void Lara_Draw_I(
 
         Matrix_Push_I();
 
-        Matrix_TranslateRel_I(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
-        Matrix_TranslateRel_I(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_LARM_L], packed_rotation2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
-        Matrix_TranslateRel_I(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HAND_L], packed_rotation2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);
@@ -494,7 +494,7 @@ void Lara_Draw_I(
     case LGT_UZIS:
         Matrix_Push_I();
 
-        Matrix_TranslateRel_I(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_InterpolateArm();
 
         packed_rotation1 =
@@ -506,11 +506,11 @@ void Lara_Draw_I(
         Matrix_RotYXZpack(packed_rotation1[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack(packed_rotation1[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack(packed_rotation1[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
@@ -522,7 +522,7 @@ void Lara_Draw_I(
 
         Matrix_Push_I();
 
-        Matrix_TranslateRel_I(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_InterpolateArm();
 
         packed_rotation1 =
@@ -534,11 +534,11 @@ void Lara_Draw_I(
         Matrix_RotYXZpack(packed_rotation1[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack(packed_rotation1[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack(packed_rotation1[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
@@ -560,17 +560,17 @@ void Lara_Draw_I(
         packed_rotation1 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         packed_rotation2 = packed_rotation1;
-        Matrix_TranslateRel_I(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
-        Matrix_TranslateRel_I(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_LARM_R], packed_rotation2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
-        Matrix_TranslateRel_I(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HAND_R], packed_rotation2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
@@ -586,17 +586,17 @@ void Lara_Draw_I(
         packed_rotation1 =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         packed_rotation2 = packed_rotation1;
-        Matrix_TranslateRel_I(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
-        Matrix_TranslateRel_I(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_LARM_L], packed_rotation2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
-        Matrix_TranslateRel_I(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HAND_L], packed_rotation2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -57,15 +57,14 @@ void Lara_Hair_Initialise(void)
     m_FirstHair = true;
     Lara_Hair_SetLaraType(O_LARA);
 
-    int32_t *bone = &g_AnimBones[g_Objects[O_HAIR].bone_idx];
+    const OBJECT *const object = Object_GetObject(O_HAIR);
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     m_Hair[0].rot.y = 0;
     m_Hair[0].rot.x = -PHD_90;
 
-    for (int i = 1; i < HAIR_SEGMENTS + 1; i++, bone += 4) {
-        m_Hair[i].pos.x = *(bone + 1);
-        m_Hair[i].pos.y = *(bone + 2);
-        m_Hair[i].pos.z = *(bone + 3);
+    for (int32_t i = 1; i < HAIR_SEGMENTS + 1; i++, bone++) {
+        m_Hair[i].pos = bone->pos;
         m_Hair[i].rot.x = -PHD_90;
         m_Hair[i].rot.y = 0;
         m_Hair[i].rot.z = 0;
@@ -88,7 +87,6 @@ void Lara_Hair_Control(void)
 
     bool in_cutscene;
     OBJECT *object;
-    int32_t *bone;
     int32_t distance;
     ANIM_FRAME *frame;
     const OBJECT_MESH *mesh;
@@ -145,7 +143,7 @@ void Lara_Hair_Control(void)
         g_LaraItem->pos.x, g_LaraItem->pos.y, g_LaraItem->pos.z);
     Matrix_RotYXZ(g_LaraItem->rot.y, g_LaraItem->rot.x, g_LaraItem->rot.z);
 
-    bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     if (frac) {
         Matrix_InitInterpolate(frac, rate);
         int32_t *packed_rotation1 = frmptr[0]->mesh_rots;
@@ -169,7 +167,8 @@ void Lara_Hair_Control(void)
 
         // torso
         Matrix_TranslateRel_I(
-            *(bone + 1 + 24), *(bone + 2 + 24), *(bone + 3 + 24));
+            bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+            bone[LM_TORSO - 1].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
         Matrix_RotYXZ_I(
@@ -188,7 +187,8 @@ void Lara_Hair_Control(void)
         // right arm
         Matrix_Push_I();
         Matrix_TranslateRel_I(
-            *(bone + 1 + 28), *(bone + 2 + 28), *(bone + 3 + 28));
+            bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+            bone[LM_UARM_R - 1].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
@@ -203,7 +203,8 @@ void Lara_Hair_Control(void)
         // left arm
         Matrix_Push_I();
         Matrix_TranslateRel_I(
-            *(bone + 1 + 40), *(bone + 2 + 40), *(bone + 3 + 40));
+            bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+            bone[LM_UARM_L - 1].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
@@ -217,7 +218,8 @@ void Lara_Hair_Control(void)
 
         // head
         Matrix_TranslateRel_I(
-            *(bone + 1 + 52), *(bone + 2 + 52), *(bone + 3 + 52));
+            bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
+            bone[LM_HEAD - 1].pos.z);
         Matrix_RotYXZpack_I(
             packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
         Matrix_RotYXZ_I(
@@ -253,7 +255,8 @@ void Lara_Hair_Control(void)
 
         // torso
         Matrix_TranslateRel(
-            *(bone + 1 + 24), *(bone + 2 + 24), *(bone + 3 + 24));
+            bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+            bone[LM_TORSO - 1].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
         Matrix_RotYXZ(
             g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
@@ -270,7 +273,8 @@ void Lara_Hair_Control(void)
         // right arm
         Matrix_Push();
         Matrix_TranslateRel(
-            *(bone + 1 + 28), *(bone + 2 + 28), *(bone + 3 + 28));
+            bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+            bone[LM_UARM_R - 1].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
@@ -283,7 +287,8 @@ void Lara_Hair_Control(void)
         // left arm
         Matrix_Push();
         Matrix_TranslateRel(
-            *(bone + 1 + 40), *(bone + 2 + 40), *(bone + 3 + 40));
+            bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+            bone[LM_UARM_L - 1].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
@@ -295,7 +300,8 @@ void Lara_Hair_Control(void)
 
         // head
         Matrix_TranslateRel(
-            *(bone + 1 + 52), *(bone + 2 + 52), *(bone + 3 + 52));
+            bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
+            bone[LM_HEAD - 1].pos.z);
         Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
         Matrix_RotYXZ(
             g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
@@ -317,19 +323,19 @@ void Lara_Hair_Control(void)
     pos.z = g_MatrixPtr->_23 >> W2V_SHIFT;
     Matrix_Pop();
 
-    bone = &g_AnimBones[g_Objects[O_HAIR].bone_idx];
+    bone = (ANIM_BONE *)&g_AnimBones[Object_GetObject(O_HAIR)->bone_idx];
 
     m_Hair[0].pos = pos;
 
     if (m_FirstHair) {
         m_FirstHair = false;
 
-        for (i = 0; i < HAIR_SEGMENTS; i++, bone += 4) {
+        for (i = 0; i < HAIR_SEGMENTS; i++, bone++) {
             Matrix_PushUnit();
             Matrix_TranslateSet(
                 m_Hair[i].pos.x, m_Hair[i].pos.y, m_Hair[i].pos.z);
             Matrix_RotYXZ(m_Hair[i].rot.y, m_Hair[i].rot.x, 0);
-            Matrix_TranslateRel(*(bone + 1), *(bone + 2), *(bone + 3));
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
 
             m_Hair[i + 1].pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;
             m_Hair[i + 1].pos.y = g_MatrixPtr->_13 >> W2V_SHIFT;
@@ -352,7 +358,7 @@ void Lara_Hair_Control(void)
             water_level = Room_GetWaterHeight(x, y, z, room_num);
         }
 
-        for (i = 1; i < HAIR_SEGMENTS + 1; i++, bone += 4) {
+        for (i = 1; i < HAIR_SEGMENTS + 1; i++, bone++) {
             m_HVel[0] = m_Hair[i].pos;
 
             sector = Room_GetSector(
@@ -424,9 +430,11 @@ void Lara_Hair_Control(void)
             Matrix_RotYXZ(m_Hair[i - 1].rot.y, m_Hair[i - 1].rot.x, 0);
 
             if (i == HAIR_SEGMENTS) {
-                Matrix_TranslateRel(*(bone - 3), *(bone - 2), *(bone - 1));
+                const ANIM_BONE *const last_bone = bone - 1;
+                Matrix_TranslateRel(
+                    last_bone->pos.x, last_bone->pos.y, last_bone->pos.z);
             } else {
-                Matrix_TranslateRel(*(bone + 1), *(bone + 2), *(bone + 3));
+                Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             }
 
             m_Hair[i].pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -197,7 +197,7 @@ void Object_DrawPickupItem(ITEM *item)
         // of the code in DrawAnimatingItem starting with the line that
         // matches the following line.
         int32_t bit = 1;
-        int32_t *bone = &g_AnimBones[object->bone_idx];
+        const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
@@ -209,16 +209,15 @@ void Object_DrawPickupItem(ITEM *item)
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
-            int32_t bone_extra_flags = *bone;
-            if (bone_extra_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
 
-            if (bone_extra_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZpack(*packed_rotation++);
 
             // Extra rotation is ignored in this case as it's not needed.
@@ -228,7 +227,7 @@ void Object_DrawPickupItem(ITEM *item)
                 Object_DrawMesh(object->mesh_idx + i, clip, false);
             }
 
-            bone += 4;
+            bone++;
         }
     }
 
@@ -248,7 +247,7 @@ void Object_DrawInterpolatedObject(
 
     Matrix_Push();
     int32_t mesh_num = 1;
-    int32_t *bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     ASSERT(rate != 0);
     if (!frac) {
@@ -263,26 +262,27 @@ void Object_DrawInterpolatedObject(
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
-            int32_t bone_flags = *bone;
-            if (bone_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
 
-            if (bone_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZpack(*packed_rotation++);
 
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_Y) != 0) {
-                Matrix_RotY(*extra_rotation++);
-            }
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_X) != 0) {
-                Matrix_RotX(*extra_rotation++);
-            }
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_Z) != 0) {
-                Matrix_RotZ(*extra_rotation++);
+            if (extra_rotation != NULL) {
+                if (bone->rot_y) {
+                    Matrix_RotY(*extra_rotation++);
+                }
+                if (bone->rot_x) {
+                    Matrix_RotX(*extra_rotation++);
+                }
+                if (bone->rot_z) {
+                    Matrix_RotZ(*extra_rotation++);
+                }
             }
 
             mesh_num <<= 1;
@@ -290,7 +290,7 @@ void Object_DrawInterpolatedObject(
                 Object_DrawMesh(object->mesh_idx + i, clip, false);
             }
 
-            bone += 4;
+            bone++;
         }
     } else {
         ASSERT(frame2 != NULL);
@@ -307,26 +307,27 @@ void Object_DrawInterpolatedObject(
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
-            int32_t bone_flags = *bone;
-            if (bone_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop_I();
             }
 
-            if (bone_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push_I();
             }
 
-            Matrix_TranslateRel_I(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZpack_I(*packed_rotation1++, *packed_rotation2++);
 
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_Y) != 0) {
-                Matrix_RotY_I(*extra_rotation++);
-            }
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_X) != 0) {
-                Matrix_RotX_I(*extra_rotation++);
-            }
-            if (extra_rotation != NULL && (bone_flags & BF_ROT_Z) != 0) {
-                Matrix_RotZ_I(*extra_rotation++);
+            if (extra_rotation != NULL) {
+                if (bone->rot_y) {
+                    Matrix_RotY_I(*extra_rotation++);
+                }
+                if (bone->rot_x) {
+                    Matrix_RotX_I(*extra_rotation++);
+                }
+                if (bone->rot_z) {
+                    Matrix_RotZ_I(*extra_rotation++);
+                }
             }
 
             mesh_num <<= 1;
@@ -334,7 +335,7 @@ void Object_DrawInterpolatedObject(
                 Object_DrawMesh(object->mesh_idx + i, clip, true);
             }
 
-            bone += 4;
+            bone++;
         }
     }
 

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -398,28 +398,27 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         -(frame->bounds.min.x + frame->bounds.max.x) / 2,
         -(frame->bounds.min.y + frame->bounds.max.y) / 2,
         -(frame->bounds.min.z + frame->bounds.max.z) / 2);
-    int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     int32_t *packed_rotation = frame->mesh_rots;
     Matrix_RotYXZpack(*packed_rotation++);
 
     Object_DrawMesh(obj->mesh_idx, 0, false);
 
     for (int i = 1; i < obj->nmeshes; i++) {
-        int32_t bone_extra_flags = *bone;
-        if (bone_extra_flags & BF_MATRIX_POP) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
 
-        if (bone_extra_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZpack(*packed_rotation++);
 
         Object_DrawMesh(obj->mesh_idx + i, 0, false);
 
-        bone += 4;
+        bone++;
     }
     Matrix_Pop();
 

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -987,7 +987,7 @@ void Skidoo_Draw(const ITEM *const item)
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
-    int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     if (frac) {
         const int16_t *mesh_rots_1 = frames[0]->mesh_rots;
         const int16_t *mesh_rots_2 = frames[1]->mesh_rots;
@@ -1000,17 +1000,16 @@ void Skidoo_Draw(const ITEM *const item)
 
         Output_InsertPolygons_I(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
-            const int32_t bone_flags = bone[0];
-            if (bone_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop_I();
             }
-            if (bone_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push_I();
             }
 
-            Matrix_TranslateRel_I(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
-            bone += 4;
+            bone++;
 
             Output_InsertPolygons_I(mesh_ptrs[mesh_idx], clip);
         }
@@ -1022,17 +1021,16 @@ void Skidoo_Draw(const ITEM *const item)
 
         Output_InsertPolygons(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
-            const int32_t bone_flags = bone[0];
-            if (bone_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
-            if (bone_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZsuperpack(&mesh_rots, 0);
-            bone += 4;
+            bone++;
 
             Output_InsertPolygons(mesh_ptrs[mesh_idx], clip);
         }

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -524,29 +524,27 @@ int32_t Collide_GetSpheres(
     spheres[0].r = mesh[3];
     Matrix_Pop();
 
-    const int32_t *bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     const int16_t *extra_rotation = (int16_t *)item->data;
-    for (int32_t i = 1; i < object->mesh_count; i++, bone += 4) {
-        const uint32_t bone_flags = bone[0];
-        if (bone_flags & BF_MATRIX_POP) {
+    for (int32_t i = 1; i < object->mesh_count; i++, bone++) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
-        if (bone_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
-        if (extra_rotation != NULL
-            && bone_flags & (BF_ROT_X | BF_ROT_Y | BF_ROT_Z)) {
-            if (bone_flags & BF_ROT_Y) {
+        if (extra_rotation != NULL) {
+            if (bone->rot_y) {
                 Matrix_RotY(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_X) {
+            if (bone->rot_x) {
                 Matrix_RotX(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_Z) {
+            if (bone->rot_z) {
                 Matrix_RotZ(*extra_rotation++);
             }
         }
@@ -581,32 +579,29 @@ void Collide_GetJointAbsPosition(
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     const int16_t *extra_rotation = item->data;
-    const int32_t *bone = &g_AnimBones[object->bone_idx];
-    for (int32_t i = 0; i < joint; i++) {
-        const uint32_t bone_flags = bone[0];
-        if (bone_flags & BF_MATRIX_POP) {
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    for (int32_t i = 0; i < joint; i++, bone++) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
-        if (bone_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
-        if (extra_rotation != NULL
-            && (bone_flags & (BF_ROT_X | BF_ROT_Y | BF_ROT_Z))) {
-            if (bone_flags & BF_ROT_Y) {
+        if (extra_rotation != NULL) {
+            if (bone->rot_y) {
                 Matrix_RotY(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_X) {
+            if (bone->rot_x) {
                 Matrix_RotX(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_Z) {
+            if (bone->rot_z) {
                 Matrix_RotZ(*extra_rotation++);
             }
         }
-        bone += 4;
     }
 
     Matrix_TranslateRel(out_vec->x, out_vec->y, out_vec->z);

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -115,7 +115,7 @@ static void M_DrawItem(
         return;
     }
 
-    const int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
     const int16_t *rot = frame_ptr->mesh_rots;
@@ -123,17 +123,15 @@ static void M_DrawItem(
 
     for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
         if (mesh_idx > 0) {
-            const int32_t bone_flags = bone[0];
-            if (bone_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
-            if (bone_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZsuperpack(&rot, 0);
-            bone += 4;
 
             if (inv_item->object_id == O_COMPASS_OPTION) {
                 if (mesh_idx == 6) {
@@ -151,6 +149,8 @@ static void M_DrawItem(
                     Matrix_RotZ(hours);
                 }
             }
+
+            bone++;
         }
 
         if (inv_item->meshes_drawn & (1 << mesh_idx)) {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -801,29 +801,27 @@ int32_t Item_Explode(
     }
 
     // additional meshes
-    const int32_t *bone = &g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     const int16_t *extra_rotation = (int16_t *)item->data;
-    for (int32_t i = 1; i < object->mesh_count; i++) {
-        uint32_t bone_flags = *bone++;
-        if (bone_flags & BF_MATRIX_POP) {
+    for (int32_t i = 1; i < object->mesh_count; i++, bone++) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
-        if (bone_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[0], bone[1], bone[2]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
-        if (extra_rotation != NULL
-            && bone_flags & (BF_ROT_X | BF_ROT_Y | BF_ROT_Z)) {
-            if (bone_flags & BF_ROT_Y) {
+        if (extra_rotation != NULL) {
+            if (bone->rot_y) {
                 Matrix_RotY(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_X) {
+            if (bone->rot_x) {
                 Matrix_RotX(*extra_rotation++);
             }
-            if (bone_flags & BF_ROT_Z) {
+            if (bone->rot_z) {
                 Matrix_RotZ(*extra_rotation++);
             }
         }
@@ -847,8 +845,6 @@ int32_t Item_Explode(
             }
             item->mesh_bits &= ~bit;
         }
-
-        bone += 3;
     }
 
     Matrix_Pop();

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -43,8 +43,11 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     m_HairSpheres[0].r = mesh[3];
     Matrix_Pop();
 
-    const int32_t *bone = &g_AnimBones[g_Objects[O_LARA].bone_idx];
-    Matrix_TranslateRel(bone[25], bone[26], bone[27]);
+    const ANIM_BONE *bone =
+        (ANIM_BONE *)&g_AnimBones[g_Objects[O_LARA].bone_idx];
+    Matrix_TranslateRel(
+        bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+        bone[LM_TORSO - 1].pos.z);
     if (g_Lara.weapon_item != NO_ITEM && g_Lara.gun_type == LGT_M16
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
@@ -68,7 +71,9 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     Matrix_Pop();
 
     Matrix_Push();
-    Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+    Matrix_TranslateRel(
+        bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+        bone[LM_UARM_R - 1].pos.z);
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_R];
@@ -80,7 +85,9 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     Matrix_Pop();
 
     Matrix_Push();
-    Matrix_TranslateRel(bone[41], bone[42], bone[43]);
+    Matrix_TranslateRel(
+        bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+        bone[LM_UARM_L - 1].pos.z);
     Matrix_RotYXZsuperpack(&mesh_rots, 2);
     mesh = g_Lara.mesh_ptrs[LM_UARM_L];
     Matrix_TranslateRel(mesh[0], mesh[1], mesh[2]);
@@ -90,7 +97,9 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     m_HairSpheres[4].r = mesh[3] * 3 / 2;
     Matrix_Pop();
 
-    Matrix_TranslateRel(bone[53], bone[54], bone[55]);
+    Matrix_TranslateRel(
+        bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
+        bone[LM_HEAD - 1].pos.z);
     Matrix_RotYXZsuperpack(&mesh_rots, 2);
     Matrix_RotYXZ(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
 
@@ -128,8 +137,11 @@ static void M_CalculateSpheres_I(
     m_HairSpheres[0].r = mesh[3];
     Matrix_Pop_I();
 
-    const int32_t *bone = &g_AnimBones[g_Objects[O_LARA].bone_idx];
-    Matrix_TranslateRel_I(bone[25], bone[26], bone[27]);
+    const ANIM_BONE *bone =
+        (ANIM_BONE *)&g_AnimBones[g_Objects[O_LARA].bone_idx];
+    Matrix_TranslateRel_I(
+        bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+        bone[LM_TORSO - 1].pos.z);
     if (g_Lara.weapon_item != NO_ITEM && g_Lara.gun_type == LGT_M16
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
@@ -156,7 +168,9 @@ static void M_CalculateSpheres_I(
     Matrix_Pop_I();
 
     Matrix_Push_I();
-    Matrix_TranslateRel_I(bone[29], bone[30], bone[31]);
+    Matrix_TranslateRel_I(
+        bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+        bone[LM_UARM_R - 1].pos.z);
     Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_R];
@@ -169,7 +183,9 @@ static void M_CalculateSpheres_I(
     Matrix_Pop_I();
 
     Matrix_Push_I();
-    Matrix_TranslateRel_I(bone[41], bone[42], bone[43]);
+    Matrix_TranslateRel_I(
+        bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+        bone[LM_UARM_L - 1].pos.z);
     Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 2);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_L];
@@ -181,7 +197,9 @@ static void M_CalculateSpheres_I(
     m_HairSpheres[4].r = mesh[3] * 3 / 2;
     Matrix_Pop_I();
 
-    Matrix_TranslateRel_I(bone[53], bone[54], bone[55]);
+    Matrix_TranslateRel_I(
+        bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
+        bone[LM_HEAD - 1].pos.z);
     Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 2);
     Matrix_RotYXZ_I(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
 
@@ -201,16 +219,13 @@ static void M_CalculateSpheres_I(
 
 void Lara_Hair_Initialise(void)
 {
-    const int32_t *const bone_base =
-        &g_AnimBones[g_Objects[O_LARA_HAIR].bone_idx];
+    const OBJECT *const object = Object_GetObject(O_LARA_HAIR);
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     m_IsFirstHair = true;
     m_HairSegments[0].rot.x = -PHD_90;
     m_HairSegments[0].rot.y = 0;
-    for (int32_t i = 0; i < HAIR_SEGMENTS; i++) {
-        const int32_t *bone = bone_base + 4 * i;
-        m_HairSegments[i + 1].pos.x = bone[1];
-        m_HairSegments[i + 1].pos.y = bone[2];
-        m_HairSegments[i + 1].pos.z = bone[3];
+    for (int32_t i = 0; i < HAIR_SEGMENTS; i++, bone++) {
+        m_HairSegments[i + 1].pos = bone->pos;
         m_HairSegments[i + 1].rot.x = -PHD_90;
         m_HairSegments[i + 1].rot.y = 0;
         m_HairSegments[i + 1].rot.z = 0;
@@ -273,7 +288,8 @@ void Lara_Hair_Control(const bool in_cutscene)
     };
     Matrix_Pop();
 
-    const int32_t *bone = &g_AnimBones[g_Objects[O_LARA_HAIR].bone_idx];
+    const OBJECT *const object = Object_GetObject(O_LARA_HAIR);
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     HAIR_SEGMENT *const fs = &m_HairSegments[0];
     fs->pos.x = pos.x;
@@ -282,7 +298,7 @@ void Lara_Hair_Control(const bool in_cutscene)
 
     if (m_IsFirstHair) {
         m_IsFirstHair = false;
-        for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone += 4) {
+        for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone++) {
             const HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
             HAIR_SEGMENT *const s = &m_HairSegments[i];
 
@@ -291,7 +307,7 @@ void Lara_Hair_Control(const bool in_cutscene)
             g_MatrixPtr->_13 = ps->pos.y << W2V_SHIFT;
             g_MatrixPtr->_23 = ps->pos.z << W2V_SHIFT;
             Matrix_RotYXZ(ps->rot.y, ps->rot.x, 0);
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
 
             s->pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;
             s->pos.y = g_MatrixPtr->_13 >> W2V_SHIFT;
@@ -339,7 +355,7 @@ void Lara_Hair_Control(const bool in_cutscene)
         m_HairWind = 0;
     }
 
-    for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone += 4) {
+    for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone++) {
         HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
         HAIR_SEGMENT *const s = &m_HairSegments[i];
 
@@ -395,10 +411,12 @@ void Lara_Hair_Control(const bool in_cutscene)
         Matrix_TranslateSet(ps->pos.x, ps->pos.y, ps->pos.z);
         Matrix_RotYXZ(ps->rot.y, ps->rot.x, 0);
 
-        if (i == 6) {
-            Matrix_TranslateRel(bone[-3], bone[-2], bone[-1]);
+        if (i == HAIR_SEGMENTS) {
+            const ANIM_BONE *const last_bone = bone - 1;
+            Matrix_TranslateRel(
+                last_bone->pos.x, last_bone->pos.y, last_bone->pos.z);
         } else {
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         }
 
         s->pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -886,13 +886,15 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
     Matrix_RotYXZ(g_LaraItem->rot.y, g_LaraItem->rot.x, g_LaraItem->rot.z);
 
     const int16_t *rot = frame_ptr->mesh_rots;
-    const int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
 
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
     Matrix_RotYXZsuperpack(&rot, 0);
 
-    Matrix_TranslateRel(bone[25], bone[26], bone[27]);
+    Matrix_TranslateRel(
+        bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+        bone[LM_TORSO - 1].pos.z);
     Matrix_RotYXZsuperpack(&rot, 6);
     Matrix_RotYXZ(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
 
@@ -903,7 +905,9 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
     }
 
     if (g_Lara.gun_type == LGT_FLARE) {
-        Matrix_TranslateRel(bone[41], bone[42], bone[43]);
+        Matrix_TranslateRel(
+            bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+            bone[LM_UARM_L - 1].pos.z);
         if (g_Lara.flare_control_left) {
             const LARA_ARM *arm = &g_Lara.left_arm;
             const ANIM *anim = &g_Anims[arm->anim_num];
@@ -915,23 +919,33 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
         }
         Matrix_RotYXZsuperpack(&rot, 11);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(
+            bone[LM_LARM_L - 1].pos.x, bone[LM_LARM_L - 1].pos.y,
+            bone[LM_LARM_L - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot, 0);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(
+            bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
+            bone[LM_HAND_L - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot, 0);
     } else if (gun_type != LGT_UNARMED) {
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(
+            bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+            bone[LM_UARM_R - 1].pos.z);
 
         const LARA_ARM *arm = &g_Lara.right_arm;
         const ANIM *anim = &g_Anims[arm->anim_num];
         rot = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot, 8);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(
+            bone[LM_LARM_R - 1].pos.x, bone[LM_LARM_R - 1].pos.y,
+            bone[LM_LARM_R - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot, 0);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(
+            bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
+            bone[LM_HAND_L - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot, 0);
     }
 

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -44,7 +44,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
     int16_t *const *mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *extra_rotation = item->data;
     const int16_t *mesh_rots[2] = {
         frames[0]->mesh_rots,
@@ -61,28 +61,27 @@ void Object_DrawAnimatingItem(const ITEM *item)
                     frames[1]->offset.y, frames[1]->offset.z);
                 Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
             } else {
-                const int32_t bone_flags = bone[0];
-                if (bone_flags & BF_MATRIX_POP) {
+                if (bone->matrix_pop) {
                     Matrix_Pop_I();
                 }
-                if (bone_flags & BF_MATRIX_PUSH) {
+                if (bone->matrix_push) {
                     Matrix_Push_I();
                 }
 
-                Matrix_TranslateRel_I(bone[1], bone[2], bone[3]);
+                Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
                 Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
                 if (extra_rotation != NULL) {
-                    if (bone_flags & BF_ROT_Y) {
+                    if (bone->rot_y) {
                         Matrix_RotY_I(*extra_rotation++);
                     }
-                    if (bone_flags & BF_ROT_X) {
+                    if (bone->rot_x) {
                         Matrix_RotX_I(*extra_rotation++);
                     }
-                    if (bone_flags & BF_ROT_Z) {
+                    if (bone->rot_z) {
                         Matrix_RotZ_I(*extra_rotation++);
                     }
                 }
-                bone += 4;
+                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -97,28 +96,27 @@ void Object_DrawAnimatingItem(const ITEM *item)
                     frames[0]->offset.z);
                 Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
             } else {
-                const int32_t bone_flags = bone[0];
-                if (bone_flags & BF_MATRIX_POP) {
+                if (bone->matrix_pop) {
                     Matrix_Pop();
                 }
-                if (bone_flags & BF_MATRIX_PUSH) {
+                if (bone->matrix_push) {
                     Matrix_Push();
                 }
 
-                Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+                Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
                 Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
                 if (extra_rotation != NULL) {
-                    if (bone_flags & BF_ROT_Y) {
+                    if (bone->rot_y) {
                         Matrix_RotY(*extra_rotation++);
                     }
-                    if (bone_flags & BF_ROT_X) {
+                    if (bone->rot_x) {
                         Matrix_RotX(*extra_rotation++);
                     }
-                    if (bone_flags & BF_ROT_Z) {
+                    if (bone->rot_z) {
                         Matrix_RotZ(*extra_rotation++);
                     }
                 }
-                bone += 4;
+                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -197,7 +195,7 @@ BOUNDS_16 Object_GetBoundingBox(
     const uint32_t mesh_bits)
 {
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
 
     Matrix_PushUnit();
@@ -219,20 +217,19 @@ BOUNDS_16 Object_GetBoundingBox(
 
     for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
         if (mesh_idx != 0) {
-            int32_t bone_extra_flags = *bone;
-            if (bone_extra_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
 
-            if (bone_extra_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             if (mesh_rots != NULL) {
                 Matrix_RotYXZsuperpack(&mesh_rots, 0);
             }
-            bone += 4;
+            bone++;
         }
 
         if (!(mesh_bits & (1 << mesh_idx))) {

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -257,7 +257,7 @@ void Pickup_Draw(const ITEM *const item)
     if (clip) {
         int32_t bit = 1;
         int16_t **meshpp = &g_Meshes[obj->mesh_idx];
-        int32_t *bone = &g_AnimBones[obj->bone_idx];
+        const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
 
         const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
         if (mesh_rots != NULL) {
@@ -269,16 +269,15 @@ void Pickup_Draw(const ITEM *const item)
         }
 
         for (int i = 1; i < obj->mesh_count; i++) {
-            int32_t bone_extra_flags = *bone;
-            if (bone_extra_flags & BF_MATRIX_POP) {
+            if (bone->matrix_pop) {
                 Matrix_Pop();
             }
 
-            if (bone_extra_flags & BF_MATRIX_PUSH) {
+            if (bone->matrix_push) {
                 Matrix_Push();
             }
 
-            Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             if (mesh_rots != NULL) {
                 Matrix_RotYXZsuperpack(&mesh_rots, 0);
             }
@@ -290,7 +289,7 @@ void Pickup_Draw(const ITEM *const item)
                 Output_InsertPolygons(*meshpp, clip);
             }
 
-            bone += 4;
+            bone++;
             meshpp++;
         }
     }

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -435,24 +435,22 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
         -(bounds.min_z + bounds.max_z) / 2);
 
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    int32_t *bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *mesh_rots = frame->mesh_rots;
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     Output_InsertPolygons(mesh_ptrs[0], 0);
-    for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
-        int32_t bone_extra_flags = *bone;
-        if (bone_extra_flags & BF_MATRIX_POP) {
+    for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++, bone++) {
+        if (bone->matrix_pop) {
             Matrix_Pop();
         }
 
-        if (bone_extra_flags & BF_MATRIX_PUSH) {
+        if (bone->matrix_push) {
             Matrix_Push();
         }
 
-        Matrix_TranslateRel(bone[1], bone[2], bone[3]);
+        Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
-        bone += 4;
 
         Output_InsertPolygons(mesh_ptrs[mesh_idx], 0);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This uses `ANIM_BONE` indexing throughout the codebase, in place of direct `int32_t` interpretation. The data is still effectively unstructured, this can be tackled on its own I think as this is large enough. I also plan to later introduce something like `Object_GetBone` to make access easier/neater and to reduce pointer arithmetic.

A remaining `TODO` is to update all creature setup functions that change bone rotation flags. I will do that next. I also stopped short of changing TR1's `Lara_Draw` functions to match TR2 as we're thinking about a bigger change here to make it more manageable.

Things to look out for are as follows - basically, everything should be drawn normally. It looks OK to me, but appreciate a second look.

- Lara
- Braid
- Inventory items
- Animating objects
- 3D pickups (on ground and HUD)
- Exploding meshes
- The skidoos
- The position of spawned effects on/from a body joint such as bubbles, flames on Lara, blood splatters
- Flare burning effect
- The initial spawn position of harpoons and grenades
