### PR TITLE
tr1/creatures: simplify child item storage

### DIFF
--- a/src/tr1/game/carrier.c
+++ b/src/tr1/game/carrier.c
@@ -42,7 +42,7 @@ static ITEM *M_GetCarrier(const int16_t item_num)
     // but then have those items dropped by the actual creatures within.
     ITEM *item = Item_Get(item_num);
     if (Object_IsType(item->object_id, g_PlaceholderObjects)) {
-        const int16_t child_item_num = *(int16_t *)item->data;
+        const int16_t child_item_num = (intptr_t)item->data;
         item = Item_Get(child_item_num);
     }
 

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -4,7 +4,6 @@
 #include "global/const.h"
 #include "global/vars.h"
 
-#include <libtrx/game/game_buf.h>
 #include <libtrx/utils.h>
 
 #define POD_EXPLODE_DIST (WALL_L * 4) // = 4096
@@ -67,9 +66,7 @@ static void M_Initialise(const int16_t item_num)
         bug->shade.value_1 = -1;
 
         Item_Initialise(bug_item_num);
-
-        item->data = GameBuf_Alloc(sizeof(int16_t), GBUF_CREATURE_DATA);
-        *(int16_t *)item->data = bug_item_num;
+        item->data = (void *)(intptr_t)bug_item_num;
     }
 
     item->flags = 0;
@@ -113,7 +110,7 @@ static void M_Control(const int16_t item_num)
             item->collidable = 0;
             Item_Explode(item_num, 0xFFFE00, 0);
 
-            int16_t bug_item_num = *(int16_t *)item->data;
+            const int16_t bug_item_num = (intptr_t)item->data;
             ITEM *const bug = Item_Get(bug_item_num);
             if (Object_Get(bug->object_id)->loaded) {
                 bug->touch_bits = 0;

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -6,7 +6,6 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
-#include <libtrx/game/game_buf.h>
 #include <libtrx/utils.h>
 
 #define STATUE_EXPLODE_DIST (WALL_L * 7 / 2) // = 3584
@@ -53,8 +52,7 @@ static void M_Initialise(const int16_t item_num)
     centaur->goal_anim_state = centaur->current_anim_state;
     centaur->rot.y = item->rot.y;
 
-    item->data = GameBuf_Alloc(sizeof(int16_t), GBUF_CREATURE_DATA);
-    *(int16_t *)item->data = centaur_item_num;
+    item->data = (void *)(intptr_t)centaur_item_num;
 }
 
 static void M_Control(const int16_t item_num)
@@ -74,7 +72,7 @@ static void M_Control(const int16_t item_num)
         Item_Kill(item_num);
         item->status = IS_DEACTIVATED;
 
-        int16_t centaur_item_num = *(int16_t *)item->data;
+        const int16_t centaur_item_num = (intptr_t)item->data;
         ITEM *const centaur = Item_Get(centaur_item_num);
         centaur->touch_bits = 0;
         Item_AddActive(centaur_item_num);

--- a/src/tr1/game/stats/common.c
+++ b/src/tr1/game/stats/common.c
@@ -99,7 +99,7 @@ static void M_CheckTriggers(
             if (item->object_id == O_PODS || item->object_id == O_BIG_POD) {
                 // Check for only valid pods
                 if (item->data != nullptr) {
-                    const int16_t bug_item_num = *(int16_t *)item->data;
+                    const int16_t bug_item_num = (intptr_t)item->data;
                     const ITEM *const bug_item = Item_Get(bug_item_num);
                     if (Object_Get(bug_item->object_id)->loaded) {
                         M_IncludeKillableItem(item_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This converts pods and centaur statues to store their child item number directly rather than via game buf. This is similar to how it's done in TR2 for Bartoli and the dragon items. A minor snag before merging carrier logic later.

Just need to ensure pods and statues spawn their items correctly.
