### PR TITLE
phase/pause: use more faithful transparency

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added an option to toggle between TR1 and TR2 camera modes (#2990)
 - changed the all items cheat to include the lead bar if present in the level (#3008)
 - changed the design of the controls dialog to use pages, making it match the new TR2X controls dialog
+- changed the pause screen to have a darker black overlay transparency (#2252)
 - fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)
 - fixed enemy hitpoints being doubled in demo mode as a result of NG+ (#2904)
 - fixed an illegal reachable slope in Lost Valley room 58, which could lead to Lara becoming softlocked (#2900)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - changed the installer to always allow downloading music files (#2891)
 - changed the dev console to no longer add duplicate entries to the history
 - changed the health bar and the air bar sizes to be slightly bigger
+- changed the pause screen to have a darker black overlay transparency (#2252)
 - fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)
 - fixed glide cameras using a default speed rather than maintaining the values set in the level file (#2962)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 0.10)

--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -51,7 +51,8 @@ static void M_Draw(PHASE *phase);
 static void M_FadeIn(M_PRIV *const p)
 {
     p->state = STATE_FADE_IN;
-    Fader_Init(&p->back_fader, FADER_TRANSPARENT, FADER_SEMI_BLACK, FADE_TIME);
+    Fader_Init(
+        &p->back_fader, FADER_TRANSPARENT, FADER_ALMOST_BLACK, FADE_TIME);
 }
 
 static void M_FadeOut(M_PRIV *const p)

--- a/src/libtrx/include/libtrx/game/fader.h
+++ b/src/libtrx/include/libtrx/game/fader.h
@@ -7,6 +7,7 @@
 #define FADER_ANY (-1)
 #define FADER_TRANSPARENT 0
 #define FADER_SEMI_BLACK 127
+#define FADER_ALMOST_BLACK 192
 #define FADER_BLACK 255
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2252.
It's a bit controversial as it works worse in badly lit areas and better in well lit areas.