### PR TITLE
tr2/camera: determine room for in-game cutscenes

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed the drawbridge producing dynamic light when open (#2294)
 - fixed the scale of several pickup models in The Golden Mask (#2652)
 - fixed the shark in The Cold War not making any sounds when biting Lara (#2678)
+- fixed the in-game cinematic camera at times yielding invalid positions (and hence views) in custom levels (#2754)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -877,6 +877,12 @@ void Camera_LoadCutsceneFrame(void)
     g_Camera.roll = roll;
     g_Camera.shift = 0;
 
+    const int16_t room_num =
+        Room_FindByPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
+    if (room_num != NO_ROOM_NEG) {
+        g_Camera.pos.room_num = room_num;
+    }
+
     Viewport_AlterFOV(fov);
 
     if (g_Config.audio.enable_lara_mic) {


### PR DESCRIPTION
Resolves #2754.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Standalone cutscene levels already determine the room for cinematic positions, but in-game cutscenes did not and hence camera interpolation clamping could yield bad results for wide ranging cinematics. The reason this wouldn't be an issue in a custom level using a different exe is that we perform that additional post-interpolation clamping; and additionally the OG in-game cutscenes don't venture too far from where they start, so this hasn't been an issue so far.

Worth checking Offshore Rig start, dragon dagger pull, and HSH start/finish.
