### PR TITLE
bear: test for creature data presence on death

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed floors being lowered too much under pushable blocks that are killed in the same trigger that flips the map (#3007, regression from 0.9)
 - fixed inventory ring items not being animated when the ring is rotating (#2964, regression from 0.9)
 - fixed the camera jumping if going from a look at trigger to a fixed camera, such as in The Cold War room 36 (#3033, regression from 0.9)
+- fixed a crash in The Golden Mask if the bear is killed with the grenade launcher (#3037, regression from 1.0)
 - fixed passport faces partially invisible
 - improved the `/set` console command to display available options if given an unknown argument
 - improved handling of items that are dropped by enemies (#2952)

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -90,7 +90,8 @@ static void M_Control(const int16_t item_num)
             break;
 
         case BEAR_STATE_DEATH:
-            if (bear->flags && (item->touch_bits & BEAR_TOUCH)) {
+            if (bear != nullptr && bear->flags != 0
+                && (item->touch_bits & BEAR_TOUCH) != 0) {
                 Lara_TakeDamage(BEAR_SLAM_DAMAGE, true);
                 bear->flags = 0;
             }


### PR DESCRIPTION
Resolves #3037.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

It's possible for the bear's control routine to run after it is exploded by the grenade launcher, in which case its creature data will have been unset. This adds a guard for that scenario.
