### PR TITLE
inject: add support to overwrite sector properties

### DIFF
--- a/src/libtrx/game/inject/editors/floor_data.c
+++ b/src/libtrx/game/inject/editors/floor_data.c
@@ -15,6 +15,7 @@ static void M_InsertFloorData(const INJECTION *injection, SECTOR *sector);
 static void M_RoomShift(const INJECTION *injection, int16_t room_num);
 static void M_TriggeredItem(const INJECTION *injection);
 static void M_RoomProperties(const INJECTION *injection, int16_t room_num);
+static void M_SectorOverwrite(const INJECTION *injection, SECTOR *sector);
 
 static void M_FloorDataEdits(
     const INJECTION *const injection, const int32_t data_count)
@@ -64,6 +65,9 @@ static void M_FloorDataEdits(
                 break;
             case FET_ROOM_PROPERTIES:
                 M_RoomProperties(injection, room_num);
+                break;
+            case FET_SECTOR_OVERWRITE:
+                M_SectorOverwrite(injection, sector);
                 break;
             default:
                 LOG_WARNING("Unknown floor data edit type: %d", edit_type);
@@ -228,6 +232,28 @@ static void M_RoomProperties(
     const uint16_t flags = VFile_ReadU16(injection->fp);
     ROOM *const room = Room_Get(room_num);
     room->flags = flags;
+}
+
+static void M_SectorOverwrite(
+    const INJECTION *const injection, SECTOR *const sector)
+{
+    const uint16_t fd_idx = VFile_ReadU16(injection->fp);
+    const int16_t box_idx = VFile_ReadS16(injection->fp);
+    const int16_t pit_room = VFile_ReadS16(injection->fp);
+    const int16_t floor = VFile_ReadS16(injection->fp);
+    const int16_t sky_room = VFile_ReadS16(injection->fp);
+    const int16_t ceiling = VFile_ReadS16(injection->fp);
+
+    if (sector == nullptr) {
+        return;
+    }
+
+    sector->idx = fd_idx;
+    sector->box = box_idx;
+    sector->portal_room.pit = pit_room;
+    sector->floor.height = floor;
+    sector->portal_room.sky = sky_room;
+    sector->ceiling.height = ceiling;
 }
 
 REGISTER_INJECT_EDITOR(IDT_FLOOR_EDITS, M_FloorDataEdits)

--- a/src/libtrx/include/libtrx/game/inject/enum.h
+++ b/src/libtrx/include/libtrx/game/inject/enum.h
@@ -79,13 +79,14 @@ typedef enum {
 } FACE_TYPE;
 
 typedef enum {
-    FET_TRIGGER_PARAM   = 0,
-    FET_MUSIC_ONESHOT   = 1,
-    FET_FD_INSERT       = 2,
-    FET_ROOM_SHIFT      = 3,
-    FET_TRIGGER_ITEM    = 4,
-    FET_ROOM_PROPERTIES = 5,
-    FET_TRIGGER_TYPE    = 6,
+    FET_TRIGGER_PARAM     = 0,
+    FET_MUSIC_ONESHOT     = 1,
+    FET_FD_INSERT         = 2,
+    FET_ROOM_SHIFT        = 3,
+    FET_TRIGGER_ITEM      = 4,
+    FET_ROOM_PROPERTIES   = 5,
+    FET_TRIGGER_TYPE      = 6,
+    FET_SECTOR_OVERWRITE  = 7,
 } FLOOR_EDIT_TYPE;
 
 typedef enum {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows injections to overwrite sectors using the TRX sector property types rather than OG, and hence allows support for having room below/above defined greater than 254.

Ref: https://github.com/LostArtefacts/TRXInjectionTool/pull/44
