### PR TITLE
objects/creatures: move bear and wolf to TRX

### DIFF
--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -1,0 +1,16 @@
+#include "game/creature.h"
+
+bool Creature_Activate(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    if (item->status != IS_INVISIBLE) {
+        return true;
+    }
+
+    if (!LOT_EnableBaddieAI(item_num, false)) {
+        return false;
+    }
+
+    item->status = IS_ACTIVE;
+    return true;
+}

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -146,3 +146,8 @@ const ANIM_FRAME *Lara_GetHitFrame(const ITEM *const item)
     const ANIM *const anim = Object_GetAnim(obj, anim_idx);
     return &anim->frame_ptr[lara->hit_frame];
 }
+
+void Lara_TakeDamage(const int16_t damage, const bool hit_status)
+{
+    Item_TakeDamage(Lara_GetItem(), damage, hit_status);
+}

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -1,49 +1,51 @@
+#include "config.h"
 #include "game/creature.h"
-#include "game/items.h"
 #include "game/lara/common.h"
-#include "game/lot.h"
 #include "game/random.h"
 #include "game/spawn.h"
-#include "global/const.h"
-#include "global/types.h"
-#include "global/vars.h"
+#include "utils.h"
 
-#include <libtrx/config.h>
-#include <libtrx/utils.h>
-
+// clang-format off
 #define BEAR_CHARGE_DAMAGE 3
-#define BEAR_SLAM_DAMAGE 200
+#define BEAR_SLAM_DAMAGE   200
 #define BEAR_ATTACK_DAMAGE 200
-#define BEAR_PAT_DAMAGE 400
-#define BEAR_TOUCH 0x2406C
-#define BEAR_ROAR_CHANCE 80
-#define BEAR_REAR_CHANCE 768
-#define BEAR_DROP_CHANCE 1536
-#define BEAR_REAR_RANGE SQUARE(WALL_L * 2) // = 4194304
-#define BEAR_ATTACK_RANGE SQUARE(WALL_L) // = 1048576
-#define BEAR_PAT_RANGE SQUARE(600) // = 360000
+#define BEAR_PAT_DAMAGE    400
+#define BEAR_TOUCH         0x2406C
+#define BEAR_ROAR_CHANCE   80
+#define BEAR_REAR_CHANCE   768
+#define BEAR_DROP_CHANCE   1536
+#define BEAR_REAR_RANGE    SQUARE(WALL_L * 2) // = 4194304
+#define BEAR_ATTACK_RANGE  SQUARE(WALL_L) // = 1048576
+#define BEAR_PAT_RANGE     SQUARE(600) // = 360000
 #define BEAR_FIX_PAT_RANGE SQUARE(300) // = 90000
-#define BEAR_RUN_TURN (5 * DEG_1) // = 910
-#define BEAR_WALK_TURN (2 * DEG_1) // = 364
-#define BEAR_EAT_RANGE SQUARE(WALL_L * 3 / 4) // = 589824
-#define BEAR_HITPOINTS 20
-#define BEAR_RADIUS (WALL_L / 3) // = 341
-#define BEAR_SMARTNESS 0x4000
+#define BEAR_RUN_TURN      (5 * DEG_1) // = 910
+#define BEAR_WALK_TURN     (2 * DEG_1) // = 364
+#define BEAR_EAT_RANGE     SQUARE(WALL_L * 3 / 4) // = 589824
+#define BEAR_HITPOINTS     20
+#define BEAR_RADIUS        (WALL_L / 3) // = 341
+#define BEAR_SMARTNESS     0x4000
+// clang-format on
 
 typedef enum {
-    BEAR_STATE_STROLL = 0,
-    BEAR_STATE_STOP = 1,
-    BEAR_STATE_WALK = 2,
-    BEAR_STATE_RUN = 3,
-    BEAR_STATE_REAR = 4,
-    BEAR_STATE_ROAR = 5,
+    // clang-format off
+    BEAR_STATE_STROLL   = 0,
+    BEAR_STATE_STOP     = 1,
+    BEAR_STATE_WALK     = 2,
+    BEAR_STATE_RUN      = 3,
+    BEAR_STATE_REAR     = 4,
+    BEAR_STATE_ROAR     = 5,
     BEAR_STATE_ATTACK_1 = 6,
     BEAR_STATE_ATTACK_2 = 7,
-    BEAR_STATE_EAT = 8,
-    BEAR_STATE_DEATH = 9,
+    BEAR_STATE_EAT      = 8,
+    BEAR_STATE_DEATH    = 9,
+    // clang-format on
 } BEAR_STATE;
 
+#if TR_VERSION == 1
 static BITE m_BearHeadBite = { 0, 96, 335, 14 };
+#else
+static BITE m_BearHeadBite = { .pos = { 0, 96, 335 }, .mesh_num = 14 };
+#endif
 
 static void M_Setup(OBJECT *obj);
 static void M_Control(int16_t item_num);
@@ -71,20 +73,22 @@ static void M_Setup(OBJECT *const obj)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-    OBJECT *const obj = Object_Get(item->object_id);
-    obj->pivot_length = g_Config.gameplay.fix_bear_ai ? 0 : 500;
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
-    CREATURE *bear = (CREATURE *)item->data;
+    ITEM *const item = Item_Get(item_num);
+    OBJECT *const obj = Object_Get(item->object_id);
+#if TR_VERSION == 1
+    const bool fix_bear_ai = g_Config.gameplay.fix_bear_ai;
+#else
+    const bool fix_bear_ai = false;
+#endif
+    obj->pivot_length = fix_bear_ai ? 0 : 500;
+
+    CREATURE *const bear = (CREATURE *)item->data;
     int16_t head = 0;
-    PHD_ANGLE angle = 0;
+    int16_t angle = 0;
 
     if (item->hit_points <= 0) {
         angle = Creature_Turn(item, DEG_1);
@@ -128,7 +132,7 @@ static void M_Control(const int16_t item_num)
 
         angle = Creature_Turn(item, bear->maximum_turn);
 
-        int dead_enemy = g_LaraItem->hit_points <= 0;
+        const bool dead_enemy = Lara_GetItem()->hit_points <= 0;
         if (item->hit_status) {
             bear->flags = 1;
         }
@@ -194,8 +198,7 @@ static void M_Control(const int16_t item_num)
             } else if (
                 info.bite
                 && info.distance
-                    < (g_Config.gameplay.fix_bear_ai ? BEAR_FIX_PAT_RANGE
-                                                     : BEAR_PAT_RANGE)) {
+                    < (fix_bear_ai ? BEAR_FIX_PAT_RANGE : BEAR_PAT_RANGE)) {
                 item->goal_anim_state = BEAR_STATE_ATTACK_2;
             } else {
                 item->goal_anim_state = BEAR_STATE_WALK;
@@ -245,4 +248,6 @@ static void M_Control(const int16_t item_num)
     Creature_Animate(item_num, angle, 0);
 }
 
+#if TR_VERSION == 1
 REGISTER_OBJECT(O_BEAR, M_Setup)
+#endif

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -1,49 +1,55 @@
 #include "game/creature.h"
-#include "game/items.h"
 #include "game/lara/common.h"
-#include "game/lot.h"
 #include "game/random.h"
 #include "game/spawn.h"
-#include "global/const.h"
-#include "global/vars.h"
+#include "utils.h"
 
-#include <libtrx/utils.h>
-
-#define WOLF_SLEEP_FRAME 96
-#define WOLF_BITE_DAMAGE 100
+// clang-format off
+#define WOLF_SLEEP_FRAME   96
+#define WOLF_BITE_DAMAGE   100
 #define WOLF_POUNCE_DAMAGE 50
-#define WOLF_DIE_ANIM 20
-#define WOLF_WALK_TURN (2 * DEG_1) // = 364
-#define WOLF_RUN_TURN (5 * DEG_1) // = 910
-#define WOLF_STALK_TURN (2 * DEG_1) // = 364
-#define WOLF_ATTACK_RANGE SQUARE(WALL_L * 3 / 2) // = 2359296
-#define WOLF_STALK_RANGE SQUARE(WALL_L * 3) // = 9437184
-#define WOLF_BITE_RANGE SQUARE(345) // = 119025
-#define WOLF_WAKE_CHANCE 32
-#define WOLF_SLEEP_CHANCE 32
-#define WOLF_HOWL_CHANCE 384
-#define WOLF_TOUCH 0x774F
-#define WOLF_HITPOINTS 6
-#define WOLF_RADIUS (WALL_L / 3) // = 341
-#define WOLF_SMARTNESS 0x2000
+#define WOLF_WALK_TURN     (2 * DEG_1) // = 364
+#define WOLF_RUN_TURN      (5 * DEG_1) // = 910
+#define WOLF_STALK_TURN    (2 * DEG_1) // = 364
+#define WOLF_ATTACK_RANGE  SQUARE(WALL_L * 3 / 2) // = 2359296
+#define WOLF_STALK_RANGE   SQUARE(WALL_L * 3) // = 9437184
+#define WOLF_BITE_RANGE    SQUARE(345) // = 119025
+#define WOLF_WAKE_CHANCE   32
+#define WOLF_SLEEP_CHANCE  32
+#define WOLF_HOWL_CHANCE   384
+#define WOLF_TOUCH         0x774F
+#define WOLF_HITPOINTS     6
+#define WOLF_RADIUS        (WALL_L / 3) // = 341
+#define WOLF_SMARTNESS     0x2000
+// clang-format on
 
 typedef enum {
-    WOLF_STATE_EMPTY = 0,
-    WOLF_STATE_STOP = 1,
-    WOLF_STATE_WALK = 2,
-    WOLF_STATE_RUN = 3,
-    WOLF_STATE_JUMP = 4,
-    WOLF_STATE_STALK = 5,
-    WOLF_STATE_ATTACK = 6,
-    WOLF_STATE_HOWL = 7,
-    WOLF_STATE_SLEEP = 8,
-    WOLF_STATE_CROUCH = 9,
+    // clang-format off
+    WOLF_STATE_EMPTY     = 0,
+    WOLF_STATE_STOP      = 1,
+    WOLF_STATE_WALK      = 2,
+    WOLF_STATE_RUN       = 3,
+    WOLF_STATE_JUMP      = 4,
+    WOLF_STATE_STALK     = 5,
+    WOLF_STATE_ATTACK    = 6,
+    WOLF_STATE_HOWL      = 7,
+    WOLF_STATE_SLEEP     = 8,
+    WOLF_STATE_CROUCH    = 9,
     WOLF_STATE_FAST_TURN = 10,
-    WOLF_STATE_DEATH = 11,
-    WOLF_STATE_BITE = 12,
+    WOLF_STATE_DEATH     = 11,
+    WOLF_STATE_BITE      = 12,
+    // clang-format on
 } WOLF_STATE;
 
+typedef enum {
+    WOLF_ANIM_DEATH = 20,
+} WOLF_ANIM;
+
+#if TR_VERSION == 1
 static BITE m_WolfJawBite = { 0, -14, 174, 6 };
+#else
+static BITE m_WolfJawBite = { .pos = { 0, -14, 174 }, .mesh_num = 6 };
+#endif
 
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
@@ -79,16 +85,12 @@ static void M_Initialise(const int16_t item_num)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
-    CREATURE *wolf = item->data;
+    ITEM *const item = Item_Get(item_num);
+    CREATURE *const wolf = (CREATURE *)item->data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;
@@ -97,7 +99,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state != WOLF_STATE_DEATH) {
             item->current_anim_state = WOLF_STATE_DEATH;
             Item_SwitchToAnim(
-                item, WOLF_DIE_ANIM + (int16_t)(Random_GetControl() / 11000),
+                item, WOLF_ANIM_DEATH + (int16_t)(Random_GetControl() / 11000),
                 0);
         }
     } else {
@@ -230,4 +232,6 @@ static void M_Control(const int16_t item_num)
     Creature_Animate(item_num, angle, tilt);
 }
 
+#if TR_VERSION == 1
 REGISTER_OBJECT(O_WOLF, M_Setup)
+#endif

--- a/src/libtrx/include/libtrx/game/creature.h
+++ b/src/libtrx/include/libtrx/game/creature.h
@@ -1,34 +1,6 @@
 #pragma once
 
-#include "items.h"
-#include "math.h"
-#include "pathing.h"
-
-#include <stdint.h>
-
-typedef enum {
-    MOOD_BORED = 0,
-    MOOD_ATTACK = 1,
-    MOOD_ESCAPE = 2,
-    MOOD_STALK = 3,
-} MOOD_TYPE;
-
-typedef struct {
-    int16_t head_rotation;
-    int16_t neck_rotation;
-    int16_t maximum_turn;
-    int16_t flags;
-    int16_t item_num;
-    MOOD_TYPE mood;
-    LOT_INFO lot;
-    XYZ_32 target;
-#if TR_VERSION == 2
-    ITEM *enemy;
-#endif
-} CREATURE;
-
-#define CREATURE_STALK_DIST (3 * WALL_L) // = 3072
-#define CREATURE_ESCAPE_DIST (5 * WALL_L) // = 5120
-#define CREATURE_TARGET_DIST (4 * WALL_L) // = 4096
-
-bool Creature_IsHostile(const ITEM *item);
+#include "./creature/common.h"
+#include "./creature/const.h"
+#include "./creature/enum.h"
+#include "./creature/types.h"

--- a/src/libtrx/include/libtrx/game/creature/common.h
+++ b/src/libtrx/include/libtrx/game/creature/common.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../collision.h"
+#include "./types.h"
+
+bool Creature_Activate(int16_t item_num);
+bool Creature_IsHostile(const ITEM *item);
+
+extern void Creature_Initialise(int16_t item_num);
+extern void Creature_Collision(
+    int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
+extern void Creature_AIInfo(ITEM *item, AI_INFO *info);
+extern void Creature_Mood(const ITEM *item, const AI_INFO *info, bool violent);
+extern int16_t Creature_Turn(ITEM *item, int16_t maximum_turn);
+extern void Creature_Tilt(ITEM *item, int16_t angle);
+extern void Creature_Head(ITEM *item, int16_t required);
+extern bool Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt);
+extern int16_t Creature_Effect(
+    const ITEM *item, const BITE *bite,
+    int16_t (*spawn)(
+        int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+        int16_t room_num));

--- a/src/libtrx/include/libtrx/game/creature/const.h
+++ b/src/libtrx/include/libtrx/game/creature/const.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define FRONT_ARC DEG_90
+#define UNIT_SHADOW 256
+
+#define CREATURE_STALK_DIST (3 * WALL_L) // = 3072
+#define CREATURE_ESCAPE_DIST (5 * WALL_L) // = 5120
+#define CREATURE_TARGET_DIST (4 * WALL_L) // = 4096

--- a/src/libtrx/include/libtrx/game/creature/enum.h
+++ b/src/libtrx/include/libtrx/game/creature/enum.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef enum {
+    MOOD_BORED = 0,
+    MOOD_ATTACK = 1,
+    MOOD_ESCAPE = 2,
+    MOOD_STALK = 3,
+} MOOD_TYPE;

--- a/src/libtrx/include/libtrx/game/creature/types.h
+++ b/src/libtrx/include/libtrx/game/creature/types.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../items.h"
+#include "../pathing.h"
+#include "./enum.h"
+
+typedef struct {
+    int16_t head_rotation;
+    int16_t neck_rotation;
+    int16_t maximum_turn;
+    int16_t flags;
+    int16_t item_num;
+    MOOD_TYPE mood;
+    LOT_INFO lot;
+    XYZ_32 target;
+#if TR_VERSION == 2
+    ITEM *enemy;
+#endif
+} CREATURE;
+
+typedef struct {
+    int16_t zone_num;
+    // TODO: merge
+    union {
+        int16_t enemy_zone;
+        int16_t enemy_zone_num;
+    };
+    int32_t distance;
+    int32_t ahead;
+    int32_t bite;
+    int16_t angle;
+    int16_t enemy_facing;
+} AI_INFO;
+
+typedef struct {
+    // TODO: merge
+#if TR_VERSION == 1
+    int32_t x;
+    int32_t y;
+    int32_t z;
+#else
+    XYZ_32 pos;
+#endif
+    int32_t mesh_num;
+} BITE;

--- a/src/libtrx/include/libtrx/game/lara/common.h
+++ b/src/libtrx/include/libtrx/game/lara/common.h
@@ -10,3 +10,4 @@ void Lara_SwapSingleMesh(LARA_MESH mesh, GAME_OBJECT_ID obj_id);
 OBJECT_MESH *Lara_GetMesh(LARA_MESH mesh);
 void Lara_SetMesh(LARA_MESH mesh, OBJECT_MESH *mesh_ptr);
 const ANIM_FRAME *Lara_GetHitFrame(const ITEM *item);
+void Lara_TakeDamage(int16_t damage, bool hit_status);

--- a/src/libtrx/include/libtrx/game/pathing.h
+++ b/src/libtrx/include/libtrx/game/pathing.h
@@ -2,4 +2,5 @@
 
 #include "pathing/box.h"
 #include "pathing/const.h"
+#include "pathing/lot.h"
 #include "pathing/types.h"

--- a/src/libtrx/include/libtrx/game/pathing/lot.h
+++ b/src/libtrx/include/libtrx/game/pathing/lot.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern bool LOT_EnableBaddieAI(int16_t item_num, bool always);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdint.h>
+
+extern int16_t Spawn_Blood(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -120,6 +120,7 @@ sources = [
   'game/console/common.c',
   'game/console/history.c',
   'game/console/registry.c',
+  'game/creature/common.c',
   'game/demo/common.c',
   'game/fader.c',
   'game/game.c',

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -170,6 +170,7 @@ sources = [
   'game/objects/common.c',
   'game/objects/names.c',
   'game/objects/creatures/bear.c',
+  'game/objects/creatures/wolf.c',
   'game/objects/traps/movable_block.c',
   'game/objects/vars.c',
   'game/output/common.c',

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -169,6 +169,7 @@ sources = [
   'game/music.c',
   'game/objects/common.c',
   'game/objects/names.c',
+  'game/objects/creatures/bear.c',
   'game/objects/traps/movable_block.c',
   'game/objects/vars.c',
   'game/output/common.c',

--- a/src/tr1/game/creature.c
+++ b/src/tr1/game/creature.c
@@ -82,7 +82,8 @@ void Creature_AIInfo(ITEM *item, AI_INFO *info)
         && (g_LaraItem->pos.y < item->pos.y + STEP_L);
 }
 
-void Creature_Mood(ITEM *item, AI_INFO *info, bool violent)
+void Creature_Mood(
+    const ITEM *const item, const AI_INFO *const info, const bool violent)
 {
     CREATURE *creature = item->data;
     if (!creature) {
@@ -317,7 +318,7 @@ void Creature_Head(ITEM *item, int16_t required)
 }
 
 int16_t Creature_Effect(
-    ITEM *item, BITE *bite,
+    const ITEM *const item, const BITE *const bite,
     int16_t (*spawn)(
         int32_t x, int32_t y, int32_t z, int16_t speed, int16_t yrot,
         int16_t room_num))

--- a/src/tr1/game/creature.h
+++ b/src/tr1/game/creature.h
@@ -22,20 +22,7 @@ typedef struct {
     } water;
 } HYBRID_INFO;
 
-void Creature_Initialise(int16_t item_num);
-void Creature_AIInfo(ITEM *item, AI_INFO *info);
-void Creature_Mood(ITEM *item, AI_INFO *info, bool violent);
-int16_t Creature_Turn(ITEM *item, int16_t maximum_turn);
-void Creature_Tilt(ITEM *item, int16_t angle);
-void Creature_Head(ITEM *item, int16_t required);
-int16_t Creature_Effect(
-    ITEM *item, BITE *bite,
-    int16_t (*spawn)(
-        int32_t x, int32_t y, int32_t z, int16_t speed, int16_t yrot,
-        int16_t room_num));
 bool Creature_CheckBaddieOverlap(int16_t item_num);
-void Creature_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-bool Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt);
 bool Creature_CanTargetEnemy(ITEM *item, AI_INFO *info);
 bool Creature_ShootAtLara(
     ITEM *item, int32_t distance, BITE *gun, int16_t extra_rotation,

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -822,8 +822,3 @@ void Lara_Push(ITEM *item, COLL_INFO *coll, bool hit_on, bool big_push)
         }
     }
 }
-
-void Lara_TakeDamage(int16_t damage, bool hit_status)
-{
-    Item_TakeDamage(g_LaraItem, damage, hit_status);
-}

--- a/src/tr1/game/lara/common.h
+++ b/src/tr1/game/lara/common.h
@@ -32,6 +32,4 @@ void Lara_AlignPosition(ITEM *item, XYZ_32 *vec);
 bool Lara_MovePosition(ITEM *item, XYZ_32 *vec);
 void Lara_Push(ITEM *item, COLL_INFO *coll, bool hit_on, bool big_push);
 
-void Lara_TakeDamage(int16_t damage, bool hit_status);
-
 void Lara_RevertToPistolsIfNeeded(void);

--- a/src/tr1/game/lot.c
+++ b/src/tr1/game/lot.c
@@ -37,7 +37,7 @@ void LOT_DisableBaddieAI(int16_t item_num)
     }
 }
 
-bool LOT_EnableBaddieAI(int16_t item_num, int32_t always)
+bool LOT_EnableBaddieAI(const int16_t item_num, const bool always)
 {
     if (Item_Get(item_num)->data != nullptr) {
         return true;

--- a/src/tr1/game/lot.h
+++ b/src/tr1/game/lot.h
@@ -2,11 +2,12 @@
 
 #include "global/types.h"
 
+#include <libtrx/game/pathing/lot.h>
+
 #include <stdint.h>
 
 void LOT_InitialiseArray(void);
 void LOT_DisableBaddieAI(int16_t item_num);
-bool LOT_EnableBaddieAI(int16_t item_num, int32_t always);
 void LOT_InitialiseSlot(int16_t item_num, int32_t slot);
 void LOT_CreateZone(ITEM *item);
 void LOT_InitialiseLOT(LOT_INFO *LOT);

--- a/src/tr1/game/spawn.h
+++ b/src/tr1/game/spawn.h
@@ -2,13 +2,11 @@
 
 #include "global/types.h"
 
+#include <libtrx/game/spawn.h>
+
 void Spawn_Splash(ITEM *item);
 
 void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
-
-int16_t Spawn_Blood(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t direction,
-    int16_t room_num);
 
 int16_t Spawn_ShardGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -66,7 +66,6 @@
 #define MIN_HEAD_TILT_SURF (-40 * DEG_1) // = -7280
 #define DIVE_WAIT 10
 #define STEPUP_HEIGHT ((STEP_L * 3) / 2) // = 384
-#define FRONT_ARC DEG_90
 #define MAX_HEAD_CHANGE (DEG_1 * 5) // = 910
 #define MAX_TILT (DEG_1 * 3) // = 546
 #define CAM_A_HANG 0
@@ -79,7 +78,6 @@
 #define COMBAT_DISTANCE (WALL_L * 5 / 2) // = 2560
 #define MAX_ELEVATION (85 * DEG_1) // = 15470
 #define DEFAULT_RADIUS 10
-#define UNIT_SHADOW 256
 #define NO_BAD_POS (-NO_HEIGHT)
 #define NO_BAD_NEG NO_HEIGHT
 #define BAD_JUMP_CEILING ((STEP_L * 3) / 4) // = 192

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -224,23 +224,6 @@ typedef struct {
 } WEAPON_INFO;
 
 typedef struct {
-    int32_t x;
-    int32_t y;
-    int32_t z;
-    int32_t mesh_num;
-} BITE;
-
-typedef struct {
-    int16_t zone_num;
-    int16_t enemy_zone;
-    int32_t distance;
-    int32_t ahead;
-    int32_t bite;
-    int16_t angle;
-    int16_t enemy_facing;
-} AI_INFO;
-
-typedef struct {
     bool is_blocked;
     char *content_text;
     TEXTSTRING *content;

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -179,7 +179,6 @@ sources = [
   'game/objects/creatures/statue.c',
   'game/objects/creatures/torso.c',
   'game/objects/creatures/trex.c',
-  'game/objects/creatures/wolf.c',
   'game/objects/effects/blood.c',
   'game/objects/effects/body_part.c',
   'game/objects/effects/bubble.c',

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -162,7 +162,6 @@ sources = [
   'game/objects/creatures/bacon_lara.c',
   'game/objects/creatures/baldy.c',
   'game/objects/creatures/bat.c',
-  'game/objects/creatures/bear.c',
   'game/objects/creatures/centaur.c',
   'game/objects/creatures/cowboy.c',
   'game/objects/creatures/crocodile.c',

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -20,7 +20,6 @@
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
 
-#define FRONT_ARC DEG_90
 #define ESCAPE_CHANCE 2048
 #define RECOVER_CHANCE 256
 #define MAX_X_ROT (20 * DEG_1) // = 3640
@@ -41,21 +40,6 @@ void Creature_Initialise(const int16_t item_num)
     item->rot.y += (Random_GetControl() - DEG_90) >> 1;
     item->collidable = 1;
     item->data = 0;
-}
-
-int32_t Creature_Activate(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    if (item->status != IS_INVISIBLE) {
-        return true;
-    }
-
-    if (!LOT_EnableBaddieAI(item_num, false)) {
-        return false;
-    }
-
-    item->status = IS_ACTIVE;
-    return true;
 }
 
 void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
@@ -130,7 +114,8 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
         && ABS(enemy->pos.y - item->pos.y) <= STEP_L;
 }
 
-void Creature_Mood(const ITEM *item, const AI_INFO *info, int32_t violent)
+void Creature_Mood(
+    const ITEM *const item, const AI_INFO *const info, const bool violent)
 {
     CREATURE *const creature = item->data;
     if (creature == nullptr) {
@@ -372,7 +357,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
     }
 }
 
-int32_t Creature_Animate(
+bool Creature_Animate(
     const int16_t item_num, const int16_t angle, const int16_t tilt)
 {
     ITEM *const item = Item_Get(item_num);

--- a/src/tr2/game/creature.h
+++ b/src/tr2/game/creature.h
@@ -4,32 +4,17 @@
 
 #include <libtrx/game/creature.h>
 
-void Creature_Initialise(int16_t item_num);
-int32_t Creature_Activate(int16_t item_num);
-void Creature_AIInfo(ITEM *item, AI_INFO *info);
-void Creature_Mood(const ITEM *item, const AI_INFO *info, int32_t violent);
 int32_t Creature_CheckBaddieOverlap(int16_t item_num);
 void Creature_Die(int16_t item_num, bool explode);
-int32_t Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt);
-int16_t Creature_Turn(ITEM *item, int16_t max_turn);
-void Creature_Tilt(ITEM *item, int16_t angle);
-void Creature_Head(ITEM *item, int16_t required);
 void Creature_Neck(ITEM *item, int16_t required);
 void Creature_Float(int16_t item_num);
 void Creature_Underwater(ITEM *item, int32_t depth);
-int16_t Creature_Effect(
-    const ITEM *item, const BITE *bite,
-    int16_t (*spawn)(
-        int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-        int16_t room_num));
 int32_t Creature_Vault(
     int16_t item_num, int16_t angle, int32_t vault, int32_t shift);
 void Creature_Kill(
     ITEM *item, int32_t kill_anim, int32_t kill_state, int32_t lara_kill_state);
 void Creature_GetBaddieTarget(int16_t item_num, int32_t goody);
-void Creature_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 int32_t Creature_CanTargetEnemy(const ITEM *item, const AI_INFO *info);
-bool Creature_IsHostile(const ITEM *item);
 bool Creature_IsAlly(const ITEM *item);
 int32_t Creature_ShootAtLara(
     ITEM *item, const AI_INFO *info, const BITE *gun, int16_t extra_rotation,

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -1005,8 +1005,3 @@ void Lara_GetOffVehicle(void)
         g_LaraItem->rot.z = 0;
     }
 }
-
-void Lara_TakeDamage(const int16_t damage, const bool hit_status)
-{
-    Item_TakeDamage(g_LaraItem, damage, hit_status);
-}

--- a/src/tr2/game/lara/control.h
+++ b/src/tr2/game/lara/control.h
@@ -25,5 +25,3 @@ void Lara_InitialiseInventory(const GF_LEVEL *level);
 void Lara_InitialiseMeshes(const GF_LEVEL *level);
 
 void Lara_GetOffVehicle(void);
-
-void Lara_TakeDamage(int16_t damage, bool hit_status);

--- a/src/tr2/game/lot.h
+++ b/src/tr2/game/lot.h
@@ -2,9 +2,10 @@
 
 #include "global/types.h"
 
+#include <libtrx/game/pathing/lot.h>
+
 void LOT_InitialiseArray(void);
 void LOT_DisableBaddieAI(int16_t item_num);
-bool LOT_EnableBaddieAI(int16_t item_num, bool always);
 void LOT_InitialiseSlot(int16_t item_num, int32_t slot);
 void LOT_CreateZone(ITEM *item);
 void LOT_ClearLOT(LOT_INFO *LOT);

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -2,6 +2,8 @@
 
 #include "game/items.h"
 
+#include <libtrx/game/spawn.h>
+
 int16_t Spawn_FireStream(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
@@ -25,10 +27,6 @@ int16_t Spawn_GunMiss(
     int16_t room_num);
 
 int16_t Spawn_Knife(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);
-
-int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
 

--- a/src/tr2/global/const.h
+++ b/src/tr2/global/const.h
@@ -193,5 +193,3 @@
 
 #define LOW_LIGHT 5120
 #define HIGH_LIGHT 4096
-
-#define UNIT_SHADOW 256

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -154,16 +154,6 @@ typedef struct {
     int16_t sample_num;
 } WEAPON_INFO;
 
-typedef struct {
-    int16_t zone_num;
-    int16_t enemy_zone_num;
-    int32_t distance;
-    int32_t ahead;
-    int32_t bite;
-    int16_t angle;
-    int16_t enemy_facing;
-} AI_INFO;
-
 typedef enum {
     GFE_PICTURE          = 0,
     GFE_LIST_START       = 1,
@@ -189,11 +179,6 @@ typedef enum {
     GFE_KILL_TO_COMPLETE = 21,
     GFE_REMOVE_AMMO      = 22,
 } GF_EVENTS;
-
-typedef struct {
-    XYZ_32 pos;
-    int32_t mesh_num;
-} BITE;
 
 typedef struct {
     SECTOR *sector;


### PR DESCRIPTION
Part of #1621.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the bear and wolf modules to TRX, along with several header dependencies. This is in preparation for GM, but currently only impacts TR1. There should be no change in creature behaviour in TR1.
