### PR TITLE
tr1/output: skip portal drawing in rooms that have none

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
 - fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)
 - fixed potential memory corruption if `/kill all` is used with a Qualopec mummy that is carrying items (#2957, regression from 4.6)
+- fixed a crash when portal debugging is enabled in rooms that have no portals (#2968, regression from 4.8)
 
 ## [4.10.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.10...tr1-4.10.1) - 2025-04-30
 - fixed water caustics appearance (#2896, regression from 4.10)

--- a/src/tr1/game/output/draw_misc.c
+++ b/src/tr1/game/output/draw_misc.c
@@ -139,6 +139,10 @@ void Output_DrawRoomMesh(ROOM *const room)
 
 void Output_DrawRoomPortals(const ROOM *const room)
 {
+    if (room->portals == nullptr) {
+        return;
+    }
+
     const int32_t vertex_count = room->portals->count * 8;
     OUTPUT_MESH_VERTEX vertices[vertex_count];
     OUTPUT_MESH_VERTEX *out_vertex = vertices;


### PR DESCRIPTION
Resolves #2968.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I think it might be an idea to look into changing `room->portals` to be the actual array, and move the count to the room itself, but that is a bigger task we can potentially look at later. This resolves the NPE for now in this scenario.
