### PR TITLE
tr2/flares: fix flare throw reset test

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added a `/cheats` console command
 - added a `/wireframe` console command (#2500)
 - fixed smashed windows blocking enemy pathing after loading a save (#2535)
+- fixed a rare issue whereby Lara would be unable to move after disposing a flare (#2545, regression from 0.9)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -293,8 +293,8 @@ void Flare_Undraw(void)
         if (Item_TestAnimEqual(g_LaraItem, LA_FLARE_THROW)) {
             g_Lara.flare_control_left = 0;
 
-            if (Item_TestFrameRange(
-                    g_LaraItem, LF_FL_THROW_FT - 1, LF_FL_THROW_END)) {
+            if (frame_num_2 >= Anim_GetAnim(LA_FLARE_THROW)->frame_base
+                    + LF_FL_THROW_FT - 1) {
                 g_Lara.gun_type = g_Lara.last_gun_type;
                 g_Lara.request_gun_type = g_Lara.last_gun_type;
                 g_Lara.gun_status = LGS_ARMLESS;

--- a/src/tr2/decomp/flares.h
+++ b/src/tr2/decomp/flares.h
@@ -5,7 +5,6 @@
 typedef enum {
     LF_FL_HOLD_FT = 1,
     LF_FL_THROW_FT = 32,
-    LF_FL_THROW_END = 35,
     LF_FL_DRAW_FT = 39,
     LF_FL_IGNITE_FT = 23,
     LF_FL_2_HOLD_FT = 15,


### PR DESCRIPTION
Resolves #2545.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reverts to testing open upper end frame range when Lara throws a flare. I think the problem can happen because throwing a flare doesn't use the conventional state change system, and relies on frame numbers in `g_Lara`, and so I think it all depends on exactly what Lara is doing when throwing a flare. Unfortunately, I don't think we can recover from the saves provided in the issue as-is in the codebase - we would need to introduce a guard in Lara's main control to check for this, because at this stage, the flare control has finished. In-game, entering and exiting the fly cheat can be used to fix the problem.

It's hard to test this one. I suppose we can spend a decent amount of time disposing flares in various states, unless we can find a way to reproduce it exactly.
