### PR TITLE
memory: zero arena contents on reset

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed harpoon's ammo counter overlapping with the air bar (#2871)
 - fixed flames showing briefly when Lara enters water and a death tile is present
 - fixed being unable to load a save made in the first level if that level removes Lara's weapons but also has a shotgun pickup (#2934, regression from 0.9)
+- fixed misplaced effects such as bubbles and dragon fire in 60 FPS (#2873, #2881, regression from 0.10)
 - improved the `/set` console command to display available options if given an unknown argument
 - removed the hard-coded inventory allocation on the first level by default, moving it instead to the game flow (#1867)
 

--- a/src/libtrx/memory.c
+++ b/src/libtrx/memory.c
@@ -108,6 +108,7 @@ void Memory_ArenaReset(MEMORY_ARENA_ALLOCATOR *const allocator)
 {
     MEMORY_ARENA_CHUNK *chunk = allocator->first_chunk;
     while (chunk != nullptr) {
+        memset(chunk->memory, 0, chunk->size);
         chunk->offset = 0;
         chunk = chunk->next;
     }


### PR DESCRIPTION
Resolves #2873.
Resolves #2881.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures to reset arena contents to zero such that, for example, `GameBuf_Alloc` can continue to guarantee zeroed memory even between level loads.
