### PR TITLE
build: fix Linux builds missing XRandR support

### DIFF
--- a/tools/tr1/docker/game-linux/Dockerfile
+++ b/tools/tr1/docker/game-linux/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get install -y \
     libwayland-egl1 \
     automake \
     gcc \
+    libxrandr-dev \
     libxext-dev
 RUN cd SDL \
     && aclocal -I acinclude \
@@ -90,6 +91,7 @@ RUN cd SDL \
     && cd sdl_build \
     && ../configure \
         --prefix=/ext/ \
+        --enable-video-x11-xrandr \
         --enable-shared \
         --enable-static \
     && make -j 4 \

--- a/tools/tr2/docker/game-linux/Dockerfile
+++ b/tools/tr2/docker/game-linux/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get install -y \
     libwayland-egl1 \
     automake \
     gcc \
+    libxrandr-dev \
     libxext-dev
 RUN cd SDL \
     && aclocal -I acinclude \
@@ -90,6 +91,7 @@ RUN cd SDL \
     && cd sdl_build \
     && ../configure \
         --prefix=/ext/ \
+        --enable-video-x11-xrandr \
         --enable-shared \
         --enable-static \
     && make -j 4 \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2382. In essence, the fix involves installing a specific library. Without this library, SDL mistakenly perceives multiple monitors as a single expansive monitor that spans the entire working area. This results in errors in fullscreen mode, particularly affecting the calculation of positions and aspect ratios.

In TR1, the problem surfaces when I switch to another workspace and then return to the one with TR. The game then occupies only half the screen. Cycling through the workspaces again resolves the issue, but repeating the process brings the issue back. I assume this behavior is present since version 3.0 that marks the dawn of the Linux builds.

In TR2, the issue shows up differently. The way the shell and viewport modules are designed leads to the half screen fullscreen problem even when I don't switch workspaces. It gets worse with FMVs, causing positioning to be twice as off in fullscreen mode and creating aspect ratio problems even in windowed mode.

The attached changes require rebuilding the toolchain but do fix all of these issues. TR2 Linux builds aren't out yet, hence no change log entry there.