### PR TITLE
tr1/savegame_bson: reset no room value in early saves 

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...develop) - ××××-××-××
 - changed examine item descriptions to remove extra blank lines
 - fixed examine item overlapping with other UI elements at large text scales
+- fixed a crash related to carried items if using saves made prior to 4.11 (#3052, regression from 4.11)
 - improved word wrapping algorithm in the dev console
 
 ## [4.11.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.11...tr1-4.11.1) - 2025-05-23

--- a/src/libtrx/game/carrier.c
+++ b/src/libtrx/game/carrier.c
@@ -148,7 +148,7 @@ static void M_InitialiseDataDrops(void)
 
         const ROOM *const room = Room_Get(carrier->room_num);
         int16_t pickup_num = room->item_num;
-        do {
+        while (pickup_num != NO_ITEM) {
             ITEM *const pickup = Item_Get(pickup_num);
             if (Object_IsType(pickup->object_id, g_PickupObjects)
                 && XYZ_32_AreEquivalent(&pickup->pos, &carrier->pos)) {
@@ -158,7 +158,7 @@ static void M_InitialiseDataDrops(void)
             }
 
             pickup_num = pickup->next_item;
-        } while (pickup_num != NO_ITEM);
+        }
 
         if (pickups->count == 0) {
             continue;
@@ -217,11 +217,18 @@ static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
             continue;
         }
 
+        if (data->count == 0) {
+            LOG_WARNING(
+                "There are no drop items defined for enemy %d",
+                data->enemy_num);
+            continue;
+        }
+
         item->carried_item =
             GameBuf_Alloc(sizeof(CARRIED_ITEM) * data->count, GBUF_ITEMS);
         CARRIED_ITEM *drop = item->carried_item;
-        for (int32_t i = 0; i < data->count; i++) {
-            drop->object_id = data->object_ids[i];
+        for (int32_t j = 0; j < data->count; j++) {
+            drop->object_id = data->object_ids[j];
             drop->spawn_num = NO_ITEM;
             drop->room_num = NO_ROOM;
             drop->fall_speed = 0;
@@ -236,7 +243,7 @@ static void M_InitialiseGameFlowDrops(const GF_LEVEL *const level)
                 drop->status = DS_COLLECTED;
             }
 
-            if (i < data->count - 1) {
+            if (j < data->count - 1) {
                 drop->next_item = drop + 1;
                 drop++;
             } else {

--- a/src/libtrx/include/libtrx/game/savegame/const.h
+++ b/src/libtrx/include/libtrx/game/savegame/const.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define SAVEGAME_CURRENT_VERSION 9
+#define SAVEGAME_CURRENT_VERSION 10

--- a/src/libtrx/include/libtrx/game/savegame/enum.h
+++ b/src/libtrx/include/libtrx/game/savegame/enum.h
@@ -34,4 +34,8 @@ typedef enum {
     // Added the current ambient track to allow triggers to change it at
     // different stages of the level.
     VERSION_9 = 9,
+
+    // Resolved an issue with TR1 game flow carried items and the NO_ROOM change
+    // from 255 to -1.
+    VERSION_10 = 10,
 } SAVEGAME_VERSION;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -28,6 +28,7 @@
 #include <zlib.h>
 
 #define SAVEGAME_BSON_MAGIC MKTAG('T', '1', 'M', 'B')
+#define M_NO_ROOM_LEGACY 255
 
 typedef struct {
     int16_t count;
@@ -651,6 +652,11 @@ static bool M_LoadItems(JSON_ARRAY *items_arr, uint16_t header_version)
                     carried_item_obj, "fall_speed", carried_item->fall_speed);
                 carried_item->status = JSON_ObjectGetInt(
                     carried_item_obj, "status", carried_item->status);
+
+                if (header_version < VERSION_10
+                    && carried_item->room_num == M_NO_ROOM_LEGACY) {
+                    carried_item->room_num = NO_ROOM;
+                }
 
                 carried_item = carried_item->next_item;
             }


### PR DESCRIPTION
Resolves #3052.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

0351429 merged the `NO_ROOM` definitions; any TR1 savegames made prior to 4.11 would have stored carried items with room numbers of 255, and no check was added with the definition change for this scenario - so this as a result was causing the crash on load as it was seeing 255 as a valid room number. This ensures the numbers get reset to -1 on load to allow the carrier module to proceed safely when the items actually drop. I've had to uprev the savegame version as this could impact saves made both in 4.10 and below and those re-saved from older versions with 4.11.

I've also tidied up some issues in the carrier module (thank you @rr- for finding these). So a general check of drops in both games would be good too here.
