### PR TITLE
demo: move demo data to TRX

### DIFF
--- a/src/libtrx/game/demo/common.c
+++ b/src/libtrx/game/demo/common.c
@@ -1,0 +1,21 @@
+#include "game/game_buf.h"
+
+#include <stdint.h>
+
+static uint32_t *m_Data = nullptr;
+
+void Demo_InitialiseData(const uint16_t data_length)
+{
+    if (data_length == 0) {
+        m_Data = nullptr;
+    } else {
+        m_Data = GameBuf_Alloc(
+            (data_length + 1) * sizeof(uint32_t), GBUF_DEMO_BUFFER);
+        m_Data[data_length] = -1;
+    }
+}
+
+uint32_t *Demo_GetData(void)
+{
+    return m_Data;
+}

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -5,6 +5,7 @@
 #include "game/anims.h"
 #include "game/camera.h"
 #include "game/const.h"
+#include "game/demo.h"
 #include "game/effects/const.h"
 #include "game/game_buf.h"
 #include "game/inject.h"
@@ -791,6 +792,19 @@ void Level_ReadItems(VFILE *const file)
     }
 
 finish:
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_ReadDemoData(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const uint16_t size = VFile_ReadU16(file);
+    LOG_INFO("demo buffer size: %d", size);
+    Demo_InitialiseData(size);
+    if (size != 0) {
+        uint32_t *const data = Demo_GetData();
+        VFile_Read(file, data, size);
+    }
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/libtrx/include/libtrx/game/demo.h
+++ b/src/libtrx/include/libtrx/game/demo.h
@@ -2,6 +2,9 @@
 
 #include "./game_flow/types.h"
 
+void Demo_InitialiseData(uint16_t data_length);
+uint32_t *Demo_GetData(void);
+
 extern bool Demo_Start(int32_t level_num);
 extern void Demo_End(void);
 extern void Demo_Pause(void);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -30,6 +30,7 @@ void Level_ReadLightMap(VFILE *file);
 void Level_ReadCinematicFrames(VFILE *file);
 void Level_ReadCamerasAndSinks(VFILE *file);
 void Level_ReadItems(VFILE *file);
+void Level_ReadDemoData(VFILE *file);
 
 void Level_LoadTexturePages(LEVEL_INFO *info);
 void Level_LoadPalettes(LEVEL_INFO *info);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -114,6 +114,7 @@ sources = [
   'game/console/common.c',
   'game/console/history.c',
   'game/console/registry.c',
+  'game/demo/common.c',
   'game/fader.c',
   'game/game.c',
   'game/game_buf.c',

--- a/src/tr1/game/demo.c
+++ b/src/tr1/game/demo.c
@@ -36,7 +36,7 @@
     PROCESS_CONFIG(gameplay.fix_bear_ai, false);
 
 typedef struct {
-    uint32_t *demo_ptr;
+    const uint32_t *demo_ptr;
     const GF_LEVEL *level;
     CONFIG old_config;
     TEXTSTRING *text;
@@ -141,14 +141,15 @@ bool Demo_Start(const int32_t level_num)
 
     Interpolation_Remember();
 
-    if (g_DemoData == nullptr) {
+    const uint32_t *const data = Demo_GetData();
+    if (data == nullptr) {
         LOG_ERROR("Level '%s' has no demo data", p->level->path);
         return false;
     }
 
     g_OverlayFlag = 1;
     Camera_Initialise();
-    p->demo_ptr = g_DemoData;
+    p->demo_ptr = data;
 
     ITEM *const lara_item = Lara_GetItem();
     lara_item->pos.x = *p->demo_ptr++;

--- a/src/tr1/game/demo.h
+++ b/src/tr1/game/demo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <libtrx/game/game_flow/types.h>
+#include <libtrx/game/demo.h>
 
 bool Demo_Start(int32_t level_num);
 void Demo_End(void);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -66,7 +66,6 @@ static void M_LoadSprites(VFILE *file);
 static void M_LoadSoundEffects(VFILE *file);
 static void M_LoadBoxes(VFILE *file);
 static void M_LoadAnimatedTextures(VFILE *file);
-static void M_LoadDemo(VFILE *file);
 static void M_LoadSamples(VFILE *file);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
@@ -243,7 +242,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     }
 
     Level_ReadCinematicFrames(file);
-    M_LoadDemo(file);
+    Level_ReadDemoData(file);
     M_LoadSamples(file);
 
     VFile_SetPos(file, 4);
@@ -448,22 +447,6 @@ static void M_LoadAnimatedTextures(VFILE *const file)
     Level_ReadAnimatedTextureRanges(num_ranges, file);
 
     VFile_SetPos(file, end_position);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadDemo(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const uint16_t size = VFile_ReadU16(file);
-    LOG_INFO("demo buffer size: %d", size);
-    if (size != 0) {
-        g_DemoData =
-            GameBuf_Alloc((size + 1) * sizeof(uint32_t), GBUF_DEMO_BUFFER);
-        VFile_Read(file, g_DemoData, size);
-        g_DemoData[size] = -1;
-    } else {
-        g_DemoData = nullptr;
-    }
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -21,7 +21,6 @@ ITEM *g_LaraItem = nullptr;
 GAME_INFO g_GameInfo = {};
 int32_t g_SavedGamesCount = 0;
 int32_t g_SaveCounter = 0;
-uint32_t *g_DemoData = nullptr;
 bool g_LevelComplete = false;
 int32_t g_OverlayFlag = 0;
 int32_t g_HeightType = 0;

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -30,7 +30,6 @@ extern ITEM *g_LaraItem;
 extern GAME_INFO g_GameInfo;
 extern int32_t g_SavedGamesCount;
 extern int32_t g_SaveCounter;
-extern uint32_t *g_DemoData;
 extern bool g_LevelComplete;
 extern int32_t g_OverlayFlag;
 extern int32_t g_HeightType;

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -24,7 +24,7 @@
 #include <libtrx/log.h>
 
 typedef struct {
-    uint32_t *demo_ptr;
+    const uint32_t *demo_ptr;
     const GF_LEVEL *level;
     TEXTSTRING *text;
 
@@ -55,7 +55,7 @@ static void M_RestoreConfig(M_PRIV *const p)
 bool Demo_GetInput(void)
 {
     M_PRIV *const p = &m_Priv;
-    if (p->demo_ptr == &g_DemoData[0]) {
+    if (p->demo_ptr == Demo_GetData()) {
         m_OldDemoInputDB = (INPUT_STATE) {};
     }
 
@@ -125,7 +125,7 @@ bool Demo_Start(const int32_t level_num)
     ASSERT(p->level != nullptr);
     ASSERT(GF_GetCurrentLevel() == p->level);
 
-    p->demo_ptr = g_DemoData;
+    p->demo_ptr = Demo_GetData();
 
     ITEM *const lara_item = Lara_GetItem();
     lara_item->pos.x = *p->demo_ptr++;

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -105,7 +105,7 @@ bool Demo_GetInput(void)
         .step_left    = demo_input.step_left,
         .step_right   = demo_input.step_right,
         .roll         = demo_input.roll,
-        .use_flare        = demo_input.use_flare,
+        .use_flare    = demo_input.use_flare,
         .menu_confirm = demo_input.menu_confirm,
         .menu_back    = demo_input.menu_back,
         .save         = demo_input.save,
@@ -125,7 +125,13 @@ bool Demo_Start(const int32_t level_num)
     ASSERT(p->level != nullptr);
     ASSERT(GF_GetCurrentLevel() == p->level);
 
-    p->demo_ptr = Demo_GetData();
+    const uint32_t *const data = Demo_GetData();
+    if (data == nullptr) {
+        LOG_ERROR("Level '%s' has no demo data", p->level->path);
+        return false;
+    }
+
+    p->demo_ptr = data;
 
     ITEM *const lara_item = Lara_GetItem();
     lara_item->pos.x = *p->demo_ptr++;

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -47,7 +47,6 @@ static void M_LoadSprites(VFILE *file);
 static void M_LoadSoundEffects(VFILE *file);
 static void M_LoadBoxes(VFILE *file);
 static void M_LoadAnimatedTextures(VFILE *file);
-static void M_LoadDemo(VFILE *file);
 static void M_LoadSamples(VFILE *file);
 static void M_CompleteSetup(void);
 
@@ -245,22 +244,6 @@ static void M_LoadAnimatedTextures(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-static void M_LoadDemo(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const uint16_t size = VFile_ReadU16(file);
-    LOG_DEBUG("demo buffer size: %d", size);
-    if (size != 0) {
-        g_DemoData =
-            GameBuf_Alloc((size + 1) * sizeof(uint32_t), GBUF_DEMO_BUFFER);
-        VFile_Read(file, g_DemoData, size);
-        g_DemoData[size] = -1;
-    } else {
-        g_DemoData = nullptr;
-    }
-    Benchmark_End(benchmark, nullptr);
-}
-
 static void M_LoadSamples(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
@@ -394,7 +377,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 
     Level_ReadLightMap(file);
     Level_ReadCinematicFrames(file);
-    M_LoadDemo(file);
+    Level_ReadDemoData(file);
     M_LoadSamples(file);
 
     VFile_Close(file);

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -87,7 +87,6 @@ int32_t g_HeightType;
 int32_t g_FlipMaps[MAX_FLIP_MAPS];
 bool g_CameraUnderwater;
 int32_t g_BoxCount;
-uint32_t *g_DemoData = nullptr;
 char g_LevelFileName[256];
 uint16_t g_MusicTrackFlags[64];
 

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -85,7 +85,6 @@ extern int32_t g_HeightType;
 extern int32_t g_FlipMaps[MAX_FLIP_MAPS];
 extern bool g_CameraUnderwater;
 extern int32_t g_BoxCount;
-extern uint32_t *g_DemoData;
 extern char g_LevelFileName[256];
 extern uint16_t g_MusicTrackFlags[64];
 extern WEAPON_INFO g_Weapons[];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves demo data reading and storage to TRX, and updates TR2 to log an error if a level has no data defined (similar to TR1). TR2 crashes in this scenario on develop, but it's unreleased and not an issue in 0.8.

Should be straight-forward to test - demos should load normally, and if you update the TR2 gameflow to use e.g. GW as a demo level, it should return to title gracefully rather than crashing.
