### PR TITLE
gun: fix pistols when wading with a wet rifle

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed falling ceiling and Damocles Sword traps not falling through stacked rooms (#2924)
 - fixed health bar in top center position covering inventory text
 - fixed the save crystal animation skipping a frame in 60 FPS (#1528)
+- fixed Lara unable to equip pistols after getting the Shotgun wet while wading (#2994)
 - fixed select level dialog not reacting to the menu back key (#2918, regression from 4.9)
 - fixed carried items falling from flying enemies not animating in 60 FPS (#2954, regression from 4.0)
 - fixed items carried by the Qualopec mummy spawning early after save/load (#2956, regression from 4.6)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)
 - fixed glide cameras using a default speed rather than maintaining the values set in the level file (#2962)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)
+- fixed Lara unable to equip pistols after getting a rifle-type weapon wet while wading (#2994)
 - fixed flame emitter 23 in room 6 not being deactivated when the lever in room 1 is used (#2851)
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door (#2215)
 - fixed Lara being able to equip guns and flares during in-game cutscenes (#2895)

--- a/src/tr1/game/gun/gun.c
+++ b/src/tr1/game/gun/gun.c
@@ -31,8 +31,9 @@ void Gun_Control(void)
     } else if (
         g_Lara.water_status == LWS_ABOVE_WATER
         || (g_Lara.water_status == LWS_WADE
-            && g_Lara.water_surface_dist
-                > -g_Weapons[g_Lara.gun_type].gun_height)) {
+            && (g_Lara.gun_status == LGS_ARMLESS
+                || g_Lara.water_surface_dist
+                    > -g_Weapons[g_Lara.gun_type].gun_height))) {
         if (g_Lara.request_gun_type != LGT_UNARMED
             && (g_Lara.request_gun_type != g_Lara.gun_type
                 || g_Lara.gun_status == LGS_ARMLESS)) {

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -51,8 +51,10 @@ void Gun_Control(void)
                     && (g_Lara.request_gun_type == LGT_HARPOON
                         || g_Lara.water_status == LWS_ABOVE_WATER
                         || (g_Lara.water_status == LWS_WADE
-                            && g_Lara.water_surface_dist
-                                > -g_Weapons[g_Lara.gun_type].gun_height)))) {
+                            && (g_Lara.gun_status == LGS_ARMLESS
+                                || g_Lara.water_surface_dist
+                                    > -g_Weapons[g_Lara.gun_type]
+                                           .gun_height))))) {
                 if (g_Lara.gun_type == LGT_FLARE) {
                     Flare_Create(0);
                     Flare_UndrawMeshes();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2994.

In the test level provided, Lara would put the Shotgun away because it was positioned too low, and would end up submerged when in use. That is fine, but the bigger problem arising from this was that she became overly cautious, refusing to draw any firearms, including pistols which would've been OK and above the water. This state continued until the player would guide her out of the water.

TR2 has the same logic. I made a similar fix, but I did _not_ test it.