### PR TITLE
lara: merge common functions

### DIFF
--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -196,10 +196,7 @@ static bool M_SwitchToLand(
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
         item->pos.y = item->floor;
-
-        if (item->room_num != room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
     }
 
     return true;
@@ -560,9 +557,7 @@ void Creature_Float(const int16_t item_num)
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 void Creature_Underwater(ITEM *const item, const int32_t depth)
@@ -683,9 +678,7 @@ bool Creature_Animate(
     if (TR_VERSION >= 2 && !Object_IsType(item->object_id, g_WaterObjects)) {
         int16_t room_num = item->room_num;
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        if (room_num != item->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
     }
 
     Item_Animate(item);
@@ -923,9 +916,7 @@ bool Creature_Animate(
         }
     }
 
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
     return true;
 }
 
@@ -951,9 +942,7 @@ void Creature_SpecialKill(
     lara_item->speed = 0;
 
     int16_t room_num = item->room_num;
-    if (room_num != lara_item->room_num) {
-        Item_NewRoom(lara->item_num, room_num);
-    }
+    Item_UpdateRoom(lara->item_num, room_num);
 
     Item_Animate(lara_item);
 
@@ -1021,7 +1010,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
         while (pickup_num != NO_ITEM) {
             ITEM *const pickup = Item_Get(pickup_num);
             pickup->pos = item->pos;
-            Item_NewRoom(pickup_num, item->room_num);
+            Item_UpdateRoom(pickup_num, item->room_num);
             pickup_num = pickup->carried_item;
         }
     }
@@ -1081,9 +1070,7 @@ int32_t Creature_Vault(
     item->floor = old.y;
     item->pos.y = old.y;
 
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
     return vault;
 }
 

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -363,6 +363,11 @@ void Item_Translate(
     item->pos.z += ((c * z - s * x) >> W2V_SHIFT);
 }
 
+int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 *const target)
+{
+    return XYZ_32_GetDistance(&item->pos, target);
+}
+
 void Item_Animate(ITEM *const item)
 {
     item->hit_status = 0;

--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -186,9 +186,13 @@ void Item_AddActive(const int16_t item_num)
     m_NextItemActive = item_num;
 }
 
-void Item_NewRoom(const int16_t item_num, const int16_t room_num)
+void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
 {
     ITEM *const item = &m_Items[item_num];
+    if (item->room_num == room_num) {
+        return;
+    }
+
     ROOM *room = nullptr;
 
     if (item->room_num != NO_ROOM) {

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -243,3 +243,23 @@ void Lara_AlignPosition(const ITEM *const item, const XYZ_32 *const vec)
 
     lara->pos = new_pos;
 }
+
+bool Lara_IsNearItem(const XYZ_32 *const pos, const int32_t distance)
+{
+    const ITEM *const item = Lara_GetItem();
+    const XYZ_32 d = {
+        .x = pos->x - item->pos.x,
+        .y = pos->y - item->pos.y,
+        .z = pos->z - item->pos.z,
+    };
+    if (ABS(d.x) > distance || ABS(d.z) > distance || ABS(d.y) > WALL_L * 3) {
+        return false;
+    }
+
+    if (SQUARE(d.x) + SQUARE(d.z) > SQUARE(distance)) {
+        return false;
+    }
+
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
+    return d.y >= bounds->min.y && d.y <= bounds->max.y + 100;
+}

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -1,10 +1,15 @@
 #include "game/lara/common.h"
 
+#include "config.h"
 #include "game/const.h"
 #include "game/item_actions.h"
 #include "game/lara/const.h"
 #include "game/matrix.h"
 #include "game/rooms.h"
+
+#define M_MOVE_ANIM_VELOCITY 12
+#define M_MOVE_SPEED 16
+#define M_MOVE_ANGLE (2 * DEG_1) // = 364
 
 void Lara_Animate(ITEM *const item)
 {
@@ -262,4 +267,117 @@ bool Lara_IsNearItem(const XYZ_32 *const pos, const int32_t distance)
 
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     return d.y >= bounds->min.y && d.y <= bounds->max.y + 100;
+}
+
+bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
+{
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+#if TR_VERSION == 1
+    const int32_t velocity = g_Config.gameplay.enable_walk_to_items
+            && lara_info->water_status != LWS_UNDERWATER
+        ? M_MOVE_ANIM_VELOCITY
+        : M_MOVE_SPEED;
+#else
+    const int32_t velocity = M_MOVE_SPEED;
+#endif
+
+    ITEM *const lara_item = Lara_GetItem();
+    const XYZ_16 new_rot = ref_item->rot;
+
+    Matrix_PushUnit();
+    Matrix_Rot16(new_rot);
+    const MATRIX *const m = g_MatrixPtr;
+    const XYZ_32 shift = {
+        .x = (vec->y * m->_01 + vec->z * m->_02 + vec->x * m->_00) >> W2V_SHIFT,
+        .y = (vec->x * m->_10 + vec->z * m->_12 + vec->y * m->_11) >> W2V_SHIFT,
+        .z = (vec->y * m->_21 + vec->x * m->_20 + vec->z * m->_22) >> W2V_SHIFT,
+    };
+    Matrix_Pop();
+
+    const XYZ_32 new_pos = {
+        .x = ref_item->pos.x + shift.x,
+        .y = ref_item->pos.y + shift.y,
+        .z = ref_item->pos.z + shift.z,
+    };
+
+#if TR_VERSION == 2
+    if (ref_item->object_id == O_FLARE_ITEM) {
+        int16_t room_num = lara_item->room_num;
+        const SECTOR *const sector =
+            Room_GetSector(new_pos.x, new_pos.y, new_pos.z, &room_num);
+        const int32_t height =
+            Room_GetHeight(sector, new_pos.x, new_pos.y, new_pos.z);
+        if (ABS(height - lara_item->pos.y) > STEP_L * 2) {
+            return false;
+        }
+        if (XYZ_32_GetDistance(&new_pos, &lara_item->pos) < STEP_L) {
+            return true;
+        }
+    }
+#endif
+
+    const XYZ_32 dpos = {
+        .x = new_pos.x - lara_item->pos.x,
+        .y = new_pos.y - lara_item->pos.y,
+        .z = new_pos.z - lara_item->pos.z,
+    };
+    const int32_t dist = XYZ_32_GetDistance0(&dpos);
+    if (velocity >= dist) {
+        lara_item->pos = new_pos;
+    } else {
+        lara_item->pos.x += velocity * dpos.x / dist;
+        lara_item->pos.y += velocity * dpos.y / dist;
+        lara_item->pos.z += velocity * dpos.z / dist;
+    }
+
+#if TR_VERSION == 1
+    if (g_Config.gameplay.enable_walk_to_items
+        && !lara_info->interact_target.is_moving) {
+        if (lara_info->water_status != LWS_UNDERWATER) {
+            const int16_t step_to_anim_num[4] = {
+                LA_SIDE_STEP_LEFT,
+                LA_WALK_FORWARD,
+                LA_SIDE_STEP_RIGHT,
+                LA_WALK_BACK,
+            };
+            const int16_t step_to_anim_state[4] = {
+                LS_STEP_LEFT,
+                LS_WALK,
+                LS_STEP_RIGHT,
+                LS_BACK,
+            };
+
+            const int32_t dx = lara_item->pos.x - new_pos.x;
+            const int32_t dz = lara_item->pos.z - new_pos.z;
+            const int32_t angle = (DEG_360 - Math_Atan(dx, dz)) % DEG_360;
+            const uint32_t src_quadrant = (uint32_t)(angle + DEG_45) / DEG_90;
+            const uint32_t dst_quadrant =
+                (uint32_t)(new_rot.y + DEG_45) / DEG_90;
+            const DIRECTION quadrant = (src_quadrant - dst_quadrant) % 4;
+
+            Item_SwitchToAnim(lara_item, step_to_anim_num[quadrant], 0);
+            lara_item->goal_anim_state = step_to_anim_state[quadrant];
+            lara_item->current_anim_state = step_to_anim_state[quadrant];
+
+            lara_info->gun_status = LGS_HANDS_BUSY;
+        }
+
+        lara_info->interact_target.is_moving = true;
+        lara_info->interact_target.move_count = 0;
+    }
+#endif
+
+    const int16_t rotation = M_MOVE_ANGLE;
+    ITEM_ADJUST_ROT(lara_item->rot.x, new_rot.x, rotation);
+    ITEM_ADJUST_ROT(lara_item->rot.y, new_rot.y, rotation);
+    ITEM_ADJUST_ROT(lara_item->rot.z, new_rot.z, rotation);
+
+    // clang-format off
+    return lara_item->pos.x == new_pos.x
+        && lara_item->pos.y == new_pos.y
+        && lara_item->pos.z == new_pos.z
+        && lara_item->rot.x == new_rot.x
+        && lara_item->rot.y == new_rot.y
+        && lara_item->rot.z == new_rot.z;
+    // clang-format on
 }

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -28,3 +28,19 @@ void Lara_GetCollisionInfo(const ITEM *const item, COLL_INFO *const coll)
         coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
         LARA_HEIGHT);
 }
+
+void Lara_UpdateRoom(const int32_t height)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    const int32_t x = lara_item->pos.x;
+    const int32_t y = height + lara_item->pos.y;
+    const int32_t z = lara_item->pos.z;
+
+    int16_t room_num = lara_item->room_num;
+    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
+    lara_item->floor = Room_GetHeight(sector, x, y, z);
+    if (lara_item->room_num != room_num) {
+        const int16_t item_num = Item_GetIndex(lara_item);
+        Item_NewRoom(item_num, room_num);
+    }
+}

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -39,10 +39,9 @@ void Lara_UpdateRoom(const int32_t height)
     int16_t room_num = lara_item->room_num;
     const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
     lara_item->floor = Room_GetHeight(sector, x, y, z);
-    if (lara_item->room_num != room_num) {
-        const int16_t item_num = Item_GetIndex(lara_item);
-        Item_NewRoom(item_num, room_num);
-    }
+
+    const int16_t item_num = Item_GetIndex(lara_item);
+    Item_UpdateRoom(item_num, room_num);
 }
 
 void Lara_ShiftCol(COLL_INFO *const coll)

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -44,3 +44,14 @@ void Lara_UpdateRoom(const int32_t height)
         Item_NewRoom(item_num, room_num);
     }
 }
+
+void Lara_ShiftCol(COLL_INFO *const coll)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    lara_item->pos.x += coll->shift.x;
+    lara_item->pos.y += coll->shift.y;
+    lara_item->pos.z += coll->shift.z;
+    coll->shift.z = 0;
+    coll->shift.y = 0;
+    coll->shift.x = 0;
+}

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -29,7 +29,7 @@ void Lara_GetCollisionInfo(const ITEM *const item, COLL_INFO *const coll)
         LARA_HEIGHT);
 }
 
-void Lara_UpdateRoom(const int32_t height)
+void Lara_UpdateRoomToHeight(const int32_t height)
 {
     ITEM *const lara_item = Lara_GetItem();
     const int32_t x = lara_item->pos.x;

--- a/src/libtrx/game/objects/general/door.c
+++ b/src/libtrx/game/objects/general/door.c
@@ -188,7 +188,7 @@ static void M_Initialise(const int16_t item_num)
         M_Shut(&door->d2flip);
 
         const int16_t prev_room = item->room_num;
-        Item_NewRoom(item_num, room_num);
+        Item_UpdateRoom(item_num, room_num);
         item->room_num = prev_room;
     }
 }

--- a/src/libtrx/game/objects/general/drawbridge.c
+++ b/src/libtrx/game/objects/general/drawbridge.c
@@ -95,9 +95,7 @@ static void M_Control(int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/libtrx/include/libtrx/game/items.h
+++ b/src/libtrx/include/libtrx/game/items.h
@@ -5,3 +5,4 @@
 #include "items/enum.h"
 #include "items/misc.h"
 #include "items/types.h"
+#include "items/utils.h"

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -47,6 +47,7 @@ bool Item_GetAnimChange(ITEM *item, const ANIM *anim);
 
 extern int16_t Item_GetHeight(const ITEM *item);
 void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
+int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 void Item_Animate(ITEM *item);
 void Item_PlayAnimSFX(const ITEM *item, const ANIM_COMMAND_EFFECT_DATA *data);

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -22,7 +22,7 @@ void Item_Kill(int16_t item_num);
 void Item_RemoveActive(int16_t item_num);
 void Item_RemoveDrawn(int16_t item_num);
 void Item_AddActive(int16_t item_num);
-void Item_NewRoom(int16_t item_num, int16_t room_num);
+void Item_UpdateRoom(int16_t item_num, int16_t room_num);
 int32_t Item_GlobalReplace(
     GAME_OBJECT_ID src_obj_id, GAME_OBJECT_ID dst_obj_id);
 

--- a/src/libtrx/include/libtrx/game/items/utils.h
+++ b/src/libtrx/include/libtrx/game/items/utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#define ITEM_ADJUST_ROT(source, target, rot)                                   \
+    do {                                                                       \
+        if ((int16_t)(target - source) > rot) {                                \
+            source += rot;                                                     \
+        } else if ((int16_t)(target - source) < -rot) {                        \
+            source -= rot;                                                     \
+        } else {                                                               \
+            source = target;                                                   \
+        }                                                                      \
+    } while (0)

--- a/src/libtrx/include/libtrx/game/lara/common.h
+++ b/src/libtrx/include/libtrx/game/lara/common.h
@@ -17,4 +17,5 @@ bool Lara_TestBoundsCollide(const ITEM *item, int32_t radius);
 void Lara_Push(const ITEM *item, COLL_INFO *coll, bool hit_on, bool big_push);
 bool Lara_TestPosition(const ITEM *item, const OBJECT_BOUNDS *bounds);
 void Lara_AlignPosition(const ITEM *item, const XYZ_32 *vec);
+bool Lara_MovePosition(const ITEM *item, const XYZ_32 *vec);
 bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);

--- a/src/libtrx/include/libtrx/game/lara/common.h
+++ b/src/libtrx/include/libtrx/game/lara/common.h
@@ -17,3 +17,4 @@ bool Lara_TestBoundsCollide(const ITEM *item, int32_t radius);
 void Lara_Push(const ITEM *item, COLL_INFO *coll, bool hit_on, bool big_push);
 bool Lara_TestPosition(const ITEM *item, const OBJECT_BOUNDS *bounds);
 void Lara_AlignPosition(const ITEM *item, const XYZ_32 *vec);
+bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -10,3 +10,4 @@ void Lara_GetCollisionInfo(const ITEM *item, COLL_INFO *coll);
 extern void Lara_CatchFire(void);
 
 void Lara_UpdateRoom(int32_t height);
+void Lara_ShiftCol(COLL_INFO *coll);

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -9,5 +9,5 @@ int16_t Lara_FloorFront(const ITEM *item, int16_t ang, int32_t dist);
 void Lara_GetCollisionInfo(const ITEM *item, COLL_INFO *coll);
 extern void Lara_CatchFire(void);
 
-void Lara_UpdateRoom(int32_t height);
+void Lara_UpdateRoomToHeight(int32_t height);
 void Lara_ShiftCol(COLL_INFO *coll);

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -8,3 +8,5 @@ void Lara_Extinguish(void);
 int16_t Lara_FloorFront(const ITEM *item, int16_t ang, int32_t dist);
 void Lara_GetCollisionInfo(const ITEM *item, COLL_INFO *coll);
 extern void Lara_CatchFire(void);
+
+void Lara_UpdateRoom(int32_t height);

--- a/src/tr1/game/carrier.c
+++ b/src/tr1/game/carrier.c
@@ -104,9 +104,7 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
         }
     }
 
-    if (room_num != pickup->room_num) {
-        Item_NewRoom(item->spawn_num, room_num);
-    }
+    Item_UpdateRoom(item->spawn_num, room_num);
 
     // Track animating status in the carrier for saving/loading.
     item->pos = pickup->pos;
@@ -304,7 +302,7 @@ void Carrier_TestItemDrops(const int16_t item_num)
             item->spawn_num = Item_Spawn(carrier, obj_id);
         } else {
             // TR2-style item drops will already have a spawn number.
-            Item_NewRoom(item->spawn_num, carrier->room_num);
+            Item_UpdateRoom(item->spawn_num, carrier->room_num);
             ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = carrier->pos;
             pickup->rot = carrier->rot;
@@ -319,9 +317,7 @@ void Carrier_TestItemDrops(const int16_t item_num)
             ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = item->pos;
             pickup->fall_speed = item->fall_speed;
-            if (pickup->room_num != item->room_num) {
-                Item_NewRoom(item->spawn_num, item->room_num);
-            }
+            Item_UpdateRoom(item->spawn_num, item->room_num);
         }
 
     } while ((item = item->next_item));

--- a/src/tr1/game/demo.c
+++ b/src/tr1/game/demo.c
@@ -160,9 +160,7 @@ bool Demo_Start(const int32_t level_num)
     lara_item->rot.z = *p->demo_ptr++;
     int16_t room_num = *p->demo_ptr++;
 
-    if (lara_item->room_num != room_num) {
-        Item_NewRoom(g_Lara.item_num, room_num);
-    }
+    Item_UpdateRoom(g_Lara.item_num, room_num);
 
     const SECTOR *const sector = Room_GetSector(
         lara_item->pos.x, lara_item->pos.y, lara_item->pos.z, &room_num);

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -104,19 +104,6 @@ void Item_Initialise(int16_t item_num)
     Interpolation_RememberItem(item);
 }
 
-void Item_UpdateRoom(ITEM *item, int32_t height)
-{
-    int32_t x = item->pos.x;
-    int32_t y = item->pos.y + height;
-    int32_t z = item->pos.z;
-    int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    item->floor = Room_GetHeight(sector, x, y, z);
-    if (item->room_num != room_num) {
-        Item_NewRoom(g_Lara.item_num, room_num);
-    }
-}
-
 int16_t Item_GetHeight(const ITEM *const item)
 {
     int16_t room_num = item->room_num;

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -160,23 +160,6 @@ bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance)
     return false;
 }
 
-int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 *const target)
-{
-    int32_t x = (item->pos.x - target->x);
-    int32_t y = (item->pos.y - target->y);
-    int32_t z = (item->pos.z - target->z);
-
-    int32_t scale = 0;
-    while ((int16_t)x != x || (int16_t)y != y || (int16_t)z != z) {
-        scale++;
-        x >>= 1;
-        y >>= 1;
-        z >>= 1;
-    }
-
-    return Math_Sqrt(SQUARE(x) + SQUARE(y) + SQUARE(z)) << scale;
-}
-
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range)
 {
     return ABS(x) < range && ABS(y) < range && ABS(z) < range

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -142,24 +142,6 @@ int16_t Item_Spawn(const ITEM *const item, const GAME_OBJECT_ID obj_id)
     return spawn_num;
 }
 
-bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance)
-{
-    int32_t x = pos->x - item->pos.x;
-    int32_t y = pos->y - item->pos.y;
-    int32_t z = pos->z - item->pos.z;
-
-    if (x >= -distance && x <= distance && z >= -distance && z <= distance
-        && y >= -WALL_L * 3 && y <= WALL_L * 3
-        && SQUARE(x) + SQUARE(z) <= SQUARE(distance)) {
-        const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
-        if (y >= bounds->min.y && y <= bounds->max.y + 100) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range)
 {
     return ABS(x) < range && ABS(y) < range && ABS(z) < range

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -274,16 +274,6 @@ bool Item_MovePosition(
     // clang-format on
 }
 
-void Item_ShiftCol(ITEM *item, COLL_INFO *coll)
-{
-    item->pos.x += coll->shift.x;
-    item->pos.y += coll->shift.y;
-    item->pos.z += coll->shift.z;
-    coll->shift.x = 0;
-    coll->shift.y = 0;
-    coll->shift.z = 0;
-}
-
 ANIM_FRAME *Item_GetBestFrame(const ITEM *item)
 {
     ANIM_FRAME *frames[2];

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -17,17 +17,6 @@
 #include <libtrx/game/matrix.h>
 #include <libtrx/utils.h>
 
-#define ITEM_ADJUST_ROT(source, target, rot)                                   \
-    do {                                                                       \
-        if ((int16_t)(target - source) > rot) {                                \
-            source += rot;                                                     \
-        } else if ((int16_t)(target - source) < -rot) {                        \
-            source -= rot;                                                     \
-        } else {                                                               \
-            source = target;                                                   \
-        }                                                                      \
-    } while (0)
-
 static BOUNDS_16 m_NullBounds = {};
 static BOUNDS_16 m_InterpolatedBounds = {};
 
@@ -146,97 +135,6 @@ bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range)
 {
     return ABS(x) < range && ABS(y) < range && ABS(z) < range
         && (SQUARE(x) + SQUARE(y) + SQUARE(z) < SQUARE(range));
-}
-
-bool Item_MovePosition(
-    ITEM *item, const ITEM *ref_item, const XYZ_32 *vec, int32_t velocity)
-{
-    const XYZ_32 *ref_pos = &ref_item->pos;
-
-    Matrix_PushUnit();
-    Matrix_Rot16(ref_item->rot);
-
-    MATRIX *mptr = g_MatrixPtr;
-    const XYZ_32 dst_pos = {
-        .x = ref_pos->x
-            + ((mptr->_00 * vec->x + mptr->_01 * vec->y + mptr->_02 * vec->z)
-               >> W2V_SHIFT),
-        .y = ref_pos->y
-            + ((mptr->_10 * vec->x + mptr->_11 * vec->y + mptr->_12 * vec->z)
-               >> W2V_SHIFT),
-        .z = ref_pos->z
-            + ((mptr->_20 * vec->x + mptr->_21 * vec->y + mptr->_22 * vec->z)
-               >> W2V_SHIFT),
-    };
-
-    const XYZ_16 dst_rot = ref_item->rot;
-
-    Matrix_Pop();
-
-    {
-        const int32_t dx = dst_pos.x - item->pos.x;
-        const int32_t dy = dst_pos.y - item->pos.y;
-        const int32_t dz = dst_pos.z - item->pos.z;
-        const int32_t dist = Math_Sqrt(SQUARE(dx) + SQUARE(dy) + SQUARE(dz));
-        if (velocity >= dist) {
-            item->pos.x = dst_pos.x;
-            item->pos.y = dst_pos.y;
-            item->pos.z = dst_pos.z;
-        } else {
-            item->pos.x += (dx * velocity) / dist;
-            item->pos.y += (dy * velocity) / dist;
-            item->pos.z += (dz * velocity) / dist;
-        }
-    }
-
-    if (item == g_LaraItem && g_Config.gameplay.enable_walk_to_items
-        && !g_Lara.interact_target.is_moving) {
-        if (g_Lara.water_status != LWS_UNDERWATER) {
-            const int16_t step_to_anim_num[4] = {
-                LA_SIDE_STEP_LEFT,
-                LA_WALK_FORWARD,
-                LA_SIDE_STEP_RIGHT,
-                LA_WALK_BACK,
-            };
-            const int16_t step_to_anim_state[4] = {
-                LS_STEP_LEFT,
-                LS_WALK,
-                LS_STEP_RIGHT,
-                LS_BACK,
-            };
-
-            const int32_t dx = item->pos.x - dst_pos.x;
-            const int32_t dz = item->pos.z - dst_pos.z;
-            const int32_t angle = (DEG_360 - Math_Atan(dx, dz)) % DEG_360;
-            const uint32_t src_quadrant = (uint32_t)(angle + DEG_45) / DEG_90;
-            const uint32_t dst_quadrant =
-                (uint32_t)(dst_rot.y + DEG_45) / DEG_90;
-            const DIRECTION quadrant = (src_quadrant - dst_quadrant) % 4;
-
-            Item_SwitchToAnim(item, step_to_anim_num[quadrant], 0);
-            item->goal_anim_state = step_to_anim_state[quadrant];
-            item->current_anim_state = step_to_anim_state[quadrant];
-
-            g_Lara.gun_status = LGS_HANDS_BUSY;
-        }
-
-        g_Lara.interact_target.is_moving = true;
-        g_Lara.interact_target.move_count = 0;
-    }
-
-    int16_t rotation = MOVE_ANG;
-    ITEM_ADJUST_ROT(item->rot.x, dst_rot.x, rotation);
-    ITEM_ADJUST_ROT(item->rot.y, dst_rot.y, rotation);
-    ITEM_ADJUST_ROT(item->rot.z, dst_rot.z, rotation);
-
-    // clang-format off
-    return item->pos.x == dst_pos.x
-        && item->pos.y == dst_pos.y
-        && item->pos.z == dst_pos.z
-        && item->rot.x == dst_rot.x
-        && item->rot.y == dst_rot.y
-        && item->rot.z == dst_rot.z;
-    // clang-format on
 }
 
 ANIM_FRAME *Item_GetBestFrame(const ITEM *item)

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -5,7 +5,6 @@
 #include <libtrx/game/items.h>
 
 void Item_Control(void);
-void Item_UpdateRoom(ITEM *item, int32_t height);
 int16_t Item_GetWaterHeight(ITEM *item);
 int16_t Item_Spawn(const ITEM *item, GAME_OBJECT_ID obj_id);
 

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -12,9 +12,6 @@ bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
 bool Item_MovePosition(
     ITEM *src_item, const ITEM *dst_item, const XYZ_32 *vec, int32_t velocity);
-void Item_ShiftCol(ITEM *item, COLL_INFO *coll);
 int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);
-
-void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -8,7 +8,6 @@ void Item_Control(void);
 int16_t Item_GetWaterHeight(ITEM *item);
 int16_t Item_Spawn(const ITEM *item, GAME_OBJECT_ID obj_id);
 
-bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
 bool Item_MovePosition(
     ITEM *src_item, const ITEM *dst_item, const XYZ_32 *vec, int32_t velocity);

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -12,6 +12,5 @@ bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
 bool Item_MovePosition(
     ITEM *src_item, const ITEM *dst_item, const XYZ_32 *vec, int32_t velocity);
-int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
 
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);

--- a/src/tr1/game/items.h
+++ b/src/tr1/game/items.h
@@ -9,7 +9,5 @@ int16_t Item_GetWaterHeight(ITEM *item);
 int16_t Item_Spawn(const ITEM *item, GAME_OBJECT_ID obj_id);
 
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
-bool Item_MovePosition(
-    ITEM *src_item, const ITEM *dst_item, const XYZ_32 *vec, int32_t velocity);
 
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -461,10 +461,8 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z, int16_t room_num)
     g_LaraItem->pos.z = z;
     g_LaraItem->floor = height;
 
-    if (g_LaraItem->room_num != room_num) {
-        const int16_t item_num = Item_GetIndex(g_LaraItem);
-        Item_NewRoom(item_num, room_num);
-    }
+    const int16_t item_num = Item_GetIndex(g_LaraItem);
+    Item_UpdateRoom(item_num, room_num);
 
     Camera_ResetPosition();
     return true;

--- a/src/tr1/game/lara/col.c
+++ b/src/tr1/game/lara/col.c
@@ -297,7 +297,7 @@ void Lara_Col_Stop(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
 }
 
@@ -411,7 +411,7 @@ void Lara_Col_Death(ITEM *item, COLL_INFO *coll)
     coll->radius = LARA_RAD * 4;
     Lara_GetCollisionInfo(item, coll);
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
     item->hit_points = -1;
     g_Lara.air = -1;
@@ -490,7 +490,7 @@ void Lara_Col_Splat(ITEM *item, COLL_INFO *coll)
     coll->slopes_are_walls = 1;
     coll->slopes_are_pits = 1;
     Lara_GetCollisionInfo(item, coll);
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 }
 
 void Lara_Col_Land(ITEM *item, COLL_INFO *coll)
@@ -840,7 +840,7 @@ void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
 }
 
@@ -872,7 +872,7 @@ void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
 }
 

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -112,7 +112,7 @@ void Lara_Control(void)
             g_Lara.air = LARA_MAX_AIR;
             item->pos.y += 100;
             item->gravity = 0;
-            Item_UpdateRoom(item, 0);
+            Lara_UpdateRoom(0);
             Sound_StopEffect(SFX_LARA_FALL, nullptr);
             if (item->current_anim_state == LS_SWAN_DIVE) {
                 item->goal_anim_state = LS_DIVE;
@@ -175,7 +175,7 @@ void Lara_Control(void)
             g_Lara.head_rot.y = 0;
             g_Lara.torso_rot.x = 0;
             g_Lara.torso_rot.y = 0;
-            Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+            Lara_UpdateRoom(-LARA_HEIGHT / 2);
             Sound_Effect(SFX_LARA_BREATH, &item->pos, SPM_ALWAYS);
         }
         break;
@@ -260,7 +260,7 @@ void Lara_Control(void)
             g_Lara.torso_rot.x = 0;
             g_Lara.head_rot.y = 0;
             g_Lara.head_rot.x = 0;
-            Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+            Lara_UpdateRoom(-LARA_HEIGHT / 2);
         }
         break;
     }
@@ -795,7 +795,7 @@ void Lara_Push(
             coll->old.x = target_item->pos.x;
             coll->old.y = target_item->pos.y;
             coll->old.z = target_item->pos.z;
-            Item_UpdateRoom(target_item, -10);
+            Lara_UpdateRoom(-10);
         }
 
         if (g_Lara.interact_target.is_moving

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -696,11 +696,6 @@ void Lara_InitialiseMeshes(const GF_LEVEL *const level)
     }
 }
 
-bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance)
-{
-    return Item_IsNearItem(g_LaraItem, pos, distance);
-}
-
 bool Lara_MovePosition(ITEM *item, XYZ_32 *vec)
 {
     int32_t velocity = g_Config.gameplay.enable_walk_to_items

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -110,7 +110,7 @@ void Lara_Control(void)
             g_Lara.air = LARA_MAX_AIR;
             item->pos.y += 100;
             item->gravity = 0;
-            Lara_UpdateRoom(0);
+            Lara_UpdateRoomToHeight(0);
             Sound_StopEffect(SFX_LARA_FALL, nullptr);
             if (item->current_anim_state == LS_SWAN_DIVE) {
                 item->goal_anim_state = LS_DIVE;
@@ -173,7 +173,7 @@ void Lara_Control(void)
             g_Lara.head_rot.y = 0;
             g_Lara.torso_rot.x = 0;
             g_Lara.torso_rot.y = 0;
-            Lara_UpdateRoom(-LARA_HEIGHT / 2);
+            Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
             Sound_Effect(SFX_LARA_BREATH, &item->pos, SPM_ALWAYS);
         }
         break;
@@ -258,7 +258,7 @@ void Lara_Control(void)
             g_Lara.torso_rot.x = 0;
             g_Lara.head_rot.y = 0;
             g_Lara.head_rot.x = 0;
-            Lara_UpdateRoom(-LARA_HEIGHT / 2);
+            Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
         }
         break;
     }
@@ -778,7 +778,7 @@ void Lara_Push(
             coll->old.x = target_item->pos.x;
             coll->old.y = target_item->pos.y;
             coll->old.z = target_item->pos.z;
-            Lara_UpdateRoom(-10);
+            Lara_UpdateRoomToHeight(-10);
         }
 
         if (g_Lara.interact_target.is_moving

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -32,8 +32,6 @@
 
 #define LARA_MOVE_TIMEOUT 90
 #define LARA_PUSH_TIMEOUT 15
-#define LARA_MOVE_ANIM_VELOCITY 12
-#define LARA_MOVE_SPEED 16
 #define LARA_UW_DAMAGE 5
 
 static int16_t m_DeathCameraTarget = NO_ITEM;
@@ -694,16 +692,6 @@ void Lara_InitialiseMeshes(const GF_LEVEL *const level)
         Gun_SetLaraHolsterLMesh(holsters_gun_type);
         Gun_SetLaraHolsterRMesh(holsters_gun_type);
     }
-}
-
-bool Lara_MovePosition(ITEM *item, XYZ_32 *vec)
-{
-    int32_t velocity = g_Config.gameplay.enable_walk_to_items
-            && g_Lara.water_status != LWS_UNDERWATER
-        ? LARA_MOVE_ANIM_VELOCITY
-        : LARA_MOVE_SPEED;
-
-    return Item_MovePosition(g_LaraItem, item, vec, velocity);
 }
 
 void Lara_Push(

--- a/src/tr1/game/lara/common.h
+++ b/src/tr1/game/lara/common.h
@@ -25,6 +25,4 @@ void Lara_InitialiseMeshes(const GF_LEVEL *level);
 void Lara_SwapMeshExtra(void);
 void Lara_UseItem(GAME_OBJECT_ID obj_id);
 
-bool Lara_MovePosition(ITEM *item, XYZ_32 *vec);
-
 void Lara_RevertToPistolsIfNeeded(void);

--- a/src/tr1/game/lara/common.h
+++ b/src/tr1/game/lara/common.h
@@ -23,7 +23,6 @@ void Lara_InitialiseInventory(const GF_LEVEL *level);
 void Lara_InitialiseMeshes(const GF_LEVEL *level);
 
 void Lara_SwapMeshExtra(void);
-bool Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);
 void Lara_UseItem(GAME_OBJECT_ID obj_id);
 
 bool Lara_MovePosition(ITEM *item, XYZ_32 *vec);

--- a/src/tr1/game/lara/control.c
+++ b/src/tr1/game/lara/control.c
@@ -303,7 +303,7 @@ void Lara_HandleAboveWater(ITEM *item, COLL_INFO *coll)
 
     M_BaddieCollision(item, coll);
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -370,7 +370,7 @@ void Lara_HandleSurface(ITEM *item, COLL_INFO *coll)
 
     M_BaddieCollision(item, coll);
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Item_UpdateRoom(item, 100);
+    Lara_UpdateRoom(100);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -461,7 +461,7 @@ void Lara_HandleUnderwater(ITEM *item, COLL_INFO *coll)
     }
 
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Item_UpdateRoom(item, 0);
+    Lara_UpdateRoom(0);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }

--- a/src/tr1/game/lara/control.c
+++ b/src/tr1/game/lara/control.c
@@ -166,7 +166,7 @@ static void M_WaterCurrent(COLL_INFO *coll)
         item->pos.y += coll->side_mid.floor;
         item->rot.x += UW_WALLDEFLECT;
     }
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     coll->old.x = item->pos.x;
     coll->old.y = item->pos.y;

--- a/src/tr1/game/lara/control.c
+++ b/src/tr1/game/lara/control.c
@@ -303,7 +303,7 @@ void Lara_HandleAboveWater(ITEM *item, COLL_INFO *coll)
 
     M_BaddieCollision(item, coll);
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -370,7 +370,7 @@ void Lara_HandleSurface(ITEM *item, COLL_INFO *coll)
 
     M_BaddieCollision(item, coll);
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Lara_UpdateRoom(100);
+    Lara_UpdateRoomToHeight(100);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -461,7 +461,7 @@ void Lara_HandleUnderwater(ITEM *item, COLL_INFO *coll)
     }
 
     g_LaraCollisionRoutines[item->current_anim_state](item, coll);
-    Lara_UpdateRoom(0);
+    Lara_UpdateRoomToHeight(0);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -187,7 +187,7 @@ bool Lara_HitCeiling(ITEM *item, COLL_INFO *coll)
 bool Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
 {
     if (coll->coll_type == COLL_FRONT || coll->coll_type == COLL_TOP_FRONT) {
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
         item->gravity = 0;
@@ -196,10 +196,10 @@ bool Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
     }
 
     if (coll->coll_type == COLL_LEFT) {
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->rot.y += LARA_DEF_ADD_EDGE;
     } else if (coll->coll_type == COLL_RIGHT) {
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->rot.y -= LARA_DEF_ADD_EDGE;
     }
     return false;
@@ -207,7 +207,7 @@ bool Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
 
 void Lara_DeflectEdgeJump(ITEM *item, COLL_INFO *coll)
 {
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     switch (coll->coll_type) {
     case COLL_LEFT:
         item->rot.y += LARA_DEF_ADD_EDGE;
@@ -249,7 +249,7 @@ void Lara_DeflectEdgeJump(ITEM *item, COLL_INFO *coll)
 
 void Lara_SlideEdgeJump(ITEM *item, COLL_INFO *coll)
 {
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     switch (coll->coll_type) {
     case COLL_LEFT:
         item->rot.y += LARA_DEF_ADD_EDGE;
@@ -317,7 +317,7 @@ bool Lara_TestVault(ITEM *item, COLL_INFO *coll)
         item->pos.y += STEP_L * 2 + hdif;
         g_Lara.gun_status = LGS_HANDS_BUSY;
         item->rot.y = angle;
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         return true;
     } else if (
         hdif >= -STEP_L * 3 - STEP_L / 2 && hdif <= -STEP_L * 3 + STEP_L / 2) {
@@ -332,7 +332,7 @@ bool Lara_TestVault(ITEM *item, COLL_INFO *coll)
         item->pos.y += STEP_L * 3 + hdif;
         g_Lara.gun_status = LGS_HANDS_BUSY;
         item->rot.y = angle;
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         return true;
     } else if (
         hdif >= -STEP_L * 7 - STEP_L / 2 && hdif <= -STEP_L * 4 + STEP_L / 2) {
@@ -343,7 +343,7 @@ bool Lara_TestVault(ITEM *item, COLL_INFO *coll)
             -(int16_t)(Math_Sqrt((int)(-2 * GRAVITY * (hdif + 800))) + 3);
         Lara_Animate(item);
         item->rot.y = angle;
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         return true;
     }
 
@@ -516,7 +516,7 @@ bool Lara_TestSlide(ITEM *item, COLL_INFO *coll)
     }
 
     PHD_ANGLE adif = ang - item->rot.y;
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     if (adif >= -DEG_90 && adif <= DEG_90) {
         if (item->current_anim_state != LS_SLIDE || old_angle != ang) {
             item->goal_anim_state = LS_SLIDE;
@@ -586,7 +586,7 @@ void Lara_SurfaceCollision(ITEM *item, COLL_INFO *coll)
         coll, item->pos.x, item->pos.y + SURF_HEIGHT, item->pos.z,
         item->room_num, obj_height);
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     if (coll->coll_type == COLL_LEFT) {
         item->rot.y += 5 * DEG_1;
@@ -834,7 +834,7 @@ void Lara_SwimCollision(ITEM *item, COLL_INFO *coll)
     Collide_GetCollisionInfo(
         coll, item->pos.x, item->pos.y + height / 2, item->pos.z,
         item->room_num, height);
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     switch (coll->coll_type) {
     case COLL_FRONT:

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -730,7 +730,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += coll->side_front.floor + SURF_HEIGHT - 5;
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
     item->gravity = 0;
     item->rot.x = 0;
     item->rot.z = 0;
@@ -767,7 +767,7 @@ bool Lara_TestWaterClimbOut(ITEM *item, COLL_INFO *coll)
     }
 
     item->pos.y += hdif - 5;
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
 
     switch (dir) {
     case DIR_NORTH:

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -730,7 +730,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += coll->side_front.floor + SURF_HEIGHT - 5;
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
     item->gravity = 0;
     item->rot.x = 0;
     item->rot.z = 0;
@@ -767,7 +767,7 @@ bool Lara_TestWaterClimbOut(ITEM *item, COLL_INFO *coll)
     }
 
     item->pos.y += hdif - 5;
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
 
     switch (dir) {
     case DIR_NORTH:

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -101,9 +101,7 @@ static bool M_Vault(int16_t item_num, int16_t angle)
     item->floor = y;
     item->pos.y = y;
 
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     return true;
 }

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -80,7 +80,7 @@ static void M_Control(const int16_t item_num)
         item->rot.x = g_LaraItem->rot.x;
         item->rot.y = g_LaraItem->rot.y - DEG_180;
         item->rot.z = g_LaraItem->rot.z;
-        Item_NewRoom(item_num, g_LaraItem->room_num);
+        Item_UpdateRoom(item_num, g_LaraItem->room_num);
 
         if (h >= lh + WALL_L && !g_LaraItem->gravity) {
             item->current_anim_state = LS_FAST_FALL;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -267,9 +267,7 @@ static void M_ControlAlligator(const int16_t item_num)
             Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        if (room_num != item->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
         return;
     }
 

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -186,9 +186,7 @@ static void M_Control(const int16_t item_num)
 static void M_KillLara(ITEM *const item)
 {
     item->goal_anim_state = TREX_STATE_KILL;
-    if (g_LaraItem->room_num != item->room_num) {
-        Item_NewRoom(g_Lara.item_num, item->room_num);
-    }
+    Item_UpdateRoom(g_Lara.item_num, item->room_num);
 
     g_LaraItem->pos.x = item->pos.x;
     g_LaraItem->pos.y = item->pos.y;

--- a/src/tr1/game/objects/general/cog.c
+++ b/src/tr1/game/objects/general/cog.c
@@ -28,9 +28,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 REGISTER_OBJECT(O_COG_1, M_Setup)

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -32,9 +32,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 REGISTER_OBJECT(O_MOVING_BAR, M_Setup)

--- a/src/tr1/game/objects/traps/dart.c
+++ b/src/tr1/game/objects/traps/dart.c
@@ -37,9 +37,7 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
     if (item->pos.y >= item->floor) {

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -55,9 +55,7 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -25,9 +25,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     if (item->status != IS_DEACTIVATED) {
         int32_t x = item->pos.x;

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -328,9 +328,7 @@ static void M_Control(const int16_t item_num)
         Item_RemoveActive(item_num);
     }
 
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -61,9 +61,7 @@ static void M_Control(const int16_t item_num)
         int16_t room_num = item->room_num;
         const SECTOR *sector =
             Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        if (item->room_num != room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
 
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
@@ -153,9 +151,7 @@ static void M_Collision(
         lara_item->hit_status = 1;
         if (lara_item->hit_points > 0) {
             lara_item->hit_points = -1;
-            if (lara_item->room_num != item->room_num) {
-                Item_NewRoom(g_Lara.item_num, item->room_num);
-            }
+            Item_UpdateRoom(g_Lara.item_num, item->room_num);
 
             lara_item->rot.x = 0;
             lara_item->rot.z = 0;

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -69,9 +69,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_ACTIVE;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -539,9 +539,7 @@ static bool M_LoadItems(JSON_ARRAY *items_arr, uint16_t header_version)
                 JSON_ObjectGetInt(item_obj, "fall_speed", item->fall_speed);
 
             int16_t room_num = JSON_ObjectGetInt(item_obj, "room_num", -1);
-            if (room_num != -1 && item->room_num != room_num) {
-                Item_NewRoom(i, room_num);
-            }
+            Item_UpdateRoom(i, room_num);
         }
 
         if (obj->save_anim) {

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -506,9 +506,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
             item->speed = M_ReadS16();
             item->fall_speed = M_ReadS16();
 
-            if (item->room_num != room_num) {
-                Item_NewRoom(i, room_num);
-            }
+            Item_UpdateRoom(i, room_num);
         }
 
         if (M_ItemHasSaveAnim(item)) {

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -61,7 +61,6 @@
 #define LOOK_SPEED 4
 #define COMBAT_SPEED 8
 #define CHASE_SPEED 12
-#define MOVE_ANG (2 * DEG_1) // = 364
 #define COMBAT_DISTANCE (WALL_L * 5 / 2) // = 2560
 #define MAX_ELEVATION (85 * DEG_1) // = 15470
 #define DEFAULT_RADIUS 10

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -77,54 +77,6 @@ void CutscenePlayer1_Initialise(const int16_t item_num)
     g_Lara.hit_direction = -1;
 }
 
-int32_t Misc_Move3DPosTo3DPos(
-    PHD_3DPOS *const src_pos, const PHD_3DPOS *const dst_pos,
-    const int32_t velocity, const int16_t ang_add)
-{
-    // TODO: this function's only usage is in Lara_MovePosition. inline it
-    const XYZ_32 dpos = {
-        .x = dst_pos->pos.x - src_pos->pos.x,
-        .y = dst_pos->pos.y - src_pos->pos.y,
-        .z = dst_pos->pos.z - src_pos->pos.z,
-    };
-    const int32_t dist = XYZ_32_GetDistance0(&dpos);
-    if (velocity >= dist) {
-        src_pos->pos.x = dst_pos->pos.x;
-        src_pos->pos.y = dst_pos->pos.y;
-        src_pos->pos.z = dst_pos->pos.z;
-    } else {
-        src_pos->pos.x += velocity * dpos.x / dist;
-        src_pos->pos.y += velocity * dpos.y / dist;
-        src_pos->pos.z += velocity * dpos.z / dist;
-    }
-
-#define ADJUST_ROT(source, target, rot)                                        \
-    do {                                                                       \
-        if ((int16_t)(target - source) > rot) {                                \
-            source += rot;                                                     \
-        } else if ((int16_t)(target - source) < -rot) {                        \
-            source -= rot;                                                     \
-        } else {                                                               \
-            source = target;                                                   \
-        }                                                                      \
-    } while (0)
-
-    ADJUST_ROT(src_pos->rot.x, dst_pos->rot.x, ang_add);
-    ADJUST_ROT(src_pos->rot.y, dst_pos->rot.y, ang_add);
-    ADJUST_ROT(src_pos->rot.z, dst_pos->rot.z, ang_add);
-
-    // clang-format off
-    return (
-        src_pos->pos.x == dst_pos->pos.x &&
-        src_pos->pos.y == dst_pos->pos.y &&
-        src_pos->pos.z == dst_pos->pos.z &&
-        src_pos->rot.x == dst_pos->rot.x &&
-        src_pos->rot.y == dst_pos->rot.y &&
-        src_pos->rot.z == dst_pos->rot.z
-    );
-    // clang-format on
-}
-
 void IncreaseScreenSize(void)
 {
     if (g_Config.rendering.sizer < 1.0) {

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -45,8 +45,8 @@ void Lara_Control_Cutscene(const int16_t item_num)
     Collide_GetJointAbsPosition(item, &pos, 0);
 
     const int16_t room_num = Room_FindByPos(pos.x, pos.y, pos.z);
-    if (room_num != NO_ROOM_NEG && item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
+    if (room_num != NO_ROOM_NEG) {
+        Item_UpdateRoom(item_num, room_num);
     }
 
     Lara_Animate(item);

--- a/src/tr2/decomp/decomp.h
+++ b/src/tr2/decomp/decomp.h
@@ -12,9 +12,6 @@
 void Game_SetCutsceneTrack(int32_t track);
 void Lara_Control_Cutscene(int16_t item_num);
 void CutscenePlayer1_Initialise(int16_t item_num);
-int32_t Misc_Move3DPosTo3DPos(
-    PHD_3DPOS *src_pos, const PHD_3DPOS *dst_pos, int32_t velocity,
-    int16_t ang_add);
 void S_InitialisePolyList(bool clear_back_buffer);
 void DecreaseScreenSize(void);
 void IncreaseScreenSize(void);

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -453,9 +453,7 @@ void Flare_Control(const int16_t item_num)
         }
     }
 
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     int32_t flare_age = ((int32_t)(intptr_t)item->data) & 0x7FFF;
     if (flare_age < MAX_FLARE_AGE) {

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -874,9 +874,7 @@ int32_t Skidoo_Control(void)
 
     if (skidoo->flags & IF_ONE_SHOT) {
         Room_TestTriggers(g_LaraItem);
-        if (room_num != skidoo->room_num) {
-            Item_NewRoom(g_Lara.skidoo, room_num);
-        }
+        Item_UpdateRoom(g_Lara.skidoo, room_num);
         if (skidoo->pos.y == skidoo->floor) {
             Skidoo_Explode(skidoo);
         }
@@ -884,10 +882,8 @@ int32_t Skidoo_Control(void)
     }
 
     Skidoo_Animation(skidoo, collide, dead);
-    if (room_num != skidoo->room_num) {
-        Item_NewRoom(g_Lara.skidoo, room_num);
-        Item_NewRoom(g_Lara.item_num, room_num);
-    }
+    Item_UpdateRoom(g_Lara.skidoo, room_num);
+    Item_UpdateRoom(g_Lara.item_num, room_num);
 
     if (g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_FALLOFF) {
         g_LaraItem->rot.x = 0;

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -146,9 +146,7 @@ bool Demo_Start(const int32_t level_num)
     lara_item->rot.z = *p->demo_ptr++;
 
     int16_t room_num = *p->demo_ptr++;
-    if (lara_item->room_num != room_num) {
-        Item_NewRoom(g_Lara.item_num, room_num);
-    }
+    Item_UpdateRoom(g_Lara.item_num, room_num);
     const SECTOR *const sector = Room_GetSector(
         lara_item->pos.x, lara_item->pos.y, lara_item->pos.z, &room_num);
     lara_item->floor = Room_GetHeight(

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -222,26 +222,6 @@ ANIM_FRAME *Item_GetBestFrame(const ITEM *const item)
     return frames[(frac > rate / 2) ? 1 : 0];
 }
 
-bool Item_IsNearItem(
-    const ITEM *const item, const XYZ_32 *const pos, const int32_t distance)
-{
-    const XYZ_32 d = {
-        .x = pos->x - item->pos.x,
-        .y = pos->y - item->pos.y,
-        .z = pos->z - item->pos.z,
-    };
-    if (ABS(d.x) > distance || ABS(d.z) > distance || ABS(d.y) > WALL_L * 3) {
-        return false;
-    }
-
-    if (SQUARE(d.x) + SQUARE(d.z) > SQUARE(distance)) {
-        return false;
-    }
-
-    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
-    return d.y >= bounds->min.y && d.y <= bounds->max.y + 100;
-}
-
 int32_t Item_Explode(
     const int16_t item_num, const int32_t mesh_bits, const int16_t damage)
 {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -119,16 +119,6 @@ bool Item_IsSmashable(const ITEM *item)
     return (item->object_id == O_WINDOW_1 || item->object_id == O_BELL);
 }
 
-void Item_ShiftCol(ITEM *const item, COLL_INFO *const coll)
-{
-    item->pos.x += coll->shift.x;
-    item->pos.y += coll->shift.y;
-    item->pos.z += coll->shift.z;
-    coll->shift.z = 0;
-    coll->shift.y = 0;
-    coll->shift.x = 0;
-}
-
 int16_t Item_GetHeight(const ITEM *const item)
 {
     int16_t room_num = item->room_num;

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -242,11 +242,6 @@ bool Item_IsNearItem(
     return d.y >= bounds->min.y && d.y <= bounds->max.y + 100;
 }
 
-int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 *const target)
-{
-    return XYZ_32_GetDistance(&item->pos, target);
-}
-
 int32_t Item_Explode(
     const int16_t item_num, const int32_t mesh_bits, const int16_t damage)
 {

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -129,20 +129,6 @@ void Item_ShiftCol(ITEM *const item, COLL_INFO *const coll)
     coll->shift.x = 0;
 }
 
-void Item_UpdateRoom(ITEM *const item, const int32_t height)
-{
-    int32_t x = item->pos.x;
-    int32_t y = height + item->pos.y;
-    int32_t z = item->pos.z;
-
-    int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    item->floor = Room_GetHeight(sector, x, y, z);
-    if (item->room_num != room_num) {
-        Item_NewRoom(g_Lara.item_num, room_num);
-    }
-}
-
 int16_t Item_GetHeight(const ITEM *const item)
 {
     int16_t room_num = item->room_num;

--- a/src/tr2/game/items.h
+++ b/src/tr2/game/items.h
@@ -7,6 +7,5 @@
 void Item_Control(void);
 void Item_ClearKilled(void);
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);
-bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 
 bool Item_IsSmashable(const ITEM *item);

--- a/src/tr2/game/items.h
+++ b/src/tr2/game/items.h
@@ -6,7 +6,6 @@
 
 void Item_Control(void);
 void Item_ClearKilled(void);
-void Item_ShiftCol(ITEM *item, COLL_INFO *coll);
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);
 bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 

--- a/src/tr2/game/items.h
+++ b/src/tr2/game/items.h
@@ -7,7 +7,6 @@
 void Item_Control(void);
 void Item_ClearKilled(void);
 void Item_ShiftCol(ITEM *item, COLL_INFO *coll);
-void Item_UpdateRoom(ITEM *item, int32_t height);
 int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);
 bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 

--- a/src/tr2/game/items.h
+++ b/src/tr2/game/items.h
@@ -10,4 +10,3 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frmptr[], int32_t *rate);
 bool Item_IsNearItem(const ITEM *item, const XYZ_32 *pos, int32_t distance);
 
 bool Item_IsSmashable(const ITEM *item);
-int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -379,10 +379,8 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z, int16_t room_num)
     g_LaraItem->pos.z = z;
     g_LaraItem->floor = height;
 
-    if (g_LaraItem->room_num != room_num) {
-        const int16_t item_num = Item_GetIndex(g_LaraItem);
-        Item_NewRoom(item_num, room_num);
-    }
+    const int16_t item_num = Item_GetIndex(g_LaraItem);
+    Item_UpdateRoom(item_num, room_num);
 
     if (g_Lara.gun_status == LGS_HANDS_BUSY) {
         g_Lara.gun_status = LGS_ARMLESS;

--- a/src/tr2/game/lara/col.c
+++ b/src/tr2/game/lara/col.c
@@ -125,7 +125,7 @@ bool Lara_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += lara_hdif - 5;
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
 
     switch (dir) {
     case DIR_NORTH:
@@ -187,7 +187,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += coll->side_front.floor + LARA_HEIGHT_SURF - 5;
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
     item->gravity = 0;
     item->rot.x = 0;
     item->rot.z = 0;

--- a/src/tr2/game/lara/col.c
+++ b/src/tr2/game/lara/col.c
@@ -125,7 +125,7 @@ bool Lara_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += lara_hdif - 5;
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
 
     switch (dir) {
     case DIR_NORTH:
@@ -187,7 +187,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
     }
 
     item->pos.y += coll->side_front.floor + LARA_HEIGHT_SURF - 5;
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
     item->gravity = 0;
     item->rot.x = 0;
     item->rot.z = 0;

--- a/src/tr2/game/lara/col.c
+++ b/src/tr2/game/lara/col.c
@@ -204,7 +204,7 @@ void Lara_SurfaceCollision(ITEM *const item, COLL_INFO *const coll)
         coll, item->pos.x, item->pos.y + LARA_HEIGHT_SURF, item->pos.z,
         item->room_num, LARA_HEIGHT_SURF + 100);
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     if (coll->coll_type == COLL_LEFT) {
         item->rot.y += 5 * DEG_1;
@@ -383,7 +383,7 @@ void Lara_Col_Stop(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
 }
 
@@ -495,7 +495,7 @@ void Lara_Col_Death(ITEM *item, COLL_INFO *coll)
     coll->radius = 400;
 
     Lara_GetCollisionInfo(item, coll);
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     item->pos.y += coll->side_mid.floor;
     item->hit_points = -1;
@@ -603,7 +603,7 @@ void Lara_Col_Splat(ITEM *item, COLL_INFO *coll)
     coll->bad_ceiling = 0;
 
     Lara_GetCollisionInfo(item, coll);
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     if (coll->side_mid.floor > -STEP_L && coll->side_mid.floor < STEP_L) {
         item->pos.y += coll->side_mid.floor;
@@ -856,7 +856,7 @@ void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     item->pos.y += coll->side_mid.floor;
 }
 
@@ -882,7 +882,7 @@ void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
         item->gravity = 1;
         item->fall_speed = 0;
     } else {
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->pos.y += coll->side_mid.floor;
     }
 }

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -274,7 +274,7 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
-    Lara_UpdateRoom(-LARA_HEIGHT / 2);
+    Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -333,7 +333,7 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
-    Lara_UpdateRoom(100);
+    Lara_UpdateRoomToHeight(100);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -423,7 +423,7 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
-    Lara_UpdateRoom(0);
+    Lara_UpdateRoomToHeight(0);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -474,7 +474,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.water_status = LWS_UNDERWATER;
                 item->gravity = 0;
                 item->pos.y += 100;
-                Lara_UpdateRoom(0);
+                Lara_UpdateRoomToHeight(0);
                 Sound_StopEffect(SFX_LARA_FALL);
                 if (item->current_anim_state == LS_SWAN_DIVE) {
                     item->rot.x = -45 * DEG_1;
@@ -534,7 +534,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
                 g_Lara.head_rot.x = 0;
-                Lara_UpdateRoom(-381);
+                Lara_UpdateRoomToHeight(-381);
                 Sound_Effect(SFX_LARA_BREATH, &item->pos, SPM_ALWAYS);
             }
             break;
@@ -613,7 +613,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
                 g_Lara.head_rot.x = 0;
-                Lara_UpdateRoom(-LARA_HEIGHT / 2);
+                Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
             }
             break;
 

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -274,7 +274,7 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
-    Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+    Lara_UpdateRoom(-LARA_HEIGHT / 2);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -333,7 +333,7 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
-    Item_UpdateRoom(item, 100);
+    Lara_UpdateRoom(100);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -423,7 +423,7 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
-    Item_UpdateRoom(item, 0);
+    Lara_UpdateRoom(0);
     Gun_Control();
     Room_TestSectorTrigger(item, sector);
 }
@@ -474,7 +474,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.water_status = LWS_UNDERWATER;
                 item->gravity = 0;
                 item->pos.y += 100;
-                Item_UpdateRoom(item, 0);
+                Lara_UpdateRoom(0);
                 Sound_StopEffect(SFX_LARA_FALL);
                 if (item->current_anim_state == LS_SWAN_DIVE) {
                     item->rot.x = -45 * DEG_1;
@@ -534,7 +534,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
                 g_Lara.head_rot.x = 0;
-                Item_UpdateRoom(item, -381);
+                Lara_UpdateRoom(-381);
                 Sound_Effect(SFX_LARA_BREATH, &item->pos, SPM_ALWAYS);
             }
             break;
@@ -613,7 +613,7 @@ void Lara_Control(const int16_t item_num)
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
                 g_Lara.head_rot.x = 0;
-                Item_UpdateRoom(item, -LARA_HEIGHT / 2);
+                Lara_UpdateRoom(-LARA_HEIGHT / 2);
             }
             break;
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1098,7 +1098,7 @@ void Lara_Push(
         coll->old.x = target_item->pos.x;
         coll->old.y = target_item->pos.y;
         coll->old.z = target_item->pos.z;
-        Item_UpdateRoom(target_item, -10);
+        Lara_UpdateRoom(-10);
     }
 }
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1152,11 +1152,6 @@ int32_t Lara_MovePosition(XYZ_32 *vec, ITEM *item, ITEM *lara_item)
     return result;
 }
 
-int32_t Lara_IsNearItem(const XYZ_32 *const pos, const int32_t distance)
-{
-    return Item_IsNearItem(g_LaraItem, pos, distance);
-}
-
 int32_t Lara_TestClimb(
     const int32_t x, const int32_t y, const int32_t z, const int32_t x_front,
     const int32_t z_front, const int32_t item_height, const int16_t item_room,

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1096,7 +1096,7 @@ void Lara_Push(
         coll->old.x = target_item->pos.x;
         coll->old.y = target_item->pos.y;
         coll->old.z = target_item->pos.z;
-        Lara_UpdateRoom(-10);
+        Lara_UpdateRoomToHeight(-10);
     }
 }
 

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -20,8 +20,6 @@
 #include <libtrx/utils.h>
 
 #define MAX_BADDIE_COLLISION 20
-#define MOVE_SPEED 16
-#define MOVE_ANGLE (2 * DEG_1) // = 364
 #define CLIMB_HANG 900
 #define CLIMB_SHIFT 70
 #define LF_FAST_FALL 1
@@ -1100,56 +1098,6 @@ void Lara_Push(
         coll->old.z = target_item->pos.z;
         Lara_UpdateRoom(-10);
     }
-}
-
-int32_t Lara_MovePosition(XYZ_32 *vec, ITEM *item, ITEM *lara_item)
-{
-    const XYZ_16 rot = item->rot;
-
-    Matrix_PushUnit();
-    Matrix_Rot16(rot);
-    const MATRIX *const m = g_MatrixPtr;
-    const XYZ_32 shift = {
-        .x = (vec->y * m->_01 + vec->z * m->_02 + vec->x * m->_00) >> W2V_SHIFT,
-        .y = (vec->x * m->_10 + vec->z * m->_12 + vec->y * m->_11) >> W2V_SHIFT,
-        .z = (vec->y * m->_21 + vec->x * m->_20 + vec->z * m->_22) >> W2V_SHIFT,
-    };
-    Matrix_Pop();
-
-    const XYZ_32 new_pos = {
-        .x = item->pos.x + shift.x,
-        .y = item->pos.y + shift.y,
-        .z = item->pos.z + shift.z,
-    };
-
-    if (item->object_id == O_FLARE_ITEM) {
-        int16_t room_num = lara_item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(new_pos.x, new_pos.y, new_pos.z, &room_num);
-        const int32_t height =
-            Room_GetHeight(sector, new_pos.x, new_pos.y, new_pos.z);
-        if (ABS(height - lara_item->pos.y) > STEP_L * 2) {
-            return false;
-        }
-        if (XYZ_32_GetDistance(&new_pos, &lara_item->pos) < STEP_L) {
-            return true;
-        }
-    }
-
-    // TODO: get rid of this conversion
-    const PHD_3DPOS new_pos_full = {
-        .pos = new_pos,
-        .rot = rot,
-    };
-    PHD_3DPOS src_pos = {
-        .pos = lara_item->pos,
-        .rot = lara_item->rot,
-    };
-    const int32_t result =
-        Misc_Move3DPosTo3DPos(&src_pos, &new_pos_full, MOVE_SPEED, MOVE_ANGLE);
-    lara_item->pos = src_pos.pos;
-    lara_item->rot = src_pos.rot;
-    return result;
 }
 
 int32_t Lara_TestClimb(

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -103,7 +103,7 @@ int32_t Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
     switch (coll->coll_type) {
     case COLL_FRONT:
     case COLL_TOP_FRONT:
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
         item->gravity = 0;
@@ -111,12 +111,12 @@ int32_t Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
         return 1;
 
     case COLL_LEFT:
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->rot.y += LARA_DEFLECT_ANGLE;
         return 0;
 
     case COLL_RIGHT:
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         item->rot.y -= LARA_DEFLECT_ANGLE;
         return 0;
 
@@ -127,7 +127,7 @@ int32_t Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
 
 void Lara_DeflectEdgeJump(ITEM *item, COLL_INFO *coll)
 {
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     switch (coll->coll_type) {
     case COLL_FRONT:
     case COLL_TOP_FRONT:
@@ -176,7 +176,7 @@ void Lara_DeflectEdgeJump(ITEM *item, COLL_INFO *coll)
 
 void Lara_SlideEdgeJump(ITEM *item, COLL_INFO *coll)
 {
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     switch (coll->coll_type) {
     case COLL_LEFT:
@@ -687,7 +687,7 @@ int32_t Lara_TestVault(ITEM *item, COLL_INFO *coll)
         g_Lara.climb_status
         && (front_floor < -STEP_L * 4 || front_ceiling >= LARA_HEIGHT - STEP_L)
         && coll->side_mid.ceiling <= -STEP_L * 5 + LARA_HEIGHT) {
-        Item_ShiftCol(item, coll);
+        Lara_ShiftCol(coll);
         if (Lara_TestClimbStance(item, coll)) {
             item->goal_anim_state = LS_CLIMB_STANCE;
             item->current_anim_state = LS_STOP;
@@ -703,7 +703,7 @@ int32_t Lara_TestVault(ITEM *item, COLL_INFO *coll)
     }
 
     item->rot.y = angle;
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
     return 1;
 }
 
@@ -727,7 +727,7 @@ int32_t Lara_TestSlide(ITEM *item, COLL_INFO *coll)
     }
 
     const int16_t angle_dif = angle - item->rot.y;
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     if (angle_dif >= -DEG_90 && angle_dif <= DEG_90) {
         if (item->current_anim_state == LS_SLIDE
@@ -1571,7 +1571,7 @@ void Lara_SwimCollision(ITEM *const item, COLL_INFO *const coll)
     Collide_GetCollisionInfo(
         coll, item->pos.x, item->pos.y + height / 2, item->pos.z,
         item->room_num, height);
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     switch (coll->coll_type) {
     case COLL_FRONT:
@@ -1709,7 +1709,7 @@ void Lara_WaterCurrent(COLL_INFO *const coll)
         item->pos.y += coll->side_mid.floor;
         item->rot.x += LARA_UW_WALL_DEFLECT;
     }
-    Item_ShiftCol(item, coll);
+    Lara_ShiftCol(coll);
 
     coll->old = item->pos;
 }

--- a/src/tr2/game/lara/misc.h
+++ b/src/tr2/game/lara/misc.h
@@ -46,7 +46,6 @@ void Lara_GetJointAbsPosition_I(
 
 void Lara_BaddieCollision(ITEM *lara_item, COLL_INFO *coll);
 void Lara_TakeHit(ITEM *lara_item, const COLL_INFO *coll);
-int32_t Lara_MovePosition(XYZ_32 *vec, ITEM *item, ITEM *lara_item);
 
 int32_t Lara_TestClimb(
     int32_t x, int32_t y, int32_t z, int32_t x_front, int32_t z_front,

--- a/src/tr2/game/lara/misc.h
+++ b/src/tr2/game/lara/misc.h
@@ -47,7 +47,6 @@ void Lara_GetJointAbsPosition_I(
 void Lara_BaddieCollision(ITEM *lara_item, COLL_INFO *coll);
 void Lara_TakeHit(ITEM *lara_item, const COLL_INFO *coll);
 int32_t Lara_MovePosition(XYZ_32 *vec, ITEM *item, ITEM *lara_item);
-int32_t Lara_IsNearItem(const XYZ_32 *pos, int32_t distance);
 
 int32_t Lara_TestClimb(
     int32_t x, int32_t y, int32_t z, int32_t x_front, int32_t z_front,

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -110,9 +110,7 @@ static void M_PullDagger(ITEM *const lara_item, ITEM *const dragon_back_item)
     lara_item->gravity = 0;
     lara_item->speed = 0;
 
-    if (dragon_back_item->room_num != lara_item->room_num) {
-        Item_NewRoom(g_Lara.item_num, dragon_back_item->room_num);
-    }
+    Item_UpdateRoom(g_Lara.item_num, dragon_back_item->room_num);
 
     Item_Animate(g_LaraItem);
 
@@ -468,9 +466,7 @@ static void M_Control(const int16_t item_num)
     dragon_back_item->rot.x = dragon_front_item->rot.x;
     dragon_back_item->rot.y = dragon_front_item->rot.y;
     dragon_back_item->rot.z = dragon_front_item->rot.z;
-    if (dragon_back_item->room_num != dragon_front_item->room_num) {
-        Item_NewRoom(dragon_back_item_num, dragon_front_item->room_num);
-    }
+    Item_UpdateRoom(dragon_back_item_num, dragon_front_item->room_num);
 }
 
 REGISTER_OBJECT(O_DRAGON_FRONT, M_SetupFront)

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -266,10 +266,7 @@ static void M_Control(const int16_t driver_item_num)
         driver_item->pos.y = skidoo_item->pos.y;
         driver_item->pos.z = skidoo_item->pos.z;
         driver_item->rot.y = skidoo_item->rot.y;
-        const int16_t room_num = skidoo_item->room_num;
-        if (room_num != driver_item->room_num) {
-            Item_NewRoom(driver_item_num, room_num);
-        }
+        Item_UpdateRoom(driver_item_num, skidoo_item->room_num);
         const int16_t anim_num =
             Item_GetRelativeObjAnim(skidoo_item, O_SKIDOO_ARMED);
         const int16_t frame_num = Item_GetRelativeFrame(skidoo_item);

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -60,9 +60,7 @@ static void M_Leap(const int16_t item_num, const int16_t angle)
     }
 
     item->pos = old_pos;
-    if (item->room_num != old_room_num) {
-        Item_NewRoom(item_num, old_room_num);
-    }
+    Item_UpdateRoom(item_num, old_room_num);
     Item_SwitchToAnim(item, SPIDER_ANIM_LEAP, 0);
     item->current_anim_state = SPIDER_STATE_ATTACK_2;
     Creature_Animate(item_num, angle, 0);

--- a/src/tr2/game/objects/general/copter.c
+++ b/src/tr2/game/objects/general/copter.c
@@ -37,9 +37,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     XYZ_32 pos = {

--- a/src/tr2/game/objects/general/cutscene_player.c
+++ b/src/tr2/game/objects/general/cutscene_player.c
@@ -36,8 +36,8 @@ static void M_Control(const int16_t item_num)
     Collide_GetJointAbsPosition(item, &pos, 0);
 
     const int16_t room_num = Room_FindByPos(pos.x, pos.y, pos.z);
-    if (room_num != NO_ROOM_NEG && item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
+    if (room_num != NO_ROOM_NEG) {
+        Item_UpdateRoom(item_num, room_num);
     }
 
     if (item->dynamic_light && item->status != IS_INVISIBLE) {

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -35,9 +35,7 @@ void General_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     XYZ_32 pos = { .x = 3000, .y = 720, .z = 0 };
     Collide_GetJointAbsPosition(item, &pos, 0);

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -61,9 +61,7 @@ static void M_Control(const int16_t item_num)
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     bool explode = false;
     int32_t radius = 0;

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -38,9 +38,7 @@ static void M_Control(const int16_t item_num)
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     for (int16_t target_num = Room_Get(item->room_num)->item_num;
          target_num != NO_ITEM; target_num = Item_Get(target_num)->next_item) {

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -210,9 +210,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 REGISTER_OBJECT(O_LIFT, M_Setup)

--- a/src/tr2/game/objects/general/mini_copter.c
+++ b/src/tr2/game/objects/general/mini_copter.c
@@ -37,9 +37,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 }
 
 REGISTER_OBJECT(O_MINI_COPTER, M_Setup)

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -255,9 +255,7 @@ static void M_Control(const int16_t item_num)
         Item_RemoveActive(item_num);
     }
 
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -183,7 +183,7 @@ static void M_DoUnderwater(const int16_t item_num, ITEM *const lara_item)
     if (g_Input.action && lara_item->current_anim_state == LS_TREAD
         && g_Lara.gun_status == LGS_ARMLESS
         && (g_Lara.gun_type != LGT_FLARE || item->object_id != O_FLARE_ITEM)) {
-        if (!Lara_MovePosition(&m_PickupPositionUW, item, lara_item)) {
+        if (!Lara_MovePosition(item, &m_PickupPositionUW)) {
             goto cleanup;
         }
 

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -214,7 +214,7 @@ static void M_CollisionUW(
         return;
     }
 
-    if (!Lara_MovePosition(&m_SwitchUWPosition, item, lara_item)) {
+    if (!Lara_MovePosition(item, &m_SwitchUWPosition)) {
         return;
     }
 

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -2,12 +2,12 @@
 
 #include "game/box.h"
 #include "game/items.h"
-#include "game/lara/misc.h"
 #include "game/objects/common.h"
 #include "game/room.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
+#include <libtrx/game/lara/common.h>
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
 

--- a/src/tr2/game/objects/general/zipline.c
+++ b/src/tr2/game/objects/general/zipline.c
@@ -76,9 +76,7 @@ static void M_Control(const int16_t item_num)
     if (!(item->flags & IF_ONE_SHOT)) {
         const GAME_VECTOR *const old = item->data;
         item->pos = old->pos;
-        if (old->room_num != item->room_num) {
-            Item_NewRoom(item_num, old->room_num);
-        }
+        Item_UpdateRoom(item_num, old->room_num);
         item->status = IS_INACTIVE;
         item->goal_anim_state = ZIPLINE_STATE_GRAB;
         item->current_anim_state = ZIPLINE_STATE_GRAB;
@@ -105,9 +103,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     const bool lara_on_zipline = g_LaraItem->current_anim_state == LS_ZIPLINE;
     if (lara_on_zipline) {

--- a/src/tr2/game/objects/traps/dart.c
+++ b/src/tr2/game/objects/traps/dart.c
@@ -58,9 +58,7 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
     const int32_t height =
         Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 

--- a/src/tr2/game/objects/traps/falling_block.c
+++ b/src/tr2/game/objects/traps/falling_block.c
@@ -89,9 +89,7 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -44,9 +44,7 @@ static void M_Control(const int16_t item_num)
         Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 
     item->floor = height;
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
     if (item->current_anim_state == TRAP_ACTIVATE && item->pos.y >= height) {
         item->pos.y = height;
         item->goal_anim_state = TRAP_WORKING;

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -59,9 +59,7 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (item->room_num != room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
     const int32_t height =
         Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -66,9 +66,7 @@ static void M_Control(const int16_t item_num)
         int16_t room_num = item->room_num;
         const SECTOR *const sector =
             Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        if (item->room_num != room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
 
         item->floor =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);

--- a/src/tr2/game/objects/traps/spike_ceiling.c
+++ b/src/tr2/game/objects/traps/spike_ceiling.c
@@ -27,9 +27,7 @@ static void M_Move(const int16_t item_num)
         item->status = IS_DEACTIVATED;
     } else {
         item->pos.y = y;
-        if (room_num != item->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
     }
     Sound_Effect(SFX_DOOR_SLIDE, &item->pos, SPM_NORMAL);
 }

--- a/src/tr2/game/objects/traps/spike_wall.c
+++ b/src/tr2/game/objects/traps/spike_wall.c
@@ -46,9 +46,7 @@ static void M_Move(const int16_t item_num)
     } else {
         item->pos.z = z;
         item->pos.x = x;
-        if (room_num != item->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
     }
 
     Sound_Effect(SFX_DOOR_SLIDE, &item->pos, SPM_NORMAL);

--- a/src/tr2/game/objects/traps/spinning_blade.c
+++ b/src/tr2/game/objects/traps/spinning_blade.c
@@ -99,9 +99,7 @@ static void M_Control(const int16_t item_num)
         Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
     item->pos.y = height;
     item->floor = height;
-    if (room_num != item->room_num) {
-        Item_NewRoom(item_num, room_num);
-    }
+    Item_UpdateRoom(item_num, room_num);
 
     if (spinning) {
         if (item->current_anim_state == SPINNING_BLADE_STATE_STOP) {

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -630,9 +630,7 @@ static void M_Collision(
     lara->goal_anim_state = 0;
     lara->current_anim_state = 0;
 
-    if (lara->room_num != boat->room_num) {
-        Item_NewRoom(g_Lara.item_num, boat->room_num);
-    }
+    Item_UpdateRoom(g_Lara.item_num, boat->room_num);
 
     Item_Animate(lara);
     if (boat->status != IS_ACTIVE) {
@@ -727,9 +725,7 @@ static void M_Control(const int16_t item_num)
     if (g_Lara.skidoo == item_num) {
         M_Animation(boat, collide);
 
-        if (room_num != boat->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
 
         boat->rot.z += boat_data->tilt_angle;
         lara->pos.x = boat->pos.x;
@@ -743,9 +739,7 @@ static void M_Control(const int16_t item_num)
 
         sector = Room_GetSector(
             lara->pos.x, lara->pos.y + BOAT_SHIFT_Y, lara->pos.z, &room_num);
-        if (room_num != g_LaraItem->room_num) {
-            Item_NewRoom(g_Lara.item_num, room_num);
-        }
+        Item_UpdateRoom(g_Lara.item_num, room_num);
 
         Item_Animate(lara);
 
@@ -759,9 +753,7 @@ static void M_Control(const int16_t item_num)
         g_Camera.target_elevation = -20 * DEG_1;
         g_Camera.target_distance = 2 * WALL_L;
     } else {
-        if (room_num != boat->room_num) {
-            Item_NewRoom(item_num, room_num);
-        }
+        Item_UpdateRoom(item_num, room_num);
         boat->rot.z += boat_data->tilt_angle;
     }
 
@@ -824,9 +816,7 @@ static void M_Control(const int16_t item_num)
         if (Room_GetHeight(sector, pos.x, pos.y, pos.z) >= pos.y - STEP_L) {
             lara->pos.x = pos.x;
             lara->pos.z = pos.z;
-            if (room_num != lara->room_num) {
-                Item_NewRoom(g_Lara.item_num, room_num);
-            }
+            Item_UpdateRoom(g_Lara.item_num, room_num);
         }
 
         lara->pos.y = pos.y;

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -781,9 +781,7 @@ static bool M_LoadItems(JSON_ARRAY *const items_arr)
                 JSON_ObjectGetInt(item_obj, "fall_speed", item->fall_speed);
 
             int16_t room_num = JSON_ObjectGetInt(item_obj, "room_num", -1);
-            if (room_num != -1 && item->room_num != room_num) {
-                Item_NewRoom(i, room_num);
-            }
+            Item_UpdateRoom(i, room_num);
         }
 
         if (obj->save_anim) {

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -220,9 +220,7 @@ static void M_ReadItems(void)
             item->speed = M_ReadS16();
             item->fall_speed = M_ReadS16();
 
-            if (item->room_num != room_num) {
-                Item_NewRoom(item_num, room_num);
-            }
+            Item_UpdateRoom(item_num, room_num);
         }
 
         if (obj->save_anim) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This merges some of Lara's common functions into TRX, but also moves previous Item functions that were used exclusively by Lara  into her module as well for clarity. `Lara_MovePosition` will allow us to offer the walk to items feature in TR2 later.

I'd appreciate some checks for pickups and switches in particular (these call `Lara_MovePosition`), plus in TR1, with and without walk to items enabled. Other checks are quite general, such as Lara responding to geometry if for example mid-roll, or being nudged by walls while swimming etc.

Also, I'm happy to delay merging this until after 4.10 is out.
