### PR TITLE
tr1: fix save crystal mode passport issues

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed trapezoid filter warping on faces close to the camera (#2629, regression from 4.9)
 - fixed Mac builds crashing upon start (regression from 4.9)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 4.9)
+- fixed being stuck on the Restart Level page if using save crystals and F5 is pressed when no saves are present (#2700, regression from 4.8.2)
 - improved rendering performance
 
 ## [4.9](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...tr1-4.9) - 2025-03-31

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed Mac builds crashing upon start (regression from 4.9)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 4.9)
 - fixed being stuck on the Restart Level page if using save crystals and F5 is pressed when no saves are present (#2700, regression from 4.8.2)
+- fixed being stuck on the Exit to Title page if using save crystals and a new save is made when there were previously none, and then F5 is pressed (#2700, regression from 4.9)
 - improved rendering performance
 
 ## [4.9](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...tr1-4.9) - 2025-03-31

--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -736,7 +736,8 @@ void Option_Passport_Control(INVENTORY_ITEM *inv_item, const bool is_busy)
             m_State.active_page = -1;
         } else if (g_InputDB.menu_back) {
             if (g_InvMode != INV_DEATH_MODE
-                && m_State.mode == PASSPORT_MODE_BROWSE) {
+                && (m_State.mode == PASSPORT_MODE_BROWSE
+                    || m_State.mode == PASSPORT_MODE_RESTART)) {
                 M_Close(inv_item);
                 m_State.active_page = -1;
             } else {

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -38,7 +38,8 @@ typedef struct {
     bool (*fill_info)(MYFILE *fp, SAVEGAME_INFO *info);
     bool (*load_from_file)(MYFILE *fp, GAME_INFO *game_info);
     bool (*load_only_resume_info)(MYFILE *fp, GAME_INFO *game_info);
-    void (*save_to_file)(MYFILE *fp, GAME_INFO *game_info);
+    void (*save_to_file)(
+        MYFILE *fp, GAME_INFO *game_info, SAVEGAME_INFO *savegame_info);
     bool (*update_death_counters)(MYFILE *fp, GAME_INFO *game_info);
 } SAVEGAME_STRATEGY;
 
@@ -540,7 +541,7 @@ bool Savegame_Save(const int32_t slot_num)
             MYFILE *const fp = File_Open(full_path, FILE_OPEN_WRITE);
             if (fp != nullptr) {
                 g_SaveCounter++;
-                strategy->save_to_file(fp, game_info);
+                strategy->save_to_file(fp, game_info, savegame_info);
                 savegame_info->format = strategy->format;
                 Memory_FreePointer(&savegame_info->full_path);
                 savegame_info->full_path = Memory_DupStr(File_GetPath(fp));

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -1509,7 +1509,9 @@ cleanup:
     return ret;
 }
 
-void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
+void Savegame_BSON_SaveToFile(
+    MYFILE *const fp, GAME_INFO *const game_info,
+    SAVEGAME_INFO *const savegame_info)
 {
     ASSERT(game_info != nullptr);
 
@@ -1536,6 +1538,8 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     JSON_VALUE *root = JSON_ValueFromObject(root_obj);
     M_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);
     JSON_ValueFree(root);
+
+    savegame_info->features.restart = true;
 }
 
 bool Savegame_BSON_UpdateDeathCounters(MYFILE *fp, GAME_INFO *game_info)

--- a/src/tr1/game/savegame/savegame_bson.h
+++ b/src/tr1/game/savegame/savegame_bson.h
@@ -13,5 +13,6 @@ const char *Savegame_BSON_GetSaveFilePattern(void);
 bool Savegame_BSON_FillInfo(MYFILE *fp, SAVEGAME_INFO *info);
 bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info);
 bool Savegame_BSON_LoadOnlyResumeInfo(MYFILE *fp, GAME_INFO *game_info);
-void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info);
+void Savegame_BSON_SaveToFile(
+    MYFILE *fp, GAME_INFO *game_info, SAVEGAME_INFO *savegame_info);
 bool Savegame_BSON_UpdateDeathCounters(MYFILE *fp, GAME_INFO *game_info);


### PR DESCRIPTION
Resolves #2700.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The first commit is quite straight-forward. The second, involving the savegame changes, is needed since we scan the save directory less often - previously, `savegame_info->features.restart` was only set during the `fill_info` stage of savegame scanning. So now we allow the strategies to set what they need during saving.
