### PR TITLE
tr1/game-flow: fix story so far showing up in UB

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fixed sprites missing the fog effect (regression from 4.9)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 4.9)
 - fixed wrong PS1-style title bar color for the end of the level stats dialog (regression from 4.9)
+- fixed Story So Far showing up even when there's nothing to play (#2611, regression from 2.10)
 - improved bubble appearance (#2672)
 - improved rendering performance
 - improved pause exit dialog - it can now be canceled with escape
@@ -83,7 +84,7 @@
 ## [4.8.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.1...tr1-4.8.2) - 2025-02-15
 - changed default FPS value to 60 (#2501)
 - changed passport to be more responsive to player inputs (#1328)
-- fixed story so far not skipping over levels (#2506, regression from 4.8)
+- fixed Story So Far not skipping over levels (#2506, regression from 4.8)
 - fixed resolving paths (especially to music files) on case-sensitive filesystems (#1934, #2504)
 - improved memory usage by shedding ca. 100-110 MB on average
 
@@ -741,7 +742,7 @@
 - added a .NET-based installer
 - added the option to make Lara revert to pistols on new level start (#557)
 - added the PS1 style UI (#517)
-- added the "Story so far..." option in the select level menu to view cutscenes and FMVs (#201)
+- added the "Story So far..." option in the select level menu to view cutscenes and FMVs (#201)
 
 ## [2.9.1](https://github.com/LostArtefacts/TRX/compare/tr1-2.9...tr1-2.9.1) - 2022-06-03
 - fixed crash on centaur hatch (#579, regression from 2.9)

--- a/src/tr1/game/game_flow/sequencer.h
+++ b/src/tr1/game/game_flow/sequencer.h
@@ -6,4 +6,9 @@ void GF_InitSequencer(void);
 
 GF_COMMAND GF_DoLevelSequence(
     const GF_LEVEL *start_level, GF_SEQUENCE_CONTEXT seq_ctx);
+
 GF_COMMAND GF_PlayAvailableStory(int32_t slot_num);
+
+// Returns true if any story cutscenes or FMVs occur before gameplay in any
+// main level up to the level in the specified save slot.
+bool GF_HasAvailableStory(int32_t slot_num);

--- a/src/tr1/game/game_flow/sequencer_misc.c
+++ b/src/tr1/game/game_flow/sequencer_misc.c
@@ -39,6 +39,30 @@ GF_COMMAND GF_PlayAvailableStory(const int32_t slot_num)
     return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
 }
 
+bool GF_HasAvailableStory(const int32_t slot_num)
+{
+    const int32_t savegame_level = Savegame_GetLevelNumber(slot_num);
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    const int32_t max_level = MIN(savegame_level, level_table->count);
+    for (int32_t i = 0; i <= max_level; i++) {
+        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
+        if (level->type == GFL_GYM) {
+            continue;
+        }
+        const GF_SEQUENCE *const seq = &level->sequence;
+        for (int32_t j = 0; j < seq->length; j++) {
+            const GF_SEQUENCE_EVENT *const ev = &seq->events[j];
+            if (ev->type == GFS_LOOP_GAME) {
+                break;
+            }
+            if (ev->type == GFS_PLAY_CUTSCENE || ev->type == GFS_PLAY_FMV) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 GF_COMMAND GF_DoLevelSequence(
     const GF_LEVEL *const start_level, const GF_SEQUENCE_CONTEXT seq_ctx)
 {

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -168,7 +168,7 @@ void Savegame_FillAvailableLevels(REQUEST_INFO *const req)
         }
     }
 
-    if (g_InvMode == INV_TITLE_MODE) {
+    if (g_InvMode == INV_TITLE_MODE && GF_HasAvailableStory(slot_num)) {
         Requester_AddItem(req, false, "%s", GS(PASSPORT_STORY_SO_FAR));
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2611.

#### Testing

UB should no longer show this feature as there are no FMVs to play.
Another good corner case that's not present with the game flows we ship, is that FMVs that come _after_ the level shouldn't trigger the Story So Far to show up. Consider a game flow where the first level is structured as follows:

```
            "sequence": [
                {"type": "loop_game"},
                {"type": "play_fmv", "fmv_id": …},
                {"type": "level_stats"},
                {"type": "level_complete"},
            ],
```

If there are no cutscenes or FMVs before this sequence and a player saves their progress during the level, the Story So Far shouldn't show up. This is because the FMV has not yet occurred when the save is made.