### PR TITLE
level: fix reading mesh radius

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -50,7 +50,8 @@ static void M_ReadFace3(FACE3 *const face, VFILE *const file)
 static void M_ReadObjectMesh(OBJECT_MESH *const mesh, VFILE *const file)
 {
     M_ReadVertex(&mesh->center, file);
-    mesh->radius = VFile_ReadS32(file);
+    mesh->radius = VFile_ReadS16(file);
+    VFile_Skip(file, sizeof(int16_t));
 
     mesh->enable_reflections = false;
 


### PR DESCRIPTION
Resolves #2407.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes interpreting mesh radii as int32 rather than int16. This bug has been around for a while, but no meshes have caused us an issue so far. The original code would only assign the first int16 from the raw data array for such things as sphere radii.
