### PR TITLE
output: remove texture info globals

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -382,7 +382,7 @@ void Level_ReadObjectTextures(
     }
 
     for (int32_t i = 0; i < num_textures; i++) {
-        OBJECT_TEXTURE *const texture = &g_ObjectTextures[base_idx + i];
+        OBJECT_TEXTURE *const texture = Output_GetObjectTexture(base_idx + i);
         texture->draw_type = VFile_ReadU16(file);
         texture->tex_page = VFile_ReadU16(file) + base_page_idx;
         for (int32_t j = 0; j < 4; j++) {

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -404,7 +404,7 @@ void Level_ReadSpriteTextures(
     }
 
     for (int32_t i = 0; i < num_textures; i++) {
-        SPRITE_TEXTURE *const sprite = &g_SpriteTextures[base_idx + i];
+        SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(base_idx + i);
         sprite->tex_page = VFile_ReadU16(file) + base_page_idx;
         sprite->offset = VFile_ReadU16(file);
         sprite->width = VFile_ReadU16(file);

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -390,6 +390,8 @@ void Level_ReadObjectTextures(
             texture->uv[j].v = VFile_ReadU16(file);
         }
     }
+
+    Output_SetObjectTextureCount(base_idx + num_textures);
 }
 
 void Level_ReadSpriteTextures(

--- a/src/libtrx/game/output.c
+++ b/src/libtrx/game/output.c
@@ -13,6 +13,7 @@ typedef struct {
     int32_t shade;
 } COMMON_LIGHT;
 
+static OBJECT_TEXTURE m_ObjectTextures[MAX_OBJECT_TEXTURES] = {};
 static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = NULL;
 static int32_t m_DynamicLightCount = 0;
 static LIGHT m_DynamicLights[MAX_DYNAMIC_LIGHTS] = {};
@@ -118,17 +119,22 @@ ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(const int32_t range_idx)
     return &m_AnimTextureRanges[range_idx];
 }
 
+OBJECT_TEXTURE *Output_GetObjectTexture(const int32_t texture_idx)
+{
+    return &m_ObjectTextures[texture_idx];
+}
+
 void Output_CycleAnimatedTextures(void)
 {
     const ANIMATED_TEXTURE_RANGE *range = m_AnimTextureRanges;
     for (; range != NULL; range = range->next_range) {
         int32_t i = 0;
-        const OBJECT_TEXTURE temp = g_ObjectTextures[range->textures[i]];
+        const OBJECT_TEXTURE temp = m_ObjectTextures[range->textures[i]];
         for (; i < range->num_textures - 1; i++) {
-            g_ObjectTextures[range->textures[i]] =
-                g_ObjectTextures[range->textures[i + 1]];
+            m_ObjectTextures[range->textures[i]] =
+                m_ObjectTextures[range->textures[i + 1]];
         }
-        g_ObjectTextures[range->textures[i]] = temp;
+        m_ObjectTextures[range->textures[i]] = temp;
     }
 
     for (int32_t i = 0; i < MAX_STATIC_OBJECTS; i++) {

--- a/src/libtrx/game/output.c
+++ b/src/libtrx/game/output.c
@@ -14,6 +14,7 @@ typedef struct {
 } COMMON_LIGHT;
 
 static OBJECT_TEXTURE m_ObjectTextures[MAX_OBJECT_TEXTURES] = {};
+static SPRITE_TEXTURE m_SpriteTextures[MAX_SPRITE_TEXTURES] = {};
 static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = NULL;
 static int32_t m_DynamicLightCount = 0;
 static LIGHT m_DynamicLights[MAX_DYNAMIC_LIGHTS] = {};
@@ -124,6 +125,11 @@ OBJECT_TEXTURE *Output_GetObjectTexture(const int32_t texture_idx)
     return &m_ObjectTextures[texture_idx];
 }
 
+SPRITE_TEXTURE *Output_GetSpriteTexture(const int32_t texture_idx)
+{
+    return &m_SpriteTextures[texture_idx];
+}
+
 void Output_CycleAnimatedTextures(void)
 {
     const ANIMATED_TEXTURE_RANGE *range = m_AnimTextureRanges;
@@ -144,12 +150,12 @@ void Output_CycleAnimatedTextures(void)
         }
 
         const int16_t frame_count = object->frame_count;
-        const SPRITE_TEXTURE temp = g_SpriteTextures[object->texture_idx];
+        const SPRITE_TEXTURE temp = m_SpriteTextures[object->texture_idx];
         for (int32_t j = 0; j < frame_count - 1; j++) {
-            g_SpriteTextures[object->texture_idx + j] =
-                g_SpriteTextures[object->texture_idx + j + 1];
+            m_SpriteTextures[object->texture_idx + j] =
+                m_SpriteTextures[object->texture_idx + j + 1];
         }
-        g_SpriteTextures[object->texture_idx + frame_count - 1] = temp;
+        m_SpriteTextures[object->texture_idx + frame_count - 1] = temp;
     }
 }
 

--- a/src/libtrx/game/output.c
+++ b/src/libtrx/game/output.c
@@ -13,6 +13,7 @@ typedef struct {
     int32_t shade;
 } COMMON_LIGHT;
 
+static int32_t m_ObjectTextureCount = 0;
 static OBJECT_TEXTURE m_ObjectTextures[MAX_OBJECT_TEXTURES] = {};
 static SPRITE_TEXTURE m_SpriteTextures[MAX_SPRITE_TEXTURES] = {};
 static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = NULL;
@@ -118,6 +119,16 @@ void Output_InitialiseAnimatedTextures(const int32_t num_ranges)
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(const int32_t range_idx)
 {
     return &m_AnimTextureRanges[range_idx];
+}
+
+void Output_SetObjectTextureCount(const int32_t num_textures)
+{
+    m_ObjectTextureCount = num_textures;
+}
+
+int32_t Output_GetObjectTextureCount(void)
+{
+    return m_ObjectTextureCount;
 }
 
 OBJECT_TEXTURE *Output_GetObjectTexture(const int32_t texture_idx)

--- a/src/libtrx/game/packer.c
+++ b/src/libtrx/game/packer.c
@@ -110,7 +110,7 @@ static void M_PreparePaletteLUT(void)
 static void M_PrepareObject(const int32_t object_index)
 {
     const OBJECT_TEXTURE *const object_texture =
-        &g_ObjectTextures[object_index];
+        Output_GetObjectTexture(object_index);
     if (object_texture->tex_page == m_StartPage) {
         const RECTANGLE bounds = M_GetObjectBounds(object_texture);
         M_FillVirtualData(m_VirtualPages, bounds);
@@ -373,7 +373,7 @@ static bool M_PackContainerAt(
 static void M_MoveObject(
     const int32_t index, const RECTANGLE old_bounds, const TEX_POS new_pos)
 {
-    OBJECT_TEXTURE *const texture = &g_ObjectTextures[index];
+    OBJECT_TEXTURE *const texture = Output_GetObjectTexture(index);
     texture->tex_page = new_pos.page;
 
     int32_t x_diff = (new_pos.x - old_bounds.x) << 8;

--- a/src/libtrx/game/packer.c
+++ b/src/libtrx/game/packer.c
@@ -129,7 +129,7 @@ static void M_PrepareObject(const int32_t object_index)
 static void M_PrepareSprite(const int32_t sprite_index)
 {
     const SPRITE_TEXTURE *const sprite_texture =
-        &g_SpriteTextures[sprite_index];
+        Output_GetSpriteTexture(sprite_index);
     if (sprite_texture->tex_page == m_StartPage) {
         const RECTANGLE bounds = M_GetSpriteBounds(sprite_texture);
         M_FillVirtualData(m_VirtualPages, bounds);
@@ -394,7 +394,7 @@ static void M_MoveObject(
 static void M_MoveSprite(
     const int32_t index, const RECTANGLE old_bounds, const TEX_POS new_pos)
 {
-    SPRITE_TEXTURE *const texture = &g_SpriteTextures[index];
+    SPRITE_TEXTURE *const texture = Output_GetSpriteTexture(index);
     texture->tex_page = new_pos.page;
     texture->offset = (new_pos.y << 8) | new_pos.x;
 }

--- a/src/libtrx/include/libtrx/game/output.h
+++ b/src/libtrx/include/libtrx/game/output.h
@@ -2,7 +2,6 @@
 
 #include "./output/const.h"
 #include "./output/types.h"
-#include "./output/vars.h"
 #include "./rooms.h"
 
 #include <stdint.h>
@@ -39,6 +38,7 @@ extern void Output_LightRoomVertices(const ROOM *room);
 void Output_InitialiseAnimatedTextures(int32_t num_ranges);
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(int32_t range_idx);
 OBJECT_TEXTURE *Output_GetObjectTexture(int32_t texture_idx);
+SPRITE_TEXTURE *Output_GetSpriteTexture(int32_t texture_idx);
 void Output_CycleAnimatedTextures(void);
 
 void Output_CalculateLight(XYZ_32 pos, int16_t room_num);

--- a/src/libtrx/include/libtrx/game/output.h
+++ b/src/libtrx/include/libtrx/game/output.h
@@ -37,6 +37,8 @@ extern void Output_LightRoomVertices(const ROOM *room);
 
 void Output_InitialiseAnimatedTextures(int32_t num_ranges);
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(int32_t range_idx);
+void Output_SetObjectTextureCount(int32_t num_textures);
+int32_t Output_GetObjectTextureCount(void);
 OBJECT_TEXTURE *Output_GetObjectTexture(int32_t texture_idx);
 SPRITE_TEXTURE *Output_GetSpriteTexture(int32_t texture_idx);
 void Output_CycleAnimatedTextures(void);

--- a/src/libtrx/include/libtrx/game/output.h
+++ b/src/libtrx/include/libtrx/game/output.h
@@ -38,6 +38,7 @@ extern void Output_LightRoomVertices(const ROOM *room);
 
 void Output_InitialiseAnimatedTextures(int32_t num_ranges);
 ANIMATED_TEXTURE_RANGE *Output_GetAnimatedTextureRange(int32_t range_idx);
+OBJECT_TEXTURE *Output_GetObjectTexture(int32_t texture_idx);
 void Output_CycleAnimatedTextures(void);
 
 void Output_CalculateLight(XYZ_32 pos, int16_t room_num);

--- a/src/libtrx/include/libtrx/game/output/vars.h
+++ b/src/libtrx/include/libtrx/game/output/vars.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include "./const.h"
-#include "./types.h"
-
-// TODO: change to output.c module scope
-extern SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES];

--- a/src/libtrx/include/libtrx/game/output/vars.h
+++ b/src/libtrx/include/libtrx/game/output/vars.h
@@ -4,5 +4,4 @@
 #include "./types.h"
 
 // TODO: change to output.c module scope
-extern OBJECT_TEXTURE g_ObjectTextures[MAX_OBJECT_TEXTURES];
 extern SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES];

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -141,7 +141,7 @@ void Object_DrawPickupItem(ITEM *item)
         // First get the sprite that was to be used,
 
         int16_t spr_num = g_Objects[item->object_id].mesh_idx - item->frame_num;
-        const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[spr_num];
+        const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(spr_num);
 
         // and get the animation bounding box, which is not the mesh one.
         int16_t min_y = frame->bounds.min.y;

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -220,7 +220,7 @@ static void M_DrawRoomSprites(const ROOM_MESH *const mesh)
 
         const int32_t zv = vbuf->zv;
         const SPRITE_TEXTURE *const sprite =
-            &g_SpriteTextures[room_sprite->texture];
+            Output_GetSpriteTexture(room_sprite->texture);
         const int32_t zp = (zv / g_PhdPersp);
         const int32_t x0 =
             Viewport_GetCenterX() + (vbuf->xv + (sprite->x0 << W2V_SHIFT)) / zp;
@@ -841,7 +841,7 @@ void Output_DrawSprite(
         g_W2VMatrix._10 * x + g_W2VMatrix._11 * y + g_W2VMatrix._12 * z;
     int32_t zp = zv / g_PhdPersp;
 
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     const int32_t x0 =
         Viewport_GetCenterX() + (xv + (sprite->x0 << W2V_SHIFT)) / zp;
     const int32_t y0 =
@@ -925,7 +925,7 @@ void Output_DrawScreenSprite(
     int32_t sx, int32_t sy, int32_t z, int32_t scale_h, int32_t scale_v,
     int16_t sprnum, int16_t shade, uint16_t flags)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     const int32_t x0 = sx + (scale_h * (sprite->x0 >> 3) / PHD_ONE);
     const int32_t x1 = sx + (scale_h * (sprite->x1 >> 3) / PHD_ONE);
     const int32_t y0 = sy + (scale_v * (sprite->y0 >> 3) / PHD_ONE);
@@ -941,7 +941,7 @@ void Output_DrawScreenSprite2D(
     int32_t sx, int32_t sy, int32_t z, int32_t scale_h, int32_t scale_v,
     int32_t sprnum, int16_t shade, uint16_t flags, int32_t page)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     const int32_t x0 = sx + (scale_h * sprite->x0 / PHD_ONE);
     const int32_t x1 = sx + (scale_h * sprite->x1 / PHD_ONE);
     const int32_t y0 = sy + (scale_v * sprite->y0 / PHD_ONE);
@@ -967,7 +967,7 @@ void Output_DrawSpriteRel(
         + g_MatrixPtr->_12 * z + g_MatrixPtr->_13;
     int32_t zp = zv / g_PhdPersp;
 
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     const int32_t x0 =
         Viewport_GetCenterX() + (xv + (sprite->x0 << W2V_SHIFT)) / zp;
     const int32_t y0 =
@@ -988,7 +988,7 @@ void Output_DrawSpriteRel(
 void Output_DrawUISprite(
     int32_t x, int32_t y, int32_t scale, int16_t sprnum, int16_t shade)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     const int32_t x0 = x + (scale * sprite->x0 >> 16);
     const int32_t x1 = x + (scale * sprite->x1 >> 16);
     const int32_t y0 = y + (scale * sprite->y0 >> 16);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -140,7 +140,7 @@ static void M_DrawTexturedFace3s(const FACE3 *const faces, const int32_t count)
             &m_VBuf[face->vertices[2]],
         };
 
-        OBJECT_TEXTURE *const tex = &g_ObjectTextures[face->texture_idx];
+        OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
         S_Output_DrawTexturedTriangle(
             vns[0], vns[1], vns[2], tex->tex_page, &tex->uv[0], &tex->uv[1],
             &tex->uv[2], tex->draw_type);
@@ -160,7 +160,7 @@ static void M_DrawTexturedFace4s(const FACE4 *const faces, const int32_t count)
             &m_VBuf[face->vertices[3]],
         };
 
-        OBJECT_TEXTURE *const tex = &g_ObjectTextures[face->texture_idx];
+        OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
         S_Output_DrawTexturedQuad(
             vns[0], vns[1], vns[2], vns[3], tex->tex_page, &tex->uv[0],
             &tex->uv[1], &tex->uv[2], &tex->uv[3], tex->draw_type);

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -18,8 +18,6 @@ int32_t g_PhdTop = 0;
 float g_FltResZ;
 float g_FltResZBuf;
 
-SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES] = {};
-
 LARA_INFO g_Lara = {};
 ITEM *g_LaraItem = NULL;
 GAME_INFO g_GameInfo = {};

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -19,7 +19,6 @@ float g_FltResZ;
 float g_FltResZBuf;
 
 SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES] = {};
-OBJECT_TEXTURE g_ObjectTextures[MAX_OBJECT_TEXTURES] = {};
 
 LARA_INFO g_Lara = {};
 ITEM *g_LaraItem = NULL;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -5,7 +5,6 @@
 
 #include <libtrx/game/camera/vars.h>
 #include <libtrx/game/inventory_ring/enum.h>
-#include <libtrx/game/output/vars.h>
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -527,7 +527,7 @@ void S_Output_DrawSprite(
 
     float multiplier = g_Config.visuals.brightness / 16.0f;
 
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprnum];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprnum);
     float vshade = (8192.0f - shade) * multiplier;
     if (vshade >= 256.0f) {
         vshade = 255.0f;

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -314,7 +314,6 @@ static void M_LoadTextures(VFILE *const file)
     Level_ReadObjectTextures(0, 0, num_textures, file);
 
     // TODO: handle this post-injection/packing
-    g_ObjectTextureCount = num_textures;
     for (int32_t i = 0; i < num_textures; i++) {
         OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
         uint16_t *const uv = &texture->uv[0].u;
@@ -856,5 +855,5 @@ void Level_Unload(void)
     strcpy(g_LevelFileName, "");
     memset(g_TexturePageBuffer8, 0, sizeof(uint8_t *) * MAX_TEXTURE_PAGES);
     memset(g_TexturePageBuffer16, 0, sizeof(uint16_t *) * MAX_TEXTURE_PAGES);
-    g_ObjectTextureCount = 0;
+    Output_SetObjectTextureCount(0);
 }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -312,27 +312,6 @@ static void M_LoadTextures(VFILE *const file)
     const int32_t num_textures = VFile_ReadS32(file);
     LOG_INFO("object textures: %d", num_textures);
     Level_ReadObjectTextures(0, 0, num_textures, file);
-
-    // TODO: handle this post-injection/packing
-    for (int32_t i = 0; i < num_textures; i++) {
-        OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
-        uint16_t *const uv = &texture->uv[0].u;
-        uint8_t byte = 0;
-        for (int32_t j = 0; j < 8; j++) {
-            if ((uv[j] & 0x80) != 0) {
-                uv[j] |= 0xFF;
-                byte |= 1 << j;
-            } else {
-                uv[j] &= 0xFF00;
-            }
-        }
-        g_LabTextureUVFlag[i] = byte;
-
-        for (int32_t j = 0; j < 4; j++) {
-            texture->uv_backup[j] = texture->uv[j];
-        }
-    }
-
     Benchmark_End(benchmark, NULL);
 }
 
@@ -757,7 +736,8 @@ static void M_CompleteSetup(void)
         Item_Initialise(i);
     }
 
-    Render_Reset(RENDER_RESET_PALETTE | RENDER_RESET_TEXTURES);
+    Render_Reset(
+        RENDER_RESET_PALETTE | RENDER_RESET_TEXTURES | RENDER_RESET_UVS);
 
     Benchmark_End(benchmark, NULL);
 }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -316,7 +316,8 @@ static void M_LoadTextures(VFILE *const file)
     // TODO: handle this post-injection/packing
     g_ObjectTextureCount = num_textures;
     for (int32_t i = 0; i < num_textures; i++) {
-        uint16_t *const uv = &g_ObjectTextures[i].uv[0].u;
+        OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
+        uint16_t *const uv = &texture->uv[0].u;
         uint8_t byte = 0;
         for (int32_t j = 0; j < 8; j++) {
             if ((uv[j] & 0x80) != 0) {
@@ -329,7 +330,7 @@ static void M_LoadTextures(VFILE *const file)
         g_LabTextureUVFlag[i] = byte;
 
         for (int32_t j = 0; j < 4; j++) {
-            g_ObjectTextures[i].uv_backup[j] = g_ObjectTextures[i].uv[j];
+            texture->uv_backup[j] = texture->uv[j];
         }
     }
 

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -283,7 +283,7 @@ static void M_DrawRoomSprites(const ROOM_MESH *const mesh)
         }
 
         const SPRITE_TEXTURE *const sprite =
-            &g_SpriteTextures[room_sprite->texture];
+            Output_GetSpriteTexture(room_sprite->texture);
         const double persp = (double)(vbuf->zv / g_PhdPersp);
         const double x0 =
             g_PhdWinCenterX + (vbuf->xv + (sprite->x0 << W2V_SHIFT)) / persp;
@@ -496,7 +496,7 @@ void Output_DrawSprite(
         yv = mptr->_13;
     }
 
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
     int32_t x0 = sprite->x0;
     int32_t y0 = sprite->y0;
     int32_t x1 = sprite->x1;
@@ -555,7 +555,7 @@ void Output_DrawPickup(
     const int32_t sx, const int32_t sy, const int32_t scale,
     const int16_t sprite_idx, const int16_t shade)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
     const int32_t x0 = sx + ((sprite->x0 * scale) / PHD_ONE);
     const int32_t y0 = sy + ((sprite->y0 * scale) / PHD_ONE);
     const int32_t x1 = sx + ((sprite->x1 * scale) / PHD_ONE);
@@ -570,7 +570,7 @@ void Output_DrawScreenSprite2D(
     const int32_t scale_v, const int16_t sprite_idx, const int16_t shade,
     const uint16_t flags)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
     const int32_t x0 = sx + ((sprite->x0 * scale_h) / PHD_ONE);
     const int32_t y0 = sy + ((sprite->y0 * scale_v) / PHD_ONE);
     const int32_t x1 = sx + ((sprite->x1 * scale_h) / PHD_ONE);
@@ -586,7 +586,7 @@ void Output_DrawScreenSprite(
     const int32_t scale_v, const int16_t sprite_idx, const int16_t shade,
     const uint16_t flags)
 {
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
     const int32_t x0 = sx + (((sprite->x0 / 8) * scale_h) / PHD_ONE);
     const int32_t x1 = sx + (((sprite->x1 / 8) * scale_h) / PHD_ONE);
     const int32_t y0 = sy + (((sprite->y0 / 8) * scale_v) / PHD_ONE);

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -641,7 +641,7 @@ void Output_LoadBackgroundFromObject(void)
     }
 
     const int32_t texture_idx = mesh->tex_face4s[0].texture_idx;
-    const OBJECT_TEXTURE *const texture = &g_ObjectTextures[texture_idx];
+    const OBJECT_TEXTURE *const texture = Output_GetObjectTexture(texture_idx);
     Render_LoadBackgroundFromTexture(texture, 8, 6);
     return;
 }

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -173,6 +173,9 @@ void Render_Reset(const RENDER_RESET_FLAGS reset_flags)
 
     r->Reset(r, reset_flags);
 
+    if (reset_flags & (RENDER_RESET_PARAMS | RENDER_RESET_UVS)) {
+        Render_ResetTextureUVs();
+    }
     if (reset_flags & (RENDER_RESET_PARAMS | RENDER_RESET_TEXTURES)) {
         Render_AdjustTextureUVs(reset_flags & RENDER_RESET_TEXTURES);
         M_ReuploadBackground();

--- a/src/tr2/game/render/common.h
+++ b/src/tr2/game/render/common.h
@@ -19,6 +19,7 @@ typedef enum {
     RENDER_RESET_PALETTE  = 1 << 1,
     RENDER_RESET_TEXTURES = 1 << 2,
     RENDER_RESET_PARAMS   = 1 << 3,
+    RENDER_RESET_UVS      = 1 << 4,
     RENDER_RESET_ALL      = INT32_MAX,
     // clang-format on
 } RENDER_RESET_FLAGS;

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -833,7 +833,7 @@ static void M_InsertSprite_Sorted(
 
     int32_t num_points = 4;
 
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
     const double rhw = g_RhwFactor / (double)z;
     const int32_t u_offset = (sprite->offset & 0xFF) * 256;
     const int32_t v_offset = (sprite->offset >> 8) * 256;

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -695,7 +695,7 @@ static void M_InsertTexturedFace3s_Sorted(
         };
 
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
         const TEXTURE_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
@@ -726,7 +726,7 @@ static void M_InsertTexturedFace4s_Sorted(
         };
 
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;
         }
@@ -1269,7 +1269,7 @@ static void M_InsertTexturedFace3s_ZBuffered(
             &g_PhdVBuf[face->vertices[2]],
         };
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;
@@ -1302,7 +1302,7 @@ static void M_InsertTexturedFace4s_ZBuffered(
 
         };
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
             continue;

--- a/src/tr2/game/render/priv.c
+++ b/src/tr2/game/render/priv.c
@@ -122,8 +122,9 @@ void Render_AdjustTextureUVs(const bool reset_uv_add)
 
     const int32_t offset = Render_GetUVAdjustment();
     for (int32_t i = 0; i < g_ObjectTextureCount; i++) {
-        TEXTURE_UV *const uv = g_ObjectTextures[i].uv;
-        const TEXTURE_UV *const uv_backup = g_ObjectTextures[i].uv_backup;
+        OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
+        TEXTURE_UV *const uv = texture->uv;
+        const TEXTURE_UV *const uv_backup = texture->uv_backup;
         int32_t uv_flags = g_LabTextureUVFlag[i];
         for (int32_t j = 0; j < 4; j++) {
             uv[j].u = uv_backup[j].u + ((uv_flags & 1) ? -offset : offset);

--- a/src/tr2/game/render/priv.c
+++ b/src/tr2/game/render/priv.c
@@ -116,12 +116,13 @@ int32_t Render_GetUVAdjustment(void)
 
 void Render_AdjustTextureUVs(const bool reset_uv_add)
 {
-    if (g_ObjectTextureCount <= 0) {
+    const int32_t num_textures = Output_GetObjectTextureCount();
+    if (num_textures <= 0) {
         return;
     }
 
     const int32_t offset = Render_GetUVAdjustment();
-    for (int32_t i = 0; i < g_ObjectTextureCount; i++) {
+    for (int32_t i = 0; i < num_textures; i++) {
         OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
         TEXTURE_UV *const uv = texture->uv;
         const TEXTURE_UV *const uv_backup = texture->uv_backup;

--- a/src/tr2/game/render/priv.h
+++ b/src/tr2/game/render/priv.h
@@ -71,6 +71,7 @@ double Render_CalculatePolyZ(
 
 void Render_SortPolyList(void);
 int32_t Render_GetUVAdjustment(void);
+void Render_ResetTextureUVs(void);
 void Render_AdjustTextureUVs(bool reset_uv_add);
 
 int32_t Render_VisibleZClip(

--- a/src/tr2/game/render/swr.c
+++ b/src/tr2/game/render/swr.c
@@ -1244,7 +1244,7 @@ static void M_DrawScaledSpriteC(
     }
 
     const DEPTHQ_ENTRY *const depth = &g_DepthQTable[shade >> 8];
-    const SPRITE_TEXTURE *const sprite = &g_SpriteTextures[sprite_idx];
+    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
 
     int32_t u_base = 0x4000;
     int32_t v_base = 0x4000;

--- a/src/tr2/game/render/swr.c
+++ b/src/tr2/game/render/swr.c
@@ -1684,7 +1684,7 @@ static void M_InsertTexturedFace3s(
         };
 
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
         const TEXTURE_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
@@ -1904,7 +1904,7 @@ static void M_InsertTexturedFace4s(
         };
 
         const OBJECT_TEXTURE *const texture =
-            &g_ObjectTextures[face->texture_idx];
+            Output_GetObjectTexture(face->texture_idx);
         const TEXTURE_UV *const uv = texture->uv;
 
         if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -25,7 +25,6 @@ bool g_GymInvOpenEnabled = true; // TODO: make me configurable
 int32_t g_MidSort = 0;
 GOURAUD_ENTRY g_GouraudTable[256];
 int32_t g_PhdWinTop;
-SPRITE_TEXTURE g_SpriteTextures[MAX_SPRITE_TEXTURES];
 int32_t g_LsAdder;
 float g_FltWinBottom;
 float g_FltResZBuf;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -112,7 +112,6 @@ int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;
 int32_t g_TexturePageCount;
-int32_t g_ObjectTextureCount;
 uint8_t g_LabTextureUVFlag[MAX_OBJECT_TEXTURES];
 int32_t g_NumCameras;
 uint32_t *g_DemoData = NULL;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -112,7 +112,6 @@ int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;
 int32_t g_TexturePageCount;
-uint8_t g_LabTextureUVFlag[MAX_OBJECT_TEXTURES];
 int32_t g_NumCameras;
 uint32_t *g_DemoData = NULL;
 char g_LevelFileName[256];

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -13,7 +13,6 @@ int16_t g_RoomsToDrawCount = 0;
 
 const float g_RhwFactor = 0x14000000.p0;
 uint16_t *g_TexturePageBuffer16[MAX_TEXTURE_PAGES] = {};
-OBJECT_TEXTURE g_ObjectTextures[MAX_OBJECT_TEXTURES];
 
 SDL_Window *g_SDLWindow = NULL;
 

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -110,7 +110,6 @@ extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;
 extern int32_t g_TexturePageCount;
-extern uint8_t g_LabTextureUVFlag[MAX_OBJECT_TEXTURES];
 extern int32_t g_NumCameras;
 extern uint32_t *g_DemoData;
 extern char g_LevelFileName[256];

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -110,7 +110,6 @@ extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;
 extern int32_t g_TexturePageCount;
-extern int32_t g_ObjectTextureCount;
 extern uint8_t g_LabTextureUVFlag[MAX_OBJECT_TEXTURES];
 extern int32_t g_NumCameras;
 extern uint32_t *g_DemoData;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -4,7 +4,6 @@
 #include "global/types.h"
 
 #include <libtrx/game/camera/vars.h>
-#include <libtrx/game/output/vars.h>
 #include <libtrx/gfx/context.h>
 
 #include <SDL2/SDL.h>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes `g_ObjectTextures`, `g_SpriteTextures`, `g_ObjectTextureCount` and `g_LabTextureUVFlag` in favour of common accessors. LMK about the last commit for the renderer if this is an acceptable approach. We would have to shift the routine for setting up the UV adjustments anyway ahead of injection work to allow for additional tex infos to be added, so thought it best to tackle now.

Just a quick test is needed I think in game to ensure textures appear OK, as well as sprites, and with bilinear toggled and SWR etc.
