### PR TITLE
Small phaser fixes

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.7.1...develop) - ××××-××-××
 - added an option for pickup aids, which will show an intermittent twinkle when Lara is nearby pickup items (#2076)
 - added an optional demo number argument to the `/demo` command
+- added pause screen support to demos
 - added a fade-out effect when exiting the game from the pause screen
 - changed demo to be interrupted only by esc or action keys
 - changed the turbo cheat to also affect ingame timer (#2167)

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -59,11 +59,11 @@ static GAME_FLOW_COMMAND M_Control(const bool demo_mode)
 
     if (demo_mode) {
         if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
-            return GF_TranslateScriptCommand(g_GameFlow.on_demo_interrupt);
+            return (GAME_FLOW_COMMAND) { .action = GF_LEVEL_COMPLETE };
         }
         if (!Demo_GetInput()) {
             g_Input = (INPUT_STATE) {};
-            return GF_TranslateScriptCommand(g_GameFlow.on_demo_end);
+            return (GAME_FLOW_COMMAND) { .action = GF_LEVEL_COMPLETE };
         }
     }
 

--- a/src/tr2/game/phase/phase_cutscene.c
+++ b/src/tr2/game/phase/phase_cutscene.c
@@ -132,7 +132,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
             if (gf_cmd.action != GF_NOOP) {
                 return (PHASE_CONTROL) {
                     .action = PHASE_ACTION_END,
-                    .gf_cmd = { .action = GF_NOOP },
+                    .gf_cmd = gf_cmd,
                 };
             }
         } else if (g_InputDB.toggle_photo_mode) {
@@ -140,7 +140,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
             if (gf_cmd.action != GF_NOOP) {
                 return (PHASE_CONTROL) {
                     .action = PHASE_ACTION_END,
-                    .gf_cmd = { .action = GF_NOOP },
+                    .gf_cmd = gf_cmd,
                 };
             }
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Fixes issuing commands like /play when paused in cutscenes
- Fixes issuing commands like /play when paused in demos
- Fixes small interpolation glitches during demo fade-outs
- Adds missing changelog documentation

#### Known issues

`/play` still doesn't work during FMVs in both games, or `legal.pcx` in TR2. This is a bit more involved and I'd like to tackle this once we have the new gameflow.