### PR TITLE
items: replace items by index rather than room

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...develop) - ××××-××-××
+- fixed guns carried by enemies not being converted to ammo if Lara has picked up the same gun elsewhere in the same level (#2856)
+- fixed guns carried by enemies not being converted to ammo if Lara starts the level with the gun and the game has later been reloaded (#2850, regression from 1.0)
 
 ## [1.0.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0...tr2-1.0.1) - 2025-04-24
 - added an option to wraparound when scrolling UI dialogs, such as save/load (#2834)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -254,6 +254,7 @@ However, you can easily download them manually from these urls:
     - fixed Floating Islands mystic plaque inventory rotation
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used
 - fixed being able to use hotkeys in the end-level statistics screen
+- fixed guns carried by enemies not being converted to ammo if Lara has picked up the same gun elsewhere in the same level
 - fixed destroyed gondolas appearing embedded in the ground after loading a save
 - improved the animation of Lara's braid
 

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -219,15 +219,11 @@ int32_t Item_GlobalReplace(
 {
     int32_t changed = 0;
 
-    for (int32_t i = 0; i < Room_GetCount(); i++) {
-        int16_t item_num = Room_Get(i)->item_num;
-        while (item_num != NO_ITEM) {
-            ITEM *const item = &m_Items[item_num];
-            if (item->object_id == src_obj_id) {
-                item->object_id = dst_obj_id;
-                changed++;
-            }
-            item_num = item->next_item;
+    for (int32_t item_num = 0; item_num < m_MaxUsedItemCount; item_num++) {
+        ITEM *const item = &m_Items[item_num];
+        if (item->object_id == src_obj_id) {
+            item->object_id = dst_obj_id;
+            changed++;
         }
     }
 


### PR DESCRIPTION
Resolves #2850.
Resolves #2856.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Carried items use `NO_ROOM` so were not included when replacing guns with ammo. This ensures everything is checked when replacing IDs. The regression issue was a result of streamlining the savegame logic, so the disjointed OG approach meant this wasn't an issue before.
