### PR TITLE
tr1/savegame: fix removing requester heading early

### DIFF
--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -176,7 +176,7 @@ static void M_RemoveAllText(void)
     }
     Requester_Shutdown(&m_SelectLevelRequester);
     Requester_Shutdown(&m_NewGameRequester);
-    Requester_ClearTextstrings(&g_SavegameRequester);
+    Requester_Shutdown(&g_SavegameRequester);
 }
 
 static void M_Close(INVENTORY_ITEM *inv_item)

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -646,7 +646,7 @@ void Savegame_ScanSavedGames(void)
 
 void Savegame_FillAvailableSaves(REQUEST_INFO *req)
 {
-    Requester_Shutdown(req);
+    Requester_ClearTextstrings(req);
     Requester_Init(req, Savegame_GetSlotCount());
 
     for (int i = 0; i < req->max_items; i++) {


### PR DESCRIPTION
Resolves #2649.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the full savegame requester shutdown to the passport control when other text is being closed rather than when present saves are filled.
