### PR TITLE
cmd/flood: add room_num arg

### DIFF
--- a/docs/tr1/COMMANDS.md
+++ b/docs/tr1/COMMANDS.md
@@ -24,7 +24,9 @@ Currently supported commands:
 
 - `/flood`  
   `/drain`  
-  Floods or drains the current room at will. For when drowning is preferable to puzzles!
+- `/flood {room_num}`  
+  `/drain {room_num}`  
+  Floods or drains the chosen room at will. For when drowning is preferable to puzzles!
 
 - `/give {item_name}`  
   `/give {num} {item_name}`  

--- a/docs/tr2/COMMANDS.md
+++ b/docs/tr2/COMMANDS.md
@@ -23,7 +23,9 @@ Currently supported commands:
 
 - `/flood`  
   `/drain`  
-  Floods or drains the current room at will. For when drowning is preferable to puzzles!
+- `/flood {room_num}`  
+  `/drain {room_num}`  
+  Floods or drains the chosen room at will. For when drowning is preferable to puzzles!
 
 - `/give {item_name}`  
   `/give {num} {item_name}`  

--- a/src/libtrx/game/console/cmd/flood.c
+++ b/src/libtrx/game/console/cmd/flood.c
@@ -7,19 +7,23 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
-    if (!String_IsEmpty(ctx->args)) {
-        return CR_BAD_INVOCATION;
-    }
+    int32_t room_num;
+    if (!String_ParseInteger(ctx->args, &room_num)) {
+        if (!String_IsEmpty(ctx->args)) {
+            return CR_BAD_INVOCATION;
+        }
 
-    ITEM *const lara_item = Lara_GetItem();
-    if (lara_item == nullptr) {
-        return CR_UNAVAILABLE;
+        ITEM *const lara_item = Lara_GetItem();
+        if (lara_item == nullptr) {
+            return CR_UNAVAILABLE;
+        }
+        room_num = lara_item->room_num;
     }
 
     if (String_Equivalent(ctx->prefix, "flood")) {
-        Room_Get(lara_item->room_num)->flags |= RF_UNDERWATER;
+        Room_Get(room_num)->flags |= RF_UNDERWATER;
     } else if (String_Equivalent(ctx->prefix, "drain")) {
-        Room_Get(lara_item->room_num)->flags &= ~RF_UNDERWATER;
+        Room_Get(room_num)->flags &= ~RF_UNDERWATER;
     } else {
         return CR_UNAVAILABLE;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This lets the player flood and drain the room that they're not currently in.
I'm actually using it for something useful – i.e. testing shader-based wibble animation where I can now do `/load 1`, `/flood 2`.