### PR TITLE
tr1/phase/stats: convert to new style

### DIFF
--- a/src/tr1/game/gameflow.c
+++ b/src/tr1/game/gameflow.c
@@ -1087,11 +1087,14 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
             break;
 
         case GFS_LEVEL_STATS: {
-            PHASE_STATS_ARGS *const args =
-                Memory_Alloc(sizeof(PHASE_STATS_ARGS));
-            args->level_num = (int32_t)(intptr_t)seq->data;
-            Phase_Set(PHASE_STATS, args);
-            command = Phase_Run();
+            PHASE *const phase = Phase_Stats_Create((PHASE_STATS_ARGS) {
+                .background_path = NULL,
+                .level_num = (int32_t)(intptr_t)seq->data,
+                .level_type = GFL_NORMAL,
+                .show_final_stats = false,
+            });
+            command = PhaseExecutor_Run(phase);
+            Phase_Stats_Destroy(phase);
             if (command.action != GF_NOOP) {
                 return command;
             }
@@ -1102,14 +1105,15 @@ GameFlow_InterpretSequence(int32_t level_num, GAME_FLOW_LEVEL_TYPE level_type)
             if (g_Config.gameplay.enable_total_stats
                 && level_type != GFL_SAVED) {
                 const GAME_FLOW_DISPLAY_PICTURE_DATA *data = seq->data;
-                PHASE_STATS_ARGS *const args =
-                    Memory_Alloc(sizeof(PHASE_STATS_ARGS));
-                args->level_num = level_num;
-                args->background_path = data->path, args->total = true,
-                args->level_type =
-                    level_type == GFL_BONUS ? GFL_BONUS : GFL_NORMAL;
-                Phase_Set(PHASE_STATS, args);
-                command = Phase_Run();
+                PHASE *const phase = Phase_Stats_Create((PHASE_STATS_ARGS) {
+                    .background_path = data->path,
+                    .level_num = level_num,
+                    .level_type =
+                        level_type == GFL_BONUS ? GFL_BONUS : GFL_NORMAL,
+                    .show_final_stats = true,
+                });
+                command = PhaseExecutor_Run(phase);
+                Phase_Stats_Destroy(phase);
                 if (command.action != GF_NOOP) {
                     return command;
                 }

--- a/src/tr1/game/phase/phase.c
+++ b/src/tr1/game/phase/phase.c
@@ -80,10 +80,6 @@ static void M_SetUnconditionally(const PHASE_ENUM phase, const void *args)
         m_Phaser = &g_CutscenePhaser;
         break;
 
-    case PHASE_STATS:
-        m_Phaser = &g_StatsPhaser;
-        break;
-
     case PHASE_INVENTORY:
         m_Phaser = &g_InventoryPhaser;
         break;

--- a/src/tr1/game/phase/phase.h
+++ b/src/tr1/game/phase/phase.h
@@ -11,7 +11,6 @@ typedef enum {
     PHASE_GAME,
     PHASE_DEMO,
     PHASE_CUTSCENE,
-    PHASE_STATS,
     PHASE_INVENTORY,
 } PHASE_ENUM;
 

--- a/src/tr1/game/phase/phase_stats.h
+++ b/src/tr1/game/phase/phase_stats.h
@@ -1,16 +1,13 @@
 #pragma once
 
-#include "game/phase/phase.h"
-#include "global/types.h"
-
-#include <stdbool.h>
-#include <stdint.h>
+#include <libtrx/game/phase/types.h>
 
 typedef struct {
-    int32_t level_num;
     const char *background_path;
-    bool total;
+    bool show_final_stats;
+    int32_t level_num;
     GAME_FLOW_LEVEL_TYPE level_type;
 } PHASE_STATS_ARGS;
 
-extern PHASER g_StatsPhaser;
+PHASE *Phase_Stats_Create(PHASE_STATS_ARGS args);
+void Phase_Stats_Destroy(PHASE *phase);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This internally refactors the TR1 stats phase to use the new phase executor.
This includes the fade out effect at the end of the gym.
