### PR TITLE
inv-ring: fix options shutdown called too late

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,9 +2,10 @@
 - added Linux builds and toolchain (#1598)
 - added pause dialog (#1638)
 - fixed showing inventory ring up/down arrows when uncalled for (#2225)
-- fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
+- fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
+- fixed stopwatch showing wrong UI in some circumstances (#2221, regression from 0.8)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -729,7 +729,9 @@ static GAME_FLOW_COMMAND M_Control(INV_RING *const ring)
         break;
     }
 
-    case RNG_DESELECT:
+    case RNG_DESELECT: {
+        INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
+        Option_Shutdown(inv_item);
         Sound_Effect(SFX_MENU_SPINOUT, NULL, SPM_ALWAYS);
         InvRing_MotionSetup(ring, RNG_DESELECTING, RNG_OPEN, SELECTING_FRAMES);
         InvRing_MotionRotation(
@@ -737,6 +739,7 @@ static GAME_FLOW_COMMAND M_Control(INV_RING *const ring)
         g_Input = (INPUT_STATE) {};
         g_InputDB = (INPUT_STATE) {};
         break;
+    }
 
     case RNG_CLOSING_ITEM: {
         INVENTORY_ITEM *inv_item = ring->list[ring->current_object];

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -505,7 +505,9 @@ static GAME_FLOW_COMMAND M_Control(INV_RING *const ring)
             break;
         }
 
-        case RNG_DESELECT:
+        case RNG_DESELECT: {
+            INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
+            Option_Shutdown(inv_item);
             Sound_Effect(SFX_MENU_SPINOUT, 0, SPM_ALWAYS);
             InvRing_MotionSetup(ring, RNG_DESELECTING, RNG_OPEN, 16);
             InvRing_MotionRotation(
@@ -513,6 +515,7 @@ static GAME_FLOW_COMMAND M_Control(INV_RING *const ring)
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
             break;
+        }
 
         case RNG_CLOSING_ITEM: {
             INVENTORY_ITEM *inv_item = ring->list[ring->current_object];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2221.
A similar change was made to TR1, though I don't think it can cause any visual problems there.