### PR TITLE
tr1/output: use tr2 Output_AnimateTextures method

### DIFF
--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -89,7 +89,7 @@ void Output_DrawUISprite(
 
 void Output_SetupBelowWater(bool underwater);
 void Output_SetupAboveWater(bool underwater);
-void Output_AnimateTextures(void);
+void Output_AnimateTextures(int32_t num_frames);
 
 void Output_ApplyFOV(void);
 void Output_ApplyTint(float *r, float *g, float *b);

--- a/src/tr1/game/phase/phase_cutscene.c
+++ b/src/tr1/game/phase/phase_cutscene.c
@@ -191,13 +191,13 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         }
     }
 
+    Output_AnimateTextures(nframes);
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }
 
 static void M_Draw(void)
 {
     Game_Draw(true);
-    Output_AnimateTextures();
 }
 
 PHASER g_CutscenePhaser = {

--- a/src/tr1/game/phase/phase_demo.c
+++ b/src/tr1/game/phase/phase_demo.c
@@ -367,6 +367,7 @@ static PHASE_CONTROL M_ControlFadeOut(void)
 
 static PHASE_CONTROL M_Control(int32_t nframes)
 {
+    Output_AnimateTextures(nframes);
     switch (m_State) {
     case STATE_INVALID:
         return (PHASE_CONTROL) {
@@ -398,7 +399,6 @@ static void M_Draw(void)
         Interpolation_Enable();
     }
 
-    Output_AnimateTextures();
     Text_Draw();
     Fader_Draw(&m_Fader);
 }

--- a/src/tr1/game/phase/phase_game.c
+++ b/src/tr1/game/phase/phase_game.c
@@ -173,13 +173,13 @@ static PHASE_CONTROL M_Control(int32_t nframes)
         }
     }
 
+    Output_AnimateTextures(nframes);
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }
 
 static void M_Draw(void)
 {
     Game_Draw(true);
-    Output_AnimateTextures();
     Text_Draw();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2239.
This switches from CLOCK_TIMER back to using frames, ensuring that Output_AnimateTextures is called from the control routines. This minimizes issues related to 30/60 FPS, turbo cheats on/off, and freezing/resuming animations during pause/inventory.