### PR TITLE
lara: use common LOT for sinks

### DIFF
--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -148,7 +148,7 @@ typedef struct {
     AMMO_INFO harpoon_ammo;
     AMMO_INFO grenade_ammo;
     AMMO_INFO m16_ammo;
-    CREATURE *creature;
+    LOT_INFO lot;
 
     struct {
         struct {

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -14,6 +14,7 @@
 #include "game/lara/look.h"
 #include "game/lara/misc.h"
 #include "game/lara/state.h"
+#include "game/lot.h"
 #include "game/music.h"
 #include "game/room.h"
 #include "game/savegame.h"
@@ -317,6 +318,8 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
 
     if (g_Lara.current_active && g_Lara.water_status != LWS_CHEAT) {
         Lara_WaterCurrent(coll);
+    } else {
+        LOT_ClearLOT(&g_Lara.lot);
     }
 
     Lara_Animate(item);
@@ -390,6 +393,8 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
     item->rot.y += g_Lara.turn_rate;
     if (g_Lara.current_active && g_Lara.water_status != LWS_CHEAT) {
         Lara_WaterCurrent(coll);
+    } else {
+        LOT_ClearLOT(&g_Lara.lot);
     }
 
     Lara_Animate(item);
@@ -785,7 +790,6 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.air = LARA_MAX_AIR;
     g_Lara.dive_count = 0;
     g_Lara.death_timer = 0;
-    g_Lara.current_active = 0;
     g_Lara.hit_effect_count = 0;
     g_Lara.flare_age = 0;
     g_Lara.back_gun = 0;
@@ -812,7 +816,13 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.right_arm.flash_gun = 0;
     g_Lara.left_arm.lock = 0;
     g_Lara.right_arm.lock = 0;
-    g_Lara.creature = nullptr;
+
+    g_Lara.current_active = 0;
+
+    LOT_InitialiseLOT(&g_Lara.lot);
+    g_Lara.lot.step = WALL_L * 20;
+    g_Lara.lot.drop = -WALL_L * 20;
+    g_Lara.lot.fly = STEP_L;
 
     if ((level->type == GFL_NORMAL || level->type == GFL_BONUS)
         && g_GF_LaraStartAnim) {

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -17,6 +17,7 @@
 #include <libtrx/game/lara/const.h>
 #include <libtrx/game/math.h>
 #include <libtrx/game/matrix.h>
+#include <libtrx/game/pathing/lot.h>
 #include <libtrx/utils.h>
 
 #define MAX_BADDIE_COLLISION 20
@@ -1572,14 +1573,8 @@ void Lara_WaterCurrent(COLL_INFO *const coll)
     g_LaraItem->box_num =
         Room_GetWorldSector(room, g_LaraItem->pos.x, g_LaraItem->pos.z)->box;
 
-    if (g_Lara.creature == nullptr) {
-        g_Lara.current_active = 0;
-        return;
-    }
-
     XYZ_32 target;
-    if (Box_CalculateTarget(&target, item, &g_Lara.creature->lot)
-        == TARGET_NONE) {
+    if (Box_CalculateTarget(&target, item, &g_Lara.lot) == TARGET_NONE) {
         return;
     }
 

--- a/src/tr2/game/lot.c
+++ b/src/tr2/game/lot.c
@@ -33,16 +33,11 @@ CREATURE *LOT_GetBaddieSlot(const int32_t i)
 
 void LOT_DisableBaddieAI(const int16_t item_num)
 {
-    CREATURE *creature;
+    ASSERT(item_num != g_Lara.item_num);
 
-    if (item_num == g_Lara.item_num) {
-        creature = g_Lara.creature;
-        g_Lara.creature = nullptr;
-    } else {
-        ITEM *const item = Item_Get(item_num);
-        creature = (CREATURE *)item->data;
-        item->data = nullptr;
-    }
+    ITEM *const item = Item_Get(item_num);
+    CREATURE *const creature = (CREATURE *)item->data;
+    item->data = nullptr;
 
     if (creature != nullptr) {
         creature->item_num = NO_ITEM;
@@ -52,11 +47,8 @@ void LOT_DisableBaddieAI(const int16_t item_num)
 
 bool LOT_EnableBaddieAI(const int16_t item_num, const bool always)
 {
-    if (g_Lara.item_num == item_num) {
-        if (g_Lara.creature != nullptr) {
-            return true;
-        }
-    } else if (Item_Get(item_num)->data != nullptr) {
+    ASSERT(item_num != g_Lara.item_num);
+    if (Item_Get(item_num)->data != nullptr) {
         return true;
     }
 
@@ -106,15 +98,10 @@ bool LOT_EnableBaddieAI(const int16_t item_num, const bool always)
 
 void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
 {
-
+    ASSERT(item_num != g_Lara.item_num);
     CREATURE *const creature = &g_BaddieSlots[slot];
     ITEM *const item = Item_Get(item_num);
-
-    if (item_num == g_Lara.item_num) {
-        g_Lara.creature = &g_BaddieSlots[slot];
-    } else {
-        item->data = creature;
-    }
+    item->data = creature;
 
     creature->item_num = item_num;
     creature->mood = MOOD_BORED;
@@ -129,12 +116,6 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     creature->lot.fly = 0;
 
     switch (item->object_id) {
-    case O_LARA:
-        creature->lot.step = WALL_L * 20;
-        creature->lot.drop = -WALL_L * 20;
-        creature->lot.fly = STEP_L;
-        break;
-
     case O_SHARK:
     case O_BARRACUDA:
     case O_DIVER:
@@ -171,10 +152,7 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     }
 
     LOT_ClearLOT(&creature->lot);
-
-    if (item_num != g_Lara.item_num) {
-        LOT_CreateZone(item);
-    }
+    LOT_CreateZone(item);
 
     m_SlotsUsed++;
 }
@@ -208,6 +186,13 @@ void LOT_CreateZone(ITEM *const item)
             creature->lot.zone_count++;
         }
     }
+}
+
+void LOT_InitialiseLOT(LOT_INFO *const lot)
+{
+    lot->node =
+        GameBuf_Alloc(sizeof(BOX_NODE) * Box_GetCount(), GBUF_CREATURE_LOT);
+    LOT_ClearLOT(lot);
 }
 
 void LOT_ClearLOT(LOT_INFO *const lot)

--- a/src/tr2/game/lot.h
+++ b/src/tr2/game/lot.h
@@ -7,3 +7,4 @@
 void LOT_InitialiseArray(void);
 void LOT_InitialiseSlot(int16_t item_num, int32_t slot);
 void LOT_CreateZone(ITEM *item);
+void LOT_InitialiseLOT(LOT_INFO *lot);

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -271,12 +271,10 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             const OBJECT_VECTOR *const sink =
                 Camera_GetFixedObject((int16_t)(intptr_t)cmd->parameter);
 
-            if (!g_Lara.creature) {
-                LOT_EnableBaddieAI(g_Lara.item_num, true);
+            if (g_Lara.lot.required_box != sink->flags) {
+                g_Lara.lot.target = sink->pos;
+                g_Lara.lot.required_box = sink->flags;
             }
-
-            g_Lara.creature->lot.target = sink->pos;
-            g_Lara.creature->lot.required_box = sink->flags;
             g_Lara.current_active = sink->data * 6;
             break;
         }

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -374,7 +374,6 @@ static void M_ReadLara(LARA_INFO *const lara)
     M_ReadAmmoInfo(&lara->grenade_ammo);
     M_ReadAmmoInfo(&lara->m16_ammo);
     M_Skip(4);
-    lara->creature = nullptr;
 }
 
 static void M_ReadLaraArm(LARA_ARM *const arm)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates TR2 to use the same approach as TR1 for Lara's `LOT` property when she is affected by water currents. Her `LOT` is now independent of a `CREATURE` slot.

Lara should behave the same when there is a current e.g. 40 Fathoms starting area, Temple of Xian waterfall. I've left some assertions in place to ensure that the previous creature usage was only for the purpose of currents for Lara (code-wise there are certainly no other uses I can find); if all looks well, I'll remove these.
