### PR TITLE
tr2/render/swr: fix skybox not clearing previous frame

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed wireframe mode discarding transparent pixels (#2315, regression from 0.7)
 - fixed sprite pickups not being paused in the pause/inventory screen (#2319, regression from 0.6)
 - fixed Skidoo snow wake effects at slow speeds (#2324, regression from 0.6)
+- fixed software renderer skybox occlusion issues (#2343, regression from 0.7)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2343. While I am planning to eventually remove SWR, I'm not sure when that'll happen, so here's the fix. 

We've added an occlusion buffer to the SWR earlier, so that we could easily render a background image behind 3D geometry, eg. `Output_DrawBackground` behind 3D inventory ring meshes. Without it, the SWR would blit the entire screen surface and overwrite the background. The occlusion buffer mimics much of the SWR 3D rendering logic, but marks a pixel as opaque rather than writing color data, with transparency as default. The problem arose because certain colors, notably palette index 0, are treated as transparent for transparent faces like windows, and aren't written to the color buffer. The skybox in Home Sweet Home uses this index, too. The occlusion buffer was designed to take shortcuts, with keeping the code size as small as possible as one of the goals. Some of these shortcuts turned out mistaken – it would incorrectly mark the pixels skipped by the color blitters as used, which resulted in the bug.
As a solution, I eliminated the Occlude function family in favor of updating `alpha_surface` directly within the color blitters.
