### PR TITLE
Refactor TR1 passport code

### DIFF
--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -118,13 +118,6 @@ typedef enum {
 } GAME_BONUS_FLAG;
 
 typedef enum {
-    PAGE_1 = 0,
-    PAGE_2 = 1,
-    PAGE_3 = 2,
-    PAGE_COUNT = 3,
-} PASSPORT_PAGE;
-
-typedef enum {
     PASSPORT_MODE_BROWSE = 0,
     PASSPORT_MODE_LOAD_GAME = 1,
     PASSPORT_MODE_SELECT_LEVEL = 2,

--- a/src/tr2/game/option/option_passport.c
+++ b/src/tr2/game/option/option_passport.c
@@ -253,22 +253,6 @@ static void M_ShowPage(const INVENTORY_ITEM *const inv_item)
         }
         break;
     }
-
-    if (g_InputDB.menu_left) {
-        for (int32_t page = m_State.active_page - 1; page >= 0; page--) {
-            if (m_State.pages[page].available) {
-                m_State.active_page = page;
-                break;
-            }
-        }
-    } else if (g_InputDB.menu_right) {
-        for (int32_t page = m_State.active_page + 1; page < 3; page++) {
-            if (m_State.pages[page].available) {
-                m_State.active_page = page;
-                break;
-            }
-        }
-    }
 }
 
 void Option_Passport_Control(INVENTORY_ITEM *const item)
@@ -292,21 +276,35 @@ void Option_Passport_Control(INVENTORY_ITEM *const item)
         M_FlipRight(item);
     } else if (m_State.current_page > m_State.active_page) {
         M_FlipLeft(item);
+    }
+
+    M_ShowPage(item);
+    if (g_InputDB.menu_confirm) {
+        g_Inv_ExtraData[0] = m_State.active_page;
+        g_Inv_ExtraData[1] = m_State.selection;
+        m_State.active_page = -1;
+        M_Close(item);
     } else if (g_InputDB.menu_back) {
-        if (g_Inv_Mode == INV_DEATH_MODE) {
+        if (g_Inv_Mode != INV_DEATH_MODE) {
+            M_Close(item);
+            m_State.active_page = -1;
+        } else {
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
-        } else {
-            M_Close(item);
-            m_State.active_page = -1;
         }
-    } else {
-        M_ShowPage(item);
-        if (g_InputDB.menu_confirm) {
-            g_Inv_ExtraData[0] = m_State.active_page;
-            g_Inv_ExtraData[1] = m_State.selection;
-            m_State.active_page = -1;
-            M_Close(item);
+    } else if (g_InputDB.menu_left) {
+        for (int32_t page = m_State.active_page - 1; page >= 0; page--) {
+            if (m_State.pages[page].available) {
+                m_State.active_page = page;
+                break;
+            }
+        }
+    } else if (g_InputDB.menu_right) {
+        for (int32_t page = m_State.active_page + 1; page < 3; page++) {
+            if (m_State.pages[page].available) {
+                m_State.active_page = page;
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the TR1 code to align more closely with the TR2 code. We keep `PASSPORT_MODE_BROWSE` to allow players to "confirm" entry into a passport page (for instances where the page initially appears blank and requires pressing the Action key to display, like loading, saving, or starting a new game). Additionally, we keep the `mode` property, instead of inferring the mode from the active page like in TR2, to support navigation to and from the savegame-specific actions menu (eg. "Select level" and "Story so far" features).

This prepares TR1 for #1328.
