### PR TITLE
gf: fix invalid events handling

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed clicks in audio sounds (#2846, regression from 2.0)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 4.9)
 - fixed game crashing if the music folder was not present (#2887, regression from 4.9)
+- fixed game crashing on unknown sequencer events
 - improved bubble appearance (#2672)
 - improved rendering performance
 - improved pause exit dialog - it can now be canceled with escape

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)
+- fixed the game crashing on unknown sequencer events
 - improved the `/set` console command to display available options if given an unknown argument
 
 ## [1.0.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...tr2-1.0.2) - 2025-04-26

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -281,16 +281,15 @@ static size_t M_LoadSequenceEvent(
     const char *const type_str = JSON_ObjectGetString(event_obj, "type", "");
     const GF_SEQUENCE_EVENT_TYPE type =
         ENUM_MAP_GET(GF_SEQUENCE_EVENT_TYPE, type_str, -1);
+    if (type == (GF_SEQUENCE_EVENT_TYPE)-1) {
+        Shell_ExitSystemFmt(
+            "Unknown game flow sequence event type: '%s'", type_str);
+    }
 
     const M_SEQUENCE_EVENT_HANDLER *handler = M_GetSequenceEventHandlers();
     while (handler->event_type != (GF_SEQUENCE_EVENT_TYPE)-1
            && handler->event_type != type) {
         handler++;
-    }
-
-    if (handler->event_type != type) {
-        Shell_ExitSystemFmt(
-            "Unknown game flow sequence event type: '%s'", type);
     }
 
     int32_t extra_data_size = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Pedro had difficulty writing an adequate script for the game and relied on outdated game sequencer events. Not only did the game fail to alert the builder about this issue, but it also filled the game flow data with invalid data, leading to a crash when it reached that point in the script.
This PR fixes the warning about invalid sequencer events.