### PR TITLE
tr1/output/objects: rewrite object mesh drawing

### DIFF
--- a/data/tr1/ship/shaders/meshes.glsl
+++ b/data/tr1/ship/shaders/meshes.glsl
@@ -1,3 +1,10 @@
+#define NEUTRAL_SHADE 0x1000
+
+#define VERT_NO_CAUSTICS 0x01
+#define VERT_FLAT_SHADED 0x02
+#define VERT_REFLECTIVE  0x04
+#define VERT_NO_LIGHTING 0x08
+
 #ifdef VERTEX
 
 uniform int uTime;
@@ -9,20 +16,25 @@ uniform bool uTrapezoidFilterEnabled;
 uniform bool uWibbleEffect;
 
 layout(location = 0) in vec3 inPosition;
-layout(location = 1) in int inUVWIdx;
-layout(location = 2) in vec2 inTrapezoidRatios;
-layout(location = 3) in int inFlags;
-layout(location = 4) in float inShade;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in int inUVWIdx;
+layout(location = 3) in vec2 inTrapezoidRatios;
+layout(location = 4) in int inFlags;
+layout(location = 5) in vec4 inColor;
+layout(location = 6) in float inShade;
 
 out vec4 gWorldPos;
+out vec3 gNormal;
 flat out int gFlags;
 flat out int gTexLayer;
 out vec2 gTexUV;
 out vec2 gTrapezoidRatios;
 out float gShade;
+out vec4 gColor;
 
 void main(void) {
     gWorldPos = uMatModelView * vec4(inPosition.xyz, 1.0);
+    gNormal = inNormal;
     gl_Position = uMatProjection * gWorldPos;
 
     if (uWibbleEffect && (inFlags & VERT_NO_CAUSTICS) == 0) {
@@ -39,15 +51,18 @@ void main(void) {
         gTexUV *= inTrapezoidRatios;
     }
     gShade = inShade;
+    gColor = inColor;
 }
 
 #elif defined(FRAGMENT)
 
 uniform int uTime;
 uniform sampler2DArray uTexAtlas;
+uniform sampler2D uTexEnvMap;
 uniform bool uSmoothingEnabled;
 uniform bool uAlphaDiscardEnabled;
 uniform bool uTrapezoidFilterEnabled;
+uniform bool uReflectionsEnabled;
 uniform float uAlphaThreshold;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;
@@ -55,21 +70,23 @@ uniform vec2 uFog; // x = fog start, y = fog end
 uniform bool uWaterEffect;
 
 in vec4 gWorldPos;
+in vec3 gNormal;
 flat in int gFlags;
 flat in int gTexLayer;
 in vec2 gTexUV;
-in vec2 gTrapezoidRatios;
 in float gShade;
+in vec4 gColor;
+in vec2 gTrapezoidRatios;
 out vec4 outColor;
 
 void main(void) {
-    vec4 texColor = vec4(1);
+    vec4 texColor = gColor;
     vec3 texCoords = vec3(gTexUV.x, gTexUV.y, gTexLayer);
     if (uTrapezoidFilterEnabled) {
         texCoords.xy /= gTrapezoidRatios.xy;
     }
 
-    if (texCoords.z >= 0) {
+    if ((gFlags & VERT_FLAT_SHADED) == 0 && texCoords.z >= 0) {
         if (uAlphaDiscardEnabled && uSmoothingEnabled && discardTranslucent(uTexAtlas, texCoords)) {
             discard;
         }
@@ -79,11 +96,16 @@ void main(void) {
             discard;
         }
     }
+    if ((gFlags & VERT_REFLECTIVE) != 0 && uReflectionsEnabled) {
+        texColor *= texture(uTexEnvMap, (normalize(gNormal) * 0.5 + 0.5).xy) * 2;
+    }
 
-    float shade = gShade;
-    shade = shadeFog(shade, gWorldPos.z, uFog);
+    if ((gFlags & VERT_NO_LIGHTING) == 0) {
+        float shade = gShade;
+        shade = shadeFog(shade, gWorldPos.z, uFog);
+        texColor.rgb = applyShade(texColor.rgb, shade);
+    }
 
-    texColor.rgb = applyShade(texColor.rgb, shade);
     texColor.rgb *= uBrightnessMultiplier;
     texColor.rgb *= uGlobalTint;
     outColor = vec4(texColor.rgb, 1.0);

--- a/data/tr1/ship/shaders/sprites.glsl
+++ b/data/tr1/ship/shaders/sprites.glsl
@@ -37,6 +37,7 @@ void main(void) {
 #elif defined(FRAGMENT)
 
 uniform sampler2DArray uTexAtlas;
+uniform sampler2D uTexEnvMap;
 uniform bool uSmoothingEnabled;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -297,6 +297,7 @@ static void M_ReadObjectMesh(OBJECT_MESH *const mesh, VFILE *const file)
     VFile_Skip(file, sizeof(int16_t));
 
     mesh->enable_reflections = false;
+    mesh->disable_lighting = false;
 
     {
         mesh->num_vertices = VFile_ReadS16(file);

--- a/src/libtrx/game/objects/common.c
+++ b/src/libtrx/game/objects/common.c
@@ -6,6 +6,7 @@
 #include "game/game_buf.h"
 #include "game/matrix.h"
 #include "game/output.h"
+#include "game/output/objects.h"
 
 static OBJECT m_Objects[O_NUMBER_OF] = {};
 static STATIC_OBJECT_3D m_StaticObjects3D[MAX_STATIC_OBJECTS] = {};
@@ -84,6 +85,16 @@ OBJECT_MESH *Object_GetMesh(const int32_t index)
     return m_MeshPointers[index];
 }
 
+int32_t Object_GetMeshIndex(const OBJECT_MESH *const mesh)
+{
+    for (int32_t i = 0; i < m_MeshCount; i++) {
+        if (mesh == m_MeshPointers[i]) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 int32_t Object_GetMeshCount(void)
 {
     return m_MeshCount;
@@ -122,6 +133,12 @@ void Object_SwapMesh(
     m_MeshPointers[obj1->mesh_idx + mesh_num] =
         m_MeshPointers[obj2->mesh_idx + mesh_num];
     m_MeshPointers[obj2->mesh_idx + mesh_num] = temp;
+
+#if TR_VERSION == 1
+    Output_Objects_ObserveMeshSwap(
+        m_MeshPointers[obj1->mesh_idx + mesh_num],
+        m_MeshPointers[obj2->mesh_idx + mesh_num]);
+#endif
 }
 
 ANIM *Object_GetAnim(const OBJECT *const obj, const int32_t anim_idx)

--- a/src/libtrx/gfx/context.c
+++ b/src/libtrx/gfx/context.c
@@ -331,11 +331,6 @@ void GFX_Context_ClearScheduledScreenshotPath(void)
     Memory_FreePointer(&m_Context.scheduled_screenshot_path);
 }
 
-void GFX_Context_GetScale(float *const out_x, float *const out_y)
-{
-    m_Context.renderer->get_scale(m_Context.renderer, out_x, out_y);
-}
-
 GFX_CONFIG *GFX_Context_GetConfig(void)
 {
     return &m_Context.config;

--- a/src/libtrx/gfx/renderers/fbo_renderer.c
+++ b/src/libtrx/gfx/renderers/fbo_renderer.c
@@ -34,8 +34,6 @@ static void M_SwapBuffers(GFX_RENDERER *renderer);
 static void M_Init(GFX_RENDERER *renderer, const GFX_CONFIG *config);
 static void M_Shutdown(GFX_RENDERER *renderer);
 static void M_Reset(GFX_RENDERER *renderer);
-static void M_GetScale(
-    const GFX_RENDERER *renderer, float *out_scale_x, float *out_scale_y);
 
 static void M_Render(GFX_RENDERER *renderer);
 static void M_Bind(const GFX_RENDERER *renderer);
@@ -246,18 +244,9 @@ static void M_Unbind(const GFX_RENDERER *renderer)
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-static void M_GetScale(
-    const GFX_RENDERER *renderer, float *const out_scale_x,
-    float *const out_scale_y)
-{
-    *out_scale_x = 1.0f;
-    *out_scale_y = 1.0f;
-}
-
 GFX_RENDERER g_GFX_Renderer_FBO = {
     .swap_buffers = &M_SwapBuffers,
     .init = &M_Init,
     .shutdown = &M_Shutdown,
     .reset = &M_Reset,
-    .get_scale = M_GetScale,
 };

--- a/src/libtrx/gfx/renderers/legacy_renderer.c
+++ b/src/libtrx/gfx/renderers/legacy_renderer.c
@@ -28,21 +28,10 @@ static void M_SwapBuffers(GFX_RENDERER *renderer)
     GFX_GL_CheckError();
 }
 
-static void M_GetScale(
-    const GFX_RENDERER *renderer, float *const out_scale_x,
-    float *const out_scale_y)
-{
-    const int32_t window_width = GFX_Context_GetWindowWidth();
-    const int32_t window_height = GFX_Context_GetWindowHeight();
-    *out_scale_x = window_width / (float)GFX_Context_GetDisplayWidth();
-    *out_scale_y = window_height / (float)GFX_Context_GetDisplayHeight();
-}
-
 GFX_RENDERER g_GFX_Renderer_Legacy = {
     .priv = nullptr,
     .swap_buffers = &M_SwapBuffers,
     .init = nullptr,
     .reset = nullptr,
     .shutdown = nullptr,
-    .get_scale = M_GetScale,
 };

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -24,6 +24,7 @@ void Object_StoreMesh(OBJECT_MESH *mesh);
 
 int32_t Object_GetMeshCount(void);
 OBJECT_MESH *Object_FindMesh(int32_t data_offset);
+int32_t Object_GetMeshIndex(const OBJECT_MESH *mesh);
 int32_t Object_GetMeshOffset(const OBJECT_MESH *mesh);
 void Object_SetMeshOffset(OBJECT_MESH *mesh, int32_t data_offset);
 

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -33,7 +33,9 @@ typedef struct {
     FACE3 *tex_face3s;
     FACE4 *flat_face4s;
     FACE3 *flat_face3s;
+
     bool enable_reflections;
+    bool disable_lighting;
 } OBJECT_MESH;
 
 #if TR_VERSION == 1

--- a/src/libtrx/include/libtrx/game/output/objects.h
+++ b/src/libtrx/include/libtrx/game/output/objects.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../objects/types.h"
+
+#if TR_VERSION == 1
+extern void Output_Objects_ObserveMeshSwap(
+    const OBJECT_MESH *mesh_1, const OBJECT_MESH *mesh_2);
+extern void Output_Objects_ObserveMeshUpdate(const OBJECT_MESH *mesh);
+#endif

--- a/src/libtrx/include/libtrx/gfx/context.h
+++ b/src/libtrx/include/libtrx/gfx/context.h
@@ -37,6 +37,5 @@ void GFX_Context_SwitchToDisplayViewport(void);
 void GFX_Context_ScheduleScreenshot(const char *path);
 const char *GFX_Context_GetScheduledScreenshotPath(void);
 void GFX_Context_ClearScheduledScreenshotPath(void);
-void GFX_Context_GetScale(float *out_x, float *out_y);
 
 GFX_CONFIG *GFX_Context_GetConfig(void);

--- a/src/libtrx/include/libtrx/gfx/renderer.h
+++ b/src/libtrx/include/libtrx/gfx/renderer.h
@@ -7,8 +7,5 @@ typedef struct GFX_Renderer {
     void (*shutdown)(struct GFX_Renderer *renderer);
     void (*reset)(struct GFX_Renderer *renderer);
     void (*swap_buffers)(struct GFX_Renderer *renderer);
-    void (*get_scale)(
-        const struct GFX_Renderer *renderer, float *out_scale_x,
-        float *out_scale_y);
     void *priv;
 } GFX_RENDERER;

--- a/src/tr1/game/game/game_draw.c
+++ b/src/tr1/game/game/game_draw.c
@@ -4,6 +4,7 @@
 #include "game/lara/draw.h"
 #include "game/lara/hair.h"
 #include "game/output.h"
+#include "game/output/textures.h"
 #include "game/overlay.h"
 #include "game/room_draw.h"
 #include "game/viewport.h"
@@ -24,7 +25,7 @@ void Game_Draw(bool draw_overlay)
         Room_DrawAllRooms(g_Camera.interp.room_num, g_Camera.target.room_num);
 
         if (g_Config.visuals.enable_reflections) {
-            Output_FillEnvironmentMap();
+            Output_Textures_UpdateEnvironmentMap();
         }
 
         if (Room_Get(g_LaraItem->room_num)->flags & RF_UNDERWATER) {

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -5,6 +5,7 @@
 #include "game/lara/common.h"
 #include "game/objects/vars.h"
 #include "game/output.h"
+#include "game/output/objects.h"
 #include "game/room.h"
 #include "game/viewport.h"
 #include "global/const.h"
@@ -290,6 +291,7 @@ void Object_SetMeshReflective(
     for (int32_t i = 0; i < mesh->num_flat_face3s; i++) {
         mesh->flat_face3s[i].enable_reflections = enabled;
     }
+    Output_Objects_ObserveMeshUpdate(mesh);
 }
 
 void Object_SetReflective(const GAME_OBJECT_ID obj_id, const bool enabled)

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -27,6 +27,17 @@ static void M_SetupLaraExtra(void)
     obj->control_func = Lara_ControlExtra;
 }
 
+static void M_SetupSkybox(void)
+{
+    const OBJECT *const obj = Object_Get(O_SKYBOX);
+    if (obj->loaded) {
+        for (int32_t i = 0; i < obj->mesh_count; i++) {
+            OBJECT_MESH *const obj_mesh = Object_GetMesh(obj->mesh_idx + i);
+            obj_mesh->disable_lighting = true;
+        }
+    }
+}
+
 static void M_DisableObject(const GAME_OBJECT_ID obj_id)
 {
     OBJECT *const obj = Object_Get(obj_id);
@@ -67,6 +78,7 @@ void Object_SetupAllObjects(void)
 
     M_SetupLara();
     M_SetupLaraExtra();
+    M_SetupSkybox();
 
     Lara_Hair_Initialise();
 

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1351,17 +1351,32 @@ void Output_GetProjectionMatrix(GLfloat output[][4])
 void Output_EnableScissor(
     const float x, const float y, const float w, const float h)
 {
+    // Causes the rendering pipeline to discard every pixel outside of the
+    // specified window. The window is in game framebuffer viewport's
+    // coordinates; to make it work properly, we need to translate it to the
+    // SDL window coordinates first.
+
     const int32_t border = 2; // to deal with precision issues
 
-    float scale_x;
-    float scale_y;
-    GFX_Context_GetScale(&scale_x, &scale_y);
+    struct {
+        GLint x, y, w, h;
+    } game_viewport = {
+        .x = Viewport_GetMinX(),
+        .y = Viewport_GetMinY(),
+        .w = Viewport_GetWidth(),
+        .h = Viewport_GetHeight(),
+    }, gl_viewport, scissor;
+    glGetIntegerv(GL_VIEWPORT, &gl_viewport.x);
+
+    const float scale_x = gl_viewport.w / (float)game_viewport.w;
+    const float scale_y = gl_viewport.h / (float)game_viewport.h;
+    scissor.x = gl_viewport.x + (x * scale_x) - border;
+    scissor.y = gl_viewport.y + (game_viewport.h - y) * scale_y - border;
+    scissor.w = w * scale_x + border * 2;
+    scissor.h = h * scale_y + border * 2;
 
     glEnable(GL_SCISSOR_TEST);
-    glScissor(
-        x * scale_x - border,
-        (GFX_Context_GetDisplayHeight() - y) * scale_y - border,
-        w * scale_x + border * 2, h * scale_y + border * 2);
+    glScissor(scissor.x, scissor.y, scissor.w, scissor.h);
 }
 
 void Output_DisableScissor(void)

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1,6 +1,7 @@
 #include "game/output.h"
 
 #include "game/output/meshes.h"
+#include "game/output/objects.h"
 #include "game/output/rooms.h"
 #include "game/output/sprites.h"
 #include "game/output/textures.h"
@@ -69,17 +70,8 @@ static struct {
 } m_CachedState;
 
 static void M_DrawSphere(const XYZ_32 pos, const int32_t radius);
-static void M_DrawFlatFace3s(const FACE3 *faces, int32_t count);
-static void M_DrawFlatFace4s(const FACE4 *faces, int32_t count);
-static void M_DrawTexturedFace3s(const FACE3 *faces, int32_t count);
-static void M_DrawTexturedFace4s(const FACE4 *faces, int32_t count);
-static void M_DrawObjectFace3EnvMap(const FACE3 *faces, int32_t count);
-static void M_DrawObjectFace4EnvMap(const FACE4 *faces, int32_t count);
 static uint16_t M_CalcVertex(PHD_VBUF *vbuf, const XYZ_16 pos);
 static bool M_CalcObjectVertices(const XYZ_16 *vertices, int16_t count);
-static void M_CalcVerticeLight(const OBJECT_MESH *mesh);
-static bool M_CalcVerticeEnvMap(const OBJECT_MESH *mesh);
-static void M_CalcSkyboxLight(const OBJECT_MESH *mesh);
 
 static void M_DrawSphere(const XYZ_32 pos, const int32_t radius)
 {
@@ -139,145 +131,6 @@ static void M_DrawSphere(const XYZ_32 pos, const int32_t radius)
 
     S_Output_SetBlendingMode(GFX_BLEND_MODE_OFF);
     GFX_Context_SetWireframeMode(wireframe_state);
-}
-
-static void M_DrawFlatFace3s(const FACE3 *const faces, const int32_t count)
-{
-    S_Output_DisableTextureMode();
-
-    for (int32_t i = 0; i < count; i++) {
-        const FACE3 *const face = &faces[i];
-        PHD_VBUF *const vns[3] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-        };
-
-        const RGBA_8888 color =
-            Output_RGB2RGBA(Output_GetPaletteColor8(face->palette_idx));
-        S_Output_DrawFlatTriangle(vns[0], vns[1], vns[2], color);
-    }
-}
-
-static void M_DrawFlatFace4s(const FACE4 *const faces, const int32_t count)
-{
-    S_Output_DisableTextureMode();
-
-    for (int32_t i = 0; i < count; i++) {
-        const FACE4 *const face = &faces[i];
-        PHD_VBUF *const vns[4] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-            &m_VBuf[face->vertices[3]],
-        };
-
-        const RGBA_8888 color =
-            Output_RGB2RGBA(Output_GetPaletteColor8(face->palette_idx));
-        S_Output_DrawFlatTriangle(vns[0], vns[1], vns[2], color);
-        S_Output_DrawFlatTriangle(vns[2], vns[3], vns[0], color);
-    }
-}
-
-static void M_DrawTexturedFace3s(const FACE3 *const faces, const int32_t count)
-{
-    S_Output_EnableTextureMode();
-
-    for (int32_t i = 0; i < count; i++) {
-        const FACE3 *const face = &faces[i];
-        PHD_VBUF *const vns[3] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-        };
-
-        OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
-        for (int32_t j = 0; j < 3; j++) {
-            vns[j]->u = tex->uv[j].u;
-            vns[j]->v = tex->uv[j].v;
-            vns[j]->z = 1.0f;
-            vns[j]->w = 1.0f;
-        }
-
-        S_Output_DrawTexturedTriangle(
-            vns[0], vns[1], vns[2], tex->tex_page, tex->draw_type);
-    }
-}
-
-static void M_DrawTexturedFace4s(const FACE4 *const faces, const int32_t count)
-{
-    S_Output_EnableTextureMode();
-
-    for (int32_t i = 0; i < count; i++) {
-        const FACE4 *const face = &faces[i];
-        PHD_VBUF *const vns[4] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-            &m_VBuf[face->vertices[3]],
-        };
-
-        OBJECT_TEXTURE *const tex = Output_GetObjectTexture(face->texture_idx);
-        for (int32_t j = 0; j < 4; j++) {
-            vns[j]->u = tex->uv[j].u;
-            vns[j]->v = tex->uv[j].v;
-            if (g_Config.rendering.enable_trapezoid_filter) {
-                vns[j]->z = face->texture_zw[j].z;
-                vns[j]->w = face->texture_zw[j].w;
-            } else {
-                vns[j]->z = 1.0f;
-                vns[j]->w = 1.0f;
-            }
-        }
-
-        S_Output_DrawTexturedQuad(
-            vns[0], vns[1], vns[2], vns[3], tex->tex_page, tex->draw_type);
-    }
-}
-
-static void M_DrawObjectFace3EnvMap(
-    const FACE3 *const faces, const int32_t count)
-{
-    for (int32_t i = 0; i < count; i++) {
-        const FACE3 *const face = &faces[i];
-        PHD_VBUF *vns[3] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-        };
-
-        for (int32_t j = 0; j < 3; j++) {
-            vns[j]->u = m_EnvMapUV[face->vertices[j]].u;
-            vns[j]->v = m_EnvMapUV[face->vertices[j]].v;
-        }
-
-        if (face->enable_reflections) {
-            S_Output_DrawEnvMapTriangle(vns[0], vns[1], vns[2]);
-        }
-    }
-}
-
-static void M_DrawObjectFace4EnvMap(
-    const FACE4 *const faces, const int32_t count)
-{
-    for (int32_t i = 0; i < count; i++) {
-        const FACE4 *const face = &faces[i];
-        PHD_VBUF *vns[4] = {
-            &m_VBuf[face->vertices[0]],
-            &m_VBuf[face->vertices[1]],
-            &m_VBuf[face->vertices[2]],
-            &m_VBuf[face->vertices[3]],
-        };
-
-        for (int32_t j = 0; j < 4; j++) {
-            vns[j]->u = m_EnvMapUV[face->vertices[j]].u;
-            vns[j]->v = m_EnvMapUV[face->vertices[j]].v;
-        }
-
-        if (face->enable_reflections) {
-            S_Output_DrawEnvMapQuad(vns[0], vns[1], vns[2], vns[3]);
-        }
-    }
 }
 
 static uint16_t M_CalcVertex(PHD_VBUF *const vbuf, const XYZ_16 pos)
@@ -344,109 +197,6 @@ static bool M_CalcObjectVertices(
     return total_clip == 0;
 }
 
-static void M_CalcVerticeLight(const OBJECT_MESH *const mesh)
-{
-    if (mesh->num_lights <= 0) {
-        for (int32_t i = 0; i < -mesh->num_lights; i++) {
-            int16_t shade = m_LsAdder + mesh->lighting.lights[i];
-            CLAMP(shade, 0, 0x1FFF);
-            m_VBuf[i].g = shade;
-        }
-
-        return;
-    }
-
-    if (m_LsDivider == 0) {
-        int16_t shade = m_LsAdder;
-        CLAMP(shade, 0, 0x1FFF);
-        for (int32_t i = 0; i < mesh->num_lights; i++) {
-            m_VBuf[i].g = shade;
-        }
-
-        return;
-    }
-
-    // clang-format off
-    const int32_t xv = (
-        g_MatrixPtr->_00 * m_LsVectorView.x +
-        g_MatrixPtr->_10 * m_LsVectorView.y +
-        g_MatrixPtr->_20 * m_LsVectorView.z
-    ) / m_LsDivider;
-
-    const int32_t yv = (
-        g_MatrixPtr->_01 * m_LsVectorView.x +
-        g_MatrixPtr->_11 * m_LsVectorView.y +
-        g_MatrixPtr->_21 * m_LsVectorView.z
-    ) / m_LsDivider;
-
-    const int32_t zv = (
-        g_MatrixPtr->_02 * m_LsVectorView.x +
-        g_MatrixPtr->_12 * m_LsVectorView.y +
-        g_MatrixPtr->_22 * m_LsVectorView.z
-    ) / m_LsDivider;
-    // clang-format on
-
-    for (int32_t i = 0; i < mesh->num_lights; i++) {
-        const XYZ_16 *const normal = &mesh->lighting.normals[i];
-        int16_t shade = m_LsAdder
-            + ((normal->x * xv + normal->y * yv + normal->z * zv) >> 16);
-        CLAMP(shade, 0, 0x1FFF);
-        m_VBuf[i].g = shade;
-    }
-}
-
-static bool M_CalcVerticeEnvMap(const OBJECT_MESH *mesh)
-{
-    if (mesh->num_lights <= 0) {
-        return false;
-    }
-
-    for (int32_t i = 0; i < mesh->num_lights; ++i) {
-        // make sure that reflection will be drawn after normal poly
-        m_VBuf[i].zv -= (double)((1 << W2V_SHIFT) / 2);
-
-        // set lighting that depends only from fog distance
-        m_VBuf[i].g = 0x1000;
-
-        const int32_t depth = g_MatrixPtr->_23 >> W2V_SHIFT;
-        m_VBuf[i].g += Output_CalcFogShade(depth);
-
-        // reflection can be darker but not brighter
-        CLAMP(m_VBuf[i].g, 0x1000, 0x1FFF);
-
-        // rotate normal vectors for X/Y, no translation
-        const XYZ_16 *const normal = &mesh->lighting.normals[i];
-
-        // clang-format off
-        int32_t x = (
-            g_MatrixPtr->_00 * normal->x +
-            g_MatrixPtr->_01 * normal->y +
-            g_MatrixPtr->_02 * normal->z
-        ) >> W2V_SHIFT;
-
-        int32_t y = (
-            g_MatrixPtr->_10 * normal->x +
-            g_MatrixPtr->_11 * normal->y +
-            g_MatrixPtr->_12 * normal->z
-        ) >> W2V_SHIFT;
-        // clang-format on
-
-        CLAMP(x, -PHD_ONE, PHD_IONE);
-        CLAMP(y, -PHD_ONE, PHD_IONE);
-        m_EnvMapUV[i].u = PHD_ONE / PHD_IONE * (x + PHD_IONE) / 2;
-        m_EnvMapUV[i].v = PHD_ONE - PHD_ONE / PHD_IONE * (y + PHD_IONE) / 2;
-    }
-
-    return true;
-}
-
-static void M_CalcSkyboxLight(const OBJECT_MESH *const mesh)
-{
-    for (int32_t i = 0; i < ABS(mesh->num_lights); i++) {
-        m_VBuf[i].g = 0xFFF;
-    }
-}
-
 bool Output_Init(void)
 {
     const bool result = S_Output_Init();
@@ -454,11 +204,13 @@ bool Output_Init(void)
     Output_Sprites_Init();
     Output_Meshes_Init();
     Output_Rooms_Init();
+    Output_Objects_Init();
     return result;
 }
 
 void Output_Shutdown(void)
 {
+    Output_Objects_Shutdown();
     Output_Rooms_Shutdown();
     Output_Meshes_Shutdown();
     Output_Sprites_Shutdown();
@@ -493,10 +245,18 @@ void Output_ObserveLevelLoad(void)
     Output_Textures_ObserveLevelLoad();
     Output_Sprites_ObserveLevelLoad();
     Output_Rooms_ObserveLevelLoad();
+    Output_Objects_ObserveLevelLoad();
 }
 
 void Output_ObserveLevelUnload(void)
 {
+    Output_Objects_ObserveLevelUnload();
+}
+
+void Output_ObserveFOVChange(void)
+{
+    Output_Meshes_UploadProjectionMatrix();
+    Output_Sprites_UploadProjectionMatrix();
 }
 
 void Output_DrawBlack(void)
@@ -548,26 +308,10 @@ void Output_ClearDepthBuffer(void)
 
 void Output_DrawObjectMesh(const OBJECT_MESH *const mesh, const int32_t clip)
 {
-    if (!M_CalcObjectVertices(mesh->vertices, mesh->num_vertices)) {
-        return;
-    }
-
-    M_CalcVerticeLight(mesh);
-    M_DrawTexturedFace4s(mesh->tex_face4s, mesh->num_tex_face4s);
-    M_DrawTexturedFace3s(mesh->tex_face3s, mesh->num_tex_face3s);
-    M_DrawFlatFace4s(mesh->flat_face4s, mesh->num_flat_face4s);
-    M_DrawFlatFace3s(mesh->flat_face3s, mesh->num_flat_face3s);
-
-    if (mesh->enable_reflections && g_Config.visuals.enable_reflections) {
-        if (!M_CalcVerticeEnvMap(mesh)) {
-            return;
-        }
-
-        M_DrawObjectFace4EnvMap(mesh->tex_face4s, mesh->num_tex_face4s);
-        M_DrawObjectFace3EnvMap(mesh->tex_face3s, mesh->num_tex_face3s);
-        M_DrawObjectFace4EnvMap(mesh->flat_face4s, mesh->num_flat_face4s);
-        M_DrawObjectFace3EnvMap(mesh->flat_face3s, mesh->num_flat_face3s);
-    }
+    S_Output_Flush();
+    Output_RememberState();
+    Output_Objects_RenderMesh(g_MatrixPtr, Output_GetTint(), mesh);
+    Output_RestoreState();
 
     if (g_Config.rendering.enable_debug_spheres) {
         M_DrawSphere(
@@ -578,6 +322,7 @@ void Output_DrawObjectMesh(const OBJECT_MESH *const mesh, const int32_t clip)
             },
             mesh->radius);
     }
+    S_Output_Flush();
 }
 
 void Output_DrawObjectMesh_I(const OBJECT_MESH *const mesh, const int32_t clip)
@@ -605,16 +350,10 @@ void Output_DrawSkybox(const OBJECT_MESH *const mesh)
     g_PhdRight = Viewport_GetMaxX();
     g_PhdBottom = Viewport_GetMaxY();
 
-    if (!M_CalcObjectVertices(mesh->vertices, mesh->num_vertices)) {
-        return;
-    }
-
     S_Output_DisableDepthTest();
-    M_CalcSkyboxLight(mesh);
-    M_DrawTexturedFace4s(mesh->tex_face4s, mesh->num_tex_face4s);
-    M_DrawTexturedFace3s(mesh->tex_face3s, mesh->num_tex_face3s);
-    M_DrawFlatFace4s(mesh->flat_face4s, mesh->num_flat_face4s);
-    M_DrawFlatFace3s(mesh->flat_face3s, mesh->num_flat_face3s);
+    Output_RememberState();
+    Output_Objects_RenderMesh(g_MatrixPtr, Output_GetTint(), mesh);
+    Output_RestoreState();
     S_Output_EnableDepthTest();
 }
 

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -16,6 +16,7 @@ void Output_SetWindowSize(int width, int height);
 void Output_ApplyRenderSettings(void);
 void Output_ObserveLevelLoad(void);
 void Output_ObserveLevelUnload(void);
+void Output_ObserveFOVChange(void);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);

--- a/src/tr1/game/output/meshes.c
+++ b/src/tr1/game/output/meshes.c
@@ -23,3 +23,8 @@ OUTPUT_SHADER *Output_Meshes_GetShader(void)
 {
     return m_Shader;
 }
+
+void Output_Meshes_UploadProjectionMatrix(void)
+{
+    Output_Shader_UploadProjectionMatrix(m_Shader);
+}

--- a/src/tr1/game/output/meshes.h
+++ b/src/tr1/game/output/meshes.h
@@ -4,9 +4,13 @@
 
 // clang-format off
 #define VERT_NO_CAUSTICS 0b0000'0001 // = 0x01
+#define VERT_FLAT_SHADED 0b0000'0010 // = 0x02
+#define VERT_REFLECTIVE  0b0000'0100 // = 0x04
+#define VERT_NO_LIGHTING 0b0000'1000 // = 0x08
 // clang-format on
 
 void Output_Meshes_Init(void);
 void Output_Meshes_Shutdown(void);
+void Output_Meshes_UploadProjectionMatrix(void);
 void Output_Meshes_RenderBegin(void);
 OUTPUT_SHADER *Output_Meshes_GetShader(void);

--- a/src/tr1/game/output/objects.c
+++ b/src/tr1/game/output/objects.c
@@ -1,0 +1,432 @@
+#include "game/output.h"
+#include "game/output/meshes.h"
+#include "game/output/textures.h"
+#include "game/output/utils.h"
+
+#include <libtrx/debug.h>
+#include <libtrx/game/output/objects.h>
+#include <libtrx/gfx/gl/utils.h>
+#include <libtrx/memory.h>
+
+#pragma pack(push, 1)
+typedef struct {
+    // clang-format off
+    XYZ_F pos;                // attribute 0
+    XYZ_F normal;             // attribute 1
+    int32_t uvw_idx;          // attribute 2
+    float trapezoid_ratio[2]; // attribute 3
+    uint16_t flags;           // attribute 4
+    RGBA_8888 color;          // attribute 5
+    // clang-format on
+} M_MESH_VERTEX;
+
+typedef int16_t M_MESH_SHADE;
+#pragma pack(pop)
+
+typedef struct {
+    int32_t vertex_start;
+    int32_t vertex_count;
+} M_BATCH;
+
+static struct {
+    GLuint vao;
+    GLuint geom_vbo;
+    size_t vertex_count;
+    GLuint shade_vbo;
+    M_MESH_VERTEX *geom_vbo_data;
+    M_MESH_SHADE *shade_vbo_data;
+    int32_t *light_idx_map;
+    size_t batch_count;
+    M_BATCH *batches;
+} m_Priv;
+
+static OUTPUT_SHADER *m_Shader = nullptr;
+
+static M_BATCH *M_GetBatch(const OBJECT_MESH *const mesh)
+{
+    const int16_t mesh_num = Object_GetMeshIndex(mesh);
+    return &m_Priv.batches[mesh_num];
+}
+
+static uint16_t M_GetFlags(const OBJECT_MESH *const mesh, const bool flat)
+{
+    uint16_t flags = 0;
+    if (flat) {
+        flags |= VERT_FLAT_SHADED;
+    }
+    if (mesh->enable_reflections) {
+        flags |= VERT_REFLECTIVE;
+    }
+    if (mesh->disable_lighting) {
+        flags |= VERT_NO_LIGHTING;
+    }
+    return flags;
+}
+
+static void M_FillVertex(
+    M_MESH_VERTEX *const out_vertex, const int32_t uvw_idx,
+    const OBJECT_MESH *const mesh, const int32_t vertex_idx,
+    const int32_t palette_idx)
+{
+    const XYZ_16 pos = mesh->vertices[vertex_idx];
+    const XYZ_16 normal = mesh->lighting.normals[vertex_idx];
+    out_vertex->pos = (XYZ_F) { .x = pos.x, .y = pos.y, .z = pos.z };
+    out_vertex->normal =
+        (XYZ_F) { .x = normal.x, .y = -normal.y, .z = normal.z };
+    out_vertex->uvw_idx = uvw_idx;
+    out_vertex->flags = M_GetFlags(mesh, palette_idx >= 0);
+    if (palette_idx >= 0) {
+        out_vertex->color =
+            Output_RGB2RGBA(Output_GetPaletteColor8(palette_idx));
+    } else {
+        out_vertex->color = (RGBA_8888) { 255, 255, 255, 255 };
+    }
+}
+
+static M_MESH_VERTEX *M_FillFace4(
+    const OBJECT_MESH *const mesh, M_MESH_VERTEX *out_vertex,
+    const FACE4 *const face, const bool flat)
+{
+    for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
+        const int32_t j = OUTPUT_QUAD_TO_FAN(i);
+        const int32_t uvw_idx = face->texture_idx * 4 + j;
+        M_FillVertex(
+            out_vertex, uvw_idx, mesh, face->vertices[j],
+            flat ? face->palette_idx : -1);
+        out_vertex->trapezoid_ratio[0] = face->texture_zw[j].z;
+        out_vertex->trapezoid_ratio[1] = face->texture_zw[j].w;
+        out_vertex++;
+    }
+    return out_vertex;
+}
+
+static M_MESH_VERTEX *M_FillFace3(
+    const OBJECT_MESH *const mesh, M_MESH_VERTEX *out_vertex,
+    const FACE3 *const face, const bool flat)
+{
+    const M_BATCH *const batch = M_GetBatch(mesh);
+    for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
+        const int32_t j = OUTPUT_TRI_TO_FAN(i);
+        const int32_t uvw_idx = face->texture_idx * 4 + j;
+        M_FillVertex(
+            out_vertex, uvw_idx, mesh, face->vertices[j],
+            flat ? face->palette_idx : -1);
+        out_vertex->trapezoid_ratio[0] = 1.0f;
+        out_vertex->trapezoid_ratio[1] = 1.0f;
+        out_vertex++;
+    }
+    return out_vertex;
+}
+
+static void M_UpdateGeometry(const OBJECT_MESH *const mesh)
+{
+    const M_BATCH *const batch = M_GetBatch(mesh);
+    M_MESH_VERTEX *out_vertex = &m_Priv.geom_vbo_data[batch->vertex_start];
+
+    for (int32_t i = 0; i < mesh->num_tex_face4s; i++) {
+        out_vertex = M_FillFace4(mesh, out_vertex, &mesh->tex_face4s[i], false);
+    }
+    for (int32_t i = 0; i < mesh->num_tex_face3s; i++) {
+        out_vertex = M_FillFace3(mesh, out_vertex, &mesh->tex_face3s[i], false);
+    }
+    for (int32_t i = 0; i < mesh->num_flat_face4s; i++) {
+        out_vertex = M_FillFace4(mesh, out_vertex, &mesh->flat_face4s[i], true);
+    }
+    for (int32_t i = 0; i < mesh->num_flat_face3s; i++) {
+        out_vertex = M_FillFace3(mesh, out_vertex, &mesh->flat_face3s[i], true);
+    }
+
+#define SET(v, j) light_idx_map[v] = face->vertices[j];
+    int32_t *const light_idx_map = &m_Priv.light_idx_map[batch->vertex_start];
+    int32_t v = 0;
+    for (int32_t i = 0; i < mesh->num_tex_face4s; i++) {
+        const FACE4 *const face = &mesh->tex_face4s[i];
+        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
+            SET(v, OUTPUT_QUAD_TO_FAN(j));
+            v++;
+        }
+    }
+    for (int32_t i = 0; i < mesh->num_tex_face3s; i++) {
+        const FACE3 *const face = &mesh->tex_face3s[i];
+        for (int32_t j = 0; j < OUTPUT_TRI_VERTICES; j++) {
+            SET(v, OUTPUT_TRI_TO_FAN(j));
+            v++;
+        }
+    }
+    for (int32_t i = 0; i < mesh->num_flat_face4s; i++) {
+        const FACE4 *const face = &mesh->flat_face4s[i];
+        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
+            SET(v, OUTPUT_QUAD_TO_FAN(j));
+            v++;
+        }
+    }
+    for (int32_t i = 0; i < mesh->num_flat_face3s; i++) {
+        const FACE3 *const face = &mesh->flat_face3s[i];
+        for (int32_t j = 0; j < OUTPUT_TRI_VERTICES; j++) {
+            SET(v, OUTPUT_TRI_TO_FAN(j));
+            v++;
+        }
+    }
+#undef SET
+}
+
+static void M_UpdateShades(
+    const MATRIX *const matrix, const OBJECT_MESH *const mesh)
+{
+    M_BATCH *const batch = M_GetBatch(mesh);
+    M_MESH_SHADE *const out_shades =
+        &m_Priv.shade_vbo_data[batch->vertex_start];
+    int32_t *const light_idx_map = &m_Priv.light_idx_map[batch->vertex_start];
+
+    const int32_t ls_adder = Output_GetLightAdder();
+    const int32_t ls_divider = Output_GetLightDivider();
+    const XYZ_32 ls_vector_view = Output_GetLightVectorView();
+
+    if (mesh->num_lights <= 0) {
+        for (int32_t i = 0; i < batch->vertex_count; i++) {
+            const int32_t j = light_idx_map[i];
+            int16_t shade = ls_adder + mesh->lighting.lights[j];
+            CLAMP(shade, 0, 0x1FFF);
+            out_shades[i] = shade;
+        }
+    } else if (ls_divider == 0) {
+        int16_t shade = ls_adder;
+        CLAMP(shade, 0, 0x1FFF);
+        for (int32_t i = 0; i < batch->vertex_count; i++) {
+            out_shades[i] = shade;
+        }
+    } else {
+        // clang-format off
+        const int32_t xv = (
+            matrix->_00 * ls_vector_view.x +
+            matrix->_10 * ls_vector_view.y +
+            matrix->_20 * ls_vector_view.z
+        ) / ls_divider;
+
+        const int32_t yv = (
+            matrix->_01 * ls_vector_view.x +
+            matrix->_11 * ls_vector_view.y +
+            matrix->_21 * ls_vector_view.z
+        ) / ls_divider;
+
+        const int32_t zv = (
+            matrix->_02 * ls_vector_view.x +
+            matrix->_12 * ls_vector_view.y +
+            matrix->_22 * ls_vector_view.z
+        ) / ls_divider;
+        // clang-format on
+
+        for (int32_t i = 0; i < batch->vertex_count; i++) {
+            const int32_t j = light_idx_map[i];
+            const XYZ_16 *const normal = &mesh->lighting.normals[j];
+            int16_t shade = ls_adder
+                + ((normal->x * xv + normal->y * yv + normal->z * zv) >> 16);
+            CLAMP(shade, 0, 0x1FFF);
+            out_shades[i] = shade;
+        }
+    }
+}
+
+static void M_UpdateVertices(void)
+{
+    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+        M_UpdateGeometry(Object_GetMesh(i));
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.geom_vbo);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        m_Priv.vertex_count * sizeof(M_MESH_VERTEX), m_Priv.geom_vbo_data,
+        GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.shade_vbo);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        m_Priv.vertex_count * sizeof(M_MESH_SHADE), m_Priv.shade_vbo_data,
+        GL_DYNAMIC_DRAW); // shades are always dynamic
+}
+
+static void M_PrepareBuffers(void)
+{
+    m_Priv.batch_count = Object_GetMeshCount();
+    m_Priv.batches =
+        Memory_Realloc(m_Priv.batches, sizeof(M_BATCH) * m_Priv.batch_count);
+
+    int32_t last_vertex = 0;
+    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+        const OBJECT_MESH *const obj_mesh = Object_GetMesh(i);
+        M_BATCH *const batch = &m_Priv.batches[i];
+        batch->vertex_start = last_vertex;
+        batch->vertex_count = 0;
+        batch->vertex_count += obj_mesh->num_tex_face4s * OUTPUT_QUAD_VERTICES;
+        batch->vertex_count += obj_mesh->num_tex_face3s * OUTPUT_TRI_VERTICES;
+        batch->vertex_count += obj_mesh->num_flat_face4s * OUTPUT_QUAD_VERTICES;
+        batch->vertex_count += obj_mesh->num_flat_face3s * OUTPUT_TRI_VERTICES;
+        last_vertex += batch->vertex_count;
+    }
+    m_Priv.vertex_count = last_vertex;
+
+    m_Priv.geom_vbo_data =
+        Memory_Alloc(m_Priv.vertex_count * sizeof(M_MESH_VERTEX));
+    m_Priv.shade_vbo_data =
+        Memory_Alloc(m_Priv.vertex_count * sizeof(M_MESH_SHADE));
+    m_Priv.light_idx_map = Memory_Alloc(m_Priv.vertex_count * sizeof(int32_t));
+
+    glGenVertexArrays(1, &m_Priv.vao);
+    glGenBuffers(1, &m_Priv.geom_vbo);
+    glGenBuffers(1, &m_Priv.shade_vbo);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.geom_vbo);
+    glBindVertexArray(m_Priv.vao);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.geom_vbo);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(
+        0, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, pos));
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(
+        1, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, normal));
+
+    glEnableVertexAttribArray(2);
+    glVertexAttribIPointer(
+        2, 1, GL_UNSIGNED_INT, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, uvw_idx));
+
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(
+        3, 2, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, trapezoid_ratio));
+
+    glEnableVertexAttribArray(4);
+    glVertexAttribIPointer(
+        4, 1, GL_UNSIGNED_SHORT, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, flags));
+
+    glEnableVertexAttribArray(5);
+    glVertexAttribPointer(
+        5, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, color));
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.shade_vbo);
+    glEnableVertexAttribArray(6);
+    glVertexAttribPointer(
+        6, 1, GL_UNSIGNED_SHORT, GL_FALSE, sizeof(M_MESH_SHADE), 0);
+
+    M_UpdateVertices();
+}
+
+static void M_FreeBuffers(void)
+{
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    if (m_Priv.vao != 0) {
+        glDeleteVertexArrays(1, &m_Priv.vao);
+        m_Priv.vao = 0;
+    }
+    if (m_Priv.geom_vbo != 0) {
+        glDeleteBuffers(1, &m_Priv.geom_vbo);
+        m_Priv.geom_vbo = 0;
+    }
+    if (m_Priv.shade_vbo != 0) {
+        glDeleteBuffers(1, &m_Priv.shade_vbo);
+        m_Priv.shade_vbo = 0;
+    }
+    Memory_FreePointer(&m_Priv.geom_vbo_data);
+    Memory_FreePointer(&m_Priv.shade_vbo_data);
+    Memory_FreePointer(&m_Priv.light_idx_map);
+    Memory_FreePointer(&m_Priv.batches);
+}
+
+void Output_Objects_Init(void)
+{
+    m_Shader = Output_Meshes_GetShader();
+}
+
+void Output_Objects_Shutdown(void)
+{
+    M_FreeBuffers();
+}
+
+void Output_Objects_ObserveLevelLoad(void)
+{
+    M_PrepareBuffers();
+}
+
+void Output_Objects_ObserveLevelUnload(void)
+{
+    M_FreeBuffers();
+}
+
+void Output_Objects_ObserveMeshSwap(
+    const OBJECT_MESH *const mesh_1, const OBJECT_MESH *const mesh_2)
+{
+    if (m_Priv.geom_vbo_data == nullptr) {
+        return;
+    }
+
+    M_BATCH *const batch_1 = M_GetBatch(mesh_1);
+    M_BATCH *const batch_2 = M_GetBatch(mesh_2);
+    const M_BATCH batch_tmp = *batch_1;
+    *batch_1 = *batch_2;
+    *batch_2 = batch_tmp;
+    Output_Objects_ObserveMeshUpdate(mesh_1);
+    Output_Objects_ObserveMeshUpdate(mesh_2);
+}
+
+void Output_Objects_ObserveMeshUpdate(const OBJECT_MESH *const mesh)
+{
+    if (m_Priv.geom_vbo_data == nullptr) {
+        return;
+    }
+
+    const M_BATCH *const batch = M_GetBatch(mesh);
+    M_UpdateGeometry(mesh);
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.geom_vbo);
+    GFX_TRACK_SUBDATA(
+        glBufferSubData, GL_ARRAY_BUFFER,
+        batch->vertex_start * sizeof(M_MESH_VERTEX),
+        batch->vertex_count * sizeof(M_MESH_VERTEX),
+        &m_Priv.geom_vbo_data[batch->vertex_start]);
+    GFX_GL_CheckError();
+}
+
+void Output_Objects_RenderMesh(
+    const MATRIX *const matrix, const RGB_F tint, const OBJECT_MESH *const mesh)
+{
+    const M_BATCH *const batch = M_GetBatch(mesh);
+
+    M_UpdateShades(matrix, mesh);
+
+    Output_Shader_UploadMatrix(m_Shader, matrix);
+    Output_Shader_UploadTint(m_Shader, tint);
+    GFX_GL_CheckError();
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_Priv.shade_vbo);
+    GFX_TRACK_SUBDATA(
+        glBufferSubData, GL_ARRAY_BUFFER,
+        batch->vertex_start * sizeof(M_MESH_SHADE),
+        batch->vertex_count * sizeof(M_MESH_SHADE),
+        &m_Priv.shade_vbo_data[batch->vertex_start]);
+    GFX_GL_CheckError();
+
+    glEnable(GL_CULL_FACE);
+    glBindVertexArray(m_Priv.vao);
+    GFX_GL_CheckError();
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, Output_Textures_GetAtlasTexture());
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_BUFFER, Output_Textures_GetObjectUVWsTexture());
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, Output_Textures_GetEnvMapTexture());
+    GFX_GL_CheckError();
+
+    Output_Shader_UploadWibbleEffect(m_Shader, false);
+    glDrawArrays(GL_TRIANGLES, batch->vertex_start, batch->vertex_count);
+
+    glDisable(GL_CULL_FACE);
+    GFX_GL_CheckError();
+}

--- a/src/tr1/game/output/objects.h
+++ b/src/tr1/game/output/objects.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <libtrx/game/matrix.h>
+#include <libtrx/game/objects/types.h>
+#include <libtrx/game/output/objects.h>
+#include <libtrx/game/output/types.h>
+
+void Output_Objects_Init(void);
+void Output_Objects_Shutdown(void);
+void Output_Objects_ObserveLevelLoad(void);
+void Output_Objects_ObserveLevelUnload(void);
+
+void Output_Objects_RenderMesh(
+    const MATRIX *matrix, RGB_F tint, const OBJECT_MESH *mesh);

--- a/src/tr1/game/output/rooms.c
+++ b/src/tr1/game/output/rooms.c
@@ -14,9 +14,9 @@
 typedef struct {
     // clang-format off
     XYZ_F pos;                // attribute 0
-    int32_t uvw_idx;          // attribute 1
-    float trapezoid_ratio[2]; // attribute 2
-    uint16_t flags;           // attribute 3
+    int32_t uvw_idx;          // attribute 2
+    float trapezoid_ratio[2]; // attribute 3
+    uint16_t flags;           // attribute 4
     // clang-format on
 } M_MESH_VERTEX;
 
@@ -213,25 +213,29 @@ static void M_PrepareBuffers(void)
         0, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
         (void *)(intptr_t)offsetof(M_MESH_VERTEX, pos));
 
-    glEnableVertexAttribArray(1);
-    glVertexAttribIPointer(
-        1, 1, GL_UNSIGNED_INT, sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, uvw_idx));
+    // ignore attribute 1 (normals) - rooms never have reflective faces
 
     glEnableVertexAttribArray(2);
-    glVertexAttribPointer(
-        2, 2, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, trapezoid_ratio));
+    glVertexAttribIPointer(
+        2, 1, GL_UNSIGNED_INT, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, uvw_idx));
 
     glEnableVertexAttribArray(3);
+    glVertexAttribPointer(
+        3, 2, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
+        (void *)(intptr_t)offsetof(M_MESH_VERTEX, trapezoid_ratio));
+
+    glEnableVertexAttribArray(4);
     glVertexAttribIPointer(
-        3, 1, GL_UNSIGNED_SHORT, sizeof(M_MESH_VERTEX),
+        4, 1, GL_UNSIGNED_SHORT, sizeof(M_MESH_VERTEX),
         (void *)(intptr_t)offsetof(M_MESH_VERTEX, flags));
 
+    // ignore attribute 5 (mesh color) - rooms only ever use textured faces
+
     glBindBuffer(GL_ARRAY_BUFFER, m_Priv.shade_vbo);
-    glEnableVertexAttribArray(4);
+    glEnableVertexAttribArray(6);
     glVertexAttribPointer(
-        4, 1, GL_UNSIGNED_SHORT, GL_FALSE, sizeof(M_MESH_SHADE), 0);
+        6, 1, GL_UNSIGNED_SHORT, GL_FALSE, sizeof(M_MESH_SHADE), 0);
 
     M_UpdateVertices();
 }
@@ -308,6 +312,8 @@ void Output_Rooms_RenderRoom(
     glBindTexture(GL_TEXTURE_2D_ARRAY, Output_Textures_GetAtlasTexture());
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_BUFFER, Output_Textures_GetObjectUVWsTexture());
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, Output_Textures_GetEnvMapTexture());
     GFX_GL_CheckError();
 
     if (Output_GetWibbleEffect()) {

--- a/src/tr1/game/output/shader.c
+++ b/src/tr1/game/output/shader.c
@@ -12,10 +12,12 @@ typedef enum {
     M_UNIFORM_TIME,
     M_UNIFORM_TEX_ATLAS,
     M_UNIFORM_TEX_UVW,
+    M_UNIFORM_TEX_ENV_MAP,
     M_UNIFORM_SMOOTHING_ENABLED,
     M_UNIFORM_ALPHA_DISCARD_ENABLED,
     M_UNIFORM_ALPHA_THRESHOLD,
     M_UNIFORM_TRAPEZOID_FILTER_ENABLED,
+    M_UNIFORM_REFLECTIONS_ENABLED,
     M_UNIFORM_BRIGHTNESS_MULTIPLIER,
     M_UNIFORM_GLOBAL_TINT,
     M_UNIFORM_FOG,
@@ -50,10 +52,12 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
         [M_UNIFORM_TIME] = "uTime",
         [M_UNIFORM_TEX_ATLAS] = "uTexAtlas",
         [M_UNIFORM_TEX_UVW] = "uUVW",
+        [M_UNIFORM_TEX_ENV_MAP] = "uTexEnvMap",
         [M_UNIFORM_SMOOTHING_ENABLED] = "uSmoothingEnabled",
         [M_UNIFORM_ALPHA_DISCARD_ENABLED] = "uAlphaDiscardEnabled",
         [M_UNIFORM_ALPHA_THRESHOLD] = "uAlphaThreshold",
         [M_UNIFORM_TRAPEZOID_FILTER_ENABLED] = "uTrapezoidFilterEnabled",
+        [M_UNIFORM_REFLECTIONS_ENABLED] = "uReflectionsEnabled",
         [M_UNIFORM_BRIGHTNESS_MULTIPLIER] = "uBrightnessMultiplier",
         [M_UNIFORM_GLOBAL_TINT] = "uGlobalTint",
         [M_UNIFORM_FOG] = "uFog",
@@ -72,6 +76,7 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
     GFX_GL_Program_Bind(&shader->program);
     glUniform1i(shader->uniforms[M_UNIFORM_TEX_ATLAS], 0);
     glUniform1i(shader->uniforms[M_UNIFORM_TEX_UVW], 1);
+    glUniform1i(shader->uniforms[M_UNIFORM_TEX_ENV_MAP], 2);
     return shader;
 }
 
@@ -95,8 +100,11 @@ void Output_Shader_UploadCommonUniforms(const OUTPUT_SHADER *const shader)
         glUniform1i, shader->uniforms[M_UNIFORM_ALPHA_DISCARD_ENABLED],
         !g_Config.rendering.enable_wireframe);
     GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_TRAPEZOID_FILTER_ENABLED],
+        glUniform1i, shader->uniforms[M_UNIFORM_TRAPEZOID_FILTER_ENABLED],
         g_Config.rendering.enable_trapezoid_filter);
+    GFX_TRACK_UNIFORM(
+        glUniform1i, shader->uniforms[M_UNIFORM_REFLECTIONS_ENABLED],
+        g_Config.visuals.enable_reflections);
     GFX_TRACK_UNIFORM(
         glUniform1f, shader->uniforms[M_UNIFORM_BRIGHTNESS_MULTIPLIER],
         g_Config.visuals.brightness);

--- a/src/tr1/game/output/sprites.c
+++ b/src/tr1/game/output/sprites.c
@@ -196,6 +196,8 @@ static void M_DrawBuffer(
     glBindTexture(GL_TEXTURE_2D_ARRAY, Output_Textures_GetAtlasTexture());
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_BUFFER, Output_Textures_GetSpriteUVWsTexture());
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, Output_Textures_GetEnvMapTexture());
     GFX_GL_CheckError();
 
     glDrawArrays(GL_TRIANGLES, start, count);
@@ -397,4 +399,9 @@ bool Output_Sprites_Flush(void)
     Vector_Clear(m_Dynamic.source);
     M_FlushBuffer(&m_Dynamic.sprite_buf);
     return true;
+}
+
+void Output_Sprites_UploadProjectionMatrix(void)
+{
+    Output_Shader_UploadProjectionMatrix(m_Shader);
 }

--- a/src/tr1/game/output/sprites.h
+++ b/src/tr1/game/output/sprites.h
@@ -8,6 +8,8 @@
 void Output_Sprites_Init(void);
 void Output_Sprites_Shutdown(void);
 void Output_Sprites_ObserveLevelLoad(void);
+void Output_Sprites_UploadProjectionMatrix(void);
+
 void Output_Sprites_RenderBegin(void);
 void Output_Sprites_RenderRoomSprites(
     const MATRIX *matrix, RGB_F tint, const ROOM *room);

--- a/src/tr1/game/output/textures.c
+++ b/src/tr1/game/output/textures.c
@@ -42,6 +42,7 @@ static struct {
 
 static struct {
     GLuint tex_atlas;
+    GLuint tex_env_map;
     M_TEXTURE_DATA objects;
     M_TEXTURE_DATA sprites;
 } m_Priv = {};
@@ -292,6 +293,17 @@ static void M_PrepareSpriteUVWs(void)
     M_FillSpriteUVWs();
 }
 
+static void M_PrepareEnvMap(void)
+{
+    glGenTextures(1, &m_Priv.tex_env_map);
+    glBindTexture(GL_TEXTURE_2D, m_Priv.tex_env_map);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    GFX_GL_CheckError();
+}
+
 static void M_UploadAtlas(void)
 {
     glGenTextures(1, &m_Priv.tex_atlas);
@@ -341,11 +353,16 @@ static void M_FreeLevelData(void)
 
 void Output_Textures_Init(void)
 {
+    M_PrepareEnvMap();
 }
 
 void Output_Textures_Shutdown(void)
 {
     M_FreeLevelData();
+    if (m_Priv.tex_env_map != 0) {
+        glDeleteTextures(1, &m_Priv.tex_env_map);
+        m_Priv.tex_env_map = 0;
+    }
 }
 
 void Output_Textures_ObserveLevelLoad(void)
@@ -357,6 +374,28 @@ void Output_Textures_ObserveLevelLoad(void)
     M_UploadObjectUVWs();
     M_UploadSpriteUVWs();
     M_UploadAtlas();
+}
+
+void Output_Textures_UpdateEnvironmentMap(void)
+{
+    GLint viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    GFX_GL_CheckError();
+
+    const GLint vp_x = viewport[0];
+    const GLint vp_y = viewport[1];
+    const GLint vp_w = viewport[2];
+    const GLint vp_h = viewport[3];
+
+    const int32_t side = MIN(vp_w, vp_h);
+    const int32_t x = vp_x + (vp_w - side) / 2;
+    const int32_t y = vp_y + (vp_h - side) / 2;
+    const int32_t w = side;
+    const int32_t h = side;
+
+    glBindTexture(GL_TEXTURE_2D, m_Priv.tex_env_map);
+    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, x, y, w, h, 0);
+    GFX_GL_CheckError();
 }
 
 void Output_Textures_CycleAnimations(void)
@@ -382,6 +421,11 @@ GLuint Output_Textures_GetSpriteUVWsTexture(void)
 GLuint Output_Textures_GetAtlasTexture(void)
 {
     return m_Priv.tex_atlas;
+}
+
+GLuint Output_Textures_GetEnvMapTexture(void)
+{
+    return m_Priv.tex_env_map;
 }
 
 void Output_Textures_ApplyRenderSettings(void)

--- a/src/tr1/game/output/textures.h
+++ b/src/tr1/game/output/textures.h
@@ -5,8 +5,10 @@
 void Output_Textures_Init(void);
 void Output_Textures_Shutdown(void);
 void Output_Textures_ObserveLevelLoad(void);
+void Output_Textures_UpdateEnvironmentMap(void);
 void Output_Textures_CycleAnimations(void);
 void Output_Textures_ApplyRenderSettings(void);
 GLuint Output_Textures_GetObjectUVWsTexture(void);
 GLuint Output_Textures_GetSpriteUVWsTexture(void);
 GLuint Output_Textures_GetAtlasTexture(void);
+GLuint Output_Textures_GetEnvMapTexture(void);

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -378,6 +378,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     int16_t old_fov = Viewport_GetFOV();
     Viewport_SetFOV(PICKUPS_FOV * DEG_1);
     Viewport_Init(vp_x1, vp_y1, vp_x2 - vp_x1, vp_y2 - vp_y1);
+    glViewport(vp_x1, -vp_y1, screen_width, screen_height);
     Output_ApplyFOV();
 
     Matrix_PushUnit();
@@ -424,6 +425,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     Matrix_Pop();
     Viewport_Init(0, 0, Screen_GetResWidth(), Screen_GetResHeight());
     Viewport_SetFOV(old_fov);
+    glViewport(0, 0, Screen_GetResWidth(), Screen_GetResHeight());
 }
 
 static void M_DrawPickups3D(void)

--- a/src/tr1/game/viewport.c
+++ b/src/tr1/game/viewport.c
@@ -1,5 +1,6 @@
 #include "game/viewport.h"
 
+#include "game/output.h"
 #include "game/screen.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -87,4 +88,5 @@ int16_t Viewport_GetUserFOV(void)
 void Viewport_SetFOV(int16_t fov)
 {
     m_CurrentFOV = fov;
+    Output_ObserveFOVChange();
 }

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -245,6 +245,7 @@ sources = [
   'game/option/option_sound.c',
   'game/output.c',
   'game/output/meshes.c',
+  'game/output/objects.c',
   'game/output/rooms.c',
   'game/output/shader.c',
   'game/output/sprites.c',

--- a/src/tr1/specific/s_output.c
+++ b/src/tr1/specific/s_output.c
@@ -1,6 +1,7 @@
 #include "specific/s_output.h"
 
 #include "game/output.h"
+#include "game/output/textures.h"
 #include "game/screen.h"
 #include "game/shell.h"
 #include "game/viewport.h"
@@ -29,7 +30,6 @@
     }
 
 static int m_TextureMap[GFX_MAX_TEXTURES] = { GFX_NO_TEXTURE };
-static int m_EnvMapTexture = GFX_NO_TEXTURE;
 
 static GFX_2D_RENDERER *m_Renderer2D = nullptr;
 static GFX_3D_RENDERER *m_Renderer3D = nullptr;
@@ -38,19 +38,16 @@ static int32_t m_SelectedTexture = -1;
 
 static int32_t m_SurfaceWidth = 0;
 static int32_t m_SurfaceHeight = 0;
-static float m_SurfaceMinX = 0.0f;
-static float m_SurfaceMinY = 0.0f;
-static float m_SurfaceMaxX = 0.0f;
-static float m_SurfaceMaxY = 0.0f;
-static GFX_2D_SURFACE *m_PrimarySurface = nullptr;
 static GFX_2D_SURFACE *m_PictureSurface = nullptr;
 static GFX_2D_SURFACE *m_TextureSurfaces[GFX_MAX_TEXTURES] = { nullptr };
 
 static inline float M_GetUV(uint16_t uv);
+static void M_SelectTexture(int32_t texture_num);
+static void M_EnableTextureMode(void);
+static void M_DrawBackdropSurface(void);
 static void M_ReleaseTextures(void);
 static void M_ReleaseSurfaces(void);
 static void M_FlipPrimaryBuffer(void);
-static void M_ClearSurface(GFX_2D_SURFACE *surface);
 static void M_DrawTriangleFan(GFX_3D_VERTEX *vertices, int vertex_count);
 static void M_DrawTriangleStrip(GFX_3D_VERTEX *vertices, int vertex_count);
 static int32_t M_VisibleZClip(
@@ -66,6 +63,40 @@ static inline float M_GetUV(const uint16_t uv)
         : ((uv & 0xFF00) + 127) / 65536.0f;
 }
 
+static void M_SelectTexture(const int32_t texture_num)
+{
+    if (texture_num == m_SelectedTexture) {
+        return;
+    }
+
+    if (m_TextureMap[texture_num] == GFX_NO_TEXTURE) {
+        LOG_ERROR("ERROR: Attempt to select unloaded texture");
+        return;
+    }
+
+    GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_TextureMap[texture_num]);
+
+    m_SelectedTexture = texture_num;
+}
+
+static void M_EnableTextureMode(void)
+{
+    if (m_IsTextureMode) {
+        return;
+    }
+
+    m_IsTextureMode = true;
+    GFX_3D_Renderer_SetTexturingEnabled(m_Renderer3D, m_IsTextureMode);
+}
+
+static void M_DrawBackdropSurface(void)
+{
+    if (m_PictureSurface == nullptr) {
+        return;
+    }
+    GFX_2D_Renderer_Render(m_Renderer2D);
+}
+
 static void M_ReleaseTextures(void)
 {
     if (m_Renderer3D == nullptr) {
@@ -78,20 +109,10 @@ static void M_ReleaseTextures(void)
             m_TextureMap[i] = GFX_NO_TEXTURE;
         }
     }
-    if (m_EnvMapTexture != GFX_NO_TEXTURE) {
-        GFX_3D_Renderer_UnregisterEnvironmentMap(m_Renderer3D, m_EnvMapTexture);
-    }
 }
 
 static void M_ReleaseSurfaces(void)
 {
-    if (m_PrimarySurface) {
-        M_ClearSurface(m_PrimarySurface);
-
-        GFX_2D_Surface_Free(m_PrimarySurface);
-        m_PrimarySurface = nullptr;
-    }
-
     for (int i = 0; i < GFX_MAX_TEXTURES; i++) {
         if (m_TextureSurfaces[i] != nullptr) {
             GFX_2D_Surface_Free(m_TextureSurfaces[i]);
@@ -105,19 +126,9 @@ static void M_ReleaseSurfaces(void)
     }
 }
 
-void Output_FillEnvironmentMap(void)
-{
-    GFX_3D_Renderer_FillEnvironmentMap(m_Renderer3D);
-}
-
 static void M_FlipPrimaryBuffer(void)
 {
     GFX_Context_SwapBuffers();
-}
-
-static void M_ClearSurface(GFX_2D_SURFACE *surface)
-{
-    GFX_2D_Surface_Clear(surface, 0);
 }
 
 static void M_DrawTriangleFan(GFX_3D_VERTEX *vertices, int vertex_count)
@@ -217,16 +228,6 @@ static int32_t M_ZedClipper(
     return count < 3 ? 0 : count;
 }
 
-void S_Output_EnableTextureMode(void)
-{
-    if (m_IsTextureMode) {
-        return;
-    }
-
-    m_IsTextureMode = true;
-    GFX_3D_Renderer_SetTexturingEnabled(m_Renderer3D, m_IsTextureMode);
-}
-
 void S_Output_DisableTextureMode(void)
 {
     if (!m_IsTextureMode) {
@@ -266,7 +267,7 @@ void S_Output_RenderBegin(void)
 {
     GFX_Context_Clear();
     GFX_Track_Reset();
-    S_Output_DrawBackdropSurface();
+    M_DrawBackdropSurface();
     GFX_3D_Renderer_RenderBegin(m_Renderer3D);
     GFX_3D_Renderer_SetTextureFilter(
         m_Renderer3D, g_Config.rendering.texture_filter);
@@ -294,14 +295,6 @@ void S_Output_ClearDepthBuffer(void)
     GFX_3D_Renderer_ClearDepth(m_Renderer3D);
 }
 
-void S_Output_DrawBackdropSurface(void)
-{
-    if (m_PictureSurface == nullptr) {
-        return;
-    }
-    GFX_2D_Renderer_Render(m_Renderer2D);
-}
-
 void S_Output_DownloadBackdropSurface(const IMAGE *const image)
 {
     GFX_2D_Surface_Free(m_PictureSurface);
@@ -314,22 +307,6 @@ void S_Output_DownloadBackdropSurface(const IMAGE *const image)
     m_PictureSurface = GFX_2D_Surface_CreateFromImage(image);
     GFX_2D_Renderer_Upload(
         m_Renderer2D, &m_PictureSurface->desc, m_PictureSurface->buffer);
-}
-
-void S_Output_SelectTexture(const int32_t texture_num)
-{
-    if (texture_num == m_SelectedTexture) {
-        return;
-    }
-
-    if (m_TextureMap[texture_num] == GFX_NO_TEXTURE) {
-        LOG_ERROR("ERROR: Attempt to select unloaded texture");
-        return;
-    }
-
-    GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_TextureMap[texture_num]);
-
-    m_SelectedTexture = texture_num;
 }
 
 void S_Output_DrawSprite(
@@ -406,8 +383,8 @@ void S_Output_DrawSprite(
     }
 
     if (m_TextureMap[sprite->tex_page] != GFX_NO_TEXTURE) {
-        S_Output_EnableTextureMode();
-        S_Output_SelectTexture(sprite->tex_page);
+        M_EnableTextureMode();
+        M_SelectTexture(sprite->tex_page);
         M_DrawTriangleFan(vertices, vertex_count);
     } else {
         S_Output_DisableTextureMode();
@@ -627,10 +604,6 @@ void S_Output_ApplyRenderSettings(void)
 
     m_SurfaceWidth = Screen_GetResWidth();
     m_SurfaceHeight = Screen_GetResHeight();
-    m_SurfaceMinX = 0.0f;
-    m_SurfaceMinY = 0.0f;
-    m_SurfaceMaxX = Screen_GetResWidth() - 1.0f;
-    m_SurfaceMaxY = Screen_GetResHeight() - 1.0f;
 
     GFX_Context_SetVSync(g_Config.rendering.enable_vsync);
     GFX_Context_SetDisplayFilter(g_Config.rendering.fbo_filter);
@@ -640,12 +613,6 @@ void S_Output_ApplyRenderSettings(void)
     GFX_Context_SetLineWidth(g_Config.rendering.wireframe_width);
     GFX_3D_Renderer_SetAnisotropyFilter(
         m_Renderer3D, g_Config.rendering.anisotropy_filter);
-
-    if (m_PrimarySurface == nullptr) {
-        GFX_2D_SURFACE_DESC surface_desc = {};
-        m_PrimarySurface = GFX_2D_Surface_Create(&surface_desc);
-    }
-    M_ClearSurface(m_PrimarySurface);
 }
 
 void S_Output_SetWindowSize(int width, int height)
@@ -745,252 +712,6 @@ void S_Output_DrawFlatTriangle(
     M_DrawTriangleFan(vertices, vertex_count);
 }
 
-void S_Output_DrawEnvMapTriangle(
-    const PHD_VBUF *const vn1, const PHD_VBUF *const vn2,
-    const PHD_VBUF *const vn3)
-{
-    int vertex_count = 3;
-    GFX_3D_VERTEX vertices[vertex_count * CLIP_VERTCOUNT_SCALE];
-
-    const float multiplier = g_Config.visuals.brightness / 16.0f;
-    const PHD_VBUF *const src_vbuf[3] = { vn1, vn2, vn3 };
-
-    if (vn3->clip & vn2->clip & vn1->clip) {
-        return;
-    }
-
-    if (vn1->clip >= 0 && vn2->clip >= 0 && vn3->clip >= 0) {
-        if (!VBUF_VISIBLE(*vn1, *vn2, *vn3)) {
-            return;
-        }
-
-        for (int32_t i = 0; i < vertex_count; i++) {
-            vertices[i].x = src_vbuf[i]->xs;
-            vertices[i].y = src_vbuf[i]->ys;
-            vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
-
-            vertices[i].w = 1.0f / src_vbuf[i]->zv;
-            vertices[i].s = M_GetUV(src_vbuf[i]->u);
-            vertices[i].t = M_GetUV(src_vbuf[i]->v);
-            vertices[i].tex_coord[2] = src_vbuf[i]->tex_coord[2];
-            vertices[i].tex_coord[3] = src_vbuf[i]->tex_coord[3];
-
-            vertices[i].r = vertices[i].g = vertices[i].b =
-                (8192.0f - src_vbuf[i]->g) * multiplier;
-
-            Output_ApplyTint(&vertices[i].r, &vertices[i].g, &vertices[i].b);
-        }
-    } else {
-        if (!M_VisibleZClip(vn1, vn2, vn3)) {
-            return;
-        }
-
-        vertex_count =
-            M_ZedClipper(vertex_count, (const PHD_VBUF **)src_vbuf, vertices);
-        if (vertex_count == 0) {
-            return;
-        }
-    }
-
-    if (!vertex_count) {
-        return;
-    }
-
-    S_Output_EnableTextureMode();
-    GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_EnvMapTexture);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_MULTIPLY);
-    M_DrawTriangleFan(vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
-    m_SelectedTexture = -1;
-}
-
-void S_Output_DrawEnvMapQuad(
-    const PHD_VBUF *const vn1, const PHD_VBUF *const vn2,
-    const PHD_VBUF *const vn3, const PHD_VBUF *const vn4)
-{
-    int vertex_count = 4;
-    GFX_3D_VERTEX vertices[vertex_count];
-
-    if (vn4->clip | vn3->clip | vn2->clip | vn1->clip) {
-        if ((vn4->clip & vn3->clip & vn2->clip & vn1->clip)) {
-            return;
-        }
-
-        if (vn1->clip >= 0 && vn2->clip >= 0 && vn3->clip >= 0
-            && vn4->clip >= 0) {
-            if (!VBUF_VISIBLE(*vn1, *vn2, *vn3)) {
-                return;
-            }
-        } else if (!M_VisibleZClip(vn1, vn2, vn3)) {
-            return;
-        }
-
-        S_Output_DrawEnvMapTriangle(vn1, vn2, vn3);
-        S_Output_DrawEnvMapTriangle(vn3, vn4, vn1);
-        return;
-    }
-
-    if (!VBUF_VISIBLE(*vn1, *vn2, *vn3)) {
-        return;
-    }
-
-    float multiplier = g_Config.visuals.brightness / 16.0f;
-
-    const PHD_VBUF *const src_vbuf[4] = { vn2, vn1, vn3, vn4 };
-
-    for (int32_t i = 0; i < vertex_count; i++) {
-        vertices[i].x = src_vbuf[i]->xs;
-        vertices[i].y = src_vbuf[i]->ys;
-        vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
-
-        vertices[i].w = 1.0f / src_vbuf[i]->zv;
-        vertices[i].s = M_GetUV(src_vbuf[i]->u);
-        vertices[i].t = M_GetUV(src_vbuf[i]->v);
-        vertices[i].tex_coord[2] = src_vbuf[i]->tex_coord[2];
-        vertices[i].tex_coord[3] = src_vbuf[i]->tex_coord[3];
-
-        vertices[i].r = vertices[i].g = vertices[i].b =
-            (8192.0f - src_vbuf[i]->g) * multiplier;
-
-        Output_ApplyTint(&vertices[i].r, &vertices[i].g, &vertices[i].b);
-    }
-
-    S_Output_EnableTextureMode();
-    GFX_3D_Renderer_SelectTexture(m_Renderer3D, m_EnvMapTexture);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_MULTIPLY);
-    GFX_3D_Renderer_RenderPrimStrip(m_Renderer3D, vertices, vertex_count);
-    GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
-    m_SelectedTexture = -1;
-}
-
-void S_Output_DrawTexturedTriangle(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage,
-    uint16_t textype)
-{
-    int vertex_count = 3;
-    GFX_3D_VERTEX vertices[vertex_count * CLIP_VERTCOUNT_SCALE];
-    PHD_VBUF *src_vbuf[3];
-
-    float multiplier = g_Config.visuals.brightness / 16.0f;
-
-    src_vbuf[0] = vn1;
-    src_vbuf[1] = vn2;
-    src_vbuf[2] = vn3;
-
-    if (vn3->clip & vn2->clip & vn1->clip) {
-        return;
-    }
-
-    if (src_vbuf[0]->clip >= 0 && src_vbuf[1]->clip >= 0
-        && src_vbuf[2]->clip >= 0) {
-        if (!VBUF_VISIBLE(*src_vbuf[0], *src_vbuf[1], *src_vbuf[2])) {
-            return;
-        }
-
-        for (int32_t i = 0; i < vertex_count; i++) {
-            vertices[i].x = src_vbuf[i]->xs;
-            vertices[i].y = src_vbuf[i]->ys;
-            vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
-
-            vertices[i].w = 1.0f / src_vbuf[i]->zv;
-            vertices[i].s = M_GetUV(src_vbuf[i]->u);
-            vertices[i].t = M_GetUV(src_vbuf[i]->v);
-            vertices[i].tex_coord[2] = src_vbuf[i]->tex_coord[2];
-            vertices[i].tex_coord[3] = src_vbuf[i]->tex_coord[3];
-
-            vertices[i].r = vertices[i].g = vertices[i].b =
-                (8192.0f - src_vbuf[i]->g) * multiplier;
-
-            Output_ApplyTint(&vertices[i].r, &vertices[i].g, &vertices[i].b);
-        }
-    } else {
-        if (!M_VisibleZClip(src_vbuf[0], src_vbuf[1], src_vbuf[2])) {
-            return;
-        }
-
-        vertex_count =
-            M_ZedClipper(vertex_count, (const PHD_VBUF **)src_vbuf, vertices);
-        if (vertex_count == 0) {
-            return;
-        }
-    }
-
-    if (!vertex_count) {
-        return;
-    }
-
-    if (m_TextureMap[tpage] != GFX_NO_TEXTURE) {
-        S_Output_EnableTextureMode();
-        S_Output_SelectTexture(tpage);
-        M_DrawTriangleFan(vertices, vertex_count);
-    } else {
-        S_Output_DisableTextureMode();
-        M_DrawTriangleFan(vertices, vertex_count);
-    }
-}
-
-void S_Output_DrawTexturedQuad(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, PHD_VBUF *vn4, int16_t tpage,
-    uint16_t textype)
-{
-    int vertex_count = 4;
-    GFX_3D_VERTEX vertices[vertex_count];
-    PHD_VBUF *src_vbuf[4] = { vn1, vn2, vn3, vn4 };
-
-    if (src_vbuf[3]->clip | src_vbuf[2]->clip | src_vbuf[1]->clip
-        | src_vbuf[0]->clip) {
-        if ((src_vbuf[3]->clip & src_vbuf[2]->clip & src_vbuf[1]->clip
-             & src_vbuf[0]->clip)) {
-            return;
-        }
-
-        if (src_vbuf[0]->clip >= 0 && src_vbuf[1]->clip >= 0
-            && src_vbuf[2]->clip >= 0 && src_vbuf[3]->clip >= 0) {
-            if (!VBUF_VISIBLE(*src_vbuf[0], *src_vbuf[1], *src_vbuf[2])) {
-                return;
-            }
-        } else if (!M_VisibleZClip(src_vbuf[0], src_vbuf[1], src_vbuf[2])) {
-            return;
-        }
-
-        S_Output_DrawTexturedTriangle(vn1, vn2, vn3, tpage, textype);
-        S_Output_DrawTexturedTriangle(vn3, vn4, vn1, tpage, textype);
-        return;
-    }
-
-    if (!VBUF_VISIBLE(*src_vbuf[0], *src_vbuf[1], *src_vbuf[2])) {
-        return;
-    }
-
-    float multiplier = g_Config.visuals.brightness / 16.0f;
-
-    for (int32_t i = 0; i < vertex_count; i++) {
-        vertices[i].x = src_vbuf[i]->xs;
-        vertices[i].y = src_vbuf[i]->ys;
-        vertices[i].z = MAP_DEPTH(src_vbuf[i]->zv);
-
-        vertices[i].w = 1.0f / src_vbuf[i]->zv;
-        vertices[i].s = M_GetUV(src_vbuf[i]->u);
-        vertices[i].t = M_GetUV(src_vbuf[i]->v);
-        vertices[i].tex_coord[2] = src_vbuf[i]->tex_coord[2];
-        vertices[i].tex_coord[3] = src_vbuf[i]->tex_coord[3];
-
-        vertices[i].r = vertices[i].g = vertices[i].b =
-            (8192.0f - src_vbuf[i]->g) * multiplier;
-
-        Output_ApplyTint(&vertices[i].r, &vertices[i].g, &vertices[i].b);
-    }
-
-    if (m_TextureMap[tpage] != GFX_NO_TEXTURE) {
-        S_Output_EnableTextureMode();
-        S_Output_SelectTexture(tpage);
-    } else {
-        S_Output_DisableTextureMode();
-    }
-
-    GFX_3D_Renderer_RenderPrimFan(m_Renderer3D, vertices, vertex_count);
-}
-
 void S_Output_DownloadTextures(int32_t pages)
 {
     if (pages > GFX_MAX_TEXTURES) {
@@ -1020,8 +741,6 @@ void S_Output_DownloadTextures(int32_t pages)
     }
 
     m_SelectedTexture = -1;
-
-    m_EnvMapTexture = GFX_3D_Renderer_RegisterEnvironmentMap(m_Renderer3D);
 }
 
 void S_Output_DrawScreenFrame(

--- a/src/tr1/specific/s_output.h
+++ b/src/tr1/specific/s_output.h
@@ -10,7 +10,6 @@
 bool S_Output_Init(void);
 void S_Output_Shutdown(void);
 
-void S_Output_EnableTextureMode(void);
 void S_Output_DisableTextureMode(void);
 void S_Output_SetBlendingMode(GFX_BLEND_MODE blend_mode);
 void S_Output_EnableDepthWrites(void);
@@ -28,23 +27,10 @@ void S_Output_SetWindowSize(int width, int height);
 void S_Output_ApplyRenderSettings(void);
 
 void S_Output_DownloadTextures(int32_t pages);
-void S_Output_SelectTexture(int32_t texture_num);
 void S_Output_DownloadBackdropSurface(const IMAGE *image);
-void S_Output_DrawBackdropSurface(void);
 
 void S_Output_DrawFlatTriangle(
     PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, RGBA_8888 color);
-void S_Output_DrawEnvMapTriangle(
-    const PHD_VBUF *vn1, const PHD_VBUF *vn2, const PHD_VBUF *vn3);
-void S_Output_DrawEnvMapQuad(
-    const PHD_VBUF *vn1, const PHD_VBUF *vn2, const PHD_VBUF *vn3,
-    const PHD_VBUF *vn4);
-void S_Output_DrawTexturedTriangle(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, int16_t tpage,
-    uint16_t textype);
-void S_Output_DrawTexturedQuad(
-    PHD_VBUF *vn1, PHD_VBUF *vn2, PHD_VBUF *vn3, PHD_VBUF *vn4, int16_t tpage,
-    uint16_t textype);
 void S_Output_Draw3DLine(
     const PHD_VBUF *vn1, const PHD_VBUF *vn2, const RGBA_8888 color);
 void S_Output_DrawSprite(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Rewrites meshes to reduce GPU bandwidth. Should improve a lot performance on Macs.
The reflections are behaving a bit different. I'm not sure it's a good thing.

#### Testing

Everything you can think of :D
Things that still get drawn using the old pipeline:
- UI 
- Shadows
- Lightings
- Debug mode things
