### PR TITLE
tr2/level: fix crash when freeing 16-bit textures

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -223,9 +223,10 @@ void Level_ReadTexturePages(
     const int32_t texture_size_16_bit =
         num_pages * TEXTURE_PAGE_SIZE * sizeof(uint16_t);
     uint16_t *input = Memory_Alloc(texture_size_16_bit);
+    uint16_t *input_ptr = input;
     VFile_Read(file, input, texture_size_16_bit);
     for (int32_t i = 0; i < num_pages * TEXTURE_PAGE_SIZE; i++) {
-        *output++ = M_ARGB1555To8888(*input++);
+        *output++ = M_ARGB1555To8888(*input_ptr++);
     }
     Memory_FreePointer(&input);
 #endif


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a regression in develop introduced in ba2d5b2a0 that tries to free up invalid pointer.