### PR TITLE
tr2: refactor sound effect loading

### DIFF
--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -31,6 +31,7 @@
         ],
     },
 
+    "sfx_path": "data/main.sfx",
     "injections": [
         "data/injections/font.bin",
     ],

--- a/data/tr2/ship/cfg/TR2X_gameflow_level.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow_level.json5
@@ -19,6 +19,7 @@
     "demo_delay": 30,
     "secret_track": 47,
 
+    "sfx_path": "data/main.sfx",
     "injections": [
         "data/injections/font.bin",
     ],

--- a/docs/GAME_FLOW.md
+++ b/docs/GAME_FLOW.md
@@ -298,6 +298,13 @@ remains distinct for each game.
       Music track to play when a secret is found. -1 to not play anything.
     </td>
   </tr>
+  <tr valign="top">
+    <td><code>sfx_path</code></td>
+    <td>String</td>
+    <td>
+      The path to the sound effects (.sfx) file to use in the game.
+    </td>
+  </tr>
 </table>
 
 ## Game flow commands
@@ -549,6 +556,14 @@ Following are each of the properties available within a level.
     </td>
   </tr>
   <tr valign="top">
+    <td><code>sfx_path</code><strong>²</strong></td>
+    <td>String</td>
+    <td colspan="2">
+      The path to the sound effects (.sfx) file to use in this level. If this
+      property is not defined, the default global file will be used.
+    </td>
+  </tr>
+  <tr valign="top">
     <td><code>unobtainable_kills</code><strong>¹</strong></td>
     <td>Integer</td>
     <td colspan="2">
@@ -581,6 +596,7 @@ Following are each of the properties available within a level.
 
 **\*** Required property.  
 **¹** Tomb Raider 1 only.
+**²** Tomb Raider 2 only.
 
 ## Sequences
 The following describes each available game flow sequence type and the required

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added a `/fps` console command
 - added `/flood` and `/drain` console commands
 - added support for `-l`/`--level` argument to play a single level
+- added the ability to specify per-level SFX files rather than enforcing the default (main.sfx) on all levels (#2615)
 - added Italian localization to the config tool
 - changed injections to a new file format with a smaller footprint, improved applicability tests and similar feature support as TR1 (#1967)
 - changed the `/pos` command to show `Demo` and `Cutscene` instead of `Level` when relevant

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -87,7 +87,6 @@ game with new enhancements and features.
 - fixed the game crashing if a cinematic is triggered but the level contains no cinematic frames
 - fixed smashed windows blocking enemy pathing after loading a save
 - fixed Lara getting stuck in a T-pose after jumping/falling and then dying before reaching fast fall speed
-- fixed several issues with pushblocks
 - fixed several issues with pushblocks:
     - fixed an invisible wall above stacked pushblocks if near a ceiling portal
     - fixed floor height issues with pushblocks poised to fall in various scenarios
@@ -165,6 +164,7 @@ game with new enhancements and features.
 - added .jpeg/.png screenshots
 - added ability to skip FMVs with both the Action key
 - added ability to skip end credits with the Action and Escape keys
+- added the ability to specify per-level SFX files rather than enforcing the default (main.sfx) on all levels
 - expanded internal game memory limit from 7.5 MB to 128 MB
 - expanded maximum object textures from 2048 to unlimited (within game's overall memory cap)
 - expanded maximum sprite textures from 512 to unlimited (within game's overall memory cap)

--- a/src/libtrx/game/game_flow/common.c
+++ b/src/libtrx/game/game_flow/common.c
@@ -49,6 +49,8 @@ static void M_FreeLevel(GF_LEVEL *const level)
         }
         Memory_FreePointer(&level->item_drops.data);
     }
+#else
+    Memory_FreePointer(&level->settings.sfx_path);
 #endif
 }
 
@@ -91,6 +93,8 @@ void GF_Shutdown(void)
     Memory_FreePointer(&gf->main_menu_background_path);
     Memory_FreePointer(&gf->savegame_fmt_legacy);
     Memory_FreePointer(&gf->savegame_fmt_bson);
+#else
+    Memory_FreePointer(&gf->settings.sfx_path);
 #endif
 }
 

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -3,7 +3,9 @@
 
 static GF_COMMAND M_LoadCommand(JSON_OBJECT *jcmd, GF_COMMAND fallback);
 
-static GF_LEVEL_SETTINGS m_DefaultSettings = {};
+static GF_LEVEL_SETTINGS m_DefaultSettings = {
+    .sfx_path = nullptr,
+};
 
 static GF_SEQUENCE_EVENT_TYPE m_LevelArgSequenceEvents[] = {
     GFS_LOOP_GAME,
@@ -46,12 +48,24 @@ static M_SEQUENCE_EVENT_HANDLER m_SequenceEventHandlers[] = {
 static void M_LoadSettings(
     JSON_OBJECT *const obj, GF_LEVEL_SETTINGS *const settings)
 {
+    {
+        const char *tmp_s =
+            JSON_ObjectGetString(obj, "sfx_path", JSON_INVALID_STRING);
+        if (tmp_s != JSON_INVALID_STRING) {
+            settings->sfx_path = Memory_DupStr(tmp_s);
+        }
+    }
 }
 
 static void M_LoadLevelGameSpecifics(
     JSON_OBJECT *const jlvl_obj, const GAME_FLOW *const gf,
     GF_LEVEL *const level)
 {
+    level->settings = gf->settings;
+#if TR_VERSION == 2
+    level->settings.sfx_path = nullptr;
+#endif
+    M_LoadSettings(jlvl_obj, &level->settings);
 }
 
 static M_SEQUENCE_EVENT_HANDLER *M_GetSequenceEventHandlers(void)

--- a/src/libtrx/include/libtrx/game/game_flow/types.h
+++ b/src/libtrx/include/libtrx/game/game_flow/types.h
@@ -83,7 +83,7 @@ typedef struct {
     float draw_distance_fade;
     float draw_distance_max;
 #elif TR_VERSION == 2
-    int32_t dummy; // silence warnings, keep the logic
+    char *sfx_path;
 #endif
 } GF_LEVEL_SETTINGS;
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -34,6 +34,8 @@
 #include <libtrx/utils.h>
 #include <libtrx/virtual_file.h>
 
+#define DEFAULT_SFX_PATH "data/main.sfx"
+
 typedef struct {
     int32_t game_index;
     int32_t file_index;
@@ -41,8 +43,8 @@ typedef struct {
 
 static int32_t M_CompareSampleOffsets(const void *a, const void *b);
 static void M_LoadFromFile(const GF_LEVEL *level);
-static void M_InitialiseSoundEffects(void);
-static void M_CompleteSetup(void);
+static void M_InitialiseSoundEffects(const char *const file_name);
+static void M_CompleteSetup(const GF_LEVEL *level);
 
 static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
 {
@@ -51,12 +53,12 @@ static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
     return entry_a->file_index - entry_b->file_index;
 }
 
-static void M_InitialiseSoundEffects(void)
+static void M_InitialiseSoundEffects(const char *const file_name)
 {
     BENCHMARK benchmark = Benchmark_Start();
     SAMPLE_ENTRY *entries = nullptr;
-    const char *const file_name = "data\\main.sfx";
-    const char *full_path = File_GetFullPath(file_name);
+    const char *full_path =
+        File_GetFullPath(file_name == nullptr ? DEFAULT_SFX_PATH : file_name);
     LOG_DEBUG("Loading samples from %s", full_path);
     MYFILE *const fp = File_Open(full_path, FILE_OPEN_READ);
     Memory_FreePointer(&full_path);
@@ -172,7 +174,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Benchmark_End(&benchmark, nullptr);
 }
 
-static void M_CompleteSetup(void)
+static void M_CompleteSetup(const GF_LEVEL *const level)
 {
     BENCHMARK benchmark = Benchmark_Start();
 
@@ -190,7 +192,7 @@ static void M_CompleteSetup(void)
     Render_Reset(
         RENDER_RESET_PALETTE | RENDER_RESET_TEXTURES | RENDER_RESET_UVS);
 
-    M_InitialiseSoundEffects();
+    M_InitialiseSoundEffects(level->settings.sfx_path);
 
     Benchmark_End(&benchmark, nullptr);
 }
@@ -213,7 +215,7 @@ bool Level_Load(const GF_LEVEL *const level)
     Inject_InitLevel(level);
 
     M_LoadFromFile(level);
-    M_CompleteSetup();
+    M_CompleteSetup(level);
 
     Inject_Cleanup();
 

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -31,66 +31,89 @@
 #include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
+#include <libtrx/utils.h>
 #include <libtrx/virtual_file.h>
 
+typedef struct {
+    int32_t game_index;
+    int32_t file_index;
+} SAMPLE_ENTRY;
+
+static int32_t M_CompareSampleOffsets(const void *a, const void *b);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_InitialiseSoundEffects(void);
 static void M_CompleteSetup(void);
 
+static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
+{
+    const SAMPLE_ENTRY *const entry_a = (SAMPLE_ENTRY *)a;
+    const SAMPLE_ENTRY *const entry_b = (SAMPLE_ENTRY *)b;
+    return entry_a->file_index - entry_b->file_index;
+}
+
 static void M_InitialiseSoundEffects(void)
 {
     BENCHMARK benchmark = Benchmark_Start();
+    SAMPLE_ENTRY *entries = nullptr;
     const char *const file_name = "data\\main.sfx";
     const char *full_path = File_GetFullPath(file_name);
     LOG_DEBUG("Loading samples from %s", full_path);
     MYFILE *const fp = File_Open(full_path, FILE_OPEN_READ);
     Memory_FreePointer(&full_path);
 
-    LEVEL_INFO *const info = Level_GetInfo();
     if (fp == nullptr) {
         Shell_ExitSystemFmt("Could not open %s file", file_name);
         goto finish;
     }
 
-    // TODO: refactor these WAVE/RIFF shenanigans
-    int32_t sample_id = 0;
-    for (int32_t i = 0; sample_id < info->samples.offset_count; i++) {
-        char header[0x2C];
-        File_ReadData(fp, header, 0x2C);
-        if (*(int32_t *)(header + 0) != 0x46464952
-            || *(int32_t *)(header + 8) != 0x45564157
-            || *(int32_t *)(header + 36) != 0x61746164) {
+    LEVEL_INFO *const info = Level_GetInfo();
+    const int32_t sample_count = info->samples.offset_count;
+    entries = Memory_Alloc(sizeof(SAMPLE_ENTRY) * sample_count);
+    for (int32_t i = 0; i < sample_count; i++) {
+        entries[i].game_index = i;
+        entries[i].file_index = info->samples.offsets[i];
+    }
+    qsort(entries, sample_count, sizeof(SAMPLE_ENTRY), M_CompareSampleOffsets);
+
+    for (int32_t i = 0, current_sample = 0; current_sample < sample_count;
+         i++) {
+        uint32_t header[11];
+        File_ReadData(fp, header, 11 * sizeof(uint32_t));
+        if (header[0] != MKTAG('R', 'I', 'F', 'F')
+            || header[2] != MKTAG('W', 'A', 'V', 'E')
+            || header[9] != MKTAG('d', 'a', 't', 'a')) {
             LOG_ERROR("Unexpected sample header for sample %d", i);
             goto finish;
         }
-        const int32_t data_size = *(int32_t *)(header + 0x28);
-        const int32_t aligned_size = (data_size + 1) & ~1;
 
-        if (info->samples.offsets[sample_id] != i) {
+        const size_t header_size = 11 * sizeof(uint32_t);
+        const size_t aligned_size = (header[10] + 1) & ~1;
+        const size_t size = aligned_size + header_size;
+        const SAMPLE_ENTRY *const entry = &entries[current_sample];
+        if (entry->file_index != i) {
             File_Seek(fp, aligned_size, FILE_SEEK_CUR);
             continue;
         }
 
-        const size_t sample_data_size = 0x2C + aligned_size;
-        char *sample_data = Memory_Alloc(sample_data_size);
-        memcpy(sample_data, header, 0x2C);
-        File_ReadData(fp, sample_data + 0x2C, aligned_size);
-
+        char *sample_data = Memory_Alloc(size);
+        memcpy(sample_data, header, header_size);
+        File_ReadData(fp, sample_data + header_size, aligned_size);
         const bool result =
-            Audio_Sample_LoadSingle(sample_id, sample_data, sample_data_size);
+            Audio_Sample_LoadSingle(entry->game_index, sample_data, size);
         Memory_FreePointer(&sample_data);
 
         if (!result) {
-            goto finish;
+            LOG_WARNING("Failed to load sample %d", entry->game_index);
         }
 
-        sample_id++;
+        current_sample++;
     }
 
 finish:
     if (fp != nullptr) {
         File_Close(fp);
     }
+    Memory_FreePointer(&entries);
     Memory_FreePointer(&info->samples.offsets);
     Benchmark_End(&benchmark, nullptr);
 }


### PR DESCRIPTION
Resolves #2615.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adjusts the reading of `main.sfx` to allow support for offsets that aren't necessarily in order, such as when we later come to inject sound fixes. We do this by scanning the file once and noting positions and lengths of all SFX, then scan over the defined offset to select the correct data.

The game flow has been updated too to support the default SFX file being defined there, as well as allowing a different one to be used in each level. This can be tested using the Golden Mask or TR3 equivalent files (although the sounds won't make sense 😄).
