### PR TITLE
lara/cheat: set maximum HP in fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -46,7 +46,7 @@
 - fixed header and arrows disappearing when the inventory ring rotates (#2352, regression from 4.4)
 - fixed Story So Far feature not playing opening FMVs from the current level (#2360, regression from 4.2)
 - fixed `/play` command crashing the game when used after loading a level (#2411, regression)
-- fixed various death counter problems (existing saves will have the count reset) (#2412, regression from 2.6)
+- fixed various death counter problems (existing saves will have the count reset) (#2264/#2412, regression from 2.6)
 - fixed `/demo` command crashing the game if no demos are present (regression from 4.1)
 - fixed Lara not being able to jump or stop swimming if the related responsive config options are enabled, but enhanced animations are not present (#2397, regression from 4.6)
 - fixed Lara being unable to climb or use guns after using an underwater lever and then entering the wading state (#2416, regression from 4.6)

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -161,6 +161,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.death_timer = 0;
     g_Lara.mesh_effects = 0;
     g_LaraItem->enable_shadow = true;
+    g_LaraItem->hit_points = LARA_MAX_HITPOINTS;
     Lara_InitialiseMeshes(Game_GetCurrentLevel());
     g_Camera.type = CAM_CHASE;
     Viewport_SetFOV(-1);

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -155,6 +155,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.mesh_effects = 0;
     g_Lara.burn = 0;
     g_Lara.extra_anim = 0;
+    g_LaraItem->hit_points = LARA_MAX_HITPOINTS;
 
     M_ReinitialiseGunMeshes();
     g_Camera.type = CAM_CHASE;


### PR DESCRIPTION
Resolves #2264.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's HP is restored immediately on entering the fly cheat to avoid the death count incrementing again on the same frame before the end of `Lara_Control` resetting the HP. I've copied this into TR2 although we don't count deaths there yet.
