### PR TITLE
Fix sprite statics conflict

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -11,6 +11,7 @@
 - changed the fix for transparent eyes on wolves to use black instead of off-white (#2252)
 - changed the `/kill` command with no arguments to look for enemies within 5 tiles (#2297)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
+- fixed ghost meshes appearing near statics in custom levels (#2310)
 - fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 4.2)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed showing inventory ring up/down arrows when uncalled for (#2225)
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
+- fixed ghost meshes appearing near statics in custom levels (#2310)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 - fixed savegame incompatibility with OG (#2271, regression from 0.8)
 - fixed stopwatch showing wrong UI in some circumstances (#2221, regression from 0.8)

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -489,6 +489,9 @@ static void M_LoadCameras(VFILE *file)
     if (g_NumberCameras != 0) {
         g_Camera.fixed = GameBuf_Alloc(
             sizeof(OBJECT_VECTOR) * g_NumberCameras, GBUF_CAMERAS);
+        if (!g_Camera.fixed) {
+            Shell_ExitSystem("Error allocating the fixed cameras.");
+        }
         for (int32_t i = 0; i < g_NumberCameras; i++) {
             OBJECT_VECTOR *camera = &g_Camera.fixed[i];
             camera->x = VFile_ReadS32(file);
@@ -509,6 +512,9 @@ static void M_LoadSoundEffects(VFILE *file)
     if (g_NumberSoundEffects != 0) {
         g_SoundEffectsTable = GameBuf_Alloc(
             sizeof(OBJECT_VECTOR) * g_NumberSoundEffects, GBUF_SOUND_FX);
+        if (!g_SoundEffectsTable) {
+            Shell_ExitSystem("Error allocating the sound effects table.");
+        }
         for (int32_t i = 0; i < g_NumberSoundEffects; i++) {
             OBJECT_VECTOR *sound = &g_SoundEffectsTable[i];
             sound->x = VFile_ReadS32(file);

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -95,7 +95,7 @@ static void M_ReleaseSurfaces(void)
     }
 
     for (int i = 0; i < GFX_MAX_TEXTURES; i++) {
-        if (m_TextureSurfaces[i]) {
+        if (m_TextureSurfaces[i] != NULL) {
             GFX_2D_Surface_Free(m_TextureSurfaces[i]);
             m_TextureSurfaces[i] = NULL;
         }
@@ -832,16 +832,6 @@ void S_Output_ApplyRenderSettings(void)
         m_PrimarySurface = GFX_2D_Surface_Create(&surface_desc);
     }
     M_ClearSurface(m_PrimarySurface);
-
-    for (int i = 0; i < GFX_MAX_TEXTURES; i++) {
-        GFX_2D_SURFACE_DESC surface_desc = {
-            .width = 256,
-            .height = 256,
-        };
-        if (m_TextureSurfaces[i] == NULL) {
-            m_TextureSurfaces[i] = GFX_2D_Surface_Create(&surface_desc);
-        }
-    }
 }
 
 void S_Output_SetWindowSize(int width, int height)
@@ -1260,6 +1250,13 @@ void S_Output_DownloadTextures(int32_t pages)
     M_ReleaseTextures();
 
     for (int i = 0; i < pages; i++) {
+        if (m_TextureSurfaces[i] == NULL) {
+            const GFX_2D_SURFACE_DESC surface_desc = {
+                .width = 256,
+                .height = 256,
+            };
+            m_TextureSurfaces[i] = GFX_2D_Surface_Create(&surface_desc);
+        }
         GFX_2D_SURFACE *const surface = m_TextureSurfaces[i];
         RGBA_8888 *output_ptr = (RGBA_8888 *)surface->buffer;
         RGBA_8888 *input_ptr = g_TexturePagePtrs[i];
@@ -1268,7 +1265,7 @@ void S_Output_DownloadTextures(int32_t pages)
             surface->desc.width * surface->desc.height * sizeof(RGBA_8888));
 
         m_TextureMap[i] = GFX_3D_Renderer_RegisterTexturePage(
-            m_Renderer3D, surface->buffer, surface->desc.width,
+            m_Renderer3D, output_ptr, surface->desc.width,
             surface->desc.height);
     }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -299,6 +299,11 @@ static void M_LoadObjects(VFILE *const file)
     LOG_INFO("objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
         const GAME_OBJECT_ID object_id = VFile_ReadS32(file);
+        if (object_id < 0 || object_id >= O_NUMBER_OF) {
+            Shell_ExitSystemFmt(
+                "Invalid object ID: %d (max=%d)", object_id, O_NUMBER_OF);
+        }
+
         OBJECT *const object = &g_Objects[object_id];
         object->mesh_count = VFile_ReadS16(file);
         object->mesh_idx = VFile_ReadS16(file);
@@ -317,8 +322,14 @@ static void M_LoadStaticObjects(VFILE *const file)
     const int32_t num_static_objects = VFile_ReadS32(file);
     LOG_INFO("static objects: %d", num_static_objects);
     for (int32_t i = 0; i < num_static_objects; i++) {
-        const int32_t static_num = VFile_ReadS32(file);
-        STATIC_INFO *static_obj = &g_StaticObjects[static_num];
+        const int32_t static_id = VFile_ReadS32(file);
+        if (static_id < 0 || static_id >= MAX_STATIC_OBJECTS) {
+            Shell_ExitSystemFmt(
+                "Invalid static ID: %d (max=%d)", static_id,
+                MAX_STATIC_OBJECTS);
+        }
+
+        STATIC_INFO *const static_obj = &g_StaticObjects[static_id];
         static_obj->mesh_idx = VFile_ReadS16(file);
         static_obj->draw_bounds.min.x = VFile_ReadS16(file);
         static_obj->draw_bounds.max.x = VFile_ReadS16(file);

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -144,6 +144,8 @@ typedef enum {
 } DRAW_TYPE;
 
 typedef struct {
+    bool loaded;
+    int16_t mesh_count;
     int16_t mesh_idx;
     uint16_t flags;
     BOUNDS_16 draw_bounds;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2310.

#### Testing

- Look for missing static objects
- Look for missing sprites
- Check if animated sprites still work (the algae at the bottom of the Tihocan lake)
- TR1 and TR2