### PR TITLE
tr1/option/option_sound: fix volume arrows display control

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed being able to use keys and puzzle items in keyholes/slots that have already been used (#2256, regression from 4.0)
 - fixed textures animating during demo fade-outs (#2217, regression from 4.0)
 - fixed waterfall mist not animating during demo (#2218, regression from 3.0)
+- fixed sound option arrows disappearing with specific volumes chosen (#2295, regression from 2.7)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/src/tr1/game/option/option_sound.c
+++ b/src/tr1/game/option/option_sound.c
@@ -118,14 +118,12 @@ void Option_Sound_Control(INVENTORY_ITEM *inv_item)
             Text_ChangeText(m_Text[TEXT_MUSIC_VOLUME], buf);
         }
 
-        if (g_Config.audio.music_volume == Music_GetMinVolume()) {
-            Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
-        } else if (g_Config.audio.music_volume == Music_GetMaxVolume()) {
-            Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
-        } else {
-            Text_Hide(m_Text[TEXT_LEFT_ARROW], false);
-            Text_Hide(m_Text[TEXT_RIGHT_ARROW], false);
-        }
+        Text_Hide(
+            m_Text[TEXT_LEFT_ARROW],
+            g_Config.audio.music_volume == Music_GetMinVolume());
+        Text_Hide(
+            m_Text[TEXT_RIGHT_ARROW],
+            g_Config.audio.music_volume == Music_GetMaxVolume());
 
         break;
 
@@ -153,14 +151,12 @@ void Option_Sound_Control(INVENTORY_ITEM *inv_item)
             Text_ChangeText(m_Text[TEXT_SOUND_VOLUME], buf);
         }
 
-        if (g_Config.audio.sound_volume == Sound_GetMinVolume()) {
-            Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
-        } else if (g_Config.audio.sound_volume == Sound_GetMaxVolume()) {
-            Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
-        } else {
-            Text_Hide(m_Text[TEXT_LEFT_ARROW], false);
-            Text_Hide(m_Text[TEXT_RIGHT_ARROW], false);
-        }
+        Text_Hide(
+            m_Text[TEXT_LEFT_ARROW],
+            g_Config.audio.sound_volume == Sound_GetMinVolume());
+        Text_Hide(
+            m_Text[TEXT_RIGHT_ARROW],
+            g_Config.audio.sound_volume == Sound_GetMaxVolume());
 
         break;
     }


### PR DESCRIPTION
Resolves #2295.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids hiding either of the arrows permanently when one volume is at the maximum and the other at the minimum.
