### PR TITLE
build: skip installer builds for PRs and pre-releases

### DIFF
--- a/.github/workflows/job_build_tr1.yml
+++ b/.github/workflows/job_build_tr1.yml
@@ -3,6 +3,10 @@ name: Build TR1X and the installer
 on:
   workflow_call:
     inputs:
+      platform:
+        type: string
+        description: "Platform to build for"
+        required: true
       target:
         type: string
         description: "Target to build for"
@@ -12,15 +16,6 @@ jobs:
   build:
     name: Build release assets
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - platform: linux
-            just_target: tr1-package-linux ${{ inputs.target }}
-          - platform: win
-            just_target: tr1-package-win-all ${{ inputs.target }}
-          - platform: win-installer
-            just_target: tr1-package-win-installer ${{ inputs.target }}
 
     steps:
       - name: Install dependencies
@@ -37,13 +32,13 @@ jobs:
         name: Prepare variables
         run: echo "version=$(just output-current-version 1)" >> $GITHUB_OUTPUT
 
-      - name: Package asset (${{ matrix.platform }})
-        run: just ${{ matrix.just_target }}
+      - name: Package asset (${{ inputs.platform }})
+        run: just tr1-package-${{ inputs.platform }} ${{ inputs.target }}
 
       - name: Upload the artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TR1X-${{ steps.vars.outputs.version }}-${{ matrix.platform }}
+          name: TR1X-${{ steps.vars.outputs.version }}-${{ inputs.platform }}
           path: |
             *.zip
             *.exe

--- a/.github/workflows/job_build_tr2.yml
+++ b/.github/workflows/job_build_tr2.yml
@@ -3,6 +3,10 @@ name: Build TR2X and the installer
 on:
   workflow_call:
     inputs:
+      platform:
+        type: string
+        description: "Platform to build for"
+        required: true
       target:
         type: string
         description: "Target to build for"
@@ -12,15 +16,6 @@ jobs:
   build:
     name: Build release assets
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - platform: linux
-            just_target: tr2-package-linux ${{ inputs.target }}
-          - platform: win
-            just_target: tr2-package-win-all ${{ inputs.target }}
-          - platform: win-installer
-            just_target: tr2-package-win-installer ${{ inputs.target }}
 
     steps:
       - name: Install dependencies
@@ -37,13 +32,13 @@ jobs:
         name: Prepare variables
         run: echo "version=$(just output-current-version 2)" >> $GITHUB_OUTPUT
 
-      - name: Package asset (${{ matrix.platform }})
-        run: just ${{ matrix.just_target }}
+      - name: Package asset (${{ inputs.platform }})
+        run: just tr2-package-${{ inputs.platform }} ${{ inputs.target }}
 
       - name: Upload the artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TR2X-${{ steps.vars.outputs.version }}-${{ matrix.platform }}
+          name: TR2X-${{ steps.vars.outputs.version }}-${{ inputs.platform }}
           path: |
             *.zip
             *.exe

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -11,34 +11,52 @@ on:
       - '!develop'
 
 jobs:
-  package_tr1_multiplatform:
-    name: Build TR1
+  package_tr1_linux:
+    name: TR1 (Linux)
     uses: ./.github/workflows/job_build_tr1.yml
     with:
-      target: 'debug'
+      platform: linux
+      target: debug
+    secrets: inherit
+
+  package_tr1_win:
+    name: TR1 (Windows)
+    uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      platform: win-all
+      target: debug
     secrets: inherit
 
   package_tr1_mac:
-    name: Build TR1
+    name: TR1 (Mac)
     if: vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1_macos.yml
     with:
-      target: 'debug'
+      target: debug
       let_mac_fail: true
     secrets: inherit
 
-  package_tr2_multiplatform:
-    name: Build TR2
+  package_tr2_linux:
+    name: TR2 (Linux)
     uses: ./.github/workflows/job_build_tr2.yml
     with:
-      target: 'debug'
+      platform: linux
+      target: debug
+    secrets: inherit
+
+  package_tr2_win:
+    name: TR2 (Windows)
+    uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      platform: win-all
+      target: debug
     secrets: inherit
 
   package_tr2_mac:
-      name: Build TR2
+      name: TR2 (Mac)
       if: vars.MACOS_ENABLE == 'true'
       uses: ./.github/workflows/job_build_tr2_macos.yml
       with:
-        target: 'debug'
+        target: debug
         let_mac_fail: true
       secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,16 +9,24 @@ on:
     - develop
 
 jobs:
-  package_tr1_multiplatform:
-    name: Build TR1
-    if: vars.PRERELEASE_ENABLE == 'true'
+  package_tr1_linux:
+    name: TR1 (Linux)
     uses: ./.github/workflows/job_build_tr1.yml
     with:
-      target: 'debug'
+      platform: linux
+      target: debug
+    secrets: inherit
+
+  package_tr1_win:
+    name: TR1 (Windows)
+    uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      platform: win-all
+      target: debug
     secrets: inherit
 
   package_tr1_mac:
-    name: Build TR1
+    name: TR1 (Mac)
     if: |
       vars.PRERELEASE_ENABLE == 'true' &&
       vars.MACOS_ENABLE == 'true'
@@ -28,16 +36,24 @@ jobs:
       let_mac_fail: true
     secrets: inherit
 
-  package_tr2_multiplatform:
-    name: Build TR2
-    if: vars.PRERELEASE_ENABLE == 'true'
+  package_tr2_linux:
+    name: TR2 (Linux)
     uses: ./.github/workflows/job_build_tr2.yml
     with:
-      target: 'debug'
+      platform: linux
+      target: debug
+    secrets: inherit
+
+  package_tr2_win:
+    name: TR2 (Windows)
+    uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      platform: win-all
+      target: debug
     secrets: inherit
 
   package_tr2_mac:
-    name: Build TR2
+    name: TR2 (Mac)
     if: |
       vars.PRERELEASE_ENABLE == 'true' &&
       vars.MACOS_ENABLE == 'true'
@@ -48,12 +64,14 @@ jobs:
     secrets: inherit
 
   publish_prerelease:
-    if: vars.PRERELEASE_ENABLE == 'true'
+    if: always() && (vars.PRERELEASE_ENABLE == 'true')
     name: Create a prerelease
     needs:
-      - package_tr1_multiplatform
+      - package_tr1_linux
+      - package_tr1_win
       - package_tr1_mac
-      - package_tr2_multiplatform
+      - package_tr2_linux
+      - package_tr2_win
       - package_tr2_mac
     with:
       draft: false

--- a/.github/workflows/release_tr1.yml
+++ b/.github/workflows/release_tr1.yml
@@ -28,30 +28,51 @@ on:
         default: github.ref_name
 
 jobs:
-  package_multiplatform:
-    name: Build release assets
+  package_tr1_linux:
+    name: Build TR1 (Linux)
     if: vars.RELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1.yml
     with:
-      target: "release"
+      platform: linux
+      target: release
+    secrets: inherit
+
+  package_tr1_win:
+    name: Build TR1 (Windows)
+    if: vars.RELEASE_ENABLE == 'true'
+    uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      platform: win-all
+      target: release
+    secrets: inherit
+
+  package_tr1_win_installer:
+    name: Build TR1 (Windows installer)
+    if: vars.RELEASE_ENABLE == 'true'
+    uses: ./.github/workflows/job_build_tr1.yml
+    with:
+      platform: win-installer
+      target: release
     secrets: inherit
 
   package_mac:
-    name: "Build release assets (mac)"
+    name: Build TR1 (Mac)
     if: |
       vars.RELEASE_ENABLE == 'true' &&
       vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr1_macos.yml
     with:
-      target: "release"
+      target: release
       let_mac_fail: ${{ inputs.let_mac_fail == true || inputs.let_mac_fail == 'true' }}
     secrets: inherit
 
   publish_release:
-    if: vars.RELEASE_ENABLE == 'true'
+    if: always() && (vars.RELEASE_ENABLE == 'true')
     name: Create a GitHub release
     needs:
-      - package_multiplatform
+      - package_tr1_linux
+      - package_tr1_win
+      - package_tr1_win_installer
       - package_mac
     with:
       draft: ${{ inputs.draft || false }}

--- a/.github/workflows/release_tr2.yml
+++ b/.github/workflows/release_tr2.yml
@@ -28,30 +28,52 @@ on:
         default: github.ref_name
 
 jobs:
-  package_multiplatform:
-    name: Build release assets
+  package_tr2_linux:
+    name: Build TR2 (Linux)
     if: vars.RELEASE_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr2.yml
     with:
-      target: "release"
+      platform: linux
+      target: release
+    secrets: inherit
+
+  package_tr2_win:
+    name: Build TR2 (Windows)
+    if: vars.RELEASE_ENABLE == 'true'
+    uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      platform: win-all
+      target: release
+    secrets: inherit
+
+  package_tr2_win_installer:
+    name: Build TR2 (Windows installer)
+    if: vars.RELEASE_ENABLE == 'true'
+    uses: ./.github/workflows/job_build_tr2.yml
+    with:
+      platform: win-installer
+      target: release
     secrets: inherit
 
   package_mac:
-    name: "Build release assets (mac)"
+    name: Build TR2 (Mac)
     if: |
       vars.RELEASE_ENABLE == 'true' &&
       vars.MACOS_ENABLE == 'true'
     uses: ./.github/workflows/job_build_tr2_macos.yml
     with:
-      target: "release"
+      target: release
       let_mac_fail: ${{ inputs.let_mac_fail == true || inputs.let_mac_fail == 'true' }}
     secrets: inherit
 
   publish_release:
-    if: vars.RELEASE_ENABLE == 'true'
+    if: always() && (vars.RELEASE_ENABLE == 'true')
     name: Create a GitHub release
     needs:
-      - package_multiplatform
+      - package_tr2_linux
+      - package_tr2_win
+      - package_tr2_win_installer
+      - package_mac
     with:
       draft: ${{ inputs.draft || false }}
       prerelease: ${{ inputs.draft || false }}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prepares us to reduce the infrastructure usage when we add more assets to the game files.

In a subsequent PR I'll offload the binary assets (mainly images) to a separate repository, TRX-data. These will be zipped and downloadable in an easy form from https://lostartefacts.dev. Release builds will continue to ship with these, however, prereleases and PR builds will not and will require the players to download these separately. This is an one-time operation, as I expect us to very rarely change these assets. Injections, shaders and other data that often changes is going to be still a part of the repository.