### PR TITLE
tr1/savegame_bson: handle Lara animation shift

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fixed the `/pos` command not showing demo and cutscene titles
 - fixed the embedded bats fix causing problems inside rooms with trapdoors (regression from 4.6)
 - fixed cutscene music looping (#2591, regression from 4.8)
+- fixed saves created before version 2.15 causing a crash on load (#2654, regression from 4.8)
 - removed perspective filter toggle (it had no effect; repurposed to trapezoid interpolation toggle)
 - improved camera mode navigation:
     - improved support for pivoting

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -542,6 +542,12 @@ static bool M_LoadItems(JSON_ARRAY *items_arr, uint16_t header_version)
                 JSON_ObjectGetInt(item_obj, "anim_num", item->anim_num);
             item->frame_num =
                 JSON_ObjectGetInt(item_obj, "frame_num", item->frame_num);
+
+            // Prevent issues with pre-injection saves and Lara's enhanced
+            // animation set.
+            if (item->object_id == O_LARA && item->anim_num < obj->anim_idx) {
+                item->anim_num += obj->anim_idx;
+            }
         }
 
         if (obj->save_hitpoints) {


### PR DESCRIPTION
Resolves #2654.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Prior to 4.8, Lara's legacy animation set could still be referenced from old savegames, but the case now is that only applicable animations are setup during level load, so after injections have reset the Lara object with the new values. This update shifts Lara's animation index to match her object if detected on load; a similar approach is already in place for TombATI saves.