### PR TITLE
tr2/objects/boat: fix initial water height test

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed a potential softlock in Nightmare in Vegas where the bird monster could remain inactive, or the flip map not set (#1851)
 - fixed invalid portals in The Deck between rooms 17 and 104, which could result in Lara seeing enemies in disconnected rooms (#2393)
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
+- fixed the boat briefly having an underwater hue when Lara first climbs on (#2787)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed some 3D pickup items rendering black in software mode (#2792, regression from 0.10)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -290,6 +290,7 @@ as Notepad.
 - fixed TGA screenshots crashing the game
 - fixed the camera being cut off after using the gong hammer in Ice Palace
 - fixed Lara's underwater hue being retained when re-entering a boat
+- fixed the boat briefly having an underwater hue when Lara first climbs on
 - fixed distant rooms sometimes not appearing, causing the skybox to be visible when it shouldn't
 - fixed rendering problems on certain Intel GPUs
 - fixed bubbles spawning from flares if Lara is in shallow water

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -46,6 +46,7 @@
 #define BOAT_TURN (DEG_1 / 8) // = 22
 #define BOAT_MAX_TURN (DEG_1 * 4) // = 728
 #define BOAT_SOUND_CEILING (WALL_L * 5) // = 5120
+#define BOAT_SHIFT_Y (-5)
 
 typedef enum {
     BOAT_STATE_GET_ON = 0,
@@ -164,7 +165,7 @@ static int32_t M_TestWaterHeight(
         }
     }
 
-    return height - 5;
+    return height + BOAT_SHIFT_Y;
 }
 
 static void M_DoWakeEffect(const ITEM *const boat)
@@ -618,7 +619,7 @@ static void M_Collision(
     ITEM *const boat = Item_Get(item_num);
 
     lara->pos.x = boat->pos.x;
-    lara->pos.y = boat->pos.y - 5;
+    lara->pos.y = boat->pos.y + BOAT_SHIFT_Y;
     lara->pos.z = boat->pos.z;
     lara->gravity = 0;
     lara->rot.x = 0;
@@ -656,8 +657,8 @@ static void M_Control(const int16_t item_num)
     const int32_t hfr = M_TestWaterHeight(boat, BOAT_FRONT, BOAT_SIDE, &fr);
 
     int16_t room_num = boat->room_num;
-    const SECTOR *sector =
-        Room_GetSector(boat->pos.x, boat->pos.y - 5, boat->pos.z, &room_num);
+    const SECTOR *sector = Room_GetSector(
+        boat->pos.x, boat->pos.y + BOAT_SHIFT_Y, boat->pos.z, &room_num);
     int32_t height =
         Room_GetHeight(sector, boat->pos.x, boat->pos.y, boat->pos.z);
     const int32_t ceiling =
@@ -695,7 +696,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    boat->floor = height - 5;
+    boat->floor = height + BOAT_SHIFT_Y;
     if (boat_data->water == NO_HEIGHT) {
         boat_data->water = height;
     } else {
@@ -741,7 +742,7 @@ static void M_Control(const int16_t item_num)
         Room_TestTriggers(boat);
 
         sector = Room_GetSector(
-            lara->pos.x, lara->pos.y - 5, lara->pos.z, &room_num);
+            lara->pos.x, lara->pos.y + BOAT_SHIFT_Y, lara->pos.z, &room_num);
         if (room_num != g_LaraItem->room_num) {
             Item_NewRoom(g_Lara.item_num, room_num);
         }
@@ -769,7 +770,7 @@ static void M_Control(const int16_t item_num)
         : boat->speed;
 
     boat_data->pitch += ((pitch - boat_data->pitch) >> 2);
-    if (boat->speed != 0 && water_height - 5 != boat->pos.y) {
+    if (boat->speed != 0 && water_height + BOAT_SHIFT_Y != boat->pos.y) {
         Sound_Effect(SFX_BOAT_ENGINE, &boat->pos, SPM_NORMAL);
     } else if (boat->speed > 20) {
         Sound_Effect(
@@ -784,7 +785,7 @@ static void M_Control(const int16_t item_num)
                 + ((0x10000 - (BOAT_MAX_SPEED - boat_data->pitch) * 100) << 8));
     }
 
-    if (boat->speed && water_height - 5 == boat->pos.y) {
+    if (boat->speed && water_height + BOAT_SHIFT_Y == boat->pos.y) {
         M_DoWakeEffect(boat);
     }
 

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -657,7 +657,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = boat->room_num;
     const SECTOR *sector =
-        Room_GetSector(boat->pos.x, boat->pos.y, boat->pos.z, &room_num);
+        Room_GetSector(boat->pos.x, boat->pos.y - 5, boat->pos.z, &room_num);
     int32_t height =
         Room_GetHeight(sector, boat->pos.x, boat->pos.y, boat->pos.z);
     const int32_t ceiling =


### PR DESCRIPTION
Resolves #2787.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The first commit contains the fix, the second makes `-5` a const where it's used for the same height shift purpose throughout the module.
