### PR TITLE
tr1/lara/control: fix testing triggers too early

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)
 - fixed the game hanging when Lara is on fire and enters the fly cheat on the same frame as reaching water (#2116, regression from 0.8)
+- fixed Lara activating triggers one frame too early (#2208, regression from 4.3)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21
 - changed the inventory examine UI to auto-hide if the item description is empty (#2097)

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -33,7 +33,6 @@ static int16_t M_GetFloorTiltHeight(
 static int16_t M_GetCeilingTiltHeight(
     const SECTOR *sector, const int32_t x, const int32_t z);
 static SECTOR *M_GetSkySector(const SECTOR *sector, int32_t x, int32_t z);
-static void M_TestSectorTrigger(const ITEM *item, const SECTOR *sector);
 static bool M_TestLava(const ITEM *const item);
 
 static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
@@ -641,7 +640,7 @@ void Room_TestTriggers(const ITEM *const item)
     const SECTOR *sector =
         Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
 
-    M_TestSectorTrigger(item, sector);
+    Room_TestSectorTrigger(item, sector);
     if (item->object_id != O_TORSO) {
         return;
     }
@@ -656,7 +655,7 @@ void Room_TestTriggers(const ITEM *const item)
             sector = Room_GetSector(
                 item->pos.x + dx * WALL_L, MAX_HEIGHT,
                 item->pos.z + dz * WALL_L, &room_num);
-            M_TestSectorTrigger(item, sector);
+            Room_TestSectorTrigger(item, sector);
         }
     }
 }
@@ -676,8 +675,7 @@ static bool M_TestLava(const ITEM *const item)
     return sector->is_death_sector;
 }
 
-static void M_TestSectorTrigger(
-    const ITEM *const item, const SECTOR *const sector)
+void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 {
     const bool is_heavy = item->object_id != O_LARA;
     if (!is_heavy && sector->is_death_sector && M_TestLava(item)) {

--- a/src/tr1/game/room.h
+++ b/src/tr1/game/room.h
@@ -29,5 +29,6 @@ BOUNDS_32 Room_GetWorldBounds(void);
 void Room_AlterFloorHeight(ITEM *item, int32_t height);
 
 void Room_TestTriggers(const ITEM *item);
+void Room_TestSectorTrigger(const ITEM *item, const SECTOR *sector);
 bool Room_IsOnWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);


### PR DESCRIPTION
Resolves #2208.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara activating triggers one frame too early, and is identical to #2212.

Test level for ease:
[level1.zip](https://github.com/user-attachments/files/18306365/level1.zip)

