### PR TITLE
tr1/stats: copy level stats death count to final stats

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)
 - fixed potential memory corruption if `/kill all` is used with a Qualopec mummy that is carrying items (#2957, regression from 4.6)
 - fixed a crash when portal debugging is enabled in rooms that have no portals (#2968, regression from 4.8)
+- fixed the final statistics always showing zero deaths regardless of the actual total (#2965, regression from 4.10)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/src/tr1/game/stats/common.c
+++ b/src/tr1/game/stats/common.c
@@ -146,6 +146,7 @@ void Stats_ComputeFinal(GF_LEVEL_TYPE level_type, FINAL_STATS *final_stats)
         final_stats->ammo_used += level_stats->ammo_used;
         final_stats->medipacks_used += level_stats->medipacks_used;
         final_stats->distance_travelled += level_stats->distance_travelled;
+        final_stats->death_count = level_stats->death_count;
     }
 }
 


### PR DESCRIPTION
Resolves #2965.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Ensures the final stats have the level stats' death count (replaced by each level as it is the same throughout).
