### PR TITLE
tr2: fix crashes when the images are missing

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)
 - fixed the console opening when remapping its key (#2641)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
+- fixed game crashing if the images were missing
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels (#1583)
 

--- a/src/libtrx/engine/image.c
+++ b/src/libtrx/engine/image.c
@@ -59,7 +59,12 @@ static bool M_Init(const char *const path, IMAGE_READER_CONTEXT *const ctx)
     ctx->packet = nullptr;
 
     char *full_path = File_GetFullPath(path);
-    int32_t error_code =
+    int32_t error_code = 0;
+    if (full_path == nullptr) {
+        error_code = AVERROR(ENOENT);
+        goto finish;
+    }
+    error_code =
         avformat_open_input(&ctx->format_ctx, full_path, nullptr, nullptr);
     Memory_FreePointer(&full_path);
 

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -158,10 +158,6 @@ static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandleIntEvent)
 static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandlePictureEvent)
 {
     const char *const path = JSON_ObjectGetString(event_obj, "path", nullptr);
-    if (path == nullptr) {
-        Shell_ExitSystem("Missing picture path");
-        return -1;
-    }
     if (event != nullptr) {
         GF_DISPLAY_PICTURE_DATA *const event_data = extra_data;
         event_data->path = (char *)extra_data + sizeof(GF_DISPLAY_PICTURE_DATA);
@@ -171,10 +167,13 @@ static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandlePictureEvent)
             JSON_ObjectGetDouble(event_obj, "fade_in_time", 1.0);
         event_data->fade_out_time =
             JSON_ObjectGetDouble(event_obj, "fade_out_time", 1.0 / 3.0);
-        strcpy(event_data->path, path);
+        if (path != nullptr) {
+            strcpy(event_data->path, path);
+        }
         event->data = event_data;
     }
-    return sizeof(GF_DISPLAY_PICTURE_DATA) + strlen(path) + 1;
+    return sizeof(GF_DISPLAY_PICTURE_DATA)
+        + (path == nullptr ? 0 : strlen(path) + 1);
 }
 
 static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandleTotalStatsEvent)
@@ -182,8 +181,10 @@ static DECLARE_SEQUENCE_EVENT_HANDLER_FUNC(M_HandleTotalStatsEvent)
     const char *const path =
         JSON_ObjectGetString(event_obj, "background_path", nullptr);
     if (path == nullptr) {
-        Shell_ExitSystem("Missing picture path");
-        return -1;
+        if (event != nullptr) {
+            event->data = nullptr;
+        }
+        return 0;
     }
     if (event != nullptr) {
         char *const event_data = extra_data;

--- a/src/libtrx/game/phase/phase_stats.c
+++ b/src/libtrx/game/phase/phase_stats.c
@@ -65,8 +65,11 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     M_PRIV *const p = phase->priv;
 
     if (p->args.background_type == BK_IMAGE) {
-        ASSERT(p->args.background_path != nullptr);
-        Output_LoadBackgroundFromFile(p->args.background_path);
+        if (p->args.background_path == nullptr) {
+            LOG_WARNING("Trying to load empty background image");
+        } else {
+            Output_LoadBackgroundFromFile(p->args.background_path);
+        }
     } else if (p->args.background_type == BK_OBJECT) {
         Output_LoadBackgroundFromObject();
     } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Also relaxes constraints around missing images.
Reported by Lore on Discord.