### PR TITLE
tr1/controls: hide the reset and unbind texts when changing keys

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...develop) - ××××-××-××
 - added support for custom levels to use `disable_floor` in the gameflow, similar to TR2's Floating Islands (#2541)
+- changed the Controls screen to hide the reset and unbind texts when changing a key (#2103)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17
 - fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)

--- a/src/tr1/game/option/option_controls.c
+++ b/src/tr1/game/option/option_controls.c
@@ -325,7 +325,7 @@ static void M_InitText(INPUT_BACKEND backend, INPUT_LAYOUT layout)
 
 static void M_UpdateText(INPUT_BACKEND backend, INPUT_LAYOUT layout)
 {
-    if (layout == INPUT_LAYOUT_DEFAULT) {
+    if (layout == INPUT_LAYOUT_DEFAULT || m_KeyMode == KM_BROWSEKEYUP) {
         Text_Hide(m_Text[TEXT_RESET], true);
         Text_Hide(m_Text[TEXT_UNBIND], true);
     } else {


### PR DESCRIPTION
Resolves #2103.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Changed the Controls screen to hide the reset and unbind texts when changing a key.