### PR TITLE
items: restore extra rotation in TR1 exploding items

### DIFF
--- a/src/libtrx/game/items.c
+++ b/src/libtrx/game/items.c
@@ -663,10 +663,7 @@ int32_t Item_Explode(
 
         Matrix_TranslateRel32(bone->pos);
         Matrix_Rot16(best_frame->mesh_rots[i]);
-#if TR_VERSION != 1
-        // Removed from TR1 by GLrage on the grounds that it sometimes crashes.
         Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
-#endif
 
         bit <<= 1;
         if ((mesh_bits & bit) && (item->mesh_bits & bit)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Object_ApplyExtraRotation` handles cases when `nullptr` is passed to it, so this removes the legacy guard for exploding items that avoided applying any extra rotations.
