### PR TITLE
libtrx/anims/common: move changes, ranges and commands to TRX

### DIFF
--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -3,12 +3,18 @@
 #include "game/gamebuf.h"
 
 static ANIM *m_Anims = NULL;
-ANIM_CHANGE *g_AnimChanges = NULL;
+static ANIM_CHANGE *m_Changes = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
 {
     m_Anims = GameBuf_Alloc(sizeof(ANIM) * num_anims, GBUF_ANIMS);
+}
+
+void Anim_InitialiseChanges(const int32_t num_changes)
+{
+    m_Changes =
+        GameBuf_Alloc(sizeof(ANIM_CHANGE) * num_changes, GBUF_ANIM_CHANGES);
 }
 
 void Anim_InitialiseBones(const int32_t num_bones)
@@ -23,7 +29,7 @@ ANIM *Anim_GetAnim(const int32_t anim_idx)
 
 ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 {
-    return &g_AnimChanges[change_idx];
+    return &m_Changes[change_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -4,6 +4,7 @@
 
 static ANIM *m_Anims = NULL;
 static ANIM_CHANGE *m_Changes = NULL;
+ANIM_RANGE *g_AnimRanges = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -30,6 +31,11 @@ ANIM *Anim_GetAnim(const int32_t anim_idx)
 ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 {
     return &m_Changes[change_idx];
+}
+
+ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
+{
+    return &g_AnimRanges[range_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -4,7 +4,7 @@
 
 static ANIM *m_Anims = NULL;
 static ANIM_CHANGE *m_Changes = NULL;
-ANIM_RANGE *g_AnimRanges = NULL;
+static ANIM_RANGE *m_Ranges = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -16,6 +16,11 @@ void Anim_InitialiseChanges(const int32_t num_changes)
 {
     m_Changes =
         GameBuf_Alloc(sizeof(ANIM_CHANGE) * num_changes, GBUF_ANIM_CHANGES);
+}
+
+void Anim_InitialiseRanges(const int32_t num_ranges)
+{
+    m_Ranges = GameBuf_Alloc(sizeof(ANIM_RANGE) * num_ranges, GBUF_ANIM_RANGES);
 }
 
 void Anim_InitialiseBones(const int32_t num_bones)
@@ -35,7 +40,7 @@ ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 
 ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
 {
-    return &g_AnimRanges[range_idx];
+    return &m_Ranges[range_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -5,7 +5,7 @@
 static ANIM *m_Anims = NULL;
 static ANIM_CHANGE *m_Changes = NULL;
 static ANIM_RANGE *m_Ranges = NULL;
-int16_t *g_AnimCommands = NULL;
+static int16_t *m_Commands = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -22,6 +22,11 @@ void Anim_InitialiseChanges(const int32_t num_changes)
 void Anim_InitialiseRanges(const int32_t num_ranges)
 {
     m_Ranges = GameBuf_Alloc(sizeof(ANIM_RANGE) * num_ranges, GBUF_ANIM_RANGES);
+}
+
+void Anim_InitialiseCommands(int32_t num_cmds)
+{
+    m_Commands = GameBuf_Alloc(sizeof(int16_t) * num_cmds, GBUF_ANIM_COMMANDS);
 }
 
 void Anim_InitialiseBones(const int32_t num_bones)
@@ -46,7 +51,7 @@ ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
 
 int16_t *Anim_GetCommand(const int32_t cmd_idx)
 {
-    return &g_AnimCommands[cmd_idx];
+    return &m_Commands[cmd_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -5,6 +5,7 @@
 static ANIM *m_Anims = NULL;
 static ANIM_CHANGE *m_Changes = NULL;
 static ANIM_RANGE *m_Ranges = NULL;
+int16_t *g_AnimCommands = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -41,6 +42,11 @@ ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
 {
     return &m_Ranges[range_idx];
+}
+
+int16_t *Anim_GetCommand(const int32_t cmd_idx)
+{
+    return &g_AnimCommands[cmd_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -3,6 +3,7 @@
 #include "game/gamebuf.h"
 
 static ANIM *m_Anims = NULL;
+ANIM_CHANGE *g_AnimChanges = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -18,6 +19,11 @@ void Anim_InitialiseBones(const int32_t num_bones)
 ANIM *Anim_GetAnim(const int32_t anim_idx)
 {
     return &m_Anims[anim_idx];
+}
+
+ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
+{
+    return &g_AnimChanges[change_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -80,3 +80,31 @@ bool Item_TestFrameRange(
         item->frame_num, Item_GetAnim(item)->frame_base + start,
         Item_GetAnim(item)->frame_base + end);
 }
+
+bool Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
+{
+    if (item->current_anim_state == item->goal_anim_state) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < anim->num_changes; i++) {
+        const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
+        if (change->goal_anim_state != item->goal_anim_state) {
+            continue;
+        }
+
+        for (int32_t j = 0; j < change->num_ranges; j++) {
+            const ANIM_RANGE *const range =
+                Anim_GetRange(change->range_idx + j);
+
+            if (Anim_TestAbsFrameRange(
+                    item->frame_num, range->start_frame, range->end_frame)) {
+                item->anim_num = range->link_anim_num;
+                item->frame_num = range->link_frame_num;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -272,6 +272,16 @@ void Level_ReadAnimRanges(
     }
 }
 
+void Level_ReadAnimCommands(
+    const int32_t base_idx, const int32_t num_cmds, VFILE *const file)
+{
+    // TODO: structure these, although they are of variable size.
+    for (int32_t i = 0; i < num_cmds; i++) {
+        int16_t *const cmd = Anim_GetCommand(base_idx + i);
+        *cmd = VFile_ReadS16(file);
+    }
+}
+
 void Level_ReadAnimBones(
     const int32_t base_idx, const int32_t num_bones, VFILE *const file)
 {

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -249,6 +249,17 @@ void Level_ReadAnims(
     }
 }
 
+void Level_ReadAnimChanges(
+    const int32_t base_idx, const int32_t num_changes, VFILE *const file)
+{
+    for (int32_t i = 0; i < num_changes; i++) {
+        ANIM_CHANGE *const anim_change = Anim_GetChange(base_idx + i);
+        anim_change->goal_anim_state = VFile_ReadS16(file);
+        anim_change->num_ranges = VFile_ReadS16(file);
+        anim_change->range_idx = VFile_ReadS16(file);
+    }
+}
+
 void Level_ReadAnimBones(
     const int32_t base_idx, const int32_t num_bones, VFILE *const file)
 {

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -260,6 +260,18 @@ void Level_ReadAnimChanges(
     }
 }
 
+void Level_ReadAnimRanges(
+    const int32_t base_idx, const int32_t num_ranges, VFILE *const file)
+{
+    for (int32_t i = 0; i < num_ranges; i++) {
+        ANIM_RANGE *const anim_range = Anim_GetRange(base_idx + i);
+        anim_range->start_frame = VFile_ReadS16(file);
+        anim_range->end_frame = VFile_ReadS16(file);
+        anim_range->link_anim_num = VFile_ReadS16(file);
+        anim_range->link_frame_num = VFile_ReadS16(file);
+    }
+}
+
 void Level_ReadAnimBones(
     const int32_t base_idx, const int32_t num_bones, VFILE *const file)
 {

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,12 +2,15 @@
 
 #include "./types.h"
 
+extern ANIM_RANGE *g_AnimRanges;
+
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);
 ANIM_CHANGE *Anim_GetChange(int32_t change_idx);
+ANIM_RANGE *Anim_GetRange(int32_t range_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,10 +2,9 @@
 
 #include "./types.h"
 
-extern ANIM_RANGE *g_AnimRanges;
-
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
+void Anim_InitialiseRanges(int32_t num_ranges);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,6 +2,8 @@
 
 #include "./types.h"
 
+extern int16_t *g_AnimCommands;
+
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseRanges(int32_t num_ranges);
@@ -10,6 +12,7 @@ void Anim_InitialiseBones(int32_t num_bones);
 ANIM *Anim_GetAnim(int32_t anim_idx);
 ANIM_CHANGE *Anim_GetChange(int32_t change_idx);
 ANIM_RANGE *Anim_GetRange(int32_t range_idx);
+int16_t *Anim_GetCommand(int32_t cmd_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,10 +2,13 @@
 
 #include "./types.h"
 
+extern ANIM_CHANGE *g_AnimChanges;
+
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);
+ANIM_CHANGE *Anim_GetChange(int32_t change_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,11 +2,10 @@
 
 #include "./types.h"
 
-extern int16_t *g_AnimCommands;
-
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseRanges(int32_t num_ranges);
+void Anim_InitialiseCommands(int32_t num_cmds);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -2,9 +2,8 @@
 
 #include "./types.h"
 
-extern ANIM_CHANGE *g_AnimChanges;
-
 void Anim_InitialiseAnims(int32_t num_anims);
+void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseBones(int32_t num_bones);
 
 ANIM *Anim_GetAnim(int32_t anim_idx);

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -25,3 +25,4 @@ void Item_SwitchToObjAnim(
     ITEM *item, int16_t anim_idx, int16_t frame, GAME_OBJECT_ID object_id);
 bool Item_TestFrameEqual(const ITEM *item, int16_t frame);
 bool Item_TestFrameRange(const ITEM *item, int16_t start, int16_t end);
+bool Item_GetAnimChange(ITEM *item, const ANIM *anim);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -10,4 +10,5 @@ void Level_ReadObjectMeshes(
 void Level_ReadAnims(
     int32_t base_idx, int32_t num_anims, VFILE *file, int32_t **frame_pointers);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
+void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -9,4 +9,5 @@ void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
 void Level_ReadAnims(
     int32_t base_idx, int32_t num_anims, VFILE *file, int32_t **frame_pointers);
+void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -11,4 +11,5 @@ void Level_ReadAnims(
     int32_t base_idx, int32_t num_anims, VFILE *file, int32_t **frame_pointers);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
+void Level_ReadAnimCommands(int32_t base_idx, int32_t num_cmds, VFILE *file);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -537,8 +537,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     VFILE *const fp = injection->fp;
 
     for (int32_t i = 0; i < inj_info->anim_change_count; i++) {
-        ANIM_CHANGE *anim_change =
-            &g_AnimChanges[level_info->anim_change_count + i];
+        ANIM_CHANGE *const anim_change =
+            Anim_GetChange(level_info->anim_change_count + i);
         anim_change->goal_anim_state = VFile_ReadS16(fp);
         anim_change->num_ranges = VFile_ReadS16(fp);
         anim_change->range_idx = VFile_ReadS16(fp);
@@ -612,8 +612,10 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
 
     // Re-align to the level.
     for (int32_t i = 0; i < inj_info->anim_change_count; i++) {
-        g_AnimChanges[level_info->anim_change_count++].range_idx +=
-            level_info->anim_range_count;
+        ANIM_CHANGE *const change =
+            Anim_GetChange(level_info->anim_change_count);
+        change->range_idx += level_info->anim_range_count;
+        level_info->anim_change_count++;
     }
 
     for (int32_t i = 0; i < inj_info->anim_range_count; i++) {
@@ -666,7 +668,8 @@ static void M_AnimRangeEdits(INJECTION *injection)
                     anim_idx);
                 continue;
             }
-            ANIM_CHANGE *change = &g_AnimChanges[anim->change_idx + change_idx];
+            const ANIM_CHANGE *const change =
+                Anim_GetChange(anim->change_idx + change_idx);
 
             if (range_idx >= change->num_ranges) {
                 LOG_WARNING(

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -540,9 +540,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
         level_info->anim_change_count, inj_info->anim_change_count, fp);
     Level_ReadAnimRanges(
         level_info->anim_range_count, inj_info->anim_range_count, fp);
-    VFile_Read(
-        fp, g_AnimCommands + level_info->anim_command_count,
-        sizeof(int16_t) * inj_info->anim_cmd_count);
+    Level_ReadAnimCommands(
+        level_info->anim_command_count, inj_info->anim_cmd_count, fp);
     Level_ReadAnimBones(
         level_info->anim_bone_count, inj_info->anim_bone_count, fp);
     const size_t frame_data_start = VFile_GetPos(fp);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -539,8 +539,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     Level_ReadAnimChanges(
         level_info->anim_change_count, inj_info->anim_change_count, fp);
     for (int32_t i = 0; i < inj_info->anim_range_count; i++) {
-        ANIM_RANGE *anim_range =
-            &g_AnimRanges[level_info->anim_range_count + i];
+        ANIM_RANGE *const anim_range =
+            Anim_GetRange(level_info->anim_range_count + i);
         anim_range->start_frame = VFile_ReadS16(fp);
         anim_range->end_frame = VFile_ReadS16(fp);
         anim_range->link_anim_num = VFile_ReadS16(fp);
@@ -614,8 +614,9 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     }
 
     for (int32_t i = 0; i < inj_info->anim_range_count; i++) {
-        g_AnimRanges[level_info->anim_range_count++].link_anim_num +=
-            level_info->anim_count;
+        ANIM_RANGE *const range = Anim_GetRange(level_info->anim_range_count);
+        range->link_anim_num += level_info->anim_count;
+        level_info->anim_range_count++;
     }
 
     Benchmark_End(benchmark, NULL);
@@ -672,7 +673,8 @@ static void M_AnimRangeEdits(INJECTION *injection)
                     range_idx, change_idx, anim_idx);
                 continue;
             }
-            ANIM_RANGE *range = &g_AnimRanges[change->range_idx + range_idx];
+            ANIM_RANGE *const range =
+                Anim_GetRange(change->range_idx + range_idx);
 
             range->start_frame = low_frame;
             range->end_frame = high_frame;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -538,14 +538,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
 
     Level_ReadAnimChanges(
         level_info->anim_change_count, inj_info->anim_change_count, fp);
-    for (int32_t i = 0; i < inj_info->anim_range_count; i++) {
-        ANIM_RANGE *const anim_range =
-            Anim_GetRange(level_info->anim_range_count + i);
-        anim_range->start_frame = VFile_ReadS16(fp);
-        anim_range->end_frame = VFile_ReadS16(fp);
-        anim_range->link_anim_num = VFile_ReadS16(fp);
-        anim_range->link_frame_num = VFile_ReadS16(fp);
-    }
+    Level_ReadAnimRanges(
+        level_info->anim_range_count, inj_info->anim_range_count, fp);
     VFile_Read(
         fp, g_AnimCommands + level_info->anim_command_count,
         sizeof(int16_t) * inj_info->anim_cmd_count);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -536,13 +536,8 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
     INJECTION_INFO *inj_info = injection->info;
     VFILE *const fp = injection->fp;
 
-    for (int32_t i = 0; i < inj_info->anim_change_count; i++) {
-        ANIM_CHANGE *const anim_change =
-            Anim_GetChange(level_info->anim_change_count + i);
-        anim_change->goal_anim_state = VFile_ReadS16(fp);
-        anim_change->num_ranges = VFile_ReadS16(fp);
-        anim_change->range_idx = VFile_ReadS16(fp);
-    }
+    Level_ReadAnimChanges(
+        level_info->anim_change_count, inj_info->anim_change_count, fp);
     for (int32_t i = 0; i < inj_info->anim_range_count; i++) {
         ANIM_RANGE *anim_range =
             &g_AnimRanges[level_info->anim_range_count + i];

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -576,7 +576,7 @@ void Item_Animate(ITEM *item)
 
     if (item->frame_num > anim->frame_end) {
         if (anim->num_commands > 0) {
-            int16_t *command = &g_AnimCommands[anim->command_idx];
+            const int16_t *command = Anim_GetCommand(anim->command_idx);
             for (int i = 0; i < anim->num_commands; i++) {
                 switch (*command++) {
                 case AC_MOVE_ORIGIN:
@@ -615,7 +615,7 @@ void Item_Animate(ITEM *item)
     }
 
     if (anim->num_commands > 0) {
-        int16_t *command = &g_AnimCommands[anim->command_idx];
+        const int16_t *command = Anim_GetCommand(anim->command_idx);
         for (int i = 0; i < anim->num_commands; i++) {
             switch (*command++) {
             case AC_MOVE_ORIGIN:

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -663,8 +663,8 @@ bool Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
         return false;
     }
 
-    ANIM_CHANGE *change = &g_AnimChanges[anim->change_idx];
-    for (int i = 0; i < anim->num_changes; i++, change++) {
+    for (int32_t i = 0; i < anim->num_changes; i++) {
+        const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
         if (change->goal_anim_state == item->goal_anim_state) {
             ANIM_RANGE *range = &g_AnimRanges[change->range_idx];
             for (int j = 0; j < change->num_ranges; j++, range++) {

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -666,8 +666,9 @@ bool Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
     for (int32_t i = 0; i < anim->num_changes; i++) {
         const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
         if (change->goal_anim_state == item->goal_anim_state) {
-            ANIM_RANGE *range = &g_AnimRanges[change->range_idx];
-            for (int j = 0; j < change->num_ranges; j++, range++) {
+            for (int32_t j = 0; j < change->num_ranges; j++) {
+                const ANIM_RANGE *const range =
+                    Anim_GetRange(change->range_idx + j);
                 if (Item_TestFrameRange(
                         item, range->start_frame - anim->frame_base,
                         range->end_frame - anim->frame_base)) {

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -657,32 +657,6 @@ void Item_Animate(ITEM *item)
     item->pos.z += (Math_Cos(item->rot.y) * item->speed) >> W2V_SHIFT;
 }
 
-bool Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
-{
-    if (item->current_anim_state == item->goal_anim_state) {
-        return false;
-    }
-
-    for (int32_t i = 0; i < anim->num_changes; i++) {
-        const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
-        if (change->goal_anim_state == item->goal_anim_state) {
-            for (int32_t j = 0; j < change->num_ranges; j++) {
-                const ANIM_RANGE *const range =
-                    Anim_GetRange(change->range_idx + j);
-                if (Item_TestFrameRange(
-                        item, range->start_frame - anim->frame_base,
-                        range->end_frame - anim->frame_base)) {
-                    item->anim_num = range->link_anim_num;
-                    item->frame_num = range->link_frame_num;
-                    return true;
-                }
-            }
-        }
-    }
-
-    return false;
-}
-
 void Item_PlayAnimSFX(
     ITEM *const item, const int16_t *const command, const uint16_t flags)
 {

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -38,7 +38,6 @@ void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 void Item_Animate(ITEM *item);
-bool Item_GetAnimChange(ITEM *item, const ANIM *anim);
 void Item_PlayAnimSFX(ITEM *item, const int16_t *command, uint16_t flags);
 
 bool Item_IsTriggerActive(ITEM *item);

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -360,8 +360,6 @@ void Lara_SetMesh(const LARA_MESH mesh, OBJECT_MESH *const mesh_ptr)
 
 void Lara_Animate(ITEM *item)
 {
-    int16_t *command;
-
     item->frame_num++;
     const ANIM *anim = Item_GetAnim(item);
     if (anim->num_changes > 0 && Item_GetAnimChange(item, anim)) {
@@ -371,7 +369,7 @@ void Lara_Animate(ITEM *item)
 
     if (item->frame_num > anim->frame_end) {
         if (anim->num_commands > 0) {
-            command = &g_AnimCommands[anim->command_idx];
+            const int16_t *command = Anim_GetCommand(anim->command_idx);
             for (int i = 0; i < anim->num_commands; i++) {
                 switch (*command++) {
                 case AC_MOVE_ORIGIN:
@@ -410,7 +408,7 @@ void Lara_Animate(ITEM *item)
     }
 
     if (anim->num_commands > 0) {
-        command = &g_AnimCommands[anim->command_idx];
+        const int16_t *command = Anim_GetCommand(anim->command_idx);
         for (int i = 0; i < anim->num_commands; i++) {
             switch (*command++) {
             case AC_MOVE_ORIGIN:

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -311,7 +311,7 @@ static void M_LoadAnimChanges(VFILE *file)
                + m_InjectionInfo->anim_change_count),
         GBUF_ANIM_CHANGES);
     for (int32_t i = 0; i < m_LevelInfo.anim_change_count; i++) {
-        ANIM_CHANGE *anim_change = &g_AnimChanges[i];
+        ANIM_CHANGE *const anim_change = Anim_GetChange(i);
         anim_change->goal_anim_state = VFile_ReadS16(file);
         anim_change->num_ranges = VFile_ReadS16(file);
         anim_change->range_idx = VFile_ReadS16(file);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -327,13 +327,9 @@ static void M_LoadAnimCommands(VFILE *file)
     BENCHMARK *const benchmark = Benchmark_Start();
     m_LevelInfo.anim_command_count = VFile_ReadS32(file);
     LOG_INFO("%d anim commands", m_LevelInfo.anim_command_count);
-    g_AnimCommands = GameBuf_Alloc(
-        sizeof(int16_t)
-            * (m_LevelInfo.anim_command_count
-               + m_InjectionInfo->anim_cmd_count),
-        GBUF_ANIM_COMMANDS);
-    VFile_Read(
-        file, g_AnimCommands, sizeof(int16_t) * m_LevelInfo.anim_command_count);
+    Anim_InitialiseCommands(
+        m_LevelInfo.anim_command_count + m_InjectionInfo->anim_cmd_count);
+    Level_ReadAnimCommands(0, m_LevelInfo.anim_command_count, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -322,7 +322,7 @@ static void M_LoadAnimRanges(VFILE *file)
                + m_InjectionInfo->anim_range_count),
         GBUF_ANIM_RANGES);
     for (int32_t i = 0; i < m_LevelInfo.anim_range_count; i++) {
-        ANIM_RANGE *anim_range = &g_AnimRanges[i];
+        ANIM_RANGE *const anim_range = Anim_GetRange(i);
         anim_range->start_frame = VFile_ReadS16(file);
         anim_range->end_frame = VFile_ReadS16(file);
         anim_range->link_anim_num = VFile_ReadS16(file);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -316,18 +316,9 @@ static void M_LoadAnimRanges(VFILE *file)
     BENCHMARK *const benchmark = Benchmark_Start();
     m_LevelInfo.anim_range_count = VFile_ReadS32(file);
     LOG_INFO("%d anim ranges", m_LevelInfo.anim_range_count);
-    g_AnimRanges = GameBuf_Alloc(
-        sizeof(ANIM_RANGE)
-            * (m_LevelInfo.anim_range_count
-               + m_InjectionInfo->anim_range_count),
-        GBUF_ANIM_RANGES);
-    for (int32_t i = 0; i < m_LevelInfo.anim_range_count; i++) {
-        ANIM_RANGE *const anim_range = Anim_GetRange(i);
-        anim_range->start_frame = VFile_ReadS16(file);
-        anim_range->end_frame = VFile_ReadS16(file);
-        anim_range->link_anim_num = VFile_ReadS16(file);
-        anim_range->link_frame_num = VFile_ReadS16(file);
-    }
+    Anim_InitialiseRanges(
+        m_LevelInfo.anim_range_count + m_InjectionInfo->anim_range_count);
+    Level_ReadAnimRanges(0, m_LevelInfo.anim_range_count, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -305,17 +305,9 @@ static void M_LoadAnimChanges(VFILE *file)
     BENCHMARK *const benchmark = Benchmark_Start();
     m_LevelInfo.anim_change_count = VFile_ReadS32(file);
     LOG_INFO("%d anim changes", m_LevelInfo.anim_change_count);
-    g_AnimChanges = GameBuf_Alloc(
-        sizeof(ANIM_CHANGE)
-            * (m_LevelInfo.anim_change_count
-               + m_InjectionInfo->anim_change_count),
-        GBUF_ANIM_CHANGES);
-    for (int32_t i = 0; i < m_LevelInfo.anim_change_count; i++) {
-        ANIM_CHANGE *const anim_change = Anim_GetChange(i);
-        anim_change->goal_anim_state = VFile_ReadS16(file);
-        anim_change->num_ranges = VFile_ReadS16(file);
-        anim_change->range_idx = VFile_ReadS16(file);
-    }
+    Anim_InitialiseChanges(
+        m_LevelInfo.anim_change_count + m_InjectionInfo->anim_change_count);
+    Level_ReadAnimChanges(0, m_LevelInfo.anim_change_count, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -50,7 +50,6 @@ uint16_t *g_Overlap = NULL;
 int16_t *g_GroundZone[2] = { NULL };
 int16_t *g_GroundZone2[2] = { NULL };
 int16_t *g_FlyZone[2] = { NULL };
-ANIM_RANGE *g_AnimRanges = NULL;
 TEXTURE_RANGE *g_AnimTextureRanges = NULL;
 int16_t *g_AnimCommands = NULL;
 ANIM_FRAME *g_AnimFrames = NULL;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -50,7 +50,6 @@ uint16_t *g_Overlap = NULL;
 int16_t *g_GroundZone[2] = { NULL };
 int16_t *g_GroundZone2[2] = { NULL };
 int16_t *g_FlyZone[2] = { NULL };
-ANIM_CHANGE *g_AnimChanges = NULL;
 ANIM_RANGE *g_AnimRanges = NULL;
 TEXTURE_RANGE *g_AnimTextureRanges = NULL;
 int16_t *g_AnimCommands = NULL;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -51,7 +51,6 @@ int16_t *g_GroundZone[2] = { NULL };
 int16_t *g_GroundZone2[2] = { NULL };
 int16_t *g_FlyZone[2] = { NULL };
 TEXTURE_RANGE *g_AnimTextureRanges = NULL;
-int16_t *g_AnimCommands = NULL;
 ANIM_FRAME *g_AnimFrames = NULL;
 int32_t *g_AnimFrameMeshRots = NULL;
 int16_t g_NumCineFrames = 0;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -58,7 +58,6 @@ extern uint16_t *g_Overlap;
 extern int16_t *g_GroundZone[2];
 extern int16_t *g_GroundZone2[2];
 extern int16_t *g_FlyZone[2];
-extern ANIM_CHANGE *g_AnimChanges;
 extern ANIM_RANGE *g_AnimRanges;
 extern TEXTURE_RANGE *g_AnimTextureRanges;
 extern int16_t *g_AnimCommands;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -58,7 +58,6 @@ extern uint16_t *g_Overlap;
 extern int16_t *g_GroundZone[2];
 extern int16_t *g_GroundZone2[2];
 extern int16_t *g_FlyZone[2];
-extern ANIM_RANGE *g_AnimRanges;
 extern TEXTURE_RANGE *g_AnimTextureRanges;
 extern int16_t *g_AnimCommands;
 extern ANIM_FRAME *g_AnimFrames;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -59,7 +59,6 @@ extern int16_t *g_GroundZone[2];
 extern int16_t *g_GroundZone2[2];
 extern int16_t *g_FlyZone[2];
 extern TEXTURE_RANGE *g_AnimTextureRanges;
-extern int16_t *g_AnimCommands;
 extern ANIM_FRAME *g_AnimFrames;
 extern int32_t *g_AnimFrameMeshRots;
 extern int16_t g_NumCineFrames;

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -602,34 +602,6 @@ void Item_Animate(ITEM *const item)
     item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
 }
 
-int32_t Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
-{
-    if (item->current_anim_state == item->goal_anim_state) {
-        return false;
-    }
-
-    for (int32_t i = 0; i < anim->num_changes; i++) {
-        const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
-        if (change->goal_anim_state != item->goal_anim_state) {
-            continue;
-        }
-
-        for (int32_t j = 0; j < change->num_ranges; j++) {
-            const ANIM_RANGE *const range =
-                Anim_GetRange(change->range_idx + j);
-
-            if (item->frame_num >= range->start_frame
-                && item->frame_num <= range->end_frame) {
-                item->anim_num = range->link_anim_num;
-                item->frame_num = range->link_frame_num;
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
 void Item_Translate(
     ITEM *const item, const int32_t x, const int32_t y, const int32_t z)
 {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -609,7 +609,7 @@ int32_t Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
     }
 
     for (int32_t i = 0; i < anim->num_changes; i++) {
-        const ANIM_CHANGE *const change = &g_AnimChanges[anim->change_idx + i];
+        const ANIM_CHANGE *const change = Anim_GetChange(anim->change_idx + i);
         if (change->goal_anim_state != item->goal_anim_state) {
             continue;
         }

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -478,7 +478,7 @@ void Item_Animate(ITEM *const item)
 
     if (item->frame_num > anim->frame_end) {
         if (anim->num_commands > 0) {
-            const int16_t *cmd_ptr = &g_AnimCommands[anim->command_idx];
+            const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
 
             for (int32_t i = 0; i < anim->num_commands; i++) {
                 const int16_t cmd = *cmd_ptr++;
@@ -526,7 +526,7 @@ void Item_Animate(ITEM *const item)
     }
 
     if (anim->num_commands > 0) {
-        const int16_t *cmd_ptr = &g_AnimCommands[anim->command_idx];
+        const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
         for (int32_t i = 0; i < anim->num_commands; i++) {
             const int16_t cmd = *cmd_ptr++;
             switch (cmd) {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -616,7 +616,7 @@ int32_t Item_GetAnimChange(ITEM *const item, const ANIM *const anim)
 
         for (int32_t j = 0; j < change->num_ranges; j++) {
             const ANIM_RANGE *const range =
-                &g_AnimRanges[change->range_idx + j];
+                Anim_GetRange(change->range_idx + j);
 
             if (item->frame_num >= range->start_frame
                 && item->frame_num <= range->end_frame) {

--- a/src/tr2/game/items.h
+++ b/src/tr2/game/items.h
@@ -24,7 +24,6 @@ int32_t Item_TestPosition(
 void Item_AlignPosition(
     const XYZ_32 *vec, const ITEM *src_item, ITEM *dst_item);
 void Item_Animate(ITEM *item);
-int32_t Item_GetAnimChange(ITEM *item, const ANIM *anim);
 void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 int32_t Item_IsTriggerActive(ITEM *item);
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -698,7 +698,7 @@ void Lara_Animate(ITEM *const item)
 
     if (item->frame_num > anim->frame_end) {
         if (anim->num_commands > 0) {
-            const int16_t *cmd_ptr = &g_AnimCommands[anim->command_idx];
+            const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
             for (int32_t i = 0; i < anim->num_commands; i++) {
                 const int16_t cmd = *cmd_ptr++;
 
@@ -743,7 +743,7 @@ void Lara_Animate(ITEM *const item)
     }
 
     if (anim->num_commands > 0) {
-        const int16_t *cmd_ptr = &g_AnimCommands[anim->command_idx];
+        const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
         for (int32_t i = 0; i < anim->num_commands; i++) {
             const int16_t cmd = *cmd_ptr++;
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -258,15 +258,8 @@ static void M_LoadAnimRanges(VFILE *const file)
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t num_anim_ranges = VFile_ReadS32(file);
     LOG_INFO("anim ranges: %d", num_anim_ranges);
-    g_AnimRanges =
-        GameBuf_Alloc(sizeof(ANIM_RANGE) * num_anim_ranges, GBUF_ANIM_RANGES);
-    for (int32_t i = 0; i < num_anim_ranges; i++) {
-        ANIM_RANGE *const range = Anim_GetRange(i);
-        range->start_frame = VFile_ReadS16(file);
-        range->end_frame = VFile_ReadS16(file);
-        range->link_anim_num = VFile_ReadS16(file);
-        range->link_frame_num = VFile_ReadS16(file);
-    }
+    Anim_InitialiseRanges(num_anim_ranges);
+    Level_ReadAnimRanges(0, num_anim_ranges, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -268,9 +268,8 @@ static void M_LoadAnimCommands(VFILE *const file)
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t num_anim_commands = VFile_ReadS32(file);
     LOG_INFO("anim commands: %d", num_anim_commands);
-    g_AnimCommands =
-        GameBuf_Alloc(sizeof(int16_t) * num_anim_commands, GBUF_ANIM_COMMANDS);
-    VFile_Read(file, g_AnimCommands, sizeof(int16_t) * num_anim_commands);
+    Anim_InitialiseCommands(num_anim_commands);
+    Level_ReadAnimCommands(0, num_anim_commands, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -248,14 +248,8 @@ static void M_LoadAnimChanges(VFILE *const file)
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t num_anim_changes = VFile_ReadS32(file);
     LOG_INFO("anim changes: %d", num_anim_changes);
-    g_AnimChanges = GameBuf_Alloc(
-        sizeof(ANIM_CHANGE) * num_anim_changes, GBUF_ANIM_CHANGES);
-    for (int32_t i = 0; i < num_anim_changes; i++) {
-        ANIM_CHANGE *const change = Anim_GetChange(i);
-        change->goal_anim_state = VFile_ReadS16(file);
-        change->num_ranges = VFile_ReadS16(file);
-        change->range_idx = VFile_ReadS16(file);
-    }
+    Anim_InitialiseChanges(num_anim_changes);
+    Level_ReadAnimChanges(0, num_anim_changes, file);
     Benchmark_End(benchmark, NULL);
 }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -261,7 +261,7 @@ static void M_LoadAnimRanges(VFILE *const file)
     g_AnimRanges =
         GameBuf_Alloc(sizeof(ANIM_RANGE) * num_anim_ranges, GBUF_ANIM_RANGES);
     for (int32_t i = 0; i < num_anim_ranges; i++) {
-        ANIM_RANGE *const range = &g_AnimRanges[i];
+        ANIM_RANGE *const range = Anim_GetRange(i);
         range->start_frame = VFile_ReadS16(file);
         range->end_frame = VFile_ReadS16(file);
         range->link_anim_num = VFile_ReadS16(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -251,7 +251,7 @@ static void M_LoadAnimChanges(VFILE *const file)
     g_AnimChanges = GameBuf_Alloc(
         sizeof(ANIM_CHANGE) * num_anim_changes, GBUF_ANIM_CHANGES);
     for (int32_t i = 0; i < num_anim_changes; i++) {
-        ANIM_CHANGE *const change = &g_AnimChanges[i];
+        ANIM_CHANGE *const change = Anim_GetChange(i);
         change->goal_anim_state = VFile_ReadS16(file);
         change->num_ranges = VFile_ReadS16(file);
         change->range_idx = VFile_ReadS16(file);

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -120,7 +120,6 @@ OBJECT_VECTOR *g_SoundEffects = NULL;
 int16_t g_SampleLUT[SFX_NUMBER_OF];
 SAMPLE_INFO *g_SampleInfos = NULL;
 int32_t g_HeightType;
-int16_t *g_AnimCommands = NULL;
 int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -121,7 +121,6 @@ int16_t g_SampleLUT[SFX_NUMBER_OF];
 SAMPLE_INFO *g_SampleInfos = NULL;
 int32_t g_HeightType;
 int16_t *g_AnimCommands = NULL;
-ANIM_CHANGE *g_AnimChanges = NULL;
 ANIM_RANGE *g_AnimRanges = NULL;
 int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -121,7 +121,6 @@ int16_t g_SampleLUT[SFX_NUMBER_OF];
 SAMPLE_INFO *g_SampleInfos = NULL;
 int32_t g_HeightType;
 int16_t *g_AnimCommands = NULL;
-ANIM_RANGE *g_AnimRanges = NULL;
 int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -117,7 +117,6 @@ extern int16_t g_SampleLUT[];
 extern SAMPLE_INFO *g_SampleInfos;
 extern int32_t g_HeightType;
 extern int16_t *g_AnimCommands;
-extern ANIM_RANGE *g_AnimRanges;
 extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -117,7 +117,6 @@ extern int16_t g_SampleLUT[];
 extern SAMPLE_INFO *g_SampleInfos;
 extern int32_t g_HeightType;
 extern int16_t *g_AnimCommands;
-extern ANIM_CHANGE *g_AnimChanges;
 extern ANIM_RANGE *g_AnimRanges;
 extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -116,7 +116,6 @@ extern OBJECT_VECTOR *g_SoundEffects;
 extern int16_t g_SampleLUT[];
 extern SAMPLE_INFO *g_SampleInfos;
 extern int32_t g_HeightType;
-extern int16_t *g_AnimCommands;
 extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates animation change, range and command storage to libtrx and introduces common accessors rather than using globals. These types are only used in `Lara_Animate` and `Item_Animate` and are related so I bundled them together in this PR. Same separate commit process as before with anims and bones.

I would like to structure commands, but will defer this for the time being. As they are of variable size, and aren't needed for savegame state, I'm thinking we could add them directly to `ANIM` rather than using a single list. But that's a future improvement I'd say.

Next up will be frames.
