### PR TITLE
tr1/savegame: fix crash in cutscenes

### DIFF
--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -22,6 +22,10 @@ void Savegame_HighlightNewestSlot(void)
 void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
 {
     RESUME_INFO *const current = Savegame_GetCurrentInfo(level);
+    if (current == nullptr) {
+        return;
+    }
+
     LOG_INFO("Applying game logic to level #%d", level->num);
 
     if (!g_Config.gameplay.disable_healing_between_levels


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a cutscene regression from ac484da.
