### PR TITLE
game-flow: use consistent naming

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -153,7 +153,7 @@ from the relevant parties.
 We maintain a changelog for each project in the `CHANGELOG.md` files, recording
 any changes except internal modifications or refactors. New features and
 original bug fixes should also be documented in the `README.md`. If a change
-affects gameflow behavior, be sure to update the `GAMEFLOW.md` accordingly.
+affects game flow behavior, be sure to update the `GAMEFLOW.md` accordingly.
 Likewise, changes to the console commands should update `COMMANDS.md`.
 
 

--- a/docs/tr1/GAMEFLOW.md
+++ b/docs/tr1/GAMEFLOW.md
@@ -1,5 +1,5 @@
-# Gameflow specification
-The gameflow in TR1X is fully configurable and contributes to removing several
+# Game flow specification
+The game flow in TR1X is fully configurable and contributes to removing several
 original hard-coded aspects of the game. This document describes each element
 available to edit.
 

--- a/docs/tr2/symbols.txt
+++ b/docs/tr2/symbols.txt
@@ -715,7 +715,7 @@ typedef enum {
     GFL_STORY     = 5,
     GFL_QUIET     = 6,
     GFL_MID_STORY = 7,
-} GAMEFLOW_LEVEL_TYPE;
+} GAME_FLOW_LEVEL_TYPE;
 
 typedef struct __unaligned {
     int16_t timer;
@@ -3289,8 +3289,8 @@ typedef enum {
 # game/gameflow.c
 0x0041FA60  0x01E9  int32_t __cdecl GF_LoadScriptFile(const char *fname);
 0x0041FC50  0x001F  int32_t __cdecl GF_DoFrontendSequence(void);
-0x0041FC70  0x0066  int32_t __cdecl GF_DoLevelSequence(int32_t level, GAMEFLOW_LEVEL_TYPE type);
-0x0041FCE0  0x047C  int32_t __cdecl GF_InterpretSequence(int16_t *ptr, GAMEFLOW_LEVEL_TYPE type, int32_t seq_type);
+0x0041FC70  0x0066  int32_t __cdecl GF_DoLevelSequence(int32_t level, GAME_FLOW_LEVEL_TYPE type);
+0x0041FCE0  0x047C  int32_t __cdecl GF_InterpretSequence(int16_t *ptr, GAME_FLOW_LEVEL_TYPE type, int32_t seq_type);
 0x004201C0  0x0CD3  void __cdecl GF_ModifyInventory(int32_t level, int32_t type);
 
 # game/hair.c
@@ -4019,7 +4019,7 @@ typedef enum {
 0x0044B150  0x0026  LPCTSTR __cdecl GetFullPath(LPCTSTR file_name);
 0x0044B180  0x00E0  BOOL __cdecl SelectDrive(void);
 0x0044B260  0x024A  bool __cdecl Level_Load(const char *file_name, int32_t level_num);
-0x0044B4B0  0x0018  BOOL __cdecl S_LoadLevelFile(LPCTSTR file_name, int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+0x0044B4B0  0x0018  BOOL __cdecl S_LoadLevelFile(LPCTSTR file_name, int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 0x0044B4D0  0x002A  void __cdecl S_UnloadLevelFile(void);
 0x0044B500  0x0014  void __cdecl S_AdjustTexelCoordinates(void);
 0x0044B520  0x00C4  BOOL __cdecl S_ReloadLevelGraphics(BOOL reload_palettes, BOOL reload_tex_pages);
@@ -4038,7 +4038,7 @@ typedef enum {
 0x0044C3F0  0x0057  void __cdecl S_Wait(int32_t timeout, BOOL input_check);
 0x0044C450  0x000E  bool __cdecl S_PlayFMV(const char *file_name);
 0x0044C460  0x0013  bool __cdecl S_IntroFMV(const char *file_name1, const char *file_name2);
-0x0044C480  0x0144  int16_t __cdecl Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+0x0044C480  0x0144  int16_t __cdecl Game_Start(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 0x0044C5D0  0x009A  int32_t __cdecl Game_Loop(bool demo_mode);
 0x0044C670  0x0006  int32_t __cdecl LevelCompleteSequence(void);
 0x0044C680  0x01C2  int32_t __cdecl LevelStats(int32_t level_num);
@@ -4107,7 +4107,7 @@ typedef enum {
 0x00450B00  0x00E4  void __cdecl S_InitialisePolyList(BOOL clear_back_buffer);
 0x00450BF0  0x0036  DWORD __cdecl S_DumpScreen(void);
 0x00450C30  0x000B  void __cdecl S_ClearScreen(void);
-0x00450C40  0x0037  void __cdecl S_InitialiseScreen(GAMEFLOW_LEVEL_TYPE level_type);
+0x00450C40  0x0037  void __cdecl S_InitialiseScreen(GAME_FLOW_LEVEL_TYPE level_type);
 0x00450C80  0x0089  void __cdecl S_OutputPolyList(void);
 0x00450CC0  0x0270  int32_t __cdecl Output_GetObjectBounds(const BOUNDS_16 *bounds);
 0x00450F30  0x0046  void __cdecl S_InsertBackPolygon(int32_t x0, int32_t y0, int32_t x1, int32_t y1);

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -18,7 +18,7 @@ static const char *M_GetPath(CONFIG_FILE_TYPE file_type);
 static const char *M_GetPath(const CONFIG_FILE_TYPE file_type)
 {
     return file_type == CFT_DEFAULT ? Shell_GetConfigPath()
-                                    : Shell_GetGameflowPath();
+                                    : Shell_GetGameFlowPath();
 }
 
 void Config_Init(void)

--- a/src/libtrx/game/console/cmd/exit_game.c
+++ b/src/libtrx/game/console/cmd/exit_game.c
@@ -11,7 +11,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_BAD_INVOCATION;
     }
 
-    Gameflow_OverrideCommand((GAMEFLOW_COMMAND) { .action = GF_EXIT_GAME });
+    GameFlow_OverrideCommand((GAME_FLOW_COMMAND) { .action = GF_EXIT_GAME });
     return CR_SUCCESS;
 }
 

--- a/src/libtrx/game/console/cmd/exit_to_title.c
+++ b/src/libtrx/game/console/cmd/exit_to_title.c
@@ -11,7 +11,8 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_BAD_INVOCATION;
     }
 
-    Gameflow_OverrideCommand((GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE });
+    GameFlow_OverrideCommand(
+        (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE });
     return CR_SUCCESS;
 }
 

--- a/src/libtrx/game/console/cmd/load_game.c
+++ b/src/libtrx/game/console/cmd/load_game.c
@@ -27,7 +27,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_FAILURE;
     }
 
-    Gameflow_OverrideCommand((GAMEFLOW_COMMAND) {
+    GameFlow_OverrideCommand((GAME_FLOW_COMMAND) {
         .action = GF_START_SAVED_GAME,
         .param = slot_idx,
     });

--- a/src/libtrx/game/console/cmd/play_demo.c
+++ b/src/libtrx/game/console/cmd/play_demo.c
@@ -11,8 +11,8 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     int32_t demo_to_load = -1;
     if (String_ParseInteger(ctx->args, &demo_to_load)) {
         demo_to_load--;
-        if (demo_to_load >= 0 && demo_to_load < Gameflow_GetDemoCount()) {
-            Gameflow_OverrideCommand((GAMEFLOW_COMMAND) {
+        if (demo_to_load >= 0 && demo_to_load < GameFlow_GetDemoCount()) {
+            GameFlow_OverrideCommand((GAME_FLOW_COMMAND) {
                 .action = GF_START_DEMO,
                 .param = demo_to_load,
             });
@@ -22,8 +22,8 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
             return CR_FAILURE;
         }
     } else if (String_IsEmpty(ctx->args)) {
-        Gameflow_OverrideCommand(
-            (GAMEFLOW_COMMAND) { .action = GF_START_DEMO, .param = -1 });
+        GameFlow_OverrideCommand(
+            (GAME_FLOW_COMMAND) { .action = GF_START_DEMO, .param = -1 });
         return CR_SUCCESS;
     } else {
         return CR_BAD_INVOCATION;

--- a/src/libtrx/game/console/cmd/play_level.c
+++ b/src/libtrx/game/console/cmd/play_level.c
@@ -21,17 +21,17 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     }
 
     source = Vector_Create(sizeof(STRING_FUZZY_SOURCE));
-    for (int32_t level_num = 0; level_num < Gameflow_GetLevelCount();
+    for (int32_t level_num = 0; level_num < GameFlow_GetLevelCount();
          level_num++) {
         STRING_FUZZY_SOURCE source_item = {
-            .key = Gameflow_GetLevelTitle(level_num),
+            .key = GameFlow_GetLevelTitle(level_num),
             .value = (void *)(intptr_t)level_num,
             .weight = 1,
         };
         Vector_Add(source, &source_item);
     }
 
-    const int32_t gym_level_num = Gameflow_GetGymLevelNumber();
+    const int32_t gym_level_num = GameFlow_GetGymLevelNumber();
     if (gym_level_num != -1) {
         STRING_FUZZY_SOURCE source_item = {
             .key = "gym",
@@ -55,12 +55,12 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     }
 
 matched:
-    if (level_to_load >= 0 && level_to_load < Gameflow_GetLevelCount()) {
-        Gameflow_OverrideCommand((GAMEFLOW_COMMAND) {
+    if (level_to_load >= 0 && level_to_load < GameFlow_GetLevelCount()) {
+        GameFlow_OverrideCommand((GAME_FLOW_COMMAND) {
             .action = GF_SELECT_GAME,
             .param = level_to_load,
         });
-        Console_Log(GS(OSD_PLAY_LEVEL), Gameflow_GetLevelTitle(level_to_load));
+        Console_Log(GS(OSD_PLAY_LEVEL), GameFlow_GetLevelTitle(level_to_load));
         result = CR_SUCCESS;
     } else {
         Console_Log(GS(OSD_INVALID_LEVEL));

--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -28,7 +28,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     Console_Log(
         GS(OSD_POS_GET),
         Game_GetCurrentLevelNum(),
-        Gameflow_GetLevelTitle(Game_GetCurrentLevelNum()),
+        GameFlow_GetLevelTitle(Game_GetCurrentLevelNum()),
         lara_item->room_num,
         lara_item->pos.x / (float)WALL_L,
         lara_item->pos.y / (float)WALL_L,

--- a/src/libtrx/include/libtrx/game/game.h
+++ b/src/libtrx/include/libtrx/game/game.h
@@ -5,5 +5,5 @@
 #include <stdbool.h>
 
 extern bool Game_IsPlayable(void);
-extern GAMEFLOW_LEVEL_TYPE Game_GetCurrentLevelType(void);
+extern GAME_FLOW_LEVEL_TYPE Game_GetCurrentLevelType(void);
 extern int32_t Game_GetCurrentLevelNum(void);

--- a/src/libtrx/include/libtrx/game/gameflow/common.h
+++ b/src/libtrx/include/libtrx/game/gameflow/common.h
@@ -2,10 +2,10 @@
 
 #include "./types.h"
 
-extern int32_t Gameflow_GetLevelCount(void);
-extern int32_t Gameflow_GetDemoCount(void);
-extern const char *Gameflow_GetLevelFileName(int32_t level_num);
-extern const char *Gameflow_GetLevelTitle(int32_t level_num);
-extern int32_t Gameflow_GetGymLevelNumber(void);
+extern int32_t GameFlow_GetLevelCount(void);
+extern int32_t GameFlow_GetDemoCount(void);
+extern const char *GameFlow_GetLevelFileName(int32_t level_num);
+extern const char *GameFlow_GetLevelTitle(int32_t level_num);
+extern int32_t GameFlow_GetGymLevelNumber(void);
 
-extern void Gameflow_OverrideCommand(GAMEFLOW_COMMAND action);
+extern void GameFlow_OverrideCommand(GAME_FLOW_COMMAND action);

--- a/src/libtrx/include/libtrx/game/gameflow/types.h
+++ b/src/libtrx/include/libtrx/game/gameflow/types.h
@@ -16,7 +16,7 @@ typedef enum {
     GF_SELECT_GAME,
     GF_START_GYM,
     GF_STORY_SO_FAR,
-} GAMEFLOW_ACTION;
+} GAME_FLOW_ACTION;
 
 typedef enum {
 #if TR_VERSION == 2
@@ -40,9 +40,9 @@ typedef enum {
     GFL_QUIET = 6,
     GFL_MID_STORY = 7,
 #endif
-} GAMEFLOW_LEVEL_TYPE;
+} GAME_FLOW_LEVEL_TYPE;
 
-typedef struct GAMEFLOW_COMMAND {
-    GAMEFLOW_ACTION action;
+typedef struct GAME_FLOW_COMMAND {
+    GAME_FLOW_ACTION action;
     int32_t param;
-} GAMEFLOW_COMMAND;
+} GAME_FLOW_COMMAND;

--- a/src/libtrx/include/libtrx/game/shell.h
+++ b/src/libtrx/include/libtrx/game/shell.h
@@ -16,6 +16,6 @@ int32_t Shell_GetCurrentDisplayHeight(void);
 void Shell_GetWindowSize(int32_t *out_width, int32_t *out_height);
 
 extern const char *Shell_GetConfigPath(void);
-extern const char *Shell_GetGameflowPath(void);
+extern const char *Shell_GetGameFlowPath(void);
 extern void Shell_ProcessInput(void);
 extern void Shell_ProcessEvents(void);

--- a/src/libtrx/screenshot.c
+++ b/src/libtrx/screenshot.c
@@ -61,7 +61,7 @@ static char *M_GetScreenshotTitle(void)
         return Memory_DupStr("Intro");
     }
 
-    const char *const level_title = Gameflow_GetLevelTitle(level_num);
+    const char *const level_title = GameFlow_GetLevelTitle(level_num);
     if (level_title != NULL && strlen(level_title) > 0) {
         char *clean_level_title = M_CleanScreenshotTitle(level_title);
         if (clean_level_title != NULL && strlen(clean_level_title) > 0) {

--- a/src/tr1/game/carrier.c
+++ b/src/tr1/game/carrier.c
@@ -28,7 +28,7 @@ static ITEM *M_GetCarrier(int16_t item_num);
 static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *carrier);
 static void M_AnimateDrop(CARRIED_ITEM *item);
 static void M_InitialiseDataDrops(void);
-static void M_InitialiseGameflowDrops(int32_t level_num);
+static void M_InitialiseGameFlowDrops(int32_t level_num);
 
 static const GAME_OBJECT_PAIR m_LegacyMap[] = {
     { O_PIERRE, O_SCION_ITEM_2 }, { O_COWBOY, O_MAGNUM_ITEM },
@@ -169,12 +169,12 @@ static void M_InitialiseDataDrops(void)
     Vector_Free(pickups);
 }
 
-static void M_InitialiseGameflowDrops(const int32_t level_num)
+static void M_InitialiseGameFlowDrops(const int32_t level_num)
 {
     int32_t total_item_count = g_LevelItemCount;
-    const GAMEFLOW_LEVEL level = g_GameFlow.levels[level_num];
+    const GAME_FLOW_LEVEL level = g_GameFlow.levels[level_num];
     for (int32_t i = 0; i < level.item_drops.count; i++) {
-        const GAMEFLOW_DROP_ITEM_DATA *const data = &level.item_drops.data[i];
+        const GAME_FLOW_DROP_ITEM_DATA *const data = &level.item_drops.data[i];
 
         ITEM *const item = M_GetCarrier(data->enemy_num);
         if (!item) {
@@ -234,7 +234,7 @@ void Carrier_InitialiseLevel(const int32_t level_num)
     if (g_GameFlow.enable_tr2_item_drops) {
         M_InitialiseDataDrops();
     } else {
-        M_InitialiseGameflowDrops(level_num);
+        M_InitialiseGameFlowDrops(level_num);
     }
 }
 

--- a/src/tr1/game/game.h
+++ b/src/tr1/game/game.h
@@ -5,13 +5,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
-GAMEFLOW_COMMAND Game_Stop(void);
+bool Game_Start(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
+GAME_FLOW_COMMAND Game_Stop(void);
 
 void Game_ProcessInput(void);
 
 void Game_DrawScene(bool draw_overlay);
 
-GAMEFLOW_COMMAND Game_MainMenu(void);
+GAME_FLOW_COMMAND Game_MainMenu(void);
 
 bool Game_IsPlayable(void);

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -65,7 +65,7 @@ void Game_ProcessInput(void)
     }
 }
 
-bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
+bool Game_Start(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
 {
     g_GameInfo.current_level_type = level_type;
 
@@ -173,7 +173,7 @@ bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     return true;
 }
 
-GAMEFLOW_COMMAND Game_Stop(void)
+GAME_FLOW_COMMAND Game_Stop(void)
 {
     Sound_StopAllSamples();
     Music_Stop();
@@ -192,7 +192,7 @@ GAMEFLOW_COMMAND Game_Stop(void)
             Savegame_CarryCurrentInfoToNextLevel(
                 g_CurrentLevel, g_GameInfo.select_level_num);
         }
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_SELECT_GAME,
             .param = g_GameInfo.select_level_num,
         };
@@ -210,44 +210,44 @@ GAMEFLOW_COMMAND Game_Stop(void)
     if (g_LevelComplete) {
         // TODO: why is this made unavailable?
         g_GameInfo.current[g_CurrentLevel].flags.available = 0;
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_LEVEL_COMPLETE,
             .param = g_GameInfo.select_level_num,
         };
     }
 
     if (g_GameInfo.passport_selection == PASSPORT_MODE_LOAD_GAME) {
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_START_SAVED_GAME,
             .param = g_GameInfo.current_save_slot,
         };
     } else if (g_GameInfo.passport_selection == PASSPORT_MODE_SELECT_LEVEL) {
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_SELECT_GAME,
             .param = g_GameInfo.select_level_num,
         };
     } else if (g_GameInfo.passport_selection == PASSPORT_MODE_STORY_SO_FAR) {
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_STORY_SO_FAR,
             .param = g_GameInfo.current_save_slot,
         };
     } else if (g_GameInfo.passport_selection == PASSPORT_MODE_RESTART) {
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_RESTART_GAME,
             .param = g_CurrentLevel,
         };
     } else if (g_GameInfo.passport_selection == PASSPORT_MODE_NEW_GAME) {
         Savegame_InitCurrentInfo();
-        return (GAMEFLOW_COMMAND) {
+        return (GAME_FLOW_COMMAND) {
             .action = GF_START_GAME,
             .param = g_GameFlow.first_level_num,
         };
     } else {
-        return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
     }
 }
 
-GAMEFLOW_LEVEL_TYPE Game_GetCurrentLevelType(void)
+GAME_FLOW_LEVEL_TYPE Game_GetCurrentLevelType(void)
 {
     return g_GameInfo.current_level_type;
 }

--- a/src/tr1/game/game/game_main_menu.c
+++ b/src/tr1/game/game/game_main_menu.c
@@ -4,7 +4,7 @@
 
 #include <libtrx/memory.h>
 
-GAMEFLOW_COMMAND Game_MainMenu(void)
+GAME_FLOW_COMMAND Game_MainMenu(void)
 {
     PHASE_INVENTORY_ARGS *const args =
         Memory_Alloc(sizeof(PHASE_INVENTORY_ARGS));

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -35,20 +35,20 @@ typedef struct {
 typedef struct {
     char *path;
     double display_time;
-} GAMEFLOW_DISPLAY_PICTURE_DATA;
+} GAME_FLOW_DISPLAY_PICTURE_DATA;
 
 typedef struct {
     GAME_OBJECT_ID object1_id;
     GAME_OBJECT_ID object2_id;
     int32_t mesh_num;
-} GAMEFLOW_MESH_SWAP_DATA;
+} GAME_FLOW_MESH_SWAP_DATA;
 
 typedef struct {
     GAME_OBJECT_ID object_id;
     int quantity;
-} GAMEFLOW_GIVE_ITEM_DATA;
+} GAME_FLOW_GIVE_ITEM_DATA;
 
-GAMEFLOW g_GameFlow = { 0 };
+GAME_FLOW g_GameFlow = { 0 };
 
 static int32_t M_StringToEnumType(
     const char *const str, const STRING_TO_ENUM_TYPE *map);
@@ -57,14 +57,14 @@ static bool M_LoadScriptGameStrings(JSON_OBJECT *obj);
 static bool M_IsLegacySequence(const char *type_str);
 static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num);
 static bool M_LoadScriptLevels(JSON_OBJECT *obj);
-static void M_StringTableShutdown(GAMEFLOW_STRING_ENTRY *dest);
+static void M_StringTableShutdown(GAME_FLOW_STRING_ENTRY *dest);
 static bool M_LoadObjectNames(
-    JSON_OBJECT *root_obj, const char *key, GAMEFLOW_STRING_ENTRY **dest);
+    JSON_OBJECT *root_obj, const char *key, GAME_FLOW_STRING_ENTRY **dest);
 static void M_ScanLevelText(
-    const GAMEFLOW_STRING_ENTRY *entry,
+    const GAME_FLOW_STRING_ENTRY *entry,
     void (*callback)(GAME_OBJECT_ID object_id, const char *text));
 
-static const STRING_TO_ENUM_TYPE m_GameflowLevelTypeEnumMap[] = {
+static const STRING_TO_ENUM_TYPE m_GameFlowLevelTypeEnumMap[] = {
     { "title", GFL_TITLE },
     { "normal", GFL_NORMAL },
     { "cutscene", GFL_CUTSCENE },
@@ -76,7 +76,7 @@ static const STRING_TO_ENUM_TYPE m_GameflowLevelTypeEnumMap[] = {
     { NULL, -1 },
 };
 
-static const STRING_TO_ENUM_TYPE m_GameflowSeqTypeEnumMap[] = {
+static const STRING_TO_ENUM_TYPE m_GameFlowSeqTypeEnumMap[] = {
     { "start_game", GFS_START_GAME },
     { "stop_game", GFS_STOP_GAME },
     { "loop_game", GFS_LOOP_GAME },
@@ -256,9 +256,9 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
     JSON_ARRAY_ELEMENT *jseq_elem = jseq_arr->start;
 
     g_GameFlow.levels[level_num].sequence =
-        Memory_Alloc(sizeof(GAMEFLOW_SEQUENCE) * (jseq_arr->length + 1));
+        Memory_Alloc(sizeof(GAME_FLOW_SEQUENCE) * (jseq_arr->length + 1));
 
-    GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
+    GAME_FLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
     int32_t i = 0;
     while (jseq_elem) {
         JSON_OBJECT *jseq_obj = JSON_ValueAsObject(jseq_elem->value);
@@ -274,7 +274,7 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
             return false;
         }
 
-        seq->type = M_StringToEnumType(type_str, m_GameflowSeqTypeEnumMap);
+        seq->type = M_StringToEnumType(type_str, m_GameFlowSeqTypeEnumMap);
 
         switch (seq->type) {
         case GFS_START_GAME:
@@ -300,8 +300,8 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
 
         case GFS_LOADING_SCREEN:
         case GFS_DISPLAY_PICTURE: {
-            GAMEFLOW_DISPLAY_PICTURE_DATA *data =
-                Memory_Alloc(sizeof(GAMEFLOW_DISPLAY_PICTURE_DATA));
+            GAME_FLOW_DISPLAY_PICTURE_DATA *data =
+                Memory_Alloc(sizeof(GAME_FLOW_DISPLAY_PICTURE_DATA));
 
             const char *tmp_s = JSON_ObjectGetString(
                 jseq_obj, "picture_path", JSON_INVALID_STRING);
@@ -340,8 +340,8 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
         }
 
         case GFS_TOTAL_STATS: {
-            GAMEFLOW_DISPLAY_PICTURE_DATA *data =
-                Memory_Alloc(sizeof(GAMEFLOW_DISPLAY_PICTURE_DATA));
+            GAME_FLOW_DISPLAY_PICTURE_DATA *data =
+                Memory_Alloc(sizeof(GAME_FLOW_DISPLAY_PICTURE_DATA));
 
             const char *tmp_s = JSON_ObjectGetString(
                 jseq_obj, "picture_path", JSON_INVALID_STRING);
@@ -397,8 +397,8 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
             break;
 
         case GFS_GIVE_ITEM: {
-            GAMEFLOW_GIVE_ITEM_DATA *give_item_data =
-                Memory_Alloc(sizeof(GAMEFLOW_GIVE_ITEM_DATA));
+            GAME_FLOW_GIVE_ITEM_DATA *give_item_data =
+                Memory_Alloc(sizeof(GAME_FLOW_GIVE_ITEM_DATA));
 
             give_item_data->object_id =
                 JSON_ObjectGetInt(jseq_obj, "object_id", JSON_INVALID_NUMBER);
@@ -430,8 +430,8 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
         }
 
         case GFS_MESH_SWAP: {
-            GAMEFLOW_MESH_SWAP_DATA *swap_data =
-                Memory_Alloc(sizeof(GAMEFLOW_MESH_SWAP_DATA));
+            GAME_FLOW_MESH_SWAP_DATA *swap_data =
+                Memory_Alloc(sizeof(GAME_FLOW_MESH_SWAP_DATA));
 
             swap_data->object1_id =
                 JSON_ObjectGetInt(jseq_obj, "object1_id", JSON_INVALID_NUMBER);
@@ -508,12 +508,12 @@ static bool M_LoadLevelSequence(JSON_OBJECT *obj, int32_t level_num)
     return true;
 }
 
-static void M_StringTableShutdown(GAMEFLOW_STRING_ENTRY *const dest)
+static void M_StringTableShutdown(GAME_FLOW_STRING_ENTRY *const dest)
 {
     if (dest == NULL) {
         return;
     }
-    GAMEFLOW_STRING_ENTRY *cur = dest;
+    GAME_FLOW_STRING_ENTRY *cur = dest;
     while (cur->key != NULL) {
         Memory_FreePointer(&cur->key);
         Memory_FreePointer(&cur->value);
@@ -524,7 +524,7 @@ static void M_StringTableShutdown(GAMEFLOW_STRING_ENTRY *const dest)
 
 static bool M_LoadObjectNames(
     JSON_OBJECT *const root_obj, const char *const key,
-    GAMEFLOW_STRING_ENTRY **dest)
+    GAME_FLOW_STRING_ENTRY **dest)
 {
     JSON_OBJECT *strings_obj = JSON_ObjectGetObject(root_obj, key);
     if (strings_obj == NULL) {
@@ -560,9 +560,9 @@ static bool M_LoadObjectNames(
         }
     }
 
-    *dest = Memory_Alloc(sizeof(GAMEFLOW_STRING_ENTRY) * (count + 1));
+    *dest = Memory_Alloc(sizeof(GAME_FLOW_STRING_ENTRY) * (count + 1));
 
-    GAMEFLOW_STRING_ENTRY *cur = *dest;
+    GAME_FLOW_STRING_ENTRY *cur = *dest;
     for (int32_t i = 0; legacy_string_defs[i].json_key != NULL; i++) {
         const char *value = JSON_ObjectGetString(
             strings_obj, legacy_string_defs[i].json_key, JSON_INVALID_STRING);
@@ -577,7 +577,7 @@ static bool M_LoadObjectNames(
 }
 
 static void M_ScanLevelText(
-    const GAMEFLOW_STRING_ENTRY *entry,
+    const GAME_FLOW_STRING_ENTRY *entry,
     void (*callback)(GAME_OBJECT_ID object_id, const char *text))
 {
     while (entry != NULL && entry->key != NULL) {
@@ -600,7 +600,7 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
 
     int32_t level_count = jlvl_arr->length;
 
-    g_GameFlow.levels = Memory_Alloc(sizeof(GAMEFLOW_LEVEL) * level_count);
+    g_GameFlow.levels = Memory_Alloc(sizeof(GAME_FLOW_LEVEL) * level_count);
     g_GameInfo.current = Memory_Alloc(sizeof(RESUME_INFO) * level_count);
 
     JSON_ARRAY_ELEMENT *jlvl_elem = jlvl_arr->start;
@@ -613,7 +613,7 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
     g_GameFlow.title_level_num = -1;
     g_GameFlow.level_count = jlvl_arr->length;
 
-    GAMEFLOW_LEVEL *cur = &g_GameFlow.levels[0];
+    GAME_FLOW_LEVEL *cur = &g_GameFlow.levels[0];
     while (jlvl_elem) {
         JSON_OBJECT *jlvl_obj = JSON_ValueAsObject(jlvl_elem->value);
         if (!jlvl_obj) {
@@ -652,7 +652,7 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
             return false;
         }
 
-        cur->level_type = M_StringToEnumType(tmp_s, m_GameflowLevelTypeEnumMap);
+        cur->level_type = M_StringToEnumType(tmp_s, m_GameFlowLevelTypeEnumMap);
 
         switch (cur->level_type) {
         case GFL_TITLE:
@@ -802,10 +802,10 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj)
         } else if (tmp_arr) {
             cur->item_drops.count = (signed)tmp_arr->length;
             cur->item_drops.data = Memory_Alloc(
-                sizeof(GAMEFLOW_DROP_ITEM_DATA) * (signed)tmp_arr->length);
+                sizeof(GAME_FLOW_DROP_ITEM_DATA) * (signed)tmp_arr->length);
 
             for (int i = 0; i < cur->item_drops.count; i++) {
-                GAMEFLOW_DROP_ITEM_DATA *data = &cur->item_drops.data[i];
+                GAME_FLOW_DROP_ITEM_DATA *data = &cur->item_drops.data[i];
                 JSON_OBJECT *jlvl_data = JSON_ArrayGetObject(tmp_arr, i);
 
                 data->enemy_num = JSON_ObjectGetInt(
@@ -937,14 +937,14 @@ void GameFlow_Shutdown(void)
                 Memory_FreePointer(&g_GameFlow.levels[i].item_drops.data);
             }
 
-            GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[i].sequence;
+            GAME_FLOW_SEQUENCE *seq = g_GameFlow.levels[i].sequence;
             if (seq) {
                 while (seq->type != GFS_END) {
                     switch (seq->type) {
                     case GFS_LOADING_SCREEN:
                     case GFS_DISPLAY_PICTURE:
                     case GFS_TOTAL_STATS: {
-                        GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
+                        GAME_FLOW_DISPLAY_PICTURE_DATA *data = seq->data;
                         Memory_FreePointer(&data->path);
                         Memory_FreePointer(&data);
                         break;
@@ -987,8 +987,8 @@ void GameFlow_Shutdown(void)
     }
 }
 
-GAMEFLOW_COMMAND
-GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
+GAME_FLOW_COMMAND
+GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
 {
     LOG_INFO("level_num=%d level_type=%d", level_num, level_type);
 
@@ -997,8 +997,8 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     g_GameInfo.remove_ammo = false;
     g_GameInfo.remove_medipacks = false;
 
-    GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
-    GAMEFLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
+    GAME_FLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
+    GAME_FLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
 
     while (seq->type != GFS_END) {
         LOG_INFO("seq %d %d", seq->type, seq->data);
@@ -1029,7 +1029,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
         case GFS_START_GAME:
             if (!Game_Start((int32_t)(intptr_t)seq->data, level_type)) {
                 g_CurrentLevel = -1;
-                return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+                return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             }
             break;
 
@@ -1100,7 +1100,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
         case GFS_TOTAL_STATS:
             if (g_Config.gameplay.enable_total_stats
                 && level_type != GFL_SAVED) {
-                const GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
+                const GAME_FLOW_DISPLAY_PICTURE_DATA *data = seq->data;
                 PHASE_STATS_ARGS *const args =
                     Memory_Alloc(sizeof(PHASE_STATS_ARGS));
                 args->level_num = level_num;
@@ -1130,7 +1130,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
                 break;
             }
 
-            GAMEFLOW_DISPLAY_PICTURE_DATA *data = seq->data;
+            GAME_FLOW_DISPLAY_PICTURE_DATA *data = seq->data;
             PHASE_PICTURE_ARGS *const args =
                 Memory_Alloc(sizeof(PHASE_PICTURE_ARGS));
             args->path = data->path;
@@ -1143,22 +1143,22 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             break;
 
         case GFS_EXIT_TO_TITLE:
-            return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
 
         case GFS_EXIT_TO_LEVEL: {
             int32_t next_level = (int32_t)(intptr_t)seq->data & ((1 << 6) - 1);
             if (g_GameFlow.levels[next_level].level_type == GFL_BONUS
                 && !g_GameInfo.bonus_level_unlock) {
-                return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+                return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             }
-            return (GAMEFLOW_COMMAND) {
+            return (GAME_FLOW_COMMAND) {
                 .action = GF_START_GAME,
                 .param = next_level,
             };
         }
 
         case GFS_EXIT_TO_CINE:
-            return (GAMEFLOW_COMMAND) {
+            return (GAME_FLOW_COMMAND) {
                 .action = GF_START_CINE,
                 .param = (int32_t)(intptr_t)seq->data & ((1 << 6) - 1),
             };
@@ -1184,8 +1184,8 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
 
         case GFS_GIVE_ITEM:
             if (level_type != GFL_SAVED) {
-                const GAMEFLOW_GIVE_ITEM_DATA *give_item_data =
-                    (const GAMEFLOW_GIVE_ITEM_DATA *)seq->data;
+                const GAME_FLOW_GIVE_ITEM_DATA *give_item_data =
+                    (const GAME_FLOW_GIVE_ITEM_DATA *)seq->data;
                 Inv_AddItemNTimes(
                     give_item_data->object_id, give_item_data->quantity);
             }
@@ -1218,7 +1218,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             break;
 
         case GFS_MESH_SWAP: {
-            const GAMEFLOW_MESH_SWAP_DATA *const swap_data = seq->data;
+            const GAME_FLOW_MESH_SWAP_DATA *const swap_data = seq->data;
             Object_SwapMesh(
                 swap_data->object1_id, swap_data->object2_id,
                 swap_data->mesh_num);
@@ -1230,7 +1230,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             if (!BaconLara_InitialiseAnchor(anchor_room)) {
                 LOG_ERROR(
                     "Could not anchor Bacon Lara to room %d", anchor_room);
-                return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+                return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             }
             break;
         }
@@ -1248,13 +1248,13 @@ GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
     return command;
 }
 
-GAMEFLOW_COMMAND
+GAME_FLOW_COMMAND
 GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
 {
     LOG_INFO("%d", level_num);
 
-    GAMEFLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
-    GAMEFLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
+    GAME_FLOW_SEQUENCE *seq = g_GameFlow.levels[level_num].sequence;
+    GAME_FLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
 
     while (seq->type != GFS_END) {
         LOG_INFO("seq %d %d", seq->type, seq->data);
@@ -1277,7 +1277,7 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
 
         case GFS_START_GAME:
             if (level_num == savegame_level) {
-                return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+                return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             }
             break;
 
@@ -1303,18 +1303,18 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
 
         case GFS_EXIT_TO_TITLE:
             Music_Stop();
-            return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
 
         case GFS_EXIT_TO_LEVEL:
             Music_Stop();
-            return (GAMEFLOW_COMMAND) {
+            return (GAME_FLOW_COMMAND) {
                 .action = GF_START_GAME,
                 .param = (int32_t)(intptr_t)seq->data & ((1 << 6) - 1),
             };
 
         case GFS_EXIT_TO_CINE:
             Music_Stop();
-            return (GAMEFLOW_COMMAND) {
+            return (GAME_FLOW_COMMAND) {
                 .action = GF_START_CINE,
                 .param = (int32_t)(intptr_t)seq->data & ((1 << 6) - 1),
             };
@@ -1339,7 +1339,7 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
             break;
 
         case GFS_MESH_SWAP: {
-            const GAMEFLOW_MESH_SWAP_DATA *const swap_data = seq->data;
+            const GAME_FLOW_MESH_SWAP_DATA *const swap_data = seq->data;
             Object_SwapMesh(
                 swap_data->object1_id, swap_data->object2_id,
                 swap_data->mesh_num);
@@ -1356,12 +1356,12 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
     return command;
 }
 
-int32_t Gameflow_GetLevelCount(void)
+int32_t GameFlow_GetLevelCount(void)
 {
     return g_GameFlow.level_count;
 }
 
-int32_t Gameflow_GetDemoCount(void)
+int32_t GameFlow_GetDemoCount(void)
 {
     int32_t demo_count = 0;
     for (int32_t i = g_GameFlow.first_level_num; i <= g_GameFlow.last_level_num;
@@ -1373,22 +1373,22 @@ int32_t Gameflow_GetDemoCount(void)
     return demo_count;
 }
 
-const char *Gameflow_GetLevelFileName(int32_t level_num)
+const char *GameFlow_GetLevelFileName(int32_t level_num)
 {
     return g_GameFlow.levels[level_num].level_file;
 }
 
-const char *Gameflow_GetLevelTitle(int32_t level_num)
+const char *GameFlow_GetLevelTitle(int32_t level_num)
 {
     return g_GameFlow.levels[level_num].level_title;
 }
 
-int32_t Gameflow_GetGymLevelNumber(void)
+int32_t GameFlow_GetGymLevelNumber(void)
 {
     return g_GameFlow.gym_level_num;
 }
 
-void Gameflow_OverrideCommand(const GAMEFLOW_COMMAND command)
+void GameFlow_OverrideCommand(const GAME_FLOW_COMMAND command)
 {
     g_GameInfo.override_gf_command = command;
 }
@@ -1471,15 +1471,15 @@ void GameFlow_LoadStrings(int32_t level_num)
 
     if (level_num >= 0) {
         ASSERT(level_num < g_GameFlow.level_count);
-        const GAMEFLOW_LEVEL *const level = &g_GameFlow.levels[level_num];
+        const GAME_FLOW_LEVEL *const level = &g_GameFlow.levels[level_num];
         M_ScanLevelText(level->object_strings, Object_SetName);
         M_ScanLevelText(level->examine_strings, Object_SetDescription);
     }
 }
 
-GAMEFLOW_COMMAND GameFlow_PlayAvailableStory(int32_t slot_num)
+GAME_FLOW_COMMAND GameFlow_PlayAvailableStory(int32_t slot_num)
 {
-    GAMEFLOW_COMMAND command = {
+    GAME_FLOW_COMMAND command = {
         .action = GF_START_GAME,
         .param = g_GameFlow.first_level_num,
     };
@@ -1495,5 +1495,5 @@ GAMEFLOW_COMMAND GameFlow_PlayAvailableStory(int32_t slot_num)
         }
     }
 
-    return (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+    return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
 }

--- a/src/tr1/game/gameflow.h
+++ b/src/tr1/game/gameflow.h
@@ -8,28 +8,28 @@
 typedef struct {
     const char *key;
     const char *value;
-} GAMEFLOW_STRING_ENTRY;
+} GAME_FLOW_STRING_ENTRY;
 
 typedef struct {
-    GAMEFLOW_SEQUENCE_TYPE type;
+    GAME_FLOW_SEQUENCE_TYPE type;
     void *data;
-} GAMEFLOW_SEQUENCE;
+} GAME_FLOW_SEQUENCE;
 
 typedef struct {
     int32_t enemy_num;
     int32_t count;
     int16_t *object_ids;
-} GAMEFLOW_DROP_ITEM_DATA;
+} GAME_FLOW_DROP_ITEM_DATA;
 
 typedef struct {
-    GAMEFLOW_LEVEL_TYPE level_type;
+    GAME_FLOW_LEVEL_TYPE level_type;
     int16_t music;
     char *level_title;
     char *level_file;
-    GAMEFLOW_STRING_ENTRY *object_strings;
-    GAMEFLOW_STRING_ENTRY *examine_strings;
+    GAME_FLOW_STRING_ENTRY *object_strings;
+    GAME_FLOW_STRING_ENTRY *examine_strings;
     int8_t demo;
-    GAMEFLOW_SEQUENCE *sequence;
+    GAME_FLOW_SEQUENCE *sequence;
     struct {
         bool override;
         RGB_F value;
@@ -53,10 +53,10 @@ typedef struct {
     } injections;
     struct {
         int count;
-        GAMEFLOW_DROP_ITEM_DATA *data;
+        GAME_FLOW_DROP_ITEM_DATA *data;
     } item_drops;
     GAME_OBJECT_ID lara_type;
-} GAMEFLOW_LEVEL;
+} GAME_FLOW_LEVEL;
 
 typedef struct {
     char *main_menu_background_path;
@@ -69,7 +69,7 @@ typedef struct {
     char *savegame_fmt_bson;
     int8_t has_demo;
     double demo_delay;
-    GAMEFLOW_LEVEL *levels;
+    GAME_FLOW_LEVEL *levels;
     RGB_F water_color;
     float draw_distance_fade;
     float draw_distance_max;
@@ -80,15 +80,15 @@ typedef struct {
     bool enable_tr2_item_drops;
     bool convert_dropped_guns;
     bool enable_killer_pushblocks;
-} GAMEFLOW;
+} GAME_FLOW;
 
-extern GAMEFLOW g_GameFlow;
+extern GAME_FLOW g_GameFlow;
 
-GAMEFLOW_COMMAND
-GameFlow_InterpretSequence(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
-GAMEFLOW_COMMAND
+GAME_FLOW_COMMAND
+GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
+GAME_FLOW_COMMAND
 GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level);
-GAMEFLOW_COMMAND GameFlow_PlayAvailableStory(int32_t slot_num);
+GAME_FLOW_COMMAND GameFlow_PlayAvailableStory(int32_t slot_num);
 
 bool GameFlow_LoadFromFile(const char *file_name);
 void GameFlow_Shutdown(void);

--- a/src/tr1/game/phase/phase.c
+++ b/src/tr1/game/phase/phase.c
@@ -35,9 +35,9 @@ static void M_SetUnconditionally(const PHASE phase, const void *args);
 static PHASE_CONTROL M_Control(int32_t nframes)
 {
     if (g_GameInfo.override_gf_command.action != GF_CONTINUE_SEQUENCE) {
-        const GAMEFLOW_COMMAND override = g_GameInfo.override_gf_command;
+        const GAME_FLOW_COMMAND override = g_GameInfo.override_gf_command;
         g_GameInfo.override_gf_command =
-            (GAMEFLOW_COMMAND) { .action = GF_CONTINUE_SEQUENCE };
+            (GAME_FLOW_COMMAND) { .action = GF_CONTINUE_SEQUENCE };
         return (PHASE_CONTROL) { .end = true, .command = override };
     }
 
@@ -138,7 +138,7 @@ static int32_t M_Wait(void)
     }
 }
 
-GAMEFLOW_COMMAND Phase_Run(void)
+GAME_FLOW_COMMAND Phase_Run(void)
 {
     int32_t nframes = Clock_WaitTick();
     PHASE_CONTROL control = { .end = false };

--- a/src/tr1/game/phase/phase.h
+++ b/src/tr1/game/phase/phase.h
@@ -16,7 +16,7 @@
 // It does not make sense to return both .end = false and .command.
 typedef struct {
     bool end;
-    GAMEFLOW_COMMAND command;
+    GAME_FLOW_COMMAND command;
 } PHASE_CONTROL;
 
 typedef enum {
@@ -54,4 +54,4 @@ PHASE Phase_Get(void);
 // routine.
 void Phase_Set(PHASE phase, const void *args);
 
-GAMEFLOW_COMMAND Phase_Run(void);
+GAME_FLOW_COMMAND Phase_Run(void);

--- a/src/tr1/game/phase/phase_stats.c
+++ b/src/tr1/game/phase/phase_stats.c
@@ -36,7 +36,7 @@ static STATE m_State = STATE_DISPLAY;
 static TEXTSTRING *m_Texts[MAX_TEXTSTRINGS] = { 0 };
 
 static void M_CreateTexts(int32_t level_num);
-static void M_CreateTextsTotal(GAMEFLOW_LEVEL_TYPE level_type);
+static void M_CreateTextsTotal(GAME_FLOW_LEVEL_TYPE level_type);
 static void M_Start(const PHASE_STATS_ARGS *arg);
 static void M_End(void);
 static PHASE_CONTROL M_Control(int32_t nframes);
@@ -135,7 +135,7 @@ static void M_CreateTexts(int32_t level_num)
     y += row_height;
 }
 
-static void M_CreateTextsTotal(GAMEFLOW_LEVEL_TYPE level_type)
+static void M_CreateTextsTotal(GAME_FLOW_LEVEL_TYPE level_type)
 {
     TOTAL_STATS stats;
     Stats_ComputeTotal(level_type, &stats);

--- a/src/tr1/game/phase/phase_stats.h
+++ b/src/tr1/game/phase/phase_stats.h
@@ -10,7 +10,7 @@ typedef struct {
     int32_t level_num;
     const char *background_path;
     bool total;
-    GAMEFLOW_LEVEL_TYPE level_type;
+    GAME_FLOW_LEVEL_TYPE level_type;
 } PHASE_STATS_ARGS;
 
 extern PHASER g_StatsPhaser;

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -38,11 +38,11 @@
 #define LEVEL_TITLE_SIZE 25
 #define TIMESTAMP_SIZE 20
 
-static const char m_TR1XGameflowPath[] = "cfg/TR1X_gameflow.json5";
-static const char m_TR1XGameflowGoldPath[] = "cfg/TR1X_gameflow_ub.json5";
-static const char m_TR1XGameflowDemoPath[] = "cfg/TR1X_gameflow_demo_pc.json5";
+static const char m_TR1XGameFlowPath[] = "cfg/TR1X_gameflow.json5";
+static const char m_TR1XGameFlowGoldPath[] = "cfg/TR1X_gameflow_ub.json5";
+static const char m_TR1XGameFlowDemoPath[] = "cfg/TR1X_gameflow_demo_pc.json5";
 
-static const char *m_CurrentGameflowPath;
+static const char *m_CurrentGameFlowPath;
 
 static void M_LoadConfig(void);
 static void M_HandleConfigChange(const EVENT *event, void *data);
@@ -133,24 +133,24 @@ const char *Shell_GetConfigPath(void)
     return "cfg/TR1X.json5";
 }
 
-const char *Shell_GetGameflowPath(void)
+const char *Shell_GetGameFlowPath(void)
 {
-    return m_CurrentGameflowPath;
+    return m_CurrentGameFlowPath;
 }
 
 void Shell_Main(void)
 {
-    m_CurrentGameflowPath = m_TR1XGameflowPath;
+    m_CurrentGameFlowPath = m_TR1XGameFlowPath;
 
     char **args = NULL;
     int arg_count = 0;
     S_Shell_GetCommandLine(&arg_count, &args);
     for (int i = 0; i < arg_count; i++) {
         if (!strcmp(args[i], "-gold")) {
-            m_CurrentGameflowPath = m_TR1XGameflowGoldPath;
+            m_CurrentGameFlowPath = m_TR1XGameFlowGoldPath;
         }
         if (!strcmp(args[i], "-demo_pc")) {
-            m_CurrentGameflowPath = m_TR1XGameflowDemoPath;
+            m_CurrentGameFlowPath = m_TR1XGameFlowDemoPath;
         }
     }
     for (int i = 0; i < arg_count; i++) {
@@ -162,9 +162,9 @@ void Shell_Main(void)
     EnumMap_Init();
     Config_Init();
 
-    Shell_Init(m_CurrentGameflowPath);
+    Shell_Init(m_CurrentGameFlowPath);
 
-    GAMEFLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
+    GAME_FLOW_COMMAND command = { .action = GF_EXIT_TO_TITLE };
     bool intro_played = false;
 
     g_GameInfo.current_save_slot = -1;
@@ -174,7 +174,7 @@ void Shell_Main(void)
 
         switch (command.action) {
         case GF_START_GAME: {
-            GAMEFLOW_LEVEL_TYPE level_type = GFL_NORMAL;
+            GAME_FLOW_LEVEL_TYPE level_type = GFL_NORMAL;
             if (g_GameFlow.levels[command.param].level_type == GFL_BONUS) {
                 level_type = GFL_BONUS;
             }
@@ -186,7 +186,7 @@ void Shell_Main(void)
             int16_t level_num = Savegame_GetLevelNumber(command.param);
             if (level_num < 0) {
                 LOG_ERROR("Corrupt save file!");
-                command = (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+                command = (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             } else {
                 g_GameInfo.current_save_slot = command.param;
                 command = GameFlow_InterpretSequence(level_num, GFL_SAVED);
@@ -222,7 +222,7 @@ void Shell_Main(void)
         }
 
         case GF_LEVEL_COMPLETE:
-            command = (GAMEFLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            command = (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
             break;
 
         case GF_EXIT_TO_TITLE:
@@ -235,7 +235,7 @@ void Shell_Main(void)
 
             Savegame_InitCurrentInfo();
             if (!Level_Initialise(g_GameFlow.title_level_num)) {
-                command = (GAMEFLOW_COMMAND) { .action = GF_EXIT_GAME };
+                command = (GAME_FLOW_COMMAND) { .action = GF_EXIT_GAME };
                 break;
             }
             g_GameInfo.current_level_type = GFL_TITLE;

--- a/src/tr1/game/stats.c
+++ b/src/tr1/game/stats.c
@@ -121,7 +121,7 @@ static void M_IncludeKillableItem(int16_t item_num)
 }
 
 void Stats_ComputeTotal(
-    GAMEFLOW_LEVEL_TYPE level_type, TOTAL_STATS *total_stats)
+    GAME_FLOW_LEVEL_TYPE level_type, TOTAL_STATS *total_stats)
 {
     memset(total_stats, 0, sizeof(TOTAL_STATS));
 
@@ -225,7 +225,7 @@ int32_t Stats_GetSecrets(void)
     return m_LevelSecrets;
 }
 
-bool Stats_CheckAllSecretsCollected(GAMEFLOW_LEVEL_TYPE level_type)
+bool Stats_CheckAllSecretsCollected(GAME_FLOW_LEVEL_TYPE level_type)
 {
     TOTAL_STATS total_stats = { 0 };
     Stats_ComputeTotal(level_type, &total_stats);

--- a/src/tr1/game/stats.h
+++ b/src/tr1/game/stats.h
@@ -22,8 +22,8 @@ void Stats_CalculateStats(void);
 int32_t Stats_GetPickups(void);
 int32_t Stats_GetKillables(void);
 int32_t Stats_GetSecrets(void);
-void Stats_ComputeTotal(GAMEFLOW_LEVEL_TYPE level_type, TOTAL_STATS *stats);
-bool Stats_CheckAllSecretsCollected(GAMEFLOW_LEVEL_TYPE level_type);
+void Stats_ComputeTotal(GAME_FLOW_LEVEL_TYPE level_type, TOTAL_STATS *stats);
+bool Stats_CheckAllSecretsCollected(GAME_FLOW_LEVEL_TYPE level_type);
 
 void Stats_StartTimer(void);
 void Stats_UpdateTimer(void);

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -302,7 +302,7 @@ typedef enum {
     GFS_REMOVE_MEDIPACKS,
     GFS_SETUP_BACON_LARA,
     GFS_LEGACY,
-} GAMEFLOW_SEQUENCE_TYPE;
+} GAME_FLOW_SEQUENCE_TYPE;
 
 typedef enum {
     BT_LARA_HEALTH = 0,
@@ -495,8 +495,8 @@ typedef struct {
     PASSPORT_MODE passport_selection;
     int32_t select_level_num;
     bool death_counter_supported;
-    GAMEFLOW_LEVEL_TYPE current_level_type;
-    GAMEFLOW_COMMAND override_gf_command;
+    GAME_FLOW_LEVEL_TYPE current_level_type;
+    GAME_FLOW_COMMAND override_gf_command;
     bool remove_guns;
     bool remove_scions;
     bool remove_ammo;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -157,7 +157,7 @@ void CutscenePlayerGen_Initialise(const int16_t item_num)
 }
 
 int32_t Level_Initialise(
-    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
+    const int32_t level_num, const GAME_FLOW_LEVEL_TYPE level_type)
 {
     g_GameInfo.current_level.num = level_num;
     g_GameInfo.current_level.type = level_type;
@@ -375,7 +375,7 @@ void DecreaseScreenSize(void)
 
 bool S_LoadLevelFile(
     const char *const file_name, const int32_t level_num,
-    const GAMEFLOW_LEVEL_TYPE level_type)
+    const GAME_FLOW_LEVEL_TYPE level_type)
 {
     S_UnloadLevelFile();
     return Level_Load(file_name, level_num);

--- a/src/tr2/decomp/decomp.h
+++ b/src/tr2/decomp/decomp.h
@@ -15,7 +15,7 @@ void CutscenePlayer_Control(int16_t item_num);
 void Lara_Control_Cutscene(int16_t item_num);
 void CutscenePlayer1_Initialise(int16_t item_num);
 void CutscenePlayerGen_Initialise(int16_t item_num);
-int32_t Level_Initialise(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+int32_t Level_Initialise(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 int32_t Misc_Move3DPosTo3DPos(
     PHD_3DPOS *src_pos, const PHD_3DPOS *dst_pos, int32_t velocity,
     int16_t ang_add);
@@ -26,7 +26,7 @@ void S_InitialisePolyList(bool clear_back_buffer);
 void DecreaseScreenSize(void);
 void IncreaseScreenSize(void);
 bool S_LoadLevelFile(
-    const char *file_name, int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+    const char *file_name, int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 void S_UnloadLevelFile(void);
 void GetValidLevelsList(REQUEST_INFO *req);
 void InitialiseGameFlags(void);

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -151,7 +151,7 @@ void Game_Draw(void)
     Output_DrawPolyList();
 }
 
-GAMEFLOW_LEVEL_TYPE Game_GetCurrentLevelType(void)
+GAME_FLOW_LEVEL_TYPE Game_GetCurrentLevelType(void)
 {
     return g_GameInfo.current_level.type;
 }

--- a/src/tr2/game/gameflow.c
+++ b/src/tr2/game/gameflow.c
@@ -366,7 +366,7 @@ bool GF_DoFrontendSequence(void)
 }
 
 GAME_FLOW_DIR GF_DoLevelSequence(
-    const int32_t start_level, const GAMEFLOW_LEVEL_TYPE type)
+    const int32_t start_level, const GAME_FLOW_LEVEL_TYPE type)
 {
     GF_N_LoadStrings(start_level);
 
@@ -389,7 +389,8 @@ GAME_FLOW_DIR GF_DoLevelSequence(
     }
 }
 
-GAME_FLOW_DIR GF_InterpretSequence(const int16_t *ptr, GAMEFLOW_LEVEL_TYPE type)
+GAME_FLOW_DIR GF_InterpretSequence(
+    const int16_t *ptr, GAME_FLOW_LEVEL_TYPE type)
 {
     g_GF_NoFloor = 0;
     g_GF_DeadlyWater = false;
@@ -654,7 +655,7 @@ GAME_FLOW_DIR GF_StartDemo(const int32_t level_num)
 }
 
 GAME_FLOW_DIR GF_StartGame(
-    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
+    const int32_t level_num, const GAME_FLOW_LEVEL_TYPE level_type)
 {
     PHASE *const phase = Phase_Game_Create(level_num, level_type);
     const GAME_FLOW_DIR dir = PhaseExecutor_Run(phase);

--- a/src/tr2/game/gameflow.h
+++ b/src/tr2/game/gameflow.h
@@ -7,12 +7,12 @@
 bool GF_LoadFromFile(const char *file_name);
 bool GF_LoadScriptFile(const char *fname);
 bool GF_DoFrontendSequence(void);
-GAME_FLOW_DIR GF_DoLevelSequence(int32_t level, GAMEFLOW_LEVEL_TYPE type);
+GAME_FLOW_DIR GF_DoLevelSequence(int32_t level, GAME_FLOW_LEVEL_TYPE type);
 GAME_FLOW_DIR GF_InterpretSequence(
-    const int16_t *ptr, GAMEFLOW_LEVEL_TYPE type);
+    const int16_t *ptr, GAME_FLOW_LEVEL_TYPE type);
 void GF_ModifyInventory(int32_t level, int32_t type);
 
 GAME_FLOW_DIR GF_StartDemo(int32_t level_num);
-GAME_FLOW_DIR GF_StartGame(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+GAME_FLOW_DIR GF_StartGame(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 GAME_FLOW_DIR GF_ShowInventory(INVENTORY_MODE mode);
 GAME_FLOW_DIR GF_ShowInventoryKeys(GAME_OBJECT_ID receptacle_type_id);

--- a/src/tr2/game/gameflow/gameflow_new.c
+++ b/src/tr2/game/gameflow/gameflow_new.c
@@ -10,7 +10,7 @@
 #include <libtrx/game/objects/names.h>
 #include <libtrx/log.h>
 
-GAMEFLOW_NEW g_GameflowNew;
+GAME_FLOW_NEW g_GameFlowNew;
 GAME_INFO g_GameInfo;
 
 static void M_LoadObjectString(const char *key, const char *value);
@@ -40,9 +40,9 @@ static void M_LoadGameString(const char *const key, const char *const value)
 
 static void M_LoadObjectStrings(const int32_t level_num)
 {
-    const GAMEFLOW_NEW *const gf = &g_GameflowNew;
+    const GAME_FLOW_NEW *const gf = &g_GameFlowNew;
 
-    const GAMEFLOW_NEW_STRING_ENTRY *entry = gf->object_strings;
+    const GAME_FLOW_NEW_STRING_ENTRY *entry = gf->object_strings;
     while (entry != NULL && entry->key != NULL) {
         M_LoadObjectString(entry->key, entry->value);
         entry++;
@@ -50,7 +50,7 @@ static void M_LoadObjectStrings(const int32_t level_num)
 
     if (level_num >= 0) {
         ASSERT(level_num < gf->level_count);
-        const GAMEFLOW_NEW_LEVEL *const level = &gf->levels[level_num];
+        const GAME_FLOW_NEW_LEVEL *const level = &gf->levels[level_num];
         entry = level->object_strings;
         while (entry != NULL && entry->key != NULL) {
             M_LoadObjectString(entry->key, entry->value);
@@ -61,9 +61,9 @@ static void M_LoadObjectStrings(const int32_t level_num)
 
 static void M_LoadGameStrings(const int32_t level_num)
 {
-    const GAMEFLOW_NEW *const gf = &g_GameflowNew;
+    const GAME_FLOW_NEW *const gf = &g_GameFlowNew;
 
-    const GAMEFLOW_NEW_STRING_ENTRY *entry = gf->game_strings;
+    const GAME_FLOW_NEW_STRING_ENTRY *entry = gf->game_strings;
     while (entry != NULL && entry->key != NULL) {
         M_LoadGameString(entry->key, entry->value);
         entry++;
@@ -71,7 +71,7 @@ static void M_LoadGameStrings(const int32_t level_num)
 
     if (level_num >= 0) {
         ASSERT(level_num < gf->level_count);
-        const GAMEFLOW_NEW_LEVEL *const level = &gf->levels[level_num];
+        const GAME_FLOW_NEW_LEVEL *const level = &gf->levels[level_num];
         entry = level->game_strings;
         while (entry != NULL && entry->key != NULL) {
             M_LoadGameString(entry->key, entry->value);
@@ -216,32 +216,32 @@ void GF_N_LoadStrings(const int32_t level_num)
     }
 }
 
-int32_t Gameflow_GetLevelCount(void)
+int32_t GameFlow_GetLevelCount(void)
 {
-    return g_GameflowNew.level_count;
+    return g_GameFlowNew.level_count;
 }
 
-int32_t Gameflow_GetDemoCount(void)
+int32_t GameFlow_GetDemoCount(void)
 {
     return g_GameFlow.num_demos;
 }
 
-const char *Gameflow_GetLevelFileName(int32_t level_num)
+const char *GameFlow_GetLevelFileName(int32_t level_num)
 {
     return g_GF_LevelFileNames[level_num];
 }
 
-const char *Gameflow_GetLevelTitle(int32_t level_num)
+const char *GameFlow_GetLevelTitle(int32_t level_num)
 {
     return g_GF_LevelNames[level_num];
 }
 
-int32_t Gameflow_GetGymLevelNumber(void)
+int32_t GameFlow_GetGymLevelNumber(void)
 {
     return g_GameFlow.gym_enabled ? LV_GYM : -1;
 }
 
-void Gameflow_OverrideCommand(const GAMEFLOW_COMMAND command)
+void GameFlow_OverrideCommand(const GAME_FLOW_COMMAND command)
 {
     switch (command.action) {
     case GF_START_GAME:

--- a/src/tr2/game/gameflow/gameflow_new.h
+++ b/src/tr2/game/gameflow/gameflow_new.h
@@ -9,7 +9,7 @@ typedef struct {
 
 typedef struct {
     struct {
-        GAMEFLOW_LEVEL_TYPE type;
+        GAME_FLOW_LEVEL_TYPE type;
         int32_t num;
     } current_level;
 } GAME_INFO;
@@ -17,23 +17,23 @@ typedef struct {
 typedef struct {
     const char *key;
     const char *value;
-} GAMEFLOW_NEW_STRING_ENTRY;
+} GAME_FLOW_NEW_STRING_ENTRY;
 
 typedef struct {
-    GAMEFLOW_NEW_STRING_ENTRY *object_strings;
-    GAMEFLOW_NEW_STRING_ENTRY *game_strings;
+    GAME_FLOW_NEW_STRING_ENTRY *object_strings;
+    GAME_FLOW_NEW_STRING_ENTRY *game_strings;
     INJECTION_DATA injections;
-} GAMEFLOW_NEW_LEVEL;
+} GAME_FLOW_NEW_LEVEL;
 
 typedef struct {
     int32_t level_count;
-    GAMEFLOW_NEW_LEVEL *levels;
-    GAMEFLOW_NEW_STRING_ENTRY *object_strings;
-    GAMEFLOW_NEW_STRING_ENTRY *game_strings;
+    GAME_FLOW_NEW_LEVEL *levels;
+    GAME_FLOW_NEW_STRING_ENTRY *object_strings;
+    GAME_FLOW_NEW_STRING_ENTRY *game_strings;
     INJECTION_DATA injections;
-} GAMEFLOW_NEW;
+} GAME_FLOW_NEW;
 
-extern GAMEFLOW_NEW g_GameflowNew;
+extern GAME_FLOW_NEW g_GameFlowNew;
 extern GAME_INFO g_GameInfo;
 
 void GF_N_LoadStrings(int32_t level_num);

--- a/src/tr2/game/gameflow/reader.c
+++ b/src/tr2/game/gameflow/reader.c
@@ -8,16 +8,16 @@
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 
-static void M_LoadGlobalInjections(JSON_OBJECT *obj, GAMEFLOW_NEW *gf);
+static void M_LoadGlobalInjections(JSON_OBJECT *obj, GAME_FLOW_NEW *gf);
 static void M_LoadLevelInjections(
-    JSON_OBJECT *obj, const GAMEFLOW_NEW *gf, GAMEFLOW_NEW_LEVEL *level);
-static void M_StringTableShutdown(GAMEFLOW_NEW_STRING_ENTRY *dest);
+    JSON_OBJECT *obj, const GAME_FLOW_NEW *gf, GAME_FLOW_NEW_LEVEL *level);
+static void M_StringTableShutdown(GAME_FLOW_NEW_STRING_ENTRY *dest);
 static bool M_LoadStringTable(
-    JSON_OBJECT *root_obj, const char *key, GAMEFLOW_NEW_STRING_ENTRY **dest);
-static bool M_LoadScriptLevels(JSON_OBJECT *obj, GAMEFLOW_NEW *gf);
+    JSON_OBJECT *root_obj, const char *key, GAME_FLOW_NEW_STRING_ENTRY **dest);
+static bool M_LoadScriptLevels(JSON_OBJECT *obj, GAME_FLOW_NEW *gf);
 
 static void M_LoadGlobalInjections(
-    JSON_OBJECT *const obj, GAMEFLOW_NEW *const gf)
+    JSON_OBJECT *const obj, GAME_FLOW_NEW *const gf)
 {
     gf->injections.count = 0;
     JSON_ARRAY *const injections = JSON_ObjectGetArray(obj, "injections");
@@ -35,8 +35,8 @@ static void M_LoadGlobalInjections(
 }
 
 static void M_LoadLevelInjections(
-    JSON_OBJECT *const obj, const GAMEFLOW_NEW *const gf,
-    GAMEFLOW_NEW_LEVEL *const level)
+    JSON_OBJECT *const obj, const GAME_FLOW_NEW *const gf,
+    GAME_FLOW_NEW_LEVEL *const level)
 {
     const bool inherit = JSON_ObjectGetBool(obj, "inherit_injections", true);
     JSON_ARRAY *const injections = JSON_ObjectGetArray(obj, "injections");
@@ -75,12 +75,12 @@ static void M_LoadLevelInjections(
     }
 }
 
-static void M_StringTableShutdown(GAMEFLOW_NEW_STRING_ENTRY *const dest)
+static void M_StringTableShutdown(GAME_FLOW_NEW_STRING_ENTRY *const dest)
 {
     if (dest == NULL) {
         return;
     }
-    GAMEFLOW_NEW_STRING_ENTRY *cur = dest;
+    GAME_FLOW_NEW_STRING_ENTRY *cur = dest;
     while (cur->key != NULL) {
         Memory_FreePointer(&cur->key);
         Memory_FreePointer(&cur->value);
@@ -91,7 +91,7 @@ static void M_StringTableShutdown(GAMEFLOW_NEW_STRING_ENTRY *const dest)
 
 static bool M_LoadStringTable(
     JSON_OBJECT *const root_obj, const char *const key,
-    GAMEFLOW_NEW_STRING_ENTRY **dest)
+    GAME_FLOW_NEW_STRING_ENTRY **dest)
 {
     const JSON_OBJECT *const strings_obj = JSON_ObjectGetObject(root_obj, key);
     if (strings_obj == NULL) {
@@ -100,9 +100,9 @@ static bool M_LoadStringTable(
     }
 
     *dest = Memory_Alloc(
-        sizeof(GAMEFLOW_NEW_STRING_ENTRY) * (strings_obj->length + 1));
+        sizeof(GAME_FLOW_NEW_STRING_ENTRY) * (strings_obj->length + 1));
 
-    GAMEFLOW_NEW_STRING_ENTRY *cur = *dest;
+    GAME_FLOW_NEW_STRING_ENTRY *cur = *dest;
     JSON_OBJECT_ELEMENT *strings_elem = strings_obj->start;
     for (size_t i = 0; i < strings_obj->length;
          i++, strings_elem = strings_elem->next) {
@@ -122,7 +122,7 @@ static bool M_LoadStringTable(
     return true;
 }
 
-static bool M_LoadScriptLevels(JSON_OBJECT *obj, GAMEFLOW_NEW *const gf)
+static bool M_LoadScriptLevels(JSON_OBJECT *obj, GAME_FLOW_NEW *const gf)
 {
     bool result = true;
 
@@ -144,11 +144,11 @@ static bool M_LoadScriptLevels(JSON_OBJECT *obj, GAMEFLOW_NEW *const gf)
     }
 
     gf->level_count = level_count;
-    gf->levels = Memory_Alloc(sizeof(GAMEFLOW_NEW_LEVEL) * level_count);
+    gf->levels = Memory_Alloc(sizeof(GAME_FLOW_NEW_LEVEL) * level_count);
 
     JSON_ARRAY_ELEMENT *jlvl_elem = jlvl_arr->start;
     for (size_t i = 0; i < jlvl_arr->length; i++, jlvl_elem = jlvl_elem->next) {
-        GAMEFLOW_NEW_LEVEL *const level = &gf->levels[i];
+        GAME_FLOW_NEW_LEVEL *const level = &gf->levels[i];
 
         JSON_OBJECT *const jlvl_obj = JSON_ValueAsObject(jlvl_elem->value);
         if (jlvl_obj == NULL) {
@@ -196,7 +196,7 @@ bool GF_N_Load(const char *const path)
         goto end;
     }
 
-    GAMEFLOW_NEW *const gf = &g_GameflowNew;
+    GAME_FLOW_NEW *const gf = &g_GameFlowNew;
     JSON_OBJECT *root_obj = JSON_ValueAsObject(root);
     M_LoadGlobalInjections(root_obj, gf);
     result &=
@@ -220,7 +220,7 @@ end:
 
 void GF_N_Shutdown(void)
 {
-    GAMEFLOW_NEW *const gf = &g_GameflowNew;
+    GAME_FLOW_NEW *const gf = &g_GameFlowNew;
 
     for (int32_t i = 0; i < gf->injections.count; i++) {
         Memory_FreePointer(&gf->injections.data_paths[i]);

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -896,7 +896,7 @@ void Lara_InitialiseLoad(const int16_t item_num)
     g_LaraItem = &g_Items[item_num];
 }
 
-void Lara_Initialise(const GAMEFLOW_LEVEL_TYPE type)
+void Lara_Initialise(const GAME_FLOW_LEVEL_TYPE type)
 {
     ITEM *const item = g_LaraItem;
 

--- a/src/tr2/game/lara/control.h
+++ b/src/tr2/game/lara/control.h
@@ -17,7 +17,7 @@ void Lara_UseItem(GAME_OBJECT_ID object_id);
 
 void Lara_InitialiseLoad(int16_t item_num);
 
-void Lara_Initialise(GAMEFLOW_LEVEL_TYPE type);
+void Lara_Initialise(GAME_FLOW_LEVEL_TYPE type);
 
 void Lara_InitialiseInventory(int32_t level_num);
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -882,7 +882,7 @@ bool Level_Load(const char *const file_name, const int32_t level_num)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
 
-    const GAMEFLOW_NEW_LEVEL *const level = &g_GameflowNew.levels[level_num];
+    const GAME_FLOW_NEW_LEVEL *const level = &g_GameFlowNew.levels[level_num];
     Inject_Init(level->injections.count, level->injections.data_paths);
 
     M_LoadFromFile(file_name, level_num);

--- a/src/tr2/game/phase/phase_game.c
+++ b/src/tr2/game/phase/phase_game.c
@@ -20,7 +20,7 @@ typedef struct {
     bool exiting;
     FADER exit_fader;
     int32_t level_num;
-    GAMEFLOW_LEVEL_TYPE level_type;
+    GAME_FLOW_LEVEL_TYPE level_type;
 } M_PRIV;
 
 static PHASE_CONTROL M_Start(PHASE *phase);
@@ -101,7 +101,7 @@ static void M_Draw(PHASE *const phase)
 }
 
 PHASE *Phase_Game_Create(
-    const int32_t level_num, const GAMEFLOW_LEVEL_TYPE level_type)
+    const int32_t level_num, const GAME_FLOW_LEVEL_TYPE level_type)
 {
     PHASE *const phase = Memory_Alloc(sizeof(PHASE));
     M_PRIV *const p = Memory_Alloc(sizeof(M_PRIV));

--- a/src/tr2/game/phase/phase_game.h
+++ b/src/tr2/game/phase/phase_game.h
@@ -3,5 +3,5 @@
 #include "game/phase/common.h"
 #include "global/types.h"
 
-PHASE *Phase_Game_Create(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type);
+PHASE *Phase_Game_Create(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 void Phase_Game_Destroy(PHASE *phase);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -36,7 +36,7 @@
 #define GAMEBUF_MEM_CAP 0x780000
 
 static Uint64 m_UpdateDebounce = 0;
-static const char *m_CurrentGameflowPath = "cfg/TR2X_gameflow.json5";
+static const char *m_CurrentGameFlowPath = "cfg/TR2X_gameflow.json5";
 
 static void M_SyncToWindow(void);
 static void M_SyncFromWindow(void);
@@ -364,7 +364,7 @@ void Shell_Main(void)
         return;
     }
 
-    if (!GF_N_Load(m_CurrentGameflowPath)) {
+    if (!GF_N_Load(m_CurrentGameFlowPath)) {
         Shell_ExitSystem("GameMain: could not load new script file");
         return;
     }
@@ -480,9 +480,9 @@ const char *Shell_GetConfigPath(void)
     return "cfg/TR2X.json5";
 }
 
-const char *Shell_GetGameflowPath(void)
+const char *Shell_GetGameFlowPath(void)
 {
-    return m_CurrentGameflowPath;
+    return m_CurrentGameFlowPath;
 }
 
 void Shell_Start(void)

--- a/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/MainWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System.ComponentModel;
 using System.IO;
 using System.Windows;
@@ -162,7 +162,7 @@ public class MainWindowViewModel : BaseLanguageViewModel
     {
         try
         {
-            _configuration.Read(filePath, TRXConstants.Instance.GameflowName);
+            _configuration.Read(filePath, TRXConstants.Instance.GameFlowName);
             SelectedFile = filePath;
             IsEditorDirty = false;
             IsEditorDefault = _configuration.IsDataDefault();

--- a/tools/config/TRX_ConfigToolLib/Models/TRXConstants.cs
+++ b/tools/config/TRX_ConfigToolLib/Models/TRXConstants.cs
@@ -16,7 +16,7 @@ public class TRXConstants
     public string AppImage { get; set; }
     public string ConfigFilterExtension { get; set; }
     public string ConfigPath { get; set; }
-    public string GameflowName { get; set; }
+    public string GameFlowName { get; set; }
     public string ExecutableName { get; set; }
     public bool GoldSupported { get; set; }
     public string GoldArgs { get; set; }

--- a/tools/tr1/config/TR1X_ConfigTool/Resources/const.json
+++ b/tools/tr1/config/TR1X_ConfigTool/Resources/const.json
@@ -1,7 +1,7 @@
 {
   "AppImage": "TR1X.png",
   "ConfigPath": "cfg\\TR1X.json5",
-  "GameflowName": "TR1X_gameflow.json5",
+  "GameFlowName": "TR1X_gameflow.json5",
   "ExecutableName": "TR1X.exe",
   "GoldSupported": true,
   "GitHubURL": "https://github.com/LostArtefacts/TRX"

--- a/tools/tr2/config/TR2X_ConfigTool/Resources/const.json
+++ b/tools/tr2/config/TR2X_ConfigTool/Resources/const.json
@@ -1,7 +1,7 @@
 {
   "AppImage": "TR2X.png",
   "ConfigPath": "cfg\\TR2X.json5",
-  "GameflowName": "TR2X_gameflow.json5",
+  "GameFlowName": "TR2X_gameflow.json5",
   "ExecutableName": "TR2X.exe",
   "GoldSupported": false,
   "GitHubURL": "https://github.com/LostArtefacts/TRX"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Renames `Gameflow` to `GameFlow` and `GAMEFLOW` to `GAME_FLOW`, with the exception of the existing `*_gameflow.json5` files and the `GAMEFLOW.md` documentation. These are internal renames only – no effects on the game expected.