### PR TITLE
tr2/objects/gondola: save gondola position

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fixed invalid portals in The Deck between rooms 17 and 104, which could result in Lara seeing enemies in disconnected rooms (#2393)
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
 - fixed the boat briefly having an underwater hue when Lara first climbs on (#2787)
+- fixed destroyed gondolas appearing embedded in the ground after loading a save (#1612)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed some 3D pickup items rendering black in software mode (#2792, regression from 0.10)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -245,6 +245,7 @@ as Notepad.
     - fixed Floating Islands mystic plaque inventory rotation
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used
 - fixed being able to use hotkeys in the end-level statistics screen
+- fixed destroyed gondolas appearing embedded in the ground after loading a save
 - improved the animation of Lara's braid
 
 #### Cheats

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -15,6 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
+    obj->save_position = 1;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -45,6 +45,7 @@ static int32_t m_BufPos = 0;
 static char *m_BufPtr = nullptr;
 
 static bool M_ItemHasSaveFlags(const OBJECT *obj, const ITEM *item);
+static bool M_ItemHasSavePosition(const OBJECT *obj, const ITEM *item);
 
 static void M_Reset(char *buffer);
 
@@ -97,6 +98,12 @@ static SAVEGAME_STRATEGY m_Strategy = {
 static bool M_ItemHasSaveFlags(const OBJECT *const obj, const ITEM *const item)
 {
     return obj->save_flags && item->object_id != O_WATERFALL;
+}
+
+static bool M_ItemHasSavePosition(
+    const OBJECT *const obj, const ITEM *const item)
+{
+    return obj->save_position && item->object_id != O_GONDOLA;
 }
 
 static void M_Reset(char *const buffer)
@@ -202,7 +209,7 @@ static void M_ReadItems(void)
         ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
 
-        if (obj->save_position) {
+        if (M_ItemHasSavePosition(obj, item)) {
             item->pos.x = M_ReadS32();
             item->pos.y = M_ReadS32();
             item->pos.z = M_ReadS32();
@@ -489,7 +496,7 @@ static void M_WriteItems(void)
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         const ITEM *const item = Item_Get(i);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->save_position) {
+        if (M_ItemHasSavePosition(obj, item)) {
             M_WriteS32(item->pos.x);
             M_WriteS32(item->pos.y);
             M_WriteS32(item->pos.z);


### PR DESCRIPTION
Resolves #1612.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates gondola objects to have their positions saved in order to be able to restore them correctly on load when they've been destroyed. Legacy saves will ignore this.
