### PR TITLE
output: fix underwater tint bleed

### DIFF
--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -142,7 +142,6 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     M_PRIV *const p = phase->priv;
 
     g_OldInputDB = g_Input;
-    Output_SetupAboveWater(false);
 
     M_PauseGame(p);
 

--- a/src/tr1/game/game/game_draw.c
+++ b/src/tr1/game/game/game_draw.c
@@ -32,9 +32,9 @@ void Game_Draw(bool draw_overlay)
         } else {
             Output_SetupAboveWater(g_Camera.underwater);
         }
-
         Lara_Draw(g_LaraItem);
         Output_FlushTranslucentObjects();
+        Output_SetupAboveWater(false);
 
         if (draw_overlay) {
             Overlay_DrawGameInfo();
@@ -54,7 +54,6 @@ void Game_Draw(bool draw_overlay)
             Room_DrawSingleRoom(room_num);
         }
 
-        Output_SetupAboveWater(false);
         Lara_Hair_Draw();
         Output_FlushTranslucentObjects();
     }

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -182,8 +182,6 @@ void InvRing_Draw(INV_RING *const ring)
     Viewport_SetFOV(PASSPORT_FOV * DEG_1);
     Output_ApplyFOV();
 
-    Output_SetupAboveWater(false);
-
     XYZ_32 view_pos;
     XYZ_16 view_rot;
     InvRing_GetView(ring, &view_pos, &view_rot);

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -387,7 +387,6 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     Output_SetLightDivider(0x6000);
     Output_SetLightAdder(LOW_LIGHT);
     Output_RotateLight(0, 0);
-    Output_SetupAboveWater(false);
 
     OBJECT *obj = &g_Objects[Inv_GetItemOption(pu->object_id)];
     const ANIM_FRAME *const frame = Object_GetAnim(obj, 0)->frame_ptr;

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -208,6 +208,7 @@ void Room_DrawAllRooms(int16_t base_room, int16_t target_room)
     for (int i = 0; i < g_RoomsToDrawCount; i++) {
         Room_DrawSingleRoom(g_RoomsToDraw[i]);
     }
+    Output_SetupAboveWater(false);
 }
 
 static void M_PrepareToDraw(int16_t room_num)

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -163,8 +163,6 @@ void InvRing_Draw(INV_RING *const ring)
 
     ring->camera.pos.z = ring->radius + 598;
 
-    Output_SetupAboveWater(false);
-
     XYZ_32 view_pos;
     XYZ_16 view_rot;
     InvRing_GetView(ring, &view_pos, &view_rot);

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -422,7 +422,6 @@ static void M_DrawPickup3D(const DISPLAY_PICKUP *const pickup)
     g_LsDivider = 0x6000;
     g_LsAdder = LOW_LIGHT;
     Output_RotateLight(0, 0);
-    Output_SetupAboveWater(false);
 
     Matrix_Push();
     Matrix_TranslateRel16(frame->offset);

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -550,4 +550,6 @@ void Room_DrawAllRooms(const int16_t current_room)
         const int16_t room_num = g_RoomsToDraw[i];
         Room_DrawSingleRoomObjects(room_num);
     }
+
+    Output_SetupAboveWater(false);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Recent phaser refactors done on develop introduced a bug where the camera wouldn't clean up after itself, and the UI (for example, the photo mode) would be drawn with underwater tint. Changed the approach to disable the UW tint right after drawing the rooms.