### PR TITLE
tr2/objects/window: unblock box on savegame load

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.2...develop) - ××××-××-××
+- fixed smashed windows blocking enemy pathing after loading a save (#2535)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -77,6 +77,7 @@ game with new enhancements and features.
     - **Temple of Xian**: fixed missing death tiles in room 91
     - **Floating Islands**: fixed door 72's position to resolve the invisible wall in front of it
 - fixed the game crashing if a cinematic is triggered but the level contains no cinematic frames
+- fixed smashed windows blocking enemy pathing after loading a save
 - improved the animation of Lara's braid
 
 #### Cheats


### PR DESCRIPTION
Resolves #2535.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that the box where a window sits is unblocked if the window has already been smashed and the game is loaded from a save. I've combined the logic into a single function for the window module, so good also to check regular window behaviour. Areas like Bartoli room 155 are good for testing.
