### PR TITLE
game-strings: fix strings loaded late

### DIFF
--- a/src/libtrx/game/console/cmd/play_level.c
+++ b/src/libtrx/game/console/cmd/play_level.c
@@ -28,7 +28,9 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
             .value = (void *)(intptr_t)i,
             .weight = 1,
         };
-        Vector_Add(source, &source_item);
+        if (source_item.key != nullptr) {
+            Vector_Add(source, &source_item);
+        }
     }
 
     const GF_LEVEL *const gym_level = GF_GetGymLevel();

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -128,6 +128,7 @@ void Shell_Init(
     GF_Init();
     GF_Load(game_flow_path);
     GameStringTable_LoadFromFile(game_strings_path);
+    GameStringTable_Apply(nullptr);
 
     Savegame_Init();
     Savegame_ScanSavedGames();

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -353,6 +353,7 @@ void Shell_Main(void)
     GF_Init();
     GF_Load(m_CurrentGameFlowPath);
     GameStringTable_LoadFromFile(m_CurrentGameStringsPath);
+    GameStringTable_Apply(nullptr);
 
     Savegame_Init();
     Savegame_InitCurrentInfo();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes problems when the player would issue the `/play` command before reaching the title screen, like during the opening legal notice or initial FMVs. Entering `/play` followed by a number would load a level, but it would incorrectly display "Loading level (null)". Even worse, attempting to use a command such as `/play caves` would crash the game as it tried to fuzzy-match against a nullptr.