### PR TITLE
camera: fix TR1 fixed cameras

### DIFF
--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -114,8 +114,12 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
                 && g_Camera.item != g_Camera.last_item))) {
         g_Camera.item = nullptr;
     }
-
+#if TR_VERSION >= 2
+    // TODO: check if this can be removed from TR2 during camera module merge.
+    // It is required not to be present in TR1 otherwise heavy triggers (that
+    // don't have camera data) can cancel active cameras triggered by Lara.
     if (g_Camera.num == -1 && g_Camera.timer > 0) {
         g_Camera.timer = -1;
     }
+#endif
 }


### PR DESCRIPTION
Resolves #2959.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes a TR2 camera check introduced in 39c3baf that as a result caused heavy triggers to be able to cancel active cameras. Further investigation is required if this check is actually needed in TR2 (it indeed causes heavy triggers to cancel cameras there, but this isn't an issue anywhere in OG). Because of the slight nuances in the camera modules, I think we can investigate during the merger at a later date. For now this gets TR1 back to the way it was.
