### PR TITLE
gym: calculate best time automatically

### DIFF
--- a/src/libtrx/config/file.c
+++ b/src/libtrx/config/file.c
@@ -363,8 +363,6 @@ bool ConfigFile_LoadAssaultStats(
             }
         }
     }
-    assault_stats->best_time =
-        JSON_ObjectGetInt(stats_obj, "best_time", assault_stats->best_time);
     assault_stats->total_attempts = JSON_ObjectGetInt(
         stats_obj, "total_attempts", assault_stats->total_attempts);
     return true;

--- a/src/libtrx/game/gym.c
+++ b/src/libtrx/game/gym.c
@@ -8,11 +8,19 @@
 #include "game/savegame.h"
 #include "game/stats.h"
 
+#define NO_TIME (-1)
+
 static bool m_IsInventoryOpenEnabled = true;
 static bool m_IsAssaultTimerDisplay = false;
 static bool m_IsAssaultTimerActive = false;
 
 static bool M_StoreAssaultTime(uint32_t time);
+
+static int32_t M_GetBestTime(void)
+{
+    const ASSAULT_STATS *const assault = &g_Config.profile.assault_stats;
+    return assault->total_attempts > 0 ? assault->entries[0].time : NO_TIME;
+}
 
 static bool M_StoreAssaultTime(const uint32_t time)
 {
@@ -91,28 +99,26 @@ void Gym_FinishAssault(void)
         return;
     }
 
+    const int32_t current_best_time = M_GetBestTime();
     ASSAULT_STATS *const assault = &g_Config.profile.assault_stats;
     const RESUME_INFO *const resume =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
     M_StoreAssaultTime(resume->stats.timer);
 
-    if (assault->best_time <= 0) {
+    if (current_best_time <= 0) {
         if (resume->stats.timer < 100 * LOGIC_FPS) {
             // "Gosh! That was my best time yet!"
             Music_Play(MX_GYM_HINT_15, MPM_ALWAYS);
-            assault->best_time = resume->stats.timer;
         } else {
             // "Congratulations! You did it! But perhaps I could've been
             // faster."
             Music_Play(MX_GYM_HINT_17, MPM_ALWAYS);
-            assault->best_time = 100 * LOGIC_FPS;
         }
-    } else if (resume->stats.timer < (uint32_t)assault->best_time) {
+    } else if (resume->stats.timer < (uint32_t)current_best_time) {
         // "Gosh! That was my best time yet!"
         Music_Play(MX_GYM_HINT_15, MPM_ALWAYS);
-        assault->best_time = resume->stats.timer;
     } else if (
-        resume->stats.timer < (uint32_t)assault->best_time + 5 * LOGIC_FPS) {
+        resume->stats.timer < (uint32_t)current_best_time + 5 * LOGIC_FPS) {
         // "Almost. Perhaps another try and I might beat it."
         Music_Play(MX_GYM_HINT_16, MPM_ALWAYS);
     } else {

--- a/src/libtrx/include/libtrx/config/types.h
+++ b/src/libtrx/include/libtrx/config/types.h
@@ -20,7 +20,6 @@ typedef struct {
         uint32_t time;
         uint32_t attempt_num;
     } entries[MAX_ASSAULT_TIMES];
-    int32_t best_time;
     uint32_t total_attempts;
 } ASSAULT_STATS;
 


### PR DESCRIPTION
Resolves #2812.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

~~Writes the best time to the config to allow it to be restored on load. As it's unreleased, best to either add the time manually in your config file if you want to retain your current stats, otherwise delete the object from the JSON, or the file itself.~~

This removes the need to store the current best time as it is always the first completed entry's time (or -1 if no completions).
