### PR TITLE
tr2/lara/control: fix testing triggers too early

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...develop) - ××××-××-××
 - added Linux builds and toolchain (#1598)
+- fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/src/libtrx/include/libtrx/game/collision.h
+++ b/src/libtrx/include/libtrx/game/collision.h
@@ -63,7 +63,6 @@ typedef struct __PACKING {
     int16_t facing;
     int16_t quadrant;
     int16_t coll_type;
-    int16_t *trigger; // TODO: linked to g_TriggerIndex, so to be eliminated
     int8_t x_tilt;
     int8_t z_tilt;
     int8_t hit_by_baddie;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -201,7 +201,6 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
     coll->old_anim_num = item->anim_num;
     coll->old_frame_num = item->frame_num;
     coll->radius = LARA_RADIUS;
-    coll->trigger = NULL;
 
     coll->slopes_are_walls = 0;
     coll->slopes_are_pits = 0;
@@ -253,6 +252,7 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
 
     Lara_Animate(item);
 
+    Room_TestTriggers(item);
     if (!g_Lara.extra_anim && g_Lara.water_status != LWS_CHEAT) {
         Lara_BaddieCollision(item, coll);
         if (g_Lara.skidoo == NO_ITEM) {
@@ -262,7 +262,6 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
 
     Item_UpdateRoom(item, -LARA_HEIGHT / 2);
     Gun_Control();
-    Room_TestTriggers(item);
 }
 
 void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
@@ -273,7 +272,6 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
     coll->old.y = item->pos.y;
     coll->old.z = item->pos.z;
     coll->radius = LARA_RADIUS;
-    coll->trigger = NULL;
 
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEP_L / 2;
@@ -314,13 +312,13 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
 
     Lara_BaddieCollision(item, coll);
 
+    Room_TestTriggers(item);
     if (g_Lara.skidoo == NO_ITEM) {
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
     Item_UpdateRoom(item, 100);
     Gun_Control();
-    Room_TestTriggers(item);
 }
 
 void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
@@ -329,7 +327,6 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
     coll->old.y = item->pos.y;
     coll->old.z = item->pos.z;
     coll->radius = LARA_RADIUS_UW;
-    coll->trigger = NULL;
 
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -LARA_HEIGHT_UW;
@@ -403,13 +400,13 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
+    Room_TestTriggers(item);
     if (!g_Lara.extra_anim) {
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
     Item_UpdateRoom(item, 0);
     Gun_Control();
-    Room_TestTriggers(item);
 }
 
 void Lara_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/keyhole.c
+++ b/src/tr2/game/objects/general/keyhole.c
@@ -8,6 +8,7 @@
 #include "game/lara/control.h"
 #include "game/objects/common.h"
 #include "game/objects/vars.h"
+#include "game/room.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
@@ -73,11 +74,19 @@ void Keyhole_Setup(OBJECT *const obj)
 void Keyhole_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
+    ITEM *const item = Item_Get(item_num);
+
     if (lara_item->current_anim_state != LS_STOP) {
+        if (lara_item->current_anim_state != LS_USE_KEY
+            || !Item_TestPosition(m_KeyholeBounds, item, lara_item)
+            || lara_item->frame_num != g_Anims[LA_USE_KEY].frame_end) {
+            return;
+        }
+
+        Room_TestTriggers(lara_item);
         return;
     }
 
-    ITEM *const item = &g_Items[item_num];
     if ((g_Inv_Chosen == NO_OBJECT && !g_Input.action)
         || g_Lara.gun_status != LGS_ARMLESS || lara_item->gravity) {
         return;

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -37,13 +37,13 @@ static int16_t m_PickupBoundsUW[12] = {
     -45 * PHD_DEGREE, +45 * PHD_DEGREE, -45 * PHD_DEGREE, +45 * PHD_DEGREE,
 };
 
-static void M_DoPickup(int16_t item_num);
+static void M_DoPickup(int16_t item_num, const ITEM *lara_item);
 static void M_DoFlarePickup(int16_t item_num);
 
 static void M_DoAboveWater(int16_t item, ITEM *lara_item);
 static void M_DoUnderwater(int16_t item, ITEM *lara_item);
 
-static void M_DoPickup(const int16_t item_num)
+static void M_DoPickup(const int16_t item_num, const ITEM *const lara_item)
 {
     ITEM *const item = Item_Get(item_num);
     if (item->object_id == O_FLARE_ITEM) {
@@ -64,6 +64,7 @@ static void M_DoPickup(const int16_t item_num)
 
     item->status = IS_INVISIBLE;
     Item_RemoveDrawn(item_num);
+    Room_TestTriggers(lara_item);
 }
 
 static void M_DoFlarePickup(const int16_t item_num)
@@ -93,7 +94,7 @@ static void M_DoAboveWater(const int16_t item_num, ITEM *const lara_item)
     if (lara_item->current_anim_state == LS_PICKUP) {
         if (lara_item->frame_num
             == g_Anims[LA_PICKUP].frame_base + LF_PICKUP_ERASE) {
-            M_DoPickup(item_num);
+            M_DoPickup(item_num, lara_item);
         }
         goto cleanup;
     }
@@ -151,7 +152,7 @@ static void M_DoUnderwater(const int16_t item_num, ITEM *const lara_item)
     if (lara_item->current_anim_state == LS_PICKUP) {
         if (lara_item->frame_num
             == g_Anims[LA_UNDERWATER_PICKUP].frame_base + LF_PICKUP_UW) {
-            M_DoPickup(item_num);
+            M_DoPickup(item_num, lara_item);
         }
         goto cleanup;
     }

--- a/src/tr2/game/objects/general/puzzle_hole.c
+++ b/src/tr2/game/objects/general/puzzle_hole.c
@@ -8,6 +8,7 @@
 #include "game/lara/control.h"
 #include "game/objects/common.h"
 #include "game/objects/vars.h"
+#include "game/room.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
@@ -96,6 +97,7 @@ void PuzzleHole_Collision(
         }
 
         M_MarkDone(item);
+        Room_TestTriggers(lara_item);
         return;
     }
 

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -4,6 +4,7 @@
 #include "game/items.h"
 #include "game/lara/control.h"
 #include "game/lara/misc.h"
+#include "game/room.h"
 #include "global/vars.h"
 
 typedef enum {
@@ -152,6 +153,7 @@ void Switch_Collision(
     item->status = IS_ACTIVE;
     Item_AddActive(item_num);
     Item_Animate(item);
+    Room_TestTriggers(lara_item);
 }
 
 void Switch_CollisionUW(
@@ -195,6 +197,7 @@ void Switch_CollisionUW(
     item->status = IS_ACTIVE;
     Item_AddActive(item_num);
     Item_Animate(item);
+    Room_TestTriggers(lara_item);
 }
 
 void Switch_Control(const int16_t item_num)


### PR DESCRIPTION
Resolves #2205.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This puts Lara's calls to test triggers before her animation updates, to be in line with the original game, which cached the trigger index from earlier calls.

This will obviously affect anything Lara triggers so worth a few tests/comparisons I'd say. I'm also wondering if there is a similar issue in TR1 since we refactored the floor data in the same way. We can perhaps create a test level to mimic this part of Venice in TR1 to make comparing with TombATI easier, but that can be tackled on its own.
