### PR TITLE
tr1/objects/traps: make falling traps acknowledge room below

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed vase room sprites in Return to Egypt and Temple of the Cat being embedded in the floor (#2095)
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 4.10)
 - fixed FPS counter turning off after a game relaunch (#2911)
+- fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -637,6 +637,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added deadly water feature from TR2+
 - added support for antitriggers, like TR2+
 - added the ability to trigger a flip effect without having to also trigger the flip map, like TR2+
+- fixed falling ceiling and Damocles Sword traps not falling through stacked rooms
 
 #### Miscellaneous
 - added Linux builds

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -33,6 +33,11 @@ static void M_Initialise(const int16_t item_num)
     item->rot.y = Random_GetControl();
     item->required_anim_state = (Random_GetControl() - 0x4000) / 16;
     item->fall_speed = 50;
+
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 }
 
 static void M_Control(const int16_t item_num)
@@ -44,6 +49,15 @@ static void M_Control(const int16_t item_num)
         item->pos.y += item->fall_speed;
         item->pos.x += item->current_anim_state;
         item->pos.z += item->goal_anim_state;
+
+        int16_t room_num = item->room_num;
+        const SECTOR *const sector =
+            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        const int16_t height =
+            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+
+        item->floor = height;
+        Item_UpdateRoom(item_num, room_num);
 
         if (item->pos.y > item->floor) {
             Sound_Effect(SFX_DAMOCLES_SWORD, &item->pos, SPM_NORMAL);

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -22,17 +22,28 @@ static void M_Control(const int16_t item_num)
     if (item->current_anim_state == TRAP_SET) {
         item->goal_anim_state = TRAP_ACTIVATE;
         item->gravity = 1;
-    } else if (item->current_anim_state == TRAP_ACTIVATE && item->touch_bits) {
+    } else if (
+        item->current_anim_state == TRAP_ACTIVATE && item->touch_bits != 0) {
         Lara_TakeDamage(FALLING_CEILING_DAMAGE, true);
     }
+
     Item_Animate(item);
     if (item->status == IS_DEACTIVATED) {
         Item_RemoveActive(item_num);
-    } else if (
-        item->current_anim_state == TRAP_ACTIVATE
-        && item->pos.y >= item->floor) {
+        return;
+    }
+
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const int16_t height =
+        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+
+    item->floor = height;
+    Item_UpdateRoom(item_num, room_num);
+    if (item->current_anim_state == TRAP_ACTIVATE && item->pos.y >= height) {
+        item->pos.y = height;
         item->goal_anim_state = TRAP_WORKING;
-        item->pos.y = item->floor;
         item->fall_speed = 0;
         item->gravity = 0;
     }


### PR DESCRIPTION
Resolves #2924.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes falling ceiling and Damocles Sword traps not falling through stacked rooms. Test level available, and worth double checking the OG instances behave normally.
