### PR TITLE
tr1/objects/common: fix using key items on consumed slots

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed wrong underwater caustics speed with the turbo cheat (#2231)
 - fixed 1-frame UI flicker on pause screen exit confirmation
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
+- fixed being able to use keys and puzzle items in keyholes/slots that have already been used (#2256, regression from 4.0)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -52,6 +52,7 @@ typedef struct {
     void (*draw_routine)(ITEM *item);
     void (*collision)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
     const OBJECT_BOUNDS *(*bounds)(void);
+    bool (*is_usable)(int16_t item_num);
     int16_t anim_idx;
     int16_t hit_points;
     int16_t pivot_length;

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -31,6 +31,9 @@ int16_t Object_FindReceptacle(GAME_OBJECT_ID object_id)
         ITEM *item = &g_Items[item_num];
         if (item->object_id == receptacle_to_check) {
             const OBJECT *const obj = &g_Objects[item->object_id];
+            if (obj->is_usable != NULL && !obj->is_usable(item_num)) {
+                continue;
+            }
             if (Lara_TestPosition(item, obj->bounds())) {
                 return item_num;
             }

--- a/src/tr1/game/objects/general/keyhole.c
+++ b/src/tr1/game/objects/general/keyhole.c
@@ -23,6 +23,7 @@ static const OBJECT_BOUNDS m_KeyHoleBounds = {
 
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 static const OBJECT_BOUNDS *M_Bounds(void);
+static bool M_IsUsable(int16_t item_num);
 
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
 {
@@ -62,11 +63,18 @@ static const OBJECT_BOUNDS *M_Bounds(void)
     return &m_KeyHoleBounds;
 }
 
+static bool M_IsUsable(const int16_t item_num)
+{
+    const ITEM *const item = Item_Get(item_num);
+    return item->status == IS_INACTIVE;
+}
+
 void KeyHole_Setup(OBJECT *obj)
 {
     obj->collision = M_Collision;
     obj->save_flags = 1;
     obj->bounds = M_Bounds;
+    obj->is_usable = M_IsUsable;
 }
 
 bool KeyHole_Trigger(int16_t item_num)

--- a/src/tr1/game/objects/general/puzzle_hole.c
+++ b/src/tr1/game/objects/general/puzzle_hole.c
@@ -37,10 +37,17 @@ static const OBJECT_BOUNDS m_PuzzleHoleBounds = {
 };
 
 static const OBJECT_BOUNDS *M_Bounds(void);
+static bool M_IsUsable(int16_t item_num);
 
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
     return &m_PuzzleHoleBounds;
+}
+
+static bool M_IsUsable(const int16_t item_num)
+{
+    const ITEM *const item = Item_Get(item_num);
+    return item->status == IS_INACTIVE;
 }
 
 void PuzzleHole_Setup(OBJECT *obj)
@@ -48,6 +55,7 @@ void PuzzleHole_Setup(OBJECT *obj)
     obj->collision = PuzzleHole_Collision;
     obj->save_flags = 1;
     obj->bounds = M_Bounds;
+    obj->is_usable = M_IsUsable;
 }
 
 void PuzzleHole_SetupDone(OBJECT *obj)

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -271,6 +271,7 @@ void Object_SetupAllObjects(void)
         obj->draw_routine = Object_DrawAnimatingItem;
         obj->ceiling_height_func = NULL;
         obj->floor_height_func = NULL;
+        obj->is_usable = NULL;
         obj->pivot_length = 0;
         obj->radius = DEFAULT_RADIUS;
         obj->shadow_size = 0;

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -32,11 +32,17 @@ static const OBJECT_BOUNDS *M_Bounds(void)
     return &m_MidasTouch_Bounds;
 }
 
+static bool M_IsUsable(const int16_t item_num)
+{
+    return g_LaraItem->current_anim_state != LS_USE_MIDAS;
+}
+
 void MidasTouch_Setup(OBJECT *obj)
 {
     obj->collision = MidasTouch_Collision;
     obj->draw_routine = Object_DrawDummyItem;
     obj->bounds = M_Bounds;
+    obj->is_usable = M_IsUsable;
 }
 
 void MidasTouch_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)


### PR DESCRIPTION
Resolves #2256.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes being able to re-use a key on already used keyholes, using a puzzle item while Lara is still in the placement animation, and the lead bar while she is still converting another one.
