### PR TITLE
tr2/objects/bird_guardian: restore bird guardian shadow

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed the drawbridge producing dynamic light when open (#2294)
 - fixed the scale of several pickup models in The Golden Mask (#2652)
 - fixed the shark in The Cold War not making any sounds when biting Lara (#2678)
+- fixed the bird monster not having a shadow (#2060)
 - fixed the in-game cinematic camera at times yielding invalid positions (and hence views) in custom levels (#2754)
 - fixed a softlock in Temple of Xian if the main chamber key is missed (#2042)
 - fixed a potential softlock in Floating Islands if returning towards the level start from the gold secret (#2590)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -294,6 +294,7 @@ as Notepad.
 - fixed the drawbridge producing dynamic light when open
 - fixed the boat when it explodes after crossing mines, where Lara's hips would appear rather than exploded boat parts
 - fixed Lara's hips appearing on Bartoli in the Temple of Xian cutscene
+- fixed the bird monster not having a shadow
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -6,6 +6,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -64,6 +65,9 @@ static void M_Setup(OBJECT *const obj)
 
     obj->hit_points = BIRD_GUARDIAN_HITPOINTS;
     obj->radius = BIRD_GUARDIAN_RADIUS;
+    if (g_Config.visuals.fix_texture_issues) {
+        obj->shadow_size = UNIT_SHADOW / 2;
+    }
 
     obj->intelligent = 1;
     obj->save_position = 1;


### PR DESCRIPTION
Resolves #2060.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores the bird guardian's shadow if texture fixes are enabled.
