### PR TITLE
box: remove zone skipping on load

### DIFF
--- a/src/libtrx/game/inject/editors/floor_data.c
+++ b/src/libtrx/game/inject/editors/floor_data.c
@@ -318,11 +318,6 @@ static void M_FixZones(
     const int16_t box_idx = sector->box;
     for (int32_t flip_status = 0; flip_status < 2; flip_status++) {
         for (int32_t zone_idx = 0; zone_idx < MAX_ZONES; zone_idx++) {
-            if (!Box_IsUsableZoneIndex(zone_idx)) {
-                VFile_Skip(injection->fp, sizeof(int16_t));
-                continue;
-            }
-
             int16_t *const ground_zone =
                 Box_GetGroundZone(flip_status, zone_idx);
             ground_zone[box_idx] = VFile_ReadS16(injection->fp);

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -987,11 +987,6 @@ void Level_ReadPathingData(VFILE *const file)
 
     for (int32_t flip_status = 0; flip_status < 2; flip_status++) {
         for (int32_t zone_idx = 0; zone_idx < MAX_ZONES; zone_idx++) {
-            if (!Box_IsUsableZoneIndex(zone_idx)) {
-                VFile_Skip(file, sizeof(int16_t) * num_boxes);
-                continue;
-            }
-
             int16_t *const ground_zone =
                 Box_GetGroundZone(flip_status, zone_idx);
             VFile_Read(file, ground_zone, sizeof(int16_t) * num_boxes);

--- a/src/libtrx/game/pathing/box.c
+++ b/src/libtrx/game/pathing/box.c
@@ -56,27 +56,6 @@ int16_t *Box_InitialiseOverlaps(const int32_t num_overlaps)
     return m_Overlaps;
 }
 
-bool Box_IsUsableZoneIndex(const int32_t zone_idx)
-{
-#if TR_VERSION == 2
-    // TODO: work out why these checks are in OG.
-    if (zone_idx == 2) {
-        return false;
-    }
-
-    if (zone_idx == 1 && !Object_Get(O_SPIDER)->loaded
-        && !Object_Get(O_SKIDOO_ARMED)->loaded) {
-        return false;
-    }
-
-    if (zone_idx == 3 && !Object_Get(O_YETI)->loaded
-        && !Object_Get(O_WORKER_3)->loaded) {
-        return false;
-    }
-#endif
-    return true;
-}
-
 int32_t Box_GetCount(void)
 {
     return m_BoxCount;

--- a/src/libtrx/include/libtrx/game/pathing/box.h
+++ b/src/libtrx/include/libtrx/game/pathing/box.h
@@ -5,7 +5,6 @@
 
 void Box_InitialiseBoxes(int32_t num_boxes);
 int16_t *Box_InitialiseOverlaps(int32_t num_overlaps);
-bool Box_IsUsableZoneIndex(int32_t zone_idx);
 int32_t Box_GetCount(void);
 BOX_INFO *Box_GetBox(int32_t box_idx);
 int16_t Box_GetOverlap(int32_t overlap_idx);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes TR2's zone skipping when reading level data based on the loaded enemy type. I believe this could have been in place for performance reasons, potentially giving a boost on PSX when these values are not needed. I've checked current develop and this PR and see no difference in loading times (`Level_ReadPathingData` in the log file).

This is my thinking.

| LOT step | Zone | Enemy |
| - | - | - |
| `STEP_L * 1` | 0 | default |
| `STEP_L * 2` | 1 | small spider, armed skidoo |
| `STEP_L * 3` | 2 | _nothing_ |
| `STEP_L * 4` | 3 | stick goons, yeti |

LOT setup assigns the above step values, and this is used in the `BOX_ZONE` macro to retrieve the relevant zone index for an enemy when doing pathing checks. So, because the old skipping checks were linked to the only enemy types that use these zones, having them in place even when the enemies themselves aren't loaded should have no impact. Other enemies will continue to use their own zone values regardless.

We can verify by for example, playing Great Wall, opening the guard tower and letting the spiders come outside. If Lara stands on a two-click block, the spiders will jump up to her, and if she's on a four-click block, they will take the "long" route by going up on the lower block first. So that's with the `STEP_L * 4` zone data loaded. A stick goon in this scenario would climb directly on the four-click block.

![image](https://github.com/user-attachments/assets/5689566d-b8d8-4a08-b978-ae15e18981f5)
