### PR TITLE
build: bump macos python to 3.13

### DIFF
--- a/.github/actions/prepare_macos_tooling/action.yml
+++ b/.github/actions/prepare_macos_tooling/action.yml
@@ -34,11 +34,11 @@ runs:
       shell: bash
       run: |
         # Install Python first to avoid multiple Python in the dep tree later on.
-        sudo port -N install python312 py312-pip
-        sudo port select --set python python312
-        sudo port select --set python3 python312
-        sudo port select --set pip pip312
-        sudo port select --set pip3 pip312
+        sudo port -N install python313 py313-pip
+        sudo port select --set python python313
+        sudo port select --set python3 python313
+        sudo port select --set pip pip313
+        sudo port select --set pip3 pip313
 
         # Install Clang to get better C23 support.
         sudo port -N install clang-16


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Python 3.12 is gone from MacPorts even though it's expected to enter LTS only next month.
Once again, Mac ecosystem proves it's more reliable at failing builds than running them.