### PR TITLE
tools: switch to new releasing strategy

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -45,7 +45,11 @@ class CommitCommand(BaseCommand):
 
     def run(self, args: argparse.Namespace, options: Options) -> None:
         # self.git.checkout_branch("develop")
-        old_tag = self.git.get_branch_version(pattern=f"tr{args.game_version}-*", branch="origin/stable", abbrev=0)
+        old_tag = self.git.get_branch_version(
+            pattern=f"tr{args.game_version}-*",
+            branch="origin/stable",
+            abbrev=0,
+        )
         new_tag = f"tr{args.game_version}-{args.version}"
 
         changelog_path = PROJECT_PATHS[args.game_version].changelog_path
@@ -68,8 +72,6 @@ class CommitCommand(BaseCommand):
         changelog_path.write_text(new_changelog)
         self.git.add(changelog_path)
         self.git.commit(f"docs/tr{args.game_version}: release {args.version}")
-        self.git.delete_tag(new_tag)
-        self.git.create_tag(new_tag)
 
 
 class BranchCommand(BaseCommand):
@@ -79,7 +81,11 @@ class BranchCommand(BaseCommand):
     def run(self, args: argparse.Namespace, options: Options) -> None:
         new_tag = f"tr{args.game_version}-{args.version}"
         self.git.checkout_branch("stable")
-        self.git.reset(new_tag, hard=True)
+        self.git.merge_reset(
+            "develop", text=f"{args.game_version}: release {args.version}"
+        )
+        self.git.delete_tag(new_tag)
+        self.git.create_tag(new_tag)
         self.git.checkout_branch("develop")
 
 

--- a/tools/shared/git.py
+++ b/tools/shared/git.py
@@ -16,6 +16,13 @@ class Git:
             ["git", "reset", "develop", *(["--hard"] if hard else [])]
         )
 
+    def merge_reset(self, target: str, text: str) -> None:
+        self.check_output(
+            ["git", "merge", target, "--strategy=ours", "--no-commit"]
+        )
+        self.check_output(["git", "read-tree", "-u", "--reset", target])
+        self.check_output(["git", "commit", "-m", text])
+
     def delete_tag(self, tag_name: str) -> None:
         self.grab_output(["git", "tag", "-d", tag_name])
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This modifies the merge process for stable releases to create a merge commit instead of using a forceful `git reset --hard`. It also skips any conflict resolution by assuming the develop branch's content will be the final release. Additionally, tags will now be applied to the `stable` branch rather than `develop`.

The main purpose of this change is to allow us to selectively cherry-pick hotfixes to the stable branch, making hotfix releases simpler. The current tooling would delete the hotfix history after a major release, because we've been keeping the `stable` and `develop` branches aligned, and this pull request aims to change that.

The downside is that doing `git log` on develop will no longer clearly the releases and we'll either have to look for `docs: release XXX` or do `git log stable`.