### PR TITLE
tr2: raise item, effect and creature limits

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed savegame files to be stored in the `saves` directory (#2087)
 - changed the default fog distance to 22 tiles cutting off at 30 tiles to match TR1X (#1622)
 - changed the number of static mesh slots from 50 to 256 (#2734)
+- changed the maximum number of items (moveables) per level from 256 to 10240 (1024 remains the limit for triggered items) (#1794)
 - fixed the inability to completely mute the sounds, even at sound volume 0 (#2722)
 - fixed the final two levels not allowing for secrets to be counted in the statistics (#1582)
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -11,6 +11,7 @@
 - changed the default fog distance to 22 tiles cutting off at 30 tiles to match TR1X (#1622)
 - changed the number of static mesh slots from 50 to 256 (#2734)
 - changed the maximum number of items (moveables) per level from 256 to 10240 (1024 remains the limit for triggered items) (#1794)
+- changed the maximum number of visible enemies from 5 to 32 (#1624)
 - fixed the inability to completely mute the sounds, even at sound volume 0 (#2722)
 - fixed the final two levels not allowing for secrets to be counted in the statistics (#1582)
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - changed the number of static mesh slots from 50 to 256 (#2734)
 - changed the maximum number of items (moveables) per level from 256 to 10240 (1024 remains the limit for triggered items) (#1794)
 - changed the maximum number of visible enemies from 5 to 32 (#1624)
+- changed the maximum number of effects (flames, embers, exploding parts etc) from 100 to 1000 (#1581)
 - fixed the inability to completely mute the sounds, even at sound volume 0 (#2722)
 - fixed the final two levels not allowing for secrets to be counted in the statistics (#1582)
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -326,6 +326,7 @@ as Notepad.
 - expanded maximum texture pages from 32 to 128
 - expanded the number of static mesh slots from 50 to 256
 - expanded maximum number of items (moveables) from 256 to 10240 (1024 remains the limit for triggered items)
+- expanded maximum number of visible enemies from 5 to 32
 - ported audio decoding library to ffmpeg
 - ported video decoding library to ffmpeg
 - ported input backend to SDL

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -327,6 +327,7 @@ as Notepad.
 - expanded the number of static mesh slots from 50 to 256
 - expanded maximum number of items (moveables) from 256 to 10240 (1024 remains the limit for triggered items)
 - expanded maximum number of visible enemies from 5 to 32
+- expanded the maximum number of effects (flames, embers, exploding parts etc) from 100 to 1000
 - ported audio decoding library to ffmpeg
 - ported video decoding library to ffmpeg
 - ported input backend to SDL

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -325,6 +325,7 @@ as Notepad.
 - expanded maximum sprite textures from 512 to unlimited (within game's overall memory cap)
 - expanded maximum texture pages from 32 to 128
 - expanded the number of static mesh slots from 50 to 256
+- expanded maximum number of items (moveables) from 256 to 10240 (1024 remains the limit for triggered items)
 - ported audio decoding library to ffmpeg
 - ported video decoding library to ffmpeg
 - ported input backend to SDL

--- a/src/libtrx/include/libtrx/game/effects/const.h
+++ b/src/libtrx/include/libtrx/game/effects/const.h
@@ -1,3 +1,4 @@
 #pragma once
 
 #define NO_EFFECT (-1)
+#define MAX_EFFECTS 1000

--- a/src/libtrx/include/libtrx/game/items/const.h
+++ b/src/libtrx/include/libtrx/game/items/const.h
@@ -1,8 +1,4 @@
 #pragma once
 
 #define NO_ITEM (-1)
-#if TR_VERSION == 1
-    #define MAX_ITEMS 10240
-#else
-    #define MAX_ITEMS 256
-#endif
+#define MAX_ITEMS 10240

--- a/src/libtrx/include/libtrx/game/pathing/const.h
+++ b/src/libtrx/include/libtrx/game/pathing/const.h
@@ -4,12 +4,11 @@
 
 #define NO_BOX (-1)
 #define BOX_ZONE(num) (((num) / STEP_L) - 1)
+#define LOT_SLOT_COUNT 32
 #if TR_VERSION == 1
     #define MAX_ZONES 2
-    #define LOT_SLOT_COUNT 32
 #else
     #define MAX_ZONES 4
-    #define LOT_SLOT_COUNT 5
 #endif
 
 #define BOX_BLOCKED 0x4000

--- a/src/tr1/game/effects.c
+++ b/src/tr1/game/effects.c
@@ -15,15 +15,15 @@ static int16_t m_NextEffectFree = NO_EFFECT;
 
 void Effect_InitialiseArray(void)
 {
-    m_Effects = GameBuf_Alloc(NUM_EFFECTS * sizeof(EFFECT), GBUF_EFFECTS);
+    m_Effects = GameBuf_Alloc(MAX_EFFECTS * sizeof(EFFECT), GBUF_EFFECTS);
     m_NextEffectActive = NO_EFFECT;
     m_NextEffectFree = 0;
-    for (int i = 0; i < NUM_EFFECTS - 1; i++) {
+    for (int32_t i = 0; i < MAX_EFFECTS - 1; i++) {
         m_Effects[i].next_draw = i + 1;
         m_Effects[i].next_free = i + 1;
     }
-    m_Effects[NUM_EFFECTS - 1].next_draw = NO_EFFECT;
-    m_Effects[NUM_EFFECTS - 1].next_free = NO_EFFECT;
+    m_Effects[MAX_EFFECTS - 1].next_draw = NO_EFFECT;
+    m_Effects[MAX_EFFECTS - 1].next_free = NO_EFFECT;
 }
 
 void Effect_Control(void)

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -34,7 +34,7 @@
 
 typedef struct {
     int16_t count;
-    int16_t id_map[NUM_EFFECTS];
+    int16_t id_map[MAX_EFFECTS];
 } SAVEGAME_BSON_FX_ORDER;
 
 static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version);
@@ -137,7 +137,7 @@ static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version)
 static void M_GetFXOrder(SAVEGAME_BSON_FX_ORDER *order)
 {
     order->count = 0;
-    for (int i = 0; i < NUM_EFFECTS; i++) {
+    for (int32_t i = 0; i < MAX_EFFECTS; i++) {
         order->id_map[i] = -1;
     }
 
@@ -677,12 +677,12 @@ static bool M_LoadEffects(JSON_ARRAY *fx_arr)
         return false;
     }
 
-    if ((signed)fx_arr->length >= NUM_EFFECTS) {
+    if ((signed)fx_arr->length >= MAX_EFFECTS) {
         LOG_WARNING(
             "Malformed save: expected a max of %d effect, got %d. effect over "
             "the "
             "maximum will not be created.",
-            NUM_EFFECTS - 1, fx_arr->length);
+            MAX_EFFECTS - 1, fx_arr->length);
     }
 
     for (int i = 0; i < (signed)fx_arr->length; i++) {

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -41,7 +41,6 @@
 #define DAMAGE_START 140
 #define DAMAGE_LENGTH 14
 #define NO_CAMERA (-1)
-#define NUM_EFFECTS 1000
 #define DEATH_WAIT (10 * LOGIC_FPS)
 #define DEATH_WAIT_MIN (2 * LOGIC_FPS)
 #define MAX_HEAD_ROTATION (50 * DEG_1) // = 9100

--- a/src/tr2/global/const.h
+++ b/src/tr2/global/const.h
@@ -28,7 +28,6 @@
 #define MAX_PALETTES 16
 #define MAX_VERTICES 0x2000
 #define MAX_BOUND_ROOMS 128
-#define MAX_EFFECTS 100
 #define MAX_LEVELS 24
 #define MAX_LEVEL_NAME_SIZE 50 // TODO: get rid of this limit
 #define MAX_DEMO_FILES MAX_LEVELS


### PR DESCRIPTION
Resolves #1581.
Resolves #1624.
Resolves #1794.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I think giving Barkhang and Temple of Xian a thorough test here will be a good idea, e.g. leaving all monks alive and trying save/load at various stages. Effects are not yet saved/restored as per TR1, but I've raised that as a separate issue for later - #2736.

I didn't create a test level for the item limit as it's a simple change - but you could try for example [this level](https://trcustoms.org/levels/3718) to confirm.
