### PR TITLE
tr2/game_flow: fix losing NG+ flag in saves

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed extremely large item quantities crashing the game (#2497, regression from 0.3)
 - fixed missing new game text in the passport when play any level is enabled (#2563, regression from 0.9)
 - fixed the play any level dialog not showing in the gym passport (#2564, regression from 0.9)
+- fixed losing the NG+ flag when loading a save that has it set (#2566, regression from 0.9.2)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -268,9 +268,8 @@ void GF_PreSequenceHook(
     g_GF_RemoveAmmo = false;
     g_GF_RemoveWeapons = false;
     g_GF_NumSecrets = 3;
-    if (seq_ctx == GFSC_SAVED) {
-        g_SaveGame.bonus_flag = false;
-    }
+    // TODO: reset bonus flag if seq_ctx == GFSC_SAVED once S_LoadGame logic is
+    // merged with overall save loading logic.
     Camera_GetCineData()->position.target_angle = DEG_90;
 }
 


### PR DESCRIPTION
Resolves #2566.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This postpones the fix for #2515 in TR2 because of the way the original savegame is loaded; `S_LoadGame` is called first and sets the bonus flag, then puts the rest of the savegame data into a buffer. We were then resetting the flag in the GF, and later processing the save buffer. This works in TR1 because the later save processing captures the NG+ flag in BSON, and legacy reading reads again from the beginning. #2515 didn't apply to TR2 so I think this is currently the best approach until we refactor the savegame logic, as that's a much bigger endeavour.

Worth testing different kinds of saves, with and without the flag and after completing the game, or exiting to title early (and any other scenario you can think of 😄).
