### PR TITLE
wip: rewrite movable block collision

### DIFF
--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -7,8 +7,58 @@
 #include "game/rooms.h"
 #include "utils.h"
 
+static void M_FillSide(
+    const COLL_INFO *coll, COLL_SIDE *side, int32_t x_pos, int32_t z_pos,
+    int32_t y_pos, int32_t obj_height, int16_t room_num);
 static bool M_IsOnWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);
+
+static void M_FillSide(
+    const COLL_INFO *const coll, COLL_SIDE *const side, const int32_t x_pos,
+    const int32_t z_pos, const int32_t y_pos, const int32_t obj_height,
+    int16_t room_num)
+{
+    const int32_t y = y_pos - obj_height;
+    const int32_t y_top = y - 160;
+
+    const SECTOR *const sector = Room_GetSector(x_pos, y_top, z_pos, &room_num);
+    int32_t height = Room_GetHeight(sector, x_pos, y_top, z_pos);
+    int32_t ceiling = Room_GetCeiling(sector, x_pos, y_top, z_pos);
+    const int32_t room_height = height;
+    const int32_t room_ceiling = ceiling;
+    const bool sim_wall = room_height == ceiling && room_height != NO_HEIGHT
+        && sector->ceiling.tilt == 0 && sector->floor.tilt == 0;
+    if (height != NO_HEIGHT) {
+        height -= y_pos;
+    }
+    if (ceiling != NO_HEIGHT) {
+        ceiling -= y;
+    }
+
+    side->floor = height;
+    side->ceiling = ceiling;
+    side->type = Room_GetHeightType();
+
+    const bool is_on_walkable =
+        M_IsOnWalkable(sector, x_pos, y_top, z_pos, room_height);
+    if (!is_on_walkable) {
+        if (coll->slopes_are_walls && side->type == HT_BIG_SLOPE
+            && side->floor < 0) {
+            side->floor = -32767;
+        } else if (
+            coll->slopes_are_pits && side->type == HT_BIG_SLOPE
+            && side->floor > 0) {
+            side->floor = STEP_L * 2;
+        } else if (
+            coll->lava_is_pit && side->floor > 0
+            && Room_GetPitSector(sector, x_pos, z_pos)->is_death_sector) {
+            side->floor = STEP_L * 2;
+        }
+    } else if (sim_wall) {
+        side->floor = NO_HEIGHT;
+        side->ceiling = NO_HEIGHT;
+    }
+}
 
 static bool M_IsOnWalkable(
     const SECTOR *const sector, const int32_t x, const int32_t y,
@@ -247,107 +297,15 @@ void Collide_GetCollisionInfo(
         break;
     }
 
-    // Front.
-    x = x_pos + x_front;
-    z = z_pos + z_front;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_front.floor = height;
-    coll->side_front.ceiling = ceiling;
-    coll->side_front.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_front.type == HT_BIG_SLOPE
-            && coll->side_front.floor < 0) {
-            coll->side_front.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_front.type == HT_BIG_SLOPE
-            && coll->side_front.floor > 0) {
-            coll->side_front.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_front.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_front.floor = 512;
-        }
-    }
-
-    // Left.
-    x = x_pos + x_left;
-    z = z_pos + z_left;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_left.floor = height;
-    coll->side_left.ceiling = ceiling;
-    coll->side_left.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_left.type == HT_BIG_SLOPE
-            && coll->side_left.floor < 0) {
-            coll->side_left.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_left.type == HT_BIG_SLOPE
-            && coll->side_left.floor > 0) {
-            coll->side_left.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_left.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_left.floor = 512;
-        }
-    }
-
-    // Right.
-    x = x_pos + x_right;
-    z = z_pos + z_right;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_right.floor = height;
-    coll->side_right.ceiling = ceiling;
-    coll->side_right.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_right.type == HT_BIG_SLOPE
-            && coll->side_right.floor < 0) {
-            coll->side_right.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_right.type == HT_BIG_SLOPE
-            && coll->side_right.floor > 0) {
-            coll->side_right.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_right.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_right.floor = 512;
-        }
-    }
+    M_FillSide(
+        coll, &coll->side_front, x_pos + x_front, z_pos + z_front, y_pos,
+        obj_height, room_num);
+    M_FillSide(
+        coll, &coll->side_left, x_pos + x_left, z_pos + z_left, y_pos,
+        obj_height, room_num);
+    M_FillSide(
+        coll, &coll->side_right, x_pos + x_right, z_pos + z_right, y_pos,
+        obj_height, room_num);
 
     if (Collide_CollideStaticObjects(
             coll, x_pos, y_pos, z_pos, room_num, obj_height)) {

--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -181,7 +181,7 @@ void Collide_GetCollisionInfo(
     }
 
     coll->side_mid.floor = height;
-    LOG_DEBUG("Mid height: %d; y_pos: %d", height, y_pos);
+    // LOG_DEBUG("Mid height: %d; y_pos: %d", height, y_pos);
     coll->side_mid.ceiling = ceiling;
     coll->side_mid.type = Room_GetHeightType();
 
@@ -254,7 +254,7 @@ void Collide_GetCollisionInfo(
     z = z_pos + z_front;
     sector = Room_GetSector(x, y_top, z, &room_num);
     height = Room_GetHeight(sector, x, y_top, z);
-    // LOG_DEBUG("Front height: %d; y_pos: %d", height, y_pos);
+    LOG_DEBUG("Front height: %d; y_pos: %d", height, y_pos);
     room_height = height;
     if (height != NO_HEIGHT) {
         height -= y_pos;
@@ -265,8 +265,8 @@ void Collide_GetCollisionInfo(
     }
 
     coll->side_front.floor = height;
-    // LOG_DEBUG("Set coll->side_front.floor: %d", coll->side_front.floor);
     coll->side_front.ceiling = ceiling;
+    LOG_DEBUG("Set coll->side_front.floor: %d; ceiling: %d", height, ceiling);
     coll->side_front.type = Room_GetHeightType();
 
     is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);

--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -5,6 +5,7 @@
 #include "game/lara/common.h"
 #include "game/matrix.h"
 #include "game/rooms.h"
+#include "log.h"
 #include "utils.h"
 
 static bool M_IsOnWalkable(
@@ -15,7 +16,7 @@ static bool M_IsOnWalkable(
     const int32_t z, const int32_t room_height)
 {
     return g_Config.gameplay.fix_bridge_collision
-        && Room_IsOnWalkable(sector, x, y, z, room_height);
+        && Room_IsOnWalkable(sector, x, y, z, room_height, NO_ITEM);
 }
 
 int32_t Collide_GetSpheres(
@@ -180,6 +181,7 @@ void Collide_GetCollisionInfo(
     }
 
     coll->side_mid.floor = height;
+    LOG_DEBUG("Mid height: %d; y_pos: %d", height, y_pos);
     coll->side_mid.ceiling = ceiling;
     coll->side_mid.type = Room_GetHeightType();
 
@@ -252,6 +254,7 @@ void Collide_GetCollisionInfo(
     z = z_pos + z_front;
     sector = Room_GetSector(x, y_top, z, &room_num);
     height = Room_GetHeight(sector, x, y_top, z);
+    // LOG_DEBUG("Front height: %d; y_pos: %d", height, y_pos);
     room_height = height;
     if (height != NO_HEIGHT) {
         height -= y_pos;
@@ -262,6 +265,7 @@ void Collide_GetCollisionInfo(
     }
 
     coll->side_front.floor = height;
+    // LOG_DEBUG("Set coll->side_front.floor: %d", coll->side_front.floor);
     coll->side_front.ceiling = ceiling;
     coll->side_front.type = Room_GetHeightType();
 

--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -5,7 +5,6 @@
 #include "game/lara/common.h"
 #include "game/matrix.h"
 #include "game/rooms.h"
-#include "log.h"
 #include "utils.h"
 
 static bool M_IsOnWalkable(
@@ -181,7 +180,6 @@ void Collide_GetCollisionInfo(
     }
 
     coll->side_mid.floor = height;
-    // LOG_DEBUG("Mid height: %d; y_pos: %d", height, y_pos);
     coll->side_mid.ceiling = ceiling;
     coll->side_mid.type = Room_GetHeightType();
 
@@ -254,7 +252,6 @@ void Collide_GetCollisionInfo(
     z = z_pos + z_front;
     sector = Room_GetSector(x, y_top, z, &room_num);
     height = Room_GetHeight(sector, x, y_top, z);
-    LOG_DEBUG("Front height: %d; y_pos: %d", height, y_pos);
     room_height = height;
     if (height != NO_HEIGHT) {
         height -= y_pos;
@@ -266,7 +263,6 @@ void Collide_GetCollisionInfo(
 
     coll->side_front.floor = height;
     coll->side_front.ceiling = ceiling;
-    LOG_DEBUG("Set coll->side_front.floor: %d; ceiling: %d", height, ceiling);
     coll->side_front.type = Room_GetHeightType();
 
     is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);

--- a/src/libtrx/game/items/col.c
+++ b/src/libtrx/game/items/col.c
@@ -108,3 +108,35 @@ const BOUNDS_16 *Item_GetBoundsAccurate(const ITEM *const item)
 
     return result;
 }
+
+BOUNDS_16 Item_RotateBounds(const ITEM *const item, int16_t rot_y)
+{
+    const BOUNDS_16 *bounds = &Item_GetBestFrame(item)->bounds;
+    BOUNDS_16 rot_bounds = { 0 };
+
+    switch (rot_y) {
+    case 0:
+        rot_bounds = *bounds;
+        break;
+    case DEG_90:
+        rot_bounds.min.x = bounds->min.z;
+        rot_bounds.max.x = bounds->max.z;
+        rot_bounds.min.z = -bounds->max.x;
+        rot_bounds.max.z = -bounds->min.x;
+        break;
+    case -DEG_90:
+        rot_bounds.min.x = -bounds->max.z;
+        rot_bounds.max.x = -bounds->min.z;
+        rot_bounds.min.z = bounds->min.x;
+        rot_bounds.max.z = bounds->max.x;
+        break;
+    case -DEG_180:
+    default:
+        rot_bounds.min.x = -bounds->max.x;
+        rot_bounds.max.x = -bounds->min.x;
+        rot_bounds.min.z = -bounds->max.z;
+        rot_bounds.max.z = -bounds->min.z;
+        break;
+    }
+    return rot_bounds;
+}

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -8,9 +8,11 @@
 #include "game/objects/common.h"
 #include "game/output/const.h"
 #include "game/rooms.h"
+#include "log.h"
 #include "utils.h"
 #include "vector.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 
 static int32_t m_LevelItemCount = 0;
@@ -438,6 +440,28 @@ void Item_SortWalkables(void)
     qsort(
         first_item_num, Item_GetWalkableCount(), sizeof(int16_t),
         M_CompareWalkables);
+
+    LOG_DEBUG("Item_SortWalkables order:");
+    const size_t buf_sz = 32 + (size_t)Item_GetWalkableCount() * 7;
+    char *buf = malloc(buf_sz);
+    if (!buf) {
+        LOG_DEBUG("Item_SortWalkables order: <out-of-memory>");
+        return;
+    }
+
+    // Prefix
+    size_t len = snprintf(buf, buf_sz, "Item_SortWalkables order:");
+
+    // Append each item number
+    for (int32_t i = 0; i < Item_GetWalkableCount() && len < buf_sz; ++i) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        len += snprintf(buf + len, buf_sz - len, " %d", item_num);
+    }
+
+    // Emit one log entry
+    LOG_DEBUG("%s", buf);
+
+    free(buf);
 }
 
 void Item_ShutdownWalkables(void)

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -9,6 +9,9 @@
 #include "game/output/const.h"
 #include "game/rooms.h"
 #include "utils.h"
+#include "vector.h"
+
+#include <stdlib.h>
 
 static int32_t m_LevelItemCount = 0;
 static int16_t m_MaxUsedItemCount = 0;
@@ -16,6 +19,7 @@ static ITEM *m_Items = nullptr;
 static int16_t m_NextItemActive = NO_ITEM;
 static int16_t m_PrevItemActive = NO_ITEM;
 static int16_t m_NextItemFree = NO_ITEM;
+static VECTOR *m_Walkables = nullptr;
 
 void Item_InitialiseItems(const int32_t num_items)
 {
@@ -386,4 +390,60 @@ bool Item_IsTriggerActive(ITEM *const item)
     }
 
     return ok;
+}
+
+static int32_t M_CompareWalkables(const void *item_idx1, const void *item_idx2)
+{
+    const ITEM *const item1 = Item_Get(*(int16_t *)item_idx1);
+    const ITEM *const item2 = Item_Get(*(int16_t *)item_idx2);
+    if (item1->pos.y == item2->pos.y) {
+        return 0;
+    }
+    // Sort lowest to highest.
+    return item1->pos.y < item2->pos.y ? 1 : -1;
+}
+
+void Item_InitialiseWalkables(void)
+{
+    m_Walkables = Vector_Create(sizeof(int16_t));
+}
+
+void Item_AddWalkable(const int16_t item_num)
+{
+    Vector_Add(m_Walkables, (void *)&item_num);
+}
+
+void Item_RemoveWalkable(const int16_t item_num)
+{
+    Vector_Remove(m_Walkables, (void *)&item_num);
+}
+
+int16_t Item_GetWalkableNum(const int32_t index)
+{
+    return *(const int16_t *)Vector_Get(m_Walkables, index);
+}
+
+int32_t Item_GetWalkableCount(void)
+{
+    return m_Walkables->count;
+}
+
+void Item_SortWalkables(void)
+{
+    if (m_Walkables == nullptr || m_Walkables->count == 0) {
+        return;
+    }
+    int16_t *first_item_num = Vector_GetData(m_Walkables);
+    // Sort walkables by ascending item y position.
+    qsort(
+        first_item_num, Item_GetWalkableCount(), sizeof(int16_t),
+        M_CompareWalkables);
+}
+
+void Item_ShutdownWalkables(void)
+{
+    if (m_Walkables != nullptr) {
+        Vector_Free(m_Walkables);
+        m_Walkables = nullptr;
+    }
 }

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -12,6 +12,7 @@
 #include "game/lara.h"
 #include "game/objects/common.h"
 #include "game/objects/setup.h"
+#include "game/objects/vars.h"
 #include "game/output.h"
 #include "game/pathing.h"
 #include "game/rooms.h"
@@ -1115,6 +1116,22 @@ void Level_ReadItems(VFILE *const file)
                 "Bad object number (%d) on item %d", item->object_id, i);
             goto finish;
         }
+    }
+
+    Item_InitialiseWalkables();
+    for (int32_t item_num = 0; item_num < num_items; item_num++) {
+        const ITEM *const item = Item_Get(item_num);
+        if (Object_IsType(item->object_id, g_WalkableObjects)) {
+            LOG_DEBUG(
+                "Add walkable: item_num: %d; object_id: %d", item_num,
+                item->object_id);
+            Item_AddWalkable(item_num);
+        }
+    }
+    Item_SortWalkables();
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        LOG_DEBUG("Sorted item_num: %d", item_num);
     }
 
 finish:

--- a/src/libtrx/game/objects/general/drawbridge.c
+++ b/src/libtrx/game/objects/general/drawbridge.c
@@ -2,7 +2,9 @@
 #include "game/items.h"
 #include "game/objects.h"
 #include "game/objects/general/door.h"
+#include "game/objects/traps/movable_block.h"
 #include "game/rooms.h"
+#include "log.h"
 
 typedef enum {
     DRAWBRIDGE_STATE_CLOSED = DOOR_STATE_CLOSED,
@@ -89,6 +91,8 @@ static void M_Control(int16_t item_num)
         item->goal_anim_state = DRAWBRIDGE_STATE_OPEN;
     } else {
         item->goal_anim_state = DRAWBRIDGE_STATE_CLOSED;
+        LOG_DEBUG("Activate blocks on drawbridge item_num: %d", item_num);
+        MovableBlock_ActivateSectors(item);
     }
 
     Item_Animate(item);

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -17,87 +17,6 @@ static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z);
 static void M_Setup(OBJECT *obj);
 static void M_Control(int16_t item_num);
 
-static void M_ActivateSectors(const ITEM *item)
-{
-    const BOUNDS_16 *orig_bounds = &Item_GetBestFrame(item)->bounds;
-    if (!orig_bounds)
-        return;
-
-    // Rotate bounds to the correct x and z.
-    LOG_DEBUG("item->rot.y: %d", item->rot.y);
-    BOUNDS_16 rot_bounds;
-    int32_t x_walk = 0;
-    int32_t z_walk = 0;
-    int32_t min_x = item->pos.x;
-    int32_t max_x = item->pos.x;
-    int32_t min_z = item->pos.z;
-    int32_t max_z = item->pos.z;
-    switch (item->rot.y) {
-    case 0:
-        rot_bounds = *orig_bounds;
-        z_walk = WALL_L;
-        max_z = item->pos.z + (rot_bounds.min.z + rot_bounds.max.z);
-        break;
-    case DEG_90:
-        rot_bounds.min.x = orig_bounds->min.z;
-        rot_bounds.max.x = orig_bounds->max.z;
-        rot_bounds.min.z = -orig_bounds->max.x;
-        rot_bounds.max.z = -orig_bounds->min.x;
-        x_walk = WALL_L;
-        max_x = item->pos.x + (rot_bounds.min.x + rot_bounds.max.x);
-        break;
-    case -DEG_180:
-        rot_bounds.min.x = -orig_bounds->max.x;
-        rot_bounds.max.x = -orig_bounds->min.x;
-        rot_bounds.min.z = -orig_bounds->max.z;
-        rot_bounds.max.z = -orig_bounds->min.z;
-        z_walk = -WALL_L;
-        max_z = item->pos.z + (rot_bounds.min.z + rot_bounds.max.z);
-        LOG_DEBUG(
-            "z pos: %d; bounds max z: %d %d", item->pos.z, rot_bounds.min.z,
-            rot_bounds.max.z);
-        break;
-    case -DEG_90:
-        rot_bounds.min.x = -orig_bounds->max.z;
-        rot_bounds.max.x = -orig_bounds->min.z;
-        rot_bounds.min.z = orig_bounds->min.x;
-        rot_bounds.max.z = orig_bounds->max.x;
-        x_walk = -WALL_L;
-        max_x = item->pos.x + (rot_bounds.min.x + rot_bounds.max.x);
-        break;
-    default:
-        rot_bounds = *orig_bounds;
-        break;
-    }
-
-    // Swap min and max for loop if traverse in a negative direction.
-    if (x_walk == -WALL_L) {
-        int32_t t = min_x;
-        min_x = max_x;
-        max_x = t;
-    }
-    if (z_walk == -WALL_L) {
-        int32_t t = min_z;
-        min_z = max_z;
-        max_z = t;
-    }
-
-    LOG_DEBUG("swapped min max x: %d %d; z: %d %d", min_x, max_x, min_z, max_z);
-
-    // Walk every covered sector.
-    for (int32_t x = min_x; x <= max_x; x += WALL_L) {
-        for (int32_t z = min_z; z <= max_z; z += WALL_L) {
-            LOG_DEBUG("Trigger xz: %d %d", x, z);
-            const XYZ_32 sector_pos = {
-                .x = x,
-                .y = item->pos.y,
-                .z = z,
-            };
-            MovableBlock_ActivateStack(item, sector_pos);
-        }
-    }
-}
-
 static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
@@ -194,7 +113,7 @@ static void M_Control(const int16_t item_num)
             // Item_RemoveWalkable(item_num);
             // Item_SortWalkables();
             LOG_DEBUG("Activate trapdoor item_num: %d", item_num);
-            M_ActivateSectors(item);
+            MovableBlock_ActivateSectors(item);
         }
     } else {
         if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -2,14 +2,13 @@
 #include "game/objects.h"
 #include "game/objects/traps/movable_block.h"
 #include "log.h"
+#include "utils.h"
 
 typedef enum {
     TRAPDOOR_STATE_CLOSED,
     TRAPDOOR_STATE_OPEN,
 } TRAPDOOR_STATE;
 
-// static void M_Initialise(const int16_t item_num);
-// static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage);
 static int16_t M_GetFloorHeight(
     const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
 static int16_t M_GetCeilingHeight(
@@ -18,25 +17,61 @@ static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z);
 static void M_Setup(OBJECT *obj);
 static void M_Control(int16_t item_num);
 
-// static void M_Initialise(const int16_t item_num)
-// {
-//     ITEM *const item = Item_Get(item_num);
-//     if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
-//         Item_RemoveWalkable(item_num);
-//         LOG_DEBUG("INIT TRAPDOOR OPEN");
-//     }
-// }
+static void M_ActivateSectors(const ITEM *item)
+{
+    const BOUNDS_16 *orig_bounds = &Item_GetBestFrame(item)->bounds;
+    if (!orig_bounds)
+        return;
 
-// static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
-// {
-//     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
-//         const int16_t item_num = Item_GetIndex(item);
-//         if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
-//             Item_RemoveWalkable(item_num);
-//             LOG_DEBUG("LOAD TRAPDOOR OPEN");
-//         }
-//     }
-// }
+    // Rotate local bounds into the world X-Z axes.
+    BOUNDS_16 rot_bounds;
+    switch (item->rot.y) {
+    case 0:
+        rot_bounds = *orig_bounds;
+        break;
+    case DEG_90:
+        rot_bounds.min.x = orig_bounds->min.z;
+        rot_bounds.max.x = orig_bounds->max.z;
+        rot_bounds.min.z = -orig_bounds->max.x;
+        rot_bounds.max.z = -orig_bounds->min.x;
+        break;
+    case -DEG_180:
+        rot_bounds.min.x = -orig_bounds->max.x;
+        rot_bounds.max.x = -orig_bounds->min.x;
+        rot_bounds.min.z = -orig_bounds->max.z;
+        rot_bounds.max.z = -orig_bounds->min.z;
+        break;
+    case -DEG_90:
+        rot_bounds.min.x = -orig_bounds->max.z;
+        rot_bounds.max.x = -orig_bounds->min.z;
+        rot_bounds.min.z = orig_bounds->min.x;
+        rot_bounds.max.z = orig_bounds->max.x;
+        break;
+    default:
+        rot_bounds = *orig_bounds;
+        break;
+    }
+
+    // World-space rectangle spanned by those bounds.
+    int32_t min_x = item->pos.x;
+    int32_t max_x = item->pos.x + rot_bounds.max.x;
+    int32_t min_z = item->pos.z;
+    int32_t max_z = item->pos.z + rot_bounds.max.z;
+
+    // Walk every covered sector.
+    for (int32_t x = min_x; x <= max_x; x += WALL_L) {
+        for (int32_t z = min_z; z <= max_z; z += WALL_L) {
+            LOG_DEBUG(
+                "Activate x: %d; z: %d; item->pos.y: %d", x, z, item->pos.y);
+            const XYZ_32 sector_pos = {
+                .x = x,
+                .y = item->pos.y,
+                .z = z,
+            };
+            MovableBlock_ActivateStack(item, sector_pos);
+        }
+    }
+}
 
 static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
@@ -140,8 +175,8 @@ static void M_Control(const int16_t item_num)
             // TODO Needed? Floor height functions should take care?
             // Item_RemoveWalkable(item_num);
             // Item_SortWalkables();
-            MovableBlock_ActivateStack(
-                item, item->pos.x, item->pos.y, item->pos.z);
+            LOG_DEBUG("Trapdoor opened item_num: %d", item_num);
+            M_ActivateSectors(item);
         }
     } else {
         if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
@@ -149,10 +184,11 @@ static void M_Control(const int16_t item_num)
             // TODO Needed? Floor height functions should take care?
             // Item_AddWalkable(item_num);
             // Item_SortWalkables();
-            MovableBlock_ActivateStack(
-                item, item->pos.x, item->pos.y, item->pos.z);
+            LOG_DEBUG("Trapdoor closed item_num: %d", item_num);
+            // M_ActivateSectors(item);
         }
     }
+
     Item_Animate(item);
 }
 

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -1,7 +1,6 @@
 #include "game/const.h"
 #include "game/objects.h"
 #include "game/objects/traps/movable_block.h"
-#include "log.h"
 #include "utils.h"
 
 typedef enum {
@@ -23,7 +22,7 @@ static void M_ActivateSectors(const ITEM *item)
     if (!orig_bounds)
         return;
 
-    // Rotate local bounds into the world X-Z axes.
+    // Rotate bounds to the correct x and z.
     BOUNDS_16 rot_bounds;
     switch (item->rot.y) {
     case 0:
@@ -61,8 +60,6 @@ static void M_ActivateSectors(const ITEM *item)
     // Walk every covered sector.
     for (int32_t x = min_x; x <= max_x; x += WALL_L) {
         for (int32_t z = min_z; z <= max_z; z += WALL_L) {
-            LOG_DEBUG(
-                "Activate x: %d; z: %d; item->pos.y: %d", x, z, item->pos.y);
             const XYZ_32 sector_pos = {
                 .x = x,
                 .y = item->pos.y,
@@ -77,21 +74,14 @@ static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
-    // LOG_DEBUG(
-    //     "item xyz: %d %d %d; test xyz: %d %d %d; height: %d", item->pos.x,
-    //     item->pos.y, item->pos.z, x, y, z, height);
 
     if (!M_IsItemOnTop(item, x, z)) {
-        // LOG_DEBUG("not on top");
         return height;
     } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
-        // LOG_DEBUG("not closed");
         return height;
     } else if (y > item->pos.y || item->pos.y > height) {
-        // LOG_DEBUG("either or");
         return height;
     } else {
-        // LOG_DEBUG("ON TRAPDOOR");
         return item->pos.y;
     }
 }
@@ -175,7 +165,6 @@ static void M_Control(const int16_t item_num)
             // TODO Needed? Floor height functions should take care?
             // Item_RemoveWalkable(item_num);
             // Item_SortWalkables();
-            LOG_DEBUG("Trapdoor opened item_num: %d", item_num);
             M_ActivateSectors(item);
         }
     } else {
@@ -184,7 +173,6 @@ static void M_Control(const int16_t item_num)
             // TODO Needed? Floor height functions should take care?
             // Item_AddWalkable(item_num);
             // Item_SortWalkables();
-            LOG_DEBUG("Trapdoor closed item_num: %d", item_num);
             // M_ActivateSectors(item);
         }
     }

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -22,6 +22,8 @@ static void M_ActivateSectors(const ITEM *item)
     if (!orig_bounds)
         return;
 
+    // TODO Trapdoor item number 36 doesn't travel second sector.
+    // pos: 26112, -1024, 9728. angle: 32767.
     // Rotate bounds to the correct x and z.
     BOUNDS_16 rot_bounds;
     switch (item->rot.y) {

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -42,13 +42,9 @@ static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
-
-    if (item->pos.y != -4992) {
-        return height;
-    }
-    LOG_DEBUG(
-        "item xyz: %d %d %d; test xyz: %d %d %d; height: %d", item->pos.x,
-        item->pos.y, item->pos.z, x, y, z, height);
+    // LOG_DEBUG(
+    //     "item xyz: %d %d %d; test xyz: %d %d %d; height: %d", item->pos.x,
+    //     item->pos.y, item->pos.z, x, y, z, height);
 
     if (!M_IsItemOnTop(item, x, z)) {
         // LOG_DEBUG("not on top");

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -1,6 +1,7 @@
 #include "game/const.h"
 #include "game/objects.h"
 #include "game/objects/traps/movable_block.h"
+#include "log.h"
 #include "utils.h"
 
 typedef enum {
@@ -22,46 +23,71 @@ static void M_ActivateSectors(const ITEM *item)
     if (!orig_bounds)
         return;
 
-    // TODO Trapdoor item number 36 doesn't travel second sector.
-    // pos: 26112, -1024, 9728. angle: 32767.
     // Rotate bounds to the correct x and z.
+    LOG_DEBUG("item->rot.y: %d", item->rot.y);
     BOUNDS_16 rot_bounds;
+    int32_t x_walk = 0;
+    int32_t z_walk = 0;
+    int32_t min_x = item->pos.x;
+    int32_t max_x = item->pos.x;
+    int32_t min_z = item->pos.z;
+    int32_t max_z = item->pos.z;
     switch (item->rot.y) {
     case 0:
         rot_bounds = *orig_bounds;
+        z_walk = WALL_L;
+        max_z = item->pos.z + (rot_bounds.min.z + rot_bounds.max.z);
         break;
     case DEG_90:
         rot_bounds.min.x = orig_bounds->min.z;
         rot_bounds.max.x = orig_bounds->max.z;
         rot_bounds.min.z = -orig_bounds->max.x;
         rot_bounds.max.z = -orig_bounds->min.x;
+        x_walk = WALL_L;
+        max_x = item->pos.x + (rot_bounds.min.x + rot_bounds.max.x);
         break;
     case -DEG_180:
         rot_bounds.min.x = -orig_bounds->max.x;
         rot_bounds.max.x = -orig_bounds->min.x;
         rot_bounds.min.z = -orig_bounds->max.z;
         rot_bounds.max.z = -orig_bounds->min.z;
+        z_walk = -WALL_L;
+        max_z = item->pos.z + (rot_bounds.min.z + rot_bounds.max.z);
+        LOG_DEBUG(
+            "z pos: %d; bounds max z: %d %d", item->pos.z, rot_bounds.min.z,
+            rot_bounds.max.z);
         break;
     case -DEG_90:
         rot_bounds.min.x = -orig_bounds->max.z;
         rot_bounds.max.x = -orig_bounds->min.z;
         rot_bounds.min.z = orig_bounds->min.x;
         rot_bounds.max.z = orig_bounds->max.x;
+        x_walk = -WALL_L;
+        max_x = item->pos.x + (rot_bounds.min.x + rot_bounds.max.x);
         break;
     default:
         rot_bounds = *orig_bounds;
         break;
     }
 
-    // World-space rectangle spanned by those bounds.
-    int32_t min_x = item->pos.x;
-    int32_t max_x = item->pos.x + rot_bounds.max.x;
-    int32_t min_z = item->pos.z;
-    int32_t max_z = item->pos.z + rot_bounds.max.z;
+    // Swap min and max for loop if traverse in a negative direction.
+    if (x_walk == -WALL_L) {
+        int32_t t = min_x;
+        min_x = max_x;
+        max_x = t;
+    }
+    if (z_walk == -WALL_L) {
+        int32_t t = min_z;
+        min_z = max_z;
+        max_z = t;
+    }
+
+    LOG_DEBUG("swapped min max x: %d %d; z: %d %d", min_x, max_x, min_z, max_z);
 
     // Walk every covered sector.
     for (int32_t x = min_x; x <= max_x; x += WALL_L) {
         for (int32_t z = min_z; z <= max_z; z += WALL_L) {
+            LOG_DEBUG("Trigger xz: %d %d", x, z);
             const XYZ_32 sector_pos = {
                 .x = x,
                 .y = item->pos.y,
@@ -167,6 +193,7 @@ static void M_Control(const int16_t item_num)
             // TODO Needed? Floor height functions should take care?
             // Item_RemoveWalkable(item_num);
             // Item_SortWalkables();
+            LOG_DEBUG("Activate trapdoor item_num: %d", item_num);
             M_ActivateSectors(item);
         }
     } else {

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -1,11 +1,15 @@
 #include "game/const.h"
 #include "game/objects.h"
+#include "game/objects/traps/movable_block.h"
+#include "log.h"
 
 typedef enum {
     TRAPDOOR_STATE_CLOSED,
     TRAPDOOR_STATE_OPEN,
 } TRAPDOOR_STATE;
 
+// static void M_Initialise(const int16_t item_num);
+// static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage);
 static int16_t M_GetFloorHeight(
     const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
 static int16_t M_GetCeilingHeight(
@@ -14,17 +18,49 @@ static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z);
 static void M_Setup(OBJECT *obj);
 static void M_Control(int16_t item_num);
 
+// static void M_Initialise(const int16_t item_num)
+// {
+//     ITEM *const item = Item_Get(item_num);
+//     if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
+//         Item_RemoveWalkable(item_num);
+//         LOG_DEBUG("INIT TRAPDOOR OPEN");
+//     }
+// }
+
+// static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
+// {
+//     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+//         const int16_t item_num = Item_GetIndex(item);
+//         if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
+//             Item_RemoveWalkable(item_num);
+//             LOG_DEBUG("LOAD TRAPDOOR OPEN");
+//         }
+//     }
+// }
+
 static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
+
+    if (item->pos.y != -4992) {
+        return height;
+    }
+    LOG_DEBUG(
+        "item xyz: %d %d %d; test xyz: %d %d %d; height: %d", item->pos.x,
+        item->pos.y, item->pos.z, x, y, z, height);
+
     if (!M_IsItemOnTop(item, x, z)) {
+        // LOG_DEBUG("not on top");
         return height;
     } else if (item->current_anim_state != TRAPDOOR_STATE_CLOSED) {
+        // LOG_DEBUG("not closed");
         return height;
     } else if (y > item->pos.y || item->pos.y > height) {
+        // LOG_DEBUG("either or");
         return height;
     } else {
+        // LOG_DEBUG("ON TRAPDOOR");
         return item->pos.y;
     }
 }
@@ -90,6 +126,8 @@ static bool M_IsItemOnTop(
 
 static void M_Setup(OBJECT *const obj)
 {
+    // obj->initialise_func = M_Initialise;
+    // obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
@@ -103,10 +141,20 @@ static void M_Control(const int16_t item_num)
     if (Item_IsTriggerActive(item)) {
         if (item->current_anim_state == TRAPDOOR_STATE_CLOSED) {
             item->goal_anim_state = TRAPDOOR_STATE_OPEN;
+            // TODO Needed? Floor height functions should take care?
+            // Item_RemoveWalkable(item_num);
+            // Item_SortWalkables();
+            MovableBlock_ActivateStack(
+                item, item->pos.x, item->pos.y, item->pos.z);
         }
     } else {
         if (item->current_anim_state == TRAPDOOR_STATE_OPEN) {
             item->goal_anim_state = TRAPDOOR_STATE_CLOSED;
+            // TODO Needed? Floor height functions should take care?
+            // Item_AddWalkable(item_num);
+            // Item_SortWalkables();
+            MovableBlock_ActivateStack(
+                item, item->pos.x, item->pos.y, item->pos.z);
         }
     }
     Item_Animate(item);

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -4,6 +4,7 @@
 #include "game/game_buf.h"
 #include "game/items.h"
 #include "game/objects/vars.h"
+#include "game/pathing.h"
 #include "vector.h"
 
 #include <stdlib.h>
@@ -105,6 +106,7 @@ void MovableBlock_Initialise(const int16_t item_num)
     data->original_rot =
         (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
     MovableBlock_UpdateRotation(item, data->original_rot);
+    MovableBlock_UpdateBox(item, true);
 }
 
 // TODO: make private
@@ -113,6 +115,29 @@ void MovableBlock_UpdateRotation(ITEM *const item, const int16_t rot_y)
     item->rot.y = rot_y;
     M_PRIV *const data = (M_PRIV *)item->data;
     data->counter_rot[0] = data->original_rot - rot_y;
+}
+
+// TODO: make private
+void MovableBlock_UpdateBox(const ITEM *const item, const bool blocked)
+{
+    // TODO Might be other cases...
+    if (blocked
+        && (item->status == IS_ACTIVE || item->status == IS_INVISIBLE
+            || (item->flags & IF_KILLED) != 0)) {
+        return;
+    }
+
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    if (sector->floor.height == item->pos.y && sector->box != NO_BOX) {
+        BOX_INFO *const box = Box_GetBox(sector->box);
+        if (blocked) {
+            box->overlap_index |= BOX_BLOCKED;
+        } else {
+            box->overlap_index &= ~BOX_BLOCKED;
+        }
+    }
 }
 
 void MovableBlock_SetupFloor(void)

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -190,7 +190,7 @@ void MovableBlock_ActivateStack(
             if (obj->floor_height_func != nullptr) {
                 if (item->pos.x == sector_pos.x && item->pos.y == stack_height
                     && item->pos.z == sector_pos.z) {
-                    stack_height += WALL_L;
+                    stack_height -= WALL_L;
                     triggered_items[triggered_count++] = item_num;
                 }
             }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -5,6 +5,7 @@
 #include "game/items.h"
 #include "game/objects/vars.h"
 #include "game/pathing.h"
+#include "log.h"
 #include "vector.h"
 
 #include <stdlib.h>
@@ -234,6 +235,9 @@ void MovableBlock_ActivateStack(int32_t stack_height, const XYZ_32 sector_pos)
                     && item->pos.z == sector_pos.z) {
                     stack_height -= WALL_L;
                     triggered_items[triggered_count++] = item_num;
+                    LOG_DEBUG(
+                        "Add item_num: %d to stack. stack_height now: %d",
+                        item_num, stack_height);
                 }
             }
         }
@@ -244,6 +248,7 @@ void MovableBlock_ActivateStack(int32_t stack_height, const XYZ_32 sector_pos)
         int16_t item_num = triggered_items[i];
         ITEM *const item = Item_Get(item_num);
         MovableBlock_SetGravityFrames(item, i);
+        LOG_DEBUG("Trigger item_num: %d with gravity frames: %d", item_num, i);
         item->status = IS_ACTIVE;
         Item_AddActive(item_num);
         Item_Animate(item);

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -9,13 +9,6 @@
 
 #include <stdlib.h>
 
-typedef struct {
-    int16_t counter_rot[3];
-    int16_t original_rot;
-    uint16_t gravity_frames;
-    bool is_push_pull;
-} M_PRIV;
-
 static int32_t m_BlockCount = 0;
 static VECTOR *m_UnsortedBlocks = nullptr;
 static int16_t *m_SortedBlocks = nullptr;
@@ -75,7 +68,8 @@ void MovableBlock_Initialise(const int16_t item_num)
     // during collision tests and can appear jarring. Additional angles are
     // stored to preserve item appearance in spite of control angle changes.
     ITEM *const item = Item_Get(item_num);
-    M_PRIV *const data = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
+    MovableBlock_Info *const data =
+        GameBuf_Alloc(sizeof(MovableBlock_Info), GBUF_ITEM_DATA);
     item->data = data;
     data->original_rot =
         (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
@@ -89,7 +83,7 @@ void MovableBlock_Initialise(const int16_t item_num)
 void MovableBlock_UpdateRotation(ITEM *const item, const int16_t rot_y)
 {
     item->rot.y = rot_y;
-    M_PRIV *const data = (M_PRIV *)item->data;
+    MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
     data->counter_rot[0] = data->original_rot - rot_y;
 }
 
@@ -154,25 +148,25 @@ void MovableBlock_HandleFlipMap(const ROOM_FLIP_STATUS flip_status)
 
 void MovableBlock_SetPushPull(ITEM *const item, const bool enable)
 {
-    M_PRIV *const data = (M_PRIV *)item->data;
+    MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
     data->is_push_pull = enable;
 }
 
 bool MovableBlock_IsPushPull(const ITEM *const item)
 {
-    const M_PRIV *const data = (M_PRIV *)item->data;
+    const MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
     return data ? data->is_push_pull : false;
 }
 
 void MovableBlock_SetGravityFrames(ITEM *const item, const uint8_t frames)
 {
-    M_PRIV *const data = (M_PRIV *)item->data;
+    MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
     data->gravity_frames = frames;
 }
 
 uint16_t MovableBlock_GetGravityFrames(const ITEM *const item)
 {
-    const M_PRIV *const data = (M_PRIV *)item->data;
+    const MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
     return data ? data->gravity_frames : 0;
 }
 

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -6,7 +6,6 @@
 #include "game/objects/vars.h"
 #include "vector.h"
 
-#include <log.h>
 #include <stdlib.h>
 
 /* -------------------------------------------------------------------------
@@ -193,9 +192,6 @@ void MovableBlock_ActivateStack(
                     && item->pos.z == sector_pos.z) {
                     stack_height += WALL_L;
                     triggered_items[triggered_count++] = item_num;
-                    LOG_DEBUG(
-                        "Activate item_num: %d; object_id: %d", item_num,
-                        item->object_id);
                 }
             }
         }
@@ -209,7 +205,6 @@ void MovableBlock_ActivateStack(
         item->status = IS_ACTIVE;
         Item_AddActive(item_num);
         Item_Animate(item);
-        LOG_DEBUG("Trigger item_num: %d; delay: %d", item_num, i);
     }
 
     free(triggered_items);

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -9,14 +9,14 @@
 
 #include <stdlib.h>
 
-/* -------------------------------------------------------------------------
+/* --------------------------------------------------------
  * Bit‑layout of ITEM->priv for movable blocks
- * -------------------------------------------------------------------------
+ * --------------------------------------------------------
  * bit 0      : LARA_PUSH_PULL flag (boolean)
  * bits 1–7   : free (reserved for future one‑bit flags)
  * bits 8–15  : CONSTANT_GRAVITY frame counter (0‑255)
- * higher bits: currently unused – still available
- * -------------------------------------------------------------------------*/
+ * higher bits: free
+ * -------------------------------------------------------*/
 #define LARA_PUSH_PULL ((uintptr_t)1u << 0)
 #define GRAVITY_SHIFT 8u
 #define GRAVITY_MASK ((uintptr_t)0xFFu << GRAVITY_SHIFT)

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -3,9 +3,23 @@
 #include "game/const.h"
 #include "game/game_buf.h"
 #include "game/items.h"
+#include "game/objects/vars.h"
 #include "vector.h"
 
+#include <log.h>
 #include <stdlib.h>
+
+/* -------------------------------------------------------------------------
+ * Bit‑layout of ITEM->priv for movable blocks
+ * -------------------------------------------------------------------------
+ * bit 0      : LARA_PUSH_PULL flag (boolean)
+ * bits 1–7   : free (reserved for future one‑bit flags)
+ * bits 8–15  : CONSTANT_GRAVITY frame counter (0‑255)
+ * higher bits: currently unused – still available
+ * -------------------------------------------------------------------------*/
+#define LARA_PUSH_PULL ((uintptr_t)1u << 0)
+#define GRAVITY_SHIFT 8u
+#define GRAVITY_MASK ((uintptr_t)0xFFu << GRAVITY_SHIFT)
 
 typedef struct {
     int16_t counter_rot[3];
@@ -20,6 +34,8 @@ static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2);
 static bool M_IsValidFloorShiftState(const ITEM *item);
 static void M_ShiftGlobalFloorUp(void);
 static void M_ShiftGlobalFloorDown(void);
+static void M_SetPrivBits(ITEM *item, uintptr_t mask, uintptr_t value_shifted);
+static bool M_TestPrivFlag(const ITEM *item, uintptr_t mask);
 
 static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2)
 {
@@ -57,6 +73,20 @@ static void M_ShiftGlobalFloorDown(void)
             Room_AlterFloorHeight(item, WALL_L);
         }
     }
+}
+
+static void M_SetPrivBits(
+    ITEM *const item, const uintptr_t mask, const uintptr_t value_shifted)
+{
+    uintptr_t bits = (uintptr_t)item->priv;
+    bits = (bits & ~mask) | value_shifted;
+    item->priv = (void *)bits;
+}
+
+static uintptr_t M_GetPrivBits(
+    const ITEM *item, const uintptr_t mask, const uint32_t shift)
+{
+    return (((uintptr_t)item->priv & mask) >> shift);
 }
 
 // TODO: make private once M_Setup can be migrated
@@ -103,7 +133,7 @@ void MovableBlock_SetupFloor(void)
     }
 
     qsort(m_SortedBlocks, m_BlockCount, sizeof(int16_t), M_CompareBlock);
-    M_ShiftGlobalFloorUp();
+    // M_ShiftGlobalFloorUp();
 
     Vector_Free(m_UnsortedBlocks);
     m_UnsortedBlocks = nullptr;
@@ -116,8 +146,83 @@ void MovableBlock_HandleFlipMap(const ROOM_FLIP_STATUS flip_status)
     }
 
     if (flip_status == RFS_FLIPPED) {
-        M_ShiftGlobalFloorUp();
+        // M_ShiftGlobalFloorUp();
     } else {
-        M_ShiftGlobalFloorDown();
+        // M_ShiftGlobalFloorDown();
     }
+}
+
+void MovableBlock_SetPushPull(ITEM *const item, const bool enable)
+{
+    uintptr_t value = enable ? LARA_PUSH_PULL : 0u;
+    M_SetPrivBits(item, LARA_PUSH_PULL, value);
+}
+
+bool MovableBlock_IsPushPull(const ITEM *const item)
+{
+    return ((uintptr_t)item->priv & LARA_PUSH_PULL) != 0u;
+}
+
+void MovableBlock_SetGravityFrames(ITEM *const item, const uint8_t frames)
+{
+    M_SetPrivBits(item, GRAVITY_MASK, (uintptr_t)frames << GRAVITY_SHIFT);
+}
+
+uint8_t MovableBlock_GetGravityFrames(const ITEM *const item)
+{
+    return (uint8_t)M_GetPrivBits(item, GRAVITY_MASK, GRAVITY_SHIFT);
+}
+
+void MovableBlock_ActivateStack(
+    const ITEM *const base_item, const int32_t x, const int32_t y,
+    const int32_t z)
+{
+    const ROOM *const room = Room_Get(base_item->room_num);
+    const SECTOR *sector =
+        Room_GetWorldSector(room, base_item->pos.x, base_item->pos.z);
+    const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
+    int32_t height = pit_sector->floor.height;
+    LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
+
+    int16_t *triggered_items =
+        (int16_t *)malloc((size_t)Item_GetWalkableCount() * sizeof(int16_t));
+    int32_t triggered_count = 0;
+
+    // Climb the stack of walkables and trigger each one.
+    int32_t test_y = y;
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        ITEM *const item = Item_Get(item_num);
+        if (Object_IsType(item->object_id, g_MovableBlockObjects)) {
+            const OBJECT *const obj = Object_Get(item->object_id);
+            if (obj->floor_height_func != nullptr) {
+                const int32_t walkable_height =
+                    obj->floor_height_func(item, x, test_y, z, height);
+                if (walkable_height != height) {
+                    test_y = walkable_height;
+                    height = walkable_height;
+                    triggered_items[triggered_count++] = item_num;
+                    LOG_DEBUG(
+                        "Activate floor height: %d; y: %d; test_y: %d; "
+                        "item_num: "
+                        "%d; object_id: "
+                        "%d",
+                        height, y, test_y, item_num, item->object_id);
+                }
+            }
+        }
+    }
+
+    // Trigger blocks top to bottom because of item control order.
+    for (int16_t i = triggered_count - 1; i >= 0; i--) {
+        int16_t item_num = triggered_items[i];
+        ITEM *const item = Item_Get(item_num);
+        MovableBlock_SetGravityFrames(item, i);
+        item->status = IS_ACTIVE;
+        Item_AddActive(item_num);
+        Item_Animate(item);
+        LOG_DEBUG("Trigger item_num: %d; delay: %d", item_num, i);
+    }
+
+    free(triggered_items);
 }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -17,6 +17,7 @@ static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2);
 static bool M_IsValidFloorShiftState(const ITEM *item);
 static void M_ShiftGlobalFloorUp(void);
 static void M_ShiftGlobalFloorDown(void);
+static int32_t M_GetSectorIndex(int32_t x, int32_t divisor);
 
 static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2)
 {
@@ -54,6 +55,11 @@ static void M_ShiftGlobalFloorDown(void)
             Room_AlterFloorHeight(item, WALL_L);
         }
     }
+}
+
+static int32_t M_GetSectorIndex(int32_t x, int32_t divisor)
+{
+    return (x >= 0) ? x / divisor : -((-x + divisor - 1) / divisor);
 }
 
 // TODO: make private once M_Setup can be migrated
@@ -170,16 +176,54 @@ uint16_t MovableBlock_GetGravityFrames(const ITEM *const item)
     return data ? data->gravity_frames : 0;
 }
 
-void MovableBlock_ActivateStack(
-    const ITEM *const base_item, const XYZ_32 sector_pos)
+void MovableBlock_ActivateSectors(const ITEM *const item)
+{
+    const BOUNDS_16 rot_bounds = Item_RotateBounds(item, item->rot.y);
+
+    // World space coordinates
+    const int32_t x0 = item->pos.x + rot_bounds.min.x;
+    const int32_t x1 = item->pos.x + rot_bounds.max.x;
+    const int32_t z0 = item->pos.z + rot_bounds.min.z;
+    const int32_t z1 = item->pos.z + rot_bounds.max.z;
+
+    // Convert to sector indices
+    int32_t sx0 = M_GetSectorIndex(x0, WALL_L);
+    int32_t sx1 = M_GetSectorIndex(x1, WALL_L);
+    int32_t sz0 = M_GetSectorIndex(z0, WALL_L);
+    int32_t sz1 = M_GetSectorIndex(z1, WALL_L);
+
+    // Swap direction if needed
+    if (sx0 > sx1) {
+        int32_t t = sx0;
+        sx0 = sx1;
+        sx1 = t;
+    }
+    if (sz0 > sz1) {
+        int32_t t = sz0;
+        sz0 = sz1;
+        sz1 = t;
+    }
+
+    // Walk every covered sector
+    for (int32_t sx = sx0; sx <= sx1; ++sx) {
+        for (int32_t sz = sz0; sz <= sz1; ++sz) {
+            const XYZ_32 pos = {
+                .x = sx * WALL_L + WALL_L / 2,
+                .y = item->pos.y,
+                .z = sz * WALL_L + WALL_L / 2,
+            };
+            MovableBlock_ActivateStack(item->pos.y, pos);
+        }
+    }
+}
+
+void MovableBlock_ActivateStack(int32_t stack_height, const XYZ_32 sector_pos)
 {
     int16_t *triggered_items =
         (int16_t *)malloc((size_t)Item_GetWalkableCount() * sizeof(int16_t));
     int32_t triggered_count = 0;
 
     // Check for a stack of movable blocks and trigger each one.
-    // Only trigger stacked blocks resting on the trapdoor pos.y.
-    int32_t stack_height = base_item->pos.y;
     for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
         const int16_t item_num = Item_GetWalkableNum(i);
         ITEM *const item = Item_Get(item_num);

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -174,40 +174,28 @@ uint8_t MovableBlock_GetGravityFrames(const ITEM *const item)
 }
 
 void MovableBlock_ActivateStack(
-    const ITEM *const base_item, const int32_t x, const int32_t y,
-    const int32_t z)
+    const ITEM *const base_item, const XYZ_32 sector_pos)
 {
-    const ROOM *const room = Room_Get(base_item->room_num);
-    const SECTOR *sector =
-        Room_GetWorldSector(room, base_item->pos.x, base_item->pos.z);
-    const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
-    int32_t height = pit_sector->floor.height;
-    LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
-
     int16_t *triggered_items =
         (int16_t *)malloc((size_t)Item_GetWalkableCount() * sizeof(int16_t));
     int32_t triggered_count = 0;
 
-    // Climb the stack of walkables and trigger each one.
-    int32_t test_y = y;
+    // Check for a stack of movable blocks and trigger each one.
+    // Only trigger stacked blocks resting on the trapdoor pos.y.
+    int32_t stack_height = base_item->pos.y;
     for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
         const int16_t item_num = Item_GetWalkableNum(i);
         ITEM *const item = Item_Get(item_num);
         if (Object_IsType(item->object_id, g_MovableBlockObjects)) {
             const OBJECT *const obj = Object_Get(item->object_id);
             if (obj->floor_height_func != nullptr) {
-                const int32_t walkable_height =
-                    obj->floor_height_func(item, x, test_y, z, height);
-                if (walkable_height != height) {
-                    test_y = walkable_height;
-                    height = walkable_height;
+                if (item->pos.x == sector_pos.x && item->pos.y == stack_height
+                    && item->pos.z == sector_pos.z) {
+                    stack_height += WALL_L;
                     triggered_items[triggered_count++] = item_num;
                     LOG_DEBUG(
-                        "Activate floor height: %d; y: %d; test_y: %d; "
-                        "item_num: "
-                        "%d; object_id: "
-                        "%d",
-                        height, y, test_y, item_num, item->object_id);
+                        "Activate item_num: %d; object_id: %d", item_num,
+                        item->object_id);
                 }
             }
         }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -109,10 +109,12 @@ void MovableBlock_UpdateBox(const ITEM *const item, const bool blocked)
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
     if (sector->floor.height == item->pos.y && sector->box != NO_BOX) {
         BOX_INFO *const box = Box_GetBox(sector->box);
-        if (blocked) {
-            box->overlap_index |= BOX_BLOCKED;
-        } else {
-            box->overlap_index &= ~BOX_BLOCKED;
+        if ((box->overlap_index & BOX_BLOCKABLE) != 0) {
+            if (blocked) {
+                box->overlap_index |= BOX_BLOCKED;
+            } else {
+                box->overlap_index &= ~BOX_BLOCKED;
+            }
         }
     }
 }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -9,21 +9,11 @@
 
 #include <stdlib.h>
 
-/* --------------------------------------------------------
- * Bit‑layout of ITEM->priv for movable blocks
- * --------------------------------------------------------
- * bit 0      : LARA_PUSH_PULL flag (boolean)
- * bits 1–7   : free (reserved for future one‑bit flags)
- * bits 8–15  : CONSTANT_GRAVITY frame counter (0‑255)
- * higher bits: free
- * -------------------------------------------------------*/
-#define LARA_PUSH_PULL ((uintptr_t)1u << 0)
-#define GRAVITY_SHIFT 8u
-#define GRAVITY_MASK ((uintptr_t)0xFFu << GRAVITY_SHIFT)
-
 typedef struct {
     int16_t counter_rot[3];
     int16_t original_rot;
+    uint16_t gravity_frames;
+    bool is_push_pull;
 } M_PRIV;
 
 static int32_t m_BlockCount = 0;
@@ -34,8 +24,6 @@ static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2);
 static bool M_IsValidFloorShiftState(const ITEM *item);
 static void M_ShiftGlobalFloorUp(void);
 static void M_ShiftGlobalFloorDown(void);
-static void M_SetPrivBits(ITEM *item, uintptr_t mask, uintptr_t value_shifted);
-static bool M_TestPrivFlag(const ITEM *item, uintptr_t mask);
 
 static int32_t M_CompareBlock(const void *item_idx1, const void *item_idx2)
 {
@@ -75,20 +63,6 @@ static void M_ShiftGlobalFloorDown(void)
     }
 }
 
-static void M_SetPrivBits(
-    ITEM *const item, const uintptr_t mask, const uintptr_t value_shifted)
-{
-    uintptr_t bits = (uintptr_t)item->priv;
-    bits = (bits & ~mask) | value_shifted;
-    item->priv = (void *)bits;
-}
-
-static uintptr_t M_GetPrivBits(
-    const ITEM *item, const uintptr_t mask, const uint32_t shift)
-{
-    return (((uintptr_t)item->priv & mask) >> shift);
-}
-
 // TODO: make private once M_Setup can be migrated
 void MovableBlock_Initialise(const int16_t item_num)
 {
@@ -106,6 +80,8 @@ void MovableBlock_Initialise(const int16_t item_num)
     data->original_rot =
         (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
     MovableBlock_UpdateRotation(item, data->original_rot);
+    data->gravity_frames = 0;
+    data->is_push_pull = false;
     MovableBlock_UpdateBox(item, true);
 }
 
@@ -178,23 +154,26 @@ void MovableBlock_HandleFlipMap(const ROOM_FLIP_STATUS flip_status)
 
 void MovableBlock_SetPushPull(ITEM *const item, const bool enable)
 {
-    uintptr_t value = enable ? LARA_PUSH_PULL : 0u;
-    M_SetPrivBits(item, LARA_PUSH_PULL, value);
+    M_PRIV *const data = (M_PRIV *)item->data;
+    data->is_push_pull = enable;
 }
 
 bool MovableBlock_IsPushPull(const ITEM *const item)
 {
-    return ((uintptr_t)item->priv & LARA_PUSH_PULL) != 0u;
+    const M_PRIV *const data = (M_PRIV *)item->data;
+    return data ? data->is_push_pull : false;
 }
 
 void MovableBlock_SetGravityFrames(ITEM *const item, const uint8_t frames)
 {
-    M_SetPrivBits(item, GRAVITY_MASK, (uintptr_t)frames << GRAVITY_SHIFT);
+    M_PRIV *const data = (M_PRIV *)item->data;
+    data->gravity_frames = frames;
 }
 
-uint8_t MovableBlock_GetGravityFrames(const ITEM *const item)
+uint16_t MovableBlock_GetGravityFrames(const ITEM *const item)
 {
-    return (uint8_t)M_GetPrivBits(item, GRAVITY_MASK, GRAVITY_SHIFT);
+    const M_PRIV *const data = (M_PRIV *)item->data;
+    return data ? data->gravity_frames : 0;
 }
 
 void MovableBlock_ActivateStack(

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -232,7 +232,7 @@ int16_t Room_GetHeightEx(
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     int32_t height = pit_sector->floor.height;
-    // LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
+    LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
@@ -272,8 +272,11 @@ int16_t Room_GetHeightEx(
             const int32_t walkable_height =
                 obj->floor_height_func(item, x, test_y, z, height);
             if (walkable_height != height) {
-                test_y = walkable_height;
                 height = walkable_height;
+                // Only update the y value if it's lower.
+                if (y > walkable_height) {
+                    test_y = walkable_height;
+                }
                 LOG_DEBUG(
                     "Change floor height: %d; y: %d; test_y: %d; item_num: "
                     "%d; object_id: "
@@ -299,6 +302,7 @@ int16_t Room_GetCeilingEx(
 {
     const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
     int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z, fix_tilts);
+    LOG_DEBUG("M_GetCeilingTiltHeight height: %d; y: %d", height, y);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     // if (pit_sector->trigger == nullptr) {
@@ -324,9 +328,9 @@ int16_t Room_GetCeilingEx(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
             height = obj->ceiling_height_func(item, x, y, z, height);
-            // LOG_DEBUG(
-            //     "Change ceiling height: %d; item_num: %d; object_id: %d",
-            //     height, item_num, item->object_id);
+            LOG_DEBUG(
+                "Change ceiling height: %d; item_num: %d; object_id: %d",
+                height, item_num, item->object_id);
         }
     }
 
@@ -560,9 +564,9 @@ int16_t Room_GetHeightIgnore(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
-            // LOG_DEBUG(
-            //     "Change height: %d; item_num: %d; object_id: %d", height,
-            //     item_num, item->object_id);
+            LOG_DEBUG(
+                "Change height: %d; item_num: %d; object_id: %d", height,
+                item_num, item->object_id);
         }
     }
 

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -232,7 +232,6 @@ int16_t Room_GetHeightEx(
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     int32_t height = pit_sector->floor.height;
-    // LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
@@ -271,10 +270,6 @@ int16_t Room_GetHeightEx(
         if (obj->floor_height_func != nullptr) {
             const int32_t walkable_height =
                 obj->floor_height_func(item, x, test_y, z, height);
-            // LOG_DEBUG(
-            //     "Stack check height: %d; walkable_height: %d; test_y: %d; "
-            //     "item_num: %d; object_id: %d",
-            //     height, walkable_height, test_y, item_num, item->object_id);
             if (walkable_height != height) {
                 height = walkable_height;
                 // Only update the y value if it's lower to fix up+jump working
@@ -283,11 +278,6 @@ int16_t Room_GetHeightEx(
                 if (y > walkable_height) {
                     test_y = walkable_height;
                 }
-                // LOG_DEBUG(
-                //     "Change floor height: %d; y: %d; test_y: %d; item_num: "
-                //     "%d; object_id: "
-                //     "%d",
-                //     height, y, test_y, item_num, item->object_id);
             }
         }
     }
@@ -308,7 +298,6 @@ int16_t Room_GetCeilingEx(
 {
     const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
     int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z, fix_tilts);
-    // LOG_DEBUG("M_GetCeilingTiltHeight height: %d; y: %d", height, y);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     // if (pit_sector->trigger == nullptr) {
@@ -334,9 +323,6 @@ int16_t Room_GetCeilingEx(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
             height = obj->ceiling_height_func(item, x, y, z, height);
-            // LOG_DEBUG(
-            //     "Change ceiling height: %d; item_num: %d; object_id: %d",
-            //     height, item_num, item->object_id);
         }
     }
 
@@ -499,9 +485,6 @@ bool Room_IsOnTriggeredWalkable(
         }
     }
 
-    // LOG_DEBUG(
-    //     "Triggered walkable object_found: %d; room_height: %d; height: %d",
-    //     object_found, room_height, height);
     return object_found && room_height == height;
 }
 
@@ -510,7 +493,6 @@ bool Room_IsOnWalkable(
     const int32_t room_height, const int16_t ignore_item_num)
 {
     sector = Room_GetPitSector(sector, x, z);
-    // LOG_DEBUG("pit floor: %d", sector->floor.height);
 
     int16_t height = sector->floor.height;
     bool object_found = false;
@@ -518,7 +500,6 @@ bool Room_IsOnWalkable(
         const int16_t item_num = Item_GetWalkableNum(i);
         // TODO Don't take into account current walkable's floor or ceiling.
         if (item_num == ignore_item_num) {
-            // LOG_DEBUG("Ignoring: %d", ignore_item_num);
             continue;
         }
         const ITEM *const item = Item_Get(item_num);
@@ -530,16 +511,10 @@ bool Room_IsOnWalkable(
                 // Check if height changed aka actually on a walkable.
                 height = test_height;
                 object_found = true;
-                // LOG_DEBUG(
-                //     "Change height: %d; item_num: %d; object_id: %d", height,
-                //     item_num, item->object_id);
             }
         }
     }
 
-    // LOG_DEBUG(
-    //     "All walkable object_found: %d; room_height: %d; height: %d",
-    //     object_found, room_height, height);
     return object_found && room_height == height;
 }
 
@@ -551,7 +526,6 @@ int16_t Room_GetHeightIgnore(
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     int32_t height = pit_sector->floor.height;
-    // LOG_DEBUG("pit floor: %d", pit_sector->floor.height);
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
@@ -563,16 +537,12 @@ int16_t Room_GetHeightIgnore(
         const int16_t item_num = Item_GetWalkableNum(i);
         // Ignore a walkable's floor or ceiling.
         if (item_num == ignore_item_num) {
-            // LOG_DEBUG("Ignoring: %d", ignore_item_num);
             continue;
         }
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
-            // LOG_DEBUG(
-            //     "Change height: %d; item_num: %d; object_id: %d", height,
-            //     item_num, item->object_id);
         }
     }
 

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -232,7 +232,7 @@ int16_t Room_GetHeightEx(
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     int32_t height = pit_sector->floor.height;
-    LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
+    // LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
@@ -271,17 +271,23 @@ int16_t Room_GetHeightEx(
         if (obj->floor_height_func != nullptr) {
             const int32_t walkable_height =
                 obj->floor_height_func(item, x, test_y, z, height);
+            // LOG_DEBUG(
+            //     "Stack check height: %d; walkable_height: %d; test_y: %d; "
+            //     "item_num: %d; object_id: %d",
+            //     height, walkable_height, test_y, item_num, item->object_id);
             if (walkable_height != height) {
                 height = walkable_height;
-                // Only update the y value if it's lower.
+                // Only update the y value if it's lower to fix up+jump working
+                // on the lowest block in a stack.
+                // TODO Should this be test_y?
                 if (y > walkable_height) {
                     test_y = walkable_height;
                 }
-                LOG_DEBUG(
-                    "Change floor height: %d; y: %d; test_y: %d; item_num: "
-                    "%d; object_id: "
-                    "%d",
-                    height, y, test_y, item_num, item->object_id);
+                // LOG_DEBUG(
+                //     "Change floor height: %d; y: %d; test_y: %d; item_num: "
+                //     "%d; object_id: "
+                //     "%d",
+                //     height, y, test_y, item_num, item->object_id);
             }
         }
     }
@@ -302,7 +308,7 @@ int16_t Room_GetCeilingEx(
 {
     const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
     int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z, fix_tilts);
-    LOG_DEBUG("M_GetCeilingTiltHeight height: %d; y: %d", height, y);
+    // LOG_DEBUG("M_GetCeilingTiltHeight height: %d; y: %d", height, y);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     // if (pit_sector->trigger == nullptr) {
@@ -328,9 +334,9 @@ int16_t Room_GetCeilingEx(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
             height = obj->ceiling_height_func(item, x, y, z, height);
-            LOG_DEBUG(
-                "Change ceiling height: %d; item_num: %d; object_id: %d",
-                height, item_num, item->object_id);
+            // LOG_DEBUG(
+            //     "Change ceiling height: %d; item_num: %d; object_id: %d",
+            //     height, item_num, item->object_id);
         }
     }
 
@@ -564,9 +570,9 @@ int16_t Room_GetHeightIgnore(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
-            LOG_DEBUG(
-                "Change height: %d; item_num: %d; object_id: %d", height,
-                item_num, item->object_id);
+            // LOG_DEBUG(
+            //     "Change height: %d; item_num: %d; object_id: %d", height,
+            //     item_num, item->object_id);
         }
     }
 

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -284,15 +284,15 @@ int16_t Room_GetHeightEx(
             if (!M_IsWalkableClose(x, z, item)) {
                 continue;
             }
-            const int32_t walkable_height =
+            const int32_t test_height =
                 obj->floor_height_func(item, x, test_y, z, height);
-            if (walkable_height != height) {
-                height = walkable_height;
-                // Only update the y value if it's lower to fix up+jump working
-                // on the lowest block in a stack.
-                // TODO Should this be test_y?
-                if (y > walkable_height) {
-                    test_y = walkable_height;
+            // If the floor height changed, climb the walkable stack.
+            if (test_height != height) {
+                height = test_height;
+                // Only raise the test y value if the test floor height is above
+                // the original y.
+                if (y > test_height) {
+                    test_y = test_height;
                 }
                 // LOG_DEBUG(
                 //     "Change floor height: %d; y: %d; test_y: %d; item_num: "

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -282,6 +282,12 @@ int16_t Room_GetHeightEx(
         }
     }
 
+    // Stops Lara from grabbing floor to ceiling blocks.
+    const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
+    if (height == sky_sector->ceiling.height) {
+        return NO_HEIGHT;
+    }
+
     return height;
 }
 
@@ -544,6 +550,12 @@ int16_t Room_GetHeightIgnore(
         if (obj->floor_height_func != nullptr) {
             height = obj->floor_height_func(item, x, y, z, height);
         }
+    }
+
+    // Stops Lara from grabbing floor to ceiling blocks.
+    const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
+    if (height == sky_sector->ceiling.height) {
+        return NO_HEIGHT;
     }
 
     return height;

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -303,12 +303,6 @@ int16_t Room_GetHeightEx(
         }
     }
 
-    // Stops Lara from grabbing floor to ceiling blocks.
-    const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
-    if (height == sky_sector->ceiling.height) {
-        return NO_HEIGHT;
-    }
-
     return height;
 }
 
@@ -580,12 +574,6 @@ int16_t Room_GetHeightIgnore(
             }
             height = obj->floor_height_func(item, x, y, z, height);
         }
-    }
-
-    // Stops Lara from grabbing floor to ceiling blocks.
-    const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
-    if (height == sky_sector->ceiling.height) {
-        return NO_HEIGHT;
     }
 
     return height;

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -232,6 +232,7 @@ int16_t Room_GetHeightEx(
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
     int32_t height = pit_sector->floor.height;
+    // LOG_DEBUG("pit floor: %d; y: %d", pit_sector->floor.height, y);
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
@@ -239,20 +240,46 @@ int16_t Room_GetHeightEx(
         height = M_GetFloorTiltHeight(pit_sector, x, z, fix_tilts);
     }
 
-    if (pit_sector->trigger == nullptr) {
-        return height;
-    }
+    // if (pit_sector->trigger == nullptr) {
+    //     return height;
+    // }
 
-    const TRIGGER_CMD *cmd = pit_sector->trigger->command;
-    for (; cmd != nullptr; cmd = cmd->next_cmd) {
-        if (cmd->type != TO_OBJECT) {
-            continue;
-        }
+    // const TRIGGER_CMD *cmd = pit_sector->trigger->command;
+    // for (; cmd != nullptr; cmd = cmd->next_cmd) {
+    //     if (cmd->type != TO_OBJECT) {
+    //         continue;
+    //     }
 
-        const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+    //     const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+    //     const OBJECT *const obj = Object_Get(item->object_id);
+    //     if (obj->floor_height_func != nullptr) {
+    //         height = obj->floor_height_func(item, x, y, z, height);
+    //     }
+    // }
+
+    // Climb the stack of walkables.
+    // TODO Climbing the walkables allows to move up stacked blocks.
+    // TOOD BUT it loses the original Y position. Ex - Lara over a trapdoor
+    // TODO over a stack of blocks. It climbs the blocks but then Y tests
+    // TODO the top block's floor when Lara's original Y pos is above the
+    // TODO the trapdoor over the top block. So the height is not raised.
+    int32_t test_y = y;
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
-            height = obj->floor_height_func(item, x, y, z, height);
+            const int32_t walkable_height =
+                obj->floor_height_func(item, x, test_y, z, height);
+            if (walkable_height != height) {
+                test_y = walkable_height;
+                height = walkable_height;
+                LOG_DEBUG(
+                    "Change floor height: %d; y: %d; test_y: %d; item_num: "
+                    "%d; object_id: "
+                    "%d",
+                    height, y, test_y, item_num, item->object_id);
+            }
         }
     }
 
@@ -274,20 +301,32 @@ int16_t Room_GetCeilingEx(
     int16_t height = M_GetCeilingTiltHeight(sky_sector, x, z, fix_tilts);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
-    if (pit_sector->trigger == nullptr) {
-        return height;
-    }
+    // if (pit_sector->trigger == nullptr) {
+    //     return height;
+    // }
 
-    const TRIGGER_CMD *cmd = pit_sector->trigger->command;
-    for (; cmd != nullptr; cmd = cmd->next_cmd) {
-        if (cmd->type != TO_OBJECT) {
-            continue;
-        }
+    // const TRIGGER_CMD *cmd = pit_sector->trigger->command;
+    // for (; cmd != nullptr; cmd = cmd->next_cmd) {
+    //     if (cmd->type != TO_OBJECT) {
+    //         continue;
+    //     }
 
-        const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+    //     const ITEM *const item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+    //     const OBJECT *const obj = Object_Get(item->object_id);
+    //     if (obj->ceiling_height_func != nullptr) {
+    //         height = obj->ceiling_height_func(item, x, y, z, height);
+    //     }
+    // }
+
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
             height = obj->ceiling_height_func(item, x, y, z, height);
+            // LOG_DEBUG(
+            //     "Change ceiling height: %d; item_num: %d; object_id: %d",
+            //     height, item_num, item->object_id);
         }
     }
 
@@ -421,7 +460,10 @@ int32_t Room_FindGridShift(int32_t src, const int32_t dst)
     }
 }
 
-bool Room_IsOnWalkable(
+// TODO Might not be needed but prob keep around to
+// preserve OG behavior where walkables with no triggers
+// have no effect.
+bool Room_IsOnTriggeredWalkable(
     const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
     const int32_t room_height)
 {
@@ -447,5 +489,82 @@ bool Room_IsOnWalkable(
         }
     }
 
+    // LOG_DEBUG(
+    //     "Triggered walkable object_found: %d; room_height: %d; height: %d",
+    //     object_found, room_height, height);
     return object_found && room_height == height;
+}
+
+bool Room_IsOnWalkable(
+    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
+    const int32_t room_height, const int16_t ignore_item_num)
+{
+    sector = Room_GetPitSector(sector, x, z);
+    // LOG_DEBUG("pit floor: %d", sector->floor.height);
+
+    int16_t height = sector->floor.height;
+    bool object_found = false;
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        // TODO Don't take into account current walkable's floor or ceiling.
+        if (item_num == ignore_item_num) {
+            // LOG_DEBUG("Ignoring: %d", ignore_item_num);
+            continue;
+        }
+        const ITEM *const item = Item_Get(item_num);
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (obj->floor_height_func != nullptr) {
+            const int32_t test_height =
+                obj->floor_height_func(item, x, y, z, height);
+            if (test_height != height) {
+                // Check if height changed aka actually on a walkable.
+                height = test_height;
+                object_found = true;
+                // LOG_DEBUG(
+                //     "Change height: %d; item_num: %d; object_id: %d", height,
+                //     item_num, item->object_id);
+            }
+        }
+    }
+
+    // LOG_DEBUG(
+    //     "All walkable object_found: %d; room_height: %d; height: %d",
+    //     object_found, room_height, height);
+    return object_found && room_height == height;
+}
+
+int16_t Room_GetHeightIgnore(
+    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
+    const bool fix_tilts, const int16_t ignore_item_num)
+{
+    m_HeightType = HT_WALL;
+
+    const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
+    int32_t height = pit_sector->floor.height;
+    // LOG_DEBUG("pit floor: %d", pit_sector->floor.height);
+
+    if (Room_IsAbyssHeight(height)) {
+        height = m_AbyssMaxHeight;
+    } else {
+        height = M_GetFloorTiltHeight(pit_sector, x, z, fix_tilts);
+    }
+
+    for (int32_t i = 0; i < Item_GetWalkableCount(); i++) {
+        const int16_t item_num = Item_GetWalkableNum(i);
+        // Ignore a walkable's floor or ceiling.
+        if (item_num == ignore_item_num) {
+            // LOG_DEBUG("Ignoring: %d", ignore_item_num);
+            continue;
+        }
+        const ITEM *const item = Item_Get(item_num);
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (obj->floor_height_func != nullptr) {
+            height = obj->floor_height_func(item, x, y, z, height);
+            // LOG_DEBUG(
+            //     "Change height: %d; item_num: %d; object_id: %d", height,
+            //     item_num, item->object_id);
+        }
+    }
+
+    return height;
 }

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -294,6 +294,11 @@ int16_t Room_GetHeightEx(
                 if (y > walkable_height) {
                     test_y = walkable_height;
                 }
+                // LOG_DEBUG(
+                //     "Change floor height: %d; y: %d; test_y: %d; item_num: "
+                //     "%d; object_id: "
+                //     "%d",
+                //     height, y, test_y, item_num, item->object_id);
             }
         }
     }

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -9,6 +9,7 @@
 
 #define M_NEG_TILT(T, H) ((T * (H & (WALL_L - 1))) >> 2)
 #define M_POS_TILT(T, H) ((T * ((WALL_L - 1 - H) & (WALL_L - 1))) >> 2)
+#define WALKABLE_CLOSE_DIST (3 * WALL_L) // = 3072
 
 static int16_t m_AbyssMinHeight = 0;
 static int32_t m_AbyssMaxHeight = 0;
@@ -18,6 +19,7 @@ static int16_t M_GetFloorTiltHeight(
     const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
 static int16_t M_GetCeilingTiltHeight(
     const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
+static bool M_IsWalkableClose(int32_t x, int32_t z, const ITEM *item);
 
 static int16_t M_GetFloorTiltHeight(
     const SECTOR *const sector, const int32_t x, const int32_t z,
@@ -83,6 +85,17 @@ static int16_t M_GetCeilingTiltHeight(
     }
 
     return height;
+}
+
+static bool M_IsWalkableClose(int32_t x, int32_t z, const ITEM *const item)
+{
+    int32_t dist_x = x - item->pos.x;
+    int32_t dist_z = z - item->pos.z;
+    if (dist_x < -WALKABLE_CLOSE_DIST || dist_x > WALKABLE_CLOSE_DIST
+        || dist_z < -WALKABLE_CLOSE_DIST || dist_z > WALKABLE_CLOSE_DIST) {
+        return false;
+    }
+    return true;
 }
 
 SECTOR *Room_GetSector(
@@ -268,6 +281,9 @@ int16_t Room_GetHeightEx(
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
+            if (!M_IsWalkableClose(x, z, item)) {
+                continue;
+            }
             const int32_t walkable_height =
                 obj->floor_height_func(item, x, test_y, z, height);
             if (walkable_height != height) {
@@ -328,6 +344,9 @@ int16_t Room_GetCeilingEx(
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
+            if (!M_IsWalkableClose(x, z, item)) {
+                continue;
+            }
             height = obj->ceiling_height_func(item, x, y, z, height);
         }
     }
@@ -511,6 +530,9 @@ bool Room_IsOnWalkable(
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
+            if (!M_IsWalkableClose(x, z, item)) {
+                continue;
+            }
             const int32_t test_height =
                 obj->floor_height_func(item, x, y, z, height);
             if (test_height != height) {
@@ -548,6 +570,9 @@ int16_t Room_GetHeightIgnore(
         const ITEM *const item = Item_Get(item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
+            if (!M_IsWalkableClose(x, z, item)) {
+                continue;
+            }
             height = obj->floor_height_func(item, x, y, z, height);
         }
     }

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -145,6 +145,7 @@ static void M_LoadPostprocess(void)
     }
 
     MovableBlock_SetupFloor();
+    Item_SortWalkables();
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
 #if TR_VERSION == 1

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -7,6 +7,7 @@
 #include "game/game_flow.h"
 #include "game/game_string.h"
 #include "game/game_string_manager.h"
+#include "game/items.h"
 #include "game/lara/pose.h"
 #include "game/lua.h"
 #include "game/music.h"
@@ -92,6 +93,7 @@ void Shell_CommonInit(void)
 void Shell_ShutdownCommonModules(void)
 {
     Lara_Pose_Shutdown();
+    Item_ShutdownWalkables();
 
     Console_Shutdown();
     Savegame_Shutdown();

--- a/src/libtrx/include/libtrx/game/items/col.h
+++ b/src/libtrx/include/libtrx/game/items/col.h
@@ -11,3 +11,4 @@ bool Item_IsNearby(const ITEM *item_1, const ITEM *item_2, int32_t distance);
 bool Item_TestBoundsCollide(
     const ITEM *src_item, const ITEM *dst_item, int32_t radius);
 const BOUNDS_16 *Item_GetBoundsAccurate(const ITEM *item);
+BOUNDS_16 Item_RotateBounds(const ITEM *item, int16_t rot_y);

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -31,3 +31,11 @@ void Item_UpdateRoom(int16_t item_num, int16_t room_num);
 int32_t Item_GlobalReplace(
     GAME_OBJECT_ID src_obj_id, GAME_OBJECT_ID dst_obj_id);
 bool Item_IsTriggerActive(ITEM *item);
+
+void Item_InitialiseWalkables(void);
+void Item_AddWalkable(int16_t item_num);
+void Item_RemoveWalkable(int16_t item_num);
+int16_t Item_GetWalkableNum(int32_t index);
+int32_t Item_GetWalkableCount(void);
+void Item_SortWalkables(void);
+void Item_ShutdownWalkables(void);

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -6,3 +6,9 @@ void MovableBlock_Initialise(int16_t item_num);
 void MovableBlock_UpdateRotation(ITEM *item, int16_t rot_y);
 void MovableBlock_SetupFloor(void);
 void MovableBlock_HandleFlipMap(ROOM_FLIP_STATUS flip_status);
+void MovableBlock_SetPushPull(ITEM *item, bool enable);
+bool MovableBlock_IsPushPull(const ITEM *item);
+void MovableBlock_SetGravityFrames(ITEM *item, uint8_t frames);
+uint8_t MovableBlock_GetGravityFrames(const ITEM *item);
+void MovableBlock_ActivateStack(
+    const ITEM *base_item, int32_t x, int32_t y, int32_t z);

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -11,7 +11,8 @@ void MovableBlock_SetPushPull(ITEM *item, bool enable);
 bool MovableBlock_IsPushPull(const ITEM *item);
 void MovableBlock_SetGravityFrames(ITEM *item, uint8_t frames);
 uint16_t MovableBlock_GetGravityFrames(const ITEM *item);
-void MovableBlock_ActivateStack(const ITEM *base_item, XYZ_32 sector_pos);
+void MovableBlock_ActivateSectors(const ITEM *item);
+void MovableBlock_ActivateStack(int32_t stack_height, XYZ_32 sector_pos);
 
 typedef struct {
     int16_t counter_rot[3];

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -4,6 +4,7 @@
 
 void MovableBlock_Initialise(int16_t item_num);
 void MovableBlock_UpdateRotation(ITEM *item, int16_t rot_y);
+void MovableBlock_UpdateBox(const ITEM *item, bool blocked);
 void MovableBlock_SetupFloor(void);
 void MovableBlock_HandleFlipMap(ROOM_FLIP_STATUS flip_status);
 void MovableBlock_SetPushPull(ITEM *item, bool enable);

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -10,5 +10,4 @@ void MovableBlock_SetPushPull(ITEM *item, bool enable);
 bool MovableBlock_IsPushPull(const ITEM *item);
 void MovableBlock_SetGravityFrames(ITEM *item, uint8_t frames);
 uint8_t MovableBlock_GetGravityFrames(const ITEM *item);
-void MovableBlock_ActivateStack(
-    const ITEM *base_item, int32_t x, int32_t y, int32_t z);
+void MovableBlock_ActivateStack(const ITEM *base_item, XYZ_32 sector_pos);

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -10,5 +10,5 @@ void MovableBlock_HandleFlipMap(ROOM_FLIP_STATUS flip_status);
 void MovableBlock_SetPushPull(ITEM *item, bool enable);
 bool MovableBlock_IsPushPull(const ITEM *item);
 void MovableBlock_SetGravityFrames(ITEM *item, uint8_t frames);
-uint8_t MovableBlock_GetGravityFrames(const ITEM *item);
+uint16_t MovableBlock_GetGravityFrames(const ITEM *item);
 void MovableBlock_ActivateStack(const ITEM *base_item, XYZ_32 sector_pos);

--- a/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
+++ b/src/libtrx/include/libtrx/game/objects/traps/movable_block.h
@@ -12,3 +12,10 @@ bool MovableBlock_IsPushPull(const ITEM *item);
 void MovableBlock_SetGravityFrames(ITEM *item, uint8_t frames);
 uint16_t MovableBlock_GetGravityFrames(const ITEM *item);
 void MovableBlock_ActivateStack(const ITEM *base_item, XYZ_32 sector_pos);
+
+typedef struct {
+    int16_t counter_rot[3];
+    int16_t original_rot;
+    uint16_t gravity_frames;
+    bool is_push_pull;
+} MovableBlock_Info;

--- a/src/libtrx/include/libtrx/game/objects/vars.h
+++ b/src/libtrx/include/libtrx/game/objects/vars.h
@@ -20,6 +20,8 @@ extern const GAME_OBJECT_ID g_InvObjects[];
 extern const GAME_OBJECT_ID g_WaterSpriteObjects[];
 extern const GAME_OBJECT_ID g_BossObjects[];
 extern const GAME_OBJECT_ID g_PlaceholderObjects[];
+extern const GAME_OBJECT_ID g_WalkableObjects[];
+extern const GAME_OBJECT_ID g_MovableBlockObjects[];
 
 extern const GAME_OBJECT_PAIR g_GunAmmoObjectMap[];
 extern const GAME_OBJECT_PAIR g_ItemToInvObjectMap[];

--- a/src/libtrx/include/libtrx/game/rooms/geometry.h
+++ b/src/libtrx/include/libtrx/game/rooms/geometry.h
@@ -28,4 +28,10 @@ void Room_AlterFloorHeight(const ITEM *item, int32_t height);
 int32_t Room_FindGridShift(int32_t src, int32_t dst);
 
 bool Room_IsOnWalkable(
+    const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height,
+    int16_t ignore_item_num);
+bool Room_IsOnTriggeredWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);
+int16_t Room_GetHeightIgnore(
+    const SECTOR *sector, int32_t x, int32_t y, int32_t z, bool fix_tilts,
+    int16_t ignore_item_num);

--- a/src/libtrx/include/libtrx/game/rooms/utils.h
+++ b/src/libtrx/include/libtrx/game/rooms/utils.h
@@ -4,3 +4,5 @@
 
 #define ROUND_TO_CLICK(V) ((V) & ~(STEP_L - 1))
 #define ROUND_TO_SECTOR(V) ((V) & ~(WALL_L - 1))
+#define ROUND_TO_CLICK_UP(V) (((V) + STEP_L / 2 - 1) & ~(STEP_L / 2 - 1))
+#define ROUND_TO_HALF_CLICK(V) ((V) & ~(STEP_L / 2 - 1))

--- a/src/libtrx/include/libtrx/game/savegame/const.h
+++ b/src/libtrx/include/libtrx/game/savegame/const.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define SAVEGAME_CURRENT_VERSION 11
+#define SAVEGAME_CURRENT_VERSION 12

--- a/src/libtrx/include/libtrx/game/savegame/enum.h
+++ b/src/libtrx/include/libtrx/game/savegame/enum.h
@@ -42,4 +42,7 @@ typedef enum {
     // Changed TR2 music tracks to no longer shift IDs, legacy saves require to
     // do the shifting on load.
     VERSION_11 = 11,
+
+    // Save and load MovableBlock_Info in item->data.
+    VERSION_12 = 12,
 } SAVEGAME_VERSION;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -346,6 +346,7 @@ void Level_Unload(void)
 {
     Lara_InitialiseLoad(NO_ITEM);
     Output_ObserveLevelUnload();
+    Item_ShutdownWalkables();
 }
 
 bool Level_Initialise(

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -77,11 +77,6 @@ static int16_t M_GetFloorHeight(
         return height;
     }
 
-    // If inside the block.
-    if (y <= item->pos.y && y > item->pos.y - WALL_L) {
-        return item->pos.y - WALL_L;
-    }
-
     // If under the bottom of the block.
     if (y > item->pos.y) {
         return height;
@@ -119,7 +114,6 @@ static int16_t M_GetCeilingHeight(
 
     // If inside the block.
     if (y <= item->pos.y && y > item->pos.y - WALL_L) {
-        // return item->pos.y - WALL_L;
         return height;
     }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -14,6 +14,7 @@
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara/const.h>
 #include <libtrx/game/objects/traps/movable_block.h>
+#include <libtrx/log.h>
 #include <libtrx/utils.h>
 
 #define LF_PPREADY 19
@@ -36,6 +37,11 @@ static const OBJECT_BOUNDS m_MovableBlock_Bounds = {
 };
 
 static const OBJECT_BOUNDS *M_Bounds(void);
+static int16_t M_GetFloorHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
+static bool M_IsItemOnTop(const ITEM *item, int32_t x, int32_t z);
 static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll);
 static bool M_TestDestination(ITEM *item, int32_t block_height);
 static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant);
@@ -51,6 +57,131 @@ static void M_Draw(const ITEM *item);
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
     return &m_MovableBlock_Bounds;
+}
+
+static int16_t M_GetFloorHeight(
+    const ITEM *const item, int32_t x, int32_t y, int32_t z, int16_t height)
+{
+    if (item->status == IS_INVISIBLE) {
+        return height;
+    }
+
+    // TODO Makes camera and shadow behave like OG during push/pull.
+    // Still on top of block at end of a pull like OG.
+    if (MovableBlock_IsPushPull(item)) {
+        return height;
+    }
+
+    // Only care if we are inside the block footprint.
+    if (!M_IsItemOnTop(item, x, z)) {
+        return height;
+    }
+
+    // If inside the block.
+    if (y <= item->pos.y && y > item->pos.y - WALL_L) {
+        return item->pos.y - WALL_L;
+    }
+
+    // If under the bottom of the block.
+    if (y > item->pos.y) {
+        return height;
+    }
+
+    // If the the top of the block is under the floor height.
+    if (item->pos.y - WALL_L >= height) {
+        return height;
+    }
+
+    // LOG_DEBUG(
+    //     "Raise floor for block. block xyz: %d %d %d; height: %d; xyz: "
+    //     "%d %d %d",
+    //     item->pos.x, item->pos.y, item->pos.z, height, x, y, z);
+
+    return item->pos.y - WALL_L;
+}
+
+static int16_t M_GetCeilingHeight(
+    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height)
+{
+    if (item->status == IS_INVISIBLE) {
+        return height;
+    }
+
+    // TODO Makes camera and shadow behave like OG during push/pull.
+    if (MovableBlock_IsPushPull(item)) {
+        return height;
+    }
+
+    // Only care if we are inside the block footprint.
+    if (!M_IsItemOnTop(item, x, z)) {
+        return height;
+    }
+
+    // If inside the block.
+    if (y <= item->pos.y && y > item->pos.y - WALL_L) {
+        // return item->pos.y - WALL_L;
+        return height;
+    }
+
+    // If above the top of the block.
+    if (y <= item->pos.y - WALL_L) {
+        return height;
+    }
+
+    // If the the bottom of the block is above the ceiling height.
+    if (item->pos.y <= height) {
+        return height;
+    }
+
+    // LOG_DEBUG(
+    //     "Raise ceiling for block. block xyz: %d %d %d; height: %d; xyz: "
+    //     "%d %d %d",
+    //     item->pos.x, item->pos.y, item->pos.z, height, x, y, z);
+
+    return item->pos.y;
+}
+
+static bool M_IsItemOnTop(
+    const ITEM *const item, const int32_t x, const int32_t z)
+{
+    const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
+    if (bounds == nullptr) {
+        return false;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    // Creature setups run before Lara is initialized.
+    if (lara_item == nullptr) {
+        return false;
+    }
+
+    int32_t dx = x - item->pos.x;
+    int32_t dz = z - item->pos.z;
+
+    DIRECTION quadrant = ((uint16_t)lara_item->rot.y + DEG_45) / DEG_90;
+    switch (quadrant) {
+    case DIR_NORTH:
+        dx = -dx;
+        dz = -dz;
+        break;
+    case DIR_EAST:
+        int32_t t1 = dx;
+        dx = dz;
+        dz = -t1;
+        break;
+    case DIR_SOUTH:
+        break;
+    case DIR_WEST:
+        int32_t t2 = dx;
+        dx = -dz;
+        dz = t2;
+        break;
+    default:
+        break;
+    }
+
+    return dx >= bounds->min.x && dx <= bounds->max.x && dz >= bounds->min.z
+        && dz <= bounds->max.z;
 }
 
 static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll)
@@ -86,12 +217,15 @@ static bool M_TestDestination(ITEM *item, int32_t block_height)
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    // Check if there is a wall above.
     if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
         == NO_HEIGHT) {
         return true;
     }
 
-    if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
+    // Make sure floor above block has nothing on it.
+    if (Room_GetHeight(
+            sector, item->pos.x, item->pos.y - block_height, item->pos.z)
         != item->pos.y - block_height) {
         return false;
     }
@@ -149,6 +283,7 @@ static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
 
 static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
 {
+    // Make sure current sector is safe.
     if (!M_TestDestination(item, block_height)) {
         return false;
     }
@@ -172,12 +307,15 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
         break;
     }
 
+    // Check sector block will be pulled to.
     int32_t x = item->pos.x + x_add;
     int32_t y = item->pos.y;
     int32_t z = item->pos.z + z_add;
 
     int16_t room_num = item->room_num;
+
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
+
     COLL_INFO coll;
     coll.quadrant = quadrant;
     coll.radius = 500;
@@ -273,6 +411,8 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = MovableBlock_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
     obj->save_position = true;
@@ -285,12 +425,17 @@ static void M_Setup(OBJECT *const obj)
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+        if (item->flags & IF_KILLED) {
+            const int16_t item_num = Item_GetIndex(item);
+            Item_RemoveWalkable(item_num);
+        }
         if (item->status == IS_ACTIVE && !item->gravity
             && item->current_anim_state == MOVABLE_BLOCK_STATE_STILL) {
             Item_RemoveActive(Item_GetIndex(item));
             item->status = IS_INACTIVE;
         }
-        item->priv = item->status == IS_ACTIVE ? (void *)true : (void *)false;
+        const bool is_push_pull = item->status == IS_ACTIVE ? true : false;
+        MovableBlock_SetPushPull(item, is_push_pull);
         MovableBlock_UpdateRotation(item, item->rot.y);
     }
 }
@@ -299,31 +444,94 @@ static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
 
+    if (item->status == IS_INVISIBLE) {
+        return;
+    }
+
+    if (MovableBlock_GetGravityFrames(item) > 0) {
+        LOG_DEBUG(
+            "DELAY item_num: %d; gravity frames: %d", item_num,
+            MovableBlock_GetGravityFrames(item) - 1);
+        MovableBlock_SetGravityFrames(
+            item, MovableBlock_GetGravityFrames(item) - 1);
+        return;
+    }
+
     if (item->flags & IF_ONE_SHOT) {
-        Room_AlterFloorHeight(item, WALL_L);
         Item_Kill(item_num);
+        Item_RemoveWalkable(item_num);
+        Item_SortWalkables();
+        // TODO Fix enemy boxes.
+        // Room_AlterFloorHeight(item, WALL_L);
         return;
     }
 
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector(
-        item->pos.x, item->pos.y - STEP_L / 2, item->pos.z, &room_num);
-    const int32_t height = Room_GetHeight(
-        sector, item->pos.x, item->pos.y - STEP_L / 2, item->pos.z);
+    LOG_DEBUG(
+        "initial item_num: %d; item->room_num: %d", item_num, item->room_num);
 
-    if (item->pos.y < height) {
+    // Check if the block is floating, on a walkable, or on the pit floor.
+    // Gets the put room number which can break behavior.
+    const ROOM *const room = Room_Get(room_num);
+    const SECTOR *sector = Room_GetWorldSector(room, item->pos.x, item->pos.z);
+    const int32_t top_of_block_height =
+        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    int32_t under_block_height = Room_GetHeightIgnore(
+        sector, item->pos.x, item->pos.y, item->pos.z, false, item_num);
+    const SECTOR *room_num_sector = Room_GetSector(
+        item->pos.x, top_of_block_height, item->pos.z, &room_num);
+
+    LOG_DEBUG("OG under_block_height: %d", under_block_height);
+    // Checks if the block fell through a walkable. Can't check before it
+    // happens because it will stop gravity one frame early. Can't nicely check
+    // after it falls through because under_block_height will then be the floor
+    // under the walkable that fell through.
+    const bool fell_through_walkable = Room_IsOnWalkable(
+        sector, item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z,
+        ROUND_TO_HALF_CLICK(item->pos.y), item_num);
+    if (fell_through_walkable) {
+        under_block_height = ROUND_TO_HALF_CLICK(item->pos.y);
+    }
+
+    LOG_DEBUG(
+        "status: %d; gravity: %d; pos.y: %d; top_of_block_height: %d, "
+        "under_block_height: %d; room_num: %d; "
+        "ROUND_TO_HALF_CLICK(item->pos.y): "
+        "%d; fell_through_walkable: %d; push/pull: %d; gravity frames: %d; "
+        "fall_speed: %d",
+        item->status, item->gravity, item->pos.y, top_of_block_height,
+        under_block_height, room_num, ROUND_TO_HALF_CLICK(item->pos.y),
+        fell_through_walkable, MovableBlock_IsPushPull(item),
+        MovableBlock_GetGravityFrames(item), item->fall_speed);
+
+    // Don't continue gravity if on a walkable.
+    // But walkable is affected by falling speed and bridges
+    // can have non click heights.
+    // ROUND_TO_CLICK_UP(item->pos.y) != under_block_height fixes blocks
+    // falling through bridges/trapdoors. BUT turns off gravity a frame early
+    // which breaks a death block just above Lara's head.
+    // && ROUND_TO_CLICK_UP(item->pos.y) != under_block_height
+    if (item->pos.y < under_block_height && !MovableBlock_IsPushPull(item)) {
+        // Start falling because the block is floating in the air.
+        LOG_DEBUG("Start gravity!");
         item->gravity = true;
     } else if (item->gravity) {
+        // The block hits the ground or walkable.
+        LOG_DEBUG("Stop gravity!");
         item->gravity = false;
-        item->pos.y = height;
+        item->pos.y = under_block_height;
         item->status = IS_DEACTIVATED;
         ItemAction_Run(ITEM_ACTION_FLOOR_SHAKE, item);
         Sound_Effect(SFX_T_REX_FOOTSTOMP, &item->pos, SPM_NORMAL);
     } else if (
-        item->pos.y >= height && !item->gravity
-        && !(bool)(intptr_t)item->priv) {
+        // If block is at/under floor height, no gravity, and isn't being
+        // pushed/pulled anymore.
+        // Prevents blocks from getting stuck in IS_INACTIVE if retriggered.
+        item->pos.y >= under_block_height && !item->gravity
+        && !MovableBlock_IsPushPull(item)) {
+        LOG_DEBUG("Remove active bc of height!");
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
     }
@@ -333,8 +541,11 @@ static void M_Control(const int16_t item_num)
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
-        Room_AlterFloorHeight(item, -WALL_L);
+        // TODO Fix enemy boxes.
+        // Room_AlterFloorHeight(item, -WALL_L);
+        Item_SortWalkables();
         Room_TestTriggers(item);
+        LOG_DEBUG("Remove active bc IS_DEACTIVATED!");
     }
 }
 
@@ -344,13 +555,17 @@ static void M_Collision(
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
 
+    if (item->status == IS_INVISIBLE) {
+        return;
+    }
+
     if (M_TestDeathCollision(item, lara_item)) {
         M_KillLara(item, lara_item);
         return;
     }
 
     if (item->current_anim_state == MOVABLE_BLOCK_STATE_STILL) {
-        item->priv = (void *)false;
+        MovableBlock_SetPushPull(item, false);
     }
 
     if (!g_Input.action || item->status == IS_ACTIVE || lara_item->gravity
@@ -445,12 +660,14 @@ static void M_Collision(
             return;
         }
 
-        Item_AddActive(item_num);
-        Room_AlterFloorHeight(item, WALL_L);
         item->status = IS_ACTIVE;
+        Item_AddActive(item_num);
+        // TODO Fix enemy boxes.
+        // Room_AlterFloorHeight(item, WALL_L);
         Item_Animate(item);
         Lara_Animate(lara_item);
-        item->priv = (void *)true;
+        MovableBlock_SetPushPull(item, true);
+        LOG_DEBUG("Start push/pull item_num: %d", item_num);
     }
 }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -14,6 +14,7 @@
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara/const.h>
 #include <libtrx/game/objects/traps/movable_block.h>
+#include <libtrx/log.h>
 #include <libtrx/utils.h>
 
 #define LF_PPREADY 19
@@ -436,6 +437,9 @@ static void M_Control(const int16_t item_num)
     }
 
     if (MovableBlock_GetGravityFrames(item) > 0) {
+        LOG_DEBUG(
+            "Skip item_num: %d bc gravity frames %d", item_num,
+            MovableBlock_GetGravityFrames(item));
         MovableBlock_SetGravityFrames(
             item, MovableBlock_GetGravityFrames(item) - 1);
         return;
@@ -452,9 +456,11 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
+    LOG_DEBUG(
+        "initial item_num: %d; item->room_num: %d", item_num, item->room_num);
 
     // Check if the block is floating, on a walkable, or on the pit floor.
-    // Gets the put room number which can break behavior.
+    // Gets the pit room number which can break behavior.
     const ROOM *const room = Room_Get(room_num);
     const SECTOR *sector = Room_GetWorldSector(room, item->pos.x, item->pos.z);
     const int32_t top_of_block_height =
@@ -474,6 +480,17 @@ static void M_Control(const int16_t item_num)
     if (rounded_on_walkable) {
         under_block_height = ROUND_TO_HALF_CLICK(item->pos.y);
     }
+
+    LOG_DEBUG(
+        "status: %d; gravity: %d; pos.y: %d; top_of_block_height: %d, "
+        "under_block_height: %d; room_num: %d; "
+        "ROUND_TO_HALF_CLICK(item->pos.y): "
+        "%d; rounded_on_walkable: %d; push/pull: %d; gravity frames: %d; "
+        "fall_speed: %d",
+        item->status, item->gravity, item->pos.y, top_of_block_height,
+        under_block_height, room_num, ROUND_TO_HALF_CLICK(item->pos.y),
+        rounded_on_walkable, MovableBlock_IsPushPull(item),
+        MovableBlock_GetGravityFrames(item), item->fall_speed);
 
     // Don't continue gravity if on a walkable.
     // But walkable is affected by falling speed and bridges
@@ -515,6 +532,7 @@ static void M_Control(const int16_t item_num)
         MovableBlock_UpdateBox(item, false);
         Item_SortWalkables();
         Room_TestTriggers(item);
+        LOG_DEBUG("IS_INACTIVE item_num: %d", item_num);
     }
 }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -62,6 +62,7 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 static int16_t M_GetFloorHeight(
     const ITEM *const item, int32_t x, int32_t y, int32_t z, int16_t height)
 {
+    // LOG_DEBUG("y: %d; item->pos.y: %d; height: %d", y, item->pos.y, height);
     if (item->status == IS_INVISIBLE) {
         return height;
     }
@@ -107,11 +108,6 @@ static int16_t M_GetCeilingHeight(
         return height;
     }
 
-    // If inside the block.
-    if (y <= item->pos.y && y > item->pos.y - WALL_L) {
-        return height;
-    }
-
     // If above the top of the block.
     if (y <= item->pos.y - WALL_L) {
         return height;
@@ -122,7 +118,7 @@ static int16_t M_GetCeilingHeight(
         return height;
     }
 
-    return item->pos.y;
+    return item->pos.y + STEP_L;
 }
 
 static bool M_IsItemOnTop(

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -413,7 +413,9 @@ static void M_Setup(OBJECT *const obj)
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
-    if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
+    if (stage == SAVEGAME_STAGE_BEFORE_LOAD) {
+        MovableBlock_UpdateBox(item, false);
+    } else if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->flags & IF_KILLED) {
             const int16_t item_num = Item_GetIndex(item);
             Item_RemoveWalkable(item_num);
@@ -426,6 +428,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
         const bool is_push_pull = item->status == IS_ACTIVE ? true : false;
         MovableBlock_SetPushPull(item, is_push_pull);
         MovableBlock_UpdateRotation(item, item->rot.y);
+        MovableBlock_UpdateBox(item, true);
     }
 }
 
@@ -447,8 +450,7 @@ static void M_Control(const int16_t item_num)
         Item_Kill(item_num);
         Item_RemoveWalkable(item_num);
         Item_SortWalkables();
-        // TODO Fix enemy boxes.
-        // Room_AlterFloorHeight(item, WALL_L);
+        MovableBlock_UpdateBox(item, false);
         return;
     }
 
@@ -514,8 +516,7 @@ static void M_Control(const int16_t item_num)
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
-        // TODO Fix enemy boxes.
-        // Room_AlterFloorHeight(item, -WALL_L);
+        MovableBlock_UpdateBox(item, false);
         Item_SortWalkables();
         Room_TestTriggers(item);
     }
@@ -634,8 +635,7 @@ static void M_Collision(
 
         item->status = IS_ACTIVE;
         Item_AddActive(item_num);
-        // TODO Fix enemy boxes.
-        // Room_AlterFloorHeight(item, WALL_L);
+        MovableBlock_UpdateBox(item, false);
         Item_Animate(item);
         Lara_Animate(lara_item);
         MovableBlock_SetPushPull(item, true);

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -356,6 +356,13 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
 
 static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
 {
+    // TODO Falling blocks are not always killing Lara because
+    // !Lara_TestBoundsCollide.
+    LOG_DEBUG(
+        "killer: %d; gravity: %d; collide: %d",
+        g_GameFlow.enable_killer_pushblocks, item->gravity,
+        Lara_TestBoundsCollide(item, 0));
+
     return g_GameFlow.enable_killer_pushblocks
         && !g_Config.debug.enable_invulnerability && item->gravity
         && Lara_TestBoundsCollide(item, 0);

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -128,42 +128,12 @@ static int16_t M_GetCeilingHeight(
 static bool M_IsItemOnTop(
     const ITEM *const item, const int32_t x, const int32_t z)
 {
-    const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
-    if (bounds == nullptr) {
-        return false;
-    }
-
     int32_t dx = x - item->pos.x;
     int32_t dz = z - item->pos.z;
 
-    const ITEM *const lara_item = Lara_GetItem();
-    // Creature setups run before Lara is initialized.
-    if (lara_item != nullptr && !Camera_IsChunky()) {
-        DIRECTION quadrant = ((uint16_t)lara_item->rot.y + DEG_45) / DEG_90;
-        switch (quadrant) {
-        case DIR_NORTH:
-            dx = -dx;
-            dz = -dz;
-            break;
-        case DIR_EAST:
-            int32_t t1 = dx;
-            dx = dz;
-            dz = -t1;
-            break;
-        case DIR_SOUTH:
-            break;
-        case DIR_WEST:
-            int32_t t2 = dx;
-            dx = -dz;
-            dz = t2;
-            break;
-        default:
-            break;
-        }
-    }
-
-    return dx >= bounds->min.x && dx <= bounds->max.x && dz >= bounds->min.z
-        && dz <= bounds->max.z;
+    // Movable block bounds are offset from the sector center so estimate.
+    return (dx >= -WALL_L / 2 && dx < WALL_L / 2)
+        && (dz >= -WALL_L / 2 && dz < WALL_L / 2);
 }
 
 static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll)

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -37,6 +37,8 @@ static const OBJECT_BOUNDS m_MovableBlock_Bounds = {
 };
 
 static const OBJECT_BOUNDS *M_Bounds(void);
+static bool M_IsAgainstFloor(const ITEM *item);
+static bool M_IsAgainstCeiling(const ITEM *item);
 static int16_t M_GetFloorHeight(
     const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
 static int16_t M_GetCeilingHeight(
@@ -46,7 +48,8 @@ static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll);
 static bool M_TestDestination(ITEM *item, int32_t block_height);
 static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant);
 static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant);
-static bool M_TestDeathCollision(ITEM *item, const ITEM *lara);
+static bool M_TestDeathCollision(const ITEM *item, const ITEM *lara);
+static bool M_TestEmbedCollision(const ITEM *item, const ITEM *lara);
 static void M_KillLara(const ITEM *item, ITEM *lara);
 static void M_Setup(OBJECT *obj);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
@@ -57,6 +60,23 @@ static void M_Draw(const ITEM *item);
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
     return &m_MovableBlock_Bounds;
+}
+
+static bool M_IsAgainstFloor(const ITEM *const item)
+{
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    return sector->floor.tilt == 0 && sector->floor.height == item->pos.y;
+}
+
+static bool M_IsAgainstCeiling(const ITEM *const item)
+{
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    return sector->ceiling.tilt == 0
+        && sector->ceiling.height == item->pos.y - WALL_L;
 }
 
 static int16_t M_GetFloorHeight(
@@ -76,6 +96,22 @@ static int16_t M_GetFloorHeight(
     // Only care if we are inside the block footprint.
     if (!M_IsItemOnTop(item, x, z)) {
         return height;
+    }
+
+    // If partially embedded from below e.g. jumping up into an overhead block.
+    if (y <= item->pos.y && y > item->pos.y - WALL_L
+        && M_IsAgainstCeiling(item)) {
+        const SECTOR *const sector = Room_GetWorldSector(
+            Room_Get(item->room_num), item->pos.x, item->pos.z);
+        if (item->pos.y < sector->floor.height) {
+            // If partially embedded from below e.g. jumping up into an overhead
+            // block.
+            return height;
+        } else if (M_IsAgainstFloor(item)) {
+            // Clamped between floor and ceiling. Match up with similar case in
+            // M_GetCeilingHeight to return same sentinel value;
+            return item->pos.y - WALL_L;
+        }
     }
 
     // If under the bottom of the block.
@@ -108,6 +144,15 @@ static int16_t M_GetCeilingHeight(
         return height;
     }
 
+    if (y <= item->pos.y && y > item->pos.y - WALL_L && !item->gravity) {
+        if (M_IsAgainstCeiling(item)) {
+            // If clamped betwee floor and ceiling return same sentinel value as
+            // M_GetFloorHeight.
+            return M_IsAgainstFloor(item) ? item->pos.y - WALL_L : item->pos.y;
+        }
+        return height;
+    }
+
     // If above the top of the block.
     if (y <= item->pos.y - WALL_L) {
         return height;
@@ -118,7 +163,7 @@ static int16_t M_GetCeilingHeight(
         return height;
     }
 
-    return item->pos.y + STEP_L;
+    return item->pos.y;
 }
 
 static bool M_IsItemOnTop(
@@ -308,7 +353,7 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
     return true;
 }
 
-static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
+static bool M_TestDeathCollision(const ITEM *const item, const ITEM *const lara)
 {
     // TODO Falling blocks are not always killing Lara because
     // !Lara_TestBoundsCollide.
@@ -319,6 +364,16 @@ static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
     return g_GameFlow.enable_killer_pushblocks
         && !g_Config.debug.enable_invulnerability && item->gravity
         && Lara_TestBoundsCollide(item, 0);
+}
+
+static bool M_TestEmbedCollision(const ITEM *const item, const ITEM *const lara)
+{
+    return M_IsItemOnTop(item, lara->pos.x, lara->pos.z)
+        && lara->pos.y <= item->pos.y && lara->pos.y > item->pos.y - WALL_L
+        && !item->gravity && !lara->gravity
+        && item->current_anim_state == MOVABLE_BLOCK_STATE_STILL
+        && lara->current_anim_state != LS_PULL_BLOCK
+        && lara->current_anim_state != LS_PUSH_BLOCK;
 }
 
 static void M_KillLara(const ITEM *const item, ITEM *const lara)
@@ -515,6 +570,10 @@ static void M_Collision(
     if (M_TestDeathCollision(item, lara_item)) {
         M_KillLara(item, lara_item);
         return;
+    }
+
+    if (M_TestEmbedCollision(item, lara_item)) {
+        lara_item->pos.y = item->pos.y - WALL_L;
     }
 
     if (item->current_anim_state == MOVABLE_BLOCK_STATE_STILL) {

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -491,6 +491,7 @@ static void M_Control(const int16_t item_num)
     } else if (item->gravity) {
         // The block hits the ground or walkable.
         item->gravity = false;
+        item->fall_speed = 0;
         item->pos.y = under_block_height;
         item->status = IS_DEACTIVATED;
         ItemAction_Run(ITEM_ACTION_FLOOR_SHAKE, item);

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -346,10 +346,10 @@ static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
 {
     // TODO Falling blocks are not always killing Lara because
     // !Lara_TestBoundsCollide.
-    LOG_DEBUG(
-        "killer: %d; gravity: %d; collide: %d",
-        g_GameFlow.enable_killer_pushblocks, item->gravity,
-        Lara_TestBoundsCollide(item, 0));
+    // LOG_DEBUG(
+    //     "killer: %d; gravity: %d; collide: %d",
+    //     g_GameFlow.enable_killer_pushblocks, item->gravity,
+    //     Lara_TestBoundsCollide(item, 0));
     return g_GameFlow.enable_killer_pushblocks
         && !g_Config.debug.enable_invulnerability && item->gravity
         && Lara_TestBoundsCollide(item, 0);

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -132,35 +132,33 @@ static bool M_IsItemOnTop(
         return false;
     }
 
-    const ITEM *const lara_item = Lara_GetItem();
-    // Creature setups run before Lara is initialized.
-    if (lara_item == nullptr) {
-        return false;
-    }
-
     int32_t dx = x - item->pos.x;
     int32_t dz = z - item->pos.z;
 
-    DIRECTION quadrant = ((uint16_t)lara_item->rot.y + DEG_45) / DEG_90;
-    switch (quadrant) {
-    case DIR_NORTH:
-        dx = -dx;
-        dz = -dz;
-        break;
-    case DIR_EAST:
-        int32_t t1 = dx;
-        dx = dz;
-        dz = -t1;
-        break;
-    case DIR_SOUTH:
-        break;
-    case DIR_WEST:
-        int32_t t2 = dx;
-        dx = -dz;
-        dz = t2;
-        break;
-    default:
-        break;
+    const ITEM *const lara_item = Lara_GetItem();
+    // Creature setups run before Lara is initialized.
+    if (lara_item != nullptr && !Camera_IsChunky()) {
+        DIRECTION quadrant = ((uint16_t)lara_item->rot.y + DEG_45) / DEG_90;
+        switch (quadrant) {
+        case DIR_NORTH:
+            dx = -dx;
+            dz = -dz;
+            break;
+        case DIR_EAST:
+            int32_t t1 = dx;
+            dx = dz;
+            dz = -t1;
+            break;
+        case DIR_SOUTH:
+            break;
+        case DIR_WEST:
+            int32_t t2 = dx;
+            dx = -dz;
+            dz = t2;
+            break;
+        default:
+            break;
+        }
     }
 
     return dx >= bounds->min.x && dx <= bounds->max.x && dz >= bounds->min.z

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -488,10 +488,10 @@ static void M_Control(const int16_t item_num)
     // happens because it will stop gravity one frame early. Can't nicely check
     // after it falls through because under_block_height will then be the floor
     // under the walkable that fell through.
-    const bool fell_through_walkable = Room_IsOnWalkable(
+    const bool rounded_on_walkable = Room_IsOnWalkable(
         sector, item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z,
         ROUND_TO_HALF_CLICK(item->pos.y), item_num);
-    if (fell_through_walkable) {
+    if (rounded_on_walkable) {
         under_block_height = ROUND_TO_HALF_CLICK(item->pos.y);
     }
 
@@ -499,11 +499,11 @@ static void M_Control(const int16_t item_num)
         "status: %d; gravity: %d; pos.y: %d; top_of_block_height: %d, "
         "under_block_height: %d; room_num: %d; "
         "ROUND_TO_HALF_CLICK(item->pos.y): "
-        "%d; fell_through_walkable: %d; push/pull: %d; gravity frames: %d; "
+        "%d; rounded_on_walkable: %d; push/pull: %d; gravity frames: %d; "
         "fall_speed: %d",
         item->status, item->gravity, item->pos.y, top_of_block_height,
         under_block_height, room_num, ROUND_TO_HALF_CLICK(item->pos.y),
-        fell_through_walkable, MovableBlock_IsPushPull(item),
+        rounded_on_walkable, MovableBlock_IsPushPull(item),
         MovableBlock_GetGravityFrames(item), item->fall_speed);
 
     // Don't continue gravity if on a walkable.
@@ -536,7 +536,11 @@ static void M_Control(const int16_t item_num)
         Item_RemoveActive(item_num);
     }
 
-    Item_UpdateRoom(item_num, room_num);
+    // Don't update room number if on a walkable because
+    // room number can fall through trapdoors to a pit room.
+    if (!rounded_on_walkable) {
+        Item_UpdateRoom(item_num, room_num);
+    }
 
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -423,9 +423,6 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
             Item_RemoveActive(Item_GetIndex(item));
             item->status = IS_INACTIVE;
         }
-        const bool is_push_pull = item->status == IS_ACTIVE ? true : false;
-        MovableBlock_SetPushPull(item, is_push_pull);
-        MovableBlock_UpdateRotation(item, item->rot.y);
         MovableBlock_UpdateBox(item, true);
     }
 }

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -14,7 +14,6 @@
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara/const.h>
 #include <libtrx/game/objects/traps/movable_block.h>
-#include <libtrx/log.h>
 #include <libtrx/utils.h>
 
 #define LF_PPREADY 19
@@ -87,11 +86,6 @@ static int16_t M_GetFloorHeight(
         return height;
     }
 
-    // LOG_DEBUG(
-    //     "Raise floor for block. block xyz: %d %d %d; height: %d; xyz: "
-    //     "%d %d %d",
-    //     item->pos.x, item->pos.y, item->pos.z, height, x, y, z);
-
     return item->pos.y - WALL_L;
 }
 
@@ -126,11 +120,6 @@ static int16_t M_GetCeilingHeight(
     if (item->pos.y <= height) {
         return height;
     }
-
-    // LOG_DEBUG(
-    //     "Raise ceiling for block. block xyz: %d %d %d; height: %d; xyz: "
-    //     "%d %d %d",
-    //     item->pos.x, item->pos.y, item->pos.z, height, x, y, z);
 
     return item->pos.y;
 }
@@ -362,7 +351,6 @@ static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
         "killer: %d; gravity: %d; collide: %d",
         g_GameFlow.enable_killer_pushblocks, item->gravity,
         Lara_TestBoundsCollide(item, 0));
-
     return g_GameFlow.enable_killer_pushblocks
         && !g_Config.debug.enable_invulnerability && item->gravity
         && Lara_TestBoundsCollide(item, 0);
@@ -450,9 +438,6 @@ static void M_Control(const int16_t item_num)
     }
 
     if (MovableBlock_GetGravityFrames(item) > 0) {
-        LOG_DEBUG(
-            "DELAY item_num: %d; gravity frames: %d", item_num,
-            MovableBlock_GetGravityFrames(item) - 1);
         MovableBlock_SetGravityFrames(
             item, MovableBlock_GetGravityFrames(item) - 1);
         return;
@@ -470,8 +455,6 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    LOG_DEBUG(
-        "initial item_num: %d; item->room_num: %d", item_num, item->room_num);
 
     // Check if the block is floating, on a walkable, or on the pit floor.
     // Gets the put room number which can break behavior.
@@ -484,7 +467,6 @@ static void M_Control(const int16_t item_num)
     const SECTOR *room_num_sector = Room_GetSector(
         item->pos.x, top_of_block_height, item->pos.z, &room_num);
 
-    LOG_DEBUG("OG under_block_height: %d", under_block_height);
     // Checks if the block fell through a walkable. Can't check before it
     // happens because it will stop gravity one frame early. Can't nicely check
     // after it falls through because under_block_height will then be the floor
@@ -496,17 +478,6 @@ static void M_Control(const int16_t item_num)
         under_block_height = ROUND_TO_HALF_CLICK(item->pos.y);
     }
 
-    LOG_DEBUG(
-        "status: %d; gravity: %d; pos.y: %d; top_of_block_height: %d, "
-        "under_block_height: %d; room_num: %d; "
-        "ROUND_TO_HALF_CLICK(item->pos.y): "
-        "%d; rounded_on_walkable: %d; push/pull: %d; gravity frames: %d; "
-        "fall_speed: %d",
-        item->status, item->gravity, item->pos.y, top_of_block_height,
-        under_block_height, room_num, ROUND_TO_HALF_CLICK(item->pos.y),
-        rounded_on_walkable, MovableBlock_IsPushPull(item),
-        MovableBlock_GetGravityFrames(item), item->fall_speed);
-
     // Don't continue gravity if on a walkable.
     // But walkable is affected by falling speed and bridges
     // can have non click heights.
@@ -516,11 +487,9 @@ static void M_Control(const int16_t item_num)
     // && ROUND_TO_CLICK_UP(item->pos.y) != under_block_height
     if (item->pos.y < under_block_height && !MovableBlock_IsPushPull(item)) {
         // Start falling because the block is floating in the air.
-        LOG_DEBUG("Start gravity!");
         item->gravity = true;
     } else if (item->gravity) {
         // The block hits the ground or walkable.
-        LOG_DEBUG("Stop gravity!");
         item->gravity = false;
         item->pos.y = under_block_height;
         item->status = IS_DEACTIVATED;
@@ -532,7 +501,6 @@ static void M_Control(const int16_t item_num)
         // Prevents blocks from getting stuck in IS_INACTIVE if retriggered.
         item->pos.y >= under_block_height && !item->gravity
         && !MovableBlock_IsPushPull(item)) {
-        LOG_DEBUG("Remove active bc of height!");
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
     }
@@ -550,7 +518,6 @@ static void M_Control(const int16_t item_num)
         // Room_AlterFloorHeight(item, -WALL_L);
         Item_SortWalkables();
         Room_TestTriggers(item);
-        LOG_DEBUG("Remove active bc IS_DEACTIVATED!");
     }
 }
 
@@ -672,7 +639,6 @@ static void M_Collision(
         Item_Animate(item);
         Lara_Animate(lara_item);
         MovableBlock_SetPushPull(item, true);
-        LOG_DEBUG("Start push/pull item_num: %d", item_num);
     }
 }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -529,7 +529,7 @@ static void M_Control(const int16_t item_num)
     if (item->status == IS_DEACTIVATED) {
         item->status = IS_INACTIVE;
         Item_RemoveActive(item_num);
-        MovableBlock_UpdateBox(item, false);
+        MovableBlock_UpdateBox(item, true);
         Item_SortWalkables();
         Room_TestTriggers(item);
         LOG_DEBUG("IS_INACTIVE item_num: %d", item_num);

--- a/src/tr1/game/objects/vars.c
+++ b/src/tr1/game/objects/vars.c
@@ -77,6 +77,34 @@ const GAME_OBJECT_ID g_BossObjects[] = {
     // clang-format on
 };
 
+const GAME_OBJECT_ID g_WalkableObjects[] = {
+    // clang-format off
+    O_DRAWBRIDGE,
+    O_MOVABLE_BLOCK_1,
+    O_MOVABLE_BLOCK_2,
+    O_MOVABLE_BLOCK_3,
+    O_MOVABLE_BLOCK_4,
+    O_SLIDING_PILLAR,
+    O_TRAPDOOR_TYPE_1,
+    O_TRAPDOOR_TYPE_2,
+    O_TRAPDOOR_TYPE_3,
+    O_BRIDGE_FLAT,
+    O_BRIDGE_TILT_1,
+    O_BRIDGE_TILT_2,
+    NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_MovableBlockObjects[] = {
+    // clang-format off
+    O_MOVABLE_BLOCK_1,
+    O_MOVABLE_BLOCK_2,
+    O_MOVABLE_BLOCK_3,
+    O_MOVABLE_BLOCK_4,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const GAME_OBJECT_ID g_PlaceholderObjects[] = {
     // clang-format off
     O_STATUE,

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -3,6 +3,7 @@
 #include "game/game_flow.h"
 #include "game/inventory.h"
 #include "game/lara.h"
+#include "game/objects/vars.h"
 #include "game/savegame.h"
 #include "game/shell.h"
 #include "game/stats.h"
@@ -14,6 +15,7 @@
 #include <libtrx/game/camera.h>
 #include <libtrx/game/carrier.h>
 #include <libtrx/game/music.h>
+#include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/game/savegame/bson.h>
 #include <libtrx/json.h>
 #include <libtrx/log.h>
@@ -624,6 +626,32 @@ static bool M_LoadItems(JSON_ARRAY *items_arr, uint16_t header_version)
                     JSON_ObjectGetInt(item_obj, "bl_status", 0);
                 item->data = (void *)(intptr_t)status;
             }
+
+            if (header_version >= VERSION_12
+                && Object_IsType(item->object_id, g_MovableBlockObjects)) {
+                const JSON_OBJECT *const data_obj =
+                    JSON_ObjectGetObject(item_obj, "data");
+                if (data_obj == nullptr) {
+                    LOG_ERROR(
+                        "Malformed save: missing movable block data for item "
+                        "%d",
+                        i);
+                    return false;
+                }
+                MovableBlock_Info *const data = (MovableBlock_Info *)item->data;
+                data->counter_rot[0] = JSON_ObjectGetInt(
+                    data_obj, "counter_rot_0", data->counter_rot[0]);
+                data->counter_rot[1] = JSON_ObjectGetInt(
+                    data_obj, "counter_rot_1", data->counter_rot[1]);
+                data->counter_rot[2] = JSON_ObjectGetInt(
+                    data_obj, "counter_rot_2", data->counter_rot[2]);
+                data->original_rot = JSON_ObjectGetInt(
+                    data_obj, "original_rot", data->original_rot);
+                data->gravity_frames = JSON_ObjectGetInt(
+                    data_obj, "gravity_frames", data->gravity_frames);
+                data->is_push_pull = JSON_ObjectGetBool(
+                    data_obj, "is_push_pull", data->is_push_pull);
+            }
         }
 
         JSON_ARRAY *carried_items =
@@ -1185,6 +1213,27 @@ static JSON_ARRAY *M_DumpItems(void)
             if (item->object_id == O_BACON_LARA && item->data) {
                 const int32_t status = (int32_t)(intptr_t)item->data;
                 JSON_ObjectAppendInt(item_obj, "bl_status", status);
+            }
+
+            if (Object_IsType(item->object_id, g_MovableBlockObjects)
+                && item->data) {
+                LOG_DEBUG("DUMP BLOCKS");
+                const MovableBlock_Info *const data =
+                    (MovableBlock_Info *)item->data;
+                JSON_OBJECT *const data_obj = JSON_ObjectNew();
+                JSON_ObjectAppendInt(
+                    data_obj, "counter_rot_0", data->counter_rot[0]);
+                JSON_ObjectAppendInt(
+                    data_obj, "counter_rot_1", data->counter_rot[1]);
+                JSON_ObjectAppendInt(
+                    data_obj, "counter_rot_2", data->counter_rot[2]);
+                JSON_ObjectAppendInt(
+                    data_obj, "original_rot", data->original_rot);
+                JSON_ObjectAppendInt(
+                    data_obj, "gravity_frames", data->gravity_frames);
+                JSON_ObjectAppendBool(
+                    data_obj, "is_push_pull", data->is_push_pull);
+                JSON_ObjectAppendObject(item_obj, "data", data_obj);
             }
         }
 

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -8,6 +8,10 @@
 #include <libtrx/debug.h>
 #include <libtrx/enum_map.h>
 #include <libtrx/game/game_string_manager.h>
+#include <libtrx/game/items.h>
+#include <libtrx/game/music.h>
+#include <libtrx/game/option.h>
+#include <libtrx/game/ui.h>
 #include <libtrx/memory.h>
 #include <libtrx/strings.h>
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -308,7 +308,6 @@ const GAME_OBJECT_ID g_BossObjects[] = {
 
 const GAME_OBJECT_ID g_PlaceholderObjects[] = {
     // clang-format off
-    O_BARTOLI,
     NO_OBJECT,
     // clang-format on
 };
@@ -323,6 +322,34 @@ const GAME_OBJECT_PAIR g_GunAmmoObjectMap[] = {
     { O_M16_ITEM, O_M16_AMMO_ITEM },
     { O_GRENADE_ITEM, O_GRENADE_AMMO_ITEM },
     { NO_OBJECT, NO_OBJECT },
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_WalkableObjects[] = {
+    // clang-format off
+    O_DRAWBRIDGE,
+    O_LIFT,
+    O_MOVABLE_BLOCK_1,
+    O_MOVABLE_BLOCK_2,
+    O_MOVABLE_BLOCK_3,
+    O_MOVABLE_BLOCK_4,
+    O_TRAPDOOR_TYPE_1,
+    O_TRAPDOOR_TYPE_2,
+    O_TRAPDOOR_TYPE_3,
+    O_BRIDGE_FLAT,
+    O_BRIDGE_TILT_1,
+    O_BRIDGE_TILT_2,
+    NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_MovableBlockObjects[] = {
+    // clang-format off
+    O_MOVABLE_BLOCK_1,
+    O_MOVABLE_BLOCK_2,
+    O_MOVABLE_BLOCK_3,
+    O_MOVABLE_BLOCK_4,
+    NO_OBJECT,
     // clang-format on
 };
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [ ] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
WIP code. Ready for testing in TR1 test level: pushblocks-bridges-trapdoors.

Tackling in parts:
- [X] Add floor height and ceiling height functions for movable block
- [X] Blocks drop when a trapdoor below opens
- [X] Rework the `item->priv` bits into `item->data`'s `M_Priv` struct
- [x] Save `item->data`
- [X] Fix saving / loading while blocks are falling
- [X] Camera enters movable block
- [x] Investigate better performance solutions to avoid iterating all walkable items so much
- [x] Improve traversal/activation code and commonize code for multi-sector items
- [x] Drop stack of blocks when drawbridges open
- [x] Enemies don't respect the new movable blocks because of the removal of the alter floor height calls
- [x] Further improve camera behavior
- [ ] Port movable block to TRX
- [ ] TR2 support (lifts?)