### PR TITLE
tr1/room: refresh track flags in gym

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...develop) - ××××-××-××
+- fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)
 
 ## [4.8.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.1...tr1-4.8.2) - 2025-02-15
 - changed default FPS value to 60 (#2501)

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -89,6 +89,7 @@ static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
     }
     // end of g_Lara gym routines
 
+    flags = Music_GetTrackFlags(track);
     if (flags & IF_ONE_SHOT) {
         return;
     }


### PR DESCRIPTION
Resolves #2514.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This refreshes the track flags after processing the gym tracks, in case the track ID has changed based on player action.