### PR TITLE
tr1/output/sprites: simplify projection matrix

### DIFF
--- a/data/tr1/ship/shaders/common.glsl
+++ b/data/tr1/ship/shaders/common.glsl
@@ -26,11 +26,11 @@ bool discardTranslucent(sampler2D tex, vec2 uv)
     return texel.a == 0.0;
 }
 
-bool discardTranslucent(sampler2DArray tex, vec3 uv)
+bool discardTranslucent(sampler2DArray tex, vec3 uvw)
 {
     // do not use smoothing for chroma key
     ivec2 size = textureSize(tex, 0).xy;
-    ivec3 texCoordsNN = ivec3(ivec2(uv.xy * size.xy) % size.xy, uv.z);
+    ivec3 texCoordsNN = ivec3(ivec2(uvw.xy * size.xy) % size.xy, uvw.z);
     vec4 texel = texelFetch(tex, texCoordsNN, 0);
     return texel.a == 0.0;
 }

--- a/data/tr1/ship/shaders/sprites.glsl
+++ b/data/tr1/ship/shaders/sprites.glsl
@@ -14,7 +14,8 @@ layout(location = 1) in vec2 inDisplacement;
 layout(location = 2) in int inTextureIdx;
 layout(location = 3) in float inShade;
 
-out vec3 gUVW; // x = u, y = v, z = layer
+out vec2 gTexUV;
+flat out int gTexLayer;
 out float gShade;
 
 void main(void) {
@@ -27,7 +28,9 @@ void main(void) {
             waterWibble(gl_Position, uViewportSize, uWibbleOffset);
     }
 
-    gUVW = texelFetch(uUVW, int(inTextureIdx)).xyz;
+    vec3 uvw = texelFetch(uUVW, int(inTextureIdx)).xyz;
+    gTexUV = uvw.xy;
+    gTexLayer = int(uvw.z);
     gShade = inShade;
 }
 
@@ -38,13 +41,15 @@ uniform bool uSmoothingEnabled;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;
 
-in vec3 gUVW;
+in vec2 gTexUV;
+flat in int gTexLayer;
 in float gShade;
 out vec4 outColor;
 
 void main(void) {
-    vec4 texColor = texture(uTexture, gUVW);
-    if (uSmoothingEnabled && discardTranslucent(uTexture, gUVW)) {
+    vec3 uvw = vec3(gTexUV.x, gTexUV.y, gTexLayer);
+    vec4 texColor = texture(uTexture, uvw);
+    if (uSmoothingEnabled && discardTranslucent(uTexture, uvw)) {
         discard;
     }
 

--- a/data/tr1/ship/shaders/sprites.glsl
+++ b/data/tr1/ship/shaders/sprites.glsl
@@ -1,20 +1,13 @@
-#define NEW_ZBUFFER 0
 #define NEUTRAL_SHADE 0x1000
 
 #ifdef VERTEX
 
 uniform samplerBuffer uUVW; // texture u, v, layer
-uniform vec2 uViewportCenter;
 uniform vec2 uViewportSize;
 uniform mat4 uMatProjection;
-uniform mat4 uMatProjectionOG;
 uniform mat4 uMatModelView;
 uniform float uWibbleOffset;
 uniform vec2 uFog; // x = start, y = end
-
-uniform float uPhdPersp;
-uniform float uPhdResZ;
-uniform float uPhdResZBuf;
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec2 inDisplacement;
@@ -25,7 +18,6 @@ out vec3 gUV; // x = u, y = v, z = layer
 out float gShade;
 
 void main(void) {
-    #if NEW_ZBUFFER
     vec4 centerEyeSpace = uMatModelView * vec4(inPosition, 1.0);
     centerEyeSpace.xy += inDisplacement;
     gl_Position = uMatProjection * centerEyeSpace;
@@ -34,26 +26,6 @@ void main(void) {
         gl_Position.xyz =
             waterWibble(gl_Position, uViewportSize, uWibbleOffset);
     }
-    #else
-    vec3 localPos = inPosition;
-    vec3 worldPos = (uMatModelView * vec4(localPos, 1)).xyz;
-
-    if ((uMatProjection * vec4(worldPos, 1)).z <= 0) {
-        // Terrible hack:
-        // Push the vertex out of view (e.g. offscreen or behind clip).
-        // Works for entire sprites, because worldPos is the position of the
-        // sprite origin, the same for all vertices.
-        gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
-        return;
-    }
-
-    vec3 screenCenterPos = vec3(
-        uViewportCenter + worldPos.xy * uPhdPersp / worldPos.z,
-        uPhdResZBuf - uPhdResZ / worldPos.z);
-    vec3 screenCornerPos = screenCenterPos;
-    screenCornerPos.xy += inDisplacement * uPhdPersp / worldPos.z;
-    gl_Position = (uMatProjectionOG * vec4(screenCornerPos, 1));
-    #endif
 
     gUV = texelFetch(uUVW, int(inTextureIdx)).xyz;
     gShade = inShade;

--- a/data/tr1/ship/shaders/sprites.glsl
+++ b/data/tr1/ship/shaders/sprites.glsl
@@ -14,7 +14,7 @@ layout(location = 1) in vec2 inDisplacement;
 layout(location = 2) in int inTextureIdx;
 layout(location = 3) in float inShade;
 
-out vec3 gUV; // x = u, y = v, z = layer
+out vec3 gUVW; // x = u, y = v, z = layer
 out float gShade;
 
 void main(void) {
@@ -27,7 +27,7 @@ void main(void) {
             waterWibble(gl_Position, uViewportSize, uWibbleOffset);
     }
 
-    gUV = texelFetch(uUVW, int(inTextureIdx)).xyz;
+    gUVW = texelFetch(uUVW, int(inTextureIdx)).xyz;
     gShade = inShade;
 }
 
@@ -38,13 +38,13 @@ uniform bool uSmoothingEnabled;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;
 
-in vec3 gUV;
+in vec3 gUVW;
 in float gShade;
 out vec4 outColor;
 
 void main(void) {
-    vec4 texColor = texture(uTexture, gUV);
-    if (uSmoothingEnabled && discardTranslucent(uTexture, gUV)) {
+    vec4 texColor = texture(uTexture, gUVW);
+    if (uSmoothingEnabled && discardTranslucent(uTexture, gUVW)) {
         discard;
     }
 

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -22,7 +22,6 @@ struct GFX_3D_RENDERER {
 
     // shader variable locations
     GLint loc_mat_projection;
-    GLint loc_mat_model_view;
     GLint loc_texturing_enabled;
     GLint loc_smoothing_enabled;
     GLint loc_alpha_point_discard;
@@ -142,8 +141,6 @@ GFX_3D_RENDERER *GFX_3D_Renderer_Create(void)
 
     renderer->loc_mat_projection =
         GFX_GL_Program_UniformLocation(&renderer->program, "matProjection");
-    renderer->loc_mat_model_view =
-        GFX_GL_Program_UniformLocation(&renderer->program, "matModelView");
     renderer->loc_texturing_enabled =
         GFX_GL_Program_UniformLocation(&renderer->program, "texturingEnabled");
     renderer->loc_smoothing_enabled =

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1409,14 +1409,8 @@ void Output_GetProjectionMatrix(GLfloat output[][4])
 
     output[2][0] = 0.0f;
     output[2][1] = 0.0f;
-    // TODO(dash): these do not match the original game Z buffer mapping.
-    // I couldn't figure out how to replicate the original MAP_DEPTH transform.
-    // To combat this, the vertex shaders for now fence the simpler matrices
-    // behind a `NEW_ZBUFFER` define, and fall back to doing the perspective
-    // transform completely manually. This will be removable once we no longer
-    // rely on PHD_VBUF / GFX_3D_Rendere for world rendering.
-    output[2][2] = (far + near) / (far - near);
-    output[2][3] = -(2.0f * far * near) / (far - near);
+    output[2][2] = g_FltResZBuf;
+    output[2][3] = -g_FltResZ / (float)(1 << W2V_SHIFT);
 
     output[3][0] = 0.0f;
     output[3][1] = 0.0f;

--- a/src/tr1/game/output/sprite_program.c
+++ b/src/tr1/game/output/sprite_program.c
@@ -13,13 +13,8 @@ typedef enum {
     M_UNIFORM_SMOOTHING_ENABLED,
     M_UNIFORM_BRIGHTNESS_MULTIPLIER,
     M_UNIFORM_GLOBAL_TINT,
-    M_UNIFORM_VIEWPORT_CENTER,
     M_UNIFORM_VIEWPORT_SIZE,
     M_UNIFORM_PROJECTION_MATRIX,
-    M_UNIFORM_PROJECTION_MATRIX_OG,
-    M_UNIFORM_PHD_PERSP,
-    M_UNIFORM_PHD_RES_Z,
-    M_UNIFORM_PHD_RES_Z_BUF,
     M_UNIFORM_MODEL_MATRIX,
     M_UNIFORM_WIBBLE_OFFSET,
     M_UNIFORM_NUMBER_OF,
@@ -46,13 +41,8 @@ void Output_SpriteProgram_Init(void)
         [M_UNIFORM_SMOOTHING_ENABLED] = "uSmoothingEnabled",
         [M_UNIFORM_BRIGHTNESS_MULTIPLIER] = "uBrightnessMultiplier",
         [M_UNIFORM_GLOBAL_TINT] = "uGlobalTint",
-        [M_UNIFORM_VIEWPORT_CENTER] = "uViewportCenter",
         [M_UNIFORM_VIEWPORT_SIZE] = "uViewportSize",
         [M_UNIFORM_PROJECTION_MATRIX] = "uMatProjection",
-        [M_UNIFORM_PROJECTION_MATRIX_OG] = "uMatProjectionOG",
-        [M_UNIFORM_PHD_PERSP] = "uPhdPersp",
-        [M_UNIFORM_PHD_RES_Z] = "uPhdResZ",
-        [M_UNIFORM_PHD_RES_Z_BUF] = "uPhdResZBuf",
         [M_UNIFORM_MODEL_MATRIX] = "uMatModelView",
         [M_UNIFORM_WIBBLE_OFFSET] = "uWibbleOffset",
     };
@@ -86,9 +76,6 @@ void Output_SpriteProgram_UploadCommonUniforms(void)
     GFX_TRACK_UNIFORM(
         glUniform1f, m_Uniforms[M_UNIFORM_BRIGHTNESS_MULTIPLIER],
         g_Config.visuals.brightness);
-    GFX_TRACK_UNIFORM(
-        glUniform2f, m_Uniforms[M_UNIFORM_VIEWPORT_CENTER],
-        Viewport_GetCenterX(), Viewport_GetCenterY());
     GFX_TRACK_UNIFORM(
         glUniform2f, m_Uniforms[M_UNIFORM_VIEWPORT_SIZE],
         GFX_Context_GetDisplayWidth(), GFX_Context_GetDisplayHeight());
@@ -135,28 +122,6 @@ void Output_SpriteProgram_UploadProjectionMatrix(void)
     GFX_TRACK_UNIFORM(
         glUniformMatrix4fv, m_Uniforms[M_UNIFORM_PROJECTION_MATRIX], 1, GL_TRUE,
         &projection[0][0]);
-
-    const float left = 0.0f;
-    const float top = 0.0f;
-    const float right = GFX_Context_GetDisplayWidth();
-    const float bottom = GFX_Context_GetDisplayHeight();
-    GLfloat projection_og[4][4] = {
-        { 2.0f / (right - left), 0.0f, 0.0f, 0.0f },
-        { 0.0f, 2.0f / (top - bottom), 0.0f, 0.0f },
-        { 0.0f, 0.0f, +1.0f, 0.0f },
-        { -(right + left) / (right - left), -(top + bottom) / (top - bottom),
-          0.0f, 1.0f },
-    };
-    GFX_TRACK_UNIFORM(
-        glUniformMatrix4fv, m_Uniforms[M_UNIFORM_PROJECTION_MATRIX_OG], 1,
-        GL_FALSE, &projection_og[0][0]);
-
-    GFX_TRACK_UNIFORM(glUniform1f, m_Uniforms[M_UNIFORM_PHD_PERSP], g_PhdPersp);
-    GFX_TRACK_UNIFORM(
-        glUniform1f, m_Uniforms[M_UNIFORM_PHD_RES_Z],
-        g_FltResZ / (float)(1 << W2V_SHIFT));
-    GFX_TRACK_UNIFORM(
-        glUniform1f, m_Uniforms[M_UNIFORM_PHD_RES_Z_BUF], g_FltResZBuf);
 }
 
 void Output_SpriteProgram_UploadTint(const RGB_F tint)

--- a/src/tr1/game/output/textures.c
+++ b/src/tr1/game/output/textures.c
@@ -207,7 +207,7 @@ static void M_FillSpriteUVWs(void)
 
 static void M_UploadSpriteUVWs(void)
 {
-    glBindTexture(GL_TEXTURE_BUFFER, m_LevelData.sprites.tex);
+    glBindBuffer(GL_TEXTURE_BUFFER, m_LevelData.sprites.tbo);
     GFX_TRACK_DATA(
         glBufferData, GL_TEXTURE_BUFFER,
         m_LevelData.sprites.count * sizeof(M_UVW_PACK), m_LevelData.sprites.uvw,
@@ -216,7 +216,7 @@ static void M_UploadSpriteUVWs(void)
 
 static void M_UploadSpriteAnimatedUVWs(const M_ANIMATION_RANGES *const source)
 {
-    glBindTexture(GL_TEXTURE_BUFFER, m_LevelData.sprites.tex);
+    glBindBuffer(GL_TEXTURE_BUFFER, m_LevelData.sprites.tbo);
     for (int32_t i = 0; i < source->range_count; i++) {
         const M_ANIMATION_RANGE *const range = &source->ranges[i];
         for (int32_t j = 0; j < range->count; j++) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Removes a lot of poor code to achieve the original depth buffer resolution, in favor of a modern approach with a perspective-capable projection matrix. The code was mostly there, but the depth buffer components were poorly defined and thus not usable.  This PR fixes it. (Matching the depth buffer calculations with the original is important, because we still use both the original and modernized pipelines).

#### Testing

Since sprites are the only elements using the new z-buffer calculations, we need to examine how they behave in TR1 concerning camera distance, scene depth, and occlusion by other objects or surfaces.
