### PR TITLE
console/teleport: use higher Y value for item teleports

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed ghost meshes appearing near statics in custom levels (#2310)
 - fixed photo mode switching to the wrong flipmap rooms at times (#2362)
 - fixed the teleporting command sometimes putting Lara in invalid flipmap rooms (#2370)
+- fixed teleporting to an item on a ledge sometimes pushing Lara to the room below (#2372)
 - fixed the upside-down camera fix to no longer limit Lara's vision (#2276, regression from 4.2)
 - fixed being unable to load some old custom levels that contain certain (invalid) floor data (#2114, regression from 4.3)
 - fixed a desync in the Lost Valley demo if responsive swim cancellation was enabled (#2113, regression from 4.6)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed potential memory corruption when reading a custom level with more than 512 sprite textures (#2338)
 - fixed photo mode switching to the wrong flipmap rooms at times (#2362)
 - fixed the teleporting command sometimes putting Lara in invalid flipmap rooms (#2370)
+- fixed teleporting to an item on a ledge sometimes pushing Lara to the room below (#2372)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 - fixed savegame incompatibility with OG (#2271, regression from 0.8)
 - fixed stopwatch showing wrong UI in some circumstances (#2221, regression from 0.8)

--- a/src/libtrx/game/console/cmd/teleport.c
+++ b/src/libtrx/game/console/cmd/teleport.c
@@ -220,7 +220,8 @@ static COMMAND_RESULT M_TeleportToObject(const char *const user_input)
     }
 
     if (Lara_Cheat_Teleport(
-            best_item->pos.x, best_item->pos.y, best_item->pos.z)) {
+            best_item->pos.x, best_item->pos.y - STEP_L / 4,
+            best_item->pos.z)) {
         Console_Log(GS(OSD_POS_SET_ITEM), obj_name);
     } else {
         Console_Log(GS(OSD_POS_SET_ITEM_FAIL), obj_name);


### PR DESCRIPTION
Resolves #2372.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This teleports Lara slightly above the item she is teleporting to, so to avoid `Room_GetSector` tests pushing through to the room below in some cases.
