### PR TITLE
level: move animated texture reading fully to TRX

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -752,9 +752,17 @@ void Level_ReadPathingData(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_ReadAnimatedTextureRanges(
-    const int32_t num_ranges, VFILE *const file)
+void Level_ReadAnimatedTextureRanges(VFILE *const file)
 {
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t data_size = VFile_ReadS32(file);
+    const size_t end_position =
+        VFile_GetPos(file) + data_size * sizeof(int16_t);
+
+    const int16_t num_ranges = VFile_ReadS16(file);
+    LOG_INFO("animated texture ranges: %d", num_ranges);
+    Output_InitialiseAnimatedTextures(num_ranges);
+
     for (int32_t i = 0; i < num_ranges; i++) {
         ANIMATED_TEXTURE_RANGE *const range = Output_GetAnimatedTextureRange(i);
         range->next_range = i == num_ranges - 1
@@ -770,6 +778,9 @@ void Level_ReadAnimatedTextureRanges(
         VFile_Read(
             file, range->textures, sizeof(int16_t) * range->num_textures);
     }
+
+    VFile_SetPos(file, end_position);
+    Benchmark_End(benchmark, nullptr);
 }
 
 void Level_ReadLightMap(VFILE *const file)

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -26,7 +26,7 @@ void Level_ReadSpriteTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 void Level_ReadSpriteSequences(VFILE *file);
 void Level_ReadPathingData(VFILE *file);
-void Level_ReadAnimatedTextureRanges(int32_t num_ranges, VFILE *file);
+void Level_ReadAnimatedTextureRanges(VFILE *file);
 void Level_ReadLightMap(VFILE *file);
 void Level_ReadCinematicFrames(VFILE *file);
 void Level_ReadCamerasAndSinks(VFILE *file);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -63,7 +63,6 @@ static void M_LoadAnimBones(VFILE *file);
 static void M_LoadAnimFrames(VFILE *file);
 static void M_LoadTextures(VFILE *file);
 static void M_LoadSprites(VFILE *file);
-static void M_LoadAnimatedTextures(VFILE *file);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
 static size_t M_CalculateMaxVertices(void);
@@ -229,7 +228,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadCamerasAndSinks(file);
     Level_ReadSoundSources(file);
     Level_ReadPathingData(file);
-    M_LoadAnimatedTextures(file);
+    Level_ReadAnimatedTextureRanges(file);
     Level_ReadItems(file);
     Stats_ObserveItemsLoad();
     Level_ReadLightMap(file);
@@ -371,22 +370,6 @@ static void M_LoadSprites(VFILE *file)
     Output_InitialiseSpriteTextures(
         num_textures + m_InjectionInfo->sprite_info_count);
     Level_ReadSpriteTextures(0, 0, num_textures, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimatedTextures(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t data_size = VFile_ReadS32(file);
-    const size_t end_position =
-        VFile_GetPos(file) + data_size * sizeof(int16_t);
-
-    const int16_t num_ranges = VFile_ReadS16(file);
-    LOG_INFO("%d animated texture ranges", num_ranges);
-    Output_InitialiseAnimatedTextures(num_ranges);
-    Level_ReadAnimatedTextureRanges(num_ranges, file);
-
-    VFile_SetPos(file, end_position);
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -44,8 +44,6 @@ static void M_LoadAnimBones(VFILE *file);
 static void M_LoadAnimFrames(VFILE *file);
 static void M_LoadTextures(VFILE *file);
 static void M_LoadSprites(VFILE *file);
-static void M_LoadSoundEffects(VFILE *file);
-static void M_LoadAnimatedTextures(VFILE *file);
 static void M_InitialiseSoundEffects(void);
 static void M_CompleteSetup(void);
 
@@ -157,22 +155,6 @@ static void M_LoadSprites(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-static void M_LoadAnimatedTextures(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    const int32_t data_size = VFile_ReadS32(file);
-    const size_t end_position =
-        VFile_GetPos(file) + data_size * sizeof(int16_t);
-
-    const int16_t num_ranges = VFile_ReadS16(file);
-    LOG_INFO("%d animated texture ranges", num_ranges);
-    Output_InitialiseAnimatedTextures(num_ranges);
-    Level_ReadAnimatedTextureRanges(num_ranges, file);
-
-    VFile_SetPos(file, end_position);
-    Benchmark_End(benchmark, nullptr);
-}
-
 static void M_InitialiseSoundEffects(void)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
@@ -272,7 +254,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadCamerasAndSinks(file);
     Level_ReadSoundSources(file);
     Level_ReadPathingData(file);
-    M_LoadAnimatedTextures(file);
+    Level_ReadAnimatedTextureRanges(file);
     Level_ReadItems(file);
 
     Level_ReadLightMap(file);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the duplicated animated texture reading logic from both level modules as it's fully common now. The remaining read functions in both files are the only ones left because of TR1 injection dependencies, so these will be cleared up during that refactor later.
