### PR TITLE
libtrx/anims/common: move ANIM_BONEs to TRX

### DIFF
--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -1,0 +1,15 @@
+#include "game/anims/common.h"
+
+#include "game/gamebuf.h"
+
+static ANIM_BONE *m_Bones = NULL;
+
+void Anim_InitialiseBones(const int32_t num_bones)
+{
+    m_Bones = GameBuf_Alloc(sizeof(ANIM_BONE) * num_bones, GBUF_ANIM_BONES);
+}
+
+ANIM_BONE *Anim_GetBone(const int32_t bone_idx)
+{
+    return &m_Bones[bone_idx];
+}

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -219,7 +219,12 @@ void Level_ReadAnimBones(
 {
     for (int32_t i = 0; i < num_bones; i++) {
         ANIM_BONE *const bone = Anim_GetBone(base_idx + i);
-        bone->flags = VFile_ReadS32(file);
+        const int32_t flags = VFile_ReadS32(file);
+        bone->matrix_pop = (flags & 1) != 0;
+        bone->matrix_push = (flags & 2) != 0;
+        bone->rot_x = false;
+        bone->rot_y = false;
+        bone->rot_z = false;
         bone->pos.x = VFile_ReadS32(file);
         bone->pos.y = VFile_ReadS32(file);
         bone->pos.z = VFile_ReadS32(file);

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -1,6 +1,7 @@
 #include "game/level/common.h"
 
 #include "debug.h"
+#include "game/anims.h"
 #include "game/gamebuf.h"
 #include "game/inject.h"
 #include "game/objects/common.h"
@@ -211,4 +212,16 @@ void Level_ReadObjectMeshes(
     LOG_INFO("%d unique meshes constructed", unique_indices->count);
 
     Vector_Free(unique_indices);
+}
+
+void Level_ReadAnimBones(
+    const int32_t base_idx, const int32_t num_bones, VFILE *const file)
+{
+    for (int32_t i = 0; i < num_bones; i++) {
+        ANIM_BONE *const bone = Anim_GetBone(base_idx + i);
+        bone->flags = VFile_ReadS32(file);
+        bone->pos.x = VFile_ReadS32(file);
+        bone->pos.y = VFile_ReadS32(file);
+        bone->pos.z = VFile_ReadS32(file);
+    }
 }

--- a/src/libtrx/game/objects/common.c
+++ b/src/libtrx/game/objects/common.c
@@ -1,5 +1,6 @@
 #include "game/objects/common.h"
 
+#include "game/anims.h"
 #include "game/gamebuf.h"
 
 static OBJECT_MESH **m_MeshPointers = NULL;
@@ -95,4 +96,9 @@ void Object_SwapMesh(
     m_MeshPointers[obj1->mesh_idx + mesh_num] =
         m_MeshPointers[obj2->mesh_idx + mesh_num];
     m_MeshPointers[obj2->mesh_idx + mesh_num] = temp;
+}
+
+ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
+{
+    return Anim_GetBone(object->bone_idx + bone_idx);
 }

--- a/src/libtrx/include/libtrx/game/anims.h
+++ b/src/libtrx/include/libtrx/game/anims.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "anims/common.h"
 #include "anims/enum.h"
 #include "anims/types.h"
 #include "anims/util.h"

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "./types.h"
+
+void Anim_InitialiseBones(int32_t num_bones);
+
+ANIM_BONE *Anim_GetBone(int32_t bone_idx);

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -16,19 +16,11 @@ typedef struct __PACKING {
 } ANIM_RANGE;
 
 typedef struct {
-    union {
-        int32_t flags;
-        // clang-format off
-        struct {
-            uint32_t matrix_pop:  1;
-            uint32_t matrix_push: 1;
-            uint32_t rot_x:       1;
-            uint32_t rot_y:       1;
-            uint32_t rot_z:       1;
-            uint32_t pad:         11;
-        };
-        // clang-format on
-    };
+    bool matrix_pop;
+    bool matrix_push;
+    bool rot_x;
+    bool rot_y;
+    bool rot_z;
     XYZ_32 pos;
 } ANIM_BONE;
 

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -2,6 +2,9 @@
 
 #include "../../virtual_file.h"
 
+#define ANIM_BONE_SIZE 4
+
 void Level_ReadRoomMesh(int32_t room_num, VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
+void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -34,6 +34,6 @@ OBJECT_MESH *Object_GetMesh(int32_t index);
 void Object_SwapMesh(
     GAME_OBJECT_ID object1_id, GAME_OBJECT_ID object2_id, int32_t mesh_num);
 
-extern ANIM_BONE *Object_GetBone(const OBJECT *object, int32_t bone_idx);
+ANIM_BONE *Object_GetBone(const OBJECT *object, int32_t bone_idx);
 
 extern void Object_DrawMesh(int32_t mesh_idx, int32_t clip, bool interpolated);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -34,4 +34,6 @@ OBJECT_MESH *Object_GetMesh(int32_t index);
 void Object_SwapMesh(
     GAME_OBJECT_ID object1_id, GAME_OBJECT_ID object2_id, int32_t mesh_num);
 
+extern ANIM_BONE *Object_GetBone(const OBJECT *object, int32_t bone_idx);
+
 extern void Object_DrawMesh(int32_t mesh_idx, int32_t clip, bool interpolated);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -70,6 +70,7 @@ sources = [
   'enum_map.c',
   'event_manager.c',
   'filesystem.c',
+  'game/anims/common.c',
   'game/clock/common.c',
   'game/clock/timer.c',
   'game/clock/turbo.c',

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -527,9 +527,9 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
     ptr++;
     Matrix_Pop();
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     const int16_t *extra_rotation = (int16_t *)item->data;
     for (int32_t i = 1; i < object->nmeshes; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }
@@ -562,7 +562,6 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
         Matrix_Pop();
 
         ptr++;
-        bone++;
     }
 
     Matrix_Pop();
@@ -618,10 +617,9 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
     int32_t *packed_rotation = frame->mesh_rots;
     Matrix_RotYXZpack(*packed_rotation++);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
-
     int16_t *extra_rotation = (int16_t *)item->data;
     for (int i = 0; i < joint; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }
@@ -641,8 +639,6 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
         if (bone->rot_z) {
             Matrix_RotZ(*extra_rotation++);
         }
-
-        bone++;
     }
 
     Matrix_TranslateRel(vec->x, vec->y, vec->z);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -260,7 +260,7 @@ static void M_LoadFromFile(INJECTION *injection, const char *filename)
     info->anim_change_count = VFile_ReadS32(fp);
     info->anim_range_count = VFile_ReadS32(fp);
     info->anim_cmd_count = VFile_ReadS32(fp);
-    info->anim_bone_count = VFile_ReadS32(fp);
+    info->anim_bone_count = VFile_ReadS32(fp) / ANIM_BONE_SIZE;
     info->anim_frame_data_count = VFile_ReadS32(fp);
     info->anim_count = VFile_ReadS32(fp);
     info->object_count = VFile_ReadS32(fp);
@@ -351,7 +351,7 @@ static void M_LoadFromFile(INJECTION *injection, const char *filename)
         VFile_Skip(fp, info->anim_change_count * 6);
         VFile_Skip(fp, info->anim_range_count * 8);
         VFile_Skip(fp, info->anim_cmd_count * 2);
-        VFile_Skip(fp, info->anim_bone_count * 4);
+        VFile_Skip(fp, info->anim_bone_count * 4 * ANIM_BONE_SIZE);
 
         info->anim_frame_count = 0;
         info->anim_frame_mesh_rot_count = 0;
@@ -554,9 +554,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     VFile_Read(
         fp, g_AnimCommands + level_info->anim_command_count,
         sizeof(int16_t) * inj_info->anim_cmd_count);
-    VFile_Read(
-        fp, g_AnimBones + level_info->anim_bone_count,
-        sizeof(int32_t) * inj_info->anim_bone_count);
+    Level_ReadAnimBones(
+        level_info->anim_bone_count, inj_info->anim_bone_count, fp);
     const size_t frame_data_start = VFile_GetPos(fp);
     VFile_Skip(fp, inj_info->anim_frame_data_count * sizeof(int16_t));
     const size_t frame_data_end = VFile_GetPos(fp);
@@ -717,7 +716,7 @@ static void M_ObjectData(
 
         const int16_t num_meshes = VFile_ReadS16(fp);
         const int16_t mesh_idx = VFile_ReadS16(fp);
-        const int32_t bone_idx = VFile_ReadS32(fp);
+        const int32_t bone_idx = VFile_ReadS32(fp) / ANIM_BONE_SIZE;
 
         // When mesh data has been omitted from the injection, this indicates
         // that we wish to retain what's already defined so to avoid duplicate

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -867,7 +867,6 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     int32_t *packed_rotation = frame->mesh_rots;
     Matrix_RotYXZpack(*packed_rotation++);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
 #if 0
     // XXX: present in OG, removed by GLrage on the grounds that it sometimes
     // crashes.
@@ -899,6 +898,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     }
 
     for (int i = 1; i < obj->nmeshes; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }
@@ -946,8 +946,6 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
             }
             item->mesh_bits -= bit;
         }
-
-        bone++;
     }
 
     Matrix_Pop();

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -98,7 +98,7 @@ void Lara_Draw(ITEM *item)
 
     Output_CalculateObjectLighting(item, &frame->bounds);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    const ANIM_BONE *const bone = Object_GetBone(object, 0);
     int32_t *packed_rotation = frame->mesh_rots;
 
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
@@ -370,7 +370,7 @@ void Lara_Draw_I(
 
     Output_CalculateObjectLighting(item, &frame1->bounds);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    const ANIM_BONE *const bone = Object_GetBone(object, 0);
     int32_t *packed_rotation1 = frame1->mesh_rots;
     int32_t *packed_rotation2 = frame2->mesh_rots;
 

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -58,12 +58,12 @@ void Lara_Hair_Initialise(void)
     Lara_Hair_SetLaraType(O_LARA);
 
     const OBJECT *const object = Object_GetObject(O_HAIR);
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     m_Hair[0].rot.y = 0;
     m_Hair[0].rot.x = -PHD_90;
 
-    for (int32_t i = 1; i < HAIR_SEGMENTS + 1; i++, bone++) {
+    for (int32_t i = 1; i < HAIR_SEGMENTS + 1; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         m_Hair[i].pos = bone->pos;
         m_Hair[i].rot.x = -PHD_90;
         m_Hair[i].rot.y = 0;
@@ -143,7 +143,7 @@ void Lara_Hair_Control(void)
         g_LaraItem->pos.x, g_LaraItem->pos.y, g_LaraItem->pos.z);
     Matrix_RotYXZ(g_LaraItem->rot.y, g_LaraItem->rot.x, g_LaraItem->rot.z);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    const ANIM_BONE *bone = Object_GetBone(object, 0);
     if (frac) {
         Matrix_InitInterpolate(frac, rate);
         int32_t *packed_rotation1 = frmptr[0]->mesh_rots;
@@ -323,19 +323,21 @@ void Lara_Hair_Control(void)
     pos.z = g_MatrixPtr->_23 >> W2V_SHIFT;
     Matrix_Pop();
 
-    bone = (ANIM_BONE *)&g_AnimBones[Object_GetObject(O_HAIR)->bone_idx];
+    const OBJECT *const hair_object = Object_GetObject(O_HAIR);
 
     m_Hair[0].pos = pos;
 
     if (m_FirstHair) {
         m_FirstHair = false;
 
-        for (i = 0; i < HAIR_SEGMENTS; i++, bone++) {
+        for (i = 0; i < HAIR_SEGMENTS; i++) {
+            const ANIM_BONE *const hair_bone = Object_GetBone(hair_object, i);
             Matrix_PushUnit();
             Matrix_TranslateSet(
                 m_Hair[i].pos.x, m_Hair[i].pos.y, m_Hair[i].pos.z);
             Matrix_RotYXZ(m_Hair[i].rot.y, m_Hair[i].rot.x, 0);
-            Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
+            Matrix_TranslateRel(
+                hair_bone->pos.x, hair_bone->pos.y, hair_bone->pos.z);
 
             m_Hair[i + 1].pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;
             m_Hair[i + 1].pos.y = g_MatrixPtr->_13 >> W2V_SHIFT;
@@ -358,7 +360,9 @@ void Lara_Hair_Control(void)
             water_level = Room_GetWaterHeight(x, y, z, room_num);
         }
 
-        for (i = 1; i < HAIR_SEGMENTS + 1; i++, bone++) {
+        for (i = 1; i < HAIR_SEGMENTS + 1; i++) {
+            const ANIM_BONE *const hair_bone =
+                Object_GetBone(hair_object, i - 1);
             m_HVel[0] = m_Hair[i].pos;
 
             sector = Room_GetSector(
@@ -430,11 +434,12 @@ void Lara_Hair_Control(void)
             Matrix_RotYXZ(m_Hair[i - 1].rot.y, m_Hair[i - 1].rot.x, 0);
 
             if (i == HAIR_SEGMENTS) {
-                const ANIM_BONE *const last_bone = bone - 1;
+                const ANIM_BONE *const last_bone = hair_bone - 1;
                 Matrix_TranslateRel(
                     last_bone->pos.x, last_bone->pos.y, last_bone->pos.z);
             } else {
-                Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
+                Matrix_TranslateRel(
+                    hair_bone->pos.x, hair_bone->pos.y, hair_bone->pos.z);
             }
 
             m_Hair[i].pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -375,17 +375,14 @@ static void M_LoadAnimCommands(VFILE *file)
     Benchmark_End(benchmark, NULL);
 }
 
-static void M_LoadAnimBones(VFILE *file)
+static void M_LoadAnimBones(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_bone_count = VFile_ReadS32(file);
+    m_LevelInfo.anim_bone_count = VFile_ReadS32(file) / ANIM_BONE_SIZE;
     LOG_INFO("%d anim bones", m_LevelInfo.anim_bone_count);
-    g_AnimBones = GameBuf_Alloc(
-        sizeof(int32_t)
-            * (m_LevelInfo.anim_bone_count + m_InjectionInfo->anim_bone_count),
-        GBUF_ANIM_BONES);
-    VFile_Read(
-        file, g_AnimBones, sizeof(int32_t) * m_LevelInfo.anim_bone_count);
+    Anim_InitialiseBones(
+        m_LevelInfo.anim_bone_count + m_InjectionInfo->anim_bone_count);
+    Level_ReadAnimBones(0, m_LevelInfo.anim_bone_count, file);
     Benchmark_End(benchmark, NULL);
 }
 
@@ -478,7 +475,7 @@ static void M_LoadObjects(VFILE *file)
 
         object->nmeshes = VFile_ReadS16(file);
         object->mesh_idx = VFile_ReadS16(file);
-        object->bone_idx = VFile_ReadS32(file);
+        object->bone_idx = VFile_ReadS32(file) / ANIM_BONE_SIZE;
 
         const int32_t frame_offset = VFile_ReadS32(file);
         object->anim_idx = VFile_ReadS16(file);

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -431,8 +431,3 @@ void Object_DrawMesh(
         Output_DrawObjectMesh(mesh, clip);
     }
 }
-
-ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
-{
-    return (ANIM_BONE *)&g_AnimBones[object->bone_idx + bone_idx * 4];
-}

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -436,3 +436,8 @@ void Object_DrawMesh(
         Output_DrawObjectMesh(mesh, clip);
     }
 }
+
+ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
+{
+    return (ANIM_BONE *)&g_AnimBones[object->bone_idx + bone_idx * 4];
+}

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -197,7 +197,6 @@ void Object_DrawPickupItem(ITEM *item)
         // of the code in DrawAnimatingItem starting with the line that
         // matches the following line.
         int32_t bit = 1;
-        const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
@@ -209,6 +208,7 @@ void Object_DrawPickupItem(ITEM *item)
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
+            const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -226,8 +226,6 @@ void Object_DrawPickupItem(ITEM *item)
             if (item->mesh_bits & bit) {
                 Object_DrawMesh(object->mesh_idx + i, clip, false);
             }
-
-            bone++;
         }
     }
 
@@ -247,7 +245,6 @@ void Object_DrawInterpolatedObject(
 
     Matrix_Push();
     int32_t mesh_num = 1;
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     ASSERT(rate != 0);
     if (!frac) {
@@ -262,6 +259,7 @@ void Object_DrawInterpolatedObject(
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
+            const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -289,8 +287,6 @@ void Object_DrawInterpolatedObject(
             if (meshes & mesh_num) {
                 Object_DrawMesh(object->mesh_idx + i, clip, false);
             }
-
-            bone++;
         }
     } else {
         ASSERT(frame2 != NULL);
@@ -307,6 +303,7 @@ void Object_DrawInterpolatedObject(
         }
 
         for (int i = 1; i < object->nmeshes; i++) {
+            const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop_I();
             }
@@ -334,8 +331,6 @@ void Object_DrawInterpolatedObject(
             if (meshes & mesh_num) {
                 Object_DrawMesh(object->mesh_idx + i, clip, true);
             }
-
-            bone++;
         }
     }
 

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -127,7 +127,7 @@ void Ape_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 13)->rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = true;
 }
 
 void Ape_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -127,8 +127,7 @@ void Ape_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[13].rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = 1;
 }
 
 void Ape_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -47,8 +47,7 @@ void Baldy_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 }
 
 void Baldy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -47,7 +47,7 @@ void Baldy_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 }
 
 void Baldy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/bear.c
+++ b/src/tr1/game/objects/creatures/bear.c
@@ -70,8 +70,7 @@ void Bear_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[13].rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = 1;
 }
 
 void Bear_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/bear.c
+++ b/src/tr1/game/objects/creatures/bear.c
@@ -70,7 +70,7 @@ void Bear_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 13)->rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = true;
 }
 
 void Bear_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -56,8 +56,8 @@ void Centaur_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 10)->rot_x = 1;
-    Object_GetBone(obj, 10)->rot_y = 1;
+    Object_GetBone(obj, 10)->rot_x = true;
+    Object_GetBone(obj, 10)->rot_y = true;
 }
 
 void Centaur_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -56,9 +56,8 @@ void Centaur_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[10].rot_x = 1;
-    bone[10].rot_y = 1;
+    Object_GetBone(obj, 10)->rot_x = 1;
+    Object_GetBone(obj, 10)->rot_y = 1;
 }
 
 void Centaur_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -50,8 +50,7 @@ void Cowboy_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 }
 
 void Cowboy_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -50,7 +50,7 @@ void Cowboy_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 }
 
 void Cowboy_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -82,7 +82,7 @@ void Croc_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 7)->rot_y = 1;
+    Object_GetBone(obj, 7)->rot_y = true;
 }
 
 void Croc_Control(int16_t item_num)
@@ -221,7 +221,7 @@ void Alligator_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 7)->rot_y = 1;
+    Object_GetBone(obj, 7)->rot_y = true;
 }
 
 void Alligator_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -82,8 +82,7 @@ void Croc_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[7].rot_y = 1;
+    Object_GetBone(obj, 7)->rot_y = 1;
 }
 
 void Croc_Control(int16_t item_num)
@@ -222,8 +221,7 @@ void Alligator_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[7].rot_y = 1;
+    Object_GetBone(obj, 7)->rot_y = 1;
 }
 
 void Alligator_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -50,7 +50,7 @@ void Larson_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
 }
 
 void Larson_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -50,8 +50,7 @@ void Larson_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
 }
 
 void Larson_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -58,8 +58,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[19].rot_y = 1;
+    Object_GetBone(obj, 19)->rot_y = 1;
 }
 
 void Lion_SetupLion(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -58,7 +58,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 19)->rot_y = 1;
+    Object_GetBone(obj, 19)->rot_y = true;
 }
 
 void Lion_SetupLion(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -32,8 +32,7 @@ void Mummy_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[2].rot_y = 1;
+    Object_GetBone(obj, 2)->rot_y = 1;
 }
 
 void Mummy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -32,7 +32,7 @@ void Mummy_Setup(OBJECT *obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 2)->rot_y = 1;
+    Object_GetBone(obj, 2)->rot_y = true;
 }
 
 void Mummy_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -83,9 +83,8 @@ void Mutant_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
-    bone[2].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 2)->rot_y = 1;
 }
 
 void Mutant_Setup2(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -83,8 +83,8 @@ void Mutant_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
-    Object_GetBone(obj, 2)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 2)->rot_y = true;
 }
 
 void Mutant_Setup2(OBJECT *obj)

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -62,8 +62,8 @@ void Natla_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 2)->rot_x = 1;
-    Object_GetBone(obj, 2)->rot_z = 1;
+    Object_GetBone(obj, 2)->rot_x = true;
+    Object_GetBone(obj, 2)->rot_z = true;
 }
 
 void Natla_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -62,9 +62,8 @@ void Natla_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[2].rot_x = 1;
-    bone[2].rot_z = 1;
+    Object_GetBone(obj, 2)->rot_x = 1;
+    Object_GetBone(obj, 2)->rot_z = 1;
 }
 
 void Natla_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -58,7 +58,7 @@ void Pierre_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
 }
 
 void Pierre_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -58,8 +58,7 @@ void Pierre_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
 }
 
 void Pierre_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -59,7 +59,7 @@ void Raptor_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 21)->rot_y = 1;
+    Object_GetBone(obj, 21)->rot_y = true;
 }
 
 void Raptor_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -59,8 +59,7 @@ void Raptor_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[21].rot_y = 1;
+    Object_GetBone(obj, 21)->rot_y = 1;
 }
 
 void Raptor_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -76,8 +76,7 @@ void Rat_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[1].rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = 1;
 }
 
 void Rat_Control(int16_t item_num)
@@ -188,8 +187,7 @@ void Vole_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[1].rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = 1;
 }
 
 void Vole_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -76,7 +76,7 @@ void Rat_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 1)->rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = true;
 }
 
 void Rat_Control(int16_t item_num)
@@ -187,7 +187,7 @@ void Vole_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 1)->rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = true;
 }
 
 void Vole_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -58,8 +58,7 @@ void SkateKid_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 
     if (!g_Objects[O_SKATEBOARD].loaded) {
         LOG_WARNING(

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -58,7 +58,7 @@ void SkateKid_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 
     if (!g_Objects[O_SKATEBOARD].loaded) {
         LOG_WARNING(

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -68,7 +68,7 @@ void Torso_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 1)->rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = true;
 }
 
 void Torso_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -68,8 +68,7 @@ void Torso_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[1].rot_y = 1;
+    Object_GetBone(obj, 1)->rot_y = 1;
 }
 
 void Torso_Control(int16_t item_num)

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -59,9 +59,8 @@ void TRex_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[10].rot_y = 1;
-    bone[11].rot_y = 1;
+    Object_GetBone(obj, 10)->rot_y = 1;
+    Object_GetBone(obj, 11)->rot_y = 1;
 }
 
 void TRex_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -59,8 +59,8 @@ void TRex_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 10)->rot_y = 1;
-    Object_GetBone(obj, 11)->rot_y = 1;
+    Object_GetBone(obj, 10)->rot_y = true;
+    Object_GetBone(obj, 11)->rot_y = true;
 }
 
 void TRex_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)

--- a/src/tr1/game/objects/creatures/wolf.c
+++ b/src/tr1/game/objects/creatures/wolf.c
@@ -66,7 +66,7 @@ void Wolf_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 2)->rot_y = 1;
+    Object_GetBone(obj, 2)->rot_y = true;
 }
 
 void Wolf_Initialise(int16_t item_num)

--- a/src/tr1/game/objects/creatures/wolf.c
+++ b/src/tr1/game/objects/creatures/wolf.c
@@ -66,8 +66,7 @@ void Wolf_Setup(OBJECT *obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[2].rot_y = 1;
+    Object_GetBone(obj, 2)->rot_y = 1;
 }
 
 void Wolf_Initialise(int16_t item_num)

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -398,13 +398,13 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         -(frame->bounds.min.x + frame->bounds.max.x) / 2,
         -(frame->bounds.min.y + frame->bounds.max.y) / 2,
         -(frame->bounds.min.z + frame->bounds.max.z) / 2);
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     int32_t *packed_rotation = frame->mesh_rots;
     Matrix_RotYXZpack(*packed_rotation++);
 
     Object_DrawMesh(obj->mesh_idx, 0, false);
 
     for (int i = 1; i < obj->nmeshes; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }
@@ -417,8 +417,6 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         Matrix_RotYXZpack(*packed_rotation++);
 
         Object_DrawMesh(obj->mesh_idx + i, 0, false);
-
-        bone++;
     }
     Matrix_Pop();
 

--- a/src/tr1/game/phase/phase_inventory.c
+++ b/src/tr1/game/phase/phase_inventory.c
@@ -567,7 +567,7 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
     const int32_t frac = InvItem_GetFrames(inv_item, &frame1, &frame2, &rate);
     if (inv_item->object_id == O_MAP_OPTION) {
         const int16_t extra_rotation[1] = { Option_Compass_GetNeedleAngle() };
-        Object_GetBone(obj, 0)->rot_y = 1;
+        Object_GetBone(obj, 0)->rot_y = true;
         Object_DrawInterpolatedObject(
             obj, inv_item->drawn_meshes, extra_rotation, frame1, frame2, frac,
             rate);

--- a/src/tr1/game/phase/phase_inventory.c
+++ b/src/tr1/game/phase/phase_inventory.c
@@ -567,8 +567,7 @@ static void Inv_DrawItem(INVENTORY_ITEM *const inv_item, const int32_t frames)
     const int32_t frac = InvItem_GetFrames(inv_item, &frame1, &frame2, &rate);
     if (inv_item->object_id == O_MAP_OPTION) {
         const int16_t extra_rotation[1] = { Option_Compass_GetNeedleAngle() };
-        ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-        bone[0].rot_y = 1;
+        Object_GetBone(obj, 0)->rot_y = 1;
         Object_DrawInterpolatedObject(
             obj, inv_item->drawn_meshes, extra_rotation, frame1, frame2, frac,
             rate);

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -55,7 +55,6 @@ ANIM_CHANGE *g_AnimChanges = NULL;
 ANIM_RANGE *g_AnimRanges = NULL;
 TEXTURE_RANGE *g_AnimTextureRanges = NULL;
 int16_t *g_AnimCommands = NULL;
-int32_t *g_AnimBones = NULL;
 ANIM_FRAME *g_AnimFrames = NULL;
 int32_t *g_AnimFrameMeshRots = NULL;
 int16_t g_NumCineFrames = 0;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -63,7 +63,6 @@ extern ANIM_CHANGE *g_AnimChanges;
 extern ANIM_RANGE *g_AnimRanges;
 extern TEXTURE_RANGE *g_AnimTextureRanges;
 extern int16_t *g_AnimCommands;
-extern int32_t *g_AnimBones;
 extern ANIM_FRAME *g_AnimFrames;
 extern int32_t *g_AnimFrameMeshRots;
 extern int16_t g_NumCineFrames;

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -987,7 +987,6 @@ void Skidoo_Draw(const ITEM *const item)
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     if (frac) {
         const int16_t *mesh_rots_1 = frames[0]->mesh_rots;
         const int16_t *mesh_rots_2 = frames[1]->mesh_rots;
@@ -1000,6 +999,7 @@ void Skidoo_Draw(const ITEM *const item)
 
         Output_InsertPolygons_I(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
+            const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop_I();
             }
@@ -1009,7 +1009,6 @@ void Skidoo_Draw(const ITEM *const item)
 
             Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
-            bone++;
 
             Output_InsertPolygons_I(mesh_ptrs[mesh_idx], clip);
         }
@@ -1021,6 +1020,7 @@ void Skidoo_Draw(const ITEM *const item)
 
         Output_InsertPolygons(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
+            const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -1030,7 +1030,6 @@ void Skidoo_Draw(const ITEM *const item)
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             Matrix_RotYXZsuperpack(&mesh_rots, 0);
-            bone++;
 
             Output_InsertPolygons(mesh_ptrs[mesh_idx], clip);
         }

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -524,9 +524,9 @@ int32_t Collide_GetSpheres(
     spheres[0].r = mesh[3];
     Matrix_Pop();
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     const int16_t *extra_rotation = (int16_t *)item->data;
-    for (int32_t i = 1; i < object->mesh_count; i++, bone++) {
+    for (int32_t i = 1; i < object->mesh_count; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }
@@ -579,8 +579,8 @@ void Collide_GetJointAbsPosition(
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     const int16_t *extra_rotation = item->data;
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
-    for (int32_t i = 0; i < joint; i++, bone++) {
+    for (int32_t i = 0; i < joint; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -115,7 +115,6 @@ static void M_DrawItem(
         return;
     }
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
     const int16_t *rot = frame_ptr->mesh_rots;
@@ -123,6 +122,7 @@ static void M_DrawItem(
 
     for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
         if (mesh_idx > 0) {
+            const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -149,8 +149,6 @@ static void M_DrawItem(
                     Matrix_RotZ(hours);
                 }
             }
-
-            bone++;
         }
 
         if (inv_item->meshes_drawn & (1 << mesh_idx)) {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -801,9 +801,9 @@ int32_t Item_Explode(
     }
 
     // additional meshes
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     const int16_t *extra_rotation = (int16_t *)item->data;
-    for (int32_t i = 1; i < object->mesh_count; i++, bone++) {
+    for (int32_t i = 1; i < object->mesh_count; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -91,7 +91,7 @@ void Lara_Draw(const ITEM *const item)
     Matrix_Push();
     Output_CalculateObjectLighting(item, &frame->bounds);
 
-    const ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    const ANIM_BONE *const bone = Object_GetBone(object, 0);
     const int16_t *mesh_rots = frame->mesh_rots;
     const int16_t *mesh_rots_c;
 
@@ -143,7 +143,7 @@ void Lara_Draw(const ITEM *const item)
     if (g_Lara.back_gun) {
         Matrix_Push();
         const ANIM_BONE *const bone_c =
-            (ANIM_BONE *)&g_AnimBones[g_Objects[g_Lara.back_gun].bone_idx];
+            Object_GetBone(&g_Objects[g_Lara.back_gun], 0);
         Matrix_TranslateRel(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
         mesh_rots_c = g_Objects[g_Lara.back_gun].frame_base + FBBOX_ROT;
@@ -338,7 +338,7 @@ void Lara_Draw_I(
     Matrix_Push();
     Output_CalculateObjectLighting(item, &frame1->bounds);
 
-    const ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
+    const ANIM_BONE *const bone = Object_GetBone(object, 0);
     const int16_t *mesh_rots_1 = frame1->mesh_rots;
     const int16_t *mesh_rots_2 = frame2->mesh_rots;
     const int16_t *mesh_rots_1_c;
@@ -397,7 +397,7 @@ void Lara_Draw_I(
     if (g_Lara.back_gun) {
         Matrix_Push_I();
         const ANIM_BONE *const bone_c =
-            (ANIM_BONE *)&g_AnimBones[g_Objects[g_Lara.back_gun].bone_idx];
+            Object_GetBone(&g_Objects[g_Lara.back_gun], 0);
         Matrix_TranslateRel_I(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
         mesh_rots_1_c = g_Objects[g_Lara.back_gun].frame_base + FBBOX_ROT;

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -43,8 +43,7 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     m_HairSpheres[0].r = mesh[3];
     Matrix_Pop();
 
-    const ANIM_BONE *bone =
-        (ANIM_BONE *)&g_AnimBones[g_Objects[O_LARA].bone_idx];
+    const ANIM_BONE *bone = Object_GetBone(&g_Objects[O_LARA], 0);
     Matrix_TranslateRel(
         bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
         bone[LM_TORSO - 1].pos.z);
@@ -137,8 +136,7 @@ static void M_CalculateSpheres_I(
     m_HairSpheres[0].r = mesh[3];
     Matrix_Pop_I();
 
-    const ANIM_BONE *bone =
-        (ANIM_BONE *)&g_AnimBones[g_Objects[O_LARA].bone_idx];
+    const ANIM_BONE *bone = Object_GetBone(&g_Objects[O_LARA], 0);
     Matrix_TranslateRel_I(
         bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
         bone[LM_TORSO - 1].pos.z);
@@ -220,11 +218,11 @@ static void M_CalculateSpheres_I(
 void Lara_Hair_Initialise(void)
 {
     const OBJECT *const object = Object_GetObject(O_LARA_HAIR);
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
     m_IsFirstHair = true;
     m_HairSegments[0].rot.x = -PHD_90;
     m_HairSegments[0].rot.y = 0;
-    for (int32_t i = 0; i < HAIR_SEGMENTS; i++, bone++) {
+    for (int32_t i = 0; i < HAIR_SEGMENTS; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i);
         m_HairSegments[i + 1].pos = bone->pos;
         m_HairSegments[i + 1].rot.x = -PHD_90;
         m_HairSegments[i + 1].rot.y = 0;
@@ -289,7 +287,6 @@ void Lara_Hair_Control(const bool in_cutscene)
     Matrix_Pop();
 
     const OBJECT *const object = Object_GetObject(O_LARA_HAIR);
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
 
     HAIR_SEGMENT *const fs = &m_HairSegments[0];
     fs->pos.x = pos.x;
@@ -298,7 +295,8 @@ void Lara_Hair_Control(const bool in_cutscene)
 
     if (m_IsFirstHair) {
         m_IsFirstHair = false;
-        for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone++) {
+        for (int32_t i = 1; i <= HAIR_SEGMENTS; i++) {
+            const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             const HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
             HAIR_SEGMENT *const s = &m_HairSegments[i];
 
@@ -355,7 +353,8 @@ void Lara_Hair_Control(const bool in_cutscene)
         m_HairWind = 0;
     }
 
-    for (int32_t i = 1; i <= HAIR_SEGMENTS; i++, bone++) {
+    for (int32_t i = 1; i <= HAIR_SEGMENTS; i++) {
+        const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
         HAIR_SEGMENT *const s = &m_HairSegments[i];
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -886,7 +886,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
     Matrix_RotYXZ(g_LaraItem->rot.y, g_LaraItem->rot.x, g_LaraItem->rot.z);
 
     const int16_t *rot = frame_ptr->mesh_rots;
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *bone = Object_GetBone(obj, 0);
 
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
@@ -968,7 +968,7 @@ void Lara_GetJointAbsPosition_I(
     g_MatrixPtr->_23 = 0;
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
 
-    const int32_t *const bone = &g_AnimBones[obj->bone_idx];
+    const ANIM_BONE *const bone = Object_GetBone(obj, 0);
     const int16_t *rot1 = frame1->mesh_rots;
     const int16_t *rot2 = frame2->mesh_rots;
     Matrix_InitInterpolate(frac, rate);
@@ -978,7 +978,9 @@ void Lara_GetJointAbsPosition_I(
         frame2->offset.y, frame2->offset.z);
     Matrix_RotYXZsuperpack_I(&rot1, &rot2, 0);
 
-    Matrix_TranslateRel_I(bone[25], bone[26], bone[27]);
+    Matrix_TranslateRel_I(
+        bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
+        bone[LM_TORSO - 1].pos.z);
     Matrix_RotYXZsuperpack_I(&rot1, &rot2, 6);
     Matrix_RotYXZ_I(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
 
@@ -990,7 +992,9 @@ void Lara_GetJointAbsPosition_I(
 
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_Interpolate();
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(
+            bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
+            bone[LM_UARM_L - 1].pos.z);
         if (g_Lara.flare_control_left) {
             const LARA_ARM *arm = &g_Lara.left_arm;
             const ANIM *anim = &g_Anims[arm->anim_num];
@@ -1002,24 +1006,34 @@ void Lara_GetJointAbsPosition_I(
         }
         Matrix_RotYXZsuperpack(&rot1, 11);
 
-        Matrix_TranslateRel(bone[45], bone[46], bone[47]);
+        Matrix_TranslateRel(
+            bone[LM_LARM_L - 1].pos.x, bone[LM_LARM_L - 1].pos.y,
+            bone[LM_LARM_L - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot1, 0);
 
-        Matrix_TranslateRel(bone[49], bone[50], bone[51]);
+        Matrix_TranslateRel(
+            bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
+            bone[LM_UARM_L - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot1, 0);
     } else if (gun_type != LGT_UNARMED) {
         Matrix_Interpolate();
-        Matrix_TranslateRel(bone[29], bone[30], bone[31]);
+        Matrix_TranslateRel(
+            bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
+            bone[LM_UARM_R - 1].pos.z);
 
         const LARA_ARM *arm = &g_Lara.right_arm;
         const ANIM *anim = &g_Anims[arm->anim_num];
         rot1 = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot1, 8);
 
-        Matrix_TranslateRel(bone[33], bone[34], bone[35]);
+        Matrix_TranslateRel(
+            bone[LM_LARM_R - 1].pos.x, bone[LM_LARM_R - 1].pos.y,
+            bone[LM_LARM_R - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot1, 0);
 
-        Matrix_TranslateRel(bone[37], bone[38], bone[39]);
+        Matrix_TranslateRel(
+            bone[LM_HAND_R - 1].pos.x, bone[LM_HAND_R - 1].pos.y,
+            bone[LM_HAND_R - 1].pos.z);
         Matrix_RotYXZsuperpack(&rot1, 0);
     }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -19,6 +19,7 @@
 #include <libtrx/engine/audio.h>
 #include <libtrx/filesystem.h>
 #include <libtrx/game/gamebuf.h>
+#include <libtrx/game/level.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 
@@ -310,11 +311,10 @@ static void M_LoadAnimCommands(VFILE *const file)
 static void M_LoadAnimBones(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t num_anim_bones = VFile_ReadS32(file);
+    const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
     LOG_INFO("anim bones: %d", num_anim_bones);
-    g_AnimBones =
-        GameBuf_Alloc(sizeof(int32_t) * num_anim_bones, GBUF_ANIM_BONES);
-    VFile_Read(file, g_AnimBones, sizeof(int32_t) * num_anim_bones);
+    Anim_InitialiseBones(num_anim_bones);
+    Level_ReadAnimBones(0, num_anim_bones, file);
     Benchmark_End(benchmark, NULL);
 }
 
@@ -341,7 +341,7 @@ static void M_LoadObjects(VFILE *const file)
         OBJECT *const object = &g_Objects[object_id];
         object->mesh_count = VFile_ReadS16(file);
         object->mesh_idx = VFile_ReadS16(file);
-        object->bone_idx = VFile_ReadS32(file);
+        object->bone_idx = VFile_ReadS32(file) / ANIM_BONE_SIZE;
         const int32_t frame_idx = VFile_ReadS32(file);
         object->frame_base = ((int16_t *)g_AnimFrames) + frame_idx / 2;
         object->anim_idx = VFile_ReadS16(file);

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -277,8 +277,3 @@ BOUNDS_16 Object_GetBoundingBox(
     Matrix_Pop();
     return new_bounds;
 }
-
-ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
-{
-    return (ANIM_BONE *)&g_AnimBones[object->bone_idx + bone_idx * 4];
-}

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -44,7 +44,6 @@ void Object_DrawAnimatingItem(const ITEM *item)
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
     int16_t *const *mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *extra_rotation = item->data;
     const int16_t *mesh_rots[2] = {
         frames[0]->mesh_rots,
@@ -61,6 +60,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
                     frames[1]->offset.y, frames[1]->offset.z);
                 Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
             } else {
+                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
                     Matrix_Pop_I();
                 }
@@ -81,7 +81,6 @@ void Object_DrawAnimatingItem(const ITEM *item)
                         Matrix_RotZ_I(*extra_rotation++);
                     }
                 }
-                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -96,6 +95,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
                     frames[0]->offset.z);
                 Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
             } else {
+                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
                     Matrix_Pop();
                 }
@@ -116,7 +116,6 @@ void Object_DrawAnimatingItem(const ITEM *item)
                         Matrix_RotZ(*extra_rotation++);
                     }
                 }
-                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -195,7 +194,6 @@ BOUNDS_16 Object_GetBoundingBox(
     const uint32_t mesh_bits)
 {
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
 
     Matrix_PushUnit();
@@ -217,6 +215,7 @@ BOUNDS_16 Object_GetBoundingBox(
 
     for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
         if (mesh_idx != 0) {
+            const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -229,7 +228,6 @@ BOUNDS_16 Object_GetBoundingBox(
             if (mesh_rots != NULL) {
                 Matrix_RotYXZsuperpack(&mesh_rots, 0);
             }
-            bone++;
         }
 
         if (!(mesh_bits & (1 << mesh_idx))) {

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -279,3 +279,8 @@ BOUNDS_16 Object_GetBoundingBox(
     Matrix_Pop();
     return new_bounds;
 }
+
+ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
+{
+    return (ANIM_BONE *)&g_AnimBones[object->bone_idx + bone_idx * 4];
+}

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -70,8 +70,8 @@ void Bandit1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 8)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 8)->rot_y = true;
 }
 
 void Bandit1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -70,9 +70,8 @@ void Bandit1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[8].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 8)->rot_y = 1;
 }
 
 void Bandit1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -70,9 +70,8 @@ void Bandit2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[8].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 8)->rot_y = 1;
 }
 
 void Bandit2B_Setup(void)
@@ -101,9 +100,8 @@ void Bandit2B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[8].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 8)->rot_y = 1;
 }
 
 void Bandit2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -70,8 +70,8 @@ void Bandit2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 8)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 8)->rot_y = true;
 }
 
 void Bandit2B_Setup(void)
@@ -100,8 +100,8 @@ void Bandit2B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 8)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 8)->rot_y = true;
 }
 
 void Bandit2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -62,7 +62,7 @@ void Barracuda_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
 }
 
 void Barracuda_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -62,8 +62,7 @@ void Barracuda_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
 }
 
 void Barracuda_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -71,8 +71,7 @@ void BirdGuardian_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[14].rot_y = 1;
+    Object_GetBone(obj, 14)->rot_y = 1;
 }
 
 void BirdGuardian_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -71,7 +71,7 @@ void BirdGuardian_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 14)->rot_y = 1;
+    Object_GetBone(obj, 14)->rot_y = true;
 }
 
 void BirdGuardian_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -69,8 +69,7 @@ void Cultist1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 }
 
 void Cultist1A_Setup(void)
@@ -99,8 +98,7 @@ void Cultist1A_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 }
 
 void Cultist1B_Setup(void)
@@ -129,8 +127,7 @@ void Cultist1B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
 }
 
 void Cultist1_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -69,7 +69,7 @@ void Cultist1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 }
 
 void Cultist1A_Setup(void)
@@ -98,7 +98,7 @@ void Cultist1A_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 }
 
 void Cultist1B_Setup(void)
@@ -127,7 +127,7 @@ void Cultist1B_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
 }
 
 void Cultist1_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -68,9 +68,8 @@ void Cultist2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
-    bone[8].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 8)->rot_y = 1;
 }
 
 void Cultist2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -68,8 +68,8 @@ void Cultist2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
-    Object_GetBone(obj, 8)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 8)->rot_y = true;
 }
 
 void Cultist2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -278,11 +278,10 @@ void Cultist3_Control(const int16_t item_num)
     Creature_Tilt(item, tilt);
 
     const OBJECT *const object = Object_GetObject(item->object_id);
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[object->bone_idx];
-    bone[0].rot_y = body != 0;
-    bone[2].rot_y = left != 0;
-    bone[6].rot_y = right != 0;
-    bone[10].rot_y = head != 0;
+    Object_GetBone(object, 0)->rot_y = body != 0;
+    Object_GetBone(object, 2)->rot_y = left != 0;
+    Object_GetBone(object, 6)->rot_y = right != 0;
+    Object_GetBone(object, 10)->rot_y = head != 0;
 
     if (body != 0) {
         Creature_Head(item, body);

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -98,8 +98,8 @@ void Diver_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    Object_GetBone(obj, 10)->rot_y = 1;
-    Object_GetBone(obj, 14)->rot_z = 1;
+    Object_GetBone(obj, 10)->rot_y = true;
+    Object_GetBone(obj, 14)->rot_z = true;
 }
 
 void Diver_Control(int16_t item_num)

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -98,9 +98,8 @@ void Diver_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[10].rot_y = 1;
-    bone[14].rot_z = 1;
+    Object_GetBone(obj, 10)->rot_y = 1;
+    Object_GetBone(obj, 14)->rot_z = 1;
 }
 
 void Diver_Control(int16_t item_num)

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -77,8 +77,7 @@ void Dog_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[19].rot_y = 1;
+    Object_GetBone(obj, 19)->rot_y = 1;
 }
 
 void Dog_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -77,7 +77,7 @@ void Dog_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 19)->rot_y = 1;
+    Object_GetBone(obj, 19)->rot_y = true;
 }
 
 void Dog_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -147,7 +147,7 @@ void Dragon_SetupFront(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 10)->rot_z = 1;
+    Object_GetBone(obj, 10)->rot_z = true;
 }
 
 void Dragon_SetupBack(void)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -147,8 +147,7 @@ void Dragon_SetupFront(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[10].rot_z = 1;
+    Object_GetBone(obj, 10)->rot_z = 1;
 }
 
 void Dragon_SetupBack(void)

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -74,8 +74,7 @@ void Monk1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
 }
 
 void Monk2_Setup(void)
@@ -98,8 +97,7 @@ void Monk2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
 }
 
 void Monk_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -74,7 +74,7 @@ void Monk1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
 }
 
 void Monk2_Setup(void)
@@ -97,7 +97,7 @@ void Monk2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
 }
 
 void Monk_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -63,7 +63,7 @@ void Mouse_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 3)->rot_y = 1;
+    Object_GetBone(obj, 3)->rot_y = true;
 }
 
 void Mouse_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -63,8 +63,7 @@ void Mouse_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[3].rot_y = 1;
+    Object_GetBone(obj, 3)->rot_y = 1;
 }
 
 void Mouse_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -71,7 +71,7 @@ void Shark_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    Object_GetBone(obj, 9)->rot_y = 1;
+    Object_GetBone(obj, 9)->rot_y = true;
 }
 
 void Shark_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -71,8 +71,7 @@ void Shark_Setup(void)
     obj->save_anim = 1;
     obj->water_creature = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[9].rot_y = 1;
+    Object_GetBone(obj, 9)->rot_y = 1;
 }
 
 void Shark_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -68,7 +68,7 @@ void Tiger_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 21)->rot_y = 1;
+    Object_GetBone(obj, 21)->rot_y = true;
 }
 
 void Tiger_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -68,8 +68,7 @@ void Tiger_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[21].rot_y = 1;
+    Object_GetBone(obj, 21)->rot_y = 1;
 }
 
 void Tiger_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -63,9 +63,8 @@ void TRex_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[10].rot_y = 1;
-    bone[11].rot_y = 1;
+    Object_GetBone(obj, 10)->rot_y = 1;
+    Object_GetBone(obj, 11)->rot_y = 1;
 }
 
 void TRex_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -63,8 +63,8 @@ void TRex_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 10)->rot_y = 1;
-    Object_GetBone(obj, 11)->rot_y = 1;
+    Object_GetBone(obj, 10)->rot_y = true;
+    Object_GetBone(obj, 11)->rot_y = true;
 }
 
 void TRex_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -65,9 +65,8 @@ void Worker1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[4].rot_y = 1;
-    bone[13].rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = 1;
 }
 
 void Worker1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -65,8 +65,8 @@ void Worker1_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = 1;
-    Object_GetBone(obj, 13)->rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = true;
+    Object_GetBone(obj, 13)->rot_y = true;
 }
 
 void Worker1_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -88,8 +88,8 @@ void Worker2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = 1;
-    Object_GetBone(obj, 13)->rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = true;
+    Object_GetBone(obj, 13)->rot_y = true;
 }
 
 void Worker5_Setup(void)
@@ -113,8 +113,8 @@ void Worker5_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = 1;
-    Object_GetBone(obj, 13)->rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = true;
+    Object_GetBone(obj, 13)->rot_y = true;
 }
 
 void Worker2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -88,9 +88,8 @@ void Worker2_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[4].rot_y = 1;
-    bone[13].rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = 1;
 }
 
 void Worker5_Setup(void)
@@ -114,9 +113,8 @@ void Worker5_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[4].rot_y = 1;
-    bone[13].rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = 1;
+    Object_GetBone(obj, 13)->rot_y = 1;
 }
 
 void Worker2_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -86,8 +86,8 @@ void Worker3_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
-    Object_GetBone(obj, 4)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 4)->rot_y = true;
 }
 
 void Worker4_Setup(void)
@@ -111,8 +111,8 @@ void Worker4_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = 1;
-    Object_GetBone(obj, 4)->rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 4)->rot_y = true;
 }
 
 void Worker3_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -86,9 +86,8 @@ void Worker3_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
-    bone[4].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = 1;
 }
 
 void Worker4_Setup(void)
@@ -112,9 +111,8 @@ void Worker4_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[0].rot_y = 1;
-    bone[4].rot_y = 1;
+    Object_GetBone(obj, 0)->rot_y = 1;
+    Object_GetBone(obj, 4)->rot_y = 1;
 }
 
 void Worker3_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_common.c
+++ b/src/tr2/game/objects/creatures/xian_common.c
@@ -40,7 +40,6 @@ void XianWarrior_Draw(const ITEM *item)
         jade_mesh_ptrs = &g_Meshes[g_Objects[O_XIAN_KNIGHT_STATUE].mesh_idx];
     }
 
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *extra_rotation = item->data;
     const int16_t *mesh_rots[2] = {
         frames[0]->mesh_rots,
@@ -57,6 +56,7 @@ void XianWarrior_Draw(const ITEM *item)
                     frames[1]->offset.y, frames[1]->offset.z);
                 Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
             } else {
+                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
                     Matrix_Pop_I();
                 }
@@ -77,7 +77,6 @@ void XianWarrior_Draw(const ITEM *item)
                         Matrix_RotZ_I(*extra_rotation++);
                     }
                 }
-                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -94,6 +93,7 @@ void XianWarrior_Draw(const ITEM *item)
                     frames[0]->offset.z);
                 Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
             } else {
+                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
                     Matrix_Pop();
                 }
@@ -114,7 +114,6 @@ void XianWarrior_Draw(const ITEM *item)
                         Matrix_RotZ(*extra_rotation++);
                     }
                 }
-                bone++;
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -100,8 +100,8 @@ void XianKnight_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 16)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 16)->rot_y = true;
 }
 
 void XianKnight_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -100,9 +100,8 @@ void XianKnight_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[16].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 16)->rot_y = 1;
 }
 
 void XianKnight_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -118,8 +118,8 @@ void XianSpearman_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 12)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 12)->rot_y = true;
 }
 
 void XianSpearman_DoDamage(

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -118,9 +118,8 @@ void XianSpearman_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[12].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 12)->rot_y = 1;
 }
 
 void XianSpearman_DoDamage(

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -91,8 +91,8 @@ void Yeti_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = 1;
-    Object_GetBone(obj, 14)->rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 14)->rot_y = true;
 }
 
 void Yeti_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -91,9 +91,8 @@ void Yeti_Setup(void)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    ANIM_BONE *const bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
-    bone[6].rot_y = 1;
-    bone[14].rot_y = 1;
+    Object_GetBone(obj, 6)->rot_y = 1;
+    Object_GetBone(obj, 14)->rot_y = 1;
 }
 
 void Yeti_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -257,7 +257,6 @@ void Pickup_Draw(const ITEM *const item)
     if (clip) {
         int32_t bit = 1;
         int16_t **meshpp = &g_Meshes[obj->mesh_idx];
-        const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
 
         const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
         if (mesh_rots != NULL) {
@@ -269,6 +268,7 @@ void Pickup_Draw(const ITEM *const item)
         }
 
         for (int i = 1; i < obj->mesh_count; i++) {
+            const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
             }
@@ -289,7 +289,6 @@ void Pickup_Draw(const ITEM *const item)
                 Output_InsertPolygons(*meshpp, clip);
             }
 
-            bone++;
             meshpp++;
         }
     }

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -435,12 +435,12 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
         -(bounds.min_z + bounds.max_z) / 2);
 
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const ANIM_BONE *bone = (ANIM_BONE *)&g_AnimBones[obj->bone_idx];
     const int16_t *mesh_rots = frame->mesh_rots;
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     Output_InsertPolygons(mesh_ptrs[0], 0);
-    for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++, bone++) {
+    for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
+        const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
         }

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -100,7 +100,6 @@ int32_t g_SoundEffectCount;
 OBJECT g_Objects[265] = { 0 };
 int16_t **g_Meshes = NULL;
 ANIM *g_Anims = NULL;
-int32_t *g_AnimBones = NULL;
 int32_t g_RoomCount;
 ROOM *g_Rooms = NULL;
 int32_t g_FlipStatus;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -98,7 +98,6 @@ extern int32_t g_SoundEffectCount;
 extern OBJECT g_Objects[265];
 extern int16_t **g_Meshes;
 extern ANIM *g_Anims;
-extern int32_t *g_AnimBones;
 extern int32_t g_RoomCount;
 extern ROOM *g_Rooms;
 extern int32_t g_FlipStatus;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates `ANIM_BONE` storage to libtrx, simplifies the struct properties and introduces accessors rather than using globals and to avoid pointer arithmetic in mesh output loops. This was completed incrementally, so probably best viewed by commit.
