### PR TITLE
tr2/music/music_main: remove legacy music play

### DIFF
--- a/src/tr2/game/item_actions.c
+++ b/src/tr2/game/item_actions.c
@@ -328,26 +328,26 @@ void M_AssaultFinished(ITEM *const item)
         if ((int32_t)g_AssaultBestTime < 0) {
             if (g_SaveGame.current_stats.timer < 100 * FRAMES_PER_SECOND) {
                 // "Gosh! That was my best time yet!"
-                Music_Legacy_Play(MX_GYM_HINT_15, false);
+                Music_Play(MX_GYM_HINT_15, MPM_ALWAYS);
                 g_AssaultBestTime = g_SaveGame.current_stats.timer;
             } else {
                 // "Congratulations! You did it! But perhaps I could've been
                 // faster."
-                Music_Legacy_Play(MX_GYM_HINT_17, false);
+                Music_Play(MX_GYM_HINT_17, MPM_ALWAYS);
                 g_AssaultBestTime = 100 * FRAMES_PER_SECOND;
             }
         } else if (g_SaveGame.current_stats.timer < g_AssaultBestTime) {
             // "Gosh! That was my best time yet!"
-            Music_Legacy_Play(MX_GYM_HINT_15, false);
+            Music_Play(MX_GYM_HINT_15, MPM_ALWAYS);
             g_AssaultBestTime = g_SaveGame.current_stats.timer;
         } else if (
             g_SaveGame.current_stats.timer
             < g_AssaultBestTime + 5 * FRAMES_PER_SECOND) {
             // "Almost. Perhaps another try and I might beat it."
-            Music_Legacy_Play(MX_GYM_HINT_16, false);
+            Music_Play(MX_GYM_HINT_16, MPM_ALWAYS);
         } else {
             // "Great. But nowhere near my best time."
-            Music_Legacy_Play(MX_GYM_HINT_14, false);
+            Music_Play(MX_GYM_HINT_14, MPM_ALWAYS);
         }
 
         g_IsAssaultTimerActive = false;

--- a/src/tr2/game/music.h
+++ b/src/tr2/game/music.h
@@ -96,6 +96,3 @@ MUSIC_TRACK_ID Music_GetDelayedTrack(void);
 void Music_Pause(void);
 void Music_Unpause(void);
 int32_t Music_GetRealTrack(int32_t track_id);
-
-// TODO: eliminate
-void Music_Legacy_Play(int16_t track_id, bool is_looped);

--- a/src/tr2/game/music/music_main.c
+++ b/src/tr2/game/music/music_main.c
@@ -109,11 +109,6 @@ void Music_Shutdown(void)
     Audio_Stream_Close(m_AudioStreamID);
 }
 
-void Music_Legacy_Play(int16_t track_id, bool is_looped)
-{
-    Music_Play(track_id, is_looped ? MPM_LOOPED : MPM_ALWAYS);
-}
-
 void Music_Play(const MUSIC_TRACK_ID track_id, const MUSIC_PLAY_MODE mode)
 {
     if (track_id == m_TrackCurrent && mode != MPM_ALWAYS) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This eliminates the legacy function for playing music, which was only being used at the end of the assault course.
