### PR TITLE
lot: use object defined LOT setup

### DIFF
--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -261,8 +261,8 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
         info->enemy_zone_num = zone[enemy->box_num];
     }
 
-    if (((Box_GetBox(enemy->box_num)->overlap_index & creature->lot.block_mask)
-         != 0)
+    const BOX_INFO *const enemy_box = Box_GetBox(enemy->box_num);
+    if (((enemy_box->overlap_index & creature->lot.setup.block_mask) != 0)
         || (creature->lot.node[item->box_num].search_num
             == (creature->lot.search_num | BOX_BLOCKED_SEARCH))) {
         info->enemy_zone_num |= BOX_BLOCKED;
@@ -431,7 +431,7 @@ void Creature_Mood(
             || Random_GetControl() < Object_Get(item->object_id)->smartness) {
             lot->target = enemy->pos;
             lot->required_box = enemy->box_num;
-            if (lot->fly != 0
+            if (lot->setup.fly != 0
                 && Lara_GetLaraInfo()->water_status == LWS_ABOVE_WATER) {
                 lot->target.y += Item_GetBestFrame(enemy)->bounds.min.y;
             }
@@ -705,7 +705,8 @@ bool Creature_Animate(
 
     const int32_t box_height = Box_GetBox(item->box_num)->height;
     if (sector->box == NO_BOX || zone[item->box_num] != zone[sector->box]
-        || box_height - height > lot->step || box_height - height < lot->drop) {
+        || box_height - height > lot->setup.step
+        || box_height - height < lot->setup.drop) {
         const int32_t pos_x = item->pos.x >> WALL_SHIFT;
         const int32_t shift_x = old.x >> WALL_SHIFT;
         const int32_t shift_z = old.z >> WALL_SHIFT;
@@ -837,9 +838,9 @@ bool Creature_Animate(
         return true;
     }
 
-    if (lot->fly) {
+    if (lot->setup.fly != 0) {
         int32_t dy = creature->target.y - item->pos.y;
-        CLAMP(dy, -lot->fly, lot->fly);
+        CLAMP(dy, -lot->setup.fly, lot->setup.fly);
 
         height = Room_GetHeight(sector, item->pos.x, y, item->pos.z);
         if (item->pos.y + dy <= height) {
@@ -863,7 +864,7 @@ bool Creature_Animate(
                 if (item->pos.y + min_y < ceiling) {
                     item->pos.x = old.x;
                     item->pos.z = old.z;
-                    dy = lot->fly;
+                    dy = lot->setup.fly;
                 } else {
                     dy = 0;
                 }
@@ -874,7 +875,7 @@ bool Creature_Animate(
         } else {
             item->pos.x = old.x;
             item->pos.z = old.z;
-            dy = -lot->fly;
+            dy = -lot->setup.fly;
         }
 
         item->pos.y += dy;

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -3,6 +3,7 @@
 #include "game/const.h"
 #include "game/creature.h"
 #include "game/lara/common.h"
+#include "game/pathing.h"
 #include "game/random.h"
 #include "game/spawn.h"
 #include "utils.h"
@@ -225,6 +226,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->pivot_length = 375;
     obj->radius = WOLF_RADIUS;
     obj->smartness = WOLF_SMARTNESS;
+    obj->lot_setup = g_LOT_Quadruped;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;

--- a/src/libtrx/game/pathing/box.c
+++ b/src/libtrx/game/pathing/box.c
@@ -83,8 +83,9 @@ int16_t *Box_GetGroundZone(const bool flip_status, const int32_t zone_idx)
 int16_t *Box_GetLotZone(const LOT_INFO *const lot)
 {
     const bool flip_status = Room_GetFlipStatus();
-    return lot->fly ? Box_GetFlyZone(flip_status)
-                    : Box_GetGroundZone(flip_status, BOX_ZONE(lot->step));
+    return lot->setup.fly != 0
+        ? Box_GetFlyZone(flip_status)
+        : Box_GetGroundZone(flip_status, BOX_ZONE(lot->setup.step));
 }
 
 bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
@@ -118,7 +119,7 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
 
             const BOX_INFO *const box = Box_GetBox(box_num);
             const int32_t change = box->height - head_box->height;
-            if (change > lot->step || change < lot->drop) {
+            if (change > lot->setup.step || change < lot->setup.drop) {
                 continue;
             }
 
@@ -146,7 +147,7 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
                     continue;
                 }
 
-                if ((box->overlap_index & lot->block_mask) != 0) {
+                if ((box->overlap_index & lot->setup.block_mask) != 0) {
                     expand->search_num = node->search_num | BOX_BLOCKED_SEARCH;
                 } else {
                     expand->search_num = node->search_num;
@@ -204,7 +205,7 @@ void Box_TargetBox(LOT_INFO *const lot, int16_t box_num)
         + (Random_GetControl() * (box->bottom + shift - box->top - WALL_L)
            >> 15);
     lot->required_box = box_num;
-    if (lot->fly != 0) {
+    if (lot->setup.fly != 0) {
         lot->target.y = box->height - STEP_L * 3 / 2;
     } else {
         lot->target.y = box->height;
@@ -272,7 +273,7 @@ bool Box_ValidBox(
     }
 
     const BOX_INFO *const box = Box_GetBox(box_num);
-    if ((box->overlap_index & creature->lot.block_mask) != 0) {
+    if ((box->overlap_index & creature->lot.setup.block_mask) != 0) {
         return false;
     }
 
@@ -304,7 +305,7 @@ TARGET_TYPE Box_CalculateTarget(
     int32_t prime_free = BOX_CLIP_ALL;
     do {
         box = Box_GetBox(box_num);
-        if (lot->fly != 0) {
+        if (lot->setup.fly != 0) {
             CLAMPG(target->y, box->height - WALL_L);
         } else {
             CLAMPG(target->y, box->height);
@@ -409,7 +410,8 @@ TARGET_TYPE Box_CalculateTarget(
 
         box_num = lot->node[box_num].exit_box;
         if (box_num != NO_BOX
-            && (Box_GetBox(box_num)->overlap_index & lot->block_mask) != 0) {
+            && (Box_GetBox(box_num)->overlap_index & lot->setup.block_mask)
+                != 0) {
             break;
         }
     } while (box_num != NO_BOX);
@@ -428,7 +430,7 @@ TARGET_TYPE Box_CalculateTarget(
         CLAMP(target->x, box->top + BOX_BIFF, box->bottom - BOX_BIFF);
     }
 
-    if (lot->fly != 0) {
+    if (lot->setup.fly != 0) {
         target->y = box->height - STEP_L * 3 / 2;
     } else {
         target->y = box->height;
@@ -447,18 +449,19 @@ bool Box_BadFloor(
     }
 
     const BOX_INFO *const box = Box_GetBox(sector->box);
-    if ((box->overlap_index & lot->block_mask) != 0) {
+    if ((box->overlap_index & lot->setup.block_mask) != 0) {
         return true;
     }
 
     const int32_t height = box->height;
-    if (box_height - height > lot->step || box_height - height < lot->drop) {
+    if (box_height - height > lot->setup.step
+        || box_height - height < lot->setup.drop) {
         return true;
     }
-    if (box_height - height < -lot->step && height > next_height) {
+    if (box_height - height < -lot->setup.step && height > next_height) {
         return true;
     }
-    if (lot->fly != 0 && y > height + lot->fly) {
+    if (lot->setup.fly != 0 && y > height + lot->setup.fly) {
         return true;
     }
     return false;

--- a/src/libtrx/game/pathing/lot.c
+++ b/src/libtrx/game/pathing/lot.c
@@ -105,41 +105,41 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     creature->maximum_turn = DEG_1;
     creature->flags = 0;
     creature->enemy = nullptr;
-    creature->lot.step = STEP_L;
+    creature->lot.setup.step = STEP_L;
 #if TR_VERSION == 1
-    creature->lot.drop = -STEP_L;
+    creature->lot.setup.drop = -STEP_L;
 #else
-    creature->lot.drop = -STEP_L * 2;
+    creature->lot.setup.drop = -STEP_L * 2;
 #endif
-    creature->lot.block_mask = BOX_BLOCKED;
-    creature->lot.fly = 0;
+    creature->lot.setup.block_mask = BOX_BLOCKED;
+    creature->lot.setup.fly = 0;
 
     switch (item->object_id) {
 #if TR_VERSION == 1
     case O_BAT:
     case O_ALLIGATOR:
     case O_FISH:
-        creature->lot.step = WALL_L * 20;
-        creature->lot.drop = -WALL_L * 20;
-        creature->lot.fly = STEP_L / 16;
+        creature->lot.setup.step = WALL_L * 20;
+        creature->lot.setup.drop = -WALL_L * 20;
+        creature->lot.setup.fly = STEP_L / 16;
         break;
 
     case O_TREX:
     case O_WARRIOR_1:
     case O_CENTAUR:
-        creature->lot.block_mask = BOX_BLOCKABLE;
+        creature->lot.setup.block_mask = BOX_BLOCKABLE;
         break;
 
     case O_WOLF:
     case O_LION:
     case O_LIONESS:
     case O_PUMA:
-        creature->lot.drop = -WALL_L;
+        creature->lot.setup.drop = -WALL_L;
         break;
 
     case O_APE:
-        creature->lot.step = WALL_L / 2;
-        creature->lot.drop = -WALL_L;
+        creature->lot.setup.step = WALL_L / 2;
+        creature->lot.setup.drop = -WALL_L;
         break;
 #else
     case O_SHARK:
@@ -148,29 +148,29 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     case O_JELLY:
     case O_CROW:
     case O_EAGLE:
-        creature->lot.step = WALL_L * 20;
-        creature->lot.drop = -WALL_L * 20;
-        creature->lot.fly = STEP_L / 16;
+        creature->lot.setup.step = WALL_L * 20;
+        creature->lot.setup.drop = -WALL_L * 20;
+        creature->lot.setup.fly = STEP_L / 16;
         if (item->object_id == O_SHARK) {
-            creature->lot.block_mask = BOX_BLOCKABLE;
+            creature->lot.setup.block_mask = BOX_BLOCKABLE;
         }
         break;
 
     case O_WORKER_3:
     case O_WORKER_4:
     case O_YETI:
-        creature->lot.step = WALL_L;
-        creature->lot.drop = -WALL_L;
+        creature->lot.setup.step = WALL_L;
+        creature->lot.setup.drop = -WALL_L;
         break;
 
     case O_SPIDER:
     case O_SKIDOO_ARMED:
-        creature->lot.step = WALL_L / 2;
-        creature->lot.drop = -WALL_L;
+        creature->lot.setup.step = WALL_L / 2;
+        creature->lot.setup.drop = -WALL_L;
         break;
 
     case O_DINO:
-        creature->lot.block_mask = BOX_BLOCKABLE;
+        creature->lot.setup.block_mask = BOX_BLOCKABLE;
         break;
 #endif
     default:
@@ -189,12 +189,12 @@ void LOT_CreateZone(ITEM *const item)
 
     const int16_t *zone;
     const int16_t *flip;
-    if (creature->lot.fly) {
+    if (creature->lot.setup.fly) {
         zone = Box_GetFlyZone(false);
         flip = Box_GetFlyZone(true);
     } else {
-        zone = Box_GetGroundZone(false, BOX_ZONE(creature->lot.step));
-        flip = Box_GetGroundZone(true, BOX_ZONE(creature->lot.step));
+        zone = Box_GetGroundZone(false, BOX_ZONE(creature->lot.setup.step));
+        flip = Box_GetGroundZone(true, BOX_ZONE(creature->lot.setup.step));
     }
 
     const ROOM *const room = Room_Get(item->room_num);

--- a/src/libtrx/game/pathing/lot.c
+++ b/src/libtrx/game/pathing/lot.c
@@ -3,6 +3,7 @@
 #include "debug.h"
 #include "game/camera.h"
 #include "game/game_buf.h"
+#include "game/objects.h"
 #include "game/pathing.h"
 #include "game/rooms.h"
 #include "utils.h"
@@ -105,77 +106,9 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     creature->maximum_turn = DEG_1;
     creature->flags = 0;
     creature->enemy = nullptr;
-    creature->lot.setup.step = STEP_L;
-#if TR_VERSION == 1
-    creature->lot.setup.drop = -STEP_L;
-#else
-    creature->lot.setup.drop = -STEP_L * 2;
-#endif
-    creature->lot.setup.block_mask = BOX_BLOCKED;
-    creature->lot.setup.fly = 0;
 
-    switch (item->object_id) {
-#if TR_VERSION == 1
-    case O_BAT:
-    case O_ALLIGATOR:
-    case O_FISH:
-        creature->lot.setup.step = WALL_L * 20;
-        creature->lot.setup.drop = -WALL_L * 20;
-        creature->lot.setup.fly = STEP_L / 16;
-        break;
-
-    case O_TREX:
-    case O_WARRIOR_1:
-    case O_CENTAUR:
-        creature->lot.setup.block_mask = BOX_BLOCKABLE;
-        break;
-
-    case O_WOLF:
-    case O_LION:
-    case O_LIONESS:
-    case O_PUMA:
-        creature->lot.setup.drop = -WALL_L;
-        break;
-
-    case O_APE:
-        creature->lot.setup.step = WALL_L / 2;
-        creature->lot.setup.drop = -WALL_L;
-        break;
-#else
-    case O_SHARK:
-    case O_BARRACUDA:
-    case O_DIVER:
-    case O_JELLY:
-    case O_CROW:
-    case O_EAGLE:
-        creature->lot.setup.step = WALL_L * 20;
-        creature->lot.setup.drop = -WALL_L * 20;
-        creature->lot.setup.fly = STEP_L / 16;
-        if (item->object_id == O_SHARK) {
-            creature->lot.setup.block_mask = BOX_BLOCKABLE;
-        }
-        break;
-
-    case O_WORKER_3:
-    case O_WORKER_4:
-    case O_YETI:
-        creature->lot.setup.step = WALL_L;
-        creature->lot.setup.drop = -WALL_L;
-        break;
-
-    case O_SPIDER:
-    case O_SKIDOO_ARMED:
-        creature->lot.setup.step = WALL_L / 2;
-        creature->lot.setup.drop = -WALL_L;
-        break;
-
-    case O_DINO:
-        creature->lot.setup.block_mask = BOX_BLOCKABLE;
-        break;
-#endif
-    default:
-        break;
-    }
+    const OBJECT *const obj = Object_Get(item->object_id);
+    creature->lot.setup = obj->lot_setup;
 
     LOT_ClearLOT(&creature->lot);
     LOT_CreateZone(item);

--- a/src/libtrx/game/pathing/vars.c
+++ b/src/libtrx/game/pathing/vars.c
@@ -1,0 +1,51 @@
+#include "game/pathing/vars.h"
+
+#include "game/pathing/const.h"
+
+#if TR_VERSION == 1
+    #define M_DEFALT_DROP (-STEP_L)
+#else
+    #define M_DEFALT_DROP (-STEP_L * 2)
+#endif
+
+const LOT_SETUP g_LOT_Default = {
+    .step = STEP_L,
+    .drop = M_DEFALT_DROP,
+    .fly = 0,
+    .block_mask = BOX_BLOCKED,
+};
+
+const LOT_SETUP g_LOT_Beast = {
+    .step = STEP_L,
+    .drop = M_DEFALT_DROP,
+    .fly = 0,
+    .block_mask = BOX_BLOCKABLE,
+};
+
+const LOT_SETUP g_LOT_Quadruped = {
+    .step = STEP_L,
+    .drop = -WALL_L,
+    .fly = 0,
+    .block_mask = BOX_BLOCKED,
+};
+
+const LOT_SETUP g_LOT_Jumper = {
+    .step = WALL_L / 2,
+    .drop = -WALL_L,
+    .fly = 0,
+    .block_mask = BOX_BLOCKED,
+};
+
+const LOT_SETUP g_LOT_Climber = {
+    .step = WALL_L,
+    .drop = -WALL_L,
+    .fly = 0,
+    .block_mask = BOX_BLOCKED,
+};
+
+const LOT_SETUP g_LOT_Flyer = {
+    .step = WALL_L * 20,
+    .drop = -WALL_L * 20,
+    .fly = STEP_L / 16,
+    .block_mask = BOX_BLOCKED,
+};

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -3,6 +3,7 @@
 #include "../anims/types.h"
 #include "../collision.h"
 #include "../items/types.h"
+#include "../pathing/types.h"
 #include "../rooms/enum.h"
 #include "../savegame/enum.h"
 #include "../types.h"
@@ -77,6 +78,7 @@ typedef struct OBJECT {
     int16_t smartness;
     bool enable_interpolation;
     XYZ_BOOL base_rot;
+    LOT_SETUP lot_setup;
 
     union {
         uint16_t flags;

--- a/src/libtrx/include/libtrx/game/pathing.h
+++ b/src/libtrx/include/libtrx/game/pathing.h
@@ -4,3 +4,4 @@
 #include "pathing/const.h"
 #include "pathing/lot.h"
 #include "pathing/types.h"
+#include "pathing/vars.h"

--- a/src/libtrx/include/libtrx/game/pathing/types.h
+++ b/src/libtrx/include/libtrx/game/pathing/types.h
@@ -19,14 +19,18 @@ typedef struct {
 } BOX_NODE;
 
 typedef struct {
+    int16_t step;
+    int16_t drop;
+    int16_t fly;
+    uint16_t block_mask;
+} LOT_SETUP;
+
+typedef struct {
+    LOT_SETUP setup;
     BOX_NODE *node;
     int16_t head;
     int16_t tail;
     uint16_t search_num;
-    uint16_t block_mask;
-    int16_t step;
-    int16_t drop;
-    int16_t fly;
     int16_t zone_count;
     int16_t target_box;
     int16_t required_box;

--- a/src/libtrx/include/libtrx/game/pathing/vars.h
+++ b/src/libtrx/include/libtrx/game/pathing/vars.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "./types.h"
+
+extern const LOT_SETUP g_LOT_Default;
+extern const LOT_SETUP g_LOT_Beast;
+extern const LOT_SETUP g_LOT_Quadruped;
+extern const LOT_SETUP g_LOT_Jumper;
+extern const LOT_SETUP g_LOT_Climber;
+extern const LOT_SETUP g_LOT_Flyer;

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -194,6 +194,7 @@ sources = [
   'game/packer.c',
   'game/pathing/box.c',
   'game/pathing/lot.c',
+  'game/pathing/vars.c',
   'game/phase/executor.c',
   'game/phase/phase_cutscene.c',
   'game/phase/phase_demo.c',

--- a/src/tr1/game/box.h
+++ b/src/tr1/game/box.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#include <libtrx/game/pathing/box.h>
-#include <libtrx/game/pathing/const.h>

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -523,9 +523,9 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.current_active = 0;
 
     LOT_InitialiseLOT(&g_Lara.lot);
-    g_Lara.lot.step = WALL_L * 20;
-    g_Lara.lot.drop = -WALL_L * 20;
-    g_Lara.lot.fly = STEP_L;
+    g_Lara.lot.setup.step = WALL_L * 20;
+    g_Lara.lot.setup.drop = -WALL_L * 20;
+    g_Lara.lot.setup.fly = STEP_L;
 
     Lara_InitialiseInventory(level);
 }

--- a/src/tr1/game/lara/control.c
+++ b/src/tr1/game/lara/control.c
@@ -1,6 +1,5 @@
 #include "game/lara/control.h"
 
-#include "game/box.h"
 #include "game/gun.h"
 #include "game/input.h"
 #include "game/lara/cheat.h"

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -117,6 +117,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 250;
     obj->radius = APE_RADIUS;
     obj->smartness = APE_SMARTNESS;
+    obj->lot_setup = g_LOT_Jumper;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -75,6 +75,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = BAT_HITPOINTS;
     obj->radius = BAT_RADIUS;
     obj->smartness = BAT_SMARTNESS;
+    obj->lot_setup = g_LOT_Flyer;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -49,6 +49,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 400;
     obj->radius = CENTAUR_RADIUS;
     obj->smartness = CENTAUR_SMARTNESS;
+    obj->lot_setup = g_LOT_Beast;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -115,6 +115,7 @@ static void M_SetupAlligator(OBJECT *const obj)
     obj->hit_points = ALLIGATOR_HITPOINTS;
     obj->radius = ALLIGATOR_RADIUS;
     obj->smartness = ALLIGATOR_SMARTNESS;
+    obj->lot_setup = g_LOT_Flyer;
 }
 
 static void M_UpdateCreatureLOT(const ITEM *const item)
@@ -124,15 +125,8 @@ static void M_UpdateCreatureLOT(const ITEM *const item)
         return;
     }
 
-    if (item->object_id == O_CROCODILE) {
-        creature->lot.setup.step = STEP_L;
-        creature->lot.setup.drop = -STEP_L;
-        creature->lot.setup.fly = 0;
-    } else if (item->object_id == O_ALLIGATOR) {
-        creature->lot.setup.step = WALL_L * 20;
-        creature->lot.setup.drop = -WALL_L * 20;
-        creature->lot.setup.fly = STEP_L / 16;
-    }
+    OBJECT *const obj = Object_Get(item->object_id);
+    creature->lot.setup = obj->lot_setup;
 }
 
 static void M_ControlCrocodile(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -125,13 +125,13 @@ static void M_UpdateCreatureLOT(const ITEM *const item)
     }
 
     if (item->object_id == O_CROCODILE) {
-        creature->lot.step = STEP_L;
-        creature->lot.drop = -STEP_L;
-        creature->lot.fly = 0;
+        creature->lot.setup.step = STEP_L;
+        creature->lot.setup.drop = -STEP_L;
+        creature->lot.setup.fly = 0;
     } else if (item->object_id == O_ALLIGATOR) {
-        creature->lot.step = WALL_L * 20;
-        creature->lot.drop = -WALL_L * 20;
-        creature->lot.fly = STEP_L / 16;
+        creature->lot.setup.step = WALL_L * 20;
+        creature->lot.setup.drop = -WALL_L * 20;
+        creature->lot.setup.fly = STEP_L / 16;
     }
 }
 

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -53,6 +53,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
+    obj->lot_setup = g_LOT_Quadruped;
     obj->pivot_length = 400;
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -76,6 +76,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 150;
     obj->radius = FLYER_RADIUS;
     obj->smartness = FLYER_SMARTNESS;
+    obj->lot_setup = g_LOT_Beast;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
@@ -94,6 +95,7 @@ static void M_Setup2(OBJECT *const obj)
     obj->setup_func = M_Setup2;
     obj->initialise_func = M_Initialise2;
     obj->smartness = WARRIOR2_SMARTNESS;
+    obj->lot_setup = g_LOT_Default;
 }
 
 static void M_Setup3(OBJECT *const obj)
@@ -104,6 +106,7 @@ static void M_Setup3(OBJECT *const obj)
     *obj = *Object_Get(O_WARRIOR_1);
     obj->setup_func = M_Setup3;
     obj->initialise_func = M_Initialise2;
+    obj->lot_setup = g_LOT_Default;
 }
 
 static void M_Initialise2(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -138,9 +138,9 @@ static void M_Control(const int16_t item_num)
         Carrier_TestItemDrops(item_num);
         return;
     } else {
-        flyer->lot.step = STEP_L;
-        flyer->lot.drop = -STEP_L;
-        flyer->lot.fly = 0;
+        flyer->lot.setup.step = STEP_L;
+        flyer->lot.setup.drop = -STEP_L;
+        flyer->lot.setup.fly = 0;
 
         AI_INFO info;
         Creature_AIInfo(item, &info);
@@ -169,9 +169,9 @@ static void M_Control(const int16_t item_num)
                     Creature_Mood(item, &info, true);
                 }
 
-                flyer->lot.step = WALL_L * 30;
-                flyer->lot.drop = -WALL_L * 30;
-                flyer->lot.fly = STEP_L / 8;
+                flyer->lot.setup.step = WALL_L * 30;
+                flyer->lot.setup.drop = -WALL_L * 30;
+                flyer->lot.setup.fly = STEP_L / 8;
                 Creature_AIInfo(item, &info);
             } else if (
                 (info.zone_num != info.enemy_zone && !shoot1 && !shoot2

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -86,9 +86,9 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points <= 0 && item->hit_points > DONT_TARGET) {
         item->goal_anim_state = NATLA_STATE_DEATH;
     } else if (item->hit_points <= NATLA_NEAR_DEATH) {
-        natla->lot.step = STEP_L;
-        natla->lot.drop = -STEP_L;
-        natla->lot.fly = 0;
+        natla->lot.setup.step = STEP_L;
+        natla->lot.setup.drop = -STEP_L;
+        natla->lot.setup.fly = 0;
 
         AI_INFO info;
         Creature_AIInfo(item, &info);
@@ -188,9 +188,9 @@ static void M_Control(const int16_t item_num)
             break;
         }
     } else {
-        natla->lot.step = STEP_L;
-        natla->lot.drop = -STEP_L;
-        natla->lot.fly = 0;
+        natla->lot.setup.step = STEP_L;
+        natla->lot.setup.drop = -STEP_L;
+        natla->lot.setup.fly = 0;
 
         AI_INFO info;
         Creature_AIInfo(item, &info);
@@ -206,9 +206,9 @@ static void M_Control(const int16_t item_num)
             if (!(natla->flags & NATLA_FLY_MODE)) {
                 Creature_Mood(item, &info, true);
             }
-            natla->lot.step = WALL_L * 20;
-            natla->lot.drop = -WALL_L * 20;
-            natla->lot.fly = STEP_L / 8;
+            natla->lot.setup.step = WALL_L * 20;
+            natla->lot.setup.drop = -WALL_L * 20;
+            natla->lot.setup.fly = STEP_L / 8;
             Creature_AIInfo(item, &info);
         } else if (!shoot) {
             natla->flags |= NATLA_FLY_MODE;

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -55,6 +55,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 2000;
     obj->radius = TREX_RADIUS;
     obj->smartness = TREX_SMARTNESS;
+    obj->lot_setup = g_LOT_Beast;
     obj->intelligent = 1;
     obj->save_position = 1;
     obj->save_hitpoints = 1;

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -70,6 +70,7 @@ void Object_SetupAllObjects(void)
         obj->shadow_size = 0;
         obj->hit_points = DONT_TARGET;
         obj->enable_interpolation = true;
+        obj->lot_setup = g_LOT_Default;
 
         if (obj->setup_func != nullptr) {
             obj->setup_func(obj);

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -758,10 +758,11 @@ static bool M_LoadLOT(JSON_OBJECT *lot_obj, LOT_INFO *lot)
     lot->head = JSON_ObjectGetInt(lot_obj, "head", lot->head);
     lot->tail = JSON_ObjectGetInt(lot_obj, "tail", lot->tail);
     lot->search_num = JSON_ObjectGetInt(lot_obj, "search_num", lot->search_num);
-    lot->block_mask = JSON_ObjectGetInt(lot_obj, "block_mask", lot->block_mask);
-    lot->step = JSON_ObjectGetInt(lot_obj, "step", lot->step);
-    lot->drop = JSON_ObjectGetInt(lot_obj, "drop", lot->drop);
-    lot->fly = JSON_ObjectGetInt(lot_obj, "fly", lot->fly);
+    lot->setup.block_mask =
+        JSON_ObjectGetInt(lot_obj, "block_mask", lot->setup.block_mask);
+    lot->setup.step = JSON_ObjectGetInt(lot_obj, "step", lot->setup.step);
+    lot->setup.drop = JSON_ObjectGetInt(lot_obj, "drop", lot->setup.drop);
+    lot->setup.fly = JSON_ObjectGetInt(lot_obj, "fly", lot->setup.fly);
     lot->zone_count = JSON_ObjectGetInt(lot_obj, "zone_count", lot->zone_count);
     lot->target_box = JSON_ObjectGetInt(lot_obj, "target_box", lot->target_box);
     lot->required_box =
@@ -1239,10 +1240,10 @@ static JSON_OBJECT *M_DumpLOT(LOT_INFO *lot)
     JSON_ObjectAppendInt(lot_obj, "head", lot->head);
     JSON_ObjectAppendInt(lot_obj, "tail", lot->tail);
     JSON_ObjectAppendInt(lot_obj, "search_num", lot->search_num);
-    JSON_ObjectAppendInt(lot_obj, "block_mask", lot->block_mask);
-    JSON_ObjectAppendInt(lot_obj, "step", lot->step);
-    JSON_ObjectAppendInt(lot_obj, "drop", lot->drop);
-    JSON_ObjectAppendInt(lot_obj, "fly", lot->fly);
+    JSON_ObjectAppendInt(lot_obj, "block_mask", lot->setup.block_mask);
+    JSON_ObjectAppendInt(lot_obj, "step", lot->setup.step);
+    JSON_ObjectAppendInt(lot_obj, "drop", lot->setup.drop);
+    JSON_ObjectAppendInt(lot_obj, "fly", lot->setup.fly);
     JSON_ObjectAppendInt(lot_obj, "zone_count", lot->zone_count);
     JSON_ObjectAppendInt(lot_obj, "target_box", lot->target_box);
     JSON_ObjectAppendInt(lot_obj, "required_box", lot->required_box);

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -321,10 +321,10 @@ static void M_ReadLOT(LOT_INFO *const lot)
     lot->head = M_ReadS16();
     lot->tail = M_ReadS16();
     lot->search_num = M_ReadU16();
-    lot->block_mask = M_ReadU16();
-    lot->step = M_ReadS16();
-    lot->drop = M_ReadS16();
-    lot->fly = M_ReadS16();
+    lot->setup.block_mask = M_ReadU16();
+    lot->setup.step = M_ReadS16();
+    lot->setup.drop = M_ReadS16();
+    lot->setup.fly = M_ReadS16();
     lot->zone_count = M_ReadS16();
     lot->target_box = M_ReadS16();
     lot->required_box = M_ReadS16();

--- a/src/tr2/game/box.h
+++ b/src/tr2/game/box.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#include <libtrx/game/pathing/box.h>
-#include <libtrx/game/pathing/const.h>

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -1,6 +1,5 @@
 #include "game/creature.h"
 
-#include "game/box.h"
 #include "game/gun/gun_misc.h"
 #include "game/los.h"
 #include "game/random.h"

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -819,9 +819,9 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.current_active = 0;
 
     LOT_InitialiseLOT(&g_Lara.lot);
-    g_Lara.lot.step = WALL_L * 20;
-    g_Lara.lot.drop = -WALL_L * 20;
-    g_Lara.lot.fly = STEP_L;
+    g_Lara.lot.setup.step = WALL_L * 20;
+    g_Lara.lot.setup.drop = -WALL_L * 20;
+    g_Lara.lot.setup.fly = STEP_L;
 
     if ((level->type == GFL_NORMAL || level->type == GFL_BONUS)
         && g_GF_LaraStartAnim) {

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1,7 +1,6 @@
 #include "game/lara/misc.h"
 
 #include "decomp/decomp.h"
-#include "game/box.h"
 #include "game/effects.h"
 #include "game/input.h"
 #include "game/inventory_ring.h"

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -55,6 +55,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = BARRACUDA_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 200;
+    obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -55,6 +55,7 @@ static void M_SetupEagle(OBJECT *const obj)
     obj->radius = BIRD_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
+    obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = 1;
     obj->save_position = 1;
@@ -77,6 +78,7 @@ static void M_SetupCrow(OBJECT *const obj)
     obj->radius = BIRD_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
+    obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -198,7 +198,7 @@ static void M_Control(const int16_t item_num)
             neck = -info.angle;
         }
         if (creature->target.y < water_level
-            && item->pos.y < water_level + creature->lot.fly) {
+            && item->pos.y < water_level + creature->lot.setup.fly) {
             item->goal_anim_state = DIVER_STATE_SWIM_2;
         } else if (creature->mood != MOOD_ESCAPE && shoot) {
             item->goal_anim_state = DIVER_STATE_AIM_1;
@@ -244,7 +244,7 @@ static void M_Control(const int16_t item_num)
         }
         if (!shoot || creature->mood == MOOD_ESCAPE
             || (creature->target.y < water_level
-                && item->pos.y < water_level + creature->lot.fly)) {
+                && item->pos.y < water_level + creature->lot.setup.fly)) {
             item->goal_anim_state = DIVER_STATE_SWIM_1;
         } else {
             item->goal_anim_state = DIVER_STATE_SHOOT_1;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -108,6 +108,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = DIVER_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
+    obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -35,6 +35,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = JELLY_HITPOINTS;
     obj->radius = JELLY_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
+    obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -63,6 +63,8 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = SHARK_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 200;
+    obj->lot_setup = g_LOT_Flyer;
+    obj->lot_setup.block_mask = BOX_BLOCKABLE;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -164,6 +164,7 @@ void Spider_Setup(OBJECT *const obj)
     obj->hit_points = SPIDER_HITPOINTS;
     obj->radius = SPIDER_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
+    obj->lot_setup = g_LOT_Jumper;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -56,6 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = TREX_RADIUS;
     obj->shadow_size = 64;
     obj->pivot_length = 1800;
+    obj->lot_setup = g_LOT_Beast;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -76,6 +76,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->radius = WORKER_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
+    obj->lot_setup = g_LOT_Climber;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -136,16 +136,16 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    creature->lot.step = STEP_L;
-    creature->lot.drop = -STEP_L;
-    creature->lot.fly = 0;
+    creature->lot.setup.step = STEP_L;
+    creature->lot.setup.drop = -STEP_L;
+    creature->lot.setup.fly = 0;
     AI_INFO info;
     Creature_AIInfo(item, &info);
     if (item->current_anim_state == XIAN_KNIGHT_STATE_FLY
         && info.zone_num != info.enemy_zone_num) {
-        creature->lot.step = WALL_L * 20;
-        creature->lot.drop = -WALL_L * 20;
-        creature->lot.fly = STEP_L / 4;
+        creature->lot.setup.step = WALL_L * 20;
+        creature->lot.setup.drop = -WALL_L * 20;
+        creature->lot.setup.fly = STEP_L / 4;
         Creature_AIInfo(item, &info);
     }
     Creature_Mood(item, &info, MOOD_ATTACK);
@@ -207,7 +207,7 @@ static void M_Control(const int16_t item_num)
             neck = info.angle;
         }
         M_SparkleTrail(item);
-        if (creature->lot.fly == 0) {
+        if (creature->lot.setup.fly == 0) {
             item->goal_anim_state = XIAN_KNIGHT_STATE_STOP;
         }
         break;

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -84,6 +84,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = YETI_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 100;
+    obj->lot_setup = g_LOT_Climber;
 
     obj->intelligent = 1;
     obj->save_position = 1;

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -1,6 +1,5 @@
 #include "game/objects/general/window.h"
 
-#include "game/box.h"
 #include "game/objects/common.h"
 #include "game/sound.h"
 #include "global/vars.h"

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -8,7 +8,6 @@
 
 static void M_SetupLara(void);
 static void M_SetupLaraExtra(void);
-static void M_SetupGeneralObjects(void);
 
 static void M_SetupLara(void)
 {
@@ -46,6 +45,7 @@ void Object_SetupAllObjects(void)
         obj->radius = DEFAULT_RADIUS;
         obj->shadow_size = 0;
         obj->enable_interpolation = true;
+        obj->lot_setup = g_LOT_Default;
 
         obj->save_position = 0;
         obj->save_hitpoints = 0;

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -23,6 +23,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = SKIDOO_ARMED_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
+    obj->lot_setup = g_LOT_Jumper;
 
     obj->intelligent = 1;
     obj->save_position = 1;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Objects are now responsible for picking their own LOT setup. I've made global const vars for this rather than duplicating the same setup in many places. I'm not convinced about the names though, LMK if you have any suggestions.

We'll need to check the enemy types impacted here. Those not listed use the default LOT, so if one of those is behaving OK, the rest should be too.

TR1: bat, crocodile/alligator, t-rex, flying and grounded Atlanteans, centaur, wolf, lion/lioness, panther, ape 
TR2: shark, barracuda, diver, crow, eagle, stick goon 1 and 2, yeti, small spider, skidoo driver, t-rex
