### PR TITLE
tr2/objects/harpoon_bolt: fix harpoon test on invalid objects

### DIFF
--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -62,6 +62,9 @@ static void M_Control(const int16_t item_num)
         }
 
         const ANIM_FRAME *const frame = Item_GetBestFrame(target_item);
+        if (frame == nullptr) {
+            continue;
+        }
         const BOUNDS_16 *const bounds = &frame->bounds;
 
         const int32_t cdy = item->pos.y - target_item->pos.y;


### PR DESCRIPTION
Resolves #2718.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes testing harpoon colliding with invalid objects, such as sprite pickups (the harpoon sprites in the demo cause the crash). Maybe though we should revert 6698e9d5117401626635b1361d808cdccf06d987 for TR2?
