### PR TITLE
tr2/inventory_ring/control: default to gym option until launched

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed excessive braid movement when dead in windy rooms (#2265, regression from 0.8)
 - fixed item counter shown even for a single medipack (#2222, regression from 0.3)
 - fixed item counter always hidden in NG+, even for keys (#2223, regression from 0.3)
+- fixed the passport object not being selected when exiting to title (#2192, regression from 0.8)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -162,6 +162,10 @@ int32_t Level_Initialise(
     g_GameInfo.current_level.num = level_num;
     g_GameInfo.current_level.type = level_type;
 
+    if (level_type != GFL_TITLE && level_type != GFL_DEMO) {
+        g_GymInvOpenEnabled = false;
+    }
+
     if (level_type != GFL_TITLE && level_type != GFL_CUTSCENE) {
         g_CurrentLevel = level_num;
     }
@@ -277,6 +281,8 @@ GAME_FLOW_COMMAND DisplayCredits(void)
     if (!Level_Initialise(0, GFL_TITLE)) {
         return (GAME_FLOW_COMMAND) { .action = GF_EXIT_TO_TITLE };
     }
+
+    g_GymInvOpenEnabled = true;
 
     Music_Play(MX_SKIDOO_THEME, MPM_ALWAYS);
 

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -619,6 +619,9 @@ void Lara_Control(const int16_t item_num)
 
     if (item->hit_points <= 0) {
         item->hit_points = -1;
+        if (g_CurrentLevel == LV_GYM) {
+            g_GymInvOpenEnabled = true;
+        }
         if (!g_Lara.death_timer) {
             Music_Stop();
         }


### PR DESCRIPTION
Resolves #2192.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Not exactly elegant, but it covers all situations (I think/hope) where you go from the inventory to some other level and then return; it should match OG now. So demos playing before having visited the gym should return back to highlighting the gym option, but anything else, the passport.
