### PR TITLE
game: move level complete flag to TRX

### DIFF
--- a/src/libtrx/game/game.c
+++ b/src/libtrx/game/game.c
@@ -7,6 +7,7 @@
 static bool m_IsPlaying = false;
 static const GF_LEVEL *m_CurrentLevel = nullptr;
 static GAME_BONUS_FLAG m_BonusFlag = GBF_NONE;
+static bool m_IsLevelComplete = false;
 
 void Game_SetIsPlaying(const bool is_playing)
 {
@@ -64,4 +65,14 @@ void Game_SetBonusFlag(const GAME_BONUS_FLAG flag)
 bool Game_IsBonusFlagSet(const GAME_BONUS_FLAG flag)
 {
     return (m_BonusFlag & flag) != 0;
+}
+
+void Game_SetIsLevelComplete(const bool is_complete)
+{
+    m_IsLevelComplete = is_complete;
+}
+
+bool Game_IsLevelComplete(void)
+{
+    return m_IsLevelComplete;
 }

--- a/src/libtrx/include/libtrx/game/game.h
+++ b/src/libtrx/include/libtrx/game/game.h
@@ -16,6 +16,9 @@ GAME_BONUS_FLAG Game_GetBonusFlag(void);
 void Game_SetBonusFlag(GAME_BONUS_FLAG flag);
 bool Game_IsBonusFlagSet(GAME_BONUS_FLAG flag);
 
+void Game_SetIsLevelComplete(bool is_complete);
+bool Game_IsLevelComplete(void);
+
 extern bool Game_Start(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
 extern void Game_End(void);
 extern void Game_Suspend(void);

--- a/src/tr1/game/demo.c
+++ b/src/tr1/game/demo.c
@@ -233,7 +233,8 @@ GF_COMMAND Demo_Control(void)
         return gf_cmd;
     }
 
-    if (g_LevelComplete || g_InputDB.menu_confirm || g_InputDB.menu_back) {
+    if (Game_IsLevelComplete() || g_InputDB.menu_confirm
+        || g_InputDB.menu_back) {
         return (GF_COMMAND) {
             .action = GF_EXIT_TO_TITLE,
             .param = p->level->num,

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -115,7 +115,7 @@ GF_COMMAND Game_Control(const bool demo_mode)
     Stats_UpdateTimer();
 
     Lara_Cheat_Control();
-    if (g_LevelComplete) {
+    if (Game_IsLevelComplete()) {
         Sound_StopAll();
         Music_Stop();
         return (GF_COMMAND) { .action = GF_LEVEL_COMPLETE };

--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -382,7 +382,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
     Shell_ProcessInput();
     Game_ProcessInput();
 
-    m_StartLevel = g_LevelComplete ? g_GameInfo.select_level_num : -1;
+    m_StartLevel = Game_IsLevelComplete() ? g_GameInfo.select_level_num : -1;
 
     if (g_Config.gameplay.enable_timer_in_inventory) {
         Stats_UpdateTimer();

--- a/src/tr1/game/item_actions/finish_level.c
+++ b/src/tr1/game/item_actions/finish_level.c
@@ -1,8 +1,8 @@
 #include "game/item_actions/finish_level.h"
 
-#include "global/vars.h"
+#include <libtrx/game/game.h>
 
 void ItemAction_FinishLevel(ITEM *item)
 {
-    g_LevelComplete = true;
+    Game_SetIsLevelComplete(true);
 }

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -102,7 +102,7 @@ void Lara_Cheat_Control(void)
     case 8:
         if (g_LaraItem->fall_speed > 0) {
             if (as == LS_JUMP_FORWARD) {
-                g_LevelComplete = true;
+                Game_SetIsLevelComplete(true);
             } else if (as == LS_JUMP_BACK) {
                 Inv_AddItem(O_SHOTGUN_ITEM);
                 Inv_AddItem(O_MAGNUM_ITEM);
@@ -129,7 +129,7 @@ void Lara_Cheat_Control(void)
 
 void Lara_Cheat_EndLevel(void)
 {
-    g_LevelComplete = true;
+    Game_SetIsLevelComplete(true);
     Console_Log(GS(OSD_COMPLETE_LEVEL));
 }
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -362,7 +362,7 @@ bool Level_Initialise(
         resume->stats.distance_travelled = 0;
     }
 
-    g_LevelComplete = false;
+    Game_SetIsLevelComplete(false);
     if (level->type != GFL_TITLE && level->type != GFL_CUTSCENE) {
         Game_SetCurrentLevel((GF_LEVEL *)level);
     }

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -2,7 +2,6 @@
 
 #include "game/box.h"
 #include "game/camera.h"
-#include "game/game.h"
 #include "game/items.h"
 #include "game/lara/misc.h"
 #include "game/lot.h"
@@ -17,6 +16,7 @@
 #include "game/stats.h"
 #include "global/vars.h"
 
+#include <libtrx/game/game.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/utils.h>
 
@@ -76,7 +76,7 @@ static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
             static int16_t gym_completion_counter = 0;
             gym_completion_counter++;
             if (gym_completion_counter == LOGIC_FPS * 4) {
-                g_LevelComplete = true;
+                Game_SetIsLevelComplete(true);
                 gym_completion_counter = 0;
             }
         } else if (g_LaraItem->current_anim_state != LS_WATER_OUT) {
@@ -621,7 +621,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             break;
 
         case TO_FINISH:
-            g_LevelComplete = true;
+            Game_SetIsLevelComplete(true);
             break;
 
         case TO_CD:

--- a/src/tr1/global/vars.c
+++ b/src/tr1/global/vars.c
@@ -15,7 +15,6 @@ float g_FltResZBuf;
 LARA_INFO g_Lara = {};
 ITEM *g_LaraItem = nullptr;
 GAME_INFO g_GameInfo = { .select_save_slot = -1 };
-bool g_LevelComplete = false;
 int32_t g_OverlayFlag = 0;
 
 #ifndef MESON_BUILD

--- a/src/tr1/global/vars.h
+++ b/src/tr1/global/vars.h
@@ -23,5 +23,4 @@ extern int32_t g_FPSCounter;
 extern LARA_INFO g_Lara;
 extern ITEM *g_LaraItem;
 extern GAME_INFO g_GameInfo;
-extern bool g_LevelComplete;
 extern int32_t g_OverlayFlag;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -17,6 +17,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/game/collision.h>
+#include <libtrx/game/game.h>
 #include <libtrx/game/game_string_table.h>
 #include <libtrx/utils.h>
 
@@ -99,7 +100,7 @@ void InitialiseGameFlags(void)
 {
     Music_ResetTrackFlags();
     Output_SetSunsetTimer(0);
-    g_LevelComplete = false;
+    Game_SetIsLevelComplete(false);
     g_DetonateAllMines = false;
     Creature_SetAlliesHostile(false);
 }

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -60,7 +60,7 @@ GF_COMMAND Game_Control(const bool demo_mode)
         Lara_Cheat_CheckKeys();
     }
 
-    if (g_LevelComplete) {
+    if (Game_IsLevelComplete()) {
         return (GF_COMMAND) { .action = GF_LEVEL_COMPLETE };
     }
 

--- a/src/tr2/game/item_actions.c
+++ b/src/tr2/game/item_actions.c
@@ -11,6 +11,7 @@
 #include "global/vars.h"
 
 #include <libtrx/game/collision.h>
+#include <libtrx/game/game.h>
 #include <libtrx/game/gym.h>
 #include <libtrx/game/lara/common.h>
 #include <libtrx/utils.h>
@@ -112,7 +113,7 @@ void M_LaraHandsFree(ITEM *const item)
 
 void M_FinishLevel(ITEM *const item)
 {
-    g_LevelComplete = true;
+    Game_SetIsLevelComplete(true);
 }
 
 void M_Turn180(ITEM *const item)

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -109,7 +109,7 @@ static void M_ResetGunStatus(void)
 
 void Lara_Cheat_EndLevel(void)
 {
-    g_LevelComplete = true;
+    Game_SetIsLevelComplete(true);
     Console_Log(GS(OSD_COMPLETE_LEVEL));
 }
 

--- a/src/tr2/game/lara/cheat_keys.c
+++ b/src/tr2/game/lara/cheat_keys.c
@@ -29,7 +29,7 @@ static void M_ExplodeLara(void);
 
 static void M_CompleteLevel(void)
 {
-    g_LevelComplete = true;
+    Game_SetIsLevelComplete(true);
 }
 
 static void M_GiveItems(void)

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -14,6 +14,7 @@
 #include "global/vars.h"
 
 #include <libtrx/config.h>
+#include <libtrx/game/game.h>
 #include <libtrx/utils.h>
 
 #define LF_ROLL 2
@@ -832,7 +833,7 @@ void Lara_State_Extra_FinalAnim(ITEM *item, COLL_INFO *coll)
     } else if (Item_TestFrameEqual(item, LF_SHOWER_SHOTGUN_PICKUP)) {
         Lara_SwapSingleMesh(LM_HAND_R, O_LARA_SHOTGUN);
     } else if (Item_TestFrameEqual(item, LF_SHOWER_END)) {
-        g_LevelComplete = true;
+        Game_SetIsLevelComplete(true);
     }
 }
 

--- a/src/tr2/game/objects/traps/dying_monk.c
+++ b/src/tr2/game/objects/traps/dying_monk.c
@@ -1,8 +1,8 @@
 #include "game/items.h"
 #include "game/objects/common.h"
 #include "game/room.h"
-#include "global/vars.h"
 
+#include <libtrx/game/game.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/lara/common.h>
 #include <libtrx/utils.h>
@@ -68,7 +68,7 @@ static void M_Control(const int16_t item_num)
     const int32_t dz = ABS(lara_item->pos.z - item->pos.z);
     if (dx < WALL_L && dz < WALL_L && !lara_item->gravity
         && lara_item->pos.y == item->pos.y) {
-        g_LevelComplete = true;
+        Game_SetIsLevelComplete(true);
     }
 }
 

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -14,6 +14,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/game.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
@@ -341,7 +342,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         }
 
         case TO_FINISH:
-            g_LevelComplete = true;
+            Game_SetIsLevelComplete(true);
             break;
 
         case TO_FLIPEFFECT:

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -50,7 +50,6 @@ int32_t g_PhdWinRight;
 int32_t g_SurfaceCount;
 SORT_ITEM *g_Sort3DPtr = nullptr;
 uint16_t g_SoundOptionLine;
-int32_t g_LevelComplete;
 LARA_INFO g_Lara;
 ITEM *g_LaraItem = nullptr;
 CREATURE *g_BaddieSlots = nullptr;

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -51,7 +51,6 @@ extern int32_t g_PhdWinRight;
 extern int32_t g_SurfaceCount;
 extern SORT_ITEM *g_Sort3DPtr;
 extern uint16_t g_SoundOptionLine;
-extern int32_t g_LevelComplete;
 extern LARA_INFO g_Lara;
 extern ITEM *g_LaraItem;
 extern CREATURE *g_BaddieSlots;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This makes the level complete flag a private property in TRX's game module, and adds an appropriate getter and setter.

Just a quick test needed of the various ways to end a level:
- normal trigger, and the end of TR1 gym
- via cheats
- bird monster death/Qualopec Larson "death"
- dying monk in Diving Area
- HSH shower cutscene
