### PR TITLE
Preparatory work for GPU optimizations

### DIFF
--- a/data/tr1/ship/shaders/2d.glsl
+++ b/data/tr1/ship/shaders/2d.glsl
@@ -1,16 +1,10 @@
 #ifdef VERTEX
-// Vertex shader
-
-#ifdef OGL33C
-    out vec2 vertTexCoords;
-    out vec2 vertCoords;
-#else
-    varying vec2 vertTexCoords;
-    varying vec2 vertCoords;
-#endif
 
 layout(location = 0) in vec2 inPosition;
 layout(location = 1) in vec2 inTexCoords;
+
+out vec2 vertTexCoords;
+out vec2 vertCoords;
 
 void main(void) {
     gl_Position = vec4(inPosition * vec2(2.0, -2.0) + vec2(-1.0, 1.0), 0.0, 1.0);
@@ -18,8 +12,7 @@ void main(void) {
     vertTexCoords = inTexCoords;
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 #define EFFECT_NONE 0
 #define EFFECT_VIGNETTE 1
@@ -33,42 +26,29 @@ uniform bool tintEnabled;
 uniform vec3 tintColor;
 uniform int effect;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURE2D texture
-    #define TEXTURE1D texture
-
-    in vec2 vertTexCoords;
-    in vec2 vertCoords;
-    out vec4 outColor;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURE2D texture2D
-    #define TEXTURE1D texture1D
-
-    varying vec2 vertTexCoords;
-    varying vec2 vertCoords;
-#endif
+in vec2 vertTexCoords;
+in vec2 vertCoords;
+out vec4 outColor;
 
 void main(void) {
     vec2 uv = vertTexCoords;
 
     if (alphaEnabled) {
-        float alpha = TEXTURE2D(texAlpha, uv).r;
+        float alpha = texture(texAlpha, uv).r;
         if (alpha < 0.5) {
             discard;
         }
     }
 
     if (paletteEnabled) {
-        float paletteIndex = TEXTURE2D(texMain, uv).r;
-        OUTCOLOR = TEXTURE1D(texPalette, paletteIndex);
+        float paletteIndex = texture(texMain, uv).r;
+        outColor = texture(texPalette, paletteIndex);
     } else {
-        OUTCOLOR = TEXTURE2D(texMain, uv);
+        outColor = texture(texMain, uv);
     }
 
     if (tintEnabled) {
-        OUTCOLOR.rgb *= tintColor.rgb;
+        outColor.rgb *= tintColor.rgb;
     }
 
     if (effect == EFFECT_VIGNETTE) {
@@ -76,7 +56,7 @@ void main(void) {
         float y_dist = vertCoords.y - 0.5;
         float light = 256 - sqrt(x_dist * x_dist + y_dist * y_dist ) * 300.0;
         light = clamp(light, 0, 255) / 255;
-        OUTCOLOR *= vec4(light, light, light, 1);
+        outColor *= vec4(light, light, light, 1);
     }
 }
-#endif // VERTEX
+#endif

--- a/data/tr1/ship/shaders/3d.glsl
+++ b/data/tr1/ship/shaders/3d.glsl
@@ -42,14 +42,8 @@ void main(void) {
     texCoords.xy /= vertTexCoords.zw;
 
     if (texturingEnabled) {
-        if (alphaPointDiscard && smoothingEnabled) {
-            // do not use smoothing for chroma key
-            ivec2 size = textureSize(tex0, 0);
-            ivec2 texCoordsNN = ivec2(texCoords.xy * size.xy) % size.xy;
-            vec4 texel = texelFetch(tex0, texCoordsNN, 0);
-            if (texel.a == 0.0) {
-                discard;
-            }
+        if (alphaPointDiscard && smoothingEnabled && discardTranslucent(tex0, texCoords)) {
+            discard;
         }
 
         vec4 texColor = texture(tex0, texCoords.xy);

--- a/data/tr1/ship/shaders/3d.glsl
+++ b/data/tr1/ship/shaders/3d.glsl
@@ -1,5 +1,4 @@
 #ifdef VERTEX
-// Vertex shader
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec4 inTexCoords;
@@ -9,15 +8,9 @@ layout(location = 3) in vec4 inColor;
 uniform mat4 matProjection;
 uniform mat4 matModelView;
 
-#ifdef OGL33C
-    out vec4 vertColor;
-    out vec4 vertTexCoords;
-    out float vertTexZ;
-#else
-    varying vec4 vertColor;
-    varying vec4 vertTexCoords;
-    varying float vertTexZ;
-#endif
+out vec4 vertColor;
+out vec4 vertTexCoords;
+out float vertTexZ;
 
 void main(void) {
     gl_Position = matProjection * matModelView * vec4(inPosition, 1);
@@ -28,8 +21,7 @@ void main(void) {
     vertTexZ = inTexZ;
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 uniform sampler2D tex0;
 uniform bool texturingEnabled;
@@ -38,52 +30,34 @@ uniform bool alphaPointDiscard;
 uniform float alphaThreshold;
 uniform float brightnessMultiplier;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURESIZE textureSize
-    #define TEXTURE texture
-    #define TEXELFETCH texelFetch
-
-    in vec4 vertColor;
-    in vec4 vertTexCoords;
-    in float vertTexZ;
-    out vec4 OUTCOLOR;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURESIZE textureSize2D
-    #define TEXELFETCH texelFetch2D
-    #define TEXTURE texture2D
-
-    varying vec4 vertColor;
-    varying vec4 vertTexCoords;
-    varying float vertTexZ;
-#endif
+in vec4 vertColor;
+in vec4 vertTexCoords;
+in float vertTexZ;
+out vec4 outColor;
 
 void main(void) {
-    OUTCOLOR = vertColor;
+    outColor = vertColor;
 
     vec2 texCoords = vertTexCoords.xy;
     texCoords.xy /= vertTexCoords.zw;
 
     if (texturingEnabled) {
-#if defined(GL_EXT_gpu_shader4) || defined(OGL33C)
         if (alphaPointDiscard && smoothingEnabled) {
             // do not use smoothing for chroma key
-            ivec2 size = TEXTURESIZE(tex0, 0);
+            ivec2 size = textureSize(tex0, 0);
             ivec2 texCoordsNN = ivec2(texCoords.xy * size.xy) % size.xy;
-            vec4 texel = TEXELFETCH(tex0, texCoordsNN, 0);
+            vec4 texel = texelFetch(tex0, texCoordsNN, 0);
             if (texel.a == 0.0) {
                 discard;
             }
         }
-#endif
 
-        vec4 texColor = TEXTURE(tex0, texCoords.xy);
+        vec4 texColor = texture(tex0, texCoords.xy);
         if (alphaThreshold >= 0.0 && texColor.a <= alphaThreshold) {
             discard;
         }
 
-        OUTCOLOR = vec4(OUTCOLOR.rgb * texColor.rgb * brightnessMultiplier, texColor.a);
+        outColor = vec4(outColor.rgb * texColor.rgb * brightnessMultiplier, texColor.a);
     }
 }
-#endif // VERTEX
+#endif

--- a/data/tr1/ship/shaders/common.glsl
+++ b/data/tr1/ship/shaders/common.glsl
@@ -1,0 +1,8 @@
+bool discardTranslucent(sampler2D tex, vec2 uv)
+{
+    // do not use smoothing for chroma key
+    ivec2 size = textureSize(tex, 0);
+    ivec2 texCoordsNN = ivec2(uv.xy * size.xy) % size.xy;
+    vec4 texel = texelFetch(tex, texCoordsNN, 0);
+    return texel.a == 0.0;
+}

--- a/data/tr1/ship/shaders/fbo.glsl
+++ b/data/tr1/ship/shaders/fbo.glsl
@@ -1,38 +1,22 @@
 #ifdef VERTEX
-// Vertex shader
 
 layout(location = 0) in vec2 inPosition;
 
-#ifdef OGL33C
-    out vec2 vertTexCoords;
-#else
-    varying vec2 vertTexCoords;
-#endif
+out vec2 vertTexCoords;
 
 void main(void) {
     vertTexCoords = inPosition;
     gl_Position = vec4(vertTexCoords * vec2(2.0, 2.0) + vec2(-1.0, -1.0), 0.0, 1.0);
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 uniform sampler2D tex0;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURE texture
-
-    in vec2 vertTexCoords;
-    out vec4 OUTCOLOR;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURE texture2D
-
-    varying vec2 vertTexCoords;
-#endif
+in vec2 vertTexCoords;
+out vec4 outColor;
 
 void main(void) {
-    OUTCOLOR = TEXTURE(tex0, vertTexCoords);
+    outColor = texture(tex0, vertTexCoords);
 }
-#endif // VERTEX
+#endif

--- a/data/tr2/ship/shaders/2d.glsl
+++ b/data/tr2/ship/shaders/2d.glsl
@@ -1,16 +1,10 @@
 #ifdef VERTEX
-// Vertex shader
-
-#ifdef OGL33C
-    out vec2 vertTexCoords;
-    out vec2 vertCoords;
-#else
-    varying vec2 vertTexCoords;
-    varying vec2 vertCoords;
-#endif
 
 layout(location = 0) in vec2 inPosition;
 layout(location = 1) in vec2 inTexCoords;
+
+out vec2 vertTexCoords;
+out vec2 vertCoords;
 
 void main(void) {
     gl_Position = vec4(inPosition * vec2(2.0, -2.0) + vec2(-1.0, 1.0), 0.0, 1.0);
@@ -18,8 +12,7 @@ void main(void) {
     vertTexCoords = inTexCoords;
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 #define EFFECT_NONE 0
 #define EFFECT_VIGNETTE 1
@@ -33,42 +26,29 @@ uniform bool tintEnabled;
 uniform vec3 tintColor;
 uniform int effect;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURE2D texture
-    #define TEXTURE1D texture
-
-    in vec2 vertTexCoords;
-    in vec2 vertCoords;
-    out vec4 outColor;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURE2D texture2D
-    #define TEXTURE1D texture1D
-
-    varying vec2 vertTexCoords;
-    varying vec2 vertCoords;
-#endif
+in vec2 vertTexCoords;
+in vec2 vertCoords;
+out vec4 outColor;
 
 void main(void) {
     vec2 uv = vertTexCoords;
 
     if (alphaEnabled) {
-        float alpha = TEXTURE2D(texAlpha, uv).r;
+        float alpha = texture(texAlpha, uv).r;
         if (alpha < 0.5) {
             discard;
         }
     }
 
     if (paletteEnabled) {
-        float paletteIndex = TEXTURE2D(texMain, uv).r;
-        OUTCOLOR = TEXTURE1D(texPalette, paletteIndex);
+        float paletteIndex = texture(texMain, uv).r;
+        outColor = texture(texPalette, paletteIndex);
     } else {
-        OUTCOLOR = TEXTURE2D(texMain, uv);
+        outColor = texture(texMain, uv);
     }
 
     if (tintEnabled) {
-        OUTCOLOR.rgb *= tintColor.rgb;
+        outColor.rgb *= tintColor.rgb;
     }
 
     if (effect == EFFECT_VIGNETTE) {
@@ -76,7 +56,7 @@ void main(void) {
         float y_dist = vertCoords.y - 0.5;
         float light = 256 - sqrt(x_dist * x_dist + y_dist * y_dist ) * 300.0;
         light = clamp(light, 0, 255) / 255;
-        OUTCOLOR *= vec4(light, light, light, 1);
+        outColor *= vec4(light, light, light, 1);
     }
 }
-#endif // VERTEX
+#endif

--- a/data/tr2/ship/shaders/3d.glsl
+++ b/data/tr2/ship/shaders/3d.glsl
@@ -42,14 +42,8 @@ void main(void) {
     texCoords.xy /= vertTexCoords.zw;
 
     if (texturingEnabled) {
-        if (alphaPointDiscard && smoothingEnabled) {
-            // do not use smoothing for chroma key
-            ivec2 size = textureSize(tex0, 0);
-            ivec2 texCoordsNN = ivec2(texCoords.xy * size.xy) % size.xy;
-            vec4 texel = texelFetch(tex0, texCoordsNN, 0);
-            if (texel.a == 0.0) {
-                discard;
-            }
+        if (alphaPointDiscard && smoothingEnabled && discardTranslucent(tex0, texCoords)) {
+            discard;
         }
 
         vec4 texColor = texture(tex0, texCoords.xy);

--- a/data/tr2/ship/shaders/3d.glsl
+++ b/data/tr2/ship/shaders/3d.glsl
@@ -1,5 +1,4 @@
 #ifdef VERTEX
-// Vertex shader
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec4 inTexCoords;
@@ -9,15 +8,9 @@ layout(location = 3) in vec4 inColor;
 uniform mat4 matProjection;
 uniform mat4 matModelView;
 
-#ifdef OGL33C
-    out vec4 vertColor;
-    out vec4 vertTexCoords;
-    out float vertTexZ;
-#else
-    varying vec4 vertColor;
-    varying vec4 vertTexCoords;
-    varying float vertTexZ;
-#endif
+out vec4 vertColor;
+out vec4 vertTexCoords;
+out float vertTexZ;
 
 void main(void) {
     gl_Position = matProjection * matModelView * vec4(inPosition, 1);
@@ -28,8 +21,7 @@ void main(void) {
     vertTexZ = inTexZ;
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 uniform sampler2D tex0;
 uniform bool texturingEnabled;
@@ -38,52 +30,34 @@ uniform bool alphaPointDiscard;
 uniform float alphaThreshold;
 uniform float brightnessMultiplier;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURESIZE textureSize
-    #define TEXTURE texture
-    #define TEXELFETCH texelFetch
-
-    in vec4 vertColor;
-    in vec4 vertTexCoords;
-    in float vertTexZ;
-    out vec4 OUTCOLOR;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURESIZE textureSize2D
-    #define TEXELFETCH texelFetch2D
-    #define TEXTURE texture2D
-
-    varying vec4 vertColor;
-    varying vec4 vertTexCoords;
-    varying float vertTexZ;
-#endif
+in vec4 vertColor;
+in vec4 vertTexCoords;
+in float vertTexZ;
+out vec4 outColor;
 
 void main(void) {
-    OUTCOLOR = vertColor;
+    outColor = vertColor;
 
     vec2 texCoords = vertTexCoords.xy;
     texCoords.xy /= vertTexCoords.zw;
 
     if (texturingEnabled) {
-#if defined(GL_EXT_gpu_shader4) || defined(OGL33C)
         if (alphaPointDiscard && smoothingEnabled) {
             // do not use smoothing for chroma key
-            ivec2 size = TEXTURESIZE(tex0, 0);
+            ivec2 size = textureSize(tex0, 0);
             ivec2 texCoordsNN = ivec2(texCoords.xy * size.xy) % size.xy;
-            vec4 texel = TEXELFETCH(tex0, texCoordsNN, 0);
+            vec4 texel = texelFetch(tex0, texCoordsNN, 0);
             if (texel.a == 0.0) {
                 discard;
             }
         }
-#endif
 
-        vec4 texColor = TEXTURE(tex0, texCoords.xy);
+        vec4 texColor = texture(tex0, texCoords.xy);
         if (alphaThreshold >= 0.0 && texColor.a <= alphaThreshold) {
             discard;
         }
 
-        OUTCOLOR = vec4(OUTCOLOR.rgb * texColor.rgb * brightnessMultiplier, texColor.a);
+        outColor = vec4(outColor.rgb * texColor.rgb * brightnessMultiplier, texColor.a);
     }
 }
-#endif // VERTEX
+#endif

--- a/data/tr2/ship/shaders/common.glsl
+++ b/data/tr2/ship/shaders/common.glsl
@@ -1,0 +1,8 @@
+bool discardTranslucent(sampler2D tex, vec2 uv)
+{
+    // do not use smoothing for chroma key
+    ivec2 size = textureSize(tex, 0);
+    ivec2 texCoordsNN = ivec2(uv.xy * size.xy) % size.xy;
+    vec4 texel = texelFetch(tex, texCoordsNN, 0);
+    return texel.a == 0.0;
+}

--- a/data/tr2/ship/shaders/fade.glsl
+++ b/data/tr2/ship/shaders/fade.glsl
@@ -1,5 +1,4 @@
 #ifdef VERTEX
-// Vertex shader
 
 layout(location = 0) in vec2 inPosition;
 
@@ -7,19 +6,12 @@ void main(void) {
     gl_Position = vec4(inPosition * vec2(2.0, -2.0) + vec2(-1.0, 1.0), 0.0, 1.0);
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 uniform float opacity;
-
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    out vec4 outColor;
-#else
-    #define OUTCOLOR gl_FragColor
-#endif
+out vec4 outColor;
 
 void main(void) {
-    OUTCOLOR = vec4(0, 0, 0, opacity);
+    outColor = vec4(0, 0, 0, opacity);
 }
-#endif // VERTEX
+#endif

--- a/data/tr2/ship/shaders/fbo.glsl
+++ b/data/tr2/ship/shaders/fbo.glsl
@@ -1,38 +1,22 @@
 #ifdef VERTEX
-// Vertex shader
 
 layout(location = 0) in vec2 inPosition;
 
-#ifdef OGL33C
-    out vec2 vertTexCoords;
-#else
-    varying vec2 vertTexCoords;
-#endif
+out vec2 vertTexCoords;
 
 void main(void) {
     vertTexCoords = inPosition;
     gl_Position = vec4(vertTexCoords * vec2(2.0, 2.0) + vec2(-1.0, -1.0), 0.0, 1.0);
 }
 
-#else
-// Fragment shader
+#elif defined(FRAGMENT)
 
 uniform sampler2D tex0;
 
-#ifdef OGL33C
-    #define OUTCOLOR outColor
-    #define TEXTURE texture
-
-    in vec2 vertTexCoords;
-    out vec4 OUTCOLOR;
-#else
-    #define OUTCOLOR gl_FragColor
-    #define TEXTURE texture2D
-
-    varying vec2 vertTexCoords;
-#endif
+in vec2 vertTexCoords;
+out vec4 outColor;
 
 void main(void) {
-    OUTCOLOR = TEXTURE(tex0, vertTexCoords);
+    outColor = texture(tex0, vertTexCoords);
 }
-#endif // VERTEX
+#endif

--- a/src/libtrx/benchmark.c
+++ b/src/libtrx/benchmark.c
@@ -6,7 +6,7 @@
 
 static void M_Log(
     BENCHMARK *const b, const char *file, int32_t line, const char *func,
-    Uint64 current, const char *message)
+    Uint64 current, const char *message, const bool closing)
 {
     const Uint64 freq = SDL_GetPerformanceFrequency();
     const double elapsed_start =
@@ -14,7 +14,14 @@ static void M_Log(
     const double elapsed_last =
         (double)(current - b->last) * 1000.0 / (double)freq;
 
-    if (b->last != b->start) {
+    if (closing) {
+        if (message == nullptr) {
+            Log_Message(file, line, func, "took %.02f ms", elapsed_start);
+        } else {
+            Log_Message(
+                file, line, func, "%s: took %.02f ms", message, elapsed_start);
+        }
+    } else {
         if (message == nullptr) {
             Log_Message(
                 file, line, func, "took %.02f ms (%.02f ms)", elapsed_start,
@@ -23,14 +30,6 @@ static void M_Log(
             Log_Message(
                 file, line, func, "%s: took %.02f ms (%.02f ms)", message,
                 elapsed_start, elapsed_last);
-        }
-    } else {
-        if (message == nullptr) {
-            Log_Message(file, line, func, "took %.02f ms", elapsed_start);
-        } else {
-            Log_Message(
-                file, line, func, "%s: took %.02f ms (%.02f ms)", message,
-                elapsed_start);
         }
     }
 }
@@ -49,7 +48,7 @@ void Benchmark_Tick_Impl(
     const char *const func, const char *const message)
 {
     const Uint64 current = SDL_GetPerformanceCounter();
-    M_Log(b, file, line, func, current, message);
+    M_Log(b, file, line, func, current, message, false);
     b->last = current;
 }
 
@@ -57,5 +56,6 @@ void Benchmark_End_Impl(
     BENCHMARK *b, const char *const file, const int32_t line,
     const char *const func, const char *const message)
 {
-    Benchmark_Tick_Impl(b, file, line, func, message);
+    const Uint64 current = SDL_GetPerformanceCounter();
+    M_Log(b, file, line, func, current, message, true);
 }

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -1,5 +1,6 @@
 #include "game/phase/executor.h"
 
+#include "benchmark.h"
 #include "config.h"
 #include "game/clock.h"
 #include "game/console/common.h"
@@ -11,7 +12,9 @@
 #include "game/savegame.h"
 #include "game/shell.h"
 #include "game/text.h"
+#include "gfx/gl/track.h"
 
+#define DEBUG_OPTIM 0
 #define MAX_PHASES 10
 
 static bool m_Exiting;
@@ -61,6 +64,9 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
 static void M_Draw(PHASE *const phase)
 {
     Output_BeginScene();
+#if DEBUG_OPTIM
+    BENCHMARK benchmark = Benchmark_Start();
+#endif
     if (phase != nullptr && phase->draw != nullptr) {
         phase->draw(phase);
     }
@@ -71,6 +77,15 @@ static void M_Draw(PHASE *const phase)
     Fader_Draw(&m_ExitFader);
 
     Output_EndScene();
+
+#if DEBUG_OPTIM
+    char buffer[80];
+    const GFX_METRICS metrics = GFX_Track_GetMetrics();
+    sprintf(
+        buffer, "%.03f KB T:%d U:%d", metrics.buffer_total_bytes / 1024.0f,
+        metrics.buffer_transfer_count, metrics.uniform_changes);
+    Benchmark_End(&benchmark, buffer);
+#endif
 }
 
 static int32_t M_Wait(PHASE *const phase)

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -189,10 +189,6 @@ void GFX_3D_Renderer_RenderBegin(GFX_3D_RENDERER *const renderer)
 {
     ASSERT(renderer != nullptr);
 
-    renderer->vertex_stream.rendered_count = 0;
-    renderer->vertex_stream.transferred = 0;
-    renderer->program.uniform_updates = 0;
-
     GFX_GL_Program_Bind(&renderer->program);
     GFX_3D_VertexStream_Bind(&renderer->vertex_stream);
     GFX_GL_Sampler_Bind(&renderer->sampler, 0);
@@ -233,12 +229,6 @@ void GFX_3D_Renderer_RenderEnd(GFX_3D_RENDERER *const renderer)
 {
     ASSERT(renderer != nullptr);
     M_Flush(renderer);
-#ifdef DEBUG_OPTIM
-    LOG_DEBUG(
-        "vertices: %d, bytes: %d, uniforms: %d",
-        renderer->vertex_stream.rendered_count,
-        renderer->vertex_stream.transferred, renderer->program.uniform_updates);
-#endif
 }
 
 void GFX_3D_Renderer_ClearDepth(GFX_3D_RENDERER *const renderer)

--- a/src/libtrx/gfx/3d/vertex_stream.c
+++ b/src/libtrx/gfx/3d/vertex_stream.c
@@ -37,8 +37,6 @@ void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *const vertex_stream)
     vertex_stream->prim_type = GFX_3D_PRIM_TRI;
     vertex_stream->buffer_size =
         M_PREALLOC_VERTEX_COUNT * sizeof(GFX_3D_VERTEX);
-    vertex_stream->rendered_count = 0;
-    vertex_stream->transferred = 0;
     vertex_stream->pending_vertices.count = 0;
     vertex_stream->pending_vertices.capacity = M_PREALLOC_VERTEX_COUNT;
     vertex_stream->pending_vertices.data = Memory_Alloc(
@@ -166,19 +164,16 @@ void GFX_3D_VertexStream_RenderPending(
         GFX_GL_Buffer_Data(
             &vertex_stream->buffer, buffer_size, nullptr, GL_STREAM_DRAW);
         vertex_stream->buffer_size = buffer_size;
-        vertex_stream->transferred += buffer_size;
     }
 
     GFX_GL_Buffer_SubData(
         &vertex_stream->buffer, 0, buffer_size,
         vertex_stream->pending_vertices.data);
-    vertex_stream->transferred += buffer_size;
 
     glDrawArrays(
         GL_PRIM_MODES[vertex_stream->prim_type], 0,
         vertex_stream->pending_vertices.count);
     GFX_GL_CheckError();
 
-    vertex_stream->rendered_count += vertex_stream->pending_vertices.count;
     vertex_stream->pending_vertices.count = 0;
 }

--- a/src/libtrx/gfx/context.c
+++ b/src/libtrx/gfx/context.c
@@ -36,7 +36,6 @@ typedef struct {
 static GFX_CONTEXT m_Context = {};
 
 static bool M_IsExtensionSupported(const char *name);
-static void M_CheckExtensionSupport(const char *name);
 
 static bool M_IsExtensionSupported(const char *name)
 {
@@ -54,12 +53,6 @@ static bool M_IsExtensionSupported(const char *name)
         }
     }
     return false;
-}
-
-static void M_CheckExtensionSupport(const char *name)
-{
-    LOG_INFO(
-        "%s supported: %s", name, M_IsExtensionSupported(name) ? "yes" : "no");
 }
 
 void GFX_Context_SwitchToWindowViewport(void)
@@ -132,12 +125,6 @@ bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend)
             "Can't activate OpenGL context: %s", SDL_GetError());
     }
 
-    // Instruct GLEW to load non-Core Profile extensions with OpenGL 2.1,
-    // as we rely on `GL_ARB_explicit_attrib_location` and
-    // `GL_EXT_gpu_shader4`.
-    if (m_Context.config.backend == GFX_GL_21) {
-        glewExperimental = GL_TRUE; // Global state
-    }
     if (glewInit() != GLEW_OK) {
         Shell_ExitSystem("Can't initialize GLEW for OpenGL extension loading");
     }
@@ -151,12 +138,6 @@ bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend)
         LOG_INFO("Shading version string: %s", shading_ver);
     } else {
         GFX_GL_CheckError();
-    }
-
-    // Check the availability of non-Core Profile extensions for OpenGL 2.1
-    if (m_Context.config.backend == GFX_GL_21) {
-        M_CheckExtensionSupport("GL_ARB_explicit_attrib_location");
-        M_CheckExtensionSupport("GL_EXT_gpu_shader4");
     }
 
     glClearColor(0, 0, 0, 0);

--- a/src/libtrx/gfx/gl/buffer.c
+++ b/src/libtrx/gfx/gl/buffer.c
@@ -1,6 +1,7 @@
 #include "gfx/gl/buffer.h"
 
 #include "debug.h"
+#include "gfx/gl/track.h"
 #include "gfx/gl/utils.h"
 
 void GFX_GL_Buffer_Init(GFX_GL_BUFFER *buf, GLenum target)
@@ -35,7 +36,7 @@ void GFX_GL_Buffer_Data(
 {
     ASSERT(buf != nullptr);
     ASSERT(buf->initialized);
-    glBufferData(buf->target, size, data, usage);
+    GFX_TRACK_DATA(glBufferData, buf->target, size, data, usage);
     GFX_GL_CheckError();
 }
 
@@ -44,7 +45,7 @@ void GFX_GL_Buffer_SubData(
 {
     ASSERT(buf != nullptr);
     ASSERT(buf->initialized);
-    glBufferSubData(buf->target, offset, size, data);
+    GFX_TRACK_SUBDATA(glBufferSubData, buf->target, offset, size, data);
     GFX_GL_CheckError();
 }
 

--- a/src/libtrx/gfx/gl/program.c
+++ b/src/libtrx/gfx/gl/program.c
@@ -44,12 +44,22 @@ char *GFX_GL_Program_PreprocessShader(
 {
     ASSERT(content != nullptr);
 
+    char *common = nullptr;
+    File_Load("shaders/common.glsl", &common, nullptr);
+
+    const char *version_ogl21 =
+        "#version 120\n"
+        "#extension GL_ARB_explicit_attrib_location: enable\n"
+        "#extension GL_EXT_gpu_shader4: enable\n";
     const char *version_ogl33c = "#version 330 core\n";
     const char *define_vertex = "#define VERTEX\n";
     const char *define_fragment = "#define FRAGMENT\n";
     const char *define_ogl33c = "#define OGL33C\n";
 
     size_t bufsize = strlen(content) + 1;
+    if (common != nullptr) {
+        bufsize += strlen(common);
+    }
 
     if (backend == GFX_GL_33C) {
         bufsize += strlen(version_ogl33c);
@@ -63,14 +73,13 @@ char *GFX_GL_Program_PreprocessShader(
     }
 
     char *processed_content = Memory_Alloc(bufsize);
-    if (!processed_content) {
-        return nullptr;
-    }
-    processed_content[0] = '\0';
-
     if (backend == GFX_GL_33C) {
         strcpy(processed_content, version_ogl33c);
         strcat(processed_content, define_ogl33c);
+    }
+
+    if (common != nullptr) {
+        strcat(processed_content, common);
     }
 
     if (type == GL_VERTEX_SHADER) {
@@ -80,6 +89,8 @@ char *GFX_GL_Program_PreprocessShader(
     }
 
     strcat(processed_content, content);
+
+    Memory_FreePointer(&common);
     return processed_content;
 }
 

--- a/src/libtrx/gfx/gl/program.c
+++ b/src/libtrx/gfx/gl/program.c
@@ -3,6 +3,7 @@
 #include "debug.h"
 #include "filesystem.h"
 #include "game/shell.h"
+#include "gfx/gl/track.h"
 #include "gfx/gl/utils.h"
 #include "log.h"
 #include "memory.h"
@@ -189,9 +190,8 @@ void GFX_GL_Program_Uniform3f(
     GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
 {
     ASSERT(program != nullptr);
-    glUniform3f(loc, v0, v1, v2);
+    GFX_TRACK_UNIFORM(glUniform3f, loc, v0, v1, v2);
     GFX_GL_CheckError();
-    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform4f(
@@ -199,25 +199,30 @@ void GFX_GL_Program_Uniform4f(
     GLfloat v3)
 {
     ASSERT(program != nullptr);
-    glUniform4f(loc, v0, v1, v2, v3);
+    GFX_TRACK_UNIFORM(glUniform4f, loc, v0, v1, v2, v3);
     GFX_GL_CheckError();
-    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0)
 {
     ASSERT(program != nullptr);
-    glUniform1i(loc, v0);
+    GFX_TRACK_UNIFORM(glUniform1i, loc, v0);
     GFX_GL_CheckError();
-    program->uniform_updates++;
 }
 
 void GFX_GL_Program_Uniform1f(GFX_GL_PROGRAM *program, GLint loc, GLfloat v0)
 {
     ASSERT(program != nullptr);
-    glUniform1f(loc, v0);
+    GFX_TRACK_UNIFORM(glUniform1f, loc, v0);
     GFX_GL_CheckError();
-    program->uniform_updates++;
+}
+
+void GFX_GL_Program_Uniform2f(
+    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1)
+{
+    ASSERT(program != nullptr);
+    GFX_TRACK_UNIFORM(glUniform2f, loc, v0, v1);
+    GFX_GL_CheckError();
 }
 
 void GFX_GL_Program_UniformMatrix4fv(
@@ -225,7 +230,6 @@ void GFX_GL_Program_UniformMatrix4fv(
     const GLfloat *value)
 {
     ASSERT(program != nullptr);
-    glUniformMatrix4fv(loc, count, transpose, value);
+    GFX_TRACK_UNIFORM(glUniformMatrix4fv, loc, count, transpose, value);
     GFX_GL_CheckError();
-    program->uniform_updates++;
 }

--- a/src/libtrx/gfx/gl/program.c
+++ b/src/libtrx/gfx/gl/program.c
@@ -44,12 +44,9 @@ char *GFX_GL_Program_PreprocessShader(
 {
     ASSERT(content != nullptr);
 
-    const char *version_ogl21 =
-        "#version 120\n"
-        "#extension GL_ARB_explicit_attrib_location: enable\n"
-        "#extension GL_EXT_gpu_shader4: enable\n";
     const char *version_ogl33c = "#version 330 core\n";
     const char *define_vertex = "#define VERTEX\n";
+    const char *define_fragment = "#define FRAGMENT\n";
     const char *define_ogl33c = "#define OGL33C\n";
 
     size_t bufsize = strlen(content) + 1;
@@ -57,12 +54,12 @@ char *GFX_GL_Program_PreprocessShader(
     if (backend == GFX_GL_33C) {
         bufsize += strlen(version_ogl33c);
         bufsize += strlen(define_ogl33c);
-    } else {
-        bufsize += strlen(version_ogl21);
     }
 
     if (type == GL_VERTEX_SHADER) {
         bufsize += strlen(define_vertex);
+    } else if (type == GL_FRAGMENT_SHADER) {
+        bufsize += strlen(define_fragment);
     }
 
     char *processed_content = Memory_Alloc(bufsize);
@@ -74,12 +71,12 @@ char *GFX_GL_Program_PreprocessShader(
     if (backend == GFX_GL_33C) {
         strcpy(processed_content, version_ogl33c);
         strcat(processed_content, define_ogl33c);
-    } else {
-        strcpy(processed_content, version_ogl21);
     }
 
     if (type == GL_VERTEX_SHADER) {
         strcat(processed_content, define_vertex);
+    } else if (type == GL_FRAGMENT_SHADER) {
+        strcat(processed_content, define_fragment);
     }
 
     strcat(processed_content, content);

--- a/src/libtrx/gfx/gl/track.c
+++ b/src/libtrx/gfx/gl/track.c
@@ -1,0 +1,13 @@
+#include "gfx/gl/track.h"
+
+GFX_METRICS g_GFX_Metrics;
+
+void GFX_Track_Reset(void)
+{
+    g_GFX_Metrics = (GFX_METRICS) { 0 };
+}
+
+GFX_METRICS GFX_Track_GetMetrics(void)
+{
+    return g_GFX_Metrics;
+}

--- a/src/libtrx/include/libtrx/gfx/3d/vertex_stream.h
+++ b/src/libtrx/include/libtrx/gfx/3d/vertex_stream.h
@@ -34,8 +34,6 @@ typedef struct {
         size_t count;
         size_t capacity;
     } pending_vertices;
-    size_t rendered_count;
-    size_t transferred;
 } GFX_3D_VERTEX_STREAM;
 
 void GFX_3D_VertexStream_Init(GFX_3D_VERTEX_STREAM *vertex_stream);

--- a/src/libtrx/include/libtrx/gfx/common.h
+++ b/src/libtrx/include/libtrx/gfx/common.h
@@ -15,6 +15,5 @@ typedef enum {
 
 typedef enum {
     GFX_GL_INVALID_BACKEND,
-    GFX_GL_21,
     GFX_GL_33C,
 } GFX_GL_BACKEND;

--- a/src/libtrx/include/libtrx/gfx/gl/program.h
+++ b/src/libtrx/include/libtrx/gfx/gl/program.h
@@ -7,7 +7,6 @@
 typedef struct {
     bool initialized;
     GLuint id;
-    int32_t uniform_updates;
 } GFX_GL_PROGRAM;
 
 bool GFX_GL_Program_Init(GFX_GL_PROGRAM *program);

--- a/src/libtrx/include/libtrx/gfx/gl/track.h
+++ b/src/libtrx/include/libtrx/gfx/gl/track.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+    int32_t buffer_transfer_count;
+    int32_t buffer_total_bytes;
+    int32_t uniform_changes;
+} GFX_METRICS;
+
+extern GFX_METRICS g_GFX_Metrics;
+
+#define GFX_TRACK_UNIFORM(fn, ...)                                             \
+    do {                                                                       \
+        g_GFX_Metrics.uniform_changes++;                                       \
+        fn(__VA_ARGS__);                                                       \
+    } while (0);
+
+#define GFX_TRACK_DATA(fn, a, b, c, d)                                         \
+    do {                                                                       \
+        g_GFX_Metrics.buffer_total_bytes += b;                                 \
+        g_GFX_Metrics.buffer_transfer_count++;                                 \
+        fn(a, b, c, d);                                                        \
+    } while (0);
+
+#define GFX_TRACK_SUBDATA(fn, a, b, c, d)                                      \
+    do {                                                                       \
+        g_GFX_Metrics.buffer_total_bytes += c;                                 \
+        g_GFX_Metrics.buffer_transfer_count++;                                 \
+        fn(a, b, c, d);                                                        \
+    } while (0);
+
+void GFX_Track_Reset(void);
+GFX_METRICS GFX_Track_GetMetrics(void);

--- a/src/libtrx/include/libtrx/gfx/gl/utils.h
+++ b/src/libtrx/include/libtrx/gfx/gl/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../log.h"
+#include "track.h"
 
 #include <GL/glew.h>
 

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -210,6 +210,7 @@ sources = [
   'gfx/gl/buffer.c',
   'gfx/gl/program.c',
   'gfx/gl/sampler.c',
+  'gfx/gl/track.c',
   'gfx/gl/texture.c',
   'gfx/gl/utils.c',
   'gfx/gl/vertex_array.c',

--- a/src/libtrx/strings/common.c
+++ b/src/libtrx/strings/common.c
@@ -307,7 +307,7 @@ char *String_Format(const char *const fmt, ...)
     va_list args;
     va_start(args, fmt);
 
-    int len = vsnprintf(NULL, 0, fmt, args);
+    int len = vsnprintf(nullptr, 0, fmt, args);
     if (len < 0) {
         va_end(args);
         return nullptr;

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -9,6 +9,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/gfx/gl/track.h>
 #include <libtrx/log.h>
 
 #include <string.h>
@@ -263,6 +264,7 @@ void S_Output_DisableDepthTest(void)
 void S_Output_RenderBegin(void)
 {
     GFX_Context_Clear();
+    GFX_Track_Reset();
     S_Output_DrawBackdropSurface();
     GFX_3D_Renderer_RenderBegin(m_Renderer3D);
     GFX_3D_Renderer_SetTextureFilter(

--- a/src/tr1/specific/s_shell.c
+++ b/src/tr1/specific/s_shell.c
@@ -221,12 +221,6 @@ void Shell_ProcessEvents(void)
 static void M_SetGLBackend(const GFX_GL_BACKEND backend)
 {
     switch (backend) {
-    case GFX_GL_21:
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
-        break;
-
     case GFX_GL_33C:
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
@@ -255,7 +249,6 @@ void S_Shell_CreateWindow(void)
     const GFX_GL_BACKEND backends_to_try[] = {
         // clang-format off
         GFX_GL_33C,
-        GFX_GL_21,
         GFX_GL_INVALID_BACKEND, // guard
         // clang-format on
     };

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -10,6 +10,7 @@
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/gfx/fade/fade_renderer.h>
+#include <libtrx/gfx/gl/track.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 #include <libtrx/utils.h>
@@ -202,6 +203,7 @@ void Render_SetupDisplay(
 void Render_BeginScene(void)
 {
     GFX_Context_Clear();
+    GFX_Track_Reset();
     RENDERER *const r = M_GetRenderer();
     r->BeginScene(r);
     M_ResetPolyList();

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -76,12 +76,6 @@ static void M_ResetPolyList(void)
 static void M_SetGLBackend(const GFX_GL_BACKEND backend)
 {
     switch (backend) {
-    case GFX_GL_21:
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
-        break;
-
     case GFX_GL_33C:
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
@@ -101,7 +95,6 @@ void Render_Init(void)
     const GFX_GL_BACKEND backends_to_try[] = {
         // clang-format off
         GFX_GL_33C,
-        GFX_GL_21,
         GFX_GL_INVALID_BACKEND, // guard
         // clang-format on
     };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the support for OpenGL 2.1 on the grounds:
- according to various GitHub contributors, it has never worked anyway: #327 #1366 #685 
- I am planning to use a 2D texture array for storing the texture atlas as part of optimizing our engine, and that is only available in OpenGL 3.2 +.

Other goodies include improving benchmark output formatting, and adding a way to share code between various shaders.