### PR TITLE
packer: refactor texture packing

### DIFF
--- a/src/libtrx/game/packer.c
+++ b/src/libtrx/game/packer.c
@@ -1,12 +1,9 @@
 #include "game/packer.h"
 
-#include "global/const.h"
-#include "global/types.h"
-#include "global/vars.h"
-
-#include <libtrx/log.h>
-#include <libtrx/memory.h>
-#include <libtrx/utils.h>
+#include "game/output.h"
+#include "log.h"
+#include "memory.h"
+#include "utils.h"
 
 #include <stddef.h>
 #include <string.h>
@@ -75,43 +72,6 @@ static int32_t m_UsedPageCount = 0;
 static TEX_PAGE *m_VirtualPages = NULL;
 static int32_t m_QueueSize = 0;
 static TEX_CONTAINER *m_Queue = NULL;
-
-bool Packer_Pack(PACKER_DATA *data)
-{
-    m_Data = data;
-
-    m_StartPage = m_Data->level_page_count - 1;
-    m_EndPage = MAX_TEXTURE_PAGES - m_StartPage;
-    m_UsedPageCount = 0;
-    m_QueueSize = 0;
-
-    M_AllocateNewPage();
-
-    for (int i = 0; i < data->object_count; i++) {
-        M_PrepareObject(i);
-    }
-    for (int i = 0; i < data->sprite_count; i++) {
-        M_PrepareSprite(i);
-    }
-
-    bool result = true;
-    for (int i = 0; i < m_QueueSize; i++) {
-        TEX_CONTAINER *container = &m_Queue[i];
-        if (!M_PackContainer(container)) {
-            LOG_ERROR("Failed to pack container %d of %d", i, m_QueueSize);
-            result = false;
-            break;
-        }
-    }
-
-    M_Cleanup();
-    return result;
-}
-
-int32_t Packer_GetAddedPageCount(void)
-{
-    return m_UsedPageCount - 1;
-}
 
 static void M_PrepareObject(int object_index)
 {
@@ -422,4 +382,41 @@ static void M_Cleanup(void)
 
     Memory_FreePointer(&m_VirtualPages);
     Memory_FreePointer(&m_Queue);
+}
+
+bool Packer_Pack(PACKER_DATA *const data)
+{
+    m_Data = data;
+
+    m_StartPage = m_Data->level_page_count - 1;
+    m_EndPage = MAX_TEXTURE_PAGES - m_StartPage;
+    m_UsedPageCount = 0;
+    m_QueueSize = 0;
+
+    M_AllocateNewPage();
+
+    for (int i = 0; i < data->object_count; i++) {
+        M_PrepareObject(i);
+    }
+    for (int i = 0; i < data->sprite_count; i++) {
+        M_PrepareSprite(i);
+    }
+
+    bool result = true;
+    for (int i = 0; i < m_QueueSize; i++) {
+        TEX_CONTAINER *container = &m_Queue[i];
+        if (!M_PackContainer(container)) {
+            LOG_ERROR("Failed to pack container %d of %d", i, m_QueueSize);
+            result = false;
+            break;
+        }
+    }
+
+    M_Cleanup();
+    return result;
+}
+
+int32_t Packer_GetAddedPageCount(void)
+{
+    return m_UsedPageCount - 1;
 }

--- a/src/libtrx/include/libtrx/game/packer.h
+++ b/src/libtrx/include/libtrx/game/packer.h
@@ -7,7 +7,9 @@
 typedef struct {
     struct {
         int32_t page_count;
-        RGBA_8888 *pages;
+        RGBA_8888 *pages_32;
+        uint8_t *pages_24;
+        RGB_888 *palette_24;
     } source, level;
     int32_t object_count;
     int32_t sprite_count;

--- a/src/libtrx/include/libtrx/game/packer.h
+++ b/src/libtrx/include/libtrx/game/packer.h
@@ -5,12 +5,12 @@
 #include <stdint.h>
 
 typedef struct {
-    int32_t level_page_count;
-    int32_t source_page_count;
+    struct {
+        int32_t page_count;
+        RGBA_8888 *pages;
+    } source, level;
     int32_t object_count;
     int32_t sprite_count;
-    RGBA_8888 *source_pages;
-    RGBA_8888 *level_pages;
 } PACKER_DATA;
 
 // Attempts to pack the provided source pages into the level pages. Packing

--- a/src/libtrx/include/libtrx/game/packer.h
+++ b/src/libtrx/include/libtrx/game/packer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "global/types.h"
+#include "./output/types.h"
 
 #include <stdint.h>
 

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -134,6 +134,7 @@ sources = [
   'game/objects/names.c',
   'game/objects/vars.c',
   'game/output.c',
+  'game/packer.c',
   'game/phase/executor.c',
   'game/phase/phase_cutscene.c',
   'game/phase/phase_demo.c',

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -1673,16 +1673,20 @@ void Inject_AllInjections(LEVEL_INFO *level_info)
     if (source_page_count != 0) {
         PACKER_DATA data = {
             .level.page_count = level_info->texture_page_count,
-            .level.pages = level_info->texture_rgb_page_ptrs,
+            .level.pages_32 = level_info->texture_rgb_page_ptrs,
+            .level.pages_24 = NULL,
+            .level.palette_24 = NULL,
             .source.page_count = source_page_count,
-            .source.pages = source_pages,
+            .source.pages_32 = source_pages,
+            .source.pages_24 = NULL,
+            .source.palette_24 = NULL,
             .object_count = level_info->texture_count,
             .sprite_count = level_info->sprite_info_count,
         };
 
         if (Packer_Pack(&data)) {
             level_info->texture_page_count += Packer_GetAddedPageCount();
-            level_info->texture_rgb_page_ptrs = data.level.pages;
+            level_info->texture_rgb_page_ptrs = data.level.pages_32;
         }
 
         Memory_FreePointer(&source_pages);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -1670,22 +1670,22 @@ void Inject_AllInjections(LEVEL_INFO *level_info)
         tpage_base += inj_info->texture_page_count;
     }
 
-    if (source_page_count) {
-        PACKER_DATA *data = Memory_Alloc(sizeof(PACKER_DATA));
-        data->level_page_count = level_info->texture_page_count;
-        data->source_page_count = source_page_count;
-        data->source_pages = source_pages;
-        data->level_pages = level_info->texture_rgb_page_ptrs;
-        data->object_count = level_info->texture_count;
-        data->sprite_count = level_info->sprite_info_count;
+    if (source_page_count != 0) {
+        PACKER_DATA data = {
+            .level.page_count = level_info->texture_page_count,
+            .level.pages = level_info->texture_rgb_page_ptrs,
+            .source.page_count = source_page_count,
+            .source.pages = source_pages,
+            .object_count = level_info->texture_count,
+            .sprite_count = level_info->sprite_info_count,
+        };
 
-        if (Packer_Pack(data)) {
+        if (Packer_Pack(&data)) {
             level_info->texture_page_count += Packer_GetAddedPageCount();
-            level_info->texture_rgb_page_ptrs = data->level_pages;
+            level_info->texture_rgb_page_ptrs = data.level.pages;
         }
 
         Memory_FreePointer(&source_pages);
-        Memory_FreePointer(&data);
     }
 
     Benchmark_End(benchmark, NULL);

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -2,7 +2,6 @@
 
 #include "game/camera.h"
 #include "game/output.h"
-#include "game/packer.h"
 #include "game/room.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -13,6 +12,7 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/level.h>
+#include <libtrx/game/packer.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 #include <libtrx/utils.h>

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -250,7 +250,6 @@ sources = [
   'game/option/option_sound.c',
   'game/output.c',
   'game/overlay.c',
-  'game/packer.c',
   'game/requester.c',
   'game/room.c',
   'game/room_draw.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the packer module to TRX and carries out some refactoring, mainly to update to standards we have for using `int32_t`, `const` etc. I've also adjusted the way it passes around rectangles, previously we were creating these on the heap so there was a lot of alloc/free calls required. The way virtual data is handled is also minimised for better efficiency. This gives a modest boost to injection loading overall.

I've also introduced 8-bit handling in preparation for TR2, the idea being we will pack the 32-bit textures just like TR1, and then replicate the same in the 8-bit pages by matching against the existing colour palette. This means we won't need to worry about changing the depth table with new colours, at least for an initial implementation.

Worth testing that TR1 levels all load OK, and injected textures look normal (Lara's braid, the explosion sprites, font sprites and Larson's gun in Qualopec).
