### PR TITLE
tr2/lara/misc: fix joint position calculation

### DIFF
--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -952,7 +952,7 @@ void Lara_GetJointAbsPosition_I(
 
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_Interpolate();
-        Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
+        Matrix_TranslateRel32(bone[LM_UARM_R - 1].pos);
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);


### PR DESCRIPTION
Resolves #2359.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores the original bone lookup for when Lara is holding a flare on an interpolated frame. This doesn't appear logical as it differs from the non-interpolated routine, but this matches the original bone indexing we had below before the refactoring work.

https://github.com/LostArtefacts/TRX/blob/48be91347093236a8491914ae18796c4fc0aecaf/src/tr2/game/lara/misc.c#L945
