### PR TITLE
level: refactor LEVEL_INFO

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -326,6 +326,15 @@ void Level_ReadAnimBones(
     }
 }
 
+void Level_LoadAnimFrames(LEVEL_INFO *const info)
+{
+    const int32_t frame_count =
+        Anim_GetTotalFrameCount(info->anims.frame_count);
+    Anim_InitialiseFrames(frame_count);
+    Anim_LoadFrames(info->anims.frames, info->anims.frame_count);
+    Memory_FreePointer(&info->anims.frames);
+}
+
 void Level_ReadObjects(const int32_t num_objects, VFILE *const file)
 {
     for (int32_t i = 0; i < num_objects; i++) {

--- a/src/libtrx/include/libtrx/game/level.h
+++ b/src/libtrx/include/libtrx/game/level.h
@@ -1,3 +1,4 @@
 #pragma once
 
 #include "level/common.h"
+#include "level/types.h"

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../virtual_file.h"
+#include "./types.h"
 
 #define ANIM_BONE_SIZE 4
 
@@ -15,6 +16,7 @@ void Level_InitialiseAnimCommands(int32_t num_cmds);
 void Level_ReadAnimCommands(int32_t base_idx, int32_t num_cmds, VFILE *file);
 void Level_LoadAnimCommands(void);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
+void Level_LoadAnimFrames(LEVEL_INFO *info);
 void Level_ReadObjects(int32_t num_objects, VFILE *file);
 void Level_ReadStaticObjects(int32_t num_objects, VFILE *file);
 void Level_ReadObjectTextures(

--- a/src/libtrx/include/libtrx/game/level/types.h
+++ b/src/libtrx/include/libtrx/game/level/types.h
@@ -3,22 +3,22 @@
 #include "../output/types.h"
 
 typedef struct {
-    int32_t mesh_count;
+    struct {
+        int32_t anim_count;
+        int32_t change_count;
+        int32_t range_count;
+        int32_t command_count;
+        int32_t bone_count;
+        int32_t frame_count;
+        int16_t *frames;
+    } anims;
     int32_t mesh_ptr_count;
-    int32_t anim_count;
-    int32_t anim_change_count;
-    int32_t anim_range_count;
-    int32_t anim_command_count;
-    int32_t anim_bone_count;
-    int32_t anim_frame_data_count;
-    int16_t *anim_frame_data;
     int32_t texture_count;
     int32_t texture_page_count;
     uint8_t *texture_palette_page_ptrs;
     RGBA_8888 *texture_rgb_page_ptrs;
     int32_t item_count;
     int32_t sprite_info_count;
-    int32_t overlap_count;
     int32_t sample_info_count;
     int32_t sample_count;
     int32_t *sample_offsets;

--- a/src/libtrx/include/libtrx/game/level/types.h
+++ b/src/libtrx/include/libtrx/game/level/types.h
@@ -25,11 +25,17 @@ typedef struct {
         int32_t size;
         RGB_888 *data_24;
     } palette;
+
+    struct {
+        int32_t info_count;
+        int32_t offset_count;
+        int32_t *offsets;
+#if TR_VERSION == 1
+        int32_t data_size;
+        char *data;
+#endif
+    } samples;
+
     int32_t mesh_ptr_count;
     int32_t item_count;
-    int32_t sample_info_count;
-    int32_t sample_count;
-    int32_t *sample_offsets;
-    int32_t sample_data_size;
-    char *sample_data;
 } LEVEL_INFO;

--- a/src/libtrx/include/libtrx/game/level/types.h
+++ b/src/libtrx/include/libtrx/game/level/types.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../output/types.h"
+
+typedef struct {
+    int32_t mesh_count;
+    int32_t mesh_ptr_count;
+    int32_t anim_count;
+    int32_t anim_change_count;
+    int32_t anim_range_count;
+    int32_t anim_command_count;
+    int32_t anim_bone_count;
+    int32_t anim_frame_data_count;
+    int16_t *anim_frame_data;
+    int32_t texture_count;
+    int32_t texture_page_count;
+    uint8_t *texture_palette_page_ptrs;
+    RGBA_8888 *texture_rgb_page_ptrs;
+    int32_t item_count;
+    int32_t sprite_info_count;
+    int32_t overlap_count;
+    int32_t sample_info_count;
+    int32_t sample_count;
+    int32_t *sample_offsets;
+    int32_t sample_data_size;
+    char *sample_data;
+    RGB_888 *palette;
+    int32_t palette_size;
+} LEVEL_INFO;

--- a/src/libtrx/include/libtrx/game/level/types.h
+++ b/src/libtrx/include/libtrx/game/level/types.h
@@ -12,18 +12,24 @@ typedef struct {
         int32_t frame_count;
         int16_t *frames;
     } anims;
+
+    struct {
+        int32_t object_count;
+        int32_t sprite_count;
+        int32_t page_count;
+        uint8_t *pages_24;
+        RGBA_8888 *pages_32;
+    } textures;
+
+    struct {
+        int32_t size;
+        RGB_888 *data_24;
+    } palette;
     int32_t mesh_ptr_count;
-    int32_t texture_count;
-    int32_t texture_page_count;
-    uint8_t *texture_palette_page_ptrs;
-    RGBA_8888 *texture_rgb_page_ptrs;
     int32_t item_count;
-    int32_t sprite_info_count;
     int32_t sample_info_count;
     int32_t sample_count;
     int32_t *sample_offsets;
     int32_t sample_data_size;
     char *sample_data;
-    RGB_888 *palette;
-    int32_t palette_size;
 } LEVEL_INFO;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -629,29 +629,29 @@ static void M_SFXData(INJECTION *injection, LEVEL_INFO *level_info)
 
     for (int32_t i = 0; i < inj_info->sfx_count; i++) {
         const int16_t sfx_id = VFile_ReadS16(fp);
-        g_SampleLUT[sfx_id] = level_info->sample_info_count;
+        g_SampleLUT[sfx_id] = level_info->samples.info_count;
 
         SAMPLE_INFO *sample_info =
-            &g_SampleInfos[level_info->sample_info_count];
+            &g_SampleInfos[level_info->samples.info_count];
         sample_info->volume = VFile_ReadS16(fp);
         sample_info->randomness = VFile_ReadS16(fp);
         sample_info->flags = VFile_ReadS16(fp);
-        sample_info->number = level_info->sample_count;
+        sample_info->number = level_info->samples.offset_count;
 
         int16_t num_samples = (sample_info->flags >> 2) & 15;
         for (int32_t j = 0; j < num_samples; j++) {
             const int32_t sample_length = VFile_ReadS32(fp);
             VFile_Read(
-                fp, level_info->sample_data + level_info->sample_data_size,
+                fp, level_info->samples.data + level_info->samples.data_size,
                 sizeof(char) * sample_length);
 
-            level_info->sample_offsets[level_info->sample_count] =
-                level_info->sample_data_size;
-            level_info->sample_data_size += sample_length;
-            level_info->sample_count++;
+            level_info->samples.offsets[level_info->samples.offset_count] =
+                level_info->samples.data_size;
+            level_info->samples.data_size += sample_length;
+            level_info->samples.offset_count++;
         }
 
-        level_info->sample_info_count++;
+        level_info->samples.info_count++;
     }
 
     Benchmark_End(benchmark, NULL);

--- a/src/tr1/game/inject.h
+++ b/src/tr1/game/inject.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "global/types.h"
-
 #include <libtrx/game/inject.h>
+#include <libtrx/game/level.h>
 
 typedef struct {
     int32_t texture_page_count;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -1062,8 +1062,3 @@ bool Level_Initialise(const GAME_FLOW_LEVEL *const level)
     Benchmark_End(benchmark, NULL);
     return true;
 }
-
-const LEVEL_INFO *Level_GetInfo(void)
-{
-    return &m_LevelInfo;
-}

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -390,11 +390,11 @@ static void M_LoadRooms(VFILE *file)
 static void M_LoadObjectMeshes(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.mesh_count = VFile_ReadS32(file);
-    LOG_INFO("%d object mesh data", m_LevelInfo.mesh_count);
+    const int32_t num_meshes = VFile_ReadS32(file);
+    LOG_INFO("%d object mesh data", num_meshes);
 
     const size_t data_start_pos = VFile_GetPos(file);
-    VFile_Skip(file, m_LevelInfo.mesh_count * sizeof(int16_t));
+    VFile_Skip(file, num_meshes * sizeof(int16_t));
 
     m_LevelInfo.mesh_ptr_count = VFile_ReadS32(file);
     LOG_INFO("%d object mesh indices", m_LevelInfo.mesh_ptr_count);
@@ -418,54 +418,57 @@ static void M_LoadObjectMeshes(VFILE *const file)
 static void M_LoadAnims(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_count = VFile_ReadS32(file);
-    LOG_INFO("%d anims", m_LevelInfo.anim_count);
-    Anim_InitialiseAnims(m_LevelInfo.anim_count + m_InjectionInfo->anim_count);
-    Level_ReadAnims(0, m_LevelInfo.anim_count, file);
+    const int32_t num_anims = VFile_ReadS32(file);
+    m_LevelInfo.anims.anim_count = num_anims;
+    LOG_INFO("%d anims", num_anims);
+    Anim_InitialiseAnims(num_anims + m_InjectionInfo->anim_count);
+    Level_ReadAnims(0, num_anims, file);
     Benchmark_End(benchmark, NULL);
 }
 
 static void M_LoadAnimChanges(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_change_count = VFile_ReadS32(file);
-    LOG_INFO("%d anim changes", m_LevelInfo.anim_change_count);
+    const int32_t num_anim_changes = VFile_ReadS32(file);
+    m_LevelInfo.anims.change_count = num_anim_changes;
+    LOG_INFO("%d anim changes", num_anim_changes);
     Anim_InitialiseChanges(
-        m_LevelInfo.anim_change_count + m_InjectionInfo->anim_change_count);
-    Level_ReadAnimChanges(0, m_LevelInfo.anim_change_count, file);
+        num_anim_changes + m_InjectionInfo->anim_change_count);
+    Level_ReadAnimChanges(0, num_anim_changes, file);
     Benchmark_End(benchmark, NULL);
 }
 
 static void M_LoadAnimRanges(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_range_count = VFile_ReadS32(file);
-    LOG_INFO("%d anim ranges", m_LevelInfo.anim_range_count);
-    Anim_InitialiseRanges(
-        m_LevelInfo.anim_range_count + m_InjectionInfo->anim_range_count);
-    Level_ReadAnimRanges(0, m_LevelInfo.anim_range_count, file);
+    const int32_t num_anim_ranges = VFile_ReadS32(file);
+    m_LevelInfo.anims.range_count = num_anim_ranges;
+    LOG_INFO("%d anim ranges", num_anim_ranges);
+    Anim_InitialiseRanges(num_anim_ranges + m_InjectionInfo->anim_range_count);
+    Level_ReadAnimRanges(0, num_anim_ranges, file);
     Benchmark_End(benchmark, NULL);
 }
 
 static void M_LoadAnimCommands(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_command_count = VFile_ReadS32(file);
-    LOG_INFO("%d anim commands", m_LevelInfo.anim_command_count);
+    const int32_t num_anim_commands = VFile_ReadS32(file);
+    m_LevelInfo.anims.command_count = num_anim_commands;
+    LOG_INFO("%d anim commands", num_anim_commands);
     Level_InitialiseAnimCommands(
-        m_LevelInfo.anim_command_count + m_InjectionInfo->anim_cmd_count);
-    Level_ReadAnimCommands(0, m_LevelInfo.anim_command_count, file);
+        num_anim_commands + m_InjectionInfo->anim_cmd_count);
+    Level_ReadAnimCommands(0, num_anim_commands, file);
     Benchmark_End(benchmark, NULL);
 }
 
 static void M_LoadAnimBones(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    m_LevelInfo.anim_bone_count = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-    LOG_INFO("%d anim bones", m_LevelInfo.anim_bone_count);
-    Anim_InitialiseBones(
-        m_LevelInfo.anim_bone_count + m_InjectionInfo->anim_bone_count);
-    Level_ReadAnimBones(0, m_LevelInfo.anim_bone_count, file);
+    const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
+    m_LevelInfo.anims.bone_count = num_anim_bones;
+    LOG_INFO("%d anim bones", num_anim_bones);
+    Anim_InitialiseBones(num_anim_bones + m_InjectionInfo->anim_bone_count);
+    Level_ReadAnimBones(0, num_anim_bones, file);
     Benchmark_End(benchmark, NULL);
 }
 
@@ -473,13 +476,13 @@ static void M_LoadAnimFrames(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
     const int32_t raw_data_count = VFile_ReadS32(file);
-    m_LevelInfo.anim_frame_data_count = raw_data_count;
-    LOG_INFO("%d raw anim frames", m_LevelInfo.anim_frame_data_count);
-    m_LevelInfo.anim_frame_data = Memory_Alloc(
+    m_LevelInfo.anims.frame_count = raw_data_count;
+    LOG_INFO("%d raw anim frames", raw_data_count);
+    m_LevelInfo.anims.frames = Memory_Alloc(
         sizeof(int16_t)
         * (raw_data_count + m_InjectionInfo->anim_frame_data_count));
     VFile_Read(
-        file, m_LevelInfo.anim_frame_data, sizeof(int16_t) * raw_data_count);
+        file, m_LevelInfo.anims.frames, sizeof(int16_t) * raw_data_count);
     Benchmark_End(benchmark, NULL);
 }
 
@@ -589,10 +592,9 @@ static void M_LoadBoxes(VFILE *file)
         box->overlap_index = VFile_ReadS16(file);
     }
 
-    m_LevelInfo.overlap_count = VFile_ReadS32(file);
-    g_Overlap = GameBuf_Alloc(
-        sizeof(uint16_t) * m_LevelInfo.overlap_count, GBUF_OVERLAPS);
-    VFile_Read(file, g_Overlap, sizeof(uint16_t) * m_LevelInfo.overlap_count);
+    const int32_t num_overlaps = VFile_ReadS32(file);
+    g_Overlap = GameBuf_Alloc(sizeof(uint16_t) * num_overlaps, GBUF_OVERLAPS);
+    VFile_Read(file, g_Overlap, sizeof(uint16_t) * num_overlaps);
 
     for (int i = 0; i < 2; i++) {
         g_GroundZone[i] =
@@ -822,11 +824,10 @@ static void M_CompleteSetup(const GAME_FLOW_LEVEL *const level)
     Inject_AllInjections(&m_LevelInfo);
 
     const int32_t frame_count =
-        Anim_GetTotalFrameCount(m_LevelInfo.anim_frame_data_count);
+        Anim_GetTotalFrameCount(m_LevelInfo.anims.frame_count);
     Anim_InitialiseFrames(frame_count);
-    Anim_LoadFrames(
-        m_LevelInfo.anim_frame_data, m_LevelInfo.anim_frame_data_count);
-    Memory_FreePointer(&m_LevelInfo.anim_frame_data);
+    Anim_LoadFrames(m_LevelInfo.anims.frames, m_LevelInfo.anims.frame_count);
+    Memory_FreePointer(&m_LevelInfo.anims.frames);
 
     Level_LoadAnimCommands();
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -817,12 +817,7 @@ static void M_CompleteSetup(const GAME_FLOW_LEVEL *const level)
 
     Inject_AllInjections(&m_LevelInfo);
 
-    const int32_t frame_count =
-        Anim_GetTotalFrameCount(m_LevelInfo.anims.frame_count);
-    Anim_InitialiseFrames(frame_count);
-    Anim_LoadFrames(m_LevelInfo.anims.frames, m_LevelInfo.anims.frame_count);
-    Memory_FreePointer(&m_LevelInfo.anims.frames);
-
+    Level_LoadAnimFrames(&m_LevelInfo);
     Level_LoadAnimCommands();
 
     M_MarkWaterEdgeVertices();

--- a/src/tr1/game/level.h
+++ b/src/tr1/game/level.h
@@ -1,10 +1,6 @@
 #pragma once
 
 #include "game/game_flow/types.h"
-#include "global/types.h"
-
-#include <stdint.h>
 
 void Level_Load(const GAME_FLOW_LEVEL *level);
 bool Level_Initialise(const GAME_FLOW_LEVEL *level);
-const LEVEL_INFO *Level_GetInfo(void);

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -285,7 +285,6 @@ static void M_WriteLara(LARA_INFO *lara)
 
 static void M_WriteArm(LARA_ARM *arm)
 {
-    const LEVEL_INFO *const level_info = Level_GetInfo();
     // frame_base is not required
     const int32_t frame_base = 0;
     M_Write(&frame_base, sizeof(int32_t));

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -341,29 +341,3 @@ typedef struct {
     int16_t randomness;
     int16_t flags;
 } SAMPLE_INFO;
-
-typedef struct {
-    int32_t mesh_count;
-    int32_t mesh_ptr_count;
-    int32_t anim_count;
-    int32_t anim_change_count;
-    int32_t anim_range_count;
-    int32_t anim_command_count;
-    int32_t anim_bone_count;
-    int32_t anim_frame_data_count;
-    int16_t *anim_frame_data;
-    int32_t texture_count;
-    int32_t texture_page_count;
-    uint8_t *texture_palette_page_ptrs;
-    RGBA_8888 *texture_rgb_page_ptrs;
-    int32_t item_count;
-    int32_t sprite_info_count;
-    int32_t overlap_count;
-    int32_t sample_info_count;
-    int32_t sample_count;
-    int32_t *sample_offsets;
-    int32_t sample_data_size;
-    char *sample_data;
-    RGB_888 *palette;
-    int32_t palette_size;
-} LEVEL_INFO;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This refactors the `LEVEL_INFO` struct by renaming some properties and reorganising them into sub structs, just for slightly better organisation. It has also been moved to TRX, and I've introduced it in TR2's level module, where we currently use it in the same way as TR1 for anim frames. Using it fully throughout in TR2 will come later as we add more injection support.

This is a stepping stone to common texture page handling as well.
