### PR TITLE
trapdoor: fix startup problems

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed being able to play with Lara invisible after using the explosion cheat then the fly cheat (#2584, regression from 4.8)
 - fixed the `/pos` command not working in cutscenes
 - fixed the `/pos` command not showing demo and cutscene titles
+- fixed the embedded bats fix causing problems inside rooms with trapdoors (regression from 4.6)
 - removed perspective filter toggle (it had no effect; repurposed to trapezoid interpolation toggle)
 
 ## [4.8.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.2...tr1-4.8.3) - 2025-02-17

--- a/src/tr1/game/objects/general/trapdoor.c
+++ b/src/tr1/game/objects/general/trapdoor.c
@@ -19,6 +19,10 @@ static int16_t M_GetCeilingHeight(
 static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z)
 {
     const BOUNDS_16 *const orig_bounds = &Item_GetBestFrame(item)->bounds;
+    if (orig_bounds == nullptr) {
+        return false;
+    }
+
     BOUNDS_16 fixed_bounds = {};
 
     // Bounds need to change in order to account for 2 sector trapdoors

--- a/src/tr2/game/objects/general/trapdoor.c
+++ b/src/tr2/game/objects/general/trapdoor.c
@@ -47,6 +47,10 @@ static bool M_IsItemOnTop(
     const ITEM *const item, const int32_t x, const int32_t z)
 {
     const BOUNDS_16 *const orig_bounds = &Item_GetBestFrame(item)->bounds;
+    if (orig_bounds == nullptr) {
+        return false;
+    }
+
     BOUNDS_16 fixed_bounds = {};
 
     // Bounds need to change in order to account for 2 sector trapdoors


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The cause was the bats - the code to fix bats embedded in room geometry tries to find the nearest open spot to move the bats to. In the case of the level "The Atlantean Armor" by Sabatu, it happened inside a room with a trapdoor. At the time of invoking the embed fix, the trapdoor didn't have its bounds ready and would crash the game with null pointer access. It seems to be working fine otherwise.