### PR TITLE
sound: use similar sample data loading API

### DIFF
--- a/src/libtrx/engine/audio_sample.c
+++ b/src/libtrx/engine/audio_sample.c
@@ -523,7 +523,7 @@ bool Audio_Sample_UnloadAll(void)
     return true;
 }
 
-bool Audio_Sample_LoadSingle(
+bool Audio_Sample_Load(
     const int32_t sample_id, const char *const data, const size_t size)
 {
     ASSERT(data != nullptr);
@@ -551,30 +551,6 @@ bool Audio_Sample_LoadSingle(
     memcpy(sample->original_data, data, size);
     m_LoadedSamplesCount++;
     return true;
-}
-
-bool Audio_Sample_LoadMany(size_t count, const char **contents, size_t *sizes)
-{
-    ASSERT(contents != nullptr);
-    ASSERT(sizes != nullptr);
-
-    if (!g_AudioDeviceID) {
-        return false;
-    }
-
-    ASSERT(count <= AUDIO_MAX_SAMPLES);
-
-    Audio_Sample_CloseAll();
-    Audio_Sample_UnloadAll();
-
-    bool result = true;
-    for (int32_t i = 0; i < (int32_t)count; i++) {
-        result &= Audio_Sample_LoadSingle(i, contents[i], sizes[i]);
-    }
-    if (!result) {
-        Audio_Sample_UnloadAll();
-    }
-    return result;
 }
 
 int32_t Audio_Sample_Play(

--- a/src/libtrx/game/sound/common.c
+++ b/src/libtrx/game/sound/common.c
@@ -31,6 +31,12 @@ void Sound_InitialiseSampleInfos(const int32_t num_sample_infos)
               sizeof(SAMPLE_INFO) * num_sample_infos, GBUF_SAMPLE_INFOS);
 }
 
+bool Sound_LoadSample(
+    const int32_t sample_num, const char *const sample_data, const size_t size)
+{
+    return Audio_Sample_Load(sample_num, sample_data, size);
+}
+
 int32_t Sound_GetSourceCount(void)
 {
     return m_SourceCount;

--- a/src/libtrx/game/sound/common.c
+++ b/src/libtrx/game/sound/common.c
@@ -1,4 +1,4 @@
-#include "game/sound.h"
+#include "game/sound/common.h"
 
 #include "engine/audio.h"
 #include "game/game_buf.h"

--- a/src/libtrx/include/libtrx/engine/audio.h
+++ b/src/libtrx/include/libtrx/engine/audio.h
@@ -28,9 +28,7 @@ bool Audio_Stream_SeekTimestamp(int32_t sound_id, double timestamp);
 bool Audio_Stream_SetStartTimestamp(int32_t sound_id, double timestamp);
 bool Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp);
 
-bool Audio_Sample_LoadMany(size_t count, const char **contents, size_t *sizes);
-bool Audio_Sample_LoadSingle(
-    int32_t sample_num, const char *content, size_t size);
+bool Audio_Sample_Load(int32_t sample_num, const char *content, size_t size);
 bool Audio_Sample_Unload(int32_t sample_id);
 bool Audio_Sample_UnloadAll(void);
 

--- a/src/libtrx/include/libtrx/game/sound/common.h
+++ b/src/libtrx/include/libtrx/game/sound/common.h
@@ -6,8 +6,14 @@
 #include "ids.h"
 #include "types.h"
 
+#include <stddef.h>
+
+// Stops and unloads all samples
+extern void Sound_Reset(void);
+
 void Sound_InitialiseSources(int32_t num_sources);
 void Sound_InitialiseSampleInfos(int32_t num_sample_infos);
+bool Sound_LoadSample(int32_t sample_num, const char *sample_data, size_t size);
 int32_t Sound_GetSourceCount(void);
 OBJECT_VECTOR *Sound_GetSource(int32_t source_idx);
 int16_t *Sound_GetSampleLUT(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -215,7 +215,7 @@ sources = [
   'game/scaler.c',
   'game/shell/common.c',
   'game/shell/main.c',
-  'game/sound.c',
+  'game/sound/common.c',
   'game/text.c',
   'game/ui/common.c',
   'game/ui/dialogs/base_passport.c',

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -47,6 +47,7 @@ typedef enum {
 
 static bool M_TryLayout(VFILE *file, LEVEL_LAYOUT layout);
 static LEVEL_LAYOUT M_GuessLayout(VFILE *file);
+static void M_InitialiseSoundEffects(void);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
@@ -167,6 +168,29 @@ static LEVEL_LAYOUT M_GuessLayout(VFILE *const file)
     return result;
 }
 
+static void M_InitialiseSoundEffects(void)
+{
+    BENCHMARK benchmark = Benchmark_Start();
+    LEVEL_INFO *const info = Level_GetInfo();
+    const int32_t sample_count = info->samples.offset_count;
+
+    // TODO: this assumes that sample pointers are sorted - adopt TR2's approach
+    // of sorting by index, verifying WAV headers and using WAV sample size.
+    for (int32_t i = 0; i < sample_count; i++) {
+        const int32_t current_offset = info->samples.offsets[i];
+        const int32_t next_offset = i + 1 >= sample_count
+            ? info->samples.data_size
+            : info->samples.offsets[i + 1];
+
+        const char *const sample_data = &info->samples.data[current_offset];
+        const size_t sample_size = next_offset - current_offset;
+        Sound_LoadSample(i, sample_data, sample_size);
+    }
+
+    Memory_FreePointer(&info->samples.offsets);
+    Benchmark_End(&benchmark, nullptr);
+}
+
 static void M_LoadFromFile(const GF_LEVEL *const level)
 {
     GameBuf_Reset();
@@ -261,30 +285,7 @@ static void M_CompleteSetup(const GF_LEVEL *const level)
     Level_LoadPalettes();
     Level_LoadFaces();
     Output_ObserveLevelLoad();
-
-    // Initialise the sound effects.
-    LEVEL_INFO *const info = Level_GetInfo();
-    const int32_t sample_count = info->samples.offset_count;
-    size_t *sample_sizes = Memory_Alloc(sizeof(size_t) * sample_count);
-    const char **sample_pointers = Memory_Alloc(sizeof(char *) * sample_count);
-    for (int i = 0; i < sample_count; i++) {
-        sample_pointers[i] = info->samples.data + info->samples.offsets[i];
-    }
-
-    // NOTE: this assumes that sample pointers are sorted
-    for (int32_t i = 0; i < sample_count; i++) {
-        const int32_t current_offset = info->samples.offsets[i];
-        const int32_t next_offset = i + 1 >= sample_count
-            ? info->samples.data_size
-            : info->samples.offsets[i + 1];
-        sample_sizes[i] = next_offset - current_offset;
-    }
-
-    Sound_LoadSamples(sample_count, sample_pointers, sample_sizes);
-
-    Memory_FreePointer(&sample_pointers);
-    Memory_FreePointer(&sample_sizes);
-    Memory_FreePointer(&info->samples.offsets);
+    M_InitialiseSoundEffects();
 
     Benchmark_End(&benchmark, nullptr);
 }
@@ -369,6 +370,7 @@ bool Level_Initialise(
 
     Music_ResetTrackFlags();
 
+    Sound_Reset();
     Object_Reset();
     Camera_Reset();
     Pierre_Reset();

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -510,10 +510,10 @@ void Sound_StopAmbientSounds(void)
     }
 }
 
-void Sound_LoadSamples(
-    size_t num_samples, const char **sample_pointers, size_t *sizes)
+void Sound_Reset(void)
 {
-    Audio_Sample_LoadMany(num_samples, sample_pointers, sizes);
+    Audio_Sample_CloseAll();
+    Audio_Sample_UnloadAll();
 }
 
 void Sound_StopAll(void)

--- a/src/tr1/game/sound.h
+++ b/src/tr1/game/sound.h
@@ -4,7 +4,6 @@
 
 #include <libtrx/game/sound.h>
 
-#include <stddef.h>
 #include <stdint.h>
 
 bool Sound_Init(void);
@@ -12,7 +11,5 @@ void Sound_Shutdown(void);
 void Sound_UpdateEffects(void);
 void Sound_ResetEffects(void);
 void Sound_StopAmbientSounds(void);
-void Sound_LoadSamples(
-    size_t num_samples, const char **sample_pointers, size_t *sizes);
 int32_t Sound_GetMaxSamples(void);
 void Sound_ResetAmbient(void);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -19,7 +19,6 @@
 #include <libtrx/benchmark.h>
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
-#include <libtrx/engine/audio.h>
 #include <libtrx/filesystem.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/carrier.h>
@@ -190,13 +189,8 @@ static void M_InitialiseSoundEffects(const char *file_name)
         char *sample_data = Memory_Alloc(size);
         memcpy(sample_data, header, header_size);
         File_ReadData(fp, sample_data + header_size, aligned_size);
-        const bool result =
-            Audio_Sample_LoadSingle(entry->game_index, sample_data, size);
+        Sound_LoadSample(entry->game_index, sample_data, size);
         Memory_FreePointer(&sample_data);
-
-        if (!result) {
-            LOG_WARNING("Failed to load sample %d", entry->game_index);
-        }
 
         current_sample++;
     }
@@ -291,9 +285,7 @@ bool Level_Load(const GF_LEVEL *const level)
 {
     BENCHMARK benchmark = Benchmark_Start();
 
-    Audio_Sample_CloseAll();
-    Audio_Sample_UnloadAll();
-
+    Sound_Reset();
     Object_Reset();
 
     Inject_InitLevel(level);
@@ -353,8 +345,6 @@ bool Level_Initialise(
 
     Overlay_Reset();
     Overlay_SetHealthBarTimer(100);
-
-    Sound_StopAll();
 
     if (Object_Get(O_FINAL_LEVEL_COUNTER)->loaded) {
         InitialiseFinalLevel();

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -324,6 +324,13 @@ void Sound_StopEffect(const SOUND_EFFECT_ID sample_id)
     }
 }
 
+void Sound_Reset(void)
+{
+    Audio_Sample_CloseAll();
+    Audio_Sample_UnloadAll();
+    M_ClearAllSlots();
+}
+
 void Sound_StopAll(void)
 {
     Audio_Sample_CloseAll();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A modest start at merging sound modules. TR1 now loads samples individually like TR2, and uses a neater approach of not having to make local copies of offsets and sizes. I've left a `TODO` to look into further improving this so that we're not assuming offset order, and to make it more like TR2 - effectively `level_info->samples.data` is equivalent to the file pointer for `main.sfx`. But that's a separate task for later.

For TR2's loading, I've simplified it a little by removing logging as `Audio_Sample_Load` will report on failures anyway.

We just need to check sound effects are OK between level loads, and that things like ambient sound sources play correctly as well as the regular ones (TR1 injected uzi SFX too).
