### PR TITLE
Small optimization to reduce gpu flushes

### DIFF
--- a/src/libtrx/game/level/faces.c
+++ b/src/libtrx/game/level/faces.c
@@ -1,0 +1,69 @@
+#include "game/level/common.h"
+#include "game/objects.h"
+#include "game/rooms.h"
+#include "game/types.h"
+
+#include <stdlib.h>
+
+static int M_CompareFace4s(const void *a, const void *b);
+static int M_CompareFace4s(const void *a, const void *b);
+static int M_CompareRoomSprites(const void *a, const void *b);
+static void M_SortRoomFaces(void);
+static void M_SortObjectFaces(void);
+
+static int M_CompareFace3s(const void *const a, const void *const b)
+{
+    const FACE3 *const face_a = a;
+    const FACE3 *const face_b = b;
+    return face_a->texture_idx - face_b->texture_idx;
+}
+
+static int M_CompareFace4s(const void *const a, const void *const b)
+{
+    const FACE4 *const face_a = a;
+    const FACE4 *const face_b = b;
+    return face_a->texture_idx - face_b->texture_idx;
+}
+
+static int M_CompareRoomSprites(const void *const a, const void *const b)
+{
+    const ROOM_SPRITE *const sprite_a = a;
+    const ROOM_SPRITE *const sprite_b = b;
+    return sprite_a->texture - sprite_b->texture;
+}
+
+static void M_SortRoomFaces(void)
+{
+    // sort room faces by material to reduce number of GPU flushes.
+    for (int32_t i = 0; i < Room_GetCount(); i++) {
+        ROOM *const room = Room_Get(i);
+        qsort(
+            room->mesh.face3s, room->mesh.num_face3s, sizeof(FACE3),
+            M_CompareFace3s);
+        qsort(
+            room->mesh.face4s, room->mesh.num_face4s, sizeof(FACE4),
+            M_CompareFace4s);
+        qsort(
+            room->mesh.sprites, room->mesh.num_sprites, sizeof(ROOM_SPRITE),
+            M_CompareRoomSprites);
+    }
+}
+
+static void M_SortObjectFaces(void)
+{
+    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+        const OBJECT_MESH *const mesh = Object_GetMesh(i);
+        qsort(
+            mesh->tex_face3s, mesh->num_tex_face3s, sizeof(FACE3),
+            M_CompareFace3s);
+        qsort(
+            mesh->tex_face4s, mesh->num_tex_face4s, sizeof(FACE4),
+            M_CompareFace4s);
+    }
+}
+
+void Level_LoadFaces(void)
+{
+    M_SortRoomFaces();
+    M_SortObjectFaces();
+}

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -191,6 +191,7 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_RENDERER *const renderer)
 
     renderer->vertex_stream.rendered_count = 0;
     renderer->vertex_stream.transferred = 0;
+    renderer->program.uniform_updates = 0;
 
     GFX_GL_Program_Bind(&renderer->program);
     GFX_3D_VertexStream_Bind(&renderer->vertex_stream);
@@ -232,6 +233,12 @@ void GFX_3D_Renderer_RenderEnd(GFX_3D_RENDERER *const renderer)
 {
     ASSERT(renderer != nullptr);
     M_Flush(renderer);
+#ifdef DEBUG_OPTIM
+    LOG_DEBUG(
+        "vertices: %d, bytes: %d, uniforms: %d",
+        renderer->vertex_stream.rendered_count,
+        renderer->vertex_stream.transferred, renderer->program.uniform_updates);
+#endif
 }
 
 void GFX_3D_Renderer_ClearDepth(GFX_3D_RENDERER *const renderer)

--- a/src/libtrx/gfx/gl/program.c
+++ b/src/libtrx/gfx/gl/program.c
@@ -191,6 +191,7 @@ void GFX_GL_Program_Uniform3f(
     ASSERT(program != nullptr);
     glUniform3f(loc, v0, v1, v2);
     GFX_GL_CheckError();
+    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform4f(
@@ -200,6 +201,7 @@ void GFX_GL_Program_Uniform4f(
     ASSERT(program != nullptr);
     glUniform4f(loc, v0, v1, v2, v3);
     GFX_GL_CheckError();
+    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0)
@@ -207,6 +209,7 @@ void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0)
     ASSERT(program != nullptr);
     glUniform1i(loc, v0);
     GFX_GL_CheckError();
+    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform1f(GFX_GL_PROGRAM *program, GLint loc, GLfloat v0)
@@ -214,6 +217,7 @@ void GFX_GL_Program_Uniform1f(GFX_GL_PROGRAM *program, GLint loc, GLfloat v0)
     ASSERT(program != nullptr);
     glUniform1f(loc, v0);
     GFX_GL_CheckError();
+    program->uniform_updates++;
 }
 
 void GFX_GL_Program_UniformMatrix4fv(
@@ -223,4 +227,5 @@ void GFX_GL_Program_UniformMatrix4fv(
     ASSERT(program != nullptr);
     glUniformMatrix4fv(loc, count, transpose, value);
     GFX_GL_CheckError();
+    program->uniform_updates++;
 }

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -48,6 +48,7 @@ void Level_AppendSpriteTextures(
 void Level_LoadTextures(void);
 void Level_LoadTexturePages(void);
 void Level_LoadPalettes(void);
+void Level_LoadFaces(void);
 void Level_LoadAnimCommands(void);
 void Level_LoadAnimFrames(void);
 void Level_LoadObjectsAndItems(void);

--- a/src/libtrx/include/libtrx/game/objects.h
+++ b/src/libtrx/include/libtrx/game/objects.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "objects/common.h"
+#include "objects/ids.h"
+#include "objects/names.h"
+#include "objects/setup.h"
+#include "objects/types.h"
+#include "objects/vars.h"

--- a/src/libtrx/include/libtrx/gfx/gl/program.h
+++ b/src/libtrx/include/libtrx/gfx/gl/program.h
@@ -7,6 +7,7 @@
 typedef struct {
     bool initialized;
     GLuint id;
+    int32_t uniform_updates;
 } GFX_GL_PROGRAM;
 
 bool GFX_GL_Program_Init(GFX_GL_PROGRAM *program);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -160,6 +160,7 @@ sources = [
   'game/lara/common.c',
   'game/lara/misc.c',
   'game/level/common.c',
+  'game/level/faces.c',
   'game/math/trig.c',
   'game/math/util.c',
   'game/matrix.c',

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -269,6 +269,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     Level_LoadTextures();
     Level_LoadTexturePages();
     Level_LoadPalettes();
+    Level_LoadFaces();
     Output_DownloadTextures();
 
     // Initialise the sound effects.

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -187,6 +187,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     Level_LoadTextures();
     Level_LoadTexturePages();
     Level_LoadPalettes();
+    Level_LoadFaces();
     Output_InitialiseNamedColors();
 
     Render_Reset(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This sorts the faces by their texture ID upon level load both for rooms and the objects, so that the textures do not change from face to face that often and we have less GPU flushes. Has the potential to slightly improve the frame rate in certain areas.