### PR TITLE
libtrx/anims/frames: expand TR1 frame rotations

### DIFF
--- a/src/libtrx/game/anims/frames.c
+++ b/src/libtrx/game/anims/frames.c
@@ -9,7 +9,8 @@ static ANIM_FRAME *m_Frames = NULL;
 
 static int32_t M_GetAnimFrameCount(int32_t anim_idx);
 static OBJECT *M_GetAnimObject(int32_t anim_idx);
-static int32_t M_ParseFrame(ANIM_FRAME *frame, const int16_t *data_ptr);
+static int32_t M_ParseFrame(
+    ANIM_FRAME *frame, const int16_t *data_ptr, int16_t mesh_count);
 
 static int32_t M_GetAnimFrameCount(const int32_t anim_idx)
 {
@@ -37,7 +38,8 @@ static OBJECT *M_GetAnimObject(const int32_t anim_idx)
     return NULL;
 }
 
-static int32_t M_ParseFrame(ANIM_FRAME *const frame, const int16_t *data_ptr)
+static int32_t M_ParseFrame(
+    ANIM_FRAME *const frame, const int16_t *data_ptr, int16_t mesh_count)
 {
 #if TR_VERSION > 1
     ASSERT_FAIL();
@@ -54,12 +56,14 @@ static int32_t M_ParseFrame(ANIM_FRAME *const frame, const int16_t *data_ptr)
     frame->offset.x = *data_ptr++;
     frame->offset.y = *data_ptr++;
     frame->offset.z = *data_ptr++;
-    frame->nmeshes = *data_ptr++;
+    #if TR_VERSION == 1
+    mesh_count = *data_ptr++;
+    #endif
 
     frame->mesh_rots =
-        GameBuf_Alloc(sizeof(int32_t) * frame->nmeshes, GBUF_ANIM_FRAMES);
-    memcpy(frame->mesh_rots, data_ptr, frame->nmeshes * sizeof(int32_t));
-    data_ptr += frame->nmeshes * sizeof(int32_t) / sizeof(int16_t);
+        GameBuf_Alloc(sizeof(int32_t) * mesh_count, GBUF_ANIM_FRAMES);
+    memcpy(frame->mesh_rots, data_ptr, mesh_count * sizeof(int32_t));
+    data_ptr += mesh_count * sizeof(int32_t) / sizeof(int16_t);
 
     return data_ptr - frame_start;
 #endif
@@ -124,7 +128,7 @@ void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
                 }
             }
 
-            data_ptr += M_ParseFrame(frame, data_ptr);
+            data_ptr += M_ParseFrame(frame, data_ptr, cur_obj->mesh_count);
         }
     }
 

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -28,7 +28,6 @@ typedef struct {
     BOUNDS_16 bounds;
     XYZ_16 offset;
 #if TR_VERSION == 1
-    int16_t nmeshes;
     int32_t *mesh_rots;
 #else
     int16_t mesh_rots[];

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -28,7 +28,7 @@ typedef struct {
     BOUNDS_16 bounds;
     XYZ_16 offset;
 #if TR_VERSION == 1
-    int32_t *mesh_rots;
+    XYZ_16 *mesh_rots;
 #else
     int16_t mesh_rots[];
 #endif

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -512,8 +512,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
-    int32_t *packed_rotation = frame->mesh_rots;
-    Matrix_RotYXZpack(*packed_rotation++);
+    Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
     OBJECT *object = &g_Objects[item->object_id];
     const OBJECT_MESH *mesh = Object_GetMesh(object->mesh_idx);
@@ -538,7 +537,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame->mesh_rots[i]);
 
         if (extra_rotation != NULL) {
             if (bone->rot_y) {
@@ -614,8 +613,7 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
-    int32_t *packed_rotation = frame->mesh_rots;
-    Matrix_RotYXZpack(*packed_rotation++);
+    Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
     int16_t *extra_rotation = (int16_t *)item->data;
     for (int i = 0; i < joint; i++) {
@@ -628,7 +626,7 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame->mesh_rots[i + 1]);
 
         if (bone->rot_y) {
             Matrix_RotY(*extra_rotation++);

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -802,8 +802,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
-    int32_t *packed_rotation = frame->mesh_rots;
-    Matrix_RotYXZpack(*packed_rotation++);
+    Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
 #if 0
     // XXX: present in OG, removed by GLrage on the grounds that it sometimes
@@ -845,7 +844,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame->mesh_rots[i]);
 
 #if 0
     if (extra_rotation) {

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -99,24 +99,24 @@ void Lara_Draw(ITEM *item)
     Output_CalculateObjectLighting(item, &frame->bounds);
 
     const ANIM_BONE *const bone = Object_GetBone(object, 0);
-    int32_t *packed_rotation = frame->mesh_rots;
+    const XYZ_16 *mesh_rots = frame->mesh_rots;
 
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-    Matrix_RotYXZpack(packed_rotation[LM_HIPS]);
+    Matrix_RotXYZ16(&mesh_rots[LM_HIPS]);
     M_DrawMesh(LM_HIPS, clip, false);
 
     Matrix_Push();
 
     Matrix_TranslateRel(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_THIGH_L]);
+    Matrix_RotXYZ16(&mesh_rots[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, false);
 
     Matrix_TranslateRel(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_CALF_L]);
+    Matrix_RotXYZ16(&mesh_rots[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, false);
 
     Matrix_TranslateRel(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_FOOT_L]);
+    Matrix_RotXYZ16(&mesh_rots[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, false);
 
     Matrix_Pop();
@@ -124,21 +124,21 @@ void Lara_Draw(ITEM *item)
     Matrix_Push();
 
     Matrix_TranslateRel(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_THIGH_R]);
+    Matrix_RotXYZ16(&mesh_rots[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, false);
 
     Matrix_TranslateRel(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_CALF_R]);
+    Matrix_RotXYZ16(&mesh_rots[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, false);
 
     Matrix_TranslateRel(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_FOOT_R]);
+    Matrix_RotXYZ16(&mesh_rots[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, false);
 
     Matrix_Pop();
 
     Matrix_TranslateRel(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
+    Matrix_RotXYZ16(&mesh_rots[LM_TORSO]);
     Matrix_RotYXZ(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
         g_Lara.interp.result.torso_rot.z);
@@ -147,7 +147,7 @@ void Lara_Draw(ITEM *item)
     Matrix_Push();
 
     Matrix_TranslateRel(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
-    Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
+    Matrix_RotXYZ16(&mesh_rots[LM_HEAD]);
     Matrix_RotYXZ(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
         g_Lara.interp.result.head_rot.z);
@@ -169,15 +169,15 @@ void Lara_Draw(ITEM *item)
         Matrix_Push();
 
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         Matrix_Pop();
@@ -185,15 +185,15 @@ void Lara_Draw(ITEM *item)
         Matrix_Push();
 
         Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         Matrix_Pop();
@@ -216,21 +216,21 @@ void Lara_Draw(ITEM *item)
         g_MatrixPtr->_21 = g_MatrixPtr[-2]._21;
         g_MatrixPtr->_22 = g_MatrixPtr[-2]._22;
 
-        packed_rotation =
+        mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_RotYXZ(
             g_Lara.right_arm.interp.result.rot.y,
             g_Lara.right_arm.interp.result.rot.x,
             g_Lara.right_arm.interp.result.rot.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -253,21 +253,21 @@ void Lara_Draw(ITEM *item)
         g_MatrixPtr->_21 = g_MatrixPtr[-2]._21;
         g_MatrixPtr->_22 = g_MatrixPtr[-2]._22;
 
-        packed_rotation =
+        mesh_rots =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         Matrix_RotYXZ(
             g_Lara.left_arm.interp.result.rot.y,
             g_Lara.left_arm.interp.result.rot.x,
             g_Lara.left_arm.interp.result.rot.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.left_arm.flash_gun) {
@@ -284,18 +284,18 @@ void Lara_Draw(ITEM *item)
     case LGT_SHOTGUN:
         Matrix_Push();
 
-        packed_rotation =
+        mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_R]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -306,18 +306,18 @@ void Lara_Draw(ITEM *item)
 
         Matrix_Push();
 
-        packed_rotation =
+        mesh_rots =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_LARM_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HAND_L]);
+        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -371,8 +371,8 @@ void Lara_Draw_I(
     Output_CalculateObjectLighting(item, &frame1->bounds);
 
     const ANIM_BONE *const bone = Object_GetBone(object, 0);
-    int32_t *packed_rotation1 = frame1->mesh_rots;
-    int32_t *packed_rotation2 = frame2->mesh_rots;
+    const XYZ_16 *mesh_rots_1 = frame1->mesh_rots;
+    const XYZ_16 *mesh_rots_2 = frame2->mesh_rots;
 
     Matrix_InitInterpolate(frac, rate);
 
@@ -380,24 +380,21 @@ void Lara_Draw_I(
         frame1->offset.x, frame1->offset.y, frame1->offset.z, frame2->offset.x,
         frame2->offset.y, frame2->offset.z);
 
-    Matrix_RotYXZpack_I(packed_rotation1[LM_HIPS], packed_rotation2[LM_HIPS]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_HIPS], &mesh_rots_2[LM_HIPS]);
     M_DrawMesh(LM_HIPS, clip, true);
 
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_THIGH_L], packed_rotation2[LM_THIGH_L]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_THIGH_L], &mesh_rots_2[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, true);
 
     Matrix_TranslateRel_I(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_CALF_L], packed_rotation2[LM_CALF_L]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_CALF_L], &mesh_rots_2[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, true);
 
     Matrix_TranslateRel_I(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_FOOT_L], packed_rotation2[LM_FOOT_L]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_FOOT_L], &mesh_rots_2[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, true);
 
     Matrix_Pop_I();
@@ -405,24 +402,21 @@ void Lara_Draw_I(
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_THIGH_R], packed_rotation2[LM_THIGH_R]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_THIGH_R], &mesh_rots_2[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, true);
 
     Matrix_TranslateRel_I(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_CALF_R], packed_rotation2[LM_CALF_R]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_CALF_R], &mesh_rots_2[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, true);
 
     Matrix_TranslateRel_I(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
-    Matrix_RotYXZpack_I(
-        packed_rotation1[LM_FOOT_R], packed_rotation2[LM_FOOT_R]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_FOOT_R], &mesh_rots_2[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, true);
 
     Matrix_Pop_I();
 
     Matrix_TranslateRel_I(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
-    Matrix_RotYXZpack_I(packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_TORSO], &mesh_rots_2[LM_TORSO]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
         g_Lara.interp.result.torso_rot.z);
@@ -431,7 +425,7 @@ void Lara_Draw_I(
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
-    Matrix_RotYXZpack_I(packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
+    Matrix_RotXYZ16_I(&mesh_rots_1[LM_HEAD], &mesh_rots_2[LM_HEAD]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
         g_Lara.interp.result.head_rot.z);
@@ -453,18 +447,15 @@ void Lara_Draw_I(
         Matrix_Push_I();
 
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_R], &mesh_rots_2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_LARM_R], packed_rotation2[LM_LARM_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_R], &mesh_rots_2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HAND_R], packed_rotation2[LM_HAND_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_R], &mesh_rots_2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
 
         Matrix_Pop_I();
@@ -472,18 +463,15 @@ void Lara_Draw_I(
         Matrix_Push_I();
 
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_L], &mesh_rots_2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_LARM_L], packed_rotation2[LM_LARM_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_L], &mesh_rots_2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HAND_L], packed_rotation2[LM_HAND_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_L], &mesh_rots_2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);
 
         Matrix_Pop_I();
@@ -497,21 +485,21 @@ void Lara_Draw_I(
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         Matrix_InterpolateArm();
 
-        packed_rotation1 =
+        mesh_rots_1 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_RotYXZ(
             g_Lara.right_arm.interp.result.rot.y,
             g_Lara.right_arm.interp.result.rot.x,
             g_Lara.right_arm.interp.result.rot.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_UARM_R]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_LARM_R]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_HAND_R]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -525,21 +513,21 @@ void Lara_Draw_I(
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
         Matrix_InterpolateArm();
 
-        packed_rotation1 =
+        mesh_rots_1 =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         Matrix_RotYXZ(
             g_Lara.left_arm.interp.result.rot.y,
             g_Lara.left_arm.interp.result.rot.x,
             g_Lara.left_arm.interp.result.rot.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_UARM_L]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_LARM_L]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack(packed_rotation1[LM_HAND_L]);
+        Matrix_RotXYZ16(&mesh_rots_1[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.left_arm.flash_gun) {
@@ -557,22 +545,19 @@ void Lara_Draw_I(
     case LGT_SHOTGUN:
         Matrix_Push_I();
 
-        packed_rotation1 =
+        mesh_rots_1 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
-        packed_rotation2 = packed_rotation1;
+        mesh_rots_2 = mesh_rots_1;
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_R], &mesh_rots_2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_LARM_R], packed_rotation2[LM_LARM_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_R], &mesh_rots_2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HAND_R], packed_rotation2[LM_HAND_R]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_R], &mesh_rots_2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -583,22 +568,19 @@ void Lara_Draw_I(
 
         Matrix_Push_I();
 
-        packed_rotation1 =
+        mesh_rots_1 =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
-        packed_rotation2 = packed_rotation1;
+        mesh_rots_2 = mesh_rots_1;
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_L], &mesh_rots_2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_LARM_L], packed_rotation2[LM_LARM_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_L], &mesh_rots_2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HAND_L], packed_rotation2[LM_HAND_L]);
+        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_L], &mesh_rots_2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);
 
         if (g_Lara.right_arm.flash_gun) {

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -145,13 +145,11 @@ void Lara_Hair_Control(void)
     const ANIM_BONE *bone = Object_GetBone(object, 0);
     if (frac) {
         Matrix_InitInterpolate(frac, rate);
-        int32_t *packed_rotation1 = frmptr[0]->mesh_rots;
-        int32_t *packed_rotation2 = frmptr[1]->mesh_rots;
         Matrix_TranslateRel_ID(
             frmptr[0]->offset.x, frmptr[0]->offset.y, frmptr[0]->offset.z,
             frmptr[1]->offset.x, frmptr[1]->offset.y, frmptr[1]->offset.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HIPS], packed_rotation2[LM_HIPS]);
+        Matrix_RotXYZ16_I(
+            &frmptr[0]->mesh_rots[LM_HIPS], &frmptr[1]->mesh_rots[LM_HIPS]);
 
         // hips
         Matrix_Push_I();
@@ -168,8 +166,8 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
             bone[LM_TORSO - 1].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_TORSO], packed_rotation2[LM_TORSO]);
+        Matrix_RotXYZ16_I(
+            &frmptr[0]->mesh_rots[LM_TORSO], &frmptr[1]->mesh_rots[LM_TORSO]);
         Matrix_RotYXZ_I(
             g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
             g_Lara.interp.result.torso_rot.z);
@@ -188,8 +186,8 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_R], packed_rotation2[LM_UARM_R]);
+        Matrix_RotXYZ16_I(
+            &frmptr[0]->mesh_rots[LM_UARM_R], &frmptr[1]->mesh_rots[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
         Matrix_TranslateRel_I(mesh->center.x, mesh->center.y, mesh->center.z);
         Matrix_Interpolate();
@@ -204,8 +202,8 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_UARM_L], packed_rotation2[LM_UARM_L]);
+        Matrix_RotXYZ16_I(
+            &frmptr[0]->mesh_rots[LM_UARM_L], &frmptr[1]->mesh_rots[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
         Matrix_TranslateRel_I(mesh->center.x, mesh->center.y, mesh->center.z);
         Matrix_Interpolate();
@@ -219,8 +217,8 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
             bone[LM_HEAD - 1].pos.z);
-        Matrix_RotYXZpack_I(
-            packed_rotation1[LM_HEAD], packed_rotation2[LM_HEAD]);
+        Matrix_RotXYZ16_I(
+            &frmptr[0]->mesh_rots[LM_HEAD], &frmptr[1]->mesh_rots[LM_HEAD]);
         Matrix_RotYXZ_I(
             g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
             g_Lara.interp.result.head_rot.z);
@@ -239,8 +237,7 @@ void Lara_Hair_Control(void)
 
     } else {
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-        int32_t *packed_rotation = frame->mesh_rots;
-        Matrix_RotYXZpack(packed_rotation[LM_HIPS]);
+        Matrix_RotXYZ16(&frame->mesh_rots[LM_HIPS]);
 
         // hips
         Matrix_Push();
@@ -256,7 +253,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
             bone[LM_TORSO - 1].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_TORSO]);
+        Matrix_RotXYZ16(&frame->mesh_rots[LM_TORSO]);
         Matrix_RotYXZ(
             g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
             g_Lara.interp.result.torso_rot.z);
@@ -274,7 +271,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_R]);
+        Matrix_RotXYZ16(&frame->mesh_rots[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
         sphere[3].x = g_MatrixPtr->_03 >> W2V_SHIFT;
@@ -288,7 +285,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_UARM_L]);
+        Matrix_RotXYZ16(&frame->mesh_rots[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
         sphere[4].x = g_MatrixPtr->_03 >> W2V_SHIFT;
@@ -301,7 +298,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
             bone[LM_HEAD - 1].pos.z);
-        Matrix_RotYXZpack(packed_rotation[LM_HEAD]);
+        Matrix_RotXYZ16(&frame->mesh_rots[LM_HEAD]);
         Matrix_RotYXZ(
             g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
             g_Lara.interp.result.head_rot.z);

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -199,8 +199,7 @@ void Object_DrawPickupItem(ITEM *item)
 
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
 
-        int32_t *packed_rotation = frame->mesh_rots;
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
         if (item->mesh_bits & bit) {
             Object_DrawMesh(object->mesh_idx, clip, false);
@@ -217,7 +216,7 @@ void Object_DrawPickupItem(ITEM *item)
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZpack(*packed_rotation++);
+            Matrix_RotXYZ16(&frame->mesh_rots[i]);
 
             // Extra rotation is ignored in this case as it's not needed.
 
@@ -250,8 +249,7 @@ void Object_DrawInterpolatedObject(
         Matrix_TranslateRel(
             frame1->offset.x, frame1->offset.y, frame1->offset.z);
 
-        int32_t *packed_rotation = frame1->mesh_rots;
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame1->mesh_rots[0]);
 
         if (meshes & mesh_num) {
             Object_DrawMesh(object->mesh_idx, clip, false);
@@ -268,7 +266,7 @@ void Object_DrawInterpolatedObject(
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZpack(*packed_rotation++);
+            Matrix_RotXYZ16(&frame1->mesh_rots[i]);
 
             if (extra_rotation != NULL) {
                 if (bone->rot_y) {
@@ -293,9 +291,7 @@ void Object_DrawInterpolatedObject(
         Matrix_TranslateRel_ID(
             frame1->offset.x, frame1->offset.y, frame1->offset.z,
             frame2->offset.x, frame2->offset.y, frame2->offset.z);
-        int32_t *packed_rotation1 = frame1->mesh_rots;
-        int32_t *packed_rotation2 = frame2->mesh_rots;
-        Matrix_RotYXZpack_I(*packed_rotation1++, *packed_rotation2++);
+        Matrix_RotXYZ16_I(&frame1->mesh_rots[0], &frame2->mesh_rots[0]);
 
         if (meshes & mesh_num) {
             Object_DrawMesh(object->mesh_idx, clip, true);
@@ -312,7 +308,7 @@ void Object_DrawInterpolatedObject(
             }
 
             Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZpack_I(*packed_rotation1++, *packed_rotation2++);
+            Matrix_RotXYZ16_I(&frame1->mesh_rots[i], &frame2->mesh_rots[i]);
 
             if (extra_rotation != NULL) {
                 if (bone->rot_y) {

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -400,8 +400,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         -(frame->bounds.min.x + frame->bounds.max.x) / 2,
         -(frame->bounds.min.y + frame->bounds.max.y) / 2,
         -(frame->bounds.min.z + frame->bounds.max.z) / 2);
-    int32_t *packed_rotation = frame->mesh_rots;
-    Matrix_RotYXZpack(*packed_rotation++);
+    Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
     Object_DrawMesh(obj->mesh_idx, 0, false);
 
@@ -416,7 +415,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZpack(*packed_rotation++);
+        Matrix_RotXYZ16(&frame->mesh_rots[i]);
 
         Object_DrawMesh(obj->mesh_idx + i, 0, false);
     }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -255,7 +255,7 @@ static void M_DrawSkybox(void)
 
     const OBJECT *const skybox = Object_GetObject(O_SKYBOX);
     const ANIM_FRAME *const frame = Object_GetAnim(skybox, 0)->frame_ptr;
-    Matrix_RotYXZpack(frame->mesh_rots[0]);
+    Matrix_RotXYZ16(&frame->mesh_rots[0]);
     Output_DrawSkybox(Object_GetMesh(skybox->mesh_idx));
 
     Matrix_Pop();

--- a/src/tr1/math/matrix.c
+++ b/src/tr1/math/matrix.c
@@ -6,10 +6,6 @@
 
 #include <stddef.h>
 
-#define EXTRACT_ROT_Y(rots) (((rots >> 10) & 0x3FF) << 6)
-#define EXTRACT_ROT_X(rots) (((rots >> 20) & 0x3FF) << 6)
-#define EXTRACT_ROT_Z(rots) ((rots & 0x3FF) << 6)
-
 static MATRIX m_MatrixStack[MAX_MATRICES] = { 0 };
 static int32_t m_IMRate = 0;
 static int32_t m_IMFrac = 0;
@@ -170,14 +166,11 @@ void Matrix_RotYXZ(PHD_ANGLE ry, PHD_ANGLE rx, PHD_ANGLE rz)
     Matrix_RotZ(rz);
 }
 
-void Matrix_RotYXZpack(int32_t rots)
+void Matrix_RotXYZ16(const XYZ_16 *const rotation)
 {
-    const PHD_ANGLE ry = EXTRACT_ROT_Y(rots);
-    const PHD_ANGLE rx = EXTRACT_ROT_X(rots);
-    const PHD_ANGLE rz = EXTRACT_ROT_Z(rots);
-    Matrix_RotY(ry);
-    Matrix_RotX(rx);
-    Matrix_RotZ(rz);
+    Matrix_RotY(rotation->y);
+    Matrix_RotX(rotation->x);
+    Matrix_RotZ(rotation->z);
 }
 
 void Matrix_TranslateRel(int32_t x, int32_t y, int32_t z)
@@ -343,12 +336,13 @@ void Matrix_RotYXZ_I(PHD_ANGLE y, PHD_ANGLE x, PHD_ANGLE z)
     g_MatrixPtr = old_matrix;
 }
 
-void Matrix_RotYXZpack_I(int32_t r1, int32_t r2)
+void Matrix_RotXYZ16_I(
+    const XYZ_16 *const rotation_1, const XYZ_16 *const rotation_2)
 {
-    Matrix_RotYXZpack(r1);
-    MATRIX *old_matrix = g_MatrixPtr;
+    Matrix_RotXYZ16(rotation_1);
+    MATRIX *const old_matrix = g_MatrixPtr;
     g_MatrixPtr = m_IMMatrixPtr;
-    Matrix_RotYXZpack(r2);
+    Matrix_RotXYZ16(rotation_2);
     g_MatrixPtr = old_matrix;
 }
 

--- a/src/tr1/math/matrix.h
+++ b/src/tr1/math/matrix.h
@@ -20,7 +20,7 @@ void Matrix_RotX(int16_t rx);
 void Matrix_RotY(int16_t ry);
 void Matrix_RotZ(int16_t rz);
 void Matrix_RotYXZ(int16_t ry, int16_t rx, int16_t rz);
-void Matrix_RotYXZpack(int32_t rots);
+void Matrix_RotXYZ16(const XYZ_16 *rotation);
 void Matrix_TranslateRel(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateSet(int32_t x, int32_t y, int32_t z);
@@ -32,7 +32,7 @@ void Matrix_RotY_I(int16_t ang);
 void Matrix_RotX_I(int16_t ang);
 void Matrix_RotZ_I(int16_t ang);
 void Matrix_RotYXZ_I(int16_t y, int16_t x, int16_t z);
-void Matrix_RotYXZpack_I(int32_t r1, int32_t r2);
+void Matrix_RotXYZ16_I(const XYZ_16 *rotation_1, const XYZ_16 *rotation_2);
 
 void Matrix_TranslateRel_I(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateRel_ID(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This parses TR1 frame mesh rotations fully once on level load, which means we eliminate the need to pass packed values to `matrix.c` and have it extract the individual values on every call.

I'm not sure if I like the name `Matrix_RotYXZ_16`. I can see potential though to change `Matrix_RotYXZ`'s signature in a follow-up task to accept an `XYZ_16` instead of the individual values.

The extraction macros are a little more complex ready for TR2, as it won't always have two `int16_t`s so we can't cast to `int32_t` and use the previous approach. Similarly, the `M_ParseMeshRotation` function returns the number of values read because of what's to come with TR2.

This also removes `nmeshes` from `ANIM_FRAME` - now taken from the related object.
