### PR TITLE
tr1|tr2/creatures: refactor anim bone rotation setup

### DIFF
--- a/src/libtrx/include/libtrx/game/anims/enum.h
+++ b/src/libtrx/include/libtrx/game/anims/enum.h
@@ -16,12 +16,4 @@ typedef enum {
     ACE_LAND  = 1,
     ACE_WATER = 2,
 } ANIM_COMMAND_ENVIRONMENT;
-
-typedef enum {
-    BF_MATRIX_POP  = 1,
-    BF_MATRIX_PUSH = 2,
-    BF_ROT_X       = 4,
-    BF_ROT_Y       = 8,
-    BF_ROT_Z       = 16,
-} BONE_FLAGS;
 // clang-format on

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -126,7 +126,9 @@ void Ape_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 52] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[13].rot_y = 1;
 }
 
 void Ape_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -46,7 +46,9 @@ void Baldy_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 }
 
 void Baldy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/bear.c
+++ b/src/tr1/game/objects/creatures/bear.c
@@ -69,7 +69,9 @@ void Bear_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 52] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[13].rot_y = 1;
 }
 
 void Bear_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -55,7 +55,10 @@ void Centaur_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 40] |= BF_ROT_X | BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[10].rot_x = 1;
+    bone[10].rot_y = 1;
 }
 
 void Centaur_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -49,7 +49,9 @@ void Cowboy_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 }
 
 void Cowboy_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -81,7 +81,9 @@ void Croc_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 28] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[7].rot_y = 1;
 }
 
 void Croc_Control(int16_t item_num)
@@ -219,7 +221,9 @@ void Alligator_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 28] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[7].rot_y = 1;
 }
 
 void Alligator_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -49,7 +49,9 @@ void Larson_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
 }
 
 void Larson_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -57,7 +57,9 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 76] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[19].rot_y = 1;
 }
 
 void Lion_SetupLion(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -31,7 +31,9 @@ void Mummy_Setup(OBJECT *obj)
     obj->save_flags = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
-    g_AnimBones[obj->bone_idx + 8] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[2].rot_y = 1;
 }
 
 void Mummy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -82,8 +82,10 @@ void Mutant_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 8] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
+    bone[2].rot_y = 1;
 }
 
 void Mutant_Setup2(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -61,7 +61,10 @@ void Natla_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 8] |= BF_ROT_Z | BF_ROT_X;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[2].rot_x = 1;
+    bone[2].rot_z = 1;
 }
 
 void Natla_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -57,7 +57,9 @@ void Pierre_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 24] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
 }
 
 void Pierre_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -58,7 +58,9 @@ void Raptor_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 84] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[21].rot_y = 1;
 }
 
 void Raptor_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -75,7 +75,9 @@ void Rat_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 4] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[1].rot_y = 1;
 }
 
 void Rat_Control(int16_t item_num)
@@ -185,7 +187,9 @@ void Vole_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 4] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[1].rot_y = 1;
 }
 
 void Vole_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -57,7 +57,9 @@ void SkateKid_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 
     if (!g_Objects[O_SKATEBOARD].loaded) {
         LOG_WARNING(

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -67,7 +67,9 @@ void Torso_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 4] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[1].rot_y = 1;
 }
 
 void Torso_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -58,8 +58,10 @@ void TRex_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 40] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 44] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[10].rot_y = 1;
+    bone[11].rot_y = 1;
 }
 
 void TRex_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)

--- a/src/tr1/game/objects/creatures/wolf.c
+++ b/src/tr1/game/objects/creatures/wolf.c
@@ -65,7 +65,9 @@ void Wolf_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    g_AnimBones[obj->bone_idx + 8] |= BF_ROT_Y;
+
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[2].rot_y = 1;
 }
 
 void Wolf_Initialise(int16_t item_num)

--- a/src/tr1/game/phase/phase_inventory.c
+++ b/src/tr1/game/phase/phase_inventory.c
@@ -567,8 +567,8 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
     const int32_t frac = InvItem_GetFrames(inv_item, &frame1, &frame2, &rate);
     if (inv_item->object_id == O_MAP_OPTION) {
         const int16_t extra_rotation[1] = { Option_Compass_GetNeedleAngle() };
-        int32_t *const bone = &g_AnimBones[obj->bone_idx];
-        bone[0] |= BF_ROT_Y;
+        ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+        bone[0].rot_y = 1;
         Object_DrawInterpolatedObject(
             obj, inv_item->drawn_meshes, extra_rotation, frame1, frame2, frac,
             rate);

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -70,8 +70,9 @@ void Bandit1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[8].rot_y = 1;
 }
 
 void Bandit1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -70,8 +70,9 @@ void Bandit2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[8].rot_y = 1;
 }
 
 void Bandit2B_Setup(void)
@@ -100,8 +101,9 @@ void Bandit2B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[8].rot_y = 1;
 }
 
 void Bandit2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -62,7 +62,8 @@ void Barracuda_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
 }
 
 void Barracuda_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -71,7 +71,8 @@ void BirdGuardian_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[14].rot_y = 1;
 }
 
 void BirdGuardian_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -69,7 +69,8 @@ void Cultist1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 }
 
 void Cultist1A_Setup(void)
@@ -98,7 +99,8 @@ void Cultist1A_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 }
 
 void Cultist1B_Setup(void)
@@ -127,7 +129,8 @@ void Cultist1B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
 }
 
 void Cultist1_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -68,8 +68,9 @@ void Cultist2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 8 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
+    bone[8].rot_y = 1;
 }
 
 void Cultist2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -277,15 +277,12 @@ void Cultist3_Control(const int16_t item_num)
 
     Creature_Tilt(item, tilt);
 
-    TOGGLE_BIT(g_AnimBones[g_Objects[O_CULT_3].bone_idx], BF_ROT_Y, body != 0);
-    TOGGLE_BIT(
-        g_AnimBones[g_Objects[O_CULT_3].bone_idx + 2 * 4], BF_ROT_Y, left != 0);
-    TOGGLE_BIT(
-        g_AnimBones[g_Objects[O_CULT_3].bone_idx + 6 * 4], BF_ROT_Y,
-        right != 0);
-    TOGGLE_BIT(
-        g_AnimBones[g_Objects[O_CULT_3].bone_idx + 10 * 4], BF_ROT_Y,
-        head != 0);
+    const OBJECT *const object = Object_GetObject(item->object_id);
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    bone[0].rot_y = body != 0;
+    bone[2].rot_y = left != 0;
+    bone[6].rot_y = right != 0;
+    bone[10].rot_y = head != 0;
 
     if (body != 0) {
         Creature_Head(item, body);

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -98,8 +98,9 @@ void Diver_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Z;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[10].rot_y = 1;
+    bone[14].rot_z = 1;
 }
 
 void Diver_Control(int16_t item_num)

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -77,7 +77,8 @@ void Dog_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 19 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[19].rot_y = 1;
 }
 
 void Dog_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -147,7 +147,8 @@ void Dragon_SetupFront(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Z;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[10].rot_z = 1;
 }
 
 void Dragon_SetupBack(void)

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -74,7 +74,8 @@ void Monk1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
 }
 
 void Monk2_Setup(void)
@@ -97,7 +98,8 @@ void Monk2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
 }
 
 void Monk_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -63,7 +63,8 @@ void Mouse_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 3 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[3].rot_y = 1;
 }
 
 void Mouse_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -71,7 +71,8 @@ void Shark_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    g_AnimBones[obj->bone_idx + 9 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[9].rot_y = 1;
 }
 
 void Shark_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -68,7 +68,8 @@ void Tiger_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 21 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[21].rot_y = 1;
 }
 
 void Tiger_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -63,8 +63,9 @@ void TRex_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 10 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 11 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[10].rot_y = 1;
+    bone[11].rot_y = 1;
 }
 
 void TRex_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -65,8 +65,9 @@ void Worker1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[4].rot_y = 1;
+    bone[13].rot_y = 1;
 }
 
 void Worker1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -88,8 +88,9 @@ void Worker2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[4].rot_y = 1;
+    bone[13].rot_y = 1;
 }
 
 void Worker5_Setup(void)
@@ -113,8 +114,9 @@ void Worker5_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 13 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[4].rot_y = 1;
+    bone[13].rot_y = 1;
 }
 
 void Worker2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -86,8 +86,9 @@ void Worker3_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
+    bone[4].rot_y = 1;
 }
 
 void Worker4_Setup(void)
@@ -111,8 +112,9 @@ void Worker4_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 4 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[0].rot_y = 1;
+    bone[4].rot_y = 1;
 }
 
 void Worker3_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -100,8 +100,9 @@ void XianKnight_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 16 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[16].rot_y = 1;
 }
 
 void XianKnight_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -118,8 +118,9 @@ void XianSpearman_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 12 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[12].rot_y = 1;
 }
 
 void XianSpearman_DoDamage(

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -91,8 +91,9 @@ void Yeti_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    g_AnimBones[obj->bone_idx + 6 * 4] |= BF_ROT_Y;
-    g_AnimBones[obj->bone_idx + 14 * 4] |= BF_ROT_Y;
+    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    bone[6].rot_y = 1;
+    bone[14].rot_y = 1;
 }
 
 void Yeti_Control(const int16_t item_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Continuing from #2203, this updates all relevant creature setup functions to use `ANIM_BONE` for defining which bones have additional rotation. This will again be further tidied up once we have nicer accessors, and the properties will eventually become proper `bool`s.
