### PR TITLE
Fix Jade Dragon disappearance in Bartoli's Hideout

### DIFF
--- a/docs/tr2/symbols.txt
+++ b/docs/tr2/symbols.txt
@@ -3121,11 +3121,11 @@ typedef enum {
 0x00414B70  0x0198  SECTOR *__cdecl Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
 0x00414D10  0x0168  int32_t __cdecl Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num);
 0x00414E80  0x0265  int32_t __cdecl Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-0x00415100  0x00E7  void __cdecl Camera_Legacy_RefreshFromTrigger(int16_t type, const int16_t *data);
-0x004151F0  0x0690  void __cdecl Room_Legacy_TestTriggers(int16_t *data, int32_t heavy);
+0x00415100  0x00E7  void __cdecl Camera_RefreshFromTrigger(int16_t type, const int16_t *data);
+0x004151F0  0x0690  void __cdecl Room_TestTriggers(int16_t *data, int32_t heavy);
 0x004158D0  0x0055  int32_t __cdecl Item_IsTriggerActive(ITEM *item);
 0x00415930  0x023D  int32_t __cdecl Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-0x00415B90  0x004E  int16_t __cdecl Room_Legacy_GetDoor(const SECTOR *sector);
+0x00415B90  0x004E  int16_t __cdecl Room_GetDoor(const SECTOR *sector);
 0x00415BE0  0x00A0  int32_t __cdecl LOS_Check(const GAME_VECTOR *start, GAME_VECTOR *target);
 0x00415C80  0x02EB  int32_t __cdecl LOS_CheckZ(const GAME_VECTOR *start, GAME_VECTOR *target);
 0x00415F70  0x02EC  int32_t __cdecl LOS_CheckX(const GAME_VECTOR *start, GAME_VECTOR *target);
@@ -3134,7 +3134,7 @@ typedef enum {
 0x00416640  0x00B3  void __cdecl Room_FlipMap(void);
 0x00416700  0x0096  void __cdecl Room_RemoveFlipItems(ROOM *r);
 0x004167A0  0x005C  void __cdecl Room_AddFlipItems(ROOM *r);
-0x00416800  0x0024  void __cdecl Room_Legacy_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);
+0x00416800  0x0024  void __cdecl Room_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);
 0x00416830  0x00DA  void __cdecl Room_TriggerMusicTrackImpl(int16_t value, int16_t flags, int16_t type);
 
 # game/demo.c
@@ -4171,7 +4171,7 @@ typedef enum {
 0x004553C0  0x001F  BOOL __cdecl S_Audio_Sample_OutIsTrackPlaying(int32_t track_id);
 0x004553E0  0x0077  bool __cdecl Music_Init(void);
 0x00455460  0x0051  void __cdecl Music_Shutdown(void);
-0x00455500  0x006F  void __cdecl Music_Legacy_Play(int16_t track_id, bool is_looped);
+0x00455500  0x006F  void __cdecl Music_Play(int16_t track_id, bool is_looped);
 0x00455570  0x0039  void __cdecl Music_Stop(void);
 0x004555B0  0x0084  bool __cdecl Music_PlaySynced(int32_t track_id);
 0x00455640  0x0061  int32_t __cdecl Music_GetFrames(void);
@@ -4550,7 +4550,7 @@ typedef enum {
 0x00526188  MATRIX *g_IMMatrixPtr;
 0x0052618C  ROOM *g_Rooms;
 0x00526240  int32_t g_FlipStatus;
-0x00526288  int16_t *g_Legacy_TriggerIndex;
+0x00526288  int16_t *g_TriggerIndex;
 0x005262A0  int32_t g_LOSRooms[20];
 0x005262F0  ITEM *g_Items;
 0x005262F6  int16_t g_NumCineFrames;
@@ -4631,7 +4631,7 @@ typedef enum {
 0x00466BDC  int32_t g_PaletteIndex;
 0x00519F78  int32_t g_HWR_TexturePageIndexes[32]; // MAX_TEXTURE_PAGES
 0x004D7790  int32_t g_HeightType;
-0x004D9D94  int16_t *g_Legacy_FloorData;
+0x004D9D94  int16_t *g_FloorData;
 0x00525B08  int16_t *g_AnimCommands;
 0x0052617C  ANIM_CHANGE *g_AnimChanges;
 0x00525B04  ANIM_RANGE *g_AnimRanges;

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -43,14 +43,13 @@ typedef struct {
     uint16_t flags;
 
     SHADE shade;
-#if TR_VERSION == 1
     void *data;
+#if TR_VERSION == 1
     void *priv;
     CARRIED_ITEM *carried_item;
     bool enable_shadow;
 #elif TR_VERSION == 2
     int16_t carried_item;
-    void *data;
 #endif
 
     XYZ_32 pos;

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -62,6 +62,7 @@ typedef struct OBJECT {
     int16_t (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     void (*activate_func)(ITEM *item);
+    void (*handle_flip_func)(ITEM *item, ROOM_FLIP_STATUS flip_status);
     void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
 #if TR_VERSION == 1
     const OBJECT_BOUNDS *(*bounds_func)(void);

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -3,6 +3,7 @@
 #include "../anims/types.h"
 #include "../collision.h"
 #include "../items/types.h"
+#include "../rooms/enum.h"
 #include "../savegame.h"
 #include "../types.h"
 
@@ -60,6 +61,7 @@ typedef struct OBJECT {
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     int16_t (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+    void (*activate_func)(ITEM *item);
     void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
 #if TR_VERSION == 1
     const OBJECT_BOUNDS *(*bounds_func)(void);

--- a/src/libtrx/include/libtrx/game/objects/vars.h
+++ b/src/libtrx/include/libtrx/game/objects/vars.h
@@ -10,8 +10,6 @@ extern const GAME_OBJECT_ID g_PickupObjects[];
 extern const GAME_OBJECT_ID g_AnimObjects[];
 extern const GAME_OBJECT_ID g_NullObjects[];
 extern const GAME_OBJECT_ID g_InvObjects[];
-extern const GAME_OBJECT_ID g_MovableBlockObjects[];
-extern const GAME_OBJECT_ID g_PuzzleHoleObjects[];
 
 extern const GAME_OBJECT_PAIR g_ItemToInvObjectMap[];
 extern const GAME_OBJECT_PAIR g_KeyItemToReceptacleMap[];

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -66,6 +66,7 @@ static void M_GetAllAtLaraPos(ITEM *item, ITEM *lara_item);
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
+static void M_Activate(ITEM *item);
 static void M_Control(int16_t item_num);
 static const OBJECT_BOUNDS *M_Bounds(void);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
@@ -104,9 +105,12 @@ static void M_GetItem(int16_t item_num, ITEM *item, ITEM *lara_item)
 {
     Overlay_AddPickup(item->object_id);
     Inv_AddItem(item->object_id);
+
     item->status = IS_INVISIBLE;
+    item->flags |= IF_KILLED;
     Item_RemoveDrawn(item_num);
     Item_RemoveActive(item_num);
+
     Savegame_GetCurrentInfo(Game_GetCurrentLevel())->stats.pickup_count++;
     g_Lara.interact_target.is_moving = false;
 }
@@ -133,6 +137,7 @@ static void M_Setup(OBJECT *const obj)
     obj->bounds_func = M_Bounds;
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;
+    obj->activate_func = M_Activate;
     obj->control_func = M_Control;
 }
 
@@ -152,6 +157,19 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
             const int16_t item_num = Item_GetIndex(item);
             Item_RemoveDrawn(item_num);
         }
+    }
+}
+
+static void M_Activate(ITEM *const item)
+{
+    if (item->status == IS_INVISIBLE) {
+        item->touch_bits = 0;
+        item->status = IS_ACTIVE;
+        const int16_t item_num = Item_GetIndex(item);
+        Item_AddActive(item_num);
+    } else {
+        item->status = IS_INVISIBLE;
+        item->flags |= IF_KILLED;
     }
 }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -44,6 +44,7 @@ static bool M_TestDeathCollision(ITEM *item, const ITEM *lara);
 static void M_KillLara(const ITEM *item, ITEM *lara);
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleFlip(ITEM *item, ROOM_FLIP_STATUS flip_status);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Control(int16_t item_num);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
@@ -271,6 +272,7 @@ static void M_KillLara(const ITEM *const item, ITEM *const lara)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_flip_func = M_HandleFlip;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
@@ -286,6 +288,15 @@ static void M_Initialise(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     if (item->status != IS_INVISIBLE && item->pos.y >= Item_GetHeight(item)) {
         Room_AlterFloorHeight(item, -WALL_L);
+    }
+}
+
+static void M_HandleFlip(ITEM *const item, const ROOM_FLIP_STATUS flip_status)
+{
+    if (flip_status == RFS_FLIPPED) {
+        Room_AlterFloorHeight(item, -WALL_L);
+    } else {
+        Room_AlterFloorHeight(item, WALL_L);
     }
 }
 

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -3,6 +3,7 @@
 #include "global/const.h"
 
 static void M_Setup(OBJECT *obj);
+static void M_HandleFlip(ITEM *item, ROOM_FLIP_STATUS flip_status);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Initialise(int16_t item_num);
 static void M_Control(int16_t item_num);
@@ -10,6 +11,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_flip_func = M_HandleFlip;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->save_position = 1;
@@ -21,6 +23,15 @@ static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     Room_AlterFloorHeight(item, -WALL_L * 2);
+}
+
+static void M_HandleFlip(ITEM *const item, const ROOM_FLIP_STATUS flip_status)
+{
+    if (flip_status == RFS_FLIPPED) {
+        Room_AlterFloorHeight(item, -WALL_L * 2);
+    } else {
+        Room_AlterFloorHeight(item, WALL_L * 2);
+    }
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -628,7 +628,10 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             }
 
             if (!item->active) {
-                if (Object_Get(item->object_id)->intelligent) {
+                const OBJECT *const obj = Object_Get(item->object_id);
+                if (obj->activate_func != nullptr) {
+                    obj->activate_func(item);
+                } else if (obj->intelligent) {
                     if (item->status == IS_INACTIVE) {
                         item->touch_bits = 0;
                         item->status = IS_ACTIVE;

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -42,6 +42,7 @@ static bool M_TestPull(
 
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
+static void M_HandleFlip(ITEM *item, ROOM_FLIP_STATUS flip_status);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Draw(const ITEM *item);
 static void M_Control(int16_t item_num);
@@ -204,6 +205,7 @@ static void M_Initialise(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->handle_flip_func = M_HandleFlip;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
@@ -211,6 +213,15 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
+}
+
+static void M_HandleFlip(ITEM *const item, const ROOM_FLIP_STATUS flip_status)
+{
+    if (flip_status == RFS_FLIPPED) {
+        Room_AlterFloorHeight(item, -WALL_L);
+    } else {
+        Room_AlterFloorHeight(item, WALL_L);
+    }
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -256,6 +256,10 @@ static void M_Activate(ITEM *const item)
 
 static void M_Draw(const ITEM *const item)
 {
+    if (item->flags & IF_INVISIBLE) {
+        return;
+    }
+
     if (!g_Config.visuals.enable_3d_pickups) {
         Object_DrawSpriteItem(item);
         return;
@@ -344,6 +348,11 @@ static void M_Draw(const ITEM *const item)
 void Pickup_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
+    const ITEM *const item = Item_Get(item_num);
+    if (item->flags & IF_INVISIBLE) {
+        return;
+    }
+
     if (g_Lara.water_status == LWS_ABOVE_WATER
         || g_Lara.water_status == LWS_WADE) {
         M_DoAboveWater(item_num, lara_item);

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -67,6 +67,7 @@ static void M_DoAboveWater(int16_t item, ITEM *lara_item);
 static void M_DoUnderwater(int16_t item, ITEM *lara_item);
 static void M_Setup(OBJECT *obj);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
+static void M_Activate(ITEM *item);
 static void M_Draw(const ITEM *item);
 
 static void M_DoPickup(const int16_t item_num)
@@ -89,7 +90,9 @@ static void M_DoPickup(const int16_t item_num)
     }
 
     item->status = IS_INVISIBLE;
+    item->flags |= IF_KILLED;
     Item_RemoveDrawn(item_num);
+    Item_RemoveActive(item_num);
 }
 
 static void M_DoFlarePickup(const int16_t item_num)
@@ -221,6 +224,7 @@ cleanup:
 static void M_Setup(OBJECT *const obj)
 {
     obj->handle_save_func = M_HandleSave;
+    obj->activate_func = M_Activate;
     obj->collision_func = Pickup_Collision;
     obj->draw_func = M_Draw;
     obj->save_position = 1;
@@ -234,6 +238,19 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
             const int16_t item_num = Item_GetIndex(item);
             Item_RemoveDrawn(item_num);
         }
+    }
+}
+
+static void M_Activate(ITEM *const item)
+{
+    if (item->status == IS_INVISIBLE) {
+        item->touch_bits = 0;
+        item->status = IS_ACTIVE;
+        const int16_t item_num = Item_GetIndex(item);
+        Item_AddActive(item_num);
+    } else {
+        item->status = IS_INVISIBLE;
+        item->flags |= IF_KILLED;
     }
 }
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -131,26 +131,6 @@ const GAME_OBJECT_ID g_TrapdoorObjects[] = {
     // clang-format on
 };
 
-const GAME_OBJECT_ID g_MovableBlockObjects[] = {
-    // clang-format off
-    O_MOVABLE_BLOCK_1,
-    O_MOVABLE_BLOCK_2,
-    O_MOVABLE_BLOCK_3,
-    O_MOVABLE_BLOCK_4,
-    NO_OBJECT,
-    // clang-format on
-};
-
-const GAME_OBJECT_ID g_PuzzleHoleObjects[] = {
-    // clang-format off
-    O_PUZZLE_HOLE_1,
-    O_PUZZLE_HOLE_2,
-    O_PUZZLE_HOLE_3,
-    O_PUZZLE_HOLE_4,
-    NO_OBJECT,
-    // clang-format on
-};
-
 const GAME_OBJECT_ID g_AnimObjects[] = {
     // clang-format off
     O_LARA_PISTOLS,

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -271,7 +271,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             }
 
             const OBJECT *const obj = Object_Get(trig_item->object_id);
-            if (obj->intelligent) {
+            if (obj->activate_func != nullptr) {
+                obj->activate_func(trig_item);
+            } else if (obj->intelligent) {
                 if (trig_item->status == IS_INACTIVE) {
                     trig_item->touch_bits = 0;
                     trig_item->status = IS_ACTIVE;

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -670,11 +670,6 @@ int32_t Room_GetHeight(
     return height;
 }
 
-void Room_Legacy_TestTriggers(const int16_t *fd, bool heavy)
-{
-    ASSERT_FAIL();
-}
-
 void Room_TestTriggers(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
@@ -712,12 +707,6 @@ int32_t Room_GetCeiling(
     return height;
 }
 
-int16_t Room_Legacy_GetDoor(const SECTOR *const sector)
-{
-    ASSERT_FAIL();
-    return NO_ROOM;
-}
-
 void Room_AlterFloorHeight(const ITEM *const item, const int32_t height)
 {
     int16_t room_num = item->room_num;
@@ -744,12 +733,6 @@ void Room_AlterFloorHeight(const ITEM *const item, const int32_t height)
             box->overlap_index &= ~BOX_BLOCKED;
         }
     }
-}
-
-void Room_Legacy_TriggerMusicTrack(
-    const int16_t track, const int16_t flags, const int16_t type)
-{
-    ASSERT_FAIL();
 }
 
 void Room_InitCinematic(void)

--- a/src/tr2/game/room.h
+++ b/src/tr2/game/room.h
@@ -25,8 +25,3 @@ int32_t Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 
 void Room_TestTriggers(const ITEM *item);
 void Room_TestSectorTrigger(const ITEM *item, const SECTOR *sector);
-
-// TODO: eliminate
-int16_t Room_Legacy_GetDoor(const SECTOR *sector);
-void Room_Legacy_TestTriggers(const int16_t *fd, bool heavy);
-void Room_Legacy_TriggerMusicTrack(int16_t value, int16_t flags, int16_t type);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2536.

The original game has a unique logic for the Jade Dragon, and only the jade variant alone, where the dragon removes itself immediately upon activation. So in terms of game mechanics, when Lara uses the detonator, it triggers the Dragon pickup, and that makes it disappear.

To me, it's a very bizarre approach, so rather than restoring it, I went with making pickups use the `IF_INVISIBLE` flags whenever their host room gets flipped, and not allowing Lara to see or interact with them if this flag is set. This method feels more conventional to me.

That said, I find it hard to believe that this is the only pickup in both games that is placed in a flippable room, requiring such intricate trigger-based solution from the OG code, and that this scenario is not already handled in some other way. Also, I'm unsure if my usage of the flag is good, and would appreciate @lahm86's opinion on this. We hardly ever seem to use `IF_INVISIBLE` anywhere beyond initial item setup.

Similar to the newest changes done in regard to the savegame↔specific object code decoupling, I've seen that the room flip logic also references certain objects, and I introduced a new method to `OBJECT` called `handle_flip_func` to address this.

#### Testing

- A quick confirmation if the push blocks and sliding pillars work as intended with flipped rooms.
- Possibly a test level that lets you flip rooms that contain pickups on and off would be good to know for sure it's working as intended.
- Also it would be good to programmatically verify whether there are any more pickup items in either game that are triggered by something.