### PR TITLE
Resolve further trigger dependencies

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed the game crashing on unknown sequencer events
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 1.0)
 - fixed harpoon's ammo counter overlapping with the air bar (#2871)
+- fixed flames showing briefly when Lara enters water and a death tile is present
 - improved the `/set` console command to display available options if given an unknown argument
 
 ## [1.0.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...tr2-1.0.2) - 2025-04-26

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -320,6 +320,7 @@ However, you can easily download them manually from these urls:
 - fixed the boat when it explodes after crossing mines, where Lara's hips would appear rather than exploded boat parts
 - fixed Lara's hips appearing on Bartoli in the Temple of Xian cutscene
 - fixed the bird monster not having a shadow
+- fixed flames showing briefly when Lara enters water and a death tile is present
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/libtrx/game/gym.c
+++ b/src/libtrx/game/gym.c
@@ -4,6 +4,7 @@
 #include "game/const.h"
 #include "game/game.h"
 #include "game/game_flow.h"
+#include "game/lara.h"
 #include "game/music.h"
 #include "game/savegame.h"
 #include "game/stats.h"
@@ -13,6 +14,7 @@
 static bool m_IsInventoryOpenEnabled = true;
 static bool m_IsAssaultTimerDisplay = false;
 static bool m_IsAssaultTimerActive = false;
+static int16_t m_CompletionTimer = 0;
 
 static int32_t M_GetBestTime(void);
 static bool M_StoreAssaultTime(uint32_t time);
@@ -134,4 +136,57 @@ void Gym_FinishAssault(void)
 bool Gym_HasAssaultStats(void)
 {
     return TR_VERSION >= 2;
+}
+
+bool Gym_CanPlayMusicTrack(int16_t *const track_id)
+{
+#if TR_VERSION == 1
+    const uint16_t flags = Music_GetTrackFlags(*track_id);
+    const ITEM *const lara = Lara_GetItem();
+    switch (*track_id) {
+    case MX_GYM_HINT_03:
+        if ((flags & IF_ONE_SHOT) != 0
+            && lara->current_anim_state == LS_JUMP_UP) {
+            *track_id = MX_GYM_HINT_04;
+        }
+        break;
+
+    case MX_GYM_HINT_12:
+        if (lara->current_anim_state != LS_HANG) {
+            return false;
+        }
+        break;
+
+    case MX_GYM_HINT_16:
+        if (lara->current_anim_state != LS_HANG) {
+            return false;
+        }
+        break;
+
+    case MX_GYM_HINT_17:
+        if ((flags & IF_ONE_SHOT) != 0 && lara->current_anim_state == LS_HANG) {
+            *track_id = MX_GYM_HINT_18;
+        }
+        break;
+
+    case MX_GYM_HINT_24:
+        if (lara->current_anim_state != LS_SURF_TREAD) {
+            return false;
+        }
+        break;
+
+    case MX_GYM_HINT_25:
+        if ((flags & IF_ONE_SHOT) != 0) {
+            m_CompletionTimer++;
+            if (m_CompletionTimer == LOGIC_FPS * 4) {
+                Game_SetIsLevelComplete(true);
+                m_CompletionTimer = 0;
+            }
+        } else if (lara->current_anim_state != LS_WATER_OUT) {
+            return false;
+        }
+        break;
+    }
+#endif
+    return true;
 }

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -1,9 +1,47 @@
 #include "game/lara/misc.h"
 
+#include "game/effects.h"
 #include "game/items.h"
 #include "game/lara/common.h"
 #include "game/lara/const.h"
+#include "game/random.h"
 #include "game/rooms.h"
+
+void Lara_TouchLava(void)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_item->hit_points < 0 || lara_info->water_status == LWS_CHEAT) {
+        return;
+    }
+
+    int16_t room_num = lara_item->room_num;
+    const SECTOR *const sector = Room_GetSector(
+        lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z, &room_num);
+    const int32_t height =
+        Room_GetHeight(sector, lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z);
+    if (lara_item->floor != height) {
+        return;
+    }
+
+    lara_item->hit_points = -1;
+    lara_item->hit_status = 1;
+
+    if (lara_info->water_status != LWS_ABOVE_WATER) {
+        return;
+    }
+
+    const OBJECT *const obj = Object_Get(O_FLAME);
+    for (int32_t i = 0; i < 10; i++) {
+        const int16_t effect_num = Effect_Create(lara_item->room_num);
+        if (effect_num != NO_EFFECT) {
+            EFFECT *const effect = Effect_Get(effect_num);
+            effect->object_id = O_FLAME;
+            effect->frame_num = obj->mesh_count * Random_GetControl() / 0x7FFF;
+            effect->counter = -1 - 24 * Random_GetControl() / 0x7FFF;
+        }
+    }
+}
 
 int16_t Lara_FloorFront(
     const ITEM *const item, const int16_t ang, const int32_t dist)

--- a/src/libtrx/include/libtrx/game/gym.h
+++ b/src/libtrx/include/libtrx/game/gym.h
@@ -12,9 +12,12 @@ bool Gym_HasAssaultStats(void);
 bool Gym_IsAssaultTimerDisplay(void);
 bool Gym_IsAssaultTimerActive(void);
 ASSAULT_STATS Gym_GetAssaultStats(void);
-void Gym_SetAssaultStats(ASSAULT_STATS stats);
 
 void Gym_ResetAssault(void);
 void Gym_StartAssault(void);
 void Gym_StopAssault(void);
 void Gym_FinishAssault(void);
+
+// Potentially converts the requested track id based on Lara's state. Returns
+// true if the track should be played.
+bool Gym_CanPlayMusicTrack(int16_t *track_id);

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -4,6 +4,7 @@
 #include "../items/types.h"
 
 void Lara_Extinguish(void);
+void Lara_TouchLava(void);
 
 int16_t Lara_FloorFront(const ITEM *item, int16_t ang, int32_t dist);
 void Lara_GetCollisionInfo(const ITEM *item, COLL_INFO *coll);

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -885,37 +885,12 @@ void Lara_SwimCollision(ITEM *item, COLL_INFO *coll)
 
 void Lara_CatchFire(void)
 {
-    if (g_Lara.water_status == LWS_CHEAT || g_LaraItem->hit_points < 0) {
-        return;
-    }
-
-    int16_t room_num = g_LaraItem->room_num;
-    const SECTOR *const sector = Room_GetSector(
-        g_LaraItem->pos.x, MAX_HEIGHT, g_LaraItem->pos.z, &room_num);
-    const int16_t height = Room_GetHeight(
-        sector, g_LaraItem->pos.x, MAX_HEIGHT, g_LaraItem->pos.z);
-
-    if (g_LaraItem->floor != height) {
-        return;
-    }
-
-    g_LaraItem->hit_points = -1;
-    g_LaraItem->hit_status = 1;
-
-    if (g_Lara.water_status != LWS_ABOVE_WATER) {
-        return;
-    }
-
-    for (int32_t i = 0; i < 10; i++) {
-        const int16_t effect_num = Effect_Create(g_LaraItem->room_num);
-        if (effect_num != NO_EFFECT) {
-            EFFECT *const effect = Effect_Get(effect_num);
-            const OBJECT *const obj = Object_Get(O_FLAME);
-            effect->object_id = O_FLAME;
-            effect->frame_num =
-                (obj->mesh_count * Random_GetControl()) / 0x7FFF;
-            effect->counter = -1 - Random_GetControl() * 24 / 0x7FFF;
-        }
+    const int16_t effect_num = Effect_Create(g_LaraItem->room_num);
+    if (effect_num != NO_EFFECT) {
+        EFFECT *const effect = Effect_Get(effect_num);
+        effect->frame_num = 0;
+        effect->object_id = O_FLAME;
+        effect->counter = -1;
     }
 }
 

--- a/src/tr1/game/objects/effects/flame.c
+++ b/src/tr1/game/objects/effects/flame.c
@@ -1,11 +1,10 @@
 #include "game/effects.h"
-#include "game/lara/common.h"
-#include "game/lara/control.h"
 #include "game/room.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
 #include <libtrx/game/collision.h>
+#include <libtrx/game/lara.h>
 
 #define FLAME_ON_FIRE_DAMAGE 5
 #define FLAME_TOO_NEAR_DAMAGE 3
@@ -80,14 +79,7 @@ static void M_Control(const int16_t effect_num)
 
         if (distance < SQUARE(300)) {
             effect->counter = 100;
-
-            const int16_t new_effect_num = Effect_Create(g_LaraItem->room_num);
-            if (new_effect_num != NO_EFFECT) {
-                effect = Effect_Get(new_effect_num);
-                effect->frame_num = 0;
-                effect->object_id = O_FLAME;
-                effect->counter = -1;
-            }
+            Lara_CatchFire();
         }
     }
 }

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -63,7 +63,7 @@ static void M_Control(const int16_t item_num)
 
     if (item->touch_bits) {
         if (g_LaraItem->hit_points > 0) {
-            Lara_CatchFire();
+            Lara_TouchLava();
         }
 
         g_Camera.item = item;

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -333,7 +333,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 {
     const bool is_heavy = item->object_id != O_LARA;
     if (!is_heavy && sector->is_death_sector && M_TestLava(item)) {
-        Lara_CatchFire();
+        Lara_TouchLava();
     }
 
     const TRIGGER *const trigger = sector->trigger;

--- a/src/tr1/game/room.c
+++ b/src/tr1/game/room.c
@@ -18,6 +18,7 @@
 
 #include <libtrx/game/game.h>
 #include <libtrx/game/game_buf.h>
+#include <libtrx/game/gym.h>
 #include <libtrx/utils.h>
 
 static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger);
@@ -32,61 +33,12 @@ static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
         return;
     }
 
-    if (track <= MX_UNUSED_1 || track >= MAX_MUSIC_TRACKS) {
+    if (track <= MX_UNUSED_1 || track >= MAX_MUSIC_TRACKS
+        || !Gym_CanPlayMusicTrack(&track)) {
         return;
     }
 
-    // handle g_Lara gym routines
     uint16_t flags = Music_GetTrackFlags(track);
-    switch (track) {
-    case MX_GYM_HINT_03:
-        if ((flags & IF_ONE_SHOT)
-            && g_LaraItem->current_anim_state == LS_JUMP_UP) {
-            track = MX_GYM_HINT_04;
-        }
-        break;
-
-    case MX_GYM_HINT_12:
-        if (g_LaraItem->current_anim_state != LS_HANG) {
-            return;
-        }
-        break;
-
-    case MX_GYM_HINT_16:
-        if (g_LaraItem->current_anim_state != LS_HANG) {
-            return;
-        }
-        break;
-
-    case MX_GYM_HINT_17:
-        if ((flags & IF_ONE_SHOT)
-            && g_LaraItem->current_anim_state == LS_HANG) {
-            track = MX_GYM_HINT_18;
-        }
-        break;
-
-    case MX_GYM_HINT_24:
-        if (g_LaraItem->current_anim_state != LS_SURF_TREAD) {
-            return;
-        }
-        break;
-
-    case MX_GYM_HINT_25:
-        if (flags & IF_ONE_SHOT) {
-            static int16_t gym_completion_counter = 0;
-            gym_completion_counter++;
-            if (gym_completion_counter == LOGIC_FPS * 4) {
-                Game_SetIsLevelComplete(true);
-                gym_completion_counter = 0;
-            }
-        } else if (g_LaraItem->current_anim_state != LS_WATER_OUT) {
-            return;
-        }
-        break;
-    }
-    // end of g_Lara gym routines
-
-    flags = Music_GetTrackFlags(track);
     if (flags & IF_ONE_SHOT) {
         return;
     }

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1670,36 +1670,6 @@ void Lara_CatchFire(void)
     g_Lara.burn = 1;
 }
 
-void Lara_TouchLava(ITEM *const item)
-{
-    if (item->hit_points < 0 || g_Lara.water_status == LWS_CHEAT) {
-        return;
-    }
-
-    int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, MAX_HEIGHT, item->pos.z);
-    if (item->floor != height) {
-        return;
-    }
-
-    item->hit_points = -1;
-    item->hit_status = 1;
-
-    const OBJECT *const obj = Object_Get(O_FLAME);
-    for (int32_t i = 0; i < 10; i++) {
-        const int16_t effect_num = Effect_Create(item->room_num);
-        if (effect_num != NO_EFFECT) {
-            EFFECT *const effect = Effect_Get(effect_num);
-            effect->object_id = O_FLAME;
-            effect->frame_num = obj->mesh_count * Random_GetControl() / 0x7FFF;
-            effect->counter = -1 - 24 * Random_GetControl() / 0x7FFF;
-        }
-    }
-}
-
 void Lara_Extinguish(void)
 {
     if (!g_Lara.burn) {

--- a/src/tr2/game/lara/misc.h
+++ b/src/tr2/game/lara/misc.h
@@ -70,8 +70,6 @@ void Lara_SwimCollision(ITEM *item, COLL_INFO *coll);
 
 void Lara_WaterCurrent(COLL_INFO *coll);
 
-void Lara_TouchLava(ITEM *item);
-
 // Returns true if Lara has the M16 equipped and is in either anim state: 0
 // (start aim); 2 (firing); or 4 (stopping firing).
 bool Lara_IsM16Active(void);

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -89,7 +89,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
     const bool is_heavy = item->object_id != O_LARA;
     if (!is_heavy) {
         if (sector->is_death_sector && M_TestLava(item)) {
-            Lara_TouchLava((ITEM *)item);
+            Lara_TouchLava();
         }
 
         const LADDER_DIRECTION direction = 1 << Math_GetDirection(item->rot.y);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A couple of further trigger dependencies, otherwise seemingly unrelated:
- TR1's gym music track handling has now been moved to the gym module. I think when we do move `M_TriggerMusicTrack` in `room.c` it will be quite a bit different in both games initially, but this should reduce some of the overly specific noise.
- `Lara_CatchFire` had different meanings with TR1 using it when Lara touched lava, and TR2 using it when she touched a flame or was hit by the dragon/flamethrower. Each game now has both `Lara_CatchFire` and `Lara_TouchLava` for consistency.

So for testing, it's making sure the TR1 gym tracks play out as normal and for both games ensuring Lara catches fire "normally" against flames or enemies, and otherwise that the lava effect of several flames remains too.
