### PR TITLE
tr2/level: pre-load default statistics

### DIFF
--- a/src/tr2/decomp/savegame.c
+++ b/src/tr2/decomp/savegame.c
@@ -794,6 +794,9 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         start->small_medipacks = 0;
         g_GF_RemoveAmmo = false;
     }
+
+    const STATS_COMMON default_stats = Savegame_GetDefaultStats(level);
+    start->stats.max_secret_count = default_stats.max_secret_count;
 }
 
 void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)

--- a/src/tr2/decomp/savegame.h
+++ b/src/tr2/decomp/savegame.h
@@ -25,3 +25,6 @@ void GetSavedGamesList(REQUEST_INFO *req);
 bool S_FrontEndCheck(void);
 bool S_SaveGame(int32_t slot_num);
 bool S_LoadGame(int32_t slot_num);
+
+void Savegame_SetDefaultStats(const GF_LEVEL *level, STATS_COMMON stats);
+STATS_COMMON Savegame_GetDefaultStats(const GF_LEVEL *level);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -47,6 +47,90 @@ static int32_t M_CompareSampleOffsets(const void *a, const void *b);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_InitialiseSoundEffects(const char *const file_name);
 static void M_CompleteSetup(const GF_LEVEL *level);
+static bool M_SkimLevel(VFILE *file);
+
+static bool M_SkimLevel(VFILE *const file)
+{
+#define TRY_OR_FAIL(call)                                                      \
+    if (!call) {                                                               \
+        return false;                                                          \
+    }
+#define TRY_OR_FAIL_ARR_S32(size)                                              \
+    {                                                                          \
+        int32_t num;                                                           \
+        TRY_OR_FAIL(VFile_TryReadS32(file, &num));                             \
+        TRY_OR_FAIL(VFile_TrySkip(file, num *size));                           \
+    }
+#define TRY_OR_FAIL_ARR_U16(size)                                              \
+    {                                                                          \
+        uint16_t num;                                                          \
+        TRY_OR_FAIL(VFile_TryReadU16(file, &num));                             \
+        TRY_OR_FAIL(VFile_TrySkip(file, num *size));                           \
+    }
+
+    VFile_SetPos(file, 0);
+
+    int32_t version;
+    TRY_OR_FAIL(VFile_TryReadS32(file, &version));
+    if (version != 45) {
+        return false;
+    }
+
+    TRY_OR_FAIL(VFile_TrySkip(file, 1792)); // palettes
+    TRY_OR_FAIL_ARR_S32(TEXTURE_PAGE_SIZE * 3); // texture pages
+    TRY_OR_FAIL(VFile_TrySkip(file, 4)); // unused version number
+
+    uint16_t room_count;
+    TRY_OR_FAIL(VFile_TryReadU16(file, &room_count));
+    for (int32_t i = 0; i < room_count; i++) {
+        TRY_OR_FAIL(VFile_TrySkip(file, 16));
+        TRY_OR_FAIL_ARR_S32(2); // meshes
+        TRY_OR_FAIL_ARR_U16(32); // portals
+
+        int16_t size_z;
+        int16_t size_x;
+        TRY_OR_FAIL(VFile_TryReadS16(file, &size_z));
+        TRY_OR_FAIL(VFile_TryReadS16(file, &size_x));
+        TRY_OR_FAIL(VFile_TrySkip(file, size_z * size_x * 8)); // sectors
+
+        TRY_OR_FAIL(VFile_TrySkip(file, 6)); // lighting
+        TRY_OR_FAIL_ARR_U16(24); // lights
+        TRY_OR_FAIL_ARR_U16(20); // static meshes
+        TRY_OR_FAIL(VFile_TrySkip(file, 4));
+    }
+
+    TRY_OR_FAIL_ARR_S32(2); // floor data
+    TRY_OR_FAIL_ARR_S32(2); // object meshes
+    TRY_OR_FAIL_ARR_S32(4); // object mesh pointers
+    TRY_OR_FAIL_ARR_S32(32); // animations
+    TRY_OR_FAIL_ARR_S32(6); // animation changes
+    TRY_OR_FAIL_ARR_S32(8); // animation ranges
+    TRY_OR_FAIL_ARR_S32(2); // animation commands
+    TRY_OR_FAIL_ARR_S32(4); // animation bones
+    TRY_OR_FAIL_ARR_S32(2); // animation frames
+    TRY_OR_FAIL_ARR_S32(18); // objects
+    TRY_OR_FAIL_ARR_S32(32); // static objects
+    TRY_OR_FAIL_ARR_S32(20); // object textures
+    TRY_OR_FAIL_ARR_S32(16); // sprite textures
+    TRY_OR_FAIL_ARR_S32(8); // sprites sequences
+    TRY_OR_FAIL_ARR_S32(16); // cameras/sinks
+    TRY_OR_FAIL_ARR_S32(16); // sound sources
+
+    int32_t box_count;
+    TRY_OR_FAIL(VFile_TryReadS32(file, &box_count));
+    TRY_OR_FAIL(VFile_TrySkip(file, box_count * 8));
+    TRY_OR_FAIL_ARR_S32(2); // overlaps
+    TRY_OR_FAIL(VFile_TrySkip(file, box_count * 20)); // zones
+
+    TRY_OR_FAIL_ARR_S32(2); // animated texture ranges
+    Level_ReadItems(file);
+
+#undef TRY_OR_FAIL
+#undef TRY_OR_FAIL_ARR_U16
+#undef TRY_OR_FAIL_ARR_S32
+
+    return true;
+}
 
 static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
 {
@@ -302,4 +386,34 @@ void Level_Unload(void)
     }
 
     Camera_Reset();
+}
+
+void Level_Init(void)
+{
+    BENCHMARK benchmark = Benchmark_Start();
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    for (int32_t i = 0; i < level_table->count; i++) {
+        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
+        if (level->type != GFL_NORMAL && level->type != GFL_BONUS) {
+            continue;
+        }
+
+        VFILE *const file = VFile_CreateFromPath(level->path);
+        if (file == nullptr) {
+            continue;
+        }
+
+        const bool result = M_SkimLevel(file);
+        VFile_Close(file);
+
+        if (result) {
+            Stats_CalculateStats();
+            STATS_COMMON stats = {};
+            stats.max_secret_count = Stats_GetSecrets();
+            Savegame_SetDefaultStats(level, stats);
+        }
+        GameBuf_Reset();
+    }
+
+    Benchmark_End(&benchmark, nullptr);
 }

--- a/src/tr2/game/level.h
+++ b/src/tr2/game/level.h
@@ -4,6 +4,7 @@
 
 #include <libtrx/game/level/common.h>
 
+void Level_Init(void);
 bool Level_Initialise(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
 bool Level_Load(const GF_LEVEL *level);
 void Level_Unload(void);

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -8,6 +8,8 @@
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 
+static STATS_COMMON *m_DefaultStats = nullptr;
+
 void Savegame_Init(void)
 {
     g_SaveGame.start = Memory_Alloc(
@@ -30,6 +32,7 @@ void Savegame_Init(void)
 void Savegame_Shutdown(void)
 {
     Memory_FreePointer(&g_SaveGame.start);
+    Memory_FreePointer(&m_DefaultStats);
 }
 
 int32_t Savegame_GetSlotCount(void)
@@ -63,4 +66,23 @@ START_INFO *Savegame_GetCurrentInfo(const GF_LEVEL *const level)
         "Warning: unable to get resume info for level %d (type=%s)", level->num,
         ENUM_MAP_TO_STRING(GF_LEVEL_TYPE, level->type));
     return nullptr;
+}
+
+void Savegame_SetDefaultStats(
+    const GF_LEVEL *const level, const STATS_COMMON stats)
+{
+    if (m_DefaultStats == nullptr) {
+        m_DefaultStats = Memory_Alloc(
+            sizeof(STATS_COMMON) * GF_GetLevelTable(GFLT_MAIN)->count);
+    }
+    m_DefaultStats[level->num] = stats;
+}
+
+STATS_COMMON Savegame_GetDefaultStats(const GF_LEVEL *const level)
+{
+    if (m_DefaultStats == nullptr
+        || (level->type != GFL_NORMAL && level->type != GFL_BONUS)) {
+        return (STATS_COMMON) {};
+    }
+    return m_DefaultStats[level->num];
 }

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -10,6 +10,7 @@
 #include "game/game_flow.h"
 #include "game/game_string.h"
 #include "game/input.h"
+#include "game/level.h"
 #include "game/music.h"
 #include "game/output.h"
 #include "game/phase.h"
@@ -410,11 +411,12 @@ void Shell_Main(void)
     GameStringTable_LoadFromFile(m_ModPaths[m_Args.mod].game_strings_path);
     GameStringTable_Apply(nullptr);
 
+    GameBuf_Init();
+    Level_Init();
+
     Savegame_Init();
     Savegame_InitCurrentInfo();
     S_FrontEndCheck();
-
-    GameBuf_Init();
 
     if (m_Args.level_to_play != nullptr) {
         Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);


### PR DESCRIPTION
Part of #2662.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows for statistics to be gathered en masse during game launch, such that legacy saves can still be utilised and refer to accurate total statistics, such as secrets. It fixes the lingering issue since #2663, so loading a save and then proceeding to the end of the game should show an accurate final total secret count.

The impact on start-up performance should be minimal - you can search for a line similar to the following in the log file to check.

`game/level.c 418 Level_Init took 28.14 ms`
