### PR TITLE
tr1/level: play cutscene music normally

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed the `/pos` command not working in cutscenes
 - fixed the `/pos` command not showing demo and cutscene titles
 - fixed the embedded bats fix causing problems inside rooms with trapdoors (regression from 4.6)
+- fixed cutscene music looping (#2591, regression from 4.8)
 - removed perspective filter toggle (it had no effect; repurposed to trapezoid interpolation toggle)
 - improved camera mode navigation:
     - improved support for pivoting

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -446,7 +446,9 @@ bool Level_Initialise(
     const bool disable_music =
         level->type == GFL_TITLE && !g_Config.audio.enable_music_in_menu;
     if (level->music_track >= 0 && !disable_music) {
-        Music_Play(level->music_track, MPM_LOOPED);
+        Music_Play(
+            level->music_track,
+            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
     }
 
     Viewport_SetFOV(-1);


### PR DESCRIPTION
Resolves #2591.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures cutscene tracks are not played as looped.
