### PR TITLE
camera: generate box data when none is present

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed an illegal reachable slope in Lost Valley room 58, which could lead to Lara becoming softlocked (#2900)
 - fixed some pickup sprites being too far embedded into the floor (#2903)
 - fixed vase room sprites in Return to Egypt and Temple of the Cat being embedded in the floor (#2095)
+- fixed the camera behaving erratically in rooms/sectors that have no pathfinding data (#2946)
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 4.10)
 - fixed FPS counter turning off after a game relaunch (#2911)
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -460,6 +460,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - fixed ceiling heights at times being miscalculated, resulting in camera issues and Lara being able to jump into the ceiling
 - fixed the camera being thrown through doors for one frame when looked at from fixed camera positions
 - fixed several instances of the camera going out of bounds
+- fixed the camera behaving erratically in rooms/sectors that have no pathfinding data
 - fixed the ape not performing the vault animation when climbing
 - fixed Natla's gun moving while she is in her semi death state
 - fixed the bear pat attack so it does not miss Lara

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)
 - fixed Lara being able to equip guns and flares during in-game cutscenes (#2895)
 - fixed an illegal reachable slope in Barkhang Monastery room 96, which could lead to Lara becoming softlocked (#2900)
+- fixed the camera behaving erratically in rooms/sectors that have no pathfinding data (#2946)
 - fixed the game crashing on unknown sequencer events
 - fixed the game crashing when editing long dev console history entries (#2913, regression from 1.0)
 - fixed harpoon's ammo counter overlapping with the air bar (#2871)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -221,6 +221,7 @@ However, you can easily download them manually from these urls:
 - fixed Lara at times not being able to jump immediately after going from her walking to running animation
 - fixed looking forward too far causing an upside down camera frame
 - fixed several instances of the camera going out of bounds
+- fixed the camera behaving erratically in rooms/sectors that have no pathfinding data
 - fixed Lara never stepping backwards off a step using her right foot
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -5,7 +5,25 @@
 #include "game/rooms.h"
 #include "utils.h"
 
+static BOX_INFO m_FixedBox = {};
 static bool m_IsChunky = false;
+
+// TODO: make private once modules are ported.
+const BOX_INFO *Camera_GetBox(
+    const SECTOR *const sector, const int32_t x, const int32_t z)
+{
+    if (sector->box != NO_BOX) {
+        return Box_GetBox(sector->box);
+    }
+
+    // A level may have blocked specific sector or room pathfinding, so create a
+    // dummy one-sector box to prevent erratic camera positioning.
+    m_FixedBox.left = z & ~(WALL_L - 1);
+    m_FixedBox.top = x & ~(WALL_L - 1);
+    m_FixedBox.right = m_FixedBox.left + WALL_L - 1;
+    m_FixedBox.bottom = m_FixedBox.top + WALL_L - 1;
+    return &m_FixedBox;
+}
 
 bool Camera_IsChunky(void)
 {

--- a/src/libtrx/include/libtrx/game/camera/common.h
+++ b/src/libtrx/include/libtrx/game/camera/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../pathing/types.h"
 #include "../rooms/types.h"
 
 extern void Camera_Update(void);
@@ -9,3 +10,5 @@ void Camera_SetChunky(bool is_chunky);
 void Camera_Reset(void);
 void Camera_ClampInterpResult(void);
 void Camera_RefreshFromTrigger(const TRIGGER *trigger);
+
+const BOX_INFO *Camera_GetBox(const SECTOR *sector, int32_t x, int32_t z);

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -363,7 +363,7 @@ static int32_t M_ShiftClamp(GAME_VECTOR *const pos, const int32_t clamp)
     const int32_t z = pos->z;
 
     const SECTOR *const sector = Room_GetSector(x, y, z, &pos->room_num);
-    const BOX_INFO *const box = Box_GetBox(sector->box);
+    const BOX_INFO *const box = Camera_GetBox(sector, x, z);
 
     const int32_t left = box->left + clamp;
     const int32_t right = box->right - clamp;
@@ -411,18 +411,18 @@ static void M_SmartShift(
     int32_t z_sector = (g_Camera.target.z - room->pos.z) >> WALL_SHIFT;
     int32_t x_sector = (g_Camera.target.x - room->pos.x) >> WALL_SHIFT;
 
-    const int16_t item_box = Room_GetUnitSector(room, x_sector, z_sector)->box;
-    const BOX_INFO *box = Box_GetBox(item_box);
+    const SECTOR *sector = Room_GetUnitSector(room, x_sector, z_sector);
+    const BOX_INFO *box =
+        Camera_GetBox(sector, g_Camera.target.x, g_Camera.target.z);
 
     room = Room_Get(ideal->room_num);
     z_sector = (ideal->z - room->pos.z) >> WALL_SHIFT;
     x_sector = (ideal->x - room->pos.x) >> WALL_SHIFT;
 
-    int16_t camera_box = Room_GetUnitSector(room, x_sector, z_sector)->box;
-    if (camera_box != NO_BOX
-        && (ideal->z < box->left || ideal->z > box->right || ideal->x < box->top
-            || ideal->x > box->bottom)) {
-        box = Box_GetBox(camera_box);
+    sector = Room_GetUnitSector(room, x_sector, z_sector);
+    if (ideal->z < box->left || ideal->z > box->right || ideal->x < box->top
+        || ideal->x > box->bottom) {
+        box = Camera_GetBox(sector, ideal->x, ideal->z);
     }
 
     int32_t left = box->left;
@@ -434,9 +434,10 @@ static void M_SmartShift(
     const bool bad_left =
         M_BadPosition(ideal->x, ideal->y, test, ideal->room_num);
     if (!bad_left) {
-        camera_box = Room_GetUnitSector(room, x_sector, z_sector - 1)->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->left < left) {
-            left = Box_GetBox(camera_box)->left;
+        sector = Room_GetUnitSector(room, x_sector, z_sector - 1);
+        box = Camera_GetBox(sector, ideal->x, test);
+        if (box->left < left) {
+            left = box->left;
         }
     }
 
@@ -444,9 +445,10 @@ static void M_SmartShift(
     const bool bad_right =
         M_BadPosition(ideal->x, ideal->y, test, ideal->room_num);
     if (!bad_right) {
-        camera_box = Room_GetUnitSector(room, x_sector, z_sector + 1)->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->right > right) {
-            right = Box_GetBox(camera_box)->right;
+        sector = Room_GetUnitSector(room, x_sector, z_sector + 1);
+        box = Camera_GetBox(sector, ideal->x, test);
+        if (box->right > right) {
+            right = box->right;
         }
     }
 
@@ -454,9 +456,10 @@ static void M_SmartShift(
     const bool bad_top =
         M_BadPosition(test, ideal->y, ideal->z, ideal->room_num);
     if (!bad_top) {
-        camera_box = Room_GetUnitSector(room, x_sector - 1, z_sector)->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->top < top) {
-            top = Box_GetBox(camera_box)->top;
+        sector = Room_GetUnitSector(room, x_sector - 1, z_sector);
+        box = Camera_GetBox(sector, test, ideal->z);
+        if (box->top < top) {
+            top = box->top;
         }
     }
 
@@ -464,9 +467,10 @@ static void M_SmartShift(
     const bool bad_bottom =
         M_BadPosition(test, ideal->y, ideal->z, ideal->room_num);
     if (!bad_bottom) {
-        camera_box = Room_GetUnitSector(room, x_sector + 1, z_sector)->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->bottom > bottom) {
-            bottom = Box_GetBox(camera_box)->bottom;
+        sector = Room_GetUnitSector(room, x_sector + 1, z_sector);
+        box = Camera_GetBox(sector, test, ideal->z);
+        if (box->bottom > bottom) {
+            bottom = box->bottom;
         }
     }
 

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -288,17 +288,17 @@ void Camera_SmartShift(
     LOS_Check(&g_Camera.target, target);
 
     const ROOM *room = Room_Get(g_Camera.target.room_num);
-    int16_t item_box =
-        Room_GetWorldSector(room, g_Camera.target.x, g_Camera.target.z)->box;
-    const BOX_INFO *box = Box_GetBox(item_box);
+    const SECTOR *sector =
+        Room_GetWorldSector(room, g_Camera.target.x, g_Camera.target.z);
+    const BOX_INFO *box =
+        Camera_GetBox(sector, g_Camera.target.x, g_Camera.target.z);
 
     room = Room_Get(target->room_num);
-    int16_t camera_box = Room_GetWorldSector(room, target->x, target->z)->box;
+    sector = Room_GetWorldSector(room, target->x, target->z);
 
-    if (camera_box != NO_BOX
-        && (target->z < box->left || target->z > box->right
-            || target->x < box->top || target->x > box->bottom)) {
-        box = Box_GetBox(camera_box);
+    if (target->z < box->left || target->z > box->right || target->x < box->top
+        || target->x > box->bottom) {
+        box = Camera_GetBox(sector, target->x, target->z);
     }
 
     int32_t left = box->left;
@@ -312,9 +312,9 @@ void Camera_SmartShift(
     const SECTOR *good_left =
         Camera_GoodPosition(target->x, target->y, test, target->room_num);
     if (good_left) {
-        camera_box = good_left->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->left < left) {
-            left = Box_GetBox(camera_box)->left;
+        box = Camera_GetBox(good_left, target->x, test);
+        if (box->left < left) {
+            left = box->left;
         }
     } else {
         left = test;
@@ -324,9 +324,9 @@ void Camera_SmartShift(
     const SECTOR *good_right =
         Camera_GoodPosition(target->x, target->y, test, target->room_num);
     if (good_right) {
-        camera_box = good_right->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->right > right) {
-            right = Box_GetBox(camera_box)->right;
+        box = Camera_GetBox(good_right, target->x, test);
+        if (box->right > right) {
+            right = box->right;
         }
     } else {
         right = test;
@@ -336,9 +336,9 @@ void Camera_SmartShift(
     const SECTOR *good_top =
         Camera_GoodPosition(test, target->y, target->z, target->room_num);
     if (good_top) {
-        camera_box = good_top->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->top < top) {
-            top = Box_GetBox(camera_box)->top;
+        box = Camera_GetBox(good_top, test, target->z);
+        if (box->top < top) {
+            top = box->top;
         }
     } else {
         top = test;
@@ -348,9 +348,9 @@ void Camera_SmartShift(
     const SECTOR *good_bottom =
         Camera_GoodPosition(test, target->y, target->z, target->room_num);
     if (good_bottom) {
-        camera_box = good_bottom->box;
-        if (camera_box != NO_BOX && Box_GetBox(camera_box)->bottom > bottom) {
-            bottom = Box_GetBox(camera_box)->bottom;
+        box = Camera_GetBox(good_bottom, test, target->z);
+        if (box->bottom > bottom) {
+            bottom = box->bottom;
         }
     } else {
         bottom = test;
@@ -525,7 +525,7 @@ int32_t Camera_ShiftClamp(GAME_VECTOR *pos, int32_t clamp)
     int32_t y = pos->y;
     int32_t z = pos->z;
     const SECTOR *const sector = Room_GetSector(x, y, z, &pos->room_num);
-    const BOX_INFO *const box = Box_GetBox(sector->box);
+    const BOX_INFO *const box = Camera_GetBox(sector, x, z);
 
     const int32_t left = box->left + clamp;
     const int32_t right = box->right - clamp;


### PR DESCRIPTION
Resolves #2946.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds a workaround to the camera for rooms/sectors that have no box data, whereby in such scenarios a dummy one-sector box is now created on the fly in order to prevent the camera using incorrect and often erratic positioning.

There are a few levels out there with this problem (that I know of):
- https://trcustoms.org/levels/3755 `/play 2, /tp 37 2 63`
- https://trcustoms.org/levels/3775  `/play 1, /tp 88 8 34` (press and release look input)
- https://trcustoms.org/levels/3573 `/play 1, /tp 58 0 46` (jump across the gap)

And of course, we'll need to check this doesn't introduce any regressions. I'll play-test thoroughly too.