### PR TITLE
tr2: define flare and pistol anim enums

### DIFF
--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -22,6 +22,16 @@
 #define FLARE_OLD_AGE (MAX_FLARE_AGE - 2 * FRAMES_PER_SECOND) // = 1740
 #define FLARE_YOUNG_AGE (FRAMES_PER_SECOND) // = 30
 
+typedef enum {
+    // clang-format off
+    LA_FLARES_HOLD   = 0,
+    LA_FLARES_THROW  = 1,
+    LA_FLARES_DRAW   = 2,
+    LA_FLARES_IGNITE = 3,
+    LA_FLARES_IDLE   = 4,
+    // clang-format on
+} LARA_FLARES_ANIMATION;
+
 static bool M_CanThrowFlare(void);
 static void M_DoIgniteEffects(XYZ_32 flare_pos, int16_t room_num);
 static void M_DoBurnEffects(
@@ -210,15 +220,15 @@ void Flare_SetArm(const int32_t frame)
 {
     int16_t anim_idx;
     if (frame < LF_FL_THROW) {
-        anim_idx = 0;
+        anim_idx = LA_FLARES_HOLD;
     } else if (frame < LF_FL_DRAW) {
-        anim_idx = 1;
+        anim_idx = LA_FLARES_THROW;
     } else if (frame < LF_FL_IGNITE) {
-        anim_idx = 2;
+        anim_idx = LA_FLARES_DRAW;
     } else if (frame < LF_FL_2_HOLD) {
-        anim_idx = 3;
+        anim_idx = LA_FLARES_IGNITE;
     } else {
-        anim_idx = 4;
+        anim_idx = LA_FLARES_IDLE;
     }
 
     const OBJECT *const object = Object_GetObject(O_LARA_FLARE);

--- a/src/tr2/game/gun/gun_pistols.c
+++ b/src/tr2/game/gun/gun_pistols.c
@@ -9,20 +9,31 @@
 
 #include <libtrx/game/math.h>
 
+typedef enum {
+    // clang-format off
+    LA_PISTOLS_AIM    = 0,
+    LA_PISTOLS_UNDRAW = 1,
+    LA_PISTOLS_DRAW   = 2,
+    LA_PISTOLS_RECOIL = 3,
+    // clang-format on
+} LARA_PISTOLS_ANIMATION;
+
 static bool m_UziRight = false;
 static bool m_UziLeft = false;
 
 void Gun_Pistols_SetArmInfo(LARA_ARM *const arm, const int32_t frame)
 {
     int16_t anim_idx;
-    if (frame >= LF_G_AIM_START && frame <= LF_G_AIM_END) {
-        anim_idx = 0;
-    } else if (frame >= LF_G_UNDRAW_START && frame <= LF_G_UNDRAW_END) {
-        anim_idx = 1;
-    } else if (frame >= LF_G_DRAW_START && frame <= LF_G_DRAW_END) {
-        anim_idx = 2;
-    } else if (frame >= LF_G_RECOIL_START && frame <= LF_G_RECOIL_END) {
-        anim_idx = 3;
+    if (Anim_TestAbsFrameRange(frame, LF_G_AIM_START, LF_G_AIM_END)) {
+        anim_idx = LA_PISTOLS_AIM;
+    } else if (Anim_TestAbsFrameRange(
+                   frame, LF_G_UNDRAW_START, LF_G_UNDRAW_END)) {
+        anim_idx = LA_PISTOLS_UNDRAW;
+    } else if (Anim_TestAbsFrameRange(frame, LF_G_DRAW_START, LF_G_DRAW_END)) {
+        anim_idx = LA_PISTOLS_DRAW;
+    } else if (Anim_TestAbsFrameRange(
+                   frame, LF_G_RECOIL_START, LF_G_RECOIL_END)) {
+        anim_idx = LA_PISTOLS_RECOIL;
     }
 
     const OBJECT *const object = Object_GetObject(O_LARA_PISTOLS);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A follow-up to #2230 to define flare and pistol anim enums, and to switch to `Anim_TestAbsFrameRange` for setting pistol arms.
