### PR TITLE
lara/cheat: prevent fly cheat after exploding death

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed extremely large item quantities crashing the game (#2497, regression from 0.3)
 - fixed Lara's meshes not resetting after using the fly cheat (#2565, #2572, regressions from 4.8)
 - fixed guns appearing in Lara's hands if the draw input is held when unarmed and while picking up a gun item (#2577, regressions from 0.8/4.3)
+- fixed being able to play with Lara invisible after using the explosion cheat then the fly cheat (#2584, regression from 4.8)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17
 - fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed the play any level dialog not showing in the gym passport (#2564, regression from 0.9)
 - fixed losing the NG+ flag when loading a save that has it set (#2566, regression from 0.9.2)
 - fixed the ammo counter not showing in demos if NG+ is set (#2574, regression from 0.9)
+- fixed being able to play with Lara invisible after using the explosion cheat then the fly cheat (#2584, regression from 0.9)
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -139,6 +139,11 @@ bool Lara_Cheat_EnterFlyMode(void)
         return false;
     }
 
+    if ((g_LaraItem->flags & IF_INVISIBLE) != 0) {
+        // The explosion cheat has been used, so Lara's death is permanent.
+        return false;
+    }
+
     g_Lara.request_gun_type = LGT_UNARMED;
     if (g_LaraItem->hit_points <= 0) {
         g_Lara.gun_status = LGS_ARMLESS;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -120,6 +120,11 @@ bool Lara_Cheat_EnterFlyMode(void)
         return false;
     }
 
+    if ((g_LaraItem->flags & IF_INVISIBLE) != 0) {
+        // The explosion cheat has been used, so Lara's death is permanent.
+        return false;
+    }
+
     if (g_Lara.extra_anim) {
         M_ResetGunStatus();
     }


### PR DESCRIPTION
Resolves #2584.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents the fly cheat from being used after the explosion cheat.
