### PR TITLE
tr1/game_flow: skip levels in story so far

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.1...develop) - ××××-××-××
 - changed default FPS value to 60 (#2501)
+- fixed story so far not skipping over levels (#2506, regression from 4.8)
 - improved memory usage by shedding ca. 100-110 MB on average
 
 ## [4.8.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.8...tr1-4.8.1) - 2025-02-14

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -60,6 +60,8 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         const int32_t savegame_level_num = (int32_t)(intptr_t)seq_ctx_arg;
         if (savegame_level_num == level->num) {
             return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        } else {
+            return (GF_COMMAND) { .action = GF_NOOP };
         }
         break;
 


### PR DESCRIPTION
Resolves #2506.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores skipping over levels in the story so far feature.
