### PR TITLE
console: fix duplicate entries in history

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed save to take priority over load when both inputs are held on the same frame, in line with OG (#2833)
 - changed the sound dialog appearance (repositioned and added text labels)
 - changed The Unfinished Business strings to default to the OG strings file for the main tables (#2847)
+- changed the dev console to no longer add duplicate entries to the history
 - fixed the bilinear filter to not readjust the UVs (#2258)
 - fixed disabling the cutscenes causing the game to exit (#2743, regression from 4.8)
 - fixed anisotropy filter causing black lines on certain GPUs (#902)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added explosion sprites to Home Sweet Home (#1569)
 - changed the sound dialog appearance (repositioned, added text labels and arrows)
 - changed the installer to always allow downloading music files (#2891)
+- changed the dev console to no longer add duplicate entries to the history
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)

--- a/src/libtrx/game/console/history.c
+++ b/src/libtrx/game/console/history.c
@@ -5,6 +5,8 @@
 #include "utils.h"
 #include "vector.h"
 
+#include <string.h>
+
 #define MAX_HISTORY_ENTRIES 30
 
 VECTOR *m_History = nullptr;
@@ -86,12 +88,21 @@ void Console_History_Clear(void)
 
 void Console_History_Append(const char *const prompt)
 {
+    for (int32_t i = m_History->count - 1; i >= 0; i--) {
+        char *const entry = *(char **)Vector_Get(m_History, i);
+        if (strcmp(entry, prompt) == 0) {
+            Memory_Free(entry);
+            Vector_RemoveAt(m_History, i);
+        }
+    }
+
     if (m_History->count == MAX_HISTORY_ENTRIES) {
-        char *const prompt = *(char **)Vector_Get(m_History, 0);
-        Memory_Free(prompt);
+        char *const oldest = *(char **)Vector_Get(m_History, 0);
+        Memory_Free(oldest);
         Vector_RemoveAt(m_History, 0);
     }
-    char *prompt_copy = Memory_DupStr(prompt);
+
+    char *const prompt_copy = Memory_DupStr(prompt);
     Vector_Add(m_History, &prompt_copy);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Small QoL change. Duplicate entries are always bumped up last. So a sequence of
```
foo
bar
baz
bar
baz
bar
baz
```
will result in a history looking like this:
```
foo
bar
baz
```