### PR TITLE
libtrx/anims/common: move ANIMs to TRX

### DIFF
--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -2,11 +2,17 @@
 
 #include "game/gamebuf.h"
 
+ANIM *g_Anims = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseBones(const int32_t num_bones)
 {
     m_Bones = GameBuf_Alloc(sizeof(ANIM_BONE) * num_bones, GBUF_ANIM_BONES);
+}
+
+ANIM *Anim_GetAnim(const int32_t anim_idx)
+{
+    return &g_Anims[anim_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -2,8 +2,13 @@
 
 #include "game/gamebuf.h"
 
-ANIM *g_Anims = NULL;
+static ANIM *m_Anims = NULL;
 static ANIM_BONE *m_Bones = NULL;
+
+void Anim_InitialiseAnims(const int32_t num_anims)
+{
+    m_Anims = GameBuf_Alloc(sizeof(ANIM) * num_anims, GBUF_ANIMS);
+}
 
 void Anim_InitialiseBones(const int32_t num_bones)
 {
@@ -12,7 +17,7 @@ void Anim_InitialiseBones(const int32_t num_bones)
 
 ANIM *Anim_GetAnim(const int32_t anim_idx)
 {
-    return &g_Anims[anim_idx];
+    return &m_Anims[anim_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -35,6 +35,11 @@ ITEM *Item_Find(const GAME_OBJECT_ID object_id)
     return NULL;
 }
 
+ANIM *Item_GetAnim(const ITEM *const item)
+{
+    return Anim_GetAnim(item->anim_num);
+}
+
 bool Item_TestAnimEqual(const ITEM *const item, const int16_t anim_idx)
 {
     const OBJECT *const object = Object_GetObject(item->object_id);

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -51,3 +51,32 @@ void Item_SwitchToAnim(
 {
     Item_SwitchToObjAnim(item, anim_idx, frame, item->object_id);
 }
+
+void Item_SwitchToObjAnim(
+    ITEM *const item, const int16_t anim_idx, const int16_t frame,
+    const GAME_OBJECT_ID object_id)
+{
+    const OBJECT *const object = Object_GetObject(object_id);
+    item->anim_num = object->anim_idx + anim_idx;
+
+    const ANIM *const anim = Item_GetAnim(item);
+    if (frame < 0) {
+        item->frame_num = anim->frame_end + frame + 1;
+    } else {
+        item->frame_num = anim->frame_base + frame;
+    }
+}
+
+bool Item_TestFrameEqual(const ITEM *const item, const int16_t frame)
+{
+    return Anim_TestAbsFrameEqual(
+        item->frame_num, Item_GetAnim(item)->frame_base + frame);
+}
+
+bool Item_TestFrameRange(
+    const ITEM *const item, const int16_t start, const int16_t end)
+{
+    return Anim_TestAbsFrameRange(
+        item->frame_num, Item_GetAnim(item)->frame_base + start,
+        Item_GetAnim(item)->frame_base + end);
+}

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -214,6 +214,41 @@ void Level_ReadObjectMeshes(
     Vector_Free(unique_indices);
 }
 
+void Level_ReadAnims(
+    const int32_t base_idx, const int32_t num_anims, VFILE *const file,
+    int32_t **frame_pointers)
+{
+    for (int32_t i = 0; i < num_anims; i++) {
+        ANIM *const anim = Anim_GetAnim(base_idx + i);
+#if TR_VERSION == 1
+        anim->frame_ofs = VFile_ReadU32(file);
+        const int16_t interpolation = VFile_ReadS16(file);
+        ASSERT(interpolation <= 0xFF);
+        anim->interpolation = interpolation & 0xFF;
+        anim->frame_size = 0;
+#else
+        const int32_t frame_idx = VFile_ReadS32(file);
+        if (frame_pointers != NULL) {
+            (*frame_pointers)[i] = frame_idx;
+        }
+        anim->frame_ptr = NULL; // filled later by the animation frame loader
+        anim->interpolation = VFile_ReadU8(file);
+        anim->frame_size = VFile_ReadU8(file);
+#endif
+        anim->current_anim_state = VFile_ReadS16(file);
+        anim->velocity = VFile_ReadS32(file);
+        anim->acceleration = VFile_ReadS32(file);
+        anim->frame_base = VFile_ReadS16(file);
+        anim->frame_end = VFile_ReadS16(file);
+        anim->jump_anim_num = VFile_ReadS16(file);
+        anim->jump_frame_num = VFile_ReadS16(file);
+        anim->num_changes = VFile_ReadS16(file);
+        anim->change_idx = VFile_ReadS16(file);
+        anim->num_commands = VFile_ReadS16(file);
+        anim->command_idx = VFile_ReadS16(file);
+    }
+}
+
 void Level_ReadAnimBones(
     const int32_t base_idx, const int32_t num_bones, VFILE *const file)
 {

--- a/src/libtrx/game/objects/common.c
+++ b/src/libtrx/game/objects/common.c
@@ -98,6 +98,11 @@ void Object_SwapMesh(
     m_MeshPointers[obj2->mesh_idx + mesh_num] = temp;
 }
 
+ANIM *Object_GetAnim(const OBJECT *const object, const int32_t anim_idx)
+{
+    return Anim_GetAnim(object->anim_idx + anim_idx);
+}
+
 ANIM_BONE *Object_GetBone(const OBJECT *const object, const int32_t bone_idx)
 {
     return Anim_GetBone(object->bone_idx + bone_idx);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,8 +2,11 @@
 
 #include "./types.h"
 
+extern ANIM *g_Anims;
+
 void Anim_InitialiseBones(int32_t num_bones);
 
+ANIM *Anim_GetAnim(int32_t anim_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,8 +2,7 @@
 
 #include "./types.h"
 
-extern ANIM *g_Anims;
-
+void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../anims.h"
 #include "./types.h"
 
 #include <stdbool.h>
@@ -17,6 +18,7 @@ void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);
 // * Zero - don't deal any damage, disable body part explosions.
 int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage);
 
+ANIM *Item_GetAnim(const ITEM *item);
 bool Item_TestAnimEqual(const ITEM *item, int16_t anim_idx);
 void Item_SwitchToAnim(ITEM *item, int16_t anim_idx, int16_t frame);
 extern void Item_SwitchToObjAnim(

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -21,7 +21,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage);
 ANIM *Item_GetAnim(const ITEM *item);
 bool Item_TestAnimEqual(const ITEM *item, int16_t anim_idx);
 void Item_SwitchToAnim(ITEM *item, int16_t anim_idx, int16_t frame);
-extern void Item_SwitchToObjAnim(
+void Item_SwitchToObjAnim(
     ITEM *item, int16_t anim_idx, int16_t frame, GAME_OBJECT_ID object_id);
-extern bool Item_TestFrameEqual(const ITEM *item, int16_t frame);
-extern bool Item_TestFrameRange(const ITEM *item, int16_t start, int16_t end);
+bool Item_TestFrameEqual(const ITEM *item, int16_t frame);
+bool Item_TestFrameRange(const ITEM *item, int16_t start, int16_t end);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -7,4 +7,6 @@
 void Level_ReadRoomMesh(int32_t room_num, VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
+void Level_ReadAnims(
+    int32_t base_idx, int32_t num_anims, VFILE *file, int32_t **frame_pointers);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -34,6 +34,7 @@ OBJECT_MESH *Object_GetMesh(int32_t index);
 void Object_SwapMesh(
     GAME_OBJECT_ID object1_id, GAME_OBJECT_ID object2_id, int32_t mesh_num);
 
+ANIM *Object_GetAnim(const OBJECT *object, int32_t anim_idx);
 ANIM_BONE *Object_GetBone(const OBJECT *object, int32_t bone_idx);
 
 extern void Object_DrawMesh(int32_t mesh_idx, int32_t clip, bool interpolated);

--- a/src/tr1/game/creature.c
+++ b/src/tr1/game/creature.c
@@ -755,7 +755,7 @@ static bool M_SwitchToWater(
 
     item->object_id = info->water.id;
     Item_SwitchToAnim(item, info->water.active_anim, 0);
-    item->current_anim_state = g_Anims[item->anim_num].current_anim_state;
+    item->current_anim_state = Item_GetAnim(item)->current_anim_state;
     item->goal_anim_state = item->current_anim_state;
     item->pos.y = *wh;
 
@@ -782,7 +782,7 @@ static bool M_SwitchToLand(
 
     if (item->hit_points > 0) {
         Item_SwitchToAnim(item, info->land.active_anim, 0);
-        item->current_anim_state = g_Anims[item->anim_num].current_anim_state;
+        item->current_anim_state = Item_GetAnim(item)->current_anim_state;
         item->goal_anim_state = item->current_anim_state;
 
     } else {

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -584,25 +584,9 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     }
     ASSERT(VFile_GetPos(fp) == frame_data_end);
 
+    Level_ReadAnims(level_info->anim_count, inj_info->anim_count, fp, NULL);
     for (int32_t i = 0; i < inj_info->anim_count; i++) {
         ANIM *const anim = Anim_GetAnim(level_info->anim_count + i);
-
-        anim->frame_ofs = VFile_ReadU32(fp);
-        const int16_t interpolation = VFile_ReadS16(fp);
-        ASSERT(interpolation <= 0xFF);
-        anim->interpolation = interpolation & 0xFF;
-        anim->frame_size = 0;
-        anim->current_anim_state = VFile_ReadS16(fp);
-        anim->velocity = VFile_ReadS32(fp);
-        anim->acceleration = VFile_ReadS32(fp);
-        anim->frame_base = VFile_ReadS16(fp);
-        anim->frame_end = VFile_ReadS16(fp);
-        anim->jump_anim_num = VFile_ReadS16(fp);
-        anim->jump_frame_num = VFile_ReadS16(fp);
-        anim->num_changes = VFile_ReadS16(fp);
-        anim->change_idx = VFile_ReadS16(fp);
-        anim->num_commands = VFile_ReadS16(fp);
-        anim->command_idx = VFile_ReadS16(fp);
 
         // Re-align to the level.
         anim->jump_anim_num += level_info->anim_count;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -585,7 +585,7 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     ASSERT(VFile_GetPos(fp) == frame_data_end);
 
     for (int32_t i = 0; i < inj_info->anim_count; i++) {
-        ANIM *anim = &g_Anims[level_info->anim_count + i];
+        ANIM *const anim = Anim_GetAnim(level_info->anim_count + i);
 
         anim->frame_ofs = VFile_ReadU32(fp);
         const int16_t interpolation = VFile_ReadS16(fp);
@@ -669,7 +669,7 @@ static void M_AnimRangeEdits(INJECTION *injection)
             continue;
         }
 
-        ANIM *anim = &g_Anims[object->anim_idx + anim_idx];
+        const ANIM *const anim = Object_GetAnim(object, anim_idx);
         for (int32_t j = 0; j < edit_count; j++) {
             const int16_t change_idx = VFile_ReadS16(fp);
             const int16_t range_idx = VFile_ReadS16(fp);
@@ -1688,7 +1688,7 @@ static void M_FrameEdits(const INJECTION *const injection)
             continue;
         }
 
-        const ANIM *const anim = &g_Anims[obj->anim_idx + anim_idx];
+        const ANIM *const anim = Object_GetAnim(obj, anim_idx);
         ANIM_FRAME *const frame = anim->frame_ptr;
         frame->mesh_rots[0] = packed_rot;
     }

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -554,21 +554,6 @@ void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z)
     item->pos.z += (c * z - s * x) >> W2V_SHIFT;
 }
 
-void Item_SwitchToObjAnim(
-    ITEM *const item, const int16_t anim_idx, const int16_t frame,
-    const GAME_OBJECT_ID object_id)
-{
-    const OBJECT *const object = Object_GetObject(object_id);
-    item->anim_num = object->anim_idx + anim_idx;
-
-    const ANIM *const anim = Item_GetAnim(item);
-    if (frame < 0) {
-        item->frame_num = anim->frame_end + frame + 1;
-    } else {
-        item->frame_num = anim->frame_base + frame;
-    }
-}
-
 void Item_Animate(ITEM *item)
 {
     item->touch_bits = 0;
@@ -821,20 +806,6 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
 
     *rate = 10;
     return final * 10;
-}
-
-bool Item_TestFrameEqual(const ITEM *const item, const int16_t frame)
-{
-    return Anim_TestAbsFrameEqual(
-        item->frame_num, Item_GetAnim(item)->frame_base + frame);
-}
-
-bool Item_TestFrameRange(
-    const ITEM *const item, const int16_t start, const int16_t end)
-{
-    const ANIM *const anim = Item_GetAnim(item);
-    return Anim_TestAbsFrameRange(
-        item->frame_num, anim->frame_base + start, anim->frame_base + end);
 }
 
 ITEM *Item_Get(const int16_t item_num)

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -38,7 +38,7 @@ void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 void Item_Animate(ITEM *item);
-bool Item_GetAnimChange(ITEM *item, ANIM *anim);
+bool Item_GetAnimChange(ITEM *item, const ANIM *anim);
 void Item_PlayAnimSFX(ITEM *item, const int16_t *command, uint16_t flags);
 
 bool Item_IsTriggerActive(ITEM *item);

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -361,12 +361,11 @@ void Lara_SetMesh(const LARA_MESH mesh, OBJECT_MESH *const mesh_ptr)
 void Lara_Animate(ITEM *item)
 {
     int16_t *command;
-    ANIM *anim;
 
     item->frame_num++;
-    anim = &g_Anims[item->anim_num];
+    const ANIM *anim = Item_GetAnim(item);
     if (anim->num_changes > 0 && Item_GetAnimChange(item, anim)) {
-        anim = &g_Anims[item->anim_num];
+        anim = Item_GetAnim(item);
         item->current_anim_state = anim->current_anim_state;
     }
 
@@ -406,7 +405,7 @@ void Lara_Animate(ITEM *item)
         item->anim_num = anim->jump_anim_num;
         item->frame_num = anim->jump_frame_num;
 
-        anim = &g_Anims[anim->jump_anim_num];
+        anim = Item_GetAnim(item);
         item->current_anim_state = anim->current_anim_state;
     }
 

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -57,16 +57,16 @@ void Lara_Draw(ITEM *item)
         switch (g_Lara.hit_direction) {
         default:
         case DIR_NORTH:
-            frame = g_Anims[object->anim_idx + LA_SPAZ_FORWARD].frame_ptr;
+            frame = Object_GetAnim(object, LA_SPAZ_FORWARD)->frame_ptr;
             break;
         case DIR_EAST:
-            frame = g_Anims[object->anim_idx + LA_SPAZ_RIGHT].frame_ptr;
+            frame = Object_GetAnim(object, LA_SPAZ_RIGHT)->frame_ptr;
             break;
         case DIR_SOUTH:
-            frame = g_Anims[object->anim_idx + LA_SPAZ_BACK].frame_ptr;
+            frame = Object_GetAnim(object, LA_SPAZ_BACK)->frame_ptr;
             break;
         case DIR_WEST:
-            frame = g_Anims[object->anim_idx + LA_SPAZ_LEFT].frame_ptr;
+            frame = Object_GetAnim(object, LA_SPAZ_LEFT)->frame_ptr;
             break;
         }
 

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -109,27 +109,26 @@ void Lara_Hair_Control(void)
     object = &g_Objects[m_LaraType];
 
     if (!in_cutscene && g_Lara.hit_direction >= 0) {
-        int16_t spaz = object->anim_idx;
-
+        LARA_ANIMATION hit_anim;
         switch (g_Lara.hit_direction) {
         case DIR_NORTH:
-            spaz += LA_SPAZ_FORWARD;
+            hit_anim = LA_SPAZ_FORWARD;
             break;
 
         case DIR_SOUTH:
-            spaz += LA_SPAZ_BACK;
+            hit_anim = LA_SPAZ_BACK;
             break;
 
         case DIR_EAST:
-            spaz += LA_SPAZ_RIGHT;
+            hit_anim = LA_SPAZ_RIGHT;
             break;
 
         default:
-            spaz += LA_SPAZ_LEFT;
+            hit_anim = LA_SPAZ_LEFT;
             break;
         }
 
-        frame = g_Anims[spaz].frame_ptr;
+        frame = Object_GetAnim(object, hit_anim)->frame_ptr;
         frame += g_Lara.hit_frame;
 
         frac = 0;

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -735,7 +735,7 @@ void Lara_State_DieMidas(ITEM *item, COLL_INFO *coll)
 
     Object_SetReflective(O_LARA_EXTRA, true);
 
-    int frm = item->frame_num - g_Anims[item->anim_num].frame_base;
+    int32_t frm = item->frame_num - Item_GetAnim(item)->frame_base;
     switch (frm) {
     case 5:
         g_Lara.mesh_effects |= (1 << LM_FOOT_L);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -295,29 +295,8 @@ static void M_LoadAnims(VFILE *file)
     BENCHMARK *const benchmark = Benchmark_Start();
     m_LevelInfo.anim_count = VFile_ReadS32(file);
     LOG_INFO("%d anims", m_LevelInfo.anim_count);
-    g_Anims = GameBuf_Alloc(
-        sizeof(ANIM) * (m_LevelInfo.anim_count + m_InjectionInfo->anim_count),
-        GBUF_ANIMS);
-    for (int32_t i = 0; i < m_LevelInfo.anim_count; i++) {
-        ANIM *const anim = Anim_GetAnim(i);
-
-        anim->frame_ofs = VFile_ReadU32(file);
-        const int16_t interpolation = VFile_ReadS16(file);
-        ASSERT(interpolation <= 0xFF);
-        anim->interpolation = interpolation & 0xFF;
-        anim->frame_size = 0;
-        anim->current_anim_state = VFile_ReadS16(file);
-        anim->velocity = VFile_ReadS32(file);
-        anim->acceleration = VFile_ReadS32(file);
-        anim->frame_base = VFile_ReadS16(file);
-        anim->frame_end = VFile_ReadS16(file);
-        anim->jump_anim_num = VFile_ReadS16(file);
-        anim->jump_frame_num = VFile_ReadS16(file);
-        anim->num_changes = VFile_ReadS16(file);
-        anim->change_idx = VFile_ReadS16(file);
-        anim->num_commands = VFile_ReadS16(file);
-        anim->command_idx = VFile_ReadS16(file);
-    }
+    Anim_InitialiseAnims(m_LevelInfo.anim_count + m_InjectionInfo->anim_count);
+    Level_ReadAnims(0, m_LevelInfo.anim_count, file, NULL);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -298,8 +298,8 @@ static void M_LoadAnims(VFILE *file)
     g_Anims = GameBuf_Alloc(
         sizeof(ANIM) * (m_LevelInfo.anim_count + m_InjectionInfo->anim_count),
         GBUF_ANIMS);
-    for (int i = 0; i < m_LevelInfo.anim_count; i++) {
-        ANIM *anim = g_Anims + i;
+    for (int32_t i = 0; i < m_LevelInfo.anim_count; i++) {
+        ANIM *const anim = Anim_GetAnim(i);
 
         anim->frame_ofs = VFile_ReadU32(file);
         const int16_t interpolation = VFile_ReadS16(file);
@@ -448,8 +448,8 @@ static void M_LoadAnimFrames(VFILE *file)
     }
     Memory_FreePointer(&raw_data);
 
-    for (int i = 0; i < m_LevelInfo.anim_count; i++) {
-        ANIM *anim = &g_Anims[i];
+    for (int32_t i = 0; i < m_LevelInfo.anim_count; i++) {
+        ANIM *const anim = Anim_GetAnim(i);
         bool found = false;
         for (int j = 0; j < m_LevelInfo.anim_frame_count; j++) {
             if (m_LevelInfo.anim_frame_offsets[j] == (signed)anim->frame_ofs) {

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -95,9 +95,8 @@ void Object_DrawPickupItem(ITEM *item)
     // Modify item to be the anim for inv item and animation 0.
     Item_SwitchToObjAnim(item, 0, 0, item_num_option);
 
-    OBJECT *object = &g_Objects[item_num_option];
-
-    const ANIM_FRAME *frame = g_Anims[item->anim_num].frame_ptr;
+    const OBJECT *const object = Object_GetObject(item_num_option);
+    const ANIM_FRAME *frame = Item_GetAnim(item)->frame_ptr;
 
     // Restore the old frame number in case we need to get the sprite again.
     item->frame_num = old_frame_num;

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -80,7 +80,7 @@ void BaconLara_Control(int16_t item_num)
         int16_t relative_anim =
             g_LaraItem->anim_num - g_Objects[g_LaraItem->object_id].anim_idx;
         int16_t relative_frame =
-            g_LaraItem->frame_num - g_Anims[g_LaraItem->anim_num].frame_base;
+            g_LaraItem->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
         Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
         item->pos.x = x;
         item->pos.y = y;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -49,7 +49,7 @@ static void M_FixEmbeddedPosition(int16_t item_num)
     // one to properly measure them. Save it so it can be restored
     // after.
     int16_t old_anim = item->anim_num - g_Objects[item->object_id].anim_idx;
-    int16_t old_frame = item->frame_num - g_Anims[item->anim_num].frame_base;
+    int16_t old_frame = item->frame_num - Item_GetAnim(item)->frame_base;
 
     Item_SwitchToAnim(item, 0, 0);
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -300,7 +300,7 @@ void Alligator_Control(int16_t item_num)
         if (item->frame_num
             == (g_Config.gameplay.fix_alligator_ai
                     ? ALLIGATOR_BITE_AF
-                    : g_Anims[item->anim_num].frame_base)) {
+                    : Item_GetAnim(item)->frame_base)) {
             item->required_anim_state = ALLIGATOR_STATE_EMPTY;
         }
 

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -182,8 +182,7 @@ void SkateKid_Draw(ITEM *item)
 
     int16_t relative_anim =
         item->anim_num - g_Objects[item->object_id].anim_idx;
-    int16_t relative_frame =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+    int16_t relative_frame = item->frame_num - Item_GetAnim(item)->frame_base;
     item->object_id = O_SKATEBOARD;
     Item_SwitchToAnim(item, relative_anim, relative_frame);
     Object_DrawAnimatingItem(item);

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -49,7 +49,7 @@ void Statue_Initialise(int16_t item_num)
     Item_Initialise(centaur_item_num);
 
     Item_SwitchToAnim(centaur, CENTAUR_REARING_ANIM, CENTAUR_REARING_FRAME);
-    centaur->current_anim_state = g_Anims[centaur->anim_num].current_anim_state;
+    centaur->current_anim_state = Item_GetAnim(centaur)->current_anim_state;
     centaur->goal_anim_state = centaur->current_anim_state;
     centaur->rot.y = item->rot.y;
 

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -102,7 +102,7 @@ void RollingBall_Control(int16_t item_num)
         item->current_anim_state = TRAP_SET;
         item->goal_anim_state = TRAP_SET;
         Item_SwitchToAnim(item, 0, 0);
-        item->current_anim_state = g_Anims[item->anim_num].current_anim_state;
+        item->current_anim_state = Item_GetAnim(item)->current_anim_state;
         item->goal_anim_state = item->current_anim_state;
         item->required_anim_state = TRAP_SET;
         Item_RemoveActive(item_num);

--- a/src/tr1/game/objects/traps/thors_hammer_handle.c
+++ b/src/tr1/game/objects/traps/thors_hammer_handle.c
@@ -61,7 +61,7 @@ void ThorsHammerHandle_Control(int16_t item_num)
         break;
 
     case THOR_HAMMER_HANDLE_STATE_ACTIVE: {
-        int32_t frm = item->frame_num - g_Anims[item->anim_num].frame_base;
+        int32_t frm = item->frame_num - Item_GetAnim(item)->frame_base;
         if (frm > 30) {
             int32_t x = item->pos.x;
             int32_t z = item->pos.z;
@@ -136,8 +136,7 @@ void ThorsHammerHandle_Control(int16_t item_num)
     ITEM *head_item = item->data;
     int16_t relative_anim =
         item->anim_num - g_Objects[item->object_id].anim_idx;
-    int16_t relative_frame =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+    int16_t relative_frame = item->frame_num - Item_GetAnim(item)->frame_base;
     Item_SwitchToAnim(head_item, relative_anim, relative_frame);
     head_item->current_anim_state = item->current_anim_state;
 }

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -391,7 +391,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     Output_SetupAboveWater(false);
 
     OBJECT *obj = &g_Objects[Inv_GetItemOption(pu->object_id)];
-    const ANIM_FRAME *const frame = g_Anims[obj->anim_idx].frame_ptr;
+    const ANIM_FRAME *const frame = Object_GetAnim(obj, 0)->frame_ptr;
 
     Matrix_Push();
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);

--- a/src/tr1/game/phase/phase_cutscene.c
+++ b/src/tr1/game/phase/phase_cutscene.c
@@ -62,7 +62,7 @@ static void M_InitialiseHair(int32_t level_num)
     Lara_Initialise(level_num);
 
     Item_SwitchToObjAnim(g_LaraItem, 0, 0, lara_type);
-    ANIM *cut_anim = &g_Anims[g_LaraItem->anim_num];
+    const ANIM *const cut_anim = Item_GetAnim(g_LaraItem);
     g_LaraItem->current_anim_state = g_LaraItem->goal_anim_state =
         g_LaraItem->required_anim_state = cut_anim->current_anim_state;
 }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -254,7 +254,7 @@ static void M_DrawSkybox(void)
     g_MatrixPtr->_23 = 0;
 
     const OBJECT *const skybox = Object_GetObject(O_SKYBOX);
-    const ANIM_FRAME *const frame = g_Anims[skybox->anim_idx].frame_ptr;
+    const ANIM_FRAME *const frame = Object_GetAnim(skybox, 0)->frame_ptr;
     Matrix_RotYXZpack(frame->mesh_rots[0]);
     Output_DrawSkybox(Object_GetMesh(skybox->mesh_idx));
 

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -50,7 +50,6 @@ uint16_t *g_Overlap = NULL;
 int16_t *g_GroundZone[2] = { NULL };
 int16_t *g_GroundZone2[2] = { NULL };
 int16_t *g_FlyZone[2] = { NULL };
-ANIM *g_Anims = NULL;
 ANIM_CHANGE *g_AnimChanges = NULL;
 ANIM_RANGE *g_AnimRanges = NULL;
 TEXTURE_RANGE *g_AnimTextureRanges = NULL;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -58,7 +58,6 @@ extern uint16_t *g_Overlap;
 extern int16_t *g_GroundZone[2];
 extern int16_t *g_GroundZone2[2];
 extern int16_t *g_FlyZone[2];
-extern ANIM *g_Anims;
 extern ANIM_CHANGE *g_AnimChanges;
 extern ANIM_RANGE *g_AnimRanges;
 extern TEXTURE_RANGE *g_AnimTextureRanges;

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -208,22 +208,23 @@ void Flare_Create(const bool thrown)
 
 void Flare_SetArm(const int32_t frame)
 {
-    int16_t anim_base;
-
+    int16_t anim_idx;
     if (frame < LF_FL_THROW) {
-        anim_base = g_Objects[O_LARA_FLARE].anim_idx;
+        anim_idx = 0;
     } else if (frame < LF_FL_DRAW) {
-        anim_base = g_Objects[O_LARA_FLARE].anim_idx + 1;
+        anim_idx = 1;
     } else if (frame < LF_FL_IGNITE) {
-        anim_base = g_Objects[O_LARA_FLARE].anim_idx + 2;
+        anim_idx = 2;
     } else if (frame < LF_FL_2_HOLD) {
-        anim_base = g_Objects[O_LARA_FLARE].anim_idx + 3;
+        anim_idx = 3;
     } else {
-        anim_base = g_Objects[O_LARA_FLARE].anim_idx + 4;
+        anim_idx = 4;
     }
 
-    g_Lara.left_arm.anim_num = anim_base;
-    g_Lara.left_arm.frame_base = g_Anims[g_Lara.left_arm.anim_num].frame_ptr;
+    const OBJECT *const object = Object_GetObject(O_LARA_FLARE);
+    const ANIM *const anim = Object_GetAnim(object, anim_idx);
+    g_Lara.left_arm.anim_num = object->anim_idx + anim_idx;
+    g_Lara.left_arm.frame_base = anim->frame_ptr;
 }
 
 void Flare_Draw(void)

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -921,7 +921,7 @@ int32_t Skidoo_Control(void)
         const int16_t lara_anim_num =
             g_LaraItem->anim_num - g_Objects[O_LARA_SKIDOO].anim_idx;
         const int16_t lara_frame_num =
-            g_LaraItem->frame_num - g_Anims[g_LaraItem->anim_num].frame_base;
+            g_LaraItem->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
         Item_SwitchToObjAnim(
             skidoo, lara_anim_num, lara_frame_num, O_SKIDOO_FAST);
     }

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -282,8 +282,9 @@ void Gun_InitialiseNewWeapon(void)
         break;
 
     default:
-        g_Lara.left_arm.frame_base = g_Anims[g_LaraItem->anim_num].frame_ptr;
-        g_Lara.right_arm.frame_base = g_Anims[g_LaraItem->anim_num].frame_ptr;
+        const ANIM *const anim = Item_GetAnim(g_LaraItem);
+        g_Lara.left_arm.frame_base = anim->frame_ptr;
+        g_Lara.right_arm.frame_base = anim->frame_ptr;
         break;
     }
 }

--- a/src/tr2/game/gun/gun_pistols.c
+++ b/src/tr2/game/gun/gun_pistols.c
@@ -14,20 +14,22 @@ static bool m_UziLeft = false;
 
 void Gun_Pistols_SetArmInfo(LARA_ARM *const arm, const int32_t frame)
 {
-    const int16_t anim_idx = g_Objects[O_LARA_PISTOLS].anim_idx;
-
+    int16_t anim_idx;
     if (frame >= LF_G_AIM_START && frame <= LF_G_AIM_END) {
-        arm->anim_num = anim_idx;
+        anim_idx = 0;
     } else if (frame >= LF_G_UNDRAW_START && frame <= LF_G_UNDRAW_END) {
-        arm->anim_num = anim_idx + 1;
+        anim_idx = 1;
     } else if (frame >= LF_G_DRAW_START && frame <= LF_G_DRAW_END) {
-        arm->anim_num = anim_idx + 2;
+        anim_idx = 2;
     } else if (frame >= LF_G_RECOIL_START && frame <= LF_G_RECOIL_END) {
-        arm->anim_num = anim_idx + 3;
+        anim_idx = 3;
     }
 
+    const OBJECT *const object = Object_GetObject(O_LARA_PISTOLS);
+    const ANIM *const anim = Object_GetAnim(object, anim_idx);
+    arm->anim_num = object->anim_idx + anim_idx;
     arm->frame_num = frame;
-    arm->frame_base = g_Anims[arm->anim_num].frame_ptr;
+    arm->frame_base = anim->frame_ptr;
 }
 
 void Gun_Pistols_Draw(const LARA_GUN_TYPE weapon_type)

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -267,13 +267,13 @@ void Gun_Rifle_Draw(const LARA_GUN_TYPE weapon_type)
     }
 
     g_Lara.left_arm.anim_num = item->anim_num;
-    g_Lara.left_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.left_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
     g_Lara.right_arm.anim_num = item->anim_num;
-    g_Lara.right_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.right_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
 }
 
 void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
@@ -302,13 +302,13 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
     }
 
     g_Lara.left_arm.anim_num = item->anim_num;
-    g_Lara.left_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.left_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
     g_Lara.right_arm.anim_num = item->anim_num;
-    g_Lara.right_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.right_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
 }
 
 void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
@@ -434,11 +434,11 @@ void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
 
     Item_Animate(item);
     g_Lara.left_arm.anim_num = item->anim_num;
-    g_Lara.left_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.left_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
     g_Lara.right_arm.anim_num = item->anim_num;
-    g_Lara.right_arm.frame_base = g_Anims[item->anim_num].frame_ptr;
+    g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.right_arm.frame_num =
-        item->frame_num - g_Anims[item->anim_num].frame_base;
+        item->frame_num - Item_GetAnim(item)->frame_base;
 }

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -105,7 +105,7 @@ static void M_DrawItem(
 
     ANIM_FRAME *frame_ptr =
         (ANIM_FRAME *)&obj->frame_base
-            [inv_item->current_frame * g_Anims[obj->anim_idx].frame_size];
+            [inv_item->current_frame * Object_GetAnim(obj, 0)->frame_size];
 
     Matrix_Push();
     const int32_t clip = Output_GetObjectBounds(&frame_ptr->bounds);

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -456,35 +456,6 @@ void Item_AlignPosition(
     dst_item->pos.z = new_pos.z;
 }
 
-void Item_SwitchToObjAnim(
-    ITEM *const item, const int16_t anim_idx, const int16_t frame,
-    const GAME_OBJECT_ID object_id)
-{
-    const OBJECT *const object = Object_GetObject(object_id);
-    item->anim_num = object->anim_idx + anim_idx;
-
-    const ANIM *const anim = Item_GetAnim(item);
-    if (frame < 0) {
-        item->frame_num = anim->frame_end + frame + 1;
-    } else {
-        item->frame_num = anim->frame_base + frame;
-    }
-}
-
-bool Item_TestFrameEqual(const ITEM *const item, const int16_t frame)
-{
-    return Anim_TestAbsFrameEqual(
-        item->frame_num, Item_GetAnim(item)->frame_base + frame);
-}
-
-bool Item_TestFrameRange(
-    const ITEM *const item, const int16_t start, const int16_t end)
-{
-    return Anim_TestAbsFrameRange(
-        item->frame_num, Item_GetAnim(item)->frame_base + start,
-        Item_GetAnim(item)->frame_base + end);
-}
-
 void Item_Animate(ITEM *const item)
 {
     item->hit_status = 0;

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -125,7 +125,7 @@ void Item_Initialise(const int16_t item_num)
 {
     ITEM *const item = &g_Items[item_num];
     Item_SwitchToAnim(item, 0, 0);
-    item->goal_anim_state = g_Anims[item->anim_num].current_anim_state;
+    item->goal_anim_state = Item_GetAnim(item)->current_anim_state;
     item->current_anim_state = item->goal_anim_state;
     item->required_anim_state = 0;
     item->rot.x = 0;
@@ -463,7 +463,7 @@ void Item_SwitchToObjAnim(
     const OBJECT *const object = Object_GetObject(object_id);
     item->anim_num = object->anim_idx + anim_idx;
 
-    const ANIM *const anim = &g_Anims[item->anim_num];
+    const ANIM *const anim = Item_GetAnim(item);
     if (frame < 0) {
         item->frame_num = anim->frame_end + frame + 1;
     } else {
@@ -474,15 +474,15 @@ void Item_SwitchToObjAnim(
 bool Item_TestFrameEqual(const ITEM *const item, const int16_t frame)
 {
     return Anim_TestAbsFrameEqual(
-        item->frame_num, g_Anims[item->anim_num].frame_base + frame);
+        item->frame_num, Item_GetAnim(item)->frame_base + frame);
 }
 
 bool Item_TestFrameRange(
     const ITEM *const item, const int16_t start, const int16_t end)
 {
     return Anim_TestAbsFrameRange(
-        item->frame_num, g_Anims[item->anim_num].frame_base + start,
-        g_Anims[item->anim_num].frame_base + end);
+        item->frame_num, Item_GetAnim(item)->frame_base + start,
+        Item_GetAnim(item)->frame_base + end);
 }
 
 void Item_Animate(ITEM *const item)
@@ -490,13 +490,13 @@ void Item_Animate(ITEM *const item)
     item->hit_status = 0;
     item->touch_bits = 0;
 
-    const ANIM *anim = &g_Anims[item->anim_num];
+    const ANIM *anim = Item_GetAnim(item);
 
     item->frame_num++;
 
     if (anim->num_changes > 0) {
         if (Item_GetAnimChange(item, anim)) {
-            anim = &g_Anims[item->anim_num];
+            anim = Item_GetAnim(item);
             item->current_anim_state = anim->current_anim_state;
 
             if (item->required_anim_state == anim->current_anim_state) {
@@ -542,7 +542,7 @@ void Item_Animate(ITEM *const item)
 
         item->anim_num = anim->jump_anim_num;
         item->frame_num = anim->jump_frame_num;
-        anim = &g_Anims[item->anim_num];
+        anim = Item_GetAnim(item);
 
         if (item->current_anim_state != anim->current_anim_state) {
             item->current_anim_state = anim->current_anim_state;
@@ -695,7 +695,7 @@ int32_t Item_IsTriggerActive(ITEM *const item)
 
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
 {
-    const ANIM *const anim = &g_Anims[item->anim_num];
+    const ANIM *const anim = Item_GetAnim(item);
     const int32_t cur_frame_num = item->frame_num - anim->frame_base;
     const int32_t size = anim->frame_size;
     const int32_t key_frame_span = anim->interpolation;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -100,8 +100,10 @@ static void M_ResetGunStatus(void)
     g_Lara.right_arm.lock = 0;
     g_Lara.left_arm.anim_num = g_LaraItem->anim_num;
     g_Lara.right_arm.anim_num = g_LaraItem->anim_num;
-    g_Lara.left_arm.frame_base = g_Anims[g_LaraItem->anim_num].frame_ptr;
-    g_Lara.right_arm.frame_base = g_Anims[g_LaraItem->anim_num].frame_ptr;
+
+    const ANIM *const anim = Item_GetAnim(g_LaraItem);
+    g_Lara.left_arm.frame_base = anim->frame_ptr;
+    g_Lara.right_arm.frame_base = anim->frame_ptr;
 }
 
 void Lara_Cheat_EndLevel(void)

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -690,9 +690,9 @@ void Lara_Animate(ITEM *const item)
 {
     item->frame_num++;
 
-    const ANIM *anim = &g_Anims[item->anim_num];
+    const ANIM *anim = Item_GetAnim(item);
     if (anim->num_changes > 0 && Item_GetAnimChange(item, anim)) {
-        anim = &g_Anims[item->anim_num];
+        anim = Item_GetAnim(item);
         item->current_anim_state = anim->current_anim_state;
     }
 
@@ -738,7 +738,7 @@ void Lara_Animate(ITEM *const item)
 
         item->anim_num = anim->jump_anim_num;
         item->frame_num = anim->jump_frame_num;
-        anim = &g_Anims[item->anim_num];
+        anim = Item_GetAnim(item);
         item->current_anim_state = anim->current_anim_state;
     }
 

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -60,16 +60,17 @@ void Lara_Draw(const ITEM *const item)
         frame = frames[0];
     } else {
         // clang-format off
-        LARA_ANIMATION anim;
+        LARA_ANIMATION anim_idx;
         switch (g_Lara.hit_direction) {
-        case DIR_EAST:  anim = LA_HIT_LEFT; break;
-        case DIR_SOUTH: anim = LA_HIT_BACK; break;
-        case DIR_WEST:  anim = LA_HIT_RIGHT; break;
-        default:        anim = LA_HIT_FRONT; break;
+        case DIR_EAST:  anim_idx = LA_HIT_LEFT; break;
+        case DIR_SOUTH: anim_idx = LA_HIT_BACK; break;
+        case DIR_WEST:  anim_idx = LA_HIT_RIGHT; break;
+        default:        anim_idx = LA_HIT_FRONT; break;
         }
         // clang-format on
-        frame = (ANIM_FRAME *)(g_Anims[anim].frame_ptr
-                               + g_Lara.hit_frame * g_Anims[anim].frame_size);
+        const ANIM *const anim = Object_GetAnim(object, anim_idx);
+        frame = (ANIM_FRAME *)(anim->frame_ptr
+                               + g_Lara.hit_frame * anim->frame_size);
     }
 
     if (g_Lara.skidoo == NO_ITEM) {
@@ -116,10 +117,10 @@ void Lara_Draw(const ITEM *const item)
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots = &g_Lara.right_arm.frame_base
-                         [g_Lara.right_arm.frame_num
-                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                          + FBBOX_ROT];
+        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
+        mesh_rots =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
@@ -171,11 +172,11 @@ void Lara_Draw(const ITEM *const item)
         Matrix_Push();
         Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         if (g_Lara.flare_control_left) {
+            const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots =
                 &g_Lara.left_arm.frame_base
-                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
-                          * (g_Lara.left_arm.frame_num
-                             - g_Anims[g_Lara.left_arm.anim_num].frame_base)
+                     [anim->frame_size
+                          * (g_Lara.left_arm.frame_num - anim->frame_base)
                       + FBBOX_ROT];
             Matrix_RotYXZsuperpack(&mesh_rots, 11);
         } else {
@@ -195,7 +196,7 @@ void Lara_Draw(const ITEM *const item)
 
     case LGT_PISTOLS:
     case LGT_MAGNUMS:
-    case LGT_UZIS:
+    case LGT_UZIS: {
         Matrix_Push();
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         g_MatrixPtr->_00 = item_matrix._00;
@@ -210,12 +211,11 @@ void Lara_Draw(const ITEM *const item)
         Matrix_RotYXZ(
             g_Lara.right_arm.rot.y, g_Lara.right_arm.rot.x,
             g_Lara.right_arm.rot.z);
-        mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Anims[g_Lara.right_arm.anim_num].frame_size
-                      * (g_Lara.right_arm.frame_num
-                         - g_Anims[g_Lara.right_arm.anim_num].frame_base)
-                  + FBBOX_ROT];
+        const ANIM *anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
+        mesh_rots = &g_Lara.right_arm.frame_base
+                         [anim->frame_size
+                              * (g_Lara.right_arm.frame_num - anim->frame_base)
+                          + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -241,10 +241,10 @@ void Lara_Draw(const ITEM *const item)
         Matrix_RotYXZ(
             g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
             g_Lara.left_arm.rot.z);
+        anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
         mesh_rots = &g_Lara.left_arm.frame_base
-                         [g_Anims[g_Lara.left_arm.anim_num].frame_size
-                              * (g_Lara.left_arm.frame_num
-                                 - g_Anims[g_Lara.left_arm.anim_num].frame_base)
+                         [anim->frame_size
+                              * (g_Lara.left_arm.frame_num - anim->frame_base)
                           + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 11);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
@@ -262,17 +262,18 @@ void Lara_Draw(const ITEM *const item)
 
         Matrix_Pop();
         break;
+    }
 
     case LGT_SHOTGUN:
     case LGT_M16:
     case LGT_GRENADE:
-    case LGT_HARPOON:
+    case LGT_HARPOON: {
         Matrix_Push();
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        mesh_rots = &g_Lara.right_arm.frame_base
-                         [g_Lara.right_arm.frame_num
-                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                          + FBBOX_ROT];
+        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
+        mesh_rots =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -296,6 +297,7 @@ void Lara_Draw(const ITEM *const item)
 
         Matrix_Pop();
         break;
+    }
 
     default:
         break;
@@ -368,10 +370,10 @@ void Lara_Draw_I(
         && ((g_Items[g_Lara.weapon_item].current_anim_state) == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots_2 = &g_Lara.right_arm.frame_base
-                           [g_Lara.right_arm.frame_num
-                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                            + FBBOX_ROT];
+        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
+        mesh_rots_2 =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
         mesh_rots_1 = mesh_rots_2;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -426,19 +428,14 @@ void Lara_Draw_I(
         Matrix_Push_I();
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         if (g_Lara.flare_control_left) {
+            const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots_1 =
                 &g_Lara.left_arm.frame_base
-                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
-                          * (g_Lara.left_arm.frame_num
-                             - g_Anims[g_Lara.left_arm.anim_num].frame_base)
+                     [anim->frame_size
+                          * (g_Lara.left_arm.frame_num - anim->frame_base)
                       + FBBOX_ROT];
 
-            mesh_rots_2 =
-                &g_Lara.left_arm.frame_base
-                     [g_Anims[g_Lara.left_arm.anim_num].frame_size
-                          * (g_Lara.left_arm.frame_num
-                             - g_Anims[g_Lara.left_arm.anim_num].frame_base)
-                      + FBBOX_ROT];
+            mesh_rots_2 = mesh_rots_1;
             Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 11);
         } else {
             Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
@@ -461,18 +458,18 @@ void Lara_Draw_I(
 
     case LGT_PISTOLS:
     case LGT_MAGNUMS:
-    case LGT_UZIS:
+    case LGT_UZIS: {
         Matrix_Push_I();
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_InterpolateArm();
         Matrix_RotYXZ(
             g_Lara.right_arm.rot.y, g_Lara.right_arm.rot.x,
             g_Lara.right_arm.rot.z);
+        const ANIM *anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots_1 =
             &g_Lara.right_arm.frame_base
-                 [g_Anims[g_Lara.right_arm.anim_num].frame_size
-                      * (g_Lara.right_arm.frame_num
-                         - g_Anims[g_Lara.right_arm.anim_num].frame_base)
+                 [anim->frame_size
+                      * (g_Lara.right_arm.frame_num - anim->frame_base)
                   + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots_1, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
@@ -491,12 +488,11 @@ void Lara_Draw_I(
         Matrix_RotYXZ(
             g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
             g_Lara.left_arm.rot.z);
-        mesh_rots_1 =
-            &g_Lara.left_arm.frame_base
-                 [g_Anims[g_Lara.left_arm.anim_num].frame_size
-                      * (g_Lara.left_arm.frame_num
-                         - g_Anims[g_Lara.left_arm.anim_num].frame_base)
-                  + FBBOX_ROT];
+        anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
+        mesh_rots_1 = &g_Lara.left_arm.frame_base
+                           [anim->frame_size
+                                * (g_Lara.left_arm.frame_num - anim->frame_base)
+                            + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots_1, 11);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
@@ -512,21 +508,19 @@ void Lara_Draw_I(
         }
         Matrix_Pop();
         break;
+    }
 
     case LGT_SHOTGUN:
     case LGT_M16:
     case LGT_GRENADE:
-    case LGT_HARPOON:
+    case LGT_HARPOON: {
         Matrix_Push_I();
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        mesh_rots_1 = &g_Lara.right_arm.frame_base
-                           [g_Lara.right_arm.frame_num
-                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                            + FBBOX_ROT];
-        mesh_rots_2 = &g_Lara.right_arm.frame_base
-                           [g_Lara.right_arm.frame_num
-                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                            + FBBOX_ROT];
+        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
+        mesh_rots_1 =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
+        mesh_rots_2 = mesh_rots_1;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 8);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -549,6 +543,7 @@ void Lara_Draw_I(
         }
         Matrix_Pop();
         break;
+    }
 
     default:
         break;

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -51,10 +51,11 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots = &g_Lara.right_arm.frame_base
-                         [g_Lara.right_arm.frame_num
-                              * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                          + FBBOX_ROT];
+        mesh_rots =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num
+                      * Anim_GetAnim(g_Lara.right_arm.anim_num)->frame_size
+                  + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 6);
@@ -144,10 +145,11 @@ static void M_CalculateSpheres_I(
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        mesh_rots_1 = &g_Lara.right_arm.frame_base
-                           [g_Lara.right_arm.frame_num
-                                * g_Anims[g_Lara.right_arm.anim_num].frame_size
-                            + FBBOX_ROT];
+        mesh_rots_1 =
+            &g_Lara.right_arm.frame_base
+                 [g_Lara.right_arm.frame_num
+                      * Anim_GetAnim(g_Lara.right_arm.anim_num)->frame_size
+                  + FBBOX_ROT];
         mesh_rots_2 = mesh_rots_1;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -261,8 +263,10 @@ void Lara_Hair_Control(const bool in_cutscene)
             break;
         }
 
-        const int16_t *const frame_ptr = g_Anims[lara_anim].frame_ptr;
-        const int32_t frame_size = g_Anims[lara_anim].frame_size;
+        const OBJECT *const object = Object_GetObject(g_LaraItem->object_id);
+        const ANIM *const anim = Object_GetAnim(object, lara_anim);
+        const int16_t *const frame_ptr = anim->frame_ptr;
+        const int32_t frame_size = anim->frame_size;
         frame_1 = (ANIM_FRAME *)&frame_ptr[g_Lara.hit_frame * frame_size];
         frac = 0;
     }

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -853,7 +853,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             anim_num = LA_HIT_FRONT;
             break;
         }
-        const ANIM *anim = &g_Anims[anim_num];
+        const ANIM *anim = Object_GetAnim(obj, anim_num);
         const int32_t frame_size = anim->frame_size;
         frame_ptr =
             (const ANIM_FRAME *)(anim->frame_ptr
@@ -892,8 +892,8 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
         if (g_Lara.flare_control_left) {
-            const LARA_ARM *arm = &g_Lara.left_arm;
-            const ANIM *anim = &g_Anims[arm->anim_num];
+            const LARA_ARM *const arm = &g_Lara.left_arm;
+            const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             rot = &arm->frame_base
                        [anim->frame_size * (arm->frame_num - anim->frame_base)
                         + FBBOX_ROT];
@@ -916,8 +916,8 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
 
-        const LARA_ARM *arm = &g_Lara.right_arm;
-        const ANIM *anim = &g_Anims[arm->anim_num];
+        const LARA_ARM *const arm = &g_Lara.right_arm;
+        const ANIM *const anim = Anim_GetAnim(arm->anim_num);
         rot = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot, 8);
 
@@ -979,8 +979,8 @@ void Lara_GetJointAbsPosition_I(
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
         if (g_Lara.flare_control_left) {
-            const LARA_ARM *arm = &g_Lara.left_arm;
-            const ANIM *anim = &g_Anims[arm->anim_num];
+            const LARA_ARM *const arm = &g_Lara.left_arm;
+            const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             rot1 = &arm->frame_base
                         [anim->frame_size * (arm->frame_num - anim->frame_base)
                          + FBBOX_ROT];
@@ -1004,8 +1004,8 @@ void Lara_GetJointAbsPosition_I(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
 
-        const LARA_ARM *arm = &g_Lara.right_arm;
-        const ANIM *anim = &g_Anims[arm->anim_num];
+        const LARA_ARM *const arm = &g_Lara.right_arm;
+        const ANIM *const anim = Anim_GetAnim(arm->anim_num);
         rot1 = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
         Matrix_RotYXZsuperpack(&rot1, 8);
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -240,7 +240,7 @@ static int32_t M_LoadAnims(VFILE *const file, int32_t **frame_pointers)
     }
 
     for (int32_t i = 0; i < num_anims; i++) {
-        ANIM *const anim = &g_Anims[i];
+        ANIM *const anim = Anim_GetAnim(i);
         const int32_t frame_idx = VFile_ReadS32(file);
         if (frame_pointers != NULL) {
             (*frame_pointers)[i] = frame_idx;
@@ -828,7 +828,7 @@ static void M_LoadFromFile(const char *const file_name, const int32_t level_num)
     M_LoadAnimFrames(file);
 
     for (int32_t i = 0; i < num_anims; i++) {
-        ANIM *const anim = &g_Anims[i];
+        ANIM *const anim = Anim_GetAnim(i);
         // TODO: this is horrible
         anim->frame_ptr = ((int16_t *)g_AnimFrames) + frame_pointers[i] / 2;
     }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -234,32 +234,11 @@ static int32_t M_LoadAnims(VFILE *const file, int32_t **frame_pointers)
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t num_anims = VFile_ReadS32(file);
     LOG_INFO("anims: %d", num_anims);
-    g_Anims = GameBuf_Alloc(sizeof(ANIM) * num_anims, GBUF_ANIMS);
     if (frame_pointers != NULL) {
         *frame_pointers = Memory_Alloc(sizeof(int32_t) * num_anims);
     }
-
-    for (int32_t i = 0; i < num_anims; i++) {
-        ANIM *const anim = Anim_GetAnim(i);
-        const int32_t frame_idx = VFile_ReadS32(file);
-        if (frame_pointers != NULL) {
-            (*frame_pointers)[i] = frame_idx;
-        }
-        anim->frame_ptr = NULL; // filled later by the animation frame loader
-        anim->interpolation = VFile_ReadU8(file);
-        anim->frame_size = VFile_ReadU8(file);
-        anim->current_anim_state = VFile_ReadS16(file);
-        anim->velocity = VFile_ReadS32(file);
-        anim->acceleration = VFile_ReadS32(file);
-        anim->frame_base = VFile_ReadS16(file);
-        anim->frame_end = VFile_ReadS16(file);
-        anim->jump_anim_num = VFile_ReadS16(file);
-        anim->jump_frame_num = VFile_ReadS16(file);
-        anim->num_changes = VFile_ReadS16(file);
-        anim->change_idx = VFile_ReadS16(file);
-        anim->num_commands = VFile_ReadS16(file);
-        anim->command_idx = VFile_ReadS16(file);
-    }
+    Anim_InitialiseAnims(num_anims);
+    Level_ReadAnims(0, num_anims, file, frame_pointers);
     Benchmark_End(benchmark, NULL);
     return num_anims;
 }

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -452,7 +452,7 @@ void Dragon_Control(const int16_t item_num)
     const int16_t anim_num =
         dragon_front_item->anim_num - g_Objects[O_DRAGON_FRONT].anim_idx;
     const int16_t frame_num = dragon_front_item->frame_num
-        - g_Anims[dragon_front_item->anim_num].frame_base;
+        - Item_GetAnim(dragon_front_item)->frame_base;
     Item_SwitchToAnim(dragon_back_item, anim_num, frame_num);
     dragon_back_item->pos.x = dragon_front_item->pos.x;
     dragon_back_item->pos.y = dragon_front_item->pos.y;

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -258,7 +258,7 @@ void SkidooDriver_Control(const int16_t driver_item_num)
         const int16_t anim_num =
             skidoo_item->anim_num - g_Objects[O_SKIDOO_ARMED].anim_idx;
         const int16_t frame_num =
-            skidoo_item->frame_num - g_Anims[skidoo_item->anim_num].frame_base;
+            skidoo_item->frame_num - Item_GetAnim(skidoo_item)->frame_base;
         Item_SwitchToAnim(driver_item, anim_num, frame_num);
     }
 }

--- a/src/tr2/game/objects/general/sphere_of_doom.c
+++ b/src/tr2/game/objects/general/sphere_of_doom.c
@@ -90,7 +90,7 @@ void SphereOfDoom_Draw(const ITEM *const item)
     mptr->_22 = (mptr->_22 * item->timer) >> 8;
 
     const ANIM_FRAME *const frame_ptr =
-        (ANIM_FRAME *)g_Anims[item->anim_num].frame_ptr;
+        (ANIM_FRAME *)Item_GetAnim(item)->frame_ptr;
     const int32_t clip = Output_GetObjectBounds(&frame_ptr->bounds);
     if (clip) {
         Output_CalculateObjectLighting(item, &frame_ptr->bounds);

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -132,7 +132,7 @@ void RollingBall_Control(const int16_t item_num)
         item->goal_anim_state = TRAP_SET;
         item->current_anim_state = TRAP_SET;
         Item_SwitchToAnim(item, 0, 0);
-        item->goal_anim_state = g_Anims[item->anim_num].current_anim_state;
+        item->goal_anim_state = Item_GetAnim(item)->current_anim_state;
         item->current_anim_state = item->goal_anim_state;
         item->required_anim_state = TRAP_SET;
         Item_RemoveActive(item_num);

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -738,7 +738,7 @@ void Boat_Control(const int16_t item_num)
             const int16_t lara_anim_num =
                 lara->anim_num - g_Objects[O_LARA_BOAT].anim_idx;
             const int16_t lara_frame_num =
-                lara->frame_num - g_Anims[g_LaraItem->anim_num].frame_base;
+                lara->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
             Item_SwitchToAnim(boat, lara_anim_num, lara_frame_num);
         }
 

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -357,7 +357,7 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
 {
     const OBJECT *const obj = pickup->inv_object;
     const ANIM_FRAME *const frame =
-        (ANIM_FRAME *)g_Anims[obj->anim_idx].frame_ptr;
+        (ANIM_FRAME *)Object_GetAnim(obj, 0)->frame_ptr;
 
     float ease = 1.0f;
     switch (pickup->phase) {

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -512,16 +512,18 @@ void Room_DrawAllRooms(const int16_t current_room)
         g_PhdWinRight = m_OutsideRight;
         g_PhdWinBottom = m_OutsideBottom;
         g_PhdWinTop = m_OutsideTop;
-        if (g_Objects[O_SKYBOX].loaded) {
+
+        const OBJECT *const skybox = Object_GetObject(O_SKYBOX);
+        if (skybox->loaded) {
             Output_SetupAboveWater(g_CameraUnderwater);
             Matrix_Push();
             g_MatrixPtr->_03 = 0;
             g_MatrixPtr->_13 = 0;
             g_MatrixPtr->_23 = 0;
             const int16_t *frame =
-                g_Anims[g_Objects[O_SKYBOX].anim_idx].frame_ptr + FBBOX_ROT;
+                Object_GetAnim(skybox, 0)->frame_ptr + FBBOX_ROT;
             Matrix_RotYXZsuperpack(&frame, 0);
-            Output_InsertSkybox(g_Meshes[g_Objects[O_SKYBOX].mesh_idx]);
+            Output_InsertSkybox(g_Meshes[skybox->mesh_idx]);
             Matrix_Pop();
         } else {
             m_Outside = -1;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -99,7 +99,6 @@ GAME_FLOW g_GameFlow;
 int32_t g_SoundEffectCount;
 OBJECT g_Objects[265] = { 0 };
 int16_t **g_Meshes = NULL;
-ANIM *g_Anims = NULL;
 int32_t g_RoomCount;
 ROOM *g_Rooms = NULL;
 int32_t g_FlipStatus;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -96,7 +96,6 @@ extern GAME_FLOW g_GameFlow;
 extern int32_t g_SoundEffectCount;
 extern OBJECT g_Objects[265];
 extern int16_t **g_Meshes;
-extern ANIM *g_Anims;
 extern int32_t g_RoomCount;
 extern ROOM *g_Rooms;
 extern int32_t g_FlipStatus;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates `ANIM` storage to libtrx and introduces accessors rather than using globals. We have three functions essentially for getting an `ANIM`:
- `Anim_GetAnim(n)` - gets an anim by global index
- `Item_GetAnim(item)` - gets the given item's current anim
- `Object_GetAnim(obj, n)`  gets the `nth` anim of the given object

Animations are read commonly in libtrx for both games, plus TR1 injections. Frame setup is still as it was, but this will be refactored later separately. All anim and frame switching/testing functions are also now in libtrx.

