### PR TITLE
rooms: merge NO_ROOM definitions

### DIFF
--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -48,7 +48,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     const ITEM *const lara_item = Lara_GetItem();
     int16_t room_num = lara_item->room_num;
     const ROOM *const room = Room_Get(room_num);
-    if (Room_GetFlipStatus() && room->flipped_room != NO_ROOM_NEG) {
+    if (Room_GetFlipStatus() && room->flipped_room != NO_ROOM) {
         room_num = room->flipped_room;
     }
     char *details = lara_item == nullptr

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -25,6 +25,8 @@
 
 #include <string.h>
 
+#define M_NO_ROOM_LEGACY 255
+
 static LEVEL_INFO m_Info = {};
 
 static RGBA_8888 M_ARGB1555To8888(uint16_t argb1555);
@@ -516,6 +518,12 @@ void Level_ReadRooms(VFILE *const file)
             sector->floor.height = VFile_ReadS8(file) * STEP_L;
             sector->portal_room.sky = VFile_ReadU8(file);
             sector->ceiling.height = VFile_ReadS8(file) * STEP_L;
+            if (sector->portal_room.pit == M_NO_ROOM_LEGACY) {
+                sector->portal_room.pit = NO_ROOM;
+            }
+            if (sector->portal_room.sky == M_NO_ROOM_LEGACY) {
+                sector->portal_room.sky = NO_ROOM;
+            }
         }
 
         room->ambient = VFile_ReadS16(file);

--- a/src/libtrx/game/objects/general/door.c
+++ b/src/libtrx/game/objects/general/door.c
@@ -81,8 +81,8 @@ static void M_Shut(DOORPOS_DATA *const d)
     sector->floor.height = NO_HEIGHT;
     sector->floor.tilt = 0;
     sector->ceiling.tilt = 0;
-    sector->portal_room.sky = NO_ROOM_NEG;
-    sector->portal_room.pit = NO_ROOM_NEG;
+    sector->portal_room.sky = NO_ROOM;
+    sector->portal_room.pit = NO_ROOM;
     sector->portal_room.wall = NO_ROOM;
 
     const int16_t box_num = d->box_num;
@@ -160,7 +160,7 @@ static void M_Initialise(const int16_t item_num)
     const ROOM *room = Room_Get(room_num);
     M_InitialisePortal(room, item, dx, dz, &door->d1);
 
-    if (room->flipped_room == NO_ROOM_NEG) {
+    if (room->flipped_room == NO_ROOM) {
         door->d1flip.sector = nullptr;
     } else {
         room = Room_Get(room->flipped_room);
@@ -177,7 +177,7 @@ static void M_Initialise(const int16_t item_num)
     } else {
         room = Room_Get(room_num);
         M_InitialisePortal(room, item, 0, 0, &door->d2);
-        if (room->flipped_room == NO_ROOM_NEG) {
+        if (room->flipped_room == NO_ROOM) {
             door->d2flip.sector = nullptr;
         } else {
             room = Room_Get(room->flipped_room);

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -89,7 +89,7 @@ ROOM *Room_Get(const int32_t room_num)
 int32_t Room_GetNumber(const ROOM *const room)
 {
     if (room == nullptr) {
-        return NO_ROOM_NEG;
+        return NO_ROOM;
     }
     return room - m_Rooms;
 }
@@ -215,16 +215,6 @@ int32_t Room_GetAdjoiningRooms(
 
 int16_t Room_GetIndexFromPos(const int32_t x, const int32_t y, const int32_t z)
 {
-    // TODO: merge this to Room_FindByPos!
-    const int32_t room_num = Room_FindByPos(x, y, z);
-    if (room_num == NO_ROOM_NEG) {
-        return NO_ROOM;
-    }
-    return room_num;
-}
-
-int32_t Room_FindByPos(const int32_t x, const int32_t y, const int32_t z)
-{
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         const ROOM *const room = Room_Get(i);
         if (room->flip_status == RFS_FLIPPED) {
@@ -241,7 +231,7 @@ int32_t Room_FindByPos(const int32_t x, const int32_t y, const int32_t z)
         }
     }
 
-    return NO_ROOM_NEG;
+    return NO_ROOM;
 }
 
 int32_t Room_GetFlippedBaseRoom(const int32_t room_num)

--- a/src/libtrx/include/libtrx/game/rooms/common.h
+++ b/src/libtrx/include/libtrx/game/rooms/common.h
@@ -23,7 +23,6 @@ int32_t Room_GetAdjoiningRooms(
     int16_t init_room_num, int16_t out_room_nums[], int32_t max_room_num_count);
 
 int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
-int32_t Room_FindByPos(int32_t x, int32_t y, int32_t z);
 int32_t Room_GetFlippedBaseRoom(int32_t room_num);
 BOUNDS_32 Room_GetWorldBounds(void);
 

--- a/src/libtrx/include/libtrx/game/rooms/const.h
+++ b/src/libtrx/include/libtrx/game/rooms/const.h
@@ -4,8 +4,7 @@
 #define MAX_ROOMS_TO_DRAW 100
 #define MAX_FLIP_MAPS 10
 
-#define NO_ROOM_NEG (-1)
-#define NO_ROOM 255 // TODO: merge this with NO_ROOM_NEG
+#define NO_ROOM (-1)
 
 #define NO_HEIGHT (-32512)
 #define MAX_HEIGHT 32000

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -46,8 +46,8 @@ typedef struct {
 #endif
     TRIGGER *trigger;
     struct {
-        uint8_t pit;
-        uint8_t sky;
+        int16_t pit;
+        int16_t sky;
         int16_t wall;
     } portal_room;
     struct {

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -823,8 +823,8 @@ void Camera_UpdateCutscene(void)
     g_Camera.pos.y = pos->y + ref->cy;
     g_Camera.pos.z = pos->z + ((c * ref->cz - s * ref->cx) >> W2V_SHIFT);
     const int16_t room_num =
-        Room_FindByPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
-    if (room_num != NO_ROOM_NEG) {
+        Room_GetIndexFromPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
+    if (room_num != NO_ROOM) {
         g_Camera.pos.room_num = room_num;
     }
     g_Camera.roll = ref->roll;

--- a/src/tr1/game/output/meshes/rooms.c
+++ b/src/tr1/game/output/meshes/rooms.c
@@ -65,7 +65,7 @@ static M_BATCH *M_GetBatch(const ROOM *const room)
     // that gets flipped to room 17 ends up getting the data from room 2,
     // whereas the VBO needs to take data from room 17.
     const int16_t room_num =
-        Room_GetFlipStatus() && room->flipped_room != NO_ROOM_NEG
+        Room_GetFlipStatus() && room->flipped_room != NO_ROOM
         ? room->flipped_room
         : Room_GetNumber(room);
     return &m_Priv.batches[room_num];

--- a/src/tr1/game/output/sprites.c
+++ b/src/tr1/game/output/sprites.c
@@ -96,7 +96,7 @@ static M_ROOM_BATCH *M_GetRoomBatch(const ROOM *const room)
     // that gets flipped to room 17 ends up getting the data from room 2,
     // whereas the VBO needs to take data from room 17.
     const int16_t room_num =
-        Room_GetFlipStatus() && room->flipped_room != NO_ROOM_NEG
+        Room_GetFlipStatus() && room->flipped_room != NO_ROOM
         ? room->flipped_room
         : Room_GetNumber(room);
     return &m_LevelData.room_batches[room_num];

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -44,8 +44,8 @@ void Lara_Control_Cutscene(const int16_t item_num)
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
 
-    const int16_t room_num = Room_FindByPos(pos.x, pos.y, pos.z);
-    if (room_num != NO_ROOM_NEG) {
+    const int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+    if (room_num != NO_ROOM) {
         Item_UpdateRoom(item_num, room_num);
     }
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -877,8 +877,8 @@ void Camera_LoadCutsceneFrame(void)
     g_Camera.shift = 0;
 
     const int16_t room_num =
-        Room_FindByPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
-    if (room_num != NO_ROOM_NEG) {
+        Room_GetIndexFromPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
+    if (room_num != NO_ROOM) {
         g_Camera.pos.room_num = room_num;
     }
 
@@ -930,8 +930,8 @@ void Camera_UpdateCutscene(void)
         .z = g_LaraItem->pos.z + ((cz * c - cx * s) >> W2V_SHIFT),
     };
     const int16_t room_num =
-        Room_FindByPos(camera_pos.x, camera_pos.y, camera_pos.z);
-    if (room_num != NO_ROOM_NEG) {
+        Room_GetIndexFromPos(camera_pos.x, camera_pos.y, camera_pos.z);
+    if (room_num != NO_ROOM) {
         g_Camera.pos.room_num = room_num;
     }
 

--- a/src/tr2/game/objects/general/cutscene_player.c
+++ b/src/tr2/game/objects/general/cutscene_player.c
@@ -35,8 +35,8 @@ static void M_Control(const int16_t item_num)
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
 
-    const int16_t room_num = Room_FindByPos(pos.x, pos.y, pos.z);
-    if (room_num != NO_ROOM_NEG) {
+    const int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+    if (room_num != NO_ROOM) {
         Item_UpdateRoom(item_num, room_num);
     }
 

--- a/src/tr2/game/room.c
+++ b/src/tr2/game/room.c
@@ -5,7 +5,7 @@ void Room_InitCinematic(void)
     const int32_t room_count = Room_GetCount();
     for (int32_t i = 0; i < room_count; i++) {
         ROOM *const room = Room_Get(i);
-        if (room->flipped_room != NO_ROOM_NEG) {
+        if (room->flipped_room != NO_ROOM) {
             Room_Get(room->flipped_room)->bound_active = 1;
         }
         room->flags |= RF_OUTSIDE;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This merges the two `NO_ROOM` concepts so `-1` is the standard. Legacy sector pit and sky portals will be converted on level load. This ultimately paves the way for allowing more than 256 rooms in a level via alternate sector data provided by injections (to be implemented).
