### PR TITLE
option: fix select level not reacting to menu back

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fixed FPS counter turning off after a game relaunch (#2911)
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
 - fixed health bar in top center position covering inventory text
+- fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/src/tr1/game/option/option_passport.c
+++ b/src/tr1/game/option/option_passport.c
@@ -333,7 +333,7 @@ static void M_LoadGame(void)
 
 static void M_SelectLevel(void)
 {
-    if (g_InputDB.menu_left) {
+    if (g_InputDB.menu_left || g_InputDB.menu_back) {
         M_InitSaveRequester(m_State.active_page);
         m_State.mode = PASSPORT_MODE_LOAD_GAME;
         g_Input = (INPUT_STATE) {};


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2918.

Rather than closing the dialog completely it just goes back to load game – I think it's natural and was the easiest fix.