### PR TITLE
output: use common texture animation routine

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added the ability to hold left/right to move through menus more quickly (#2298)
 - added the ability to disable exit fade effects alone (#2348)
 - added a fade-out effect when completing Lara's Home
+- added support for animated sprites (#2401)
 - changed default input bindings to let the photo mode binding be compatible with TR1X:
     | Key                           | Old binding | New binding  |
     | ----------------------------- | ----------- | ------------ |

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -25,7 +25,6 @@
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - fixed ghost meshes appearing near statics in custom levels (#2310)
 - fixed potential memory corruption when reading a custom level with more than 512 sprite textures (#2338)
-- fixed photo mode switching to the wrong flipmap rooms at times (#2362)
 - fixed the teleporting command sometimes putting Lara in invalid flipmap rooms (#2370)
 - fixed teleporting to an item on a ledge sometimes pushing Lara to the room below (#2372)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -107,6 +107,7 @@ game with new enhancements and features.
 - added ability to toggle between the software/hardware renderer at runtime
 - added optional fade effects to the hardware renderer
 - added text information when changing rendering options at runtime
+- added support for animated sprites
 - changed the hardware renderer to always use 16-bit textures
 - changed the software renderer to use the picture's palette for the background pictures
 - changed fullscreen behavior to use windowed desktop mode

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -444,9 +444,9 @@ void Level_ReadAnimatedTextureRanges(
     const int32_t num_ranges, VFILE *const file)
 {
     for (int32_t i = 0; i < num_ranges; i++) {
-        ANIMATED_TEXTURE_RANGE *const range = &g_AnimTextureRanges[i];
+        ANIMATED_TEXTURE_RANGE *const range = Output_GetAnimatedTextureRange(i);
         range->next_range =
-            i == num_ranges - 1 ? NULL : &g_AnimTextureRanges[i + 1];
+            i == num_ranges - 1 ? NULL : Output_GetAnimatedTextureRange(i + 1);
 
         // Level data is tied to the original logic in Output_AnimateTextures
         // and hence stores one less than the actual count here.

--- a/src/libtrx/game/output.c
+++ b/src/libtrx/game/output.c
@@ -13,6 +13,7 @@ typedef struct {
     int32_t shade;
 } COMMON_LIGHT;
 
+static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = NULL;
 static int32_t m_DynamicLightCount = 0;
 static LIGHT m_DynamicLights[MAX_DYNAMIC_LIGHTS] = {};
 
@@ -105,16 +106,21 @@ static int32_t M_CalculateDynamicLight(
 
 void Output_InitialiseAnimatedTextures(const int32_t num_ranges)
 {
-    g_AnimTextureRanges = num_ranges == 0
+    m_AnimTextureRanges = num_ranges == 0
         ? NULL
         : GameBuf_Alloc(
               sizeof(ANIMATED_TEXTURE_RANGE) * num_ranges,
               GBUF_ANIMATED_TEXTURE_RANGES);
 }
 
+ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(const int32_t range_idx)
+{
+    return &m_AnimTextureRanges[range_idx];
+}
+
 void Output_CycleAnimatedTextures(void)
 {
-    const ANIMATED_TEXTURE_RANGE *range = g_AnimTextureRanges;
+    const ANIMATED_TEXTURE_RANGE *range = m_AnimTextureRanges;
     for (; range != NULL; range = range->next_range) {
         int32_t i = 0;
         const OBJECT_TEXTURE temp = g_ObjectTextures[range->textures[i]];

--- a/src/libtrx/game/output.c
+++ b/src/libtrx/game/output.c
@@ -102,6 +102,15 @@ static int32_t M_CalculateDynamicLight(
     return adder;
 }
 
+void Output_InitialiseAnimatedTextures(const int32_t num_ranges)
+{
+    g_AnimTextureRanges = num_ranges == 0
+        ? NULL
+        : GameBuf_Alloc(
+              sizeof(ANIMATED_TEXTURE_RANGE) * num_ranges,
+              GBUF_ANIMATED_TEXTURE_RANGES);
+}
+
 void Output_CalculateLight(const XYZ_32 pos, const int16_t room_num)
 {
     const ROOM *const room = Room_Get(room_num);
@@ -146,15 +155,6 @@ void Output_CalculateLight(const XYZ_32 pos, const int16_t room_num)
 
     Output_SetLightAdder(global_adder);
     Output_SetLightDivider(global_divider);
-}
-
-void Output_InitialiseAnimatedTextures(const int32_t num_ranges)
-{
-    g_AnimTextureRanges = num_ranges == 0
-        ? NULL
-        : GameBuf_Alloc(
-              sizeof(ANIMATED_TEXTURE_RANGE) * num_ranges,
-              GBUF_ANIMATED_TEXTURE_RANGES);
 }
 
 void Output_CalculateStaticLight(const int16_t adder)

--- a/src/libtrx/include/libtrx/game/output.h
+++ b/src/libtrx/include/libtrx/game/output.h
@@ -37,6 +37,7 @@ extern int32_t Output_GetRoomLightShade(ROOM_LIGHT_MODE mode);
 extern void Output_LightRoomVertices(const ROOM *room);
 
 void Output_InitialiseAnimatedTextures(int32_t num_ranges);
+ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(int32_t range_idx);
 void Output_CycleAnimatedTextures(void);
 
 void Output_CalculateLight(XYZ_32 pos, int16_t room_num);

--- a/src/libtrx/include/libtrx/game/output.h
+++ b/src/libtrx/include/libtrx/game/output.h
@@ -37,6 +37,7 @@ extern int32_t Output_GetRoomLightShade(ROOM_LIGHT_MODE mode);
 extern void Output_LightRoomVertices(const ROOM *room);
 
 void Output_InitialiseAnimatedTextures(int32_t num_ranges);
+void Output_CycleAnimatedTextures(void);
 
 void Output_CalculateLight(XYZ_32 pos, int16_t room_num);
 void Output_CalculateStaticLight(int16_t adder);

--- a/src/libtrx/include/libtrx/game/output/vars.h
+++ b/src/libtrx/include/libtrx/game/output/vars.h
@@ -6,4 +6,3 @@
 // TODO: change to output.c module scope
 extern OBJECT_TEXTURE g_ObjectTextures[MAX_OBJECT_TEXTURES];
 extern SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES];
-extern ANIMATED_TEXTURE_RANGE *g_AnimTextureRanges;

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1081,32 +1081,7 @@ void Output_AnimateTextures(const int32_t num_frames)
     m_WibbleOffset = (m_WibbleOffset + num_frames) % WIBBLE_SIZE;
     m_AnimatedTexturesOffset += num_frames;
     while (m_AnimatedTexturesOffset > 5) {
-        const ANIMATED_TEXTURE_RANGE *range = g_AnimTextureRanges;
-        while (range != NULL) {
-            int32_t i = 0;
-            const OBJECT_TEXTURE temp = g_ObjectTextures[range->textures[i]];
-            for (; i < range->num_textures - 1; i++) {
-                g_ObjectTextures[range->textures[i]] =
-                    g_ObjectTextures[range->textures[i + 1]];
-            }
-            g_ObjectTextures[range->textures[i]] = temp;
-            range = range->next_range;
-        }
-
-        for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-            const STATIC_OBJECT_2D *const object = Object_GetStaticObject2D(i);
-            if (!object->loaded || object->frame_count == 1) {
-                continue;
-            }
-
-            const int16_t frame_count = object->frame_count;
-            const SPRITE_TEXTURE temp = g_SpriteTextures[object->texture_idx];
-            for (int32_t j = 0; j < frame_count - 1; j++) {
-                g_SpriteTextures[object->texture_idx + j] =
-                    g_SpriteTextures[object->texture_idx + j + 1];
-            }
-            g_SpriteTextures[object->texture_idx + frame_count - 1] = temp;
-        }
+        Output_CycleAnimatedTextures();
         m_AnimatedTexturesOffset -= 5;
     }
 }

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -46,7 +46,6 @@ uint16_t *g_Overlap = NULL;
 int16_t *g_GroundZone[2] = { NULL };
 int16_t *g_GroundZone2[2] = { NULL };
 int16_t *g_FlyZone[2] = { NULL };
-ANIMATED_TEXTURE_RANGE *g_AnimTextureRanges = NULL;
 int16_t g_NumCineFrames = 0;
 int16_t g_CineFrame = -1;
 CINE_CAMERA *g_CineCamera = NULL;

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -742,40 +742,6 @@ int16_t Output_FindColor(
     return best_idx;
 }
 
-void Output_DoAnimateTextures(const int32_t ticks)
-{
-    m_TickComp += ticks;
-    while (m_TickComp > TICKS_PER_FRAME * 5) {
-        const ANIMATED_TEXTURE_RANGE *range = g_AnimTextureRanges;
-        while (range != NULL) {
-            int32_t i = 0;
-            const OBJECT_TEXTURE temp = g_ObjectTextures[range->textures[i]];
-            for (; i < range->num_textures - 1; i++) {
-                g_ObjectTextures[range->textures[i]] =
-                    g_ObjectTextures[range->textures[i + 1]];
-            }
-            g_ObjectTextures[range->textures[i]] = temp;
-            range = range->next_range;
-        }
-
-        for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
-            const STATIC_OBJECT_2D *const object = Object_GetStaticObject2D(i);
-            if (!object->loaded || object->frame_count == 1) {
-                continue;
-            }
-
-            const int16_t frame_count = object->frame_count;
-            const SPRITE_TEXTURE temp = g_SpriteTextures[object->texture_idx];
-            for (int32_t j = 0; j < frame_count - 1; j++) {
-                g_SpriteTextures[object->texture_idx + j] =
-                    g_SpriteTextures[object->texture_idx + j + 1];
-            }
-            g_SpriteTextures[object->texture_idx + frame_count - 1] = temp;
-        }
-        m_TickComp -= TICKS_PER_FRAME * 5;
-    }
-}
-
 void Output_InsertShadow(
     int16_t radius, const BOUNDS_16 *bounds, const ITEM *item)
 {
@@ -933,7 +899,11 @@ void Output_AnimateTextures(const int32_t ticks)
             g_SunsetTimer * (WIBBLE_SIZE - 1) / SUNSET_TIMEOUT;
     }
 
-    Output_DoAnimateTextures(ticks);
+    m_TickComp += ticks;
+    while (m_TickComp > TICKS_PER_FRAME * 5) {
+        Output_CycleAnimatedTextures();
+        m_TickComp -= TICKS_PER_FRAME * 5;
+    }
 }
 
 void Output_SetLightAdder(const int32_t adder)

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -757,6 +757,21 @@ void Output_DoAnimateTextures(const int32_t ticks)
             g_ObjectTextures[range->textures[i]] = temp;
             range = range->next_range;
         }
+
+        for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {
+            const STATIC_OBJECT_2D *const object = Object_GetStaticObject2D(i);
+            if (!object->loaded || object->frame_count == 1) {
+                continue;
+            }
+
+            const int16_t frame_count = object->frame_count;
+            const SPRITE_TEXTURE temp = g_SpriteTextures[object->texture_idx];
+            for (int32_t j = 0; j < frame_count - 1; j++) {
+                g_SpriteTextures[object->texture_idx + j] =
+                    g_SpriteTextures[object->texture_idx + j + 1];
+            }
+            g_SpriteTextures[object->texture_idx + frame_count - 1] = temp;
+        }
         m_TickComp -= TICKS_PER_FRAME * 5;
     }
 }

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -74,7 +74,6 @@ void Output_DrawAirBar(int32_t percent);
 void Output_LoadBackgroundFromObject(void);
 
 int16_t Output_FindColor(int32_t red, int32_t green, int32_t blue);
-void Output_DoAnimateTextures(int32_t ticks);
 void Output_InsertShadow(
     int16_t radius, const BOUNDS_16 *bounds, const ITEM *item);
 

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -117,7 +117,6 @@ int32_t g_TexturePageCount;
 int32_t g_ObjectTextureCount;
 uint8_t g_LabTextureUVFlag[MAX_OBJECT_TEXTURES];
 int32_t g_NumCameras;
-ANIMATED_TEXTURE_RANGE *g_AnimTextureRanges = NULL;
 uint32_t *g_DemoData = NULL;
 char g_LevelFileName[256];
 uint16_t g_MusicTrackFlags[64];


### PR DESCRIPTION
Resolves #2401.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The main goal here was to get a common texture animation function, so adding support for animated sprites in TR2 was a given. Test level below for checking. I've also moved the range storage to the common output module.

I also realised I'd mistakenly logged the photo mode flip map fix in the TR2 changelog so have removed that (photo mode itself is unreleased).

[WALL.zip](https://github.com/user-attachments/files/18564794/WALL.zip)

