### PR TITLE
tr2/objects/waterfall: save waterfall flags

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -11,6 +11,7 @@
 - added BSON savegame support, removing the limits imposed by the OG 8KB file size, so allowing for storing more data and offering improved feature support (legacy save files can still be read, similar to TR1) (#2662)
 - added NG+, Japanese, and Japanese NG+ game mode options to the New Game page in the passport (#2731)
 - added the ability for spike walls to be reset (antitriggered)
+- added waterfalls to the savegame so that they now persist on load (#2686)
 - changed savegame files to be stored in the `saves` directory (#2087)
 - changed the default fog distance to 22 tiles cutting off at 30 tiles to match TR1X (#1622)
 - changed the number of static mesh slots from 50 to 256 (#2734)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -180,6 +180,7 @@ as Notepad.
 - added a photo mode feature
 - added combined support for The Golden Mask
 - added NG+, Japanese, and Japanese NG+ game mode options to the New Game page in the passport
+- added waterfalls to the savegame so that they now persist on load
 - changed inventory to pause the music rather than muting it
 - fixed killing the T-Rex with a grenade launcher crashing the game
 - fixed secret rewards not displaying shotgun ammo

--- a/src/tr2/game/objects/general/waterfall.c
+++ b/src/tr2/game/objects/general/waterfall.c
@@ -17,6 +17,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
+    obj->save_flags = 1;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -45,6 +45,8 @@ typedef struct {
 static int32_t m_BufPos = 0;
 static char *m_BufPtr = nullptr;
 
+static bool M_ItemHasSaveFlags(const OBJECT *obj, const ITEM *item);
+
 static void M_Reset(char *buffer);
 
 static void M_Read(void *ptr, size_t size);
@@ -92,6 +94,11 @@ static SAVEGAME_STRATEGY m_Strategy = {
     .update_death_counters_func = nullptr,
     // clang-format on
 };
+
+static bool M_ItemHasSaveFlags(const OBJECT *const obj, const ITEM *const item)
+{
+    return obj->save_flags && item->object_id != O_WATERFALL;
+}
 
 static void M_Reset(char *const buffer)
 {
@@ -224,7 +231,7 @@ static void M_ReadItems(void)
             item->hit_points = M_ReadS16();
         }
 
-        if (obj->save_flags) {
+        if (M_ItemHasSaveFlags(obj, item)) {
             item->flags = M_ReadU16();
 
             if (obj->intelligent) {
@@ -507,7 +514,7 @@ static void M_WriteItems(void)
             M_WriteS16(item->hit_points);
         }
 
-        if (obj->save_flags) {
+        if (M_ItemHasSaveFlags(obj, item)) {
             uint16_t flags = item->flags + item->active + (item->status << 1)
                 + (item->gravity << 3) + (item->collidable << 4);
             if (obj->intelligent && item->data != nullptr) {


### PR DESCRIPTION
Resolves #2686.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates waterfall objects to have their flags saved in order to be able to restore them correctly on load.  Legacy saves will ignore this.
