### PR TITLE
input: ignore ALT-F4 on Windows

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fixed anisotropy filter causing black lines on some GPUs (#902)
 - fixed mesh faces not being drawn under some circumstances (#2452, #2438)
 - fixed objects disappearing too early around screen edges (#2005)
+- fixed the trapezoid filter being toggled if Alt-F4 (either left or right) is used to close the game (#2690)
 - fixed trapezoid filter warping on faces close to the camera (#2629, regression from 4.9)
 - fixed Mac builds crashing upon start (regression from 4.9)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 4.9)

--- a/src/libtrx/game/input/backends/keyboard.c
+++ b/src/libtrx/game/input/backends/keyboard.c
@@ -299,7 +299,8 @@ static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
         return false;
     }
 #ifdef _WIN32
-    if (scancode == SDL_SCANCODE_F4 && KEY_DOWN(SDL_SCANCODE_LALT)) {
+    if (scancode == SDL_SCANCODE_F4
+        && (KEY_DOWN(SDL_SCANCODE_LALT) || KEY_DOWN(SDL_SCANCODE_RALT))) {
         return false;
     }
 #endif


### PR DESCRIPTION
Resolves #2690.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Either Alt key can be used with F4 to close windows, so this ensures both cases are accounted for to ensure no action is taken on the F4 input role.
