### PR TITLE
libtrx/items/common: move Item_PlayAnimSFX to TRX

### DIFF
--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -3,6 +3,7 @@
 #include "game/const.h"
 #include "game/lara/common.h"
 #include "game/objects/common.h"
+#include "game/objects/vars.h"
 #include "game/rooms.h"
 #include "game/sound/common.h"
 #include "utils.h"
@@ -119,7 +120,6 @@ void Item_PlayAnimSFX(
         return;
     }
 
-    const bool underwater = Room_Get(item->room_num)->flags & RF_UNDERWATER;
     const ITEM *const lara_item = Lara_GetItem();
     const ANIM_COMMAND_ENVIRONMENT mode = data->environment;
 
@@ -127,7 +127,7 @@ void Item_PlayAnimSFX(
         int32_t height = NO_HEIGHT;
         if (item == lara_item) {
             height = Lara_GetLaraInfo()->water_surface_dist;
-        } else if (underwater) {
+        } else if (Room_Get(item->room_num)->flags & RF_UNDERWATER) {
             height = -STEP_L;
         }
 
@@ -140,15 +140,11 @@ void Item_PlayAnimSFX(
     SOUND_PLAY_MODE play_mode = SPM_NORMAL;
     if (item == lara_item) {
         play_mode = SPM_ALWAYS;
-    }
-#if TR_VERSION == 1
-    else if (underwater) {
+    } else if (Object_IsObjectType(item->object_id, g_WaterObjects)) {
         play_mode = SPM_UNDERWATER;
     }
-#else
-    else if (Object_GetObject(item->object_id)->water_creature) {
-        play_mode = SPM_UNDERWATER;
-    } else if (item->object_id == O_LARA_HARPOON) {
+#if TR_VERSION > 1
+    else if (item->object_id == O_LARA_HARPOON) {
         play_mode = SPM_ALWAYS;
     }
 #endif

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -26,3 +26,5 @@ void Item_SwitchToObjAnim(
 bool Item_TestFrameEqual(const ITEM *item, int16_t frame);
 bool Item_TestFrameRange(const ITEM *item, int16_t start, int16_t end);
 bool Item_GetAnimChange(ITEM *item, const ANIM *anim);
+
+void Item_PlayAnimSFX(const ITEM *item, const ANIM_COMMAND_EFFECT_DATA *data);

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -101,8 +101,7 @@ typedef struct {
             uint16_t save_flags:       1; // 0x10 16
             uint16_t save_anim:        1; // 0x20 32
             uint16_t semi_transparent: 1; // 0x40 64
-            uint16_t water_creature:   1; // 0x80 128
-            uint16_t pad:              8;
+            uint16_t pad:              9;
         };
         // clang-format on
     };

--- a/src/libtrx/include/libtrx/game/objects/vars.h
+++ b/src/libtrx/include/libtrx/game/objects/vars.h
@@ -4,6 +4,7 @@
 #include "ids.h"
 
 extern const GAME_OBJECT_ID g_EnemyObjects[];
+extern const GAME_OBJECT_ID g_WaterObjects[];
 extern const GAME_OBJECT_ID g_AllyObjects[];
 extern const GAME_OBJECT_ID g_PickupObjects[];
 extern const GAME_OBJECT_ID g_AnimObjects[];

--- a/src/libtrx/include/libtrx/game/rooms/enum.h
+++ b/src/libtrx/include/libtrx/game/rooms/enum.h
@@ -1,6 +1,14 @@
 #pragma once
 
 typedef enum {
+    RF_UNDERWATER = 0x01,
+    RF_OUTSIDE = 0x08,
+    RF_DYNAMIC_LIT = 0x10,
+    RF_NOT_INSIDE = 0x20,
+    RF_INSIDE = 0x40,
+} ROOM_FLAG;
+
+typedef enum {
     SMF_NON_COLLIDABLE = 1 << 0,
     SMF_VISIBLE = 1 << 1,
 } STATIC_MESH_FLAG;

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -619,7 +619,7 @@ void Item_Animate(ITEM *item)
         case AC_SOUND_FX: {
             const ANIM_COMMAND_EFFECT_DATA *const data =
                 (ANIM_COMMAND_EFFECT_DATA *)command->data;
-            Item_PlayAnimSFX(item, data, Room_Get(item->room_num)->flags);
+            Item_PlayAnimSFX(item, data);
             break;
         }
 
@@ -650,26 +650,6 @@ void Item_Animate(ITEM *item)
 
     item->pos.x += (Math_Sin(item->rot.y) * item->speed) >> W2V_SHIFT;
     item->pos.z += (Math_Cos(item->rot.y) * item->speed) >> W2V_SHIFT;
-}
-
-void Item_PlayAnimSFX(
-    ITEM *const item, const ANIM_COMMAND_EFFECT_DATA *const data,
-    const uint16_t flags)
-{
-    if (item->frame_num != data->frame_num) {
-        return;
-    }
-
-    const ANIM_COMMAND_ENVIRONMENT mode = data->environment;
-    if (mode != ACE_ALL) {
-        const int16_t height = Item_GetWaterHeight(item);
-        if ((mode == ACE_WATER && (height >= 0 || height == NO_HEIGHT))
-            || (mode == ACE_LAND && height < 0 && height != NO_HEIGHT)) {
-            return;
-        }
-    }
-
-    Sound_Effect(data->effect_num, &item->pos, flags);
 }
 
 bool Item_IsTriggerActive(ITEM *item)

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -38,8 +38,6 @@ void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 void Item_Animate(ITEM *item);
-void Item_PlayAnimSFX(
-    ITEM *item, const ANIM_COMMAND_EFFECT_DATA *data, uint16_t flags);
 
 bool Item_IsTriggerActive(ITEM *item);
 

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -412,7 +412,7 @@ void Lara_Animate(ITEM *item)
         case AC_SOUND_FX: {
             const ANIM_COMMAND_EFFECT_DATA *const data =
                 (ANIM_COMMAND_EFFECT_DATA *)command->data;
-            Item_PlayAnimSFX(item, data, SPM_ALWAYS);
+            Item_PlayAnimSFX(item, data);
             break;
         }
 

--- a/src/tr1/game/objects/vars.c
+++ b/src/tr1/game/objects/vars.c
@@ -37,6 +37,15 @@ const GAME_OBJECT_ID g_EnemyObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_WaterObjects[] = {
+    // clang-format off
+    O_ALLIGATOR,
+    O_VOLE,
+    O_FISH,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_AllyObjects[] = {
     // clang-format off
     O_LARA,

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -186,10 +186,6 @@ typedef enum {
 } HEIGHT_TYPE;
 
 typedef enum {
-    RF_UNDERWATER = 1,
-} ROOM_FLAG;
-
-typedef enum {
     IC_BLACK = 0,
     IC_GREY = 1,
     IC_WHITE = 2,

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -398,7 +398,7 @@ int32_t Creature_Animate(
         zone = g_GroundZone[BOX_ZONE(lot->step)][g_FlipStatus];
     }
 
-    if (!object->water_creature) {
+    if (!Object_IsObjectType(item->object_id, g_WaterObjects)) {
         int16_t room_num = item->room_num;
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
         if (room_num != item->room_num) {
@@ -617,7 +617,7 @@ int32_t Creature_Animate(
         item->rot.x = 0;
     }
 
-    if (!object->water_creature) {
+    if (!Object_IsObjectType(item->object_id, g_WaterObjects)) {
         Room_GetSector(
             item->pos.x, item->pos.y - (STEP_L * 2), item->pos.z, &room_num);
         if (g_Rooms[room_num].flags & RF_UNDERWATER) {

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -23,6 +23,18 @@
 static bool m_M16Firing = false;
 static bool m_HarpoonFired = false;
 
+static void M_AnimateGun(ITEM *item);
+
+static void M_AnimateGun(ITEM *const item)
+{
+    // While the item is drawn in Lara_Draw, it needs a world position for
+    // sound effect commands in Item_Animate.
+    item->pos.x = g_LaraItem->pos.x;
+    item->pos.y = g_LaraItem->pos.y - LARA_HEIGHT;
+    item->pos.z = g_LaraItem->pos.z;
+    Item_Animate(item);
+}
+
 void Gun_Rifle_DrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
     Gun_SetLaraHandRMesh(weapon_type);
@@ -256,7 +268,7 @@ void Gun_Rifle_Draw(const LARA_GUN_TYPE weapon_type)
         g_Lara.right_arm.frame_base = g_Objects[item->object_id].frame_base;
         g_Lara.left_arm.frame_base = g_Objects[item->object_id].frame_base;
     }
-    Item_Animate(item);
+    M_AnimateGun(item);
 
     if (item->current_anim_state == LA_G_AIM
         || item->current_anim_state == LA_G_UAIM) {
@@ -285,7 +297,7 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
     } else {
         item->goal_anim_state = LA_G_UNDRAW;
     }
-    Item_Animate(item);
+    M_AnimateGun(item);
 
     if (item->status == IS_DEACTIVATED) {
         Item_Kill(g_Lara.weapon_item);
@@ -433,7 +445,7 @@ void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
         break;
     }
 
-    Item_Animate(item);
+    M_AnimateGun(item);
     g_Lara.left_arm.anim_num = item->anim_num;
     g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
     g_Lara.left_arm.frame_num =

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -524,28 +524,7 @@ void Item_Animate(ITEM *const item)
         case AC_SOUND_FX: {
             const ANIM_COMMAND_EFFECT_DATA *const data =
                 (ANIM_COMMAND_EFFECT_DATA *)command->data;
-            if (item->frame_num != data->frame_num) {
-                break;
-            }
-
-            const ANIM_COMMAND_ENVIRONMENT type = data->environment;
-            if (g_Objects[item->object_id].water_creature) {
-                Sound_Effect(data->effect_num, &item->pos, SPM_UNDERWATER);
-            } else if (item->room_num == NO_ROOM) {
-                item->pos.x = g_LaraItem->pos.x;
-                item->pos.y = g_LaraItem->pos.y - LARA_HEIGHT;
-                item->pos.z = g_LaraItem->pos.z;
-                Sound_Effect(
-                    data->effect_num, &item->pos,
-                    item->object_id == O_LARA_HARPOON ? SPM_ALWAYS
-                                                      : SPM_NORMAL);
-            } else if (g_Rooms[item->room_num].flags & RF_UNDERWATER) {
-                if (type == ACE_ALL || type == ACE_WATER) {
-                    Sound_Effect(data->effect_num, &item->pos, SPM_NORMAL);
-                }
-            } else if (type == ACE_ALL || type == ACE_LAND) {
-                Sound_Effect(data->effect_num, &item->pos, SPM_NORMAL);
-            }
+            Item_PlayAnimSFX(item, data);
             break;
         }
 

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -746,19 +746,7 @@ void Lara_Animate(ITEM *const item)
         case AC_SOUND_FX: {
             const ANIM_COMMAND_EFFECT_DATA *const data =
                 (ANIM_COMMAND_EFFECT_DATA *)command->data;
-            if (item->frame_num != data->frame_num) {
-                break;
-            }
-
-            const ANIM_COMMAND_ENVIRONMENT type = data->environment;
-            if (type == ACE_ALL
-                || (type == ACE_LAND
-                    && (g_Lara.water_surface_dist >= 0
-                        || g_Lara.water_surface_dist == NO_HEIGHT))
-                || (type == ACE_WATER && g_Lara.water_surface_dist < 0
-                    && g_Lara.water_surface_dist != NO_HEIGHT)) {
-                Sound_Effect(data->effect_num, &item->pos, SPM_ALWAYS);
-            }
+            Item_PlayAnimSFX(item, data);
             break;
         }
         case AC_EFFECT: {

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -60,7 +60,6 @@ void Barracuda_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 
     Object_GetBone(obj, 6)->rot_y = true;
 }

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -56,7 +56,6 @@ void BigEel_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 }
 
 void BigEel_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -96,7 +96,6 @@ void Diver_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 
     Object_GetBone(obj, 10)->rot_y = true;
     Object_GetBone(obj, 14)->rot_z = true;

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -56,7 +56,6 @@ void Eel_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 }
 
 void Eel_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -43,7 +43,6 @@ void Jelly_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 }
 
 void Jelly_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -69,7 +69,6 @@ void Shark_Setup(void)
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 
     Object_GetBone(obj, 9)->rot_y = true;
 }

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -47,5 +47,4 @@ void General_Setup(void)
     obj->collision = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = 1;
 }

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -209,9 +209,9 @@ void Object_SetupTrapObjects(void)
     Pendulum_Setup(Object_GetObject(O_PENDULUM_1));
     Pendulum_Setup(Object_GetObject(O_PENDULUM_2));
     PowerSaw_Setup();
-    Propeller_Setup(Object_GetObject(O_PROPELLER_1), false);
-    Propeller_Setup(Object_GetObject(O_PROPELLER_2), true);
-    Propeller_Setup(Object_GetObject(O_PROPELLER_3), false);
+    Propeller_Setup(Object_GetObject(O_PROPELLER_1));
+    Propeller_Setup(Object_GetObject(O_PROPELLER_2));
+    Propeller_Setup(Object_GetObject(O_PROPELLER_3));
     RollingBall_Setup(Object_GetObject(O_ROLLING_BALL_1));
     RollingBall_Setup(Object_GetObject(O_ROLLING_BALL_2));
     RollingBall_Setup(Object_GetObject(O_ROLLING_BALL_3));
@@ -394,7 +394,6 @@ void Object_SetupAllObjects(void)
         object->save_flags = 0;
         object->save_anim = 0;
         object->intelligent = 0;
-        object->water_creature = 0;
     }
 
     Object_SetupBaddyObjects();

--- a/src/tr2/game/objects/traps/propeller.c
+++ b/src/tr2/game/objects/traps/propeller.c
@@ -65,11 +65,10 @@ void Propeller_Control(const int16_t item_num)
     }
 }
 
-void Propeller_Setup(OBJECT *const obj, const bool is_underwater)
+void Propeller_Setup(OBJECT *const obj)
 {
     obj->control = Propeller_Control;
     obj->collision = Object_Collision_Trap;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->water_creature = is_underwater;
 }

--- a/src/tr2/game/objects/traps/propeller.h
+++ b/src/tr2/game/objects/traps/propeller.h
@@ -2,5 +2,5 @@
 
 #include "game/objects/common.h"
 
-void Propeller_Setup(OBJECT *obj, bool is_underwater);
+void Propeller_Setup(OBJECT *obj);
 void Propeller_Control(int16_t item_num);

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -44,6 +44,20 @@ const GAME_OBJECT_ID g_EnemyObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_WaterObjects[] = {
+    // clang-format off
+    O_SHARK,
+    O_EEL,
+    O_BIG_EEL,
+    O_BARRACUDA,
+    O_DIVER,
+    O_JELLY,
+    O_GENERAL,
+    O_PROPELLER_2,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_AllyObjects[] = {
     // clang-format off
     O_LARA,

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -271,14 +271,6 @@ typedef struct {
     int32_t mesh_num;
 } BITE;
 
-typedef enum {
-    RF_UNDERWATER  = 0x01,
-    RF_OUTSIDE     = 0x08,
-    RF_DYNAMIC_LIT = 0x10,
-    RF_NOT_INSIDE  = 0x20,
-    RF_INSIDE      = 0x40,
-} ROOM_FLAG;
-
 typedef struct {
     SECTOR *sector;
     SECTOR old_sector;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This merges all variations of playing SFX from `Lara_Animate` and `Item_Animate` in both games into a common function in TRX.

TR2 had a bit of a hack in `Item_Animate` for Lara's back guns, which don't have a world position, so it was setting their position there before playing their SFX. I've moved this to `gun_rifle.c` rather than having item modification while playing SFX.

Other than regular SFX from animations, like Lara hitting walls, switches in action, enemy noises etc, these are the main things to check over. There's no need to check every possible sound effect, it's more the different possible environments:
- Lara footsteps on land and in water
- Using shotgun, harpoon, M16 and grenade launcher in TR2 (and with Lara in motion, sound should follow her)
- Firing harpoon (should always play regardless of environment)
- Water creature sounds should only play underwater
- Enemies in shallow water e.g. Tiger at start of GW
- TR1 Lara's footsteps in shallow water - infamous wading test level is [here](https://github.com/LostArtefacts/TRX/pull/1728), but can also check in Tihocan room 99
