### PR TITLE
tr1/lara/cheat: retain current meshes in fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed Lara not being able to jump if responsive jumping is disabled via the console in-level in certain scenarios (#2444, regression from 4.6)
 - fixed Lara being unable to climb or use guns after using an underwater lever and then entering the wading state (#2416, regression from 4.6)
 - fixed Eidos logo briefly flashing prior to the initial fade-in effect (#1388, regression from 4.1)
+- fixed Lara's meshes being incorrectly swapped in various scenarios using the fly cheat (#2461, regression from 4.7)
 - improved pause screen compatibility with PS1 (#2248)
 - improved level loading times with respect to injection processing
 - improved wireframe mode appearance around screen edges

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -162,7 +162,6 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.mesh_effects = 0;
     g_LaraItem->enable_shadow = true;
     g_LaraItem->hit_points = LARA_MAX_HITPOINTS;
-    Lara_InitialiseMeshes(Game_GetCurrentLevel());
     g_Camera.type = CAM_CHASE;
     Viewport_SetFOV(-1);
     Console_Log(GS(OSD_FLY_MODE_ON));


### PR DESCRIPTION
Resolves #2461.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids resetting Lara's meshes when entering the fly cheat, so to avoid further problems with save/load and gun state.
