### PR TITLE
gfx: fix wireframe mode discarding transparent pixels

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed textures animating during demo fade-outs (#2217, regression from 4.0)
 - fixed waterfall mist not animating during demo (#2218, regression from 3.0)
 - fixed sound option arrows disappearing with specific volumes chosen (#2295, regression from 2.7)
+- fixed wireframe mode discarding transparent pixels (#2315, regression from 4.2)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fixed the passport object not being selected when exiting to title (#2192, regression from 0.8)
 - fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 0.8)
 - fixed /kill command freezing the game under rare circumstances (#2297, regression from 0.3)
+- fixed wireframe mode discarding transparent pixels (#2315, regression from 0.7)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2315.

![20250116_143751_Venice](https://github.com/user-attachments/assets/4b35f4a7-815e-4b2c-9dde-de7af4e5cb0b)
