### PR TITLE
tr2/demo: restore config caching on demo start

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed missing new game text in the passport when play any level is enabled (#2563, regression from 0.9)
 - fixed the play any level dialog not showing in the gym passport (#2564, regression from 0.9)
 - fixed losing the NG+ flag when loading a save that has it set (#2566, regression from 0.9.2)
+- fixed the ammo counter not showing in demos if NG+ is set (#2574, regression from 0.9)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -125,6 +125,8 @@ bool Demo_Start(const int32_t level_num)
     ASSERT(p->level != nullptr);
     ASSERT(GF_GetCurrentLevel() == p->level);
 
+    M_PrepareConfig(p);
+
     const uint32_t *const data = Demo_GetData();
     if (data == nullptr) {
         LOG_ERROR("Level '%s' has no demo data", p->level->path);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2574.
