### PR TITLE
tr2/objects/springboard: handle skidoo interaction

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed Lara's hips appearing on Bartoli in the Temple of Xian cutscene (#2558)
 - fixed collision issues with drawbridges, trapdoors, and bridges when stacked over each other, over slopes, and near the ground (#2752)
 - fixed the lift to work in any cardinal direction in custom levels, not just South (#2100)
+- fixed the springboard not responding correctly when Lara drives across one on a skidoo (#1903)
 - fixed the drawbridge producing dynamic light when open (#2294)
 - fixed the scale of several pickup models in The Golden Mask (#2652)
 - fixed the shark in The Cold War not making any sounds when biting Lara (#2678)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -316,6 +316,7 @@ as Notepad.
 - added per-level customizable fog distance
 - added the ability for spike walls to be reset (antitriggered)
 - fixed the lift to work in any cardinal direction in custom levels, not just South
+- fixed the springboard not responding correctly when Lara drives across one on a skidoo
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels
 
 #### Miscellaneous

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -35,17 +35,29 @@ static void M_Control(const int16_t item_num)
             return;
         }
 
-        if (lara_item->current_anim_state == LS_BACK
-            || lara_item->current_anim_state == LS_FAST_BACK) {
-            lara_item->speed = -lara_item->speed;
+        const LARA_INFO *const lara = Lara_GetLaraInfo();
+        if (lara->skidoo != NO_ITEM) {
+            ITEM *const skidoo = Item_Get(lara->skidoo);
+            if (skidoo->object_id != O_SKIDOO_FAST
+                && skidoo->object_id != O_SKIDOO_ARMED) {
+                return;
+            }
+
+            skidoo->fall_speed = -200;
+            skidoo->pos.y -= STEP_L;
+        } else {
+            if (lara_item->current_anim_state == LS_BACK
+                || lara_item->current_anim_state == LS_FAST_BACK) {
+                lara_item->speed = -lara_item->speed;
+            }
+
+            lara_item->fall_speed = -240;
+            lara_item->gravity = 1;
+
+            Item_SwitchToAnim(lara_item, LA_FALL_START, 0);
+            lara_item->current_anim_state = LS_JUMP_FORWARD;
+            lara_item->goal_anim_state = LS_JUMP_FORWARD;
         }
-
-        lara_item->fall_speed = -240;
-        lara_item->gravity = 1;
-
-        Item_SwitchToAnim(lara_item, LA_FALL_START, 0);
-        lara_item->current_anim_state = LS_JUMP_FORWARD;
-        lara_item->goal_anim_state = LS_JUMP_FORWARD;
         item->goal_anim_state = SPRINGBOARD_STATE_ON;
     }
 


### PR DESCRIPTION
Resolves #1903.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the springboard to deal with the scenario when Lara crosses one on a skidoo. The skidoo will now be thrown into the air (along with Lara) rather than Lara falling indefinitely.
