### PR TITLE
objects: merge type definitions; tidy member names

### DIFF
--- a/docs/tr2/symbols.txt
+++ b/docs/tr2/symbols.txt
@@ -1143,16 +1143,16 @@ typedef struct __unaligned {
     int32_t bone_idx;
     int16_t *frame_base; // TODO: make me FRAME_INFO
 
-    void (*initialise)(int16_t item_num);
-    void (*control)(int16_t item_num);
-    void (*floor)(
+    void (*initialise_func)(int16_t item_num);
+    void (*control_func)(int16_t item_num);
+    void (*floor_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z,
         int32_t *out_height);
-    void (*ceiling)(
+    void (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z,
         int32_t *out_height);
-    void (*draw_routine)(const ITEM *item);
-    void (*collision)(int16_t
+    void (*draw_func)(const ITEM *item);
+    void (*collision_func)(int16_t
         item_num, ITEM *lara_item, COLL_INFO *coll);
 
     int16_t anim_idx;

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -172,7 +172,7 @@ void Item_RemoveDrawn(const int16_t item_num)
 void Item_AddActive(const int16_t item_num)
 {
     ITEM *const item = &m_Items[item_num];
-    if (Object_Get(item->object_id)->control == nullptr) {
+    if (Object_Get(item->object_id)->control_func == nullptr) {
         item->status = IS_INACTIVE;
         return;
     }

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -41,6 +41,7 @@ typedef struct {
         XYZ_16 max;
     } shift, rot;
 } OBJECT_BOUNDS;
+#endif
 
 typedef struct {
     int16_t mesh_count;
@@ -48,52 +49,26 @@ typedef struct {
     int32_t bone_idx;
     uint32_t frame_ofs;
     ANIM_FRAME *frame_base;
-    void (*initialise)(int16_t item_num);
-    void (*control)(int16_t item_num);
+
+    void (*initialise_func)(int16_t item_num);
+    void (*control_func)(int16_t item_num);
+    void (*draw_func)(const ITEM *item);
+    void (*collision_func)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
     int16_t (*floor_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     int16_t (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
-    void (*draw_routine)(ITEM *item);
-    void (*collision)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-    const OBJECT_BOUNDS *(*bounds)(void);
-    bool (*is_usable)(int16_t item_num);
+#if TR_VERSION == 1
+    const OBJECT_BOUNDS *(*bounds_func)(void);
+    bool (*is_usable_func)(int16_t item_num);
+#endif
+
     int16_t anim_idx;
     int16_t hit_points;
     int16_t pivot_length;
     int16_t radius;
+    int16_t shadow_size;
     int16_t smartness;
-    int16_t shadow_size;
-    uint16_t loaded : 1;
-    uint16_t intelligent : 1;
-    uint16_t save_position : 1;
-    uint16_t save_hitpoints : 1;
-    uint16_t save_flags : 1;
-    uint16_t save_anim : 1;
-} OBJECT;
-
-#elif TR_VERSION == 2
-typedef struct {
-    int16_t mesh_count;
-    int16_t mesh_idx;
-    int32_t bone_idx;
-    uint32_t frame_ofs;
-    ANIM_FRAME *frame_base;
-
-    void (*initialise)(int16_t item_num);
-    void (*control)(int16_t item_num);
-    void (*floor)(
-        const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-    void (*ceiling)(
-        const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-    void (*draw_routine)(const ITEM *item);
-    void (*collision)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-
-    int16_t anim_idx;
-    int16_t hit_points;
-    int16_t pivot_length;
-    int16_t radius;
-    int16_t shadow_size;
 
     union {
         uint16_t flags;
@@ -111,7 +86,6 @@ typedef struct {
         // clang-format on
     };
 } OBJECT;
-#endif
 
 typedef struct {
     bool loaded;

--- a/src/tr1/game/effects.c
+++ b/src/tr1/game/effects.c
@@ -32,8 +32,8 @@ void Effect_Control(void)
     while (effect_num != NO_EFFECT) {
         EFFECT *effect = Effect_Get(effect_num);
         const OBJECT *const obj = Object_Get(effect->object_id);
-        if (obj->control) {
-            obj->control(effect_num);
+        if (obj->control_func != nullptr) {
+            obj->control_func(effect_num);
         }
         effect_num = effect->next_active;
     }

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -35,8 +35,8 @@ void Item_Control(void)
     while (item_num != NO_ITEM) {
         ITEM *item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->control) {
-            obj->control(item_num);
+        if (obj->control_func != nullptr) {
+            obj->control_func(item_num);
         }
         item_num = item->next_active;
     }
@@ -94,8 +94,8 @@ void Item_Initialise(int16_t item_num)
     if (g_GameInfo.bonus_flag & GBF_NGPLUS) {
         item->hit_points *= 2;
     }
-    if (obj->initialise) {
-        obj->initialise(item_num);
+    if (obj->initialise_func) {
+        obj->initialise_func(item_num);
     }
 
     Interpolation_RememberItem(item);

--- a/src/tr1/game/lara/control.c
+++ b/src/tr1/game/lara/control.c
@@ -124,14 +124,14 @@ static void M_BaddieCollision(ITEM *lara_item, COLL_INFO *coll)
             const ITEM *const item = Item_Get(item_num);
             if (item->collidable && item->status != IS_INVISIBLE) {
                 const OBJECT *const obj = Object_Get(item->object_id);
-                if (obj->collision != nullptr) {
+                if (obj->collision_func != nullptr) {
                     int32_t x = lara_item->pos.x - item->pos.x;
                     int32_t y = lara_item->pos.y - item->pos.y;
                     int32_t z = lara_item->pos.z - item->pos.z;
                     if (x > -TARGET_DIST && x < TARGET_DIST && y > -TARGET_DIST
                         && y < TARGET_DIST && z > -TARGET_DIST
                         && z < TARGET_DIST) {
-                        obj->collision(item_num, lara_item, coll);
+                        obj->collision_func(item_num, lara_item, coll);
                     }
                 }
             }

--- a/src/tr1/game/lara/draw.c
+++ b/src/tr1/game/lara/draw.c
@@ -23,7 +23,7 @@ static void M_DrawMesh(
     }
 }
 
-void Lara_Draw(ITEM *item)
+void Lara_Draw(const ITEM *const item)
 {
     ANIM_FRAME *frmptr[2];
     MATRIX saved_matrix;
@@ -307,8 +307,8 @@ end:
 }
 
 void Lara_Draw_I(
-    ITEM *item, ANIM_FRAME *frame1, ANIM_FRAME *frame2, int32_t frac,
-    int32_t rate)
+    const ITEM *const item, ANIM_FRAME *frame1, ANIM_FRAME *frame2,
+    int32_t frac, int32_t rate)
 {
     MATRIX saved_matrix;
 

--- a/src/tr1/game/lara/draw.h
+++ b/src/tr1/game/lara/draw.h
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 
-void Lara_Draw(ITEM *item);
+void Lara_Draw(const ITEM *item);
 void Lara_Draw_I(
-    ITEM *item, ANIM_FRAME *frame1, ANIM_FRAME *frame2, int32_t frac,
+    const ITEM *item, ANIM_FRAME *frame1, ANIM_FRAME *frame2, int32_t frac,
     int32_t rate);

--- a/src/tr1/game/objects/common.h
+++ b/src/tr1/game/objects/common.h
@@ -12,11 +12,11 @@ void Object_DrawInterpolatedObject(
     const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,
     const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,
     int32_t rate);
-void Object_DrawDummyItem(ITEM *item);
-void Object_DrawSpriteItem(ITEM *item);
-void Object_DrawPickupItem(ITEM *item);
-void Object_DrawAnimatingItem(ITEM *item);
-void Object_DrawUnclippedItem(ITEM *item);
+void Object_DrawDummyItem(const ITEM *item);
+void Object_DrawSpriteItem(const ITEM *item);
+void Object_DrawPickupItem(const ITEM *item);
+void Object_DrawAnimatingItem(const ITEM *item);
+void Object_DrawUnclippedItem(const ITEM *item);
 void Object_SetMeshReflective(
     GAME_OBJECT_ID obj_id, int32_t mesh_idx, bool enabled);
 void Object_SetReflective(GAME_OBJECT_ID obj_id, bool enabled);

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -113,9 +113,9 @@ void Ape_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Ape_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Ape_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = APE_HITPOINTS;
     obj->pivot_length = 250;

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -16,10 +16,10 @@ static int32_t m_AnchorZ = -1;
 
 void BaconLara_Setup(OBJECT *obj)
 {
-    obj->initialise = BaconLara_Initialise;
-    obj->control = BaconLara_Control;
-    obj->draw_routine = BaconLara_Draw;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = BaconLara_Initialise;
+    obj->control_func = BaconLara_Control;
+    obj->draw_func = BaconLara_Draw;
+    obj->collision_func = Creature_Collision;
     obj->hit_points = LARA_MAX_HITPOINTS;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = 1;
@@ -127,7 +127,7 @@ void BaconLara_Control(int16_t item_num)
     }
 }
 
-void BaconLara_Draw(ITEM *item)
+void BaconLara_Draw(const ITEM *item)
 {
     if (item->current_anim_state == LS_DEATH) {
         Object_DrawAnimatingItem(item);

--- a/src/tr1/game/objects/creatures/bacon_lara.h
+++ b/src/tr1/game/objects/creatures/bacon_lara.h
@@ -6,4 +6,4 @@ void BaconLara_Setup(OBJECT *obj);
 void BaconLara_Initialise(int16_t item_num);
 bool BaconLara_InitialiseAnchor(int32_t room_index);
 void BaconLara_Control(int16_t item_num);
-void BaconLara_Draw(ITEM *item);
+void BaconLara_Draw(const ITEM *item);

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -34,9 +34,9 @@ void Baldy_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Baldy_Initialise;
-    obj->control = Baldy_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Baldy_Initialise;
+    obj->control_func = Baldy_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = BALDY_HITPOINTS;
     obj->radius = BALDY_RADIUS;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -70,9 +70,9 @@ void Bat_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Bat_Initialise;
-    obj->control = Bat_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Bat_Initialise;
+    obj->control_func = Bat_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = BAT_HITPOINTS;
     obj->radius = BAT_RADIUS;

--- a/src/tr1/game/objects/creatures/bear.c
+++ b/src/tr1/game/objects/creatures/bear.c
@@ -52,9 +52,9 @@ void Bear_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Bear_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Bear_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = BEAR_HITPOINTS;
     if (g_Config.gameplay.fix_bear_ai) {

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -42,9 +42,9 @@ void Centaur_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Centaur_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Centaur_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->hit_points = CENTAUR_HITPOINTS;
     obj->pivot_length = 400;

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -37,9 +37,9 @@ void Cowboy_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Cowboy_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Cowboy_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = COWBOY_HITPOINTS;
     obj->radius = COWBOY_RADIUS;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -68,9 +68,9 @@ void Croc_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Croc_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Croc_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->hit_points = CROCODILE_HITPOINTS;
     obj->pivot_length = 600;
@@ -207,9 +207,9 @@ void Alligator_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Alligator_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Alligator_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->hit_points = ALLIGATOR_HITPOINTS;
     obj->pivot_length = 600;

--- a/src/tr1/game/objects/creatures/cutscene_player.c
+++ b/src/tr1/game/objects/creatures/cutscene_player.c
@@ -6,8 +6,8 @@
 
 void CutscenePlayer_Setup(OBJECT *obj)
 {
-    obj->initialise = CutscenePlayer_Initialise;
-    obj->control = CutscenePlayer_Control;
+    obj->initialise_func = CutscenePlayer_Initialise;
+    obj->control_func = CutscenePlayer_Control;
     obj->hit_points = 1;
 }
 

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -37,9 +37,9 @@ void Larson_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Larson_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Larson_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = LARSON_HITPOINTS;
     obj->radius = LARSON_RADIUS;

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -47,9 +47,9 @@ static BITE m_LionBite = { -2, -10, 132, 21 };
 
 static void M_SetupBase(OBJECT *const obj)
 {
-    obj->initialise = Creature_Initialise;
-    obj->control = Lion_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Lion_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 400;
     obj->intelligent = 1;

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -26,9 +26,9 @@ void Mummy_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Mummy_Initialise;
-    obj->control = Mummy_Control;
-    obj->collision = Object_Collision;
+    obj->initialise_func = Mummy_Initialise;
+    obj->control_func = Mummy_Control;
+    obj->collision_func = Object_Collision;
     obj->hit_points = MUMMY_HITPOINTS;
     obj->save_flags = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -69,9 +69,9 @@ void Mutant_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Mutant_FlyerControl;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Mutant_FlyerControl;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->hit_points = FLYER_HITPOINTS;
     obj->pivot_length = 150;
@@ -93,7 +93,7 @@ void Mutant_Setup2(OBJECT *obj)
         return;
     }
     *obj = *Object_Get(O_WARRIOR_1);
-    obj->initialise = Mutant_Initialise2;
+    obj->initialise_func = Mutant_Initialise2;
     obj->smartness = WARRIOR2_SMARTNESS;
 }
 
@@ -103,7 +103,7 @@ void Mutant_Setup3(OBJECT *obj)
         return;
     }
     *obj = *Object_Get(O_WARRIOR_1);
-    obj->initialise = Mutant_Initialise2;
+    obj->initialise_func = Mutant_Initialise2;
 }
 
 void Mutant_FlyerControl(int16_t item_num)

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -49,9 +49,9 @@ void Natla_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->collision = Creature_Collision;
-    obj->initialise = Creature_Initialise;
-    obj->control = Natla_Control;
+    obj->collision_func = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Natla_Control;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = NATLA_HITPOINTS;
     obj->radius = NATLA_RADIUS;

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -46,9 +46,9 @@ void Pierre_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Pierre_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Pierre_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = PIERRE_HITPOINTS;
     obj->radius = PIERRE_RADIUS;

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -21,9 +21,9 @@ void Pod_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Pod_Initialise;
-    obj->control = Pod_Control;
-    obj->collision = Object_Collision;
+    obj->initialise_func = Pod_Initialise;
+    obj->control_func = Pod_Control;
+    obj->collision_func = Object_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -45,9 +45,9 @@ void Raptor_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Raptor_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Raptor_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = RAPTOR_HITPOINTS;
     obj->pivot_length = 400;

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -62,9 +62,9 @@ void Rat_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Rat_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Rat_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = RAT_HITPOINTS;
     obj->pivot_length = 200;
@@ -173,9 +173,9 @@ void Vole_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Vole_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Vole_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = RAT_HITPOINTS;
     obj->pivot_length = 200;

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -44,10 +44,10 @@ void SkateKid_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = SkateKid_Initialise;
-    obj->control = SkateKid_Control;
-    obj->draw_routine = SkateKid_Draw;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = SkateKid_Initialise;
+    obj->control_func = SkateKid_Control;
+    obj->draw_func = SkateKid_Draw;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = SKATE_KID_HITPOINTS;
     obj->radius = SKATE_KID_RADIUS;
@@ -173,7 +173,7 @@ void SkateKid_Control(int16_t item_num)
     Creature_Animate(item_num, angle, 0);
 }
 
-void SkateKid_Draw(ITEM *item)
+void SkateKid_Draw(const ITEM *const item)
 {
     Object_DrawAnimatingItem(item);
     if (!Object_Get(O_SKATEBOARD)->loaded) {
@@ -182,10 +182,10 @@ void SkateKid_Draw(ITEM *item)
 
     const int16_t relative_anim = Item_GetRelativeAnim(item);
     const int16_t relative_frame = Item_GetRelativeFrame(item);
-    item->object_id = O_SKATEBOARD;
-    Item_SwitchToAnim(item, relative_anim, relative_frame);
+    ((ITEM *)item)->object_id = O_SKATEBOARD;
+    Item_SwitchToAnim((ITEM *)item, relative_anim, relative_frame);
     Object_DrawAnimatingItem(item);
 
-    item->object_id = O_SKATEKID;
-    Item_SwitchToAnim(item, relative_anim, relative_frame);
+    ((ITEM *)item)->object_id = O_SKATEKID;
+    Item_SwitchToAnim((ITEM *)item, relative_anim, relative_frame);
 }

--- a/src/tr1/game/objects/creatures/skate_kid.h
+++ b/src/tr1/game/objects/creatures/skate_kid.h
@@ -5,4 +5,4 @@
 void SkateKid_Setup(OBJECT *obj);
 void SkateKid_Initialise(int16_t item_num);
 void SkateKid_Control(int16_t item_num);
-void SkateKid_Draw(ITEM *item);
+void SkateKid_Draw(const ITEM *item);

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -20,9 +20,9 @@ void Statue_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Statue_Initialise;
-    obj->control = Statue_Control;
-    obj->collision = Object_Collision;
+    obj->initialise_func = Statue_Initialise;
+    obj->control_func = Statue_Control;
+    obj->collision_func = Object_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -56,9 +56,9 @@ void Torso_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = Torso_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = Torso_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->hit_points = TORSO_HITPOINTS;
     obj->radius = TORSO_RADIUS;

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -45,10 +45,10 @@ void TRex_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Creature_Initialise;
-    obj->control = TRex_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = TRex_Collision;
+    obj->initialise_func = Creature_Initialise;
+    obj->control_func = TRex_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = TRex_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = TREX_HITPOINTS;
     obj->pivot_length = 2000;

--- a/src/tr1/game/objects/creatures/wolf.c
+++ b/src/tr1/game/objects/creatures/wolf.c
@@ -52,9 +52,9 @@ void Wolf_Setup(OBJECT *obj)
     if (!obj->loaded) {
         return;
     }
-    obj->initialise = Wolf_Initialise;
-    obj->control = Wolf_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Wolf_Initialise;
+    obj->control_func = Wolf_Control;
+    obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = WOLF_HITPOINTS;
     obj->pivot_length = 375;

--- a/src/tr1/game/objects/effects/blood.c
+++ b/src/tr1/game/objects/effects/blood.c
@@ -8,7 +8,7 @@
 
 void Blood_Setup(OBJECT *obj)
 {
-    obj->control = Blood_Control;
+    obj->control_func = Blood_Control;
 }
 
 void Blood_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/body_part.c
+++ b/src/tr1/game/objects/effects/body_part.c
@@ -11,7 +11,7 @@
 
 void BodyPart_Setup(OBJECT *obj)
 {
-    obj->control = BodyPart_Control;
+    obj->control_func = BodyPart_Control;
     obj->mesh_count = 0;
     obj->loaded = 1;
 }

--- a/src/tr1/game/objects/effects/bubble.c
+++ b/src/tr1/game/objects/effects/bubble.c
@@ -9,7 +9,7 @@
 
 void Bubble_Setup(OBJECT *obj)
 {
-    obj->control = Bubble_Control;
+    obj->control_func = Bubble_Control;
 }
 
 void Bubble_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/dart_effect.c
+++ b/src/tr1/game/objects/effects/dart_effect.c
@@ -6,8 +6,8 @@
 
 void DartEffect_Setup(OBJECT *obj)
 {
-    obj->control = DartEffect_Control;
-    obj->draw_routine = Object_DrawSpriteItem;
+    obj->control_func = DartEffect_Control;
+    obj->draw_func = Object_DrawSpriteItem;
 }
 
 void DartEffect_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/ember.c
+++ b/src/tr1/game/objects/effects/ember.c
@@ -11,7 +11,7 @@
 
 void Ember_Setup(OBJECT *obj)
 {
-    obj->control = Ember_Control;
+    obj->control_func = Ember_Control;
 }
 
 void Ember_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/explosion.c
+++ b/src/tr1/game/objects/effects/explosion.c
@@ -8,7 +8,7 @@
 
 void Explosion_Setup(OBJECT *obj)
 {
-    obj->control = Explosion_Control;
+    obj->control_func = Explosion_Control;
 }
 
 void Explosion_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/flame.c
+++ b/src/tr1/game/objects/effects/flame.c
@@ -13,7 +13,7 @@
 
 void Flame_Setup(OBJECT *obj)
 {
-    obj->control = Flame_Control;
+    obj->control_func = Flame_Control;
 }
 
 void Flame_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/gunshot.c
+++ b/src/tr1/game/objects/effects/gunshot.c
@@ -8,7 +8,7 @@
 
 void GunShot_Setup(OBJECT *obj)
 {
-    obj->control = GunShot_Control;
+    obj->control_func = GunShot_Control;
 }
 
 void GunShot_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/missile.c
+++ b/src/tr1/game/objects/effects/missile.c
@@ -19,7 +19,7 @@
 
 void Missile_Setup(OBJECT *obj)
 {
-    obj->control = Missile_Control;
+    obj->control_func = Missile_Control;
 }
 
 void Missile_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/natla_gun.c
+++ b/src/tr1/game/objects/effects/natla_gun.c
@@ -8,7 +8,7 @@
 
 void NatlaGun_Setup(OBJECT *obj)
 {
-    obj->control = NatlaGun_Control;
+    obj->control_func = NatlaGun_Control;
 }
 
 void NatlaGun_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/pickup_aid.c
+++ b/src/tr1/game/objects/effects/pickup_aid.c
@@ -19,5 +19,5 @@ static void M_Control(int16_t effect_num)
 
 void PickupAid_Setup(OBJECT *const obj)
 {
-    obj->control = M_Control;
+    obj->control_func = M_Control;
 }

--- a/src/tr1/game/objects/effects/ricochet.c
+++ b/src/tr1/game/objects/effects/ricochet.c
@@ -4,7 +4,7 @@
 
 void Ricochet_Setup(OBJECT *obj)
 {
-    obj->control = Ricochet_Control;
+    obj->control_func = Ricochet_Control;
 }
 
 void Ricochet_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/splash.c
+++ b/src/tr1/game/objects/effects/splash.c
@@ -7,7 +7,7 @@
 
 void Splash_Setup(OBJECT *obj)
 {
-    obj->control = Splash_Control;
+    obj->control_func = Splash_Control;
 }
 
 void Splash_Control(int16_t effect_num)

--- a/src/tr1/game/objects/effects/twinkle.c
+++ b/src/tr1/game/objects/effects/twinkle.c
@@ -9,7 +9,7 @@
 
 void Twinkle_Setup(OBJECT *obj)
 {
-    obj->control = Twinkle_Control;
+    obj->control_func = Twinkle_Control;
 }
 
 void Twinkle_Control(int16_t effect_num)

--- a/src/tr1/game/objects/general/boat.c
+++ b/src/tr1/game/objects/general/boat.c
@@ -11,7 +11,7 @@ typedef enum {
 
 void Boat_Setup(OBJECT *obj)
 {
-    obj->control = Boat_Control;
+    obj->control_func = Boat_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
     obj->save_position = 1;

--- a/src/tr1/game/objects/general/bridge_flat.c
+++ b/src/tr1/game/objects/general/bridge_flat.c
@@ -57,7 +57,7 @@ static int16_t M_GetCeilingHeight(
 
 void BridgeFlat_Setup(OBJECT *const obj)
 {
-    obj->initialise = M_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr1/game/objects/general/bridge_tilt1.c
+++ b/src/tr1/game/objects/general/bridge_tilt1.c
@@ -15,8 +15,8 @@ static void M_Initialise(const int16_t item_num)
     Bridge_FixEmbeddedPosition(item_num);
 }
 
-int16_t M_GetFloorHeight(
-    const ITEM *item, const int32_t x, const int32_t y, const int32_t z,
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
     if (g_Config.gameplay.fix_bridge_collision
@@ -37,8 +37,8 @@ int16_t M_GetFloorHeight(
     return offset_height;
 }
 
-int16_t M_GetCeilingHeight(
-    const ITEM *item, const int32_t x, const int32_t y, const int32_t z,
+static int16_t M_GetCeilingHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
     if (g_Config.gameplay.fix_bridge_collision
@@ -61,7 +61,7 @@ int16_t M_GetCeilingHeight(
 
 void BridgeTilt1_Setup(OBJECT *obj)
 {
-    obj->initialise = M_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr1/game/objects/general/bridge_tilt2.c
+++ b/src/tr1/game/objects/general/bridge_tilt2.c
@@ -60,7 +60,7 @@ int16_t M_GetCeilingHeight(
 
 void BridgeTilt2_Setup(OBJECT *obj)
 {
-    obj->initialise = M_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr1/game/objects/general/cabin.c
+++ b/src/tr1/game/objects/general/cabin.c
@@ -14,9 +14,9 @@ typedef enum {
 
 void Cabin_Setup(OBJECT *obj)
 {
-    obj->control = Cabin_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = Object_Collision;
+    obj->control_func = Cabin_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = Object_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/general/camera_target.c
+++ b/src/tr1/game/objects/general/camera_target.c
@@ -4,5 +4,5 @@
 
 void CameraTarget_Setup(OBJECT *obj)
 {
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->draw_func = Object_DrawDummyItem;
 }

--- a/src/tr1/game/objects/general/cog.c
+++ b/src/tr1/game/objects/general/cog.c
@@ -10,7 +10,7 @@ typedef enum {
 
 void Cog_Setup(OBJECT *obj)
 {
-    obj->control = Cog_Control;
+    obj->control_func = Cog_Control;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/general/door.c
+++ b/src/tr1/game/objects/general/door.c
@@ -127,10 +127,10 @@ static void M_Open(DOORPOS_DATA *const d)
 
 void Door_Setup(OBJECT *obj)
 {
-    obj->initialise = Door_Initialise;
-    obj->control = Door_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = Door_Collision;
+    obj->initialise_func = Door_Initialise;
+    obj->control_func = Door_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = Door_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/general/drawbridge.c
+++ b/src/tr1/game/objects/general/drawbridge.c
@@ -108,8 +108,8 @@ void Drawbridge_Setup(OBJECT *obj)
         return;
     }
     obj->ceiling_height_func = M_GetCeilingHeight;
-    obj->collision = M_Collision;
-    obj->control = M_Control;
+    obj->collision_func = M_Collision;
+    obj->control_func = M_Control;
     obj->save_anim = 1;
     obj->save_flags = 1;
     obj->floor_height_func = M_GetFloorHeight;

--- a/src/tr1/game/objects/general/earthquake.c
+++ b/src/tr1/game/objects/general/earthquake.c
@@ -9,8 +9,8 @@
 
 void Earthquake_Setup(OBJECT *obj)
 {
-    obj->control = Earthquake_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = Earthquake_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/general/keyhole.c
+++ b/src/tr1/game/objects/general/keyhole.c
@@ -46,7 +46,7 @@ static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         return;
     }
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 
@@ -71,10 +71,10 @@ static bool M_IsUsable(const int16_t item_num)
 
 void KeyHole_Setup(OBJECT *obj)
 {
-    obj->collision = M_Collision;
+    obj->collision_func = M_Collision;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
-    obj->is_usable = M_IsUsable;
+    obj->bounds_func = M_Bounds;
+    obj->is_usable_func = M_IsUsable;
 }
 
 bool KeyHole_Trigger(int16_t item_num)

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -5,8 +5,8 @@
 
 void MovingBar_Setup(OBJECT *obj)
 {
-    obj->control = Cog_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Cog_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
     obj->save_position = 1;

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -153,7 +153,7 @@ static void M_GetAllAtLaraPos(ITEM *item, ITEM *lara_item)
     while (pickup_num != NO_ITEM) {
         ITEM *const check_item = Item_Get(pickup_num);
         if (check_item->pos.x == item->pos.x && check_item->pos.z == item->pos.z
-            && Object_Get(check_item->object_id)->collision
+            && Object_Get(check_item->object_id)->collision_func
                 == Pickup_Collision) {
             M_GetItem(pickup_num, check_item, lara_item);
         }
@@ -163,12 +163,12 @@ static void M_GetAllAtLaraPos(ITEM *item, ITEM *lara_item)
 
 void Pickup_Setup(OBJECT *obj)
 {
-    obj->draw_routine = Object_DrawPickupItem;
-    obj->collision = Pickup_Collision;
+    obj->draw_func = Object_DrawPickupItem;
+    obj->collision_func = Pickup_Collision;
     obj->save_flags = 1;
-    obj->bounds = Pickup_Bounds;
-    obj->initialise = M_Initialise;
-    obj->control = M_Control;
+    obj->bounds_func = Pickup_Bounds;
+    obj->initialise_func = M_Initialise;
+    obj->control_func = M_Control;
 }
 
 const OBJECT_BOUNDS *Pickup_Bounds(void)
@@ -200,7 +200,7 @@ void Pickup_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     if (g_Lara.water_status == LWS_ABOVE_WATER
         || g_Lara.water_status == LWS_WADE) {
         item->rot.x = 0;
-        if (!Lara_TestPosition(item, obj->bounds())) {
+        if (!Lara_TestPosition(item, obj->bounds_func())) {
             goto cleanup;
         }
 
@@ -223,7 +223,7 @@ void Pickup_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         }
     } else if (g_Lara.water_status == LWS_UNDERWATER) {
         item->rot.x = -25 * DEG_1;
-        if (!Lara_TestPosition(item, obj->bounds())) {
+        if (!Lara_TestPosition(item, obj->bounds_func())) {
             goto cleanup;
         }
 
@@ -278,7 +278,7 @@ void Pickup_CollisionControlled(
             have_item = false;
             item->rot.x = 0;
 
-            if (Lara_TestPosition(item, obj->bounds())) {
+            if (Lara_TestPosition(item, obj->bounds_func())) {
                 m_PickUpPosition.y = lara_item->pos.y - item->pos.y;
                 if (Lara_MovePosition(item, &m_PickUpPosition)) {
                     Item_SwitchToAnim(lara_item, LA_PICKUP, 0);
@@ -317,7 +317,7 @@ void Pickup_CollisionControlled(
             || (g_Lara.interact_target.is_moving
                 && g_Lara.interact_target.item_num == item_num)) {
 
-            if (Lara_TestPosition(item, obj->bounds())) {
+            if (Lara_TestPosition(item, obj->bounds_func())) {
                 if (Lara_MovePosition(item, &m_PickUpPositionUW)) {
                     Item_SwitchToAnim(lara_item, LA_PICKUP_UW, 0);
                     lara_item->current_anim_state = LS_PICKUP;

--- a/src/tr1/game/objects/general/puzzle_hole.c
+++ b/src/tr1/game/objects/general/puzzle_hole.c
@@ -52,10 +52,10 @@ static bool M_IsUsable(const int16_t item_num)
 
 void PuzzleHole_Setup(OBJECT *obj)
 {
-    obj->collision = PuzzleHole_Collision;
+    obj->collision_func = PuzzleHole_Collision;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
-    obj->is_usable = M_IsUsable;
+    obj->bounds_func = M_Bounds;
+    obj->is_usable_func = M_IsUsable;
 }
 
 void PuzzleHole_SetupDone(OBJECT *obj)
@@ -69,7 +69,7 @@ void PuzzleHole_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     const OBJECT *const obj = Object_Get(item->object_id);
 
     if (lara_item->current_anim_state == LS_USE_PUZZLE) {
-        if (!Lara_TestPosition(item, obj->bounds())) {
+        if (!Lara_TestPosition(item, obj->bounds_func())) {
             return;
         }
 
@@ -117,7 +117,7 @@ void PuzzleHole_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         return;
     }
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 

--- a/src/tr1/game/objects/general/save_crystal.c
+++ b/src/tr1/game/objects/general/save_crystal.c
@@ -30,13 +30,13 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 
 void SaveCrystal_Setup(OBJECT *obj)
 {
-    obj->initialise = SaveCrystal_Initialise;
+    obj->initialise_func = SaveCrystal_Initialise;
     if (g_Config.gameplay.enable_save_crystals) {
-        obj->control = SaveCrystal_Control;
-        obj->collision = SaveCrystal_Collision;
+        obj->control_func = SaveCrystal_Control;
+        obj->collision_func = SaveCrystal_Collision;
         obj->save_flags = 1;
     }
-    obj->bounds = M_Bounds;
+    obj->bounds_func = M_Bounds;
     Object_SetReflective(O_SAVEGAME_ITEM, true);
 }
 
@@ -74,7 +74,7 @@ void SaveCrystal_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     item->rot.y = lara_item->rot.y;
     item->rot.z = 0;
     item->rot.x = 0;
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 

--- a/src/tr1/game/objects/general/scion1.c
+++ b/src/tr1/game/objects/general/scion1.c
@@ -37,10 +37,10 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 
 void Scion1_Setup(OBJECT *obj)
 {
-    obj->draw_routine = Object_DrawPickupItem;
-    obj->collision = Scion1_Collision;
+    obj->draw_func = Object_DrawPickupItem;
+    obj->collision_func = Scion1_Collision;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
+    obj->bounds_func = M_Bounds;
 }
 
 void Scion1_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
@@ -54,7 +54,7 @@ void Scion1_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     item->rot.x = 0;
     item->rot.z = 0;
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         goto cleanup;
     }
 

--- a/src/tr1/game/objects/general/scion3.c
+++ b/src/tr1/game/objects/general/scion3.c
@@ -10,7 +10,7 @@
 
 void Scion3_Setup(OBJECT *obj)
 {
-    obj->control = Scion3_Control;
+    obj->control_func = Scion3_Control;
     obj->hit_points = 5;
     obj->save_flags = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/general/scion4.c
+++ b/src/tr1/game/objects/general/scion4.c
@@ -30,10 +30,10 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 
 void Scion4_Setup(OBJECT *obj)
 {
-    obj->control = Scion4_Control;
-    obj->collision = Scion4_Collision;
+    obj->control_func = Scion4_Control;
+    obj->collision_func = Scion4_Collision;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
+    obj->bounds_func = M_Bounds;
 }
 
 void Scion4_Control(int16_t item_num)
@@ -52,7 +52,7 @@ void Scion4_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     item->rot.x = 0;
     item->rot.z = 0;
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         goto cleanup;
     }
 

--- a/src/tr1/game/objects/general/scion_holder.c
+++ b/src/tr1/game/objects/general/scion_holder.c
@@ -6,8 +6,8 @@
 
 void ScionHolder_Setup(OBJECT *obj)
 {
-    obj->control = ScionHolder_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = ScionHolder_Control;
+    obj->collision_func = Object_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -60,20 +60,20 @@ static const OBJECT_BOUNDS *M_BoundsUW(void)
 
 void Switch_Setup(OBJECT *obj)
 {
-    obj->control = Switch_Control;
-    obj->collision = Switch_Collision;
+    obj->control_func = Switch_Control;
+    obj->collision_func = Switch_Collision;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
+    obj->bounds_func = M_Bounds;
 }
 
 void Switch_SetupUW(OBJECT *obj)
 {
-    obj->control = Switch_Control;
-    obj->collision = Switch_CollisionUW;
+    obj->control_func = Switch_Control;
+    obj->collision_func = Switch_CollisionUW;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    obj->bounds = M_BoundsUW;
+    obj->bounds_func = M_BoundsUW;
 }
 
 void Switch_Control(int16_t item_num)
@@ -106,7 +106,7 @@ void Switch_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         return;
     }
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 
@@ -200,7 +200,7 @@ void Switch_CollisionUW(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         return;
     }
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 

--- a/src/tr1/game/objects/general/trapdoor.c
+++ b/src/tr1/game/objects/general/trapdoor.c
@@ -53,7 +53,7 @@ static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z)
 
 void TrapDoor_Setup(OBJECT *obj)
 {
-    obj->control = TrapDoor_Control;
+    obj->control_func = TrapDoor_Control;
     obj->floor_height_func = TrapDoor_GetFloorHeight;
     obj->ceiling_height_func = TrapDoor_GetCeilingHeight;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/general/waterfall.c
+++ b/src/tr1/game/objects/general/waterfall.c
@@ -13,8 +13,8 @@
 
 void Waterfall_Setup(OBJECT *obj)
 {
-    obj->control = Waterfall_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = Waterfall_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -96,8 +96,8 @@ static void M_DisableObject(GAME_OBJECT_ID obj_id);
 static void M_SetupLara(void)
 {
     OBJECT *const obj = Object_Get(O_LARA);
-    obj->initialise = Lara_InitialiseLoad;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->initialise_func = Lara_InitialiseLoad;
+    obj->draw_func = Object_DrawDummyItem;
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = 1;
@@ -109,7 +109,7 @@ static void M_SetupLara(void)
 static void M_SetupLaraExtra(void)
 {
     OBJECT *const obj = Object_Get(O_LARA_EXTRA);
-    obj->control = Lara_ControlExtra;
+    obj->control_func = Lara_ControlExtra;
 }
 
 static void M_SetupCreatures(void)
@@ -272,10 +272,10 @@ static void M_SetupMiscObjects(void)
 static void M_DisableObject(const GAME_OBJECT_ID obj_id)
 {
     OBJECT *const obj = Object_Get(obj_id);
-    obj->initialise = nullptr;
-    obj->collision = nullptr;
-    obj->control = nullptr;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->initialise_func = nullptr;
+    obj->collision_func = nullptr;
+    obj->control_func = nullptr;
+    obj->draw_func = Object_DrawDummyItem;
     obj->floor_height_func = nullptr;
     obj->ceiling_height_func = nullptr;
 }
@@ -289,13 +289,13 @@ void Object_SetupAllObjects(void)
         obj->save_hitpoints = 0;
         obj->save_flags = 0;
         obj->save_anim = 0;
-        obj->initialise = nullptr;
-        obj->collision = nullptr;
-        obj->control = nullptr;
-        obj->draw_routine = Object_DrawAnimatingItem;
+        obj->initialise_func = nullptr;
+        obj->collision_func = nullptr;
+        obj->control_func = nullptr;
+        obj->draw_func = Object_DrawAnimatingItem;
         obj->ceiling_height_func = nullptr;
         obj->floor_height_func = nullptr;
-        obj->is_usable = nullptr;
+        obj->is_usable_func = nullptr;
         obj->pivot_length = 0;
         obj->radius = DEFAULT_RADIUS;
         obj->shadow_size = 0;

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -15,9 +15,9 @@
 
 void DamoclesSword_Setup(OBJECT *obj)
 {
-    obj->initialise = DamoclesSword_Initialise;
-    obj->control = DamoclesSword_Control;
-    obj->collision = DamoclesSword_Collision;
+    obj->initialise_func = DamoclesSword_Initialise;
+    obj->control_func = DamoclesSword_Control;
+    obj->collision_func = DamoclesSword_Collision;
     obj->shadow_size = UNIT_SHADOW;
     obj->save_position = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/traps/dart.c
+++ b/src/tr1/game/objects/traps/dart.c
@@ -13,8 +13,8 @@
 
 void Dart_Setup(OBJECT *obj)
 {
-    obj->collision = Object_Collision;
-    obj->control = Dart_Control;
+    obj->collision_func = Object_Collision;
+    obj->control_func = Dart_Control;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/dart_emitter.c
+++ b/src/tr1/game/objects/traps/dart_emitter.c
@@ -11,7 +11,7 @@ typedef enum {
 
 void DartEmitter_Setup(OBJECT *obj)
 {
-    obj->control = DartEmitter_Control;
+    obj->control_func = DartEmitter_Control;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/traps/ember_emitter.c
+++ b/src/tr1/game/objects/traps/ember_emitter.c
@@ -9,9 +9,9 @@
 
 void EmberEmitter_Setup(OBJECT *obj)
 {
-    obj->control = EmberEmitter_Control;
-    obj->draw_routine = Object_DrawDummyItem;
-    obj->collision = Object_Collision;
+    obj->control_func = EmberEmitter_Control;
+    obj->draw_func = Object_DrawDummyItem;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -7,7 +7,7 @@
 
 void FallingBlock_Setup(OBJECT *obj)
 {
-    obj->control = FallingBlock_Control;
+    obj->control_func = FallingBlock_Control;
     obj->floor_height_func = FallingBlock_GetFloorHeight;
     obj->ceiling_height_func = FallingBlock_GetCeilingHeight;
     obj->save_position = 1;

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -8,8 +8,8 @@
 
 void FallingCeiling_Setup(OBJECT *obj)
 {
-    obj->control = FallingCeiling_Control;
-    obj->collision = Object_CollisionTrap;
+    obj->control_func = FallingCeiling_Control;
+    obj->collision_func = Object_CollisionTrap;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/traps/flame_emitter.c
+++ b/src/tr1/game/objects/traps/flame_emitter.c
@@ -7,8 +7,8 @@
 
 void FlameEmitter_Setup(OBJECT *obj)
 {
-    obj->control = FlameEmitter_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = FlameEmitter_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }
 

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -11,8 +11,8 @@
 
 void LavaWedge_Setup(OBJECT *obj)
 {
-    obj->control = LavaWedge_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = LavaWedge_Control;
+    obj->collision_func = Object_Collision;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/traps/lightning_emitter.c
+++ b/src/tr1/game/objects/traps/lightning_emitter.c
@@ -35,10 +35,10 @@ typedef struct {
 
 void LightningEmitter_Setup(OBJECT *obj)
 {
-    obj->initialise = LightningEmitter_Initialise;
-    obj->control = LightningEmitter_Control;
-    obj->draw_routine = LightningEmitter_Draw;
-    obj->collision = LightningEmitter_Collision;
+    obj->initialise_func = LightningEmitter_Initialise;
+    obj->control_func = LightningEmitter_Control;
+    obj->draw_func = LightningEmitter_Draw;
+    obj->collision_func = LightningEmitter_Collision;
     obj->save_flags = 1;
 }
 
@@ -164,7 +164,7 @@ void LightningEmitter_Collision(
     }
 }
 
-void LightningEmitter_Draw(ITEM *item)
+void LightningEmitter_Draw(const ITEM *const item)
 {
     ANIM_FRAME *frmptr[2];
     int32_t rate;

--- a/src/tr1/game/objects/traps/lightning_emitter.h
+++ b/src/tr1/game/objects/traps/lightning_emitter.h
@@ -7,4 +7,4 @@ void LightningEmitter_Initialise(int16_t item_num);
 void LightningEmitter_Control(int16_t item_num);
 void LightningEmitter_Collision(
     int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-void LightningEmitter_Draw(ITEM *item);
+void LightningEmitter_Draw(const ITEM *item);

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -40,10 +40,10 @@ static bool M_IsUsable(const int16_t item_num)
 
 void MidasTouch_Setup(OBJECT *obj)
 {
-    obj->collision = MidasTouch_Collision;
-    obj->draw_routine = Object_DrawDummyItem;
-    obj->bounds = M_Bounds;
-    obj->is_usable = M_IsUsable;
+    obj->collision_func = MidasTouch_Collision;
+    obj->draw_func = Object_DrawDummyItem;
+    obj->bounds_func = M_Bounds;
+    obj->is_usable_func = M_IsUsable;
 }
 
 void MidasTouch_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
@@ -110,7 +110,7 @@ void MidasTouch_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
         return;
     }
 
-    if (!Lara_TestPosition(item, obj->bounds())) {
+    if (!Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -266,14 +266,14 @@ static void M_KillLara(const ITEM *const item, ITEM *const lara)
 
 void MovableBlock_Setup(OBJECT *obj)
 {
-    obj->initialise = MovableBlock_Initialise;
-    obj->control = MovableBlock_Control;
-    obj->draw_routine = MovableBlock_Draw;
-    obj->collision = MovableBlock_Collision;
+    obj->initialise_func = MovableBlock_Initialise;
+    obj->control_func = MovableBlock_Control;
+    obj->draw_func = MovableBlock_Draw;
+    obj->collision_func = MovableBlock_Collision;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    obj->bounds = M_Bounds;
+    obj->bounds_func = M_Bounds;
 }
 
 void MovableBlock_Initialise(int16_t item_num)
@@ -373,7 +373,7 @@ void MovableBlock_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
             break;
         }
 
-        if (!Lara_TestPosition(item, obj->bounds())) {
+        if (!Lara_TestPosition(item, obj->bounds_func())) {
             return;
         }
 
@@ -416,7 +416,7 @@ void MovableBlock_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
             return;
         }
 
-        if (!Lara_TestPosition(item, obj->bounds())) {
+        if (!Lara_TestPosition(item, obj->bounds_func())) {
             return;
         }
 
@@ -445,7 +445,7 @@ void MovableBlock_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
     }
 }
 
-void MovableBlock_Draw(ITEM *item)
+void MovableBlock_Draw(const ITEM *const item)
 {
     if (item->status == IS_ACTIVE) {
         Object_DrawUnclippedItem(item);

--- a/src/tr1/game/objects/traps/movable_block.h
+++ b/src/tr1/game/objects/traps/movable_block.h
@@ -6,4 +6,4 @@ void MovableBlock_Setup(OBJECT *obj);
 void MovableBlock_Initialise(int16_t item_num);
 void MovableBlock_Control(int16_t item_num);
 void MovableBlock_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-void MovableBlock_Draw(ITEM *item);
+void MovableBlock_Draw(const ITEM *item);

--- a/src/tr1/game/objects/traps/pendulum.c
+++ b/src/tr1/game/objects/traps/pendulum.c
@@ -13,8 +13,8 @@
 
 void Pendulum_Setup(OBJECT *obj)
 {
-    obj->control = Pendulum_Control;
-    obj->collision = Object_CollisionTrap;
+    obj->control_func = Pendulum_Control;
+    obj->collision_func = Object_CollisionTrap;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -19,9 +19,9 @@
 
 void RollingBall_Setup(OBJECT *obj)
 {
-    obj->initialise = RollingBall_Initialise;
-    obj->control = RollingBall_Control;
-    obj->collision = RollingBall_Collision;
+    obj->initialise_func = RollingBall_Initialise;
+    obj->control_func = RollingBall_Control;
+    obj->collision_func = RollingBall_Collision;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -6,8 +6,8 @@
 
 void SlidingPillar_Setup(OBJECT *obj)
 {
-    obj->initialise = SlidingPillar_Initialise;
-    obj->control = SlidingPillar_Control;
+    obj->initialise_func = SlidingPillar_Initialise;
+    obj->control_func = SlidingPillar_Control;
     obj->save_position = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/traps/spikes.c
+++ b/src/tr1/game/objects/traps/spikes.c
@@ -10,7 +10,7 @@
 
 void Spikes_Setup(OBJECT *obj)
 {
-    obj->collision = Spikes_Collision;
+    obj->collision_func = Spikes_Collision;
 }
 
 void Spikes_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)

--- a/src/tr1/game/objects/traps/teeth_trap.c
+++ b/src/tr1/game/objects/traps/teeth_trap.c
@@ -35,8 +35,8 @@ static void M_BiteEffect(ITEM *item, BITE *bite)
 
 void TeethTrap_Setup(OBJECT *obj)
 {
-    obj->control = TeethTrap_Control;
-    obj->collision = Object_CollisionTrap;
+    obj->control_func = TeethTrap_Control;
+    obj->collision_func = Object_CollisionTrap;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr1/game/objects/traps/thors_hammer_handle.c
+++ b/src/tr1/game/objects/traps/thors_hammer_handle.c
@@ -17,10 +17,10 @@ typedef enum {
 
 void ThorsHammerHandle_Setup(OBJECT *obj)
 {
-    obj->initialise = ThorsHammerHandle_Initialise;
-    obj->control = ThorsHammerHandle_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = ThorsHammerHandle_Collision;
+    obj->initialise_func = ThorsHammerHandle_Initialise;
+    obj->control_func = ThorsHammerHandle_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = ThorsHammerHandle_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr1/game/objects/traps/thors_hammer_head.c
+++ b/src/tr1/game/objects/traps/thors_hammer_head.c
@@ -13,8 +13,8 @@ typedef enum {
 
 void ThorsHammerHead_Setup(OBJECT *obj)
 {
-    obj->collision = ThorsHammerHead_Collision;
-    obj->draw_routine = Object_DrawUnclippedItem;
+    obj->collision_func = ThorsHammerHead_Collision;
+    obj->draw_func = Object_DrawUnclippedItem;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -268,7 +268,7 @@ int16_t Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z)
 
         const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->ceiling_height_func) {
+        if (obj->ceiling_height_func != nullptr) {
             height = obj->ceiling_height_func(item, x, y, z, height);
         }
     }
@@ -295,7 +295,7 @@ int16_t Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z)
 
         const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->floor_height_func) {
+        if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
         }
     }
@@ -817,7 +817,7 @@ bool Room_IsOnWalkable(
         const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->floor_height_func) {
+        if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
             object_found = true;
         }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -286,7 +286,7 @@ void Room_DrawSingleRoom(int16_t room_num)
     while (item_num != NO_ITEM) {
         ITEM *const item = Item_Get(item_num);
         if (item->status != IS_INVISIBLE) {
-            Object_Get(item->object_id)->draw_routine(item);
+            Object_Get(item->object_id)->draw_func(item);
         }
         item_num = item->next_item;
     }

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -118,26 +118,27 @@ static void M_LoadPostprocess(void)
         if (obj->save_flags) {
             item->flags &= 0xFF00;
 
-            if (obj->collision == PuzzleHole_Collision
+            if (obj->collision_func == PuzzleHole_Collision
                 && (item->status == IS_DEACTIVATED
                     || item->status == IS_ACTIVE)) {
                 item->object_id += O_PUZZLE_DONE_1 - O_PUZZLE_HOLE_1;
             }
 
-            if (obj->control == Pod_Control && item->status == IS_DEACTIVATED) {
+            if (obj->control_func == Pod_Control
+                && item->status == IS_DEACTIVATED) {
                 item->mesh_bits = 0x1FF;
                 item->collidable = 0;
             }
 
-            if ((obj->collision == Pickup_Collision
-                 || obj->collision == SaveCrystal_Collision
-                 || obj->collision == Scion1_Collision)
+            if ((obj->collision_func == Pickup_Collision
+                 || obj->collision_func == SaveCrystal_Collision
+                 || obj->collision_func == Scion1_Collision)
                 && item->status == IS_DEACTIVATED) {
                 Item_RemoveDrawn(i);
             }
         }
 
-        if (obj->control == MovableBlock_Control) {
+        if (obj->control_func == MovableBlock_Control) {
             item->priv =
                 item->status == IS_ACTIVE ? (void *)true : (void *)false;
             if (item->status == IS_INACTIVE) {
@@ -145,7 +146,7 @@ static void M_LoadPostprocess(void)
             }
         }
 
-        if (obj->control == SlidingPillar_Control
+        if (obj->control_func == SlidingPillar_Control
             && item->current_anim_state != SPS_MOVING) {
             Room_AlterFloorHeight(item, -WALL_L * 2);
         }
@@ -245,11 +246,12 @@ void Savegame_ProcessItemsBeforeLoad(void)
         ITEM *const item = Item_Get(i);
         const OBJECT *const obj = Object_Get(item->object_id);
 
-        if (obj->control == MovableBlock_Control && item->status != IS_INVISIBLE
+        if (obj->control_func == MovableBlock_Control
+            && item->status != IS_INVISIBLE
             && item->pos.y >= Item_GetHeight(item)) {
             Room_AlterFloorHeight(item, WALL_L);
         }
-        if (obj->control == SlidingPillar_Control) {
+        if (obj->control_func == SlidingPillar_Control) {
             Room_AlterFloorHeight(item, WALL_L * 2);
         }
     }
@@ -261,7 +263,7 @@ void Savegame_ProcessItemsBeforeSave(void)
         ITEM *const item = Item_Get(i);
         const OBJECT *const obj = Object_Get(item->object_id);
 
-        if (obj->control == SaveCrystal_Control && item->data) {
+        if (obj->control_func == SaveCrystal_Control && item->data) {
             // need to reset the crystal status
             item->status = IS_DEACTIVATED;
             item->data = nullptr;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -83,8 +83,8 @@ void Lara_Control_Cutscene(const int16_t item_num)
 void CutscenePlayer1_Initialise(const int16_t item_num)
 {
     OBJECT *const obj = Object_Get(O_LARA);
-    obj->draw_routine = Lara_Draw;
-    obj->control = Lara_Control_Cutscene;
+    obj->draw_func = Lara_Draw;
+    obj->control_func = Lara_Control_Cutscene;
 
     Item_AddActive(item_num);
     ITEM *const item = Item_Get(item_num);

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -125,7 +125,8 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
 
     const OBJECT *const obj = Object_Get(item->object_id);
     const bool is_availanche = item->object_id == O_ROLLING_BALL_2;
-    if (obj->collision == nullptr || (!obj->intelligent && !is_availanche)) {
+    if (obj->collision_func == nullptr
+        || (!obj->intelligent && !is_availanche)) {
         return false;
     }
 

--- a/src/tr2/game/effects.c
+++ b/src/tr2/game/effects.c
@@ -72,8 +72,8 @@ void Effect_Control(void)
         const EFFECT *const effect = Effect_Get(effect_num);
         const OBJECT *const obj = Object_Get(effect->object_id);
         const int16_t next = effect->next_active;
-        if (obj->control != nullptr) {
-            obj->control(effect_num);
+        if (obj->control_func != nullptr) {
+            obj->control_func(effect_num);
         }
         effect_num = next;
     }

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -57,8 +57,8 @@ void Item_Control(void)
         const ITEM *const item = Item_Get(item_num);
         const int16_t next = item->next_active;
         const OBJECT *obj = Object_Get(item->object_id);
-        if (!(item->flags & IF_KILLED) && obj->control != nullptr) {
-            obj->control(item_num);
+        if (!(item->flags & IF_KILLED) && obj->control_func != nullptr) {
+            obj->control_func(item_num);
         }
         item_num = next;
     }
@@ -122,8 +122,8 @@ void Item_Initialise(const int16_t item_num)
         item->hit_points *= 2;
     }
 
-    if (obj->initialise != nullptr) {
-        obj->initialise(item_num);
+    if (obj->initialise_func != nullptr) {
+        obj->initialise_func(item_num);
     }
 }
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1015,7 +1015,7 @@ void Lara_BaddieCollision(ITEM *lara_item, COLL_INFO *coll)
 
             if (item->collidable && item->status != IS_INVISIBLE) {
                 const OBJECT *const obj = Object_Get(item->object_id);
-                if (obj->collision != nullptr) {
+                if (obj->collision_func != nullptr) {
                     // clang-format off
                     const XYZ_32 d = {
                         .x = lara_item->pos.x - item->pos.x,
@@ -1025,7 +1025,7 @@ void Lara_BaddieCollision(ITEM *lara_item, COLL_INFO *coll)
                     if (d.x > -TARGET_DIST && d.x < TARGET_DIST &&
                         d.y > -TARGET_DIST && d.y < TARGET_DIST &&
                         d.z > -TARGET_DIST && d.z < TARGET_DIST) {
-                        obj->collision(item_num, lara_item, coll);
+                        obj->collision_func(item_num, lara_item, coll);
                     }
                     // clang-format on
                 }

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -56,8 +56,8 @@ void Bandit1_Setup(void)
         return;
     }
 
-    obj->control = Bandit1_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Bandit1_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BANDIT_1_HITPOINTS;
     obj->radius = BANDIT_RADIUS;

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -56,8 +56,8 @@ void Bandit2_Setup(void)
         return;
     }
 
-    obj->control = Bandit2_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Bandit2_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BANDIT_2_HITPOINTS;
     obj->radius = BANDIT_RADIUS;
@@ -86,8 +86,8 @@ void Bandit2B_Setup(void)
     obj->anim_idx = ref_obj->anim_idx;
     obj->frame_base = ref_obj->frame_base;
 
-    obj->control = Bandit2_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Bandit2_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BANDIT_2_HITPOINTS;
     obj->radius = BANDIT_RADIUS;

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -47,8 +47,8 @@ void Barracuda_Setup(void)
         return;
     }
 
-    obj->control = Barracuda_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Barracuda_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BARRACUDA_HITPOINTS;
     obj->radius = BARRACUDA_RADIUS;

--- a/src/tr2/game/objects/creatures/bartoli.c
+++ b/src/tr2/game/objects/creatures/bartoli.c
@@ -70,8 +70,8 @@ void Bartoli_Setup(void)
         return;
     }
 
-    obj->initialise = Bartoli_Initialise;
-    obj->control = Bartoli_Control;
+    obj->initialise_func = Bartoli_Initialise;
+    obj->control_func = Bartoli_Control;
 
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -48,8 +48,8 @@ void BigEel_Setup(void)
         return;
     }
 
-    obj->control = BigEel_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = BigEel_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BIG_EEL_HITPOINTS;
 

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -42,8 +42,8 @@ void BigSpider_Setup(void)
         return;
     }
 
-    obj->control = BigSpider_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = BigSpider_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BIG_SPIDER_HITPOINTS;
     obj->radius = BIG_SPIDER_RADIUS;

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -46,9 +46,9 @@ void Bird_SetupEagle(void)
         return;
     }
 
-    obj->initialise = Bird_Initialise;
-    obj->control = Bird_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Bird_Initialise;
+    obj->control_func = Bird_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = EAGLE_HITPOINTS;
     obj->radius = BIRD_RADIUS;
@@ -69,9 +69,9 @@ void Bird_SetupCrow(void)
         return;
     }
 
-    obj->initialise = Bird_Initialise;
-    obj->control = Bird_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Bird_Initialise;
+    obj->control_func = Bird_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CROW_HITPOINTS;
     obj->radius = BIRD_RADIUS;

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -60,8 +60,8 @@ void BirdGuardian_Setup(void)
         return;
     }
 
-    obj->control = BirdGuardian_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = BirdGuardian_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = BIRD_GUARDIAN_HITPOINTS;
     obj->radius = BIRD_GUARDIAN_RADIUS;

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -54,9 +54,9 @@ void Cultist1_Setup(void)
         return;
     }
 
-    obj->initialise = Cultist1_Initialise;
-    obj->control = Cultist1_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Cultist1_Initialise;
+    obj->control_func = Cultist1_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CULTIST_1_HITPOINTS;
     obj->radius = CULTIST_RADIUS;
@@ -84,9 +84,9 @@ void Cultist1A_Setup(void)
     obj->frame_base = cult_1_obj->frame_base;
     obj->anim_idx = cult_1_obj->anim_idx;
 
-    obj->initialise = Cultist1_Initialise;
-    obj->control = Cultist1_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Cultist1_Initialise;
+    obj->control_func = Cultist1_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CULTIST_1_HITPOINTS;
     obj->radius = CULTIST_RADIUS;
@@ -114,9 +114,9 @@ void Cultist1B_Setup(void)
     obj->frame_base = cult_1_obj->frame_base;
     obj->anim_idx = cult_1_obj->anim_idx;
 
-    obj->initialise = Cultist1_Initialise;
-    obj->control = Cultist1_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Cultist1_Initialise;
+    obj->control_func = Cultist1_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CULTIST_1_HITPOINTS;
     obj->radius = CULTIST_RADIUS;

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -54,8 +54,8 @@ void Cultist2_Setup(void)
         return;
     }
 
-    obj->control = Cultist2_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Cultist2_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CULTIST_2_HITPOINTS;
     obj->radius = CULTIST_RADIUS;

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -57,9 +57,9 @@ void Cultist3_Setup(void)
         return;
     }
 
-    obj->initialise = Cultist3_Initialise;
-    obj->control = Cultist3_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = Cultist3_Initialise;
+    obj->control_func = Cultist3_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = CULTIST_3_HITPOINTS;
     obj->radius = CULTIST_RADIUS;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -71,8 +71,8 @@ void Diver_Setup(void)
         return;
     }
 
-    obj->control = Diver_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Diver_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = DIVER_HITPOINTS;
     obj->radius = DIVER_RADIUS;

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -63,8 +63,8 @@ void Dog_Setup(void)
         return;
     }
 
-    obj->control = Dog_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Dog_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = DOG_HITPOINTS;
     obj->radius = DOG_RADIUS;

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -131,8 +131,8 @@ void Dragon_SetupFront(void)
     }
 
     ASSERT(Object_Get(O_DRAGON_BACK)->loaded);
-    obj->control = Dragon_Control;
-    obj->collision = Dragon_Collision;
+    obj->control_func = Dragon_Control;
+    obj->collision_func = Dragon_Collision;
 
     obj->hit_points = DRAGON_HITPOINTS;
     obj->radius = DRAGON_RADIUS;
@@ -154,8 +154,8 @@ void Dragon_SetupBack(void)
         return;
     }
 
-    obj->control = Dragon_Control;
-    obj->collision = Dragon_Collision;
+    obj->control_func = Dragon_Control;
+    obj->collision_func = Dragon_Collision;
 
     obj->radius = DRAGON_RADIUS;
 

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -48,8 +48,8 @@ void Eel_Setup(void)
         return;
     }
 
-    obj->control = Eel_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Eel_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = EEL_HITPOINTS;
 

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -31,8 +31,8 @@ void Jelly_Setup(void)
         return;
     }
 
-    obj->control = Jelly_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Jelly_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = JELLY_HITPOINTS;
     obj->radius = JELLY_RADIUS;

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -60,8 +60,8 @@ void Monk1_Setup(void)
         return;
     }
 
-    obj->control = Monk_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Monk_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = MONK_HITPOINTS;
     obj->radius = MONK_RADIUS;
@@ -84,8 +84,8 @@ void Monk2_Setup(void)
         return;
     }
 
-    obj->control = Monk_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Monk_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = MONK_HITPOINTS;
     obj->radius = MONK_RADIUS;

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -49,8 +49,8 @@ void Mouse_Setup(void)
         return;
     }
 
-    obj->control = Mouse_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Mouse_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = MOUSE_HITPOINTS;
     obj->radius = MOUSE_RADIUS;

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -55,9 +55,9 @@ void Shark_Setup(void)
         return;
     }
 
-    obj->control = Shark_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = Creature_Collision;
+    obj->control_func = Shark_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = SHARK_HITPOINTS;
     obj->radius = SHARK_RADIUS;

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -172,8 +172,8 @@ void SkidooDriver_Setup(void)
         return;
     }
 
-    obj->initialise = SkidooDriver_Initialise;
-    obj->control = SkidooDriver_Control;
+    obj->initialise_func = SkidooDriver_Initialise;
+    obj->control_func = SkidooDriver_Control;
 
     obj->hit_points = 1;
 

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -51,8 +51,8 @@ void Spider_Setup(void)
         return;
     }
 
-    obj->control = Spider_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Spider_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = SPIDER_HITPOINTS;
     obj->radius = SPIDER_RADIUS;

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -54,8 +54,8 @@ void Tiger_Setup(void)
         return;
     }
 
-    obj->control = Tiger_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Tiger_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = TIGER_HITPOINTS;
     obj->radius = TIGER_RADIUS;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -49,8 +49,8 @@ void TRex_Setup(void)
         return;
     }
 
-    obj->control = TRex_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = TRex_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = TREX_HITPOINTS;
     obj->radius = TREX_RADIUS;

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -30,8 +30,8 @@ void Winston_Setup(void)
         return;
     }
 
-    obj->control = Winston_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Winston_Control;
+    obj->collision_func = Object_Collision;
 
     obj->hit_points = DONT_TARGET;
     obj->radius = WINSTON_RADIUS;

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -51,8 +51,8 @@ void Worker1_Setup(void)
         return;
     }
 
-    obj->control = Worker1_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Worker1_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = WORKER_1_HITPOINTS;
     obj->radius = WORKER_RADIUS;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -74,8 +74,8 @@ void Worker2_Setup(void)
         return;
     }
 
-    obj->control = Worker2_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Worker2_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = WORKER_2_HITPOINTS;
     obj->radius = WORKER_RADIUS;
@@ -99,8 +99,8 @@ void Worker5_Setup(void)
         return;
     }
 
-    obj->control = Worker2_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Worker2_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = WORKER_5_HITPOINTS;
     obj->radius = WORKER_RADIUS;

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -72,8 +72,8 @@ void Worker3_Setup(void)
         return;
     }
 
-    obj->control = Worker3_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Worker3_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = WORKER_3_HITPOINTS;
     obj->radius = WORKER_RADIUS;
@@ -97,8 +97,8 @@ void Worker4_Setup(void)
         return;
     }
 
-    obj->control = Worker3_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Worker3_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = WORKER_4_HITPOINTS;
     obj->radius = WORKER_RADIUS;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -84,10 +84,10 @@ void XianKnight_Setup(void)
 
     ASSERT(Object_Get(O_XIAN_KNIGHT_STATUE)->loaded);
 
-    obj->initialise = M_Initialise;
-    obj->draw_routine = XianWarrior_Draw;
-    obj->control = XianKnight_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = M_Initialise;
+    obj->draw_func = XianWarrior_Draw;
+    obj->control_func = XianKnight_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = XIAN_KNIGHT_HITPOINTS;
     obj->radius = XIAN_KNIGHT_RADIUS;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -100,10 +100,10 @@ void XianSpearman_Setup(void)
     }
 
     ASSERT(Object_Get(O_XIAN_SPEARMAN_STATUE)->loaded);
-    obj->initialise = M_Initialise;
-    obj->draw_routine = XianWarrior_Draw;
-    obj->control = XianSpearman_Control;
-    obj->collision = Creature_Collision;
+    obj->initialise_func = M_Initialise;
+    obj->draw_func = XianWarrior_Draw;
+    obj->control_func = XianSpearman_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = XIAN_SPEARMAN_HITPOINTS;
     obj->radius = XIAN_SPEARMAN_RADIUS;

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -77,8 +77,8 @@ void Yeti_Setup(void)
         return;
     }
 
-    obj->control = Yeti_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Yeti_Control;
+    obj->collision_func = Creature_Collision;
 
     obj->hit_points = YETI_HITPOINTS;
     obj->radius = YETI_RADIUS;

--- a/src/tr2/game/objects/effects/blood.c
+++ b/src/tr2/game/objects/effects/blood.c
@@ -25,6 +25,6 @@ void Blood_Control(const int16_t effect_num)
 void Blood_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BLOOD);
-    obj->control = Blood_Control;
+    obj->control_func = Blood_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/body_part.c
+++ b/src/tr2/game/objects/effects/body_part.c
@@ -13,7 +13,7 @@
 void BodyPart_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BODY_PART);
-    obj->control = BodyPart_Control;
+    obj->control_func = BodyPart_Control;
     obj->loaded = 1;
     obj->mesh_count = 0;
 }

--- a/src/tr2/game/objects/effects/bubble.c
+++ b/src/tr2/game/objects/effects/bubble.c
@@ -9,7 +9,7 @@
 void Bubble_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BUBBLE);
-    obj->control = Bubble_Control;
+    obj->control_func = Bubble_Control;
 }
 
 void Bubble_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/dart_effect.c
+++ b/src/tr2/game/objects/effects/dart_effect.c
@@ -22,7 +22,7 @@ void DartEffect_Control(int16_t effect_num)
 void DartEffect_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DART_EFFECT);
-    obj->control = DartEffect_Control;
-    obj->draw_routine = Object_DrawSpriteItem;
+    obj->control_func = DartEffect_Control;
+    obj->draw_func = Object_DrawSpriteItem;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/ember.c
+++ b/src/tr2/game/objects/effects/ember.c
@@ -37,6 +37,6 @@ void Ember_Control(const int16_t effect_num)
 void Ember_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_EMBER);
-    obj->control = Ember_Control;
+    obj->control_func = Ember_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/explosion.c
+++ b/src/tr2/game/objects/effects/explosion.c
@@ -29,6 +29,6 @@ void Explosion_Control(const int16_t effect_num)
 void Explosion_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_EXPLOSION);
-    obj->control = Explosion_Control;
+    obj->control_func = Explosion_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/flame.c
+++ b/src/tr2/game/objects/effects/flame.c
@@ -68,6 +68,6 @@ void Flame_Control(const int16_t effect_num)
 void Flame_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_FLAME);
-    obj->control = Flame_Control;
+    obj->control_func = Flame_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/glow.c
+++ b/src/tr2/game/objects/effects/glow.c
@@ -20,5 +20,5 @@ void Glow_Control(const int16_t effect_num)
 void Glow_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GLOW);
-    obj->control = Glow_Control;
+    obj->control_func = Glow_Control;
 }

--- a/src/tr2/game/objects/effects/gun_flash.c
+++ b/src/tr2/game/objects/effects/gun_flash.c
@@ -26,5 +26,5 @@ void GunFlash_Control(const int16_t effect_num)
 void GunFlash_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GUN_FLASH);
-    obj->control = GunFlash_Control;
+    obj->control_func = GunFlash_Control;
 }

--- a/src/tr2/game/objects/effects/hot_liquid.c
+++ b/src/tr2/game/objects/effects/hot_liquid.c
@@ -44,6 +44,6 @@ void HotLiquid_Control(const int16_t effect_num)
 void HotLiquid_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_HOT_LIQUID);
-    obj->control = HotLiquid_Control;
+    obj->control_func = HotLiquid_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/missile_flame.c
+++ b/src/tr2/game/objects/effects/missile_flame.c
@@ -6,6 +6,6 @@
 void MissileFlame_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_MISSILE_FLAME);
-    obj->control = Missile_Control;
+    obj->control_func = Missile_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/effects/missile_harpoon.c
+++ b/src/tr2/game/objects/effects/missile_harpoon.c
@@ -6,6 +6,6 @@
 void MissileHarpoon_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_MISSILE_HARPOON);
-    obj->control = Missile_Control;
+    obj->control_func = Missile_Control;
     obj->save_position = 1;
 }

--- a/src/tr2/game/objects/effects/missile_knife.c
+++ b/src/tr2/game/objects/effects/missile_knife.c
@@ -6,6 +6,6 @@
 void MissileSpawn_Knife_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_MISSILE_KNIFE);
-    obj->control = Missile_Control;
+    obj->control_func = Missile_Control;
     obj->save_position = 1;
 }

--- a/src/tr2/game/objects/effects/ricochet.c
+++ b/src/tr2/game/objects/effects/ricochet.c
@@ -15,5 +15,5 @@ void Spawn_Ricochet_Control(const int16_t effect_num)
 void Spawn_Ricochet_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_RICOCHET);
-    obj->control = Spawn_Ricochet_Control;
+    obj->control_func = Spawn_Ricochet_Control;
 }

--- a/src/tr2/game/objects/effects/snow_sprite.c
+++ b/src/tr2/game/objects/effects/snow_sprite.c
@@ -27,5 +27,5 @@ void SnowSprite_Control(const int16_t effect_num)
 void SnowSprite_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SNOW_SPRITE);
-    obj->control = SnowSprite_Control;
+    obj->control_func = SnowSprite_Control;
 }

--- a/src/tr2/game/objects/effects/splash.c
+++ b/src/tr2/game/objects/effects/splash.c
@@ -9,7 +9,7 @@
 void Spawn_Splash_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SPLASH);
-    obj->control = Spawn_Splash_Control;
+    obj->control_func = Spawn_Splash_Control;
     obj->semi_transparent = 1;
 }
 

--- a/src/tr2/game/objects/effects/twinkle.c
+++ b/src/tr2/game/objects/effects/twinkle.c
@@ -48,7 +48,7 @@ static bool M_ShouldDisappear(
 void Twinkle_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_TWINKLE);
-    obj->control = Twinkle_Control;
+    obj->control_func = Twinkle_Control;
 }
 
 void Twinkle_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/water_sprite.c
+++ b/src/tr2/game/objects/effects/water_sprite.c
@@ -34,6 +34,6 @@ void WaterSprite_Control(const int16_t effect_num)
 void WaterSprite_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_WATER_SPRITE);
-    obj->control = WaterSprite_Control;
+    obj->control_func = WaterSprite_Control;
     obj->semi_transparent = 1;
 }

--- a/src/tr2/game/objects/general/alarm_sound.c
+++ b/src/tr2/game/objects/general/alarm_sound.c
@@ -26,6 +26,6 @@ void AlarmSound_Control(int16_t item_num)
 void AlarmSound_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_ALARM_SOUND);
-    obj->control = AlarmSound_Control;
+    obj->control_func = AlarmSound_Control;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/bell.c
+++ b/src/tr2/game/objects/general/bell.c
@@ -13,8 +13,8 @@ typedef enum {
 void Bell_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BELL);
-    obj->control = Bell_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Bell_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/big_bowl.c
+++ b/src/tr2/game/objects/general/big_bowl.c
@@ -58,7 +58,7 @@ void BigBowl_Control(const int16_t item_num)
 void BigBowl_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BIG_BOWL);
-    obj->control = BigBowl_Control;
+    obj->control_func = BigBowl_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/bird_tweeter.c
+++ b/src/tr2/game/objects/general/bird_tweeter.c
@@ -19,6 +19,6 @@ void BirdTweeter_Control(const int16_t item_num)
 
 void BirdTweeter_Setup(OBJECT *const obj)
 {
-    obj->control = BirdTweeter_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = BirdTweeter_Control;
+    obj->draw_func = Object_DrawDummyItem;
 }

--- a/src/tr2/game/objects/general/bridge_flat.c
+++ b/src/tr2/game/objects/general/bridge_flat.c
@@ -1,26 +1,33 @@
 #include "game/objects/general/bridge_flat.h"
 
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (y > item->pos.y) {
+        return height;
+    }
+    return item->pos.y;
+}
+
+static int16_t M_GetCeilingHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (y <= item->pos.y) {
+        return height;
+    }
+    return item->pos.y + STEP_L;
+}
+
 void BridgeFlat_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BRIDGE_FLAT);
-    obj->ceiling = BridgeFlat_Ceiling;
-    obj->floor = BridgeFlat_Floor;
-}
-
-void BridgeFlat_Floor(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (y <= item->pos.y) {
-        *out_height = item->pos.y;
-    }
-}
-
-void BridgeFlat_Ceiling(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (y > item->pos.y) {
-        *out_height = item->pos.y + STEP_L;
-    }
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr2/game/objects/general/bridge_flat.h
+++ b/src/tr2/game/objects/general/bridge_flat.h
@@ -3,9 +3,3 @@
 #include "global/types.h"
 
 void BridgeFlat_Setup(void);
-
-void BridgeFlat_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-
-void BridgeFlat_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);

--- a/src/tr2/game/objects/general/bridge_tilt_1.c
+++ b/src/tr2/game/objects/general/bridge_tilt_1.c
@@ -2,37 +2,38 @@
 
 #include "game/objects/general/bridge_common.h"
 
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    const int32_t offset_height =
+        item->pos.y + (Bridge_GetOffset(item, x, z) / 4);
+    if (y > offset_height) {
+        return height;
+    }
+    return offset_height;
+}
+
+static int16_t M_GetCeilingHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    const int32_t offset_height =
+        item->pos.y + (Bridge_GetOffset(item, x, z) / 4);
+    if (y <= offset_height) {
+        return height;
+    }
+    return offset_height + STEP_L;
+}
+
 void BridgeTilt1_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BRIDGE_TILT_1);
-    obj->ceiling = BridgeTilt1_Ceiling;
-    obj->floor = BridgeTilt1_Floor;
-}
-
-void BridgeTilt1_Floor(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    const int32_t offset_height =
-        item->pos.y + (Bridge_GetOffset(item, x, z) / 4);
-
-    if (y > offset_height) {
-        return;
-    }
-
-    *out_height = offset_height;
-}
-
-void BridgeTilt1_Ceiling(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    const int32_t offset_height =
-        item->pos.y + (Bridge_GetOffset(item, x, z) / 4);
-
-    if (y <= offset_height) {
-        return;
-    }
-
-    *out_height = offset_height + STEP_L;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr2/game/objects/general/bridge_tilt_1.h
+++ b/src/tr2/game/objects/general/bridge_tilt_1.h
@@ -3,9 +3,3 @@
 #include "global/types.h"
 
 void BridgeTilt1_Setup(void);
-
-void BridgeTilt1_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-
-void BridgeTilt1_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);

--- a/src/tr2/game/objects/general/bridge_tilt_2.c
+++ b/src/tr2/game/objects/general/bridge_tilt_2.c
@@ -2,36 +2,38 @@
 
 #include "game/objects/general/bridge_common.h"
 
-void BridgeTilt2_Setup(void)
-{
-    OBJECT *const obj = Object_Get(O_BRIDGE_TILT_2);
-    obj->ceiling = BridgeTilt2_Ceiling;
-    obj->floor = BridgeTilt2_Floor;
-}
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
 
-void BridgeTilt2_Floor(
+static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
+    const int16_t height)
 {
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, z) / 2);
-
     if (y > offset_height) {
-        return;
+        return height;
     }
-
-    *out_height = offset_height;
+    return offset_height;
 }
 
-void BridgeTilt2_Ceiling(
+static int16_t M_GetCeilingHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
+    const int16_t height)
 {
     const int32_t offset_height =
         item->pos.y + (Bridge_GetOffset(item, x, z) / 2);
     if (y <= offset_height) {
-        return;
+        return height;
     }
+    return offset_height + STEP_L;
+}
 
-    *out_height = offset_height + STEP_L;
+void BridgeTilt2_Setup(void)
+{
+    OBJECT *const obj = Object_Get(O_BRIDGE_TILT_2);
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
 }

--- a/src/tr2/game/objects/general/bridge_tilt_2.h
+++ b/src/tr2/game/objects/general/bridge_tilt_2.h
@@ -3,9 +3,3 @@
 #include "global/types.h"
 
 void BridgeTilt2_Setup(void);
-
-void BridgeTilt2_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-
-void BridgeTilt2_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);

--- a/src/tr2/game/objects/general/camera_target.c
+++ b/src/tr2/game/objects/general/camera_target.c
@@ -5,5 +5,5 @@
 void CameraTarget_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_CAMERA_TARGET);
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->draw_func = Object_DrawDummyItem;
 }

--- a/src/tr2/game/objects/general/clock_chimes.c
+++ b/src/tr2/game/objects/general/clock_chimes.c
@@ -38,7 +38,7 @@ void ClockChimes_Control(const int16_t item_num)
 void ClockChimes_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_CLOCK_CHIMES);
-    obj->control = ClockChimes_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = ClockChimes_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/copter.c
+++ b/src/tr2/game/objects/general/copter.c
@@ -52,7 +52,7 @@ void Copter_Control(const int16_t item_num)
 void Copter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_COPTER);
-    obj->control = Copter_Control;
+    obj->control_func = Copter_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/cutscene_player.c
+++ b/src/tr2/game/objects/general/cutscene_player.c
@@ -4,7 +4,7 @@
 
 void CutscenePlayer_Setup(OBJECT *const obj)
 {
-    obj->initialise = CutscenePlayerGen_Initialise;
-    obj->control = CutscenePlayer_Control;
+    obj->initialise_func = CutscenePlayerGen_Initialise;
+    obj->control_func = CutscenePlayer_Control;
     obj->hit_points = 1;
 }

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -61,14 +61,14 @@ static void M_CreateGongBonger(ITEM *const lara_item)
 void Detonator1_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DETONATOR_1);
-    obj->collision = Detonator_Collision;
+    obj->collision_func = Detonator_Collision;
 }
 
 void Detonator2_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DETONATOR_2);
-    obj->collision = Detonator_Collision;
-    obj->control = Detonator_Control;
+    obj->collision_func = Detonator_Collision;
+    obj->control_func = Detonator_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/ding_dong.c
+++ b/src/tr2/game/objects/general/ding_dong.c
@@ -15,6 +15,6 @@ void DingDong_Control(const int16_t item_num)
 void DingDong_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DING_DONG);
-    obj->control = DingDong_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = DingDong_Control;
+    obj->draw_func = Object_DrawDummyItem;
 }

--- a/src/tr2/game/objects/general/door.c
+++ b/src/tr2/game/objects/general/door.c
@@ -96,10 +96,10 @@ void Door_Open(DOORPOS_DATA *const d)
 
 void Door_Setup(OBJECT *const obj)
 {
-    obj->initialise = Door_Initialise;
-    obj->control = Door_Control;
-    obj->draw_routine = Object_DrawUnclippedItem;
-    obj->collision = Door_Collision;
+    obj->initialise_func = Door_Initialise;
+    obj->control_func = Door_Control;
+    obj->draw_func = Object_DrawUnclippedItem;
+    obj->collision_func = Door_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/drawbridge.c
+++ b/src/tr2/game/objects/general/drawbridge.c
@@ -8,16 +8,49 @@ typedef enum {
     DRAWBRIDGE_STATE_OPEN = DOOR_STATE_OPEN,
 } DRAWBRIDGE_STATE;
 
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (item->current_anim_state != DRAWBRIDGE_STATE_OPEN) {
+        return height;
+    } else if (!Drawbridge_IsItemOnTop(item, z, x)) {
+        return height;
+    } else if (item->pos.y < y) {
+        return height;
+    }
+    return item->pos.y;
+}
+
+static int16_t M_GetCeilingHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (item->current_anim_state != DRAWBRIDGE_STATE_OPEN) {
+        return height;
+    } else if (!Drawbridge_IsItemOnTop(item, z, x)) {
+        return height;
+    } else if (item->pos.y >= y) {
+        return height;
+    }
+    return item->pos.y + STEP_L;
+}
+
 void Drawbridge_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DRAWBRIDGE);
     if (!obj->loaded) {
         return;
     }
-    obj->control = General_Control;
-    obj->collision = Drawbridge_Collision;
-    obj->ceiling = Drawbridge_Ceiling;
-    obj->floor = Drawbridge_Floor;
+    obj->control_func = General_Control;
+    obj->collision_func = Drawbridge_Collision;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
@@ -52,34 +85,6 @@ int32_t Drawbridge_IsItemOnTop(
     }
 
     return false;
-}
-
-void Drawbridge_Floor(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (item->current_anim_state != DRAWBRIDGE_STATE_OPEN) {
-        return;
-    } else if (!Drawbridge_IsItemOnTop(item, z, x)) {
-        return;
-    } else if (item->pos.y < y) {
-        return;
-    }
-    *out_height = item->pos.y;
-}
-
-void Drawbridge_Ceiling(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (item->current_anim_state != DRAWBRIDGE_STATE_OPEN) {
-        return;
-    } else if (!Drawbridge_IsItemOnTop(item, z, x)) {
-        return;
-    } else if (item->pos.y >= y) {
-        return;
-    }
-    *out_height = item->pos.y + STEP_L;
 }
 
 void Drawbridge_Collision(

--- a/src/tr2/game/objects/general/drawbridge.h
+++ b/src/tr2/game/objects/general/drawbridge.h
@@ -6,10 +6,4 @@ void Drawbridge_Setup(void);
 
 int32_t Drawbridge_IsItemOnTop(const ITEM *item, int32_t z, int32_t x);
 
-void Drawbridge_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-
-void Drawbridge_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-
 void Drawbridge_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);

--- a/src/tr2/game/objects/general/earthquake.c
+++ b/src/tr2/game/objects/general/earthquake.c
@@ -53,7 +53,7 @@ void Earthquake_Control(const int16_t item_num)
 void Earthquake_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_EARTHQUAKE);
-    obj->control = Earthquake_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = Earthquake_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/final_cutscene.c
+++ b/src/tr2/game/objects/general/final_cutscene.c
@@ -17,7 +17,7 @@ void FinalCutscene_Control(const int16_t item_num)
 void FinalCutscene_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_CUT_SHOTGUN);
-    obj->control = FinalCutscene_Control;
+    obj->control_func = FinalCutscene_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/final_level_counter.c
+++ b/src/tr2/game/objects/general/final_level_counter.c
@@ -84,8 +84,8 @@ static void M_PrepareCutscene(const int16_t item_num)
 void FinalLevelCounter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_FINAL_LEVEL_COUNTER);
-    obj->control = FinalLevelCounter_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = FinalLevelCounter_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/general/flare_item.c
+++ b/src/tr2/game/objects/general/flare_item.c
@@ -6,9 +6,9 @@
 void FlareItem_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_FLARE_ITEM);
-    obj->collision = Pickup_Collision;
-    obj->control = Flare_Control;
-    obj->draw_routine = Flare_DrawInAir;
+    obj->collision_func = Pickup_Collision;
+    obj->control_func = Flare_Control;
+    obj->draw_func = Flare_DrawInAir;
     obj->save_position = 1;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -43,8 +43,8 @@ void General_Control(const int16_t item_num)
 void General_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GENERAL);
-    obj->control = General_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = General_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/gong_bonger.c
+++ b/src/tr2/game/objects/general/gong_bonger.c
@@ -21,7 +21,7 @@ static void M_ActivateHeavyTriggers(const int16_t item_num)
 void GongBonger_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GONG_BONGER);
-    obj->control = GongBonger_Control;
+    obj->control_func = GongBonger_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -36,7 +36,7 @@ static void M_Explode(int16_t grenade_item_num, const XYZ_32 pos)
 void Grenade_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GRENADE);
-    obj->control = Grenade_Control;
+    obj->control_func = Grenade_Control;
     obj->save_position = 1;
 }
 
@@ -88,7 +88,7 @@ void Grenade_Control(int16_t item_num)
 
         if (target_item->object_id != O_WINDOW_1
             && (!target_obj->intelligent || target_item->status == IS_INVISIBLE
-                || target_obj->collision == nullptr)) {
+                || target_obj->collision_func == nullptr)) {
             continue;
         }
 

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -12,7 +12,7 @@
 void HarpoonBolt_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_HARPOON_BOLT);
-    obj->control = HarpoonBolt_Control;
+    obj->control_func = HarpoonBolt_Control;
     obj->save_position = 1;
 }
 
@@ -56,7 +56,7 @@ void HarpoonBolt_Control(const int16_t item_num)
 
         if (target_item->object_id != O_WINDOW_1
             && (target_item->status == IS_INVISIBLE
-                || target_obj->collision == nullptr)) {
+                || target_obj->collision_func == nullptr)) {
             continue;
         }
 

--- a/src/tr2/game/objects/general/keyhole.c
+++ b/src/tr2/game/objects/general/keyhole.c
@@ -68,7 +68,7 @@ static void M_Consume(
 
 void Keyhole_Setup(OBJECT *const obj)
 {
-    obj->collision = Keyhole_Collision;
+    obj->collision_func = Keyhole_Collision;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/general/lara_alarm.c
+++ b/src/tr2/game/objects/general/lara_alarm.c
@@ -14,7 +14,7 @@ void LaraAlarm_Control(const int16_t item_num)
 void LaraAlarm_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_LARA_ALARM);
-    obj->control = LaraAlarm_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = LaraAlarm_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -16,74 +16,15 @@ typedef enum {
     LIFT_STATE_DOOR_OPEN = 1,
 } LIFT_STATE;
 
-void Lift_Setup(void)
-{
-    OBJECT *const obj = Object_Get(O_LIFT);
-    obj->initialise = Lift_Initialise;
-    obj->control = Lift_Control;
-    obj->ceiling = Lift_Ceiling;
-    obj->floor = Lift_Floor;
-    obj->save_position = 1;
-    obj->save_flags = 1;
-    obj->save_anim = 1;
-}
+static void M_FloorCeiling(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_floor,
+    int32_t *out_ceiling);
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
 
-void Lift_Initialise(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    LIFT_INFO *const lift_data =
-        GameBuf_Alloc(sizeof(LIFT_INFO), GBUF_ITEM_DATA);
-    lift_data->start_height = item->pos.y;
-    lift_data->wait_time = 0;
-
-    item->data = lift_data;
-}
-
-void Lift_Control(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    LIFT_INFO *const lift_data = item->data;
-
-    if (Item_IsTriggerActive(item)) {
-        if (item->pos.y
-            < lift_data->start_height + LIFT_TRAVEL_DIST - LIFT_SHIFT) {
-            if (lift_data->wait_time < LIFT_WAIT_TIME) {
-                item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
-                lift_data->wait_time++;
-            } else {
-                item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
-                item->pos.y += LIFT_SHIFT;
-            }
-        } else {
-            item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
-            lift_data->wait_time = 0;
-        }
-    } else {
-        if (item->pos.y > lift_data->start_height + LIFT_SHIFT) {
-            if (lift_data->wait_time < LIFT_WAIT_TIME) {
-                item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
-                lift_data->wait_time++;
-            } else {
-                item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
-                item->pos.y -= LIFT_SHIFT;
-            }
-        } else {
-            item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
-            lift_data->wait_time = 0;
-        }
-    }
-
-    Item_Animate(item);
-
-    int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
-}
-
-void Lift_FloorCeiling(
+static void M_FloorCeiling(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     int32_t *const out_floor, int32_t *const out_ceiling)
 {
@@ -154,26 +95,95 @@ void Lift_FloorCeiling(
     }
 }
 
-void Lift_Floor(
+static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
+    const int16_t height)
 {
-    int32_t floor;
-    int32_t height;
-    Lift_FloorCeiling(item, x, y, z, &floor, &height);
-    if (floor < *out_height) {
-        *out_height = floor;
+    int32_t new_floor;
+    int32_t new_height;
+    M_FloorCeiling(item, x, y, z, &new_floor, &new_height);
+    if (new_floor >= height) {
+        return height;
     }
+    return new_floor;
 }
 
-void Lift_Ceiling(
+static int16_t M_GetCeilingHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
+    const int16_t height)
 {
-    int32_t floor;
-    int32_t height;
-    Lift_FloorCeiling(item, x, y, z, &floor, &height);
-    if (height > *out_height) {
-        *out_height = height;
+    int32_t new_floor;
+    int32_t new_height;
+    M_FloorCeiling(item, x, y, z, &new_floor, &new_height);
+    if (new_height <= height) {
+        return height;
+    }
+    return new_height;
+}
+
+void Lift_Setup(void)
+{
+    OBJECT *const obj = Object_Get(O_LIFT);
+    obj->initialise_func = Lift_Initialise;
+    obj->control_func = Lift_Control;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
+    obj->save_position = 1;
+    obj->save_flags = 1;
+    obj->save_anim = 1;
+}
+
+void Lift_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+
+    LIFT_INFO *const lift_data =
+        GameBuf_Alloc(sizeof(LIFT_INFO), GBUF_ITEM_DATA);
+    lift_data->start_height = item->pos.y;
+    lift_data->wait_time = 0;
+
+    item->data = lift_data;
+}
+
+void Lift_Control(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    LIFT_INFO *const lift_data = item->data;
+
+    if (Item_IsTriggerActive(item)) {
+        if (item->pos.y
+            < lift_data->start_height + LIFT_TRAVEL_DIST - LIFT_SHIFT) {
+            if (lift_data->wait_time < LIFT_WAIT_TIME) {
+                item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+                lift_data->wait_time++;
+            } else {
+                item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
+                item->pos.y += LIFT_SHIFT;
+            }
+        } else {
+            item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+            lift_data->wait_time = 0;
+        }
+    } else {
+        if (item->pos.y > lift_data->start_height + LIFT_SHIFT) {
+            if (lift_data->wait_time < LIFT_WAIT_TIME) {
+                item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+                lift_data->wait_time++;
+            } else {
+                item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
+                item->pos.y -= LIFT_SHIFT;
+            }
+        } else {
+            item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+            lift_data->wait_time = 0;
+        }
+    }
+
+    Item_Animate(item);
+
+    int16_t room_num = item->room_num;
+    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    if (item->room_num != room_num) {
+        Item_NewRoom(item_num, room_num);
     }
 }

--- a/src/tr2/game/objects/general/lift.h
+++ b/src/tr2/game/objects/general/lift.h
@@ -10,10 +10,3 @@ typedef struct {
 void Lift_Setup(void);
 void Lift_Initialise(int16_t item_num);
 void Lift_Control(int16_t item_num);
-void Lift_FloorCeiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_floor,
-    int32_t *out_ceiling);
-void Lift_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-void Lift_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);

--- a/src/tr2/game/objects/general/mini_copter.c
+++ b/src/tr2/game/objects/general/mini_copter.c
@@ -37,7 +37,7 @@ void MiniCopter_Control(const int16_t item_num)
 void MiniCopter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_MINI_COPTER);
-    obj->control = MiniCopter_Control;
+    obj->control_func = MiniCopter_Control;
     obj->save_position = 1;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -342,10 +342,10 @@ void MovableBlock_Draw(const ITEM *const item)
 
 void MovableBlock_Setup(OBJECT *const obj)
 {
-    obj->initialise = MovableBlock_Initialise;
-    obj->control = MovableBlock_Control;
-    obj->collision = MovableBlock_Collision;
-    obj->draw_routine = MovableBlock_Draw;
+    obj->initialise_func = MovableBlock_Initialise;
+    obj->control_func = MovableBlock_Control;
+    obj->collision_func = MovableBlock_Collision;
+    obj->draw_func = MovableBlock_Draw;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -218,8 +218,8 @@ cleanup:
 
 void Pickup_Setup(OBJECT *const obj)
 {
-    obj->collision = Pickup_Collision;
-    obj->draw_routine = Pickup_Draw;
+    obj->collision_func = Pickup_Collision;
+    obj->draw_func = Pickup_Draw;
     obj->save_position = 1;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/puzzle_hole.c
+++ b/src/tr2/game/objects/general/puzzle_hole.c
@@ -79,7 +79,7 @@ static void M_MarkDone(ITEM *const puzzle_hole_item)
 void PuzzleHole_Setup(OBJECT *const obj, const bool done)
 {
     if (!done) {
-        obj->collision = PuzzleHole_Collision;
+        obj->collision_func = PuzzleHole_Collision;
     }
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/general/secret.c
+++ b/src/tr2/game/objects/general/secret.c
@@ -16,5 +16,5 @@ void Secret2_Setup(void)
     OBJECT *const obj = Object_Get(O_SECRET_2);
     Pickup_Setup(obj);
     // TODO: why is it so special?
-    obj->control = Secret2_Control;
+    obj->control_func = Secret2_Control;
 }

--- a/src/tr2/game/objects/general/sphere_of_doom.c
+++ b/src/tr2/game/objects/general/sphere_of_doom.c
@@ -101,9 +101,9 @@ void SphereOfDoom_Draw(const ITEM *const item)
 
 void SphereOfDoom_Setup(OBJECT *const obj, const bool transparent)
 {
-    obj->collision = SphereOfDoom_Collision;
-    obj->control = SphereOfDoom_Control;
-    obj->draw_routine = SphereOfDoom_Draw;
+    obj->collision_func = SphereOfDoom_Collision;
+    obj->control_func = SphereOfDoom_Control;
+    obj->draw_func = SphereOfDoom_Draw;
     obj->save_position = 1;
     obj->save_flags = 1;
     if (transparent) {

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -123,8 +123,8 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
 
 void Switch_Setup(OBJECT *const obj, const bool underwater)
 {
-    obj->control = Switch_Control;
-    obj->collision = underwater ? Switch_CollisionUW : Switch_Collision;
+    obj->control_func = Switch_Control;
+    obj->collision_func = underwater ? Switch_CollisionUW : Switch_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/trapdoor.c
+++ b/src/tr2/game/objects/general/trapdoor.c
@@ -7,11 +7,46 @@ typedef enum {
     TRAPDOOR_STATE_OPEN,
 } TRAPDOOR_STATE;
 
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (!Trapdoor_IsItemOnTop(item, x, z)) {
+        return height;
+    } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
+        return height;
+    } else if (y > item->pos.y || item->pos.y > height) {
+        return height;
+    } else {
+        return item->pos.y;
+    }
+}
+
+static int16_t M_GetCeilingHeight(
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
+{
+    if (!Trapdoor_IsItemOnTop(item, x, z)) {
+        return height;
+    } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
+        return height;
+    } else if (y <= item->pos.y || item->pos.y <= height) {
+        return height;
+    } else {
+        return item->pos.y + STEP_L;
+    }
+}
+
 void Trapdoor_Setup(OBJECT *const obj)
 {
-    obj->control = Trapdoor_Control;
-    obj->ceiling = Trapdoor_Ceiling;
-    obj->floor = Trapdoor_Floor;
+    obj->control_func = Trapdoor_Control;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
@@ -54,35 +89,6 @@ int32_t Trapdoor_IsItemOnTop(
     }
 
     return false;
-}
-
-void Trapdoor_Floor(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (!Trapdoor_IsItemOnTop(item, x, z)) {
-        return;
-    } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
-        return;
-    } else if (y > item->pos.y || item->pos.y > *out_height) {
-        return;
-    }
-    *out_height = item->pos.y;
-}
-
-void Trapdoor_Ceiling(
-    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
-    int32_t *const out_height)
-{
-    if (!Trapdoor_IsItemOnTop(item, x, z)) {
-        return;
-    } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
-        return;
-    } else if (y <= item->pos.y || item->pos.y <= *out_height) {
-        return;
-    } else {
-        *out_height = item->pos.y + STEP_L;
-    }
 }
 
 void Trapdoor_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/trapdoor.h
+++ b/src/tr2/game/objects/general/trapdoor.h
@@ -5,9 +5,4 @@
 int32_t Trapdoor_IsItemOnTop(const ITEM *item, int32_t x, int32_t z);
 
 void Trapdoor_Setup(OBJECT *obj);
-
-void Trapdoor_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-void Trapdoor_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
 void Trapdoor_Control(int16_t item_num);

--- a/src/tr2/game/objects/general/waterfall.c
+++ b/src/tr2/game/objects/general/waterfall.c
@@ -46,6 +46,6 @@ void Waterfall_Control(const int16_t item_num)
 void Waterfall_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_WATERFALL);
-    obj->control = Waterfall_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = Waterfall_Control;
+    obj->draw_func = Object_DrawDummyItem;
 }

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -14,9 +14,9 @@
 void Window_1_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_WINDOW_1);
-    obj->initialise = Window_Initialise;
-    obj->collision = Object_Collision;
-    obj->control = Window_1_Control;
+    obj->initialise_func = Window_Initialise;
+    obj->collision_func = Object_Collision;
+    obj->control_func = Window_1_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
@@ -24,9 +24,9 @@ void Window_1_Setup(void)
 void Window_2_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_WINDOW_2);
-    obj->initialise = Window_Initialise;
-    obj->collision = Object_Collision;
-    obj->control = Window_2_Control;
+    obj->initialise_func = Window_Initialise;
+    obj->collision_func = Object_Collision;
+    obj->control_func = Window_2_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/zipline.c
+++ b/src/tr2/game/objects/general/zipline.c
@@ -149,9 +149,9 @@ void Zipline_Control(const int16_t item_num)
 void Zipline_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_ZIPLINE_HANDLE);
-    obj->initialise = RollingBall_Initialise;
-    obj->control = Zipline_Control;
-    obj->collision = Zipline_Collision;
+    obj->initialise_func = RollingBall_Initialise;
+    obj->control_func = Zipline_Control;
+    obj->collision_func = Zipline_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -126,11 +126,11 @@ static void M_SetupGeneralObjects(void);
 static void M_SetupLara(void)
 {
     OBJECT *const obj = Object_Get(O_LARA);
-    obj->initialise = Lara_InitialiseLoad;
+    obj->initialise_func = Lara_InitialiseLoad;
 
     obj->shadow_size = (UNIT_SHADOW / 16) * 10;
     obj->hit_points = LARA_MAX_HITPOINTS;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->draw_func = Object_DrawDummyItem;
 
     obj->save_position = 1;
     obj->save_hitpoints = 1;
@@ -141,7 +141,7 @@ static void M_SetupLara(void)
 static void M_SetupLaraExtra(void)
 {
     OBJECT *const obj = Object_Get(O_LARA_EXTRA);
-    obj->control = Lara_ControlExtra;
+    obj->control_func = Lara_ControlExtra;
 }
 
 static void M_SetupBaddyObjects(void)
@@ -379,12 +379,12 @@ void Object_SetupAllObjects(void)
 {
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
         OBJECT *const obj = Object_Get(i);
-        obj->initialise = nullptr;
-        obj->control = nullptr;
-        obj->floor = nullptr;
-        obj->ceiling = nullptr;
-        obj->draw_routine = Object_DrawAnimatingItem;
-        obj->collision = nullptr;
+        obj->initialise_func = nullptr;
+        obj->control_func = nullptr;
+        obj->floor_height_func = nullptr;
+        obj->ceiling_height_func = nullptr;
+        obj->draw_func = Object_DrawAnimatingItem;
+        obj->collision_func = nullptr;
         obj->hit_points = DONT_TARGET;
         obj->pivot_length = 0;
         obj->radius = DEFAULT_RADIUS;

--- a/src/tr2/game/objects/traps/blade.c
+++ b/src/tr2/game/objects/traps/blade.c
@@ -61,9 +61,9 @@ void Blade_Control(const int16_t item_num)
 void Blade_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BLADE);
-    obj->initialise = Blade_Initialise;
-    obj->control = Blade_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->initialise_func = Blade_Initialise;
+    obj->control_func = Blade_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/dart.c
+++ b/src/tr2/game/objects/traps/dart.c
@@ -67,7 +67,7 @@ void Dart_Control(const int16_t item_num)
 void Dart_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DART);
-    obj->control = Dart_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Dart_Control;
+    obj->collision_func = Object_Collision;
     obj->shadow_size = 128;
 }

--- a/src/tr2/game/objects/traps/dart_emitter.c
+++ b/src/tr2/game/objects/traps/dart_emitter.c
@@ -78,6 +78,6 @@ void DartEmitter_Control(const int16_t item_num)
 void DartEmitter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DART_EMITTER);
-    obj->control = DartEmitter_Control;
+    obj->control_func = DartEmitter_Control;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/dying_monk.c
+++ b/src/tr2/game/objects/traps/dying_monk.c
@@ -65,8 +65,8 @@ void DyingMonk_Control(const int16_t item_num)
 void DyingMonk_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_DYING_MONK);
-    obj->initialise = DyingMonk_Initialise;
-    obj->control = DyingMonk_Control;
-    obj->collision = Object_Collision;
+    obj->initialise_func = DyingMonk_Initialise;
+    obj->control_func = DyingMonk_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/ember_emitter.c
+++ b/src/tr2/game/objects/traps/ember_emitter.c
@@ -27,8 +27,8 @@ void EmberEmitter_Control(const int16_t item_num)
 void EmberEmitter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_EMBER_EMITTER);
-    obj->control = EmberEmitter_Control;
-    obj->collision = Object_Collision;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = EmberEmitter_Control;
+    obj->collision_func = Object_Collision;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/falling_block.h
+++ b/src/tr2/game/objects/traps/falling_block.h
@@ -3,8 +3,4 @@
 #include "global/types.h"
 
 void FallingBlock_Control(int16_t item_num);
-void FallingBlock_Floor(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
-void FallingBlock_Ceiling(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int32_t *out_height);
 void FallingBlock_Setup(OBJECT *obj);

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -46,8 +46,8 @@ void FallingCeiling_Control(const int16_t item_num)
 void FallingCeiling_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_FALLING_CEILING);
-    obj->control = FallingCeiling_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->control_func = FallingCeiling_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/traps/flame_emitter.c
+++ b/src/tr2/game/objects/traps/flame_emitter.c
@@ -33,7 +33,7 @@ void FlameEmitter_Control(const int16_t item_num)
 void FlameEmitter_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_FLAME_EMITTER);
-    obj->control = FlameEmitter_Control;
-    obj->draw_routine = Object_DrawDummyItem;
+    obj->control_func = FlameEmitter_Control;
+    obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -45,8 +45,8 @@ void Gondola_Control(const int16_t item_num)
 void Gondola_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_GONDOLA);
-    obj->control = Gondola_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Gondola_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/hook.c
+++ b/src/tr2/game/objects/traps/hook.c
@@ -28,8 +28,8 @@ void Hook_Control(const int16_t item_num)
 void Hook_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_HOOK);
-    obj->control = Hook_Control;
-    obj->collision = Creature_Collision;
+    obj->control_func = Hook_Control;
+    obj->collision_func = Creature_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -68,8 +68,8 @@ void Icicle_Control(const int16_t item_num)
 void Icicle_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_ICICLE);
-    obj->control = Icicle_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->control_func = Icicle_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/traps/killer_statue.c
+++ b/src/tr2/game/objects/traps/killer_statue.c
@@ -69,9 +69,9 @@ void KillerStatue_Control(const int16_t item_num)
 void KillerStatue_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_KILLER_STATUE);
-    obj->initialise = KillerStatue_Initialise;
-    obj->control = KillerStatue_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->initialise_func = KillerStatue_Initialise;
+    obj->control_func = KillerStatue_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -109,7 +109,7 @@ void Mine_Control(const int16_t item_num)
 void Mine_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_MINE);
-    obj->control = Mine_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Mine_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/pendulum.c
+++ b/src/tr2/game/objects/traps/pendulum.c
@@ -37,8 +37,8 @@ void Pendulum_Control(const int16_t item_num)
 
 void Pendulum_Setup(OBJECT *const obj)
 {
-    obj->control = Pendulum_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Pendulum_Control;
+    obj->collision_func = Object_Collision;
     obj->shadow_size = 128;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/traps/power_saw.c
+++ b/src/tr2/game/objects/traps/power_saw.c
@@ -6,8 +6,8 @@
 void PowerSaw_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_POWER_SAW);
-    obj->control = Propeller_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = Propeller_Control;
+    obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/propeller.c
+++ b/src/tr2/game/objects/traps/propeller.c
@@ -67,8 +67,8 @@ void Propeller_Control(const int16_t item_num)
 
 void Propeller_Setup(OBJECT *const obj)
 {
-    obj->control = Propeller_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->control_func = Propeller_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -207,9 +207,9 @@ void RollingBall_Collision(
 
 void RollingBall_Setup(OBJECT *const obj)
 {
-    obj->initialise = RollingBall_Initialise;
-    obj->control = RollingBall_Control;
-    obj->collision = RollingBall_Collision;
+    obj->initialise_func = RollingBall_Initialise;
+    obj->control_func = RollingBall_Control;
+    obj->collision_func = RollingBall_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/traps/spike_ceiling.c
+++ b/src/tr2/game/objects/traps/spike_ceiling.c
@@ -61,8 +61,8 @@ void SpikeCeiling_Control(const int16_t item_num)
 void SpikeCeiling_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_CEILING_SPIKES);
-    obj->control = SpikeCeiling_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->control_func = SpikeCeiling_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_position = 1;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/spike_wall.c
+++ b/src/tr2/game/objects/traps/spike_wall.c
@@ -68,8 +68,8 @@ void SpikeWall_Control(const int16_t item_num)
 void SpikeWall_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SPIKE_WALL);
-    obj->control = SpikeWall_Control;
-    obj->collision = Object_Collision;
+    obj->control_func = SpikeWall_Control;
+    obj->collision_func = Object_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
 }

--- a/src/tr2/game/objects/traps/spikes.c
+++ b/src/tr2/game/objects/traps/spikes.c
@@ -56,5 +56,5 @@ void Spikes_Collision(
 void Spikes_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SPIKES);
-    obj->collision = Spikes_Collision;
+    obj->collision_func = Spikes_Collision;
 }

--- a/src/tr2/game/objects/traps/spinning_blade.c
+++ b/src/tr2/game/objects/traps/spinning_blade.c
@@ -101,9 +101,9 @@ void SpinningBlade_Control(const int16_t item_num)
 void SpinningBlade_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SPINNING_BLADE);
-    obj->initialise = M_Initialise;
-    obj->control = SpinningBlade_Control;
-    obj->collision = Object_Collision;
+    obj->initialise_func = M_Initialise;
+    obj->control_func = SpinningBlade_Control;
+    obj->collision_func = Object_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -48,7 +48,7 @@ void Springboard_Control(const int16_t item_num)
 void Springboard_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SPRINGBOARD);
-    obj->control = Springboard_Control;
+    obj->control_func = Springboard_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/teeth_trap.c
+++ b/src/tr2/game/objects/traps/teeth_trap.c
@@ -57,8 +57,8 @@ void TeethTrap_Control(const int16_t item_num)
 void TeethTrap_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_TEETH_TRAP);
-    obj->control = TeethTrap_Control;
-    obj->collision = Object_Collision_Trap;
+    obj->control_func = TeethTrap_Control;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -78,9 +78,9 @@ void Boat_Initialise(const int16_t item_num)
 void Boat_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_BOAT);
-    obj->initialise = Boat_Initialise;
-    obj->control = Boat_Control;
-    obj->collision = Boat_Collision;
+    obj->initialise_func = Boat_Initialise;
+    obj->control_func = Boat_Control;
+    obj->collision_func = Boat_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -18,7 +18,7 @@ void SkidooArmed_Setup(void)
         return;
     }
 
-    obj->collision = SkidooArmed_Collision;
+    obj->collision_func = SkidooArmed_Collision;
 
     obj->hit_points = SKIDOO_DRIVER_HITPOINTS;
     obj->radius = SKIDOO_ARMED_RADIUS;

--- a/src/tr2/game/objects/vehicles/skidoo_fast.c
+++ b/src/tr2/game/objects/vehicles/skidoo_fast.c
@@ -5,9 +5,9 @@
 void SkidooFast_Setup(void)
 {
     OBJECT *const obj = Object_Get(O_SKIDOO_FAST);
-    obj->initialise = Skidoo_Initialise;
-    obj->draw_routine = Skidoo_Draw;
-    obj->collision = Skidoo_Collision;
+    obj->initialise_func = Skidoo_Initialise;
+    obj->draw_func = Skidoo_Draw;
+    obj->collision_func = Skidoo_Collision;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -660,8 +660,8 @@ int32_t Room_GetHeight(
 
         const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->floor) {
-            obj->floor(item, x, y, z, &height);
+        if (obj->floor_height_func != nullptr) {
+            height = obj->floor_height_func(item, x, y, z, height);
         }
     }
 
@@ -702,8 +702,8 @@ int32_t Room_GetCeiling(
 
         const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->ceiling) {
-            obj->ceiling(item, x, y, z, &height);
+        if (obj->ceiling_height_func != nullptr) {
+            height = obj->ceiling_height_func(item, x, y, z, height);
         }
     }
 

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -435,7 +435,7 @@ void Room_DrawSingleRoomObjects(const int16_t room_num)
         ITEM *const item = Item_Get(item_num);
         if (item->status != IS_INVISIBLE) {
             const OBJECT *const obj = Object_Get(item->object_id);
-            obj->draw_routine(item);
+            obj->draw_func(item);
         }
         item_num = item->next_item;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The OBJECT definitions were separate for TR1 and TR2, and this PR consolidates them, as well as tidying function pointer names.

#### Testing

While most of the object information was already consistent for both games, some additional work had to be done for the TR2 height functions, and as such it would be nice to give extra attention to:

- Collapsible floor tiles
- Drawbridges (Opera House)
- Tilted and flat bridges (`/tp tilt` – Catacombs of the Talion)
- Trapdoors
- Lift / elevator (Opera House)

