### PR TITLE
tr1/output: fix calculating texture sizes

### DIFF
--- a/data/tr1/ship/shaders/sprites.glsl
+++ b/data/tr1/ship/shaders/sprites.glsl
@@ -4,7 +4,6 @@ uniform samplerBuffer uUVW; // texture u, v, layer
 uniform vec2 uViewportSize;
 uniform mat4 uMatProjection;
 uniform mat4 uMatModelView;
-uniform bool uWibbleEffect;
 uniform int uTime;
 
 layout(location = 0) in vec3 inPosition;
@@ -22,11 +21,6 @@ void main(void) {
     gWorldPos = centerEyeSpace;
     centerEyeSpace.xy += inDisplacement;
     gl_Position = uMatProjection * centerEyeSpace;
-
-    if (uWibbleEffect) {
-        gl_Position.xyz =
-            waterWibble(gl_Position, uViewportSize, uTime);
-    }
 
     gTexUV = inUVW.xy;
     gTexLayer = int(inUVW.z);

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -881,6 +881,7 @@ void Level_AppendObjectTextures(
 {
     for (int32_t i = 0; i < num_textures; i++) {
         OBJECT_TEXTURE *const texture = Output_GetObjectTexture(base_idx + i);
+        texture->uv_count = 4; // Default to 4 vertices
         texture->draw_type = VFile_ReadU16(file);
         texture->tex_page = VFile_ReadU16(file) + base_page_idx;
         for (int32_t j = 0; j < 4; j++) {
@@ -1189,6 +1190,26 @@ finish:
 
 void Level_LoadTextures(void)
 {
+    for (int32_t room_num = 0; room_num < Room_GetCount(); room_num++) {
+        const ROOM *const room = Room_Get(room_num);
+        for (int32_t j = 0; j < room->mesh.num_face3s; j++) {
+            const FACE3 *const face = &room->mesh.face3s[j];
+            OBJECT_TEXTURE *const texture =
+                Output_GetObjectTexture(face->texture_idx);
+            texture->uv_count = 3;
+        }
+    }
+
+    for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+        const OBJECT_MESH *const mesh = Object_GetMesh(i);
+        for (int32_t j = 0; j < mesh->num_tex_face3s; j++) {
+            const FACE3 *const face = &mesh->tex_face3s[j];
+            OBJECT_TEXTURE *const texture =
+                Output_GetObjectTexture(face->texture_idx);
+            texture->uv_count = 3;
+        }
+    }
+
     for (int32_t room_num = 0; room_num < Room_GetCount(); room_num++) {
         ROOM *const room = Room_Get(room_num);
         for (int32_t j = 0; j < room->mesh.num_face4s; j++) {

--- a/src/libtrx/include/libtrx/game/output/types.h
+++ b/src/libtrx/include/libtrx/game/output/types.h
@@ -38,6 +38,7 @@ typedef struct {
 typedef struct {
     uint16_t draw_type;
     uint16_t tex_page;
+    int32_t uv_count;
     TEXTURE_UV uv[4];
 #if TR_VERSION == 2
     TEXTURE_UV uv_backup[4];

--- a/src/tr1/game/output/textures.c
+++ b/src/tr1/game/output/textures.c
@@ -139,7 +139,7 @@ static void M_FillAtlasObjectSize(const int32_t i)
     size->y0 = texture->uv[0].v;
     size->x1 = texture->uv[0].u;
     size->y1 = texture->uv[0].v;
-    for (int32_t j = 1; j < 3; j++) {
+    for (int32_t j = 1; j < texture->uv_count; j++) {
         size->x0 = MIN(size->x0, texture->uv[j].u);
         size->y0 = MIN(size->y0, texture->uv[j].v);
         size->x1 = MAX(size->x1, texture->uv[j].u);

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -322,15 +322,10 @@ void Room_DrawSingleRoom(int16_t room_num)
         Output_DrawRoomPortals(room);
     }
 
-    Output_EnableScissor(
-        room->bound_left, room->bound_bottom,
-        room->bound_right - room->bound_left,
-        room->bound_bottom - room->bound_top);
     Output_RememberState();
     Output_Sprites_RenderRoomSprites(g_MatrixPtr, Output_GetTint(), room);
     Output_Sprites_Flush();
     Output_RestoreState();
-    Output_DisableScissor();
     Matrix_Pop();
 
     room->bound_left = Viewport_GetMaxX();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes faces such as this:
![image](https://github.com/user-attachments/assets/7945dca6-4859-4c7e-9b62-01ef2c81dba8)
The original code only looked at 3 corners to establish the texture size, which wouldn't work with certain trapezoid shapes.

~~The fix is simple and it's to take the fourth corner into account. However, it has the potential of reintroducing the bug in other places. Specifically, the fourth corner is also used to establish the min/max sizes for triangles. If it contains garbage data, we might see weird lines around triangle faces. @lahm86 is there a simple way for us to see if `OBJECT_TEXTURE` is part of a 3-face or 4-face without iterating through every possible mesh in the level?~~
Aredfan found out that this approach does indeed cause issues. Updated to establish the relevant UV count.

Additionally the wibble effect applying also to sprites – they should remain unaffected.