### PR TITLE
items: reorganise item struct

### DIFF
--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -1010,7 +1010,7 @@ void Camera_Update(void)
             lara_info->torso_rot.x = lara_info->head_rot.x;
             lara_info->torso_rot.y = lara_info->head_rot.y;
             g_Camera.type = CAM_LOOK;
-            g_Camera.item->looked_at = 1;
+            g_Camera.item->looked_at = true;
         }
     }
 

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -218,7 +218,7 @@ void Creature_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     item->rot.y += (Random_GetControl() - DEG_90) >> 1;
-    item->collidable = 1;
+    item->collidable = true;
     item->data = nullptr;
 }
 
@@ -989,7 +989,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
         break;
     }
 
-    item->collidable = 0;
+    item->collidable = false;
     item->hit_points = DONT_TARGET;
     if (explode) {
         Item_Explode(item_num, -1, 0);

--- a/src/libtrx/game/items/anim.c
+++ b/src/libtrx/game/items/anim.c
@@ -142,7 +142,7 @@ int32_t Item_GetFrames(const ITEM *item, ANIM_FRAME *frames[], int32_t *rate)
 
 void Item_Animate(ITEM *const item)
 {
-    item->hit_status = 0;
+    item->hit_status = false;
     item->touch_bits = 0;
     item->frame_num++;
 

--- a/src/libtrx/game/items/anim.c
+++ b/src/libtrx/game/items/anim.c
@@ -226,7 +226,7 @@ void Item_Animate(ITEM *const item)
         }
     }
 
-    if (item->gravity != 0) {
+    if (item->gravity) {
         item->fall_speed += item->fall_speed < FAST_FALL_SPEED ? GRAVITY : 1;
         item->pos.y += item->fall_speed;
     } else {

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -151,9 +151,9 @@ void Item_Initialise(const int16_t item_num)
     item->enable_shadow = true;
 
 #if TR_VERSION >= 2
-    item->killed = 0;
+    item->killed = false;
     if ((item->flags & IF_KILLED) != 0) {
-        item->killed = 1;
+        item->killed = true;
         item->flags &= ~IF_KILLED;
     }
 #endif

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -28,7 +28,7 @@ void Item_InitialiseItems(const int32_t num_items)
 
     for (int32_t i = m_NextItemFree; i < MAX_ITEMS - 1; i++) {
         ITEM *const item = &m_Items[i];
-        item->active = 0;
+        item->active = false;
         item->next_item = i + 1;
     }
     m_Items[MAX_ITEMS - 1].next_item = NO_ITEM;
@@ -141,7 +141,7 @@ void Item_Initialise(const int16_t item_num)
     item->priv = nullptr;
     item->carried_item = nullptr;
 
-    item->active = 0;
+    item->active = false;
     item->status = IS_INACTIVE;
     item->gravity = 0;
     item->hit_status = 0;
@@ -243,7 +243,7 @@ void Item_RemoveActive(const int16_t item_num)
         return;
     }
 
-    item->active = 0;
+    item->active = false;
 
     int16_t link_num = m_NextItemActive;
     if (link_num == item_num) {
@@ -309,7 +309,7 @@ void Item_AddActive(const int16_t item_num)
         return;
     }
 
-    item->active = 1;
+    item->active = true;
     item->next_active = m_NextItemActive;
     m_NextItemActive = item_num;
 }

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -145,7 +145,7 @@ void Item_Initialise(const int16_t item_num)
     item->status = IS_INACTIVE;
     item->gravity = false;
     item->hit_status = false;
-    item->collidable = 1;
+    item->collidable = true;
     item->looked_at = 0;
     item->enable_interpolation = true;
     item->enable_shadow = true;

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -148,10 +148,9 @@ void Item_Initialise(const int16_t item_num)
     item->collidable = 1;
     item->looked_at = 0;
     item->enable_interpolation = true;
-
-#if TR_VERSION == 1
     item->enable_shadow = true;
-#else
+
+#if TR_VERSION >= 2
     item->killed = 0;
     if ((item->flags & IF_KILLED) != 0) {
         item->killed = 1;

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -144,7 +144,7 @@ void Item_Initialise(const int16_t item_num)
     item->active = false;
     item->status = IS_INACTIVE;
     item->gravity = false;
-    item->hit_status = 0;
+    item->hit_status = false;
     item->collidable = 1;
     item->looked_at = 0;
     item->enable_interpolation = true;

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -143,7 +143,7 @@ void Item_Initialise(const int16_t item_num)
 
     item->active = false;
     item->status = IS_INACTIVE;
-    item->gravity = 0;
+    item->gravity = false;
     item->hit_status = 0;
     item->collidable = 1;
     item->looked_at = 0;

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -146,7 +146,7 @@ void Item_Initialise(const int16_t item_num)
     item->gravity = false;
     item->hit_status = false;
     item->collidable = true;
-    item->looked_at = 0;
+    item->looked_at = false;
     item->enable_interpolation = true;
     item->enable_shadow = true;
 

--- a/src/libtrx/game/items/utils.c
+++ b/src/libtrx/game/items/utils.c
@@ -20,7 +20,7 @@ void Item_TakeDamage(
     CLAMPL(item->hit_points, 0);
 
     if (hit_status) {
-        item->hit_status = 1;
+        item->hit_status = true;
     }
 }
 

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -95,7 +95,7 @@ void Lara_Animate(ITEM *const item)
         }
     }
 
-    if (item->gravity != 0) {
+    if (item->gravity) {
         int32_t speed = anim->velocity
             + anim->acceleration * (item->frame_num - anim->frame_base - 1);
         item->speed -= (int16_t)(speed >> 16);

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -20,11 +20,7 @@ typedef struct {
     int32_t floor;
     uint32_t touch_bits;
     uint32_t mesh_bits;
-#if TR_VERSION == 1
     GAME_OBJECT_ID object_id;
-#elif TR_VERSION == 2
-    int16_t object_id;
-#endif
     int16_t current_anim_state;
     int16_t goal_anim_state;
     int16_t required_anim_state;

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -40,13 +40,11 @@ typedef struct {
     void *data;
     void *priv;
     CARRIED_ITEM *carried_item;
-#if TR_VERSION == 1
-    bool enable_shadow;
-#endif
 
     XYZ_32 pos;
     XYZ_16 rot;
 
+    bool enable_shadow;
     uint16_t active : 1; // 0x0001
     uint16_t status : 2; // 0x0002…0x0004
     uint16_t gravity : 1; // 0x0008

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -49,10 +49,11 @@ typedef struct {
     bool enable_shadow;
     bool active;
     bool gravity;
+    bool hit_status;
     uint16_t pad_1 : 1; // 0x0001
     uint16_t pad_2 : 2; // 0x0002…0x0004
     uint16_t pad_3 : 1; // 0x0008
-    uint16_t hit_status : 1; // 0x0010
+    uint16_t pad_4 : 1; // 0x0010
     uint16_t collidable : 1; // 0x0020
     uint16_t looked_at : 1; // 0x0040
 #if TR_VERSION == 1

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -44,8 +44,10 @@ typedef struct {
     XYZ_32 pos;
     XYZ_16 rot;
 
+    bool enable_interpolation;
     bool enable_shadow;
-    uint16_t active : 1; // 0x0001
+    bool active;
+    uint16_t pad_1 : 1; // 0x0001
     uint16_t status : 2; // 0x0002…0x0004
     uint16_t gravity : 1; // 0x0008
     uint16_t hit_status : 1; // 0x0010
@@ -58,8 +60,6 @@ typedef struct {
     uint16_t killed : 1; // 0x0100
     uint16_t pad : 7; // 0x0200…0x8000
 #endif
-
-    bool enable_interpolation;
 
     struct {
         struct {

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -51,12 +51,13 @@ typedef struct {
     bool gravity;
     bool hit_status;
     bool collidable;
+    bool looked_at;
     uint16_t pad_1 : 1; // 0x0001
     uint16_t pad_2 : 2; // 0x0002…0x0004
     uint16_t pad_3 : 1; // 0x0008
     uint16_t pad_4 : 1; // 0x0010
     uint16_t pad_5 : 1; // 0x0020
-    uint16_t looked_at : 1; // 0x0040
+    uint16_t pad_6 : 1; // 0x0040
 #if TR_VERSION == 1
     uint16_t pad : 9; // 0x0080…0x8000
 #elif TR_VERSION == 2

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -61,7 +61,8 @@ typedef struct {
 #if TR_VERSION == 1
     uint16_t pad : 9; // 0x0080…0x8000
 #elif TR_VERSION == 2
-    uint16_t dynamic_light : 1; // 0x0080
+    bool dynamic_light;
+    uint16_t pad_7 : 1; // 0x0080
     uint16_t killed : 1; // 0x0100
     uint16_t pad : 7; // 0x0200…0x8000
 #endif

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -50,11 +50,12 @@ typedef struct {
     bool active;
     bool gravity;
     bool hit_status;
+    bool collidable;
     uint16_t pad_1 : 1; // 0x0001
     uint16_t pad_2 : 2; // 0x0002…0x0004
     uint16_t pad_3 : 1; // 0x0008
     uint16_t pad_4 : 1; // 0x0010
-    uint16_t collidable : 1; // 0x0020
+    uint16_t pad_5 : 1; // 0x0020
     uint16_t looked_at : 1; // 0x0040
 #if TR_VERSION == 1
     uint16_t pad : 9; // 0x0080…0x8000

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -44,11 +44,12 @@ typedef struct {
     XYZ_32 pos;
     XYZ_16 rot;
 
+    ITEM_STATUS status;
     bool enable_interpolation;
     bool enable_shadow;
     bool active;
     uint16_t pad_1 : 1; // 0x0001
-    uint16_t status : 2; // 0x0002…0x0004
+    uint16_t pad_2 : 2; // 0x0002…0x0004
     uint16_t gravity : 1; // 0x0008
     uint16_t hit_status : 1; // 0x0010
     uint16_t collidable : 1; // 0x0020

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -48,9 +48,10 @@ typedef struct {
     bool enable_interpolation;
     bool enable_shadow;
     bool active;
+    bool gravity;
     uint16_t pad_1 : 1; // 0x0001
     uint16_t pad_2 : 2; // 0x0002…0x0004
-    uint16_t gravity : 1; // 0x0008
+    uint16_t pad_3 : 1; // 0x0008
     uint16_t hit_status : 1; // 0x0010
     uint16_t collidable : 1; // 0x0020
     uint16_t looked_at : 1; // 0x0040

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -52,19 +52,9 @@ typedef struct {
     bool hit_status;
     bool collidable;
     bool looked_at;
-    uint16_t pad_1 : 1; // 0x0001
-    uint16_t pad_2 : 2; // 0x0002…0x0004
-    uint16_t pad_3 : 1; // 0x0008
-    uint16_t pad_4 : 1; // 0x0010
-    uint16_t pad_5 : 1; // 0x0020
-    uint16_t pad_6 : 1; // 0x0040
-#if TR_VERSION == 1
-    uint16_t pad : 9; // 0x0080…0x8000
-#elif TR_VERSION == 2
+#if TR_VERSION == 2
     bool dynamic_light;
-    uint16_t pad_7 : 1; // 0x0080
-    uint16_t killed : 1; // 0x0100
-    uint16_t pad : 7; // 0x0200…0x8000
+    bool killed;
 #endif
 
     struct {

--- a/src/tr1/game/lara/col.c
+++ b/src/tr1/game/lara/col.c
@@ -95,7 +95,7 @@ static void M_Jumper(ITEM *item, COLL_INFO *coll)
             item->goal_anim_state = LS_STOP;
         }
         item->pos.y += coll->side_mid.floor;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 }
@@ -129,7 +129,7 @@ static void M_CollideStop(ITEM *const item, const COLL_INFO *const coll)
 void Lara_Col_Walk(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = STEPUP_HEIGHT;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -198,7 +198,7 @@ void Lara_Col_Walk(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Run(ITEM *item, COLL_INFO *coll)
 {
     if (g_Config.gameplay.fix_qwop_glitch) {
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 
@@ -265,7 +265,7 @@ void Lara_Col_Run(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Stop(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = STEPUP_HEIGHT;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -286,7 +286,7 @@ void Lara_Col_Stop(ITEM *item, COLL_INFO *coll)
         item->current_anim_state = LS_JUMP_FORWARD;
         item->goal_anim_state = LS_JUMP_FORWARD;
         Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -320,7 +320,7 @@ void Lara_Col_ForwardJump(ITEM *item, COLL_INFO *coll)
             item->goal_anim_state = LS_STOP;
         }
         item->pos.y += coll->side_mid.floor;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
         item->speed = 0;
 
@@ -338,7 +338,7 @@ void Lara_Col_Pose(ITEM *item, COLL_INFO *coll)
 void Lara_Col_FastBack(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y - DEG_180;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -355,7 +355,7 @@ void Lara_Col_FastBack(ITEM *item, COLL_INFO *coll)
         item->current_anim_state = LS_FALL_BACK;
         item->goal_anim_state = LS_FALL_BACK;
         Item_SwitchToAnim(item, LA_FALL_BACK, 0);
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -370,7 +370,7 @@ void Lara_Col_FastBack(ITEM *item, COLL_INFO *coll)
 void Lara_Col_TurnR(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = STEPUP_HEIGHT;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -383,7 +383,7 @@ void Lara_Col_TurnR(ITEM *item, COLL_INFO *coll)
         item->current_anim_state = LS_JUMP_FORWARD;
         item->goal_anim_state = LS_JUMP_FORWARD;
         Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -417,7 +417,7 @@ void Lara_Col_Death(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_FastFall(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 1;
+    item->gravity = true;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
     coll->bad_ceiling = BAD_JUMP_CEILING;
@@ -434,7 +434,7 @@ void Lara_Col_FastFall(ITEM *item, COLL_INFO *coll)
         }
         Sound_StopEffect(SFX_LARA_FALL);
         item->pos.y += coll->side_mid.floor;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 }
@@ -455,7 +455,7 @@ void Lara_Col_Hang(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Reach(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 1;
+    item->gravity = true;
     g_Lara.move_angle = item->rot.y;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = 0;
@@ -474,7 +474,7 @@ void Lara_Col_Reach(ITEM *item, COLL_INFO *coll)
             item->goal_anim_state = LS_STOP;
         }
         item->pos.y += coll->side_mid.floor;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 }
@@ -498,7 +498,7 @@ void Lara_Col_Land(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = NO_BAD_NEG;
@@ -509,7 +509,7 @@ void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
         Item_SwitchToAnim(item, LA_STOP, 0);
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
         item->speed = 0;
         item->pos.x = coll->old.x;
@@ -521,7 +521,7 @@ void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Back(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y - DEG_180;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     if (g_Lara.water_status == LWS_WADE) {
         coll->bad_pos = NO_BAD_POS;
@@ -576,7 +576,7 @@ void Lara_Col_FastTurn(ITEM *item, COLL_INFO *coll)
 void Lara_Col_StepRight(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y + DEG_90;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     if (g_Lara.water_status == LWS_WADE) {
         coll->bad_pos = NO_BAD_POS;
@@ -611,7 +611,7 @@ void Lara_Col_StepRight(ITEM *item, COLL_INFO *coll)
 void Lara_Col_StepLeft(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y - DEG_90;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     if (g_Lara.water_status == LWS_WADE) {
         coll->bad_pos = NO_BAD_POS;
@@ -709,7 +709,7 @@ void Lara_Col_UpJump(ITEM *item, COLL_INFO *coll)
         item->goal_anim_state = LS_STOP;
     }
     item->pos.y += coll->side_mid.floor;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
 }
 
@@ -730,7 +730,7 @@ void Lara_Col_FallBack(ITEM *item, COLL_INFO *coll)
             item->goal_anim_state = LS_STOP;
         }
         item->pos.y += coll->side_mid.floor;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 }
@@ -813,7 +813,7 @@ void Lara_Col_UsePuzzle(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -833,7 +833,7 @@ void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
         item->current_anim_state = LS_JUMP_FORWARD;
         item->goal_anim_state = LS_JUMP_FORWARD;
         Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -845,7 +845,7 @@ void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
 {
     g_Lara.move_angle = item->rot.y - DEG_180;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -865,7 +865,7 @@ void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
         item->current_anim_state = LS_FALL_BACK;
         item->goal_anim_state = LS_FALL_BACK;
         Item_SwitchToAnim(item, LA_FALL_BACK, 0);
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -900,7 +900,7 @@ void Lara_Col_SwanDive(ITEM *item, COLL_INFO *coll)
 
     if (item->fall_speed > 0 && coll->side_mid.floor <= 0) {
         item->goal_anim_state = LS_STOP;
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
         item->pos.y += coll->side_mid.floor;
     }
@@ -922,7 +922,7 @@ void Lara_Col_FastDive(ITEM *item, COLL_INFO *coll)
         } else {
             item->goal_anim_state = LS_STOP;
         }
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
         item->pos.y += coll->side_mid.floor;
     }

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -106,7 +106,7 @@ void Lara_Control(void)
             g_Lara.water_status = LWS_UNDERWATER;
             g_Lara.air = LARA_MAX_AIR;
             item->pos.y += 100;
-            item->gravity = 0;
+            item->gravity = false;
             Lara_UpdateRoomToHeight(0);
             Sound_StopEffect(SFX_LARA_FALL);
             if (item->current_anim_state == LS_SWAN_DIVE) {
@@ -149,7 +149,7 @@ void Lara_Control(void)
             Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
             item->speed = item->fall_speed / 4;
             item->fall_speed = 0;
-            item->gravity = 1;
+            item->gravity = true;
             item->rot.x = 0;
             item->rot.z = 0;
             g_Lara.head_rot.x = 0;
@@ -197,7 +197,7 @@ void Lara_Control(void)
             Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
             item->speed = item->fall_speed / 4;
             item->fall_speed = 0;
-            item->gravity = 1;
+            item->gravity = true;
             item->rot.x = 0;
             item->rot.z = 0;
             g_Lara.head_rot.x = 0;
@@ -248,7 +248,7 @@ void Lara_Control(void)
 
             item->rot.z = 0;
             item->rot.x = 0;
-            item->gravity = 0;
+            item->gravity = false;
             item->fall_speed = 0;
             g_Lara.dive_timer = 0;
             g_Lara.torso_rot.y = 0;

--- a/src/tr1/game/lara/misc.c
+++ b/src/tr1/game/lara/misc.c
@@ -34,7 +34,7 @@ void Lara_HangTest(ITEM *item, COLL_INFO *coll)
     }
 
     g_Lara.move_angle = item->rot.y;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
 
     PHD_ANGLE angle = (uint16_t)(item->rot.y + DEG_45) / DEG_90;
@@ -73,7 +73,7 @@ void Lara_HangTest(ITEM *item, COLL_INFO *coll)
         }
         item->pos.x += coll->shift.x;
         item->pos.z += coll->shift.z;
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 1;
         item->speed = 2;
         g_Lara.gun_status = LGS_ARMLESS;
@@ -138,7 +138,7 @@ void Lara_SlideSlope(ITEM *item, COLL_INFO *coll)
             item->goal_anim_state = LS_FALL_BACK;
             Item_SwitchToAnim(item, LA_FALL_BACK, 0);
         }
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -160,7 +160,7 @@ bool Lara_Fallen(ITEM *item, COLL_INFO *coll)
     item->current_anim_state = LS_JUMP_FORWARD;
     item->goal_anim_state = LS_JUMP_FORWARD;
     Item_SwitchToAnim(item, LA_FALL_DOWN, 0);
-    item->gravity = 1;
+    item->gravity = true;
     item->fall_speed = 0;
     return true;
 }
@@ -177,7 +177,7 @@ bool Lara_HitCeiling(ITEM *item, COLL_INFO *coll)
     item->goal_anim_state = LS_STOP;
     item->current_anim_state = LS_STOP;
     Item_SwitchToAnim(item, LA_STOP, 0);
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->speed = 0;
     return true;
@@ -188,7 +188,7 @@ bool Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
         Lara_ShiftCol(coll);
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
-        item->gravity = 0;
+        item->gravity = false;
         item->speed = 0;
         return true;
     }
@@ -400,7 +400,7 @@ bool Lara_TestHangJump(ITEM *item, COLL_INFO *coll)
     item->pos.x += coll->shift.x;
     item->pos.z += coll->shift.z;
     item->rot.y = angle;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->speed = 0;
     g_Lara.gun_status = LGS_HANDS_BUSY;
@@ -486,7 +486,7 @@ bool Lara_TestHangJumpUp(ITEM *item, COLL_INFO *coll)
     item->pos.x += coll->shift.x;
     item->pos.z += coll->shift.z;
     item->rot.y = angle;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->speed = 0;
     g_Lara.gun_status = LGS_HANDS_BUSY;
@@ -699,7 +699,7 @@ void Lara_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
     item->goal_anim_state = LS_STOP;
     item->rot.x = 0;
     item->rot.z = 0;
-    item->gravity = 0;
+    item->gravity = false;
     item->speed = 0;
     item->fall_speed = 0;
     g_Lara.water_status = LWS_WADE;
@@ -729,7 +729,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
 
     item->pos.y += coll->side_front.floor + SURF_HEIGHT - 5;
     Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
-    item->gravity = 0;
+    item->gravity = false;
     item->rot.x = 0;
     item->rot.z = 0;
     item->speed = 0;
@@ -799,7 +799,7 @@ bool Lara_TestWaterClimbOut(ITEM *item, COLL_INFO *coll)
     item->rot.x = 0;
     item->rot.y = Math_DirectionToAngle(dir);
     item->rot.z = 0;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->speed = 0;
     g_Lara.gun_status = LGS_HANDS_BUSY;

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -703,7 +703,7 @@ void Lara_State_UseMidas(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_DieMidas(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
 

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -86,7 +86,7 @@ static void M_Control(const int16_t item_num)
             Item_SwitchToAnim(item, LA_FAST_FALL, BLF_FASTFALL);
             item->speed = 0;
             item->fall_speed = 0;
-            item->gravity = 1;
+            item->gravity = true;
             item->data = (void *)-1;
             item->pos.y += 50;
         }
@@ -109,7 +109,7 @@ static void M_Control(const int16_t item_num)
             item->floor = h;
             item->pos.y = h;
             Room_TestTriggers(item);
-            item->gravity = 0;
+            item->gravity = false;
             item->fall_speed = 0;
             item->goal_anim_state = LS_DEATH;
             item->required_anim_state = LS_DEATH;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -98,11 +98,11 @@ static void M_Control(const int16_t item_num)
     PHD_ANGLE angle = 0;
     if (item->hit_points <= 0) {
         if (item->pos.y < item->floor) {
-            item->gravity = 1;
+            item->gravity = true;
             item->goal_anim_state = BAT_STATE_FALL;
             item->speed = 0;
         } else {
-            item->gravity = 0;
+            item->gravity = false;
             item->fall_speed = 0;
             item->goal_anim_state = BAT_STATE_DEATH;
             item->pos.y = item->floor;

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -113,10 +113,10 @@ static void M_Control(const int16_t item_num)
         switch (item->current_anim_state) {
         case NATLA_STATE_FALL:
             if (item->pos.y < item->floor) {
-                item->gravity = 1;
+                item->gravity = true;
                 item->speed = 0;
             } else {
-                item->gravity = 0;
+                item->gravity = false;
                 item->goal_anim_state = NATLA_STATE_SEMIDEATH;
                 item->pos.y = item->floor;
                 timer = 0;

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -138,7 +138,7 @@ static void M_Control(const int16_t item_num)
 
         if (pierre->flags) {
             info.enemy_zone = -1;
-            item->hit_status = 1;
+            item->hit_status = true;
         }
         Creature_Mood(item, &info, false);
 

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -76,7 +76,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->status == IS_DEACTIVATED) {
             item->mesh_bits = 0x1FF;
-            item->collidable = 0;
+            item->collidable = false;
         }
     }
 }
@@ -105,7 +105,7 @@ static void M_Control(const int16_t item_num)
         if (explode) {
             item->goal_anim_state = POD_STATE_EXPLODE;
             item->mesh_bits = 0xFFFFFF;
-            item->collidable = 0;
+            item->collidable = false;
             Item_Explode(item_num, 0xFFFE00, 0);
 
             const int16_t bug_item_num = (intptr_t)item->data;

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -112,7 +112,7 @@ static void M_Control(const int16_t item_num)
         switch (item->current_anim_state) {
         case TORSO_STATE_SET:
             item->goal_anim_state = TORSO_STATE_FALL;
-            item->gravity = 1;
+            item->gravity = true;
             break;
 
         case TORSO_STATE_STOP:
@@ -241,7 +241,7 @@ static void M_Control(const int16_t item_num)
 
         if (item->pos.y > item->floor) {
             item->goal_anim_state = TORSO_STATE_STOP;
-            item->gravity = 0;
+            item->gravity = false;
             item->pos.y = item->floor;
             g_Camera.bounce = 500;
         }

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -179,7 +179,7 @@ static void M_Control(const int16_t item_num)
     Creature_Head(item, head >> 1);
     dino->neck_rotation = dino->head_rotation;
     Creature_Animate(item_num, angle, 0);
-    item->collidable = 1;
+    item->collidable = true;
 }
 
 static void M_KillLara(ITEM *const item)

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -61,7 +61,7 @@ static void M_Control(const int16_t item_num)
         if (item->pos.y > item->floor) {
             Sound_Effect(SFX_DAMOCLES_SWORD, &item->pos, SPM_NORMAL);
             item->pos.y = item->floor + 10;
-            item->gravity = 0;
+            item->gravity = false;
             item->status = IS_DEACTIVATED;
             Item_RemoveActive(item_num);
         }
@@ -75,7 +75,7 @@ static void M_Control(const int16_t item_num)
             && y < WALL_L * 3) {
             item->current_anim_state = x / 32;
             item->goal_anim_state = z / 32;
-            item->gravity = 1;
+            item->gravity = true;
         }
     }
 }

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -39,7 +39,7 @@ static void M_Control(const int16_t item_num)
 
     case TRAP_WORKING:
         if (item->goal_anim_state != TRAP_FINISHED) {
-            item->gravity = 1;
+            item->gravity = true;
         }
         break;
     }
@@ -62,7 +62,7 @@ static void M_Control(const int16_t item_num)
         item->goal_anim_state = TRAP_FINISHED;
         item->pos.y = item->floor;
         item->fall_speed = 0;
-        item->gravity = 0;
+        item->gravity = false;
     }
 }
 

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -20,7 +20,7 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     if (item->current_anim_state == TRAP_SET) {
         item->goal_anim_state = TRAP_ACTIVATE;
-        item->gravity = 1;
+        item->gravity = true;
     } else if (
         item->current_anim_state == TRAP_ACTIVATE && item->touch_bits != 0) {
         Lara_TakeDamage(FALLING_CEILING_DAMAGE, true);
@@ -44,7 +44,7 @@ static void M_Control(const int16_t item_num)
         item->pos.y = height;
         item->goal_anim_state = TRAP_WORKING;
         item->fall_speed = 0;
-        item->gravity = 0;
+        item->gravity = false;
     }
 }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -312,9 +312,9 @@ static void M_Control(const int16_t item_num)
         sector, item->pos.x, item->pos.y - STEP_L / 2, item->pos.z);
 
     if (item->pos.y < height) {
-        item->gravity = 1;
+        item->gravity = true;
     } else if (item->gravity) {
-        item->gravity = 0;
+        item->gravity = false;
         item->pos.y = height;
         item->status = IS_DEACTIVATED;
         ItemAction_Run(ITEM_ACTION_FLOOR_SHAKE, item);

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -45,7 +45,7 @@ static void M_Control(const int16_t item_num)
     if (item->status == IS_ACTIVE) {
         if (item->pos.y < item->floor) {
             if (!item->gravity) {
-                item->gravity = 1;
+                item->gravity = true;
                 item->fall_speed = -10;
             }
         } else if (item->current_anim_state == TRAP_SET) {
@@ -67,7 +67,7 @@ static void M_Control(const int16_t item_num)
         Room_TestTriggers(item);
 
         if (item->pos.y >= item->floor - STEP_L) {
-            item->gravity = 0;
+            item->gravity = false;
             item->fall_speed = 0;
             item->pos.y = item->floor;
         }

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -539,7 +539,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
                     item->gravity = true;
                 }
                 if (!(item->flags & 16)) {
-                    item->collidable = 0;
+                    item->collidable = false;
                 }
             }
 

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -536,7 +536,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
                 }
                 item->status = (item->flags & 6) >> 1;
                 if (item->flags & 8) {
-                    item->gravity = 1;
+                    item->gravity = true;
                 }
                 if (!(item->flags & 16)) {
                     item->collidable = 0;

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -67,7 +67,7 @@ void CutscenePlayer1_Initialise(const int16_t item_num)
     camera->pos.room_num = item->room_num;
 
     item->rot.y = 0;
-    item->dynamic_light = 0;
+    item->dynamic_light = false;
     item->goal_anim_state = 0;
     item->current_anim_state = 0;
     item->frame_num = 0;

--- a/src/tr2/game/item_actions.c
+++ b/src/tr2/game/item_actions.c
@@ -285,12 +285,12 @@ void M_InvisibilityOff(ITEM *const item)
 
 void M_DynamicLightOn(ITEM *const item)
 {
-    item->dynamic_light = 1;
+    item->dynamic_light = true;
 }
 
 void M_DynamicLightOff(ITEM *const item)
 {
-    item->dynamic_light = 0;
+    item->dynamic_light = false;
 }
 
 void M_ResetHair(ITEM *const item)

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -157,6 +157,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.mesh_effects = 0;
     g_Lara.burn = 0;
     g_Lara.extra_anim = 0;
+    g_LaraItem->enable_shadow = true;
     g_LaraItem->hit_points = LARA_MAX_HITPOINTS;
 
     M_ReinitialiseGunMeshes();

--- a/src/tr2/game/lara/col.c
+++ b/src/tr2/game/lara/col.c
@@ -80,7 +80,7 @@ bool Lara_Fallen(ITEM *const item, const COLL_INFO *const coll)
     item->current_anim_state = LS_JUMP_FORWARD;
     item->goal_anim_state = LS_JUMP_FORWARD;
     Item_SwitchToAnim(item, LA_FALL_START, 0);
-    item->gravity = 1;
+    item->gravity = true;
     item->fall_speed = 0;
     return true;
 }
@@ -155,7 +155,7 @@ bool Lara_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
     item->rot.y = Math_DirectionToAngle(dir);
     item->rot.x = 0;
     item->rot.z = 0;
-    item->gravity = 0;
+    item->gravity = false;
     item->speed = 0;
     item->fall_speed = 0;
     g_Lara.gun_status = LGS_HANDS_BUSY;
@@ -186,7 +186,7 @@ bool Lara_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
 
     item->pos.y += coll->side_front.floor + LARA_HEIGHT_SURF - 5;
     Lara_UpdateRoomToHeight(-LARA_HEIGHT / 2);
-    item->gravity = 0;
+    item->gravity = false;
     item->rot.x = 0;
     item->rot.z = 0;
     item->speed = 0;
@@ -238,7 +238,7 @@ void Lara_Col_Empty(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Walk(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y;
     coll->slopes_are_pits = 1;
@@ -305,7 +305,7 @@ void Lara_Col_Walk(ITEM *item, COLL_INFO *coll)
 void Lara_Col_Run(ITEM *item, COLL_INFO *coll)
 {
     if (g_Config.gameplay.fix_qwop_glitch) {
-        item->gravity = 0;
+        item->gravity = false;
         item->fall_speed = 0;
     }
 
@@ -366,7 +366,7 @@ void Lara_Col_Run(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Stop(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y;
     coll->slopes_are_pits = 1;
@@ -415,7 +415,7 @@ void Lara_Col_ForwardJump(ITEM *item, COLL_INFO *coll)
         item->goal_anim_state = LS_STOP;
     }
 
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
     item->speed = 0;
@@ -424,7 +424,7 @@ void Lara_Col_ForwardJump(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_FastBack(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y + DEG_180;
     coll->slopes_are_pits = 1;
@@ -447,14 +447,14 @@ void Lara_Col_FastBack(ITEM *item, COLL_INFO *coll)
         Item_SwitchToAnim(item, LA_FALL_BACK, 0);
         item->current_anim_state = LS_FALL_BACK;
         item->goal_anim_state = LS_FALL_BACK;
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
     }
 }
 
 void Lara_Col_TurnRight(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y;
     coll->slopes_are_pits = 1;
@@ -473,7 +473,7 @@ void Lara_Col_TurnRight(ITEM *item, COLL_INFO *coll)
         Item_SwitchToAnim(item, LA_FALL_START, 0);
         item->current_anim_state = LS_JUMP_FORWARD;
         item->goal_anim_state = LS_JUMP_FORWARD;
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
     }
 }
@@ -502,7 +502,7 @@ void Lara_Col_Death(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_FastFall(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 1;
+    item->gravity = true;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
     coll->bad_ceiling = BAD_JUMP_CEILING;
@@ -522,7 +522,7 @@ void Lara_Col_FastFall(ITEM *item, COLL_INFO *coll)
     }
 
     Sound_StopEffect(SFX_LARA_FALL);
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -565,7 +565,7 @@ void Lara_Col_Hang(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Reach(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 1;
+    item->gravity = true;
     g_Lara.move_angle = item->rot.y;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = 0;
@@ -586,7 +586,7 @@ void Lara_Col_Reach(ITEM *item, COLL_INFO *coll)
     } else {
         item->goal_anim_state = LS_STOP;
     }
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -615,7 +615,7 @@ void Lara_Col_Land(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = NO_BAD_NEG;
@@ -627,7 +627,7 @@ void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
         Item_SwitchToAnim(item, LA_STAND_STILL, 0);
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
-        item->gravity = 0;
+        item->gravity = false;
         item->speed = 0;
         item->fall_speed = 0;
         item->pos.x = coll->old.x;
@@ -642,7 +642,7 @@ void Lara_Col_Compress(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Back(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y + DEG_180;
     if (g_Lara.water_status == LWS_WADE) {
@@ -690,7 +690,7 @@ void Lara_Col_StepRight(ITEM *item, COLL_INFO *coll)
         g_Lara.move_angle = item->rot.y - DEG_90;
     }
 
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     if (g_Lara.water_status == LWS_WADE) {
         coll->bad_pos = NO_BAD_POS;
@@ -783,7 +783,7 @@ void Lara_Col_UpJump(ITEM *item, COLL_INFO *coll)
     } else {
         item->goal_anim_state = LS_STOP;
     }
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -808,7 +808,7 @@ void Lara_Col_Fallback(ITEM *item, COLL_INFO *coll)
         item->goal_anim_state = LS_STOP;
     }
 
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -840,7 +840,7 @@ void Lara_Col_Null(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y;
     coll->slopes_are_walls = 1;
@@ -860,7 +860,7 @@ void Lara_Col_Roll(ITEM *item, COLL_INFO *coll)
 
 void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y + DEG_180;
     coll->slopes_are_walls = 1;
@@ -877,7 +877,7 @@ void Lara_Col_Roll2(ITEM *item, COLL_INFO *coll)
         Item_SwitchToAnim(item, LA_FALL_BACK, 0);
         item->current_anim_state = LS_FALL_BACK;
         item->goal_anim_state = LS_FALL_BACK;
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
     } else {
         Lara_ShiftCol(coll);
@@ -899,7 +899,7 @@ void Lara_Col_SwanDive(ITEM *item, COLL_INFO *coll)
     }
 
     item->goal_anim_state = LS_STOP;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -923,7 +923,7 @@ void Lara_Col_FastDive(ITEM *item, COLL_INFO *coll)
     } else {
         item->goal_anim_state = LS_STOP;
     }
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }
@@ -1009,7 +1009,7 @@ void Lara_Col_Jumper(ITEM *item, COLL_INFO *coll)
     } else {
         item->goal_anim_state = LS_STOP;
     }
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
 }

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -776,7 +776,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     ITEM *const item = g_LaraItem;
 
     item->data = &g_Lara;
-    item->collidable = 0;
+    item->collidable = false;
     item->hit_points = LARA_MAX_HITPOINTS;
 
     g_Lara.hit_direction = -1;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -474,7 +474,7 @@ void Lara_Control(const int16_t item_num)
             } else if (room_submerged) {
                 g_Lara.air = LARA_MAX_AIR;
                 g_Lara.water_status = LWS_UNDERWATER;
-                item->gravity = 0;
+                item->gravity = false;
                 item->pos.y += 100;
                 Lara_UpdateRoomToHeight(0);
                 Sound_StopEffect(SFX_LARA_FALL);
@@ -513,7 +513,7 @@ void Lara_Control(const int16_t item_num)
                 Item_SwitchToAnim(item, LA_FALL_START, 0);
                 item->goal_anim_state = LS_JUMP_FORWARD;
                 item->current_anim_state = LS_JUMP_FORWARD;
-                item->gravity = 1;
+                item->gravity = true;
                 item->speed = item->fall_speed / 4;
                 item->fall_speed = 0;
                 item->rot.x = 0;
@@ -551,7 +551,7 @@ void Lara_Control(const int16_t item_num)
                 Item_SwitchToAnim(item, LA_FALL_START, 0);
                 item->goal_anim_state = LS_JUMP_FORWARD;
                 item->current_anim_state = LS_JUMP_FORWARD;
-                item->gravity = 1;
+                item->gravity = true;
                 item->speed = item->fall_speed / 4;
             } else {
                 g_Lara.water_status = LWS_WADE;
@@ -608,7 +608,7 @@ void Lara_Control(const int16_t item_num)
 
                 item->rot.z = 0;
                 item->rot.x = 0;
-                item->gravity = 0;
+                item->gravity = false;
                 item->fall_speed = 0;
                 g_Lara.dive_count = 0;
                 g_Lara.torso_rot.y = 0;

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -64,7 +64,7 @@ void Lara_SlideSlope(ITEM *item, COLL_INFO *coll)
             item->current_anim_state = LS_FALL_BACK;
             Item_SwitchToAnim(item, LA_FALL_BACK, 0);
         }
-        item->gravity = 1;
+        item->gravity = true;
         item->fall_speed = 0;
         return;
     }
@@ -89,7 +89,7 @@ int32_t Lara_HitCeiling(ITEM *item, COLL_INFO *coll)
     item->current_anim_state = LS_STOP;
     Item_SwitchToAnim(item, LA_STAND_STILL, 0);
     item->speed = 0;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     return 1;
 }
@@ -102,7 +102,7 @@ int32_t Lara_DeflectEdge(ITEM *item, COLL_INFO *coll)
         Lara_ShiftCol(coll);
         item->goal_anim_state = LS_STOP;
         item->current_anim_state = LS_STOP;
-        item->gravity = 0;
+        item->gravity = false;
         item->speed = 0;
         return 1;
 
@@ -356,7 +356,7 @@ void Lara_HangTest(ITEM *item, COLL_INFO *coll)
     Lara_GetCollisionInfo(item, coll);
     bool flag = coll->side_front.floor < 200;
 
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.move_angle = item->rot.y;
 
@@ -401,7 +401,7 @@ void Lara_HangTest(ITEM *item, COLL_INFO *coll)
             item->current_anim_state = LS_JUMP_FORWARD;
             Item_SwitchToAnim(item, LA_FALL_START, 0);
             item->pos.y += STEP_L;
-            item->gravity = 1;
+            item->gravity = true;
             item->speed = 2;
             item->fall_speed = 1;
             g_Lara.gun_status = LGS_ARMLESS;
@@ -435,7 +435,7 @@ void Lara_HangTest(ITEM *item, COLL_INFO *coll)
         item->pos.y += bounds->max.y;
         item->pos.x += coll->shift.x;
         item->pos.z += coll->shift.z;
-        item->gravity = 1;
+        item->gravity = true;
         item->speed = 2;
         item->fall_speed = 1;
         g_Lara.gun_status = LGS_ARMLESS;
@@ -535,7 +535,7 @@ int32_t Lara_TestHangJumpUp(ITEM *item, COLL_INFO *coll)
     item->pos.z += coll->shift.z;
     item->rot.y = angle;
     item->speed = 0;
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
     g_Lara.gun_status = LGS_HANDS_BUSY;
     return 1;
@@ -582,7 +582,7 @@ int32_t Lara_TestHangJump(ITEM *item, COLL_INFO *coll)
 
     item->rot.y = angle;
     item->speed = 2;
-    item->gravity = 1;
+    item->gravity = true;
     item->fall_speed = 1;
     g_Lara.gun_status = LGS_HANDS_BUSY;
     return 1;
@@ -780,7 +780,7 @@ int32_t Lara_LandedBad(ITEM *item, COLL_INFO *coll)
 
 int32_t Lara_CheckForLetGo(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed = 0;
 
     if (g_Input.action && item->hit_points > 0) {
@@ -790,7 +790,7 @@ int32_t Lara_CheckForLetGo(ITEM *item, COLL_INFO *coll)
     item->goal_anim_state = LS_JUMP_FORWARD;
     item->current_anim_state = LS_JUMP_FORWARD;
     Item_SwitchToAnim(item, LA_FALL_START, 0);
-    item->gravity = 1;
+    item->gravity = true;
     item->speed = 2;
     item->fall_speed = 1;
     g_Lara.gun_status = LGS_ARMLESS;
@@ -1483,7 +1483,7 @@ void Lara_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
         item->goal_anim_state = LS_STOP;
         item->rot.x = 0;
         item->rot.z = 0;
-        item->gravity = 0;
+        item->gravity = false;
         item->speed = 0;
         item->fall_speed = 0;
         g_Lara.water_status = LWS_WADE;

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -1126,7 +1126,7 @@ void Lara_State_Dive(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_UWDeath(ITEM *item, COLL_INFO *coll)
 {
-    item->gravity = 0;
+    item->gravity = false;
     item->fall_speed -= 8;
     CLAMPL(item->fall_speed, 0);
 

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -116,7 +116,7 @@ static void M_Control(const int16_t item_num)
         case BIRD_STATE_FALL:
             if (item->pos.y > item->floor) {
                 item->pos.y = item->floor;
-                item->gravity = 0;
+                item->gravity = false;
                 item->fall_speed = 0;
                 item->goal_anim_state = BIRD_STATE_DEATH;
             }
@@ -131,7 +131,7 @@ static void M_Control(const int16_t item_num)
                 item->object_id == O_CROW ? CROW_DIE_ANIM : BIRD_DIE_ANIM;
             Item_SwitchToAnim(item, anim_idx, 0);
             item->current_anim_state = BIRD_STATE_FALL;
-            item->gravity = 1;
+            item->gravity = true;
             item->speed = 0;
             break;
         }

--- a/src/tr2/game/objects/general/cutscene_player.c
+++ b/src/tr2/game/objects/general/cutscene_player.c
@@ -19,7 +19,7 @@ static void M_Initialise(const int16_t item_num)
     Item_AddActive(item_num);
     ITEM *const item = Item_Get(item_num);
     item->rot.y = 0;
-    item->dynamic_light = 0;
+    item->dynamic_light = false;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -239,9 +239,9 @@ static void M_Control(const int16_t item_num)
         sector, item->pos.x, item->pos.y - STEP_L / 2, item->pos.z);
 
     if (item->pos.y < height) {
-        item->gravity = 1;
+        item->gravity = true;
     } else if (item->gravity) {
-        item->gravity = 0;
+        item->gravity = false;
         item->pos.y = height;
         item->status = IS_DEACTIVATED;
         ItemAction_Run(ITEM_ACTION_FLOOR_SHAKE, item);

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -74,6 +74,9 @@ static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
     case O_SWITCH_TYPE_BUTTON:
         Lara_AlignPosition(switch_item, &g_PushSwitchPosition);
         break;
+
+    default:
+        break;
     }
 }
 

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -89,7 +89,7 @@ static void M_Control2(const int16_t item_num)
     M_SetBoxBlocked(item, false);
 
     item->mesh_bits = ~1;
-    item->collidable = 0;
+    item->collidable = false;
     Item_Explode(item_num, 65278, 0);
     Sound_Effect(SFX_BRITTLE_GROUND_BREAK, &item->pos, SPM_NORMAL);
 
@@ -117,7 +117,7 @@ void Window_Smash(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_SetBoxBlocked(item, false);
 
-    item->collidable = 0;
+    item->collidable = false;
     item->mesh_bits = ~1;
     Item_Explode(item_num, 65278, 0);
     Sound_Effect(SFX_GLASS_BREAK, &item->pos, SPM_NORMAL);

--- a/src/tr2/game/objects/traps/falling_block.c
+++ b/src/tr2/game/objects/traps/falling_block.c
@@ -70,7 +70,7 @@ static void M_Control(const int16_t item_num)
 
     case TRAP_WORKING:
         if (item->goal_anim_state != TRAP_FINISHED) {
-            item->gravity = 1;
+            item->gravity = true;
         }
         break;
 
@@ -96,7 +96,7 @@ static void M_Control(const int16_t item_num)
         item->goal_anim_state = TRAP_FINISHED;
         item->pos.y = item->floor;
         item->fall_speed = 0;
-        item->gravity = 0;
+        item->gravity = false;
     }
 }
 

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -23,7 +23,7 @@ static void M_Control(const int16_t item_num)
 
     if (item->current_anim_state == TRAP_SET) {
         item->goal_anim_state = TRAP_ACTIVATE;
-        item->gravity = 1;
+        item->gravity = true;
     } else if (
         item->current_anim_state == TRAP_ACTIVATE && item->touch_bits != 0) {
         Lara_TakeDamage(FALLING_CEILING_DAMAGE, true);
@@ -47,7 +47,7 @@ static void M_Control(const int16_t item_num)
         item->pos.y = height;
         item->goal_anim_state = TRAP_WORKING;
         item->fall_speed = 0;
-        item->gravity = 0;
+        item->gravity = false;
     }
 }
 

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -35,7 +35,7 @@ static void M_Control(const int16_t item_num)
 
     case ICICLE_FALL:
         if (!item->gravity) {
-            item->gravity = 1;
+            item->gravity = true;
             item->fall_speed = 50;
         }
         if (item->touch_bits != 0) {
@@ -44,7 +44,7 @@ static void M_Control(const int16_t item_num)
         break;
 
     case ICICLE_LAND:
-        item->gravity = 0;
+        item->gravity = false;
         break;
     }
 
@@ -63,7 +63,7 @@ static void M_Control(const int16_t item_num)
 
     item->floor = height;
     if (item->current_anim_state == ICICLE_FALL && item->pos.y >= height) {
-        item->gravity = 0;
+        item->gravity = false;
         item->goal_anim_state = ICICLE_LAND;
         item->pos.y = height;
         item->fall_speed = 0;

--- a/src/tr2/game/objects/traps/propeller.c
+++ b/src/tr2/game/objects/traps/propeller.c
@@ -68,7 +68,7 @@ void Propeller_Control(const int16_t item_num)
     if (item->status == IS_DEACTIVATED) {
         Item_RemoveActive(item_num);
         if (item->object_id != O_POWER_SAW) {
-            item->collidable = 0;
+            item->collidable = false;
         }
     }
 }

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -51,7 +51,7 @@ static void M_Control(const int16_t item_num)
 
         if (item->pos.y < item->floor) {
             if (!item->gravity) {
-                item->gravity = 1;
+                item->gravity = true;
                 item->fall_speed = -10;
             }
         } else if (item->current_anim_state == TRAP_SET) {
@@ -72,7 +72,7 @@ static void M_Control(const int16_t item_num)
         Room_TestTriggers(item);
 
         if (item->pos.y >= item->floor - STEP_L) {
-            item->gravity = 0;
+            item->gravity = false;
             item->fall_speed = 0;
             item->pos.y = item->floor;
             if (item->object_id == O_ROLLING_BALL_2) {

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -762,6 +762,10 @@ void Output_DrawScreenFlatQuad(
 void Output_InsertShadow(
     int16_t radius, const BOUNDS_16 *bounds, const ITEM *item)
 {
+    if (!item->enable_shadow) {
+        return;
+    }
+
     const int32_t x1 = bounds->min.x;
     const int32_t x2 = bounds->max.x;
     const int32_t z1 = bounds->min.z;

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -252,7 +252,7 @@ static void M_ReadItems(void)
 
                 item->status = (item->flags & 6) >> 1;
                 if (item->flags & 8) {
-                    item->gravity = 1;
+                    item->gravity = true;
                 }
                 if (!(item->flags & 0x10)) {
                     item->collidable = 0;

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -293,6 +293,9 @@ static void M_ReadItems(void)
         case O_LIFT:
             M_Read(item->data, sizeof(LIFT_INFO));
             break;
+
+        default:
+            break;
         }
 
         if (obj->handle_save_func != nullptr) {
@@ -551,6 +554,9 @@ static void M_WriteItems(void)
 
         case O_LIFT:
             M_Write(item->data, sizeof(LIFT_INFO));
+            break;
+
+        default:
             break;
         }
     }

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -255,7 +255,7 @@ static void M_ReadItems(void)
                     item->gravity = true;
                 }
                 if (!(item->flags & 0x10)) {
-                    item->collidable = 0;
+                    item->collidable = false;
                 }
             }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reorganises the `ITEM` struct to convert bit flags into appropriate types, and to bring the two games into line. There is now only one `#if` for TR2's additional two properties.

A general test would be good, but one thing to check in particular is loading legacy saves with items in various different states.
