### PR TITLE
Small output refactors; remove screen plane clipping

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed Eidos logo briefly flashing prior to the initial fade-in effect (#1388, regression from 4.1)
 - improved pause screen compatibility with PS1 (#2248)
 - improved level loading times with respect to injection processing
+- improved wireframe mode appearance around screen edges
 
 ## [4.7.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.7...tr1-4.7.1) - 2024-12-21
 - changed the inventory examine UI to auto-hide if the item description is empty (#2097)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -51,6 +51,7 @@
 - fixed gunflare from bandits in Tibetan levels spawning too far from their guns (#2365, regression from 0.8)
 - fixed guns sometimes appearing in Lara's hands when entering the fly cheat while undrawing weapons (#2376, regression from 0.3)
 - improved rendering to achieve a slight performance boost in big rooms (#2325)
+- improved wireframe mode appearance around screen edges
 
 ## [0.8](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.8) - 2025-01-01
 - completed decompilation efforts – TR2X.dll is gone, Tomb2.exe no longer needed (#1694)

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -144,9 +144,13 @@ static void M_DrawTexturedFace3s(const FACE3 *const faces, const int32_t count)
         };
 
         OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
+        for (int32_t j = 0; j < 3; j++) {
+            vns[j]->u = tex->uv[j].u;
+            vns[j]->v = tex->uv[j].v;
+        }
+
         S_Output_DrawTexturedTriangle(
-            vns[0], vns[1], vns[2], tex->tex_page, &tex->uv[0], &tex->uv[1],
-            &tex->uv[2], tex->draw_type);
+            vns[0], vns[1], vns[2], tex->tex_page, tex->draw_type);
     }
 }
 
@@ -164,29 +168,34 @@ static void M_DrawTexturedFace4s(const FACE4 *const faces, const int32_t count)
         };
 
         OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
+        for (int32_t j = 0; j < 4; j++) {
+            vns[j]->u = tex->uv[j].u;
+            vns[j]->v = tex->uv[j].v;
+        }
+
         S_Output_DrawTexturedQuad(
-            vns[0], vns[1], vns[2], vns[3], tex->tex_page, &tex->uv[0],
-            &tex->uv[1], &tex->uv[2], &tex->uv[3], tex->draw_type);
+            vns[0], vns[1], vns[2], vns[3], tex->tex_page, tex->draw_type);
     }
 }
 
 static void M_DrawObjectFace3EnvMap(
     const FACE3 *const faces, const int32_t count)
 {
-    const PHD_VBUF *vns[3];
-    const TEXTURE_UV *uv[3];
-
     for (int32_t i = 0; i < count; i++) {
         const FACE3 *const face = &faces[i];
+        PHD_VBUF *vns[3] = {
+            &m_VBuf[face->vertices[0]],
+            &m_VBuf[face->vertices[1]],
+            &m_VBuf[face->vertices[2]],
+        };
+
         for (int32_t j = 0; j < 3; j++) {
-            const uint16_t vertex_num = face->vertices[j];
-            vns[j] = &m_VBuf[vertex_num];
-            uv[j] = &m_EnvMapUV[vertex_num];
+            vns[j]->u = m_EnvMapUV[face->vertices[j]].u;
+            vns[j]->v = m_EnvMapUV[face->vertices[j]].v;
         }
 
         if (face->enable_reflections) {
-            S_Output_DrawEnvMapTriangle(
-                vns[0], vns[1], vns[2], uv[0], uv[1], uv[2]);
+            S_Output_DrawEnvMapTriangle(vns[0], vns[1], vns[2]);
         }
     }
 }
@@ -194,20 +203,22 @@ static void M_DrawObjectFace3EnvMap(
 static void M_DrawObjectFace4EnvMap(
     const FACE4 *const faces, const int32_t count)
 {
-    const PHD_VBUF *vns[4];
-    const TEXTURE_UV *uv[4];
-
     for (int32_t i = 0; i < count; i++) {
         const FACE4 *const face = &faces[i];
+        PHD_VBUF *vns[4] = {
+            &m_VBuf[face->vertices[0]],
+            &m_VBuf[face->vertices[1]],
+            &m_VBuf[face->vertices[2]],
+            &m_VBuf[face->vertices[3]],
+        };
+
         for (int32_t j = 0; j < 4; j++) {
-            const uint16_t vertex_num = face->vertices[j];
-            vns[j] = &m_VBuf[vertex_num];
-            uv[j] = &m_EnvMapUV[vertex_num];
+            vns[j]->u = m_EnvMapUV[face->vertices[j]].u;
+            vns[j]->v = m_EnvMapUV[face->vertices[j]].v;
         }
 
         if (face->enable_reflections) {
-            S_Output_DrawEnvMapQuad(
-                vns[0], vns[1], vns[2], vns[3], uv[0], uv[1], uv[2], uv[3]);
+            S_Output_DrawEnvMapQuad(vns[0], vns[1], vns[2], vns[3]);
         }
     }
 }

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -148,17 +148,6 @@ typedef struct {
     float zv;
     float xs;
     float ys;
-    float u;
-    float v;
-    float g;
-} POINT_INFO;
-
-typedef struct {
-    float xv;
-    float yv;
-    float zv;
-    float xs;
-    float ys;
     int16_t clip;
     int16_t g;
     int16_t u;

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -724,8 +724,7 @@ void S_Output_DrawFlatTriangle(
 
 void S_Output_DrawEnvMapTriangle(
     const PHD_VBUF *const vn1, const PHD_VBUF *const vn2,
-    const PHD_VBUF *const vn3, const TEXTURE_UV *const uv1,
-    const TEXTURE_UV *const uv2, const TEXTURE_UV *const uv3)
+    const PHD_VBUF *const vn3)
 {
     int vertex_count = 3;
     GFX_3D_VERTEX vertices[vertex_count * CLIP_VERTCOUNT_SCALE];
@@ -733,7 +732,6 @@ void S_Output_DrawEnvMapTriangle(
     const float multiplier = g_Config.visuals.brightness / 16.0f;
 
     const PHD_VBUF *const src_vbuf[3] = { vn1, vn2, vn3 };
-    const TEXTURE_UV *const src_uv[3] = { uv1, uv2, uv3 };
 
     if (vn3->clip & vn2->clip & vn1->clip) {
         return;
@@ -750,8 +748,8 @@ void S_Output_DrawEnvMapTriangle(
             vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
 
             vertices[i].w = 1.0f / src_vbuf[i]->zv;
-            vertices[i].s = M_GetUV(src_uv[i]->u) * vertices[i].w;
-            vertices[i].t = M_GetUV(src_uv[i]->v) * vertices[i].w;
+            vertices[i].s = M_GetUV(src_vbuf[i]->u) * vertices[i].w;
+            vertices[i].t = M_GetUV(src_vbuf[i]->v) * vertices[i].w;
 
             vertices[i].r = vertices[i].g = vertices[i].b =
                 (8192.0f - src_vbuf[i]->g) * multiplier;
@@ -771,8 +769,8 @@ void S_Output_DrawEnvMapTriangle(
             points[i].xs = src_vbuf[i]->xs;
             points[i].ys = src_vbuf[i]->ys;
             points[i].g = src_vbuf[i]->g;
-            points[i].u = M_GetUV(src_uv[i]->u);
-            points[i].v = M_GetUV(src_uv[i]->v);
+            points[i].u = M_GetUV(src_vbuf[i]->u);
+            points[i].v = M_GetUV(src_vbuf[i]->v);
         }
 
         vertex_count = M_ZedClipper(vertex_count, points, vertices);
@@ -795,9 +793,7 @@ void S_Output_DrawEnvMapTriangle(
 
 void S_Output_DrawEnvMapQuad(
     const PHD_VBUF *const vn1, const PHD_VBUF *const vn2,
-    const PHD_VBUF *const vn3, const PHD_VBUF *const vn4,
-    const TEXTURE_UV *const uv1, const TEXTURE_UV *const uv2,
-    const TEXTURE_UV *const uv3, const TEXTURE_UV *const uv4)
+    const PHD_VBUF *const vn3, const PHD_VBUF *const vn4)
 {
     int vertex_count = 4;
     GFX_3D_VERTEX vertices[vertex_count];
@@ -816,8 +812,8 @@ void S_Output_DrawEnvMapQuad(
             return;
         }
 
-        S_Output_DrawEnvMapTriangle(vn1, vn2, vn3, uv1, uv2, uv3);
-        S_Output_DrawEnvMapTriangle(vn3, vn4, vn1, uv3, uv4, uv1);
+        S_Output_DrawEnvMapTriangle(vn1, vn2, vn3);
+        S_Output_DrawEnvMapTriangle(vn3, vn4, vn1);
         return;
     }
 
@@ -828,7 +824,6 @@ void S_Output_DrawEnvMapQuad(
     float multiplier = g_Config.visuals.brightness / 16.0f;
 
     const PHD_VBUF *const src_vbuf[4] = { vn2, vn1, vn3, vn4 };
-    const TEXTURE_UV *const src_uv[4] = { uv2, uv1, uv3, uv4 };
 
     for (int i = 0; i < vertex_count; i++) {
         vertices[i].x = src_vbuf[i]->xs;
@@ -836,8 +831,8 @@ void S_Output_DrawEnvMapQuad(
         vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
 
         vertices[i].w = 1.0f / src_vbuf[i]->zv;
-        vertices[i].s = M_GetUV(src_uv[i]->u) * vertices[i].w;
-        vertices[i].t = M_GetUV(src_uv[i]->v) * vertices[i].w;
+        vertices[i].s = M_GetUV(src_vbuf[i]->u) * vertices[i].w;
+        vertices[i].t = M_GetUV(src_vbuf[i]->v) * vertices[i].w;
 
         vertices[i].r = vertices[i].g = vertices[i].b =
             (8192.0f - src_vbuf[i]->g) * multiplier;
@@ -854,24 +849,19 @@ void S_Output_DrawEnvMapQuad(
 }
 
 void S_Output_DrawTexturedTriangle(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage, TEXTURE_UV *uv1,
-    TEXTURE_UV *uv2, TEXTURE_UV *uv3, uint16_t textype)
+    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage,
+    uint16_t textype)
 {
     int vertex_count = 3;
     GFX_3D_VERTEX vertices[vertex_count * CLIP_VERTCOUNT_SCALE];
     POINT_INFO points[3];
     PHD_VBUF *src_vbuf[3];
-    TEXTURE_UV *src_uv[3];
 
     float multiplier = g_Config.visuals.brightness / 16.0f;
 
     src_vbuf[0] = vn1;
     src_vbuf[1] = vn2;
     src_vbuf[2] = vn3;
-
-    src_uv[0] = uv1;
-    src_uv[1] = uv2;
-    src_uv[2] = uv3;
 
     if (vn3->clip & vn2->clip & vn1->clip) {
         return;
@@ -888,8 +878,8 @@ void S_Output_DrawTexturedTriangle(
             vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
 
             vertices[i].w = 1.0f / src_vbuf[i]->zv;
-            vertices[i].s = M_GetUV(src_uv[i]->u) * vertices[i].w;
-            vertices[i].t = M_GetUV(src_uv[i]->v) * vertices[i].w;
+            vertices[i].s = M_GetUV(src_vbuf[i]->u) * vertices[i].w;
+            vertices[i].t = M_GetUV(src_vbuf[i]->v) * vertices[i].w;
 
             vertices[i].r = vertices[i].g = vertices[i].b =
                 (8192.0f - src_vbuf[i]->g) * multiplier;
@@ -908,8 +898,8 @@ void S_Output_DrawTexturedTriangle(
             points[i].xs = src_vbuf[i]->xs;
             points[i].ys = src_vbuf[i]->ys;
             points[i].g = src_vbuf[i]->g;
-            points[i].u = M_GetUV(src_uv[i]->u);
-            points[i].v = M_GetUV(src_uv[i]->v);
+            points[i].u = M_GetUV(src_vbuf[i]->u);
+            points[i].v = M_GetUV(src_vbuf[i]->v);
         }
 
         vertex_count = M_ZedClipper(vertex_count, points, vertices);
@@ -934,13 +924,11 @@ void S_Output_DrawTexturedTriangle(
 
 void S_Output_DrawTexturedQuad(
     PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, PHD_VBUF *vn4, int16_t tpage,
-    TEXTURE_UV *uv1, TEXTURE_UV *uv2, TEXTURE_UV *uv3, TEXTURE_UV *uv4,
     uint16_t textype)
 {
     int vertex_count = 4;
     GFX_3D_VERTEX vertices[vertex_count];
     PHD_VBUF *src_vbuf[4];
-    TEXTURE_UV *src_uv[4];
 
     if (vn4->clip | vn3->clip | vn2->clip | vn1->clip) {
         if ((vn4->clip & vn3->clip & vn2->clip & vn1->clip)) {
@@ -956,10 +944,8 @@ void S_Output_DrawTexturedQuad(
             return;
         }
 
-        S_Output_DrawTexturedTriangle(
-            vn1, vn2, vn3, tpage, uv1, uv2, uv3, textype);
-        S_Output_DrawTexturedTriangle(
-            vn3, vn4, vn1, tpage, uv3, uv4, uv1, textype);
+        S_Output_DrawTexturedTriangle(vn1, vn2, vn3, tpage, textype);
+        S_Output_DrawTexturedTriangle(vn3, vn4, vn1, tpage, textype);
         return;
     }
 
@@ -974,19 +960,14 @@ void S_Output_DrawTexturedQuad(
     src_vbuf[2] = vn3;
     src_vbuf[3] = vn4;
 
-    src_uv[0] = uv2;
-    src_uv[1] = uv1;
-    src_uv[2] = uv3;
-    src_uv[3] = uv4;
-
     for (int i = 0; i < vertex_count; i++) {
         vertices[i].x = src_vbuf[i]->xs;
         vertices[i].y = src_vbuf[i]->ys;
         vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
 
         vertices[i].w = 1.0f / src_vbuf[i]->zv;
-        vertices[i].s = M_GetUV(src_uv[i]->u) * vertices[i].w;
-        vertices[i].t = M_GetUV(src_uv[i]->v) * vertices[i].w;
+        vertices[i].s = M_GetUV(src_vbuf[i]->u) * vertices[i].w;
+        vertices[i].t = M_GetUV(src_vbuf[i]->v) * vertices[i].w;
 
         vertices[i].r = vertices[i].g = vertices[i].b =
             (8192.0f - src_vbuf[i]->g) * multiplier;

--- a/src/tr1/specific/s_output.h
+++ b/src/tr1/specific/s_output.h
@@ -35,18 +35,15 @@ void S_Output_DrawBackdropSurface(void);
 void S_Output_DrawFlatTriangle(
     PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, RGBA_8888 color);
 void S_Output_DrawEnvMapTriangle(
-    const PHD_VBUF *vn1, const PHD_VBUF *vn2, const PHD_VBUF *vn3,
-    const TEXTURE_UV *uv1, const TEXTURE_UV *uv2, const TEXTURE_UV *uv3);
+    const PHD_VBUF *vn1, const PHD_VBUF *vn2, const PHD_VBUF *vn3);
 void S_Output_DrawEnvMapQuad(
     const PHD_VBUF *vn1, const PHD_VBUF *vn2, const PHD_VBUF *vn3,
-    const PHD_VBUF *vn4, const TEXTURE_UV *uv1, const TEXTURE_UV *uv2,
-    const TEXTURE_UV *uv3, const TEXTURE_UV *uv4);
+    const PHD_VBUF *vn4);
 void S_Output_DrawTexturedTriangle(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage, TEXTURE_UV *uv1,
-    TEXTURE_UV *uv2, TEXTURE_UV *uv3, uint16_t textype);
+    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage,
+    uint16_t textype);
 void S_Output_DrawTexturedQuad(
     PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, PHD_VBUF *vn4, int16_t tpage,
-    TEXTURE_UV *uv1, TEXTURE_UV *uv2, TEXTURE_UV *uv3, TEXTURE_UV *uv4,
     uint16_t textype);
 void S_Output_DrawSprite(
     int16_t x1, int16_t y1, int16_t x2, int y2, int z, int sprnum, int shade);

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -441,11 +441,6 @@ static void M_InsertGT3_Sorted(
         }
     }
 
-    num_points = Render_XYGUVClipper(num_points, m_VBuffer);
-    if (num_points == 0) {
-        return;
-    }
-
     M_InsertPolyTextured(num_points, zv, poly_type, texture->tex_page);
 }
 
@@ -869,10 +864,6 @@ static void M_InsertSprite_Sorted(
         g_FltWinTop = 0.0f;
         g_FltWinRight = g_PhdWinWidth;
         g_FltWinBottom = g_PhdWinHeight;
-        num_points = Render_XYGUVClipper(num_points, m_VBuffer);
-        if (num_points == 0) {
-            return;
-        }
     }
 
     const bool old_shade = g_IsShadeEffect;
@@ -1040,11 +1031,6 @@ static void M_InsertGT3_ZBuffered(
         if (num_points == 0) {
             return;
         }
-    }
-
-    num_points = Render_XYGUVClipper(num_points, m_VBuffer);
-    if (num_points == 0) {
-        return;
     }
 
     M_SelectTexture(renderer, texture->tex_page);


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Removing screen plane clipping

The removal of screen plane clipping improves the wireframe mode appearance by no longer distracting the player with ever-changing level geometry.

In TR1, the clippers code could be fully eliminated. However, for TR2, it needs to be kept since it is still utilized by the SWR. Similarly, ZedClipper must also be retained at this time because it manages culling within the view frustum rather than at the screen boundaries, and removing it results in severe visual glitches.

#### Additional refactors

- I decided to remove `TEXTURE_UV` arguments from TR1's drawing functions and instead use the `PHD_VBUF` `u, v` directly. This significantly simplifies the calls.
- `POINT_INFO`, used by ZedClipper, is now removed in favor of direct usage of `PHD_VBUF`.
- Silly back and forth multiplications and divisions by 256 and 256² were removed which simplified the code a lot.