### PR TITLE
tr1/savegame: optimize scanning saved games

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed the `/pos` command to show `Demo` and `Cutscene` instead of `Level` when relevant
 - changed the `/pos` command to show demo and cutscene numbers starting at 1, in line with `/play`
 - changed the `/play` and `/pos` commands to always treat the gym level as the level 0 – even if it's not included
+- fixed delays when scanning available save games (#2610, #1335, regression from <3.0)
 - fixed several instances of the camera going out of bounds (#1034)
 - fixed issues with stacked, floating and flipmap pushblocks in custom levels
 - fixed issues with fixed cameras in 60 FPS shifting before settling on their target (#1186)

--- a/src/libtrx/benchmark.c
+++ b/src/libtrx/benchmark.c
@@ -1,7 +1,6 @@
 #include "benchmark.h"
 
 #include "log.h"
-#include "memory.h"
 
 #include <SDL2/SDL_timer.h>
 
@@ -36,12 +35,13 @@ static void M_Log(
     }
 }
 
-BENCHMARK *Benchmark_Start(void)
+BENCHMARK Benchmark_Start(void)
 {
-    BENCHMARK *const b = Memory_Alloc(sizeof(BENCHMARK));
-    b->start = SDL_GetPerformanceCounter();
-    b->last = b->start;
-    return b;
+    const Uint64 perf = SDL_GetPerformanceCounter();
+    return (BENCHMARK) {
+        .start = perf,
+        .last = perf,
+    };
 }
 
 void Benchmark_Tick_Impl(
@@ -58,5 +58,4 @@ void Benchmark_End_Impl(
     const char *const func, const char *const message)
 {
     Benchmark_Tick_Impl(b, file, line, func, message);
-    Memory_FreePointer(&b);
 }

--- a/src/libtrx/filesystem.c
+++ b/src/libtrx/filesystem.c
@@ -444,3 +444,28 @@ void File_CreateDirectory(const char *path)
 #endif
     Memory_FreePointer(&full_path);
 }
+
+void *File_OpenDirectory(const char *const path)
+{
+    ASSERT(path != nullptr);
+    char *full_path = File_GetFullPath(path);
+    DIR *path_dir = opendir(full_path);
+    Memory_FreePointer(&full_path);
+    return path_dir;
+}
+
+const char *File_ReadDirectory(void *const dir)
+{
+    DIR *path_dir = (DIR *)dir;
+    struct dirent *cur_file = readdir(dir);
+    if (cur_file == nullptr) {
+        return nullptr;
+    }
+    return cur_file->d_name;
+}
+
+void File_CloseDirectory(void *const dir)
+{
+    ASSERT(dir != nullptr);
+    closedir(dir);
+}

--- a/src/libtrx/filesystem.c
+++ b/src/libtrx/filesystem.c
@@ -28,23 +28,25 @@ const char *m_GameDir = nullptr;
 
 static void M_PathAppendSeparator(char *path);
 static void M_PathAppendPart(char *path, const char *part);
-static char *M_CasePath(char const *path);
+static char *M_CasePath(const char *path);
+static FILE *M_ResolveAndOpen(
+    const char *path, const char *mode, char **out_full_path);
 static bool M_ExistsRaw(const char *path);
 
-static void M_PathAppendSeparator(char *path)
+static void M_PathAppendSeparator(char *const path)
 {
     if (!String_EndsWith(path, PATH_SEPARATOR)) {
         strcat(path, PATH_SEPARATOR);
     }
 }
 
-static void M_PathAppendPart(char *path, const char *part)
+static void M_PathAppendPart(char *const path, const char *const part)
 {
     M_PathAppendSeparator(path);
     strcat(path, part);
 }
 
-static char *M_CasePath(char const *path)
+static char *M_CasePath(const char *const path)
 {
     ASSERT(path != nullptr);
 
@@ -117,6 +119,40 @@ static char *M_CasePath(char const *path)
     return result;
 }
 
+static FILE *M_ResolveAndOpen(
+    const char *const path, const char *const mode, char **out_full_path)
+{
+    char *abs_path = nullptr;
+    if (File_IsRelative(path)) {
+        const char *game_dir = File_GetGameDirectory();
+        if (game_dir != nullptr) {
+            abs_path = String_Format("%s%s", game_dir, path);
+        }
+    }
+    if (abs_path == nullptr) {
+        abs_path = Memory_DupStr(path);
+    }
+
+    FILE *fp = fopen(abs_path, mode);
+    char *resolved_path = nullptr;
+    if (fp != nullptr) {
+        resolved_path = Memory_DupStr(abs_path);
+        goto finish;
+    } else {
+        resolved_path = M_CasePath(abs_path);
+        if (resolved_path != nullptr) {
+            fp = fopen(resolved_path, mode);
+        }
+    }
+
+finish:
+    if (out_full_path != nullptr) {
+        *out_full_path = resolved_path;
+    }
+    Memory_FreePointer(&abs_path);
+    return fp;
+}
+
 static bool M_ExistsRaw(const char *path)
 {
     FILE *fp = fopen(path, "rb");
@@ -172,23 +208,10 @@ bool File_Exists(const char *path)
 char *File_GetFullPath(const char *path)
 {
     char *full_path = nullptr;
-    if (File_IsRelative(path)) {
-        const char *game_dir = File_GetGameDirectory();
-        if (game_dir) {
-            full_path = Memory_Alloc(strlen(game_dir) + strlen(path) + 1);
-            sprintf(full_path, "%s%s", game_dir, path);
-        }
+    FILE *fp = M_ResolveAndOpen(path, "rb", &full_path);
+    if (fp != nullptr) {
+        fclose(fp);
     }
-    if (!full_path) {
-        full_path = Memory_DupStr(path);
-    }
-
-    char *case_path = M_CasePath(full_path);
-    if (case_path) {
-        Memory_FreePointer(&full_path);
-        return case_path;
-    }
-
     return full_path;
 }
 
@@ -235,24 +258,22 @@ fallback:
 
 MYFILE *File_Open(const char *path, FILE_OPEN_MODE mode)
 {
-    char *full_path = File_GetFullPath(path);
     MYFILE *file = Memory_Alloc(sizeof(MYFILE));
     file->path = Memory_DupStr(path);
     switch (mode) {
     case FILE_OPEN_WRITE:
-        file->fp = fopen(full_path, "wb");
+        file->fp = M_ResolveAndOpen(path, "wb", nullptr);
         break;
     case FILE_OPEN_READ:
-        file->fp = fopen(full_path, "rb");
+        file->fp = M_ResolveAndOpen(path, "rb", nullptr);
         break;
     case FILE_OPEN_READ_WRITE:
-        file->fp = fopen(full_path, "r+b");
+        file->fp = M_ResolveAndOpen(path, "r+b", nullptr);
         break;
     default:
         file->fp = nullptr;
         break;
     }
-    Memory_FreePointer(&full_path);
     if (!file->fp) {
         Memory_FreePointer(&file->path);
         Memory_FreePointer(&file);

--- a/src/libtrx/game/anims/commands.c
+++ b/src/libtrx/game/anims/commands.c
@@ -50,7 +50,7 @@ static void M_ParseCommand(ANIM_COMMAND *const command, const int16_t **data)
 
 void Anim_LoadCommands(const int16_t *data)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t anim_count = Anim_GetTotalCount();
     for (int32_t i = 0; i < anim_count; i++) {
@@ -68,5 +68,5 @@ void Anim_LoadCommands(const int16_t *data)
         }
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }

--- a/src/libtrx/game/anims/frames.c
+++ b/src/libtrx/game/anims/frames.c
@@ -163,7 +163,7 @@ void Anim_InitialiseFrames(const int32_t num_frames)
 
 void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t anim_count = Anim_GetTotalCount();
     OBJECT *cur_obj = nullptr;
@@ -207,5 +207,5 @@ void Anim_LoadFrames(const int16_t *data, const int32_t data_length)
         }
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }

--- a/src/libtrx/game/inject/common.c
+++ b/src/libtrx/game/inject/common.c
@@ -254,14 +254,14 @@ void Inject_InitLevel(const GF_LEVEL *const level)
         return;
     }
 
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     m_Injections = Memory_Alloc(sizeof(INJECTION) * m_NumInjections);
     for (int32_t i = 0; i < m_NumInjections; i++) {
         M_LoadFromFile(&m_Injections[i], level->injections.data_paths[i]);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Inject_AllInjections(void)
@@ -270,7 +270,7 @@ void Inject_AllInjections(void)
         return;
     }
 
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     for (int32_t i = 0; i < m_NumInjections; i++) {
         INJECTION *const injection = &m_Injections[i];
@@ -307,7 +307,7 @@ void Inject_AllInjections(void)
         ASSERT(VFile_GetPos(injection->fp) == injection->fp->size);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Inject_Cleanup(void)
@@ -316,7 +316,7 @@ void Inject_Cleanup(void)
         return;
     }
 
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     for (int32_t i = 0; i < m_NumInjections; i++) {
         const INJECTION *const injection = &m_Injections[i];
@@ -336,7 +336,7 @@ void Inject_Cleanup(void)
     m_RoomMetaCount = 0;
     m_CachedInfo = (LEVEL_INFO) {};
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 INJECTION_MESH_META Inject_GetRoomMeshMeta(const int32_t room_index)

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -259,7 +259,7 @@ static void M_ReadObjectVector(OBJECT_VECTOR *const obj, VFILE *const file)
 
 void Level_ReadPalettes(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t palette_size = 256;
     m_Info.palette.size = palette_size;
@@ -289,12 +289,12 @@ void Level_ReadPalettes(VFILE *const file)
     }
 #endif
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadTexturePages(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t num_pages = VFile_ReadS32(file);
     m_Info.textures.page_count = num_pages;
@@ -335,12 +335,12 @@ void Level_ReadTexturePages(VFILE *const file)
     Memory_FreePointer(&input);
 #endif
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadRooms(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const int32_t num_rooms = VFile_ReadS16(file);
     LOG_INFO("rooms: %d", num_rooms);
@@ -454,12 +454,12 @@ void Level_ReadRooms(VFILE *const file)
     Memory_FreePointer(&floor_data);
 
 finish:
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadObjectMeshes(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_meshes = VFile_ReadS32(file);
     LOG_INFO("object mesh data: %d", num_meshes);
 
@@ -482,7 +482,7 @@ void Level_ReadObjectMeshes(VFILE *const file)
     VFile_SetPos(file, end_pos);
     Memory_FreePointer(&mesh_indices);
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendObjectMeshes(
@@ -528,13 +528,13 @@ void Level_AppendObjectMeshes(
 
 void Level_ReadAnims(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anims = VFile_ReadS32(file);
     m_Info.anims.anim_count = num_anims;
     LOG_INFO("anims: %d", num_anims);
     Anim_InitialiseAnims(num_anims + Inject_GetDataCount(IDT_ANIMS));
     Level_AppendAnims(0, num_anims, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnims(
@@ -562,14 +562,14 @@ void Level_AppendAnims(
 
 void Level_ReadAnimChanges(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anim_changes = VFile_ReadS32(file);
     m_Info.anims.change_count = num_anim_changes;
     LOG_INFO("anim changes: %d", num_anim_changes);
     Anim_InitialiseChanges(
         num_anim_changes + Inject_GetDataCount(IDT_ANIM_CHANGES));
     Level_AppendAnimChanges(0, num_anim_changes, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnimChanges(
@@ -585,14 +585,14 @@ void Level_AppendAnimChanges(
 
 void Level_ReadAnimRanges(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anim_ranges = VFile_ReadS32(file);
     m_Info.anims.range_count = num_anim_ranges;
     LOG_INFO("anim ranges: %d", num_anim_ranges);
     Anim_InitialiseRanges(
         num_anim_ranges + Inject_GetDataCount(IDT_ANIM_RANGES));
     Level_AppendAnimRanges(0, num_anim_ranges, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnimRanges(
@@ -609,7 +609,7 @@ void Level_AppendAnimRanges(
 
 void Level_ReadAnimCommands(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_commands = VFile_ReadS32(file);
     m_Info.anims.command_count = num_commands;
     LOG_INFO("anim commands: %d", num_commands);
@@ -617,7 +617,7 @@ void Level_ReadAnimCommands(VFILE *const file)
         sizeof(int16_t)
         * (num_commands + Inject_GetDataCount(IDT_ANIM_COMMANDS)));
     Level_AppendAnimCommands(0, num_commands, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnimCommands(
@@ -635,13 +635,13 @@ void Level_LoadAnimCommands(void)
 
 void Level_ReadAnimBones(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_anim_bones = VFile_ReadS32(file) / ANIM_BONE_SIZE;
     m_Info.anims.bone_count = num_anim_bones;
     LOG_INFO("anim bones: %d", num_anim_bones);
     Anim_InitialiseBones(num_anim_bones + Inject_GetDataCount(IDT_ANIM_BONES));
     Level_AppendAnimBones(0, num_anim_bones, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnimBones(
@@ -661,7 +661,7 @@ void Level_AppendAnimBones(
 
 void Level_ReadAnimFrames(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t raw_data_count = VFile_ReadS32(file);
     m_Info.anims.frame_count = raw_data_count;
     LOG_INFO("raw anim frames: %d", raw_data_count);
@@ -669,7 +669,7 @@ void Level_ReadAnimFrames(VFILE *const file)
         sizeof(int16_t)
         * (raw_data_count + Inject_GetDataCount(IDT_ANIM_FRAMES)));
     Level_AppendAnimFrames(0, raw_data_count, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendAnimFrames(
@@ -690,7 +690,7 @@ void Level_LoadAnimFrames(void)
 
 void Level_ReadObjects(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_INFO("objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
@@ -710,12 +710,12 @@ void Level_ReadObjects(VFILE *const file)
         obj->loaded = true;
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadStaticObjects(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_INFO("static objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
@@ -738,19 +738,19 @@ void Level_ReadStaticObjects(VFILE *const file)
         obj->visible = (flags & 2) != 0;
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadObjectTextures(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_textures = VFile_ReadS32(file);
     m_Info.textures.object_count = num_textures;
     LOG_INFO("object textures: %d", num_textures);
     Output_InitialiseObjectTextures(
         num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
     Level_AppendObjectTextures(0, 0, num_textures, file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendObjectTextures(
@@ -770,7 +770,7 @@ void Level_AppendObjectTextures(
 
 void Level_ReadSpriteTextures(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_textures = VFile_ReadS32(file);
     m_Info.textures.sprite_count = num_textures;
     LOG_INFO("sprite textures: %d", num_textures);
@@ -778,7 +778,7 @@ void Level_ReadSpriteTextures(VFILE *const file)
         num_textures + Inject_GetDataCount(IDT_SPRITE_TEXTURES));
     Level_AppendSpriteTextures(0, 0, num_textures, file);
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendSpriteTextures(
@@ -800,7 +800,7 @@ void Level_AppendSpriteTextures(
 
 void Level_ReadSpriteSequences(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_sequences = VFile_ReadS32(file);
     LOG_DEBUG("sprite sequences: %d", num_sequences);
     for (int32_t i = 0; i < num_sequences; i++) {
@@ -824,12 +824,12 @@ void Level_ReadSpriteSequences(VFILE *const file)
         }
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadPathingData(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_boxes = VFile_ReadS32(file);
     Box_InitialiseBoxes(num_boxes);
     for (int32_t i = 0; i < num_boxes; i++) {
@@ -876,12 +876,12 @@ void Level_ReadPathingData(VFILE *const file)
         VFile_Read(file, fly_zone, sizeof(int16_t) * num_boxes);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadAnimatedTextureRanges(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t data_size = VFile_ReadS32(file);
     const size_t end_position =
         VFile_GetPos(file) + data_size * sizeof(int16_t);
@@ -907,12 +907,12 @@ void Level_ReadAnimatedTextureRanges(VFILE *const file)
     }
 
     VFile_SetPos(file, end_position);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadLightMap(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     for (int32_t i = 0; i < 32; i++) {
         LIGHT_MAP *const light_map = Output_GetLightMap(i);
         VFile_Read(file, light_map->index, sizeof(uint8_t) * 256);
@@ -927,12 +927,12 @@ void Level_ReadLightMap(VFILE *const file)
         }
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadCinematicFrames(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int16_t num_frames = VFile_ReadS16(file);
     LOG_INFO("cinematic frames: %d", num_frames);
     Camera_InitialiseCineFrames(num_frames);
@@ -948,12 +948,12 @@ void Level_ReadCinematicFrames(VFILE *const file)
         frame->roll = VFile_ReadS16(file);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadCamerasAndSinks(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_DEBUG("fixed cameras/sinks: %d", num_objects);
     Camera_InitialiseFixedObjects(num_objects);
@@ -961,12 +961,12 @@ void Level_ReadCamerasAndSinks(VFILE *const file)
         M_ReadObjectVector(Camera_GetFixedObject(i), file);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadItems(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_items = VFile_ReadS32(file);
     LOG_INFO("items: %d", num_items);
     if (num_items > MAX_ITEMS) {
@@ -991,12 +991,12 @@ void Level_ReadItems(VFILE *const file)
     }
 
 finish:
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadDemoData(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const uint16_t size = VFile_ReadU16(file);
     LOG_INFO("demo buffer size: %d", size);
     Demo_InitialiseData(size);
@@ -1004,12 +1004,12 @@ void Level_ReadDemoData(VFILE *const file)
         uint32_t *const data = Demo_GetData();
         VFile_Read(file, data, size);
     }
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadSoundSources(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_sources = VFile_ReadS32(file);
     LOG_INFO("sound sources: %d", num_sources);
     Sound_InitialiseSources(num_sources);
@@ -1017,12 +1017,12 @@ void Level_ReadSoundSources(VFILE *const file)
         M_ReadObjectVector(Sound_GetSource(i), file);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_ReadSamples(VFILE *const file)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     int16_t *const sample_lut = Sound_GetSampleLUT();
     VFile_Read(file, sample_lut, sizeof(int16_t) * SFX_NUMBER_OF);
@@ -1060,7 +1060,7 @@ void Level_ReadSamples(VFILE *const file)
     VFile_Read(file, m_Info.samples.offsets, sizeof(int32_t) * num_offsets);
 
 finish:
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_LoadTexturePages(void)

--- a/src/libtrx/game/packer.c
+++ b/src/libtrx/game/packer.c
@@ -430,7 +430,7 @@ static void M_Cleanup(void)
 
 bool Packer_Pack(PACKER_DATA *const data)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     m_Data = data;
     M_PreparePaletteLUT();
 
@@ -459,7 +459,7 @@ bool Packer_Pack(PACKER_DATA *const data)
     }
 
     M_Cleanup();
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
     return result;
 }
 

--- a/src/libtrx/include/libtrx/benchmark.h
+++ b/src/libtrx/include/libtrx/benchmark.h
@@ -7,7 +7,7 @@ typedef struct {
     Uint64 last;
 } BENCHMARK;
 
-BENCHMARK *Benchmark_Start(void);
+BENCHMARK Benchmark_Start(void);
 
 #define Benchmark_End(b, ...)                                                  \
     Benchmark_End_Impl(b, __FILE__, __LINE__, __func__, __VA_ARGS__)

--- a/src/libtrx/include/libtrx/filesystem.h
+++ b/src/libtrx/include/libtrx/filesystem.h
@@ -73,3 +73,7 @@ void File_Close(MYFILE *file);
 bool File_Load(const char *path, char **output_data, size_t *output_size);
 
 void File_CreateDirectory(const char *path);
+
+void *File_OpenDirectory(const char *path);
+const char *File_ReadDirectory(void *dir);
+void File_CloseDirectory(void *dir);

--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -863,6 +863,8 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     if (mode == INV_TITLE_MODE) {
         g_InvRing_Source[RT_OPTION].count = TITLE_RING_OBJECTS;
         InvRing_ShowVersionText();
+        Savegame_ScanSavedGames();
+        Savegame_FillAvailableSaves(&g_SavegameRequester);
     } else {
         g_InvRing_Source[RT_OPTION].count = OPTION_RING_OBJECTS;
         InvRing_RemoveVersionText();

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -161,14 +161,14 @@ static bool M_TryLayout(VFILE *const file, const LEVEL_LAYOUT layout)
 static LEVEL_LAYOUT M_GuessLayout(VFILE *const file)
 {
     LEVEL_LAYOUT result = LEVEL_LAYOUT_UNKNOWN;
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     for (LEVEL_LAYOUT layout = 0; layout < LEVEL_LAYOUT_NUMBER_OF; layout++) {
         if (M_TryLayout(file, layout)) {
             result = layout;
             break;
         }
     }
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
     return result;
 }
 
@@ -238,7 +238,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 
 static void M_CompleteSetup(const GF_LEVEL *const level)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     // We inject explosions sprites and sounds, although in the original game,
     // some levels lack them, resulting in no audio or visual effects when
@@ -294,7 +294,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     Memory_FreePointer(&sample_sizes);
     Memory_FreePointer(&info->samples.offsets);
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 static void M_MarkWaterEdgeVertices(void)
@@ -303,7 +303,7 @@ static void M_MarkWaterEdgeVertices(void)
         return;
     }
 
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         const ROOM *const room = Room_Get(i);
         const int32_t y_test =
@@ -316,12 +316,12 @@ static void M_MarkWaterEdgeVertices(void)
         }
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 static size_t M_CalculateMaxVertices(void)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     int32_t max_vertices = 0;
     for (int32_t i = 0; i < O_NUMBER_OF; i++) {
         const OBJECT *const obj = Object_Get(i);
@@ -350,14 +350,14 @@ static size_t M_CalculateMaxVertices(void)
         max_vertices = MAX(max_vertices, room->mesh.num_vertices);
     }
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
     return max_vertices;
 }
 
 void Level_Load(const GF_LEVEL *const level)
 {
     LOG_INFO("%d (%s)", level->num, level->path);
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     Inject_InitLevel(level);
 
@@ -372,13 +372,13 @@ void Level_Load(const GF_LEVEL *const level)
     Output_SetSkyboxEnabled(
         g_Config.visuals.enable_skybox && Object_Get(O_SKYBOX)->loaded);
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 bool Level_Initialise(
     const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     LOG_DEBUG("num=%d (%s)", level->num, level->path);
     if (level->type == GFL_DEMO) {
         Random_SeedDraw(0xD371F947);
@@ -451,6 +451,6 @@ bool Level_Initialise(
     Viewport_SetFOV(-1);
 
     g_Camera.underwater = false;
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
     return true;
 }

--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -343,7 +343,7 @@ static void M_InitSaveRequester(int16_t page_num)
             + (req->line_height * req->vis_lines);
     }
 
-    Savegame_ScanSavedGames();
+    Savegame_FillAvailableSaves(req);
 }
 
 static void M_RestoreSaveRequester(void)
@@ -377,7 +377,7 @@ static void M_InitSelectLevelRequester(void)
             + (req->line_height * req->vis_lines);
     }
 
-    Savegame_ScanAvailableLevels(req);
+    Savegame_FillAvailableLevels(req);
 }
 
 static void M_InitNewGameRequester(void)

--- a/src/tr1/game/savegame.h
+++ b/src/tr1/game/savegame.h
@@ -14,7 +14,7 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
-#define SAVEGAME_CURRENT_VERSION 6
+#define SAVEGAME_CURRENT_VERSION 7
 
 typedef enum {
     VERSION_LEGACY = -1,
@@ -25,6 +25,11 @@ typedef enum {
     VERSION_4 = 4,
     VERSION_5 = 5,
     VERSION_6 = 6,
+
+    VERSION_7 = 7,
+    // Added extra footer after the compressed BSON structure for quicker
+    // access to essential data, such as the level counter and the level title,
+    // without the need to parse the entire BSON document.
 } SAVEGAME_VERSION;
 
 typedef enum {

--- a/src/tr1/game/savegame.h
+++ b/src/tr1/game/savegame.h
@@ -64,7 +64,8 @@ bool Savegame_UpdateDeathCounters(int32_t slot_num, GAME_INFO *game_info);
 bool Savegame_LoadOnlyResumeInfo(int32_t slot_num, GAME_INFO *game_info);
 
 void Savegame_ScanSavedGames(void);
-void Savegame_ScanAvailableLevels(REQUEST_INFO *req);
+void Savegame_FillAvailableSaves(REQUEST_INFO *req);
+void Savegame_FillAvailableLevels(REQUEST_INFO *req);
 void Savegame_HighlightNewestSlot(void);
 bool Savegame_RestartAvailable(int32_t slot_num);
 

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -21,6 +21,7 @@
 #include <libtrx/filesystem.h>
 #include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/memory.h>
+#include <libtrx/strings.h>
 
 #include <stdint.h>
 #include <stdio.h>
@@ -32,7 +33,7 @@ typedef struct {
     bool allow_load;
     bool allow_save;
     SAVEGAME_FORMAT format;
-    char *(*get_save_filename)(int32_t slot_num);
+    const char *(*get_save_filename_pattern)(void);
     bool (*fill_info)(MYFILE *fp, SAVEGAME_INFO *info);
     bool (*load_from_file)(MYFILE *fp, GAME_INFO *game_info);
     bool (*load_only_resume_info)(MYFILE *fp, GAME_INFO *game_info);
@@ -49,7 +50,7 @@ static const SAVEGAME_STRATEGY m_Strategies[] = {
         .allow_load = true,
         .allow_save = true,
         .format = SAVEGAME_FORMAT_BSON,
-        .get_save_filename = Savegame_BSON_GetSaveFileName,
+        .get_save_filename_pattern = Savegame_BSON_GetSaveFilePattern,
         .fill_info = Savegame_BSON_FillInfo,
         .load_from_file = Savegame_BSON_LoadFromFile,
         .load_only_resume_info = Savegame_BSON_LoadOnlyResumeInfo,
@@ -60,7 +61,7 @@ static const SAVEGAME_STRATEGY m_Strategies[] = {
         .allow_load = true,
         .allow_save = false,
         .format = SAVEGAME_FORMAT_LEGACY,
-        .get_save_filename = Savegame_Legacy_GetSaveFileName,
+        .get_save_filename_pattern = Savegame_Legacy_GetSaveFilePattern,
         .fill_info = Savegame_Legacy_FillInfo,
         .load_from_file = Savegame_Legacy_LoadFromFile,
         .load_only_resume_info = Savegame_Legacy_LoadOnlyResumeInfo,
@@ -70,17 +71,20 @@ static const SAVEGAME_STRATEGY m_Strategies[] = {
     { 0 },
 };
 
-static void M_Clear(void);
+static void M_ClearSlots(void);
+static bool M_FillSlot(
+    const SAVEGAME_STRATEGY *strategy, int32_t slot_num, const char *path);
+static void M_ScanSavedGamesDir(const char *dir_path);
 static void M_LoadPreprocess(void);
 static void M_LoadPostprocess(void);
 
-static void M_Clear(void)
+static void M_ClearSlots(void)
 {
     if (m_SavegameInfo == nullptr) {
         return;
     }
 
-    for (int i = 0; i < m_SaveSlots; i++) {
+    for (int32_t i = 0; i < m_SaveSlots; i++) {
         SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[i];
         savegame_info->format = 0;
         savegame_info->counter = -1;
@@ -88,6 +92,66 @@ static void M_Clear(void)
         Memory_FreePointer(&savegame_info->full_path);
         Memory_FreePointer(&savegame_info->level_title);
     }
+}
+
+static bool M_FillSlot(
+    const SAVEGAME_STRATEGY *const strategy, const int32_t slot_num,
+    const char *const path)
+{
+    SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
+    if (savegame_info->format != 0) {
+        // do not override already filled slots
+        return true;
+    }
+
+    bool result = false;
+    MYFILE *const fp = File_Open(path, FILE_OPEN_READ);
+    if (fp != nullptr) {
+        if (strategy->fill_info(fp, savegame_info)) {
+            savegame_info->format = strategy->format;
+            Memory_FreePointer(&savegame_info->full_path);
+            savegame_info->full_path = Memory_DupStr(path);
+            result = true;
+        }
+        File_Close(fp);
+    }
+    return result;
+}
+
+static void M_ScanSavedGamesDir(const char *const dir_path)
+{
+    void *dir_handle = File_OpenDirectory(dir_path);
+    if (dir_handle == nullptr) {
+        return;
+    }
+
+    while (true) {
+        const char *file_name = File_ReadDirectory(dir_handle);
+        if (file_name == nullptr) {
+            break;
+        }
+        if (strcmp(file_name, ".") == 0 || strcmp(file_name, "..") == 0) {
+            continue;
+        }
+
+        for (const SAVEGAME_STRATEGY *strategy = m_Strategies; strategy->format;
+             strategy++) {
+            if (!strategy->allow_load) {
+                continue;
+            }
+
+            int32_t slot = -1;
+            int32_t parsed =
+                sscanf(file_name, strategy->get_save_filename_pattern(), &slot);
+            if (parsed == 1 && slot >= 0 && slot < m_SaveSlots) {
+                char *file_path = String_Format("%s/%s", dir_path, file_name);
+                M_FillSlot(strategy, slot, file_path);
+                Memory_FreePointer(&file_path);
+            }
+        }
+    }
+
+    File_CloseDirectory(dir_handle);
 }
 
 static void M_LoadPreprocess(void)
@@ -177,7 +241,7 @@ RESUME_INFO *Savegame_GetCurrentInfo(const GF_LEVEL *const level)
 
 void Savegame_Shutdown(void)
 {
-    M_Clear();
+    M_ClearSlots();
     Memory_FreePointer(&m_SavegameInfo);
     Memory_FreePointer(&g_GameInfo.current);
 }
@@ -466,10 +530,9 @@ bool Savegame_Save(const int32_t slot_num)
     const SAVEGAME_STRATEGY *strategy = &m_Strategies[0];
     while (strategy->format) {
         if (strategy->allow_save && strategy->save_to_file != nullptr) {
-            char *filename = strategy->get_save_filename(slot_num);
-            char *full_path =
-                Memory_Alloc(strlen(SAVES_DIR) + strlen(filename) + 2);
-            sprintf(full_path, "%s/%s", SAVES_DIR, filename);
+            char *filename =
+                String_Format(strategy->get_save_filename_pattern(), slot_num);
+            char *full_path = String_Format("%s/%s", SAVES_DIR, filename);
 
             MYFILE *fp = File_Open(full_path, FILE_OPEN_WRITE);
             if (fp) {
@@ -552,47 +615,17 @@ bool Savegame_LoadOnlyResumeInfo(int32_t slot_num, GAME_INFO *game_info)
 
 void Savegame_ScanSavedGames(void)
 {
-    M_Clear();
+    M_ClearSlots();
 
     g_SaveCounter = 0;
     g_SavedGamesCount = 0;
 
+    M_ScanSavedGamesDir(SAVES_DIR);
+    M_ScanSavedGamesDir(".");
+
     for (int i = 0; i < m_SaveSlots; i++) {
         SAVEGAME_INFO *savegame_info = &m_SavegameInfo[i];
-        const SAVEGAME_STRATEGY *strategy = &m_Strategies[0];
-        while (strategy->format) {
-            if (!savegame_info->format && strategy->allow_load) {
-                char *filename = strategy->get_save_filename(i);
-
-                char *full_path =
-                    Memory_Alloc(strlen(SAVES_DIR) + strlen(filename) + 2);
-                sprintf(full_path, "%s/%s", SAVES_DIR, filename);
-
-                MYFILE *fp = nullptr;
-                if (!fp) {
-                    fp = File_Open(full_path, FILE_OPEN_READ);
-                }
-                if (!fp) {
-                    fp = File_Open(filename, FILE_OPEN_READ);
-                }
-
-                if (fp) {
-                    if (strategy->fill_info(fp, savegame_info)) {
-                        savegame_info->format = strategy->format;
-                        Memory_FreePointer(&savegame_info->full_path);
-                        savegame_info->full_path =
-                            Memory_DupStr(File_GetPath(fp));
-                    }
-                    File_Close(fp);
-                }
-
-                Memory_FreePointer(&filename);
-                Memory_FreePointer(&full_path);
-            }
-            strategy++;
-        }
-
-        if (savegame_info->level_title) {
+        if (savegame_info->level_title != nullptr) {
             if (savegame_info->counter > g_SaveCounter) {
                 g_SaveCounter = savegame_info->counter;
             }

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -42,7 +42,7 @@ typedef struct {
 } SAVEGAME_STRATEGY;
 
 static int32_t m_SaveSlots = 0;
-static uint16_t m_NewestSlot = 0;
+static int16_t m_NewestSlot = -1;
 static SAVEGAME_INFO *m_SavegameInfo = nullptr;
 
 static const SAVEGAME_STRATEGY m_Strategies[] = {
@@ -99,8 +99,8 @@ static bool M_FillSlot(
     const char *const path)
 {
     SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
-    if (savegame_info->format != 0) {
-        // do not override already filled slots
+    if (strategy->format <= savegame_info->format) {
+        // do not override already filled slots or for less preferred strategies
         return true;
     }
 
@@ -485,7 +485,7 @@ bool Savegame_Load(const int32_t slot_num)
     M_LoadPreprocess();
 
     bool ret = false;
-    const SAVEGAME_STRATEGY *strategy = &m_Strategies[0];
+    const SAVEGAME_STRATEGY *strategy = m_Strategies;
     while (strategy->format) {
         if (savegame_info->format == strategy->format) {
             MYFILE *fp = File_Open(savegame_info->full_path, FILE_OPEN_READ);
@@ -510,7 +510,7 @@ bool Savegame_Load(const int32_t slot_num)
 bool Savegame_Save(const int32_t slot_num)
 {
     GAME_INFO *const game_info = &g_GameInfo;
-    bool ret = true;
+    bool ret = false;
     Savegame_BindSlot(slot_num);
 
     File_CreateDirectory(SAVES_DIR);
@@ -525,26 +525,31 @@ bool Savegame_Save(const int32_t slot_num)
             game_info->current[i] = game_info->current[current_level->num];
         }
     }
+    const char *const level_title = Game_GetCurrentLevel()->title;
 
     SAVEGAME_INFO *savegame_info = &m_SavegameInfo[slot_num];
-    const SAVEGAME_STRATEGY *strategy = &m_Strategies[0];
-    while (strategy->format) {
+    const bool was_slot_empty = savegame_info->full_path == nullptr;
+    const SAVEGAME_STRATEGY *strategy = m_Strategies;
+    while (strategy->format != 0) {
         if (strategy->allow_save && strategy->save_to_file != nullptr) {
             char *filename =
                 String_Format(strategy->get_save_filename_pattern(), slot_num);
             char *full_path = String_Format("%s/%s", SAVES_DIR, filename);
 
-            MYFILE *fp = File_Open(full_path, FILE_OPEN_WRITE);
-            if (fp) {
+            MYFILE *const fp = File_Open(full_path, FILE_OPEN_WRITE);
+            if (fp != nullptr) {
+                g_SaveCounter++;
                 strategy->save_to_file(fp, game_info);
                 savegame_info->format = strategy->format;
                 Memory_FreePointer(&savegame_info->full_path);
                 savegame_info->full_path = Memory_DupStr(File_GetPath(fp));
                 savegame_info->counter = g_SaveCounter;
                 savegame_info->level_num = current_level->num;
+                savegame_info->level_title = level_title != nullptr
+                    ? Memory_DupStr(level_title)
+                    : nullptr;
                 File_Close(fp);
-            } else {
-                ret = false;
+                ret = true;
             }
 
             Memory_FreePointer(&filename);
@@ -554,12 +559,12 @@ bool Savegame_Save(const int32_t slot_num)
     }
 
     if (ret) {
-        REQUEST_INFO *req = &g_SavegameRequester;
-        Requester_ChangeItem(
-            req, slot_num, false, "%s %d", current_level->title, g_SaveCounter);
+        m_NewestSlot = slot_num;
+        if (was_slot_empty) {
+            g_SavedGamesCount++;
+        }
+        Savegame_HighlightNewestSlot();
     }
-
-    Savegame_ScanSavedGames();
 
     return ret;
 }
@@ -619,31 +624,32 @@ void Savegame_ScanSavedGames(void)
 
     g_SaveCounter = 0;
     g_SavedGamesCount = 0;
+    m_NewestSlot = -1;
 
     M_ScanSavedGamesDir(SAVES_DIR);
     M_ScanSavedGamesDir(".");
 
-    for (int i = 0; i < m_SaveSlots; i++) {
+    for (int32_t i = 0; i < m_SaveSlots; i++) {
         SAVEGAME_INFO *savegame_info = &m_SavegameInfo[i];
         if (savegame_info->level_title != nullptr) {
             if (savegame_info->counter > g_SaveCounter) {
                 g_SaveCounter = savegame_info->counter;
+                m_NewestSlot = i;
             }
             g_SavedGamesCount++;
         }
     }
+}
 
-    REQUEST_INFO *req = &g_SavegameRequester;
+void Savegame_FillAvailableSaves(REQUEST_INFO *req)
+{
     Requester_ClearTextstrings(req);
-    Requester_Init(&g_SavegameRequester, Savegame_GetSlotCount());
+    Requester_Init(req, Savegame_GetSlotCount());
 
     for (int i = 0; i < req->max_items; i++) {
         SAVEGAME_INFO *savegame_info = &m_SavegameInfo[i];
 
-        if (savegame_info->level_title) {
-            if (savegame_info->counter == g_SaveCounter) {
-                m_NewestSlot = i;
-            }
+        if (savegame_info->level_title != nullptr) {
             Requester_AddItem(
                 req, false, "%s %d", savegame_info->level_title,
                 savegame_info->counter);
@@ -657,12 +663,11 @@ void Savegame_ScanSavedGames(void)
     } else if (req->requested < req->line_offset) {
         req->line_offset = req->requested;
     }
-
-    g_SaveCounter++;
 }
 
-void Savegame_ScanAvailableLevels(REQUEST_INFO *req)
+void Savegame_FillAvailableLevels(REQUEST_INFO *req)
 {
+    ASSERT(req != nullptr);
     const int32_t slot_num = g_GameInfo.select_save_slot;
     if (slot_num == -1) {
         return;
@@ -696,7 +701,7 @@ void Savegame_ScanAvailableLevels(REQUEST_INFO *req)
 
 void Savegame_HighlightNewestSlot(void)
 {
-    g_SavegameRequester.requested = m_NewestSlot;
+    g_SavegameRequester.requested = MAX(0, m_NewestSlot);
 }
 
 bool Savegame_RestartAvailable(int32_t slot_num)

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -15,6 +15,7 @@
 #include "global/types.h"
 #include "global/vars.h"
 
+#include <libtrx/benchmark.h>
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/enum_map.h>
@@ -620,6 +621,7 @@ bool Savegame_LoadOnlyResumeInfo(int32_t slot_num, GAME_INFO *game_info)
 
 void Savegame_ScanSavedGames(void)
 {
+    BENCHMARK benchmark = Benchmark_Start();
     M_ClearSlots();
 
     g_SaveCounter = 0;
@@ -639,6 +641,7 @@ void Savegame_ScanSavedGames(void)
             g_SavedGamesCount++;
         }
     }
+    Benchmark_End(&benchmark, nullptr);
 }
 
 void Savegame_FillAvailableSaves(REQUEST_INFO *req)

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -1287,13 +1287,9 @@ static JSON_ARRAY *M_DumpMusicTrackFlags(void)
     return music_track_arr;
 }
 
-char *Savegame_BSON_GetSaveFileName(int32_t slot)
+const char *Savegame_BSON_GetSaveFilePattern(void)
 {
-    size_t out_size =
-        snprintf(nullptr, 0, g_GameFlow.savegame_fmt_bson, slot) + 1;
-    char *out = Memory_Alloc(out_size);
-    snprintf(out, out_size, g_GameFlow.savegame_fmt_bson, slot);
-    return out;
+    return g_GameFlow.savegame_fmt_bson;
 }
 
 bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -39,6 +39,13 @@ typedef struct {
     int32_t compressed_size;
     int32_t uncompressed_size;
 } SAVEGAME_BSON_HEADER;
+
+typedef struct {
+    uint32_t flags;
+    int32_t counter;
+    int32_t level_num;
+    size_t title_size;
+} SAVEGAME_BSON_EXTENDED_HEADER;
 #pragma pack(pop)
 
 typedef struct {
@@ -112,7 +119,18 @@ static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version)
     };
 
     File_WriteData(fp, &header, sizeof(header));
+
     File_WriteData(fp, compressed, compressed_size);
+
+    const GF_LEVEL *const level = Game_GetCurrentLevel();
+    SAVEGAME_BSON_EXTENDED_HEADER extra_header = {
+        .flags = g_GameInfo.bonus_flag,
+        .counter = g_SaveCounter,
+        .level_num = level->num,
+        .title_size = strlen(level->title),
+    };
+    File_WriteData(fp, &extra_header, sizeof(extra_header));
+    File_WriteData(fp, level->title, strlen(level->title));
 
     Memory_FreePointer(&compressed);
 }
@@ -1295,26 +1313,40 @@ const char *Savegame_BSON_GetSaveFilePattern(void)
 bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info)
 {
     bool ret = false;
-    JSON_VALUE *root = M_ParseFromFile(fp, nullptr);
-    JSON_OBJECT *root_obj = JSON_ValueAsObject(root);
-    if (root_obj) {
-        info->counter = JSON_ObjectGetInt(root_obj, "save_counter", -1);
-        info->level_num = JSON_ObjectGetInt(root_obj, "level_num", -1);
-        const char *level_title =
-            JSON_ObjectGetString(root_obj, "level_title", nullptr);
-        if (level_title) {
-            info->level_title = Memory_DupStr(level_title);
-        }
-        ret = info->level_num != -1;
-    }
-    JSON_ValueFree(root);
-
     SAVEGAME_BSON_HEADER header;
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER));
     info->initial_version = header.initial_version;
     info->features.restart = header.initial_version >= VERSION_LEGACY;
     info->features.select_level = header.initial_version >= VERSION_1;
+
+    if (header.version >= VERSION_7) {
+        // recover the slot information from the end of the file
+        File_Skip(fp, header.compressed_size);
+        SAVEGAME_BSON_EXTENDED_HEADER extra_header;
+        File_ReadData(fp, &extra_header, sizeof(extra_header));
+        info->counter = extra_header.counter;
+        info->level_num = extra_header.level_num;
+        info->level_title = Memory_Alloc(extra_header.title_size + 1);
+        File_ReadData(fp, info->level_title, extra_header.title_size);
+        ret = true;
+    } else {
+        // recover the slot information from the bson structures
+        File_Seek(fp, 0, FILE_SEEK_SET);
+        JSON_VALUE *root = M_ParseFromFile(fp, nullptr);
+        JSON_OBJECT *root_obj = JSON_ValueAsObject(root);
+        if (root_obj != nullptr) {
+            info->counter = JSON_ObjectGetInt(root_obj, "save_counter", -1);
+            info->level_num = JSON_ObjectGetInt(root_obj, "level_num", -1);
+            const char *level_title =
+                JSON_ObjectGetString(root_obj, "level_title", nullptr);
+            if (level_title != nullptr) {
+                info->level_title = Memory_DupStr(level_title);
+            }
+            ret = info->level_num != -1;
+        }
+        JSON_ValueFree(root);
+    }
 
     return ret;
 }

--- a/src/tr1/game/savegame/savegame_bson.h
+++ b/src/tr1/game/savegame/savegame_bson.h
@@ -9,7 +9,7 @@
 
 // TR1X implementation of savegames.
 
-char *Savegame_BSON_GetSaveFileName(int32_t slot);
+const char *Savegame_BSON_GetSaveFilePattern(void);
 bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
 bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
 bool Savegame_BSON_LoadOnlyResumeInfo(MYFILE *fp, GAME_INFO *game_info);

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -379,13 +379,9 @@ static void M_ReadResumeInfo(MYFILE *const fp, GAME_INFO *const game_info)
     game_info->death_count = -1;
 }
 
-char *Savegame_Legacy_GetSaveFileName(const int32_t slot)
+const char *Savegame_Legacy_GetSaveFilePattern(void)
 {
-    const size_t out_size =
-        snprintf(nullptr, 0, g_GameFlow.savegame_fmt_legacy, slot) + 1;
-    char *out = Memory_Alloc(out_size);
-    snprintf(out, out_size, g_GameFlow.savegame_fmt_legacy, slot);
-    return out;
+    return g_GameFlow.savegame_fmt_legacy;
 }
 
 bool Savegame_Legacy_FillInfo(MYFILE *const fp, SAVEGAME_INFO *const info)

--- a/src/tr1/game/savegame/savegame_legacy.h
+++ b/src/tr1/game/savegame/savegame_legacy.h
@@ -9,7 +9,7 @@
 
 // TombATI implementation of savegames.
 
-char *Savegame_Legacy_GetSaveFileName(int32_t slot);
+const char *Savegame_Legacy_GetSaveFilePattern(void);
 bool Savegame_Legacy_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
 bool Savegame_Legacy_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
 bool Savegame_Legacy_LoadOnlyResumeInfo(MYFILE *fp, GAME_INFO *game_info);

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -90,6 +90,8 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
         Savegame_Shutdown();
         Savegame_Init();
         Savegame_ScanSavedGames();
+        Savegame_FillAvailableSaves(&g_SavegameRequester);
+        Savegame_HighlightNewestSlot();
     }
 
     Output_ApplyRenderSettings();
@@ -187,6 +189,7 @@ void Shell_Main(void)
 
     Savegame_Init();
     Savegame_ScanSavedGames();
+    Savegame_FillAvailableSaves(&g_SavegameRequester);
     Savegame_HighlightNewestSlot();
     GameBuf_Init();
     Console_Init();

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -39,7 +39,7 @@ static void M_CompleteSetup(void);
 
 static void M_InitialiseSoundEffects(void)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
     const char *const file_name = "data\\main.sfx";
     const char *full_path = File_GetFullPath(file_name);
     LOG_DEBUG("Loading samples from %s", full_path);
@@ -92,7 +92,7 @@ finish:
         File_Close(fp);
     }
     Memory_FreePointer(&info->samples.offsets);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 static void M_LoadFromFile(const GF_LEVEL *const level)
@@ -100,7 +100,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     LOG_DEBUG("%s (num=%d)", level->title, level->num);
     GameBuf_Reset();
 
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     const char *full_path = File_GetFullPath(level->path);
     strcpy(g_LevelFileName, full_path);
@@ -146,12 +146,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadSamples(file);
 
     VFile_Close(file);
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 static void M_CompleteSetup(void)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     Inject_AllInjections();
 
@@ -168,12 +168,12 @@ static void M_CompleteSetup(void)
 
     M_InitialiseSoundEffects();
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 }
 
 bool Level_Load(const GF_LEVEL *const level)
 {
-    BENCHMARK *const benchmark = Benchmark_Start();
+    BENCHMARK benchmark = Benchmark_Start();
 
     Audio_Sample_CloseAll();
     Audio_Sample_UnloadAll();
@@ -193,7 +193,7 @@ bool Level_Load(const GF_LEVEL *const level)
 
     Inject_Cleanup();
 
-    Benchmark_End(benchmark, nullptr);
+    Benchmark_End(&benchmark, nullptr);
 
     return true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2610. Resolves #1335.

With all the accumulated additions over time – case sensitivity resolving, for example, or guessing the game root directory – the previous approach grew to be quite horrible.
The downside is that the save file names are now case sensitive due to usage of `scanf()`, but I'm not sure how big of an issue this is.