### PR TITLE
Add support for -l/--level

### DIFF
--- a/data/tr1/ship/cfg/TR1X_gameflow_level.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow_level.json5
@@ -1,0 +1,36 @@
+{
+    // This file is used to enable the -l argument support.
+
+    "main_menu_picture": "data/images/title.webp",
+    "savegame_fmt_legacy": "save_tmp.%d",
+    "savegame_fmt_bson": "save_tmp_%02d.dat",
+    "demo_delay": 0,
+    "water_color": [0.45, 1.0, 1.0],
+    "draw_distance_fade": 22.0,
+    "draw_distance_max": 30.0,
+    "injections": [
+        "data/injections/backpack.bin",
+        "data/injections/braid.bin",
+        "data/injections/lara_animations.bin",
+        "data/injections/lara_jumping.bin",
+        "data/injections/uzi_sfx.bin",
+        "data/injections/explosion.bin",
+        "data/injections/pickup_aid.bin",
+    ],
+    "enable_tr2_item_drops": false,
+    "convert_dropped_guns": false,
+    "enable_killer_pushblocks": true,
+
+    "levels": [
+        {
+            "path": "PLACEHOLDER",
+            "music_track": 0,
+            "sequence": [
+                {"type": "loop_game"},
+                {"type": "level_stats"},
+                {"type": "level_complete"},
+            ],
+            "injections": [],
+        },
+    ],
+}

--- a/data/tr1/ship/cfg/TR1X_strings_level.json5
+++ b/data/tr1/ship/cfg/TR1X_strings_level.json5
@@ -1,0 +1,8 @@
+{
+    "levels": [
+        // Level 0: Lara's Home
+        {
+            "title": "Test Level",
+        },
+    ]
+}

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...develop) - ××××-××-××
+- added support for `-l`/`--level` argument to play a single level
 - added support for custom levels to use `disable_floor` in the gameflow, similar to TR2's Floating Islands (#2541)
 - added drawing of object mesh spheres to the `/debug` console command
 - changed the Controls screen to hide the reset and unbind texts when changing a key (#2103)

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -473,14 +473,20 @@ static void M_LoadGlobalInjections(JSON_OBJECT *const obj, GAME_FLOW *const gf)
     }
 }
 
-void GF_Load(const char *const path)
+void GF_LoadFromFile(const char *const path)
 {
-    GF_Shutdown();
-
     char *script_data = nullptr;
     if (!File_Load(path, &script_data, nullptr)) {
         Shell_ExitSystem("Failed to open script file");
     }
+
+    GF_LoadFromString(script_data);
+    Memory_FreePointer(&script_data);
+}
+
+void GF_LoadFromString(const char *const script_data)
+{
+    GF_Shutdown();
 
     JSON_PARSE_RESULT parse_result;
     JSON_VALUE *const root = JSON_ParseEx(
@@ -505,5 +511,4 @@ void GF_Load(const char *const path)
     if (root != nullptr) {
         JSON_ValueFree(root);
     }
-    Memory_FreePointer(&script_data);
 }

--- a/src/libtrx/game/game_string_table/reader.c
+++ b/src/libtrx/game/game_string_table/reader.c
@@ -132,24 +132,29 @@ static void M_LoadLevelsFromJSON(
 
 void GameStringTable_LoadFromFile(const char *const path)
 {
+    char *data = nullptr;
+    if (!File_Load(path, &data, nullptr)) {
+        Shell_ExitSystemFmt("failed to open strings file (path: %d)", path);
+    }
+    GameStringTable_LoadFromString(data);
+    Memory_FreePointer(&data);
+}
+
+void GameStringTable_LoadFromString(const char *const data)
+{
     GameStringTable_Shutdown();
 
     JSON_VALUE *root = nullptr;
 
-    char *script_data = nullptr;
-    if (!File_Load(path, &script_data, nullptr)) {
-        Shell_ExitSystemFmt("failed to open strings file (path: %d)", path);
-    }
-
     JSON_PARSE_RESULT parse_result;
     root = JSON_ParseEx(
-        script_data, strlen(script_data), JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr,
-        nullptr, &parse_result);
+        data, strlen(data), JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr, nullptr,
+        &parse_result);
     if (root == nullptr) {
         Shell_ExitSystemFmt(
-            "Failed to parse script file: %s in line %d, char %d",
+            "Failed to parse strings table: %s in line %d, char %d",
             JSON_GetErrorDescription(parse_result.error),
-            parse_result.error_line_no, parse_result.error_row_no, script_data);
+            parse_result.error_line_no, parse_result.error_row_no, data);
     }
 
     GS_FILE *const gs_file = &g_GST_File;
@@ -163,5 +168,4 @@ void GameStringTable_LoadFromFile(const char *const path)
         JSON_ValueFree(root);
         root = nullptr;
     }
-    Memory_FreePointer(&script_data);
 }

--- a/src/libtrx/include/libtrx/game/game_flow/reader.h
+++ b/src/libtrx/include/libtrx/game/game_flow/reader.h
@@ -1,3 +1,4 @@
 #pragma once
 
-void GF_Load(const char *path);
+void GF_LoadFromFile(const char *path);
+void GF_LoadFromString(const char *script_data);

--- a/src/libtrx/include/libtrx/game/game_string_table.h
+++ b/src/libtrx/include/libtrx/game/game_string_table.h
@@ -3,5 +3,6 @@
 #include <stdint.h>
 
 void GameStringTable_LoadFromFile(const char *path);
+void GameStringTable_LoadFromString(const char *data);
 void GameStringTable_Apply(const GF_LEVEL *level);
 void GameStringTable_Shutdown(void);

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -99,43 +99,6 @@ static void M_LoadConfig(void)
     Music_SetVolume(g_Config.audio.music_volume);
 }
 
-void Shell_Init(
-    const char *const game_flow_path, const char *const game_strings_path)
-{
-    Text_Init();
-    UI_Init();
-
-    Input_Init();
-    Sound_Init();
-    Music_Init();
-
-    M_LoadConfig();
-
-    Clock_Init();
-
-    S_Shell_CreateWindow();
-    S_Shell_Init();
-
-    Random_Seed();
-
-    if (!Output_Init()) {
-        Shell_ExitSystem("Could not initialise video system");
-        return;
-    }
-    Screen_Init();
-
-    GF_Init();
-    GF_LoadFromFile(game_flow_path);
-    GameStringTable_LoadFromFile(game_strings_path);
-    GameStringTable_Apply(nullptr);
-
-    Savegame_Init();
-    Savegame_ScanSavedGames();
-    Savegame_HighlightNewestSlot();
-    GameBuf_Init();
-    Console_Init();
-}
-
 void Shell_Shutdown(void)
 {
     Console_Shutdown();
@@ -187,9 +150,38 @@ void Shell_Main(void)
     EnumMap_Init();
     Config_Init();
 
-    Shell_Init(
-        m_ModPaths[m_ActiveMod].game_flow_path,
-        m_ModPaths[m_ActiveMod].game_strings_path);
+    Text_Init();
+    UI_Init();
+
+    Input_Init();
+    Sound_Init();
+    Music_Init();
+
+    M_LoadConfig();
+
+    Clock_Init();
+
+    S_Shell_CreateWindow();
+    S_Shell_Init();
+
+    Random_Seed();
+
+    if (!Output_Init()) {
+        Shell_ExitSystem("Could not initialise video system");
+        return;
+    }
+    Screen_Init();
+
+    GF_Init();
+    GF_LoadFromFile(m_ModPaths[m_ActiveMod].game_flow_path);
+    GameStringTable_LoadFromFile(m_ModPaths[m_ActiveMod].game_strings_path);
+    GameStringTable_Apply(nullptr);
+
+    Savegame_Init();
+    Savegame_ScanSavedGames();
+    Savegame_HighlightNewestSlot();
+    GameBuf_Init();
+    Console_Init();
 
     GF_COMMAND gf_cmd = GF_DoFrontendSequence();
     bool loop_continue = !Shell_IsExiting();

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -125,7 +125,7 @@ void Shell_Init(
     Screen_Init();
 
     GF_Init();
-    GF_Load(game_flow_path);
+    GF_LoadFromFile(game_flow_path);
     GameStringTable_LoadFromFile(game_strings_path);
     GameStringTable_Apply(nullptr);
 

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -41,6 +41,7 @@ typedef enum {
     M_MOD_OG,
     M_MOD_UB,
     M_MOD_DEMO_PC,
+    M_MOD_CUSTOM_LEVEL,
 } M_MOD;
 
 static struct {
@@ -58,6 +59,10 @@ static struct {
     [M_MOD_DEMO_PC] = {
         .game_flow_path = "cfg/TR1X_gameflow_demo_pc.json5",
         .game_strings_path = "cfg/TR1X_strings_demo_pc.json5",
+    },
+    [M_MOD_CUSTOM_LEVEL] = {
+        .game_flow_path = "cfg/TR1X_gameflow_level.json5",
+        .game_strings_path = "cfg/TR1X_strings_level.json5",
     },
 };
 static M_MOD m_ActiveMod = M_MOD_UNKNOWN;
@@ -130,6 +135,8 @@ void Shell_Main(void)
 {
     m_ActiveMod = M_MOD_OG;
 
+    const char *level_to_play = nullptr;
+
     char **args = nullptr;
     int32_t arg_count = 0;
     S_Shell_GetCommandLine(&arg_count, &args);
@@ -140,11 +147,12 @@ void Shell_Main(void)
         if (!strcmp(args[i], "-demo_pc")) {
             m_ActiveMod = M_MOD_DEMO_PC;
         }
+        if ((!strcmp(args[i], "-l") || !strcmp(args[i], "--level"))
+            && i + 1 < arg_count) {
+            level_to_play = args[i + 1];
+            m_ActiveMod = M_MOD_CUSTOM_LEVEL;
+        }
     }
-    for (int i = 0; i < arg_count; i++) {
-        Memory_FreePointer(&args[i]);
-    }
-    Memory_FreePointer(&args);
 
     GameString_Init();
     EnumMap_Init();
@@ -183,7 +191,15 @@ void Shell_Main(void)
     GameBuf_Init();
     Console_Init();
 
-    GF_COMMAND gf_cmd = GF_DoFrontendSequence();
+    if (level_to_play != nullptr) {
+        Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
+        g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
+            Memory_DupStr(level_to_play);
+    }
+
+    GF_COMMAND gf_cmd = level_to_play != nullptr
+        ? (GF_COMMAND) { .action = GF_START_GAME, .param = 0 }
+        : GF_DoFrontendSequence();
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {
         LOG_INFO(
@@ -241,7 +257,9 @@ void Shell_Main(void)
             break;
 
         case GF_EXIT_TO_TITLE:
-            if (g_GameFlow.title_level == nullptr) {
+            if (level_to_play != nullptr) {
+                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
+            } else if (g_GameFlow.title_level == nullptr) {
                 Shell_ExitSystem("Title disabled");
             } else {
                 gf_cmd = GF_RunTitle();
@@ -262,6 +280,14 @@ void Shell_Main(void)
     Config_Write();
     EnumMap_Shutdown();
     GameString_Shutdown();
+
+    if (level_to_play != nullptr) {
+        Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
+    }
+    for (int i = 0; i < arg_count; i++) {
+        Memory_FreePointer(&args[i]);
+    }
+    Memory_FreePointer(&args);
 }
 
 void Shell_ProcessInput(void)

--- a/src/tr1/game/shell.h
+++ b/src/tr1/game/shell.h
@@ -2,5 +2,4 @@
 
 #include <libtrx/game/shell.h>
 
-void Shell_Init(const char *game_flow_path, const char *game_strings_path);
 void Shell_Main(void);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -349,7 +349,7 @@ void Shell_Main(void)
     Render_Reset(RENDER_RESET_PARAMS);
 
     GF_Init();
-    GF_Load(m_CurrentGameFlowPath);
+    GF_LoadFromFile(m_CurrentGameFlowPath);
     GameStringTable_LoadFromFile(m_CurrentGameStringsPath);
     GameStringTable_Apply(nullptr);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This feature allows the player to run a single level using `-l` / `--level`, simplifying the debugging process for custom levels. It eliminates the need to manually rename files and adjust injection settings in the original game flow file. To support this, we introduce a dedicated game flow file designed specifically for this purpose, which includes a single level that will be dynamically overridden at runtime. Additionally, a new game string table is created to supply the level title as required by the engine.

The downside is that we litter the `cfg/` directory with an additional file. I looked into the C23 `#embed` preprocessor directive, but the compilers that ship with our Docker build do not yet support it.

TR2 doesn't yet support this.