### PR TITLE
cmd: fix /kill sometimes freezing the game

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed the pause screen to wait before yielding control during fade out effect
 - changed the compass and final stats to use two columns, similar to TR2 (doesn't apply to end-of-level "bare" stats)
 - changed the fix for transparent eyes on wolves to use black instead of off-white (#2252)
+- changed the `/kill` command with no arguments to look for enemies within 5 tiles (#2297)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 4.2)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
     | Increase internal screen size | F2          | F10          |
     | Toggle photo mode             | ---         | F1           |
     | Toggle photo mode UI          | ---         | H            |
+- changed the `/kill` command with no arguments to look for enemies within 5 tiles (#2297)
 - fixed showing inventory ring up/down arrows when uncalled for (#2225)
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
@@ -23,6 +24,7 @@
 - fixed item counter always hidden in NG+, even for keys (#2223, regression from 0.3)
 - fixed the passport object not being selected when exiting to title (#2192, regression from 0.8)
 - fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 0.8)
+- fixed /kill command freezing the game under rare circumstances (#2297, regression from 0.3)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2297. The previous implementation was too frugal in its size which led to an infinite loop bug when an item was deemed unkillable.