### PR TITLE
console: use room numbers for teleporting and update pos output

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed Story So Far showing up even when there's nothing to play (#2611, regression from 2.10)
 - fixed Story So Far not playing the opening FMV, `cafe.rpl` (#2779, regression from 2.10)
 - fixed Lara at times ending up in incorrect rooms when using the teleport cheat (#2486, regression from 3.0)
+- fixed the `/pos` console command reporting the base room number when Lara is actually in a flipped room (#2487, regression from 3.0)
 - improved bubble appearance (#2672)
 - improved rendering performance
 - improved pause exit dialog - it can now be canceled with escape

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed wrong PS1-style title bar color for the end of the level stats dialog (regression from 4.9)
 - fixed Story So Far showing up even when there's nothing to play (#2611, regression from 2.10)
 - fixed Story So Far not playing the opening FMV, `cafe.rpl` (#2779, regression from 2.10)
+- fixed Lara at times ending up in incorrect rooms when using the teleport cheat (#2486, regression from 3.0)
 - improved bubble appearance (#2672)
 - improved rendering performance
 - improved pause exit dialog - it can now be canceled with escape

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed Lara at times ending up in incorrect rooms when using the teleport cheat (#2486, regression from 0.3)
+- fixed the `/pos` console command reporting the base room number when Lara is actually in a flipped room (#2487, regression from 0.3)
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)
 - fixed a crash in custom levels with large rooms (#2749)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
+- fixed Lara at times ending up in incorrect rooms when using the teleport cheat (#2486, regression from 0.3)
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)
 - fixed a crash in custom levels with large rooms (#2749)

--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -6,6 +6,7 @@
 #include "game/game_string.h"
 #include "game/lara/common.h"
 #include "game/objects/common.h"
+#include "game/rooms.h"
 #include "memory.h"
 #include "strings.h"
 
@@ -45,10 +46,15 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         String_Format(level_type_fmt, current_level->num + reindex);
 
     const ITEM *const lara_item = Lara_GetItem();
+    int16_t room_num = lara_item->room_num;
+    const ROOM *const room = Room_Get(room_num);
+    if (Room_GetFlipStatus() && room->flipped_room != NO_ROOM_NEG) {
+        room_num = room->flipped_room;
+    }
     char *details = lara_item == nullptr
         ? String_Format("%s", GS(OSD_POS_LARA_MISSING))
         : String_Format(
-              GS(OSD_POS_LARA_POS_FMT), lara_item->room_num,
+              GS(OSD_POS_LARA_POS_FMT), room_num,
               lara_item->pos.x / (float)WALL_L,
               lara_item->pos.y / (float)WALL_L,
               lara_item->pos.z / (float)WALL_L,

--- a/src/libtrx/game/console/cmd/teleport.c
+++ b/src/libtrx/game/console/cmd/teleport.c
@@ -156,7 +156,7 @@ static COMMAND_RESULT M_TeleportToXYZ(float x, const float y, float z)
         z += 0.5f;
     }
 
-    if (!Lara_Cheat_Teleport(x * WALL_L, y * WALL_L, z * WALL_L)) {
+    if (!Lara_Cheat_Teleport(x * WALL_L, y * WALL_L, z * WALL_L, NO_ROOM)) {
         Console_Log(GS(OSD_POS_SET_POS_FAIL), x, y, z);
         return CR_FAILURE;
     }
@@ -185,7 +185,7 @@ static COMMAND_RESULT M_TeleportToRoom(const int16_t room_num)
         int32_t x = x1 + Random_GetControl() * (x2 - x1) / 0x7FFF;
         int32_t y = y1;
         int32_t z = z1 + Random_GetControl() * (z2 - z1) / 0x7FFF;
-        if (Lara_Cheat_Teleport(x, y, z)) {
+        if (Lara_Cheat_Teleport(x, y, z, room_num)) {
             success = true;
             break;
         }
@@ -219,8 +219,8 @@ static COMMAND_RESULT M_TeleportToObject(const char *const user_input)
     }
 
     if (Lara_Cheat_Teleport(
-            best_item->pos.x, best_item->pos.y - STEP_L / 4,
-            best_item->pos.z)) {
+            best_item->pos.x, best_item->pos.y - STEP_L / 4, best_item->pos.z,
+            best_item->room_num)) {
         Console_Log(GS(OSD_POS_SET_ITEM), obj_name);
     } else {
         Console_Log(GS(OSD_POS_SET_ITEM_FAIL), obj_name);

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -467,6 +467,17 @@ int32_t Room_FindByPos(const int32_t x, const int32_t y, const int32_t z)
     return NO_ROOM_NEG;
 }
 
+int32_t Room_GetFlippedBaseRoom(const int32_t room_num)
+{
+    for (int32_t i = 0; i < Room_GetCount(); i++) {
+        const ROOM *const room = Room_Get(i);
+        if (room->flipped_room == room_num) {
+            return i;
+        }
+    }
+    return NO_ROOM;
+}
+
 BOUNDS_32 Room_GetWorldBounds(void)
 {
     BOUNDS_32 bounds = {

--- a/src/libtrx/include/libtrx/game/lara/cheat.h
+++ b/src/libtrx/include/libtrx/game/lara/cheat.h
@@ -9,4 +9,5 @@ extern bool Lara_Cheat_EnterFlyMode(void);
 extern bool Lara_Cheat_ExitFlyMode(void);
 extern bool Lara_Cheat_KillEnemy(int16_t item_num);
 extern void Lara_Cheat_EndLevel(void);
-extern bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z);
+extern bool Lara_Cheat_Teleport(
+    int32_t x, int32_t y, int32_t z, int16_t room_num);

--- a/src/libtrx/include/libtrx/game/rooms/common.h
+++ b/src/libtrx/include/libtrx/game/rooms/common.h
@@ -31,6 +31,7 @@ void Room_PopulateSectorData(
 
 int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
 int32_t Room_FindByPos(int32_t x, int32_t y, int32_t z);
+int32_t Room_GetFlippedBaseRoom(int32_t room_num);
 BOUNDS_32 Room_GetWorldBounds(void);
 
 extern SECTOR *Room_GetSector(

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -383,11 +383,21 @@ bool Lara_Cheat_KillEnemy(const int16_t item_num)
     return true;
 }
 
-bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
+bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z, int16_t room_num)
 {
-    int16_t room_num = Room_GetIndexFromPos(x, y, z);
+    if (room_num == NO_ROOM) {
+        room_num = Room_GetIndexFromPos(x, y, z);
+    }
     if (room_num == NO_ROOM) {
         return false;
+    }
+
+    const ROOM *const room = Room_Get(room_num);
+    if (room->flip_status == RFS_FLIPPED && Room_GetFlipStatus()) {
+        room_num = Room_GetFlippedBaseRoom(room_num);
+        if (room_num == NO_ROOM) {
+            return false;
+        }
     }
 
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
@@ -411,12 +421,9 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
                     .y = y,
                     .z = ROUND_TO_SECTOR(z + dz * unit) + WALL_L / 2,
                 };
-                room_num = Room_GetIndexFromPos(point.x, point.y, point.z);
-                if (room_num == NO_ROOM) {
-                    continue;
-                }
                 sector = Room_GetSector(point.x, point.y, point.z, &room_num);
-                height = Room_GetHeight(sector, point.x, point.y, point.z);
+                height =
+                    Room_GetHeightEx(sector, point.x, point.y, point.z, true);
                 if (height == NO_HEIGHT) {
                     continue;
                 }
@@ -443,12 +450,8 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
         }
     }
 
-    room_num = Room_GetIndexFromPos(x, y, z);
-    if (room_num == NO_ROOM) {
-        return false;
-    }
     sector = Room_GetSector(x, y, z, &room_num);
-    height = Room_GetHeight(sector, x, y, z);
+    height = Room_GetHeightEx(sector, x, y, z, true);
     if (height == NO_HEIGHT) {
         return false;
     }

--- a/src/tr1/game/lara/cheat.h
+++ b/src/tr1/game/lara/cheat.h
@@ -11,4 +11,3 @@ bool Lara_Cheat_GiveAllGuns(void);
 bool Lara_Cheat_GiveAllItems(void);
 bool Lara_Cheat_OpenNearestDoor(void);
 bool Lara_Cheat_KillEnemy(int16_t item_num);
-bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z);

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -301,11 +301,21 @@ bool Lara_Cheat_GiveAllItems(void)
     return true;
 }
 
-bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
+bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z, int16_t room_num)
 {
-    int16_t room_num = Room_GetIndexFromPos(x, y, z);
+    if (room_num == NO_ROOM) {
+        room_num = Room_GetIndexFromPos(x, y, z);
+    }
     if (room_num == NO_ROOM) {
         return false;
+    }
+
+    const ROOM *const room = Room_Get(room_num);
+    if (room->flip_status == RFS_FLIPPED && Room_GetFlipStatus()) {
+        room_num = Room_GetFlippedBaseRoom(room_num);
+        if (room_num == NO_ROOM) {
+            return false;
+        }
     }
 
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
@@ -329,12 +339,9 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
                     .y = y,
                     .z = ROUND_TO_SECTOR(z + dz * unit) + WALL_L / 2,
                 };
-                room_num = Room_GetIndexFromPos(point.x, point.y, point.z);
-                if (room_num == NO_ROOM) {
-                    continue;
-                }
                 sector = Room_GetSector(point.x, point.y, point.z, &room_num);
-                height = Room_GetHeight(sector, point.x, point.y, point.z);
+                height =
+                    Room_GetHeightEx(sector, point.x, point.y, point.z, true);
                 if (height == NO_HEIGHT) {
                     continue;
                 }
@@ -361,12 +368,8 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z)
         }
     }
 
-    room_num = Room_GetIndexFromPos(x, y, z);
-    if (room_num == NO_ROOM) {
-        return false;
-    }
     sector = Room_GetSector(x, y, z, &room_num);
-    height = Room_GetHeight(sector, x, y, z);
+    height = Room_GetHeightEx(sector, x, y, z, true);
     if (height == NO_HEIGHT) {
         return false;
     }

--- a/src/tr2/game/lara/cheat.h
+++ b/src/tr2/game/lara/cheat.h
@@ -10,5 +10,4 @@ bool Lara_Cheat_GiveAllKeys(void);
 bool Lara_Cheat_GiveAllGuns(void);
 bool Lara_Cheat_GiveAllItems(void);
 bool Lara_Cheat_OpenNearestDoor(void);
-bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z);
 bool Lara_Cheat_KillEnemy(int16_t item_num);


### PR DESCRIPTION
Resolves #2486.
Resolves #2487.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

If teleporting to a specific room or item, the room number is already known so we now pass that to Lara's teleporting function. Teleporting to a position will continue to locate the room by position. I've also updated it to make use of the `no-space` fix to avoid Lara teleporting into these types of walls (example where it was common was Temple of the Cat room 75).

I've also added a guard for this approach if you try to `tp` to a flipped room when the flipmap is set. An example is Khamoon, room 54, set the flipmap so you're effectively in room 60 (although 60 is in 54's slot) then try to `tp 60`. Without the check, the game will hang as slot 60 is invalid in the current state. This worked OK previously as we were going by position.

The `/pos` command will also now check the flipmap status and report the alternative room when applicable (again as above, the old room index is technically correct, it's the slots that have swapped, but I think the change is good as it ties in with what you see in trview, TombEditor etc).

My only concern with the updates is that teleporting _by position_ may be less lenient than it was before when overlapping rooms are involved. But perhaps this is acceptable, LMK what you think.
