### PR TITLE
tr1/fmv: stop FMV if game is exiting

### DIFF
--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -123,7 +123,8 @@ static bool M_Play(const char *const file_path)
 
         Input_Update();
 
-        if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
+        if (g_InputDB.menu_confirm || g_InputDB.menu_back
+            || Shell_IsExiting()) {
             Video_Stop(video);
         }
     }


### PR DESCRIPTION
Resolves #2386.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents having to wait for an FMV to end or be skipped and the player wants to close the game.
