### PR TITLE
docs: update docs for save crystal animation

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed FPS counter turning off after a game relaunch (#2911)
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
 - fixed health bar in top center position covering inventory text
+- fixed the save crystal animation skipping a frame in 60 FPS (#1528)
 - fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
 - fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
 - fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The save crystal animation was fixed in 85c77aaeb with the merger of `Item_GetFrames`. This adds a retrospective changelog entry for #1528.
