### PR TITLE
tr2/flares: fix flicker in 60 fps

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
 - fixed the boat briefly having an underwater hue when Lara first climbs on (#2787)
 - fixed destroyed gondolas appearing embedded in the ground after loading a save (#1612)
+- fixed flares flipped to the right when thrown (regression from 0.10)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
 - fixed some 3D pickup items rendering black in software mode (#2792, regression from 0.10)
@@ -50,6 +51,7 @@
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)
 - fixed a crash in custom levels with large rooms (#2749)
+- fixed flares missing the flicker effect in 60 FPS (#2806)
 - improved pause exit dialog - it can now be canceled with escape
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels (#1583)

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -83,7 +83,7 @@ int32_t Flare_DoLight(const XYZ_32 *const pos, const int32_t flare_age)
 
     const int32_t random = Random_GetDraw();
     const XYZ_32 light_pos = {
-        .x = pos->x + (random & 0xF),
+        .x = pos->x + (random & 0xA0),
         .y = pos->y,
         .z = pos->z,
     };

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -912,7 +912,7 @@ void Lara_GetJointAbsPosition_I(
 
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_Interpolate();
-        Matrix_TranslateRel32(bone[LM_UARM_R - 1].pos);
+        Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
         if (g_Lara.flare_control_left) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
@@ -948,7 +948,6 @@ void Lara_GetJointAbsPosition_I(
     vec->x = item->pos.x + (g_MatrixPtr->_03 >> W2V_SHIFT);
     vec->y = item->pos.y + (g_MatrixPtr->_13 >> W2V_SHIFT);
     vec->z = item->pos.z + (g_MatrixPtr->_23 >> W2V_SHIFT);
-
     Matrix_Pop();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2806. The OG mistakenly used the wrong arm (right instead of left) to determine the flare light position in
`Lara_GetJointAbsPosition_I`. At 60 FPS, this mistake caused Lara's hand position to appear significantly off from the expected location, which coincidentally led to the flicker effect disappearing. While fixing the bone did position Lara's hand correctly, it didn't bring back the missing flicker at 60 FPS. In fact, it caused the flicker effect to disappear at 30 FPS as well, making it static at both frame rates. It turned out that although the game does randomize the position of the flares' light source, it doesn't do so sufficiently. The primary cause of the flickering was actually the randomness introduced by using the incorrect bone. To restore the flicker effect to how it originally appeared, I had to enhance the randomness of the flare's light position.