### PR TITLE
camera: move some globals to TRX

### DIFF
--- a/src/libtrx/game/camera/cinematic.c
+++ b/src/libtrx/game/camera/cinematic.c
@@ -2,7 +2,7 @@
 #include "game/camera/vars.h"
 #include "game/game_buf.h"
 
-static CINE_FRAME *m_CineFrames = NULL;
+static CINE_FRAME *m_CineFrames = nullptr;
 static CINE_DATA m_CineData = {};
 
 void Camera_InitialiseCineFrames(const int32_t num_frames)

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -1,0 +1,11 @@
+static bool m_IsChunky = false;
+
+bool Camera_IsChunky(void)
+{
+    return m_IsChunky;
+}
+
+void Camera_SetChunky(const bool is_chunky)
+{
+    m_IsChunky = is_chunky;
+}

--- a/src/libtrx/game/camera/fixed.c
+++ b/src/libtrx/game/camera/fixed.c
@@ -1,0 +1,17 @@
+#include "game/camera/vars.h"
+#include "game/game_buf.h"
+
+static int32_t m_FixedObjectCount = 0;
+
+void Camera_InitialiseFixedObjects(const int32_t num_objects)
+{
+    m_FixedObjectCount = num_objects;
+    g_Camera.fixed = num_objects == 0
+        ? nullptr
+        : GameBuf_Alloc(num_objects * sizeof(OBJECT_VECTOR), GBUF_CAMERAS);
+}
+
+int32_t Camera_GetFixedObjectCount(void)
+{
+    return m_FixedObjectCount;
+}

--- a/src/libtrx/game/camera/fixed.c
+++ b/src/libtrx/game/camera/fixed.c
@@ -1,12 +1,13 @@
-#include "game/camera/vars.h"
 #include "game/game_buf.h"
+#include "game/types.h"
 
 static int32_t m_FixedObjectCount = 0;
+static OBJECT_VECTOR *m_FixedObjects = nullptr;
 
 void Camera_InitialiseFixedObjects(const int32_t num_objects)
 {
     m_FixedObjectCount = num_objects;
-    g_Camera.fixed = num_objects == 0
+    m_FixedObjects = num_objects == 0
         ? nullptr
         : GameBuf_Alloc(num_objects * sizeof(OBJECT_VECTOR), GBUF_CAMERAS);
 }
@@ -14,4 +15,12 @@ void Camera_InitialiseFixedObjects(const int32_t num_objects)
 int32_t Camera_GetFixedObjectCount(void)
 {
     return m_FixedObjectCount;
+}
+
+OBJECT_VECTOR *Camera_GetFixedObject(const int32_t object_idx)
+{
+    if (m_FixedObjects == nullptr) {
+        return nullptr;
+    }
+    return &m_FixedObjects[object_idx];
 }

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -604,6 +604,24 @@ void Level_ReadCinematicFrames(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
+void Level_ReadCamerasAndSinks(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_objects = VFile_ReadS32(file);
+    LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
+    Camera_InitialiseFixedObjects(num_objects);
+    for (int32_t i = 0; i < num_objects; i++) {
+        OBJECT_VECTOR *const camera = Camera_GetFixedObject(i);
+        camera->x = VFile_ReadS32(file);
+        camera->y = VFile_ReadS32(file);
+        camera->z = VFile_ReadS32(file);
+        camera->data = VFile_ReadS16(file);
+        camera->flags = VFile_ReadS16(file);
+    }
+
+    Benchmark_End(benchmark, nullptr);
+}
+
 void Level_LoadTexturePages(LEVEL_INFO *const info)
 {
     const int32_t num_pages = info->textures.page_count;

--- a/src/libtrx/include/libtrx/game/camera.h
+++ b/src/libtrx/include/libtrx/game/camera.h
@@ -4,6 +4,7 @@
 #include "./camera/common.h"
 #include "./camera/const.h"
 #include "./camera/enum.h"
+#include "./camera/fixed.h"
 #include "./camera/photo_mode.h"
 #include "./camera/types.h"
 #include "./camera/vars.h"

--- a/src/libtrx/include/libtrx/game/camera/common.h
+++ b/src/libtrx/include/libtrx/game/camera/common.h
@@ -2,3 +2,5 @@
 
 extern void Camera_Update(void);
 extern void Camera_Apply(void);
+bool Camera_IsChunky(void);
+void Camera_SetChunky(bool is_chunky);

--- a/src/libtrx/include/libtrx/game/camera/enum.h
+++ b/src/libtrx/include/libtrx/game/camera/enum.h
@@ -9,3 +9,10 @@ typedef enum {
     CAM_HEAVY = 5,
     CAM_PHOTO_MODE = 6,
 } CAMERA_TYPE;
+
+typedef enum {
+    CF_NORMAL = 0,
+    CF_FOLLOW_CENTRE = 1,
+    CF_NO_CHUNKY = 2,
+    CF_CHASE_OBJECT = 3,
+} CAMERA_FLAGS;

--- a/src/libtrx/include/libtrx/game/camera/fixed.h
+++ b/src/libtrx/include/libtrx/game/camera/fixed.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <stdint.h>
+#include "../types.h"
 
 void Camera_InitialiseFixedObjects(int32_t num_objects);
 int32_t Camera_GetFixedObjectCount(void);
+OBJECT_VECTOR *Camera_GetFixedObject(int32_t object_idx);

--- a/src/libtrx/include/libtrx/game/camera/fixed.h
+++ b/src/libtrx/include/libtrx/game/camera/fixed.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+
+void Camera_InitialiseFixedObjects(int32_t num_objects);
+int32_t Camera_GetFixedObjectCount(void);

--- a/src/libtrx/include/libtrx/game/camera/types.h
+++ b/src/libtrx/include/libtrx/game/camera/types.h
@@ -10,7 +10,7 @@ typedef struct {
 
     int32_t shift;
     uint32_t flags;
-    int32_t fixed_camera;
+    bool fixed_camera;
     int32_t bounce;
     bool underwater;
     int32_t target_distance;

--- a/src/libtrx/include/libtrx/game/camera/types.h
+++ b/src/libtrx/include/libtrx/game/camera/types.h
@@ -27,7 +27,6 @@ typedef struct {
     int16_t roll;
     ITEM *item;
     ITEM *last_item;
-    OBJECT_VECTOR *fixed;
 
     int32_t debuff;
 

--- a/src/libtrx/include/libtrx/game/camera/types.h
+++ b/src/libtrx/include/libtrx/game/camera/types.h
@@ -9,7 +9,7 @@ typedef struct {
     CAMERA_TYPE type;
 
     int32_t shift;
-    uint32_t flags;
+    CAMERA_FLAGS flags;
     bool fixed_camera;
     int32_t bounce;
     bool underwater;

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -29,6 +29,7 @@ void Level_ReadSpriteSequences(int32_t num_sequences, VFILE *file);
 void Level_ReadAnimatedTextureRanges(int32_t num_ranges, VFILE *file);
 void Level_ReadLightMap(VFILE *file);
 void Level_ReadCinematicFrames(VFILE *file);
+void Level_ReadCamerasAndSinks(VFILE *file);
 
 void Level_LoadTexturePages(LEVEL_INFO *info);
 void Level_LoadPalettes(LEVEL_INFO *info);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -83,6 +83,7 @@ sources = [
   'game/anims/frames.c',
   'game/camera/common.c',
   'game/camera/cinematic.c',
+  'game/camera/fixed.c',
   'game/camera/photo_mode.c',
   'game/camera/vars.c',
   'game/clock/common.c',

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -81,6 +81,7 @@ sources = [
   'game/anims/commands.c',
   'game/anims/common.c',
   'game/anims/frames.c',
+  'game/camera/common.c',
   'game/camera/cinematic.c',
   'game/camera/photo_mode.c',
   'game/camera/vars.c',

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -293,7 +293,7 @@ static void M_Move(const GAME_VECTOR *const ideal, const int32_t speed)
     g_Camera.pos.y += (ideal->y - g_Camera.pos.y) / speed;
     g_Camera.pos.room_num = ideal->room_num;
 
-    g_ChunkyFlag = false;
+    Camera_SetChunky(false);
 
     const SECTOR *sector = Room_GetSector(
         g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
@@ -657,7 +657,7 @@ void Camera_Update(void)
     }
 
     if (g_Camera.flags != NO_CHUNKY) {
-        g_ChunkyFlag = true;
+        Camera_SetChunky(true);
     }
 
     const bool fixed_camera = g_Camera.item
@@ -770,7 +770,7 @@ void Camera_Update(void)
         if (g_Camera.target.y > Room_GetHeight(
                 sector, g_Camera.target.x, g_Camera.target.y,
                 g_Camera.target.z)) {
-            g_ChunkyFlag = false;
+            Camera_SetChunky(false);
         }
 
         if (g_Camera.type == CAM_CHASE || g_Camera.flags == CHASE_OBJECT) {
@@ -808,7 +808,7 @@ void Camera_Update(void)
         g_Camera.flags = 0;
     }
 
-    g_ChunkyFlag = false;
+    Camera_SetChunky(false);
 }
 
 void Camera_UpdateCutscene(void)

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -182,7 +182,7 @@ static void M_Fixed(void)
         .room_num = fixed->data,
     };
 
-    g_Camera.fixed_camera = 1;
+    g_Camera.fixed_camera = true;
 
     M_Move(&ideal, g_Camera.speed);
 
@@ -729,7 +729,7 @@ void Camera_Update(void)
                 g_Camera.type == CAM_LOOK ? LOOK_SPEED : COMBAT_SPEED;
         }
 
-        g_Camera.fixed_camera = 0;
+        g_Camera.fixed_camera = false;
 
         if (g_Camera.type == CAM_LOOK) {
             M_Look(item);
@@ -757,11 +757,11 @@ void Camera_Update(void)
 
         if (g_Camera.fixed_camera != fixed_camera) {
             g_Camera.target.y = y;
-            g_Camera.fixed_camera = 1;
+            g_Camera.fixed_camera = true;
             g_Camera.speed = 1;
         } else {
             g_Camera.target.y += (y - g_Camera.target.y) / 4;
-            g_Camera.fixed_camera = 0;
+            g_Camera.fixed_camera = false;
         }
 
         const SECTOR *const sector = Room_GetSector(

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -637,7 +637,7 @@ void Camera_ResetPosition(void)
     g_Camera.item = nullptr;
 
     g_Camera.type = CAM_CHASE;
-    g_Camera.flags = 0;
+    g_Camera.flags = CF_NORMAL;
     g_Camera.bounce = 0;
     g_Camera.num = NO_CAMERA;
     g_Camera.additional_angle = 0;
@@ -656,7 +656,7 @@ void Camera_Update(void)
         return;
     }
 
-    if (g_Camera.flags != NO_CHUNKY) {
+    if (g_Camera.flags != CF_NO_CHUNKY) {
         Camera_SetChunky(true);
     }
 
@@ -747,7 +747,7 @@ void Camera_Update(void)
             g_Camera.target.z = item->pos.z;
         }
 
-        if (g_Camera.flags == FOLLOW_CENTRE) {
+        if (g_Camera.flags == CF_FOLLOW_CENTRE) {
             const int16_t shift = (bounds->min.z + bounds->max.z) / 2;
             g_Camera.target.z += Math_Cos(item->rot.y) * shift >> W2V_SHIFT;
             g_Camera.target.x += Math_Sin(item->rot.y) * shift >> W2V_SHIFT;
@@ -773,7 +773,7 @@ void Camera_Update(void)
             Camera_SetChunky(false);
         }
 
-        if (g_Camera.type == CAM_CHASE || g_Camera.flags == CHASE_OBJECT) {
+        if (g_Camera.type == CAM_CHASE || g_Camera.flags == CF_CHASE_OBJECT) {
             M_Chase(item);
         } else {
             M_Fixed();
@@ -805,7 +805,7 @@ void Camera_Update(void)
         g_Camera.target_angle = g_Camera.additional_angle;
         g_Camera.target_elevation = g_Camera.additional_elevation;
         g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
-        g_Camera.flags = 0;
+        g_Camera.flags = CF_NORMAL;
     }
 
     Camera_SetChunky(false);

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -174,7 +174,7 @@ static void M_Look(const ITEM *const item)
 
 static void M_Fixed(void)
 {
-    const OBJECT_VECTOR *const fixed = &g_Camera.fixed[g_Camera.num];
+    const OBJECT_VECTOR *const fixed = Camera_GetFixedObject(g_Camera.num);
     GAME_VECTOR ideal = {
         .x = fixed->x,
         .y = fixed->y,

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -1586,7 +1586,7 @@ static void M_CameraEdits(const INJECTION *const injection)
             continue;
         }
 
-        OBJECT_VECTOR *const camera = &g_Camera.fixed[camera_num];
+        OBJECT_VECTOR *const camera = Camera_GetFixedObject(camera_num);
         camera->pos = pos;
         camera->data = room_num;
         camera->flags = flags;

--- a/src/tr1/game/inject.c
+++ b/src/tr1/game/inject.c
@@ -1580,7 +1580,7 @@ static void M_CameraEdits(const INJECTION *const injection)
         const int16_t room_num = VFile_ReadS16(fp);
         const int16_t flags = VFile_ReadS16(fp);
 
-        if (camera_num < 0 || camera_num >= g_NumberCameras) {
+        if (camera_num < 0 || camera_num >= Camera_GetFixedObjectCount()) {
             LOG_WARNING(
                 "Camera number %d is out of level camera range", camera_num);
             continue;

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -559,7 +559,7 @@ void Lara_State_StepLeft(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Slide(ITEM *item, COLL_INFO *coll)
 {
-    g_Camera.flags = NO_CHUNKY;
+    g_Camera.flags = CF_NO_CHUNKY;
     g_Camera.target_elevation = -45 * DEG_1;
     if (g_Input.jump
         && (!g_Config.gameplay.enable_jump_twists || !g_Input.back)) {
@@ -648,7 +648,7 @@ void Lara_State_PushBlock(ITEM *item, COLL_INFO *coll)
 {
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
-    g_Camera.flags = FOLLOW_CENTRE;
+    g_Camera.flags = CF_FOLLOW_CENTRE;
     g_Camera.target_angle = 35 * DEG_1;
     g_Camera.target_elevation = -25 * DEG_1;
 }
@@ -657,7 +657,7 @@ void Lara_State_PullBlock(ITEM *item, COLL_INFO *coll)
 {
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
-    g_Camera.flags = FOLLOW_CENTRE;
+    g_Camera.flags = CF_FOLLOW_CENTRE;
     g_Camera.target_angle = 35 * DEG_1;
     g_Camera.target_elevation = -25 * DEG_1;
 }
@@ -736,13 +736,13 @@ void Lara_State_Special(ITEM *item, COLL_INFO *coll)
     ITEM *const target_item = Lara_GetDeathCameraTarget();
     if (target_item != nullptr) {
         g_Camera.item = target_item;
-        g_Camera.flags = CHASE_OBJECT;
+        g_Camera.flags = CF_CHASE_OBJECT;
         g_Camera.type = CAM_FIXED;
         g_Camera.target_angle = item->rot.y;
         g_Camera.target_distance = WALL_L * 2;
         g_Camera.target_elevation = -25 * DEG_1;
     } else {
-        g_Camera.flags = FOLLOW_CENTRE;
+        g_Camera.flags = CF_FOLLOW_CENTRE;
         g_Camera.target_angle = 170 * DEG_1;
         g_Camera.target_elevation = -25 * DEG_1;
     }
@@ -887,7 +887,7 @@ void Lara_State_WaterOut(ITEM *item, COLL_INFO *coll)
 {
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
-    g_Camera.flags = FOLLOW_CENTRE;
+    g_Camera.flags = CF_FOLLOW_CENTRE;
 }
 
 void Lara_State_SurfSwim(ITEM *item, COLL_INFO *coll)

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -67,7 +67,6 @@ static void M_LoadObjects(VFILE *file);
 static void M_LoadStaticObjects(VFILE *file);
 static void M_LoadTextures(VFILE *file);
 static void M_LoadSprites(VFILE *file);
-static void M_LoadCameras(VFILE *file);
 static void M_LoadSoundEffects(VFILE *file);
 static void M_LoadBoxes(VFILE *file);
 static void M_LoadAnimatedTextures(VFILE *file);
@@ -235,7 +234,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
         Level_ReadPalettes(&m_LevelInfo, file);
     }
 
-    M_LoadCameras(file);
+    Level_ReadCamerasAndSinks(file);
     M_LoadSoundEffects(file);
     M_LoadBoxes(file);
     M_LoadAnimatedTextures(file);
@@ -523,24 +522,6 @@ static void M_LoadSprites(VFILE *file)
     const int32_t num_sequences = VFile_ReadS32(file);
     LOG_DEBUG("sprite sequences: %d", num_sequences);
     Level_ReadSpriteSequences(num_sequences, file);
-
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadCameras(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t num_objects = VFile_ReadS32(file);
-    LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
-    Camera_InitialiseFixedObjects(num_objects);
-    for (int32_t i = 0; i < num_objects; i++) {
-        OBJECT_VECTOR *const camera = Camera_GetFixedObject(i);
-        camera->x = VFile_ReadS32(file);
-        camera->y = VFile_ReadS32(file);
-        camera->z = VFile_ReadS32(file);
-        camera->data = VFile_ReadS16(file);
-        camera->flags = VFile_ReadS16(file);
-    }
 
     Benchmark_End(benchmark, nullptr);
 }

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -530,23 +530,18 @@ static void M_LoadSprites(VFILE *file)
 static void M_LoadCameras(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    g_NumberCameras = VFile_ReadS32(file);
-    LOG_INFO("%d cameras", g_NumberCameras);
-    if (g_NumberCameras != 0) {
-        g_Camera.fixed = GameBuf_Alloc(
-            sizeof(OBJECT_VECTOR) * g_NumberCameras, GBUF_CAMERAS);
-        if (!g_Camera.fixed) {
-            Shell_ExitSystem("Error allocating the fixed cameras.");
-        }
-        for (int32_t i = 0; i < g_NumberCameras; i++) {
-            OBJECT_VECTOR *camera = &g_Camera.fixed[i];
-            camera->x = VFile_ReadS32(file);
-            camera->y = VFile_ReadS32(file);
-            camera->z = VFile_ReadS32(file);
-            camera->data = VFile_ReadS16(file);
-            camera->flags = VFile_ReadS16(file);
-        }
+    const int32_t num_objects = VFile_ReadS32(file);
+    LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
+    Camera_InitialiseFixedObjects(num_objects);
+    for (int32_t i = 0; i < num_objects; i++) {
+        OBJECT_VECTOR *const camera = &g_Camera.fixed[i];
+        camera->x = VFile_ReadS32(file);
+        camera->y = VFile_ReadS32(file);
+        camera->z = VFile_ReadS32(file);
+        camera->data = VFile_ReadS16(file);
+        camera->flags = VFile_ReadS16(file);
     }
+
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -534,7 +534,7 @@ static void M_LoadCameras(VFILE *file)
     LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
     Camera_InitialiseFixedObjects(num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
-        OBJECT_VECTOR *const camera = &g_Camera.fixed[i];
+        OBJECT_VECTOR *const camera = Camera_GetFixedObject(i);
         camera->x = VFile_ReadS32(file);
         camera->y = VFile_ReadS32(file);
         camera->z = VFile_ReadS32(file);

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -225,13 +225,13 @@ void Torso_Control(int16_t item_num)
                 g_Lara.gun_type = LGT_UNARMED;
 
                 g_Camera.target_distance = WALL_L * 2;
-                g_Camera.flags = FOLLOW_CENTRE;
+                g_Camera.flags = CF_FOLLOW_CENTRE;
             }
             break;
 
         case TORSO_STATE_KILL:
             g_Camera.target_distance = WALL_L * 2;
-            g_Camera.flags = FOLLOW_CENTRE;
+            g_Camera.flags = CF_FOLLOW_CENTRE;
             break;
         }
     }

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -203,7 +203,7 @@ void TRex_LaraDeath(ITEM *item)
     g_Lara.gun_status = LGS_HANDS_BUSY;
     g_Lara.gun_type = LGT_UNARMED;
 
-    g_Camera.flags = FOLLOW_CENTRE;
+    g_Camera.flags = CF_FOLLOW_CENTRE;
     g_Camera.target_angle = 170 * DEG_1;
     g_Camera.target_elevation = -25 * DEG_1;
 }

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -68,7 +68,7 @@ void LavaWedge_Control(int16_t item_num)
         }
 
         g_Camera.item = item;
-        g_Camera.flags = CHASE_OBJECT;
+        g_Camera.flags = CF_CHASE_OBJECT;
         g_Camera.type = CAM_FIXED;
         g_Camera.target_angle = -DEG_180;
         g_Camera.target_distance = WALL_L * 3;

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -161,7 +161,7 @@ void RollingBall_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
             lara_item->goal_anim_state = LS_SPECIAL;
             Item_SwitchToAnim(lara_item, LA_ROLLING_BALL_DEATH, 0);
 
-            g_Camera.flags = FOLLOW_CENTRE;
+            g_Camera.flags = CF_FOLLOW_CENTRE;
             g_Camera.target_angle = 170 * DEG_1;
             g_Camera.target_elevation = -25 * DEG_1;
             for (int i = 0; i < 15; i++) {

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -389,7 +389,7 @@ static int16_t M_GetFloorTiltHeight(
 
     const HEIGHT_TYPE slope_type =
         (ABS(z_off) > 2 || ABS(x_off) > 2) ? HT_BIG_SLOPE : HT_SMALL_SLOPE;
-    if (g_ChunkyFlag && slope_type == HT_BIG_SLOPE) {
+    if (Camera_IsChunky() && slope_type == HT_BIG_SLOPE) {
         return height;
     }
 
@@ -421,7 +421,7 @@ static int16_t M_GetCeilingTiltHeight(
     const int32_t z_off = sector->ceiling.tilt >> 8;
     const int32_t x_off = (int8_t)sector->ceiling.tilt;
 
-    if (g_ChunkyFlag && (ABS(z_off) > 2 || ABS(x_off) > 2)) {
+    if (Camera_IsChunky() && (ABS(z_off) > 2 || ABS(x_off) > 2)) {
         return height;
     }
 

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -767,7 +767,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_CAMERA: {
             const TRIGGER_CAMERA_DATA *const cam_data =
                 (TRIGGER_CAMERA_DATA *)cmd->parameter;
-            if (g_Camera.fixed[cam_data->camera_num].flags & IF_ONE_SHOT) {
+            OBJECT_VECTOR *const camera =
+                Camera_GetFixedObject(cam_data->camera_num);
+            if (camera->flags & IF_ONE_SHOT) {
                 break;
             }
 
@@ -795,7 +797,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             }
 
             if (cam_data->one_shot) {
-                g_Camera.fixed[g_Camera.num].flags |= IF_ONE_SHOT;
+                camera->flags |= IF_ONE_SHOT;
             }
 
             g_Camera.speed = cam_data->glide + 1;
@@ -808,17 +810,15 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             break;
 
         case TO_SINK: {
-            const OBJECT_VECTOR *const obvector =
-                &g_Camera.fixed[(int16_t)(intptr_t)cmd->parameter];
+            const OBJECT_VECTOR *const sink =
+                Camera_GetFixedObject((int16_t)(intptr_t)cmd->parameter);
 
-            if (g_Lara.lot.required_box != obvector->flags) {
-                g_Lara.lot.target.x = obvector->x;
-                g_Lara.lot.target.y = obvector->y;
-                g_Lara.lot.target.z = obvector->z;
-                g_Lara.lot.required_box = obvector->flags;
+            if (g_Lara.lot.required_box != sink->flags) {
+                g_Lara.lot.target = sink->pos;
+                g_Lara.lot.required_box = sink->flags;
             }
 
-            g_Lara.current_active = obvector->data * 6;
+            g_Lara.current_active = sink->data * 6;
             break;
         }
 

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -449,13 +449,14 @@ static bool M_LoadCameras(JSON_ARRAY *cameras_arr)
         LOG_ERROR("Malformed save: invalid or missing cameras array");
         return false;
     }
-    if ((signed)cameras_arr->length != g_NumberCameras) {
+    const int32_t num_cameras = Camera_GetFixedObjectCount();
+    if ((signed)cameras_arr->length != num_cameras) {
         LOG_ERROR(
-            "Malformed save: expected %d cameras, got %d", g_NumberCameras,
+            "Malformed save: expected %d cameras, got %d", num_cameras,
             cameras_arr->length);
         return false;
     }
-    for (int i = 0; i < (signed)cameras_arr->length; i++) {
+    for (int32_t i = 0; i < num_cameras; i++) {
         g_Camera.fixed[i].flags = JSON_ArrayGetInt(cameras_arr, i, 0);
     }
     return true;
@@ -1023,7 +1024,7 @@ static JSON_OBJECT *M_DumpFlipmaps(void)
 static JSON_ARRAY *M_DumpCameras(void)
 {
     JSON_ARRAY *cameras_arr = JSON_ArrayNew();
-    for (int i = 0; i < g_NumberCameras; i++) {
+    for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         JSON_ArrayAppendInt(cameras_arr, g_Camera.fixed[i].flags);
     }
     return cameras_arr;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -457,7 +457,8 @@ static bool M_LoadCameras(JSON_ARRAY *cameras_arr)
         return false;
     }
     for (int32_t i = 0; i < num_cameras; i++) {
-        g_Camera.fixed[i].flags = JSON_ArrayGetInt(cameras_arr, i, 0);
+        OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        object->flags = JSON_ArrayGetInt(cameras_arr, i, 0);
     }
     return true;
 }
@@ -1025,7 +1026,8 @@ static JSON_ARRAY *M_DumpCameras(void)
 {
     JSON_ARRAY *cameras_arr = JSON_ArrayNew();
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
-        JSON_ArrayAppendInt(cameras_arr, g_Camera.fixed[i].flags);
+        const OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        JSON_ArrayAppendInt(cameras_arr, object->flags);
     }
     return cameras_arr;
 }

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -581,7 +581,8 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     }
 
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
-        M_Read(&g_Camera.fixed[i].flags, sizeof(int16_t));
+        OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        M_Read(&object->flags, sizeof(int16_t));
     }
 
     Savegame_ProcessItemsBeforeLoad();
@@ -762,7 +763,8 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     }
 
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
-        M_Write(&g_Camera.fixed[i].flags, sizeof(int16_t));
+        const OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        M_Write(&object->flags, sizeof(int16_t));
     }
 
     Savegame_ProcessItemsBeforeSave();

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -142,7 +142,7 @@ static bool M_NeedsBaconLaraFix(char *buffer)
     M_Skip(sizeof(SAVEGAME_LEGACY_ITEM_STATS)); // item stats
     M_Skip(sizeof(int32_t)); // flipmap status
     M_Skip(MAX_FLIP_MAPS * sizeof(int8_t)); // flipmap table
-    M_Skip(g_NumberCameras * sizeof(int16_t)); // cameras
+    M_Skip(Camera_GetFixedObjectCount() * sizeof(int16_t)); // cameras
 
     for (int i = 0; i < g_LevelItemCount; i++) {
         ITEM *item = &g_Items[i];
@@ -580,7 +580,7 @@ bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         g_FlipMapTable[i] = tmp8 << 8;
     }
 
-    for (int i = 0; i < g_NumberCameras; i++) {
+    for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         M_Read(&g_Camera.fixed[i].flags, sizeof(int16_t));
     }
 
@@ -761,7 +761,7 @@ void Savegame_Legacy_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
         M_Write(&flag, sizeof(int8_t));
     }
 
-    for (int i = 0; i < g_NumberCameras; i++) {
+    for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         M_Write(&g_Camera.fixed[i].flags, sizeof(int16_t));
     }
 

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -82,9 +82,6 @@
 #define CAM_A_HANG 0
 #define CAM_E_HANG (-60 * DEG_1) // = -10920
 #define CAM_WADE_ELEVATION (-22 * DEG_1) // = -4004
-#define FOLLOW_CENTRE 1
-#define NO_CHUNKY 2
-#define CHASE_OBJECT 3
 #define LOOK_SPEED 4
 #define COMBAT_SPEED 8
 #define CHASE_SPEED 12

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -38,7 +38,6 @@ uint16_t *g_Overlap = nullptr;
 int16_t *g_GroundZone[2] = { nullptr };
 int16_t *g_GroundZone2[2] = { nullptr };
 int16_t *g_FlyZone[2] = { nullptr };
-int32_t g_NumberCameras = 0;
 int32_t g_NumberSoundEffects = 0;
 OBJECT_VECTOR *g_SoundEffectsTable = nullptr;
 int16_t g_RoomsToDraw[MAX_ROOMS_TO_DRAW] = { -1 };

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -23,7 +23,6 @@ int32_t g_SavedGamesCount = 0;
 int32_t g_SaveCounter = 0;
 uint32_t *g_DemoData = nullptr;
 bool g_LevelComplete = false;
-bool g_ChunkyFlag = false;
 int32_t g_OverlayFlag = 0;
 int32_t g_HeightType = 0;
 

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -32,7 +32,6 @@ extern int32_t g_SavedGamesCount;
 extern int32_t g_SaveCounter;
 extern uint32_t *g_DemoData;
 extern bool g_LevelComplete;
-extern bool g_ChunkyFlag;
 extern int32_t g_OverlayFlag;
 extern int32_t g_HeightType;
 

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -47,7 +47,6 @@ extern uint16_t *g_Overlap;
 extern int16_t *g_GroundZone[2];
 extern int16_t *g_GroundZone2[2];
 extern int16_t *g_FlyZone[2];
-extern int32_t g_NumberCameras;
 extern int32_t g_NumberSoundEffects;
 extern OBJECT_VECTOR *g_SoundEffectsTable;
 extern int16_t g_RoomsToDraw[MAX_ROOMS_TO_DRAW];

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -884,7 +884,8 @@ void CreateSaveGameInfo(void)
 
     M_Write(g_MusicTrackFlags, MAX_CD_TRACKS * sizeof(uint16_t));
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
-        M_WriteS16(g_Camera.fixed[i].flags);
+        const OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        M_WriteS16(object->flags);
     }
 
     M_WriteItems();
@@ -936,7 +937,8 @@ void ExtractSaveGameInfo(void)
     }
 
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
-        g_Camera.fixed[i].flags = M_ReadS16();
+        OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
+        object->flags = M_ReadS16();
     }
 
     M_ReadItems();

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -883,7 +883,7 @@ void CreateSaveGameInfo(void)
     }
 
     M_Write(g_MusicTrackFlags, MAX_CD_TRACKS * sizeof(uint16_t));
-    for (int32_t i = 0; i < g_NumCameras; i++) {
+    for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         M_WriteS16(g_Camera.fixed[i].flags);
     }
 
@@ -935,7 +935,7 @@ void ExtractSaveGameInfo(void)
         g_MusicTrackFlags[i] = M_ReadU16();
     }
 
-    for (int32_t i = 0; i < g_NumCameras; i++) {
+    for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         g_Camera.fixed[i].flags = M_ReadS16();
     }
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -118,7 +118,7 @@ void Camera_ResetPosition(void)
     g_Camera.flags = CF_NORMAL;
     g_Camera.bounce = 0;
     g_Camera.num = NO_CAMERA;
-    g_Camera.fixed_camera = 0;
+    g_Camera.fixed_camera = false;
 }
 
 void Camera_Move(const GAME_VECTOR *target, int32_t speed)
@@ -698,7 +698,7 @@ void Camera_Fixed(void)
         Camera_ShiftClamp(&target, STEP_L);
     }
 
-    g_Camera.fixed_camera = 1;
+    g_Camera.fixed_camera = true;
     Camera_Move(&target, g_Camera.speed);
 
     if (g_Camera.timer) {
@@ -725,7 +725,7 @@ void Camera_Update(void)
         g_IsChunkyCamera = 1;
     }
 
-    const int32_t fixed_camera = g_Camera.item != nullptr
+    const bool fixed_camera = g_Camera.item != nullptr
         && (g_Camera.type == CAM_FIXED || g_Camera.type == CAM_HEAVY);
     const ITEM *const item = fixed_camera ? g_Camera.item : g_LaraItem;
 
@@ -790,7 +790,7 @@ void Camera_Update(void)
             g_Camera.speed =
                 g_Camera.type == CAM_LOOK ? LOOK_SPEED : COMBAT_SPEED;
         }
-        g_Camera.fixed_camera = 0;
+        g_Camera.fixed_camera = false;
         if (g_Camera.type == CAM_LOOK) {
             Camera_Look(item);
         } else {
@@ -816,10 +816,10 @@ void Camera_Update(void)
         g_Camera.target.room_num = item->room_num;
         if (g_Camera.fixed_camera != fixed_camera) {
             g_Camera.target.y = y;
-            g_Camera.fixed_camera = 1;
+            g_Camera.fixed_camera = true;
             g_Camera.speed = 1;
         } else {
-            g_Camera.fixed_camera = 0;
+            g_Camera.fixed_camera = false;
             g_Camera.target.y += (y - g_Camera.target.y) / 4;
         }
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -128,7 +128,7 @@ void Camera_Move(const GAME_VECTOR *target, int32_t speed)
     g_Camera.pos.y += (target->y - g_Camera.pos.y) / speed;
     g_Camera.pos.room_num = target->room_num;
 
-    g_IsChunkyCamera = 0;
+    Camera_SetChunky(false);
 
     const SECTOR *sector = Room_GetSector(
         g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
@@ -722,7 +722,7 @@ void Camera_Update(void)
     }
 
     if (g_Camera.flags != CF_NO_CHUNKY) {
-        g_IsChunkyCamera = 1;
+        Camera_SetChunky(true);
     }
 
     const bool fixed_camera = g_Camera.item != nullptr
@@ -828,7 +828,7 @@ void Camera_Update(void)
         const int32_t height = Room_GetHeight(
             sector, g_Camera.target.x, g_Camera.target.y, g_Camera.target.z);
         if (g_Camera.target.y > height) {
-            g_IsChunkyCamera = 0;
+            Camera_SetChunky(false);
         }
 
         if (g_Camera.type == CAM_CHASE || g_Camera.flags == CF_CHASE_OBJECT) {
@@ -851,7 +851,7 @@ void Camera_Update(void)
         g_Camera.target_distance = CHASE_ELEVATION;
         g_Camera.flags = CF_NORMAL;
     }
-    g_IsChunkyCamera = 0;
+    Camera_SetChunky(false);
 }
 
 void Camera_LoadCutsceneFrame(void)

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -687,7 +687,7 @@ void Camera_Look(const ITEM *item)
 
 void Camera_Fixed(void)
 {
-    const OBJECT_VECTOR *fixed = &g_Camera.fixed[g_Camera.num];
+    const OBJECT_VECTOR *const fixed = Camera_GetFixedObject(g_Camera.num);
     GAME_VECTOR target = {
         .x = fixed->x,
         .y = fixed->y,

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -346,15 +346,10 @@ finish:
 static void M_LoadCameras(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
-    g_NumCameras = VFile_ReadS32(file);
-    LOG_DEBUG("fixed cameras: %d", g_NumCameras);
-    if (!g_NumCameras) {
-        goto finish;
-    }
-
-    g_Camera.fixed =
-        GameBuf_Alloc(sizeof(OBJECT_VECTOR) * g_NumCameras, GBUF_CAMERAS);
-    for (int32_t i = 0; i < g_NumCameras; i++) {
+    const int32_t num_objects = VFile_ReadS32(file);
+    LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
+    Camera_InitialiseFixedObjects(num_objects);
+    for (int32_t i = 0; i < num_objects; i++) {
         OBJECT_VECTOR *const camera = &g_Camera.fixed[i];
         camera->x = VFile_ReadS32(file);
         camera->y = VFile_ReadS32(file);
@@ -363,7 +358,6 @@ static void M_LoadCameras(VFILE *const file)
         camera->flags = VFile_ReadS16(file);
     }
 
-finish:
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -49,7 +49,6 @@ static void M_LoadStaticObjects(VFILE *file);
 static void M_LoadTextures(VFILE *file);
 static void M_LoadSprites(VFILE *file);
 static void M_LoadItems(VFILE *file);
-static void M_LoadCameras(VFILE *file);
 static void M_LoadSoundEffects(VFILE *file);
 static void M_LoadBoxes(VFILE *file);
 static void M_LoadAnimatedTextures(VFILE *file);
@@ -343,24 +342,6 @@ finish:
     Benchmark_End(benchmark, nullptr);
 }
 
-static void M_LoadCameras(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t num_objects = VFile_ReadS32(file);
-    LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
-    Camera_InitialiseFixedObjects(num_objects);
-    for (int32_t i = 0; i < num_objects; i++) {
-        OBJECT_VECTOR *const camera = Camera_GetFixedObject(i);
-        camera->x = VFile_ReadS32(file);
-        camera->y = VFile_ReadS32(file);
-        camera->z = VFile_ReadS32(file);
-        camera->data = VFile_ReadS16(file);
-        camera->flags = VFile_ReadS16(file);
-    }
-
-    Benchmark_End(benchmark, nullptr);
-}
-
 static void M_LoadSoundEffects(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
@@ -589,7 +570,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     M_LoadTextures(file);
 
     M_LoadSprites(file);
-    M_LoadCameras(file);
+    Level_ReadCamerasAndSinks(file);
     M_LoadSoundEffects(file);
     M_LoadBoxes(file);
     M_LoadAnimatedTextures(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -350,7 +350,7 @@ static void M_LoadCameras(VFILE *const file)
     LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
     Camera_InitialiseFixedObjects(num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
-        OBJECT_VECTOR *const camera = &g_Camera.fixed[i];
+        OBJECT_VECTOR *const camera = Camera_GetFixedObject(i);
         camera->x = VFile_ReadS32(file);
         camera->y = VFile_ReadS32(file);
         camera->z = VFile_ReadS32(file);

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -42,7 +42,7 @@ static int16_t M_GetFloorTiltHeight(
 
     const HEIGHT_TYPE slope_type =
         (ABS(z_off) > 2 || ABS(x_off) > 2) ? HT_BIG_SLOPE : HT_SMALL_SLOPE;
-    if (g_IsChunkyCamera && slope_type == HT_BIG_SLOPE) {
+    if (Camera_IsChunky() && slope_type == HT_BIG_SLOPE) {
         return height;
     }
 
@@ -74,7 +74,7 @@ static int16_t M_GetCeilingTiltHeight(
     const int32_t z_off = sector->ceiling.tilt >> 8;
     const int32_t x_off = (int8_t)sector->ceiling.tilt;
 
-    if (g_IsChunkyCamera && (ABS(z_off) > 2 || ABS(x_off) > 2)) {
+    if (Camera_IsChunky() && (ABS(z_off) > 2 || ABS(x_off) > 2)) {
         return height;
     }
 

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -296,7 +296,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_CAMERA: {
             const TRIGGER_CAMERA_DATA *const cam_data =
                 (TRIGGER_CAMERA_DATA *)cmd->parameter;
-            if (g_Camera.fixed[cam_data->camera_num].flags & IF_ONE_SHOT) {
+            OBJECT_VECTOR *const camera =
+                Camera_GetFixedObject(cam_data->camera_num);
+            if (camera->flags & IF_ONE_SHOT) {
                 break;
             }
 
@@ -321,7 +323,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             g_Camera.timer = FRAMES_PER_SECOND * cam_data->timer;
 
             if (cam_data->one_shot) {
-                g_Camera.fixed[g_Camera.num].flags |= IF_ONE_SHOT;
+                camera->flags |= IF_ONE_SHOT;
             }
 
             g_Camera.speed = cam_data->glide + 1;
@@ -330,18 +332,16 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         }
 
         case TO_SINK: {
-            const OBJECT_VECTOR *const object_vector =
-                &g_Camera.fixed[(int16_t)(intptr_t)cmd->parameter];
+            const OBJECT_VECTOR *const sink =
+                Camera_GetFixedObject((int16_t)(intptr_t)cmd->parameter);
 
             if (!g_Lara.creature) {
                 LOT_EnableBaddieAI(g_Lara.item_num, true);
             }
 
-            g_Lara.creature->lot.target.x = object_vector->x;
-            g_Lara.creature->lot.target.y = object_vector->y;
-            g_Lara.creature->lot.target.z = object_vector->z;
-            g_Lara.creature->lot.required_box = object_vector->flags;
-            g_Lara.current_active = object_vector->data * 6;
+            g_Lara.creature->lot.target = sink->pos;
+            g_Lara.creature->lot.required_box = sink->flags;
+            g_Lara.current_active = sink->data * 6;
             break;
         }
 

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -227,13 +227,6 @@ typedef enum {
     TRAP_FINISHED = 3,
 } TRAP_ANIM;
 
-typedef enum {
-    CF_NORMAL        = 0,
-    CF_FOLLOW_CENTRE = 1,
-    CF_NO_CHUNKY     = 2,
-    CF_CHASE_OBJECT  = 3,
-} CAMERA_FLAGS;
-
 typedef struct {
     uint16_t key[14]; // INPUT_ROLE_NUMBER_OF
 } CONTROL_LAYOUT;

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -99,7 +99,6 @@ int32_t g_HeightType;
 int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;
-int32_t g_NumCameras;
 uint32_t *g_DemoData = nullptr;
 char g_LevelFileName[256];
 uint16_t g_MusicTrackFlags[64];

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -63,7 +63,6 @@ int32_t g_WibbleOffset;
 bool g_IsWibbleEffect;
 bool g_IsWaterEffect;
 bool g_IsShadeEffect;
-int32_t g_IsChunkyCamera;
 int32_t g_FlipTimer;
 bool g_IsDemoLoaded;
 bool g_IsAssaultTimerDisplay;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -62,7 +62,6 @@ extern int32_t g_WibbleOffset;
 extern bool g_IsWibbleEffect;
 extern bool g_IsWaterEffect;
 extern bool g_IsShadeEffect;
-extern int32_t g_IsChunkyCamera;
 extern int32_t g_FlipTimer;
 extern bool g_IsDemoLoaded;
 extern bool g_IsAssaultTimerDisplay;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -97,7 +97,6 @@ extern int32_t g_HeightType;
 extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;
-extern int32_t g_NumCameras;
 extern uint32_t *g_DemoData;
 extern char g_LevelFileName[256];
 extern uint16_t g_MusicTrackFlags[64];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the chunky camera flag, and fixed cameras/sinks (plus count) to TRX. `g_Camera` remains as the only global camera variable; splitting this out into an API is a bigger task, which we can perhaps tackle in the future.

For testing, we can check fixed cameras and sinks (currents) and make sure they behave OK.
