### PR TITLE
tr2/game-flow: eliminate GAME_FLOW_DIR

### DIFF
--- a/docs/tr2/symbols.txt
+++ b/docs/tr2/symbols.txt
@@ -1109,7 +1109,6 @@ typedef enum {
     GFD_EXIT_GAME        = 0x0700,
     GFD_EXIT_TO_OPTION   = 0x0800,
     GFD_TITLE_DESELECT   = 0x0900,
-    GFD_OVERRIDE         = 0x0A00,
 } GAME_FLOW_DIR;
 
 typedef struct __unaligned {

--- a/src/libtrx/include/libtrx/game/gameflow/types.h
+++ b/src/libtrx/include/libtrx/game/gameflow/types.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 typedef enum {
-    GF_CONTINUE_SEQUENCE,
+    GF_NOOP = -1,
     GF_START_GAME,
     GF_START_CINE,
     GF_START_FMV,
@@ -12,10 +12,14 @@ typedef enum {
     GF_LEVEL_COMPLETE,
     GF_EXIT_GAME,
     GF_START_SAVED_GAME,
+#if TR_VERSION == 1
     GF_RESTART_GAME,
+#endif
     GF_SELECT_GAME,
+#if TR_VERSION == 1
     GF_START_GYM,
     GF_STORY_SO_FAR,
+#endif
 } GAME_FLOW_ACTION;
 
 typedef enum {

--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -1040,14 +1040,14 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
             }
             Phase_Set(PHASE_GAME, NULL);
             command = Phase_Run();
-            if (command.action != GF_CONTINUE_SEQUENCE) {
+            if (command.action != GF_NOOP) {
                 return command;
             }
             break;
 
         case GFS_STOP_GAME:
             command = Game_Stop();
-            if (command.action != GF_CONTINUE_SEQUENCE
+            if (command.action != GF_NOOP
                 && command.action != GF_LEVEL_COMPLETE) {
                 return command;
             }
@@ -1072,7 +1072,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
         case GFS_LOOP_CINE:
             if (level_type != GFL_SAVED) {
                 command = Phase_Run();
-                if (command.action != GF_CONTINUE_SEQUENCE
+                if (command.action != GF_NOOP
                     && command.action != GF_LEVEL_COMPLETE) {
                     return command;
                 }
@@ -1091,7 +1091,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
             args->level_num = (int32_t)(intptr_t)seq->data;
             Phase_Set(PHASE_STATS, args);
             command = Phase_Run();
-            if (command.action != GF_CONTINUE_SEQUENCE) {
+            if (command.action != GF_NOOP) {
                 return command;
             }
             break;
@@ -1109,7 +1109,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
                     level_type == GFL_BONUS ? GFL_BONUS : GFL_NORMAL;
                 Phase_Set(PHASE_STATS, args);
                 command = Phase_Run();
-                if (command.action != GF_CONTINUE_SEQUENCE) {
+                if (command.action != GF_NOOP) {
                     return command;
                 }
             }
@@ -1137,7 +1137,7 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
             args->display_time = data->display_time;
             Phase_Set(PHASE_PICTURE, args);
             command = Phase_Run();
-            if (command.action != GF_CONTINUE_SEQUENCE) {
+            if (command.action != GF_NOOP) {
                 return command;
             }
             break;
@@ -1291,7 +1291,7 @@ GameFlow_StorySoFar(int32_t level_num, int32_t savegame_level)
 
         case GFS_LOOP_CINE:
             command = Phase_Run();
-            if (command.action != GF_CONTINUE_SEQUENCE
+            if (command.action != GF_NOOP
                 && command.action != GF_LEVEL_COMPLETE) {
                 return command;
             }

--- a/src/tr1/game/phase/phase.c
+++ b/src/tr1/game/phase/phase.c
@@ -34,10 +34,10 @@ static void M_SetUnconditionally(const PHASE phase, const void *args);
 
 static PHASE_CONTROL M_Control(int32_t nframes)
 {
-    if (g_GameInfo.override_gf_command.action != GF_CONTINUE_SEQUENCE) {
+    if (g_GameInfo.override_gf_command.action != GF_NOOP) {
         const GAME_FLOW_COMMAND override = g_GameInfo.override_gf_command;
         g_GameInfo.override_gf_command =
-            (GAME_FLOW_COMMAND) { .action = GF_CONTINUE_SEQUENCE };
+            (GAME_FLOW_COMMAND) { .action = GF_NOOP };
         return (PHASE_CONTROL) { .end = true, .command = override };
     }
 

--- a/src/tr1/game/phase/phase.h
+++ b/src/tr1/game/phase/phase.h
@@ -9,9 +9,9 @@
 // - Set .end = true to end the current phase.
 //
 // To continue executing current game sequence, .command.action member should
-// be set to GF_CONTINUE_SEQUENCE. To break out of the current sequence and
-// switch to a different game flow action, .command.action should be set to
-// the action to run.
+// be set to GF_NOOP. To break out of the current sequence and switch to a
+// different game flow action, .command.action should be set to the action to
+// run.
 //
 // It does not make sense to return both .end = false and .command.
 typedef struct {

--- a/src/tr1/game/phase/phase_demo.c
+++ b/src/tr1/game/phase/phase_demo.c
@@ -373,7 +373,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
     ASSERT_FAIL();
     return (PHASE_CONTROL) {
         .end = true,
-        .command = { .action = GF_CONTINUE_SEQUENCE },
+        .command = { .action = GF_NOOP },
     };
 }
 

--- a/src/tr1/game/phase/phase_game.c
+++ b/src/tr1/game/phase/phase_game.c
@@ -58,7 +58,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         if (g_LevelComplete) {
             return (PHASE_CONTROL) {
                 .end = true,
-                .command = { .action = GF_CONTINUE_SEQUENCE },
+                .command = { .action = GF_NOOP },
             };
         }
 

--- a/src/tr1/game/phase/phase_inventory.c
+++ b/src/tr1/game/phase/phase_inventory.c
@@ -357,7 +357,7 @@ static PHASE_CONTROL Inv_Close(GAME_OBJECT_ID inv_chosen)
     if (g_InvMode == INV_TITLE_MODE) {
         return (PHASE_CONTROL) {
             .end = true,
-            .command = { .action = GF_CONTINUE_SEQUENCE },
+            .command = { .action = GF_NOOP },
         };
     } else {
         Music_Unpause();

--- a/src/tr1/game/phase/phase_picture.c
+++ b/src/tr1/game/phase/phase_picture.c
@@ -68,7 +68,8 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         if (g_InputDB.any || !Output_FadeIsAnimating()) {
             Output_FadeResetToBlack();
             return (PHASE_CONTROL) {
-                .end = true, .command = { .action = GF_CONTINUE_SEQUENCE }
+                .end = true,
+                .command = { .action = GF_NOOP },
             };
         }
         break;

--- a/src/tr1/game/phase/phase_stats.c
+++ b/src/tr1/game/phase/phase_stats.c
@@ -309,7 +309,7 @@ static PHASE_CONTROL M_Control(int32_t nframes)
             Output_FadeResetToBlack();
             return (PHASE_CONTROL) {
                 .end = true,
-                .command = { .action = GF_CONTINUE_SEQUENCE },
+                .command = { .action = GF_NOOP },
             };
         }
         break;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -28,9 +28,7 @@ MATRIX g_W2VMatrix = { 0 };
 LARA_INFO g_Lara = { 0 };
 ITEM *g_LaraItem = NULL;
 CAMERA_INFO g_Camera = { 0 };
-GAME_INFO g_GameInfo = {
-    .override_gf_command = { .action = GF_CONTINUE_SEQUENCE }, 0
-};
+GAME_INFO g_GameInfo = { .override_gf_command = { .action = GF_NOOP }, 0 };
 int32_t g_SavedGamesCount = 0;
 int32_t g_SaveCounter = 0;
 int16_t g_CurrentLevel = -1;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -58,12 +58,12 @@ typedef enum {
     LA_VEHICLE_HIT_BACK = 14,
 } LARA_ANIM_VEHICLE;
 
-int16_t TitleSequence(void)
+GAME_FLOW_COMMAND TitleSequence(void)
 {
     GF_N_LoadStrings(-1);
 
     if (!Level_Initialise(0, GFL_TITLE)) {
-        return GFD_EXIT_GAME;
+        return (GAME_FLOW_COMMAND) { .action = GF_EXIT_GAME };
     }
 
     if (g_GameFlow.title_track) {
@@ -266,9 +266,9 @@ int32_t Misc_Move3DPosTo3DPos(
     // clang-format on
 }
 
-int32_t LevelCompleteSequence(void)
+GAME_FLOW_COMMAND LevelCompleteSequence(void)
 {
-    return GFD_EXIT_TO_TITLE;
+    return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
 }
 
 void S_Wait(int32_t frames, const bool input_check)
@@ -311,11 +311,11 @@ void S_Wait(int32_t frames, const bool input_check)
     }
 }
 
-GAME_FLOW_DIR DisplayCredits(void)
+GAME_FLOW_COMMAND DisplayCredits(void)
 {
     S_UnloadLevelFile();
     if (!Level_Initialise(0, GFL_TITLE)) {
-        return GFD_EXIT_TO_TITLE;
+        return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
     }
 
     Music_Play(MX_SKIDOO_THEME, MPM_ALWAYS);
@@ -330,11 +330,11 @@ GAME_FLOW_DIR DisplayCredits(void)
             .fade_in_time = FRAMES_PER_SECOND / 2,
             .fade_out_time = FRAMES_PER_SECOND / 2,
         });
-        const GAME_FLOW_DIR dir = PhaseExecutor_Run(phase);
+        const GAME_FLOW_COMMAND gf_cmd = PhaseExecutor_Run(phase);
         Phase_Picture_Destroy(phase);
 
-        if (dir != (GAME_FLOW_DIR)-1) {
-            return dir;
+        if (gf_cmd.action != GF_NOOP) {
+            return gf_cmd;
         }
     }
 
@@ -344,15 +344,15 @@ GAME_FLOW_DIR DisplayCredits(void)
             .fade_in_time = FRAMES_PER_SECOND / 2,
             .fade_out_time = FRAMES_PER_SECOND / 2,
         });
-        const GAME_FLOW_DIR dir = PhaseExecutor_Run(phase);
+        const GAME_FLOW_COMMAND gf_cmd = PhaseExecutor_Run(phase);
 
         Phase_Stats_Destroy(phase);
-        if (dir != (GAME_FLOW_DIR)-1) {
-            return dir;
+        if (gf_cmd.action != GF_NOOP) {
+            return gf_cmd;
         }
     }
 
-    return GFD_EXIT_TO_TITLE;
+    return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
 }
 
 void IncreaseScreenSize(void)

--- a/src/tr2/decomp/decomp.h
+++ b/src/tr2/decomp/decomp.h
@@ -9,7 +9,7 @@
 // they'll need to be properly modularized. The same applies to all files
 // within the decomp/ directory which are scheduled for extensive refactoring.
 
-int16_t TitleSequence(void);
+GAME_FLOW_COMMAND TitleSequence(void);
 void Game_SetCutsceneTrack(int32_t track);
 void CutscenePlayer_Control(int16_t item_num);
 void Lara_Control_Cutscene(int16_t item_num);
@@ -19,9 +19,9 @@ int32_t Level_Initialise(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
 int32_t Misc_Move3DPosTo3DPos(
     PHD_3DPOS *src_pos, const PHD_3DPOS *dst_pos, int32_t velocity,
     int16_t ang_add);
-int32_t LevelCompleteSequence(void);
+GAME_FLOW_COMMAND LevelCompleteSequence(void);
 void S_Wait(int32_t frames, bool input_check);
-GAME_FLOW_DIR DisplayCredits(void);
+GAME_FLOW_COMMAND DisplayCredits(void);
 void S_InitialisePolyList(bool clear_back_buffer);
 void DecreaseScreenSize(void);
 void IncreaseScreenSize(void);

--- a/src/tr2/game/game.h
+++ b/src/tr2/game/game.h
@@ -2,7 +2,7 @@
 
 #include "global/types.h"
 
-GAME_FLOW_DIR Game_Control(int32_t num_frames, bool demo_mode);
+GAME_FLOW_COMMAND Game_Control(int32_t num_frames, bool demo_mode);
 void Game_Draw(void);
 bool Game_IsPlayable(void);
 void Game_ProcessInput(void);

--- a/src/tr2/game/gameflow.h
+++ b/src/tr2/game/gameflow.h
@@ -7,12 +7,15 @@
 bool GF_LoadFromFile(const char *file_name);
 bool GF_LoadScriptFile(const char *fname);
 bool GF_DoFrontendSequence(void);
-GAME_FLOW_DIR GF_DoLevelSequence(int32_t level, GAME_FLOW_LEVEL_TYPE type);
-GAME_FLOW_DIR GF_InterpretSequence(
+GAME_FLOW_COMMAND GF_DoLevelSequence(int32_t level, GAME_FLOW_LEVEL_TYPE type);
+GAME_FLOW_COMMAND GF_InterpretSequence(
     const int16_t *ptr, GAME_FLOW_LEVEL_TYPE type);
 void GF_ModifyInventory(int32_t level, int32_t type);
 
-GAME_FLOW_DIR GF_StartDemo(int32_t level_num);
-GAME_FLOW_DIR GF_StartGame(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
-GAME_FLOW_DIR GF_ShowInventory(INVENTORY_MODE mode);
-GAME_FLOW_DIR GF_ShowInventoryKeys(GAME_OBJECT_ID receptacle_type_id);
+GAME_FLOW_COMMAND GF_StartDemo(int32_t level_num);
+GAME_FLOW_COMMAND GF_StartGame(
+    int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type);
+GAME_FLOW_COMMAND GF_ShowInventory(INVENTORY_MODE mode);
+GAME_FLOW_COMMAND GF_ShowInventoryKeys(GAME_OBJECT_ID receptacle_type_id);
+
+GAME_FLOW_COMMAND GF_TranslateScriptCommand(uint16_t dir);

--- a/src/tr2/game/gameflow/gameflow_new.c
+++ b/src/tr2/game/gameflow/gameflow_new.c
@@ -243,35 +243,5 @@ int32_t GameFlow_GetGymLevelNumber(void)
 
 void GameFlow_OverrideCommand(const GAME_FLOW_COMMAND command)
 {
-    switch (command.action) {
-    case GF_START_GAME:
-    case GF_SELECT_GAME:
-        g_GF_OverrideDir = GFD_START_GAME | command.param;
-        break;
-    case GF_START_SAVED_GAME:
-        g_GF_OverrideDir = GFD_START_SAVED_GAME | command.param;
-        break;
-    case GF_START_CINE:
-        g_GF_OverrideDir = GFD_START_CINE;
-        break;
-    case GF_START_FMV:
-        g_GF_OverrideDir = GFD_START_FMV;
-        break;
-    case GF_START_DEMO:
-        g_GF_OverrideDir = GFD_START_DEMO | (command.param & 0xFF);
-        break;
-    case GF_EXIT_TO_TITLE:
-        g_GF_OverrideDir = GFD_EXIT_TO_TITLE;
-        break;
-    case GF_LEVEL_COMPLETE:
-        g_GF_OverrideDir = GFD_LEVEL_COMPLETE;
-        break;
-    case GF_EXIT_GAME:
-        g_GF_OverrideDir = GFD_EXIT_GAME;
-        break;
-    default:
-        LOG_ERROR("Not implemented");
-        ASSERT_FAIL();
-        break;
-    }
+    g_GF_OverrideCommand = command;
 }

--- a/src/tr2/game/inventory_ring/control.h
+++ b/src/tr2/game/inventory_ring/control.h
@@ -5,8 +5,8 @@
 #include <libtrx/game/objects/types.h>
 
 INV_RING *InvRing_Open(INVENTORY_MODE mode);
-GAME_FLOW_DIR InvRing_Control(INV_RING *ring, int32_t num_frames);
-GAME_FLOW_DIR InvRing_Close(INV_RING *ring);
+GAME_FLOW_COMMAND InvRing_Control(INV_RING *ring, int32_t num_frames);
+GAME_FLOW_COMMAND InvRing_Close(INV_RING *ring);
 
 void InvRing_ClearSelection(void);
 void InvRing_SetRequestedObjectID(const GAME_OBJECT_ID object_id);

--- a/src/tr2/game/phase/executor.h
+++ b/src/tr2/game/phase/executor.h
@@ -3,4 +3,4 @@
 #include "game/phase/common.h"
 #include "global/types.h"
 
-GAME_FLOW_DIR PhaseExecutor_Run(PHASE *phase);
+GAME_FLOW_COMMAND PhaseExecutor_Run(PHASE *phase);

--- a/src/tr2/game/phase/phase_cutscene.c
+++ b/src/tr2/game/phase/phase_cutscene.c
@@ -54,7 +54,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     if (!Level_Initialise(p->level_num, GFL_CUTSCENE)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_TO_TITLE,
+            .gf_cmd = { .action = GF_EXIT_TO_TITLE },
         };
     }
 
@@ -68,7 +68,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     if (!Music_PlaySynced(g_CineTrackID)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_TO_TITLE,
+            .gf_cmd = { .action = GF_EXIT_TO_TITLE },
         };
     }
 
@@ -98,7 +98,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
     } else if (p->exiting && !Fader_IsActive(&p->exit_fader)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_GAME,
+            .gf_cmd = { .action = GF_EXIT_GAME },
         };
     } else {
         M_FixAudioDrift();
@@ -108,7 +108,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
         if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
-                .dir = (GAME_FLOW_DIR)-1,
+                .gf_cmd = { .action = GF_NOOP },
             };
         }
         Shell_ProcessInput();
@@ -124,7 +124,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
         if (g_CineFrameIdx >= g_NumCineFrames) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
-                .dir = (GAME_FLOW_DIR)-1,
+                .gf_cmd = { .action = GF_NOOP },
             };
         }
 

--- a/src/tr2/game/phase/phase_demo.c
+++ b/src/tr2/game/phase/phase_demo.c
@@ -129,7 +129,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     if (p->level_num < 0) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_TO_TITLE,
+            .gf_cmd = { .action = GF_EXIT_TO_TITLE },
         };
     }
 
@@ -137,7 +137,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     if (!M_LoadLevel(p)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_TO_TITLE,
+            .gf_cmd = { .action = GF_EXIT_TO_TITLE },
         };
     }
     M_PrepareGame();
@@ -182,16 +182,16 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
     } else if (p->exiting && !Fader_IsActive(&p->exit_fader)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_GAME,
+            .gf_cmd = { .action = GF_EXIT_GAME },
         };
     } else {
         Fader_Control(&p->exit_fader);
 
-        const GAME_FLOW_DIR dir = Game_Control(num_frames, true);
-        if (dir != (GAME_FLOW_DIR)-1) {
+        const GAME_FLOW_COMMAND gf_cmd = Game_Control(num_frames, true);
+        if (gf_cmd.action != GF_NOOP) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
-                .dir = dir,
+                .gf_cmd = gf_cmd,
             };
         }
     }

--- a/src/tr2/game/phase/phase_game.c
+++ b/src/tr2/game/phase/phase_game.c
@@ -47,7 +47,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
         g_CurrentLevel = 0;
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
-            .dir = GFD_EXIT_GAME,
+            .gf_cmd = { .action = GF_EXIT_GAME },
         };
     }
 
@@ -76,19 +76,22 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
 {
     M_PRIV *const p = phase->priv;
 
-    GAME_FLOW_DIR dir;
+    GAME_FLOW_COMMAND gf_cmd;
     if (g_IsGameToExit && !p->exiting) {
         p->exiting = true;
         Fader_InitAnyToBlack(&p->exit_fader, FRAMES_PER_SECOND / 3);
     } else if (p->exiting && !Fader_IsActive(&p->exit_fader)) {
-        dir = GFD_EXIT_GAME;
+        gf_cmd = (GAME_FLOW_COMMAND) { .action = GF_EXIT_GAME };
     } else {
         Fader_Control(&p->exit_fader);
-        dir = Game_Control(num_frames, false);
+        gf_cmd = Game_Control(num_frames, false);
     }
 
-    if (dir != (GAME_FLOW_DIR)-1) {
-        return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .dir = dir };
+    if (gf_cmd.action != GF_NOOP) {
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END,
+            .gf_cmd = gf_cmd,
+        };
     }
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }

--- a/src/tr2/game/phase/phase_picture.c
+++ b/src/tr2/game/phase/phase_picture.c
@@ -78,7 +78,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
             || !Fader_Control(&p->fader)) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
-                .dir = (GAME_FLOW_DIR)-1,
+                .gf_cmd = { .action = GF_NOOP },
             };
         }
     }

--- a/src/tr2/game/phase/phase_stats.c
+++ b/src/tr2/game/phase/phase_stats.c
@@ -89,7 +89,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
             || !Fader_Control(&p->fader)) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,
-                .dir = (GAME_FLOW_DIR)-1,
+                .gf_cmd = { .action = GF_NOOP },
             };
         }
     }

--- a/src/tr2/game/phase/priv.h
+++ b/src/tr2/game/phase/priv.h
@@ -10,7 +10,7 @@ typedef enum {
 
 typedef struct {
     PHASE_ACTION action;
-    GAME_FLOW_DIR dir;
+    GAME_FLOW_COMMAND gf_cmd;
 } PHASE_CONTROL;
 
 typedef PHASE_CONTROL (*PHASE_START_FUNC)(PHASE *phase);

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -430,20 +430,6 @@ typedef enum {
     TRAP_FINISHED = 3,
 } TRAP_ANIM;
 
-typedef enum {
-    GFD_START_GAME       = 0x0000,
-    GFD_START_SAVED_GAME = 0x0100,
-    GFD_START_CINE       = 0x0200,
-    GFD_START_FMV        = 0x0300,
-    GFD_START_DEMO       = 0x0400,
-    GFD_EXIT_TO_TITLE    = 0x0500,
-    GFD_LEVEL_COMPLETE   = 0x0600,
-    GFD_EXIT_GAME        = 0x0700,
-    GFD_EXIT_TO_OPTION   = 0x0800,
-    GFD_TITLE_DESELECT   = 0x0900,
-    GFD_OVERRIDE         = 0x0A00,
-} GAME_FLOW_DIR;
-
 typedef struct {
     int32_t first_option;
     int32_t title_replace;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -8,7 +8,7 @@
 const char *g_TR2XVersion = "TR2X (non-Docker build)";
 #endif
 
-GAME_FLOW_DIR g_GF_OverrideDir = (GAME_FLOW_DIR)-1;
+GAME_FLOW_COMMAND g_GF_OverrideCommand = { .action = GF_NOOP };
 
 int16_t g_RoomsToDraw[MAX_ROOMS_TO_DRAW] = { 0 };
 int16_t g_RoomsToDrawCount = 0;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -7,7 +7,7 @@
 #include <SDL2/SDL.h>
 
 extern const char *g_TR2XVersion;
-extern GAME_FLOW_DIR g_GF_OverrideDir;
+extern GAME_FLOW_COMMAND g_GF_OverrideCommand;
 
 extern int16_t g_RoomsToDraw[MAX_ROOMS_TO_DRAW];
 extern int16_t g_RoomsToDrawCount;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Switches from using the `uint16_t`-based `GAME_FLOW_DIR` to the TR1X `GAME_FLOW_COMMAND` structure. This structure supports an arbitrary `int32_t` parameter and includes a `GAME_FLOW_ACTION`, which is a basic enum rather than part of a bitmask. It simplifies the state management, and reduces differences between game flow TR1 and TR2 code.

Impacted areas deal with in-game transitions (title screen, saving/loading, cutscene start/end, stats, etc.).