### PR TITLE
room: ignore tilts in walls for the camera

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed being stuck on the Exit to Title page if using save crystals and a new save is made when there were previously none, and then F5 is pressed (#2700, regression from 4.9)
 - fixed the sprite UVs to restore the right and bottom edge pixels (#2672, regression from 4.8)
 - fixed sprites missing the fog effect (regression from 4.9)
+- fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 4.9)
 - improved bubble appearance (#2672)
 - improved rendering performance
 - removed the pretty pixels options (it's now always enabled, #2258)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed a softlock in Temple of Xian if the main chamber key is missed (#2042)
 - fixed a potential softlock in Floating Islands if returning towards the level start from the gold secret (#2590)
 - fixed a potential softlock in Nightmare in Vegas where the bird monster could remain inactive, or the flip map not set (#1851)
+- fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -50,8 +50,10 @@ void Camera_ClampInterpResult(void)
     CLAMP(pos->z, box->left, box->right);
 
 finish:
-    const int32_t floor = Room_GetHeight(sector, pos->x, pos->y, pos->z);
-    const int32_t ceiling = Room_GetCeiling(sector, pos->x, pos->y, pos->z);
+    const int32_t floor =
+        Room_GetHeightEx(sector, pos->x, pos->y, pos->z, true);
+    const int32_t ceiling =
+        Room_GetCeilingEx(sector, pos->x, pos->y, pos->z, true);
     if (floor != NO_HEIGHT && ceiling != NO_HEIGHT) {
         CLAMP(pos->y, ceiling - shift, floor - shift);
     }

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -43,9 +43,10 @@ static const int16_t *M_ReadTrigger(
     const int16_t *data, int16_t fd_entry, SECTOR *sector);
 static void M_AddFlipItems(const ROOM *room);
 static void M_RemoveFlipItems(const ROOM *room);
-static int16_t M_GetFloorTiltHeight(const SECTOR *sector, int32_t x, int32_t z);
+static int16_t M_GetFloorTiltHeight(
+    const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
 static int16_t M_GetCeilingTiltHeight(
-    const SECTOR *sector, int32_t x, int32_t z);
+    const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
 
 static const int16_t *M_ReadTrigger(
     const int16_t *data, const int16_t fd_entry, SECTOR *const sector)
@@ -155,10 +156,11 @@ static void M_RemoveFlipItems(const ROOM *const room)
 }
 
 static int16_t M_GetFloorTiltHeight(
-    const SECTOR *const sector, const int32_t x, const int32_t z)
+    const SECTOR *const sector, const int32_t x, const int32_t z,
+    const bool fix_tilts)
 {
     int16_t height = sector->floor.height;
-    if (sector->floor.tilt == 0) {
+    if (sector->floor.tilt == 0 || (height == NO_HEIGHT && fix_tilts)) {
         return height;
     }
 
@@ -189,10 +191,11 @@ static int16_t M_GetFloorTiltHeight(
 }
 
 static int16_t M_GetCeilingTiltHeight(
-    const SECTOR *sector, const int32_t x, const int32_t z)
+    const SECTOR *sector, const int32_t x, const int32_t z,
+    const bool fix_tilts)
 {
     int16_t height = sector->ceiling.height;
-    if (sector->ceiling.tilt == 0) {
+    if (sector->ceiling.tilt == 0 || (height == NO_HEIGHT && fix_tilts)) {
         return height;
     }
 
@@ -547,7 +550,15 @@ HEIGHT_TYPE Room_GetHeightType(void)
 }
 
 int16_t Room_GetHeight(
-    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z)
+    const SECTOR *const sector, const int32_t x, const int32_t y,
+    const int32_t z)
+{
+    return Room_GetHeightEx(sector, x, y, z, false);
+}
+
+int16_t Room_GetHeightEx(
+    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
+    const bool fix_tilts)
 {
     m_HeightType = HT_WALL;
 
@@ -557,7 +568,7 @@ int16_t Room_GetHeight(
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
     } else {
-        height = M_GetFloorTiltHeight(pit_sector, x, z);
+        height = M_GetFloorTiltHeight(pit_sector, x, z, fix_tilts);
     }
 
     if (pit_sector->trigger == nullptr) {
@@ -584,8 +595,15 @@ int16_t Room_GetCeiling(
     const SECTOR *const sector, const int32_t x, const int32_t y,
     const int32_t z)
 {
+    return Room_GetCeilingEx(sector, x, y, z, false);
+}
+
+int16_t Room_GetCeilingEx(
+    const SECTOR *const sector, const int32_t x, const int32_t y,
+    const int32_t z, const bool fix_tilts)
+{
     const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
-    int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z);
+    int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z, fix_tilts);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     if (pit_sector->trigger == nullptr) {

--- a/src/libtrx/include/libtrx/game/rooms/common.h
+++ b/src/libtrx/include/libtrx/game/rooms/common.h
@@ -45,9 +45,13 @@ void Room_SetAbyssHeight(int16_t height);
 bool Room_IsAbyssHeight(int16_t height);
 HEIGHT_TYPE Room_GetHeightType(void);
 int16_t Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
+int16_t Room_GetHeightEx(
+    const SECTOR *sector, int32_t x, int32_t y, int32_t z, bool fix_tilts);
 extern int32_t Room_GetWaterHeight(
     int32_t x, int32_t y, int32_t z, int16_t room_num);
 int16_t Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
+int16_t Room_GetCeilingEx(
+    const SECTOR *sector, int32_t x, int32_t y, int32_t z, bool fix_tilts);
 extern int16_t Room_GetTiltType(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 extern int32_t Room_FindGridShift(int32_t src, int32_t dst);


### PR DESCRIPTION
Resolves #2764.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

OG levels contain no-space (tilt FD entries in walls), which can cause checks against `NO_HEIGHT` to yield inaccurate results. No-space is used in glitched playthroughs, but this change ensures that `NO_HEIGHT` is respected when the camera is involved (other than in photo mode).

This could affect TR1 as well, although I can't find an instance of it happening in-game.
