### PR TITLE
tr1/level: reset static mesh mesh count

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed wireframe mode discarding transparent pixels (#2315, regression from 4.2)
 - fixed sprite pickup not being paused in the pause/inventory screen (#2319, regression from 4.1)
 - fixed 3D pickups not being paused in the pause/inventory screen (#2319, regression from 2.16)
+- fixed incorrect sprite sequences potentially animating after visiting a level with valid animating sprites (#2309, regression from 4.0)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -412,6 +412,7 @@ static void M_LoadStaticObjects(VFILE *file)
         object->c.max.z = VFile_ReadS16(file);
         object->flags = VFile_ReadU16(file);
         object->loaded = true;
+        object->mesh_count = 1;
     }
 
     Benchmark_End(benchmark, NULL);


### PR DESCRIPTION
Resolves #2309.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that if a static was previously used as an animating sprite (with a negative mesh count) it will be reset to 1 on the next load.
