### PR TITLE
libtrx/anims/frames: expand TR2 frame rotations

### DIFF
--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -27,11 +27,7 @@ typedef struct {
 typedef struct {
     BOUNDS_16 bounds;
     XYZ_16 offset;
-#if TR_VERSION == 1
     XYZ_16 *mesh_rots;
-#else
-    int16_t *mesh_rots;
-#endif
 } ANIM_FRAME;
 
 typedef struct {

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -511,8 +511,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
 
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-    Matrix_RotXYZ16(&frame->mesh_rots[0]);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     OBJECT *object = &g_Objects[item->object_id];
     const OBJECT_MESH *mesh = Object_GetMesh(object->mesh_idx);
@@ -537,7 +536,7 @@ int32_t Collide_GetSpheres(ITEM *item, SPHERE *ptr, int32_t world_space)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[i]);
+        Matrix_RotXYZ16(frame->mesh_rots[i]);
 
         if (extra_rotation != NULL) {
             if (bone->rot_y) {
@@ -612,8 +611,7 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
 
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-    Matrix_RotXYZ16(&frame->mesh_rots[0]);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     int16_t *extra_rotation = (int16_t *)item->data;
     const int32_t abs_joint = MIN(object->mesh_count, joint);
@@ -627,7 +625,7 @@ void Collide_GetJointAbsPosition(ITEM *item, XYZ_32 *vec, int32_t joint)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[i + 1]);
+        Matrix_RotXYZ16(frame->mesh_rots[i + 1]);
 
         if (bone->rot_y) {
             Matrix_RotY(*extra_rotation++);

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -801,8 +801,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     Matrix_PushUnit();
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-    Matrix_RotXYZ16(&frame->mesh_rots[0]);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
 #if 0
     // XXX: present in OG, removed by GLrage on the grounds that it sometimes
@@ -844,7 +843,7 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[i]);
+        Matrix_RotXYZ16(frame->mesh_rots[i]);
 
 #if 0
     if (extra_rotation) {

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -102,21 +102,21 @@ void Lara_Draw(ITEM *item)
     const XYZ_16 *mesh_rots = frame->mesh_rots;
 
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_HIPS]);
+    Matrix_RotXYZ16(mesh_rots[LM_HIPS]);
     M_DrawMesh(LM_HIPS, clip, false);
 
     Matrix_Push();
 
     Matrix_TranslateRel(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_THIGH_L]);
+    Matrix_RotXYZ16(mesh_rots[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, false);
 
     Matrix_TranslateRel(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_CALF_L]);
+    Matrix_RotXYZ16(mesh_rots[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, false);
 
     Matrix_TranslateRel(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_FOOT_L]);
+    Matrix_RotXYZ16(mesh_rots[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, false);
 
     Matrix_Pop();
@@ -124,21 +124,21 @@ void Lara_Draw(ITEM *item)
     Matrix_Push();
 
     Matrix_TranslateRel(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_THIGH_R]);
+    Matrix_RotXYZ16(mesh_rots[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, false);
 
     Matrix_TranslateRel(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_CALF_R]);
+    Matrix_RotXYZ16(mesh_rots[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, false);
 
     Matrix_TranslateRel(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_FOOT_R]);
+    Matrix_RotXYZ16(mesh_rots[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, false);
 
     Matrix_Pop();
 
     Matrix_TranslateRel(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_TORSO]);
+    Matrix_RotXYZ16(mesh_rots[LM_TORSO]);
     Matrix_RotYXZ(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
         g_Lara.interp.result.torso_rot.z);
@@ -147,7 +147,7 @@ void Lara_Draw(ITEM *item)
     Matrix_Push();
 
     Matrix_TranslateRel(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
-    Matrix_RotXYZ16(&mesh_rots[LM_HEAD]);
+    Matrix_RotXYZ16(mesh_rots[LM_HEAD]);
     Matrix_RotYXZ(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
         g_Lara.interp.result.head_rot.z);
@@ -169,15 +169,15 @@ void Lara_Draw(ITEM *item)
         Matrix_Push();
 
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         Matrix_Pop();
@@ -185,15 +185,15 @@ void Lara_Draw(ITEM *item)
         Matrix_Push();
 
         Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         Matrix_Pop();
@@ -222,15 +222,15 @@ void Lara_Draw(ITEM *item)
             g_Lara.right_arm.interp.result.rot.y,
             g_Lara.right_arm.interp.result.rot.x,
             g_Lara.right_arm.interp.result.rot.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -259,15 +259,15 @@ void Lara_Draw(ITEM *item)
             g_Lara.left_arm.interp.result.rot.y,
             g_Lara.left_arm.interp.result.rot.x,
             g_Lara.left_arm.interp.result.rot.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.left_arm.flash_gun) {
@@ -287,15 +287,15 @@ void Lara_Draw(ITEM *item)
         mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -309,15 +309,15 @@ void Lara_Draw(ITEM *item)
         mesh_rots =
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         Matrix_TranslateRel(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_UARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_LARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16(&mesh_rots[LM_HAND_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -380,21 +380,21 @@ void Lara_Draw_I(
         frame1->offset.x, frame1->offset.y, frame1->offset.z, frame2->offset.x,
         frame2->offset.y, frame2->offset.z);
 
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_HIPS], &mesh_rots_2[LM_HIPS]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HIPS], mesh_rots_2[LM_HIPS]);
     M_DrawMesh(LM_HIPS, clip, true);
 
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[0].pos.x, bone[0].pos.y, bone[0].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_THIGH_L], &mesh_rots_2[LM_THIGH_L]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_THIGH_L], mesh_rots_2[LM_THIGH_L]);
     M_DrawMesh(LM_THIGH_L, clip, true);
 
     Matrix_TranslateRel_I(bone[1].pos.x, bone[1].pos.y, bone[1].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_CALF_L], &mesh_rots_2[LM_CALF_L]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_CALF_L], mesh_rots_2[LM_CALF_L]);
     M_DrawMesh(LM_CALF_L, clip, true);
 
     Matrix_TranslateRel_I(bone[2].pos.x, bone[2].pos.y, bone[2].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_FOOT_L], &mesh_rots_2[LM_FOOT_L]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_FOOT_L], mesh_rots_2[LM_FOOT_L]);
     M_DrawMesh(LM_FOOT_L, clip, true);
 
     Matrix_Pop_I();
@@ -402,21 +402,21 @@ void Lara_Draw_I(
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[3].pos.x, bone[3].pos.y, bone[3].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_THIGH_R], &mesh_rots_2[LM_THIGH_R]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_THIGH_R], mesh_rots_2[LM_THIGH_R]);
     M_DrawMesh(LM_THIGH_R, clip, true);
 
     Matrix_TranslateRel_I(bone[4].pos.x, bone[4].pos.y, bone[4].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_CALF_R], &mesh_rots_2[LM_CALF_R]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_CALF_R], mesh_rots_2[LM_CALF_R]);
     M_DrawMesh(LM_CALF_R, clip, true);
 
     Matrix_TranslateRel_I(bone[5].pos.x, bone[5].pos.y, bone[5].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_FOOT_R], &mesh_rots_2[LM_FOOT_R]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_FOOT_R], mesh_rots_2[LM_FOOT_R]);
     M_DrawMesh(LM_FOOT_R, clip, true);
 
     Matrix_Pop_I();
 
     Matrix_TranslateRel_I(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_TORSO], &mesh_rots_2[LM_TORSO]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_TORSO], mesh_rots_2[LM_TORSO]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
         g_Lara.interp.result.torso_rot.z);
@@ -425,7 +425,7 @@ void Lara_Draw_I(
     Matrix_Push_I();
 
     Matrix_TranslateRel_I(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
-    Matrix_RotXYZ16_I(&mesh_rots_1[LM_HEAD], &mesh_rots_2[LM_HEAD]);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HEAD], mesh_rots_2[LM_HEAD]);
     Matrix_RotYXZ_I(
         g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
         g_Lara.interp.result.head_rot.z);
@@ -447,15 +447,15 @@ void Lara_Draw_I(
         Matrix_Push_I();
 
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_R], &mesh_rots_2[LM_UARM_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_R], mesh_rots_2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_R], &mesh_rots_2[LM_LARM_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_LARM_R], mesh_rots_2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_R], &mesh_rots_2[LM_HAND_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HAND_R], mesh_rots_2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
 
         Matrix_Pop_I();
@@ -463,15 +463,15 @@ void Lara_Draw_I(
         Matrix_Push_I();
 
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_L], &mesh_rots_2[LM_UARM_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_L], mesh_rots_2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_L], &mesh_rots_2[LM_LARM_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_LARM_L], mesh_rots_2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_L], &mesh_rots_2[LM_HAND_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HAND_L], mesh_rots_2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);
 
         Matrix_Pop_I();
@@ -491,15 +491,15 @@ void Lara_Draw_I(
             g_Lara.right_arm.interp.result.rot.y,
             g_Lara.right_arm.interp.result.rot.x,
             g_Lara.right_arm.interp.result.rot.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_UARM_R]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, false);
 
         Matrix_TranslateRel(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_LARM_R]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, false);
 
         Matrix_TranslateRel(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_HAND_R]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, false);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -519,15 +519,15 @@ void Lara_Draw_I(
             g_Lara.left_arm.interp.result.rot.y,
             g_Lara.left_arm.interp.result.rot.x,
             g_Lara.left_arm.interp.result.rot.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_UARM_L]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, false);
 
         Matrix_TranslateRel(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_LARM_L]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, false);
 
         Matrix_TranslateRel(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16(&mesh_rots_1[LM_HAND_L]);
+        Matrix_RotXYZ16(mesh_rots_1[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, false);
 
         if (g_Lara.left_arm.flash_gun) {
@@ -549,15 +549,15 @@ void Lara_Draw_I(
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
         Matrix_TranslateRel_I(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_R], &mesh_rots_2[LM_UARM_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_R], mesh_rots_2[LM_UARM_R]);
         M_DrawMesh(LM_UARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[8].pos.x, bone[8].pos.y, bone[8].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_R], &mesh_rots_2[LM_LARM_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_LARM_R], mesh_rots_2[LM_LARM_R]);
         M_DrawMesh(LM_LARM_R, clip, true);
 
         Matrix_TranslateRel_I(bone[9].pos.x, bone[9].pos.y, bone[9].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_R], &mesh_rots_2[LM_HAND_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HAND_R], mesh_rots_2[LM_HAND_R]);
         M_DrawMesh(LM_HAND_R, clip, true);
 
         if (g_Lara.right_arm.flash_gun) {
@@ -572,15 +572,15 @@ void Lara_Draw_I(
             g_Lara.left_arm.frame_base[g_Lara.left_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
         Matrix_TranslateRel_I(bone[10].pos.x, bone[10].pos.y, bone[10].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_UARM_L], &mesh_rots_2[LM_UARM_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_L], mesh_rots_2[LM_UARM_L]);
         M_DrawMesh(LM_UARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[11].pos.x, bone[11].pos.y, bone[11].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_LARM_L], &mesh_rots_2[LM_LARM_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_LARM_L], mesh_rots_2[LM_LARM_L]);
         M_DrawMesh(LM_LARM_L, clip, true);
 
         Matrix_TranslateRel_I(bone[12].pos.x, bone[12].pos.y, bone[12].pos.z);
-        Matrix_RotXYZ16_I(&mesh_rots_1[LM_HAND_L], &mesh_rots_2[LM_HAND_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HAND_L], mesh_rots_2[LM_HAND_L]);
         M_DrawMesh(LM_HAND_L, clip, true);
 
         if (g_Lara.right_arm.flash_gun) {

--- a/src/tr1/game/lara/hair.c
+++ b/src/tr1/game/lara/hair.c
@@ -144,12 +144,14 @@ void Lara_Hair_Control(void)
 
     const ANIM_BONE *bone = Object_GetBone(object, 0);
     if (frac) {
+        const XYZ_16 *const mesh_rots_1 = frmptr[0]->mesh_rots;
+        const XYZ_16 *const mesh_rots_2 = frmptr[1]->mesh_rots;
+
         Matrix_InitInterpolate(frac, rate);
         Matrix_TranslateRel_ID(
             frmptr[0]->offset.x, frmptr[0]->offset.y, frmptr[0]->offset.z,
             frmptr[1]->offset.x, frmptr[1]->offset.y, frmptr[1]->offset.z);
-        Matrix_RotXYZ16_I(
-            &frmptr[0]->mesh_rots[LM_HIPS], &frmptr[1]->mesh_rots[LM_HIPS]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HIPS], mesh_rots_2[LM_HIPS]);
 
         // hips
         Matrix_Push_I();
@@ -166,8 +168,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
             bone[LM_TORSO - 1].pos.z);
-        Matrix_RotXYZ16_I(
-            &frmptr[0]->mesh_rots[LM_TORSO], &frmptr[1]->mesh_rots[LM_TORSO]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_TORSO], mesh_rots_2[LM_TORSO]);
         Matrix_RotYXZ_I(
             g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
             g_Lara.interp.result.torso_rot.z);
@@ -186,8 +187,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
-        Matrix_RotXYZ16_I(
-            &frmptr[0]->mesh_rots[LM_UARM_R], &frmptr[1]->mesh_rots[LM_UARM_R]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_R], mesh_rots_2[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
         Matrix_TranslateRel_I(mesh->center.x, mesh->center.y, mesh->center.z);
         Matrix_Interpolate();
@@ -202,8 +202,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
-        Matrix_RotXYZ16_I(
-            &frmptr[0]->mesh_rots[LM_UARM_L], &frmptr[1]->mesh_rots[LM_UARM_L]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_L], mesh_rots_2[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
         Matrix_TranslateRel_I(mesh->center.x, mesh->center.y, mesh->center.z);
         Matrix_Interpolate();
@@ -217,8 +216,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel_I(
             bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
             bone[LM_HEAD - 1].pos.z);
-        Matrix_RotXYZ16_I(
-            &frmptr[0]->mesh_rots[LM_HEAD], &frmptr[1]->mesh_rots[LM_HEAD]);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_HEAD], mesh_rots_2[LM_HEAD]);
         Matrix_RotYXZ_I(
             g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
             g_Lara.interp.result.head_rot.z);
@@ -236,8 +234,9 @@ void Lara_Hair_Control(void)
         Matrix_Interpolate();
 
     } else {
+        const XYZ_16 *const mesh_rots = frame->mesh_rots;
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[LM_HIPS]);
+        Matrix_RotXYZ16(mesh_rots[LM_HIPS]);
 
         // hips
         Matrix_Push();
@@ -253,7 +252,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
             bone[LM_TORSO - 1].pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[LM_TORSO]);
+        Matrix_RotXYZ16(mesh_rots[LM_TORSO]);
         Matrix_RotYXZ(
             g_Lara.interp.result.torso_rot.y, g_Lara.interp.result.torso_rot.x,
             g_Lara.interp.result.torso_rot.z);
@@ -271,7 +270,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
             bone[LM_UARM_R - 1].pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[LM_UARM_R]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_R);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
         sphere[3].x = g_MatrixPtr->_03 >> W2V_SHIFT;
@@ -285,7 +284,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[LM_UARM_L]);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         mesh = Object_GetMesh(object->mesh_idx + LM_UARM_L);
         Matrix_TranslateRel(mesh->center.x, mesh->center.y, mesh->center.z);
         sphere[4].x = g_MatrixPtr->_03 >> W2V_SHIFT;
@@ -298,7 +297,7 @@ void Lara_Hair_Control(void)
         Matrix_TranslateRel(
             bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
             bone[LM_HEAD - 1].pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[LM_HEAD]);
+        Matrix_RotXYZ16(mesh_rots[LM_HEAD]);
         Matrix_RotYXZ(
             g_Lara.interp.result.head_rot.y, g_Lara.interp.result.head_rot.x,
             g_Lara.interp.result.head_rot.z);

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -201,8 +201,7 @@ void Object_DrawPickupItem(ITEM *item)
         int32_t bit = 1;
 
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-        Matrix_RotXYZ16(&frame->mesh_rots[0]);
+        Matrix_RotXYZ16(frame->mesh_rots[0]);
 
         if (item->mesh_bits & bit) {
             Object_DrawMesh(object->mesh_idx, clip, false);
@@ -219,7 +218,7 @@ void Object_DrawPickupItem(ITEM *item)
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotXYZ16(&frame->mesh_rots[i]);
+            Matrix_RotXYZ16(frame->mesh_rots[i]);
 
             // Extra rotation is ignored in this case as it's not needed.
 
@@ -251,8 +250,7 @@ void Object_DrawInterpolatedObject(
     if (!frac) {
         Matrix_TranslateRel(
             frame1->offset.x, frame1->offset.y, frame1->offset.z);
-
-        Matrix_RotXYZ16(&frame1->mesh_rots[0]);
+        Matrix_RotXYZ16(frame1->mesh_rots[0]);
 
         if (meshes & mesh_num) {
             Object_DrawMesh(object->mesh_idx, clip, false);
@@ -269,7 +267,7 @@ void Object_DrawInterpolatedObject(
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotXYZ16(&frame1->mesh_rots[i]);
+            Matrix_RotXYZ16(frame1->mesh_rots[i]);
 
             if (extra_rotation != NULL) {
                 if (bone->rot_y) {
@@ -294,7 +292,7 @@ void Object_DrawInterpolatedObject(
         Matrix_TranslateRel_ID(
             frame1->offset.x, frame1->offset.y, frame1->offset.z,
             frame2->offset.x, frame2->offset.y, frame2->offset.z);
-        Matrix_RotXYZ16_I(&frame1->mesh_rots[0], &frame2->mesh_rots[0]);
+        Matrix_RotXYZ16_I(frame1->mesh_rots[0], frame2->mesh_rots[0]);
 
         if (meshes & mesh_num) {
             Object_DrawMesh(object->mesh_idx, clip, true);
@@ -311,7 +309,7 @@ void Object_DrawInterpolatedObject(
             }
 
             Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotXYZ16_I(&frame1->mesh_rots[i], &frame2->mesh_rots[i]);
+            Matrix_RotXYZ16_I(frame1->mesh_rots[i], frame2->mesh_rots[i]);
 
             if (extra_rotation != NULL) {
                 if (bone->rot_y) {

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -400,7 +400,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         -(frame->bounds.min.x + frame->bounds.max.x) / 2,
         -(frame->bounds.min.y + frame->bounds.max.y) / 2,
         -(frame->bounds.min.z + frame->bounds.max.z) / 2);
-    Matrix_RotXYZ16(&frame->mesh_rots[0]);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     Object_DrawMesh(obj->mesh_idx, 0, false);
 
@@ -415,7 +415,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotXYZ16(&frame->mesh_rots[i]);
+        Matrix_RotXYZ16(frame->mesh_rots[i]);
 
         Object_DrawMesh(obj->mesh_idx + i, 0, false);
     }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -254,8 +254,7 @@ static void M_DrawSkybox(void)
     g_MatrixPtr->_23 = 0;
 
     const OBJECT *const skybox = Object_GetObject(O_SKYBOX);
-    const ANIM_FRAME *const frame = Object_GetAnim(skybox, 0)->frame_ptr;
-    Matrix_RotXYZ16(&frame->mesh_rots[0]);
+    Matrix_RotXYZ16(skybox->frame_base->mesh_rots[0]);
     Output_DrawSkybox(Object_GetMesh(skybox->mesh_idx));
 
     Matrix_Pop();

--- a/src/tr1/math/matrix.c
+++ b/src/tr1/math/matrix.c
@@ -166,11 +166,11 @@ void Matrix_RotYXZ(PHD_ANGLE ry, PHD_ANGLE rx, PHD_ANGLE rz)
     Matrix_RotZ(rz);
 }
 
-void Matrix_RotXYZ16(const XYZ_16 *const rotation)
+void Matrix_RotXYZ16(const XYZ_16 rotation)
 {
-    Matrix_RotY(rotation->y);
-    Matrix_RotX(rotation->x);
-    Matrix_RotZ(rotation->z);
+    Matrix_RotY(rotation.y);
+    Matrix_RotX(rotation.x);
+    Matrix_RotZ(rotation.z);
 }
 
 void Matrix_TranslateRel(int32_t x, int32_t y, int32_t z)
@@ -336,8 +336,7 @@ void Matrix_RotYXZ_I(PHD_ANGLE y, PHD_ANGLE x, PHD_ANGLE z)
     g_MatrixPtr = old_matrix;
 }
 
-void Matrix_RotXYZ16_I(
-    const XYZ_16 *const rotation_1, const XYZ_16 *const rotation_2)
+void Matrix_RotXYZ16_I(const XYZ_16 rotation_1, const XYZ_16 rotation_2)
 {
     Matrix_RotXYZ16(rotation_1);
     MATRIX *const old_matrix = g_MatrixPtr;

--- a/src/tr1/math/matrix.h
+++ b/src/tr1/math/matrix.h
@@ -20,7 +20,7 @@ void Matrix_RotX(int16_t rx);
 void Matrix_RotY(int16_t ry);
 void Matrix_RotZ(int16_t rz);
 void Matrix_RotYXZ(int16_t ry, int16_t rx, int16_t rz);
-void Matrix_RotXYZ16(const XYZ_16 *rotation);
+void Matrix_RotXYZ16(XYZ_16 rotation);
 void Matrix_TranslateRel(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateSet(int32_t x, int32_t y, int32_t z);
@@ -32,7 +32,7 @@ void Matrix_RotY_I(int16_t ang);
 void Matrix_RotX_I(int16_t ang);
 void Matrix_RotZ_I(int16_t ang);
 void Matrix_RotYXZ_I(int16_t y, int16_t x, int16_t z);
-void Matrix_RotXYZ16_I(const XYZ_16 *rotation_1, const XYZ_16 *rotation_2);
+void Matrix_RotXYZ16_I(XYZ_16 rotation_1, XYZ_16 rotation_2);
 
 void Matrix_TranslateRel_I(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateRel_ID(

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -980,14 +980,11 @@ void Skidoo_Draw(const ITEM *const item)
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
     if (frac) {
-        const int16_t *mesh_rots_1 = frames[0]->mesh_rots;
-        const int16_t *mesh_rots_2 = frames[1]->mesh_rots;
-
         Matrix_InitInterpolate(frac, rate);
         Matrix_TranslateRel_ID(
             frames[0]->offset.x, frames[0]->offset.y, frames[0]->offset.z,
             frames[1]->offset.x, frames[1]->offset.y, frames[1]->offset.z);
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
+        Matrix_RotXYZ16_I(frames[0]->mesh_rots[0], frames[1]->mesh_rots[0]);
 
         Output_InsertPolygons_I(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
@@ -1000,15 +997,15 @@ void Skidoo_Draw(const ITEM *const item)
             }
 
             Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
+            Matrix_RotXYZ16_I(
+                frames[0]->mesh_rots[mesh_idx], frames[1]->mesh_rots[mesh_idx]);
 
             Output_InsertPolygons_I(mesh_ptrs[mesh_idx], clip);
         }
     } else {
-        const int16_t *mesh_rots = frames[0]->mesh_rots;
         Matrix_TranslateRel(
             frames[0]->offset.x, frames[0]->offset.y, frames[0]->offset.z);
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(frames[0]->mesh_rots[0]);
 
         Output_InsertPolygons(mesh_ptrs[0], clip);
         for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
@@ -1021,7 +1018,7 @@ void Skidoo_Draw(const ITEM *const item)
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZsuperpack(&mesh_rots, 0);
+            Matrix_RotXYZ16(frames[0]->mesh_rots[mesh_idx]);
 
             Output_InsertPolygons(mesh_ptrs[mesh_idx], clip);
         }

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -509,9 +509,7 @@ int32_t Collide_GetSpheres(
 
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-    const int16_t *mesh_rots = frame->mesh_rots;
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     const OBJECT *const object = Object_GetObject(item->object_id);
     int16_t **mesh_ptr = &g_Meshes[object->mesh_idx];
@@ -535,7 +533,7 @@ int32_t Collide_GetSpheres(
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(frame->mesh_rots[i]);
 
         if (extra_rotation != NULL) {
             if (bone->rot_y) {
@@ -574,9 +572,7 @@ void Collide_GetJointAbsPosition(
     Matrix_TranslateSet(0, 0, 0);
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-
-    const int16_t *mesh_rots = frame->mesh_rots;
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     const int16_t *extra_rotation = item->data;
     const int32_t abs_joint = MIN(object->mesh_count, joint);
@@ -590,7 +586,7 @@ void Collide_GetJointAbsPosition(
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(frame->mesh_rots[i + 1]);
 
         if (extra_rotation != NULL) {
             if (bone->rot_y) {

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -114,8 +114,7 @@ static void M_DrawItem(
 
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
-    const int16_t *rot = frame_ptr->mesh_rots;
-    Matrix_RotYXZsuperpack(&rot, 0);
+    Matrix_RotXYZ16(frame_ptr->mesh_rots[0]);
 
     for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
         if (mesh_idx > 0) {
@@ -128,7 +127,7 @@ static void M_DrawItem(
             }
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-            Matrix_RotYXZsuperpack(&rot, 0);
+            Matrix_RotXYZ16(frame_ptr->mesh_rots[mesh_idx]);
 
             if (inv_item->object_id == O_COMPASS_OPTION) {
                 if (mesh_idx == 6) {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -745,9 +745,7 @@ int32_t Item_Explode(
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
     Matrix_TranslateRel(
         best_frame->offset.x, best_frame->offset.y, best_frame->offset.z);
-
-    const int16_t *mesh_rots = best_frame->mesh_rots;
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(best_frame->mesh_rots[0]);
 
     // main mesh
     int32_t bit = 1;
@@ -782,7 +780,7 @@ int32_t Item_Explode(
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(best_frame->mesh_rots[i]);
 
         if (extra_rotation != NULL) {
             if (bone->rot_y) {

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -9,23 +9,22 @@
 #include "global/vars.h"
 
 static void M_DrawBodyPart(
-    LARA_MESH mesh, const ANIM_BONE *bone, const int16_t **mesh_rots_1,
-    const int16_t **mesh_rots_2, int32_t clip);
+    LARA_MESH mesh, const ANIM_BONE *bone, const XYZ_16 *mesh_rots_1,
+    const XYZ_16 *mesh_rots_2, int32_t clip);
 
 static void M_DrawBodyPart(
     const LARA_MESH mesh, const ANIM_BONE *const bone,
-    const int16_t **mesh_rots_1, const int16_t **mesh_rots_2,
-    const int32_t clip)
+    const XYZ_16 *mesh_rots_1, const XYZ_16 *mesh_rots_2, const int32_t clip)
 {
     if (mesh_rots_2 != NULL) {
         Matrix_TranslateRel_I(
             bone[mesh - 1].pos.x, bone[mesh - 1].pos.y, bone[mesh - 1].pos.z);
-        Matrix_RotYXZsuperpack_I(mesh_rots_1, mesh_rots_2, 0);
+        Matrix_RotXYZ16_I(mesh_rots_1[mesh], mesh_rots_2[mesh]);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[mesh], clip);
     } else {
         Matrix_TranslateRel(
             bone[mesh - 1].pos.x, bone[mesh - 1].pos.y, bone[mesh - 1].pos.z);
-        Matrix_RotYXZsuperpack(mesh_rots_1, 0);
+        Matrix_RotXYZ16(mesh_rots_1[mesh]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[mesh], clip);
     }
 }
@@ -92,23 +91,23 @@ void Lara_Draw(const ITEM *const item)
     Output_CalculateObjectLighting(item, &frame->bounds);
 
     const ANIM_BONE *const bone = Object_GetBone(object, 0);
-    const int16_t *mesh_rots = frame->mesh_rots;
-    const int16_t *mesh_rots_c;
+    const XYZ_16 *mesh_rots = frame->mesh_rots;
+    const XYZ_16 *mesh_rots_c;
 
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(mesh_rots[LM_HIPS]);
     Output_InsertPolygons(g_Lara.mesh_ptrs[LM_HIPS], clip);
 
     Matrix_Push();
-    M_DrawBodyPart(LM_THIGH_L, bone, &mesh_rots, NULL, clip);
-    M_DrawBodyPart(LM_CALF_L, bone, &mesh_rots, NULL, clip);
-    M_DrawBodyPart(LM_FOOT_L, bone, &mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_THIGH_L, bone, mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_CALF_L, bone, mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_FOOT_L, bone, mesh_rots, NULL, clip);
     Matrix_Pop();
 
     Matrix_Push();
-    M_DrawBodyPart(LM_THIGH_R, bone, &mesh_rots, NULL, clip);
-    M_DrawBodyPart(LM_CALF_R, bone, &mesh_rots, NULL, clip);
-    M_DrawBodyPart(LM_FOOT_R, bone, &mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_THIGH_R, bone, mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_CALF_R, bone, mesh_rots, NULL, clip);
+    M_DrawBodyPart(LM_FOOT_R, bone, mesh_rots, NULL, clip);
     Matrix_Pop();
 
     Matrix_TranslateRel(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
@@ -118,17 +117,16 @@ void Lara_Draw(const ITEM *const item)
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
         mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots, 7);
-    } else {
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
     }
+
+    Matrix_RotXYZ16(mesh_rots[LM_TORSO]);
     Matrix_RotYXZ(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
     Output_InsertPolygons(g_Lara.mesh_ptrs[LM_TORSO], clip);
 
     Matrix_Push();
     Matrix_TranslateRel(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
     mesh_rots_c = mesh_rots;
-    Matrix_RotYXZsuperpack(&mesh_rots, 6);
+    Matrix_RotXYZ16(mesh_rots[LM_HEAD]);
     mesh_rots = mesh_rots_c;
     Matrix_RotYXZ(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
     Output_InsertPolygons(g_Lara.mesh_ptrs[LM_HEAD], clip);
@@ -145,7 +143,7 @@ void Lara_Draw(const ITEM *const item)
         Matrix_TranslateRel(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
         mesh_rots_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots_c, 14);
+        Matrix_RotXYZ16(mesh_rots_c[LM_HEAD]);
         Output_InsertPolygons(
             g_Meshes[g_Objects[g_Lara.back_gun].mesh_idx + LM_HEAD], clip);
         Matrix_Pop();
@@ -161,9 +159,9 @@ void Lara_Draw(const ITEM *const item)
     case LGT_UNARMED:
     case LGT_FLARE:
         Matrix_Push();
-        M_DrawBodyPart(LM_UARM_R, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_UARM_R, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots, NULL, clip);
         Matrix_Pop();
 
         Matrix_Push();
@@ -174,14 +172,13 @@ void Lara_Draw(const ITEM *const item)
                 g_Lara.left_arm
                     .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
                     .mesh_rots;
-            Matrix_RotYXZsuperpack(&mesh_rots, 11);
-        } else {
-            Matrix_RotYXZsuperpack(&mesh_rots, 0);
         }
+
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots, NULL, clip);
 
         if (g_Lara.gun_type == LGT_FLARE && g_Lara.left_arm.flash_gun) {
             Gun_DrawFlash(LGT_FLARE, clip);
@@ -212,11 +209,11 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.right_arm
                 .frame_base[g_Lara.right_arm.frame_num - anim->frame_base]
                 .mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots, 8);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots, NULL, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             saved_matrix = *g_MatrixPtr;
@@ -242,11 +239,11 @@ void Lara_Draw(const ITEM *const item)
             g_Lara.left_arm
                 .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
                 .mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots, 11);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots, NULL, clip);
 
         if (g_Lara.left_arm.flash_gun) {
             Gun_DrawFlash(gun_type, clip);
@@ -268,11 +265,11 @@ void Lara_Draw(const ITEM *const item)
         Matrix_TranslateRel(bone[7].pos.x, bone[7].pos.y, bone[7].pos.z);
         mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots, 8);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots, NULL, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             saved_matrix = *g_MatrixPtr;
@@ -280,9 +277,9 @@ void Lara_Draw(const ITEM *const item)
         Matrix_Pop();
 
         Matrix_Push();
-        M_DrawBodyPart(LM_UARM_L, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots, NULL, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_UARM_L, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots, NULL, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots, NULL, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             *g_MatrixPtr = saved_matrix;
@@ -335,28 +332,28 @@ void Lara_Draw_I(
     Output_CalculateObjectLighting(item, &frame1->bounds);
 
     const ANIM_BONE *const bone = Object_GetBone(object, 0);
-    const int16_t *mesh_rots_1 = frame1->mesh_rots;
-    const int16_t *mesh_rots_2 = frame2->mesh_rots;
-    const int16_t *mesh_rots_1_c;
-    const int16_t *mesh_rots_2_c;
+    const XYZ_16 *mesh_rots_1 = frame1->mesh_rots;
+    const XYZ_16 *mesh_rots_2 = frame2->mesh_rots;
+    const XYZ_16 *mesh_rots_1_c;
+    const XYZ_16 *mesh_rots_2_c;
 
     Matrix_InitInterpolate(frac, rate);
     Matrix_TranslateRel_ID(
         frame1->offset.x, frame1->offset.y, frame1->offset.z, frame2->offset.x,
         frame2->offset.y, frame2->offset.z);
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HIPS], mesh_rots_2[LM_HIPS]);
     Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_HIPS], clip);
 
     Matrix_Push_I();
-    M_DrawBodyPart(LM_THIGH_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
-    M_DrawBodyPart(LM_CALF_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
-    M_DrawBodyPart(LM_FOOT_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
+    M_DrawBodyPart(LM_THIGH_L, bone, mesh_rots_1, mesh_rots_2, clip);
+    M_DrawBodyPart(LM_CALF_L, bone, mesh_rots_1, mesh_rots_2, clip);
+    M_DrawBodyPart(LM_FOOT_L, bone, mesh_rots_1, mesh_rots_2, clip);
     Matrix_Pop_I();
 
     Matrix_Push_I();
-    M_DrawBodyPart(LM_THIGH_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
-    M_DrawBodyPart(LM_CALF_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
-    M_DrawBodyPart(LM_FOOT_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
+    M_DrawBodyPart(LM_THIGH_R, bone, mesh_rots_1, mesh_rots_2, clip);
+    M_DrawBodyPart(LM_CALF_R, bone, mesh_rots_1, mesh_rots_2, clip);
+    M_DrawBodyPart(LM_FOOT_R, bone, mesh_rots_1, mesh_rots_2, clip);
     Matrix_Pop_I();
 
     Matrix_TranslateRel_I(bone[6].pos.x, bone[6].pos.y, bone[6].pos.z);
@@ -367,10 +364,9 @@ void Lara_Draw_I(
         mesh_rots_2 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_1 = mesh_rots_2;
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
-    } else {
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
     }
+
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_TORSO], mesh_rots_2[LM_TORSO]);
     Matrix_RotYXZ_I(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
     Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_TORSO], clip);
 
@@ -378,7 +374,7 @@ void Lara_Draw_I(
     Matrix_TranslateRel_I(bone[13].pos.x, bone[13].pos.y, bone[13].pos.z);
     mesh_rots_1_c = mesh_rots_1;
     mesh_rots_2_c = mesh_rots_2;
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 6);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HEAD], mesh_rots_2[LM_HEAD]);
     mesh_rots_1 = mesh_rots_1_c;
     mesh_rots_2 = mesh_rots_2_c;
     Matrix_RotYXZ_I(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
@@ -396,7 +392,7 @@ void Lara_Draw_I(
             bone_c[13].pos.x, bone_c[13].pos.y, bone_c[13].pos.z);
         mesh_rots_1_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
         mesh_rots_2_c = g_Objects[g_Lara.back_gun].frame_base->mesh_rots;
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1_c, &mesh_rots_2_c, 14);
+        Matrix_RotXYZ16_I(mesh_rots_1_c[LM_HEAD], mesh_rots_2_c[LM_HEAD]);
         Output_InsertPolygons_I(
             g_Meshes[g_Objects[g_Lara.back_gun].mesh_idx + LM_HEAD], clip);
         Matrix_Pop_I();
@@ -412,9 +408,9 @@ void Lara_Draw_I(
     case LGT_UNARMED:
     case LGT_FLARE:
         Matrix_Push_I();
-        M_DrawBodyPart(LM_UARM_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
+        M_DrawBodyPart(LM_UARM_R, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots_1, mesh_rots_2, clip);
         Matrix_Pop_I();
 
         Matrix_Push_I();
@@ -425,16 +421,14 @@ void Lara_Draw_I(
                 g_Lara.left_arm
                     .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
                     .mesh_rots;
-
             mesh_rots_2 = mesh_rots_1;
-            Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 11);
-        } else {
-            Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
         }
+
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_L], mesh_rots_2[LM_UARM_L]);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots_1, mesh_rots_2, clip);
 
         if (g_Lara.gun_type == LGT_FLARE && g_Lara.left_arm.flash_gun) {
             Matrix_TranslateRel_I(11, 32, 80);
@@ -461,11 +455,11 @@ void Lara_Draw_I(
             g_Lara.right_arm
                 .frame_base[g_Lara.right_arm.frame_num - anim->frame_base]
                 .mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots_1, 8);
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_R]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots_1, NULL, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots_1, NULL, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots_1, NULL, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots_1, NULL, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             saved_matrix = *g_MatrixPtr;
@@ -483,11 +477,11 @@ void Lara_Draw_I(
             g_Lara.left_arm
                 .frame_base[g_Lara.left_arm.frame_num - anim->frame_base]
                 .mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots_1, 11);
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_L]);
         Output_InsertPolygons(g_Lara.mesh_ptrs[LM_UARM_L], clip);
 
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots_1, NULL, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots_1, NULL, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots_1, NULL, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots_1, NULL, clip);
 
         if (g_Lara.left_arm.flash_gun) {
             Gun_DrawFlash((int32_t)gun_type, clip);
@@ -509,11 +503,11 @@ void Lara_Draw_I(
         mesh_rots_1 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 8);
+        Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_R], mesh_rots_2[LM_UARM_R]);
         Output_InsertPolygons_I(g_Lara.mesh_ptrs[LM_UARM_R], clip);
 
-        M_DrawBodyPart(LM_LARM_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_HAND_R, bone, &mesh_rots_1, &mesh_rots_2, clip);
+        M_DrawBodyPart(LM_LARM_R, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_HAND_R, bone, mesh_rots_1, mesh_rots_2, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             saved_matrix = *g_MatrixPtr;
@@ -521,9 +515,9 @@ void Lara_Draw_I(
         Matrix_Pop_I();
 
         Matrix_Push_I();
-        M_DrawBodyPart(LM_UARM_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_LARM_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
-        M_DrawBodyPart(LM_HAND_L, bone, &mesh_rots_1, &mesh_rots_2, clip);
+        M_DrawBodyPart(LM_UARM_L, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_LARM_L, bone, mesh_rots_1, mesh_rots_2, clip);
+        M_DrawBodyPart(LM_HAND_L, bone, mesh_rots_1, mesh_rots_2, clip);
 
         if (g_Lara.right_arm.flash_gun) {
             *g_MatrixPtr = saved_matrix;

--- a/src/tr2/game/lara/hair.c
+++ b/src/tr2/game/lara/hair.c
@@ -30,9 +30,9 @@ static void M_CalculateSpheres_I(
 
 static void M_CalculateSpheres(const ANIM_FRAME *const frame)
 {
-    const int16_t *mesh_rots = frame->mesh_rots;
+    const XYZ_16 *mesh_rots = frame->mesh_rots;
     Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(mesh_rots[LM_HIPS]);
 
     Matrix_Push();
     const int16_t *mesh = g_Lara.mesh_ptrs[LM_HIPS];
@@ -53,10 +53,9 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
             || g_Items[g_Lara.weapon_item].current_anim_state == 4)) {
         mesh_rots =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
-        Matrix_RotYXZsuperpack(&mesh_rots, 7);
-    } else {
-        Matrix_RotYXZsuperpack(&mesh_rots, 6);
     }
+
+    Matrix_RotXYZ16(mesh_rots[LM_TORSO]);
     Matrix_RotYXZ(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
     Matrix_Push();
     mesh = g_Lara.mesh_ptrs[LM_TORSO];
@@ -71,7 +70,7 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     Matrix_TranslateRel(
         bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
         bone[LM_UARM_R - 1].pos.z);
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_R];
     Matrix_TranslateRel(mesh[0], mesh[1], mesh[2]);
@@ -85,7 +84,7 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     Matrix_TranslateRel(
         bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
         bone[LM_UARM_L - 1].pos.z);
-    Matrix_RotYXZsuperpack(&mesh_rots, 2);
+    Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
     mesh = g_Lara.mesh_ptrs[LM_UARM_L];
     Matrix_TranslateRel(mesh[0], mesh[1], mesh[2]);
     m_HairSpheres[4].x = g_MatrixPtr->_03 >> W2V_SHIFT;
@@ -97,7 +96,7 @@ static void M_CalculateSpheres(const ANIM_FRAME *const frame)
     Matrix_TranslateRel(
         bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
         bone[LM_HEAD - 1].pos.z);
-    Matrix_RotYXZsuperpack(&mesh_rots, 2);
+    Matrix_RotXYZ16(mesh_rots[LM_HEAD]);
     Matrix_RotYXZ(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
 
     Matrix_Push();
@@ -116,13 +115,13 @@ static void M_CalculateSpheres_I(
     const ANIM_FRAME *const frame_1, const ANIM_FRAME *const frame_2,
     const int32_t frac, const int32_t rate)
 {
-    const int16_t *mesh_rots_1 = frame_1->mesh_rots;
-    const int16_t *mesh_rots_2 = frame_2->mesh_rots;
+    const XYZ_16 *mesh_rots_1 = frame_1->mesh_rots;
+    const XYZ_16 *mesh_rots_2 = frame_2->mesh_rots;
     Matrix_InitInterpolate(frac, rate);
     Matrix_TranslateRel_ID(
         frame_1->offset.x, frame_1->offset.y, frame_1->offset.z,
         frame_2->offset.x, frame_2->offset.y, frame_2->offset.z);
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HIPS], mesh_rots_2[LM_HIPS]);
 
     Matrix_Push_I();
     const int16_t *mesh = g_Lara.mesh_ptrs[LM_HIPS];
@@ -145,10 +144,9 @@ static void M_CalculateSpheres_I(
         mesh_rots_1 =
             g_Lara.right_arm.frame_base[g_Lara.right_arm.frame_num].mesh_rots;
         mesh_rots_2 = mesh_rots_1;
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 7);
-    } else {
-        Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 6);
     }
+
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_TORSO], mesh_rots_2[LM_TORSO]);
     Matrix_RotYXZ_I(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
 
     Matrix_Push_I();
@@ -165,7 +163,7 @@ static void M_CalculateSpheres_I(
     Matrix_TranslateRel_I(
         bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
         bone[LM_UARM_R - 1].pos.z);
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 0);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_R], mesh_rots_2[LM_UARM_R]);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_R];
     Matrix_TranslateRel_I(mesh[0], mesh[1], mesh[2]);
@@ -180,7 +178,7 @@ static void M_CalculateSpheres_I(
     Matrix_TranslateRel_I(
         bone[LM_UARM_L - 1].pos.x, bone[LM_UARM_L - 1].pos.y,
         bone[LM_UARM_L - 1].pos.z);
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 2);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_UARM_L], mesh_rots_2[LM_UARM_L]);
 
     mesh = g_Lara.mesh_ptrs[LM_UARM_L];
     Matrix_TranslateRel_I(mesh[0], mesh[1], mesh[2]);
@@ -194,7 +192,7 @@ static void M_CalculateSpheres_I(
     Matrix_TranslateRel_I(
         bone[LM_HEAD - 1].pos.x, bone[LM_HEAD - 1].pos.y,
         bone[LM_HEAD - 1].pos.z);
-    Matrix_RotYXZsuperpack_I(&mesh_rots_1, &mesh_rots_2, 2);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HEAD], mesh_rots_2[LM_HEAD]);
     Matrix_RotYXZ_I(g_Lara.head_y_rot, g_Lara.head_x_rot, g_Lara.head_z_rot);
 
     Matrix_Push_I();

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -865,17 +865,17 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
     g_MatrixPtr->_23 = 0;
     Matrix_RotYXZ(g_LaraItem->rot.y, g_LaraItem->rot.x, g_LaraItem->rot.z);
 
-    const int16_t *rot = frame_ptr->mesh_rots;
+    const XYZ_16 *mesh_rots = frame_ptr->mesh_rots;
     const ANIM_BONE *bone = Object_GetBone(obj, 0);
 
     Matrix_TranslateRel(
         frame_ptr->offset.x, frame_ptr->offset.y, frame_ptr->offset.z);
-    Matrix_RotYXZsuperpack(&rot, 0);
+    Matrix_RotXYZ16(mesh_rots[LM_HIPS]);
 
     Matrix_TranslateRel(
         bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
         bone[LM_TORSO - 1].pos.z);
-    Matrix_RotYXZsuperpack(&rot, 6);
+    Matrix_RotXYZ16(mesh_rots[LM_TORSO]);
     Matrix_RotYXZ(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
 
     LARA_GUN_TYPE gun_type = LGT_UNARMED;
@@ -891,21 +891,22 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-            rot = arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
+            mesh_rots =
+                arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
         } else {
-            rot = frame_ptr->mesh_rots;
+            mesh_rots = frame_ptr->mesh_rots;
         }
-        Matrix_RotYXZsuperpack(&rot, 11);
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_L]);
 
         Matrix_TranslateRel(
             bone[LM_LARM_L - 1].pos.x, bone[LM_LARM_L - 1].pos.y,
             bone[LM_LARM_L - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot, 0);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_L]);
 
         Matrix_TranslateRel(
             bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
             bone[LM_HAND_L - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot, 0);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_L]);
     } else if (gun_type != LGT_UNARMED) {
         Matrix_TranslateRel(
             bone[LM_UARM_R - 1].pos.x, bone[LM_UARM_R - 1].pos.y,
@@ -913,18 +914,18 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
 
         const LARA_ARM *const arm = &g_Lara.right_arm;
         const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-        rot = arm->frame_base[arm->frame_num].mesh_rots;
-        Matrix_RotYXZsuperpack(&rot, 8);
+        mesh_rots = arm->frame_base[arm->frame_num].mesh_rots;
+        Matrix_RotXYZ16(mesh_rots[LM_UARM_R]);
 
         Matrix_TranslateRel(
             bone[LM_LARM_R - 1].pos.x, bone[LM_LARM_R - 1].pos.y,
             bone[LM_LARM_R - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot, 0);
+        Matrix_RotXYZ16(mesh_rots[LM_LARM_R]);
 
         Matrix_TranslateRel(
-            bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
-            bone[LM_HAND_L - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot, 0);
+            bone[LM_HAND_R - 1].pos.x, bone[LM_HAND_R - 1].pos.y,
+            bone[LM_HAND_R - 1].pos.z);
+        Matrix_RotXYZ16(mesh_rots[LM_HAND_R]);
     }
 
     Matrix_TranslateRel(vec->x, vec->y, vec->z);
@@ -947,19 +948,19 @@ void Lara_GetJointAbsPosition_I(
     Matrix_RotYXZ(item->rot.y, item->rot.x, item->rot.z);
 
     const ANIM_BONE *const bone = Object_GetBone(obj, 0);
-    const int16_t *rot1 = frame1->mesh_rots;
-    const int16_t *rot2 = frame2->mesh_rots;
+    const XYZ_16 *mesh_rots_1 = frame1->mesh_rots;
+    const XYZ_16 *mesh_rots_2 = frame2->mesh_rots;
     Matrix_InitInterpolate(frac, rate);
 
     Matrix_TranslateRel_ID(
         frame1->offset.x, frame1->offset.y, frame1->offset.z, frame2->offset.x,
         frame2->offset.y, frame2->offset.z);
-    Matrix_RotYXZsuperpack_I(&rot1, &rot2, 0);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_HIPS], mesh_rots_2[LM_HIPS]);
 
     Matrix_TranslateRel_I(
         bone[LM_TORSO - 1].pos.x, bone[LM_TORSO - 1].pos.y,
         bone[LM_TORSO - 1].pos.z);
-    Matrix_RotYXZsuperpack_I(&rot1, &rot2, 6);
+    Matrix_RotXYZ16_I(mesh_rots_1[LM_TORSO], mesh_rots_2[LM_TORSO]);
     Matrix_RotYXZ_I(g_Lara.torso_y_rot, g_Lara.torso_x_rot, g_Lara.torso_z_rot);
 
     LARA_GUN_TYPE gun_type = LGT_UNARMED;
@@ -976,21 +977,22 @@ void Lara_GetJointAbsPosition_I(
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-            rot1 = arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
+            mesh_rots_1 =
+                arm->frame_base[arm->frame_num - anim->frame_base].mesh_rots;
         } else {
-            rot1 = frame1->mesh_rots;
+            mesh_rots_1 = frame1->mesh_rots;
         }
-        Matrix_RotYXZsuperpack(&rot1, 11);
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_L]);
 
         Matrix_TranslateRel(
             bone[LM_LARM_L - 1].pos.x, bone[LM_LARM_L - 1].pos.y,
             bone[LM_LARM_L - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot1, 0);
+        Matrix_RotXYZ16(mesh_rots_1[LM_LARM_L]);
 
         Matrix_TranslateRel(
             bone[LM_HAND_L - 1].pos.x, bone[LM_HAND_L - 1].pos.y,
             bone[LM_UARM_L - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot1, 0);
+        Matrix_RotXYZ16(mesh_rots_1[LM_HAND_L]);
     } else if (gun_type != LGT_UNARMED) {
         Matrix_Interpolate();
         Matrix_TranslateRel(
@@ -999,18 +1001,18 @@ void Lara_GetJointAbsPosition_I(
 
         const LARA_ARM *const arm = &g_Lara.right_arm;
         const ANIM *const anim = Anim_GetAnim(arm->anim_num);
-        rot1 = arm->frame_base[arm->frame_num].mesh_rots;
-        Matrix_RotYXZsuperpack(&rot1, 8);
+        mesh_rots_1 = arm->frame_base[arm->frame_num].mesh_rots;
+        Matrix_RotXYZ16(mesh_rots_1[LM_UARM_R]);
 
         Matrix_TranslateRel(
             bone[LM_LARM_R - 1].pos.x, bone[LM_LARM_R - 1].pos.y,
             bone[LM_LARM_R - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot1, 0);
+        Matrix_RotXYZ16(mesh_rots_1[LM_LARM_R]);
 
         Matrix_TranslateRel(
             bone[LM_HAND_R - 1].pos.x, bone[LM_HAND_R - 1].pos.y,
             bone[LM_HAND_R - 1].pos.z);
-        Matrix_RotYXZsuperpack(&rot1, 0);
+        Matrix_RotXYZ16(mesh_rots_1[LM_HAND_R]);
     }
 
     Matrix_TranslateRel(vec->x, vec->y, vec->z);

--- a/src/tr2/game/matrix.c
+++ b/src/tr2/game/matrix.c
@@ -190,48 +190,11 @@ void Matrix_RotYXZ(const int16_t ry, const int16_t rx, const int16_t rz)
     Matrix_RotZ(rz);
 }
 
-void Matrix_RotYXZpack(const uint32_t rpack)
+void Matrix_RotXYZ16(const XYZ_16 rotation)
 {
-    const int16_t rx = ((rpack >> 20) & 0x3FF) << 6;
-    const int16_t ry = ((rpack >> 10) & 0x3FF) << 6;
-    const int16_t rz = ((rpack >> 0) & 0x3FF) << 6;
-    Matrix_RotYXZ(ry, rx, rz);
-}
-
-void Matrix_RotYXZsuperpack(const int16_t **pprot, int32_t index)
-{
-    const uint16_t *prot = (const uint16_t *)*pprot;
-
-    for (int32_t i = 0; i < index; i++) {
-        if ((*prot >> 14) == 0) {
-            prot += 2;
-        } else {
-            prot += 1;
-        }
-    }
-
-    switch (*prot >> 14) {
-    case 0: {
-        uint32_t packed = (prot[0] << 16) + prot[1];
-        Matrix_RotYXZpack(packed);
-        prot += 2;
-        break;
-    }
-    case 1:
-        Matrix_RotX((int16_t)((*prot & 1023) << 6));
-        prot += 1;
-        break;
-    case 2:
-        Matrix_RotY((int16_t)((*prot & 1023) << 6));
-        prot += 1;
-        break;
-    default:
-        Matrix_RotZ((int16_t)((*prot & 1023) << 6));
-        prot += 1;
-        break;
-    }
-
-    *pprot = (int16_t *)prot;
+    Matrix_RotY(rotation.y);
+    Matrix_RotX(rotation.x);
+    Matrix_RotZ(rotation.z);
 }
 
 bool Matrix_TranslateRel(int32_t x, int32_t y, int32_t z)
@@ -394,13 +357,12 @@ void Matrix_RotYXZ_I(int16_t y, int16_t x, int16_t z)
     g_MatrixPtr = old_matrix;
 }
 
-void Matrix_RotYXZsuperpack_I(
-    const int16_t **pprot1, const int16_t **pprot2, int32_t index)
+void Matrix_RotXYZ16_I(const XYZ_16 rotation_1, const XYZ_16 rotation_2)
 {
-    Matrix_RotYXZsuperpack(pprot1, index);
-    MATRIX *old_matrix = g_MatrixPtr;
+    Matrix_RotXYZ16(rotation_1);
+    MATRIX *const old_matrix = g_MatrixPtr;
     g_MatrixPtr = m_IMMatrixPtr;
-    Matrix_RotYXZsuperpack(pprot2, index);
+    Matrix_RotXYZ16(rotation_2);
     g_MatrixPtr = old_matrix;
 }
 

--- a/src/tr2/game/matrix.h
+++ b/src/tr2/game/matrix.h
@@ -36,8 +36,7 @@ void Matrix_RotX(int16_t rx);
 void Matrix_RotY(int16_t ry);
 void Matrix_RotZ(int16_t rz);
 void Matrix_RotYXZ(int16_t ry, int16_t rx, int16_t rz);
-void Matrix_RotYXZpack(uint32_t rpack);
-void Matrix_RotYXZsuperpack(const int16_t **pprot, int32_t index);
+void Matrix_RotXYZ16(XYZ_16 rotation);
 bool Matrix_TranslateRel(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateSet(int32_t x, int32_t y, int32_t z);
@@ -51,8 +50,7 @@ void Matrix_RotX_I(int16_t ang);
 void Matrix_RotY_I(int16_t ang);
 void Matrix_RotZ_I(int16_t ang);
 void Matrix_RotYXZ_I(int16_t y, int16_t x, int16_t z);
-void Matrix_RotYXZsuperpack_I(
-    const int16_t **pprot1, const int16_t **pprot2, int32_t index);
+void Matrix_RotXYZ16_I(XYZ_16 rotation_1, XYZ_16 rotation_2);
 void Matrix_TranslateRel_I(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateRel_ID(
     int32_t x, int32_t y, int32_t z, int32_t x2, int32_t y2, int32_t z2);

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -45,10 +45,6 @@ void Object_DrawAnimatingItem(const ITEM *item)
 
     int16_t *const *mesh_ptrs = &g_Meshes[obj->mesh_idx];
     const int16_t *extra_rotation = item->data;
-    const int16_t *mesh_rots[2] = {
-        frames[0]->mesh_rots,
-        frames[1]->mesh_rots,
-    };
 
     if (frac != 0) {
         for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
@@ -58,7 +54,9 @@ void Object_DrawAnimatingItem(const ITEM *item)
                     frames[0]->offset.x, frames[0]->offset.y,
                     frames[0]->offset.z, frames[1]->offset.x,
                     frames[1]->offset.y, frames[1]->offset.z);
-                Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
+                Matrix_RotXYZ16_I(
+                    frames[0]->mesh_rots[mesh_idx],
+                    frames[1]->mesh_rots[mesh_idx]);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -69,7 +67,9 @@ void Object_DrawAnimatingItem(const ITEM *item)
                 }
 
                 Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
-                Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
+                Matrix_RotXYZ16_I(
+                    frames[0]->mesh_rots[mesh_idx],
+                    frames[1]->mesh_rots[mesh_idx]);
                 if (extra_rotation != NULL) {
                     if (bone->rot_y) {
                         Matrix_RotY_I(*extra_rotation++);
@@ -93,7 +93,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
                 Matrix_TranslateRel(
                     frames[0]->offset.x, frames[0]->offset.y,
                     frames[0]->offset.z);
-                Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
+                Matrix_RotXYZ16(frames[0]->mesh_rots[mesh_idx]);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -104,7 +104,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
                 }
 
                 Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-                Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
+                Matrix_RotXYZ16(frames[0]->mesh_rots[mesh_idx]);
                 if (extra_rotation != NULL) {
                     if (bone->rot_y) {
                         Matrix_RotY(*extra_rotation++);
@@ -194,14 +194,14 @@ BOUNDS_16 Object_GetBoundingBox(
     const uint32_t mesh_bits)
 {
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
+    const XYZ_16 *const mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
 
     Matrix_PushUnit();
     if (frame != NULL) {
         Matrix_TranslateRel(frame->offset.x, frame->offset.y, frame->offset.z);
     }
     if (mesh_rots != NULL) {
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(mesh_rots[0]);
     }
 
     BOUNDS_16 new_bounds = {
@@ -226,7 +226,7 @@ BOUNDS_16 Object_GetBoundingBox(
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             if (mesh_rots != NULL) {
-                Matrix_RotYXZsuperpack(&mesh_rots, 0);
+                Matrix_RotXYZ16(mesh_rots[mesh_idx]);
             }
         }
 

--- a/src/tr2/game/objects/creatures/xian_common.c
+++ b/src/tr2/game/objects/creatures/xian_common.c
@@ -41,10 +41,6 @@ void XianWarrior_Draw(const ITEM *item)
     }
 
     const int16_t *extra_rotation = item->data;
-    const int16_t *mesh_rots[2] = {
-        frames[0]->mesh_rots,
-        frames[1]->mesh_rots,
-    };
 
     if (frac != 0) {
         for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
@@ -54,7 +50,9 @@ void XianWarrior_Draw(const ITEM *item)
                     frames[0]->offset.x, frames[0]->offset.y,
                     frames[0]->offset.z, frames[1]->offset.x,
                     frames[1]->offset.y, frames[1]->offset.z);
-                Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
+                Matrix_RotXYZ16_I(
+                    frames[0]->mesh_rots[mesh_idx],
+                    frames[1]->mesh_rots[mesh_idx]);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -65,7 +63,9 @@ void XianWarrior_Draw(const ITEM *item)
                 }
 
                 Matrix_TranslateRel_I(bone->pos.x, bone->pos.y, bone->pos.z);
-                Matrix_RotYXZsuperpack_I(&mesh_rots[0], &mesh_rots[1], 0);
+                Matrix_RotXYZ16_I(
+                    frames[0]->mesh_rots[mesh_idx],
+                    frames[1]->mesh_rots[mesh_idx]);
                 if (extra_rotation != NULL) {
                     if (bone->rot_y) {
                         Matrix_RotY_I(*extra_rotation++);
@@ -91,7 +91,7 @@ void XianWarrior_Draw(const ITEM *item)
                 Matrix_TranslateRel(
                     frames[0]->offset.x, frames[0]->offset.y,
                     frames[0]->offset.z);
-                Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
+                Matrix_RotXYZ16(frames[0]->mesh_rots[mesh_idx]);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -102,7 +102,7 @@ void XianWarrior_Draw(const ITEM *item)
                 }
 
                 Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-                Matrix_RotYXZsuperpack(&mesh_rots[0], 0);
+                Matrix_RotXYZ16(frames[0]->mesh_rots[mesh_idx]);
                 if (extra_rotation != NULL) {
                     if (bone->rot_y) {
                         Matrix_RotY(*extra_rotation++);

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -252,9 +252,9 @@ void Pickup_Draw(const ITEM *const item)
         int32_t bit = 1;
         int16_t **meshpp = &g_Meshes[obj->mesh_idx];
 
-        const int16_t *mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
+        const XYZ_16 *const mesh_rots = frame != NULL ? frame->mesh_rots : NULL;
         if (mesh_rots != NULL) {
-            Matrix_RotYXZsuperpack(&mesh_rots, 0);
+            Matrix_RotXYZ16(mesh_rots[0]);
         }
 
         if (item->mesh_bits & bit) {
@@ -273,7 +273,7 @@ void Pickup_Draw(const ITEM *const item)
 
             Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
             if (mesh_rots != NULL) {
-                Matrix_RotYXZsuperpack(&mesh_rots, 0);
+                Matrix_RotXYZ16(mesh_rots[i]);
             }
 
             // Extra rotation is ignored in this case as it's not needed.

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -434,8 +434,7 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
         -(bounds.min.z + bounds.max.z) / 2);
 
     int16_t **mesh_ptrs = &g_Meshes[obj->mesh_idx];
-    const int16_t *mesh_rots = frame->mesh_rots;
-    Matrix_RotYXZsuperpack(&mesh_rots, 0);
+    Matrix_RotXYZ16(frame->mesh_rots[0]);
 
     Output_InsertPolygons(mesh_ptrs[0], 0);
     for (int32_t mesh_idx = 1; mesh_idx < obj->mesh_count; mesh_idx++) {
@@ -449,7 +448,7 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
         }
 
         Matrix_TranslateRel(bone->pos.x, bone->pos.y, bone->pos.z);
-        Matrix_RotYXZsuperpack(&mesh_rots, 0);
+        Matrix_RotXYZ16(frame->mesh_rots[mesh_idx]);
 
         Output_InsertPolygons(mesh_ptrs[mesh_idx], 0);
     }

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -520,8 +520,7 @@ void Room_DrawAllRooms(const int16_t current_room)
             g_MatrixPtr->_03 = 0;
             g_MatrixPtr->_13 = 0;
             g_MatrixPtr->_23 = 0;
-            const int16_t *mesh_rots = skybox->frame_base->mesh_rots;
-            Matrix_RotYXZsuperpack(&mesh_rots, 0);
+            Matrix_RotXYZ16(skybox->frame_base->mesh_rots[0]);
             Output_InsertSkybox(g_Meshes[skybox->mesh_idx]);
             Matrix_Pop();
         } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This parses TR2 frame mesh rotations fully once on level load, which means we eliminate the need to pass superpacked values to matrix.c and have it extract the component values on every call.

I've used pass by value for `Matrix_RotXYZ16` to make things easier to read and manage, and I've added a separate commit for TR1 to do the same.

Testing should be straight-forward - general item animation, including 3D pickups (ground and HUD) and skyboxes, should appear normal. It would be good to give Lara some particular attention - `Matrix_RotYXZsuperpack` used to advance the pointer on each call, but also accepted an index value to jump to a particular mesh, so this meant deciphering all of this into direct array access instead. It's pretty similar to TR1 now, but worth some attention.

TR1 is a more straight-forward change, so a quick check here should be all that's needed.