### PR TITLE
tr1/ui: fix loading from empty slots

### DIFF
--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -98,14 +98,6 @@ static void M_HandleFlipInputs(void);
 
 static void M_InitRequesters(void)
 {
-    if (m_State.select_level.state != nullptr) {
-        UI_SelectLevelDialog_Free(m_State.select_level.state);
-        m_State.select_level.state = nullptr;
-    }
-    if (m_State.save_slot.state != nullptr) {
-        UI_SaveSlotDialog_Free(m_State.save_slot.state);
-        m_State.save_slot.state = nullptr;
-    }
     UI_NewGame_Init(&m_State.new_game.state);
 }
 
@@ -286,7 +278,7 @@ static void M_DeterminePages(void)
     }
 }
 
-static void M_InitSaveRequester(int16_t page_num)
+static void M_InitSaveRequester(const int16_t page_num)
 {
     int32_t save_slot = g_GameInfo.select_save_slot;
     if (save_slot == -1) {
@@ -365,7 +357,6 @@ static void M_ShowSelectLevel(void)
 static void M_LoadGame(void)
 {
     M_ChangePageTextContent(GS(PASSPORT_LOAD_GAME));
-
     if (m_State.mode == PASSPORT_MODE_BROWSE) {
         if (g_InputDB.menu_confirm) {
             M_InitSaveRequester(m_State.active_page);
@@ -396,7 +387,6 @@ static void M_SelectLevel(void)
 static void M_SaveGame(void)
 {
     M_ChangePageTextContent(GS(PASSPORT_SAVE_GAME));
-
     if (m_State.mode == PASSPORT_MODE_BROWSE) {
         if (g_InputDB.menu_confirm) {
             M_InitSaveRequester(m_State.active_page);
@@ -607,15 +597,20 @@ void Option_Passport_Draw(INVENTORY_ITEM *const item)
             UI_NewGame(&m_State.new_game.state);
         }
         break;
+
     case PASSPORT_MODE_SELECT_LEVEL:
-        UI_SelectLevelDialog(m_State.select_level.state);
+        if (m_State.select_level.state != nullptr) {
+            UI_SelectLevelDialog(m_State.select_level.state);
+        }
         break;
+
     case PASSPORT_MODE_LOAD_GAME:
     case PASSPORT_MODE_SAVE_GAME:
-        if (m_State.is_ready) {
+        if (m_State.is_ready && m_State.save_slot.state != nullptr) {
             UI_SaveSlotDialog(m_State.save_slot.state);
         }
         break;
+
     default:
         break;
     }

--- a/src/tr1/game/ui/dialogs/save_slot.c
+++ b/src/tr1/game/ui/dialogs/save_slot.c
@@ -145,20 +145,22 @@ UI_SAVE_SLOT_DIALOG_CHOICE UI_SaveSlotDialog_Control(
         };
     }
     const int32_t choice = UI_Requester_Control(&s->req);
-    if (choice == UI_REQUESTER_NO_CHOICE) {
-        return (UI_SAVE_SLOT_DIALOG_CHOICE) {
-            .action = UI_SAVE_SLOT_DIALOG_NO_CHOICE
-        };
-    } else if (choice == UI_REQUESTER_CANCEL) {
+    if (choice == UI_REQUESTER_CANCEL) {
         return (UI_SAVE_SLOT_DIALOG_CHOICE) {
             .action = UI_SAVE_SLOT_DIALOG_CANCEL,
         };
-    } else {
+    } else if (
+        choice != UI_REQUESTER_NO_CHOICE
+        && (s->type == UI_SAVE_SLOT_DIALOG_SAVE_GAME
+            || !Savegame_IsSlotFree(choice))) {
         return (UI_SAVE_SLOT_DIALOG_CHOICE) {
             .action = UI_SAVE_SLOT_DIALOG_CONFIRM,
             .slot_num = sel_row,
         };
     }
+    return (UI_SAVE_SLOT_DIALOG_CHOICE) {
+        .action = UI_SAVE_SLOT_DIALOG_NO_CHOICE,
+    };
 }
 
 void UI_SaveSlotDialog(const UI_SAVE_SLOT_DIALOG_STATE *const s)
@@ -166,7 +168,7 @@ void UI_SaveSlotDialog(const UI_SAVE_SLOT_DIALOG_STATE *const s)
     UI_BeginModal(0.5f, g_InvMode == INV_TITLE_MODE ? 0.72f : 0.55f);
     UI_BeginResize(300.0f, -1.0f);
 
-    const char *title = (s->type == UI_SAVE_SLOT_DIALOG_SAVE_GAME)
+    const char *const title = (s->type == UI_SAVE_SLOT_DIALOG_SAVE_GAME)
         ? GS(PASSPORT_SAVE_GAME)
         : GS(PASSPORT_LOAD_GAME);
     UI_BeginRequester(&s->req, title);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the ability to select an empty save slot in TR1 load game dialog.
