### PR TITLE
tr2/inventory: fix flare pickup quantity

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added a `/wireframe` console command (#2500)
 - fixed smashed windows blocking enemy pathing after loading a save (#2535)
 - fixed a rare issue whereby Lara would be unable to move after disposing a flare (#2545, regression from 0.9)
+- fixed flare pickups only adding one flare to Lara's inventory rather than six (#2551, regression from 0.9)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr2/game/inventory.c
+++ b/src/tr2/game/inventory.c
@@ -18,7 +18,9 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
         INV_RING_SOURCE *const source = &g_InvRing_Source[ring_type];
         for (int32_t i = 0; i < source->count; i++) {
             if (source->items[i]->object_id == inv_obj_id) {
-                source->qtys[i]++;
+                const int32_t qty =
+                    obj_id == O_FLARES_ITEM ? FLARE_AMMO_QTY : 1;
+                source->qtys[i] += qty;
                 return true;
             }
         }


### PR DESCRIPTION
Resolves #2551.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures we always add 6 flares when Lara picks up item 151. The other logic for single flares is required for gameflow flare additions, like in Great Wall.
