### PR TITLE
tr1/inv-ring: fix item counts staying at 1

### DIFF
--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -868,7 +868,6 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
 
     g_InvRing_Source[RT_MAIN].current = 0;
     for (int32_t i = 0; i < g_InvRing_Source[RT_MAIN].count; i++) {
-        g_InvRing_Source[RT_MAIN].qtys[i] = 1;
         InvRing_InitInvItem(g_InvRing_Source[RT_MAIN].items[i]);
     }
     g_InvRing_Source[RT_OPTION].current = 0;

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -788,6 +788,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
         InvRing_InitInvItem(g_InvRing_Source[RT_MAIN].items[i]);
     }
     for (int32_t i = 0; i < g_InvRing_Source[RT_OPTION].count; i++) {
+        g_InvRing_Source[RT_OPTION].qtys[i] = 1;
         InvRing_InitInvItem(g_InvRing_Source[RT_OPTION].items[i]);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2390. Regression made in 529d482.
Applies the same change for passport as 529d482 to TR2 while at it, but with the fix in place.