### PR TITLE
tr2/render/hwr: reduce duplication

### DIFF
--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -58,14 +58,21 @@ static void M_DrawPrimitive(
     const GFX_3D_VERTEX *vertices, int32_t vtx_count, bool is_no_clip);
 static void M_DrawPolyTextured(RENDERER *renderer, int32_t vtx_count);
 static void M_DrawPolyFlat(
-    RENDERER *renderer, int32_t vtx_count, int32_t red, int32_t green,
-    int32_t blue);
+    RENDERER *renderer, int32_t vtx_count, int32_t palette_idx);
 
 static void M_InsertPolyTextured(
     int32_t vtx_count, const float z, int16_t poly_type, int16_t tex_page);
 static void M_InsertPolyFlat(
-    int32_t vtx_count, const float z, int32_t red, int32_t green, int32_t blue,
-    int16_t poly_type);
+    int32_t vtx_count, const float z, int32_t palette_idx, int16_t poly_type);
+
+static void M_InsertFlatFace3s(
+    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
+static void M_InsertFlatFace4s(
+    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
+static void M_InsertTexturedFace3s(
+    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
+static void M_InsertTexturedFace4s(
+    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
 
 static void M_InsertGT3_Sorted(
     RENDERER *renderer, const PHD_VBUF *vtx0, const PHD_VBUF *vtx1,
@@ -75,27 +82,19 @@ static void M_InsertGT4_Sorted(
     RENDERER *renderer, const PHD_VBUF *vtx0, const PHD_VBUF *vtx1,
     const PHD_VBUF *vtx2, const PHD_VBUF *vtx3, const OBJECT_TEXTURE *texture,
     const SORT_TYPE sort_type);
-static void M_InsertFlatFace3s_Sorted(
-    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertFlatFace4s_Sorted(
-    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertTexturedFace3s_Sorted(
-    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertTexturedFace4s_Sorted(
-    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
 static void M_InsertFlatRect_Sorted(
     RENDERER *renderer, int32_t x1, int32_t y1, int32_t x2, int32_t y2,
     int32_t z, uint8_t color_idx);
 static void M_InsertLine_Sorted(
     RENDERER *renderer, int32_t x1, int32_t y1, int32_t x2, int32_t y2,
     int32_t z, uint8_t color_idx);
-static void M_InsertSprite_Sorted(
+static void M_InsertSprite(
     RENDERER *renderer, int32_t z, int32_t x0, int32_t y0, int32_t x1,
     int32_t y1, int32_t sprite_idx, int16_t shade);
-static void M_InsertTransQuad_Sorted(
+static void M_InsertTransQuad(
     RENDERER *renderer, int32_t x, int32_t y, int32_t width, int32_t height,
     int32_t z);
-static void M_InsertTransOctagon_Sorted(
+static void M_InsertTransOctagon(
     RENDERER *renderer, const PHD_VBUF *vbuf, int16_t shade);
 
 static void M_InsertGT3_ZBuffered(
@@ -105,14 +104,6 @@ static void M_InsertGT3_ZBuffered(
 static void M_InsertGT4_ZBuffered(
     RENDERER *renderer, const PHD_VBUF *vtx0, const PHD_VBUF *vtx1,
     const PHD_VBUF *vtx2, const PHD_VBUF *vtx3, const OBJECT_TEXTURE *texture);
-static void M_InsertFlatFace3s_ZBuffered(
-    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertFlatFace4s_ZBuffered(
-    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertTexturedFace3s_ZBuffered(
-    RENDERER *renderer, const FACE3 *faces, int32_t num, SORT_TYPE sort_type);
-static void M_InsertTexturedFace4s_ZBuffered(
-    RENDERER *renderer, const FACE4 *faces, int32_t num, SORT_TYPE sort_type);
 static void M_InsertFlatRect_ZBuffered(
     RENDERER *renderer, int32_t x1, int32_t y1, int32_t x2, int32_t y2,
     int32_t z, uint8_t color_idx);
@@ -283,9 +274,10 @@ static void M_DrawPolyTextured(
 }
 
 static void M_DrawPolyFlat(
-    RENDERER *const renderer, const int32_t vtx_count, const int32_t red,
-    const int32_t green, const int32_t blue)
+    RENDERER *const renderer, const int32_t vtx_count,
+    const int32_t palette_idx)
 {
+    const RGB_888 color = Output_GetPaletteColor16(palette_idx >> 8);
     for (int32_t i = 0; i < vtx_count; i++) {
         const VERTEX_INFO *const vbuf = &m_VBuffer[i];
         GFX_3D_VERTEX *const vbuf_gl = &m_VBufferGL[i];
@@ -293,7 +285,8 @@ static void M_DrawPolyFlat(
         vbuf_gl->y = vbuf->pos.y;
         vbuf_gl->z = MAKE_DEPTH(vbuf);
         vbuf_gl->w = vbuf->rhw;
-        M_ShadeLightColor(vbuf_gl, vbuf->g, false, red, green, blue, 0xFF);
+        M_ShadeLightColor(
+            vbuf_gl, vbuf->g, false, color.r, color.g, color.b, 0xFF);
     }
     M_DrawPrimitive(renderer, GFX_3D_PRIM_TRI, m_VBufferGL, vtx_count, true);
 }
@@ -331,9 +324,13 @@ static void M_InsertPolyTextured(
 }
 
 static void M_InsertPolyFlat(
-    const int32_t vtx_count, const float z, const int32_t red,
-    const int32_t green, const int32_t blue, const int16_t poly_type)
+    const int32_t vtx_count, const float z, const int32_t palette_idx,
+    const int16_t poly_type)
 {
+    const RGB_888 color = poly_type == POLY_HWR_TRANS
+        ? (RGB_888) { 0, 0, 0 }
+        : Output_GetPaletteColor16(palette_idx >> 8);
+
     g_Sort3DPtr->_0 = g_Info3DPtr;
     g_Sort3DPtr->_1 = MAKE_ZSORT(z);
     g_Sort3DPtr++;
@@ -351,12 +348,218 @@ static void M_InsertPolyFlat(
         vbuf_gl->z = MAKE_DEPTH(vbuf);
         vbuf_gl->w = vbuf->rhw;
         M_ShadeLightColor(
-            vbuf_gl, vbuf->g, false, red, green, blue,
+            vbuf_gl, vbuf->g, false, color.r, color.g, color.b,
             poly_type == POLY_HWR_TRANS ? 0x80 : 0xFF);
     }
 
     m_HWR_VertexPtr += vtx_count;
     g_SurfaceCount++;
+}
+
+static void M_InsertFlatFace3s(
+    RENDERER *const renderer, const FACE3 *const faces, const int32_t num,
+    const SORT_TYPE sort_type)
+{
+    if (g_Config.rendering.enable_zbuffer) {
+        M_SelectTexture(renderer, -1);
+        M_EnableColorKey(renderer, false);
+    }
+
+    for (int32_t i = 0; i < num; i++) {
+        if (M_VertexBufferFull()) {
+            break;
+        }
+
+        int32_t num_points = 3;
+        const FACE3 *const face = &faces[i];
+        const PHD_VBUF *vtx[3] = {
+            &g_PhdVBuf[face->vertices[0]],
+            &g_PhdVBuf[face->vertices[1]],
+            &g_PhdVBuf[face->vertices[2]],
+        };
+
+        const int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
+        const int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
+        if (clip_and != 0) {
+            continue;
+        }
+
+        if (clip_or >= 0) {
+            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
+                continue;
+            }
+
+            for (int32_t i = 0; i < 3; i++) {
+                VERTEX_INFO *const vbuf = &m_VBuffer[i];
+                vbuf->pos.x = vtx[i]->xs;
+                vbuf->pos.y = vtx[i]->ys;
+                vbuf->pos.z = vtx[i]->zv;
+                vbuf->rhw = vtx[i]->rhw;
+                vbuf->g = vtx[i]->g;
+            }
+        } else {
+            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
+                continue;
+            }
+
+            POINT_INFO points[3];
+            for (int32_t i = 0; i < 3; i++) {
+                points[i].xv = vtx[i]->xv;
+                points[i].yv = vtx[i]->yv;
+                points[i].zv = vtx[i]->zv;
+                points[i].rhw = vtx[i]->rhw;
+                points[i].xs = vtx[i]->xs;
+                points[i].ys = vtx[i]->ys;
+                points[i].g = vtx[i]->g;
+            }
+            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
+            if (num_points == 0) {
+                continue;
+            }
+        }
+
+        if (num_points == 0) {
+            continue;
+        }
+
+        if (g_Config.rendering.enable_zbuffer) {
+            M_DrawPolyFlat(renderer, num_points, face->palette_idx);
+        } else {
+            const double zv = Render_CalculatePolyZ(
+                sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, -1.0);
+            M_InsertPolyFlat(
+                num_points, zv, face->palette_idx, POLY_HWR_GOURAUD);
+        }
+    }
+}
+
+static void M_InsertFlatFace4s(
+    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
+    const SORT_TYPE sort_type)
+{
+    if (g_Config.rendering.enable_zbuffer) {
+        M_SelectTexture(renderer, -1);
+        M_EnableColorKey(renderer, false);
+    }
+
+    for (int32_t i = 0; i < num; i++) {
+        if (M_VertexBufferFull()) {
+            break;
+        }
+
+        int32_t num_points = 4;
+        const FACE4 *const face = &faces[i];
+        const PHD_VBUF *const vtx[4] = {
+            &g_PhdVBuf[face->vertices[0]],
+            &g_PhdVBuf[face->vertices[1]],
+            &g_PhdVBuf[face->vertices[2]],
+            &g_PhdVBuf[face->vertices[3]],
+        };
+
+        const int8_t clip_or =
+            vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
+        const int8_t clip_and =
+            vtx[0]->clip & vtx[1]->clip & vtx[2]->clip & vtx[3]->clip;
+        if (clip_and != 0) {
+            continue;
+        }
+
+        if (clip_or >= 0) {
+            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
+                continue;
+            }
+
+            for (int32_t i = 0; i < 4; i++) {
+                VERTEX_INFO *const vbuf = &m_VBuffer[i];
+                vbuf->pos.x = vtx[i]->xs;
+                vbuf->pos.y = vtx[i]->ys;
+                vbuf->pos.z = vtx[i]->zv;
+                vbuf->rhw = vtx[i]->rhw;
+                vbuf->g = vtx[i]->g;
+            }
+        } else {
+            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
+                continue;
+            }
+
+            POINT_INFO points[4];
+            for (int32_t i = 0; i < 4; i++) {
+                points[i].xv = vtx[i]->xv;
+                points[i].yv = vtx[i]->yv;
+                points[i].zv = vtx[i]->zv;
+                points[i].rhw = vtx[i]->rhw;
+                points[i].xs = vtx[i]->xs;
+                points[i].ys = vtx[i]->ys;
+                points[i].g = vtx[i]->g;
+            }
+            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
+            if (num_points == 0) {
+                continue;
+            }
+        }
+
+        if (num_points == 0) {
+            continue;
+        }
+
+        if (g_Config.rendering.enable_zbuffer) {
+            M_DrawPolyFlat(renderer, num_points, face->palette_idx);
+        } else {
+            const double zv = Render_CalculatePolyZ(
+                sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, vtx[3]->zv);
+            M_InsertPolyFlat(
+                num_points, zv, face->palette_idx, POLY_HWR_GOURAUD);
+        }
+    }
+}
+
+static void M_InsertTexturedFace4s(
+    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
+    const SORT_TYPE sort_type)
+{
+    for (int32_t i = 0; i < num; i++) {
+        if (M_VertexBufferFull()) {
+            break;
+        }
+
+        const FACE4 *const face = &faces[i];
+        PHD_VBUF *const vtx[4] = {
+            &g_PhdVBuf[face->vertices[0]],
+            &g_PhdVBuf[face->vertices[1]],
+            &g_PhdVBuf[face->vertices[2]],
+            &g_PhdVBuf[face->vertices[3]],
+        };
+        const OBJECT_TEXTURE *const texture =
+            Output_GetObjectTexture(face->texture_idx);
+        for (int32_t i = 0; i < 4; i++) {
+            if (g_Config.rendering.enable_trapezoid_filter) {
+                vtx[i]->tex.z = face->texture_zw[i].z;
+                vtx[i]->tex.w = face->texture_zw[i].w;
+            } else {
+                vtx[i]->tex.z = 1.0f;
+                vtx[i]->tex.w = 1.0f;
+            }
+        }
+
+        if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
+            continue;
+        }
+
+        if (g_Config.rendering.enable_zbuffer) {
+            const TEXTURE_UV *const uv = texture->uv;
+            if (texture->draw_type != DRAW_OPAQUE) {
+                M_InsertGT4_Sorted(
+                    renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture,
+                    sort_type);
+            } else {
+                M_InsertGT4_ZBuffered(
+                    renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture);
+            }
+        } else {
+            M_InsertGT4_Sorted(
+                renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture, sort_type);
+        }
+    }
 }
 
 static void M_InsertGT3_Sorted(
@@ -527,228 +730,6 @@ static void M_InsertGT4_Sorted(
     }
 }
 
-static void M_InsertFlatFace3s_Sorted(
-    RENDERER *const renderer, const FACE3 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    for (int32_t i = 0; i < num; i++) {
-        if (M_VertexBufferFull()) {
-            break;
-        }
-
-        int32_t num_points = 3;
-        const FACE3 *const face = &faces[i];
-        const PHD_VBUF *vtx[3] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-        };
-
-        const int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
-        const int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
-        if (clip_and != 0) {
-            continue;
-        }
-
-        if (clip_or >= 0) {
-            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
-                continue;
-            }
-
-            for (int32_t i = 0; i < 3; i++) {
-                VERTEX_INFO *const vbuf = &m_VBuffer[i];
-                vbuf->pos.x = vtx[i]->xs;
-                vbuf->pos.y = vtx[i]->ys;
-                vbuf->pos.z = vtx[i]->zv;
-                vbuf->rhw = vtx[i]->rhw;
-                vbuf->g = vtx[i]->g;
-            }
-            if (clip_or > 0) {
-                num_points = Render_XYGClipper(num_points, m_VBuffer);
-            }
-        } else {
-            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
-                continue;
-            }
-
-            POINT_INFO points[3];
-            for (int32_t i = 0; i < 3; i++) {
-                points[i].xv = vtx[i]->xv;
-                points[i].yv = vtx[i]->yv;
-                points[i].zv = vtx[i]->zv;
-                points[i].rhw = vtx[i]->rhw;
-                points[i].xs = vtx[i]->xs;
-                points[i].ys = vtx[i]->ys;
-                points[i].g = vtx[i]->g;
-            }
-            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
-            if (num_points == 0) {
-                continue;
-            }
-
-            num_points = Render_XYGClipper(num_points, m_VBuffer);
-        }
-
-        if (num_points == 0) {
-            continue;
-        }
-
-        const RGB_888 color = Output_GetPaletteColor16(face->palette_idx >> 8);
-        const double zv = Render_CalculatePolyZ(
-            sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, -1.0);
-        M_InsertPolyFlat(
-            num_points, zv, color.r, color.g, color.b, POLY_HWR_GOURAUD);
-    }
-}
-
-static void M_InsertFlatFace4s_Sorted(
-    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    for (int32_t i = 0; i < num; i++) {
-        if (M_VertexBufferFull()) {
-            break;
-        }
-
-        int32_t num_points = 4;
-        const FACE4 *const face = &faces[i];
-        const PHD_VBUF *const vtx[4] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-            &g_PhdVBuf[face->vertices[3]],
-        };
-
-        const int8_t clip_or =
-            vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
-        const int8_t clip_and =
-            vtx[0]->clip & vtx[1]->clip & vtx[2]->clip & vtx[3]->clip;
-        if (clip_and != 0) {
-            continue;
-        }
-
-        if (clip_or >= 0) {
-            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
-                continue;
-            }
-
-            for (int32_t i = 0; i < 4; i++) {
-                VERTEX_INFO *const vbuf = &m_VBuffer[i];
-                vbuf->pos.x = vtx[i]->xs;
-                vbuf->pos.y = vtx[i]->ys;
-                vbuf->pos.z = vtx[i]->zv;
-                vbuf->rhw = vtx[i]->rhw;
-                vbuf->g = vtx[i]->g;
-            }
-
-            if (clip_or > 0) {
-                num_points = Render_XYGClipper(num_points, m_VBuffer);
-            }
-        } else {
-            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
-                continue;
-            }
-
-            POINT_INFO points[4];
-            for (int32_t i = 0; i < 4; i++) {
-                points[i].xv = vtx[i]->xv;
-                points[i].yv = vtx[i]->yv;
-                points[i].zv = vtx[i]->zv;
-                points[i].rhw = vtx[i]->rhw;
-                points[i].xs = vtx[i]->xs;
-                points[i].ys = vtx[i]->ys;
-                points[i].g = vtx[i]->g;
-            }
-            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
-            if (num_points == 0) {
-                continue;
-            }
-            num_points = Render_XYGClipper(num_points, m_VBuffer);
-        }
-
-        if (num_points == 0) {
-            continue;
-        }
-
-        const RGB_888 color = Output_GetPaletteColor16(face->palette_idx >> 8);
-        const double zv = Render_CalculatePolyZ(
-            sort_type, vtx[0]->zv, vtx[1]->zv, vtx[2]->zv, vtx[3]->zv);
-        M_InsertPolyFlat(
-            num_points, zv, color.r, color.g, color.b, POLY_HWR_GOURAUD);
-    }
-}
-
-static void M_InsertTexturedFace3s_Sorted(
-    RENDERER *const renderer, const FACE3 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    for (int32_t i = 0; i < num; i++) {
-        if (M_VertexBufferFull()) {
-            break;
-        }
-
-        const FACE3 *const face = &faces[i];
-        PHD_VBUF *const vtx[3] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-        };
-        for (int32_t i = 0; i < 3; i++) {
-            vtx[i]->tex.z = 1.0;
-            vtx[i]->tex.w = 1.0;
-        }
-
-        const OBJECT_TEXTURE *const texture =
-            Output_GetObjectTexture(face->texture_idx);
-        const TEXTURE_UV *const uv = texture->uv;
-
-        if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
-            continue;
-        }
-
-        M_InsertGT3_Sorted(
-            renderer, vtx[0], vtx[1], vtx[2], texture, &uv[0], &uv[1], &uv[2],
-            sort_type);
-    }
-}
-
-static void M_InsertTexturedFace4s_Sorted(
-    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    for (int32_t i = 0; i < num; i++) {
-        if (M_VertexBufferFull()) {
-            break;
-        }
-
-        const FACE4 *const face = &faces[i];
-        PHD_VBUF *const vtx[4] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-            &g_PhdVBuf[face->vertices[3]],
-        };
-        for (int32_t i = 0; i < 4; i++) {
-            if (g_Config.rendering.enable_trapezoid_filter) {
-                vtx[i]->tex.z = face->texture_zw[i].z;
-                vtx[i]->tex.w = face->texture_zw[i].w;
-            } else {
-                vtx[i]->tex.z = 1.0f;
-                vtx[i]->tex.w = 1.0f;
-            }
-        }
-
-        const OBJECT_TEXTURE *const texture =
-            Output_GetObjectTexture(face->texture_idx);
-        if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
-            continue;
-        }
-
-        M_InsertGT4_Sorted(
-            renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture, sort_type);
-    }
-}
-
 static void M_InsertFlatRect_Sorted(
     RENDERER *const renderer, int32_t x1, int32_t y1, int32_t x2, int32_t y2,
     const int32_t z, const uint8_t color_idx)
@@ -771,7 +752,6 @@ static void M_InsertFlatRect_Sorted(
     *(GFX_3D_VERTEX **)g_Info3DPtr = m_HWR_VertexPtr;
     g_Info3DPtr += sizeof(GFX_3D_VERTEX *) / sizeof(int16_t);
 
-    const RGB_888 color = Output_GetPaletteColor8(color_idx);
     const double rhw = g_RhwFactor / (double)z;
     const double sz = MAKE_DEPTH_FROM_RHW(rhw);
 
@@ -788,6 +768,7 @@ static void M_InsertFlatRect_Sorted(
         GFX_3D_VERTEX *const vbuf_gl = &m_HWR_VertexPtr[i];
         vbuf_gl->z = sz;
         vbuf_gl->w = rhw;
+        const RGB_888 color = Output_GetPaletteColor8(color_idx);
         M_ShadeColor(vbuf_gl, color.r, color.g, color.b, 0xFF);
     }
 
@@ -799,7 +780,6 @@ static void M_InsertLine_Sorted(
     RENDERER *const renderer, const int32_t x1, const int32_t y1,
     const int32_t x2, const int32_t y2, int32_t z, const uint8_t color_idx)
 {
-    const RGB_888 color = Output_GetPaletteColor8(color_idx);
     const double rhw = g_RhwFactor / (double)z;
     const double sz = MAKE_DEPTH_FROM_RHW(rhw);
 
@@ -821,6 +801,7 @@ static void M_InsertLine_Sorted(
         GFX_3D_VERTEX *const vbuf_gl = &m_HWR_VertexPtr[i];
         vbuf_gl->z = sz;
         vbuf_gl->w = rhw;
+        const RGB_888 color = Output_GetPaletteColor8(color_idx);
         M_ShadeColor(vbuf_gl, color.r, color.g, color.b, 0xFF);
     }
 
@@ -828,7 +809,7 @@ static void M_InsertLine_Sorted(
     g_SurfaceCount++;
 }
 
-static void M_InsertSprite_Sorted(
+static void M_InsertSprite(
     RENDERER *const renderer, int32_t z, int32_t x0, int32_t y0, int32_t x1,
     int32_t y1, const int32_t sprite_idx, const int16_t shade)
 {
@@ -899,7 +880,7 @@ static void M_InsertSprite_Sorted(
     Output_SetShadeEffect(old_shade);
 }
 
-static void M_InsertTransQuad_Sorted(
+static void M_InsertTransQuad(
     RENDERER *const renderer, const int32_t x, const int32_t y,
     const int32_t width, const int32_t height, const int32_t z)
 {
@@ -942,7 +923,7 @@ static void M_InsertTransQuad_Sorted(
     g_SurfaceCount++;
 }
 
-static void M_InsertTransOctagon_Sorted(
+static void M_InsertTransOctagon(
     RENDERER *const renderer, const PHD_VBUF *const vtx, const int16_t shade)
 {
     int8_t clip_or = 0x00;
@@ -985,7 +966,7 @@ static void M_InsertTransOctagon_Sorted(
     poly_z /= num_vtx;
 
     M_InsertPolyFlat(
-        num_points, (double)(poly_z - 0x20000), 0, 0, 0, POLY_HWR_TRANS);
+        num_points, (double)(poly_z - 0x20000), -1, POLY_HWR_TRANS);
 }
 
 static void M_InsertGT3_ZBuffered(
@@ -1122,160 +1103,15 @@ static void M_InsertGT4_ZBuffered(
     M_DrawPrimitive(renderer, GFX_3D_PRIM_TRI, m_VBufferGL, 4, true);
 }
 
-static void M_InsertFlatFace3s_ZBuffered(
-    RENDERER *const renderer, const FACE3 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    M_SelectTexture(renderer, -1);
-    M_EnableColorKey(renderer, false);
-
-    if (num == 0) {
-        return;
-    }
-
-    for (int32_t i = 0; i < num; i++) {
-        int32_t num_points = 3;
-        const FACE3 *const face = &faces[i];
-        PHD_VBUF *vtx[3] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-        };
-
-        const int8_t clip_or = vtx[0]->clip | vtx[1]->clip | vtx[2]->clip;
-        const int8_t clip_and = vtx[0]->clip & vtx[1]->clip & vtx[2]->clip;
-
-        if (clip_and != 0) {
-            continue;
-        }
-
-        if (clip_or >= 0) {
-            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
-                continue;
-            }
-
-            for (int32_t i = 0; i < 3; i++) {
-                VERTEX_INFO *const vbuf = &m_VBuffer[i];
-                vbuf->pos.x = vtx[i]->xs;
-                vbuf->pos.y = vtx[i]->ys;
-                vbuf->pos.z = vtx[i]->zv;
-                vbuf->rhw = vtx[i]->rhw;
-                vbuf->g = vtx[i]->g;
-            }
-        } else {
-            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
-                continue;
-            }
-
-            POINT_INFO points[3];
-            for (int32_t i = 0; i < 3; i++) {
-                points[i].xv = vtx[i]->xv;
-                points[i].yv = vtx[i]->yv;
-                points[i].zv = vtx[i]->zv;
-                points[i].rhw = vtx[i]->rhw;
-                points[i].xs = vtx[i]->xs;
-                points[i].ys = vtx[i]->ys;
-                points[i].g = vtx[i]->g;
-            }
-            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
-            if (num_points == 0) {
-                continue;
-            }
-        }
-
-        if (clip_or != 0) {
-            num_points = Render_XYGClipper(num_points, m_VBuffer);
-        }
-        if (num_points == 0) {
-            continue;
-        }
-
-        const RGB_888 color = Output_GetPaletteColor16(face->palette_idx >> 8);
-        M_DrawPolyFlat(renderer, num_points, color.r, color.g, color.b);
-    }
-}
-
-static void M_InsertFlatFace4s_ZBuffered(
-    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    M_SelectTexture(renderer, -1);
-    M_EnableColorKey(renderer, false);
-
-    if (num == 0) {
-        return;
-    }
-
-    for (int32_t i = 0; i < num; i++) {
-        int32_t num_points = 4;
-        const FACE4 *const face = &faces[i];
-        const PHD_VBUF *const vtx[4] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-            &g_PhdVBuf[face->vertices[3]],
-        };
-
-        const int8_t clip_or =
-            vtx[0]->clip | vtx[1]->clip | vtx[2]->clip | vtx[3]->clip;
-        const int8_t clip_and =
-            vtx[0]->clip & vtx[1]->clip & vtx[2]->clip & vtx[3]->clip;
-
-        if (clip_and != 0) {
-            continue;
-        }
-
-        if (clip_or >= 0) {
-            if (!VBUF_VISIBLE(*vtx[0], *vtx[1], *vtx[2])) {
-                continue;
-            }
-
-            for (int32_t i = 0; i < 4; i++) {
-                VERTEX_INFO *const vbuf = &m_VBuffer[i];
-                vbuf->pos.x = vtx[i]->xs;
-                vbuf->pos.y = vtx[i]->ys;
-                vbuf->pos.z = vtx[i]->zv;
-                vbuf->rhw = vtx[i]->rhw;
-                vbuf->g = vtx[i]->g;
-            }
-        } else {
-            if (!Render_VisibleZClip(vtx[0], vtx[1], vtx[2])) {
-                continue;
-            }
-
-            POINT_INFO points[4];
-            for (int32_t i = 0; i < 4; i++) {
-                points[i].xv = vtx[i]->xv;
-                points[i].yv = vtx[i]->yv;
-                points[i].zv = vtx[i]->zv;
-                points[i].rhw = vtx[i]->rhw;
-                points[i].xs = vtx[i]->xs;
-                points[i].ys = vtx[i]->ys;
-                points[i].g = vtx[i]->g;
-            }
-            num_points = Render_ZedClipper(num_points, points, m_VBuffer);
-            if (num_points == 0) {
-                continue;
-            }
-        }
-
-        if (clip_or != 0) {
-            num_points = Render_XYGClipper(num_points, m_VBuffer);
-        }
-        if (num_points == 0) {
-            continue;
-        }
-
-        const RGB_888 color = Output_GetPaletteColor16(face->palette_idx >> 8);
-        M_DrawPolyFlat(renderer, num_points, color.r, color.g, color.b);
-    }
-}
-
-static void M_InsertTexturedFace3s_ZBuffered(
+static void M_InsertTexturedFace3s(
     RENDERER *const renderer, const FACE3 *const faces, const int32_t num,
     const SORT_TYPE sort_type)
 {
     for (int32_t i = 0; i < num; i++) {
+        if (M_VertexBufferFull()) {
+            break;
+        }
+
         const FACE3 *const face = &faces[i];
         PHD_VBUF *const vtx[3] = {
             &g_PhdVBuf[face->vertices[0]],
@@ -1294,54 +1130,15 @@ static void M_InsertTexturedFace3s_ZBuffered(
         }
 
         const TEXTURE_UV *const uv = texture->uv;
-        if (texture->draw_type != DRAW_OPAQUE) {
-            M_InsertGT3_Sorted(
-                renderer, vtx[0], vtx[1], vtx[2], texture, &uv[0], &uv[1],
-                &uv[2], sort_type);
-        } else {
+        if (g_Config.rendering.enable_zbuffer
+            && texture->draw_type == DRAW_OPAQUE) {
             M_InsertGT3_ZBuffered(
                 renderer, vtx[0], vtx[1], vtx[2], texture, &uv[0], &uv[1],
                 &uv[2]);
-        }
-    }
-}
-
-static void M_InsertTexturedFace4s_ZBuffered(
-    RENDERER *const renderer, const FACE4 *const faces, const int32_t num,
-    const SORT_TYPE sort_type)
-{
-    for (int32_t i = 0; i < num; i++) {
-        const FACE4 *const face = &faces[i];
-        PHD_VBUF *const vtx[4] = {
-            &g_PhdVBuf[face->vertices[0]],
-            &g_PhdVBuf[face->vertices[1]],
-            &g_PhdVBuf[face->vertices[2]],
-            &g_PhdVBuf[face->vertices[3]],
-
-        };
-        const OBJECT_TEXTURE *const texture =
-            Output_GetObjectTexture(face->texture_idx);
-        for (int32_t i = 0; i < 4; i++) {
-            if (g_Config.rendering.enable_trapezoid_filter) {
-                vtx[i]->tex.z = face->texture_zw[i].z;
-                vtx[i]->tex.w = face->texture_zw[i].w;
-            } else {
-                vtx[i]->tex.z = 1.0f;
-                vtx[i]->tex.w = 1.0f;
-            }
-        }
-
-        if (texture->draw_type != DRAW_OPAQUE && g_DiscardTransparent) {
-            continue;
-        }
-
-        const TEXTURE_UV *const uv = texture->uv;
-        if (texture->draw_type != DRAW_OPAQUE) {
-            M_InsertGT4_Sorted(
-                renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture, sort_type);
         } else {
-            M_InsertGT4_ZBuffered(
-                renderer, vtx[0], vtx[1], vtx[2], vtx[3], texture);
+            M_InsertGT3_Sorted(
+                renderer, vtx[0], vtx[1], vtx[2], texture, &uv[0], &uv[1],
+                &uv[2], sort_type);
         }
     }
 }
@@ -1363,8 +1160,6 @@ static void M_InsertFlatRect_ZBuffered(
     const double rhw = g_RhwFactor / (double)z;
     const double sz = MAKE_DEPTH_FROM_RHW(rhw);
 
-    const RGB_888 color = Output_GetPaletteColor8(color_idx);
-
     m_VBufferGL[0].x = x1;
     m_VBufferGL[0].y = y1;
     m_VBufferGL[1].x = x2;
@@ -1377,6 +1172,7 @@ static void M_InsertFlatRect_ZBuffered(
         GFX_3D_VERTEX *const vbuf_gl = &m_VBufferGL[i];
         vbuf_gl->z = sz;
         vbuf_gl->w = rhw;
+        const RGB_888 color = Output_GetPaletteColor8(color_idx);
         M_ShadeColor(vbuf_gl, color.r, color.g, color.b, 0xFF);
     }
 
@@ -1396,7 +1192,6 @@ static void M_InsertLine_ZBuffered(
 
     const double rhw = g_RhwFactor / (double)z;
     const double sz = MAKE_DEPTH_FROM_RHW(rhw);
-    const RGB_888 color = Output_GetPaletteColor8(color_idx);
 
     m_VBufferGL[0].x = x1;
     m_VBufferGL[0].y = y1;
@@ -1406,6 +1201,7 @@ static void M_InsertLine_ZBuffered(
         GFX_3D_VERTEX *const vbuf_gl = &m_VBufferGL[i];
         vbuf_gl->z = sz;
         vbuf_gl->w = rhw;
+        const RGB_888 color = Output_GetPaletteColor8(color_idx);
         M_ShadeColor(vbuf_gl, color.r, color.g, color.b, 0xFF);
     }
 
@@ -1416,21 +1212,17 @@ static void M_InsertLine_ZBuffered(
 
 static void M_ResetFuncPtrs(RENDERER *const renderer)
 {
-    renderer->InsertTransQuad = M_InsertTransQuad_Sorted;
-    renderer->InsertTransOctagon = M_InsertTransOctagon_Sorted;
-    renderer->InsertSprite = M_InsertSprite_Sorted;
+    renderer->InsertFlatFace3s = M_InsertFlatFace3s;
+    renderer->InsertFlatFace4s = M_InsertFlatFace4s;
+    renderer->InsertTexturedFace3s = M_InsertTexturedFace3s;
+    renderer->InsertTexturedFace4s = M_InsertTexturedFace4s;
+    renderer->InsertTransQuad = M_InsertTransQuad;
+    renderer->InsertTransOctagon = M_InsertTransOctagon;
+    renderer->InsertSprite = M_InsertSprite;
     if (g_Config.rendering.enable_zbuffer) {
-        renderer->InsertFlatFace3s = M_InsertFlatFace3s_ZBuffered;
-        renderer->InsertFlatFace4s = M_InsertFlatFace4s_ZBuffered;
-        renderer->InsertTexturedFace3s = M_InsertTexturedFace3s_ZBuffered;
-        renderer->InsertTexturedFace4s = M_InsertTexturedFace4s_ZBuffered;
         renderer->InsertLine = M_InsertLine_ZBuffered;
         renderer->InsertFlatRect = M_InsertFlatRect_ZBuffered;
     } else {
-        renderer->InsertFlatFace3s = M_InsertFlatFace3s_Sorted;
-        renderer->InsertFlatFace4s = M_InsertFlatFace4s_Sorted;
-        renderer->InsertTexturedFace3s = M_InsertTexturedFace3s_Sorted;
-        renderer->InsertTexturedFace4s = M_InsertTexturedFace4s_Sorted;
         renderer->InsertLine = M_InsertLine_Sorted;
         renderer->InsertFlatRect = M_InsertFlatRect_Sorted;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Merges the z-buffered and sorted variants of textured/flat 3-/4-faces. It's just one additional `if` per face, no need to unroll it like this considering the majority of our performance problems stem from GPU transfers.
- Passes palette indices rather than colors to the shading functions. This is a change made in consideration to the potential 8-bit mode rendering. The shadows use a hardcoded check for `POLY_HWR_TRANS` to set themselves to black, without relying on the palette index (16-bit palettes aren't guaranteed to hold black at index 0).