### PR TITLE
libtrx/phase/phase_inventory: handle null ring on exit

### DIFF
--- a/src/libtrx/game/phase/phase_inventory.c
+++ b/src/libtrx/game/phase/phase_inventory.c
@@ -45,9 +45,10 @@ static PHASE_CONTROL M_Control(PHASE *const phase, int32_t num_frames)
 static void M_End(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
-    ASSERT(p->ring != NULL);
-    InvRing_Close(p->ring);
-    p->ring = NULL;
+    if (p->ring != NULL) {
+        InvRing_Close(p->ring);
+        p->ring = NULL;
+    }
 }
 
 static void M_Draw(PHASE *const phase)


### PR DESCRIPTION
Resolves #2306.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The inventory ring may be null when the phase exits if Lara has tried to use a keyhole or puzzle slot but doesn't have any key items, so this handles that case rather than asserting that the ring is not null.

I've noticed Lara doesn't say "no" in TR1 in this case, but she does in TR2 (and this is the case in current release). I can't remember if that was a change we introduced on purpose or is it a separate bug?
