### PR TITLE
tr1/objects/bear: apply AI fix in bear control

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...develop) - ××××-××-××
 - added support for custom levels to use `disable_floor` in the gameflow, similar to TR2's Floating Islands (#2541)
 - changed the Controls screen to hide the reset and unbind texts when changing a key (#2103)
+- fixed the bear AI fix option being applied in the Vilcabamba demo (#2559, regression from 4.8)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17
 - fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)

--- a/src/tr1/game/objects/creatures/bear.c
+++ b/src/tr1/game/objects/creatures/bear.c
@@ -58,11 +58,6 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = BEAR_HITPOINTS;
-    if (g_Config.gameplay.fix_bear_ai) {
-        obj->pivot_length = 0;
-    } else {
-        obj->pivot_length = 500;
-    }
     obj->radius = BEAR_RADIUS;
     obj->smartness = BEAR_SMARTNESS;
     obj->intelligent = 1;
@@ -77,6 +72,8 @@ static void M_Setup(OBJECT *const obj)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    OBJECT *const obj = Object_Get(item->object_id);
+    obj->pivot_length = g_Config.gameplay.fix_bear_ai ? 0 : 500;
 
     if (item->status == IS_INVISIBLE) {
         if (!LOT_EnableBaddieAI(item_num, 0)) {


### PR DESCRIPTION
Resolves #2559.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the bear AI fix to the control routine as otherwise when the demo alters the setting, its effect has already taken place in the bear setup function. It's not ideal calling it on every frame a bear is active, but I suppose a benefit is that it does allow changing the setting in-game with the console without having to reload.
