### PR TITLE
game: prioritize save over load

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed the number of static mesh slots from 50 to 256 (#2734)
 - changed the "enable EIDOS logo" option to disable the Core Design and Bink Video Codec FMVs as well; renamed to "enable legal" (#2741)
 - changed sprite pickups to respect the water tint if placed underwater (#2673)
+- changed save to take priority over load when both inputs are held on the same frame, in line with OG (#2833)
 - fixed the bilinear filter to not readjust the UVs (#2258)
 - fixed disabling the cutscenes causing the game to exit (#2743, regression from 4.8)
 - fixed anisotropy filter causing black lines on certain GPUs (#902)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.0...develop) - ××××-××-××
 - added an option to wraparound when scrolling UI dialogs, such as save/load (#2834)
+- changed save to take priority over load when both inputs are held on the same frame, in line with OG (#2833)
 - fixed the selected keyboard/controller layout not being saved (#2830, regression from 1.0)
 - fixed toggling the PSX FOV option not having an immediate effect (#2831, regression from 1.0)
 - fixed changing the aspect ratio not updating the current background image (#2832, regression from 1.0)

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -142,10 +142,10 @@ GF_COMMAND Game_Control(const bool demo_mode)
         if (g_Camera.type == CAM_CINEMATIC) {
             g_OverlayFlag = 0;
         } else if (g_OverlayFlag > 0) {
-            if (g_Input.load) {
-                g_OverlayFlag = -1;
-            } else if (g_Input.save) {
+            if (g_Input.save) {
                 g_OverlayFlag = -2;
+            } else if (g_Input.load) {
+                g_OverlayFlag = -1;
             } else {
                 g_OverlayFlag = 0;
             }

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -114,10 +114,10 @@ GF_COMMAND Game_Control(const bool demo_mode)
         if (g_OverlayStatus > 0) {
             if (g_GameFlow.load_save_disabled) {
                 g_OverlayStatus = 0;
-            } else if (g_Input.load) {
-                g_OverlayStatus = -1;
+            } else if (g_Input.save) {
+                g_OverlayStatus = -2;
             } else {
-                g_OverlayStatus = g_Input.save ? -2 : 0;
+                g_OverlayStatus = g_Input.load ? -1 : 0;
             }
         } else {
             GF_COMMAND gf_cmd;


### PR DESCRIPTION
Resolves #2833.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This matches OG behaviour where save is preferred over load when both inputs are detected on the same frame.
