### PR TITLE
tr2/objects/final_level_counter: clear Lara target on completion

### DIFF
--- a/src/tr2/game/objects/general/final_level_counter.c
+++ b/src/tr2/game/objects/general/final_level_counter.c
@@ -74,6 +74,7 @@ static void M_PrepareCutscene(const int16_t item_num)
     Gun_SetLaraHandLMesh(LGT_UNARMED);
     Gun_SetLaraHandRMesh(LGT_UNARMED);
     g_Lara.water_status = LWS_ABOVE_WATER;
+    g_Lara.target = nullptr;
 
     ITEM *const item = Item_Get(item_num);
     Creature_SpecialKill(item, 0, 0, LA_EXTRA_FINAL_ANIM);


### PR DESCRIPTION
Resolves #3050.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids the enemy healthbar remaining visible in the shower cutscene if Lara remains locked on the final boss.
