### PR TITLE
libtrx/anims/commands: structure animation commands

### DIFF
--- a/src/libtrx/game/anims/commands.c
+++ b/src/libtrx/game/anims/commands.c
@@ -1,0 +1,72 @@
+#include "benchmark.h"
+#include "game/anims.h"
+#include "game/gamebuf.h"
+
+static void M_ParseCommand(ANIM_COMMAND *command, const int16_t **data);
+
+static void M_ParseCommand(ANIM_COMMAND *const command, const int16_t **data)
+{
+    const int16_t *data_ptr = *data;
+    command->type = *data_ptr++;
+
+    switch (command->type) {
+    case AC_MOVE_ORIGIN: {
+        XYZ_16 *const pos = GameBuf_Alloc(sizeof(XYZ_16), GBUF_ANIM_COMMANDS);
+        pos->x = *data_ptr++;
+        pos->y = *data_ptr++;
+        pos->z = *data_ptr++;
+        command->data = (void *)pos;
+        break;
+    }
+
+    case AC_JUMP_VELOCITY: {
+        ANIM_COMMAND_VELOCITY_DATA *const data = GameBuf_Alloc(
+            sizeof(ANIM_COMMAND_VELOCITY_DATA), GBUF_ANIM_COMMANDS);
+        data->fall_speed = *data_ptr++;
+        data->speed = *data_ptr++;
+        command->data = (void *)data;
+        break;
+    }
+
+    case AC_SOUND_FX:
+    case AC_EFFECT: {
+        ANIM_COMMAND_EFFECT_DATA *const data =
+            GameBuf_Alloc(sizeof(ANIM_COMMAND_EFFECT_DATA), GBUF_ANIM_COMMANDS);
+        data->frame_num = *data_ptr++;
+        const int16_t effect_data = *data_ptr++;
+        data->effect_num = effect_data & 0x3FFF;
+        data->environment = (effect_data & 0xC000) >> 14;
+        command->data = (void *)data;
+        break;
+    }
+
+    default:
+        command->data = NULL;
+        break;
+    }
+
+    *data = data_ptr;
+}
+
+void Anim_LoadCommands(const int16_t *data)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+
+    const int32_t anim_count = Anim_GetTotalCount();
+    for (int32_t i = 0; i < anim_count; i++) {
+        ANIM *const anim = Anim_GetAnim(i);
+        if (anim->num_commands == 0) {
+            continue;
+        }
+
+        anim->commands = GameBuf_Alloc(
+            sizeof(ANIM_COMMAND) * anim->num_commands, GBUF_ANIM_COMMANDS);
+        const int16_t *data_ptr = &data[anim->command_idx];
+        for (int32_t j = 0; j < anim->num_commands; j++) {
+            ANIM_COMMAND *const command = &anim->commands[j];
+            M_ParseCommand(command, &data_ptr);
+        }
+    }
+
+    Benchmark_End(benchmark, NULL);
+}

--- a/src/libtrx/game/anims/common.c
+++ b/src/libtrx/game/anims/common.c
@@ -6,7 +6,6 @@ static int32_t m_AnimCount = 0;
 static ANIM *m_Anims = NULL;
 static ANIM_CHANGE *m_Changes = NULL;
 static ANIM_RANGE *m_Ranges = NULL;
-static int16_t *m_Commands = NULL;
 static ANIM_BONE *m_Bones = NULL;
 
 void Anim_InitialiseAnims(const int32_t num_anims)
@@ -24,11 +23,6 @@ void Anim_InitialiseChanges(const int32_t num_changes)
 void Anim_InitialiseRanges(const int32_t num_ranges)
 {
     m_Ranges = GameBuf_Alloc(sizeof(ANIM_RANGE) * num_ranges, GBUF_ANIM_RANGES);
-}
-
-void Anim_InitialiseCommands(int32_t num_cmds)
-{
-    m_Commands = GameBuf_Alloc(sizeof(int16_t) * num_cmds, GBUF_ANIM_COMMANDS);
 }
 
 void Anim_InitialiseBones(const int32_t num_bones)
@@ -54,11 +48,6 @@ ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
 {
     return &m_Ranges[range_idx];
-}
-
-int16_t *Anim_GetCommand(const int32_t cmd_idx)
-{
-    return &m_Commands[cmd_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -7,8 +7,11 @@
 #include "game/objects/common.h"
 #include "game/rooms.h"
 #include "log.h"
+#include "memory.h"
 #include "utils.h"
 #include "vector.h"
+
+static int16_t *m_AnimCommands = NULL;
 
 static void M_ReadVertex(XYZ_16 *vertex, VFILE *file);
 static void M_ReadFace4(FACE4 *face, VFILE *file);
@@ -260,14 +263,21 @@ void Level_ReadAnimRanges(
     }
 }
 
+void Level_InitialiseAnimCommands(const int32_t num_cmds)
+{
+    m_AnimCommands = Memory_Alloc(sizeof(int16_t) * num_cmds);
+}
+
 void Level_ReadAnimCommands(
     const int32_t base_idx, const int32_t num_cmds, VFILE *const file)
 {
-    // TODO: structure these, although they are of variable size.
-    for (int32_t i = 0; i < num_cmds; i++) {
-        int16_t *const cmd = Anim_GetCommand(base_idx + i);
-        *cmd = VFile_ReadS16(file);
-    }
+    VFile_Read(file, m_AnimCommands + base_idx, sizeof(int16_t) * num_cmds);
+}
+
+void Level_LoadAnimCommands(void)
+{
+    Anim_LoadCommands(m_AnimCommands);
+    Memory_FreePointer(&m_AnimCommands);
 }
 
 void Level_ReadAnimBones(

--- a/src/libtrx/include/libtrx/game/anims.h
+++ b/src/libtrx/include/libtrx/game/anims.h
@@ -3,4 +3,3 @@
 #include "anims/common.h"
 #include "anims/enum.h"
 #include "anims/types.h"
-#include "anims/util.h"

--- a/src/libtrx/include/libtrx/game/anims/common.h
+++ b/src/libtrx/include/libtrx/game/anims/common.h
@@ -5,8 +5,9 @@
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseRanges(int32_t num_ranges);
-void Anim_InitialiseCommands(int32_t num_cmds);
 void Anim_InitialiseBones(int32_t num_bones);
+
+void Anim_LoadCommands(const int16_t *data);
 
 int32_t Anim_GetTotalFrameCount(int32_t frame_data_length);
 void Anim_InitialiseFrames(int32_t num_frames);
@@ -16,7 +17,6 @@ int32_t Anim_GetTotalCount(void);
 ANIM *Anim_GetAnim(int32_t anim_idx);
 ANIM_CHANGE *Anim_GetChange(int32_t change_idx);
 ANIM_RANGE *Anim_GetRange(int32_t range_idx);
-int16_t *Anim_GetCommand(int32_t cmd_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);

--- a/src/libtrx/include/libtrx/game/anims/enum.h
+++ b/src/libtrx/include/libtrx/game/anims/enum.h
@@ -9,7 +9,7 @@ typedef enum {
     AC_DEACTIVATE    = 4,
     AC_SOUND_FX      = 5,
     AC_EFFECT        = 6,
-} ANIM_COMMAND;
+} ANIM_COMMAND_TYPE;
 
 typedef enum {
     ACE_ALL   = 0,

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../math.h"
+#include "./enum.h"
 
 typedef struct {
     int16_t goal_anim_state;
@@ -14,6 +15,22 @@ typedef struct {
     int16_t link_anim_num;
     int16_t link_frame_num;
 } ANIM_RANGE;
+
+typedef struct {
+    ANIM_COMMAND_TYPE type;
+    void *data;
+} ANIM_COMMAND;
+
+typedef struct {
+    int16_t fall_speed;
+    int16_t speed;
+} ANIM_COMMAND_VELOCITY_DATA;
+
+typedef struct {
+    int16_t frame_num;
+    int16_t effect_num;
+    ANIM_COMMAND_ENVIRONMENT environment;
+} ANIM_COMMAND_EFFECT_DATA;
 
 typedef struct {
     bool matrix_pop;
@@ -46,4 +63,5 @@ typedef struct {
     int16_t change_idx;
     int16_t num_commands;
     int16_t command_idx;
+    ANIM_COMMAND *commands;
 } ANIM;

--- a/src/libtrx/include/libtrx/game/anims/util.h
+++ b/src/libtrx/include/libtrx/game/anims/util.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#define ANIM_CMD_ENVIRONMENT_BITS(C) ((C & 0xC000) >> 14)
-#define ANIM_CMD_PARAM_BITS(C) (C & 0x3FFF)

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -10,5 +10,7 @@ void Level_ReadObjectMeshes(
 void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
+void Level_InitialiseAnimCommands(int32_t num_cmds);
 void Level_ReadAnimCommands(int32_t base_idx, int32_t num_cmds, VFILE *file);
+void Level_LoadAnimCommands(void);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -78,6 +78,7 @@ sources = [
   'enum_map.c',
   'event_manager.c',
   'filesystem.c',
+  'game/anims/commands.c',
   'game/anims/common.c',
   'game/anims/frames.c',
   'game/camera/photo_mode.c',

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -38,7 +38,8 @@ void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 void Item_Animate(ITEM *item);
-void Item_PlayAnimSFX(ITEM *item, const int16_t *command, uint16_t flags);
+void Item_PlayAnimSFX(
+    ITEM *item, const ANIM_COMMAND_EFFECT_DATA *data, uint16_t flags);
 
 bool Item_IsTriggerActive(ITEM *item);
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -327,7 +327,7 @@ static void M_LoadAnimCommands(VFILE *file)
     BENCHMARK *const benchmark = Benchmark_Start();
     m_LevelInfo.anim_command_count = VFile_ReadS32(file);
     LOG_INFO("%d anim commands", m_LevelInfo.anim_command_count);
-    Anim_InitialiseCommands(
+    Level_InitialiseAnimCommands(
         m_LevelInfo.anim_command_count + m_InjectionInfo->anim_cmd_count);
     Level_ReadAnimCommands(0, m_LevelInfo.anim_command_count, file);
     Benchmark_End(benchmark, NULL);
@@ -799,6 +799,8 @@ static void M_CompleteSetup(int32_t level_num)
     Anim_LoadFrames(
         m_LevelInfo.anim_frame_data, m_LevelInfo.anim_frame_data_count);
     Memory_FreePointer(&m_LevelInfo.anim_frame_data);
+
+    Level_LoadAnimCommands();
 
     M_MarkWaterEdgeVertices();
 

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -477,37 +477,30 @@ void Item_Animate(ITEM *const item)
     }
 
     if (item->frame_num > anim->frame_end) {
-        if (anim->num_commands > 0) {
-            const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
+        for (int32_t i = 0; i < anim->num_commands; i++) {
+            const ANIM_COMMAND *const command = &anim->commands[i];
+            switch (command->type) {
+            case AC_MOVE_ORIGIN: {
+                const XYZ_16 *const pos = (XYZ_16 *)command->data;
+                Item_Translate(item, pos->x, pos->y, pos->z);
+                break;
+            }
 
-            for (int32_t i = 0; i < anim->num_commands; i++) {
-                const int16_t cmd = *cmd_ptr++;
+            case AC_JUMP_VELOCITY: {
+                const ANIM_COMMAND_VELOCITY_DATA *const data =
+                    (ANIM_COMMAND_VELOCITY_DATA *)command->data;
+                item->fall_speed = data->fall_speed;
+                item->speed = data->speed;
+                item->gravity = true;
+                break;
+            }
 
-                switch (cmd) {
-                case AC_MOVE_ORIGIN:
-                    Item_Translate(item, cmd_ptr[0], cmd_ptr[1], cmd_ptr[2]);
-                    cmd_ptr += 3;
-                    break;
+            case AC_DEACTIVATE:
+                item->status = IS_DEACTIVATED;
+                break;
 
-                case AC_JUMP_VELOCITY:
-                    item->fall_speed = cmd_ptr[0];
-                    item->speed = cmd_ptr[1];
-                    item->gravity = 1;
-                    cmd_ptr += 2;
-                    break;
-
-                case AC_DEACTIVATE:
-                    item->status = IS_DEACTIVATED;
-                    break;
-
-                case AC_SOUND_FX:
-                case AC_EFFECT:
-                    cmd_ptr += 2;
-                    break;
-
-                default:
-                    break;
-                }
+            default:
+                break;
             }
         }
 
@@ -525,65 +518,47 @@ void Item_Animate(ITEM *const item)
         }
     }
 
-    if (anim->num_commands > 0) {
-        const int16_t *cmd_ptr = Anim_GetCommand(anim->command_idx);
-        for (int32_t i = 0; i < anim->num_commands; i++) {
-            const int16_t cmd = *cmd_ptr++;
-            switch (cmd) {
-            case AC_MOVE_ORIGIN:
-                cmd_ptr += 3;
-                break;
-
-            case AC_JUMP_VELOCITY:
-                cmd_ptr += 2;
-                break;
-
-            case AC_SOUND_FX: {
-                const int32_t frame = cmd_ptr[0];
-                const SOUND_EFFECT_ID sound_id =
-                    ANIM_CMD_PARAM_BITS(cmd_ptr[1]);
-                const ANIM_COMMAND_ENVIRONMENT type =
-                    ANIM_CMD_ENVIRONMENT_BITS(cmd_ptr[1]);
-                cmd_ptr += 2;
-
-                if (item->frame_num != frame) {
-                    break;
-                }
-
-                if (g_Objects[item->object_id].water_creature) {
-                    Sound_Effect(sound_id, &item->pos, SPM_UNDERWATER);
-                } else if (item->room_num == NO_ROOM) {
-                    item->pos.x = g_LaraItem->pos.x;
-                    item->pos.y = g_LaraItem->pos.y - LARA_HEIGHT;
-                    item->pos.z = g_LaraItem->pos.z;
-                    Sound_Effect(
-                        sound_id, &item->pos,
-                        item->object_id == O_LARA_HARPOON ? SPM_ALWAYS
-                                                          : SPM_NORMAL);
-                } else if (g_Rooms[item->room_num].flags & RF_UNDERWATER) {
-                    if (type == ACE_ALL || type == ACE_WATER) {
-                        Sound_Effect(sound_id, &item->pos, SPM_NORMAL);
-                    }
-                } else if (type == ACE_ALL || type == ACE_LAND) {
-                    Sound_Effect(sound_id, &item->pos, SPM_NORMAL);
-                }
+    for (int32_t i = 0; i < anim->num_commands; i++) {
+        const ANIM_COMMAND *const command = &anim->commands[i];
+        switch (command->type) {
+        case AC_SOUND_FX: {
+            const ANIM_COMMAND_EFFECT_DATA *const data =
+                (ANIM_COMMAND_EFFECT_DATA *)command->data;
+            if (item->frame_num != data->frame_num) {
                 break;
             }
 
-            case AC_EFFECT: {
-                const int32_t frame = cmd_ptr[0];
-                const int32_t action_id = cmd_ptr[1] & 0x3FFF;
-                cmd_ptr += 2;
-
-                if (item->frame_num == frame) {
-                    ItemAction_Run(action_id, item);
+            const ANIM_COMMAND_ENVIRONMENT type = data->environment;
+            if (g_Objects[item->object_id].water_creature) {
+                Sound_Effect(data->effect_num, &item->pos, SPM_UNDERWATER);
+            } else if (item->room_num == NO_ROOM) {
+                item->pos.x = g_LaraItem->pos.x;
+                item->pos.y = g_LaraItem->pos.y - LARA_HEIGHT;
+                item->pos.z = g_LaraItem->pos.z;
+                Sound_Effect(
+                    data->effect_num, &item->pos,
+                    item->object_id == O_LARA_HARPOON ? SPM_ALWAYS
+                                                      : SPM_NORMAL);
+            } else if (g_Rooms[item->room_num].flags & RF_UNDERWATER) {
+                if (type == ACE_ALL || type == ACE_WATER) {
+                    Sound_Effect(data->effect_num, &item->pos, SPM_NORMAL);
                 }
-                break;
+            } else if (type == ACE_ALL || type == ACE_LAND) {
+                Sound_Effect(data->effect_num, &item->pos, SPM_NORMAL);
             }
+            break;
+        }
 
-            default:
-                break;
+        case AC_EFFECT:
+            const ANIM_COMMAND_EFFECT_DATA *const data =
+                (ANIM_COMMAND_EFFECT_DATA *)command->data;
+            if (item->frame_num == data->frame_num) {
+                ItemAction_Run(data->effect_num, item);
             }
+            break;
+
+        default:
+            break;
         }
     }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -267,7 +267,7 @@ static void M_LoadAnimCommands(VFILE *const file)
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t num_anim_commands = VFile_ReadS32(file);
     LOG_INFO("anim commands: %d", num_anim_commands);
-    Anim_InitialiseCommands(num_anim_commands);
+    Level_InitialiseAnimCommands(num_anim_commands);
     Level_ReadAnimCommands(0, num_anim_commands, file);
     Benchmark_End(benchmark, NULL);
 }
@@ -823,6 +823,8 @@ static void M_CompleteSetup(void)
     Anim_InitialiseFrames(frame_count);
     Anim_LoadFrames(m_AnimFrameData, m_AnimFrameDataLength);
     Memory_FreePointer(&m_AnimFrameData);
+
+    Level_LoadAnimCommands();
 
     // Must be called after Setup_AllObjects using the cached item
     // count, as individual setups may increment g_LevelItemCount.


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This parses animation commands into structures and moves their storage to the animations to which they belong. This is similar to frame handling in loading, so we read and store the raw `int16_t` array, append anything we need in `inject.c` (TR1) and then interpret the data as a whole at the end of the loading process.

I see scope soon to try to merge `Item_Animate` in both games, but there are some differences yet with how effects/actions are handled. It was tempting to tackle it here, but thought it best to keep this fairly simple as just a storage/interpretation change.

Something else I will be following up in the injection refactor is how we handle the temporary data in the two `level.c` modules, for things like commands, frames and floor data. I realise there is a difference currently as TR2 doesn't have a `LEVEL_INFO` yet. So the static variables there are temporary for now.
