### PR TITLE
types: use union for face textures

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -30,7 +30,7 @@ static void M_ReadFace4(FACE4 *const face, VFILE *const file)
     for (int32_t i = 0; i < 4; i++) {
         face->vertices[i] = VFile_ReadU16(file);
     }
-    face->texture = VFile_ReadU16(file);
+    face->texture_idx = VFile_ReadU16(file);
     face->enable_reflections = false;
 }
 
@@ -39,7 +39,7 @@ static void M_ReadFace3(FACE3 *const face, VFILE *const file)
     for (int32_t i = 0; i < 3; i++) {
         face->vertices[i] = VFile_ReadU16(file);
     }
-    face->texture = VFile_ReadU16(file);
+    face->texture_idx = VFile_ReadU16(file);
     face->enable_reflections = false;
 }
 

--- a/src/libtrx/include/libtrx/game/types.h
+++ b/src/libtrx/include/libtrx/game/types.h
@@ -31,13 +31,19 @@ typedef struct {
 } OBJECT_VECTOR;
 
 typedef struct {
-    uint16_t texture;
+    union {
+        uint16_t texture_idx;
+        uint16_t palette_idx;
+    };
     uint16_t vertices[4];
     bool enable_reflections;
 } FACE4;
 
 typedef struct {
-    uint16_t texture;
+    union {
+        uint16_t texture_idx;
+        uint16_t palette_idx;
+    };
     uint16_t vertices[3];
     bool enable_reflections;
 } FACE3;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -685,21 +685,21 @@ static void M_AlignTextureReferences(
     for (int32_t i = 0; i < object->mesh_count; i++) {
         OBJECT_MESH *const mesh = Object_GetMesh(object->mesh_idx + i);
         for (int32_t j = 0; j < mesh->num_tex_face4s; j++) {
-            mesh->tex_face4s[j].texture += tex_info_base;
+            mesh->tex_face4s[j].texture_idx += tex_info_base;
         }
 
         for (int32_t j = 0; j < mesh->num_tex_face3s; j++) {
-            mesh->tex_face3s[j].texture += tex_info_base;
+            mesh->tex_face3s[j].texture_idx += tex_info_base;
         }
 
         for (int32_t j = 0; j < mesh->num_flat_face4s; j++) {
             FACE4 *const face = &mesh->flat_face4s[j];
-            face->texture = palette_map[face->texture];
+            face->palette_idx = palette_map[face->palette_idx];
         }
 
         for (int32_t j = 0; j < mesh->num_flat_face3s; j++) {
             FACE3 *const face = &mesh->flat_face3s[j];
-            face->texture = palette_map[face->texture];
+            face->palette_idx = palette_map[face->palette_idx];
         }
     }
 }
@@ -863,7 +863,7 @@ static void M_ApplyFace4Edit(
 {
     for (int32_t i = 0; i < edit->target_count; i++) {
         FACE4 *const face = &faces[edit->targets[i]];
-        face->texture = texture;
+        face->texture_idx = texture;
     }
 }
 
@@ -872,7 +872,7 @@ static void M_ApplyFace3Edit(
 {
     for (int32_t i = 0; i < edit->target_count; i++) {
         FACE3 *const face = &faces[edit->targets[i]];
-        face->texture = texture;
+        face->texture_idx = texture;
     }
 }
 
@@ -888,22 +888,22 @@ static uint16_t *M_GetMeshTexture(const FACE_EDIT *const face_edit)
 
     if (face_edit->face_type == FT_TEXTURED_QUAD) {
         FACE4 *const face = &mesh->tex_face4s[face_edit->face_index];
-        return &face->texture;
+        return &face->texture_idx;
     }
 
     if (face_edit->face_type == FT_TEXTURED_TRIANGLE) {
         FACE3 *const face = &mesh->tex_face3s[face_edit->face_index];
-        return &face->texture;
+        return &face->texture_idx;
     }
 
     if (face_edit->face_type == FT_COLOURED_QUAD) {
         FACE4 *const face = &mesh->flat_face4s[face_edit->face_index];
-        return &face->texture;
+        return &face->palette_idx;
     }
 
     if (face_edit->face_type == FT_COLOURED_TRIANGLE) {
         FACE3 *const face = &mesh->flat_face3s[face_edit->face_index];
-        return &face->texture;
+        return &face->palette_idx;
     }
 
     return NULL;
@@ -1345,13 +1345,13 @@ static void M_AddRoomFace(const INJECTION *const injection)
     uint16_t *face_vertices;
     if (face_type == FT_TEXTURED_QUAD) {
         FACE4 *const face = &room->mesh.face4s[room->mesh.num_face4s];
-        face->texture = *source_texture;
+        face->texture_idx = *source_texture;
         face_vertices = face->vertices;
         room->mesh.num_face4s++;
 
     } else {
         FACE3 *const face = &room->mesh.face3s[room->mesh.num_face3s];
-        face->texture = *source_texture;
+        face->texture_idx = *source_texture;
         face_vertices = face->vertices;
         room->mesh.num_face3s++;
     }
@@ -1409,10 +1409,10 @@ static uint16_t *M_GetRoomTexture(
     const ROOM *const room = Room_Get(room_num);
     if (face_type == FT_TEXTURED_QUAD && face_index < room->mesh.num_face4s) {
         FACE4 *const face = &room->mesh.face4s[face_index];
-        return &face->texture;
+        return &face->texture_idx;
     } else if (face_index < room->mesh.num_face3s) {
         FACE3 *const face = &room->mesh.face3s[face_index];
-        return &face->texture;
+        return &face->texture_idx;
     }
 
     LOG_WARNING(

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -105,7 +105,7 @@ static void M_DrawFlatFace3s(const FACE3 *const faces, const int32_t count)
             &m_VBuf[face->vertices[2]],
         };
 
-        const RGB_888 color = Output_GetPaletteColor(face->texture);
+        const RGB_888 color = Output_GetPaletteColor(face->palette_idx);
         S_Output_DrawFlatTriangle(vns[0], vns[1], vns[2], color);
     }
 }
@@ -123,7 +123,7 @@ static void M_DrawFlatFace4s(const FACE4 *const faces, const int32_t count)
             &m_VBuf[face->vertices[3]],
         };
 
-        const RGB_888 color = Output_GetPaletteColor(face->texture);
+        const RGB_888 color = Output_GetPaletteColor(face->palette_idx);
         S_Output_DrawFlatTriangle(vns[0], vns[1], vns[2], color);
         S_Output_DrawFlatTriangle(vns[2], vns[3], vns[0], color);
     }
@@ -141,7 +141,7 @@ static void M_DrawTexturedFace3s(const FACE3 *const faces, const int32_t count)
             &m_VBuf[face->vertices[2]],
         };
 
-        PHD_TEXTURE *const tex = &g_PhdTextureInfo[face->texture];
+        PHD_TEXTURE *const tex = &g_PhdTextureInfo[face->texture_idx];
         S_Output_DrawTexturedTriangle(
             vns[0], vns[1], vns[2], tex->tpage, &tex->uv[0], &tex->uv[1],
             &tex->uv[2], tex->drawtype);
@@ -161,7 +161,7 @@ static void M_DrawTexturedFace4s(const FACE4 *const faces, const int32_t count)
             &m_VBuf[face->vertices[3]],
         };
 
-        PHD_TEXTURE *const tex = &g_PhdTextureInfo[face->texture];
+        PHD_TEXTURE *const tex = &g_PhdTextureInfo[face->texture_idx];
         S_Output_DrawTexturedQuad(
             vns[0], vns[1], vns[2], vns[3], tex->tpage, &tex->uv[0],
             &tex->uv[1], &tex->uv[2], &tex->uv[3], tex->drawtype);

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -649,7 +649,7 @@ void Output_LoadBackgroundFromObject(void)
         return;
     }
 
-    const int32_t texture_idx = mesh->tex_face4s[0].texture;
+    const int32_t texture_idx = mesh->tex_face4s[0].texture_idx;
     const PHD_TEXTURE *const texture = &g_TextureInfo[texture_idx];
     Render_LoadBackgroundFromTexture(texture, 8, 6);
     return;

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -539,7 +539,6 @@ static void M_InsertFlatFace3s_Sorted(
             &g_PhdVBuf[face->vertices[1]],
             &g_PhdVBuf[face->vertices[2]],
         };
-        const int16_t color_idx = face->texture;
 
         const int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
         const int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
@@ -590,7 +589,7 @@ static void M_InsertFlatFace3s_Sorted(
             continue;
         }
 
-        const RGB_888 *const color = &g_GamePalette16[color_idx >> 8];
+        const RGB_888 *const color = &g_GamePalette16[face->palette_idx >> 8];
         const double zv = Render_CalculatePolyZ(
             sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, -1.0);
         M_InsertPolyFlat(
@@ -615,7 +614,6 @@ static void M_InsertFlatFace4s_Sorted(
             &g_PhdVBuf[face->vertices[2]],
             &g_PhdVBuf[face->vertices[3]],
         };
-        const int16_t color_idx = face->texture;
 
         const int8_t clip_or =
             vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
@@ -668,7 +666,7 @@ static void M_InsertFlatFace4s_Sorted(
             continue;
         }
 
-        const RGB_888 *const color = &g_GamePalette16[color_idx >> 8];
+        const RGB_888 *const color = &g_GamePalette16[face->palette_idx >> 8];
         const double zv = Render_CalculatePolyZ(
             sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, vtx[3]->zv);
         M_InsertPolyFlat(
@@ -692,7 +690,7 @@ static void M_InsertTexturedFace3s_Sorted(
             &g_PhdVBuf[face->vertices[2]],
         };
 
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
         const PHD_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
@@ -722,7 +720,7 @@ static void M_InsertTexturedFace4s_Sorted(
             &g_PhdVBuf[face->vertices[3]],
         };
 
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;
         }
@@ -1123,7 +1121,6 @@ static void M_InsertFlatFace3s_ZBuffered(
             &g_PhdVBuf[face->vertices[1]],
             &g_PhdVBuf[face->vertices[2]],
         };
-        const int16_t color_idx = face->texture;
 
         const int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
         const int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
@@ -1173,7 +1170,7 @@ static void M_InsertFlatFace3s_ZBuffered(
             continue;
         }
 
-        const RGB_888 *const color = &g_GamePalette16[color_idx >> 8];
+        const RGB_888 *const color = &g_GamePalette16[face->palette_idx >> 8];
         M_DrawPolyFlat(renderer, num_points, color->r, color->g, color->b);
     }
 }
@@ -1198,7 +1195,6 @@ static void M_InsertFlatFace4s_ZBuffered(
             &g_PhdVBuf[face->vertices[2]],
             &g_PhdVBuf[face->vertices[3]],
         };
-        const int16_t color_idx = face->texture;
 
         const int8_t clip_or =
             vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
@@ -1250,7 +1246,7 @@ static void M_InsertFlatFace4s_ZBuffered(
             continue;
         }
 
-        const RGB_888 *const color = &g_GamePalette16[color_idx >> 8];
+        const RGB_888 *const color = &g_GamePalette16[face->palette_idx >> 8];
         M_DrawPolyFlat(renderer, num_points, color->r, color->g, color->b);
     }
 }
@@ -1266,7 +1262,7 @@ static void M_InsertTexturedFace3s_ZBuffered(
             &g_PhdVBuf[face->vertices[1]],
             &g_PhdVBuf[face->vertices[2]],
         };
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;
@@ -1298,7 +1294,7 @@ static void M_InsertTexturedFace4s_ZBuffered(
             &g_PhdVBuf[face->vertices[3]],
 
         };
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;

--- a/src/tr2/game/render/swr.c
+++ b/src/tr2/game/render/swr.c
@@ -1511,7 +1511,6 @@ static void M_InsertFlatFace3s(
             &g_PhdVBuf[face->vertices[1]],
             &g_PhdVBuf[face->vertices[2]],
         };
-        const int16_t color_idx = face->texture;
 
         int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
         int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
@@ -1592,7 +1591,7 @@ static void M_InsertFlatFace3s(
         g_Sort3DPtr++;
 
         *g_Info3DPtr++ = POLY_GOURAUD;
-        *g_Info3DPtr++ = color_idx;
+        *g_Info3DPtr++ = face->palette_idx;
         *g_Info3DPtr++ = num_points;
 
         for (int32_t j = 0; j < num_points; j++) {
@@ -1617,7 +1616,6 @@ static void M_InsertFlatFace4s(
             &g_PhdVBuf[face->vertices[2]],
             &g_PhdVBuf[face->vertices[3]],
         };
-        const int16_t color_idx = face->texture;
 
         const int8_t clip_or =
             vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
@@ -1714,7 +1712,7 @@ static void M_InsertFlatFace4s(
         g_Sort3DPtr++;
 
         *g_Info3DPtr++ = POLY_GOURAUD;
-        *g_Info3DPtr++ = color_idx;
+        *g_Info3DPtr++ = face->palette_idx;
         *g_Info3DPtr++ = num_points;
 
         for (int32_t j = 0; j < num_points; j++) {
@@ -1739,7 +1737,7 @@ static void M_InsertTexturedFace3s(
             &g_PhdVBuf[face->vertices[2]],
         };
 
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
         const PHD_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
@@ -1958,7 +1956,7 @@ static void M_InsertTexturedFace4s(
             &g_PhdVBuf[face->vertices[3]],
         };
 
-        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture];
+        const PHD_TEXTURE *const texture = &g_TextureInfo[face->texture_idx];
         const PHD_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A follow up from #2323, this creates a union for texture/palette index on faces, so making their access more logical depending on the function context.
