### PR TITLE
game-flow: fix setting the NG+ flag

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -355,7 +355,7 @@
                 {"type": "display_picture", "path": "data/images/credits_2.webp", "display_time": 7.5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "path": "data/images/credits_3.webp", "display_time": 7.5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "total_stats", "background_path": "data/images/install.webp"},
-                {"type": "exit_to_title"},
+                {"type": "level_complete"},
             ],
             "injections": [
                 "data/injections/pyramid_fd.bin",

--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -351,7 +351,7 @@
                 {"type": "display_picture", "path": "data/credit07.pcx", "display_time": 15, "fade_in_time": 0.5, "fade_out_time": 0.5},
                 {"type": "display_picture", "path": "data/credit08.pcx", "display_time": 15, "fade_in_time": 0.5, "fade_out_time": 0.5},
                 {"type": "total_stats", "background_path": "data/end.pcx"},
-                {"type": "exit_to_title"},
+                {"type": "level_complete"},
             ],
             "injections": [
                 "data/injections/house_itemrots.bin",


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2474. The check for the last level only happens in the `level_complete` event, which will be followed with an exit to title anyway.