### PR TITLE
tr2/objects/creatures/bandit_2: fix bite position

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed sprite pickups not being paused in the pause/inventory screen (#2319, regression from 0.6)
 - fixed Skidoo snow wake effects at slow speeds (#2324, regression from 0.6)
 - fixed software renderer skybox occlusion issues (#2343, regression from 0.7)
+- fixed gunflare from bandits in Tibetan levels spawning too far from their guns (#2365, regression from 0.8)
 - improved rendering to achieve a slight performance boost in big rooms (#2325)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -45,7 +45,7 @@ typedef enum {
 } BANDIT_2_ANIM;
 
 static const BITE m_Bandit2Gun = {
-    .pos = { .x = -1, .y = 930, .z = 9 },
+    .pos = { .x = -1, .y = 230, .z = 9 },
     .mesh_num = 17,
 };
 


### PR DESCRIPTION
Resolves #2365.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This corrects the Y value on bandit 2's bite position, so that gunflare doesn't appear too far from the gun.
