### PR TITLE
libtrx/anims/frames: migrate TR2 frame handling to TRX

### DIFF
--- a/src/libtrx/game/anims/frames.c
+++ b/src/libtrx/game/anims/frames.c
@@ -4,18 +4,22 @@
 #include "game/gamebuf.h"
 #include "game/objects/common.h"
 #include "log.h"
+#include "utils.h"
 
 static ANIM_FRAME *m_Frames = NULL;
 
-static int32_t M_GetAnimFrameCount(int32_t anim_idx);
+static int32_t M_GetAnimFrameCount(int32_t anim_idx, int32_t frame_data_length);
 static OBJECT *M_GetAnimObject(int32_t anim_idx);
+static ANIM_FRAME *M_FindFrameBase(uint32_t frame_ofs);
 static int32_t M_ParseFrame(
-    ANIM_FRAME *frame, const int16_t *data_ptr, int16_t mesh_count);
+    ANIM_FRAME *frame, const int16_t *data_ptr, int16_t mesh_count,
+    uint8_t frame_size);
 static void M_ParseMeshRotation(XYZ_16 *rot, const int16_t **data);
 static void M_ExtractRotation(
     XYZ_16 *rot, int16_t rot_val_1, int16_t rot_val_2);
 
-static int32_t M_GetAnimFrameCount(const int32_t anim_idx)
+static int32_t M_GetAnimFrameCount(
+    const int32_t anim_idx, const int32_t frame_data_length)
 {
     const ANIM *const anim = Anim_GetAnim(anim_idx);
 #if TR_VERSION == 1
@@ -23,8 +27,11 @@ static int32_t M_GetAnimFrameCount(const int32_t anim_idx)
         ((anim->frame_end - anim->frame_base) / (float)anim->interpolation)
         + 1);
 #else
-    ASSERT_FAIL();
-    return 0;
+    uint32_t next_ofs = anim_idx == Anim_GetTotalCount() - 1
+        ? (unsigned)(sizeof(int16_t) * frame_data_length)
+        : Anim_GetAnim(anim_idx + 1)->frame_ofs;
+    return (next_ofs - anim->frame_ofs)
+        / (int32_t)(sizeof(int16_t) * anim->frame_size);
 #endif
 }
 
@@ -41,15 +48,40 @@ static OBJECT *M_GetAnimObject(const int32_t anim_idx)
     return NULL;
 }
 
-static int32_t M_ParseFrame(
-    ANIM_FRAME *const frame, const int16_t *data_ptr, int16_t mesh_count)
+static ANIM_FRAME *M_FindFrameBase(const uint32_t frame_ofs)
 {
-#if TR_VERSION > 1
-    ASSERT_FAIL();
-    return 0;
-#else
-    const int16_t *const frame_start = data_ptr;
+    const int32_t anim_count = Anim_GetTotalCount();
+    for (int32_t i = 0; i < anim_count; i++) {
+        const ANIM *const anim = Anim_GetAnim(i);
+        if (anim->frame_ofs == frame_ofs) {
+            return anim->frame_ptr;
+        }
+    }
 
+    return NULL;
+}
+
+static int32_t M_ParseFrame(
+    ANIM_FRAME *const frame, const int16_t *data_ptr, int16_t mesh_count,
+    const uint8_t frame_size)
+{
+    const int16_t *const frame_start = data_ptr;
+#if TR_VERSION > 1
+    frame->bounds.min_x = *data_ptr++;
+    frame->bounds.max_x = *data_ptr++;
+    frame->bounds.min_y = *data_ptr++;
+    frame->bounds.max_y = *data_ptr++;
+    frame->bounds.min_z = *data_ptr++;
+    frame->bounds.max_z = *data_ptr++;
+    frame->offset.x = *data_ptr++;
+    frame->offset.y = *data_ptr++;
+    frame->offset.z = *data_ptr++;
+
+    frame->mesh_rots =
+        GameBuf_Alloc(sizeof(int16_t) * (frame_size - 9), GBUF_ANIM_FRAMES);
+    memcpy(frame->mesh_rots, data_ptr, sizeof(int16_t) * (frame_size - 9));
+    data_ptr += MAX(0, frame_size - (data_ptr - frame_start));
+#else
     frame->bounds.min.x = *data_ptr++;
     frame->bounds.max.x = *data_ptr++;
     frame->bounds.min.y = *data_ptr++;
@@ -69,9 +101,8 @@ static int32_t M_ParseFrame(
         XYZ_16 *const rot = &frame->mesh_rots[i];
         M_ParseMeshRotation(rot, &data_ptr);
     }
-
-    return data_ptr - frame_start;
 #endif
+    return data_ptr - frame_start;
 }
 
 static void M_ParseMeshRotation(XYZ_16 *const rot, const int16_t **data)
@@ -95,36 +126,24 @@ static void M_ExtractRotation(
     rot->z = (rot_val_2 & 0x3FF) << 6;
 }
 
-int32_t Anim_GetTotalFrameCount(void)
+int32_t Anim_GetTotalFrameCount(const int32_t frame_data_length)
 {
-#if TR_VERSION > 1
-    ASSERT_FAIL();
-    return 0;
-#else
     const int32_t anim_count = Anim_GetTotalCount();
     int32_t total_frame_count = 0;
     for (int32_t i = 0; i < anim_count; i++) {
-        total_frame_count += M_GetAnimFrameCount(i);
+        total_frame_count += M_GetAnimFrameCount(i, frame_data_length);
     }
     return total_frame_count;
-#endif
 }
 
 void Anim_InitialiseFrames(const int32_t num_frames)
 {
-#if TR_VERSION > 1
-    ASSERT_FAIL();
-#else
     LOG_INFO("%d anim frames", num_frames);
     m_Frames = GameBuf_Alloc(sizeof(ANIM_FRAME) * num_frames, GBUF_ANIM_FRAMES);
-#endif
 }
 
 void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
 {
-#if TR_VERSION > 1
-    ASSERT_FAIL();
-#else
     BENCHMARK *const benchmark = Benchmark_Start();
 
     const int32_t anim_count = Anim_GetTotalCount();
@@ -143,7 +162,7 @@ void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
         }
 
         ANIM *const anim = Anim_GetAnim(i);
-        const int32_t frame_count = M_GetAnimFrameCount(i);
+        const int32_t frame_count = M_GetAnimFrameCount(i, data_length);
         const int16_t *data_ptr = &data[anim->frame_ofs / sizeof(int16_t)];
         for (int32_t j = 0; j < frame_count; j++) {
             ANIM_FRAME *const frame = &m_Frames[frame_idx++];
@@ -154,10 +173,20 @@ void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
                 }
             }
 
-            data_ptr += M_ParseFrame(frame, data_ptr, cur_obj->mesh_count);
+            data_ptr += M_ParseFrame(
+                frame, data_ptr, cur_obj->mesh_count, anim->frame_size);
+        }
+    }
+
+    // Some OG data contains objects that point to the previous object's frames,
+    // so ensure everything that's loaded is configured as such.
+    for (int32_t i = 0; i < O_NUMBER_OF; i++) {
+        OBJECT *const object = Object_GetObject(i);
+        if (object->loaded && object->mesh_count >= 0 && object->anim_idx == -1
+            && object->frame_base == NULL) {
+            object->frame_base = M_FindFrameBase(object->frame_ofs);
         }
     }
 
     Benchmark_End(benchmark, NULL);
-#endif
 }

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -215,23 +215,18 @@ void Level_ReadObjectMeshes(
 }
 
 void Level_ReadAnims(
-    const int32_t base_idx, const int32_t num_anims, VFILE *const file,
-    int32_t **frame_pointers)
+    const int32_t base_idx, const int32_t num_anims, VFILE *const file)
 {
     for (int32_t i = 0; i < num_anims; i++) {
         ANIM *const anim = Anim_GetAnim(base_idx + i);
-#if TR_VERSION == 1
         anim->frame_ofs = VFile_ReadU32(file);
+        anim->frame_ptr = NULL; // filled later by the animation frame loader
+#if TR_VERSION == 1
         const int16_t interpolation = VFile_ReadS16(file);
         ASSERT(interpolation <= 0xFF);
         anim->interpolation = interpolation & 0xFF;
         anim->frame_size = 0;
 #else
-        const int32_t frame_idx = VFile_ReadS32(file);
-        if (frame_pointers != NULL) {
-            (*frame_pointers)[i] = frame_idx;
-        }
-        anim->frame_ptr = NULL; // filled later by the animation frame loader
         anim->interpolation = VFile_ReadU8(file);
         anim->frame_size = VFile_ReadU8(file);
 #endif

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -221,15 +221,8 @@ void Level_ReadAnims(
         ANIM *const anim = Anim_GetAnim(base_idx + i);
         anim->frame_ofs = VFile_ReadU32(file);
         anim->frame_ptr = NULL; // filled later by the animation frame loader
-#if TR_VERSION == 1
-        const int16_t interpolation = VFile_ReadS16(file);
-        ASSERT(interpolation <= 0xFF);
-        anim->interpolation = interpolation & 0xFF;
-        anim->frame_size = 0;
-#else
         anim->interpolation = VFile_ReadU8(file);
         anim->frame_size = VFile_ReadU8(file);
-#endif
         anim->current_anim_state = VFile_ReadS16(file);
         anim->velocity = VFile_ReadS32(file);
         anim->acceleration = VFile_ReadS32(file);

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -8,7 +8,7 @@ void Anim_InitialiseRanges(int32_t num_ranges);
 void Anim_InitialiseCommands(int32_t num_cmds);
 void Anim_InitialiseBones(int32_t num_bones);
 
-int32_t Anim_GetTotalFrameCount(void);
+int32_t Anim_GetTotalFrameCount(int32_t frame_data_length);
 void Anim_InitialiseFrames(int32_t num_frames);
 void Anim_LoadFrames(const int16_t *data, int32_t data_length);
 

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -30,17 +30,13 @@ typedef struct {
 #if TR_VERSION == 1
     XYZ_16 *mesh_rots;
 #else
-    int16_t mesh_rots[];
+    int16_t *mesh_rots;
 #endif
 } ANIM_FRAME;
 
 typedef struct {
-#if TR_VERSION == 1
     ANIM_FRAME *frame_ptr;
     uint32_t frame_ofs;
-#elif TR_VERSION == 2
-    int16_t *frame_ptr;
-#endif
     uint8_t interpolation;
     uint8_t frame_size;
     int16_t current_anim_state;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -83,7 +83,7 @@ typedef struct {
 } AMMO_INFO;
 
 typedef struct {
-    int16_t *frame_base;
+    ANIM_FRAME *frame_base;
     int16_t frame_num;
     int16_t anim_num;
     int16_t lock;

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -7,8 +7,7 @@
 void Level_ReadRoomMesh(int32_t room_num, VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
-void Level_ReadAnims(
-    int32_t base_idx, int32_t num_anims, VFILE *file, int32_t **frame_pointers);
+void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
 void Level_ReadAnimCommands(int32_t base_idx, int32_t num_cmds, VFILE *file);

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -41,6 +41,7 @@ typedef struct {
     int16_t mesh_count;
     int16_t mesh_idx;
     int32_t bone_idx;
+    uint32_t frame_ofs;
     ANIM_FRAME *frame_base;
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);
@@ -70,7 +71,8 @@ typedef struct {
     int16_t mesh_count;
     int16_t mesh_idx;
     int32_t bone_idx;
-    int16_t *frame_base; // TODO: make me ANIM_FRAME
+    uint32_t frame_ofs;
+    ANIM_FRAME *frame_base;
 
     void (*initialise)(int16_t item_num);
     void (*control)(int16_t item_num);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -507,7 +507,7 @@ static void M_AnimData(INJECTION *injection, LEVEL_INFO *level_info)
         fp, level_info->anim_frame_data + level_info->anim_frame_data_count,
         inj_info->anim_frame_data_count * sizeof(int16_t));
 
-    Level_ReadAnims(level_info->anim_count, inj_info->anim_count, fp, NULL);
+    Level_ReadAnims(level_info->anim_count, inj_info->anim_count, fp);
     for (int32_t i = 0; i < inj_info->anim_count; i++) {
         ANIM *const anim = Anim_GetAnim(level_info->anim_count + i);
 
@@ -624,7 +624,8 @@ static void M_ObjectData(
             object->bone_idx = bone_idx + level_info->anim_bone_count;
         }
 
-        VFile_Skip(fp, sizeof(int32_t));
+        object->frame_ofs = VFile_ReadU32(fp);
+        object->frame_base = NULL;
         object->anim_idx = VFile_ReadS16(fp);
         if (object->anim_idx != -1) {
             object->anim_idx += level_info->anim_count;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -296,7 +296,7 @@ static void M_LoadAnims(VFILE *file)
     m_LevelInfo.anim_count = VFile_ReadS32(file);
     LOG_INFO("%d anims", m_LevelInfo.anim_count);
     Anim_InitialiseAnims(m_LevelInfo.anim_count + m_InjectionInfo->anim_count);
-    Level_ReadAnims(0, m_LevelInfo.anim_count, file, NULL);
+    Level_ReadAnims(0, m_LevelInfo.anim_count, file);
     Benchmark_End(benchmark, NULL);
 }
 
@@ -370,8 +370,8 @@ static void M_LoadObjects(VFILE *file)
         object->mesh_count = VFile_ReadS16(file);
         object->mesh_idx = VFile_ReadS16(file);
         object->bone_idx = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-
-        VFile_Skip(file, sizeof(int32_t)); // Frame offset implied by anim_idx
+        object->frame_ofs = VFile_ReadU32(file);
+        object->frame_base = NULL;
         object->anim_idx = VFile_ReadS16(file);
         object->loaded = true;
     }
@@ -793,7 +793,8 @@ static void M_CompleteSetup(int32_t level_num)
 
     Inject_AllInjections(&m_LevelInfo);
 
-    const int32_t frame_count = Anim_GetTotalFrameCount();
+    const int32_t frame_count =
+        Anim_GetTotalFrameCount(m_LevelInfo.anim_frame_data_count);
     Anim_InitialiseFrames(frame_count);
     Anim_LoadFrames(
         m_LevelInfo.anim_frame_data, m_LevelInfo.anim_frame_data_count);

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -315,8 +315,7 @@ static void M_ReadLara(LARA_INFO *const lara)
 
 static void M_ReadLaraArm(LARA_ARM *const arm)
 {
-    arm->frame_base =
-        (int16_t *)((intptr_t)g_AnimFrames + (intptr_t)M_ReadS32());
+    M_ReadS32(); // arm frame_base is not required
     arm->frame_num = M_ReadS16();
     arm->anim_num = M_ReadS16();
     arm->lock = M_ReadS16();
@@ -500,8 +499,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
 
 static void M_WriteLaraArm(const LARA_ARM *const arm)
 {
-    const int32_t frame_base =
-        (intptr_t)arm->frame_base - (intptr_t)g_AnimFrames;
+    const int32_t frame_base = 0; // not required
     M_WriteS32(frame_base);
     M_WriteS16(arm->frame_num);
     M_WriteS16(arm->anim_num);

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -103,9 +103,7 @@ static void M_DrawItem(
         }
     }
 
-    ANIM_FRAME *frame_ptr =
-        (ANIM_FRAME *)&obj->frame_base
-            [inv_item->current_frame * Object_GetAnim(obj, 0)->frame_size];
+    ANIM_FRAME *frame_ptr = &obj->frame_base[inv_item->current_frame];
 
     Matrix_Push();
     const int32_t clip = Output_GetObjectBounds(&frame_ptr->bounds);

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -640,11 +640,10 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
 {
     const ANIM *const anim = Item_GetAnim(item);
     const int32_t cur_frame_num = item->frame_num - anim->frame_base;
-    const int32_t size = anim->frame_size;
     const int32_t key_frame_span = anim->interpolation;
     const int32_t key_frame_shift = cur_frame_num % key_frame_span;
-    const int32_t first_key_frame_num = cur_frame_num / key_frame_span * size;
-    const int32_t second_key_frame_num = first_key_frame_num + size;
+    const int32_t first_key_frame_num = cur_frame_num / key_frame_span;
+    const int32_t second_key_frame_num = first_key_frame_num + 1;
 
     const int32_t numerator = key_frame_shift;
     int32_t denominator = key_frame_span;
@@ -657,8 +656,8 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
         }
     }
 
-    frmptr[0] = (ANIM_FRAME *)(anim->frame_ptr + first_key_frame_num);
-    frmptr[1] = (ANIM_FRAME *)(anim->frame_ptr + second_key_frame_num);
+    frmptr[0] = &anim->frame_ptr[first_key_frame_num];
+    frmptr[1] = &anim->frame_ptr[second_key_frame_num];
     *rate = denominator;
     return numerator;
 }

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -69,8 +69,7 @@ void Lara_Draw(const ITEM *const item)
         }
         // clang-format on
         const ANIM *const anim = Object_GetAnim(object, anim_idx);
-        frame = (ANIM_FRAME *)(anim->frame_ptr
-                               + g_Lara.hit_frame * anim->frame_size);
+        frame = &anim->frame_ptr[g_Lara.hit_frame];
     }
 
     if (g_Lara.skidoo == NO_ITEM) {
@@ -117,10 +116,8 @@ void Lara_Draw(const ITEM *const item)
         && (g_Items[g_Lara.weapon_item].current_anim_state == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 0);
@@ -147,7 +144,7 @@ void Lara_Draw(const ITEM *const item)
             Object_GetBone(&g_Objects[g_Lara.back_gun], 0);
         Matrix_TranslateRel(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
-        mesh_rots_c = g_Objects[g_Lara.back_gun].frame_base + FBBOX_ROT;
+        mesh_rots_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots_c, 14);
         Output_InsertPolygons(
             g_Meshes[g_Objects[g_Lara.back_gun].mesh_idx + LM_HEAD], clip);
@@ -174,10 +171,9 @@ void Lara_Draw(const ITEM *const item)
         if (g_Lara.flare_control_left) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots =
-                &g_Lara.left_arm.frame_base
-                     [anim->frame_size
-                          * (g_Lara.left_arm.frame_num - anim->frame_base)
-                      + FBBOX_ROT];
+                g_Lara.left_arm
+                    .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
+                    .mesh_rots;
             Matrix_RotYXZsuperpack(&mesh_rots, 11);
         } else {
             Matrix_RotYXZsuperpack(&mesh_rots, 0);
@@ -212,10 +208,10 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.right_arm.rot.y, g_Lara.right_arm.rot.x,
             g_Lara.right_arm.rot.z);
         const ANIM *anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
-        mesh_rots = &g_Lara.right_arm.frame_base
-                         [anim->frame_size
-                              * (g_Lara.right_arm.frame_num - anim->frame_base)
-                          + FBBOX_ROT];
+        mesh_rots =
+            g_Lara.right_arm
+                .frame_base[g_Lara.right_arm.frame_num - anim->frame_base]
+                .mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -242,10 +238,10 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
             g_Lara.left_arm.rot.z);
         anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
-        mesh_rots = &g_Lara.left_arm.frame_base
-                         [anim->frame_size
-                              * (g_Lara.left_arm.frame_num - anim->frame_base)
-                          + FBBOX_ROT];
+        mesh_rots =
+            g_Lara.left_arm
+                .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
+                .mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots, 11);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
@@ -270,10 +266,8 @@ void Lara_Draw(const ITEM *const item)
     case LGT_HARPOON: {
         Matrix_Push();
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -370,10 +364,8 @@ void Lara_Draw_I(
         && ((g_Items[g_Lara.weapon_item].current_anim_state) == 0
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
-        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots_2 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_1 = mesh_rots_2;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -402,8 +394,8 @@ void Lara_Draw_I(
             Object_GetBone(&g_Objects[g_Lara.back_gun], 0);
         Matrix_TranslateRel_I(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
-        mesh_rots_1_c = g_Objects[g_Lara.back_gun].frame_base + FBBOX_ROT;
-        mesh_rots_2_c = g_Objects[g_Lara.back_gun].frame_base + FBBOX_ROT;
+        mesh_rots_1_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
+        mesh_rots_2_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1_c, &mesh_rots_2_c, 14);
         Output_InsertPolygons_I(
             g_Meshes[g_Objects[g_Lara.back_gun].mesh_idx + LM_HEAD], clip);
@@ -430,10 +422,9 @@ void Lara_Draw_I(
         if (g_Lara.flare_control_left) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots_1 =
-                &g_Lara.left_arm.frame_base
-                     [anim->frame_size
-                          * (g_Lara.left_arm.frame_num - anim->frame_base)
-                      + FBBOX_ROT];
+                g_Lara.left_arm
+                    .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
+                    .mesh_rots;
 
             mesh_rots_2 = mesh_rots_1;
             Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 11);
@@ -467,10 +458,9 @@ void Lara_Draw_I(
             g_Lara.right_arm.rot.z);
         const ANIM *anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots_1 =
-            &g_Lara.right_arm.frame_base
-                 [anim->frame_size
-                      * (g_Lara.right_arm.frame_num - anim->frame_base)
-                  + FBBOX_ROT];
+            g_Lara.right_arm
+                .frame_base[g_Lara.right_arm.frame_num - anim->frame_base]
+                .mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots_1, 8);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
@@ -489,10 +479,10 @@ void Lara_Draw_I(
             g_Lara.left_arm.rot.y, g_Lara.left_arm.rot.x,
             g_Lara.left_arm.rot.z);
         anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
-        mesh_rots_1 = &g_Lara.left_arm.frame_base
-                           [anim->frame_size
-                                * (g_Lara.left_arm.frame_num - anim->frame_base)
-                            + FBBOX_ROT];
+        mesh_rots_1 =
+            g_Lara.left_arm
+                .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
+                .mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots_1, 11);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
@@ -516,10 +506,8 @@ void Lara_Draw_I(
     case LGT_HARPOON: {
         Matrix_Push_I();
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        const ANIM *const anim = Anim_GetAnim(g_Lara.right_arm.anim_num);
         mesh_rots_1 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num * anim->frame_size + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 8);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_UARM_R], clip);

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -52,10 +52,7 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
         mesh_rots =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * Anim_GetAnim(g_Lara.right_arm.anim_num)->frame_size
-                  + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_RotYXZsuperpack(&mesh_rots, 7);
     } else {
         Matrix_RotYXZsuperpack(&mesh_rots, 6);
@@ -146,10 +143,7 @@ static void M_CalculateSpheres_I(
             || g_Items[g_Lara.weapon_item].current_anim_state == 2
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
         mesh_rots_1 =
-            &g_Lara.right_arm.frame_base
-                 [g_Lara.right_arm.frame_num
-                      * Anim_GetAnim(g_Lara.right_arm.anim_num)->frame_size
-                  + FBBOX_ROT];
+            g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
         Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
     } else {
@@ -265,9 +259,7 @@ void Lara_Hair_Control(const bool in_cutscene)
 
         const OBJECT *const object = Object_GetObject(g_LaraItem->object_id);
         const ANIM *const anim = Object_GetAnim(object, lara_anim);
-        const int16_t *const frame_ptr = anim->frame_ptr;
-        const int32_t frame_size = anim->frame_size;
-        frame_1 = (ANIM_FRAME *)&frame_ptr[g_Lara.hit_frame * frame_size];
+        frame_1 = &anim->frame_ptr[g_Lara.hit_frame];
         frac = 0;
     }
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -854,10 +854,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
             break;
         }
         const ANIM *anim = Object_GetAnim(obj, anim_num);
-        const int32_t frame_size = anim->frame_size;
-        frame_ptr =
-            (const ANIM_FRAME *)(anim->frame_ptr
-                                 + (int32_t)(g_Lara.hit_frame * frame_size));
+        frame_ptr = &anim->frame_ptr[g_Lara.hit_frame];
     } else {
         frame_ptr = frmptr[0];
     }
@@ -894,9 +891,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-            rot = &arm->frame_base
-                       [anim->frame_size * (arm->frame_num - anim->frame_base)
-                        + FBBOX_ROT];
+            rot = arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
         } else {
             rot = frame_ptr->mesh_rots;
         }
@@ -918,7 +913,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
 
         const LARA_ARM *const arm = &g_Lara.right_arm;
         const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-        rot = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
+        rot = arm->frame_base[arm->frame_num].mesh_rots;
         Matrix_RotYXZsuperpack(&rot, 8);
 
         Matrix_TranslateRel(
@@ -981,9 +976,7 @@ void Lara_GetJointAbsPosition_I(
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-            rot1 = &arm->frame_base
-                        [anim->frame_size * (arm->frame_num - anim->frame_base)
-                         + FBBOX_ROT];
+            rot1 = arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
         } else {
             rot1 = frame1->mesh_rots;
         }
@@ -1006,7 +999,7 @@ void Lara_GetJointAbsPosition_I(
 
         const LARA_ARM *const arm = &g_Lara.right_arm;
         const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-        rot1 = &arm->frame_base[arm->frame_num * anim->frame_size + FBBOX_ROT];
+        rot1 = arm->frame_base[arm->frame_num].mesh_rots;
         Matrix_RotYXZsuperpack(&rot1, 8);
 
         Matrix_TranslateRel(

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -229,7 +229,7 @@ void Pickup_Draw(const ITEM *const item)
     // animations, and for such items we need to calculate this information
     // manually.
     if (obj->anim_idx != -1) {
-        frame = (const ANIM_FRAME *)obj->frame_base;
+        frame = obj->frame_base;
         bounds = frame->bounds;
         const int16_t y_off = frame->offset.y - bounds.max_y;
         bounds.max_y -= bounds.max_y;

--- a/src/tr2/game/objects/general/sphere_of_doom.c
+++ b/src/tr2/game/objects/general/sphere_of_doom.c
@@ -89,8 +89,7 @@ void SphereOfDoom_Draw(const ITEM *const item)
     mptr->_21 = (mptr->_21 * item->timer) >> 8;
     mptr->_22 = (mptr->_22 * item->timer) >> 8;
 
-    const ANIM_FRAME *const frame_ptr =
-        (ANIM_FRAME *)Item_GetAnim(item)->frame_ptr;
+    const ANIM_FRAME *const frame_ptr = Item_GetAnim(item)->frame_ptr;
     const int32_t clip = Output_GetObjectBounds(&frame_ptr->bounds);
     if (clip) {
         Output_CalculateObjectLighting(item, &frame_ptr->bounds);

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -356,8 +356,7 @@ void Overlay_InitialisePickUpDisplay(void)
 static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
 {
     const OBJECT *const obj = pickup->inv_object;
-    const ANIM_FRAME *const frame =
-        (ANIM_FRAME *)Object_GetAnim(obj, 0)->frame_ptr;
+    const ANIM_FRAME *const frame = obj->frame_base;
 
     float ease = 1.0f;
     switch (pickup->phase) {

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -520,9 +520,8 @@ void Room_DrawAllRooms(const int16_t current_room)
             g_MatrixPtr->_03 = 0;
             g_MatrixPtr->_13 = 0;
             g_MatrixPtr->_23 = 0;
-            const int16_t *frame =
-                Object_GetAnim(skybox, 0)->frame_ptr + FBBOX_ROT;
-            Matrix_RotYXZsuperpack(&frame, 0);
+            const int16_t *mesh_rots = skybox->frame_base->mesh_rots;
+            Matrix_RotYXZsuperpack(&mesh_rots, 0);
             Output_InsertSkybox(g_Meshes[skybox->mesh_idx]);
             Matrix_Pop();
         } else {

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -438,19 +438,6 @@ typedef enum {
     CF_CHASE_OBJECT  = 3,
 } CAMERA_FLAGS;
 
-typedef enum {
-    FBBOX_MIN_X = 0,
-    FBBOX_MAX_X = 1,
-    FBBOX_MIN_Y = 2,
-    FBBOX_MAX_Y = 3,
-    FBBOX_MIN_Z = 4,
-    FBBOX_MAX_Z = 5,
-    FBBOX_X     = 6,
-    FBBOX_Y     = 7,
-    FBBOX_Z     = 8,
-    FBBOX_ROT   = 9,
-} FRAME_BBOX_INFO;
-
 typedef struct {
     int16_t tx;
     int16_t ty;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -127,7 +127,6 @@ int32_t g_TexturePageCount;
 int16_t *g_MeshBase = NULL;
 int32_t g_TextureInfoCount;
 uint8_t g_LabTextureUVFlag[MAX_TEXTURES];
-ANIM_FRAME *g_AnimFrames = NULL;
 int32_t g_NumCameras;
 int16_t *g_AnimTextureRanges = NULL;
 uint32_t *g_DemoPtr = NULL;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -123,7 +123,6 @@ extern int32_t g_TexturePageCount;
 extern int16_t *g_MeshBase;
 extern int32_t g_TextureInfoCount;
 extern uint8_t g_LabTextureUVFlag[MAX_TEXTURES];
-extern ANIM_FRAME *g_AnimFrames;
 extern int32_t g_NumCameras;
 extern int16_t *g_AnimTextureRanges;
 extern uint32_t *g_DemoPtr;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves TR2 frame handling into TRX. We retain the original (super)packed rotations for the time being, this will be tackled on its own. Apologies that this is mostly one fairly large commit - everything was so dependent I couldn't see a way to split it up further.

There is a workaround added for objects like the prayer wheel, which do not have any animations. Because we set the object's frame base while iterating animations, the wheel remained with a null pointer. The workaround is to store the frame offset while reading the level, then later point it to the matching animation (and to clarify, the wheel points to the flare pack's animation - we will fix this in the future with injections).

I've removed `frame_base` from the savegame (well, we're now skipping reading and just writing a 0) in line with TR1. This is set on each frame anyway and I've confirmed by saving in TR2X while using a gun for example, then loading it in OG, plus vice-versa. I'd appreciate some other tests around saving/loading while Lara's arms are busy with guns/flares.

Once this lands, we can migrate TR2's `BOUNDS16` to match TR1, which means we can streamline things like `M_ParseFrame`.
