### PR TITLE
tr1/stats: include scion in kill stats

### DIFF
--- a/src/tr1/game/stats/common.c
+++ b/src/tr1/game/stats/common.c
@@ -109,7 +109,8 @@ static void M_CheckTriggers(
             }
 
             // Add killable if object triggered
-            if (Object_IsType(item->object_id, g_EnemyObjects)) {
+            if (Object_IsType(item->object_id, g_EnemyObjects)
+                || item->object_id == O_SCION_ITEM_3) {
                 M_IncludeKillableItem(item_num);
             }
         }


### PR DESCRIPTION
Resolves #2465.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds a special case check for scions to include as killable items.
