### PR TITLE
objects: handle savegames by themselves

### DIFF
--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -3,6 +3,7 @@
 #include "../anims/types.h"
 #include "../collision.h"
 #include "../items/types.h"
+#include "../savegame.h"
 #include "../types.h"
 
 #include <stdint.h>
@@ -59,6 +60,7 @@ typedef struct OBJECT {
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     int16_t (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+    void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
 #if TR_VERSION == 1
     const OBJECT_BOUNDS *(*bounds_func)(void);
     bool (*is_usable_func)(int16_t item_num);

--- a/src/libtrx/include/libtrx/game/savegame.h
+++ b/src/libtrx/include/libtrx/game/savegame.h
@@ -2,6 +2,12 @@
 
 #include <stdint.h>
 
+typedef enum {
+    SAVEGAME_STAGE_BEFORE_LOAD,
+    SAVEGAME_STAGE_AFTER_LOAD,
+    SAVEGAME_STAGE_BEFORE_SAVE,
+} SAVEGAME_STAGE;
+
 // Remembers the slot used when the player starts a loaded game.
 // Persists across level reloads.
 void Savegame_BindSlot(int32_t slot_num);

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -1,6 +1,7 @@
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lot.h"
+#include "game/music.h"
 #include "global/const.h"
 #include "global/vars.h"
 
@@ -29,6 +30,7 @@ static BITE m_BaldyGun = { -20, 440, 20, 9 };
 
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
@@ -37,6 +39,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
@@ -56,6 +59,16 @@ static void M_Initialise(const int16_t item_num)
 {
     Creature_Initialise(item_num);
     Item_Get(item_num)->current_anim_state = BALDY_STATE_RUN;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->hit_points <= 0) {
+            const uint16_t flags = Music_GetTrackFlags(MX_BALDY_SPEECH);
+            Music_SetTrackFlags(MX_BALDY_SPEECH, flags | IF_ONE_SHOT);
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -2,6 +2,7 @@
 #include "game/effects.h"
 #include "game/items.h"
 #include "game/lot.h"
+#include "game/music.h"
 #include "game/spawn.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -31,6 +32,7 @@ static BITE m_CowboyGun1 = { 1, 200, 41, 5 };
 static BITE m_CowboyGun2 = { -2, 200, 40, 8 };
 
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
@@ -39,6 +41,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
     obj->initialise_func = Creature_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
@@ -52,6 +55,16 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
 
     Object_GetBone(obj, 0)->rot_y = true;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->hit_points <= 0) {
+            const uint16_t flags = Music_GetTrackFlags(MX_COWBOY_SPEECH);
+            Music_SetTrackFlags(MX_COWBOY_SPEECH, flags | IF_ONE_SHOT);
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -1,6 +1,7 @@
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lot.h"
+#include "game/music.h"
 #include "game/random.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -31,6 +32,7 @@ typedef enum {
 static BITE m_LarsonGun = { -60, 170, 0, 14 };
 
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
@@ -39,6 +41,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
     obj->initialise_func = Creature_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
@@ -52,6 +55,16 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
 
     Object_GetBone(obj, 6)->rot_y = true;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->hit_points <= 0) {
+            const uint16_t flags = Music_GetTrackFlags(MX_LARSON_SPEECH);
+            Music_SetTrackFlags(MX_LARSON_SPEECH, flags | IF_ONE_SHOT);
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -5,6 +5,7 @@
 #include "game/items.h"
 #include "game/los.h"
 #include "game/lot.h"
+#include "game/music.h"
 #include "game/random.h"
 #include "game/room.h"
 #include "global/const.h"
@@ -42,6 +43,7 @@ static BITE m_PierreGun2 = { -57, 200, 0, 14 };
 static int16_t m_PierreItemNum = NO_ITEM;
 
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
@@ -50,6 +52,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
     obj->initialise_func = Creature_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
@@ -63,6 +66,16 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
 
     Object_GetBone(obj, 6)->rot_y = true;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->hit_points <= 0 && (item->flags & IF_ONE_SHOT)) {
+            const uint16_t flags = Music_GetTrackFlags(MX_PIERRE_SPEECH);
+            Music_SetTrackFlags(MX_PIERRE_SPEECH, flags | IF_ONE_SHOT);
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -16,6 +16,7 @@ typedef enum {
 
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
@@ -24,6 +25,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_anim = 1;
@@ -72,6 +74,16 @@ static void M_Initialise(const int16_t item_num)
 
     item->flags = 0;
     item->mesh_bits = 0xFF0001FF;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED) {
+            item->mesh_bits = 0x1FF;
+            item->collidable = 0;
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/puzzle_hole.c
+++ b/src/tr1/game/objects/general/puzzle_hole.c
@@ -38,6 +38,7 @@ static const OBJECT_BOUNDS *M_Bounds(void);
 static bool M_IsUsable(int16_t item_num);
 static void M_Setup(OBJECT *obj);
 static void M_SetupDone(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 static const OBJECT_BOUNDS *M_Bounds(void)
@@ -56,12 +57,22 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_flags = 1;
     obj->bounds_func = M_Bounds;
+    obj->handle_save_func = M_HandleSave;
     obj->is_usable_func = M_IsUsable;
 }
 
 static void M_SetupDone(OBJECT *const obj)
 {
     obj->save_flags = 1;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED || item->status == IS_ACTIVE) {
+            item->object_id += O_PUZZLE_DONE_1 - O_PUZZLE_HOLE_1;
+        }
+    }
 }
 
 static void M_Collision(

--- a/src/tr1/game/objects/general/scion1.c
+++ b/src/tr1/game/objects/general/scion1.c
@@ -31,6 +31,7 @@ static const OBJECT_BOUNDS m_Scion1_Bounds = {
 
 static const OBJECT_BOUNDS *M_Bounds(void);
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 static const OBJECT_BOUNDS *M_Bounds(void)
@@ -40,10 +41,21 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->handle_save_func = M_HandleSave;
     obj->draw_func = Object_DrawPickupItem;
     obj->collision_func = M_Collision;
     obj->save_flags = 1;
     obj->bounds_func = M_Bounds;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED) {
+            const int16_t item_num = Item_GetIndex(item);
+            Item_RemoveDrawn(item_num);
+        }
+    }
 }
 
 static void M_Collision(

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -44,6 +44,7 @@ static bool M_TestDeathCollision(ITEM *item, const ITEM *lara);
 static void M_KillLara(const ITEM *item, ITEM *lara);
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 static void M_Draw(const ITEM *item);
@@ -270,6 +271,7 @@ static void M_KillLara(const ITEM *const item, ITEM *const lara)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
@@ -282,9 +284,30 @@ static void M_Setup(OBJECT *const obj)
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-
     if (item->status != IS_INVISIBLE && item->pos.y >= Item_GetHeight(item)) {
         Room_AlterFloorHeight(item, -WALL_L);
+    }
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    switch (stage) {
+    case SAVEGAME_STAGE_BEFORE_LOAD:
+        if (item->status != IS_INVISIBLE
+            && item->pos.y >= Item_GetHeight(item)) {
+            Room_AlterFloorHeight(item, WALL_L);
+        }
+        break;
+
+    case SAVEGAME_STAGE_AFTER_LOAD:
+        item->priv = item->status == IS_ACTIVE ? (void *)true : (void *)false;
+        if (item->status == IS_INACTIVE) {
+            Room_AlterFloorHeight(item, -WALL_L);
+        }
+        break;
+
+    default:
+        break;
     }
 }
 

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -3,12 +3,14 @@
 #include "global/const.h"
 
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Initialise(int16_t item_num);
 static void M_Control(int16_t item_num);
 
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->save_position = 1;
     obj->save_anim = 1;
@@ -19,6 +21,24 @@ static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     Room_AlterFloorHeight(item, -WALL_L * 2);
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    switch (stage) {
+    case SAVEGAME_STAGE_BEFORE_LOAD:
+        Room_AlterFloorHeight(item, WALL_L * 2);
+        break;
+
+    case SAVEGAME_STAGE_AFTER_LOAD:
+        if (item->current_anim_state != SPS_MOVING) {
+            Room_AlterFloorHeight(item, -WALL_L * 2);
+        }
+        break;
+
+    default:
+        break;
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dragon.h
+++ b/src/tr2/game/objects/creatures/dragon.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include <stdint.h>
-
-void Dragon_Bones(int16_t item_num);

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -39,6 +39,7 @@ static void M_ControlDead(ITEM *driver_item, ITEM *skidoo_item);
 static int16_t M_ControlAlive(ITEM *driver_item, ITEM *skidoo_item);
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static void M_KillDriver(ITEM *const driver_item)
@@ -175,6 +176,7 @@ static void M_Setup(OBJECT *const obj)
     }
 
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
 
     obj->hit_points = 1;
@@ -203,6 +205,18 @@ static void M_Initialise(const int16_t item_num)
     Item_Initialise(skidoo_item_num);
 
     skidoo_driver->data = (void *)(intptr_t)skidoo_item_num;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED) {
+            const int16_t skidoo_num = (int16_t)(intptr_t)item->data;
+            ITEM *const skidoo = Item_Get(skidoo_num);
+            skidoo->object_id = O_SKIDOO_FAST;
+            Skidoo_Initialise(skidoo_num);
+        }
+    }
 }
 
 static void M_Control(const int16_t driver_item_num)

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -42,6 +42,7 @@ static bool M_TestPull(
 
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Draw(const ITEM *item);
 static void M_Control(int16_t item_num);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
@@ -203,12 +204,31 @@ static void M_Initialise(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->draw_func = M_Draw;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    switch (stage) {
+    case SAVEGAME_STAGE_BEFORE_LOAD:
+        Room_AlterFloorHeight(item, WALL_L);
+        break;
+
+    case SAVEGAME_STAGE_AFTER_LOAD:
+        if (item->status == IS_INACTIVE) {
+            Room_AlterFloorHeight(item, -WALL_L);
+        }
+        break;
+
+    default:
+        break;
+    }
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -66,6 +66,7 @@ static void M_DoFlarePickup(int16_t item_num);
 static void M_DoAboveWater(int16_t item, ITEM *lara_item);
 static void M_DoUnderwater(int16_t item, ITEM *lara_item);
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Draw(const ITEM *item);
 
 static void M_DoPickup(const int16_t item_num)
@@ -219,10 +220,21 @@ cleanup:
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->handle_save_func = M_HandleSave;
     obj->collision_func = Pickup_Collision;
     obj->draw_func = M_Draw;
     obj->save_position = 1;
     obj->save_flags = 1;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED) {
+            const int16_t item_num = Item_GetIndex(item);
+            Item_RemoveDrawn(item_num);
+        }
+    }
 }
 
 static void M_Draw(const ITEM *const item)

--- a/src/tr2/game/objects/general/puzzle_hole.c
+++ b/src/tr2/game/objects/general/puzzle_hole.c
@@ -40,6 +40,7 @@ static void M_Consume(
 static void M_MarkDone(ITEM *puzzle_hole_item);
 static void M_SetupEmpty(OBJECT *obj);
 static void M_SetupDone(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 static void M_Refuse(const ITEM *const lara_item)
@@ -80,12 +81,22 @@ static void M_MarkDone(ITEM *const puzzle_hole_item)
 static void M_SetupEmpty(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
+    obj->handle_save_func = M_HandleSave;
     obj->save_flags = 1;
 }
 
 static void M_SetupDone(OBJECT *const obj)
 {
     obj->save_flags = 1;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->status == IS_DEACTIVATED || item->status == IS_ACTIVE) {
+            item->object_id += O_PUZZLE_DONE_1 - O_PUZZLE_HOLE_1;
+        }
+    }
 }
 
 static void M_Collision(

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -11,28 +11,33 @@
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
 
+static void M_SetupBase(OBJECT *obj);
 static void M_Setup1(OBJECT *obj);
 static void M_Setup2(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control1(int16_t item_num);
 static void M_Control2(int16_t item_num);
 
-static void M_Setup1(OBJECT *const obj)
+static void M_SetupBase(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_save_func = M_HandleSave;
     obj->collision_func = Object_Collision;
-    obj->control_func = M_Control1;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
 
+static void M_Setup1(OBJECT *const obj)
+{
+    M_SetupBase(obj);
+    obj->control_func = M_Control1;
+}
+
 static void M_Setup2(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
-    obj->collision_func = Object_Collision;
+    M_SetupBase(obj);
     obj->control_func = M_Control2;
-    obj->save_flags = 1;
-    obj->save_anim = 1;
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -48,6 +53,16 @@ static void M_Initialise(const int16_t item_num)
 
     if (box->overlap_index & BOX_BLOCKABLE) {
         box->overlap_index |= BOX_BLOCKED;
+    }
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if ((item->object_id == O_WINDOW_1 || item->object_id == O_WINDOW_2)
+            && (item->flags & IF_ONE_SHOT)) {
+            item->mesh_bits = 0x100;
+        }
     }
 }
 

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -14,6 +14,7 @@ static void M_DetonateAll(
     const ITEM *mine_item, int16_t boat_item_num, int16_t boat_room_num);
 static void M_Explode(ITEM *mine_item);
 static void M_Setup(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 
 static int16_t M_GetBoatItem(const XYZ_32 *const pos, int16_t *const room_num)
@@ -81,9 +82,19 @@ static void M_Explode(ITEM *const mine_item)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = 1;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->flags & IF_ONE_SHOT) {
+            item->mesh_bits = 1;
+        }
+    }
 }
 
 static void M_Control(const int16_t item_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This refactor changes the system so that each object in the game can set itself up when a game is loaded, instead of relying on one central piece of code to do it for all objects. This makes the code easier to work with because each object knows how to handle its own setup. It's done by introducing a new callback, `handle_save_func` in `OBJECT` with an additional argument, `SAVEGAME_STAGE` that tells whether it's called before loading the item, after loading the item, or before saving the item to the savegame file.

#### Considerations

Unfortunately, we still do have three specific objects references left hardcoded in TR2's savegame code, and these are the boat, the skidoo, and the lift. This is because unlike other objects that simply change level geometry or flip some internal flags, these require reading and writing additional state to the savegame data. I'd rather not touch this until we have BSON saves in place.

I've coupled the objects module to rely on the savegame module solely for the `SAVEGAME_STAGE` enum, which creates a soft cyclic dependency between them. I think that's acceptable.

Additionally, there's one event, `SAVEGAME_STAGE_BEFORE_SAVE`, which exists solely for the save crystal object. The crystal needs to be removed after the player confirms the save slot, but also needs to stay when the player chooses not to save. Rather than passing the outcome whether the save was done or not all the way to `GF_ShowInventory(INV_SAVE_CRYSTAL_MODE)`, the crystal chooses a different approach and handles this with this pseudo-event. It's a bit on the ugly side, considering it's literally the only object in the game that could benefit from this enum member, but I couldn't think of anything better. This approach also allows `GF_ShowInventory` to become asynchronous at some point (even if it currently is not).

#### Testing

We need to test saving and loading all objects affected by these changes - both prior to "consuming" and after "consuming" an object. Here's a handy table.

| Object            | TR1 | TR2 | Notes                                                 |
| ---               | --- | --- | ---                                                   |
| Baldy             | ✅  |     | Speech needs to trigger once                          |
| Cowboy            | ✅  |     | Speech needs to trigger once                          |
| Larson            | ✅  |     | Speech needs to trigger once                          |
| Pierre            | ✅  |     | Speech needs to trigger once                          |
| Mutant pods       | ✅  |     | Exploded pods need to stay invisible                  |
| Save crystals     | ✅  |     | Consumed crystals disappear                           |
| Sliding pillar    | ✅  |     | (Qualopec) Level geometry stays as expected           |
| Push blocks       | ✅  | ✅  | Level geometry stays as expected                      |
| Pickups           | ✅  | ✅  | Collected pickups disappear                           |
| Puzzle holes      | ✅  | ✅  | Used puzzle holes cannot be reused                    |
| Dragon            |     | ✅  | Dragon needs to stay as a skeleton after death        |
| Black skidoo      |     | ✅  | The skidoo needs to be mountable after driver's death |
| Aquatic mine      |     | ✅  | (Bartoli's Hideout)                                   |
| Smashable windows |     | ✅  | Smashed windows needs to stay invisible and passable  |
