### PR TITLE
tr2/sound: fix sound slot issues

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed teleporting to an item on a ledge sometimes pushing Lara to the room below (#2372)
 - fixed the game crashing if a cinematic is triggered but the level contains no cinematic frames (#2413)
 - fixed being unable to load a level that contains no sound effect data (#2460)
+- fixed issues with sound effects not playing or looping forever in some cases when many other effects are playing (#2494)
 - fixed Lara activating triggers one frame too early (#2205, regression from 0.7)
 - fixed savegame incompatibility with OG (#2271, regression from 0.8)
 - fixed stopwatch showing wrong UI in some circumstances (#2221, regression from 0.8)


### PR DESCRIPTION
Resolves #2494.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves problems when the sound slot list is full but the game continues to try to play further SFX. The previous result would be that some sounds would be permanently disabled, or some could start playing but become untracked.

Thanks @rr- for helping with this.
