### PR TITLE
creature: set TR1 enemy room number above position

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed mesh faces not being drawn under some circumstances (#2452, #2438)
 - fixed objects disappearing too early around screen edges (#2005)
 - fixed the trapezoid filter being toggled if Alt-F4 (either left or right) is used to close the game (#2690)
+- fixed enemies in one-click high water appearing with a water tint, and not making any animation sounds (#2753)
 - fixed a crash when 3D pickups are disabled and Lara crosses a trigger to look at a pickup item (#2711, regression from 4.8)
 - fixed trapezoid filter warping on faces close to the camera (#2629, regression from 4.9)
 - fixed Mac builds crashing upon start (regression from 4.9)

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -912,10 +912,13 @@ bool Creature_Animate(
         item->rot.x = 0;
     }
 
-    if (TR_VERSION >= 2 && !Object_IsType(item->object_id, g_WaterObjects)) {
+    if (!Object_IsType(item->object_id, g_WaterObjects)) {
+        // Get the room just above the enemy so that if it is in one-click high
+        // water, its effects behave still as though in a dry room.
         Room_GetSector(
             item->pos.x, item->pos.y - (STEP_L * 2), item->pos.z, &room_num);
-        if (Room_Get(room_num)->flags & RF_UNDERWATER) {
+        if (TR_VERSION >= 2
+            && (Room_Get(room_num)->flags & RF_UNDERWATER) != 0) {
             item->hit_points = 0;
         }
     }


### PR DESCRIPTION
Resolves #2753.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This uses the same approach as TR2 to set an enemy's room number slightly above their position, so that one click water does not produce a tint and to allow sound effects to play. Re tint, #2086 can be tackled later for responsive tinting, this PR brings things into line with Lara in one-click water.

Test level in issue comment (original attachment has missing SFX data, but the bug is present nonetheless).
