### PR TITLE
tr1/room: allow isolated flip effect triggers

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.1...develop) - ××××-××-××
+- added the ability to trigger a flip effect without having to also trigger the flip map, in line with TR2 (#2921)
 - fixed enemy hitpoints being doubled in demo mode as a result of NG+ (#2904)
 - fixed an illegal reachable slope in Lost Valley room 58, which could lead to Lara becoming softlocked (#2900)
 - fixed some pickup sprites being too far embedded into the floor (#2903)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -636,6 +636,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added per-level customizable fog distance
 - added deadly water feature from TR2+
 - added support for antitriggers, like TR2+
+- added the ability to trigger a flip effect without having to also trigger the flip map, like TR2+
 
 #### Miscellaneous
 - added Linux builds

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -395,6 +395,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
     bool switch_off = false;
     bool flip_map = false;
+    bool flip_available = false;
     int32_t new_effect = -1;
     ITEM *camera_item = nullptr;
     const bool flip_status = Room_GetFlipStatus();
@@ -572,6 +573,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_FLIPMAP: {
             const int16_t flip_slot = (int16_t)(intptr_t)cmd->parameter;
             int32_t slot_flags = Room_GetFlipSlotFlags(flip_slot);
+            flip_available = true;
             if (slot_flags & IF_ONE_SHOT) {
                 break;
             }
@@ -601,6 +603,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_FLIPON: {
             const int16_t flip_slot = (int16_t)(intptr_t)cmd->parameter;
             const int32_t slot_flags = Room_GetFlipSlotFlags(flip_slot);
+            flip_available = true;
             if ((slot_flags & IF_CODE_BITS) == IF_CODE_BITS && !flip_status) {
                 flip_map = true;
             }
@@ -610,6 +613,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_FLIPOFF: {
             const int16_t flip_slot = (int16_t)(intptr_t)cmd->parameter;
             const int32_t slot_flags = Room_GetFlipSlotFlags(flip_slot);
+            flip_available = true;
             if ((slot_flags & IF_CODE_BITS) == IF_CODE_BITS && flip_status) {
                 flip_map = true;
             }
@@ -645,9 +649,10 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
     if (flip_map) {
         Room_FlipMap();
-        if (new_effect != -1) {
-            Room_SetFlipEffect(new_effect);
-            Room_SetFlipTimer(0);
-        }
+    }
+
+    if (new_effect != -1 && (flip_map || !flip_available)) {
+        Room_SetFlipEffect(new_effect);
+        Room_SetFlipTimer(0);
     }
 }


### PR DESCRIPTION
Resolves #2921.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This brings TR1 flip effect triggers into line with TR2, where they can be triggered without also triggering the flip map at the same time.
