### PR TITLE
tr2/objects/switch: align Lara after airlock test

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - changed the sound dialog appearance (repositioned, added text labels and arrows)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
+- fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)
 
 ## [1.0.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...tr2-1.0.2) - 2025-04-26
 - changed The Golden Mask strings to default to the OG strings file for the main tables (#2847)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -258,6 +258,7 @@ However, you can easily download them manually from these urls:
 - fixed guns carried by enemies not being converted to ammo if Lara has picked up the same gun elsewhere in the same level
 - fixed destroyed gondolas appearing embedded in the ground after loading a save
 - fixed Lara voiding if she stops on a tile with a closing door, and the door isn't on a portal
+- fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door
 - improved the animation of Lara's braid
 
 #### Cheats

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -64,6 +64,7 @@ static const OBJECT_BOUNDS *M_BoundsUW(void)
 
 static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
 {
+    lara_item->rot.y = switch_item->rot.y;
     switch (switch_item->object_id) {
     case O_SWITCH_TYPE_AIRLOCK:
         Lara_AlignPosition(switch_item, &m_AirlockPosition);
@@ -167,8 +168,6 @@ static void M_Collision(
         || !Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }
-
-    lara_item->rot.y = item->rot.y;
 
     if (item->object_id == O_SWITCH_TYPE_AIRLOCK
         && item->current_anim_state == SWITCH_STATE_ON) {


### PR DESCRIPTION
Resolves #2215.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's angle is only aligned after all other collision/state tests for switches/airlocks.
