### PR TITLE
camera: move misc functions to TRX

### DIFF
--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -1,6 +1,8 @@
 #include "game/camera/common.h"
 
 #include "config.h"
+#include "debug.h"
+#include "game/camera/const.h"
 #include "game/camera/vars.h"
 #include "game/lara.h"
 #include "game/los.h"
@@ -193,6 +195,42 @@ bool Camera_IsChunky(void)
 void Camera_SetChunky(const bool is_chunky)
 {
     m_IsChunky = is_chunky;
+}
+
+void Camera_ResetPosition(void)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    ASSERT(lara_item != nullptr);
+    g_Camera.shift = lara_item->pos.y - WALL_L;
+
+    g_Camera.target.x = lara_item->pos.x;
+    g_Camera.target.y = g_Camera.shift;
+    g_Camera.target.z = lara_item->pos.z;
+    g_Camera.target.room_num = lara_item->room_num;
+
+    g_Camera.pos.x = g_Camera.target.x;
+    g_Camera.pos.y = g_Camera.target.y;
+    g_Camera.pos.z = g_Camera.target.z - 100;
+    g_Camera.pos.room_num = g_Camera.target.room_num;
+
+    g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
+    g_Camera.item = nullptr;
+
+    g_Camera.speed = 1;
+    g_Camera.flags = CF_NORMAL;
+    g_Camera.bounce = 0;
+    g_Camera.num = NO_CAMERA;
+    g_Camera.fixed_camera = false;
+#if TR_VERSION == 1
+    g_Camera.additional_angle = 0;
+    g_Camera.additional_elevation = 0;
+    g_Camera.type = CAM_CHASE;
+#else
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (!lara_info->extra_anim) {
+        g_Camera.type = CAM_CHASE;
+    }
+#endif
 }
 
 void Camera_Reset(void)

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -12,6 +12,7 @@
 #include "game/random.h"
 #include "game/rooms.h"
 #include "game/sound.h"
+#include "game/viewport.h"
 #include "utils.h"
 
 #if TR_VERSION == 2
@@ -195,6 +196,18 @@ bool Camera_IsChunky(void)
 void Camera_SetChunky(const bool is_chunky)
 {
     m_IsChunky = is_chunky;
+}
+
+void Camera_Initialise(void)
+{
+    Matrix_ResetStack();
+    g_Camera.underwater = false;
+    g_Camera.last = NO_CAMERA;
+    Camera_ResetPosition();
+#if TR_VERSION == 2
+    Viewport_AlterFOV(-1);
+#endif
+    Camera_Update();
 }
 
 void Camera_ResetPosition(void)

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -4,9 +4,12 @@
 #include "game/camera/vars.h"
 #include "game/lara.h"
 #include "game/los.h"
+#include "game/matrix.h"
+#include "game/music.h"
 #include "game/pathing.h"
 #include "game/random.h"
 #include "game/rooms.h"
+#include "game/sound.h"
 #include "utils.h"
 
 #if TR_VERSION == 2
@@ -16,6 +19,59 @@ extern int32_t g_PhdPersp;
 
 static BOX_INFO m_FixedBox = {};
 static bool m_IsChunky = false;
+
+static void M_AdjustMusicVolume(bool underwater);
+static void M_EnsureEnvironment(void);
+
+static void M_AdjustMusicVolume(const bool underwater)
+{
+    const bool is_ambient =
+        Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
+    double multiplier = 1.0;
+
+    if (underwater) {
+        switch (g_Config.audio.underwater_music_mode) {
+        case UMM_QUIET:
+            multiplier = 0.5;
+            break;
+        case UMM_NONE:
+            multiplier = 0.0;
+            break;
+        case UMM_FULL_NO_AMBIENT:
+            multiplier = is_ambient ? 0.0 : 1.0;
+            break;
+        case UMM_QUIET_NO_AMBIENT:
+            multiplier = is_ambient ? 0.0 : 0.5;
+            break;
+        case UMM_FULL:
+        default:
+            multiplier = 1.0;
+            break;
+        }
+    }
+
+    Music_SetVolume(g_Config.audio.music_volume * multiplier);
+}
+
+static void M_EnsureEnvironment(void)
+{
+    if (g_Camera.pos.room_num == NO_ROOM) {
+        return;
+    }
+
+    const ROOM *const room = Room_Get(g_Camera.pos.room_num);
+    if ((room->flags & RF_UNDERWATER) != 0) {
+        M_AdjustMusicVolume(true);
+        Sound_Effect(SFX_UNDERWATER, nullptr, SPM_ALWAYS);
+        g_Camera.underwater = true;
+    } else {
+        M_AdjustMusicVolume(false);
+        if (g_Camera.underwater) {
+            Sound_StopEffect(SFX_UNDERWATER);
+            g_Camera.underwater = false;
+        }
+    }
+}
 
 // TODO: make private once modules are ported.
 const BOX_INFO *Camera_GetBox(
@@ -234,4 +290,15 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
         g_Camera.timer = -1;
     }
 #endif
+}
+
+void Camera_Apply(void)
+{
+    M_EnsureEnvironment();
+    Matrix_LookAt(
+        g_Camera.interp.result.pos.x,
+        g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
+        g_Camera.interp.result.pos.z, g_Camera.interp.result.target.x,
+        g_Camera.interp.result.target.y, g_Camera.interp.result.target.z,
+        g_Camera.roll);
 }

--- a/src/libtrx/include/libtrx/game/camera/common.h
+++ b/src/libtrx/include/libtrx/game/camera/common.h
@@ -8,6 +8,7 @@ void Camera_Apply(void);
 void Camera_Move(const GAME_VECTOR *target, int32_t speed);
 bool Camera_IsChunky(void);
 void Camera_SetChunky(bool is_chunky);
+void Camera_ResetPosition(void);
 void Camera_Reset(void);
 void Camera_ClampInterpResult(void);
 void Camera_RefreshFromTrigger(const TRIGGER *trigger);

--- a/src/libtrx/include/libtrx/game/camera/common.h
+++ b/src/libtrx/include/libtrx/game/camera/common.h
@@ -8,6 +8,7 @@ void Camera_Apply(void);
 void Camera_Move(const GAME_VECTOR *target, int32_t speed);
 bool Camera_IsChunky(void);
 void Camera_SetChunky(bool is_chunky);
+void Camera_Initialise(void);
 void Camera_ResetPosition(void);
 void Camera_Reset(void);
 void Camera_ClampInterpResult(void);

--- a/src/libtrx/include/libtrx/game/camera/common.h
+++ b/src/libtrx/include/libtrx/game/camera/common.h
@@ -4,7 +4,7 @@
 #include "../rooms/types.h"
 
 extern void Camera_Update(void);
-extern void Camera_Apply(void);
+void Camera_Apply(void);
 void Camera_Move(const GAME_VECTOR *target, int32_t speed);
 bool Camera_IsChunky(void);
 void Camera_SetChunky(bool is_chunky);

--- a/src/libtrx/include/libtrx/game/camera/const.h
+++ b/src/libtrx/include/libtrx/game/camera/const.h
@@ -2,4 +2,5 @@
 
 #include "../const.h"
 
+#define NO_CAMERA (-1)
 #define CAMERA_DEFAULT_DISTANCE (WALL_L * 3 / 2)

--- a/src/libtrx/include/libtrx/game/music/common.h
+++ b/src/libtrx/include/libtrx/game/music/common.h
@@ -34,6 +34,12 @@ extern void Music_Unpause(void);
 // Returns the delayed track. Ignores looped tracks.
 extern MUSIC_TRACK_ID Music_GetDelayedTrack(void);
 
+// Returns the currently playing track. Includes looped music.
+extern MUSIC_TRACK_ID Music_GetCurrentPlayingTrack(void);
+
+// Returns the looped track.
+extern MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void);
+
 void Music_ResetTrackFlags(void);
 uint16_t Music_GetTrackFlags(int32_t track_idx);
 void Music_SetTrackFlags(int32_t track, uint16_t flags);

--- a/src/libtrx/include/libtrx/game/sound/common.h
+++ b/src/libtrx/include/libtrx/game/sound/common.h
@@ -27,4 +27,5 @@ extern void Sound_StopAmbientSounds(void);
 extern void Sound_StopAll(void);
 extern bool Sound_Effect(
     SOUND_EFFECT_ID sfx_num, const XYZ_32 *pos, uint32_t flags);
+extern void Sound_StopEffect(SOUND_EFFECT_ID sfx_num);
 bool Sound_IsAvailable(SOUND_EFFECT_ID sfx_num);

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -495,32 +495,6 @@ void Camera_Initialise(void)
     Camera_Update();
 }
 
-void Camera_ResetPosition(void)
-{
-    ASSERT(g_LaraItem != nullptr);
-    g_Camera.shift = g_LaraItem->pos.y - WALL_L;
-
-    g_Camera.target.x = g_LaraItem->pos.x;
-    g_Camera.target.y = g_Camera.shift;
-    g_Camera.target.z = g_LaraItem->pos.z;
-    g_Camera.target.room_num = g_LaraItem->room_num;
-
-    g_Camera.pos.x = g_Camera.target.x;
-    g_Camera.pos.y = g_Camera.target.y;
-    g_Camera.pos.z = g_Camera.target.z - 100;
-    g_Camera.pos.room_num = g_Camera.target.room_num;
-
-    g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
-    g_Camera.item = nullptr;
-
-    g_Camera.type = CAM_CHASE;
-    g_Camera.flags = CF_NORMAL;
-    g_Camera.bounce = 0;
-    g_Camera.num = NO_CAMERA;
-    g_Camera.additional_angle = 0;
-    g_Camera.additional_elevation = 0;
-}
-
 void Camera_Update(void)
 {
     if (g_Camera.type == CAM_PHOTO_MODE) {

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -10,7 +10,6 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/math.h>
-#include <libtrx/game/matrix.h>
 
 // Camera speed option ranges from 1-10, so index 0 is unused.
 static double m_ManualCameraMultiplier[11] = {
@@ -485,14 +484,6 @@ static void M_Shift(
         *x = right;
         *y = top;
     }
-}
-
-void Camera_Initialise(void)
-{
-    Matrix_ResetStack();
-    g_Camera.underwater = false;
-    Camera_ResetPosition();
-    Camera_Update();
 }
 
 void Camera_Update(void)

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -277,7 +277,7 @@ static void M_EnsureEnvironment(void)
     } else {
         M_AdjustMusicVolume(false);
         if (g_Camera.underwater) {
-            Sound_StopEffect(SFX_UNDERWATER, nullptr);
+            Sound_StopEffect(SFX_UNDERWATER);
             g_Camera.underwater = false;
         }
     }

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -547,6 +547,7 @@ static void M_Shift(
 void Camera_Initialise(void)
 {
     Matrix_ResetStack();
+    g_Camera.underwater = false;
     Camera_ResetPosition();
     Camera_Update();
 }

--- a/src/tr1/game/camera/common.c
+++ b/src/tr1/game/camera/common.c
@@ -2,9 +2,7 @@
 
 #include "game/input.h"
 #include "game/los.h"
-#include "game/music.h"
 #include "game/random.h"
-#include "game/sound.h"
 #include "game/viewport.h"
 #include "global/vars.h"
 
@@ -28,9 +26,6 @@ static void M_LoadCutsceneFrame(void);
 static void M_OffsetAdditionalAngle(int16_t delta);
 static void M_OffsetAdditionalElevation(int16_t delta);
 static void M_OffsetReset(void);
-
-static void M_AdjustMusicVolume(bool underwater);
-static void M_EnsureEnvironment(void);
 
 static bool M_BadPosition(int32_t x, int32_t y, int32_t z, int16_t room_num);
 static int32_t M_ShiftClamp(GAME_VECTOR *pos, int32_t clamp);
@@ -229,58 +224,6 @@ static void M_OffsetReset(void)
 {
     g_Camera.additional_angle = 0;
     g_Camera.additional_elevation = 0;
-}
-
-static void M_AdjustMusicVolume(const bool underwater)
-{
-    const bool is_ambient =
-        Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
-
-    double multiplier = 1.0;
-
-    if (underwater) {
-        switch (g_Config.audio.underwater_music_mode) {
-        case UMM_FULL:
-            multiplier = 1.0;
-            break;
-        case UMM_QUIET:
-            multiplier = 0.5;
-            break;
-        case UMM_NONE:
-            multiplier = 0.0;
-            break;
-        case UMM_FULL_NO_AMBIENT:
-            multiplier = is_ambient ? 0.0 : 1.0;
-            break;
-        case UMM_QUIET_NO_AMBIENT:
-            multiplier = is_ambient ? 0.0 : 0.5;
-            break;
-        default:
-            multiplier = 1.0;
-            break;
-        }
-    }
-
-    Music_SetVolume(g_Config.audio.music_volume * multiplier);
-}
-
-static void M_EnsureEnvironment(void)
-{
-    if (g_Camera.pos.room_num == NO_ROOM) {
-        return;
-    }
-
-    if (Room_Get(g_Camera.pos.room_num)->flags & RF_UNDERWATER) {
-        M_AdjustMusicVolume(true);
-        Sound_Effect(SFX_UNDERWATER, nullptr, SPM_ALWAYS);
-        g_Camera.underwater = true;
-    } else {
-        M_AdjustMusicVolume(false);
-        if (g_Camera.underwater) {
-            Sound_StopEffect(SFX_UNDERWATER);
-            g_Camera.underwater = false;
-        }
-    }
 }
 
 static bool M_BadPosition(
@@ -791,15 +734,4 @@ void Camera_MoveManual(void)
     if (g_Input.camera_reset) {
         M_OffsetReset();
     }
-}
-
-void Camera_Apply(void)
-{
-    M_EnsureEnvironment();
-    Matrix_LookAt(
-        g_Camera.interp.result.pos.x,
-        g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
-        g_Camera.interp.result.pos.z, g_Camera.interp.result.target.x,
-        g_Camera.interp.result.target.y, g_Camera.interp.result.target.z,
-        g_Camera.roll);
 }

--- a/src/tr1/game/camera/common.h
+++ b/src/tr1/game/camera/common.h
@@ -5,6 +5,5 @@
 #include <stdint.h>
 
 void Camera_Initialise(void);
-void Camera_ResetPosition(void);
 void Camera_UpdateCutscene(void);
 void Camera_MoveManual(void);

--- a/src/tr1/game/camera/common.h
+++ b/src/tr1/game/camera/common.h
@@ -4,6 +4,5 @@
 
 #include <stdint.h>
 
-void Camera_Initialise(void);
 void Camera_UpdateCutscene(void);
 void Camera_MoveManual(void);

--- a/src/tr1/game/lara/col.c
+++ b/src/tr1/game/lara/col.c
@@ -432,7 +432,7 @@ void Lara_Col_FastFall(ITEM *item, COLL_INFO *coll)
             item->current_anim_state = LS_STOP;
             Item_SwitchToAnim(item, LA_LAND_FAR, 0);
         }
-        Sound_StopEffect(SFX_LARA_FALL, nullptr);
+        Sound_StopEffect(SFX_LARA_FALL);
         item->pos.y += coll->side_mid.floor;
         item->gravity = 0;
         item->fall_speed = 0;

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -109,7 +109,7 @@ void Lara_Control(void)
             item->pos.y += 100;
             item->gravity = 0;
             Lara_UpdateRoomToHeight(0);
-            Sound_StopEffect(SFX_LARA_FALL, nullptr);
+            Sound_StopEffect(SFX_LARA_FALL);
             if (item->current_anim_state == LS_SWAN_DIVE) {
                 item->goal_anim_state = LS_DIVE;
                 item->rot.x = -45 * DEG_1;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -409,7 +409,6 @@ bool Level_Initialise(
 
     Viewport_SetFOV(-1);
 
-    g_Camera.underwater = false;
     Benchmark_End(&benchmark, nullptr);
     return true;
 }

--- a/src/tr1/game/music.h
+++ b/src/tr1/game/music.h
@@ -16,12 +16,6 @@ void Music_Mute(void);
 // Unmutes the game music. Doesn't change the music volume.
 void Music_Unmute(void);
 
-// Returns the currently playing track. Includes looped music.
-MUSIC_TRACK_ID Music_GetCurrentPlayingTrack(void);
-
-// Returns the looped track.
-MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void);
-
 // Returns the last played track. Ignores looped tracks.
 MUSIC_TRACK_ID Music_GetLastPlayedTrack(void);
 

--- a/src/tr1/game/objects/effects/flame.c
+++ b/src/tr1/game/objects/effects/flame.c
@@ -28,7 +28,7 @@ static void M_Control(const int16_t effect_num)
     if (effect->counter < 0) {
         if (g_Lara.water_status == LWS_CHEAT) {
             effect->counter = 0;
-            Sound_StopEffect(SFX_FIRE, nullptr);
+            Sound_StopEffect(SFX_FIRE);
             Effect_Kill(effect_num);
             return;
         }
@@ -50,7 +50,7 @@ static void M_Control(const int16_t effect_num)
 
         if (y != NO_HEIGHT && effect->pos.y > y) {
             effect->counter = 0;
-            Sound_StopEffect(SFX_FIRE, nullptr);
+            Sound_StopEffect(SFX_FIRE);
             Effect_Kill(effect_num);
         } else {
             if (effect->room_num != g_LaraItem->room_num) {

--- a/src/tr1/game/objects/traps/flame_emitter.c
+++ b/src/tr1/game/objects/traps/flame_emitter.c
@@ -30,7 +30,7 @@ static void M_Control(const int16_t item_num)
             item->data = (void *)(intptr_t)(effect_num + 1);
         }
     } else if (item->data) {
-        Sound_StopEffect(SFX_FIRE, nullptr);
+        Sound_StopEffect(SFX_FIRE);
         Effect_Kill((int16_t)(intptr_t)item->data - 1);
         item->data = nullptr;
     }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -259,14 +259,11 @@ static void M_DrawSkybox(void)
 
 void Room_DrawSingleRoom(int16_t room_num)
 {
-    bool camera_underwater =
-        Room_Get(g_Camera.pos.room_num)->flags & RF_UNDERWATER;
-
     ROOM *const room = Room_Get(room_num);
     if (room->flags & RF_UNDERWATER) {
-        Output_SetupBelowWater(camera_underwater);
+        Output_SetupBelowWater(g_Camera.underwater);
     } else {
-        Output_SetupAboveWater(camera_underwater);
+        Output_SetupAboveWater(g_Camera.underwater);
     }
 
     room->bound_active = 0;

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -440,27 +440,21 @@ bool Sound_Effect(
     return false;
 }
 
-bool Sound_StopEffect(const SOUND_EFFECT_ID sfx_num, const XYZ_32 *const pos)
+void Sound_StopEffect(const SOUND_EFFECT_ID sfx_num)
 {
     if (!m_SoundIsActive) {
-        return false;
+        return;
     }
 
-    for (int i = 0; i < MAX_PLAYING_FX; i++) {
-        SOUND_SLOT *slot = &m_SFXPlaying[i];
-        if ((slot->flags & SOUND_FLAG_USED)
+    for (int32_t i = 0; i < MAX_PLAYING_FX; i++) {
+        SOUND_SLOT *const slot = &m_SFXPlaying[i];
+        if ((slot->flags & SOUND_FLAG_USED) != 0 && slot->effect_num == sfx_num
             && Audio_Sample_IsPlaying(slot->sound_id)) {
-            if ((!pos && slot->effect_num == sfx_num)
-                || (pos && sfx_num >= 0 && slot->effect_num == sfx_num)
-                || (pos && sfx_num < 0)) {
-                Audio_Sample_Close(slot->sound_id);
-                M_ClearSlot(slot);
-                return true;
-            }
+            Audio_Sample_Close(slot->sound_id);
+            M_ClearSlot(slot);
+            break;
         }
     }
-
-    return false;
 }
 
 void Sound_ResetEffects(void)

--- a/src/tr1/game/sound.h
+++ b/src/tr1/game/sound.h
@@ -9,7 +9,6 @@
 
 bool Sound_Init(void);
 void Sound_Shutdown(void);
-void Sound_StopEffect(SOUND_EFFECT_ID sfx_num);
 void Sound_UpdateEffects(void);
 void Sound_ResetEffects(void);
 void Sound_StopAmbientSounds(void);

--- a/src/tr1/game/sound.h
+++ b/src/tr1/game/sound.h
@@ -9,7 +9,7 @@
 
 bool Sound_Init(void);
 void Sound_Shutdown(void);
-bool Sound_StopEffect(SOUND_EFFECT_ID sfx_num, const XYZ_32 *pos);
+void Sound_StopEffect(SOUND_EFFECT_ID sfx_num);
 void Sound_UpdateEffects(void);
 void Sound_ResetEffects(void);
 void Sound_StopAmbientSounds(void);

--- a/src/tr1/global/const.h
+++ b/src/tr1/global/const.h
@@ -39,7 +39,6 @@
 #define WATER_FRICTION 6
 #define DAMAGE_START 140
 #define DAMAGE_LENGTH 14
-#define NO_CAMERA (-1)
 #define DEATH_WAIT (10 * LOGIC_FPS)
 #define DEATH_WAIT_MIN (2 * LOGIC_FPS)
 #define MAX_HEAD_ROTATION (50 * DEG_1) // = 9100

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -26,16 +26,6 @@
 
 #define MAX_ELEVATION (85 * DEG_1) // = 15470
 
-void Camera_Initialise(void)
-{
-    Matrix_ResetStack();
-    g_Camera.underwater = false;
-    g_Camera.last = NO_CAMERA;
-    Camera_ResetPosition();
-    Viewport_AlterFOV(-1);
-    Camera_Update();
-}
-
 void Camera_Clip(
     int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,
     int32_t target_h, int32_t left, int32_t top, int32_t right, int32_t bottom)

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -1,10 +1,8 @@
 #include "game/camera.h"
 
 #include "game/los.h"
-#include "game/music.h"
 #include "game/output.h"
 #include "game/random.h"
-#include "game/sound.h"
 #include "game/viewport.h"
 #include "global/const.h"
 #include "global/vars.h"
@@ -27,59 +25,6 @@
 #define LOOK_SPEED 4
 
 #define MAX_ELEVATION (85 * DEG_1) // = 15470
-
-static void M_AdjustMusicVolume(bool underwater);
-static void M_EnsureEnvironment(void);
-
-static void M_AdjustMusicVolume(const bool underwater)
-{
-    const bool is_ambient =
-        Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
-    double multiplier = 1.0;
-
-    if (underwater) {
-        switch (g_Config.audio.underwater_music_mode) {
-        case UMM_QUIET:
-            multiplier = 0.5;
-            break;
-        case UMM_NONE:
-            multiplier = 0.0;
-            break;
-        case UMM_FULL_NO_AMBIENT:
-            multiplier = is_ambient ? 0.0 : 1.0;
-            break;
-        case UMM_QUIET_NO_AMBIENT:
-            multiplier = is_ambient ? 0.0 : 0.5;
-            break;
-        case UMM_FULL:
-        default:
-            multiplier = 1.0;
-            break;
-        }
-    }
-
-    Music_SetVolume(g_Config.audio.music_volume * multiplier);
-}
-
-static void M_EnsureEnvironment(void)
-{
-    if (g_Camera.pos.room_num == NO_ROOM) {
-        return;
-    }
-
-    const ROOM *const room = Room_Get(g_Camera.pos.room_num);
-    if ((room->flags & RF_UNDERWATER) != 0) {
-        M_AdjustMusicVolume(true);
-        Sound_Effect(SFX_UNDERWATER, nullptr, SPM_ALWAYS);
-        g_Camera.underwater = true;
-    } else {
-        M_AdjustMusicVolume(false);
-        if (g_Camera.underwater) {
-            Sound_StopEffect(SFX_UNDERWATER);
-            g_Camera.underwater = false;
-        }
-    }
-}
 
 void Camera_Initialise(void)
 {
@@ -860,15 +805,4 @@ void Camera_UpdateCutscene(void)
     g_Camera.roll = roll;
     g_Camera.shift = 0;
     Viewport_AlterFOV(fov);
-}
-
-void Camera_Apply(void)
-{
-    M_EnsureEnvironment();
-    Matrix_LookAt(
-        g_Camera.interp.result.pos.x,
-        g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
-        g_Camera.interp.result.pos.z, g_Camera.interp.result.target.x,
-        g_Camera.interp.result.target.y, g_Camera.interp.result.target.z,
-        g_Camera.roll);
 }

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -36,35 +36,6 @@ void Camera_Initialise(void)
     Camera_Update();
 }
 
-void Camera_ResetPosition(void)
-{
-    ASSERT(g_LaraItem != nullptr);
-    g_Camera.shift = g_LaraItem->pos.y - WALL_L;
-
-    g_Camera.target.x = g_LaraItem->pos.x;
-    g_Camera.target.y = g_Camera.shift;
-    g_Camera.target.z = g_LaraItem->pos.z;
-    g_Camera.target.room_num = g_LaraItem->room_num;
-
-    g_Camera.pos.x = g_Camera.target.x;
-    g_Camera.pos.y = g_Camera.target.y;
-    g_Camera.pos.z = g_Camera.target.z - 100;
-    g_Camera.pos.room_num = g_Camera.target.room_num;
-
-    g_Camera.target_distance = WALL_L * 3 / 2;
-    g_Camera.item = nullptr;
-
-    if (!g_Lara.extra_anim) {
-        g_Camera.type = CAM_CHASE;
-    }
-
-    g_Camera.speed = 1;
-    g_Camera.flags = CF_NORMAL;
-    g_Camera.bounce = 0;
-    g_Camera.num = NO_CAMERA;
-    g_Camera.fixed_camera = false;
-}
-
 void Camera_Clip(
     int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,
     int32_t target_h, int32_t left, int32_t top, int32_t right, int32_t bottom)

--- a/src/tr2/game/camera.c
+++ b/src/tr2/game/camera.c
@@ -84,6 +84,7 @@ static void M_EnsureEnvironment(void)
 void Camera_Initialise(void)
 {
     Matrix_ResetStack();
+    g_Camera.underwater = false;
     g_Camera.last = NO_CAMERA;
     Camera_ResetPosition();
     Viewport_AlterFOV(-1);

--- a/src/tr2/game/camera.h
+++ b/src/tr2/game/camera.h
@@ -5,7 +5,6 @@
 #include <libtrx/game/camera.h>
 
 void Camera_Initialise(void);
-void Camera_ResetPosition(void);
 void Camera_Clip(
     int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,
     int32_t target_h, int32_t left, int32_t top, int32_t right, int32_t bottom);

--- a/src/tr2/game/camera.h
+++ b/src/tr2/game/camera.h
@@ -4,7 +4,6 @@
 
 #include <libtrx/game/camera.h>
 
-void Camera_Initialise(void);
 void Camera_Clip(
     int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,
     int32_t target_h, int32_t left, int32_t top, int32_t right, int32_t bottom);

--- a/src/tr2/game/cutscene.c
+++ b/src/tr2/game/cutscene.c
@@ -98,7 +98,6 @@ GF_COMMAND Cutscene_Control(void)
 
 void Cutscene_Draw(void)
 {
-    g_CameraUnderwater = false;
     Interpolation_Interpolate();
     Camera_Apply();
     Room_DrawAllRooms(g_Camera.interp.room_num);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -368,7 +368,6 @@ bool Level_Initialise(
     }
 
     Gym_ResetAssault();
-    g_Camera.underwater = 0;
     return true;
 }
 

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -363,10 +363,10 @@ void Room_DrawSingleRoomGeometry(const int16_t room_num)
 {
     ROOM *const room = Room_Get(room_num);
 
-    if (room->flags & RF_UNDERWATER) {
-        Output_SetupBelowWater(g_CameraUnderwater);
+    if ((room->flags & RF_UNDERWATER) != 0) {
+        Output_SetupBelowWater(g_Camera.underwater);
     } else {
-        Output_SetupAboveWater(g_CameraUnderwater);
+        Output_SetupAboveWater(g_Camera.underwater);
     }
 
     Matrix_TranslateAbs32(room->pos);
@@ -390,10 +390,10 @@ void Room_DrawSingleRoomObjects(const int16_t room_num)
 {
     ROOM *const room = Room_Get(room_num);
 
-    if (room->flags & RF_UNDERWATER) {
-        Output_SetupBelowWater(g_CameraUnderwater);
+    if ((room->flags & RF_UNDERWATER) != 0) {
+        Output_SetupBelowWater(g_Camera.underwater);
     } else {
-        Output_SetupAboveWater(g_CameraUnderwater);
+        Output_SetupAboveWater(g_Camera.underwater);
     }
 
     room->bound_active = 0;
@@ -488,7 +488,6 @@ void Room_DrawAllRooms(const int16_t current_room)
         m_OutsideRight = 0;
     }
 
-    g_CameraUnderwater = room->flags & RF_UNDERWATER;
     Room_GetBounds();
 
     g_MidSort = 0;
@@ -500,7 +499,7 @@ void Room_DrawAllRooms(const int16_t current_room)
 
         const OBJECT *const skybox = Object_Get(O_SKYBOX);
         if (skybox->loaded) {
-            Output_SetupAboveWater(g_CameraUnderwater);
+            Output_SetupAboveWater(g_Camera.underwater);
             Matrix_Push();
             g_MatrixPtr->_03 = 0;
             g_MatrixPtr->_13 = 0;
@@ -515,10 +514,10 @@ void Room_DrawAllRooms(const int16_t current_room)
 
     if (Object_Get(O_LARA)->loaded && !(g_LaraItem->flags & IF_ONE_SHOT)) {
         const ROOM *const lara_room = Room_Get(g_LaraItem->room_num);
-        if (lara_room->flags & RF_UNDERWATER) {
-            Output_SetupBelowWater(g_CameraUnderwater);
+        if ((lara_room->flags & RF_UNDERWATER) != 0) {
+            Output_SetupBelowWater(g_Camera.underwater);
         } else {
-            Output_SetupAboveWater(g_CameraUnderwater);
+            Output_SetupAboveWater(g_Camera.underwater);
         }
         g_MidSort = lara_room->bound_active >> 8;
         if (g_MidSort) {

--- a/src/tr2/game/sound.h
+++ b/src/tr2/game/sound.h
@@ -10,5 +10,4 @@ void Sound_Init(void);
 void Sound_Shutdown(void);
 
 void Sound_UpdateEffects(void);
-void Sound_StopEffect(SOUND_EFFECT_ID sample_id);
 void Sound_EndScene(void);

--- a/src/tr2/global/const.h
+++ b/src/tr2/global/const.h
@@ -19,7 +19,6 @@
 #define MIN_SQUARE SQUARE(WALL_L / 3)
 #define NO_BOX (-1)
 #define NO_ITEM (-1)
-#define NO_CAMERA (-1)
 
 #define SUNSET_TIMEOUT (40 * 60 * (FRAMES_PER_SECOND)) // = 72000
 

--- a/src/tr2/global/vars.c
+++ b/src/tr2/global/vars.c
@@ -54,8 +54,6 @@ LARA_INFO g_Lara;
 ITEM *g_LaraItem = nullptr;
 CREATURE *g_BaddieSlots = nullptr;
 
-bool g_CameraUnderwater;
-
 WEAPON_INFO g_Weapons[] = {
     {},
     {

--- a/src/tr2/global/vars.h
+++ b/src/tr2/global/vars.h
@@ -54,7 +54,6 @@ extern uint16_t g_SoundOptionLine;
 extern LARA_INFO g_Lara;
 extern ITEM *g_LaraItem;
 extern CREATURE *g_BaddieSlots;
-extern bool g_CameraUnderwater;
 extern WEAPON_INFO g_Weapons[];
 extern int16_t g_FinalBossActive;
 extern uint16_t g_FinalLevelCount;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves some basic camera functions to TRX, along with a few other dependent changes.

- `Sound_StopEffect` in TR1 no longer accepts a position arg. This was never used and so it makes the signature the same as TR2
- `g_CameraUnderwater` has been removed from TR2; `g_Camera.underwater` is now used in both games to determine this

Worth a general check of starting levels, transitioning from various other ones like finishing a level underwater, then playing one on land, jumping to/from cutscenes at different points etc. And checking that above/below water works as expected.
