### PR TITLE
tr2/lara/misc: fix landing damage check

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added a `/wireframe` console command (#2500)
 - fixed smashed windows blocking enemy pathing after loading a save (#2535)
 - fixed several instances of the camera going out of bounds (#1034)
+- fixed Lara getting stuck in a T-pose after jumping/falling and then dying before reaching fast fall speed (#2575)
 - fixed a rare issue whereby Lara would be unable to move after disposing a flare (#2545, regression from 0.9)
 - fixed flare pickups only adding one flare to Lara's inventory rather than six (#2551, regression from 0.9)
 - fixed play any level causing the game to hang when no gym level is present (#2560, regression from 0.9)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -79,6 +79,7 @@ game with new enhancements and features.
     - **Floating Islands**: fixed door 72's position to resolve the invisible wall in front of it
 - fixed the game crashing if a cinematic is triggered but the level contains no cinematic frames
 - fixed smashed windows blocking enemy pathing after loading a save
+- fixed Lara getting stuck in a T-pose after jumping/falling and then dying before reaching fast fall speed
 - improved the animation of Lara's braid
 
 #### Cheats

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -795,12 +795,13 @@ int32_t Lara_LandedBad(ITEM *item, COLL_INFO *coll)
         return 0;
     }
     if (land_speed <= DAMAGE_LENGTH) {
-        item->hit_points += -LARA_MAX_HITPOINTS * land_speed * land_speed
-            / (DAMAGE_LENGTH * DAMAGE_LENGTH);
+        Lara_TakeDamage(
+            LARA_MAX_HITPOINTS * SQUARE(land_speed) / SQUARE(DAMAGE_LENGTH),
+            false);
     } else {
         item->hit_points = -1;
     }
-    return item->hit_points <= 0;
+    return item->hit_points < 0;
 }
 
 int32_t Lara_CheckForLetGo(ITEM *item, COLL_INFO *coll)


### PR DESCRIPTION
Resolves #2575.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This brings TR2 into line with TR1 when Lara has landed bad, so that later checks can make decisions on the goal anim state more accurately.

This is related to #675 - had that change been implemented, TR1 would have suffered from the same bug. This also means it's now possible for Lara to behave like in TR1 where she can land seemingly normally but then she switches to the death animation. This can be compared in the same area in Venice but instead of jumping off the roof, just shimmy to the right, pull up and let her drop to the floor.
