### PR TITLE
tr2: update gameflow properties

### DIFF
--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -2,6 +2,8 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "main_menu_picture": "data/title.pcx",
+
     "cmd_init":           {"action": "exit_to_title"},
     "cmd_title":          {"action": "noop"},
     "cmd_death_in_demo":  {"action": "exit_to_title"},

--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -3,6 +3,7 @@
     // Lines starting with double slashes are comments and are ignored.
 
     "main_menu_picture": "data/title.pcx",
+    "savegame_fmt_legacy": "savegame.%d",
 
     "cmd_init":           {"action": "exit_to_title"},
     "cmd_title":          {"action": "noop"},

--- a/data/tr2/ship/cfg/TR2X_gameflow_level.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow_level.json5
@@ -2,6 +2,7 @@
     // This file is used to enable the -l argument support.
 
     "main_menu_picture": "data/title.pcx",
+    "savegame_fmt_legacy": "savegame.%d",
 
     "cmd_init":           {"action": "exit_to_title"},
     "cmd_title":          {"action": "noop"},

--- a/data/tr2/ship/cfg/TR2X_gameflow_level.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow_level.json5
@@ -1,6 +1,8 @@
 {
     // This file is used to enable the -l argument support.
 
+    "main_menu_picture": "data/title.pcx",
+
     "cmd_init":           {"action": "exit_to_title"},
     "cmd_title":          {"action": "noop"},
     "cmd_death_in_demo":  {"action": "exit_to_title"},

--- a/docs/GAME_FLOW.md
+++ b/docs/GAME_FLOW.md
@@ -292,6 +292,11 @@ remains distinct for each game.
     </td>
   </tr>
   <tr valign="top">
+    <td><code>main_menu_picture</code></td>
+    <td>String<strong>*</strong></td>
+    <td>Path to the main menu background image.</td>
+  </tr>
+  <tr valign="top">
     <td><code>secret_track</code></td>
     <td>Integer</td>
     <td>

--- a/docs/GAME_FLOW.md
+++ b/docs/GAME_FLOW.md
@@ -297,6 +297,11 @@ remains distinct for each game.
     <td>Path to the main menu background image.</td>
   </tr>
   <tr valign="top">
+    <td><code>savegame_fmt_legacy</code></td>
+    <td>String<strong>*</strong></td>
+    <td>Path pattern to look for the original savegame files.</td>
+  </tr>
+  <tr valign="top">
     <td><code>secret_track</code></td>
     <td>Integer</td>
     <td>

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -41,6 +41,7 @@
     - improved roll support
     - expanded world bounding box by 5 tiles in each direction
     - added support for 60 FPS
+- removed the hardcoded title screen image path, replacing it with a game flow file property instead
 
 ## [0.9.2](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.1...tr2-0.9.2) - 2025-02-19
 - fixed secret rewards not handed out after loading a save (#2528, regression from 0.8)

--- a/src/libtrx/game/game_flow/common.c
+++ b/src/libtrx/game/game_flow/common.c
@@ -90,8 +90,8 @@ void GF_Shutdown(void)
     }
 
     Memory_FreePointer(&gf->main_menu_background_path);
-#if TR_VERSION == 1
     Memory_FreePointer(&gf->savegame_fmt_legacy);
+#if TR_VERSION == 1
     Memory_FreePointer(&gf->savegame_fmt_bson);
 #else
     Memory_FreePointer(&gf->settings.sfx_path);

--- a/src/libtrx/game/game_flow/common.c
+++ b/src/libtrx/game/game_flow/common.c
@@ -89,8 +89,8 @@ void GF_Shutdown(void)
         Memory_FreePointer(&gf->title_level);
     }
 
-#if TR_VERSION == 1
     Memory_FreePointer(&gf->main_menu_background_path);
+#if TR_VERSION == 1
     Memory_FreePointer(&gf->savegame_fmt_legacy);
     Memory_FreePointer(&gf->savegame_fmt_bson);
 #else

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -71,6 +71,7 @@ static void M_LoadFMV(
     void *user_arg);
 static void M_LoadFMVs(JSON_OBJECT *obj, GAME_FLOW *gf);
 static void M_LoadGlobalInjections(JSON_OBJECT *obj, GAME_FLOW *gf);
+static void M_LoadCommonRoot(JSON_OBJECT *obj, GAME_FLOW *gf);
 static void M_LoadRoot(JSON_OBJECT *obj, GAME_FLOW *gf);
 
 #if TR_VERSION == 1
@@ -78,6 +79,23 @@ static void M_LoadRoot(JSON_OBJECT *obj, GAME_FLOW *gf);
 #elif TR_VERSION == 2
     #include "./reader_tr2.def.c"
 #endif
+
+static void M_LoadCommonRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)
+{
+    const char *tmp_s =
+        JSON_ObjectGetString(obj, "main_menu_picture", JSON_INVALID_STRING);
+    if (tmp_s == JSON_INVALID_STRING) {
+        Shell_ExitSystem("'main_menu_picture' must be a string");
+    }
+    gf->main_menu_background_path = Memory_DupStr(tmp_s);
+
+    tmp_s =
+        JSON_ObjectGetString(obj, "savegame_fmt_legacy", JSON_INVALID_STRING);
+    if (tmp_s == JSON_INVALID_STRING) {
+        Shell_ExitSystem("'savegame_fmt_legacy' must be a string");
+    }
+    gf->savegame_fmt_legacy = Memory_DupStr(tmp_s);
+}
 
 static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandleIntEvent)
 {
@@ -501,6 +519,7 @@ void GF_LoadFromString(const char *const script_data)
     JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
 
     GAME_FLOW *const gf = &g_GameFlow;
+    M_LoadCommonRoot(root_obj, gf);
     M_LoadRoot(root_obj, gf);
     M_LoadLevels(root_obj, gf);
     M_LoadCutscenes(root_obj, gf);

--- a/src/libtrx/game/game_flow/reader_tr1.def.c
+++ b/src/libtrx/game/game_flow/reader_tr1.def.c
@@ -232,19 +232,6 @@ static void M_LoadRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)
     double tmp_d;
     JSON_ARRAY *tmp_arr;
 
-    tmp_s = JSON_ObjectGetString(obj, "main_menu_picture", JSON_INVALID_STRING);
-    if (tmp_s == JSON_INVALID_STRING) {
-        Shell_ExitSystem("'main_menu_picture' must be a string");
-    }
-    gf->main_menu_background_path = Memory_DupStr(tmp_s);
-
-    tmp_s =
-        JSON_ObjectGetString(obj, "savegame_fmt_legacy", JSON_INVALID_STRING);
-    if (tmp_s == JSON_INVALID_STRING) {
-        Shell_ExitSystem("'savegame_fmt_legacy' must be a string");
-    }
-    gf->savegame_fmt_legacy = Memory_DupStr(tmp_s);
-
     tmp_s = JSON_ObjectGetString(obj, "savegame_fmt_bson", JSON_INVALID_STRING);
     if (tmp_s == JSON_INVALID_STRING) {
         Shell_ExitSystem("'savegame_fmt_bson' must be a string");

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -124,12 +124,19 @@ static void M_LoadRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)
     gf->settings = m_DefaultSettings;
     M_LoadSettings(obj, &gf->settings);
 
-    const char *const tmp_s =
+    const char *tmp_s =
         JSON_ObjectGetString(obj, "main_menu_picture", JSON_INVALID_STRING);
     if (tmp_s == JSON_INVALID_STRING) {
         Shell_ExitSystem("'main_menu_picture' must be a string");
     }
     gf->main_menu_background_path = Memory_DupStr(tmp_s);
+
+    tmp_s =
+        JSON_ObjectGetString(obj, "savegame_fmt_legacy", JSON_INVALID_STRING);
+    if (tmp_s == JSON_INVALID_STRING) {
+        Shell_ExitSystem("'savegame_fmt_legacy' must be a string");
+    }
+    gf->savegame_fmt_legacy = Memory_DupStr(tmp_s);
 
     // clang-format off
     gf->demo_delay = JSON_ObjectGetInt(obj, "demo_delay", 30);

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -124,20 +124,6 @@ static void M_LoadRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)
     gf->settings = m_DefaultSettings;
     M_LoadSettings(obj, &gf->settings);
 
-    const char *tmp_s =
-        JSON_ObjectGetString(obj, "main_menu_picture", JSON_INVALID_STRING);
-    if (tmp_s == JSON_INVALID_STRING) {
-        Shell_ExitSystem("'main_menu_picture' must be a string");
-    }
-    gf->main_menu_background_path = Memory_DupStr(tmp_s);
-
-    tmp_s =
-        JSON_ObjectGetString(obj, "savegame_fmt_legacy", JSON_INVALID_STRING);
-    if (tmp_s == JSON_INVALID_STRING) {
-        Shell_ExitSystem("'savegame_fmt_legacy' must be a string");
-    }
-    gf->savegame_fmt_legacy = Memory_DupStr(tmp_s);
-
     // clang-format off
     gf->demo_delay = JSON_ObjectGetInt(obj, "demo_delay", 30);
     gf->load_save_disabled = JSON_ObjectGetBool(obj, "load_save_disabled", false);

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -124,6 +124,13 @@ static void M_LoadRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)
     gf->settings = m_DefaultSettings;
     M_LoadSettings(obj, &gf->settings);
 
+    const char *const tmp_s =
+        JSON_ObjectGetString(obj, "main_menu_picture", JSON_INVALID_STRING);
+    if (tmp_s == JSON_INVALID_STRING) {
+        Shell_ExitSystem("'main_menu_picture' must be a string");
+    }
+    gf->main_menu_background_path = Memory_DupStr(tmp_s);
+
     // clang-format off
     gf->demo_delay = JSON_ObjectGetInt(obj, "demo_delay", 30);
     gf->load_save_disabled = JSON_ObjectGetBool(obj, "load_save_disabled", false);

--- a/src/libtrx/include/libtrx/game/game_flow/types.h
+++ b/src/libtrx/include/libtrx/game/game_flow/types.h
@@ -168,6 +168,11 @@ typedef struct {
         GF_COMMAND cmd_demo_end;
     };
 
+    // savegame settings
+    struct {
+        char *savegame_fmt_legacy;
+    };
+
     // global settings
     struct {
         float demo_delay;

--- a/src/libtrx/include/libtrx/game/game_flow/types.h
+++ b/src/libtrx/include/libtrx/game/game_flow/types.h
@@ -171,6 +171,7 @@ typedef struct {
     // global settings
     struct {
         float demo_delay;
+        char *main_menu_background_path;
         bool is_demo_version;
         bool play_any_level;
         bool gym_enabled;

--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -1007,7 +1007,7 @@ bool S_FrontEndCheck(void)
     g_SavedGames = 0;
     for (int32_t i = 0; i < MAX_REQUESTER_ITEMS; i++) {
         char file_name[80];
-        sprintf(file_name, "savegame.%d", i);
+        sprintf(file_name, g_GameFlow.savegame_fmt_legacy, i);
 
         if (!File_Exists(file_name)) {
             Requester_AddItem(
@@ -1045,7 +1045,7 @@ bool S_FrontEndCheck(void)
 bool S_SaveGame(const int32_t slot_num)
 {
     char file_name[80];
-    sprintf(file_name, "savegame.%d", slot_num);
+    sprintf(file_name, g_GameFlow.savegame_fmt_legacy, slot_num);
 
     MYFILE *const fp = File_Open(file_name, FILE_OPEN_WRITE);
     if (fp == nullptr) {
@@ -1094,7 +1094,7 @@ bool S_SaveGame(const int32_t slot_num)
 bool S_LoadGame(const int32_t slot_num)
 {
     char file_name[80];
-    sprintf(file_name, "savegame.%d", slot_num);
+    sprintf(file_name, g_GameFlow.savegame_fmt_legacy, slot_num);
 
     MYFILE *const fp = File_Open(file_name, FILE_OPEN_READ);
     if (fp == nullptr) {

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -856,7 +856,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     }
 
     if (mode == INV_TITLE_MODE) {
-        Output_LoadBackgroundFromFile("data/title.pcx");
+        Output_LoadBackgroundFromFile(g_GameFlow.main_menu_background_path);
         Fader_Init(
             &ring->top_fader, FADER_BLACK, FADER_TRANSPARENT,
             INV_RING_FADE_TIME_FAST);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -53,10 +53,13 @@ static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
     return entry_a->file_index - entry_b->file_index;
 }
 
-static void M_InitialiseSoundEffects(const char *const file_name)
+static void M_InitialiseSoundEffects(const char *file_name)
 {
     BENCHMARK benchmark = Benchmark_Start();
     SAMPLE_ENTRY *entries = nullptr;
+    if (file_name == nullptr) {
+        file_name = g_GameFlow.settings.sfx_path;
+    }
     const char *full_path =
         File_GetFullPath(file_name == nullptr ? DEFAULT_SFX_PATH : file_name);
     LOG_DEBUG("Loading samples from %s", full_path);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the title screen path and savegame format string to the gameflow. It also resolves the global game flow SFX path effectively being ignored, noticeable if you change the global to something other than the default and don't specify anything different in levels.
