### PR TITLE
anims: fix crash when an anim has no frames

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -21,7 +21,8 @@
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)
 - fixed the console opening when remapping its key (#2641)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
-- fixed game crashing if the images were missing
+- fixed a crash if an image was missing
+- fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels (#1583)
 

--- a/src/libtrx/game/anims/frames.c
+++ b/src/libtrx/game/anims/frames.c
@@ -41,6 +41,10 @@ static int32_t M_GetAnimFrameCount(
     uint32_t next_ofs = anim_idx == Anim_GetTotalCount() - 1
         ? (unsigned)(sizeof(int16_t) * frame_data_length)
         : Anim_GetAnim(anim_idx + 1)->frame_ofs;
+    if (anim->frame_size == 0) {
+        ASSERT(next_ofs - anim->frame_ofs == 0);
+        return 0;
+    }
     return (next_ofs - anim->frame_ofs)
         / (int32_t)(sizeof(int16_t) * anim->frame_size);
 #endif


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2746.