### PR TITLE
music: detect ambient trigger tracks

### DIFF
--- a/docs/GAME_FLOW.md
+++ b/docs/GAME_FLOW.md
@@ -201,6 +201,18 @@ remains distinct for each game.
       See <a href="#water-color-table">this table</a> for reference values.</a>
     </td>
   </tr>
+  <tr valign="top">
+    <td>
+      <a name="ambient-tracks"></a>
+      <code>ambient_tracks</code>
+    </td>
+    <td>Integer array</td>
+    <td>
+      A list of music track IDs, which will be treated as ambient music. If
+      Lara crosses a trigger for any of these, it will become the current looped
+      track, and will persist on save/load.
+    </td>
+  </tr>
 </table>
 
 **\*** Required property.
@@ -346,6 +358,17 @@ remains distinct for each game.
       See <a href="#water-color-table">this table</a> for reference values.</a>
     </td>
   </tr>
+  <tr valign="top">
+    <td>
+      <code>ambient_tracks</code>
+    </td>
+    <td>Integer array</td>
+    <td>
+      A list of music track IDs, which will be treated as ambient music. If
+      Lara crosses a trigger for any of these, it will become the current looped
+      track, and will persist on save/load.
+    </td>
+  </tr>
 </table>
 
 ## Game flow commands
@@ -464,6 +487,7 @@ Following are each of the properties available within a level.
         "data/level_injection1.bin",
         "data/level_injection2.bin",
     ],
+    "ambient_tracks": [30, 31, 32, 33],
     "item_drops": [
         {"enemy_num": 17, "object_ids": [86]},
         {"enemy_num": 50, "object_ids": [87]},
@@ -630,6 +654,14 @@ Following are each of the properties available within a level.
     <td>Float array</td>
     <td colspan="2">
       Can be customized per level. See <a href="#water-color">above</a> for
+      details.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td><code>ambient_tracks</code></td>
+    <td>Integer array</td>
+    <td colspan="2">
+      Can be customized per level. See <a href="#ambient-tracks">above</a> for
       details.
     </td>
   </tr>

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added the ability to trigger a flip effect without having to also trigger the flip map, in line with TR2 (#2921)
 - added a /help command (#2917)
 - added an option to toggle between TR1 and TR2 camera modes (#2990)
+- added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves (#811)
 - changed the all items cheat to include the lead bar if present in the level (#3008)
 - changed the design of the controls dialog to use pages, making it match the new TR2X controls dialog
 - fixed Lara's braid pointing straight down when swimming below sloped ceilings (#1600)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed a hole appearing in the floor in Natla's Mines room 84 after exploding the TNT box (#3007, regression from 4.9)
 - fixed button mashing causing quick save/load to misbehave on a specific passport animation frame (#3021, regression from 4.10)
 - fixed save level numbers being replaced incorrectly if Lara dies in a level and the last save was in the previous level (#3026, regression from 4.9)
+- fixed ambient music not looping correctly after reloading a save with the option to reload ambient timestamps enabled (#3032, regression from 4.6)
 
 ## [4.10.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.1...tr1-4.10.2) - 2025-05-15
 - fixed animated textures not working the right way in flipped rooms (#2966, regression from 4.10)

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -601,6 +601,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
 - added the current music track and timestamp to the savegame so they now persist on load
 - added the triggered music tracks to the savegame so one shot tracks don't replay on load
 - added detection for animation commands to play SFX on land, water or both
+- added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves
 - fixed the sound of collecting a secret killing the music
 - fixed audio mixer stopping playing sounds on big explosions
 - fixed game audio not muting when game is minimized

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -13,6 +13,7 @@
 - added the ability to reset active inputs layout
 - added the ability to unbind non-essential keys
 - added the ability to rebind more keys
+- added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves
 - changed the design of the controls dialog to use pages, making it better suited for small screens, larger text sizes, and more key bindings
 - changed on-screen messages (such as `Z-Buffer on` to use the dev console, like in TR1X)
 - changed the sound dialog appearance (repositioned, added text labels and arrows)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -345,6 +345,7 @@ However, you can easily download them manually from these urls:
 #### Audio
 - added an option to control how music is played while underwater rather than simply muting it
 - added the current music track and timestamp to the savegame so they now persist on load
+- added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves
 - fixed music not playing with certain game versions
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace
 - fixed sound settings resuming the music

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -707,7 +707,6 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
     }
 
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
-    stream->start_at = timestamp;
     if (!stream->is_used) {
         return false;
     }

--- a/src/libtrx/game/game_flow/common.c
+++ b/src/libtrx/game/game_flow/common.c
@@ -39,6 +39,7 @@ static void M_FreeLevel(GF_LEVEL *const level)
 {
     Memory_FreePointer(&level->path);
     Memory_FreePointer(&level->title);
+    Memory_FreePointer(&level->settings.ambient_tracks.ids);
     M_FreeInjections(&level->injections);
     M_FreeSequence(&level->sequence);
 
@@ -92,6 +93,7 @@ void GF_Shutdown(void)
     Memory_FreePointer(&gf->main_menu_background_path);
     Memory_FreePointer(&gf->savegame_fmt_legacy);
     Memory_FreePointer(&gf->savegame_fmt_bson);
+    Memory_FreePointer(&gf->settings.ambient_tracks.ids);
 #if TR_VERSION == 2
     Memory_FreePointer(&gf->settings.sfx_path);
 #endif

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -132,6 +132,21 @@ static void M_LoadCommonSettings(
             }
         }
     }
+
+    {
+        const JSON_ARRAY *const tmp_arr =
+            JSON_ObjectGetArray(obj, "ambient_tracks");
+        if (tmp_arr != nullptr && tmp_arr->length != 0) {
+            settings->ambient_tracks.is_present = true;
+            settings->ambient_tracks.count = tmp_arr->length;
+            settings->ambient_tracks.ids =
+                Memory_Alloc(sizeof(MUSIC_TRACK_ID) * tmp_arr->length);
+            for (size_t i = 0; i < tmp_arr->length; i++) {
+                settings->ambient_tracks.ids[i] =
+                    JSON_ArrayGetInt(tmp_arr, i, MX_INACTIVE);
+            }
+        }
+    }
 }
 
 static void M_LoadCommonRoot(JSON_OBJECT *const obj, GAME_FLOW *const gf)

--- a/src/libtrx/game/level/settings.c
+++ b/src/libtrx/game/level/settings.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "game/game_flow.h"
+#include "game/game_flow/vars.h"
 
 RGB_888 Level_GetWaterColor(void)
 {
@@ -28,4 +29,16 @@ float Level_GetFogEnd(void)
         return level->settings.fog_end.value;
     }
     return g_Config.visuals.fog_end;
+}
+
+const GF_AMBIENT_DATA *Level_GetAmbientData(void)
+{
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level != nullptr && level->settings.ambient_tracks.is_present) {
+        return &level->settings.ambient_tracks;
+    }
+    if (g_GameFlow.settings.ambient_tracks.is_present) {
+        return &g_GameFlow.settings.ambient_tracks;
+    }
+    return nullptr;
 }

--- a/src/libtrx/game/music/common.c
+++ b/src/libtrx/game/music/common.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "engine/audio.h"
+#include "game/level.h"
 #include "game/music.h"
 #include "game/music/backend_cdaudio.h"
 #include "game/music/backend_files.h"
@@ -10,9 +11,12 @@
 
 static uint16_t m_MusicTrackFlags[MAX_MUSIC_TRACKS] = {};
 static MUSIC_TRACK_ID m_TrackCurrent = MX_INACTIVE;
-static MUSIC_TRACK_ID m_TrackLastPlayed = MX_INACTIVE;
 static MUSIC_TRACK_ID m_TrackDelayed = MX_INACTIVE;
 static MUSIC_TRACK_ID m_TrackLooped = MX_INACTIVE;
+// Remember the last played track, whether normal or looped, to prevent
+// immediately restarting it if Lara remains on the same trigger.
+static MUSIC_TRACK_ID m_TrackLastPlayed = MX_INACTIVE;
+static MUSIC_TRACK_ID m_TrackLastLooped = MX_INACTIVE;
 
 static bool m_Muted = false;
 static int16_t m_MusicVolume = 0;
@@ -24,6 +28,7 @@ static void M_StopActiveStream(void);
 static void M_StreamFinished(int32_t stream_id, void *user_data);
 static bool M_IsBrokenTrack(MUSIC_TRACK_ID track);
 static int32_t M_GetRealTrack(int32_t track_id);
+static bool M_IsAmbientTrack(MUSIC_TRACK_ID track_id);
 static void M_SyncVolume(int32_t audio_stream_id);
 
 static const MUSIC_BACKEND *M_FindBackend(void)
@@ -77,6 +82,7 @@ static void M_StreamFinished(const int32_t stream_id, void *const user_data)
         m_TrackCurrent = MX_INACTIVE;
         m_AudioStreamID = -1;
         if (m_TrackLooped >= 0) {
+            m_TrackLastLooped = MX_INACTIVE;
             Music_Play(m_TrackLooped, MPM_LOOPED);
         }
     }
@@ -111,6 +117,22 @@ static int32_t M_GetRealTrack(const int32_t track_id)
 #endif
 }
 
+static bool M_IsAmbientTrack(const MUSIC_TRACK_ID track_id)
+{
+    const GF_AMBIENT_DATA *const ambient_data = Level_GetAmbientData();
+    if (ambient_data == nullptr) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < ambient_data->count; i++) {
+        if (ambient_data->ids[i] == track_id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void M_SyncVolume(const int32_t audio_stream_id)
 {
     if (audio_stream_id < 0) {
@@ -140,6 +162,7 @@ finish:
     m_TrackLastPlayed = MX_INACTIVE;
     m_TrackDelayed = MX_INACTIVE;
     m_TrackLooped = MX_INACTIVE;
+    m_TrackLastLooped = MX_INACTIVE;
     return result && Audio_Init();
 }
 
@@ -160,6 +183,11 @@ bool Music_Play(const MUSIC_TRACK_ID track_id, const MUSIC_PLAY_MODE mode)
     }
 
     if (mode == MPM_TRACKED && track_id == m_TrackLastPlayed) {
+        return false;
+    }
+
+    const bool is_looped = mode == MPM_LOOPED || M_IsAmbientTrack(track_id);
+    if (is_looped && track_id == m_TrackLastLooped) {
         return false;
     }
 
@@ -205,13 +233,18 @@ bool Music_Play(const MUSIC_TRACK_ID track_id, const MUSIC_PLAY_MODE mode)
     }
 
     M_SyncVolume(m_AudioStreamID);
-    Audio_Stream_SetIsLooped(m_AudioStreamID, mode == MPM_LOOPED);
+    Audio_Stream_SetIsLooped(m_AudioStreamID, is_looped);
     Audio_Stream_SetFinishCallback(m_AudioStreamID, M_StreamFinished, nullptr);
 
 finish:
     m_TrackDelayed = MX_INACTIVE;
-    if (mode == MPM_LOOPED) {
+    if (is_looped) {
+        // Reset the regular track outside of M_StreamFinished so that
+        // Music_GetCurrentPlayingTrack returns the looped track; otherwise, the
+        // stopped track could be stored in the savegame despite being inactive.
+        m_TrackCurrent = MX_INACTIVE;
         m_TrackLooped = track_id;
+        m_TrackLastLooped = track_id;
     } else {
         m_TrackCurrent = track_id;
         m_TrackLastPlayed = track_id;
@@ -225,6 +258,7 @@ void Music_Stop(void)
     m_TrackLastPlayed = MX_INACTIVE;
     m_TrackDelayed = MX_INACTIVE;
     m_TrackLooped = MX_INACTIVE;
+    m_TrackLastLooped = MX_INACTIVE;
     M_StopActiveStream();
 }
 

--- a/src/libtrx/include/libtrx/game/game_flow/types.h
+++ b/src/libtrx/include/libtrx/game/game_flow/types.h
@@ -80,6 +80,12 @@ typedef struct {
 } GF_FMV;
 
 typedef struct {
+    bool is_present;
+    int32_t count;
+    MUSIC_TRACK_ID *ids;
+} GF_AMBIENT_DATA;
+
+typedef struct {
     struct {
         bool is_present;
         float value;
@@ -91,6 +97,7 @@ typedef struct {
 #if TR_VERSION == 2
     char *sfx_path;
 #endif
+    GF_AMBIENT_DATA ambient_tracks;
 } GF_LEVEL_SETTINGS;
 
 #if TR_VERSION == 1

--- a/src/libtrx/include/libtrx/game/level/settings.h
+++ b/src/libtrx/include/libtrx/game/level/settings.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../../colors.h"
+#include "../game_flow/types.h"
 
 extern RGB_888 Level_GetWaterColor(void);
 extern float Level_GetFogStart(void);
 extern float Level_GetFogEnd(void);
+const GF_AMBIENT_DATA *Level_GetAmbientData(void);

--- a/src/libtrx/include/libtrx/game/savegame/const.h
+++ b/src/libtrx/include/libtrx/game/savegame/const.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define SAVEGAME_CURRENT_VERSION 8
+#define SAVEGAME_CURRENT_VERSION 9

--- a/src/libtrx/include/libtrx/game/savegame/enum.h
+++ b/src/libtrx/include/libtrx/game/savegame/enum.h
@@ -30,4 +30,8 @@ typedef enum {
 
     // Added the current TRX version string.
     VERSION_8 = 8,
+
+    // Added the current ambient track to allow triggers to change it at
+    // different stages of the level.
+    VERSION_9 = 9,
 } SAVEGAME_VERSION;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -53,7 +53,7 @@ static bool M_LoadAmmo(JSON_OBJECT *ammo_obj, AMMO_INFO *ammo);
 static bool M_LoadLOT(JSON_OBJECT *lot_obj, LOT_INFO *lot);
 static bool M_LoadLara(
     JSON_OBJECT *lara_obj, LARA_INFO *lara, uint16_t header_version);
-static bool M_LoadCurrentMusic(JSON_OBJECT *music_obj);
+static bool M_LoadCurrentMusic(JSON_OBJECT *music_obj, uint16_t header_version);
 static bool M_LoadMusicTrackFlags(JSON_ARRAY *music_track_arr);
 static JSON_ARRAY *M_DumpResumeInfo(void);
 static JSON_OBJECT *M_DumpMisc(void);
@@ -918,37 +918,52 @@ static bool M_LoadLara(
     return true;
 }
 
-static bool M_LoadCurrentMusic(JSON_OBJECT *music_obj)
+static bool M_LoadCurrentMusic(
+    JSON_OBJECT *music_obj, const uint16_t header_version)
 {
-    if (g_Config.audio.music_load_condition == MUSIC_LOAD_NEVER) {
-        return true;
-    }
-
-    if (!music_obj) {
+    if (music_obj == nullptr) {
         LOG_WARNING("Malformed save: invalid or missing current music");
         return true;
     }
 
-    int16_t current_track = JSON_ObjectGetInt(music_obj, "current_track", -1);
-    double timestamp = JSON_ObjectGetDouble(music_obj, "timestamp", -1.0);
-    if (current_track != MX_INACTIVE) {
-        const bool is_ambient =
-            JSON_ObjectGetBool(music_obj, "is_ambient", false);
-        if (is_ambient) {
-            if (g_Config.audio.music_load_condition == MUSIC_LOAD_NON_AMBIENT) {
-                return true;
-            }
-            Music_Play(current_track, MPM_LOOPED);
-        } else {
-            Music_Play(current_track, MPM_ALWAYS);
-        }
+    const MUSIC_TRACK_ID current_track =
+        JSON_ObjectGetInt(music_obj, "current_track", MX_INACTIVE);
+    MUSIC_TRACK_ID ambient_track =
+        JSON_ObjectGetInt(music_obj, "current_ambient", MX_INACTIVE);
+    const double timestamp = JSON_ObjectGetDouble(music_obj, "timestamp", -1.0);
 
-        if (!Music_SeekTimestamp(timestamp)) {
-            LOG_WARNING(
-                "Could not load current track %d at timestamp %" PRId64 ".",
-                current_track, timestamp);
+    if (header_version < VERSION_9) {
+        const bool legacy_ambient =
+            JSON_ObjectGetBool(music_obj, "is_ambient", false);
+        if (legacy_ambient && current_track != MX_INACTIVE) {
+            ambient_track = current_track;
         }
     }
+
+    if (ambient_track != MX_INACTIVE) {
+        // Always restart the ambient as it may have changed based on the
+        // current position in the level.
+        Music_Play(ambient_track, MPM_LOOPED);
+    }
+
+    if (g_Config.audio.music_load_condition == MUSIC_LOAD_NEVER) {
+        return true;
+    }
+
+    const bool is_ambient =
+        current_track != MX_INACTIVE && current_track == ambient_track;
+    if (!is_ambient && current_track != MX_INACTIVE) {
+        Music_Play(current_track, MPM_ALWAYS);
+    }
+
+    const bool load_timestamp =
+        !is_ambient || g_Config.audio.music_load_condition == MUSIC_LOAD_ALWAYS;
+    if (load_timestamp && !Music_SeekTimestamp(timestamp)) {
+        LOG_WARNING(
+            "Could not load current track %d at timestamp %" PRId64 ".",
+            current_track, timestamp);
+    }
+
     return true;
 }
 
@@ -1327,12 +1342,12 @@ static JSON_OBJECT *M_DumpLara(LARA_INFO *lara)
 static JSON_OBJECT *M_DumpCurrentMusic(void)
 {
     const MUSIC_TRACK_ID current_track = Music_GetCurrentPlayingTrack();
-    const bool is_ambient = current_track == Music_GetCurrentLoopedTrack();
+    const MUSIC_TRACK_ID current_ambient = Music_GetCurrentLoopedTrack();
     JSON_OBJECT *const current_music_obj = JSON_ObjectNew();
     JSON_ObjectAppendInt(current_music_obj, "current_track", current_track);
+    JSON_ObjectAppendInt(current_music_obj, "current_ambient", current_ambient);
     JSON_ObjectAppendDouble(
         current_music_obj, "timestamp", Music_GetTimestamp());
-    JSON_ObjectAppendBool(current_music_obj, "is_ambient", is_ambient);
 
     return current_music_obj;
 }
@@ -1453,7 +1468,8 @@ static bool M_LoadFromFile(MYFILE *const fp)
     }
 
     if (version >= VERSION_3) {
-        if (!M_LoadCurrentMusic(JSON_ObjectGetObject(root_obj, "music"))) {
+        if (!M_LoadCurrentMusic(
+                JSON_ObjectGetObject(root_obj, "music"), version)) {
             goto cleanup;
         }
 

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -58,7 +58,7 @@ static JSON_OBJECT *M_DumpArm(const LARA_ARM *arm);
 static JSON_OBJECT *M_DumpAmmo(const AMMO_INFO *ammo);
 
 static bool M_LoadMisc(JSON_OBJECT *misc_obj);
-static bool M_LoadMusic(JSON_OBJECT *music_obj);
+static bool M_LoadMusic(JSON_OBJECT *music_obj, uint16_t header_version);
 static bool M_LoadResumeInfo(JSON_ARRAY *resume_arr);
 static bool M_LoadInventory(JSON_OBJECT *inv_obj);
 static bool M_LoadFlipmaps(JSON_OBJECT *flipmap_obj);
@@ -194,7 +194,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
         goto cleanup;
     }
 
-    if (!M_LoadMusic(JSON_ObjectGetObject(root_obj, "music"))) {
+    if (!M_LoadMusic(JSON_ObjectGetObject(root_obj, "music"), version)) {
         goto cleanup;
     }
 
@@ -310,17 +310,18 @@ static JSON_OBJECT *M_DumpMusic(void)
     JSON_ObjectAppendArray(music_obj, "flags", track_arr);
 
     const MUSIC_TRACK_ID current_track = Music_GetCurrentPlayingTrack();
-    const bool is_ambient = current_track == Music_GetCurrentLoopedTrack();
+    const MUSIC_TRACK_ID current_ambient = Music_GetCurrentLoopedTrack();
     JSON_OBJECT *const current_obj = JSON_ObjectNew();
     JSON_ObjectAppendInt(current_obj, "current_track", current_track);
+    JSON_ObjectAppendInt(current_obj, "current_ambient", current_ambient);
     JSON_ObjectAppendDouble(current_obj, "timestamp", Music_GetTimestamp());
-    JSON_ObjectAppendBool(current_obj, "is_ambient", is_ambient);
     JSON_ObjectAppendObject(music_obj, "current", current_obj);
 
     return music_obj;
 }
 
-static bool M_LoadMusic(JSON_OBJECT *const music_obj)
+static bool M_LoadMusic(
+    JSON_OBJECT *const music_obj, const uint16_t header_version)
 {
     if (music_obj == nullptr) {
         LOG_ERROR("Malformed save: invalid or missing music info");
@@ -346,31 +347,47 @@ static bool M_LoadMusic(JSON_OBJECT *const music_obj)
 
     const JSON_OBJECT *const current_obj =
         JSON_ObjectGetObject(music_obj, "current");
-    if (current_obj == nullptr
-        || g_Config.audio.music_load_condition == MUSIC_LOAD_NEVER) {
+    if (current_obj == nullptr) {
         return true;
     }
 
-    const int16_t current_track =
-        JSON_ObjectGetInt(current_obj, "current_track", -1);
-    double timestamp = JSON_ObjectGetDouble(current_obj, "timestamp", -1.0);
-    if (current_track != MX_INACTIVE) {
-        const bool is_ambient =
-            JSON_ObjectGetBool(music_obj, "is_ambient", false);
-        if (is_ambient) {
-            if (g_Config.audio.music_load_condition == MUSIC_LOAD_NON_AMBIENT) {
-                return true;
-            }
-            Music_Play(current_track, MPM_LOOPED);
-        } else {
-            Music_Play(current_track, MPM_ALWAYS);
-        }
+    const MUSIC_TRACK_ID current_track =
+        JSON_ObjectGetInt(current_obj, "current_track", MX_INACTIVE);
+    MUSIC_TRACK_ID ambient_track =
+        JSON_ObjectGetInt(current_obj, "current_ambient", MX_INACTIVE);
+    const double timestamp =
+        JSON_ObjectGetDouble(current_obj, "timestamp", -1.0);
 
-        if (!Music_SeekTimestamp(timestamp)) {
-            LOG_WARNING(
-                "Could not load current track %d at timestamp %" PRId64 ".",
-                current_track, timestamp);
+    if (header_version < VERSION_9) {
+        const bool legacy_ambient =
+            JSON_ObjectGetBool(current_obj, "is_ambient", false);
+        if (legacy_ambient && current_track != MX_INACTIVE) {
+            ambient_track = current_track;
         }
+    }
+
+    if (ambient_track != MX_INACTIVE) {
+        // Always restart the ambient as it may have changed based on the
+        // current position in the level.
+        Music_Play(ambient_track, MPM_LOOPED);
+    }
+
+    if (g_Config.audio.music_load_condition == MUSIC_LOAD_NEVER) {
+        return true;
+    }
+
+    const bool is_ambient =
+        current_track != MX_INACTIVE && current_track == ambient_track;
+    if (!is_ambient && current_track != MX_INACTIVE) {
+        Music_Play(current_track, MPM_ALWAYS);
+    }
+
+    const bool load_timestamp =
+        !is_ambient || g_Config.audio.music_load_condition == MUSIC_LOAD_ALWAYS;
+    if (load_timestamp && !Music_SeekTimestamp(timestamp)) {
+        LOG_WARNING(
+            "Could not load current track %d at timestamp %" PRId64 ".",
+            current_track, timestamp);
     }
 
     return true;


### PR DESCRIPTION
Resolves #811.
Resolves #3032.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds support to have ambient tracks listed in the game flow, so that the game will know to play these tracks looped if Lara crosses a trigger for any of them. The current ambient track is saved and restored on load regardless of music loading option (but the timestamp loading still respects the player's setting). Also fixed the issue with looping tracks after reloading a timestamp.

Would be good to double check timestamp reloading with existing saves as this uprevs the savegame version.