### PR TITLE
tr1/game_draw: reset output water status in cutscenes

### DIFF
--- a/src/tr1/game/game/game_draw.c
+++ b/src/tr1/game/game/game_draw.c
@@ -54,6 +54,7 @@ void Game_Draw(bool draw_overlay)
             Room_DrawSingleRoom(room_num);
         }
 
+        Output_SetupAboveWater(false);
         Lara_Hair_Draw();
         Output_FlushTranslucentObjects();
     }


### PR DESCRIPTION
Resolves #2330.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids the last drawn room in cutscenes determining Lara's braid tinting. This does effectively hard-code Lara to being on land in TR1 cutscenes, but that's OG.
