### PR TITLE
tr2/savegame: fix SAVEGAME_INFO layout I/O

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
+- fixed savegame incompatibility with OG (#2271, regression from 0.8)
 - fixed stopwatch showing wrong UI in some circumstances (#2221, regression from 0.8)
 - fixed excessive braid movement when dead in windy rooms (#2265, regression from 0.8)
 - fixed item counter shown even for a single medipack (#2222, regression from 0.3)

--- a/docs/tr2/symbols.txt
+++ b/docs/tr2/symbols.txt
@@ -586,7 +586,6 @@ typedef struct __unaligned {
     uint32_t hits;
     uint32_t distance;
     uint16_t kills;
-    uint16_ secrets_count;
     uint8_t secrets_flags;
     uint8_t medipacks;
 } STATISTICS_INFO;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -388,7 +388,7 @@ void InitialiseLevelFlags(void)
     g_SaveGame.current_stats.ammo_hits = 0;
     g_SaveGame.current_stats.ammo_used = 0;
     g_SaveGame.current_stats.medipacks = 0;
-    g_SaveGame.current_stats.secrets_bitmap = 0;
+    g_SaveGame.current_stats.secret_flags = 0;
 }
 
 void GetCarriedItems(void)

--- a/src/tr2/decomp/savegame.h
+++ b/src/tr2/decomp/savegame.h
@@ -16,5 +16,5 @@ void ReadSG(void *pointer, size_t size);
 
 void GetSavedGamesList(REQUEST_INFO *req);
 bool S_FrontEndCheck(void);
-int32_t S_SaveGame(const void *save_data, size_t save_size, int32_t slot_num);
-int32_t S_LoadGame(void *save_data, size_t save_size, int32_t slot_num);
+int32_t S_SaveGame(int32_t slot_num);
+int32_t S_LoadGame(int32_t slot_num);

--- a/src/tr2/game/inventory.c
+++ b/src/tr2/game/inventory.c
@@ -206,15 +206,15 @@ bool Inv_AddItem(const GAME_OBJECT_ID object_id)
         return true;
 
     case O_SECRET_1:
-        g_SaveGame.current_stats.secrets_bitmap |= 1;
+        g_SaveGame.current_stats.secret_flags |= 1;
         return true;
 
     case O_SECRET_2:
-        g_SaveGame.current_stats.secrets_bitmap |= 2;
+        g_SaveGame.current_stats.secret_flags |= 2;
         return true;
 
     case O_SECRET_3:
-        g_SaveGame.current_stats.secrets_bitmap |= 4;
+        g_SaveGame.current_stats.secret_flags |= 4;
         return true;
 
     case O_KEY_ITEM_1:

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -754,8 +754,7 @@ GAME_FLOW_COMMAND InvRing_Close(INV_RING *const ring)
             if (g_Inv_ExtraData[0] == 0) {
                 // first passport page: load game.
                 Inv_RemoveAllItems();
-                S_LoadGame(
-                    &g_SaveGame, sizeof(SAVEGAME_INFO), g_Inv_ExtraData[1]);
+                S_LoadGame(g_Inv_ExtraData[1]);
                 gf_cmd = (GAME_FLOW_COMMAND) {
                     .action = GF_START_SAVED_GAME,
                     .param = g_Inv_ExtraData[1],
@@ -792,8 +791,7 @@ GAME_FLOW_COMMAND InvRing_Close(INV_RING *const ring)
                     } else {
                         CreateSaveGameInfo();
                         const int16_t slot_num = g_Inv_ExtraData[1];
-                        S_SaveGame(
-                            &g_SaveGame, sizeof(SAVEGAME_INFO), slot_num);
+                        S_SaveGame(slot_num);
                     }
                 }
             } else {

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -55,9 +55,9 @@ static void M_DoPickup(const int16_t item_num)
 
     if ((item->object_id == O_SECRET_1 || item->object_id == O_SECRET_2
          || item->object_id == O_SECRET_3)
-        && (g_SaveGame.current_stats.secrets_bitmap & 1)
-                + ((g_SaveGame.current_stats.secrets_bitmap >> 1) & 1)
-                + ((g_SaveGame.current_stats.secrets_bitmap >> 2) & 1)
+        && (g_SaveGame.current_stats.secret_flags & 1)
+                + ((g_SaveGame.current_stats.secret_flags >> 1) & 1)
+                + ((g_SaveGame.current_stats.secret_flags >> 2) & 1)
             >= 3) {
         GF_ModifyInventory(g_CurrentLevel, 1);
     }

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -17,7 +17,7 @@ bool Savegame_IsSlotFree(const int32_t slot_idx)
 bool Savegame_Save(const int32_t slot_idx)
 {
     CreateSaveGameInfo();
-    S_SaveGame(&g_SaveGame, sizeof(SAVEGAME_INFO), slot_idx);
+    S_SaveGame(slot_idx);
     GetSavedGamesList(&g_LoadGameRequester);
     return true;
 }

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -410,7 +410,7 @@ void Shell_Main(void)
             break;
 
         case GF_START_SAVED_GAME:
-            S_LoadGame(&g_SaveGame, sizeof(SAVEGAME_INFO), gf_cmd.param);
+            S_LoadGame(gf_cmd.param);
             if (g_SaveGame.current_level > g_GameFlow.num_levels) {
                 Shell_ExitSystemFmt(
                     "GameMain: STARTSAVEDGAME with invalid level number (%d)",

--- a/src/tr2/game/stats.c
+++ b/src/tr2/game/stats.c
@@ -47,7 +47,7 @@ FINAL_STATS Stats_ComputeFinalStats(void)
         // TODO: #170, consult GFE_NUM_SECRETS rather than hardcoding this
         if (i < total_levels - 2) {
             for (int32_t j = 0; j < 3; j++) {
-                if (g_SaveGame.start[i].stats.secrets_bitmap & (1 << j)) {
+                if (g_SaveGame.start[i].stats.secret_flags & (1 << j)) {
                     result.found_secrets++;
                 }
                 result.total_secrets++;

--- a/src/tr2/game/ui/widgets/stats_dialog.c
+++ b/src/tr2/game/ui/widgets/stats_dialog.c
@@ -82,7 +82,7 @@ static void M_AddRowFromRole(
         char *ptr = buf;
         int32_t num_secrets = 0;
         for (int32_t i = 0; i < 3; i++) {
-            if (((LEVEL_STATS *)stats)->secrets_bitmap & (1 << i)) {
+            if (((LEVEL_STATS *)stats)->secret_flags & (1 << i)) {
                 sprintf(ptr, "\\{secret %d}", i + 1);
                 num_secrets++;
             } else {

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -165,7 +165,7 @@ typedef struct {
 
 typedef struct {
     struct STATS_COMMON;
-    uint8_t secrets_bitmap;
+    uint8_t secret_flags;
 } LEVEL_STATS;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2271.

#### Testing

General savegame quick checks.

- statistics (including final stats taking into account stats from completed levels)
- inventory (guns, ammo, pickups, flares)
- NG+ flag
- starting gun

There is more than the above to the savegames, but we've not touched much beyond what I listed above.