### PR TITLE
camera: fix Lara's vision range

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -7,13 +7,14 @@
 - changed the pause screen to wait before yielding control during fade out effect
 - changed the compass and final stats to use two columns, similar to TR2 (doesn't apply to end-of-level "bare" stats)
 - changed the fix for transparent eyes on wolves to use black instead of off-white (#2252)
+- fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
+- fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 4.2)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)
 - fixed the game hanging when Lara is on fire and enters the fly cheat on the same frame as reaching water (#2116, regression from 0.8)
 - fixed Lara activating triggers one frame too early (#2208, regression from 4.3)
 - fixed wrong underwater caustics speed with the turbo cheat (#2231)
 - fixed 1-frame UI flicker on pause screen exit confirmation
-- fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - fixed being able to use keys and puzzle items in keyholes/slots that have already been used (#2256, regression from 4.0)
 - fixed textures animating during demo fade-outs (#2217, regression from 4.0)
 - fixed waterfall mist not animating during demo (#2218, regression from 3.0)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed item counter shown even for a single medipack (#2222, regression from 0.3)
 - fixed item counter always hidden in NG+, even for keys (#2223, regression from 0.3)
 - fixed the passport object not being selected when exiting to title (#2192, regression from 0.8)
+- fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 0.8)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/src/libtrx/include/libtrx/game/camera/types.h
+++ b/src/libtrx/include/libtrx/game/camera/types.h
@@ -20,7 +20,6 @@ typedef struct {
     int16_t actual_angle;
 #endif
     int16_t target_elevation;
-    int16_t box;
     int16_t num;
     int16_t last;
     int16_t timer;
@@ -29,6 +28,8 @@ typedef struct {
     ITEM *item;
     ITEM *last_item;
     OBJECT_VECTOR *fixed;
+
+    int32_t debuff;
 
 #if TR_VERSION == 1
     // used for the manual camera control
@@ -44,8 +45,6 @@ typedef struct {
         int16_t room_num;
     } interp;
 #else
-    // TODO: remove this - now stored in g_Config
-    int32_t is_lara_mic;
     XYZ_32 mic_pos;
 #endif
 } CAMERA_INFO;

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -172,6 +172,7 @@ static void M_Look(const ITEM *const item)
     g_Camera.target.x = old.x + (g_Camera.target.x - old.x) / g_Camera.speed;
 
     M_Move(&ideal, g_Camera.speed);
+    g_Camera.debuff = 5;
 }
 
 static void M_Fixed(void)
@@ -737,8 +738,15 @@ void Camera_Update(void)
             M_Combat(item);
         }
     } else {
-        g_Camera.target.x = item->pos.x;
-        g_Camera.target.z = item->pos.z;
+        if (g_Camera.debuff > 0) {
+            const XYZ_32 old = g_Camera.target.pos;
+            g_Camera.target.x = (item->pos.x + old.x) / 2;
+            g_Camera.target.z = (item->pos.z + old.z) / 2;
+            g_Camera.debuff--;
+        } else {
+            g_Camera.target.x = item->pos.x;
+            g_Camera.target.z = item->pos.z;
+        }
 
         if (g_Camera.flags == FOLLOW_CENTRE) {
             const int16_t shift = (bounds->min.z + bounds->max.z) / 2;

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -70,7 +70,7 @@
 #define DEATH_WAIT_MIN (2 * LOGIC_FPS)
 #define MAX_HEAD_ROTATION (50 * DEG_1) // = 9100
 #define MAX_HEAD_TILT_LOOK (22 * DEG_1) // = 4004
-#define MIN_HEAD_TILT_LOOK (-35 * DEG_1) // = -6370
+#define MIN_HEAD_TILT_LOOK (-42 * DEG_1) // = -7644
 #define MAX_HEAD_TILT_CAM (85 * DEG_1) // = 15470
 #define MIN_HEAD_TILT_CAM (-85 * DEG_1) // = 15470
 #define HEAD_TURN (4 * DEG_1) // = 728

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -682,6 +682,7 @@ void Camera_Look(const ITEM *item)
     g_Camera.target.z = old.z + (g_Camera.target.z - old.z) / g_Camera.speed;
     g_Camera.target.x = old.x + (g_Camera.target.x - old.x) / g_Camera.speed;
     Camera_Move(&target, g_Camera.speed);
+    g_Camera.debuff = 5;
 }
 
 void Camera_Fixed(void)
@@ -796,8 +797,15 @@ void Camera_Update(void)
             Camera_Combat(item);
         }
     } else {
-        g_Camera.target.x = item->pos.x;
-        g_Camera.target.z = item->pos.z;
+        if (g_Camera.debuff > 0) {
+            const XYZ_32 old = g_Camera.target.pos;
+            g_Camera.target.x = (item->pos.x + old.x) / 2;
+            g_Camera.target.z = (item->pos.z + old.z) / 2;
+            g_Camera.debuff--;
+        } else {
+            g_Camera.target.x = item->pos.x;
+            g_Camera.target.z = item->pos.z;
+        }
 
         if (g_Camera.flags == CF_FOLLOW_CENTRE) {
             const int32_t shift = (bounds->min.z + bounds->max.z) / 2;

--- a/src/tr2/global/const.h
+++ b/src/tr2/global/const.h
@@ -58,7 +58,7 @@
 
 #define HEAD_TURN (2 * DEG_1) // = 364
 #define MAX_HEAD_TILT (22 * DEG_1) // = 4004
-#define MIN_HEAD_TILT (-35 * DEG_1) // = -6370
+#define MIN_HEAD_TILT (-42 * DEG_1) // = -7644
 #define MAX_HEAD_ROTATION (44 * DEG_1) // = 8008
 #define MIN_HEAD_ROTATION (-MAX_HEAD_ROTATION) // = -8008
 #define HEAD_TURN_CAM (4 * DEG_1) // = 728


### PR DESCRIPTION
Resolves #2276.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The look camera looks at Lara with some offset, and when the player releases the look key, `Camera_Update` sets `g_Camera.target` to immediately point back right at Lara. Meanwhile `Camera_Apply` calculates the pitch and yaw by checking the angles between the camera position and the target position. The problem is that when the player releases the look key, these differences are too big and briefly point in weird directions. To fix the original issue, it's enough to smooth the position reset over a few frames. The impact on the existing camera work should be minimal apart from the 5 frames after releasing the look button in both games.