### PR TITLE
tr2/inventory: fix level number for play any level

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed smashed windows blocking enemy pathing after loading a save (#2535)
 - fixed a rare issue whereby Lara would be unable to move after disposing a flare (#2545, regression from 0.9)
 - fixed flare pickups only adding one flare to Lara's inventory rather than six (#2551, regression from 0.9)
+- fixed play any level causing the game to hang when no gym level is present (#2560, regression from 0.9)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -203,7 +203,8 @@ static GF_COMMAND M_Finish(INV_RING *const ring, const bool apply_changes)
                 if (g_GameFlow.play_any_level) {
                     return (GF_COMMAND) {
                         .action = GF_START_GAME,
-                        .param = g_Inv_ExtraData[1] + 1,
+                        .param = g_Inv_ExtraData[1]
+                            + (GF_GetGymLevel() != nullptr ? 1 : 0),
                     };
                 } else {
                     if (apply_changes) {
@@ -224,7 +225,8 @@ static GF_COMMAND M_Finish(INV_RING *const ring, const bool apply_changes)
                     if (g_GameFlow.play_any_level) {
                         return (GF_COMMAND) {
                             .action = GF_START_GAME,
-                            .param = g_Inv_ExtraData[1] + 1,
+                            .param = g_Inv_ExtraData[1]
+                                + (GF_GetGymLevel() != nullptr ? 1 : 0),
                         };
                     } else {
                         return (GF_COMMAND) {


### PR DESCRIPTION
Resolves #2560.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This increments the selected level to play only if there is a gym level present.
