### PR TITLE
tr2/objects/final_level_counter: fix boss proximity logic

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed a missing collapsible tile trigger in The Cold War room 82 (#3058)
 - fixed missing sound effects for collapsible tiles in Opera House and Catacombs of the Talion (#2262, #2872)
 - fixed texture and visibility issues with the skyboxes in The Cold War and Kingdom (#3056)
+- fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity (#3062)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -269,6 +269,7 @@ However, you can easily download them manually from these urls:
 - fixed Lara voiding if she stops on a tile with a closing door, and the door isn't on a portal
 - fixed Lara snapping to face forwards if she has a slight angle and action is pressed after using an airlock door
 - fixed Lara being able to equip guns and flares during in-game cutscenes
+- fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -253,11 +253,6 @@ void InitialiseFinalLevel(void)
         case O_CULT_3:
             g_FinalBossItem[g_FinalBossCount] = item_num;
             g_FinalBossCount++;
-            if (item->status == IS_ACTIVE) {
-                g_FinalBossActive = 1;
-            } else if (item->status == IS_DEACTIVATED) {
-                g_FinalBossActive = 2;
-            }
             break;
 
         default:

--- a/src/tr2/game/objects/general/final_level_counter.c
+++ b/src/tr2/game/objects/general/final_level_counter.c
@@ -20,10 +20,17 @@ static void M_Control(int16_t item_num);
 
 static int16_t M_FindBestBoss(void)
 {
-    int32_t best_dist = 0;
+    // Note that in the original, the first boss item was always selected here.
+    // For speedruns, the change here means that is no longer guaranteed, but
+    // positional manipulation can be used for the best outcome.
+    int32_t best_dist = INT32_MAX;
     int16_t best_item = g_FinalBossItem[0];
     for (int32_t i = 0; i < g_FinalBossCount; i++) {
         const ITEM *const item = Item_Get(g_FinalBossItem[i]);
+        if (item->status == IS_ACTIVE || item->status == IS_DEACTIVATED) {
+            best_item = g_FinalBossItem[i];
+            break;
+        }
 
         GAME_VECTOR start;
         start.pos.x = g_LaraItem->pos.x;
@@ -55,11 +62,13 @@ static void M_ActivateLastBoss(void)
 {
     const int16_t item_num = M_FindBestBoss();
     ITEM *const item = Item_Get(item_num);
-    item->touch_bits = 0;
-    item->status = IS_ACTIVE;
-    item->mesh_bits = 0xFFFF1FFF;
-    Item_AddActive(item_num);
-    LOT_EnableBaddieAI(item_num, true);
+    if (item->status != IS_ACTIVE && item->status != IS_DEACTIVATED) {
+        item->touch_bits = 0;
+        item->status = IS_ACTIVE;
+        item->mesh_bits = 0xFFFF1FFF;
+        Item_AddActive(item_num);
+        LOT_EnableBaddieAI(item_num, true);
+    }
     g_FinalBossActive = 1;
 }
 


### PR DESCRIPTION
Resolves #3062.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that the best boss in terms of proximity is selected in the final level.
