### PR TITLE
tr2/option/passport: rewrite and simplify

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -52,6 +52,7 @@
 - fixed gunflare from bandits in Tibetan levels spawning too far from their guns (#2365, regression from 0.8)
 - fixed guns sometimes appearing in Lara's hands when entering the fly cheat while undrawing weapons (#2376, regression from 0.3)
 - fixed the `/play` console command not resetting Lara's inventory (#2267, regression from 0.3)
+- fixed flashing text when trying to exit passport while Lara is dead and an action is required (#2263)
 - improved rendering to achieve a slight performance boost in big rooms (#2325)
 - improved wireframe mode appearance around screen edges
 

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -1060,7 +1060,7 @@ bool S_FrontEndCheck(void)
         if (!File_Exists(file_name)) {
             Requester_AddItem(
                 &g_LoadGameRequester, GS(MISC_EMPTY_SLOT), 0, 0, 0);
-            g_SavedLevels[i] = 0;
+            g_SavedLevels[i] = false;
         } else {
             MYFILE *const fp = File_Open(file_name, FILE_OPEN_READ);
             char level_title[80];
@@ -1079,7 +1079,7 @@ bool S_FrontEndCheck(void)
                 g_SaveCounter = save_num;
                 g_LoadGameRequester.selected = i;
             }
-            g_SavedLevels[i] = 1;
+            g_SavedLevels[i] = true;
             g_SavedGames++;
         }
     }
@@ -1132,7 +1132,7 @@ int32_t S_SaveGame(const int32_t slot_num)
 
     m_ReqFlags1[slot_num] = g_RequesterFlags1[slot_num];
     m_ReqFlags2[slot_num] = g_RequesterFlags2[slot_num];
-    g_SavedLevels[slot_num] = 1;
+    g_SavedLevels[slot_num] = true;
     g_SaveCounter++;
     g_SavedGames++;
 

--- a/src/tr2/game/requester.c
+++ b/src/tr2/game/requester.c
@@ -321,16 +321,9 @@ int32_t Requester_Display(
         return 0;
     }
 
-    // TODO: WTF!?
-    if (!strcmp(
-            req->item_texts1[req->selected - req->line_offset]->content,
-            GS(MISC_EMPTY_SLOT))
-        && !strcmp(g_PasswordText1->content, GS(PASSPORT_LOAD_GAME))) {
-        g_Input = (INPUT_STATE) {};
-        return 0;
+    if (destroy) {
+        Requester_Shutdown(req);
     }
-
-    Requester_Shutdown(req);
     return req->selected + 1;
 }
 

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -287,7 +287,6 @@ int32_t g_GF_LaraStartAnim;
 int32_t g_GF_ScriptVersion;
 
 int32_t g_SavedGames;
-TEXTSTRING *g_PasswordText1 = nullptr;
 char g_ValidLevelStrings1[MAX_LEVELS][50];
 char g_ValidLevelStrings2[MAX_LEVELS][50];
 uint32_t g_RequesterFlags1[MAX_REQUESTER_ITEMS];

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -98,7 +98,6 @@ extern int16_t g_GF_NumSecrets;
 extern int32_t g_GF_LaraStartAnim;
 
 extern int32_t g_SavedGames;
-extern TEXTSTRING *g_PasswordText1;
 extern char g_ValidLevelStrings1[MAX_LEVELS][50];
 extern char g_ValidLevelStrings2[MAX_LEVELS][50];
 extern uint32_t g_RequesterFlags1[MAX_REQUESTER_ITEMS];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2346. Resolves #2263.
This refactors the option passport module to determine the passport pages availability and roles internally, and act on those, rather than do everything at once. The resulting setup is even simpler than what we currently have in TR1.
We still do rely on `g_Inv_ExtraData` and hardcoded page numbers in the consumer code, though, as we never expose the active page role to the outside world. Let's not handle that just yet, though.

#### Testing

All passport interaction:

- Gym load/new game/exit
- Ingame load/save/exit
- Title load/new game/exit
- Death state load/exit
- F5
- F6
- Having no save states present for each of these scenarios
- Trying to cycle to unavailable pages
- Saving and loading
- Saving and loading twice, in different slots