### PR TITLE
tr1/inventory: respect busy hands status

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed the bear AI fix option being applied in the Vilcabamba demo (#2559, regression from 4.8)
 - fixed extremely large item quantities crashing the game (#2497, regression from 0.3)
 - fixed Lara's meshes not resetting after using the fly cheat (#2565, #2572, regressions from 4.8)
+- fixed guns appearing in Lara's hands if the draw input is held when unarmed and while picking up a gun item (#2577, regressions from 0.8/4.3)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17
 - fixed some of Lara's speech in the gym not playing in response to player action (#2514, regression from 4.8)

--- a/src/tr1/game/inventory.c
+++ b/src/tr1/game/inventory.c
@@ -19,8 +19,12 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
         Gun_UpdateLaraMeshes(obj_id);
         if (g_Lara.gun_type == LGT_UNARMED) {
             g_Lara.gun_type = Gun_GetType(obj_id);
+            const bool hands_busy = g_Lara.gun_status == LGS_HANDS_BUSY;
             g_Lara.gun_status = LGS_ARMLESS;
             Gun_InitialiseNewWeapon();
+            if (hands_busy) {
+                g_Lara.gun_status = LGS_HANDS_BUSY;
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #2577.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that if Lara's hands are busy while a gun item is added to the inventory, the status is restored after initialising said gun.
