### PR TITLE
room: fix abyss height check

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fixed Lara at times ending up in incorrect rooms when using the teleport cheat (#2486, regression from 3.0)
 - fixed the `/pos` console command reporting the base room number when Lara is actually in a flipped room (#2487, regression from 3.0)
 - fixed clicks in audio sounds (#2846, regression from 2.0)
+- fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 4.9)
 - improved bubble appearance (#2672)
 - improved rendering performance
 - improved pause exit dialog - it can now be canceled with escape

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added aliases to CLI options (`-gold` becomes `-g/--gold`)
 - added a `--help` CLI option (may not output anything on Windows machines – OS bug)
 - changed the sound dialog appearance (repositioned, added text labels and arrows)
+- fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 
 ## [1.0.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...tr2-1.0.2) - 2025-04-26
 - changed The Golden Mask strings to default to the OG strings file for the main tables (#2847)

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -550,7 +550,7 @@ void Room_SetAbyssHeight(const int16_t height)
     CLAMPG(m_AbyssMaxHeight, MAX_HEIGHT - STEP_L);
 }
 
-bool Room_IsAbyssHeight(const int16_t height)
+bool Room_IsAbyssHeight(const int32_t height)
 {
     return m_AbyssMinHeight != 0 && height >= m_AbyssMinHeight;
 }

--- a/src/libtrx/include/libtrx/game/rooms/common.h
+++ b/src/libtrx/include/libtrx/game/rooms/common.h
@@ -43,7 +43,7 @@ SECTOR *Room_GetPitSector(const SECTOR *sector, int32_t x, int32_t z);
 SECTOR *Room_GetSkySector(const SECTOR *sector, int32_t x, int32_t z);
 
 void Room_SetAbyssHeight(int16_t height);
-bool Room_IsAbyssHeight(int16_t height);
+bool Room_IsAbyssHeight(int32_t height);
 HEIGHT_TYPE Room_GetHeightType(void);
 int16_t Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
 int16_t Room_GetHeightEx(


### PR DESCRIPTION
Resolves #2874.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

As Lara's position is stored as int32, we need to use the same in the abyss height check function, otherwise internal casting yields invalid results. Saves attached in the issue for both games.
