### PR TITLE
tr1: rename nmeshes to mesh_count

### DIFF
--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -38,7 +38,7 @@ typedef struct {
 } OBJECT_BOUNDS;
 
 typedef struct {
-    int16_t nmeshes;
+    int16_t mesh_count;
     int16_t mesh_idx;
     int32_t bone_idx;
     ANIM_FRAME *frame_base;

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -528,7 +528,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
     Matrix_Pop();
 
     const int16_t *extra_rotation = (int16_t *)item->data;
-    for (int32_t i = 1; i < object->nmeshes; i++) {
+    for (int32_t i = 1; i < object->mesh_count; i++) {
         const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
@@ -565,7 +565,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
     }
 
     Matrix_Pop();
-    return object->nmeshes;
+    return object->mesh_count;
 }
 
 int32_t Collide_TestCollision(ITEM *item, ITEM *lara_item)

--- a/src/tr1/game/effects.c
+++ b/src/tr1/game/effects.c
@@ -145,7 +145,7 @@ void Effect_Draw(const int16_t effect_num)
         return;
     }
 
-    if (object->nmeshes < 0) {
+    if (object->mesh_count < 0) {
         Output_DrawSprite(
             effect->interp.result.pos.x, effect->interp.result.pos.y,
             effect->interp.result.pos.z, object->mesh_idx - effect->frame_num,
@@ -160,7 +160,7 @@ void Effect_Draw(const int16_t effect_num)
             Matrix_RotYXZ(
                 effect->interp.result.rot.y, effect->interp.result.rot.x,
                 effect->interp.result.rot.z);
-            if (object->nmeshes) {
+            if (object->mesh_count) {
                 Output_CalculateStaticLight(effect->shade);
                 Object_DrawMesh(object->mesh_idx, -1, false);
             } else {

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -487,7 +487,7 @@ static void M_TextureData(
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < STATIC_NUMBER_OF) {
             STATIC_INFO *object = &g_StaticObjects[object_id - O_NUMBER_OF];
-            object->nmeshes = num_meshes;
+            object->mesh_count = num_meshes;
             object->mesh_num = mesh_idx + level_info->sprite_info_count;
             object->loaded = true;
         }

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -482,7 +482,7 @@ static void M_TextureData(
 
         if (object_id < O_NUMBER_OF) {
             OBJECT *object = &g_Objects[object_id];
-            object->nmeshes = num_meshes;
+            object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < STATIC_NUMBER_OF) {
@@ -699,7 +699,7 @@ static void M_ObjectData(
         // that we wish to retain what's already defined so to avoid duplicate
         // packing.
         if (!object->loaded || num_meshes) {
-            object->nmeshes = num_meshes;
+            object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx + level_info->mesh_ptr_count;
             object->bone_idx = bone_idx + level_info->anim_bone_count;
         }
@@ -774,7 +774,7 @@ static void M_AlignTextureReferences(
     const OBJECT *const object, const uint16_t *const palette_map,
     const int32_t tex_info_base)
 {
-    for (int32_t i = 0; i < object->nmeshes; i++) {
+    for (int32_t i = 0; i < object->mesh_count; i++) {
         OBJECT_MESH *const mesh = Object_GetMesh(object->mesh_idx + i);
         for (int32_t j = 0; j < mesh->num_tex_face4s; j++) {
             mesh->tex_face4s[j].texture += tex_info_base;

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -81,7 +81,7 @@ static void M_DrawItem(
     Matrix_RotYXZ(inv_item->y_rot, inv_item->x_rot, 0);
 
     OBJECT *const obj = Object_GetObject(inv_item->object_id);
-    if (obj->nmeshes < 0) {
+    if (obj->mesh_count < 0) {
         Output_DrawSpriteRel(0, 0, 0, obj->mesh_idx, 4096);
         return;
     }

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -835,7 +835,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
         item->mesh_bits -= bit;
     }
 
-    for (int i = 1; i < obj->nmeshes; i++) {
+    for (int i = 1; i < obj->mesh_count; i++) {
         const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();
@@ -888,5 +888,5 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
 
     Matrix_Pop();
 
-    return !(item->mesh_bits & (0x7FFFFFFF >> (31 - obj->nmeshes)));
+    return !(item->mesh_bits & (0x7FFFFFFF >> (31 - obj->mesh_count)));
 }

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -463,7 +463,7 @@ void Lara_Hair_Draw(void)
     const OBJECT *const object = Object_GetObject(O_HAIR);
     int16_t mesh_idx = object->mesh_idx;
     if ((g_Lara.mesh_effects & (1 << LM_HEAD))
-        && object->nmeshes >= HAIR_SEGMENTS * 2) {
+        && object->mesh_count >= HAIR_SEGMENTS * 2) {
         mesh_idx += HAIR_SEGMENTS;
     }
 

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -921,7 +921,7 @@ void Lara_CatchFire(void)
             EFFECT *const effect = Effect_Get(effect_num);
             effect->object_id = O_FLAME;
             effect->frame_num =
-                (g_Objects[O_FLAME].nmeshes * Random_GetControl()) / 0x7FFF;
+                (g_Objects[O_FLAME].mesh_count * Random_GetControl()) / 0x7FFF;
             effect->counter = -1 - Random_GetControl() * 24 / 0x7FFF;
         }
     }

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -431,7 +431,7 @@ static void M_LoadObjects(VFILE *file)
         const GAME_OBJECT_ID object_id = VFile_ReadS32(file);
         OBJECT *object = &g_Objects[object_id];
 
-        object->nmeshes = VFile_ReadS16(file);
+        object->mesh_count = VFile_ReadS16(file);
         object->mesh_idx = VFile_ReadS16(file);
         object->bone_idx = VFile_ReadS32(file) / ANIM_BONE_SIZE;
 
@@ -530,7 +530,7 @@ static void M_LoadSprites(VFILE *file)
 
         if (object_id < O_NUMBER_OF) {
             OBJECT *object = &g_Objects[object_id];
-            object->nmeshes = num_meshes;
+            object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < STATIC_NUMBER_OF) {
@@ -959,7 +959,7 @@ static size_t M_CalculateMaxVertices(void)
             continue;
         }
 
-        for (int32_t j = 0; j < object->nmeshes; j++) {
+        for (int32_t j = 0; j < object->mesh_count; j++) {
             const OBJECT_MESH *const mesh =
                 Object_GetMesh(object->mesh_idx + j);
             max_vertices = MAX(max_vertices, mesh->num_vertices);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -535,7 +535,7 @@ static void M_LoadSprites(VFILE *file)
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < STATIC_NUMBER_OF) {
             STATIC_INFO *object = &g_StaticObjects[object_id - O_NUMBER_OF];
-            object->nmeshes = num_meshes;
+            object->mesh_count = num_meshes;
             object->mesh_num = mesh_idx;
             object->loaded = true;
         }
@@ -968,7 +968,7 @@ static size_t M_CalculateMaxVertices(void)
 
     for (int32_t i = 0; i < STATIC_NUMBER_OF; i++) {
         const STATIC_INFO *static_info = &g_StaticObjects[i];
-        if (!static_info->loaded || static_info->nmeshes < 0) {
+        if (!static_info->loaded || static_info->mesh_count < 0) {
             continue;
         }
 

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -102,7 +102,7 @@ void Object_DrawPickupItem(ITEM *item)
     item->frame_num = old_frame_num;
 
     // Fall back to normal sprite rendering if not found.
-    if (object->nmeshes < 0) {
+    if (object->mesh_count < 0) {
         Object_DrawSpriteItem(item);
         return;
     }
@@ -206,7 +206,7 @@ void Object_DrawPickupItem(ITEM *item)
             Object_DrawMesh(object->mesh_idx, clip, false);
         }
 
-        for (int i = 1; i < object->nmeshes; i++) {
+        for (int i = 1; i < object->mesh_count; i++) {
             const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
@@ -257,7 +257,7 @@ void Object_DrawInterpolatedObject(
             Object_DrawMesh(object->mesh_idx, clip, false);
         }
 
-        for (int i = 1; i < object->nmeshes; i++) {
+        for (int i = 1; i < object->mesh_count; i++) {
             const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop();
@@ -301,7 +301,7 @@ void Object_DrawInterpolatedObject(
             Object_DrawMesh(object->mesh_idx, clip, true);
         }
 
-        for (int i = 1; i < object->nmeshes; i++) {
+        for (int i = 1; i < object->mesh_count; i++) {
             const ANIM_BONE *const bone = Object_GetBone(object, i - 1);
             if (bone->matrix_pop) {
                 Matrix_Pop_I();
@@ -415,7 +415,7 @@ void Object_SetMeshReflective(
 void Object_SetReflective(const GAME_OBJECT_ID object_id, const bool enabled)
 {
     const OBJECT *const object = Object_GetObject(object_id);
-    for (int32_t i = 0; i < object->nmeshes; i++) {
+    for (int32_t i = 0; i < object->mesh_count; i++) {
         Object_SetMeshReflective(object_id, i, enabled);
     }
 }

--- a/src/tr1/game/objects/effects/blood.c
+++ b/src/tr1/game/objects/effects/blood.c
@@ -20,7 +20,7 @@ void Blood_Control(int16_t effect_num)
     if (effect->counter == 4) {
         effect->counter = 0;
         effect->frame_num--;
-        if (effect->frame_num <= g_Objects[effect->object_id].nmeshes) {
+        if (effect->frame_num <= g_Objects[effect->object_id].mesh_count) {
             Effect_Kill(effect_num);
         }
     }

--- a/src/tr1/game/objects/effects/body_part.c
+++ b/src/tr1/game/objects/effects/body_part.c
@@ -12,7 +12,7 @@
 void BodyPart_Setup(OBJECT *obj)
 {
     obj->control = BodyPart_Control;
-    obj->nmeshes = 0;
+    obj->mesh_count = 0;
     obj->loaded = 1;
 }
 

--- a/src/tr1/game/objects/effects/dart_effect.c
+++ b/src/tr1/game/objects/effects/dart_effect.c
@@ -17,7 +17,7 @@ void DartEffect_Control(int16_t effect_num)
     if (effect->counter >= 3) {
         effect->counter = 0;
         effect->frame_num--;
-        if (effect->frame_num <= g_Objects[effect->object_id].nmeshes) {
+        if (effect->frame_num <= g_Objects[effect->object_id].mesh_count) {
             Effect_Kill(effect_num);
         }
     }

--- a/src/tr1/game/objects/effects/explosion.c
+++ b/src/tr1/game/objects/effects/explosion.c
@@ -15,7 +15,7 @@ void Explosion_Control(int16_t effect_num)
     if (effect->counter == 2) {
         effect->counter = 0;
         effect->frame_num--;
-        if (effect->frame_num <= g_Objects[effect->object_id].nmeshes) {
+        if (effect->frame_num <= g_Objects[effect->object_id].mesh_count) {
             Effect_Kill(effect_num);
         }
     }

--- a/src/tr1/game/objects/effects/flame.c
+++ b/src/tr1/game/objects/effects/flame.c
@@ -21,7 +21,7 @@ void Flame_Control(int16_t effect_num)
     EFFECT *effect = Effect_Get(effect_num);
 
     effect->frame_num--;
-    if (effect->frame_num <= g_Objects[O_FLAME].nmeshes) {
+    if (effect->frame_num <= g_Objects[O_FLAME].mesh_count) {
         effect->frame_num = 0;
     }
 

--- a/src/tr1/game/objects/effects/natla_gun.c
+++ b/src/tr1/game/objects/effects/natla_gun.c
@@ -17,7 +17,7 @@ void NatlaGun_Control(int16_t effect_num)
     OBJECT *object = &g_Objects[effect->object_id];
 
     effect->frame_num--;
-    if (effect->frame_num <= object->nmeshes) {
+    if (effect->frame_num <= object->mesh_count) {
         Effect_Kill(effect_num);
     }
 

--- a/src/tr1/game/objects/effects/pickup_aid.c
+++ b/src/tr1/game/objects/effects/pickup_aid.c
@@ -11,7 +11,8 @@ static void M_Control(int16_t effect_num)
     if (effect->counter == 1) {
         effect->counter = 0;
         effect->frame_num--;
-        if (effect->frame_num <= Object_GetObject(effect->object_id)->nmeshes) {
+        if (effect->frame_num
+            <= Object_GetObject(effect->object_id)->mesh_count) {
             Effect_Kill(effect_num);
         }
     }

--- a/src/tr1/game/objects/effects/splash.c
+++ b/src/tr1/game/objects/effects/splash.c
@@ -16,7 +16,7 @@ void Splash_Control(int16_t effect_num)
     const OBJECT *const object = Object_GetObject(effect->object_id);
 
     effect->frame_num--;
-    if (effect->frame_num <= object->nmeshes) {
+    if (effect->frame_num <= object->mesh_count) {
         Effect_Kill(effect_num);
         return;
     }

--- a/src/tr1/game/objects/effects/twinkle.c
+++ b/src/tr1/game/objects/effects/twinkle.c
@@ -19,7 +19,7 @@ void Twinkle_Control(int16_t effect_num)
     if (effect->counter == 1) {
         effect->counter = 0;
         effect->frame_num--;
-        if (effect->frame_num <= g_Objects[effect->object_id].nmeshes) {
+        if (effect->frame_num <= g_Objects[effect->object_id].mesh_count) {
             Effect_Kill(effect_num);
         }
     }

--- a/src/tr1/game/objects/traps/lightning_emitter.c
+++ b/src/tr1/game/objects/traps/lightning_emitter.c
@@ -47,7 +47,7 @@ void LightningEmitter_Initialise(int16_t item_num)
     LIGHTNING *l = GameBuf_Alloc(sizeof(LIGHTNING), GBUF_ITEM_DATA);
     g_Items[item_num].data = l;
 
-    if (g_Objects[g_Items[item_num].object_id].nmeshes > 1) {
+    if (g_Objects[g_Items[item_num].object_id].mesh_count > 1) {
         g_Items[item_num].mesh_bits = 1;
         l->no_target = false;
     } else {

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1191,11 +1191,11 @@ void Output_AnimateTextures(void)
 
     for (int32_t i = 0; i < STATIC_NUMBER_OF; i++) {
         const STATIC_INFO *const static_info = &g_StaticObjects[i];
-        if (!static_info->loaded || static_info->nmeshes >= -1) {
+        if (!static_info->loaded || static_info->mesh_count >= -1) {
             continue;
         }
 
-        const int32_t num_meshes = -static_info->nmeshes;
+        const int32_t num_meshes = -static_info->mesh_count;
         const PHD_SPRITE temp = g_PhdSpriteInfo[static_info->mesh_num];
         for (int32_t j = 0; j < num_meshes - 1; j++) {
             g_PhdSpriteInfo[static_info->mesh_num + j] =

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -405,7 +405,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
 
     Object_DrawMesh(obj->mesh_idx, 0, false);
 
-    for (int i = 1; i < obj->nmeshes; i++) {
+    for (int i = 1; i < obj->mesh_count; i++) {
         const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {
             Matrix_Pop();

--- a/src/tr1/game/text.c
+++ b/src/tr1/game/text.c
@@ -183,7 +183,7 @@ void Text_DrawText(TEXTSTRING *const text)
                 + Screen_GetRenderScale(glyph->combine_with.offset_x, RSR_TEXT);
             const int32_t csy = sy
                 + Screen_GetRenderScale(glyph->combine_with.offset_y, RSR_TEXT);
-            if (glyph->combine_with.mesh_idx >= ABS(obj->nmeshes)) {
+            if (glyph->combine_with.mesh_idx >= ABS(obj->mesh_count)) {
                 goto loop_end;
             }
 
@@ -192,7 +192,7 @@ void Text_DrawText(TEXTSTRING *const text)
                 obj->mesh_idx + glyph->combine_with.mesh_idx, 16 << 8, 0, 0);
         }
 
-        if (glyph->mesh_idx >= ABS(obj->nmeshes)) {
+        if (glyph->mesh_idx >= ABS(obj->mesh_count)) {
             goto loop_end;
         }
         Output_DrawScreenSprite2D(

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -487,7 +487,7 @@ typedef enum {
 
 typedef struct {
     bool loaded;
-    int16_t nmeshes;
+    int16_t mesh_count;
     int16_t mesh_num;
     int16_t flags;
     BOUNDS_16 p;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A little housekeeping before tackling frames to rename `nmeshes` to `mesh_count` in `OBJECT` for TR1. I did the same for `STATIC_INFO` to be consistent (TR2 statics don't have a mesh count, we introduced this in #1282).

No logical changes here, it's purely an internal renaming.
