### PR TITLE
Convert miscellaneous elements to UI

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 4.10)
 - fixed FPS counter turning off after a game relaunch (#2911)
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
+- fixed health bar in top center position covering inventory text
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...develop) - ××××-××-××
+- added a flashing Demo Mode caption to demos (#1556)
 - added aliases to CLI options (`-gold` becomes `-g/--gold`)
 - added a `--help` CLI option (may not output anything on Windows machines – OS bug)
 - added explosion sprites to Home Sweet Home (#1569)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...develop) - ××××-××-××
 - added a flashing Demo Mode caption to demos (#1556)
+- added arrows to the passport text like in TR1X (#2926)
 - added aliases to CLI options (`-gold` becomes `-g/--gold`)
 - added a `--help` CLI option (may not output anything on Windows machines – OS bug)
 - added explosion sprites to Home Sweet Home (#1569)

--- a/src/libtrx/game/inventory_ring/priv.c
+++ b/src/libtrx/game/inventory_ring/priv.c
@@ -9,11 +9,10 @@
 #include "game/objects/names.h"
 #include "game/output.h"
 #include "game/overlay.h"
-#include "game/text.h"
 #include "game/ui.h"
-#include "version.h"
 
 #include <stdio.h>
+#include <string.h>
 
 #define RING_CAMERA_Y_OFFSET (-96)
 
@@ -30,16 +29,7 @@ typedef enum {
     // clang-format on
 } PASS_MESH;
 
-typedef enum {
-    IT_NAME,
-    IT_QTY,
-    IT_NUMBER_OF,
-} INV_TEXT;
-
-// TODO: drop in favor of the Overlay APIs
-static TEXTSTRING *m_HeadingText = nullptr;
-static TEXTSTRING *m_VersionText = nullptr;
-static TEXTSTRING *m_ItemText[IT_NUMBER_OF] = {};
+static char m_CountText[128];
 static GAME_OBJECT_ID m_RequestedObjectID = NO_OBJECT;
 
 static void M_HandleRequestedObject(INV_RING *ring);
@@ -418,37 +408,27 @@ void InvRing_SelectMeshes(INVENTORY_ITEM *const inv_item)
 
 void InvRing_ShowItemName(const INVENTORY_ITEM *const inv_item)
 {
-    if (m_ItemText[IT_NAME] != nullptr) {
-        return;
-    }
     if (inv_item->object_id == O_PASSPORT_OPTION) {
         return;
     }
-    m_ItemText[IT_NAME] =
-        Text_Create(0, -16, Object_GetName(inv_item->object_id));
-    Text_AlignBottom(m_ItemText[IT_NAME], true);
-    Text_CentreH(m_ItemText[IT_NAME], true);
+    Overlay_SetBottomText(Object_GetName(inv_item->object_id), false);
 }
 
 void InvRing_ShowItemQuantity(const char *const fmt, const int32_t qty)
 {
-    if (m_ItemText[IT_QTY] != nullptr) {
-        return;
-    }
-    char string[128];
-    sprintf(string, fmt, qty);
-    UI_AmmoLabel_MakeString(string);
-    m_ItemText[IT_QTY] = Text_Create(64, -56, string);
-    Text_AlignBottom(m_ItemText[IT_QTY], true);
-    Text_CentreH(m_ItemText[IT_QTY], true);
+    sprintf(m_CountText, fmt, qty);
+    UI_AmmoLabel_MakeString(m_CountText);
+}
+
+const char *InvRing_GetItemQuantityText(void)
+{
+    return m_CountText;
 }
 
 void InvRing_RemoveItemTexts(void)
 {
-    for (int32_t i = 0; i < IT_NUMBER_OF; i++) {
-        Text_Remove(m_ItemText[i]);
-        m_ItemText[i] = nullptr;
-    }
+    Overlay_SetBottomText(nullptr, false);
+    strcpy(m_CountText, "");
 }
 
 void InvRing_ShowHeader(INV_RING *const ring)
@@ -457,29 +437,22 @@ void InvRing_ShowHeader(INV_RING *const ring)
         return;
     }
 
-    if (m_HeadingText == nullptr) {
-        switch (ring->type) {
-        case RT_MAIN:
-            m_HeadingText = Text_Create(0, 26, GS(HEADING_INVENTORY));
-            break;
-
-        case RT_OPTION:
-            if (ring->mode == INV_DEATH_MODE) {
-                m_HeadingText = Text_Create(0, 26, GS(HEADING_GAME_OVER));
-            } else {
-                m_HeadingText = Text_Create(0, 26, GS(HEADING_OPTION));
-            }
-            break;
-
-        case RT_KEYS:
-            m_HeadingText = Text_Create(0, 26, GS(HEADING_ITEMS));
-            break;
-
-        case RT_NUMBER_OF:
-            break;
+    switch (ring->type) {
+    case RT_MAIN:
+        Overlay_SetTopText(GS(HEADING_INVENTORY), false);
+        break;
+    case RT_OPTION:
+        if (ring->mode == INV_DEATH_MODE) {
+            Overlay_SetTopText(GS(HEADING_GAME_OVER), false);
+        } else {
+            Overlay_SetTopText(GS(HEADING_OPTION), false);
         }
-
-        Text_CentreH(m_HeadingText, true);
+        break;
+    case RT_KEYS:
+        Overlay_SetTopText(GS(HEADING_ITEMS), false);
+        break;
+    case RT_NUMBER_OF:
+        break;
     }
 
     if (ring->mode != INV_GAME_MODE) {
@@ -500,8 +473,7 @@ void InvRing_ShowHeader(INV_RING *const ring)
 
 void InvRing_RemoveHeader(void)
 {
-    Text_Remove(m_HeadingText);
-    m_HeadingText = nullptr;
+    Overlay_SetTopText(nullptr, false);
     Overlay_ShowArrows(UI_OVERLAY_ARROW_TL, false);
     Overlay_ShowArrows(UI_OVERLAY_ARROW_TR, false);
     Overlay_ShowArrows(UI_OVERLAY_ARROW_BL, false);
@@ -515,16 +487,12 @@ void InvRing_HideArrow(const INV_RING_ARROW arrow, const bool hide)
 
 void InvRing_ShowVersionText(void)
 {
-    m_VersionText = Text_Create(-20, -18, g_TRXVersion);
-    Text_AlignRight(m_VersionText, true);
-    Text_AlignBottom(m_VersionText, true);
-    Text_SetScale(m_VersionText, TEXT_BASE_SCALE * 0.5, TEXT_BASE_SCALE * 0.5);
+    Overlay_ShowVersion(true);
 }
 
 void InvRing_RemoveVersionText(void)
 {
-    Text_Remove(m_VersionText);
-    m_VersionText = nullptr;
+    Overlay_ShowVersion(false);
 }
 
 void InvRing_UpdateInventoryItem(

--- a/src/libtrx/game/inventory_ring/priv.c
+++ b/src/libtrx/game/inventory_ring/priv.c
@@ -464,25 +464,25 @@ void InvRing_ShowHeader(INV_RING *const ring)
     const bool show_bottom_arrow = ring->type == RT_KEYS
         || (ring->type == RT_MAIN && !InvRing_IsOptionLockedOut());
 
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_TL, show_up_arrow);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_TR, show_up_arrow);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_TL, show_up_arrow);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_TR, show_up_arrow);
 
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_BL, show_bottom_arrow);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_BR, show_bottom_arrow);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BL, show_bottom_arrow);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BR, show_bottom_arrow);
 }
 
 void InvRing_RemoveHeader(void)
 {
     Overlay_SetTopText(nullptr, false);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_TL, false);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_TR, false);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_BL, false);
-    Overlay_ShowArrows(UI_OVERLAY_ARROW_BR, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_TL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_TR, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BR, false);
 }
 
 void InvRing_HideArrow(const INV_RING_ARROW arrow, const bool hide)
 {
-    Overlay_ShowArrows((UI_OVERLAY_ARROW)arrow, hide);
+    Overlay_ShowArrow((UI_OVERLAY_ARROW)arrow, hide);
 }
 
 void InvRing_ShowVersionText(void)

--- a/src/libtrx/game/overlay.c
+++ b/src/libtrx/game/overlay.c
@@ -43,10 +43,10 @@ void Overlay_SetHealthBarTimer(const int16_t timer)
     UI_LaraHealthBar_SetTimer(timer);
 }
 
-void Overlay_ShowArrows(const UI_OVERLAY_ARROW arrow, const bool show)
+void Overlay_ShowArrow(const UI_OVERLAY_ARROW arrow, const bool show)
 {
     if (m_UI != nullptr) {
-        UI_Overlay_ShowArrows(m_UI, arrow, show);
+        UI_Overlay_ShowArrow(m_UI, arrow, show);
     }
 }
 

--- a/src/libtrx/game/overlay.c
+++ b/src/libtrx/game/overlay.c
@@ -50,6 +50,20 @@ void Overlay_ShowArrows(const UI_OVERLAY_ARROW arrow, const bool show)
     }
 }
 
+void Overlay_ShowVersion(const bool show)
+{
+    if (m_UI != nullptr) {
+        UI_Overlay_ShowVersion(m_UI, show);
+    }
+}
+
+void Overlay_SetTopText(const char *const text, const bool flash)
+{
+    if (m_UI != nullptr) {
+        UI_Overlay_SetTopText(m_UI, text, flash);
+    }
+}
+
 void Overlay_SetBottomText(const char *const text, const bool flash)
 {
     if (m_UI != nullptr) {

--- a/src/libtrx/game/phase/phase_demo.c
+++ b/src/libtrx/game/phase/phase_demo.c
@@ -7,7 +7,6 @@
 #include "game/inventory_ring.h"
 #include "game/output.h"
 #include "game/shell.h"
-#include "game/text.h"
 #include "memory.h"
 
 typedef enum {
@@ -119,7 +118,6 @@ static void M_Draw(PHASE *const phase)
     if (p->state == STATE_FADE_OUT) {
         Interpolation_Enable();
     }
-    Text_Draw();
     Fader_Draw(&p->top_fader);
     Output_DrawPolyList();
 }

--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -31,7 +31,6 @@ typedef struct {
         bool is_ready;
         UI_PAUSE_STATE state;
     } ui;
-    TEXTSTRING *mode_text;
     GF_ACTION action;
     FADER back_fader;
 } M_PRIV;
@@ -90,17 +89,12 @@ static void M_ExitToTitle(M_PRIV *const p)
 
 static void M_CreateText(M_PRIV *const p)
 {
-    if (p->mode_text == nullptr) {
-        p->mode_text = Text_Create(0, -24, GS(PAUSE_PAUSED));
-        Text_CentreH(p->mode_text, true);
-        Text_AlignBottom(p->mode_text, true);
-    }
+    Overlay_SetBottomText(GS(PAUSE_PAUSED), false);
 }
 
 static void M_RemoveText(M_PRIV *const p)
 {
-    Text_Remove(p->mode_text);
-    p->mode_text = nullptr;
+    Overlay_SetBottomText(nullptr, false);
 }
 
 static PHASE_CONTROL M_Start(PHASE *const phase)

--- a/src/libtrx/game/ui/hud/overlay.c
+++ b/src/libtrx/game/ui/hud/overlay.c
@@ -18,6 +18,7 @@
 #include "game/ui/elements/spacer.h"
 #include "game/ui/elements/stack.h"
 #include "memory.h"
+#include "version.h"
 
 typedef struct UI_OVERLAY_STATE {
     struct {
@@ -27,10 +28,11 @@ typedef struct UI_OVERLAY_STATE {
     UI_FPS_COUNTER_STATE *fps;
     bool force_show_healthbar;
     bool show_arrows[4];
+    bool show_version;
     struct {
         const char *text;
         bool flash_enabled;
-    } bottom_text;
+    } top_text, bottom_text;
     UI_FLASH_STATE flash_state;
 } UI_OVERLAY_STATE;
 
@@ -137,6 +139,15 @@ static void M_TopCenterRegion(const UI_OVERLAY_STATE *const s)
     M_LaraHealthBar(s, BL_TOP_CENTER);
     M_LaraAirBar(s, BL_TOP_CENTER);
     M_EnemyHealthBar(BL_TOP_CENTER);
+    if (s->top_text.text != nullptr) {
+        if (s->top_text.flash_enabled) {
+            UI_BeginFlash(&s->flash_state);
+        }
+        UI_Label(s->top_text.text);
+        if (s->top_text.flash_enabled) {
+            UI_EndFlash();
+        }
+    }
     UI_EndOverlayRegion();
 }
 
@@ -196,6 +207,9 @@ static void M_BottomRightRegion(const UI_OVERLAY_STATE *const s)
     bar_shown |= M_EnemyHealthBar(BL_BOTTOM_RIGHT);
     if (!bar_shown) {
         M_Arrow(s, UI_OVERLAY_ARROW_BR);
+    }
+    if (s->show_version) {
+        UI_LabelEx(g_TRXVersion, (UI_LABEL_SETTINGS) { .scale = 0.5f });
     }
     UI_EndOverlayRegion();
 }
@@ -277,6 +291,18 @@ void UI_Overlay_ShowArrows(
     UI_OVERLAY_STATE *const s, const UI_OVERLAY_ARROW arrow, const bool show)
 {
     s->show_arrows[arrow] = show;
+}
+
+void UI_Overlay_ShowVersion(UI_OVERLAY_STATE *const s, const bool show)
+{
+    s->show_version = show;
+}
+
+void UI_Overlay_SetTopText(
+    UI_OVERLAY_STATE *const s, const char *const text, const bool flash)
+{
+    s->top_text.text = text;
+    s->top_text.flash_enabled = flash;
 }
 
 void UI_Overlay_SetBottomText(

--- a/src/libtrx/game/ui/hud/overlay.c
+++ b/src/libtrx/game/ui/hud/overlay.c
@@ -9,6 +9,7 @@
 #include "game/ui/elements/bar_enemy_hp.h"
 #include "game/ui/elements/bar_lara_air.h"
 #include "game/ui/elements/bar_lara_hp.h"
+#include "game/ui/elements/fixed.h"
 #include "game/ui/elements/flash.h"
 #include "game/ui/elements/fps_counter.h"
 #include "game/ui/elements/label.h"
@@ -27,7 +28,7 @@ typedef struct UI_OVERLAY_STATE {
     } blink;
     UI_FPS_COUNTER_STATE *fps;
     bool force_show_healthbar;
-    bool show_arrows[4];
+    bool show_arrows[6];
     bool show_version;
     struct {
         const char *text;
@@ -35,6 +36,18 @@ typedef struct UI_OVERLAY_STATE {
     } top_text, bottom_text;
     UI_FLASH_STATE flash_state;
 } UI_OVERLAY_STATE;
+
+static struct {
+    bool resize;
+    const char *label;
+} m_ArrowInfo[] = {
+    [UI_OVERLAY_ARROW_TR] = { true, "\\{arrow up}" },
+    [UI_OVERLAY_ARROW_TL] = { true, "\\{arrow up}" },
+    [UI_OVERLAY_ARROW_BL] = { true, "\\{arrow down}" },
+    [UI_OVERLAY_ARROW_BR] = { true, "\\{arrow down}" },
+    [UI_OVERLAY_ARROW_BCL] = { false, "\\{button left}" },
+    [UI_OVERLAY_ARROW_BCR] = { false, "\\{button right}" },
+};
 
 static bool M_LaraHealthBar(const UI_OVERLAY_STATE *s, BAR_LOCATION location);
 static bool M_LaraAirBar(const UI_OVERLAY_STATE *s, BAR_LOCATION location);
@@ -99,21 +112,20 @@ static void M_Arrow(
 {
     if (s->show_arrows[arrow]) {
         // make sure the arrow has exactly the same size as the bar
-        UI_BeginResize(
-            -1.0,
-            UI_BAR_HEIGHT * Scaler_GetScale(SCALER_TARGET_BAR)
-                / Scaler_GetScale(SCALER_TARGET_TEXT));
-        switch (arrow) {
-        case UI_OVERLAY_ARROW_TL:
-        case UI_OVERLAY_ARROW_TR:
-            UI_Label("\\{arrow up}");
-            break;
-        case UI_OVERLAY_ARROW_BL:
-        case UI_OVERLAY_ARROW_BR:
-            UI_Label("\\{arrow down}");
-            break;
+        if (m_ArrowInfo[arrow].resize) {
+            UI_BeginResize(
+                -1.0,
+                UI_BAR_HEIGHT * Scaler_GetScale(SCALER_TARGET_BAR)
+                    / Scaler_GetScale(SCALER_TARGET_TEXT));
+        } else {
+            UI_BeginFixed(0.5f, 0.5f);
         }
-        UI_EndResize();
+        UI_Label(m_ArrowInfo[arrow].label);
+        if (m_ArrowInfo[arrow].resize) {
+            UI_EndResize();
+        } else {
+            UI_EndFixed();
+        }
     }
 }
 
@@ -187,7 +199,15 @@ static void M_BottomCenterRegion(const UI_OVERLAY_STATE *const s)
         if (s->bottom_text.flash_enabled) {
             UI_BeginFlash(&s->flash_state);
         }
+        UI_BeginStackEx((UI_STACK_SETTINGS) {
+            .orientation = UI_STACK_HORIZONTAL,
+            .spacing = { .h = 20 },
+            .align = { .v = UI_STACK_V_ALIGN_CENTER },
+        });
+        M_Arrow(s, UI_OVERLAY_ARROW_BCL);
         UI_Label(s->bottom_text.text);
+        M_Arrow(s, UI_OVERLAY_ARROW_BCR);
+        UI_EndStack();
         if (s->bottom_text.flash_enabled) {
             UI_EndFlash();
         }
@@ -287,7 +307,7 @@ void UI_EndOverlayRegion(void)
     UI_EndModal();
 }
 
-void UI_Overlay_ShowArrows(
+void UI_Overlay_ShowArrow(
     UI_OVERLAY_STATE *const s, const UI_OVERLAY_ARROW arrow, const bool show)
 {
     s->show_arrows[arrow] = show;

--- a/src/libtrx/include/libtrx/game/inventory_ring/priv.h
+++ b/src/libtrx/include/libtrx/game/inventory_ring/priv.h
@@ -54,6 +54,7 @@ void InvRing_RemoveHeader(void);
 void InvRing_HideArrow(INV_RING_ARROW arrow, bool hide);
 void InvRing_ShowVersionText(void);
 void InvRing_RemoveVersionText(void);
+const char *InvRing_GetItemQuantityText(void);
 
 void InvRing_UpdateInventoryItem(
     const INV_RING *ring, INVENTORY_ITEM *inv_item, int32_t num_frames);

--- a/src/libtrx/include/libtrx/game/overlay.h
+++ b/src/libtrx/include/libtrx/game/overlay.h
@@ -14,7 +14,7 @@ extern void Overlay_DrawModeInfo(void);
 
 void Overlay_ForceHealthBar(bool show);
 void Overlay_SetHealthBarTimer(int16_t health_bar_timer);
-void Overlay_ShowArrows(UI_OVERLAY_ARROW arrow, bool show);
+void Overlay_ShowArrow(UI_OVERLAY_ARROW arrow, bool show);
 void Overlay_ShowVersion(bool show);
 void Overlay_SetTopText(const char *text, bool flash);
 void Overlay_SetBottomText(const char *text, bool flash);

--- a/src/libtrx/include/libtrx/game/overlay.h
+++ b/src/libtrx/include/libtrx/game/overlay.h
@@ -15,4 +15,6 @@ extern void Overlay_DrawModeInfo(void);
 void Overlay_ForceHealthBar(bool show);
 void Overlay_SetHealthBarTimer(int16_t health_bar_timer);
 void Overlay_ShowArrows(UI_OVERLAY_ARROW arrow, bool show);
+void Overlay_ShowVersion(bool show);
+void Overlay_SetTopText(const char *text, bool flash);
 void Overlay_SetBottomText(const char *text, bool flash);

--- a/src/libtrx/include/libtrx/game/ui/hud/overlay.h
+++ b/src/libtrx/include/libtrx/game/ui/hud/overlay.h
@@ -26,5 +26,7 @@ void UI_EndOverlayRegion(void);
 void UI_Overlay_ForceHealthBar(UI_OVERLAY_STATE *s, bool show);
 void UI_Overlay_ShowArrows(
     UI_OVERLAY_STATE *s, UI_OVERLAY_ARROW arrow, bool show);
+void UI_Overlay_ShowVersion(UI_OVERLAY_STATE *s, bool show);
+void UI_Overlay_SetTopText(UI_OVERLAY_STATE *s, const char *text, bool flash);
 void UI_Overlay_SetBottomText(
     UI_OVERLAY_STATE *s, const char *text, bool flash);

--- a/src/libtrx/include/libtrx/game/ui/hud/overlay.h
+++ b/src/libtrx/include/libtrx/game/ui/hud/overlay.h
@@ -5,10 +5,12 @@
 #include "../common.h"
 
 typedef enum {
-    UI_OVERLAY_ARROW_TL,
-    UI_OVERLAY_ARROW_TR,
-    UI_OVERLAY_ARROW_BL,
-    UI_OVERLAY_ARROW_BR,
+    UI_OVERLAY_ARROW_TL, // top-left screen corner
+    UI_OVERLAY_ARROW_TR, // top-right screen corner
+    UI_OVERLAY_ARROW_BL, // bottom-left screen corner
+    UI_OVERLAY_ARROW_BR, // bottom-right screen corner
+    UI_OVERLAY_ARROW_BCL, // low text left side
+    UI_OVERLAY_ARROW_BCR, // low text right side
 } UI_OVERLAY_ARROW;
 
 typedef struct UI_OVERLAY_STATE UI_OVERLAY_STATE;
@@ -24,7 +26,7 @@ void UI_BeginOverlayRegion(float x, float y);
 void UI_EndOverlayRegion(void);
 
 void UI_Overlay_ForceHealthBar(UI_OVERLAY_STATE *s, bool show);
-void UI_Overlay_ShowArrows(
+void UI_Overlay_ShowArrow(
     UI_OVERLAY_STATE *s, UI_OVERLAY_ARROW arrow, bool show);
 void UI_Overlay_ShowVersion(UI_OVERLAY_STATE *s, bool show);
 void UI_Overlay_SetTopText(UI_OVERLAY_STATE *s, const char *text, bool flash);

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -16,6 +16,7 @@
 #include <libtrx/game/interpolation.h>
 #include <libtrx/game/inventory_ring/priv.h>
 #include <libtrx/game/matrix.h>
+#include <libtrx/game/ui.h>
 
 static int32_t M_GetFrames(
     const INV_RING *ring, const INVENTORY_ITEM *inv_item,
@@ -197,6 +198,15 @@ void InvRing_Draw(INV_RING *const ring)
         for (int32_t i = 0; i < num_frames; i++) {
             InvRing_DoMotions(ring);
         }
+    }
+
+    const char *const count_text = InvRing_GetItemQuantityText();
+    if (count_text != nullptr) {
+        UI_BeginModal(0.5f, 1.0f);
+        UI_BeginOffset(64.0f, -56.0f);
+        UI_Label(count_text);
+        UI_EndOffset();
+        UI_EndModal();
     }
 
     Fader_Draw(&ring->top_fader);

--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -6,6 +6,7 @@
 #include "game/input.h"
 #include "game/inventory.h"
 #include "game/inventory_ring.h"
+#include "game/overlay.h"
 #include "game/savegame.h"
 #include "game/screen.h"
 #include "game/sound.h"
@@ -18,17 +19,6 @@
 #include <libtrx/memory.h>
 
 #include <stdint.h>
-
-#define MAX_GAME_MODES 4
-#define MIN_NAME_WIDTH 140
-#define NAME_SPACER 15
-
-typedef enum {
-    TEXT_PAGE_NAME = 0,
-    TEXT_LEFT_ARROW = 1,
-    TEXT_RIGHT_ARROW = 2,
-    TEXT_NUMBER_OF = 5,
-} PASSPORT_TEXT;
 
 typedef enum {
     PAGE_UNDETERMINED = -1,
@@ -70,13 +60,9 @@ static struct {
     },
 };
 
-static bool m_IsTextInit = false;
-static TEXTSTRING *m_Text[TEXT_NUMBER_OF] = {};
-
 static void M_InitRequesters(void);
 static void M_InitText(void);
 static void M_RemoveAllText(void);
-static void M_Close(INVENTORY_ITEM *inv_item);
 static void M_SyncArrowsVisibility(void);
 static void M_ChangePageTextContent(const char *text);
 static void M_SetPage(int32_t page, PASSPORT_MODE role, bool available);
@@ -90,8 +76,9 @@ static void M_SelectLevel(void);
 static void M_SaveGame(void);
 static void M_NewGame(void);
 static void M_Restart(INVENTORY_ITEM *inv_item);
-static void M_FlipRight(INVENTORY_ITEM *inv_item);
 static void M_FlipLeft(INVENTORY_ITEM *inv_item);
+static void M_FlipRight(INVENTORY_ITEM *inv_item);
+static void M_Close(INVENTORY_ITEM *inv_item);
 static void M_ShowPage(INVENTORY_ITEM *inv_item);
 static void M_HandleFlipInputs(void);
 
@@ -109,26 +96,16 @@ static void M_FreeRequesters(void)
 
 static void M_InitText(void)
 {
-    m_Text[TEXT_LEFT_ARROW] = Text_Create(-85, -15, "\\{button left}");
-    Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
-
-    m_Text[TEXT_RIGHT_ARROW] = Text_Create(70, -15, "\\{button right}");
-    Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
-
-    m_Text[TEXT_PAGE_NAME] = Text_Create(0, -16, "");
-
-    for (int i = 0; i < TEXT_NUMBER_OF; i++) {
-        Text_AlignBottom(m_Text[i], 1);
-        Text_CentreH(m_Text[i], 1);
-    }
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, false);
+    Overlay_SetBottomText(nullptr, false);
 }
 
 static void M_RemoveAllText(void)
 {
-    for (int i = 0; i < TEXT_NUMBER_OF; i++) {
-        Text_Remove(m_Text[i]);
-        m_Text[i] = nullptr;
-    }
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, false);
+    Overlay_SetBottomText(nullptr, false);
     if (m_State.select_level.state != nullptr) {
         UI_SelectLevelDialog_Free(m_State.select_level.state);
         m_State.select_level.state = nullptr;
@@ -140,23 +117,11 @@ static void M_RemoveAllText(void)
     M_FreeRequesters();
 }
 
-static void M_Close(INVENTORY_ITEM *inv_item)
-{
-    M_RemoveAllText();
-    if (m_State.current_page == PAGE_3) {
-        inv_item->anim_direction = 1;
-        inv_item->goal_frame = inv_item->frames_total - 1;
-    } else {
-        inv_item->anim_direction = -1;
-        inv_item->goal_frame = 0;
-    }
-}
-
 static void M_SyncArrowsVisibility(void)
 {
     if (m_State.mode != PASSPORT_MODE_BROWSE) {
-        Text_Hide(m_Text[TEXT_LEFT_ARROW], true);
-        Text_Hide(m_Text[TEXT_RIGHT_ARROW], true);
+        Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, false);
+        Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, false);
     } else {
         bool has_pages_to_left = false;
         bool has_pages_to_right = false;
@@ -166,19 +131,15 @@ static void M_SyncArrowsVisibility(void)
             has_pages_to_right |=
                 (page > m_State.active_page) && m_State.pages[page].available;
         }
-        Text_Hide(m_Text[TEXT_LEFT_ARROW], !has_pages_to_left);
-        Text_Hide(m_Text[TEXT_RIGHT_ARROW], !has_pages_to_right);
+        Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, has_pages_to_left);
+        Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, has_pages_to_right);
     }
 }
 
 static void M_ChangePageTextContent(const char *const content)
 {
     InvRing_RemoveAllText();
-    Text_ChangeText(m_Text[TEXT_PAGE_NAME], content);
-    const int32_t width = Text_GetWidth(m_Text[TEXT_PAGE_NAME]);
-    const int32_t x_pos = MAX(width, MIN_NAME_WIDTH) / 2 + NAME_SPACER;
-    Text_SetPos(m_Text[TEXT_LEFT_ARROW], -x_pos, -15);
-    Text_SetPos(m_Text[TEXT_RIGHT_ARROW], x_pos, -15);
+    Overlay_SetBottomText(content, false);
 }
 
 static void M_SetPage(
@@ -461,6 +422,13 @@ static void M_Restart(INVENTORY_ITEM *inv_item)
     }
 }
 
+static void M_FlipLeft(INVENTORY_ITEM *inv_item)
+{
+    inv_item->anim_direction = -1;
+    inv_item->goal_frame = inv_item->open_frame + 5 * m_State.active_page;
+    Sound_Effect(SFX_MENU_PASSPORT, nullptr, SPM_ALWAYS);
+}
+
 static void M_FlipRight(INVENTORY_ITEM *inv_item)
 {
     inv_item->anim_direction = 1;
@@ -468,11 +436,16 @@ static void M_FlipRight(INVENTORY_ITEM *inv_item)
     Sound_Effect(SFX_MENU_PASSPORT, nullptr, SPM_ALWAYS);
 }
 
-static void M_FlipLeft(INVENTORY_ITEM *inv_item)
+static void M_Close(INVENTORY_ITEM *inv_item)
 {
-    inv_item->anim_direction = -1;
-    inv_item->goal_frame = inv_item->open_frame + 5 * m_State.active_page;
-    Sound_Effect(SFX_MENU_PASSPORT, nullptr, SPM_ALWAYS);
+    M_RemoveAllText();
+    if (m_State.current_page == PAGE_3) {
+        inv_item->anim_direction = 1;
+        inv_item->goal_frame = inv_item->frames_total - 1;
+    } else {
+        inv_item->anim_direction = -1;
+        inv_item->goal_frame = 0;
+    }
 }
 
 static void M_ShowPage(INVENTORY_ITEM *const inv_item)
@@ -541,7 +514,6 @@ void Option_Passport_Control(INVENTORY_ITEM *inv_item, const bool is_busy)
     if (m_State.active_page == -1) {
         M_InitRequesters();
         M_InitText();
-        m_IsTextInit = true;
         M_DeterminePages();
     }
 

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -16,7 +16,6 @@
 #include "game/savegame.h"
 #include "game/sound.h"
 #include "game/stats.h"
-#include "game/text.h"
 #include "global/vars.h"
 
 #include <libtrx/config.h>
@@ -161,11 +160,7 @@ bool Demo_Start(const int32_t level_num)
     Camera_Initialise();
     Stats_StartTimer();
 
-    p->text = Text_Create(0, g_PhdWinHeight - 16, GS(MISC_DEMO_MODE));
-    Text_Flash(p->text, true, 20);
-    Text_CentreV(p->text, true);
-    Text_CentreH(p->text, true);
-
+    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
     return true;
 }
 
@@ -173,18 +168,18 @@ void Demo_End(void)
 {
     M_PRIV *const p = &m_Priv;
     M_RestoreConfig(p);
-    Text_Remove(p->text);
+    Overlay_SetBottomText(nullptr, false);
     Overlay_HideGameInfo();
     Sound_StopAll();
     Music_Stop();
     Music_SetVolume(g_Config.audio.music_volume);
-    p->text = nullptr;
 }
 
 void Demo_Pause(void)
 {
     M_PRIV *const p = &m_Priv;
     M_RestoreConfig(p);
+    Overlay_SetBottomText(nullptr, false);
 }
 
 void Demo_Unpause(void)
@@ -192,6 +187,7 @@ void Demo_Unpause(void)
     M_PRIV *const p = &m_Priv;
     M_PrepareConfig(p);
     Stats_StartTimer();
+    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
 }
 
 int32_t Demo_ChooseLevel(const int32_t demo_num)
@@ -214,6 +210,5 @@ GF_COMMAND Demo_Control(void)
 
 void Demo_StopFlashing(void)
 {
-    M_PRIV *const p = &m_Priv;
-    Text_Flash(p->text, false, 0);
+    Overlay_SetBottomText(GS(MISC_DEMO_MODE), false);
 }

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -15,6 +15,7 @@
 #include <libtrx/game/inventory_ring/priv.h>
 #include <libtrx/game/matrix.h>
 #include <libtrx/game/objects/common.h>
+#include <libtrx/game/ui.h>
 
 static int32_t M_GetFrames(
     const INV_RING *ring, const INVENTORY_ITEM *inv_item,
@@ -192,6 +193,15 @@ void InvRing_Draw(INV_RING *const ring)
         for (int32_t i = 0; i < num_frames; i++) {
             InvRing_DoMotions(ring);
         }
+    }
+
+    const char *const count_text = InvRing_GetItemQuantityText();
+    if (count_text != nullptr) {
+        UI_BeginModal(0.5f, 1.0f);
+        UI_BeginOffset(64.0f, -56.0f);
+        UI_Label(count_text);
+        UI_EndOffset();
+        UI_EndModal();
     }
 
     Fader_Draw(&ring->top_fader);

--- a/src/tr2/game/option/option_passport.c
+++ b/src/tr2/game/option/option_passport.c
@@ -6,14 +6,16 @@
 #include "game/inventory.h"
 #include "game/inventory_ring.h"
 #include "game/option/option.h"
+#include "game/overlay.h"
 #include "game/savegame.h"
 #include "game/sound.h"
-#include "game/text.h"
 #include "global/vars.h"
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/game/ui.h>
+
+#define M_PAGE_COUNT 3
 
 typedef enum {
     M_ROLE_LOAD_GAME,
@@ -52,14 +54,14 @@ static struct {
     } save_slot;
 } m_State = { .active_page = -1 };
 
-TEXTSTRING *m_SubtitleText = nullptr;
-
-static void M_ChangePageTextContent(const char *title);
-static void M_SetPage(int32_t page, M_PAGE_ROLE role, bool available);
 static void M_InitRequesters(void);
 static void M_FreeRequesters(void);
-static void M_DeterminePages(void);
+static void M_InitText(void);
 static void M_RemoveAllText(void);
+static void M_SyncArrowsVisibility(void);
+static void M_ChangePageTextContent(const char *title);
+static void M_SetPage(int32_t page, M_PAGE_ROLE role, bool available);
+static void M_DeterminePages(void);
 static void M_InitSaveRequester(M_PAGE_ROLE page_role);
 static void M_ShowSaves(INVENTORY_ITEM *inv_item);
 static void M_LoadGame(INVENTORY_ITEM *inv_item);
@@ -74,22 +76,6 @@ static void M_Close(INVENTORY_ITEM *inv_item);
 static void M_ShowPage(INVENTORY_ITEM *inv_item);
 static void M_HandleFlipInputs(void);
 
-static void M_ChangePageTextContent(const char *const title)
-{
-    if (m_SubtitleText == nullptr) {
-        m_SubtitleText = Text_Create(0, -16, title);
-        Text_AlignBottom(m_SubtitleText, true);
-        Text_CentreH(m_SubtitleText, true);
-    }
-}
-
-static void M_SetPage(
-    const int32_t page, const M_PAGE_ROLE role, const bool available)
-{
-    m_State.pages[page].role = role;
-    m_State.pages[page].available = available;
-}
-
 static void M_InitRequesters(void)
 {
     UI_NewGame_Init(&m_State.new_game.state);
@@ -102,11 +88,61 @@ static void M_FreeRequesters(void)
     m_State.is_ready = false;
 }
 
+static void M_InitText(void)
+{
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, false);
+    Overlay_SetBottomText(nullptr, false);
+}
+
+static void M_RemoveAllText(void)
+{
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, false);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, false);
+    Overlay_SetBottomText(nullptr, false);
+    if (m_State.save_slot.state != nullptr) {
+        UI_SaveSlotDialog_Free(m_State.save_slot.state);
+        m_State.save_slot.state = nullptr;
+    }
+    if (m_State.play_any_level.state != nullptr) {
+        UI_PlayAnyLevelDialog_Free(m_State.play_any_level.state);
+        m_State.play_any_level.state = nullptr;
+    }
+    M_FreeRequesters();
+}
+
+static void M_SyncArrowsVisibility(void)
+{
+    bool has_pages_to_left = false;
+    bool has_pages_to_right = false;
+    for (int32_t page = 0; page < M_PAGE_COUNT; page++) {
+        has_pages_to_left |=
+            (page < m_State.active_page) && m_State.pages[page].available;
+        has_pages_to_right |=
+            (page > m_State.active_page) && m_State.pages[page].available;
+    }
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCL, has_pages_to_left);
+    Overlay_ShowArrow(UI_OVERLAY_ARROW_BCR, has_pages_to_right);
+}
+
+static void M_ChangePageTextContent(const char *const content)
+{
+    InvRing_RemoveAllText();
+    Overlay_SetBottomText(content, false);
+}
+
+static void M_SetPage(
+    const int32_t page, const M_PAGE_ROLE role, const bool available)
+{
+    m_State.pages[page].role = role;
+    m_State.pages[page].available = available;
+}
+
 static void M_DeterminePages(void)
 {
     const bool has_saves = Savegame_GetTotalCount() != 0;
 
-    for (int32_t i = 0; i < 3; i++) {
+    for (int32_t i = 0; i < M_PAGE_COUNT; i++) {
         m_State.pages[i].available = false;
     }
 
@@ -153,7 +189,7 @@ static void M_DeterminePages(void)
     }
 
     if (Game_IsInGym()) {
-        for (int32_t i = 0; i < 3; i++) {
+        for (int32_t i = 0; i < M_PAGE_COUNT; i++) {
             if (m_State.pages[i].role == M_ROLE_SAVE_GAME) {
                 m_State.pages[i].role = g_GameFlow.play_any_level
                     ? M_ROLE_PLAY_ANY_LEVEL
@@ -164,7 +200,7 @@ static void M_DeterminePages(void)
 
     // disable save & load
     if (g_GameFlow.load_save_disabled) {
-        for (int32_t i = 0; i < 3; i++) {
+        for (int32_t i = 0; i < M_PAGE_COUNT; i++) {
             if (m_State.pages[i].role == M_ROLE_LOAD_GAME
                 || m_State.pages[i].role == M_ROLE_SAVE_GAME) {
                 m_State.pages[i].available = false;
@@ -173,35 +209,18 @@ static void M_DeterminePages(void)
     }
 
     // select first available page
-    for (int32_t i = 0; i < 3; i++) {
+    for (int32_t i = 0; i < M_PAGE_COUNT; i++) {
         if (m_State.pages[i].available) {
             m_State.active_page = i;
             break;
         }
     }
 
-    for (int32_t i = 0; i < 3; i++) {
+    for (int32_t i = 0; i < M_PAGE_COUNT; i++) {
         LOG_DEBUG(
             "page %d: role=%d available=%d", i, m_State.pages[i].role,
             m_State.pages[i].available);
     }
-}
-
-static void M_RemoveAllText(void)
-{
-    if (m_SubtitleText != nullptr) {
-        Text_Remove(m_SubtitleText);
-        m_SubtitleText = nullptr;
-    }
-    if (m_State.save_slot.state != nullptr) {
-        UI_SaveSlotDialog_Free(m_State.save_slot.state);
-        m_State.save_slot.state = nullptr;
-    }
-    if (m_State.play_any_level.state != nullptr) {
-        UI_SaveSlotDialog_Free(m_State.save_slot.state);
-        m_State.play_any_level.state = nullptr;
-    }
-    M_FreeRequesters();
 }
 
 static void M_InitSaveRequester(const M_PAGE_ROLE role)
@@ -401,7 +420,8 @@ static void M_HandleFlipInputs(void)
             }
         }
     } else if (g_InputDB.menu_right) {
-        for (int32_t page = m_State.active_page + 1; page < 3; page++) {
+        for (int32_t page = m_State.active_page + 1; page < M_PAGE_COUNT;
+             page++) {
             if (m_State.pages[page].available) {
                 m_State.active_page = page;
                 break;
@@ -441,6 +461,7 @@ void Option_Passport_Control(INVENTORY_ITEM *const item, const bool is_busy)
         g_InputDB = (INPUT_STATE) {};
     } else {
         m_State.is_ready = true;
+        M_SyncArrowsVisibility();
         M_ShowPage(item);
         if (g_InputDB.menu_confirm) {
             g_Inv_ExtraData[0] = m_State.active_page;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The following elements were changed to use the UI module instead of manual positioning:
- inventory ring top header
- inventory ring bottom text
- inventory ring item count indicator
- inventory ring bottom arrows near passport (also ported to TR2, #2926)
- inventory ring version text
- pause mode text
- demo mode text (also ported to TR2, #1556)

Remaining elements:
- examine item buttons
- the entire TR1 controls dialog
- the entire TR1 graphic settings dialog
- TR2 graphic settings messages in the corner (I'd like TR1 to adopt these rather than relying on the console)