### PR TITLE
camera: fix unchecked NO_HEIGHT usage

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...develop) - ××××-××-××
 - added support for custom levels to use `disable_floor` in the gameflow, similar to TR2's Floating Islands (#2541)
 - changed the Controls screen to hide the reset and unbind texts when changing a key (#2103)
+- fixed several instances of the camera going out of bounds (#1034)
 - fixed the bear AI fix option being applied in the Vilcabamba demo (#2559, regression from 4.8)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -437,6 +437,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed triggered flip effects not working if there are no sound devices
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling
 - fixed the camera being thrown through doors for one frame when looked at from fixed camera positions
+- fixed several instances of the camera going out of bounds
 - fixed the ape not performing the vault animation when climbing
 - fixed Natla's gun moving while she is in her semi death state
 - fixed the bear pat attack so it does not miss Lara

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added a `/cheats` console command
 - added a `/wireframe` console command (#2500)
 - fixed smashed windows blocking enemy pathing after loading a save (#2535)
+- fixed several instances of the camera going out of bounds (#1034)
 - fixed a rare issue whereby Lara would be unable to move after disposing a flare (#2545, regression from 0.9)
 - fixed flare pickups only adding one flare to Lara's inventory rather than six (#2551, regression from 0.9)
 - fixed play any level causing the game to hang when no gym level is present (#2560, regression from 0.9)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -67,6 +67,7 @@ game with new enhancements and features.
 - fixed Lara prioritising throwing a spent flare while mid-air, so to avoid missing ledge grabs
 - fixed Lara at times not being able to jump immediately after going from her walking to running animation
 - fixed looking forward too far causing an upside down camera frame
+- fixed several instances of the camera going out of bounds
 - fixed Lara never stepping backwards off a step using her right foot
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -288,32 +288,34 @@ static void M_EnsureEnvironment(void)
 
 static void M_Move(const GAME_VECTOR *const ideal, const int32_t speed)
 {
-    g_Camera.pos.x += (ideal->x - g_Camera.pos.x) / speed;
-    g_Camera.pos.z += (ideal->z - g_Camera.pos.z) / speed;
-    g_Camera.pos.y += (ideal->y - g_Camera.pos.y) / speed;
-    g_Camera.pos.room_num = ideal->room_num;
+    const GAME_VECTOR old_pos = g_Camera.pos;
+    GAME_VECTOR pos = g_Camera.pos;
+    pos.x += (ideal->x - pos.x) / speed;
+    pos.z += (ideal->z - pos.z) / speed;
+    pos.y += (ideal->y - pos.y) / speed;
+    pos.room_num = ideal->room_num;
 
     Camera_SetChunky(false);
 
-    const SECTOR *sector = Room_GetSector(
-        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
-    int32_t height =
-        Room_GetHeight(sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-        - GROUND_SHIFT;
-
-    if (g_Camera.pos.y >= height && ideal->y >= height) {
-        LOS_Check(&g_Camera.target, &g_Camera.pos);
-        sector = Room_GetSector(
-            g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z,
-            &g_Camera.pos.room_num);
-        height = Room_GetHeight(
-                     sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-            - GROUND_SHIFT;
+    const SECTOR *sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+    int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    if (height == NO_HEIGHT) {
+        pos.y = old_pos.y;
+        pos.room_num = old_pos.room_num;
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
     }
 
-    int32_t ceiling =
-        Room_GetCeiling(sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-        + GROUND_SHIFT;
+    height -= STEP_L;
+    if (pos.y >= height && ideal->y >= height) {
+        LOS_Check(&g_Camera.target, &pos);
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z) - STEP_L;
+    }
+
+    g_Camera.pos = pos;
+
+    int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z) + STEP_L;
     if (height < ceiling) {
         ceiling = (height + ceiling) >> 1;
         height = ceiling;

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -321,24 +321,23 @@ static void M_Move(const GAME_VECTOR *const ideal, const int32_t speed)
         height = ceiling;
     }
 
-    if (g_Camera.bounce) {
-        if (g_Camera.bounce > 0) {
-            g_Camera.pos.y += g_Camera.bounce;
-            g_Camera.target.y += g_Camera.bounce;
-            g_Camera.bounce = 0;
-        } else {
-            int32_t shake;
-            shake = (Random_GetControl() - 0x4000) * g_Camera.bounce / 0x7FFF;
-            g_Camera.pos.x += shake;
-            g_Camera.target.y += shake;
-            shake = (Random_GetControl() - 0x4000) * g_Camera.bounce / 0x7FFF;
-            g_Camera.pos.y += shake;
-            g_Camera.target.y += shake;
-            shake = (Random_GetControl() - 0x4000) * g_Camera.bounce / 0x7FFF;
-            g_Camera.pos.z += shake;
-            g_Camera.target.z += shake;
-            g_Camera.bounce += 5;
-        }
+    if (g_Camera.bounce > 0) {
+        g_Camera.pos.y += g_Camera.bounce;
+        g_Camera.target.y += g_Camera.bounce;
+        g_Camera.bounce = 0;
+    } else if (g_Camera.bounce < 0) {
+        const XYZ_32 shake = {
+            .x = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+            .y = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+            .z = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+        };
+        g_Camera.pos.x += shake.x;
+        g_Camera.pos.y += shake.y;
+        g_Camera.pos.z += shake.z;
+        g_Camera.target.y += shake.x;
+        g_Camera.target.y += shake.y;
+        g_Camera.target.z += shake.z;
+        g_Camera.bounce += 5;
     }
 
     if (g_Camera.pos.y > height) {

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -123,7 +123,6 @@
 #define END_BIT 0x8000
 
 #define MIN_SQUARE SQUARE(WALL_L / 4) // = 65536
-#define GROUND_SHIFT (STEP_L)
 
 #define DEFAULT_RADIUS 10
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -123,32 +123,34 @@ void Camera_ResetPosition(void)
 
 void Camera_Move(const GAME_VECTOR *target, int32_t speed)
 {
-    g_Camera.pos.x += (target->x - g_Camera.pos.x) / speed;
-    g_Camera.pos.z += (target->z - g_Camera.pos.z) / speed;
-    g_Camera.pos.y += (target->y - g_Camera.pos.y) / speed;
-    g_Camera.pos.room_num = target->room_num;
+    const GAME_VECTOR old_pos = g_Camera.pos;
+    GAME_VECTOR pos = g_Camera.pos;
+    pos.x += (target->x - pos.x) / speed;
+    pos.z += (target->z - pos.z) / speed;
+    pos.y += (target->y - pos.y) / speed;
+    pos.room_num = target->room_num;
 
     Camera_SetChunky(false);
 
-    const SECTOR *sector = Room_GetSector(
-        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
-    int32_t height =
-        Room_GetHeight(sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-        - STEP_L;
-
-    if (g_Camera.pos.y >= height && target->y >= height) {
-        LOS_Check(&g_Camera.target, &g_Camera.pos);
-        sector = Room_GetSector(
-            g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z,
-            &g_Camera.pos.room_num);
-        height = Room_GetHeight(
-                     sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-            - STEP_L;
+    const SECTOR *sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+    int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    if (height == NO_HEIGHT) {
+        pos.y = old_pos.y;
+        pos.room_num = old_pos.room_num;
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
     }
 
-    int32_t ceiling =
-        Room_GetCeiling(sector, g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z)
-        + STEP_L;
+    height -= STEP_L;
+    if (pos.y >= height && target->y >= height) {
+        LOS_Check(&g_Camera.target, &pos);
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z) - STEP_L;
+    }
+
+    g_Camera.pos = pos;
+
+    int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z) + STEP_L;
     if (height < ceiling) {
         ceiling = (height + ceiling) >> 1;
         height = ceiling;


### PR DESCRIPTION
Resolves #1034.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves instances where the camera Y shift could result in extremely large values when `NO_HEIGHT` is involved, hence resulting in the camera going out of bounds for a frame or so. We now check for this case and use the previous valid Y position of the camera. @aredfan has provided saves in the issue where there are prominent cases of this.

This doesn't fix all instances where the camera can go into walls/OOB - the other related issue is with the interpolated values, which we'll tackle separately. This PR addresses only those instances where the camera is thrown up to -32768.
