### PR TITLE
tr2/objects/lift: adjust directional tests

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed Lara's holsters being empty if a game flow level removes all weapons but also re-adds the pistols (#2677)
 - fixed the console opening when remapping its key (#2641)
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground (#2752)
+- fixed the lift to work in any cardinal direction in custom levels, not just South (#2100)
 - fixed the drawbridge producing dynamic light when open (#2294)
 - fixed the scale of several pickup models in The Golden Mask (#2652)
 - fixed the shark in The Cold War not making any sounds when biting Lara (#2678)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -312,6 +312,7 @@ as Notepad.
 - added ability to disable FMVs
 - added per-level customizable fog distance
 - added the ability for spike walls to be reset (antitriggered)
+- fixed the lift to work in any cardinal direction in custom levels, not just South
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels
 
 #### Miscellaneous

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -5,6 +5,7 @@
 #include "global/vars.h"
 
 #include <libtrx/game/game_buf.h>
+#include <libtrx/game/math.h>
 
 #define LIFT_WAIT_TIME (3 * FRAMES_PER_SECOND) // = 90
 #define LIFT_SHIFT 16
@@ -46,14 +47,38 @@ static void M_FloorCeiling(
         .z = z >> WALL_SHIFT,
     };
 
+    const DIRECTION direction = Math_GetDirection(item->rot.y);
+    int32_t dx = 0;
+    int32_t dz = 0;
+    switch (direction) {
+    case DIR_NORTH:
+        dx = -1;
+        dz = 1;
+        break;
+    case DIR_EAST:
+        dx = 1;
+        dz = 1;
+        break;
+    case DIR_SOUTH:
+        dx = 1;
+        dz = -1;
+        break;
+    case DIR_WEST:
+        dx = -1;
+        dz = -1;
+        break;
+    default:
+        break;
+    }
+
     // clang-format off
     const bool point_in_shaft =
-        (test_tile.x == lift_tile.x || test_tile.x + 1 == lift_tile.x) &&
-        (test_tile.z == lift_tile.z || test_tile.z - 1 == lift_tile.z);
+        (test_tile.x == lift_tile.x || test_tile.x + dx == lift_tile.x) &&
+        (test_tile.z == lift_tile.z || test_tile.z + dz == lift_tile.z);
 
     const bool lara_in_shaft =
-        (lara_tile.x == lift_tile.x || lara_tile.x + 1 == lift_tile.x) &&
-        (lara_tile.z == lift_tile.z || lara_tile.z - 1 == lift_tile.z);
+        (lara_tile.x == lift_tile.x || lara_tile.x + dx == lift_tile.x) &&
+        (lara_tile.z == lift_tile.z || lara_tile.z + dz == lift_tile.z);
     // clang-format on
 
     const int32_t lift_floor = item->pos.y;


### PR DESCRIPTION
Resolves #2100.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the lift so that it can be used facing any cardinal direction in custom levels, and not just South.
