### PR TITLE
tr2/inventory: fix button mashing loading game instead of saving

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -5,6 +5,7 @@
 - changed the sound dialog appearance (repositioned, added text labels and arrows)
 - fixed Lara voiding if she stops on a tile with a closing door, and the door isn't on a portal (#2848)
 - fixed guns carried by enemies not being converted to ammo if Lara has picked up the same gun elsewhere in the same level (#2856)
+- fixed button mashing triggering load instead of save on a specific passport animation frame (#2863, regression from 1.0)
 - fixed guns carried by enemies not being converted to ammo if Lara starts the level with the gun and the game has later been reloaded (#2850, regression from 1.0)
 - fixed 1920x1080 screenshots in 16:9 aspect mode being saved as 1919x1080 (#2845, regression from 0.8)
 - fixed clicks in audio sounds (#2846, regression from 0.2)

--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -694,7 +694,6 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                 InvRing_MotionSetup(ring, RNG_CLOSING_ITEM, RNG_DESELECT, 0);
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
-
                 if (ring->mode == INV_LOAD_MODE || ring->mode == INV_SAVE_MODE
                     || ring->mode == INV_SAVE_CRYSTAL_MODE) {
                     InvRing_MotionSetup(
@@ -713,7 +712,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                 }
 
                 if (ring->mode == INV_TITLE_MODE
-                    && ((inv_item->object_id == O_DETAIL_OPTION)
+                    && (inv_item->object_id == O_DETAIL_OPTION
                         || inv_item->object_id == O_SOUND_OPTION
                         || inv_item->object_id == O_CONTROL_OPTION
                         || inv_item->object_id == O_GAMMA_OPTION)) {

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -639,10 +639,10 @@ static GF_COMMAND M_Control(INV_RING *const ring)
 
             if (g_InputDB.menu_confirm) {
                 g_Inv_Chosen = inv_item->object_id;
-                if (ring->type != RT_MAIN) {
-                    g_InvRing_Source[RT_OPTION].current = ring->current_object;
-                } else {
+                if (ring->type == RT_MAIN) {
                     g_InvRing_Source[RT_MAIN].current = ring->current_object;
+                } else {
+                    g_InvRing_Source[RT_OPTION].current = ring->current_object;
                 }
                 if (ring->mode == INV_TITLE_MODE
                     && (inv_item->object_id == O_DETAIL_OPTION
@@ -783,7 +783,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        g_Inv_ExtraData[i] = 0;
+        g_Inv_ExtraData[i] = -1;
     }
 
     g_InvRing_Source[RT_MAIN].current = 0;

--- a/src/tr2/game/option/option_passport.c
+++ b/src/tr2/game/option/option_passport.c
@@ -66,6 +66,8 @@ static void M_LoadGame(INVENTORY_ITEM *inv_item);
 static void M_SaveGame(INVENTORY_ITEM *inv_item);
 static void M_NewGame(void);
 static void M_PlayAnyLevel(INVENTORY_ITEM *inv_item);
+static int32_t M_GetCurrentPage(const INVENTORY_ITEM *inv_item);
+static bool M_IsFlipping(const INVENTORY_ITEM *inv_item);
 static void M_FlipLeft(INVENTORY_ITEM *inv_item);
 static void M_FlipRight(INVENTORY_ITEM *inv_item);
 static void M_Close(INVENTORY_ITEM *inv_item);
@@ -318,6 +320,17 @@ static void M_PlayAnyLevel(INVENTORY_ITEM *const inv_item)
     }
 }
 
+static int32_t M_GetCurrentPage(const INVENTORY_ITEM *const inv_item)
+{
+    const int32_t frame = inv_item->goal_frame - inv_item->open_frame;
+    return frame % 5 == 0 ? frame / 5 : -1;
+}
+
+static bool M_IsFlipping(const INVENTORY_ITEM *const inv_item)
+{
+    return M_GetCurrentPage(inv_item) == -1;
+}
+
 static void M_FlipLeft(INVENTORY_ITEM *const inv_item)
 {
     M_RemoveAllText();
@@ -413,18 +426,19 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
 
     InvRing_RemoveAllText();
 
-    const int32_t frame = item->goal_frame - item->open_frame;
-    const int32_t page = frame % 5 == 0 ? frame / 5 : -1;
-    const bool is_flipping = page == -1;
-    if (is_flipping) {
+    if (M_IsFlipping(item)) {
         return;
     }
 
-    m_State.current_page = page;
+    m_State.current_page = M_GetCurrentPage(item);
     if (m_State.current_page < m_State.active_page) {
         M_FlipRight(item);
+        g_Input = (INPUT_STATE) {};
+        g_InputDB = (INPUT_STATE) {};
     } else if (m_State.current_page > m_State.active_page) {
         M_FlipLeft(item);
+        g_Input = (INPUT_STATE) {};
+        g_InputDB = (INPUT_STATE) {};
     } else {
         m_State.is_ready = true;
         M_ShowPage(item);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2863.

Doesn't seem to apply to TR1 as we have exorcised `g_Inv_ExtraData` away in there.

#### Testing

I recommend using the turbo cheat and a laptop keyboard that has shorter key travel to be able to mash the buttons better. The keypress has to happen exactly on the frame where the pages start to flip.

During my testing of one of the potential fixes I encountered passport getting stuck on the closing animation, and staying so until the player would press the action key. Please look out for this potential regression, which I haven't been able to reproduce with this patch.

Useful diff for logging

```diff
diff --git a/src/tr2/game/inventory_ring/control.c b/src/tr2/game/inventory_ring/control.c
index 5f1b04969..246552cb6 100644
--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -20,6 +20,7 @@
 #include "game/viewport.h"
 #include "global/vars.h"
 
+#include <libtrx/log.h>
 #include <libtrx/config.h>
 #include <libtrx/game/gun/const.h>
 #include <libtrx/game/gym.h>
@@ -187,6 +188,7 @@ static GF_COMMAND M_Finish(INV_RING *const ring, const bool apply_changes)
         return (GF_COMMAND) { .action = GF_NOOP };
     }
 
+    LOG_INFO("extra data: %d,%d", g_Inv_ExtraData[0], g_Inv_ExtraData[1]);
     switch (g_Inv_Chosen) {
     case O_PASSPORT_OPTION:
         if (g_Inv_ExtraData[0] == 0) {
@@ -415,6 +417,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         }
 
         if (g_InputDB.menu_confirm) {
+            LOG_INFO("got a confirm");
             if ((ring->mode == INV_SAVE_MODE || ring->mode == INV_LOAD_MODE
                  || ring->mode == INV_DEATH_MODE)
                 && !ring->is_pass_open) {
diff --git a/src/tr2/game/option/option_passport.c b/src/tr2/game/option/option_passport.c
index bf3e4490e..d47719a93 100644
--- a/src/tr2/game/option/option_passport.c
+++ b/src/tr2/game/option/option_passport.c
@@ -408,6 +408,7 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
         if (g_Config.input.enable_responsive_passport) {
             M_HandleFlipInputs();
         }
+        LOG_INFO("control: confirm=%d, busy=%d, extradata=%d,%d", g_InputDB.menu_confirm, is_busy, g_Inv_ExtraData[0], g_Inv_ExtraData[1]);
         return;
     }
 
@@ -417,14 +418,17 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
     const int32_t page = frame % 5 == 0 ? frame / 5 : -1;
     const bool is_flipping = page == -1;
     if (is_flipping) {
+        LOG_INFO("control: confirm=%d, busy=%d, extradata=%d,%d", g_InputDB.menu_confirm, is_busy, g_Inv_ExtraData[0], g_Inv_ExtraData[1]);
         return;
     }
 
     m_State.current_page = page;
     if (m_State.current_page < m_State.active_page) {
         M_FlipRight(item);
+        LOG_INFO("doing a page flip to the right");
     } else if (m_State.current_page > m_State.active_page) {
         M_FlipLeft(item);
+        LOG_INFO("doing a page flip to the left");
     } else {
         m_State.is_ready = true;
         M_ShowPage(item);
@@ -437,6 +441,7 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
         g_Inv_ExtraData[0] = m_State.active_page;
         g_Inv_ExtraData[1] = m_State.selection;
         M_Close(item);
+        LOG_INFO("confirming %d,%d", g_InputDB.menu_confirm, g_Inv_ExtraData[0], g_Inv_ExtraData[1]);
     } else if (g_InputDB.menu_back) {
         if (g_Inv_Mode == INV_DEATH_MODE) {
             g_Input = (INPUT_STATE) {};
@@ -445,6 +450,7 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
             M_Close(item);
         }
     }
+    LOG_INFO("control: confirm=%d, busy=%d, extradata=%d,%d", g_InputDB.menu_confirm, is_busy, g_Inv_ExtraData[0], g_Inv_ExtraData[1]);
 }
 
 void Option_Passport_Draw(INVENTORY_ITEM *const item)
```