### PR TITLE
tr1/lara/cheat: reset meshes in fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed several instances of the camera going out of bounds (#1034)
 - fixed the bear AI fix option being applied in the Vilcabamba demo (#2559, regression from 4.8)
 - fixed extremely large item quantities crashing the game (#2497, regression from 0.3)
+- fixed Lara's meshes not resetting after using the fly cheat (#2565, #2572, regressions from 4.8)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17
 - fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -139,6 +139,12 @@ bool Lara_Cheat_EnterFlyMode(void)
         return false;
     }
 
+    g_Lara.request_gun_type = LGT_UNARMED;
+    if (g_LaraItem->hit_points <= 0) {
+        g_Lara.gun_status = LGS_ARMLESS;
+        Lara_InitialiseMeshes(GF_GetCurrentLevel());
+    }
+
     if (g_Lara.water_status != LWS_UNDERWATER || g_LaraItem->hit_points <= 0) {
         g_LaraItem->pos.y -= STEP_L;
         g_LaraItem->current_anim_state = LS_SWIM;
@@ -193,6 +199,7 @@ bool Lara_Cheat_ExitFlyMode(void)
         g_Lara.torso_rot.y = 0;
     }
     g_Lara.gun_status = LGS_ARMLESS;
+    Lara_InitialiseMeshes(GF_GetCurrentLevel());
     Console_Log(GS(OSD_FLY_MODE_OFF));
     return true;
 }

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -655,30 +655,40 @@ void Lara_RevertToPistolsIfNeeded(void)
 void Lara_InitialiseMeshes(const GF_LEVEL *const level)
 {
     const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-
-    if (resume != nullptr && resume->flags.costume) {
-        for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
-            Lara_SwapSingleMesh(mesh, mesh == LM_HEAD ? O_LARA : O_LARA_EXTRA);
-        }
-        return;
-    }
+    const bool use_costume = resume != nullptr && resume->flags.costume
+        && Object_Get(O_LARA_EXTRA)->loaded;
 
     for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
-        Lara_SwapSingleMesh(mesh, O_LARA);
+        Lara_SwapSingleMesh(
+            mesh, mesh == LM_HEAD || !use_costume ? O_LARA : O_LARA_EXTRA);
     }
 
-    LARA_GUN_TYPE holsters_gun_type =
-        resume != nullptr ? resume->holsters_gun_type : LGT_UNKNOWN;
-    LARA_GUN_TYPE back_gun_type =
-        resume != nullptr ? resume->back_gun_type : LGT_UNKNOWN;
+    LARA_GUN_TYPE back_gun_type = g_Lara.back_gun_type;
+    LARA_GUN_TYPE holsters_gun_type = g_Lara.holsters_gun_type;
 
-    if (holsters_gun_type != LGT_UNKNOWN) {
+    if (back_gun_type == LGT_UNARMED && Inv_RequestItem(O_SHOTGUN_ITEM)) {
+        back_gun_type = LGT_SHOTGUN;
+    }
+
+    if (holsters_gun_type == LGT_UNARMED) {
+        if (g_Lara.gun_type != LGT_UNARMED && g_Lara.gun_type != LGT_SHOTGUN) {
+            holsters_gun_type = g_Lara.gun_type;
+        } else if (Inv_RequestItem(O_PISTOL_ITEM)) {
+            holsters_gun_type = LGT_PISTOLS;
+        } else if (Inv_RequestItem(O_MAGNUM_ITEM)) {
+            holsters_gun_type = LGT_MAGNUMS;
+        } else if (Inv_RequestItem(O_UZI_ITEM)) {
+            holsters_gun_type = LGT_UZIS;
+        }
+    }
+
+    if (back_gun_type != LGT_UNARMED && back_gun_type != LGT_UNKNOWN) {
+        Gun_SetLaraBackMesh(back_gun_type);
+    }
+
+    if (holsters_gun_type != LGT_UNARMED && holsters_gun_type != LGT_UNKNOWN) {
         Gun_SetLaraHolsterLMesh(holsters_gun_type);
         Gun_SetLaraHolsterRMesh(holsters_gun_type);
-    }
-
-    if (back_gun_type != LGT_UNKNOWN) {
-        Gun_SetLaraBackMesh(back_gun_type);
     }
 }
 

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -346,7 +346,6 @@ void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)
 
     current->lara_hitpoints = g_LaraItem->hit_points;
     current->flags.available = 1;
-    current->flags.costume = 0;
 
     current->pistol_ammo = 1000;
     if (Inv_RequestItem(O_PISTOL_ITEM)) {


### PR DESCRIPTION
Resolves #2565.
Resolves #2572.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores Lara's meshes if she is resurrected with the fly cheat. The only scenario we can't efficiently cover is the following:
- draw magnums or uzis
- draw shotgun
- die and resurrect

In this case the holstered guns will be pistols because we don't store the last holstered gun type, and looking it up would involve a lot of mesh comparison which I don't feel is worth it, plus for things like the T-Rex and Midas deaths, the information is lost anyway. If the last gun is not the shotgun, the correct holster meshes will be restored normally.

Otherwise, other scenarios should hopefully work as expected 🤞 Worth checking #2461 too.
