### PR TITLE
rooms/geometry: account for tilts in water height

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.1...develop) - ××××-××-××
 - added the ability to trigger a flip effect without having to also trigger the flip map, in line with TR2 (#2921)
 - added a /help command (#2917)
+- fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)
 - fixed enemy hitpoints being doubled in demo mode as a result of NG+ (#2904)
 - fixed an illegal reachable slope in Lost Valley room 58, which could lead to Lara becoming softlocked (#2900)
 - fixed some pickup sprites being too far embedded into the floor (#2903)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - changed the installer to always allow downloading music files (#2891)
 - changed the dev console to no longer add duplicate entries to the history
 - changed the health bar and the air bar sizes to be slightly bigger
+- fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -321,6 +321,7 @@ However, you can easily download them manually from these urls:
 - fixed Lara's hips appearing on Bartoli in the Temple of Xian cutscene
 - fixed the bird monster not having a shadow
 - fixed flames showing briefly when Lara enters water and a death tile is present
+- fixed Lara's braid pointing straight down when swimming below sloped ceilings
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -332,17 +332,17 @@ int32_t Room_GetWaterHeight(
     if (room->flags & RF_UNDERWATER) {
         while (sector->portal_room.sky != NO_ROOM) {
             room = Room_Get(sector->portal_room.sky);
-            if (!(room->flags & RF_UNDERWATER)) {
+            if ((room->flags & RF_UNDERWATER) == 0) {
                 break;
             }
             sector = Room_GetWorldSector(room, x, z);
         }
-        return sector->ceiling.height;
+        return M_GetCeilingTiltHeight(sector, x, z, true);
     } else {
         while (sector->portal_room.pit != NO_ROOM) {
             room = Room_Get(sector->portal_room.pit);
-            if (room->flags & RF_UNDERWATER) {
-                return sector->floor.height;
+            if ((room->flags & RF_UNDERWATER) != 0) {
+                return M_GetFloorTiltHeight(sector, x, z, true);
             }
             sector = Room_GetWorldSector(room, x, z);
         }


### PR DESCRIPTION
Resolves #1600.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates water height checks to account for tilts and essentially to fix Lara's braid pointing straight down when swimming below a ceiling tilt.

It'd be good to check other general water behaviour, like wading, surface swimming, footsteps in shallow water etc.
