### PR TITLE
level: finalise reading migration to TRX

### DIFF
--- a/src/libtrx/game/inject/data/anims.c
+++ b/src/libtrx/game/inject/data/anims.c
@@ -18,7 +18,7 @@ static void M_HandleAnimData(const INJECTION_CHUNK chunk)
 
         switch (data_type) {
         case IDT_ANIMS: {
-            Level_ReadAnims(
+            Level_AppendAnims(
                 level_info->anims.anim_count, data_count, chunk.injection->fp);
             level_info->anims.anim_count += data_count;
 
@@ -34,14 +34,14 @@ static void M_HandleAnimData(const INJECTION_CHUNK chunk)
         }
 
         case IDT_ANIM_BONES: {
-            Level_ReadAnimBones(
+            Level_AppendAnimBones(
                 level_info->anims.bone_count, data_count, chunk.injection->fp);
             level_info->anims.bone_count += data_count;
             break;
         }
 
         case IDT_ANIM_CHANGES: {
-            Level_ReadAnimChanges(
+            Level_AppendAnimChanges(
                 level_info->anims.change_count, data_count,
                 chunk.injection->fp);
             level_info->anims.change_count += data_count;
@@ -55,25 +55,22 @@ static void M_HandleAnimData(const INJECTION_CHUNK chunk)
         }
 
         case IDT_ANIM_COMMANDS: {
-            VFile_Read(
-                chunk.injection->fp,
-                level_info->anims.commands + level_info->anims.command_count,
-                data_count * sizeof(int16_t));
+            Level_AppendAnimCommands(
+                level_info->anims.command_count, data_count,
+                chunk.injection->fp);
             level_info->anims.command_count += data_count;
             break;
         }
 
         case IDT_ANIM_FRAMES: {
-            VFile_Read(
-                chunk.injection->fp,
-                level_info->anims.frames + level_info->anims.frame_count,
-                data_count * sizeof(int16_t));
+            Level_AppendAnimFrames(
+                level_info->anims.frame_count, data_count, chunk.injection->fp);
             level_info->anims.frame_count += data_count;
             break;
         }
 
         case IDT_ANIM_RANGES: {
-            Level_ReadAnimRanges(
+            Level_AppendAnimRanges(
                 level_info->anims.range_count, data_count, chunk.injection->fp);
             level_info->anims.range_count += data_count;
 

--- a/src/libtrx/game/inject/data/anims.c
+++ b/src/libtrx/game/inject/data/anims.c
@@ -55,9 +55,10 @@ static void M_HandleAnimData(const INJECTION_CHUNK chunk)
         }
 
         case IDT_ANIM_COMMANDS: {
-            Level_ReadAnimCommands(
-                level_info->anims.command_count, data_count,
-                chunk.injection->fp);
+            VFile_Read(
+                chunk.injection->fp,
+                level_info->anims.commands + level_info->anims.command_count,
+                data_count * sizeof(int16_t));
             level_info->anims.command_count += data_count;
             break;
         }

--- a/src/libtrx/game/inject/data/meshes.c
+++ b/src/libtrx/game/inject/data/meshes.c
@@ -27,7 +27,7 @@ static void M_HandleMeshData(const INJECTION_CHUNK chunk)
 
         case IDT_OBJECT_MESHES: {
             ASSERT(mesh_indices != nullptr);
-            Level_ReadObjectMeshes(
+            Level_AppendObjectMeshes(
                 mesh_ptr_count, mesh_indices, chunk.injection->fp);
             LEVEL_INFO *const info = Level_GetInfo();
             info->mesh_ptr_count += mesh_ptr_count;

--- a/src/libtrx/game/inject/data/textures.c
+++ b/src/libtrx/game/inject/data/textures.c
@@ -112,13 +112,13 @@ static void M_HandleTextureInfo(const INJECTION_CHUNK chunk)
 
         switch (data_type) {
         case IDT_OBJECT_TEXTURES:
-            Level_ReadObjectTextures(
+            Level_AppendObjectTextures(
                 level_info->textures.object_count, page_base, data_count,
                 chunk.injection->fp);
             level_info->textures.object_count += data_count;
             break;
         case IDT_SPRITE_TEXTURES:
-            Level_ReadSpriteTextures(
+            Level_AppendSpriteTextures(
                 level_info->textures.sprite_count, page_base, data_count,
                 chunk.injection->fp);
             break;

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -24,6 +24,8 @@
 
 #include <string.h>
 
+static LEVEL_INFO m_Info = {};
+
 static RGBA_8888 M_ARGB1555To8888(uint16_t argb1555);
 static void M_ReadPosition(XYZ_32 *pos, VFILE *file);
 static void M_ReadShade(SHADE *shade, VFILE *file);
@@ -255,47 +257,47 @@ static void M_ReadObjectVector(OBJECT_VECTOR *const obj, VFILE *const file)
     obj->flags = VFile_ReadS16(file);
 }
 
-void Level_ReadPalettes(LEVEL_INFO *const info, VFILE *const file)
+void Level_ReadPalettes(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
 
     const int32_t palette_size = 256;
-    info->palette.size = palette_size;
+    m_Info.palette.size = palette_size;
 
-    info->palette.data_24 = Memory_Alloc(sizeof(RGB_888) * palette_size);
-    VFile_Read(file, info->palette.data_24, sizeof(RGB_888) * palette_size);
-    info->palette.data_24[0].r = 0;
-    info->palette.data_24[0].g = 0;
-    info->palette.data_24[0].b = 0;
+    m_Info.palette.data_24 = Memory_Alloc(sizeof(RGB_888) * palette_size);
+    VFile_Read(file, m_Info.palette.data_24, sizeof(RGB_888) * palette_size);
+    m_Info.palette.data_24[0].r = 0;
+    m_Info.palette.data_24[0].g = 0;
+    m_Info.palette.data_24[0].b = 0;
     for (int32_t i = 1; i < palette_size; i++) {
-        RGB_888 *const col = &info->palette.data_24[i];
+        RGB_888 *const col = &m_Info.palette.data_24[i];
         col->r = (col->r << 2) | (col->r >> 4);
         col->g = (col->g << 2) | (col->g >> 4);
         col->b = (col->b << 2) | (col->b >> 4);
     }
 
 #if TR_VERSION == 1
-    info->palette.data_32 = nullptr;
+    m_Info.palette.data_32 = nullptr;
 #else
     RGBA_8888 palette_16[palette_size];
-    info->palette.data_32 = Memory_Alloc(sizeof(RGB_888) * palette_size);
+    m_Info.palette.data_32 = Memory_Alloc(sizeof(RGB_888) * palette_size);
     VFile_Read(file, palette_16, sizeof(RGBA_8888) * palette_size);
     for (int32_t i = 0; i < palette_size; i++) {
-        info->palette.data_32[i].r = palette_16[i].r;
-        info->palette.data_32[i].g = palette_16[i].g;
-        info->palette.data_32[i].b = palette_16[i].b;
+        m_Info.palette.data_32[i].r = palette_16[i].r;
+        m_Info.palette.data_32[i].g = palette_16[i].g;
+        m_Info.palette.data_32[i].b = palette_16[i].b;
     }
 #endif
 
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_ReadTexturePages(LEVEL_INFO *const info, VFILE *const file)
+void Level_ReadTexturePages(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
 
     const int32_t num_pages = VFile_ReadS32(file);
-    info->textures.page_count = num_pages;
+    m_Info.textures.page_count = num_pages;
     LOG_INFO("texture pages: %d", num_pages);
 
     const int32_t extra_pages = Inject_GetDataCount(IDT_TEXTURE_PAGES);
@@ -304,17 +306,17 @@ void Level_ReadTexturePages(LEVEL_INFO *const info, VFILE *const file)
     const int32_t texture_size_32_bit =
         (num_pages + extra_pages) * TEXTURE_PAGE_SIZE * sizeof(RGBA_8888);
 
-    info->textures.pages_24 = Memory_Alloc(texture_size_8_bit);
-    VFile_Read(file, info->textures.pages_24, num_pages * TEXTURE_PAGE_SIZE);
+    m_Info.textures.pages_24 = Memory_Alloc(texture_size_8_bit);
+    VFile_Read(file, m_Info.textures.pages_24, num_pages * TEXTURE_PAGE_SIZE);
 
-    info->textures.pages_32 = Memory_Alloc(texture_size_32_bit);
-    RGBA_8888 *output = info->textures.pages_32;
+    m_Info.textures.pages_32 = Memory_Alloc(texture_size_32_bit);
+    RGBA_8888 *output = m_Info.textures.pages_32;
 
 #if TR_VERSION == 1
-    const uint8_t *input = info->textures.pages_24;
+    const uint8_t *input = m_Info.textures.pages_24;
     for (int32_t i = 0; i < num_pages * TEXTURE_PAGE_SIZE; i++) {
         const uint8_t index = *input++;
-        const RGB_888 pix = info->palette.data_24[index];
+        const RGB_888 pix = m_Info.palette.data_24[index];
         output->r = pix.r;
         output->g = pix.g;
         output->b = pix.b;
@@ -542,10 +544,10 @@ void Level_ReadAnimRanges(
     }
 }
 
-void Level_LoadAnimCommands(LEVEL_INFO *const info)
+void Level_LoadAnimCommands(void)
 {
-    Anim_LoadCommands(info->anims.commands);
-    Memory_FreePointer(&info->anims.commands);
+    Anim_LoadCommands(m_Info.anims.commands);
+    Memory_FreePointer(&m_Info.anims.commands);
 }
 
 void Level_ReadAnimBones(
@@ -563,13 +565,13 @@ void Level_ReadAnimBones(
     }
 }
 
-void Level_LoadAnimFrames(LEVEL_INFO *const info)
+void Level_LoadAnimFrames(void)
 {
     const int32_t frame_count =
-        Anim_GetTotalFrameCount(info->anims.frame_count);
+        Anim_GetTotalFrameCount(m_Info.anims.frame_count);
     Anim_InitialiseFrames(frame_count);
-    Anim_LoadFrames(info->anims.frames, info->anims.frame_count);
-    Memory_FreePointer(&info->anims.frames);
+    Anim_LoadFrames(m_Info.anims.frames, m_Info.anims.frame_count);
+    Memory_FreePointer(&m_Info.anims.frames);
 }
 
 void Level_ReadObjects(VFILE *const file)
@@ -879,7 +881,7 @@ void Level_ReadSoundSources(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_ReadSamples(LEVEL_INFO *const info, VFILE *const file)
+void Level_ReadSamples(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
 
@@ -887,7 +889,7 @@ void Level_ReadSamples(LEVEL_INFO *const info, VFILE *const file)
     VFile_Read(file, sample_lut, sizeof(int16_t) * SFX_NUMBER_OF);
 
     const int32_t num_sample_infos = VFile_ReadS32(file);
-    info->samples.info_count = num_sample_infos;
+    m_Info.samples.info_count = num_sample_infos;
     LOG_INFO("sample infos: %d", num_sample_infos);
     Sound_InitialiseSampleInfos(
         num_sample_infos + Inject_GetDataCount(IDT_SAMPLE_INFOS));
@@ -901,55 +903,55 @@ void Level_ReadSamples(LEVEL_INFO *const info, VFILE *const file)
 
 #if TR_VERSION == 1
     const int32_t data_size = VFile_ReadS32(file);
-    info->samples.data_size = data_size;
+    m_Info.samples.data_size = data_size;
     LOG_INFO("%d sample data size", data_size);
 
-    info->samples.data = GameBuf_Alloc(
+    m_Info.samples.data = GameBuf_Alloc(
         data_size + Inject_GetDataCount(IDT_SAMPLE_DATA), GBUF_SAMPLES);
-    VFile_Read(file, info->samples.data, sizeof(char) * data_size);
+    VFile_Read(file, m_Info.samples.data, sizeof(char) * data_size);
 #endif
 
     const int32_t num_offsets = VFile_ReadS32(file);
     LOG_INFO("samples: %d", num_offsets);
-    info->samples.offset_count = num_offsets;
+    m_Info.samples.offset_count = num_offsets;
 
-    info->samples.offsets = Memory_Alloc(
+    m_Info.samples.offsets = Memory_Alloc(
         sizeof(int32_t)
         * (num_offsets + Inject_GetDataCount(IDT_SAMPLE_INDICES)));
-    VFile_Read(file, info->samples.offsets, sizeof(int32_t) * num_offsets);
+    VFile_Read(file, m_Info.samples.offsets, sizeof(int32_t) * num_offsets);
 
 finish:
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_LoadTexturePages(LEVEL_INFO *const info)
+void Level_LoadTexturePages(void)
 {
-    const int32_t num_pages = info->textures.page_count;
+    const int32_t num_pages = m_Info.textures.page_count;
     Output_InitialiseTexturePages(num_pages, TR_VERSION == 2);
     for (int32_t i = 0; i < num_pages; i++) {
 #if TR_VERSION == 2
         uint8_t *const target_8 = Output_GetTexturePage8(i);
         const uint8_t *const source_8 =
-            &info->textures.pages_24[i * TEXTURE_PAGE_SIZE];
+            &m_Info.textures.pages_24[i * TEXTURE_PAGE_SIZE];
         memcpy(target_8, source_8, TEXTURE_PAGE_SIZE * sizeof(uint8_t));
 #endif
 
         RGBA_8888 *const target_32 = Output_GetTexturePage32(i);
         const RGBA_8888 *const source_32 =
-            &info->textures.pages_32[i * TEXTURE_PAGE_SIZE];
+            &m_Info.textures.pages_32[i * TEXTURE_PAGE_SIZE];
         memcpy(target_32, source_32, TEXTURE_PAGE_SIZE * sizeof(RGBA_8888));
     }
 
-    Memory_FreePointer(&info->textures.pages_24);
-    Memory_FreePointer(&info->textures.pages_32);
+    Memory_FreePointer(&m_Info.textures.pages_24);
+    Memory_FreePointer(&m_Info.textures.pages_32);
 }
 
-void Level_LoadPalettes(LEVEL_INFO *const info)
+void Level_LoadPalettes(void)
 {
     Output_InitialisePalettes(
-        info->palette.size, info->palette.data_24, info->palette.data_32);
-    Memory_FreePointer(&info->palette.data_24);
-    Memory_FreePointer(&info->palette.data_32);
+        m_Info.palette.size, m_Info.palette.data_24, m_Info.palette.data_32);
+    Memory_FreePointer(&m_Info.palette.data_24);
+    Memory_FreePointer(&m_Info.palette.data_32);
 }
 
 void Level_LoadObjectsAndItems(void)
@@ -963,4 +965,9 @@ void Level_LoadObjectsAndItems(void)
     for (int32_t i = 0; i < item_count; i++) {
         Item_Initialise(i);
     }
+}
+
+LEVEL_INFO *Level_GetInfo(void)
+{
+    return &m_Info;
 }

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -457,7 +457,35 @@ finish:
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_ReadObjectMeshes(
+void Level_ReadObjectMeshes(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_meshes = VFile_ReadS32(file);
+    LOG_INFO("object mesh data: %d", num_meshes);
+
+    const size_t data_start_pos = VFile_GetPos(file);
+    VFile_Skip(file, num_meshes * sizeof(int16_t));
+
+    m_Info.mesh_ptr_count = VFile_ReadS32(file);
+    LOG_INFO("object mesh indices: %d", m_Info.mesh_ptr_count);
+    const int32_t alloc_size = m_Info.mesh_ptr_count * sizeof(int32_t);
+    int32_t *mesh_indices = Memory_Alloc(alloc_size);
+    VFile_Read(file, mesh_indices, alloc_size);
+
+    const size_t end_pos = VFile_GetPos(file);
+    VFile_SetPos(file, data_start_pos);
+
+    Object_InitialiseMeshes(
+        m_Info.mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
+    Level_AppendObjectMeshes(m_Info.mesh_ptr_count, mesh_indices, file);
+
+    VFile_SetPos(file, end_pos);
+    Memory_FreePointer(&mesh_indices);
+
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendObjectMeshes(
     const int32_t num_indices, const int32_t *const indices, VFILE *const file)
 {
     // Construct and store distinct meshes only e.g. Lara's hips are referenced

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -24,8 +24,6 @@
 
 #include <string.h>
 
-static int16_t *m_AnimCommands = nullptr;
-
 static RGBA_8888 M_ARGB1555To8888(uint16_t argb1555);
 static void M_ReadPosition(XYZ_32 *pos, VFILE *file);
 static void M_ReadShade(SHADE *shade, VFILE *file);
@@ -544,21 +542,10 @@ void Level_ReadAnimRanges(
     }
 }
 
-void Level_InitialiseAnimCommands(const int32_t num_cmds)
+void Level_LoadAnimCommands(LEVEL_INFO *const info)
 {
-    m_AnimCommands = Memory_Alloc(sizeof(int16_t) * num_cmds);
-}
-
-void Level_ReadAnimCommands(
-    const int32_t base_idx, const int32_t num_cmds, VFILE *const file)
-{
-    VFile_Read(file, m_AnimCommands + base_idx, sizeof(int16_t) * num_cmds);
-}
-
-void Level_LoadAnimCommands(void)
-{
-    Anim_LoadCommands(m_AnimCommands);
-    Memory_FreePointer(&m_AnimCommands);
+    Anim_LoadCommands(info->anims.commands);
+    Memory_FreePointer(&info->anims.commands);
 }
 
 void Level_ReadAnimBones(

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -498,7 +498,18 @@ void Level_ReadObjectMeshes(
     Vector_Free(unique_indices);
 }
 
-void Level_ReadAnims(
+void Level_ReadAnims(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_anims = VFile_ReadS32(file);
+    m_Info.anims.anim_count = num_anims;
+    LOG_INFO("anims: %d", num_anims);
+    Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
+    Level_AppendAnims(0, num_anims, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnims(
     const int32_t base_idx, const int32_t num_anims, VFILE *const file)
 {
     for (int32_t i = 0; i < num_anims; i++) {
@@ -521,7 +532,19 @@ void Level_ReadAnims(
     }
 }
 
-void Level_ReadAnimChanges(
+void Level_ReadAnimChanges(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_anim_changes = VFile_ReadS32(file);
+    m_Info.anims.change_count = num_anim_changes;
+    LOG_INFO("anim changes: %d", num_anim_changes);
+    Anim_InitialiseChanges(
+        num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
+    Level_AppendAnimChanges(0, num_anim_changes, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnimChanges(
     const int32_t base_idx, const int32_t num_changes, VFILE *const file)
 {
     for (int32_t i = 0; i < num_changes; i++) {
@@ -532,7 +555,19 @@ void Level_ReadAnimChanges(
     }
 }
 
-void Level_ReadAnimRanges(
+void Level_ReadAnimRanges(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_anim_ranges = VFile_ReadS32(file);
+    m_Info.anims.range_count = num_anim_ranges;
+    LOG_INFO("anim ranges: %d", num_anim_ranges);
+    Anim_InitialiseRanges(
+        num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
+    Level_AppendAnimRanges(0, num_anim_ranges, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnimRanges(
     const int32_t base_idx, const int32_t num_ranges, VFILE *const file)
 {
     for (int32_t i = 0; i < num_ranges; i++) {
@@ -544,13 +579,44 @@ void Level_ReadAnimRanges(
     }
 }
 
+void Level_ReadAnimCommands(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_commands = VFile_ReadS32(file);
+    m_Info.anims.command_count = num_commands;
+    LOG_INFO("anim commands: %d", num_commands);
+    m_Info.anims.commands = Memory_Alloc(
+        sizeof(int16_t)
+        * (num_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
+    Level_AppendAnimCommands(0, num_commands, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnimCommands(
+    const int32_t base_idx, const int32_t num_commands, VFILE *const file)
+{
+    VFile_Read(
+        file, &m_Info.anims.commands[base_idx], sizeof(int16_t) * num_commands);
+}
+
 void Level_LoadAnimCommands(void)
 {
     Anim_LoadCommands(m_Info.anims.commands);
     Memory_FreePointer(&m_Info.anims.commands);
 }
 
-void Level_ReadAnimBones(
+void Level_ReadAnimBones(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
+    m_Info.anims.bone_count = num_anim_bones;
+    LOG_INFO("anim bones: %d", num_anim_bones);
+    Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
+    Level_AppendAnimBones(0, num_anim_bones, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnimBones(
     const int32_t base_idx, const int32_t num_bones, VFILE *const file)
 {
     for (int32_t i = 0; i < num_bones; i++) {
@@ -563,6 +629,26 @@ void Level_ReadAnimBones(
         bone->rot_z = false;
         M_ReadPosition(&bone->pos, file);
     }
+}
+
+void Level_ReadAnimFrames(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t raw_data_count = VFile_ReadS32(file);
+    m_Info.anims.frame_count = raw_data_count;
+    LOG_INFO("raw anim frames: %d", raw_data_count);
+    m_Info.anims.frames = Memory_Alloc(
+        sizeof(int16_t)
+        * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
+    Level_AppendAnimFrames(0, raw_data_count, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendAnimFrames(
+    const int32_t base_idx, const int32_t num_frames, VFILE *const file)
+{
+    VFile_Read(
+        file, &m_Info.anims.frames[base_idx], sizeof(int16_t) * num_frames);
 }
 
 void Level_LoadAnimFrames(void)

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -627,7 +627,19 @@ void Level_ReadStaticObjects(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-void Level_ReadObjectTextures(
+void Level_ReadObjectTextures(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_textures = VFile_ReadS32(file);
+    m_Info.textures.object_count = num_textures;
+    LOG_INFO("object textures: %d", num_textures);
+    Output_InitialiseObjectTextures(
+        num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
+    Level_AppendObjectTextures(0, 0, num_textures, file);
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendObjectTextures(
     const int32_t base_idx, const int16_t base_page_idx,
     const int32_t num_textures, VFILE *const file)
 {
@@ -642,7 +654,20 @@ void Level_ReadObjectTextures(
     }
 }
 
-void Level_ReadSpriteTextures(
+void Level_ReadSpriteTextures(VFILE *const file)
+{
+    BENCHMARK *const benchmark = Benchmark_Start();
+    const int32_t num_textures = VFile_ReadS32(file);
+    m_Info.textures.sprite_count = num_textures;
+    LOG_INFO("sprite textures: %d", num_textures);
+    Output_InitialiseSpriteTextures(
+        num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
+    Level_AppendSpriteTextures(0, 0, num_textures, file);
+
+    Benchmark_End(benchmark, nullptr);
+}
+
+void Level_AppendSpriteTextures(
     const int32_t base_idx, const int16_t base_page_idx,
     const int32_t num_textures, VFILE *const file)
 {

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -13,9 +13,7 @@ void Level_ReadObjectMeshes(
 void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
-void Level_InitialiseAnimCommands(int32_t num_cmds);
-void Level_ReadAnimCommands(int32_t base_idx, int32_t num_cmds, VFILE *file);
-void Level_LoadAnimCommands(void);
+void Level_LoadAnimCommands(LEVEL_INFO *info);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
 void Level_LoadAnimFrames(LEVEL_INFO *info);
 void Level_ReadObjects(VFILE *file);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -10,12 +10,12 @@ void Level_ReadTexturePages(VFILE *file);
 void Level_ReadRooms(VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
-void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
-void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
-void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
-void Level_LoadAnimCommands(void);
-void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
-void Level_LoadAnimFrames(void);
+void Level_ReadAnims(VFILE *file);
+void Level_ReadAnimChanges(VFILE *file);
+void Level_ReadAnimRanges(VFILE *file);
+void Level_ReadAnimCommands(VFILE *file);
+void Level_ReadAnimBones(VFILE *file);
+void Level_ReadAnimFrames(VFILE *file);
 void Level_ReadObjects(VFILE *file);
 void Level_ReadStaticObjects(VFILE *file);
 void Level_ReadObjectTextures(VFILE *file);
@@ -31,6 +31,14 @@ void Level_ReadDemoData(VFILE *file);
 void Level_ReadSoundSources(VFILE *file);
 void Level_ReadSamples(VFILE *file);
 
+void Level_AppendAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
+void Level_AppendAnimChanges(
+    int32_t base_idx, int32_t num_changes, VFILE *file);
+void Level_AppendAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
+void Level_AppendAnimCommands(
+    int32_t base_idx, int32_t num_commands, VFILE *file);
+void Level_AppendAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
+void Level_AppendAnimFrames(int32_t base_idx, int32_t num_frames, VFILE *file);
 void Level_AppendObjectTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 void Level_AppendSpriteTextures(
@@ -38,6 +46,8 @@ void Level_AppendSpriteTextures(
 
 void Level_LoadTexturePages(void);
 void Level_LoadPalettes(void);
+void Level_LoadAnimCommands(void);
+void Level_LoadAnimFrames(void);
 void Level_LoadObjectsAndItems(void);
 
 LEVEL_INFO *Level_GetInfo(void);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -5,17 +5,17 @@
 
 #define ANIM_BONE_SIZE 4
 
-void Level_ReadPalettes(LEVEL_INFO *info, VFILE *file);
-void Level_ReadTexturePages(LEVEL_INFO *info, VFILE *file);
+void Level_ReadPalettes(VFILE *file);
+void Level_ReadTexturePages(VFILE *file);
 void Level_ReadRooms(VFILE *file);
 void Level_ReadObjectMeshes(
     int32_t num_indices, const int32_t *indices, VFILE *file);
 void Level_ReadAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_ReadAnimChanges(int32_t base_idx, int32_t num_changes, VFILE *file);
 void Level_ReadAnimRanges(int32_t base_idx, int32_t num_ranges, VFILE *file);
-void Level_LoadAnimCommands(LEVEL_INFO *info);
+void Level_LoadAnimCommands(void);
 void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
-void Level_LoadAnimFrames(LEVEL_INFO *info);
+void Level_LoadAnimFrames(void);
 void Level_ReadObjects(VFILE *file);
 void Level_ReadStaticObjects(VFILE *file);
 void Level_ReadObjectTextures(
@@ -31,10 +31,10 @@ void Level_ReadCamerasAndSinks(VFILE *file);
 void Level_ReadItems(VFILE *file);
 void Level_ReadDemoData(VFILE *file);
 void Level_ReadSoundSources(VFILE *file);
-void Level_ReadSamples(LEVEL_INFO *info, VFILE *file);
+void Level_ReadSamples(VFILE *file);
 
-void Level_LoadTexturePages(LEVEL_INFO *info);
-void Level_LoadPalettes(LEVEL_INFO *info);
+void Level_LoadTexturePages(void);
+void Level_LoadPalettes(void);
 void Level_LoadObjectsAndItems(void);
 
-extern LEVEL_INFO *Level_GetInfo(void);
+LEVEL_INFO *Level_GetInfo(void);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -8,8 +8,7 @@
 void Level_ReadPalettes(VFILE *file);
 void Level_ReadTexturePages(VFILE *file);
 void Level_ReadRooms(VFILE *file);
-void Level_ReadObjectMeshes(
-    int32_t num_indices, const int32_t *indices, VFILE *file);
+void Level_ReadObjectMeshes(VFILE *file);
 void Level_ReadAnims(VFILE *file);
 void Level_ReadAnimChanges(VFILE *file);
 void Level_ReadAnimRanges(VFILE *file);
@@ -31,6 +30,8 @@ void Level_ReadDemoData(VFILE *file);
 void Level_ReadSoundSources(VFILE *file);
 void Level_ReadSamples(VFILE *file);
 
+void Level_AppendObjectMeshes(
+    int32_t num_indices, const int32_t *indices, VFILE *file);
 void Level_AppendAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_AppendAnimChanges(
     int32_t base_idx, int32_t num_changes, VFILE *file);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -18,10 +18,8 @@ void Level_ReadAnimBones(int32_t base_idx, int32_t num_bones, VFILE *file);
 void Level_LoadAnimFrames(void);
 void Level_ReadObjects(VFILE *file);
 void Level_ReadStaticObjects(VFILE *file);
-void Level_ReadObjectTextures(
-    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
-void Level_ReadSpriteTextures(
-    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
+void Level_ReadObjectTextures(VFILE *file);
+void Level_ReadSpriteTextures(VFILE *file);
 void Level_ReadSpriteSequences(VFILE *file);
 void Level_ReadPathingData(VFILE *file);
 void Level_ReadAnimatedTextureRanges(VFILE *file);
@@ -32,6 +30,11 @@ void Level_ReadItems(VFILE *file);
 void Level_ReadDemoData(VFILE *file);
 void Level_ReadSoundSources(VFILE *file);
 void Level_ReadSamples(VFILE *file);
+
+void Level_AppendObjectTextures(
+    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
+void Level_AppendSpriteTextures(
+    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 
 void Level_LoadTexturePages(void);
 void Level_LoadPalettes(void);

--- a/src/libtrx/include/libtrx/game/level/types.h
+++ b/src/libtrx/include/libtrx/game/level/types.h
@@ -8,6 +8,7 @@ typedef struct {
         int32_t change_count;
         int32_t range_count;
         int32_t command_count;
+        int16_t *commands;
         int32_t bone_count;
         int32_t frame_count;
         int16_t *frames;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -59,8 +59,6 @@ static void M_LoadAnimRanges(VFILE *file);
 static void M_LoadAnimCommands(VFILE *file);
 static void M_LoadAnimBones(VFILE *file);
 static void M_LoadAnimFrames(VFILE *file);
-static void M_LoadTextures(VFILE *file);
-static void M_LoadSprites(VFILE *file);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
 static size_t M_CalculateMaxVertices(void);
@@ -215,8 +213,8 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     M_LoadAnimFrames(file);
     Level_ReadObjects(file);
     Level_ReadStaticObjects(file);
-    M_LoadTextures(file);
-    M_LoadSprites(file);
+    Level_ReadObjectTextures(file);
+    Level_ReadSpriteTextures(file);
     Level_ReadSpriteSequences(file);
 
     if (layout == LEVEL_LAYOUT_TR1_DEMO_PC) {
@@ -349,32 +347,6 @@ static void M_LoadAnimFrames(VFILE *file)
         sizeof(int16_t)
         * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
     VFile_Read(file, info->anims.frames, sizeof(int16_t) * raw_data_count);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadTextures(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_textures = VFile_ReadS32(file);
-    info->textures.object_count = num_textures;
-    LOG_INFO("%d object textures", num_textures);
-    Output_InitialiseObjectTextures(
-        num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
-    Level_ReadObjectTextures(0, 0, num_textures, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadSprites(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_textures = VFile_ReadS32(file);
-    info->textures.sprite_count = num_textures;
-    LOG_DEBUG("sprite textures: %d", num_textures);
-    Output_InitialiseSpriteTextures(
-        num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
-    Level_ReadSpriteTextures(0, 0, num_textures, file);
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -53,12 +53,6 @@ static bool M_TryLayout(VFILE *file, LEVEL_LAYOUT layout);
 static LEVEL_LAYOUT M_GuessLayout(VFILE *file);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_LoadObjectMeshes(VFILE *file);
-static void M_LoadAnims(VFILE *file);
-static void M_LoadAnimChanges(VFILE *file);
-static void M_LoadAnimRanges(VFILE *file);
-static void M_LoadAnimCommands(VFILE *file);
-static void M_LoadAnimBones(VFILE *file);
-static void M_LoadAnimFrames(VFILE *file);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
 static size_t M_CalculateMaxVertices(void);
@@ -205,12 +199,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 
     Level_ReadRooms(file);
     M_LoadObjectMeshes(file);
-    M_LoadAnims(file);
-    M_LoadAnimChanges(file);
-    M_LoadAnimRanges(file);
-    M_LoadAnimCommands(file);
-    M_LoadAnimBones(file);
-    M_LoadAnimFrames(file);
+    Level_ReadAnims(file);
+    Level_ReadAnimChanges(file);
+    Level_ReadAnimRanges(file);
+    Level_ReadAnimCommands(file);
+    Level_ReadAnimBones(file);
+    Level_ReadAnimFrames(file);
     Level_ReadObjects(file);
     Level_ReadStaticObjects(file);
     Level_ReadObjectTextures(file);
@@ -269,84 +263,6 @@ static void M_LoadObjectMeshes(VFILE *const file)
     VFile_SetPos(file, end_pos);
     Memory_FreePointer(&mesh_indices);
 
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnims(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anims = VFile_ReadS32(file);
-    info->anims.anim_count = num_anims;
-    LOG_INFO("%d anims", num_anims);
-    Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
-    Level_ReadAnims(0, num_anims, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimChanges(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_changes = VFile_ReadS32(file);
-    info->anims.change_count = num_anim_changes;
-    LOG_INFO("%d anim changes", num_anim_changes);
-    Anim_InitialiseChanges(
-        num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
-    Level_ReadAnimChanges(0, num_anim_changes, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimRanges(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_ranges = VFile_ReadS32(file);
-    info->anims.range_count = num_anim_ranges;
-    LOG_INFO("%d anim ranges", num_anim_ranges);
-    Anim_InitialiseRanges(
-        num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
-    Level_ReadAnimRanges(0, num_anim_ranges, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimCommands(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_commands = VFile_ReadS32(file);
-    info->anims.command_count = num_anim_commands;
-    LOG_INFO("%d anim commands", num_anim_commands);
-    info->anims.commands = Memory_Alloc(
-        sizeof(int16_t)
-        * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
-    VFile_Read(file, info->anims.commands, sizeof(int16_t) * num_anim_commands);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimBones(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-    info->anims.bone_count = num_anim_bones;
-    LOG_INFO("%d anim bones", num_anim_bones);
-    Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
-    Level_ReadAnimBones(0, num_anim_bones, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimFrames(VFILE *file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t raw_data_count = VFile_ReadS32(file);
-    info->anims.frame_count = raw_data_count;
-    LOG_INFO("%d raw anim frames", raw_data_count);
-    info->anims.frames = Memory_Alloc(
-        sizeof(int16_t)
-        * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
-    VFile_Read(file, info->anims.frames, sizeof(int16_t) * raw_data_count);
     Benchmark_End(benchmark, nullptr);
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -410,11 +410,10 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
 
     Level_LoadTexturePages();
     Level_LoadPalettes();
-    // TODO: output already has the count
-    LEVEL_INFO *const info = Level_GetInfo();
-    Output_DownloadTextures(info->textures.page_count);
+    Output_DownloadTextures();
 
     // Initialise the sound effects.
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t sample_count = info->samples.offset_count;
     size_t *sample_sizes = Memory_Alloc(sizeof(size_t) * sample_count);
     const char **sample_pointers = Memory_Alloc(sizeof(char *) * sample_count);

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -316,9 +316,11 @@ static void M_LoadAnimCommands(VFILE *file)
     const int32_t num_anim_commands = VFile_ReadS32(file);
     m_LevelInfo.anims.command_count = num_anim_commands;
     LOG_INFO("%d anim commands", num_anim_commands);
-    Level_InitialiseAnimCommands(
-        num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS));
-    Level_ReadAnimCommands(0, num_anim_commands, file);
+    m_LevelInfo.anims.commands = Memory_Alloc(
+        sizeof(int16_t)
+        * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
+    VFile_Read(
+        file, m_LevelInfo.anims.commands, sizeof(int16_t) * num_anim_commands);
     Benchmark_End(benchmark, nullptr);
 }
 
@@ -383,7 +385,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     Inject_AllInjections();
 
     Level_LoadAnimFrames(&m_LevelInfo);
-    Level_LoadAnimCommands();
+    Level_LoadAnimCommands(&m_LevelInfo);
 
     M_MarkWaterEdgeVertices();
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -52,7 +52,6 @@ typedef enum {
 static bool M_TryLayout(VFILE *file, LEVEL_LAYOUT layout);
 static LEVEL_LAYOUT M_GuessLayout(VFILE *file);
 static void M_LoadFromFile(const GF_LEVEL *level);
-static void M_LoadObjectMeshes(VFILE *file);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
 static size_t M_CalculateMaxVertices(void);
@@ -198,7 +197,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     LOG_INFO("file level num: %d", file_level_num);
 
     Level_ReadRooms(file);
-    M_LoadObjectMeshes(file);
+    Level_ReadObjectMeshes(file);
     Level_ReadAnims(file);
     Level_ReadAnimChanges(file);
     Level_ReadAnimRanges(file);
@@ -235,35 +234,6 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadTexturePages(file);
 
     VFile_Close(file);
-}
-
-static void M_LoadObjectMeshes(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_meshes = VFile_ReadS32(file);
-    LOG_INFO("%d object mesh data", num_meshes);
-
-    const size_t data_start_pos = VFile_GetPos(file);
-    VFile_Skip(file, num_meshes * sizeof(int16_t));
-
-    info->mesh_ptr_count = VFile_ReadS32(file);
-    LOG_INFO("%d object mesh indices", info->mesh_ptr_count);
-    const int32_t alloc_size = info->mesh_ptr_count * sizeof(int32_t);
-    int32_t *mesh_indices = Memory_Alloc(alloc_size);
-    VFile_Read(file, mesh_indices, alloc_size);
-
-    const size_t end_pos = VFile_GetPos(file);
-    VFile_SetPos(file, data_start_pos);
-
-    Object_InitialiseMeshes(
-        info->mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
-    Level_ReadObjectMeshes(info->mesh_ptr_count, mesh_indices, file);
-
-    VFile_SetPos(file, end_pos);
-    Memory_FreePointer(&mesh_indices);
-
-    Benchmark_End(benchmark, nullptr);
 }
 
 static void M_CompleteSetup(const GF_LEVEL *const level)

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -49,8 +49,6 @@ typedef enum {
     LEVEL_LAYOUT_NUMBER_OF,
 } LEVEL_LAYOUT;
 
-static LEVEL_INFO m_LevelInfo = {};
-
 static bool M_TryLayout(VFILE *file, LEVEL_LAYOUT layout);
 static LEVEL_LAYOUT M_GuessLayout(VFILE *file);
 static void M_LoadFromFile(const GF_LEVEL *level);
@@ -222,7 +220,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadSpriteSequences(file);
 
     if (layout == LEVEL_LAYOUT_TR1_DEMO_PC) {
-        Level_ReadPalettes(&m_LevelInfo, file);
+        Level_ReadPalettes(file);
     }
 
     Level_ReadCamerasAndSinks(file);
@@ -234,15 +232,15 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadLightMap(file);
 
     if (layout != LEVEL_LAYOUT_TR1_DEMO_PC) {
-        Level_ReadPalettes(&m_LevelInfo, file);
+        Level_ReadPalettes(file);
     }
 
     Level_ReadCinematicFrames(file);
     Level_ReadDemoData(file);
-    Level_ReadSamples(&m_LevelInfo, file);
+    Level_ReadSamples(file);
 
     VFile_SetPos(file, 4);
-    Level_ReadTexturePages(&m_LevelInfo, file);
+    Level_ReadTexturePages(file);
 
     VFile_Close(file);
 }
@@ -250,15 +248,16 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 static void M_LoadObjectMeshes(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_meshes = VFile_ReadS32(file);
     LOG_INFO("%d object mesh data", num_meshes);
 
     const size_t data_start_pos = VFile_GetPos(file);
     VFile_Skip(file, num_meshes * sizeof(int16_t));
 
-    m_LevelInfo.mesh_ptr_count = VFile_ReadS32(file);
-    LOG_INFO("%d object mesh indices", m_LevelInfo.mesh_ptr_count);
-    const int32_t alloc_size = m_LevelInfo.mesh_ptr_count * sizeof(int32_t);
+    info->mesh_ptr_count = VFile_ReadS32(file);
+    LOG_INFO("%d object mesh indices", info->mesh_ptr_count);
+    const int32_t alloc_size = info->mesh_ptr_count * sizeof(int32_t);
     int32_t *mesh_indices = Memory_Alloc(alloc_size);
     VFile_Read(file, mesh_indices, alloc_size);
 
@@ -266,8 +265,8 @@ static void M_LoadObjectMeshes(VFILE *const file)
     VFile_SetPos(file, data_start_pos);
 
     Object_InitialiseMeshes(
-        m_LevelInfo.mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
-    Level_ReadObjectMeshes(m_LevelInfo.mesh_ptr_count, mesh_indices, file);
+        info->mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
+    Level_ReadObjectMeshes(info->mesh_ptr_count, mesh_indices, file);
 
     VFile_SetPos(file, end_pos);
     Memory_FreePointer(&mesh_indices);
@@ -278,8 +277,9 @@ static void M_LoadObjectMeshes(VFILE *const file)
 static void M_LoadAnims(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anims = VFile_ReadS32(file);
-    m_LevelInfo.anims.anim_count = num_anims;
+    info->anims.anim_count = num_anims;
     LOG_INFO("%d anims", num_anims);
     Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
     Level_ReadAnims(0, num_anims, file);
@@ -289,8 +289,9 @@ static void M_LoadAnims(VFILE *file)
 static void M_LoadAnimChanges(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_changes = VFile_ReadS32(file);
-    m_LevelInfo.anims.change_count = num_anim_changes;
+    info->anims.change_count = num_anim_changes;
     LOG_INFO("%d anim changes", num_anim_changes);
     Anim_InitialiseChanges(
         num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
@@ -301,8 +302,9 @@ static void M_LoadAnimChanges(VFILE *file)
 static void M_LoadAnimRanges(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_ranges = VFile_ReadS32(file);
-    m_LevelInfo.anims.range_count = num_anim_ranges;
+    info->anims.range_count = num_anim_ranges;
     LOG_INFO("%d anim ranges", num_anim_ranges);
     Anim_InitialiseRanges(
         num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
@@ -313,22 +315,23 @@ static void M_LoadAnimRanges(VFILE *file)
 static void M_LoadAnimCommands(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_commands = VFile_ReadS32(file);
-    m_LevelInfo.anims.command_count = num_anim_commands;
+    info->anims.command_count = num_anim_commands;
     LOG_INFO("%d anim commands", num_anim_commands);
-    m_LevelInfo.anims.commands = Memory_Alloc(
+    info->anims.commands = Memory_Alloc(
         sizeof(int16_t)
         * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
-    VFile_Read(
-        file, m_LevelInfo.anims.commands, sizeof(int16_t) * num_anim_commands);
+    VFile_Read(file, info->anims.commands, sizeof(int16_t) * num_anim_commands);
     Benchmark_End(benchmark, nullptr);
 }
 
 static void M_LoadAnimBones(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-    m_LevelInfo.anims.bone_count = num_anim_bones;
+    info->anims.bone_count = num_anim_bones;
     LOG_INFO("%d anim bones", num_anim_bones);
     Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
     Level_ReadAnimBones(0, num_anim_bones, file);
@@ -338,22 +341,23 @@ static void M_LoadAnimBones(VFILE *const file)
 static void M_LoadAnimFrames(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t raw_data_count = VFile_ReadS32(file);
-    m_LevelInfo.anims.frame_count = raw_data_count;
+    info->anims.frame_count = raw_data_count;
     LOG_INFO("%d raw anim frames", raw_data_count);
-    m_LevelInfo.anims.frames = Memory_Alloc(
+    info->anims.frames = Memory_Alloc(
         sizeof(int16_t)
         * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
-    VFile_Read(
-        file, m_LevelInfo.anims.frames, sizeof(int16_t) * raw_data_count);
+    VFile_Read(file, info->anims.frames, sizeof(int16_t) * raw_data_count);
     Benchmark_End(benchmark, nullptr);
 }
 
 static void M_LoadTextures(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_textures = VFile_ReadS32(file);
-    m_LevelInfo.textures.object_count = num_textures;
+    info->textures.object_count = num_textures;
     LOG_INFO("%d object textures", num_textures);
     Output_InitialiseObjectTextures(
         num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
@@ -364,8 +368,9 @@ static void M_LoadTextures(VFILE *file)
 static void M_LoadSprites(VFILE *file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_textures = VFile_ReadS32(file);
-    m_LevelInfo.textures.sprite_count = num_textures;
+    info->textures.sprite_count = num_textures;
     LOG_DEBUG("sprite textures: %d", num_textures);
     Output_InitialiseSpriteTextures(
         num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
@@ -384,8 +389,8 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
 
     Inject_AllInjections();
 
-    Level_LoadAnimFrames(&m_LevelInfo);
-    Level_LoadAnimCommands(&m_LevelInfo);
+    Level_LoadAnimFrames();
+    Level_LoadAnimCommands();
 
     M_MarkWaterEdgeVertices();
 
@@ -403,25 +408,26 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     LOG_INFO("Maximum vertices: %d", max_vertices);
     Output_ReserveVertexBuffer(max_vertices);
 
-    Level_LoadTexturePages(&m_LevelInfo);
-    Level_LoadPalettes(&m_LevelInfo);
-    Output_DownloadTextures(m_LevelInfo.textures.page_count);
+    Level_LoadTexturePages();
+    Level_LoadPalettes();
+    // TODO: output already has the count
+    LEVEL_INFO *const info = Level_GetInfo();
+    Output_DownloadTextures(info->textures.page_count);
 
     // Initialise the sound effects.
-    const int32_t sample_count = m_LevelInfo.samples.offset_count;
+    const int32_t sample_count = info->samples.offset_count;
     size_t *sample_sizes = Memory_Alloc(sizeof(size_t) * sample_count);
     const char **sample_pointers = Memory_Alloc(sizeof(char *) * sample_count);
     for (int i = 0; i < sample_count; i++) {
-        sample_pointers[i] =
-            m_LevelInfo.samples.data + m_LevelInfo.samples.offsets[i];
+        sample_pointers[i] = info->samples.data + info->samples.offsets[i];
     }
 
     // NOTE: this assumes that sample pointers are sorted
-    for (int i = 0; i < sample_count; i++) {
-        int current_offset = m_LevelInfo.samples.offsets[i];
-        int next_offset = i + 1 >= sample_count
-            ? m_LevelInfo.samples.data_size
-            : m_LevelInfo.samples.offsets[i + 1];
+    for (int32_t i = 0; i < sample_count; i++) {
+        const int32_t current_offset = info->samples.offsets[i];
+        const int32_t next_offset = i + 1 >= sample_count
+            ? info->samples.data_size
+            : info->samples.offsets[i + 1];
         sample_sizes[i] = next_offset - current_offset;
     }
 
@@ -429,7 +435,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
 
     Memory_FreePointer(&sample_pointers);
     Memory_FreePointer(&sample_sizes);
-    Memory_FreePointer(&m_LevelInfo.samples.offsets);
+    Memory_FreePointer(&info->samples.offsets);
 
     Benchmark_End(benchmark, nullptr);
 }
@@ -590,9 +596,4 @@ bool Level_Initialise(
     g_Camera.underwater = false;
     Benchmark_End(benchmark, nullptr);
     return true;
-}
-
-LEVEL_INFO *Level_GetInfo(void)
-{
-    return &m_LevelInfo;
 }

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -702,9 +702,9 @@ void Output_ApplyRenderSettings(void)
     }
 }
 
-void Output_DownloadTextures(int page_count)
+void Output_DownloadTextures(void)
 {
-    S_Output_DownloadTextures(page_count);
+    S_Output_DownloadTextures(Output_GetTexturePageCount());
 }
 
 void Output_DrawBlack(void)

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -13,7 +13,7 @@ void Output_ReserveVertexBuffer(size_t size);
 
 void Output_SetWindowSize(int width, int height);
 void Output_ApplyRenderSettings(void);
-void Output_DownloadTextures(int page_count);
+void Output_DownloadTextures(void);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -117,9 +117,11 @@ static void M_LoadAnimCommands(VFILE *const file)
     const int32_t num_anim_commands = VFile_ReadS32(file);
     m_LevelInfo.anims.command_count = num_anim_commands;
     LOG_INFO("anim commands: %d", num_anim_commands);
-    Level_InitialiseAnimCommands(
-        num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS));
-    Level_ReadAnimCommands(0, num_anim_commands, file);
+    m_LevelInfo.anims.commands = Memory_Alloc(
+        sizeof(int16_t)
+        * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
+    VFile_Read(
+        file, m_LevelInfo.anims.commands, sizeof(int16_t) * num_anim_commands);
     Benchmark_End(benchmark, nullptr);
 }
 
@@ -290,7 +292,7 @@ static void M_CompleteSetup(void)
     Inject_AllInjections();
 
     Level_LoadAnimFrames(&m_LevelInfo);
-    Level_LoadAnimCommands();
+    Level_LoadAnimCommands(&m_LevelInfo);
     Level_LoadObjectsAndItems();
 
     Level_LoadTexturePages(&m_LevelInfo);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -35,12 +35,6 @@
 
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_LoadObjectMeshes(VFILE *file);
-static void M_LoadAnims(VFILE *file);
-static void M_LoadAnimChanges(VFILE *file);
-static void M_LoadAnimRanges(VFILE *file);
-static void M_LoadAnimCommands(VFILE *file);
-static void M_LoadAnimBones(VFILE *file);
-static void M_LoadAnimFrames(VFILE *file);
 static void M_InitialiseSoundEffects(void);
 static void M_CompleteSetup(void);
 
@@ -70,84 +64,6 @@ static void M_LoadObjectMeshes(VFILE *const file)
     VFile_SetPos(file, end_pos);
     Memory_FreePointer(&mesh_indices);
 
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnims(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anims = VFile_ReadS32(file);
-    info->anims.anim_count = num_anims;
-    LOG_INFO("anims: %d", num_anims);
-    Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
-    Level_ReadAnims(0, num_anims, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimChanges(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_changes = VFile_ReadS32(file);
-    info->anims.change_count = num_anim_changes;
-    LOG_INFO("anim changes: %d", num_anim_changes);
-    Anim_InitialiseChanges(
-        num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
-    Level_ReadAnimChanges(0, num_anim_changes, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimRanges(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_ranges = VFile_ReadS32(file);
-    info->anims.range_count = num_anim_ranges;
-    LOG_INFO("anim ranges: %d", num_anim_ranges);
-    Anim_InitialiseRanges(
-        num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
-    Level_ReadAnimRanges(0, num_anim_ranges, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimCommands(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_commands = VFile_ReadS32(file);
-    info->anims.command_count = num_anim_commands;
-    LOG_INFO("anim commands: %d", num_anim_commands);
-    info->anims.commands = Memory_Alloc(
-        sizeof(int16_t)
-        * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
-    VFile_Read(file, info->anims.commands, sizeof(int16_t) * num_anim_commands);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimBones(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-    info->anims.bone_count = num_anim_bones;
-    LOG_INFO("anim bones: %d", num_anim_bones);
-    Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
-    Level_ReadAnimBones(0, num_anim_bones, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadAnimFrames(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t raw_data_count = VFile_ReadS32(file);
-    info->anims.frame_count = raw_data_count;
-    LOG_INFO("raw anim frames: %d", raw_data_count);
-    info->anims.frames = Memory_Alloc(
-        sizeof(int16_t)
-        * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
-    VFile_Read(file, info->anims.frames, sizeof(int16_t) * raw_data_count);
     Benchmark_End(benchmark, nullptr);
 }
 
@@ -235,12 +151,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 
     M_LoadObjectMeshes(file);
 
-    M_LoadAnims(file);
-    M_LoadAnimChanges(file);
-    M_LoadAnimRanges(file);
-    M_LoadAnimCommands(file);
-    M_LoadAnimBones(file);
-    M_LoadAnimFrames(file);
+    Level_ReadAnims(file);
+    Level_ReadAnimChanges(file);
+    Level_ReadAnimRanges(file);
+    Level_ReadAnimCommands(file);
+    Level_ReadAnimBones(file);
+    Level_ReadAnimFrames(file);
 
     Level_ReadObjects(file);
     Level_ReadStaticObjects(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -34,38 +34,8 @@
 #include <libtrx/virtual_file.h>
 
 static void M_LoadFromFile(const GF_LEVEL *level);
-static void M_LoadObjectMeshes(VFILE *file);
 static void M_InitialiseSoundEffects(void);
 static void M_CompleteSetup(void);
-
-static void M_LoadObjectMeshes(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_meshes = VFile_ReadS32(file);
-    LOG_INFO("object mesh data: %d", num_meshes);
-
-    const size_t data_start_pos = VFile_GetPos(file);
-    VFile_Skip(file, num_meshes * sizeof(int16_t));
-
-    info->mesh_ptr_count = VFile_ReadS32(file);
-    LOG_INFO("object mesh indices: %d", info->mesh_ptr_count);
-    const int32_t alloc_size = info->mesh_ptr_count * sizeof(int32_t);
-    int32_t *mesh_indices = Memory_Alloc(alloc_size);
-    VFile_Read(file, mesh_indices, alloc_size);
-
-    const size_t end_pos = VFile_GetPos(file);
-    VFile_SetPos(file, data_start_pos);
-
-    Object_InitialiseMeshes(
-        info->mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
-    Level_ReadObjectMeshes(info->mesh_ptr_count, mesh_indices, file);
-
-    VFile_SetPos(file, end_pos);
-    Memory_FreePointer(&mesh_indices);
-
-    Benchmark_End(benchmark, nullptr);
-}
 
 static void M_InitialiseSoundEffects(void)
 {
@@ -149,7 +119,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     VFile_Skip(file, 4);
     Level_ReadRooms(file);
 
-    M_LoadObjectMeshes(file);
+    Level_ReadObjectMeshes(file);
 
     Level_ReadAnims(file);
     Level_ReadAnimChanges(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -33,8 +33,6 @@
 #include <libtrx/memory.h>
 #include <libtrx/virtual_file.h>
 
-static LEVEL_INFO m_LevelInfo = {};
-
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_LoadObjectMeshes(VFILE *file);
 static void M_LoadAnims(VFILE *file);
@@ -51,15 +49,16 @@ static void M_CompleteSetup(void);
 static void M_LoadObjectMeshes(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_meshes = VFile_ReadS32(file);
     LOG_INFO("object mesh data: %d", num_meshes);
 
     const size_t data_start_pos = VFile_GetPos(file);
     VFile_Skip(file, num_meshes * sizeof(int16_t));
 
-    m_LevelInfo.mesh_ptr_count = VFile_ReadS32(file);
-    LOG_INFO("object mesh indices: %d", m_LevelInfo.mesh_ptr_count);
-    const int32_t alloc_size = m_LevelInfo.mesh_ptr_count * sizeof(int32_t);
+    info->mesh_ptr_count = VFile_ReadS32(file);
+    LOG_INFO("object mesh indices: %d", info->mesh_ptr_count);
+    const int32_t alloc_size = info->mesh_ptr_count * sizeof(int32_t);
     int32_t *mesh_indices = Memory_Alloc(alloc_size);
     VFile_Read(file, mesh_indices, alloc_size);
 
@@ -67,8 +66,8 @@ static void M_LoadObjectMeshes(VFILE *const file)
     VFile_SetPos(file, data_start_pos);
 
     Object_InitialiseMeshes(
-        m_LevelInfo.mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
-    Level_ReadObjectMeshes(m_LevelInfo.mesh_ptr_count, mesh_indices, file);
+        info->mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
+    Level_ReadObjectMeshes(info->mesh_ptr_count, mesh_indices, file);
 
     VFile_SetPos(file, end_pos);
     Memory_FreePointer(&mesh_indices);
@@ -79,8 +78,9 @@ static void M_LoadObjectMeshes(VFILE *const file)
 static void M_LoadAnims(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anims = VFile_ReadS32(file);
-    m_LevelInfo.anims.anim_count = num_anims;
+    info->anims.anim_count = num_anims;
     LOG_INFO("anims: %d", num_anims);
     Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
     Level_ReadAnims(0, num_anims, file);
@@ -90,8 +90,9 @@ static void M_LoadAnims(VFILE *const file)
 static void M_LoadAnimChanges(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_changes = VFile_ReadS32(file);
-    m_LevelInfo.anims.change_count = num_anim_changes;
+    info->anims.change_count = num_anim_changes;
     LOG_INFO("anim changes: %d", num_anim_changes);
     Anim_InitialiseChanges(
         num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
@@ -102,8 +103,9 @@ static void M_LoadAnimChanges(VFILE *const file)
 static void M_LoadAnimRanges(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_ranges = VFile_ReadS32(file);
-    m_LevelInfo.anims.range_count = num_anim_ranges;
+    info->anims.range_count = num_anim_ranges;
     LOG_INFO("anim ranges: %d", num_anim_ranges);
     Anim_InitialiseRanges(
         num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
@@ -114,22 +116,23 @@ static void M_LoadAnimRanges(VFILE *const file)
 static void M_LoadAnimCommands(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_commands = VFile_ReadS32(file);
-    m_LevelInfo.anims.command_count = num_anim_commands;
+    info->anims.command_count = num_anim_commands;
     LOG_INFO("anim commands: %d", num_anim_commands);
-    m_LevelInfo.anims.commands = Memory_Alloc(
+    info->anims.commands = Memory_Alloc(
         sizeof(int16_t)
         * (num_anim_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
-    VFile_Read(
-        file, m_LevelInfo.anims.commands, sizeof(int16_t) * num_anim_commands);
+    VFile_Read(file, info->anims.commands, sizeof(int16_t) * num_anim_commands);
     Benchmark_End(benchmark, nullptr);
 }
 
 static void M_LoadAnimBones(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
-    m_LevelInfo.anims.bone_count = num_anim_bones;
+    info->anims.bone_count = num_anim_bones;
     LOG_INFO("anim bones: %d", num_anim_bones);
     Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
     Level_ReadAnimBones(0, num_anim_bones, file);
@@ -139,22 +142,23 @@ static void M_LoadAnimBones(VFILE *const file)
 static void M_LoadAnimFrames(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t raw_data_count = VFile_ReadS32(file);
-    m_LevelInfo.anims.frame_count = raw_data_count;
+    info->anims.frame_count = raw_data_count;
     LOG_INFO("raw anim frames: %d", raw_data_count);
-    m_LevelInfo.anims.frames = Memory_Alloc(
+    info->anims.frames = Memory_Alloc(
         sizeof(int16_t)
         * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
-    VFile_Read(
-        file, m_LevelInfo.anims.frames, sizeof(int16_t) * raw_data_count);
+    VFile_Read(file, info->anims.frames, sizeof(int16_t) * raw_data_count);
     Benchmark_End(benchmark, nullptr);
 }
 
 static void M_LoadTextures(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_textures = VFile_ReadS32(file);
-    m_LevelInfo.textures.object_count = num_textures;
+    info->textures.object_count = num_textures;
     LOG_INFO("object textures: %d", num_textures);
     Output_InitialiseObjectTextures(
         num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
@@ -165,8 +169,9 @@ static void M_LoadTextures(VFILE *const file)
 static void M_LoadSprites(VFILE *const file)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
     const int32_t num_textures = VFile_ReadS32(file);
-    m_LevelInfo.textures.sprite_count = num_textures;
+    info->textures.sprite_count = num_textures;
     LOG_DEBUG("sprite textures: %d", num_textures);
     Output_InitialiseSpriteTextures(
         num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
@@ -183,6 +188,7 @@ static void M_InitialiseSoundEffects(void)
     MYFILE *const fp = File_Open(full_path, FILE_OPEN_READ);
     Memory_FreePointer(&full_path);
 
+    LEVEL_INFO *const info = Level_GetInfo();
     if (fp == nullptr) {
         Shell_ExitSystemFmt("Could not open %s file", file_name);
         goto finish;
@@ -190,7 +196,7 @@ static void M_InitialiseSoundEffects(void)
 
     // TODO: refactor these WAVE/RIFF shenanigans
     int32_t sample_id = 0;
-    for (int32_t i = 0; sample_id < m_LevelInfo.samples.offset_count; i++) {
+    for (int32_t i = 0; sample_id < info->samples.offset_count; i++) {
         char header[0x2C];
         File_ReadData(fp, header, 0x2C);
         if (*(int32_t *)(header + 0) != 0x46464952
@@ -202,7 +208,7 @@ static void M_InitialiseSoundEffects(void)
         const int32_t data_size = *(int32_t *)(header + 0x28);
         const int32_t aligned_size = (data_size + 1) & ~1;
 
-        if (m_LevelInfo.samples.offsets[sample_id] != i) {
+        if (info->samples.offsets[sample_id] != i) {
             File_Seek(fp, aligned_size, FILE_SEEK_CUR);
             continue;
         }
@@ -227,7 +233,7 @@ finish:
     if (fp != nullptr) {
         File_Close(fp);
     }
-    Memory_FreePointer(&m_LevelInfo.samples.offsets);
+    Memory_FreePointer(&info->samples.offsets);
     Benchmark_End(benchmark, nullptr);
 }
 
@@ -250,8 +256,8 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
             45, level->path);
     }
 
-    Level_ReadPalettes(&m_LevelInfo, file);
-    Level_ReadTexturePages(&m_LevelInfo, file);
+    Level_ReadPalettes(file);
+    Level_ReadTexturePages(file);
     VFile_Skip(file, 4);
     Level_ReadRooms(file);
 
@@ -279,7 +285,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadLightMap(file);
     Level_ReadCinematicFrames(file);
     Level_ReadDemoData(file);
-    Level_ReadSamples(&m_LevelInfo, file);
+    Level_ReadSamples(file);
 
     VFile_Close(file);
     Benchmark_End(benchmark, nullptr);
@@ -291,12 +297,12 @@ static void M_CompleteSetup(void)
 
     Inject_AllInjections();
 
-    Level_LoadAnimFrames(&m_LevelInfo);
-    Level_LoadAnimCommands(&m_LevelInfo);
+    Level_LoadAnimFrames();
+    Level_LoadAnimCommands();
     Level_LoadObjectsAndItems();
 
-    Level_LoadTexturePages(&m_LevelInfo);
-    Level_LoadPalettes(&m_LevelInfo);
+    Level_LoadTexturePages();
+    Level_LoadPalettes();
     Output_InitialiseNamedColors();
 
     Render_Reset(
@@ -407,9 +413,4 @@ void Level_Unload(void)
     }
 
     Camera_Reset();
-}
-
-LEVEL_INFO *Level_GetInfo(void)
-{
-    return &m_LevelInfo;
 }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -41,8 +41,6 @@ static void M_LoadAnimRanges(VFILE *file);
 static void M_LoadAnimCommands(VFILE *file);
 static void M_LoadAnimBones(VFILE *file);
 static void M_LoadAnimFrames(VFILE *file);
-static void M_LoadTextures(VFILE *file);
-static void M_LoadSprites(VFILE *file);
 static void M_InitialiseSoundEffects(void);
 static void M_CompleteSetup(void);
 
@@ -153,32 +151,6 @@ static void M_LoadAnimFrames(VFILE *const file)
     Benchmark_End(benchmark, nullptr);
 }
 
-static void M_LoadTextures(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_textures = VFile_ReadS32(file);
-    info->textures.object_count = num_textures;
-    LOG_INFO("object textures: %d", num_textures);
-    Output_InitialiseObjectTextures(
-        num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
-    Level_ReadObjectTextures(0, 0, num_textures, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
-static void M_LoadSprites(VFILE *const file)
-{
-    BENCHMARK *const benchmark = Benchmark_Start();
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t num_textures = VFile_ReadS32(file);
-    info->textures.sprite_count = num_textures;
-    LOG_DEBUG("sprite textures: %d", num_textures);
-    Output_InitialiseSpriteTextures(
-        num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
-    Level_ReadSpriteTextures(0, 0, num_textures, file);
-    Benchmark_End(benchmark, nullptr);
-}
-
 static void M_InitialiseSoundEffects(void)
 {
     BENCHMARK *const benchmark = Benchmark_Start();
@@ -272,9 +244,9 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 
     Level_ReadObjects(file);
     Level_ReadStaticObjects(file);
-    M_LoadTextures(file);
+    Level_ReadObjectTextures(file);
 
-    M_LoadSprites(file);
+    Level_ReadSpriteTextures(file);
     Level_ReadSpriteSequences(file);
     Level_ReadCamerasAndSinks(file);
     Level_ReadSoundSources(file);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This completes moving all level reading into the common TRX module. The functions can now be categorised as:
- `Level_Read...` - called from the main level loading process, initialises target data structures
- `Level_Append...` - called from within injection modules
- `Level_Load...` - called after injections to finalise certain setups (textures, frames etc)

We may want to look at making parts of the TRX module private at a later date, perhaps having a function pointer list for each game to determine the loading order. The only specific data handling left in place is for the sound effect setup at the end of the processing in each game, but I will be looking at refactoring TR2's `main.sfx` reading next, so we may be able to find some further commonality here.

Testing should be straight-forward as any failures in loading should be immediately obvious.
