### PR TITLE
creature: restore death state based on type ID

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed potential memory corruption if `/kill all` is used with a Qualopec mummy that is carrying items (#2957, regression from 4.6)
 - fixed a crash when portal debugging is enabled in rooms that have no portals (#2968, regression from 4.8)
 - fixed the final statistics always showing zero deaths regardless of the actual total (#2965, regression from 4.10)
+- fixed rats/voles and crocodiles/alligators at times not assuming the correct death pose after reloading a save (#2960, regression from 0.12)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -29,9 +29,9 @@ static bool m_AlliesHostile = false;
 
 static ITEM *M_ChooseEnemy(const ITEM *item);
 static bool M_SwitchToWater(
-    int16_t item_num, const int32_t *wh, const HYBRID_INFO *info);
+    int16_t item_num, int32_t wh, const HYBRID_INFO *info);
 static bool M_SwitchToLand(
-    int16_t item_num, const int32_t *wh, const HYBRID_INFO *info);
+    int16_t item_num, int32_t wh, const HYBRID_INFO *info);
 static bool M_TestSwitchOrKill(int16_t item_num, GAME_OBJECT_ID target_id);
 
 static void M_GetBaddieTarget(const int16_t item_num, const bool goody)
@@ -130,40 +130,41 @@ static ITEM *M_ChooseEnemy(const ITEM *const item)
 }
 
 static bool M_SwitchToWater(
-    const int16_t item_num, const int32_t *const wh,
-    const HYBRID_INFO *const info)
+    const int16_t item_num, const int32_t wh, const HYBRID_INFO *const info)
 {
-    if (*wh == NO_HEIGHT) {
+    if (wh == NO_HEIGHT) {
         return false;
     }
 
     ITEM *const item = Item_Get(item_num);
 
-    if (item->hit_points <= 0) {
+    if (item->hit_points <= 0
+        && item->current_anim_state == info->land.death_state) {
         // Dead land creatures should remain in their pose permanently.
         return false;
     }
 
-    // The land creature is alive and the room has been flooded. Switch to the
-    // water creature.
+    // Switch to the water creature, but only switch animations if the creature
+    // is alive to avoid savegame reload issues.
     if (!M_TestSwitchOrKill(item_num, info->water.id)) {
         return false;
     }
 
     item->object_id = info->water.id;
-    Item_SwitchToAnim(item, info->water.active_anim, 0);
-    item->current_anim_state = Item_GetAnim(item)->current_anim_state;
-    item->goal_anim_state = item->current_anim_state;
-    item->pos.y = *wh;
+    if (item->hit_points > 0) {
+        Item_SwitchToAnim(item, info->water.active_anim, 0);
+        item->current_anim_state = Item_GetAnim(item)->current_anim_state;
+        item->goal_anim_state = item->current_anim_state;
+    }
+    item->pos.y = wh;
 
     return true;
 }
 
 static bool M_SwitchToLand(
-    const int16_t item_num, const int32_t *const wh,
-    const HYBRID_INFO *const info)
+    const int16_t item_num, const int32_t wh, const HYBRID_INFO *const info)
 {
-    if (*wh != NO_HEIGHT) {
+    if (wh != NO_HEIGHT) {
         return false;
     }
 
@@ -297,12 +298,18 @@ bool Creature_EnsureHabitat(
     // Test the environment for a hybrid creature. Record the water height and
     // return whether or not a type conversion has taken place.
     const ITEM *const item = Item_Get(item_num);
-    *wh = Room_GetWaterHeight(
+    const int32_t water_height = Room_GetWaterHeight(
         item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    if (wh != nullptr) {
+        *wh = water_height;
+    }
+    if (item->status == IS_INACTIVE) {
+        return false;
+    }
 
     return item->object_id == info->land.id
-        ? M_SwitchToWater(item_num, wh, info)
-        : M_SwitchToLand(item_num, wh, info);
+        ? M_SwitchToWater(item_num, water_height, info)
+        : M_SwitchToLand(item_num, water_height, info);
 }
 
 void Creature_Mood(

--- a/src/libtrx/include/libtrx/game/creature/types.h
+++ b/src/libtrx/include/libtrx/game/creature/types.h
@@ -41,9 +41,5 @@ typedef struct {
         int16_t active_anim;
         int16_t death_anim;
         int16_t death_state;
-    } land;
-    struct {
-        GAME_OBJECT_ID id;
-        int16_t active_anim;
-    } water;
+    } land, water;
 } HYBRID_INFO;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -50,8 +50,11 @@ typedef enum {
 
 static BITE m_CrocodileBite = { .pos = { 5, -21, 467 }, .mesh_num = 9 };
 
+static void M_SetupBase(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_SetupCrocodile(OBJECT *obj);
 static void M_SetupAlligator(OBJECT *obj);
+static void M_UpdateCreatureLOT(const ITEM *item);
 static void M_ControlCrocodile(int16_t item_num);
 static void M_ControlAlligator(int16_t item_num);
 
@@ -62,6 +65,8 @@ static const HYBRID_INFO m_CrocodileInfo = {
     .land.death_state = CROCODILE_STATE_DEATH,
     .water.id = O_ALLIGATOR,
     .water.active_anim = ALLIGATOR_STATE_EMPTY,
+    .water.death_anim = ALLIGATOR_DIE_ANIM,
+    .water.death_state = ALLIGATOR_STATE_DEATH,
 };
 
 static void M_SetupBase(OBJECT *const obj)
@@ -75,7 +80,18 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 7)->rot.y = true;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (Creature_EnsureHabitat(
+                Item_GetIndex(item), nullptr, &m_CrocodileInfo)) {
+            M_UpdateCreatureLOT(item);
+        }
+    }
 }
 
 static void M_SetupCrocodile(OBJECT *const obj)
@@ -100,6 +116,24 @@ static void M_SetupAlligator(OBJECT *const obj)
     obj->hit_points = ALLIGATOR_HITPOINTS;
     obj->radius = ALLIGATOR_RADIUS;
     obj->smartness = ALLIGATOR_SMARTNESS;
+}
+
+static void M_UpdateCreatureLOT(const ITEM *const item)
+{
+    CREATURE *const creature = (CREATURE *)item->data;
+    if (creature == nullptr) {
+        return;
+    }
+
+    if (item->object_id == O_CROCODILE) {
+        creature->lot.step = STEP_L;
+        creature->lot.drop = -STEP_L;
+        creature->lot.fly = 0;
+    } else if (item->object_id == O_ALLIGATOR) {
+        creature->lot.step = WALL_L * 20;
+        creature->lot.drop = -WALL_L * 20;
+        creature->lot.fly = STEP_L / 16;
+    }
 }
 
 static void M_ControlCrocodile(const int16_t item_num)
@@ -205,11 +239,8 @@ static void M_ControlCrocodile(const int16_t item_num)
     }
 
     // Test conversion to alligator and set relevant pathfinding values.
-    int32_t wh;
-    if (Creature_EnsureHabitat(item_num, &wh, &m_CrocodileInfo) && croc) {
-        croc->lot.step = WALL_L * 20;
-        croc->lot.drop = -WALL_L * 20;
-        croc->lot.fly = STEP_L / 16;
+    if (Creature_EnsureHabitat(item_num, nullptr, &m_CrocodileInfo)) {
+        M_UpdateCreatureLOT(item);
     }
 
     if (croc) {
@@ -316,9 +347,7 @@ static void M_ControlAlligator(const int16_t item_num)
 
     // Test alive conversion to crocodile and set relevant pathfinding values.
     if (Creature_EnsureHabitat(item_num, &wh, &m_CrocodileInfo)) {
-        gator->lot.step = STEP_L;
-        gator->lot.drop = -STEP_L;
-        gator->lot.fly = 0;
+        M_UpdateCreatureLOT(item);
     } else if (item->pos.y < wh + STEP_L) {
         item->pos.y = wh + STEP_L;
     }

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -45,6 +45,7 @@ typedef enum {
 static BITE m_RatBite = { .pos = { 0, -11, 108 }, .mesh_num = 3 };
 
 static void M_SetupBase(OBJECT *obj);
+static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
 static void M_SetupRat(OBJECT *obj);
 static void M_SetupVole(OBJECT *obj);
 static void M_ControlRat(int16_t item_num);
@@ -57,6 +58,8 @@ static const HYBRID_INFO m_RatInfo = {
     .land.death_state = RAT_STATE_DEATH,
     .water.id = O_VOLE,
     .water.active_anim = VOLE_STATE_EMPTY,
+    .water.death_anim = VOLE_DIE_ANIM,
+    .water.death_state = VOLE_STATE_DEATH,
 };
 
 static void M_SetupBase(OBJECT *const obj)
@@ -73,6 +76,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
+    obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 1)->rot.y = true;
 }
 
@@ -92,6 +96,13 @@ static void M_SetupVole(OBJECT *const obj)
     }
     M_SetupBase(obj);
     obj->control_func = M_ControlVole;
+}
+
+static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+{
+    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        Creature_EnsureHabitat(Item_GetIndex(item), nullptr, &m_RatInfo);
+    }
 }
 
 static void M_ControlRat(const int16_t item_num)
@@ -177,8 +188,7 @@ static void M_ControlRat(const int16_t item_num)
 
     Creature_Head(item, head);
 
-    int32_t wh;
-    Creature_EnsureHabitat(item_num, &wh, &m_RatInfo);
+    Creature_EnsureHabitat(item_num, nullptr, &m_RatInfo);
 
     Creature_Animate(item_num, angle, 0);
 }
@@ -208,15 +218,7 @@ static void M_ControlVole(const int16_t item_num)
 
         Item_Animate(item);
 
-        int32_t wh = Room_GetWaterHeight(
-            item->pos.x, item->pos.y, item->pos.z, item->room_num);
-        if (wh == NO_HEIGHT) {
-            item->object_id = O_RAT;
-            item->current_anim_state = RAT_STATE_DEATH;
-            item->goal_anim_state = RAT_STATE_DEATH;
-            Item_SwitchToAnim(item, RAT_DIE_ANIM, -1);
-            item->pos.y = item->floor;
-        }
+        Creature_EnsureHabitat(item_num, nullptr, &m_RatInfo);
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);


### PR DESCRIPTION
Resolves #2960.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that post-load, a hybrid creature's correct state is reinstated. The savegame will have stored the state and animation against the original type ID in the level, but we need to infer the actual type ID on load.