### PR TITLE
tr1/lara/state: check for responsive state changes

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed header and arrows disappearing when the inventory ring rotates (#2352, regression from 4.4)
 - fixed Story So Far feature not playing opening FMVs from the current level (#2360, regression from 4.2)
 - fixed `/demo` command crashing the game if no demos are present (regression from 4.1)
+- fixed Lara not being able to jump or stop swimming if the related responsive config options are enabled, but enhanced animations are not present (#2397, regression from 4.6)
 - improved pause screen compatibility with PS1 (#2248)
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21

--- a/src/libtrx/include/libtrx/game/lara/enum_tr1.h
+++ b/src/libtrx/include/libtrx/game/lara/enum_tr1.h
@@ -68,6 +68,7 @@ typedef enum {
     LA_SIDE_STEP_RIGHT      = 67,
     LA_LAND_FAR             = 24,
     LA_GRAB_LEDGE           = 96,
+    LA_SWIM_FORWARD         = 86,
     LA_SWIM_GLIDE           = 87,
     LA_FALL_BACK            = 93,
     LA_HANG                 = 96,

--- a/src/tr1/game/lara/state.h
+++ b/src/tr1/game/lara/state.h
@@ -6,6 +6,8 @@
 
 extern void (*g_LaraStateRoutines[])(ITEM *item, COLL_INFO *coll);
 
+void Lara_State_Initialise(void);
+
 void Lara_State_Walk(ITEM *item, COLL_INFO *coll);
 void Lara_State_Run(ITEM *item, COLL_INFO *coll);
 void Lara_State_Stop(ITEM *item, COLL_INFO *coll);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -8,6 +8,7 @@
 #include "game/inventory_ring/vars.h"
 #include "game/items.h"
 #include "game/lara/common.h"
+#include "game/lara/state.h"
 #include "game/lot.h"
 #include "game/music.h"
 #include "game/objects/creatures/mutant.h"
@@ -865,6 +866,8 @@ static void M_CompleteSetup(const GAME_FLOW_LEVEL *const level)
     for (int i = 0; i < m_LevelInfo.item_count; i++) {
         Item_Initialise(i);
     }
+
+    Lara_State_Initialise();
 
     // Configure enemies who carry and drop items
     Carrier_InitialiseLevel(level);


### PR DESCRIPTION
Resolves #2397.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This augments the config options for responsive jumping and swimming to verify that relevant state changes exist in Lara's animation set. This can be tested by removing/re-adding `lara_animations.bin` and toggling the two related options.
