### PR TITLE
movable_block: fix state tests for killed blocks

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed incorrect camera shifts when some fixed cameras return to normal view (#2971, regression from 4.9)
 - fixed Lara not having weapons when playing a level with -l/--level (#2995, regression from 4.9)
 - fixed inventory ring items not being animated when the ring is rotating (#2964, regression from 4.9)
+- fixed a hole appearing in the floor in Natla's Mines room 84 after exploding the TNT box (#3007, regression from 4.9)
 
 ## [4.10.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.1...tr1-4.10.2) - 2025-05-15
 - fixed animated textures not working the right way in flipped rooms (#2966, regression from 4.10)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -33,6 +33,7 @@
 - fixed misplaced effects such as bubbles and dragon fire in 60 FPS (#2873, #2881, regression from 0.10)
 - fixed incorrect camera shifts when some fixed cameras return to normal view (#2971, regression from 0.10)
 - fixed blood not spawning when Lara is run down by boulders/barrels (#2982, regression from 0.7)
+- fixed floors being lowered too much under pushable blocks that are killed in the same trigger that flips the map (#3007, regression from 4.9)
 - improved the `/set` console command to display available options if given an unknown argument
 - improved handling of items that are dropped by enemies (#2952)
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -17,6 +17,7 @@ static VECTOR *m_UnsortedBlocks = nullptr;
 static int16_t *m_SortedBlocks = nullptr;
 
 static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2);
+static bool M_IsValidFloorShiftState(const ITEM *item);
 static void M_ShiftGlobalFloorUp(void);
 static void M_ShiftGlobalFloorDown(void);
 
@@ -30,12 +31,19 @@ static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2)
     return item1->pos.y < item2->pos.y ? 1 : -1;
 }
 
+static bool M_IsValidFloorShiftState(const ITEM *const item)
+{
+    return (item->status == IS_INACTIVE
+            || (item->status == IS_ACTIVE && !(bool)(intptr_t)item->priv))
+        && (item->flags & IF_KILLED) == 0
+        && item->pos.y >= Item_GetHeight(item);
+}
+
 static void M_ShiftGlobalFloorUp(void)
 {
     for (int32_t i = 0; i < m_BlockCount; i++) {
         ITEM *const item = Item_Get(m_SortedBlocks[i]);
-        if (item->status == IS_INACTIVE
-            && item->pos.y >= Item_GetHeight(item)) {
+        if (M_IsValidFloorShiftState(item)) {
             Room_AlterFloorHeight(item, -WALL_L);
         }
     }
@@ -45,8 +53,7 @@ static void M_ShiftGlobalFloorDown(void)
 {
     for (int32_t i = m_BlockCount - 1; i >= 0; i--) {
         ITEM *const item = Item_Get(m_SortedBlocks[i]);
-        if (item->status == IS_INACTIVE
-            && item->pos.y >= Item_GetHeight(item)) {
+        if (M_IsValidFloorShiftState(item)) {
             Room_AlterFloorHeight(item, WALL_L);
         }
     }


### PR DESCRIPTION
Resolves #3007.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This covers scenarios where a block is activated by the same trigger that also flips the map, and the block is about to be killed. It prevents shifting the floor twice effectively.
