### PR TITLE
tr1/room: add support for antitriggers

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added an ability to customize the fog distances (#634)
 - added an ability to customize the water color [see the reference](/docs/GAME_FLOW.md#water-color-table) (#1532)  
 - added support for a hex water color notation (eg. `#80FFFF`) in the game flow file
+- added support for antitriggers, like TR2+ (#2580)
 - changed the `draw_distance_min` and `draw_distance_max` to `fog_start` and `fog_end`
 - changed `Select Detail` dialog title to `Graphic Options`
 - changed the number of static mesh slots from 50 to 256 (#2734)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -620,6 +620,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added per-level customizable water color (with customizable blue component)
 - added per-level customizable fog distance
 - added deadly water feature from TR2+
+- added support for antitriggers, like TR2+
 
 #### Miscellaneous
 - added Linux builds

--- a/src/libtrx/include/libtrx/game/rooms/enum.h
+++ b/src/libtrx/include/libtrx/game/rooms/enum.h
@@ -67,9 +67,7 @@ typedef enum {
     TT_ANTIPAD = 6,
     TT_COMBAT = 7,
     TT_DUMMY = 8,
-#if TR_VERSION == 2
     TT_ANTITRIGGER = 9,
-#endif
 } TRIGGER_TYPE;
 
 #if TR_VERSION == 2

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -26,7 +26,8 @@ static bool M_TestLava(const ITEM *const item);
 
 static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
 {
-    if (track == MX_UNUSED_0 && trigger->type == TT_ANTIPAD) {
+    if (track == MX_UNUSED_0
+        && (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER)) {
         Music_Stop();
         return;
     }
@@ -92,7 +93,7 @@ static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
 
     if (trigger->type == TT_SWITCH) {
         flags ^= trigger->mask;
-    } else if (trigger->type == TT_ANTIPAD) {
+    } else if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER) {
         flags &= -1 - trigger->mask;
     } else if (trigger->mask) {
         flags |= trigger->mask;
@@ -404,9 +405,6 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         }
     } else {
         switch (trigger->type) {
-        case TT_TRIGGER:
-            break;
-
         case TT_SWITCH: {
             if (!Switch_Trigger(trigger->item_index, trigger->timer)) {
                 return;
@@ -446,6 +444,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 return;
             }
             break;
+
+        default:
+            break;
         }
     }
 
@@ -466,7 +467,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
             if (trigger->type == TT_SWITCH) {
                 item->flags ^= trigger->mask;
-            } else if (trigger->type == TT_ANTIPAD) {
+            } else if (
+                trigger->type == TT_ANTIPAD
+                || trigger->type == TT_ANTITRIGGER) {
                 item->flags &= -1 - trigger->mask;
             } else if (trigger->mask) {
                 item->flags |= trigger->mask;


### PR DESCRIPTION
Resolves #2580.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows antitriggers to be used like in TR2+.
