### PR TITLE
lara: test alignment position height validity in TR1

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed the scale of the four keys in St. Francis' Folly (#2652)
 - fixed the panther at times not making a sound when it dies, and restored Skate Kid's death SFX (#2647)
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used (#2776)
+- fixed Lara becoming clamped if she picks up an item under a steeply sloped ceiling (#2879)
 - fixed a crash when 3D pickups are disabled and Lara crosses a trigger to look at a pickup item (#2711, regression from 4.8)
 - fixed trapezoid filter warping on faces close to the camera (#2629, regression from 4.9)
 - fixed Mac builds crashing upon start (regression from 4.9)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -485,6 +485,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed being able to shoot the scion multiple times if save/load is used while it blows up
 - fixed the game crashing if a cinematic is triggered but the level contains no cinematic frames
 - fixed pushblocks being rotated when Lara grabs them, most noticeable if asymmetric textures have been used
+- fixed Lara becoming clamped if she picks up an item under a steeply sloped ceiling
 
 #### Cheats
 - added a fly cheat

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -228,8 +228,6 @@ void Lara_AlignPosition(const ITEM *const item, const XYZ_32 *const vec)
         .z = item->pos.z + shift.z,
     };
 
-#if TR_VERSION == 2
-    // TODO: check the significance of this in TR1
     int16_t room_num = lara->room_num;
     const SECTOR *const sector =
         Room_GetSector(new_pos.x, new_pos.y, new_pos.z, &room_num);
@@ -242,7 +240,6 @@ void Lara_AlignPosition(const ITEM *const item, const XYZ_32 *const vec)
         || ABS(ceiling - lara->pos.y) < LARA_HEIGHT) {
         return;
     }
-#endif
 
     lara->pos = new_pos;
 }


### PR DESCRIPTION
Resolves #2879.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This applies a fix introduced in TR2 to TR1 so that Lara doesn't become clamped under a steeply sloped ceiling if picking up an item there.
