### PR TITLE
tr2/shell: fix exiting the game

### DIFF
--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -433,8 +433,6 @@ void Shell_Main(void)
 
 void Shell_Shutdown(void)
 {
-    SDL_DestroyWindow(g_SDLWindow);
-
     GF_Shutdown();
     GameString_Shutdown();
     Console_Shutdown();
@@ -444,8 +442,6 @@ void Shell_Shutdown(void)
     GameBuf_Shutdown();
     Config_Shutdown();
     EnumMap_Shutdown();
-
-    SDL_Quit();
 }
 
 const char *Shell_GetConfigPath(void)

--- a/src/tr2/main.c
+++ b/src/tr2/main.c
@@ -14,6 +14,6 @@ int main(int argc, char **argv)
 
     Shell_Setup();
     Shell_Main();
-    Shell_Shutdown();
+    Shell_Terminate(0);
     return 0;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2425. Regression from 1240537, which attempted to optimize away a memory leak by destroying the main window. However, this action was performed too soon, causing certain subsystems to malfunction during the shutdown phase. As a result, since GL wasn't in a stable state, not only the textures would fail to be destroyed, but also the error handling routine activated during shutdown would get stuck in an infinite loop.