### PR TITLE
tr2/savegame: move first level inventory allocation to game flow

### DIFF
--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -58,6 +58,10 @@
             "music_track": 33,
             "sequence": [
                 {"type": "play_fmv", "fmv_id": 2},
+                {"type": "give_item", "object_id": "shotgun"},
+                {"type": "give_item", "object_id": "small_medipack"},
+                {"type": "give_item", "object_id": "large_medipack"},
+                {"type": "give_item", "object_id": "flare", "quantity": 2},
                 {"type": "add_secret_reward", "object_id": "grenade_launcher"},
                 {"type": "add_secret_reward", "object_id": "grenade_launcher_ammo", "quantity": 2},
                 {"type": "add_secret_reward", "object_id": "small_medipack"},

--- a/data/tr2/ship/cfg/TR2X_gameflow_gm.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow_gm.json5
@@ -55,6 +55,10 @@
             "path": "data/level1.tr2",
             "music_track": 33,
             "sequence": [
+                {"type": "give_item", "object_id": "shotgun"},
+                {"type": "give_item", "object_id": "small_medipack"},
+                {"type": "give_item", "object_id": "large_medipack"},
+                {"type": "give_item", "object_id": "flare", "quantity": 2},
                 {"type": "loop_game"},
                 {"type": "play_music", "music_track": 41},
                 {"type": "level_stats"},

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -43,3 +43,13 @@
    item titles or item names need to be configured entirely in the new file, so
    all `"strings"` keys can be safely removed from the game flow. Refer to
    [GAME_STRINGS.md](GAME_STRINGS.md) for more details.
+
+## TR2X
+
+### Version 1.0.2 to 1.1
+
+1. **Update first level inventory allocation**  
+   The first level no longer hard-codes the shotgun, flare and small/large medi
+   pack allocations. To continue to have Lara start with these items, refer to
+   the shipped game flow file's `Great Wall` sequences, specifically the
+   `give_item` entries.

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -21,7 +21,9 @@
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 1.0)
 - fixed harpoon's ammo counter overlapping with the air bar (#2871)
 - fixed flames showing briefly when Lara enters water and a death tile is present
+- fixed being unable to load a save made in the first level if that level removes Lara's weapons but also has a shotgun pickup (#2934, regression from 0.9)
 - improved the `/set` console command to display available options if given an unknown argument
+- removed the hard-coded inventory allocation on the first level by default, moving it instead to the game flow (#1867)
 
 ## [1.0.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.1...tr2-1.0.2) - 2025-04-26
 - changed The Golden Mask strings to default to the OG strings file for the main tables (#2847)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -345,6 +345,7 @@ However, you can easily download them manually from these urls:
 - fixed the lift to work in any cardinal direction in custom levels, not just South
 - fixed the springboard not responding correctly when Lara drives across one on a skidoo
 - removed the hard-coded end-level behaviour of the bird guardian for custom levels
+- removed the hard-coded inventory allocation on the first level by default, moving it instead to the game flow
 
 #### Miscellaneous
 - added Linux builds

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -60,23 +60,23 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         resume->flags.available = 1;
 
         resume->flags.has_pistols = 1;
-        resume->flags.has_shotgun = 1;
+        resume->flags.has_shotgun = 0;
         resume->flags.has_magnums = 0;
         resume->flags.has_uzis = 0;
         resume->flags.has_harpoon = 0;
         resume->flags.has_m16 = 0;
         resume->flags.has_grenade = 0;
 
-        resume->shotgun_ammo = 2 * SHOTGUN_AMMO_CLIP;
+        resume->shotgun_ammo = 0;
         resume->magnum_ammo = 0;
         resume->uzi_ammo = 0;
         resume->harpoon_ammo = 0;
         resume->m16_ammo = 0;
         resume->grenade_ammo = 0;
 
-        resume->flares = 2;
-        resume->small_medipacks = 1;
-        resume->large_medipacks = 1;
+        resume->flares = 0;
+        resume->small_medipacks = 0;
+        resume->large_medipacks = 0;
         resume->gun_status = LGS_ARMLESS;
     }
 


### PR DESCRIPTION
Resolves #1867.
Resolves #2934.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the allocation of the shotgun, flares and medi packs in the first level to the game flow as standard, and as a result resolves savegame issues when a level removes weapons but adds a shotgun pickup.
