### PR TITLE
savegame: fix death counter overwriting level number

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed inventory ring items not being animated when the ring is rotating (#2964, regression from 4.9)
 - fixed a hole appearing in the floor in Natla's Mines room 84 after exploding the TNT box (#3007, regression from 4.9)
 - fixed button mashing causing quick save/load to misbehave on a specific passport animation frame (#3021, regression from 4.10)
+- fixed save level numbers being replaced incorrectly if Lara dies in a level and the last save was in the previous level (#3026, regression from 4.9)
 
 ## [4.10.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.1...tr1-4.10.2) - 2025-05-15
 - fixed animated textures not working the right way in flipped rooms (#2966, regression from 4.10)

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -607,7 +607,8 @@ bool Savegame_UpdateDeathCounters(
             MYFILE *const fp =
                 File_Open(savegame_info->full_path, FILE_OPEN_READ_WRITE);
             if (fp != nullptr) {
-                ret = strategy.update_death_counters_func(fp, death_count);
+                ret = strategy.update_death_counters_func(
+                    fp, savegame_info->level_num, death_count);
                 File_Close(fp);
             }
             break;

--- a/src/libtrx/include/libtrx/game/savegame/types.h
+++ b/src/libtrx/include/libtrx/game/savegame/types.h
@@ -69,5 +69,6 @@ typedef struct {
     bool (*load_from_file_func)(MYFILE *fp);
     bool (*load_only_resume_info_func)(MYFILE *fp);
     void (*save_to_file_func)(MYFILE *fp, SAVEGAME_INFO *savegame_info);
-    bool (*update_death_counters_func)(MYFILE *fp, int32_t death_count);
+    bool (*update_death_counters_func)(
+        MYFILE *fp, int32_t level_num, int32_t death_count);
 } SAVEGAME_STRATEGY;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -34,7 +34,8 @@ typedef struct {
     int16_t id_map[MAX_EFFECTS];
 } SAVEGAME_BSON_FX_ORDER;
 
-static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version);
+static void M_SaveRaw(
+    MYFILE *fp, JSON_VALUE *root, int32_t version, int32_t level_num);
 static JSON_VALUE *M_ParseFromBuffer(
     const char *buffer, size_t buffer_size, int32_t *version_out);
 static JSON_VALUE *M_ParseFromFile(MYFILE *fp, int32_t *version_out);
@@ -77,7 +78,8 @@ static bool M_FillInfo(MYFILE *fp, SAVEGAME_INFO *savegame_info);
 static bool M_LoadFromFile(MYFILE *fp);
 static bool M_LoadOnlyResumeInfo(MYFILE *fp);
 static void M_SaveToFile(MYFILE *fp, SAVEGAME_INFO *savegame_info);
-static bool M_UpdateDeathCounters(MYFILE *fp, int32_t death_count);
+static bool M_UpdateDeathCounters(
+    MYFILE *fp, int32_t level_num, int32_t death_count);
 
 static SAVEGAME_STRATEGY m_Strategy = {
     .allow_load = true,
@@ -91,7 +93,8 @@ static SAVEGAME_STRATEGY m_Strategy = {
     .update_death_counters_func = M_UpdateDeathCounters,
 };
 
-static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version)
+static void M_SaveRaw(
+    MYFILE *fp, JSON_VALUE *root, int32_t version, const int32_t level_num)
 {
     size_t uncompressed_size;
     char *uncompressed = BSON_Write(root, &uncompressed_size);
@@ -118,7 +121,7 @@ static void M_SaveRaw(MYFILE *fp, JSON_VALUE *root, int32_t version)
 
     File_WriteData(fp, compressed, compressed_size);
 
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
+    const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
     const SAVEGAME_BSON_EXTENDED_HEADER extra_header = {
         .flags = Game_GetBonusFlag(),
         .counter = Savegame_GetCounter(),
@@ -1524,13 +1527,14 @@ static void M_SaveToFile(MYFILE *const fp, SAVEGAME_INFO *const savegame_info)
         root_obj, "music_track_flags", M_DumpMusicTrackFlags());
 
     JSON_VALUE *root = JSON_ValueFromObject(root_obj);
-    M_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);
+    M_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION, current_level->num);
     JSON_ValueFree(root);
 
     savegame_info->features.restart = true;
 }
 
-static bool M_UpdateDeathCounters(MYFILE *const fp, const int32_t death_count)
+static bool M_UpdateDeathCounters(
+    MYFILE *const fp, int32_t level_num, const int32_t death_count)
 {
     bool result = false;
     int32_t version;
@@ -1550,7 +1554,7 @@ static bool M_UpdateDeathCounters(MYFILE *const fp, const int32_t death_count)
     JSON_ObjectAppendInt(misc_obj, "death_count", death_count);
 
     File_Seek(fp, 0, FILE_SEEK_SET);
-    M_SaveRaw(fp, root, version);
+    M_SaveRaw(fp, root, version, level_num);
     result = true;
 
 cleanup:

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -41,7 +41,7 @@
         value.z = JSON_ObjectGetInt(sub_obj, "z", value.z);                    \
     } while (0)
 
-static void M_SaveRaw(MYFILE *fp, const JSON_VALUE *root);
+static void M_SaveRaw(MYFILE *fp, const JSON_VALUE *root, int32_t level_num);
 static JSON_VALUE *M_ReadRaw(MYFILE *fp, int32_t *version_out);
 static JSON_VALUE *M_ParseFromBuffer(const char *buffer, int32_t *version_out);
 
@@ -135,11 +135,12 @@ static void M_SaveToFile(MYFILE *const fp, SAVEGAME_INFO *const info)
     JSON_ObjectAppendObject(root_obj, "lara", M_DumpLara());
 
     JSON_VALUE *const root = JSON_ValueFromObject(root_obj);
-    M_SaveRaw(fp, root);
+    M_SaveRaw(fp, root, current_level->num);
     JSON_ValueFree(root);
 }
 
-static void M_SaveRaw(MYFILE *const fp, const JSON_VALUE *const root)
+static void M_SaveRaw(
+    MYFILE *const fp, const JSON_VALUE *const root, const int32_t level_num)
 {
     size_t uncompressed_size;
     char *uncompressed = BSON_Write(root, &uncompressed_size);
@@ -153,7 +154,7 @@ static void M_SaveRaw(MYFILE *const fp, const JSON_VALUE *const root)
         Shell_ExitSystem("Failed to compress savegame data");
     }
 
-    const GF_LEVEL *const level = Game_GetCurrentLevel();
+    const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
     const SAVEGAME_BSON_HEADER header = {
         .magic = SAVEGAME_BSON_MAGIC,
         .initial_version = Savegame_GetInitialVersion(),


### PR DESCRIPTION
Resolves #3026.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves the death counter overwriting the bound save's level number, for scenarios where a player has started a new level and not yet saved in that level; Lara has then died, and so the save remains bound to the last level when updating the death counter.

TR2 is unaffected, although I've updated the saving logic to match.
