### PR TITLE
cmd: add flood and drain console commands

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...develop) - ××××-××-××
 - added quadrilateral interpolation (#354)
+- added `/flood` and `/drain` console commands
 - added support for `-l`/`--level` argument to play a single level
 - added support for custom levels to use `disable_floor` in the gameflow, similar to TR2's Floating Islands (#2541)
 - added drawing of object mesh spheres to the `/debug` console command

--- a/docs/tr1/COMMANDS.md
+++ b/docs/tr1/COMMANDS.md
@@ -22,6 +22,10 @@ Currently supported commands:
   `/flip on`  
   Switches the global flipmap on or off, turning the reality around you on its head.
 
+- `/flood`  
+  `/drain`  
+  Floods or drains the current room at will. For when drowning is preferable to puzzles!
+
 - `/give {item_name}`  
   `/give {num} {item_name}`  
   `/give all`  

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added a `/cheats` console command
 - added a `/wireframe` console command (#2500)
 - added a `/fps` console command
+- added `/flood` and `/drain` console commands
 - added support for `-l`/`--level` argument to play a single level
 - added Italian localization to the config tool
 - changed injections to a new file format with a smaller footprint, improved applicability tests and similar feature support as TR1 (#1967)

--- a/docs/tr2/COMMANDS.md
+++ b/docs/tr2/COMMANDS.md
@@ -21,6 +21,10 @@ Currently supported commands:
   `/flip on`  
   Switches the global flipmap on or off, turning the reality around you on its head.
 
+- `/flood`  
+  `/drain`  
+  Floods or drains the current room at will. For when drowning is preferable to puzzles!
+
 - `/give {item_name}`  
   `/give {num} {item_name}`  
   `/give all`  

--- a/src/libtrx/game/console/cmd/flood.c
+++ b/src/libtrx/game/console/cmd/flood.c
@@ -1,0 +1,30 @@
+#include "game/console/registry.h"
+#include "game/lara/common.h"
+#include "game/rooms.h"
+#include "strings.h"
+
+static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
+
+static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+{
+    if (!String_IsEmpty(ctx->args)) {
+        return CR_BAD_INVOCATION;
+    }
+
+    ITEM *const lara_item = Lara_GetItem();
+    if (lara_item == nullptr) {
+        return CR_UNAVAILABLE;
+    }
+
+    if (String_Equivalent(ctx->prefix, "flood")) {
+        Room_Get(lara_item->room_num)->flags |= RF_UNDERWATER;
+    } else if (String_Equivalent(ctx->prefix, "drain")) {
+        Room_Get(lara_item->room_num)->flags &= ~RF_UNDERWATER;
+    } else {
+        return CR_UNAVAILABLE;
+    }
+
+    return CR_SUCCESS;
+}
+
+REGISTER_CONSOLE_COMMAND("flood|drain", M_Entrypoint)

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -98,6 +98,7 @@ sources = [
   'game/console/cmd/exit_game.c',
   'game/console/cmd/exit_to_title.c',
   'game/console/cmd/flipmap.c',
+  'game/console/cmd/flood.c',
   'game/console/cmd/fly.c',
   'game/console/cmd/give_item.c',
   'game/console/cmd/heal.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Some lighthearted fun. It doesn’t try to be bigger than what it is and just toggles the flooded flag, without adding textured water tiles at runtime.

![image](https://github.com/user-attachments/assets/bf94f7b7-965b-4cbf-9dd0-d22cb2d32566)
