### PR TITLE
items: introduce relative anim/frame getters

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed various death counter problems (existing saves will have the count reset) (#2264/#2412, regression from 2.6)
 - fixed `/demo` command crashing the game if no demos are present (regression from 4.1)
 - fixed Lara not being able to jump or stop swimming if the related responsive config options are enabled, but enhanced animations are not present (#2397, regression from 4.6)
+- fixed Lara not being able to jump if responsive jumping is disabled via the console in-level in certain scenarios (#2444, regression from 4.6)
 - fixed Lara being unable to climb or use guns after using an underwater lever and then entering the wading state (#2416, regression from 4.6)
 - fixed Eidos logo briefly flashing prior to the initial fade-in effect (#1388, regression from 4.1)
 - improved pause screen compatibility with PS1 (#2248)

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -49,6 +49,22 @@ bool Item_TestAnimEqual(const ITEM *const item, const int16_t anim_idx)
     return item->anim_num == obj->anim_idx + anim_idx;
 }
 
+int16_t Item_GetRelativeAnim(const ITEM *const item)
+{
+    return Item_GetRelativeObjAnim(item, item->object_id);
+}
+
+int16_t Item_GetRelativeObjAnim(
+    const ITEM *const item, const GAME_OBJECT_ID obj_id)
+{
+    return item->anim_num - Object_Get(obj_id)->anim_idx;
+}
+
+int16_t Item_GetRelativeFrame(const ITEM *const item)
+{
+    return item->frame_num - Item_GetAnim(item)->frame_base;
+}
+
 void Item_SwitchToAnim(
     ITEM *const item, const int16_t anim_idx, const int16_t frame)
 {

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -18,6 +18,9 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage);
 
 ANIM *Item_GetAnim(const ITEM *item);
 bool Item_TestAnimEqual(const ITEM *item, int16_t anim_idx);
+int16_t Item_GetRelativeAnim(const ITEM *item);
+int16_t Item_GetRelativeObjAnim(const ITEM *item, GAME_OBJECT_ID obj_id);
+int16_t Item_GetRelativeFrame(const ITEM *item);
 void Item_SwitchToAnim(ITEM *item, int16_t anim_idx, int16_t frame);
 void Item_SwitchToObjAnim(
     ITEM *item, int16_t anim_idx, int16_t frame, GAME_OBJECT_ID obj_id);

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -765,8 +765,8 @@ void Lara_State_DieMidas(ITEM *item, COLL_INFO *coll)
 
     Object_SetReflective(O_LARA_EXTRA, true);
 
-    int32_t frm = item->frame_num - Item_GetAnim(item)->frame_base;
-    switch (frm) {
+    const int32_t frame_num = Item_GetRelativeFrame(item);
+    switch (frame_num) {
     case 5:
         g_Lara.mesh_effects |= (1 << LM_FOOT_L);
         g_Lara.mesh_effects |= (1 << LM_FOOT_R);

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -157,14 +157,15 @@ void Lara_State_Run(ITEM *item, COLL_INFO *coll)
     }
 
     if (g_Config.gameplay.enable_tr2_jumping) {
-        // TODO: Item_GetRelativeAnim
-        int16_t anim = item->anim_num - Object_Get(item->object_id)->anim_idx;
-        if (anim == LA_RUN_START) {
+        if (Item_TestAnimEqual(item, LA_RUN_START)) {
             m_JumpPermitted = false;
         } else if (
-            anim != LA_RUN || Item_TestFrameEqual(item, LF_JUMP_READY - 1)) {
+            !Item_TestAnimEqual(item, LA_RUN)
+            || Item_TestFrameEqual(item, LF_JUMP_READY - 1)) {
             m_JumpPermitted = true;
         }
+    } else {
+        m_JumpPermitted = true;
     }
 
     if (g_Input.jump && m_JumpPermitted && !item->gravity) {

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -79,11 +79,8 @@ void BaconLara_Control(int16_t item_num)
         int32_t lh = Room_GetHeight(
             sector, g_LaraItem->pos.x, g_LaraItem->pos.y, g_LaraItem->pos.z);
 
-        // TODO: Item_GetRelativeAnim, Item_GetRelativeFrame
-        int16_t relative_anim =
-            g_LaraItem->anim_num - Object_Get(g_LaraItem->object_id)->anim_idx;
-        int16_t relative_frame =
-            g_LaraItem->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
+        const int16_t relative_anim = Item_GetRelativeAnim(g_LaraItem);
+        const int16_t relative_frame = Item_GetRelativeFrame(g_LaraItem);
         Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
         item->pos.x = x;
         item->pos.y = y;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -48,9 +48,8 @@ static void M_FixEmbeddedPosition(int16_t item_num)
     // The bats animation and frame have to be changed to the hanging
     // one to properly measure them. Save it so it can be restored
     // after.
-    // TODO: Item_GetRelativeAnim, Item_GetRelativeFrame
-    int16_t old_anim = item->anim_num - Object_Get(item->object_id)->anim_idx;
-    int16_t old_frame = item->frame_num - Item_GetAnim(item)->frame_base;
+    const int16_t old_anim = Item_GetRelativeAnim(item);
+    const int16_t old_frame = Item_GetRelativeFrame(item);
 
     Item_SwitchToAnim(item, 0, 0);
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -180,10 +180,8 @@ void SkateKid_Draw(ITEM *item)
         return;
     }
 
-    // TODO: Item_GetRelativeAnim, Item_GetRelativeFrame
-    int16_t relative_anim =
-        item->anim_num - Object_Get(item->object_id)->anim_idx;
-    int16_t relative_frame = item->frame_num - Item_GetAnim(item)->frame_base;
+    const int16_t relative_anim = Item_GetRelativeAnim(item);
+    const int16_t relative_frame = Item_GetRelativeFrame(item);
     item->object_id = O_SKATEBOARD;
     Item_SwitchToAnim(item, relative_anim, relative_frame);
     Object_DrawAnimatingItem(item);

--- a/src/tr1/game/objects/traps/thors_hammer_handle.c
+++ b/src/tr1/game/objects/traps/thors_hammer_handle.c
@@ -64,8 +64,8 @@ void ThorsHammerHandle_Control(int16_t item_num)
         break;
 
     case THOR_HAMMER_HANDLE_STATE_ACTIVE: {
-        int32_t frm = item->frame_num - Item_GetAnim(item)->frame_base;
-        if (frm > 30) {
+        const int32_t frame_num = Item_GetRelativeFrame(item);
+        if (frame_num > 30) {
             int32_t x = item->pos.x;
             int32_t z = item->pos.z;
 
@@ -136,11 +136,9 @@ void ThorsHammerHandle_Control(int16_t item_num)
     }
     Item_Animate(item);
 
-    ITEM *head_item = item->data;
-    // TODO: Item_GetRelativeAnim, Item_GetRelativeFrame
-    int16_t relative_anim =
-        item->anim_num - Object_Get(item->object_id)->anim_idx;
-    int16_t relative_frame = item->frame_num - Item_GetAnim(item)->frame_base;
+    ITEM *const head_item = item->data;
+    const int16_t relative_anim = Item_GetRelativeAnim(item);
+    const int16_t relative_frame = Item_GetRelativeFrame(item);
     Item_SwitchToAnim(head_item, relative_anim, relative_frame);
     head_item->current_anim_state = item->current_anim_state;
 }

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -912,11 +912,9 @@ int32_t Skidoo_Control(void)
     if (dead) {
         Item_SwitchToObjAnim(skidoo, LA_SKIDOO_DEAD, 0, O_SKIDOO_FAST);
     } else {
-        // TODO: Item_GetRelativeAnim
         const int16_t lara_anim_num =
-            g_LaraItem->anim_num - Object_Get(O_LARA_SKIDOO)->anim_idx;
-        const int16_t lara_frame_num =
-            g_LaraItem->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
+            Item_GetRelativeObjAnim(g_LaraItem, O_LARA_SKIDOO);
+        const int16_t lara_frame_num = Item_GetRelativeFrame(g_LaraItem);
         Item_SwitchToObjAnim(
             skidoo, lara_anim_num, lara_frame_num, O_SKIDOO_FAST);
     }

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -275,12 +275,10 @@ void Gun_Rifle_Draw(const LARA_GUN_TYPE weapon_type)
 
     g_Lara.left_arm.anim_num = item->anim_num;
     g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.left_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.left_arm.frame_num = Item_GetRelativeFrame(item);
     g_Lara.right_arm.anim_num = item->anim_num;
     g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.right_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.right_arm.frame_num = Item_GetRelativeFrame(item);
 }
 
 void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
@@ -310,12 +308,10 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
 
     g_Lara.left_arm.anim_num = item->anim_num;
     g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.left_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.left_arm.frame_num = Item_GetRelativeFrame(item);
     g_Lara.right_arm.anim_num = item->anim_num;
     g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.right_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.right_arm.frame_num = Item_GetRelativeFrame(item);
 }
 
 void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
@@ -444,10 +440,8 @@ void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
     M_AnimateGun(item);
     g_Lara.left_arm.anim_num = item->anim_num;
     g_Lara.left_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.left_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.left_arm.frame_num = Item_GetRelativeFrame(item);
     g_Lara.right_arm.anim_num = item->anim_num;
     g_Lara.right_arm.frame_base = Item_GetAnim(item)->frame_ptr;
-    g_Lara.right_arm.frame_num =
-        item->frame_num - Item_GetAnim(item)->frame_base;
+    g_Lara.right_arm.frame_num = Item_GetRelativeFrame(item);
 }

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -444,10 +444,8 @@ void Dragon_Control(const int16_t item_num)
     Creature_Animate(dragon_front_item_num, angle, 0);
     dragon_back_item->current_anim_state =
         dragon_front_item->current_anim_state;
-    // TODO: Item_GetRelativeAnim, Item_GetRelativeFrame
-    const int16_t anim_num = dragon_front_item->anim_num - front_obj->anim_idx;
-    const int16_t frame_num = dragon_front_item->frame_num
-        - Item_GetAnim(dragon_front_item)->frame_base;
+    const int16_t anim_num = Item_GetRelativeAnim(dragon_front_item);
+    const int16_t frame_num = Item_GetRelativeFrame(dragon_front_item);
     Item_SwitchToAnim(dragon_back_item, anim_num, frame_num);
     dragon_back_item->pos.x = dragon_front_item->pos.x;
     dragon_back_item->pos.y = dragon_front_item->pos.y;

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -256,9 +256,8 @@ void SkidooDriver_Control(const int16_t driver_item_num)
             Item_NewRoom(driver_item_num, room_num);
         }
         const int16_t anim_num =
-            skidoo_item->anim_num - Object_Get(O_SKIDOO_ARMED)->anim_idx;
-        const int16_t frame_num =
-            skidoo_item->frame_num - Item_GetAnim(skidoo_item)->frame_base;
+            Item_GetRelativeObjAnim(skidoo_item, O_SKIDOO_ARMED);
+        const int16_t frame_num = Item_GetRelativeFrame(skidoo_item);
         Item_SwitchToAnim(driver_item, anim_num, frame_num);
     }
 }

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -735,11 +735,9 @@ void Boat_Control(const int16_t item_num)
         Item_Animate(lara);
 
         if (lara->hit_points > 0) {
-            // TODO: Item_GetRelativeAnim
             const int16_t lara_anim_num =
-                lara->anim_num - Object_Get(O_LARA_BOAT)->anim_idx;
-            const int16_t lara_frame_num =
-                lara->frame_num - Item_GetAnim(g_LaraItem)->frame_base;
+                Item_GetRelativeObjAnim(g_LaraItem, O_LARA_BOAT);
+            const int16_t lara_frame_num = Item_GetRelativeFrame(g_LaraItem);
             Item_SwitchToAnim(boat, lara_anim_num, lara_frame_num);
         }
 


### PR DESCRIPTION
Resolves #2444.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A follow-up from #2436, this introduces some utilities to get relative anim and frame number for items, to reduce some code duplication in various control routines.

Following are the areas this touches on so worth checking:
- Lara's meshes turning to gold correctly in Midas
- Bacon Lara matching Lara's anim/frame
- The fix for bats being embedded in the ceiling
- Skater boy's skateboard being in sync
- Thor's hammer and handle being in sync
- Lara being in sync with the boat and skidoo
- Skidoo drivers being in sync with their skidoos
- Dragon front and back being in sync
- Lara's arms behaving normally with rifle type weapons equipped

The fix for #2444 is also in place, that is resetting the lock if responsive jumping is off, plus the anim/frame test here is now similarly structured to TR2.
