### PR TITLE
level: read floor data in TRX

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -181,6 +181,16 @@ void Level_ReadRoomMesh(const int32_t room_num, VFILE *const file)
     ASSERT(total_read == mesh_length);
 }
 
+void Level_ReadFloorData(VFILE *const file)
+{
+    const int32_t floor_data_size = VFile_ReadS32(file);
+    int16_t *floor_data = Memory_Alloc(sizeof(int16_t) * floor_data_size);
+    VFile_Read(file, floor_data, sizeof(int16_t) * floor_data_size);
+
+    Room_ParseFloorData(floor_data);
+    Memory_FreePointer(&floor_data);
+}
+
 void Level_ReadObjectMeshes(
     const int32_t num_indices, const int32_t *const indices, VFILE *const file)
 {

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -5,6 +5,7 @@
 #define ANIM_BONE_SIZE 4
 
 void Level_ReadRoomMesh(int32_t room_num, VFILE *file);
+void Level_ReadFloorData(VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
 void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -257,9 +257,8 @@ static void M_LoadRooms(VFILE *file)
         r->effect_num = NO_EFFECT;
     }
 
-    const int32_t fd_length = VFile_ReadS32(file);
-    m_LevelInfo.floor_data = Memory_Alloc(sizeof(int16_t) * fd_length);
-    VFile_Read(file, m_LevelInfo.floor_data, sizeof(int16_t) * fd_length);
+    Level_ReadFloorData(file);
+
     Benchmark_End(benchmark, NULL);
 }
 
@@ -778,10 +777,6 @@ static void M_LoadSamples(VFILE *file)
 static void M_CompleteSetup(int32_t level_num)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-
-    // Expand raw floor data into sectors
-    Room_ParseFloorData(m_LevelInfo.floor_data);
-    Memory_FreePointer(&m_LevelInfo.floor_data);
 
     // Expand paletted texture data to RGB
     m_LevelInfo.texture_rgb_page_ptrs = Memory_Alloc(

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -565,7 +565,6 @@ typedef struct {
     int32_t texture_page_count;
     uint8_t *texture_palette_page_ptrs;
     RGBA_8888 *texture_rgb_page_ptrs;
-    int16_t *floor_data;
     int32_t anim_texture_range_count;
     int32_t item_count;
     int32_t sprite_info_count;

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -24,7 +24,6 @@
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 
-static int16_t *m_FloorData = NULL;
 static int16_t *m_AnimFrameData = NULL;
 static int32_t m_AnimFrameDataLength = 0;
 
@@ -189,12 +188,7 @@ static void M_LoadRooms(VFILE *const file)
         r->effect_num = NO_EFFECT;
     }
 
-    // TODO: store this temporarily in a m_LevelInfo property similar to TR1 and
-    // release after parsing.
-    const int32_t floor_data_size = VFile_ReadS32(file);
-    m_FloorData =
-        GameBuf_Alloc(sizeof(int16_t) * floor_data_size, GBUF_FLOOR_DATA);
-    VFile_Read(file, m_FloorData, sizeof(int16_t) * floor_data_size);
+    Level_ReadFloorData(file);
 
 finish:
     Benchmark_End(benchmark, NULL);
@@ -824,10 +818,6 @@ static void M_LoadFromFile(const char *const file_name, const int32_t level_num)
 static void M_CompleteSetup(void)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-
-    // Expand raw floor data into sectors
-    Room_ParseFloorData(m_FloorData);
-    // TODO: store raw FD temporarily, release here and eliminate g_FloorData
 
     Inject_AllInjections();
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A little cleanup to shift floor data reading and parsing to TRX. Injections access and manipulate sectors directly so we don't need to wait until the end of level loading to parse the raw data (that was a leftover from legacy FD injection, which just appended to the raw array).
