### PR TITLE
tools/installer: always allow TR2 music download

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added a `--help` CLI option (may not output anything on Windows machines – OS bug)
 - added explosion sprites to Home Sweet Home (#1569)
 - changed the sound dialog appearance (repositioned, added text labels and arrows)
+- changed the installer to always allow downloading music files (#2891)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)

--- a/tools/installer/TR2X_Installer/Installers/GenericInstallSource.cs
+++ b/tools/installer/TR2X_Installer/Installers/GenericInstallSource.cs
@@ -15,15 +15,10 @@ public abstract class GenericInstallSource : BaseInstallSource
     };
 
     public override bool IsDownloadingMusicNeeded(string sourceDirectory)
-    {
-        return !Directory.Exists(Path.Combine(sourceDirectory, "audio"))
-            && !Directory.Exists(Path.Combine(sourceDirectory, "music"));
-    }
+        => true;
 
     public override bool IsDownloadingExpansionNeeded(string sourceDirectory)
-    {
-        return true;
-    }
+        => true;
 
     public override async Task CopyOriginalGameFiles(
         string sourceDirectory,


### PR DESCRIPTION
Resolves #2891.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Rather than second guess users' OG music setup, the installer will now always offer the option to download the required music files.
