### PR TITLE
tr2/savegame: fix reading bools crashing on Linux

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.9...develop) - ××××-××-××
 - fixed resolving paths (especially to music files) on case-sensitive filesystems (#1934, #2504)
+- fixed loading a game crashing on Linux (#2508, regression from 0.9)
 - improved memory usage by shedding ca. 100-110 MB on average
 
 ## [0.9](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.9) - 2025-02-14

--- a/src/tr2/decomp/savegame.h
+++ b/src/tr2/decomp/savegame.h
@@ -21,10 +21,6 @@ void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *level);
 void CreateSaveGameInfo(void);
 void ExtractSaveGameInfo(void);
 
-void ResetSG(void);
-void WriteSG(const void *pointer, size_t size);
-void ReadSG(void *pointer, size_t size);
-
 void GetSavedGamesList(REQUEST_INFO *req);
 bool S_FrontEndCheck(void);
 int32_t S_SaveGame(int32_t slot_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2508. We had a faulty read routine that read 4 bytes into a `bool` which on Linux apparently takes 1 byte.