### PR TITLE
carrier: merge carried item logic

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed health bar in top center position covering inventory text
 - fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
 - fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
+- fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
 - fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
 - fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)
+- fixed potential memory corruption if `/kill all` is used with a Qualopec mummy that is carrying items (#2957, regression from 4.6)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
 - fixed health bar in top center position covering inventory text
 - fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
+- fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -27,6 +27,9 @@
 - fixed being unable to load a save made in the first level if that level removes Lara's weapons but also has a shotgun pickup (#2934, regression from 0.9)
 - fixed misplaced effects such as bubbles and dragon fire in 60 FPS (#2873, #2881, regression from 0.10)
 - improved the `/set` console command to display available options if given an unknown argument
+- improved handling of items that are dropped by enemies (#2952)
+    - added the ability for any enemy type to drop items, excluding eels
+    - fixed items dropped by flying creatures not falling to the ground
 - removed the hard-coded inventory allocation on the first level by default, moving it instead to the game flow (#1867)
 - removed the hard-coded repositioning of Bartoli (pre-dragon) on initialise (#2950)
 

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -267,6 +267,9 @@ However, you can easily download them manually from these urls:
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door
 - fixed Lara being able to equip guns and flares during in-game cutscenes
 - improved the animation of Lara's braid
+- improved handling of items that are dropped by enemies
+    - added the ability for any enemy type to drop items, excluding eels
+    - fixed items dropped by flying creatures not falling to the ground
 
 #### Cheats
 - added a fly cheat

--- a/src/libtrx/game/carrier.c
+++ b/src/libtrx/game/carrier.c
@@ -107,10 +107,12 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
 
     if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {
         item->status = DS_DROPPED;
+        pickup->status = IS_INACTIVE;
         pickup->pos.y = height;
         pickup->fall_speed = 0;
         m_AnimatingCount--;
     } else {
+        pickup->status = IS_ACTIVE;
         pickup->fall_speed +=
             (!in_water && pickup->fall_speed < FAST_FALL_SPEED)
             ? M_DROP_FAST_RATE

--- a/src/libtrx/game/carrier.c
+++ b/src/libtrx/game/carrier.c
@@ -76,7 +76,8 @@ static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *const carrier)
 #if TR_VERSION == 1
     // Qualopec mummy can drop items just from having touched it. Runaway Pierre
     // can never drop items.
-    can_drop |= carrier->object_id == O_MUMMY;
+    can_drop |=
+        carrier->object_id == O_MUMMY && carrier->status == IS_DEACTIVATED;
     can_drop &=
         (carrier->object_id != O_PIERRE || (carrier->flags & IF_ONE_SHOT) != 0);
 #else

--- a/src/libtrx/game/carrier.c
+++ b/src/libtrx/game/carrier.c
@@ -17,6 +17,7 @@
 static int16_t m_AnimatingCount = 0;
 
 static ITEM *M_GetCarrier(int16_t item_num);
+static bool M_IsCarrierType(GAME_OBJECT_ID obj_id);
 static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *carrier);
 static void M_AnimateDrop(CARRIED_ITEM *item);
 static void M_InitialiseDataDrops(void);
@@ -52,21 +53,38 @@ static ITEM *M_GetCarrier(const int16_t item_num)
     return item;
 }
 
+static bool M_IsCarrierType(const GAME_OBJECT_ID obj_id)
+{
+    bool is_enemy = Object_IsType(obj_id, g_EnemyObjects);
+#if TR_VERSION == 2
+    // Eels are hostile but cannot be killed, so must be excluded. Monks may be
+    // allocated drop items whether or not they are hostile. Drop items must be
+    // assigned to the skidoo and not the rider to avoid issues with /kill, and
+    // O_DRAGON_BACK is the active dragon, but having this in g_EnemyObjects
+    // also creates issues with /kill, hence a separate check is required here.
+    is_enemy &= obj_id != O_EEL && obj_id != O_BIG_EEL;
+    is_enemy &= obj_id != O_SKIDOO_DRIVER;
+    is_enemy |= obj_id == O_MONK_1 || obj_id == O_MONK_2;
+    is_enemy |= obj_id == O_DRAGON_BACK || obj_id == O_SKIDOO_ARMED;
+#endif
+    return is_enemy;
+}
+
 static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *const carrier)
 {
-    // TODO: consolidate/tidy
+    bool can_drop = carrier->hit_points <= 0;
 #if TR_VERSION == 1
-    if (carrier->hit_points > 0 && carrier->object_id != O_MUMMY) {
-        return nullptr;
-    }
-
-    if (carrier->object_id == O_PIERRE && !(carrier->flags & IF_ONE_SHOT)) {
-        return nullptr;
-    }
-    return carrier->carried_item;
+    // Qualopec mummy can drop items just from having touched it. Runaway Pierre
+    // can never drop items.
+    can_drop |= carrier->object_id == O_MUMMY;
+    can_drop &=
+        (carrier->object_id != O_PIERRE || (carrier->flags & IF_ONE_SHOT) != 0);
 #else
-    return nullptr;
+    can_drop &=
+        (carrier->object_id != O_DRAGON_BACK
+         || carrier->status == IS_DEACTIVATED);
 #endif
+    return can_drop ? carrier->carried_item : nullptr;
 }
 
 static void M_AnimateDrop(CARRIED_ITEM *const item)
@@ -117,13 +135,11 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
 
 static void M_InitialiseDataDrops(void)
 {
-#if TR_VERSION == 1
     VECTOR *const pickups = Vector_Create(sizeof(int16_t));
 
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         ITEM *const carrier = M_GetCarrier(i);
-        if (carrier == nullptr
-            || !Object_IsType(carrier->object_id, g_EnemyObjects)) {
+        if (carrier == nullptr || !M_IsCarrierType(carrier->object_id)) {
             continue;
         }
 
@@ -166,7 +182,6 @@ static void M_InitialiseDataDrops(void)
     }
 
     Vector_Free(pickups);
-#endif
 }
 
 static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
@@ -192,7 +207,7 @@ static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
             continue;
         }
 
-        if (!Object_IsType(item->object_id, g_EnemyObjects)) {
+        if (!M_IsCarrierType(item->object_id)) {
             LOG_WARNING(
                 "Item %d of type %d cannot carry items", data->enemy_num,
                 item->object_id);
@@ -243,7 +258,6 @@ void Carrier_InitialiseLevel(const GF_LEVEL *const level)
 
 int32_t Carrier_GetItemCount(const int16_t item_num)
 {
-#if TR_VERSION == 1
     const ITEM *const carrier = M_GetCarrier(item_num);
     if (carrier == nullptr) {
         return 0;
@@ -259,9 +273,6 @@ int32_t Carrier_GetItemCount(const int16_t item_num)
     }
 
     return count;
-#else
-    return 0;
-#endif
 }
 
 bool Carrier_IsItemCarried(const int16_t item_num)
@@ -339,7 +350,6 @@ void Carrier_TestItemDrops(const int16_t item_num)
 
 void Carrier_TestLegacyDrops(const int16_t item_num)
 {
-#if TR_VERSION == 1
     const ITEM *const carrier = Item_Get(item_num);
     if (carrier->hit_points > 0) {
         return;
@@ -365,7 +375,6 @@ void Carrier_TestLegacyDrops(const int16_t item_num)
             item = item->next_item;
         }
     }
-#endif
 }
 
 void Carrier_AnimateDrops(void)
@@ -373,7 +382,7 @@ void Carrier_AnimateDrops(void)
     if (m_AnimatingCount == 0) {
         return;
     }
-#if TR_VERSION == 1
+
     // Make items that spawn in mid-air or water gracefully fall to the floor.
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         const ITEM *const carrier = Item_Get(i);
@@ -383,5 +392,4 @@ void Carrier_AnimateDrops(void)
             item = item->next_item;
         }
     }
-#endif
 }

--- a/src/libtrx/game/carrier.c
+++ b/src/libtrx/game/carrier.c
@@ -1,22 +1,18 @@
 #include "game/carrier.h"
 
+#include "game/game_buf.h"
 #include "game/game_flow.h"
+#include "game/game_flow/vars.h"
 #include "game/inventory.h"
-#include "game/items.h"
-#include "game/objects/vars.h"
-#include "global/const.h"
-#include "global/types.h"
-#include "global/vars.h"
+#include "game/objects.h"
+#include "game/rooms.h"
+#include "log.h"
+#include "vector.h"
 
-#include <libtrx/game/game_buf.h>
-#include <libtrx/game/math.h>
-#include <libtrx/log.h>
-#include <libtrx/vector.h>
-
-#define DROP_FAST_RATE GRAVITY
-#define DROP_SLOW_RATE 1
-#define DROP_FAST_TURN (DEG_1 * 5)
-#define DROP_SLOW_TURN (DEG_1 * 3)
+#define M_DROP_FAST_RATE GRAVITY
+#define M_DROP_SLOW_RATE 1
+#define M_DROP_FAST_TURN (DEG_1 * 5)
+#define M_DROP_SLOW_TURN (DEG_1 * 3)
 
 static int16_t m_AnimatingCount = 0;
 
@@ -27,8 +23,10 @@ static void M_InitialiseDataDrops(void);
 static void M_InitialiseGameFlowDrops(const GF_LEVEL *level);
 
 static const GAME_OBJECT_PAIR m_LegacyMap[] = {
+#if TR_VERSION == 1
     { O_PIERRE, O_SCION_ITEM_2 }, { O_COWBOY, O_MAGNUM_ITEM },
     { O_SKATEKID, O_UZI_ITEM },   { O_BALDY, O_SHOTGUN_ITEM },
+#endif
     { NO_OBJECT, NO_OBJECT },
 };
 
@@ -56,6 +54,8 @@ static ITEM *M_GetCarrier(const int16_t item_num)
 
 static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *const carrier)
 {
+    // TODO: consolidate/tidy
+#if TR_VERSION == 1
     if (carrier->hit_points > 0 && carrier->object_id != O_MUMMY) {
         return nullptr;
     }
@@ -63,8 +63,10 @@ static CARRIED_ITEM *M_GetFirstDropItem(const ITEM *const carrier)
     if (carrier->object_id == O_PIERRE && !(carrier->flags & IF_ONE_SHOT)) {
         return nullptr;
     }
-
     return carrier->carried_item;
+#else
+    return nullptr;
+#endif
 }
 
 static void M_AnimateDrop(CARRIED_ITEM *const item)
@@ -82,7 +84,8 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
         pickup->pos.x, pickup->pos.y - 10, pickup->pos.z, &room_num);
     const int16_t height =
         Room_GetHeight(sector, pickup->pos.x, pickup->pos.y, pickup->pos.z);
-    const bool in_water = Room_Get(pickup->room_num)->flags & RF_UNDERWATER;
+    const bool in_water =
+        (Room_Get(pickup->room_num)->flags & RF_UNDERWATER) != 0;
 
     if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {
         item->status = DS_DROPPED;
@@ -92,10 +95,10 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
     } else {
         pickup->fall_speed +=
             (!in_water && pickup->fall_speed < FAST_FALL_SPEED)
-            ? DROP_FAST_RATE
-            : DROP_SLOW_RATE;
+            ? M_DROP_FAST_RATE
+            : M_DROP_SLOW_RATE;
         pickup->pos.y += pickup->fall_speed;
-        pickup->rot.y += in_water ? DROP_SLOW_TURN : DROP_FAST_TURN;
+        pickup->rot.y += in_water ? M_DROP_SLOW_TURN : M_DROP_FAST_TURN;
 
         if (sector->portal_room.pit != NO_ROOM
             && pickup->pos.y > sector->floor.height) {
@@ -114,6 +117,7 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
 
 static void M_InitialiseDataDrops(void)
 {
+#if TR_VERSION == 1
     VECTOR *const pickups = Vector_Create(sizeof(int16_t));
 
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
@@ -162,10 +166,12 @@ static void M_InitialiseDataDrops(void)
     }
 
     Vector_Free(pickups);
+#endif
 }
 
 static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
 {
+#if TR_VERSION == 1
     int32_t total_item_count = Item_GetLevelCount();
     for (int32_t i = 0; i < level->item_drops.count; i++) {
         const GF_DROP_ITEM_DATA *const data = &level->item_drops.data[i];
@@ -220,28 +226,32 @@ static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
             }
         }
     }
+#endif
 }
 
 void Carrier_InitialiseLevel(const GF_LEVEL *const level)
 {
     m_AnimatingCount = 0;
-    if (g_GameFlow.enable_tr2_item_drops) {
-        M_InitialiseDataDrops();
-    } else {
+#if TR_VERSION == 1
+    if (!g_GameFlow.enable_tr2_item_drops) {
         M_InitialiseGameFlowDrops(level);
+        return;
     }
+#endif
+    M_InitialiseDataDrops();
 }
 
 int32_t Carrier_GetItemCount(const int16_t item_num)
 {
+#if TR_VERSION == 1
     const ITEM *const carrier = M_GetCarrier(item_num);
-    if (!carrier) {
+    if (carrier == nullptr) {
         return 0;
     }
 
     const CARRIED_ITEM *item = carrier->carried_item;
     int32_t count = 0;
-    while (item) {
+    while (item != nullptr) {
         if (item->object_id != NO_OBJECT) {
             count++;
         }
@@ -249,13 +259,16 @@ int32_t Carrier_GetItemCount(const int16_t item_num)
     }
 
     return count;
+#else
+    return 0;
+#endif
 }
 
 bool Carrier_IsItemCarried(const int16_t item_num)
 {
     // This only applies to TR2-style drops; gameflow drop item numbers are not
     // assigned until they are dropped, so this would always logically be false.
-    const ITEM *item = Item_Get(item_num);
+    const ITEM *const item = Item_Get(item_num);
     return item->room_num == NO_ROOM;
 }
 
@@ -290,11 +303,13 @@ void Carrier_TestItemDrops(const int16_t item_num)
         }
 
         GAME_OBJECT_ID obj_id = item->object_id;
+#if TR_VERSION == 1
         if (g_GameFlow.convert_dropped_guns
             && Object_IsType(obj_id, g_GunObjects) && Inv_RequestItem(obj_id)
             && obj_id != O_PISTOL_ITEM) {
             obj_id = Object_GetCognate(obj_id, g_GunAmmoObjectMap);
         }
+#endif
 
         if (item->spawn_num == NO_ITEM) {
             // This is a gameflow-defined drop, so a spawn number is required.
@@ -319,11 +334,12 @@ void Carrier_TestItemDrops(const int16_t item_num)
             Item_UpdateRoom(item->spawn_num, item->room_num);
         }
 
-    } while ((item = item->next_item));
+    } while ((item = item->next_item) != nullptr);
 }
 
 void Carrier_TestLegacyDrops(const int16_t item_num)
 {
+#if TR_VERSION == 1
     const ITEM *const carrier = Item_Get(item_num);
     if (carrier->hit_points > 0) {
         return;
@@ -343,27 +359,29 @@ void Carrier_TestLegacyDrops(const int16_t item_num)
         Carrier_TestItemDrops(item_num);
     } else {
         CARRIED_ITEM *item = carrier->carried_item;
-        while (item) {
+        while (item != nullptr) {
             // Simulate Lara having picked up the item.
             item->status = DS_COLLECTED;
             item = item->next_item;
         }
     }
+#endif
 }
 
 void Carrier_AnimateDrops(void)
 {
-    if (!m_AnimatingCount) {
+    if (m_AnimatingCount == 0) {
         return;
     }
-
+#if TR_VERSION == 1
     // Make items that spawn in mid-air or water gracefully fall to the floor.
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         const ITEM *const carrier = Item_Get(i);
         CARRIED_ITEM *item = carrier->carried_item;
-        while (item) {
+        while (item != nullptr) {
             M_AnimateDrop(item);
             item = item->next_item;
         }
     }
+#endif
 }

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -1,4 +1,5 @@
 #include "game/camera/vars.h"
+#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/lara/common.h"
 #include "game/los.h"
@@ -32,10 +33,6 @@ static bool M_SwitchToWater(
 static bool M_SwitchToLand(
     int16_t item_num, const int32_t *wh, const HYBRID_INFO *info);
 static bool M_TestSwitchOrKill(int16_t item_num, GAME_OBJECT_ID target_id);
-
-#if TR_VERSION == 1
-extern void Carrier_TestItemDrops(int16_t item_num);
-#endif
 
 static void M_GetBaddieTarget(const int16_t item_num, const bool goody)
 {
@@ -1004,19 +1001,9 @@ void Creature_Die(const int16_t item_num, const bool explode)
         item->next_active = Item_GetPrevActive();
         Item_SetPrevActive(item_num);
     }
-
-    if (obj->intelligent) {
-        int16_t pickup_num = item->carried_item;
-        while (pickup_num != NO_ITEM) {
-            ITEM *const pickup = Item_Get(pickup_num);
-            pickup->pos = item->pos;
-            Item_UpdateRoom(pickup_num, item->room_num);
-            pickup_num = pickup->carried_item;
-        }
-    }
-#else
-    Carrier_TestItemDrops(item_num);
 #endif
+
+    Carrier_TestItemDrops(item_num);
 }
 
 int32_t Creature_Vault(

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -138,6 +138,7 @@ void Item_Initialise(const int16_t item_num)
     item->touch_bits = 0;
     item->data = nullptr;
     item->priv = nullptr;
+    item->carried_item = nullptr;
 
     item->active = 0;
     item->status = IS_INACTIVE;
@@ -148,7 +149,6 @@ void Item_Initialise(const int16_t item_num)
     item->enable_interpolation = true;
 
 #if TR_VERSION == 1
-    item->carried_item = nullptr;
     item->enable_shadow = true;
 #else
     item->killed = 0;

--- a/src/libtrx/include/libtrx/game/carrier.h
+++ b/src/libtrx/include/libtrx/game/carrier.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "game/game_flow/types.h"
-#include "global/types.h"
+#include "./game_flow/types.h"
+#include "./items/types.h"
 
 void Carrier_InitialiseLevel(const GF_LEVEL *level);
 int32_t Carrier_GetItemCount(int16_t item_num);

--- a/src/libtrx/include/libtrx/game/items/enum.h
+++ b/src/libtrx/include/libtrx/game/items/enum.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#if TR_VERSION == 1
 typedef enum {
-    DS_CARRIED = 0,
-    DS_FALLING = 1,
-    DS_DROPPED = 2,
+    // clang-format off
+    DS_CARRIED   = 0,
+    DS_FALLING   = 1,
+    DS_DROPPED   = 2,
     DS_COLLECTED = 3,
+    // clang-format on
 } DROP_STATUS;
-#endif
 
 typedef enum {
     // clang-format off

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -5,7 +5,6 @@
 #include "../output/types.h"
 #include "./enum.h"
 
-#if TR_VERSION == 1
 typedef struct CARRIED_ITEM {
     GAME_OBJECT_ID object_id;
     int16_t spawn_num;
@@ -16,7 +15,6 @@ typedef struct CARRIED_ITEM {
     DROP_STATUS status;
     struct CARRIED_ITEM *next_item;
 } CARRIED_ITEM;
-#endif
 
 typedef struct {
     int32_t floor;

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -43,11 +43,9 @@ typedef struct {
     SHADE shade;
     void *data;
     void *priv;
-#if TR_VERSION == 1
     CARRIED_ITEM *carried_item;
+#if TR_VERSION == 1
     bool enable_shadow;
-#elif TR_VERSION == 2
-    int16_t carried_item;
 #endif
 
     XYZ_32 pos;

--- a/src/libtrx/include/libtrx/game/objects/vars.h
+++ b/src/libtrx/include/libtrx/game/objects/vars.h
@@ -7,12 +7,15 @@ extern const GAME_OBJECT_ID g_EnemyObjects[];
 extern const GAME_OBJECT_ID g_WaterObjects[];
 extern const GAME_OBJECT_ID g_AllyObjects[];
 extern const GAME_OBJECT_ID g_PickupObjects[];
+extern const GAME_OBJECT_ID g_GunObjects[];
 extern const GAME_OBJECT_ID g_AnimObjects[];
 extern const GAME_OBJECT_ID g_NullObjects[];
 extern const GAME_OBJECT_ID g_InvObjects[];
 extern const GAME_OBJECT_ID g_WaterSpriteObjects[];
 extern const GAME_OBJECT_ID g_BossObjects[];
+extern const GAME_OBJECT_ID g_PlaceholderObjects[];
 
+extern const GAME_OBJECT_PAIR g_GunAmmoObjectMap[];
 extern const GAME_OBJECT_PAIR g_ItemToInvObjectMap[];
 extern const GAME_OBJECT_PAIR g_KeyItemToReceptacleMap[];
 extern const GAME_OBJECT_PAIR g_ReceptacleToReceptacleDoneMap[];

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -90,6 +90,7 @@ sources = [
   'game/camera/fixed.c',
   'game/camera/photo_mode.c',
   'game/camera/vars.c',
+  'game/carrier.c',
   'game/clock/common.c',
   'game/clock/timer.c',
   'game/clock/turbo.c',

--- a/src/tr1/game/items.c
+++ b/src/tr1/game/items.c
@@ -1,6 +1,6 @@
 #include "game/items.h"
 
-#include "game/carrier.h"
+#include <libtrx/game/carrier.h>
 
 void Item_Control(void)
 {

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -376,7 +376,12 @@ bool Lara_Cheat_KillEnemy(const int16_t item_num)
     Item_Explode(item_num, -1, 0);
     Sound_Effect(SFX_EXPLOSION_CHEAT, &item->pos, SPM_NORMAL);
     Item_Kill(item_num);
-    LOT_DisableBaddieAI(item_num);
+    if (item->object_id != O_MUMMY) {
+        // The Qualopec mummy uses only one short as its creature data; having
+        // LOT disable this can lead to memory corruption as it expects a
+        // regular CREATURE.
+        LOT_DisableBaddieAI(item_num);
+    }
     item->flags |= IF_ONE_SHOT;
     Carrier_TestItemDrops(item_num);
     return true;

--- a/src/tr1/game/lara/cheat.c
+++ b/src/tr1/game/lara/cheat.c
@@ -1,7 +1,6 @@
 #include "game/lara/cheat.h"
 
 #include "game/camera.h"
-#include "game/carrier.h"
 #include "game/console/common.h"
 #include "game/game.h"
 #include "game/game_flow.h"
@@ -18,6 +17,7 @@
 #include "global/types.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
 #include <libtrx/vector.h>

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -1,7 +1,6 @@
 #include "game/level.h"
 
 #include "game/camera.h"
-#include "game/carrier.h"
 #include "game/effects.h"
 #include "game/game.h"
 #include "game/inventory_ring/vars.h"
@@ -27,6 +26,7 @@
 #include <libtrx/benchmark.h>
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/game_string_table.h>
 #include <libtrx/game/inject.h>

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -1,4 +1,3 @@
-#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lara/common.h"
@@ -8,6 +7,7 @@
 #include "global/vars.h"
 
 #include <libtrx/config.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 #define CROCODILE_BITE_DAMAGE 100

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -1,4 +1,3 @@
-#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/game.h"
 #include "game/items.h"
@@ -8,6 +7,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -1,6 +1,5 @@
 #include "game/objects/creatures/mutant.h"
 
-#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lara/common.h"
@@ -11,6 +10,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 #define FLYER_CHARGE_DAMAGE 100

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -1,4 +1,3 @@
-#include "game/carrier.h"
 #include "game/creature.h"
 #include "game/items.h"
 #include "game/lara/common.h"
@@ -8,6 +7,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 #define RAT_BITE_DAMAGE 20

--- a/src/tr1/game/objects/vars.h
+++ b/src/tr1/game/objects/vars.h
@@ -2,9 +2,5 @@
 
 #include <libtrx/game/objects/vars.h>
 
-extern const GAME_OBJECT_ID g_PlaceholderObjects[];
-extern const GAME_OBJECT_ID g_GunObjects[];
 extern const GAME_OBJECT_ID g_DoorObjects[];
 extern const GAME_OBJECT_ID g_TrapdoorObjects[];
-
-extern const GAME_OBJECT_PAIR g_GunAmmoObjectMap[];

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -1,5 +1,4 @@
 #include "game/camera.h"
-#include "game/carrier.h"
 #include "game/effects.h"
 #include "game/game.h"
 #include "game/game_flow.h"
@@ -17,6 +16,7 @@
 #include <libtrx/bson.h>
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/savegame/bson.h>
 #include <libtrx/json.h>
 #include <libtrx/log.h>

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -1,5 +1,4 @@
 #include "game/camera.h"
-#include "game/carrier.h"
 #include "game/effects.h"
 #include "game/game.h"
 #include "game/game_flow.h"
@@ -15,6 +14,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 #include <libtrx/utils.h>

--- a/src/tr1/game/stats/common.c
+++ b/src/tr1/game/stats/common.c
@@ -1,4 +1,3 @@
-#include "game/carrier.h"
 #include "game/clock.h"
 #include "game/game.h"
 #include "game/game_flow.h"
@@ -11,6 +10,7 @@
 #include "global/types.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/log.h>
 #include <libtrx/utils.h>

--- a/src/tr1/meson.build
+++ b/src/tr1/meson.build
@@ -102,7 +102,6 @@ endif
 sources = [
   init,
   'game/camera/common.c',
-  'game/carrier.c',
   'game/clock.c',
   'game/console/cmd/debug.c',
   'game/console/cmd/easy_config.c',

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -104,35 +104,6 @@ void InitialiseGameFlags(void)
     Creature_SetAlliesHostile(false);
 }
 
-void GetCarriedItems(void)
-{
-    for (int32_t item_num = 0; item_num < Item_GetLevelCount(); item_num++) {
-        ITEM *const item = Item_Get(item_num);
-        if (!Object_Get(item->object_id)->intelligent) {
-            continue;
-        }
-        item->carried_item = NO_ITEM;
-
-        const ROOM *const room = Room_Get(item->room_num);
-        int16_t pickup_item_num = room->item_num;
-        do {
-            ITEM *const pickup_item = Item_Get(pickup_item_num);
-
-            if (pickup_item->pos.x == item->pos.x
-                && pickup_item->pos.y == item->pos.y
-                && pickup_item->pos.z == item->pos.z
-                && Object_IsType(pickup_item->object_id, g_PickupObjects)) {
-                pickup_item->carried_item = item->carried_item;
-                item->carried_item = pickup_item_num;
-                Item_RemoveDrawn(pickup_item_num);
-                pickup_item->room_num = NO_ROOM;
-            }
-
-            pickup_item_num = pickup_item->next_item;
-        } while (pickup_item_num != NO_ITEM);
-    }
-}
-
 int32_t DoShift(
     ITEM *const vehicle, const XYZ_32 *const pos, const XYZ_32 *const old)
 {

--- a/src/tr2/decomp/decomp.h
+++ b/src/tr2/decomp/decomp.h
@@ -17,7 +17,6 @@ void DecreaseScreenSize(void);
 void IncreaseScreenSize(void);
 void S_UnloadLevelFile(void);
 void InitialiseGameFlags(void);
-void GetCarriedItems(void);
 int32_t DoShift(ITEM *vehicle, const XYZ_32 *pos, const XYZ_32 *old);
 int32_t DoDynamics(int32_t height, int32_t fall_speed, int32_t *out_y);
 int32_t GetCollisionAnim(const ITEM *vehicle, XYZ_32 *moved);

--- a/src/tr2/game/items.c
+++ b/src/tr2/game/items.c
@@ -1,5 +1,7 @@
 #include "game/items.h"
 
+#include <libtrx/game/carrier.h>
+
 void Item_Control(void)
 {
     int16_t item_num = Item_GetNextActive();
@@ -12,4 +14,6 @@ void Item_Control(void)
         }
         item_num = next;
     }
+
+    Carrier_AnimateDrops();
 }

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -25,6 +25,7 @@
 #include <libtrx/debug.h>
 #include <libtrx/engine/audio.h>
 #include <libtrx/filesystem.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/game_string_table.h>
 #include <libtrx/game/gym.h>
@@ -343,7 +344,7 @@ bool Level_Initialise(
     if (g_Lara.item_num != NO_ITEM) {
         Lara_Initialise(level);
     }
-    GetCarriedItems();
+    Carrier_InitialiseLevel(level);
 
     if (seq_ctx != GFSC_SAVED) {
         MovableBlock_SetupFloor();

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -4,6 +4,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -145,6 +146,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state != BARRACUDA_ANIM_DEATH) {
             Item_SwitchToAnim(item, BARRACUDA_ANIM_DEATH, 0);
             item->current_anim_state = BARRACUDA_STATE_DEATH;
+            Carrier_TestItemDrops(item_num);
         }
         Creature_Float(item_num);
     }

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -5,6 +5,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/lara/const.h>
 
 // clang-format off
@@ -131,6 +132,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state != DIVER_STATE_DEATH) {
             Item_SwitchToAnim(item, DIVER_DIE_ANIM, 0);
             item->current_anim_state = DIVER_STATE_DEATH;
+            Carrier_TestItemDrops(item_num);
         }
         Creature_Float(item_num);
         return;

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -13,6 +13,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara/common.h>
 #include <libtrx/game/math.h>
@@ -67,7 +68,7 @@ static const BITE m_DragonMouth = {
     .mesh_num = 12,
 };
 
-static void M_MarkDragonDead(const ITEM *dragon_back_item);
+static void M_MarkDragonDead(ITEM *dragon_back_item);
 static void M_PushLaraAway(ITEM *lara_item, ITEM *dragon_item, int32_t shift);
 static void M_PullDagger(ITEM *lara_item, ITEM *dragon_back_item);
 static void M_SetupFront(OBJECT *obj);
@@ -76,13 +77,20 @@ static void M_HandleSaveFront(ITEM *item, SAVEGAME_STAGE stage);
 static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 static void M_Control(int16_t item_num);
 
-static void M_MarkDragonDead(const ITEM *const dragon_back_item)
+static void M_MarkDragonDead(ITEM *const dragon_back_item)
 {
     const int16_t dragon_front_item_num = (intptr_t)dragon_back_item->data;
     const ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
     CREATURE *const creature = dragon_front_item->data;
     creature->flags = -1;
     Stats_AddKill();
+
+    // Allow drops to occur at the beginning of the cinematic camera for a
+    // better window to avoid seeing the items spawn.
+    const ITEM_STATUS current_status = dragon_back_item->status;
+    dragon_back_item->status = IS_DEACTIVATED;
+    Carrier_TestItemDrops(Item_GetIndex(dragon_back_item));
+    dragon_back_item->status = current_status;
 }
 
 static void M_PushLaraAway(

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -7,6 +7,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -88,6 +89,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state != SHARK_STATE_DEATH) {
             Item_SwitchToAnim(item, SHARK_ANIM_DEATH, 0);
             item->current_anim_state = SHARK_STATE_DEATH;
+            Carrier_TestItemDrops(item_num);
         }
         Creature_Float(item_num);
     } else {

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -8,6 +8,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 #define SKIDOO_DRIVER_MIN_TURN (SKIDOO_MAX_TURN / 3) // = 364
@@ -75,6 +76,7 @@ static void M_ControlDead(ITEM *const driver_item, ITEM *const skidoo_item)
         driver_item->room_num = skidoo_item->room_num;
         Item_SwitchToAnim(driver_item, SKIDOO_DRIVER_ANIM_DEATH, 0);
         driver_item->current_anim_state = SKIDOO_DRIVER_STATE_DEATH;
+        Carrier_TestItemDrops(Item_GetIndex(skidoo_item));
 
         if (g_Lara.target == skidoo_item) {
             g_Lara.target = nullptr;

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -11,6 +11,7 @@
 #include "global/const.h"
 #include "global/vars.h"
 
+#include <libtrx/game/carrier.h>
 #include <libtrx/utils.h>
 
 // clang-format off
@@ -146,6 +147,7 @@ static void M_Control(const int16_t item_num)
         Item_Kill(item_num);
         item->status = IS_DEACTIVATED;
         Sound_Effect(SFX_SPIDER_EXPLODE, &item->pos, SPM_NORMAL);
+        Carrier_TestItemDrops(item_num);
         return;
     }
 

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -12,6 +12,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/interpolation.h>
 #include <libtrx/utils.h>
 
@@ -132,6 +133,7 @@ static void M_Control(const int16_t item_num)
             Item_Kill(item_num);
             item->status = IS_DEACTIVATED;
             item->flags |= IF_ONE_SHOT;
+            Carrier_TestItemDrops(item_num);
         }
         return;
     }

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -11,6 +11,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/interpolation.h>
 #include <libtrx/utils.h>
 
@@ -169,6 +170,7 @@ static void M_Control(const int16_t item_num)
             Item_Kill(item_num);
             item->status = IS_DEACTIVATED;
             item->flags |= IF_ONE_SHOT;
+            Carrier_TestItemDrops(item_num);
         }
         return;
     }

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -280,15 +280,16 @@ static void M_Draw(const ITEM *const item)
         const int16_t y_off = frame->offset.y - bounds.max.y;
         bounds.max.y -= bounds.max.y;
         bounds.min.y -= bounds.max.y;
-        offset = item->pos.y + y_off;
+        offset = item->interp.result.pos.y + y_off;
     } else {
         bounds = Object_GetBoundingBox(obj, nullptr, item->mesh_bits);
         offset = item->pos.y - (bounds.max.y - bounds.min.y) / 2;
     }
 
     Matrix_Push();
-    Matrix_TranslateAbs(item->pos.x, offset, item->pos.z);
-    Matrix_Rot16(item->rot);
+    Matrix_TranslateAbs(
+        item->interp.result.pos.x, offset, item->interp.result.pos.z);
+    Matrix_Rot16(item->interp.result.rot);
 
     Output_CalculateLight(item->pos, item->room_num);
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -110,6 +110,19 @@ const GAME_OBJECT_ID g_PickupObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_GunObjects[] = {
+    // clang-format off
+    O_PISTOL_ITEM,
+    O_SHOTGUN_ITEM,
+    O_MAGNUM_ITEM,
+    O_UZI_ITEM,
+    O_HARPOON_ITEM,
+    O_M16_ITEM,
+    O_GRENADE_ITEM,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_SecretObjects[] = {
     // clang-format off
     O_SECRET_1,
@@ -268,6 +281,25 @@ const GAME_OBJECT_ID g_BossObjects[] = {
     O_SKIDOO_ARMED,
     O_DINO,
     NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_PlaceholderObjects[] = {
+    // clang-format off
+    NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_PAIR g_GunAmmoObjectMap[] = {
+    // clang-format off
+    { O_PISTOL_ITEM, O_PISTOL_AMMO_ITEM },
+    { O_SHOTGUN_ITEM, O_SHOTGUN_AMMO_ITEM },
+    { O_MAGNUM_ITEM, O_MAGNUM_AMMO_ITEM },
+    { O_UZI_ITEM, O_UZI_AMMO_ITEM },
+    { O_HARPOON_ITEM, O_HARPOON_AMMO_ITEM },
+    { O_M16_ITEM, O_M16_AMMO_ITEM },
+    { O_GRENADE_ITEM, O_GRENADE_AMMO_ITEM },
+    { NO_OBJECT, NO_OBJECT },
     // clang-format on
 };
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -29,7 +29,6 @@ const GAME_OBJECT_ID g_EnemyObjects[] = {
     O_BEAR,
     O_CROW,
     O_TIGER,
-    O_BARTOLI,
     O_XIAN_SPEARMAN,
     O_XIAN_SPEARMAN_STATUE,
     O_XIAN_KNIGHT,
@@ -286,6 +285,7 @@ const GAME_OBJECT_ID g_BossObjects[] = {
 
 const GAME_OBJECT_ID g_PlaceholderObjects[] = {
     // clang-format off
+    O_BARTOLI,
     NO_OBJECT,
     // clang-format on
 };

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -11,6 +11,7 @@
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/savegame/bson.h>
 #include <libtrx/game/shell.h>
@@ -677,11 +678,27 @@ static JSON_ARRAY *M_DumpItems(void)
                     item_obj, "creature_flags", creature->flags);
                 JSON_ObjectAppendInt(item_obj, "creature_mood", creature->mood);
             }
-            if (obj->intelligent) {
-                JSON_ObjectAppendInt(
-                    item_obj, "carried_item", item->carried_item);
-            }
         }
+
+        JSON_ARRAY *const carried_items_arr = JSON_ArrayNew();
+
+        const CARRIED_ITEM *drop_item = item->carried_item;
+        while (drop_item != nullptr) {
+            JSON_OBJECT *drop_obj = JSON_ObjectNew();
+            JSON_ObjectAppendInt(drop_obj, "object_id", drop_item->object_id);
+            DUMP_XYZ(drop_obj, "pos", drop_item->pos);
+            JSON_ObjectAppendInt(drop_obj, "y_rot", drop_item->rot.y);
+            JSON_ObjectAppendInt(drop_obj, "room_num", drop_item->room_num);
+            JSON_ObjectAppendInt(drop_obj, "fall_speed", drop_item->fall_speed);
+
+            const DROP_STATUS status = Carrier_GetSaveStatus(drop_item);
+            JSON_ObjectAppendInt(drop_obj, "status", status);
+
+            JSON_ArrayAppendObject(carried_items_arr, drop_obj);
+            drop_item = drop_item->next_item;
+        }
+
+        JSON_ObjectAppendArray(item_obj, "carried_items", carried_items_arr);
 
         switch (item->object_id) {
         case O_BOAT: {
@@ -846,9 +863,35 @@ static bool M_LoadItems(JSON_ARRAY *const items_arr)
                 }
             }
 
-            if (obj->intelligent) {
-                item->carried_item =
-                    JSON_ObjectGetInt(item_obj, "carried_item", NO_ITEM);
+            JSON_ARRAY *const carried_items =
+                JSON_ObjectGetArray(item_obj, "carried_items");
+            if (carried_items != nullptr) {
+                CARRIED_ITEM *carried_item = item->carried_item;
+                for (int32_t j = 0; j < (signed)carried_items->length; j++) {
+                    if (carried_item == nullptr) {
+                        LOG_ERROR("Malformed save: carried item mismatch");
+                        return false;
+                    }
+
+                    JSON_OBJECT *const carried_item_obj =
+                        JSON_ArrayGetObject(carried_items, j);
+                    carried_item->object_id = JSON_ObjectGetInt(
+                        carried_item_obj, "object_id", carried_item->object_id);
+                    LOAD_XYZ(carried_item_obj, "pos", carried_item->pos);
+                    carried_item->rot.y = JSON_ObjectGetInt(
+                        carried_item_obj, "y_rot", carried_item->rot.y);
+                    carried_item->room_num = JSON_ObjectGetInt(
+                        carried_item_obj, "room_num", carried_item->room_num);
+                    carried_item->fall_speed = JSON_ObjectGetInt(
+                        carried_item_obj, "fall_speed",
+                        carried_item->fall_speed);
+                    carried_item->status = JSON_ObjectGetInt(
+                        carried_item_obj, "status", carried_item->status);
+
+                    carried_item = carried_item->next_item;
+                }
+
+                Carrier_TestItemDrops(i);
             }
 
             switch (item->object_id) {

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -13,6 +13,7 @@
 #include "global/vars.h"
 
 #include <libtrx/debug.h>
+#include <libtrx/game/carrier.h>
 #include <libtrx/game/music.h>
 #include <libtrx/memory.h>
 
@@ -238,7 +239,7 @@ static void M_ReadItems(void)
             item->flags = M_ReadU16();
 
             if (obj->intelligent) {
-                item->carried_item = M_ReadS16();
+                M_Skip(sizeof(int16_t)); // legacy carried item
             }
             item->timer = M_ReadS16();
 
@@ -523,8 +524,10 @@ static void M_WriteItems(void)
                 flags |= SAVE_CREATURE;
             }
             M_WriteU16(flags);
-            if (obj->intelligent) {
-                M_WriteS16(item->carried_item);
+
+            const CARRIED_ITEM *const carried_item = item->carried_item;
+            if (carried_item != nullptr) {
+                M_WriteS16(carried_item->spawn_num);
             }
 
             M_WriteS16(item->timer);


### PR DESCRIPTION
Resolves #2952.
Resolves #2954.
Resolves #2956.
Resolves #2957.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves TR1's carrier logic to TRX and updates TR2 to use the same approach. Game flow defined drops remain a TR1-only feature, as these are required for the OG setup only, and the TR2 approach we had introduced previously is already compatible with TR2 itself. All enemies in TR2 can now drop, but the two eel types remain excluded as they can't be killed. Falling items now animate in 60 FPS as well.

I'll share a test level, but checking OG in both games would be good too. Checking current TR2X saves and legacy saves would be ideal as well.
