### PR TITLE
objects: use common approach for extra bone rotation

### DIFF
--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -65,18 +65,7 @@ int32_t Collide_GetSpheres(
 
         Matrix_TranslateRel32(bone->pos);
         Matrix_Rot16(frame->mesh_rots[i]);
-
-        if (extra_rotation != nullptr) {
-            if (bone->rot_y) {
-                Matrix_RotY(*extra_rotation++);
-            }
-            if (bone->rot_x) {
-                Matrix_RotX(*extra_rotation++);
-            }
-            if (bone->rot_z) {
-                Matrix_RotZ(*extra_rotation++);
-            }
-        }
+        Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
 
         mesh = Object_GetMesh(obj->mesh_idx + i);
         Matrix_Push();
@@ -154,18 +143,7 @@ void Collide_GetJointAbsPosition(
 
         Matrix_TranslateRel32(bone->pos);
         Matrix_Rot16(frame->mesh_rots[i + 1]);
-
-        if (extra_rotation != nullptr) {
-            if (bone->rot_y) {
-                Matrix_RotY(*extra_rotation++);
-            }
-            if (bone->rot_x) {
-                Matrix_RotX(*extra_rotation++);
-            }
-            if (bone->rot_z) {
-                Matrix_RotZ(*extra_rotation++);
-            }
-        }
+        Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
     }
 
     Matrix_TranslateRel32(*out_vec);

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -774,9 +774,9 @@ void Level_AppendAnimBones(
         const int32_t flags = VFile_ReadS32(file);
         bone->matrix_pop = (flags & 1) != 0;
         bone->matrix_push = (flags & 2) != 0;
-        bone->rot_x = false;
-        bone->rot_y = false;
-        bone->rot_z = false;
+        bone->rot.x = false;
+        bone->rot.y = false;
+        bone->rot.z = false;
         M_ReadPosition(&bone->pos, file);
     }
 }

--- a/src/libtrx/game/objects/common.c
+++ b/src/libtrx/game/objects/common.c
@@ -185,17 +185,7 @@ void Object_DrawInterpolatedObject(
                 Matrix_TranslateRel16_ID(frame1->offset, frame2->offset);
                 Matrix_Rot16_ID(
                     frame1->mesh_rots[mesh_idx], frame2->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (obj->base_rot.y) {
-                        Matrix_RotY_I(*extra_rotation++);
-                    }
-                    if (obj->base_rot.x) {
-                        Matrix_RotX_I(*extra_rotation++);
-                    }
-                    if (obj->base_rot.z) {
-                        Matrix_RotZ_I(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(&extra_rotation, obj->base_rot, true);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -208,17 +198,7 @@ void Object_DrawInterpolatedObject(
                 Matrix_TranslateRel32_I(bone->pos);
                 Matrix_Rot16_ID(
                     frame1->mesh_rots[mesh_idx], frame2->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (bone->rot_y) {
-                        Matrix_RotY_I(*extra_rotation++);
-                    }
-                    if (bone->rot_x) {
-                        Matrix_RotX_I(*extra_rotation++);
-                    }
-                    if (bone->rot_z) {
-                        Matrix_RotZ_I(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
             }
 
             if (meshes & (1 << mesh_idx)) {
@@ -230,17 +210,8 @@ void Object_DrawInterpolatedObject(
             if (mesh_idx == 0) {
                 Matrix_TranslateRel16(frame1->offset);
                 Matrix_Rot16(frame1->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (obj->base_rot.y) {
-                        Matrix_RotY(*extra_rotation++);
-                    }
-                    if (obj->base_rot.x) {
-                        Matrix_RotX(*extra_rotation++);
-                    }
-                    if (obj->base_rot.z) {
-                        Matrix_RotZ(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(
+                    &extra_rotation, obj->base_rot, false);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -252,17 +223,7 @@ void Object_DrawInterpolatedObject(
 
                 Matrix_TranslateRel32(bone->pos);
                 Matrix_Rot16(frame1->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (bone->rot_y) {
-                        Matrix_RotY(*extra_rotation++);
-                    }
-                    if (bone->rot_x) {
-                        Matrix_RotX(*extra_rotation++);
-                    }
-                    if (bone->rot_z) {
-                        Matrix_RotZ(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
             }
 
             if (meshes & (1 << mesh_idx)) {
@@ -272,4 +233,30 @@ void Object_DrawInterpolatedObject(
     }
 
     Matrix_Pop();
+}
+
+void Object_ApplyExtraRotation(
+    const int16_t **extra_rotation, const XYZ_BOOL rot_flags,
+    const bool interpolated)
+{
+    const int16_t *rot_ptr = *extra_rotation;
+    if (rot_ptr == nullptr) {
+        return;
+    }
+
+#define APPLY_ROTATION(axis_, flag_)                                           \
+    if (rot_flags.flag_) {                                                     \
+        if (interpolated) {                                                    \
+            Matrix_Rot##axis_##_I(*rot_ptr++);                                 \
+        } else {                                                               \
+            Matrix_Rot##axis_(*rot_ptr++);                                     \
+        }                                                                      \
+    }
+
+    APPLY_ROTATION(Y, y);
+    APPLY_ROTATION(X, x);
+    APPLY_ROTATION(Z, z);
+
+#undef APPLY_ROTATION
+    *extra_rotation = rot_ptr;
 }

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -243,7 +243,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 13)->rot_y = true;
+    Object_GetBone(obj, 13)->rot.y = true;
 }
 
 REGISTER_OBJECT(O_BEAR, Bear_Setup)

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -231,7 +231,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 2)->rot_y = true;
+    Object_GetBone(obj, 2)->rot.y = true;
 }
 
 REGISTER_OBJECT(O_WOLF, Wolf_Setup)

--- a/src/libtrx/include/libtrx/game/anims/types.h
+++ b/src/libtrx/include/libtrx/game/anims/types.h
@@ -35,9 +35,7 @@ typedef struct {
 typedef struct {
     bool matrix_pop;
     bool matrix_push;
-    bool rot_x;
-    bool rot_y;
-    bool rot_z;
+    XYZ_BOOL rot;
     XYZ_32 pos;
 } ANIM_BONE;
 

--- a/src/libtrx/include/libtrx/game/math/types.h
+++ b/src/libtrx/include/libtrx/game/math/types.h
@@ -27,6 +27,12 @@ typedef struct {
 } XYZ_16;
 
 typedef struct {
+    bool x;
+    bool y;
+    bool z;
+} XYZ_BOOL;
+
+typedef struct {
     float x, y, z;
 } XYZ_F;
 

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -42,6 +42,9 @@ void Object_DrawInterpolatedObject(
     const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,
     const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,
     int32_t rate);
+void Object_ApplyExtraRotation(
+    const int16_t **extra_rotation, const XYZ_BOOL rot_flags,
+    bool interpolated);
 
 #define REGISTER_OBJECT(object_id, setup_func_)                                \
     __attribute__((constructor)) static void M_RegisterObject##object_id(void) \

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -78,12 +78,7 @@ typedef struct OBJECT {
     int16_t shadow_size;
     int16_t smartness;
     bool enable_interpolation;
-
-    struct {
-        bool x;
-        bool y;
-        bool z;
-    } base_rot;
+    XYZ_BOOL base_rot;
 
     union {
         uint16_t flags;

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -90,7 +90,7 @@ static void M_DrawItem(
     const int32_t frac = M_GetFrames(ring, inv_item, &frame1, &frame2, &rate);
     if (inv_item->object_id == O_COMPASS_OPTION) {
         const int16_t extra_rotation[1] = { Option_Compass_GetNeedleAngle() };
-        Object_GetBone(obj, 0)->rot_y = true;
+        Object_GetBone(obj, 0)->rot.y = true;
         Object_DrawInterpolatedObject(
             obj, inv_item->meshes_drawn, extra_rotation, frame1, frame2, frac,
             rate);

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -459,12 +459,6 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
     Matrix_TranslateRel16(frame->offset);
     Matrix_Rot16(frame->mesh_rots[0]);
 
-#if 0
-    // XXX: present in OG, removed by GLrage on the grounds that it sometimes
-    // crashes.
-    int16_t *extra_rotation = (int16_t*)item->data;
-#endif
-
     int32_t bit = 1;
     if ((bit & mesh_bits) && (bit & item->mesh_bits)) {
         int16_t effect_num = Effect_Create(item->room_num);
@@ -502,17 +496,10 @@ int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage)
         Matrix_Rot16(frame->mesh_rots[i]);
 
 #if 0
-    if (extra_rotation) {
-        if (bone->rot_y) {
-            Matrix_RotY(*extra_rotation++);
-        }
-        if (bone->rot_x) {
-            Matrix_RotX(*extra_rotation++);
-        }
-        if (bone->rot_z) {
-            Matrix_RotZ(*extra_rotation++);
-        }
-    }
+        // XXX: present in OG, removed by GLrage on the grounds that it
+        // sometimes crashes.
+        const int16_t *extra_rotation = (int16_t *)item->data;
+        Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
 #endif
 
         bit <<= 1;

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -127,7 +127,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 13)->rot_y = true;
+    Object_GetBone(obj, 13)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -52,7 +52,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -57,8 +57,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 10)->rot_x = true;
-    Object_GetBone(obj, 10)->rot_y = true;
+    Object_GetBone(obj, 10)->rot.x = true;
+    Object_GetBone(obj, 10)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -77,7 +77,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    Object_GetBone(obj, 7)->rot_y = true;
+    Object_GetBone(obj, 7)->rot.y = true;
 }
 
 static void M_SetupCrocodile(OBJECT *const obj)

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -62,7 +62,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 19)->rot_y = true;
+    Object_GetBone(obj, 19)->rot.y = true;
 }
 
 static void M_SetupLion(OBJECT *const obj)

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 2)->rot_y = true;
+    Object_GetBone(obj, 2)->rot.y = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -83,8 +83,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    Object_GetBone(obj, 0)->rot_y = true;
-    Object_GetBone(obj, 2)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
+    Object_GetBone(obj, 2)->rot.y = true;
 }
 
 static void M_Setup2(OBJECT *const obj)

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -63,8 +63,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 2)->rot_x = true;
-    Object_GetBone(obj, 2)->rot_z = true;
+    Object_GetBone(obj, 2)->rot.x = true;
+    Object_GetBone(obj, 2)->rot.z = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -65,7 +65,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 21)->rot_y = true;
+    Object_GetBone(obj, 21)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -75,7 +75,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
-    Object_GetBone(obj, 1)->rot_y = true;
+    Object_GetBone(obj, 1)->rot.y = true;
 }
 
 static void M_SetupRat(OBJECT *const obj)

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 
     if (!Object_Get(O_SKATEBOARD)->loaded) {
         LOG_WARNING(

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -70,7 +70,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 1)->rot_y = true;
+    Object_GetBone(obj, 1)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -63,8 +63,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = 1;
     obj->save_flags = 1;
 
-    Object_GetBone(obj, 10)->rot_y = true;
-    Object_GetBone(obj, 11)->rot_y = true;
+    Object_GetBone(obj, 10)->rot.y = true;
+    Object_GetBone(obj, 11)->rot.y = true;
 }
 
 static void M_Collision(

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -100,9 +100,9 @@ static void M_DrawItem(
         const int32_t seconds = (total_seconds % 60) * DEG_1 * -360 / 60;
 
         const int16_t extra_rotation[3] = { hours, minutes, seconds };
-        Object_GetBone(obj, 3)->rot_z = true;
-        Object_GetBone(obj, 4)->rot_z = true;
-        Object_GetBone(obj, 5)->rot_z = true;
+        Object_GetBone(obj, 3)->rot.z = true;
+        Object_GetBone(obj, 4)->rot.z = true;
+        Object_GetBone(obj, 5)->rot.z = true;
         Object_DrawInterpolatedObject(
             obj, inv_item->meshes_drawn, extra_rotation, frame1, frame2, frac,
             rate);

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -448,18 +448,7 @@ int32_t Item_Explode(
 
         Matrix_TranslateRel32(bone->pos);
         Matrix_Rot16(best_frame->mesh_rots[i]);
-
-        if (extra_rotation != nullptr) {
-            if (bone->rot_y) {
-                Matrix_RotY(*extra_rotation++);
-            }
-            if (bone->rot_x) {
-                Matrix_RotX(*extra_rotation++);
-            }
-            if (bone->rot_z) {
-                Matrix_RotZ(*extra_rotation++);
-            }
-        }
+        Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
 
         bit <<= 1;
         if ((mesh_bits & bit) && (item->mesh_bits & bit)) {

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -70,8 +70,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 8)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 8)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -71,8 +71,8 @@ static void M_Setup2A(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 8)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 8)->rot.y = true;
 }
 
 static void M_Setup2B(OBJECT *const obj)
@@ -100,8 +100,8 @@ static void M_Setup2B(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 8)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 8)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -75,7 +75,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 14)->rot_y = true;
+    Object_GetBone(obj, 14)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -72,7 +72,7 @@ static void M_Setup1(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 }
 
 static void M_Setup1A(OBJECT *const obj)
@@ -101,7 +101,7 @@ static void M_Setup1A(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 }
 
 static void M_Setup1B(OBJECT *const obj)
@@ -130,7 +130,7 @@ static void M_Setup1B(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -68,8 +68,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
-    Object_GetBone(obj, 8)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
+    Object_GetBone(obj, 8)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -276,10 +276,10 @@ static void M_Control(const int16_t item_num)
     Creature_Tilt(item, tilt);
 
     const OBJECT *const obj = Object_Get(item->object_id);
-    Object_GetBone(obj, 0)->rot_y = body != 0;
-    Object_GetBone(obj, 2)->rot_y = left != 0;
-    Object_GetBone(obj, 6)->rot_y = right != 0;
-    Object_GetBone(obj, 10)->rot_y = head != 0;
+    Object_GetBone(obj, 0)->rot.y = body != 0;
+    Object_GetBone(obj, 2)->rot.y = left != 0;
+    Object_GetBone(obj, 6)->rot.y = right != 0;
+    Object_GetBone(obj, 10)->rot.y = head != 0;
 
     if (body != 0) {
         Creature_Head(item, body);

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -115,8 +115,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 10)->rot_y = true;
-    Object_GetBone(obj, 14)->rot_z = true;
+    Object_GetBone(obj, 10)->rot.y = true;
+    Object_GetBone(obj, 14)->rot.z = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -77,7 +77,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 19)->rot_y = true;
+    Object_GetBone(obj, 19)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -185,7 +185,7 @@ static void M_SetupFront(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 10)->rot_z = true;
+    Object_GetBone(obj, 10)->rot.z = true;
 }
 
 static void M_SetupBack(OBJECT *const obj)

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -70,7 +70,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
 }
 
 static void M_Setup2(OBJECT *const obj)

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -63,7 +63,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 3)->rot_y = true;
+    Object_GetBone(obj, 3)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -70,7 +70,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 9)->rot_y = true;
+    Object_GetBone(obj, 9)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -68,7 +68,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 21)->rot_y = true;
+    Object_GetBone(obj, 21)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -63,8 +63,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 10)->rot_y = true;
-    Object_GetBone(obj, 11)->rot_y = true;
+    Object_GetBone(obj, 10)->rot.y = true;
+    Object_GetBone(obj, 11)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -65,8 +65,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = true;
-    Object_GetBone(obj, 13)->rot_y = true;
+    Object_GetBone(obj, 4)->rot.y = true;
+    Object_GetBone(obj, 13)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -88,8 +88,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = true;
-    Object_GetBone(obj, 13)->rot_y = true;
+    Object_GetBone(obj, 4)->rot.y = true;
+    Object_GetBone(obj, 13)->rot.y = true;
 }
 
 static void M_Setup5(OBJECT *const obj)
@@ -112,8 +112,8 @@ static void M_Setup5(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 4)->rot_y = true;
-    Object_GetBone(obj, 13)->rot_y = true;
+    Object_GetBone(obj, 4)->rot.y = true;
+    Object_GetBone(obj, 13)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -83,8 +83,8 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 0)->rot_y = true;
-    Object_GetBone(obj, 4)->rot_y = true;
+    Object_GetBone(obj, 0)->rot.y = true;
+    Object_GetBone(obj, 4)->rot.y = true;
 }
 
 static void M_Setup3(OBJECT *const obj)

--- a/src/tr2/game/objects/creatures/xian_common.c
+++ b/src/tr2/game/objects/creatures/xian_common.c
@@ -48,6 +48,7 @@ void XianWarrior_Draw(const ITEM *item)
                 Matrix_Rot16_ID(
                     frames[0]->mesh_rots[mesh_idx],
                     frames[1]->mesh_rots[mesh_idx]);
+                Object_ApplyExtraRotation(&extra_rotation, obj->base_rot, true);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -61,17 +62,7 @@ void XianWarrior_Draw(const ITEM *item)
                 Matrix_Rot16_ID(
                     frames[0]->mesh_rots[mesh_idx],
                     frames[1]->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (bone->rot_y) {
-                        Matrix_RotY_I(*extra_rotation++);
-                    }
-                    if (bone->rot_x) {
-                        Matrix_RotX_I(*extra_rotation++);
-                    }
-                    if (bone->rot_z) {
-                        Matrix_RotZ_I(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {
@@ -85,6 +76,8 @@ void XianWarrior_Draw(const ITEM *item)
             if (mesh_idx == 0) {
                 Matrix_TranslateRel16(frames[0]->offset);
                 Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
+                Object_ApplyExtraRotation(
+                    &extra_rotation, obj->base_rot, false);
             } else {
                 const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
                 if (bone->matrix_pop) {
@@ -96,17 +89,7 @@ void XianWarrior_Draw(const ITEM *item)
 
                 Matrix_TranslateRel32(bone->pos);
                 Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                if (extra_rotation != nullptr) {
-                    if (bone->rot_y) {
-                        Matrix_RotY(*extra_rotation++);
-                    }
-                    if (bone->rot_x) {
-                        Matrix_RotX(*extra_rotation++);
-                    }
-                    if (bone->rot_z) {
-                        Matrix_RotZ(*extra_rotation++);
-                    }
-                }
+                Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
             }
 
             if (item->mesh_bits & (1 << mesh_idx)) {

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -101,8 +101,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 16)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 16)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -127,8 +127,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 12)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 12)->rot.y = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -91,8 +91,8 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = 1;
     obj->save_anim = 1;
 
-    Object_GetBone(obj, 6)->rot_y = true;
-    Object_GetBone(obj, 14)->rot_y = true;
+    Object_GetBone(obj, 6)->rot.y = true;
+    Object_GetBone(obj, 14)->rot.y = true;
 }
 
 static void M_Control(const int16_t item_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A follow-up from #2786, this removes duplicated logic for applying extra rotations to animation bones.

The main thing to check is that enemies' heads/necks rotate as normal e.g. towards Lara. The compass needle in TR1 and the stopwatch/clock hands in TR2 also use this logic, so they should behave as expected too.
