### PR TITLE
tr1|tr2: fix Lara blood spawn position

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed Lara activating triggers one frame too early (#2208, regression from 4.3)
 - fixed wrong underwater caustics speed with the turbo cheat (#2231)
 - fixed 1-frame UI flicker on pause screen exit confirmation
+- fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -553,6 +553,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed incorrect transparent pixels on some Egypt textures
 - fixed doors at times disappearing if Lara is close to portals and the door's room is no longer visible
 - fixed being able to see the flipmap in Natla's Mines when moving the boat
+- fixed blood spawning on Lara from gunshots using incorrect positioning data
 - improved vertex movement when looking through water portals
 
 #### Audio

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed showing inventory ring up/down arrows when uncalled for (#2225)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
+- fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -109,6 +109,7 @@ game with new enhancements and features.
 - fixed rendering problems on certain Intel GPUs
 - fixed bubbles spawning from flares if Lara is in shallow water
 - fixed the inventory up arrow at times overlapping the health bar
+- fixed blood spawning on Lara from gunshots using incorrect positioning data
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -616,7 +616,8 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
     Matrix_RotXYZ16(&frame->mesh_rots[0]);
 
     int16_t *extra_rotation = (int16_t *)item->data;
-    for (int i = 0; i < joint; i++) {
+    const int32_t abs_joint = MIN(object->mesh_count, joint);
+    for (int32_t i = 0; i < abs_joint; i++) {
         const ANIM_BONE *const bone = Object_GetBone(object, i);
         if (bone->matrix_pop) {
             Matrix_Pop();

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -164,12 +164,12 @@ int16_t Spawn_GunShotHit(
     int16_t room_num)
 {
     XYZ_32 pos = {
-        .x = 0,
-        .y = 0,
-        .z = 0,
+        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
     };
     Collide_GetJointAbsPosition(
-        g_LaraItem, &pos, (Random_GetControl() * 25) / 0x7FFF);
+        g_LaraItem, &pos, (Random_GetControl() * LM_NUMBER_OF) / 0x7FFF);
     Spawn_Blood(
         pos.x, pos.y, pos.z, g_LaraItem->speed, g_LaraItem->rot.y,
         g_LaraItem->room_num);

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -579,7 +579,8 @@ void Collide_GetJointAbsPosition(
     Matrix_RotYXZsuperpack(&mesh_rots, 0);
 
     const int16_t *extra_rotation = item->data;
-    for (int32_t i = 0; i < joint; i++) {
+    const int32_t abs_joint = MIN(object->mesh_count, joint);
+    for (int32_t i = 0; i < abs_joint; i++) {
         const ANIM_BONE *const bone = Object_GetBone(object, i);
         if (bone->matrix_pop) {
             Matrix_Pop();

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -143,9 +143,13 @@ int16_t Spawn_GunHit(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)
 {
-    XYZ_32 vec = {};
+    XYZ_32 vec = {
+        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+    };
     Collide_GetJointAbsPosition(
-        g_LaraItem, &vec, Random_GetControl() * 25 / 0x7FFF);
+        g_LaraItem, &vec, Random_GetControl() * LM_NUMBER_OF / 0x7FFF);
     Spawn_Blood(
         vec.x, vec.y, vec.z, g_LaraItem->speed, g_LaraItem->rot.y,
         g_LaraItem->room_num);


### PR DESCRIPTION
Resolves #2253.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes assigning a blood splat to a bone beyond Lara's data and introduces proper random positioning for it. This only affects blood spawned on Lara from gunshots; enemy blood is dealt with differently as are bites from creatures.

Let me know if you think the randomness itself looks OK in-game. A good test is to stand still in front of a gun goon and just monitor where the splats spawn. One of Lara's meshes is chosen at random, its world position obtained and then a random value between -64 and 63 applied to each coordinate.

This shouldn't affect TR1 demos as there are no gun enemies in those. It will change the TR2 demos but only in as much as the blood appearing differently e.g. in Tibet, and as a result anything that calls `Random_GetDraw`. There should be no desync issues as we are not changing the control random variable. If we prefer though, I can remove the randomness in TR2 if it's demo mode.
