### PR TITLE
objects: assign default sprite lighting if not set

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed objects disappearing too early around screen edges (#2005)
 - fixed trapezoid filter warping on faces close to the camera (#2629, regression from 4.9)
 - fixed Mac builds crashing upon start (regression from 4.9)
+- fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 4.9)
 - improved rendering performance
 
 ## [4.9](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...tr1-4.9) - 2025-03-31

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed the final two levels not allowing for secrets to be counted in the statistics (#1582)
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)
 - fixed the console opening when remapping its key (#2641)
+- fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)
 
 ## [0.10](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.2...tr2-0.10) - 2025-03-18

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -77,7 +77,7 @@ void Object_DrawSpriteItem(const ITEM *const item)
         item->interp.result.pos.x, item->interp.result.pos.y,
         item->interp.result.pos.z,
         Object_Get(item->object_id)->mesh_idx - item->frame_num,
-        item->shade.value_1);
+        item->shade.value_1 < 0 ? HIGH_LIGHT : item->shade.value_1);
 }
 
 void Object_DrawPickupItem(const ITEM *const item)

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -62,8 +62,12 @@ void Object_DrawUnclippedItem(const ITEM *const item)
 
 void Object_DrawSpriteItem(const ITEM *const item)
 {
+    SHADE shade = item->shade;
+    if (shade.value_1 < 0) {
+        shade.value_1 = HIGH_LIGHT;
+    }
     Output_CalculateStaticMeshLight(
-        item->interp.result.pos, item->shade, Room_Get(item->room_num));
+        item->interp.result.pos, shade, Room_Get(item->room_num));
 
     const OBJECT *const obj = Object_Get(item->object_id);
 


### PR DESCRIPTION
Resolves #2701.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores default shading on sprites that have values below zero (i.e. TombEditor default) in the level file.
