### PR TITLE
tr2/lara/cheat: reset gun status if undrawing weapons

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed Skidoo snow wake effects at slow speeds (#2324, regression from 0.6)
 - fixed software renderer skybox occlusion issues (#2343, regression from 0.7)
 - fixed gunflare from bandits in Tibetan levels spawning too far from their guns (#2365, regression from 0.8)
+- fixed guns sometimes appearing in Lara's hands when entering the fly cheat while undrawing weapons (#2376, regression from 0.3)
 - improved rendering to achieve a slight performance boost in big rooms (#2325)
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -124,7 +124,8 @@ bool Lara_Cheat_EnterFlyMode(void)
         M_ResetGunStatus();
     }
 
-    if (g_Lara.gun_status == LGS_HANDS_BUSY) {
+    if (g_Lara.gun_status == LGS_HANDS_BUSY
+        || (g_Lara.gun_status == LGS_UNDRAW && g_Lara.back_gun != O_LARA)) {
         g_Lara.gun_status = LGS_ARMLESS;
     }
 


### PR DESCRIPTION
Resolves #2376.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR1X/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes guns potentially appearing in Lara's hand while entering the fly cheat and the weapon undraw animation is still running.
