### PR TITLE
tr2/shell: fix support for dual monitors

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -15,6 +15,7 @@
 - added the current music track and timestamp to the savegame so they now persist on load (#2579)
 - added waterfalls to the savegame so that they now persist on load (#2686)
 - added support for aspect ratio-specific images (#1840)
+- added a guard to ensure the game always starts on a visible screen even after unplugging displays (#2819)
 - changed savegame files to be stored in the `saves` directory (#2087)
 - changed the default fog distance to 22 tiles cutting off at 30 tiles to match TR1X (#1622)
 - changed the number of static mesh slots from 50 to 256 (#2734)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -45,6 +45,9 @@
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
 - fixed the boat briefly having an underwater hue when Lara first climbs on (#2787)
 - fixed destroyed gondolas appearing embedded in the ground after loading a save (#1612)
+- fixed a crash in custom levels with large rooms (#2749)
+- fixed the viewport not always in sync with the window (#2820)
+- fixed inability to move the window to another screen (#2820)
 - fixed flares flipped to the right when thrown (regression from 0.10)
 - fixed the camera going out of bounds in 60fps near specific invalid floor data (known as no-space) (#2764, regression from 0.10)
 - fixed sprites rendering black if no shade value is assigned in the level (#2701, regression from 0.8)
@@ -53,9 +56,7 @@
 - fixed the `/pos` console command reporting the base room number when Lara is actually in a flipped room (#2487, regression from 0.3)
 - fixed a crash if an image was missing
 - fixed a crash on level load if an animation has no frames (#2746, regression from 0.8)
-- fixed a crash in custom levels with large rooms (#2749)
-- fixed flares missing the flicker effect in 60 FPS (#2806)
-- fixed the viewport not always in sync with the window (#2820)
+- fixed flares missing the flicker effect in 60 FPS (#2806, regression from 0.10)
 - improved performance when moving the window around
 - improved pause exit dialog - it can now be canceled with escape
 - removed the need to specify in the game flow levels that have no secrets (secrets will be automatically counted) (#1582)

--- a/src/libtrx/game/shell/common.c
+++ b/src/libtrx/game/shell/common.c
@@ -156,9 +156,16 @@ SHELL_SIZE Shell_GetCurrentSize(void)
 
 SHELL_SIZE Shell_GetCurrentDisplaySize(void)
 {
+    int32_t display_idx = 0;
+    SDL_Window *const window = Shell_GetWindow();
+    if (window != nullptr) {
+        display_idx = SDL_GetWindowDisplayIndex(window);
+    }
     SDL_DisplayMode dm;
-    SDL_GetCurrentDisplayMode(0, &dm);
-    return (SHELL_SIZE) { .w = dm.w, .h = dm.h };
+    if (SDL_GetCurrentDisplayMode(display_idx, &dm) == 0) {
+        return (SHELL_SIZE) { .w = dm.w, .h = dm.h };
+    }
+    return (SHELL_SIZE) { .w = -1, .h = -1 };
 }
 
 void Shell_ScheduleExit(void)

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -79,6 +79,7 @@ static SHELL_ARGS m_Args = {
 
 static SHELL_SIZE m_ViewportSize = { .w = -1, .h = -1 };
 static Uint64 m_UpdateDebounce = 0;
+static bool m_IgnoreConfigChanges = false;
 
 static void M_SyncToWindow(void);
 static void M_SyncFromWindow(bool update_viewport);
@@ -155,7 +156,7 @@ static void M_SyncFromWindow(const bool update_viewport)
     // Determine if this call should sync config, i.e., skip immediate
     // programmatic events
     const Uint32 now = SDL_GetTicks();
-    const bool skip_config = (now - m_UpdateDebounce) < 100;
+    const bool skip_config = (now - m_UpdateDebounce) < 500;
 
     // Always pull current window state for logging and viewport reset
     const Uint32 window_flags = SDL_GetWindowFlags(g_SDLWindow);
@@ -176,7 +177,9 @@ static void M_SyncFromWindow(const bool update_viewport)
             g_Config.window.height = height;
         }
         if (g_Config.loaded) {
+            m_IgnoreConfigChanges = true;
             Config_Write();
+            m_IgnoreConfigChanges = false;
         }
     }
 
@@ -351,6 +354,10 @@ static void M_LoadConfig(void)
 
 static void M_HandleConfigChange(const EVENT *const event, void *const data)
 {
+    if (m_IgnoreConfigChanges) {
+        return;
+    }
+
     const CONFIG *const old = &g_Config;
     const CONFIG *const new = &g_SavedConfig;
 

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -138,7 +138,7 @@ static void M_SyncToWindow(void)
             width = 1280;
             height = 720;
         }
-        if (x <= 0 || y <= 0) {
+        if (x == -1 && y == -1) { // default config state
             const SHELL_SIZE display_size = Shell_GetCurrentDisplaySize();
             x = (display_size.w - width) / 2;
             y = (display_size.h - height) / 2;

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -138,10 +138,35 @@ static void M_SyncToWindow(void)
             width = 1280;
             height = 720;
         }
-        if (x == -1 && y == -1) { // default config state
-            const SHELL_SIZE display_size = Shell_GetCurrentDisplaySize();
-            x = (display_size.w - width) / 2;
-            y = (display_size.h - height) / 2;
+
+        // Handle default position
+        if (x == -1 && y == -1) {
+            SDL_DisplayMode display_mode;
+            SDL_GetCurrentDisplayMode(0, &display_mode);
+            x = (display_mode.w - width) / 2;
+            y = (display_mode.h - height) / 2;
+        } else {
+            // Adjust window position if completely offscreen
+            bool on_screen = false;
+            const int32_t num_displays = SDL_GetNumVideoDisplays();
+            for (int32_t i = 0; i < num_displays; i++) {
+                SDL_Rect bounds;
+                SDL_GetDisplayBounds(i, &bounds);
+                if (x + width > bounds.x && x < bounds.x + bounds.w
+                    && y + height > bounds.y && y < bounds.y + bounds.h) {
+                    on_screen = true;
+                    break;
+                }
+            }
+            if (!on_screen) {
+                x = 0;
+                y = 0;
+                // Find the first display to reposition the window
+                SDL_Rect bounds;
+                SDL_GetDisplayBounds(0, &bounds);
+                x = bounds.x + (bounds.w - width) / 2;
+                y = bounds.y + (bounds.h - height) / 2;
+            }
         }
 
         SDL_SetWindowFullscreen(g_SDLWindow, 0);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Addresses #2820.

When the window changes, the new state was saved to the config, but this triggered the config change callback, which then attempted to sync the changes back to the window. Although a debounce timer was used to reduce this effect, at least one unnecessary call still occurred. This would cause the window to snap to the primary display, as the APIs we use sanitize the window position. This PR implements a guard that ignores config change events during window events.

Additionally, there was an issue related to scaling. Previously, we used the main display size to determine the viewport state, which caused incorrect screen sizing when the game was moved to a display with a different resolution. This PR changes it to refer to the window's current display instead.