### PR TITLE
tr1/option: fix restart level save slot logic

### DIFF
--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -582,7 +582,7 @@ static void M_Restart(INVENTORY_ITEM *inv_item)
 {
     M_ChangePageTextContent(GS(PASSPORT_RESTART_LEVEL));
 
-    if (Savegame_RestartAvailable(g_GameInfo.select_save_slot)) {
+    if (Savegame_RestartAvailable(Savegame_GetBoundSlot())) {
         if (g_InputDB.menu_confirm) {
             g_GameInfo.passport_selection = PASSPORT_MODE_RESTART;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2454. Instead of using the active save slot that the game is running from, it was using the most recent passport selection.