### PR TITLE
tr2/shell: fix crash when exiting with -l

### DIFF
--- a/src/libtrx/include/libtrx/game/game_flow/types.h
+++ b/src/libtrx/include/libtrx/game/game_flow/types.h
@@ -98,11 +98,7 @@ typedef struct {
 typedef struct {
     int32_t num;
     GF_LEVEL_TYPE type;
-#if TR_VERSION == 1
     char *path;
-#elif TR_VERSION == 2
-    const char *path;
-#endif
     char *title;
 
     MUSIC_TRACK_ID music_track;

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -393,7 +393,9 @@ void Shell_Main(void)
     GameBuf_Init();
 
     if (level_to_play != nullptr) {
-        g_GameFlow.level_tables[GFLT_MAIN].levels[0].path = level_to_play;
+        Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
+        g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
+            Memory_DupStr(level_to_play);
     }
 
     GF_COMMAND gf_cmd = level_to_play != nullptr
@@ -468,6 +470,9 @@ void Shell_Main(void)
     }
 
     Config_Write();
+    if (level_to_play != nullptr) {
+        Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
+    }
 }
 
 void Shell_Shutdown(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a crash when the player exits the game ran with `-l` / `--level` argument. I mistakenly believed that the level paths use a shared area allocation due to a leftover `const` TR2-specific specialization of the `char *path` `GF_LEVEL` member, but it's just `Memory_DupStr()`'d in both engines. Fixed the confusing define.