### PR TITLE
camera: reset debuff when fixed camera triggered

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -85,6 +85,7 @@
 - fixed clicks in audio sounds (#2846, regression from 2.0)
 - fixed Lara being killed if she enters the void in a level that uses the `disable_floor` sequence in the game flow (#2874, regression from 4.9)
 - fixed game crashing if the music folder was not present (#2887, regression from 4.9)
+- fixed the camera jumping if going from a look at trigger to a fixed camera (#3033, regression from 4.8)
 - fixed game crashing on unknown sequencer events
 - improved bubble appearance (#2672)
 - improved rendering performance

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed blood not spawning when Lara is run down by boulders/barrels (#2982, regression from 0.7)
 - fixed floors being lowered too much under pushable blocks that are killed in the same trigger that flips the map (#3007, regression from 0.9)
 - fixed inventory ring items not being animated when the ring is rotating (#2964, regression from 0.9)
+- fixed the camera jumping if going from a look at trigger to a fixed camera, such as in The Cold War room 36 (#3033, regression from 0.9)
 - fixed passport faces partially invisible
 - improved the `/set` console command to display available options if given an unknown argument
 - improved handling of items that are dropped by enemies (#2952)

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -1026,6 +1026,9 @@ void Camera_Update(void)
             M_Combat(item);
         }
     } else {
+        if (fixed_camera) {
+            g_Camera.debuff = 0;
+        }
         if (g_Camera.debuff > 0) {
             const XYZ_32 old = g_Camera.target.pos;
             g_Camera.target.x = (item->pos.x + old.x) / 2;


### PR DESCRIPTION
Resolves  #3033.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves issues with the camera target jumping if Lara goes from a look at trigger immediately to a fixed camera trigger. Test level for TR1 shared as I don't think this can happen in OG levels.
