### PR TITLE
tr2/objects/xian: fix Xian warriors twitching in 60 fps

### DIFF
--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -69,6 +69,8 @@ typedef struct {
     uint16_t pad : 7; // 0x0200…0x8000
 #endif
 
+    bool enable_interpolation;
+
     struct {
         struct {
             XYZ_32 pos;

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -71,6 +71,7 @@ void Item_Initialise(int16_t item_num)
     item->priv = nullptr;
     item->carried_item = nullptr;
     item->enable_shadow = true;
+    item->enable_interpolation = true;
 
     if (item->flags & IF_INVISIBLE) {
         item->status = IS_INVISIBLE;

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -93,6 +93,7 @@ void Item_Initialise(const int16_t item_num)
     item->collidable = 1;
     item->looked_at = 0;
     item->killed = 0;
+    item->enable_interpolation = true;
 
     if ((item->flags & IF_INVISIBLE) != 0) {
         item->status = IS_INVISIBLE;
@@ -360,6 +361,7 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate)
     // interpolated
     if (item != g_LaraItem
         && (!item->active || item->status != IS_ACTIVE
+            || !item->enable_interpolation
             || !Object_Get(item->object_id)->enable_interpolation)) {
         *rate = denominator;
         return numerator;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -12,6 +12,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/interpolation.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -120,6 +121,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points <= 0) {
         item->current_anim_state = XIAN_KNIGHT_STATE_DEATH;
         item->mesh_bits >>= 1;
+        item->enable_interpolation = false;
         if (item->mesh_bits == 0) {
             Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
             item->mesh_bits = -1;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -11,6 +11,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/interpolation.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -157,6 +158,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points <= 0) {
         item->current_anim_state = XIAN_SPEARMAN_STATE_DEATH;
         item->mesh_bits >>= 1;
+        item->enable_interpolation = false;
         if (item->mesh_bits == 0) {
             Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
             item->mesh_bits = -1;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2644.