### PR TITLE
controls: fix console opening when remapping its key

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed the embedded bats fix causing problems inside rooms with trapdoors (regression from 4.6)
 - fixed cutscene music looping (#2591, regression from 4.8)
 - fixed saves created before version 2.15 causing a crash on load (#2654, regression from 4.8)
+- fixed the console opening when remapping its key (#2641)
 - removed perspective filter toggle (it had no effect; repurposed to trapezoid interpolation toggle)
 - improved camera mode navigation:
     - improved support for pivoting

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added the ability for custom levels to have up to two of each secret type per level (#2674)
 - fixed the final two levels not allowing for secrets to be counted in the statistics (#1582)
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)
+- fixed the console opening when remapping its key (#2641)
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)
 
 ## [0.10](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.2...tr2-0.10) - 2025-03-18

--- a/src/tr1/game/option/option_controls.c
+++ b/src/tr1/game/option/option_controls.c
@@ -620,6 +620,11 @@ static void M_CheckUnbindKey(INPUT_BACKEND backend, INPUT_LAYOUT layout)
         m_Text[TEXT_UNBIND], &m_ProgressBars[M_PROGERSS_BAR_UNBIND], progress);
 }
 
+bool Option_Controls_IsKeyChangeMode(void)
+{
+    return m_KeyMode == KM_CHANGE || m_KeyMode == KM_CHANGEKEYUP;
+}
+
 CONTROL_MODE Option_Controls_Control(
     INVENTORY_ITEM *inv_item, const bool is_busy, INPUT_BACKEND backend)
 {

--- a/src/tr1/game/option/option_controls.h
+++ b/src/tr1/game/option/option_controls.h
@@ -10,6 +10,7 @@ typedef enum {
     CM_CONTROLLER,
 } CONTROL_MODE;
 
+bool Option_Controls_IsKeyChangeMode(void);
 CONTROL_MODE Option_Controls_Control(
     INVENTORY_ITEM *inv_item, bool is_busy, INPUT_BACKEND backend);
 void Option_Controls_Draw(INVENTORY_ITEM *inv_item, INPUT_BACKEND backend);

--- a/src/tr1/specific/s_shell.c
+++ b/src/tr1/specific/s_shell.c
@@ -4,6 +4,7 @@
 #include "game/fmv.h"
 #include "game/input.h"
 #include "game/music.h"
+#include "game/option/option_controls.h"
 #include "game/output.h"
 #include "game/shell.h"
 #include "game/sound.h"
@@ -181,7 +182,7 @@ void Shell_ProcessEvents(void)
             // some keypresses if the player types really fast, so we need to
             // react sooner.
             if (!FMV_IsPlaying() && g_Config.gameplay.enable_console
-                && !Console_IsOpened()
+                && !Console_IsOpened() && !Option_Controls_IsKeyChangeMode()
                 && Input_IsPressed(
                     INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
                     INPUT_ROLE_ENTER_CONSOLE)) {

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -238,7 +238,7 @@ static void M_HandleKeyDown(const SDL_Event *const event)
     // some keypresses if the player types really fast, so we need to
     // react sooner.
     if (!FMV_IsPlaying() && g_Config.gameplay.enable_console
-        && !Console_IsOpened()
+        && !Console_IsOpened() && !Input_IsInListenMode()
         && Input_IsPressed(
             INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
             INPUT_ROLE_ENTER_CONSOLE)) {


### PR DESCRIPTION
Resolves #2641.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Fixed the console opening when remapping its key.