### PR TITLE
objects: refactor static mesh and room sprite interpretation

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -355,7 +355,8 @@ void Level_ReadStaticObjects(const int32_t num_objects, VFILE *const file)
                 MAX_STATIC_OBJECTS);
         }
 
-        STATIC_INFO *const static_obj = Object_GetStaticObject(static_id);
+        STATIC_OBJECT_3D *const static_obj =
+            Object_GetStaticObject3D(static_id);
         static_obj->mesh_idx = VFile_ReadS16(file);
         static_obj->mesh_count = 1;
         static_obj->loaded = true;

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -368,3 +368,27 @@ void Level_ReadStaticObjects(const int32_t num_objects, VFILE *const file)
         static_obj->visible = (flags & 2) != 0;
     }
 }
+
+void Level_ReadSpriteSequences(const int32_t num_sequences, VFILE *const file)
+{
+    for (int32_t i = 0; i < num_sequences; i++) {
+        const int32_t object_id = VFile_ReadS32(file);
+        const int16_t num_meshes = VFile_ReadS16(file);
+        const int16_t mesh_idx = VFile_ReadS16(file);
+
+        if (object_id >= 0 && object_id < O_NUMBER_OF) {
+            OBJECT *const object = Object_GetObject(object_id);
+            object->mesh_count = num_meshes;
+            object->mesh_idx = mesh_idx;
+            object->loaded = true;
+        } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
+            STATIC_OBJECT_2D *const object =
+                Object_GetStaticObject2D(object_id - O_NUMBER_OF);
+            object->frame_count = ABS(num_meshes);
+            object->texture_idx = mesh_idx;
+            object->loaded = true;
+        } else {
+            Shell_ExitSystemFmt("Invalid sprite slot (%d)", object_id);
+        }
+    }
+}

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -358,7 +358,6 @@ void Level_ReadStaticObjects(const int32_t num_objects, VFILE *const file)
         STATIC_OBJECT_3D *const static_obj =
             Object_GetStaticObject3D(static_id);
         static_obj->mesh_idx = VFile_ReadS16(file);
-        static_obj->mesh_count = 1;
         static_obj->loaded = true;
 
         M_ReadBounds16(&static_obj->draw_bounds, file);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -17,3 +17,4 @@ void Level_LoadAnimCommands(void);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
 void Level_ReadObjects(int32_t num_objects, VFILE *file);
 void Level_ReadStaticObjects(int32_t num_objects, VFILE *file);
+void Level_ReadSpriteSequences(int32_t num_sequences, VFILE *file);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -14,6 +14,7 @@ typedef struct {
 
 extern OBJECT *Object_GetObject(GAME_OBJECT_ID object_id);
 extern STATIC_OBJECT_3D *Object_GetStaticObject3D(int32_t static_id);
+extern STATIC_OBJECT_2D *Object_GetStaticObject2D(int32_t static_id);
 
 bool Object_IsObjectType(
     GAME_OBJECT_ID object_id, const GAME_OBJECT_ID *test_arr);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -13,7 +13,7 @@ typedef struct {
 } GAME_OBJECT_PAIR;
 
 extern OBJECT *Object_GetObject(GAME_OBJECT_ID object_id);
-extern STATIC_INFO *Object_GetStaticObject(int32_t static_id);
+extern STATIC_OBJECT_3D *Object_GetStaticObject3D(int32_t static_id);
 
 bool Object_IsObjectType(
     GAME_OBJECT_ID object_id, const GAME_OBJECT_ID *test_arr);

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -116,4 +116,4 @@ typedef struct {
     bool visible;
     BOUNDS_16 draw_bounds;
     BOUNDS_16 collision_bounds;
-} STATIC_INFO;
+} STATIC_OBJECT_3D;

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -110,10 +110,15 @@ typedef struct {
 
 typedef struct {
     bool loaded;
-    int16_t mesh_count;
     int16_t mesh_idx;
     bool collidable;
     bool visible;
     BOUNDS_16 draw_bounds;
     BOUNDS_16 collision_bounds;
 } STATIC_OBJECT_3D;
+
+typedef struct {
+    bool loaded;
+    int16_t frame_count;
+    int16_t texture_idx;
+} STATIC_OBJECT_2D;

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -346,7 +346,8 @@ bool Collide_CollideStaticObjects(
 
         for (int j = 0; j < r->num_static_meshes; j++) {
             const STATIC_MESH *const mesh = &r->static_meshes[j];
-            const STATIC_INFO *const sinfo = &g_StaticObjects[mesh->static_num];
+            const STATIC_OBJECT_3D *const sinfo =
+                &g_StaticObjects3D[mesh->static_num];
             if (!sinfo->collidable) {
                 continue;
             }

--- a/src/tr1/game/collide.c
+++ b/src/tr1/game/collide.c
@@ -347,7 +347,7 @@ bool Collide_CollideStaticObjects(
         for (int j = 0; j < r->num_static_meshes; j++) {
             const STATIC_MESH *const mesh = &r->static_meshes[j];
             const STATIC_OBJECT_3D *const sinfo =
-                &g_StaticObjects3D[mesh->static_num];
+                Object_GetStaticObject3D(mesh->static_num);
             if (!sinfo->collidable) {
                 continue;
             }

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -445,7 +445,8 @@ static void M_TextureData(
             object->mesh_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_INFO *object = &g_StaticObjects[object_id - O_NUMBER_OF];
+            STATIC_OBJECT_3D *object =
+                &g_StaticObjects3D[object_id - O_NUMBER_OF];
             object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = true;
@@ -803,8 +804,8 @@ static void M_ApplyMeshEdit(
 
         mesh = Object_GetMesh(object->mesh_idx + mesh_edit->mesh_idx);
     } else if (mesh_edit->object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-        const STATIC_INFO *const info =
-            &g_StaticObjects[mesh_edit->object_id - O_NUMBER_OF];
+        const STATIC_OBJECT_3D *const info =
+            &g_StaticObjects3D[mesh_edit->object_id - O_NUMBER_OF];
         mesh = Object_GetMesh(info->mesh_idx);
     } else {
         LOG_WARNING("Invalid object ID %d", mesh_edit->object_id);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -440,13 +440,13 @@ static void M_TextureData(
         const int16_t mesh_idx = VFile_ReadS16(fp);
 
         if (object_id < O_NUMBER_OF) {
-            OBJECT *const object = &g_Objects[object_id];
+            OBJECT *const object = Object_GetObject(object_id);
             object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = true;
         } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
             STATIC_OBJECT_2D *const object =
-                &g_StaticObjects2D[object_id - O_NUMBER_OF];
+                Object_GetStaticObject2D(object_id - O_NUMBER_OF);
             object->frame_count = ABS(num_meshes);
             object->texture_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = true;
@@ -804,7 +804,7 @@ static void M_ApplyMeshEdit(
         mesh = Object_GetMesh(object->mesh_idx + mesh_edit->mesh_idx);
     } else if (mesh_edit->object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
         const STATIC_OBJECT_3D *const info =
-            &g_StaticObjects3D[mesh_edit->object_id - O_NUMBER_OF];
+            Object_GetStaticObject3D(mesh_edit->object_id - O_NUMBER_OF);
         mesh = Object_GetMesh(info->mesh_idx);
     } else {
         LOG_WARNING("Invalid object ID %d", mesh_edit->object_id);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -440,19 +440,18 @@ static void M_TextureData(
         const int16_t mesh_idx = VFile_ReadS16(fp);
 
         if (object_id < O_NUMBER_OF) {
-            OBJECT *object = &g_Objects[object_id];
-            object->mesh_count = num_meshes;
-            object->mesh_idx = mesh_idx + level_info->sprite_info_count;
-            object->loaded = 1;
-        } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_OBJECT_3D *object =
-                &g_StaticObjects3D[object_id - O_NUMBER_OF];
+            OBJECT *const object = &g_Objects[object_id];
             object->mesh_count = num_meshes;
             object->mesh_idx = mesh_idx + level_info->sprite_info_count;
             object->loaded = true;
+        } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
+            STATIC_OBJECT_2D *const object =
+                &g_StaticObjects2D[object_id - O_NUMBER_OF];
+            object->frame_count = ABS(num_meshes);
+            object->texture_idx = mesh_idx + level_info->sprite_info_count;
+            object->loaded = true;
         }
-        level_info->sprite_info_count -= num_meshes;
-        level_info->sprite_count++;
+        level_info->sprite_info_count += ABS(num_meshes);
     }
 
     Benchmark_End(benchmark, NULL);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -420,26 +420,7 @@ static void M_LoadSprites(VFILE *file)
 
     const int32_t num_sequences = VFile_ReadS32(file);
     LOG_DEBUG("sprite sequences: %d", num_sequences);
-    for (int i = 0; i < num_sequences; i++) {
-        const int32_t object_id = VFile_ReadS32(file);
-        const int16_t num_meshes = VFile_ReadS16(file);
-        const int16_t mesh_idx = VFile_ReadS16(file);
-
-        if (object_id >= 0 && object_id < O_NUMBER_OF) {
-            OBJECT *const object = &g_Objects[object_id];
-            object->mesh_count = num_meshes;
-            object->mesh_idx = mesh_idx;
-            object->loaded = 1;
-        } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_OBJECT_2D *const object =
-                &g_StaticObjects2D[object_id - O_NUMBER_OF];
-            object->frame_count = ABS(num_meshes);
-            object->texture_idx = mesh_idx;
-            object->loaded = true;
-        } else {
-            Shell_ExitSystemFmt("Invalid sprite slot (%d)", object_id);
-        }
-    }
+    Level_ReadSpriteSequences(num_sequences, file);
 
     Benchmark_End(benchmark, NULL);
 }
@@ -872,7 +853,7 @@ static size_t M_CalculateMaxVertices(void)
     }
 
     for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-        const STATIC_OBJECT_3D *static_info = &g_StaticObjects3D[i];
+        const STATIC_OBJECT_3D *static_info = Object_GetStaticObject3D(i);
         if (!static_info->loaded) {
             continue;
         }

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -953,10 +953,11 @@ bool Level_Initialise(int32_t level_num)
 
     /* Clear Object Loaded flags */
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
-        g_Objects[i].loaded = 0;
+        Object_GetObject(i)->loaded = false;
     }
     for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-        g_StaticObjects3D[i].loaded = false;
+        Object_GetStaticObject2D(i)->loaded = false;
+        Object_GetStaticObject3D(i)->loaded = false;
     }
 
     Camera_Reset();

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -429,8 +429,8 @@ static void M_LoadSprites(VFILE *file)
             object->mesh_idx = mesh_idx;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_INFO *const object =
-                &g_StaticObjects[object_id - O_NUMBER_OF];
+            STATIC_OBJECT_3D *const object =
+                &g_StaticObjects3D[object_id - O_NUMBER_OF];
             if (object->loaded) {
                 LOG_WARNING(
                     "sprite %d is already loaded "
@@ -878,7 +878,7 @@ static size_t M_CalculateMaxVertices(void)
     }
 
     for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-        const STATIC_INFO *static_info = &g_StaticObjects[i];
+        const STATIC_OBJECT_3D *static_info = &g_StaticObjects3D[i];
         if (!static_info->loaded || static_info->mesh_count < 0) {
             continue;
         }
@@ -981,7 +981,7 @@ bool Level_Initialise(int32_t level_num)
         g_Objects[i].loaded = 0;
     }
     for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-        g_StaticObjects[i].loaded = false;
+        g_StaticObjects3D[i].loaded = false;
     }
 
     Camera_Reset();

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -28,6 +28,11 @@ STATIC_OBJECT_3D *Object_GetStaticObject3D(const int32_t static_id)
     return &g_StaticObjects3D[static_id];
 }
 
+STATIC_OBJECT_2D *Object_GetStaticObject2D(const int32_t static_id)
+{
+    return &g_StaticObjects2D[static_id];
+}
+
 int16_t Object_FindReceptacle(GAME_OBJECT_ID object_id)
 {
     GAME_OBJECT_ID receptacle_to_check =

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -23,9 +23,9 @@ OBJECT *Object_GetObject(const GAME_OBJECT_ID object_id)
     return &g_Objects[object_id];
 }
 
-STATIC_INFO *Object_GetStaticObject(const int32_t static_id)
+STATIC_OBJECT_3D *Object_GetStaticObject3D(const int32_t static_id)
 {
-    return &g_StaticObjects[static_id];
+    return &g_StaticObjects3D[static_id];
 }
 
 int16_t Object_FindReceptacle(GAME_OBJECT_ID object_id)

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1186,7 +1186,7 @@ void Output_AnimateTextures(const int32_t num_frames)
         }
 
         for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-            const STATIC_OBJECT_2D *const object = &g_StaticObjects2D[i];
+            const STATIC_OBJECT_2D *const object = Object_GetStaticObject2D(i);
             if (!object->loaded || object->frame_count == 1) {
                 continue;
             }

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1186,7 +1186,7 @@ void Output_AnimateTextures(const int32_t num_frames)
         }
 
         for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-            const STATIC_INFO *const static_info = &g_StaticObjects[i];
+            const STATIC_OBJECT_3D *const static_info = &g_StaticObjects3D[i];
             if (!static_info->loaded || static_info->mesh_count >= -1) {
                 continue;
             }

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1186,18 +1186,18 @@ void Output_AnimateTextures(const int32_t num_frames)
         }
 
         for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-            const STATIC_OBJECT_3D *const static_info = &g_StaticObjects3D[i];
-            if (!static_info->loaded || static_info->mesh_count >= -1) {
+            const STATIC_OBJECT_2D *const object = &g_StaticObjects2D[i];
+            if (!object->loaded || object->frame_count == 1) {
                 continue;
             }
 
-            const int32_t num_meshes = -static_info->mesh_count;
-            const PHD_SPRITE temp = g_PhdSpriteInfo[static_info->mesh_idx];
-            for (int32_t j = 0; j < num_meshes - 1; j++) {
-                g_PhdSpriteInfo[static_info->mesh_idx + j] =
-                    g_PhdSpriteInfo[static_info->mesh_idx + j + 1];
+            const int16_t frame_count = object->frame_count;
+            const PHD_SPRITE temp = g_PhdSpriteInfo[object->texture_idx];
+            for (int32_t j = 0; j < frame_count - 1; j++) {
+                g_PhdSpriteInfo[object->texture_idx + j] =
+                    g_PhdSpriteInfo[object->texture_idx + j + 1];
             }
-            g_PhdSpriteInfo[static_info->mesh_idx + num_meshes - 1] = temp;
+            g_PhdSpriteInfo[object->texture_idx + frame_count - 1] = temp;
         }
         m_AnimatedTexturesOffset -= 5;
     }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -294,7 +294,7 @@ void Room_DrawSingleRoom(int16_t room_num)
     for (int i = 0; i < r->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &r->static_meshes[i];
         const STATIC_OBJECT_3D *const info =
-            &g_StaticObjects3D[mesh->static_num];
+            Object_GetStaticObject3D(mesh->static_num);
         if (!info->visible) {
             continue;
         }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -293,7 +293,8 @@ void Room_DrawSingleRoom(int16_t room_num)
 
     for (int i = 0; i < r->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &r->static_meshes[i];
-        const STATIC_INFO *const info = &g_StaticObjects[mesh->static_num];
+        const STATIC_OBJECT_3D *const info =
+            &g_StaticObjects3D[mesh->static_num];
         if (!info->visible) {
             continue;
         }

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -503,7 +503,6 @@ typedef struct {
     int32_t anim_texture_range_count;
     int32_t item_count;
     int32_t sprite_info_count;
-    int32_t sprite_count;
     int32_t overlap_count;
     int32_t sample_info_count;
     int32_t sample_count;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -35,7 +35,7 @@ int32_t g_HeightType = 0;
 
 ROOM *g_RoomInfo = NULL;
 OBJECT g_Objects[O_NUMBER_OF] = {};
-STATIC_INFO g_StaticObjects[MAX_STATIC_OBJECTS] = {};
+STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS] = {};
 RGBA_8888 *g_TexturePagePtrs[MAX_TEXTPAGES] = { NULL };
 int16_t g_RoomCount = 0;
 int32_t g_LevelItemCount = 0;

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -36,6 +36,7 @@ int32_t g_HeightType = 0;
 ROOM *g_RoomInfo = NULL;
 OBJECT g_Objects[O_NUMBER_OF] = {};
 STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS] = {};
+STATIC_OBJECT_2D g_StaticObjects2D[MAX_STATIC_OBJECTS] = {};
 RGBA_8888 *g_TexturePagePtrs[MAX_TEXTPAGES] = { NULL };
 int16_t g_RoomCount = 0;
 int32_t g_LevelItemCount = 0;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -43,7 +43,7 @@ extern int32_t g_HeightType;
 
 extern ROOM *g_RoomInfo;
 extern OBJECT g_Objects[O_NUMBER_OF];
-extern STATIC_INFO g_StaticObjects[MAX_STATIC_OBJECTS];
+extern STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
 extern RGBA_8888 *g_TexturePagePtrs[MAX_TEXTPAGES];
 extern int16_t g_RoomCount;
 extern int32_t g_LevelItemCount;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -44,6 +44,7 @@ extern int32_t g_HeightType;
 extern ROOM *g_RoomInfo;
 extern OBJECT g_Objects[O_NUMBER_OF];
 extern STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
+extern STATIC_OBJECT_2D g_StaticObjects2D[MAX_STATIC_OBJECTS];
 extern RGBA_8888 *g_TexturePagePtrs[MAX_TEXTPAGES];
 extern int16_t g_RoomCount;
 extern int32_t g_LevelItemCount;

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -311,7 +311,7 @@ int32_t Collide_CollideStaticObjects(
         for (int32_t j = 0; j < room->num_static_meshes; j++) {
             const STATIC_MESH *const mesh = &room->static_meshes[j];
             const STATIC_OBJECT_3D *const sinfo =
-                &g_StaticObjects3D[mesh->static_num];
+                Object_GetStaticObject3D(mesh->static_num);
 
             if (!sinfo->collidable) {
                 continue;

--- a/src/tr2/game/collide.c
+++ b/src/tr2/game/collide.c
@@ -310,7 +310,8 @@ int32_t Collide_CollideStaticObjects(
 
         for (int32_t j = 0; j < room->num_static_meshes; j++) {
             const STATIC_MESH *const mesh = &room->static_meshes[j];
-            const STATIC_INFO *const sinfo = &g_StaticObjects[mesh->static_num];
+            const STATIC_OBJECT_3D *const sinfo =
+                &g_StaticObjects3D[mesh->static_num];
 
             if (!sinfo->collidable) {
                 continue;

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -23,6 +23,7 @@
 #include <libtrx/game/level.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
+#include <libtrx/utils.h>
 
 static int16_t *m_AnimFrameData = NULL;
 static int32_t m_AnimFrameDataLength = 0;
@@ -342,9 +343,9 @@ static void M_LoadTextures(VFILE *const file)
 static void M_LoadSprites(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t num_sprites = VFile_ReadS32(file);
-    LOG_DEBUG("sprites: %d", num_sprites);
-    for (int32_t i = 0; i < num_sprites; i++) {
+    const int32_t num_textures = VFile_ReadS32(file);
+    LOG_DEBUG("sprite textures: %d", num_textures);
+    for (int32_t i = 0; i < num_textures; i++) {
         PHD_SPRITE *const sprite = &g_PhdSprites[i];
         sprite->tex_page = VFile_ReadU16(file);
         sprite->offset = VFile_ReadU16(file);
@@ -356,9 +357,9 @@ static void M_LoadSprites(VFILE *const file)
         sprite->y1 = VFile_ReadS16(file);
     }
 
-    const int32_t num_statics = VFile_ReadS32(file);
-    LOG_DEBUG("statics: %d", num_statics);
-    for (int32_t i = 0; i < num_statics; i++) {
+    const int32_t num_sequences = VFile_ReadS32(file);
+    LOG_DEBUG("sprite sequences: %d", num_sequences);
+    for (int32_t i = 0; i < num_sequences; i++) {
         const int32_t object_id = VFile_ReadS32(file);
         const int16_t num_meshes = VFile_ReadS16(file);
         const int16_t mesh_idx = VFile_ReadS16(file);
@@ -369,19 +370,11 @@ static void M_LoadSprites(VFILE *const file)
             object->mesh_idx = mesh_idx;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_OBJECT_3D *const object =
-                &g_StaticObjects3D[object_id - O_NUMBER_OF];
-            if (object->loaded) {
-                LOG_WARNING(
-                    "sprite %d is already loaded "
-                    "(trying to override %d:%d with %d:%d)",
-                    object_id - O_NUMBER_OF, object->mesh_count,
-                    object->mesh_idx, num_meshes, mesh_idx);
-            } else {
-                object->mesh_count = num_meshes;
-                object->mesh_idx = mesh_idx;
-                object->loaded = true;
-            }
+            STATIC_OBJECT_2D *const object =
+                &g_StaticObjects2D[object_id - O_NUMBER_OF];
+            object->frame_count = ABS(num_meshes);
+            object->texture_idx = mesh_idx;
+            object->loaded = true;
         } else {
             Shell_ExitSystemFmt("Invalid sprite slot (%d)", object_id);
         }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -369,8 +369,8 @@ static void M_LoadSprites(VFILE *const file)
             object->mesh_idx = mesh_idx;
             object->loaded = 1;
         } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_INFO *const object =
-                &g_StaticObjects[object_id - O_NUMBER_OF];
+            STATIC_OBJECT_3D *const object =
+                &g_StaticObjects3D[object_id - O_NUMBER_OF];
             if (object->loaded) {
                 LOG_WARNING(
                     "sprite %d is already loaded "

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -23,7 +23,6 @@
 #include <libtrx/game/level.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
-#include <libtrx/utils.h>
 
 static int16_t *m_AnimFrameData = NULL;
 static int32_t m_AnimFrameDataLength = 0;
@@ -359,26 +358,7 @@ static void M_LoadSprites(VFILE *const file)
 
     const int32_t num_sequences = VFile_ReadS32(file);
     LOG_DEBUG("sprite sequences: %d", num_sequences);
-    for (int32_t i = 0; i < num_sequences; i++) {
-        const int32_t object_id = VFile_ReadS32(file);
-        const int16_t num_meshes = VFile_ReadS16(file);
-        const int16_t mesh_idx = VFile_ReadS16(file);
-
-        if (object_id >= 0 && object_id < O_NUMBER_OF) {
-            OBJECT *const object = &g_Objects[object_id];
-            object->mesh_count = num_meshes;
-            object->mesh_idx = mesh_idx;
-            object->loaded = 1;
-        } else if (object_id - O_NUMBER_OF < MAX_STATIC_OBJECTS) {
-            STATIC_OBJECT_2D *const object =
-                &g_StaticObjects2D[object_id - O_NUMBER_OF];
-            object->frame_count = ABS(num_meshes);
-            object->texture_idx = mesh_idx;
-            object->loaded = true;
-        } else {
-            Shell_ExitSystemFmt("Invalid sprite slot (%d)", object_id);
-        }
-    }
+    Level_ReadSpriteSequences(num_sequences, file);
 
     Benchmark_End(benchmark, NULL);
 }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -779,8 +779,11 @@ bool Level_Load(const char *const file_name, const int32_t level_num)
     BENCHMARK *const benchmark = Benchmark_Start();
 
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
-        OBJECT *const object = Object_GetObject(i);
-        object->loaded = false;
+        Object_GetObject(i)->loaded = false;
+    }
+    for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
+        Object_GetStaticObject2D(i)->loaded = false;
+        Object_GetStaticObject3D(i)->loaded = false;
     }
 
     const GAME_FLOW_LEVEL *const level = &g_GameFlow.levels[level_num];

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -21,6 +21,11 @@ STATIC_OBJECT_3D *Object_GetStaticObject3D(const int32_t static_id)
     return &g_StaticObjects3D[static_id];
 }
 
+STATIC_OBJECT_2D *Object_GetStaticObject2D(const int32_t static_id)
+{
+    return &g_StaticObjects2D[static_id];
+}
+
 void Object_DrawDummyItem(const ITEM *const item)
 {
 }

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -16,9 +16,9 @@ OBJECT *Object_GetObject(const GAME_OBJECT_ID object_id)
     return &g_Objects[object_id];
 }
 
-STATIC_INFO *Object_GetStaticObject(const int32_t static_id)
+STATIC_OBJECT_3D *Object_GetStaticObject3D(const int32_t static_id)
 {
-    return &g_StaticObjects[static_id];
+    return &g_StaticObjects3D[static_id];
 }
 
 void Object_DrawDummyItem(const ITEM *const item)

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -422,7 +422,7 @@ void Room_DrawSingleRoomObjects(const int16_t room_num)
     for (int32_t i = 0; i < r->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &r->static_meshes[i];
         const STATIC_OBJECT_3D *const static_obj =
-            &g_StaticObjects3D[mesh->static_num];
+            Object_GetStaticObject3D(mesh->static_num);
         if (!static_obj->visible) {
             continue;
         }

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -421,8 +421,8 @@ void Room_DrawSingleRoomObjects(const int16_t room_num)
 
     for (int32_t i = 0; i < r->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &r->static_meshes[i];
-        const STATIC_INFO *const static_obj =
-            &g_StaticObjects[mesh->static_num];
+        const STATIC_OBJECT_3D *const static_obj =
+            &g_StaticObjects3D[mesh->static_num];
         if (!static_obj->visible) {
             continue;
         }

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -112,6 +112,7 @@ CREATURE *g_BaddieSlots = NULL;
 int32_t g_DynamicLightCount;
 
 STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
+STATIC_OBJECT_2D g_StaticObjects2D[MAX_STATIC_OBJECTS];
 OBJECT_VECTOR *g_SoundEffects = NULL;
 int16_t g_SampleLUT[SFX_NUMBER_OF];
 SAMPLE_INFO *g_SampleInfos = NULL;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -111,7 +111,7 @@ uint16_t *g_Overlap = NULL;
 CREATURE *g_BaddieSlots = NULL;
 int32_t g_DynamicLightCount;
 
-STATIC_INFO g_StaticObjects[MAX_STATIC_OBJECTS];
+STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
 OBJECT_VECTOR *g_SoundEffects = NULL;
 int16_t g_SampleLUT[SFX_NUMBER_OF];
 SAMPLE_INFO *g_SampleInfos = NULL;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -108,7 +108,7 @@ extern int16_t *g_GroundZone[][2];
 extern uint16_t *g_Overlap;
 extern CREATURE *g_BaddieSlots;
 extern int32_t g_DynamicLightCount;
-extern STATIC_INFO g_StaticObjects[MAX_STATIC_OBJECTS];
+extern STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
 extern OBJECT_VECTOR *g_SoundEffects;
 extern int16_t g_SampleLUT[];
 extern SAMPLE_INFO *g_SampleInfos;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -109,6 +109,7 @@ extern uint16_t *g_Overlap;
 extern CREATURE *g_BaddieSlots;
 extern int32_t g_DynamicLightCount;
 extern STATIC_OBJECT_3D g_StaticObjects3D[MAX_STATIC_OBJECTS];
+extern STATIC_OBJECT_2D g_StaticObjects2D[MAX_STATIC_OBJECTS];
 extern OBJECT_VECTOR *g_SoundEffects;
 extern int16_t g_SampleLUT[];
 extern SAMPLE_INFO *g_SampleInfos;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This creates firmer distinction between 3D static meshes and 2D room sprites, and so builds upon #2311 to allow the two to co-exist in similar slot numbers. Reading sprites is also moved to TRX, aside from injections currently, but this will be tackled under that refactor later.

I think this should also make it easier/clearer in the future when we need to extend `GAME_OBJECT_ID` - we'd just need to adapt the sprite sequence slot tests and introduce a fixed `OG_O_NUMBER_OF` const or similar.

Test level below with an animated room sprite in slot 0, a regular room sprite in slot 1 and a 3D static mesh in slot 0. Also worth double checking Cistern/Tihocan sprites, TR2's basement sprites and regular statics.
[level1.zip](https://github.com/user-attachments/files/18470313/level1.zip)
