### PR TITLE
objects: reorganise OBJECT struct

### DIFF
--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -238,7 +238,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->hit_points = BEAR_HITPOINTS;
     obj->radius = BEAR_RADIUS;
     obj->smartness = BEAR_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -239,7 +239,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->radius = BEAR_RADIUS;
     obj->smartness = BEAR_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -241,7 +241,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 13)->rot.y = true;

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -242,7 +242,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 13)->rot.y = true;
 }

--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -240,7 +240,7 @@ void Bear_Setup(OBJECT *const obj)
     obj->smartness = BEAR_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -228,7 +228,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->smartness = WOLF_SMARTNESS;
     obj->lot_setup = g_LOT_Quadruped;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -230,7 +230,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 2)->rot.y = true;

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -227,7 +227,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->radius = WOLF_RADIUS;
     obj->smartness = WOLF_SMARTNESS;
     obj->lot_setup = g_LOT_Quadruped;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -229,7 +229,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Quadruped;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -231,7 +231,7 @@ void Wolf_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 2)->rot.y = true;
 }

--- a/src/libtrx/game/objects/general/door.c
+++ b/src/libtrx/game/objects/general/door.c
@@ -135,7 +135,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Door_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/libtrx/game/objects/general/door.c
+++ b/src/libtrx/game/objects/general/door.c
@@ -134,7 +134,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Door_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/libtrx/game/objects/general/drawbridge.c
+++ b/src/libtrx/game/objects/general/drawbridge.c
@@ -107,7 +107,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->floor_height_func = M_GetFloorHeight;
 }
 

--- a/src/libtrx/game/objects/general/drawbridge.c
+++ b/src/libtrx/game/objects/general/drawbridge.c
@@ -106,7 +106,7 @@ static void M_Setup(OBJECT *const obj)
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->floor_height_func = M_GetFloorHeight;
 }

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -94,7 +94,7 @@ static void M_Setup(OBJECT *const obj)
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/libtrx/game/objects/general/trapdoor.c
+++ b/src/libtrx/game/objects/general/trapdoor.c
@@ -93,7 +93,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -82,12 +82,13 @@ typedef struct OBJECT {
 
     bool enable_interpolation;
     bool loaded;
+    bool intelligent;
     union {
         uint16_t flags;
         // clang-format off
         struct {
             uint16_t pad_1:            1; // 0x01 1
-            uint16_t intelligent:      1; // 0x02 2
+            uint16_t pad_2:            1; // 0x02 2
             uint16_t save_position:    1; // 0x04 4
             uint16_t save_hitpoints:   1; // 0x08 8
             uint16_t save_flags:       1; // 0x10 16

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -85,6 +85,7 @@ typedef struct OBJECT {
     bool intelligent;
     bool save_position;
     bool save_hitpoints;
+    bool save_flags;
     union {
         uint16_t flags;
         // clang-format off
@@ -93,7 +94,7 @@ typedef struct OBJECT {
             uint16_t pad_2:            1; // 0x02 2
             uint16_t pad_3:            1; // 0x04 4
             uint16_t pad_4:            1; // 0x08 8
-            uint16_t save_flags:       1; // 0x10 16
+            uint16_t pad_5:            1; // 0x10 16
             uint16_t save_anim:        1; // 0x20 32
             uint16_t semi_transparent: 1; // 0x40 64
             uint16_t pad:              9;

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -86,6 +86,7 @@ typedef struct OBJECT {
     bool save_position;
     bool save_hitpoints;
     bool save_flags;
+    bool save_anim;
     union {
         uint16_t flags;
         // clang-format off
@@ -95,7 +96,7 @@ typedef struct OBJECT {
             uint16_t pad_3:            1; // 0x04 4
             uint16_t pad_4:            1; // 0x08 8
             uint16_t pad_5:            1; // 0x10 16
-            uint16_t save_anim:        1; // 0x20 32
+            uint16_t pad_6:            1; // 0x20 32
             uint16_t semi_transparent: 1; // 0x40 64
             uint16_t pad:              9;
         };

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -77,15 +77,16 @@ typedef struct OBJECT {
     int16_t radius;
     int16_t shadow_size;
     int16_t smartness;
-    bool enable_interpolation;
     XYZ_BOOL base_rot;
     LOT_SETUP lot_setup;
 
+    bool enable_interpolation;
+    bool loaded;
     union {
         uint16_t flags;
         // clang-format off
         struct {
-            uint16_t loaded:           1; // 0x01 1
+            uint16_t pad_1:            1; // 0x01 1
             uint16_t intelligent:      1; // 0x02 2
             uint16_t save_position:    1; // 0x04 4
             uint16_t save_hitpoints:   1; // 0x08 8

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -84,6 +84,7 @@ typedef struct OBJECT {
     bool loaded;
     bool intelligent;
     bool save_position;
+    bool save_hitpoints;
     union {
         uint16_t flags;
         // clang-format off
@@ -91,7 +92,7 @@ typedef struct OBJECT {
             uint16_t pad_1:            1; // 0x01 1
             uint16_t pad_2:            1; // 0x02 2
             uint16_t pad_3:            1; // 0x04 4
-            uint16_t save_hitpoints:   1; // 0x08 8
+            uint16_t pad_4:            1; // 0x08 8
             uint16_t save_flags:       1; // 0x10 16
             uint16_t save_anim:        1; // 0x20 32
             uint16_t semi_transparent: 1; // 0x40 64

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -87,21 +87,7 @@ typedef struct OBJECT {
     bool save_hitpoints;
     bool save_flags;
     bool save_anim;
-    union {
-        uint16_t flags;
-        // clang-format off
-        struct {
-            uint16_t pad_1:            1; // 0x01 1
-            uint16_t pad_2:            1; // 0x02 2
-            uint16_t pad_3:            1; // 0x04 4
-            uint16_t pad_4:            1; // 0x08 8
-            uint16_t pad_5:            1; // 0x10 16
-            uint16_t pad_6:            1; // 0x20 32
-            uint16_t semi_transparent: 1; // 0x40 64
-            uint16_t pad:              9;
-        };
-        // clang-format on
-    };
+    bool semi_transparent;
     UUID uuid;
 } OBJECT;
 

--- a/src/libtrx/include/libtrx/game/objects/types.h
+++ b/src/libtrx/include/libtrx/game/objects/types.h
@@ -83,13 +83,14 @@ typedef struct OBJECT {
     bool enable_interpolation;
     bool loaded;
     bool intelligent;
+    bool save_position;
     union {
         uint16_t flags;
         // clang-format off
         struct {
             uint16_t pad_1:            1; // 0x01 1
             uint16_t pad_2:            1; // 0x02 2
-            uint16_t save_position:    1; // 0x04 4
+            uint16_t pad_3:            1; // 0x04 4
             uint16_t save_hitpoints:   1; // 0x08 8
             uint16_t save_flags:       1; // 0x10 16
             uint16_t save_anim:        1; // 0x20 32

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -122,7 +122,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 13)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -118,7 +118,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = APE_RADIUS;
     obj->smartness = APE_SMARTNESS;
     obj->lot_setup = g_LOT_Jumper;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -121,7 +121,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 13)->rot.y = true;

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -120,7 +120,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Jumper;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/ape.c
+++ b/src/tr1/game/objects/creatures/ape.c
@@ -119,7 +119,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = APE_SMARTNESS;
     obj->lot_setup = g_LOT_Jumper;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -28,7 +28,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -26,7 +26,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = LARA_MAX_HITPOINTS;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -27,7 +27,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr1/game/objects/creatures/bacon_lara.c
+++ b/src/tr1/game/objects/creatures/bacon_lara.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->hit_points = LARA_MAX_HITPOINTS;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -48,7 +48,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -45,7 +45,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = BALDY_RADIUS;
     obj->smartness = BALDY_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -47,7 +47,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -46,7 +46,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = BALDY_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/baldy.c
+++ b/src/tr1/game/objects/creatures/baldy.c
@@ -44,7 +44,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = BALDY_HITPOINTS;
     obj->radius = BALDY_RADIUS;
     obj->smartness = BALDY_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -79,7 +79,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -77,7 +77,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = BAT_SMARTNESS;
     obj->lot_setup = g_LOT_Flyer;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -78,7 +78,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -76,7 +76,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = BAT_RADIUS;
     obj->smartness = BAT_SMARTNESS;
     obj->lot_setup = g_LOT_Flyer;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -80,7 +80,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -51,7 +51,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = CENTAUR_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -53,7 +53,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 10)->rot.x = true;

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -52,7 +52,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -50,7 +50,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = CENTAUR_RADIUS;
     obj->smartness = CENTAUR_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/centaur.c
+++ b/src/tr1/game/objects/creatures/centaur.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 10)->rot.x = true;
     Object_GetBone(obj, 10)->rot.y = true;

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -50,7 +50,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -49,7 +49,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -46,7 +46,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = COWBOY_HITPOINTS;
     obj->radius = COWBOY_RADIUS;
     obj->smartness = COWBOY_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -48,7 +48,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = COWBOY_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/cowboy.c
+++ b/src/tr1/game/objects/creatures/cowboy.c
@@ -47,7 +47,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = COWBOY_RADIUS;
     obj->smartness = COWBOY_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -77,7 +77,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 7)->rot.y = true;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -78,7 +78,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 7)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -75,7 +75,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->pivot_length = 600;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -74,7 +74,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 3;
     obj->pivot_length = 600;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/crocodile.c
+++ b/src/tr1/game/objects/creatures/crocodile.c
@@ -76,7 +76,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->pivot_length = 600;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
     obj->handle_save_func = M_HandleSave;

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -46,7 +46,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = LARSON_HITPOINTS;
     obj->radius = LARSON_RADIUS;
     obj->smartness = LARSON_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -49,7 +49,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -50,7 +50,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -47,7 +47,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = LARSON_RADIUS;
     obj->smartness = LARSON_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/larson.c
+++ b/src/tr1/game/objects/creatures/larson.c
@@ -48,7 +48,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = LARSON_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -58,7 +58,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 19)->rot.y = true;

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -55,7 +55,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->lot_setup = g_LOT_Quadruped;
     obj->pivot_length = 400;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -59,7 +59,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 19)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -56,7 +56,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->lot_setup = g_LOT_Quadruped;
     obj->pivot_length = 400;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/lion.c
+++ b/src/tr1/game/objects/creatures/lion.c
@@ -57,7 +57,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->pivot_length = 400;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -33,7 +33,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->hit_points = MUMMY_HITPOINTS;
     obj->save_flags = 1;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 2)->rot.y = true;

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -32,7 +32,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->hit_points = MUMMY_HITPOINTS;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
 

--- a/src/tr1/game/objects/creatures/mummy.c
+++ b/src/tr1/game/objects/creatures/mummy.c
@@ -34,7 +34,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = MUMMY_HITPOINTS;
     obj->save_flags = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 2)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -77,7 +77,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = FLYER_RADIUS;
     obj->smartness = FLYER_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -79,7 +79,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -78,7 +78,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = FLYER_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -80,7 +80,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 2)->rot.y = true;

--- a/src/tr1/game/objects/creatures/mutant.c
+++ b/src/tr1/game/objects/creatures/mutant.c
@@ -81,7 +81,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 2)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 2)->rot.x = true;

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = NATLA_HITPOINTS;
     obj->radius = NATLA_RADIUS;
     obj->smartness = NATLA_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 2)->rot.x = true;
     Object_GetBone(obj, 2)->rot.z = true;

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -55,7 +55,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = NATLA_RADIUS;
     obj->smartness = NATLA_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/natla.c
+++ b/src/tr1/game/objects/creatures/natla.c
@@ -56,7 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = NATLA_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = PIERRE_RADIUS;
     obj->smartness = PIERRE_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -56,7 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = PIERRE_HITPOINTS;
     obj->radius = PIERRE_RADIUS;
     obj->smartness = PIERRE_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/pierre.c
+++ b/src/tr1/game/objects/creatures/pierre.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = PIERRE_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/creatures/pod.c
+++ b/src/tr1/game/objects/creatures/pod.c
@@ -26,7 +26,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -56,7 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 21)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -53,7 +53,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = RAPTOR_RADIUS;
     obj->smartness = RAPTOR_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = RAPTOR_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -55,7 +55,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 21)->rot.y = true;

--- a/src/tr1/game/objects/creatures/raptor.c
+++ b/src/tr1/game/objects/creatures/raptor.c
@@ -52,7 +52,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 400;
     obj->radius = RAPTOR_RADIUS;
     obj->smartness = RAPTOR_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -71,7 +71,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->radius = RAT_RADIUS;
     obj->smartness = RAT_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -70,7 +70,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->pivot_length = 200;
     obj->radius = RAT_RADIUS;
     obj->smartness = RAT_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -74,7 +74,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 1)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -72,7 +72,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->smartness = RAT_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
     obj->handle_save_func = M_HandleSave;

--- a/src/tr1/game/objects/creatures/rat.c
+++ b/src/tr1/game/objects/creatures/rat.c
@@ -73,7 +73,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->handle_save_func = M_HandleSave;
     Object_GetBone(obj, 1)->rot.y = true;

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -56,7 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -53,7 +53,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = SKATE_KID_HITPOINTS;
     obj->radius = SKATE_KID_RADIUS;
     obj->smartness = SKATE_KID_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = SKATE_KID_RADIUS;
     obj->smartness = SKATE_KID_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -55,7 +55,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = SKATE_KID_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/skate_kid.c
+++ b/src/tr1/game/objects/creatures/skate_kid.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -22,7 +22,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->enable_interpolation = false;
 }

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -23,7 +23,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->enable_interpolation = false;
 }
 

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -63,7 +63,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = TORSO_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = TORSO_HITPOINTS;
     obj->radius = TORSO_RADIUS;
     obj->smartness = TORSO_SMARTNESS;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = TORSO_RADIUS;
     obj->smartness = TORSO_SMARTNESS;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -64,7 +64,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 1)->rot.y = true;

--- a/src/tr1/game/objects/creatures/torso.c
+++ b/src/tr1/game/objects/creatures/torso.c
@@ -65,7 +65,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 1)->rot.y = true;
 }

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = TREX_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     Object_GetBone(obj, 10)->rot.y = true;
     Object_GetBone(obj, 11)->rot.y = true;

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 
     Object_GetBone(obj, 10)->rot.y = true;

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Beast;
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 

--- a/src/tr1/game/objects/creatures/trex.c
+++ b/src/tr1/game/objects/creatures/trex.c
@@ -56,7 +56,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = TREX_RADIUS;
     obj->smartness = TREX_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;

--- a/src/tr1/game/objects/effects/body_part.c
+++ b/src/tr1/game/objects/effects/body_part.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->mesh_count = 0;
-    obj->loaded = 1;
+    obj->loaded = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr1/game/objects/general/boat.c
+++ b/src/tr1/game/objects/general/boat.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/boat.c
+++ b/src/tr1/game/objects/general/boat.c
@@ -13,7 +13,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
     obj->save_position = true;
 }

--- a/src/tr1/game/objects/general/boat.c
+++ b/src/tr1/game/objects/general/boat.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_position = true;
 }
 

--- a/src/tr1/game/objects/general/cabin.c
+++ b/src/tr1/game/objects/general/cabin.c
@@ -17,7 +17,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Object_Collision;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/cabin.c
+++ b/src/tr1/game/objects/general/cabin.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Object_Collision;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/general/cog.c
+++ b/src/tr1/game/objects/general/cog.c
@@ -12,7 +12,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/earthquake.c
+++ b/src/tr1/game/objects/general/earthquake.c
@@ -11,7 +11,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/keyhole.c
+++ b/src/tr1/game/objects/general/keyhole.c
@@ -70,7 +70,7 @@ static bool M_IsUsable(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
     obj->is_usable_func = M_IsUsable;
 }

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
     obj->save_position = true;
 }

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_position = true;
 }
 

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -133,7 +133,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->draw_func = Object_DrawPickupItem;
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;

--- a/src/tr1/game/objects/general/puzzle_hole.c
+++ b/src/tr1/game/objects/general/puzzle_hole.c
@@ -54,7 +54,7 @@ static bool M_IsUsable(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
     obj->handle_save_func = M_HandleSave;
     obj->is_usable_func = M_IsUsable;
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
 
 static void M_SetupDone(OBJECT *const obj)
 {
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr1/game/objects/general/save_crystal.c
+++ b/src/tr1/game/objects/general/save_crystal.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
         obj->handle_save_func = M_HandleSave;
         obj->control_func = M_Control;
         obj->collision_func = M_Collision;
-        obj->save_flags = 1;
+        obj->save_flags = true;
     }
     obj->bounds_func = M_Bounds;
     Object_SetReflective(O_SAVEGAME_ITEM, true);

--- a/src/tr1/game/objects/general/scion1.c
+++ b/src/tr1/game/objects/general/scion1.c
@@ -45,7 +45,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->draw_func = Object_DrawPickupItem;
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
 }
 

--- a/src/tr1/game/objects/general/scion3.c
+++ b/src/tr1/game/objects/general/scion3.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->hit_points = 5;
     obj->save_flags = 1;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/scion3.c
+++ b/src/tr1/game/objects/general/scion3.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->hit_points = 5;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_hitpoints = true;
 }
 

--- a/src/tr1/game/objects/general/scion4.c
+++ b/src/tr1/game/objects/general/scion4.c
@@ -35,7 +35,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
 }
 

--- a/src/tr1/game/objects/general/scion_holder.c
+++ b/src/tr1/game/objects/general/scion_holder.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/general/scion_holder.c
+++ b/src/tr1/game/objects/general/scion_holder.c
@@ -8,7 +8,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -72,7 +72,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->bounds_func = M_Bounds;
 }
@@ -81,7 +81,7 @@ static void M_SetupUW(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = M_CollisionUW;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->bounds_func = M_BoundsUW;
 }

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -73,7 +73,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_Bounds;
 }
 
@@ -82,7 +82,7 @@ static void M_SetupUW(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_CollisionUW;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->bounds_func = M_BoundsUW;
 }
 

--- a/src/tr1/game/objects/general/waterfall.c
+++ b/src/tr1/game/objects/general/waterfall.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -15,7 +15,7 @@ static void M_SetupLara(void)
     obj->draw_func = Object_DrawDummyItem;
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_anim = 1;
     obj->save_flags = 1;
@@ -54,7 +54,7 @@ void Object_SetupAllObjects(void)
     for (int i = O_FIRST; i < O_NUMBER_OF; i++) {
         OBJECT *const obj = Object_Get(i);
         obj->intelligent = false;
-        obj->save_position = 0;
+        obj->save_position = false;
         obj->save_hitpoints = 0;
         obj->save_flags = 0;
         obj->save_anim = 0;

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -16,7 +16,7 @@ static void M_SetupLara(void)
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }
@@ -55,7 +55,7 @@ void Object_SetupAllObjects(void)
         OBJECT *const obj = Object_Get(i);
         obj->intelligent = false;
         obj->save_position = false;
-        obj->save_hitpoints = 0;
+        obj->save_hitpoints = false;
         obj->save_flags = 0;
         obj->save_anim = 0;
         obj->initialise_func = nullptr;

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -53,7 +53,7 @@ void Object_SetupAllObjects(void)
 {
     for (int i = O_FIRST; i < O_NUMBER_OF; i++) {
         OBJECT *const obj = Object_Get(i);
-        obj->intelligent = 0;
+        obj->intelligent = false;
         obj->save_position = 0;
         obj->save_hitpoints = 0;
         obj->save_flags = 0;

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -17,7 +17,7 @@ static void M_SetupLara(void)
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 
@@ -57,7 +57,7 @@ void Object_SetupAllObjects(void)
         obj->save_position = false;
         obj->save_hitpoints = false;
         obj->save_flags = false;
-        obj->save_anim = 0;
+        obj->save_anim = false;
         obj->initialise_func = nullptr;
         obj->collision_func = nullptr;
         obj->control_func = nullptr;

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -18,7 +18,7 @@ static void M_SetupLara(void)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_SetupLaraExtra(void)
@@ -56,7 +56,7 @@ void Object_SetupAllObjects(void)
         obj->intelligent = false;
         obj->save_position = false;
         obj->save_hitpoints = false;
-        obj->save_flags = 0;
+        obj->save_flags = false;
         obj->save_anim = 0;
         obj->initialise_func = nullptr;
         obj->collision_func = nullptr;

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -22,7 +22,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->shadow_size = UNIT_SHADOW;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -23,7 +23,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/traps/damocles_sword.c
+++ b/src/tr1/game/objects/traps/damocles_sword.c
@@ -21,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->shadow_size = UNIT_SHADOW;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/dart.c
+++ b/src/tr1/game/objects/traps/dart.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->control_func = M_Control;
     obj->shadow_size = UNIT_SHADOW / 2;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/dart_emitter.c
+++ b/src/tr1/game/objects/traps/dart_emitter.c
@@ -12,7 +12,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/ember_emitter.c
+++ b/src/tr1/game/objects/traps/ember_emitter.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/falling_block.c
+++ b/src/tr1/game/objects/traps/falling_block.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_CollisionTrap;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -10,7 +10,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_CollisionTrap;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -11,7 +11,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_CollisionTrap;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/flame_emitter.c
+++ b/src/tr1/game/objects/traps/flame_emitter.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/lightning_emitter.c
+++ b/src/tr1/game/objects/traps/lightning_emitter.c
@@ -41,7 +41,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -274,7 +274,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
     obj->base_rot.y = true;
     obj->bounds_func = M_Bounds;

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -273,7 +273,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
     obj->base_rot.y = true;

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -275,7 +275,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->base_rot.y = true;
     obj->bounds_func = M_Bounds;
 }

--- a/src/tr1/game/objects/traps/pendulum.c
+++ b/src/tr1/game/objects/traps/pendulum.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_CollisionTrap;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/pendulum.c
+++ b/src/tr1/game/objects/traps/pendulum.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_CollisionTrap;
     obj->shadow_size = UNIT_SHADOW / 2;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -23,7 +23,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -24,7 +24,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -23,7 +23,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_flip_func = M_HandleFlip;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_anim = 1;
     obj->save_flags = 1;
 }

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->save_position = true;
     obj->save_anim = 1;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr1/game/objects/traps/sliding_pillar.c
+++ b/src/tr1/game/objects/traps/sliding_pillar.c
@@ -24,7 +24,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->save_position = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/teeth_trap.c
+++ b/src/tr1/game/objects/traps/teeth_trap.c
@@ -34,7 +34,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_CollisionTrap;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr1/game/objects/traps/teeth_trap.c
+++ b/src/tr1/game/objects/traps/teeth_trap.c
@@ -33,7 +33,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_CollisionTrap;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr1/game/objects/traps/thors_hammer.c
+++ b/src/tr1/game/objects/traps/thors_hammer.c
@@ -27,7 +27,7 @@ static void M_SetupHandle(OBJECT *const obj)
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = M_CollisionHandle;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_InitialiseHandle(const int16_t item_num)
@@ -164,7 +164,7 @@ static void M_SetupHead(OBJECT *const obj)
     obj->collision_func = M_CollisionHead;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_CollisionHead(

--- a/src/tr1/game/objects/traps/thors_hammer.c
+++ b/src/tr1/game/objects/traps/thors_hammer.c
@@ -26,7 +26,7 @@ static void M_SetupHandle(OBJECT *const obj)
     obj->control_func = M_ControlHandle;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = M_CollisionHandle;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 
@@ -163,7 +163,7 @@ static void M_SetupHead(OBJECT *const obj)
 {
     obj->collision_func = M_CollisionHead;
     obj->draw_func = Object_DrawUnclippedItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/inventory_ring/draw.c
+++ b/src/tr2/game/inventory_ring/draw.c
@@ -80,7 +80,7 @@ static void M_DrawItem(
     Matrix_RotY(inv_item->y_rot);
     Matrix_RotX(inv_item->x_rot);
     const OBJECT *const obj = Object_Get(inv_item->object_id);
-    if ((obj->flags & 1) == 0) {
+    if (!obj->loaded) {
         return;
     }
 

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -67,7 +67,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -64,7 +64,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -66,7 +66,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -65,7 +65,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/bandit_1.c
+++ b/src/tr2/game/objects/creatures/bandit_1.c
@@ -68,7 +68,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -67,7 +67,7 @@ static void M_Setup2A(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 
@@ -96,7 +96,7 @@ static void M_Setup2B(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -65,7 +65,7 @@ static void M_Setup2A(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
@@ -94,7 +94,7 @@ static void M_Setup2B(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -68,7 +68,7 @@ static void M_Setup2A(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;
@@ -97,7 +97,7 @@ static void M_Setup2B(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -69,7 +69,7 @@ static void M_Setup2A(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;
@@ -98,7 +98,7 @@ static void M_Setup2B(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -66,7 +66,7 @@ static void M_Setup2A(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -95,7 +95,7 @@ static void M_Setup2B(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 200;
     obj->lot_setup = g_LOT_Flyer;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/barracuda.c
+++ b/src/tr2/game/objects/creatures/barracuda.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/bartoli.c
+++ b/src/tr2/game/objects/creatures/bartoli.c
@@ -71,7 +71,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
 
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/bartoli.c
+++ b/src/tr2/game/objects/creatures/bartoli.c
@@ -72,7 +72,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
 
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -52,7 +52,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->hit_points = BIG_EEL_HITPOINTS;
 
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/big_eel.c
+++ b/src/tr2/game/objects/creatures/big_eel.c
@@ -53,7 +53,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = BIG_EEL_HITPOINTS;
 
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -129,7 +129,7 @@ void BigSpider_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -127,7 +127,7 @@ void BigSpider_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -128,7 +128,7 @@ void BigSpider_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -130,7 +130,7 @@ void BigSpider_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 REGISTER_OBJECT(O_BIG_SPIDER, BigSpider_Setup)

--- a/src/tr2/game/objects/creatures/big_spider.c
+++ b/src/tr2/game/objects/creatures/big_spider.c
@@ -126,7 +126,7 @@ void BigSpider_Setup(OBJECT *const obj)
     obj->radius = BIG_SPIDER_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -57,7 +57,7 @@ static void M_SetupEagle(OBJECT *const obj)
     obj->pivot_length = 0;
     obj->lot_setup = g_LOT_Flyer;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
@@ -80,7 +80,7 @@ static void M_SetupCrow(OBJECT *const obj)
     obj->pivot_length = 0;
     obj->lot_setup = g_LOT_Flyer;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -60,7 +60,7 @@ static void M_SetupEagle(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 
@@ -83,7 +83,7 @@ static void M_SetupCrow(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -59,7 +59,7 @@ static void M_SetupEagle(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
@@ -82,7 +82,7 @@ static void M_SetupCrow(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -61,7 +61,7 @@ static void M_SetupEagle(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_SetupCrow(OBJECT *const obj)
@@ -84,7 +84,7 @@ static void M_SetupCrow(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/bird.c
+++ b/src/tr2/game/objects/creatures/bird.c
@@ -58,7 +58,7 @@ static void M_SetupEagle(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -81,7 +81,7 @@ static void M_SetupCrow(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -71,7 +71,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -72,7 +72,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 14)->rot.y = true;

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -69,7 +69,7 @@ static void M_Setup(OBJECT *const obj)
         obj->shadow_size = UNIT_SHADOW / 2;
     }
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -70,7 +70,7 @@ static void M_Setup(OBJECT *const obj)
     }
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/bird_guardian.c
+++ b/src/tr2/game/objects/creatures/bird_guardian.c
@@ -73,7 +73,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 14)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -66,7 +66,7 @@ static void M_Setup1(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
@@ -95,7 +95,7 @@ static void M_Setup1A(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
@@ -124,7 +124,7 @@ static void M_Setup1B(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -67,7 +67,7 @@ static void M_Setup1(OBJECT *const obj)
     obj->pivot_length = 50;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -96,7 +96,7 @@ static void M_Setup1A(OBJECT *const obj)
     obj->pivot_length = 50;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -125,7 +125,7 @@ static void M_Setup1B(OBJECT *const obj)
     obj->pivot_length = 50;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -69,7 +69,7 @@ static void M_Setup1(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 0)->rot.y = true;
@@ -98,7 +98,7 @@ static void M_Setup1A(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 0)->rot.y = true;
@@ -127,7 +127,7 @@ static void M_Setup1B(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -68,7 +68,7 @@ static void M_Setup1(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 
@@ -97,7 +97,7 @@ static void M_Setup1A(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 
@@ -126,7 +126,7 @@ static void M_Setup1B(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/cultist_1.c
+++ b/src/tr2/game/objects/creatures/cultist_1.c
@@ -70,7 +70,7 @@ static void M_Setup1(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 }
@@ -99,7 +99,7 @@ static void M_Setup1A(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 }
@@ -128,7 +128,7 @@ static void M_Setup1B(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -63,7 +63,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 50;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -65,7 +65,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -64,7 +64,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/cultist_2.c
+++ b/src/tr2/game/objects/creatures/cultist_2.c
@@ -66,7 +66,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 8)->rot.y = true;

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -71,7 +71,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -67,7 +67,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -68,7 +68,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -70,7 +70,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/cultist_3.c
+++ b/src/tr2/game/objects/creatures/cultist_3.c
@@ -69,7 +69,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -111,7 +111,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -112,7 +112,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -113,7 +113,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 10)->rot.y = true;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -114,7 +114,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 10)->rot.y = true;
     Object_GetBone(obj, 14)->rot.z = true;

--- a/src/tr2/game/objects/creatures/diver.c
+++ b/src/tr2/game/objects/creatures/diver.c
@@ -110,7 +110,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 50;
     obj->lot_setup = g_LOT_Flyer;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -73,7 +73,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -75,7 +75,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 19)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -74,7 +74,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 19)->rot.y = true;

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -72,7 +72,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 300;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/dog.c
+++ b/src/tr2/game/objects/creatures/dog.c
@@ -71,7 +71,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 300;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -184,7 +184,7 @@ static void M_SetupFront(OBJECT *const obj)
     obj->radius = DRAGON_RADIUS;
     obj->pivot_length = 300;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -185,7 +185,7 @@ static void M_SetupFront(OBJECT *const obj)
     obj->pivot_length = 300;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -204,7 +204,7 @@ static void M_SetupBack(OBJECT *const obj)
 
     obj->radius = DRAGON_RADIUS;
 
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -186,7 +186,7 @@ static void M_SetupFront(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -188,7 +188,7 @@ static void M_SetupFront(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 10)->rot.z = true;
 }
@@ -206,7 +206,7 @@ static void M_SetupBack(OBJECT *const obj)
 
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_HandleSaveFront(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -187,7 +187,7 @@ static void M_SetupFront(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 10)->rot.z = true;
@@ -205,7 +205,7 @@ static void M_SetupBack(OBJECT *const obj)
     obj->radius = DRAGON_RADIUS;
 
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -53,7 +53,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = EEL_HITPOINTS;
 
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -54,7 +54,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/eel.c
+++ b/src/tr2/game/objects/creatures/eel.c
@@ -52,7 +52,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->hit_points = EEL_HITPOINTS;
 
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->lot_setup = g_LOT_Flyer;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -39,7 +39,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -41,7 +41,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -40,7 +40,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/jelly.c
+++ b/src/tr2/game/objects/creatures/jelly.c
@@ -38,7 +38,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -66,7 +66,7 @@ static void M_SetupBase(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -64,7 +64,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->radius = MONK_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -68,7 +68,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -67,7 +67,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/monk.c
+++ b/src/tr2/game/objects/creatures/monk.c
@@ -65,7 +65,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 50;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 3)->rot.y = true;

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -57,7 +57,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/mouse.c
+++ b/src/tr2/game/objects/creatures/mouse.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 3)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -68,7 +68,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -69,7 +69,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 9)->rot.y = true;

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -70,7 +70,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 9)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -66,7 +66,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Flyer;
     obj->lot_setup.block_mask = BOX_BLOCKABLE;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/shark.c
+++ b/src/tr2/game/objects/creatures/shark.c
@@ -67,7 +67,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup.block_mask = BOX_BLOCKABLE;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -181,7 +181,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->hit_points = 1;
 
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -182,7 +182,7 @@ static void M_Setup(OBJECT *const obj)
     obj->hit_points = 1;
 
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -183,7 +183,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -166,7 +166,7 @@ void Spider_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->lot_setup = g_LOT_Jumper;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -170,7 +170,7 @@ void Spider_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 REGISTER_OBJECT(O_SPIDER, Spider_Setup)

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -168,7 +168,7 @@ void Spider_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -169,7 +169,7 @@ void Spider_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/spider.c
+++ b/src/tr2/game/objects/creatures/spider.c
@@ -167,7 +167,7 @@ void Spider_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Jumper;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -66,7 +66,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 21)->rot.y = true;
 }

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 200;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -63,7 +63,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 200;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -64,7 +64,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/tiger.c
+++ b/src/tr2/game/objects/creatures/tiger.c
@@ -65,7 +65,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 21)->rot.y = true;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Beast;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 10)->rot.y = true;
     Object_GetBone(obj, 11)->rot.y = true;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 10)->rot.y = true;

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -58,7 +58,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 1800;
     obj->lot_setup = g_LOT_Beast;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -40,7 +40,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -38,7 +38,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 4;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -39,7 +39,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = WINSTON_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 4;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -60,7 +60,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -59,7 +59,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -62,7 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 4)->rot.y = true;

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -61,7 +61,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/worker_1.c
+++ b/src/tr2/game/objects/creatures/worker_1.c
@@ -63,7 +63,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 4)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -86,7 +86,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 4)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;
@@ -110,7 +110,7 @@ static void M_Setup5(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 4)->rot.y = true;
     Object_GetBone(obj, 13)->rot.y = true;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -85,7 +85,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 4)->rot.y = true;
@@ -109,7 +109,7 @@ static void M_Setup5(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 4)->rot.y = true;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -82,7 +82,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
@@ -106,7 +106,7 @@ static void M_Setup5(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -83,7 +83,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -107,7 +107,7 @@ static void M_Setup5(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/worker_2.c
+++ b/src/tr2/game/objects/creatures/worker_2.c
@@ -84,7 +84,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 
@@ -108,7 +108,7 @@ static void M_Setup5(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -80,7 +80,7 @@ static void M_SetupBase(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -82,7 +82,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 4)->rot.y = true;

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -79,7 +79,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->lot_setup = g_LOT_Climber;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -78,7 +78,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->pivot_length = 0;
     obj->lot_setup = g_LOT_Climber;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/worker_3.c
+++ b/src/tr2/game/objects/creatures/worker_3.c
@@ -81,7 +81,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 0)->rot.y = true;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -96,7 +96,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -98,7 +98,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 16)->rot.y = true;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -95,7 +95,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -94,7 +94,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/xian_knight.c
+++ b/src/tr2/game/objects/creatures/xian_knight.c
@@ -97,7 +97,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -124,7 +124,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 12)->rot.y = true;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -120,7 +120,7 @@ static void M_Setup(OBJECT *const obj)
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 0;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -123,7 +123,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -121,7 +121,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/xian_spearman.c
+++ b/src/tr2/game/objects/creatures/xian_spearman.c
@@ -122,7 +122,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -86,7 +86,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 100;
     obj->lot_setup = g_LOT_Climber;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -90,7 +90,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 
     Object_GetBone(obj, 6)->rot.y = true;
     Object_GetBone(obj, 14)->rot.y = true;

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -88,7 +88,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -87,7 +87,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Climber;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/creatures/yeti.c
+++ b/src/tr2/game/objects/creatures/yeti.c
@@ -89,7 +89,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 
     Object_GetBone(obj, 6)->rot.y = true;

--- a/src/tr2/game/objects/effects/blood.c
+++ b/src/tr2/game/objects/effects/blood.c
@@ -10,7 +10,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/body_part.c
+++ b/src/tr2/game/objects/effects/body_part.c
@@ -13,7 +13,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->loaded = 1;
+    obj->loaded = true;
     obj->mesh_count = 0;
 }
 

--- a/src/tr2/game/objects/effects/dart_effect.c
+++ b/src/tr2/game/objects/effects/dart_effect.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawSpriteItem;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/ember.c
+++ b/src/tr2/game/objects/effects/ember.c
@@ -11,7 +11,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/explosion.c
+++ b/src/tr2/game/objects/effects/explosion.c
@@ -11,7 +11,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/flame.c
+++ b/src/tr2/game/objects/effects/flame.c
@@ -14,7 +14,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 static void M_Control(const int16_t effect_num)
 {

--- a/src/tr2/game/objects/effects/hot_liquid.c
+++ b/src/tr2/game/objects/effects/hot_liquid.c
@@ -9,7 +9,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/missile_flame.c
+++ b/src/tr2/game/objects/effects/missile_flame.c
@@ -6,7 +6,7 @@ static void M_Setup(OBJECT *obj);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = Missile_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 REGISTER_OBJECT(O_MISSILE_FLAME, M_Setup)

--- a/src/tr2/game/objects/effects/missile_harpoon.c
+++ b/src/tr2/game/objects/effects/missile_harpoon.c
@@ -6,7 +6,7 @@ static void M_Setup(OBJECT *obj);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = Missile_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 REGISTER_OBJECT(O_MISSILE_HARPOON, M_Setup)

--- a/src/tr2/game/objects/effects/missile_knife.c
+++ b/src/tr2/game/objects/effects/missile_knife.c
@@ -6,7 +6,7 @@ static void M_Setup(OBJECT *obj);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = Missile_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 REGISTER_OBJECT(O_MISSILE_KNIFE, M_Setup)

--- a/src/tr2/game/objects/effects/splash.c
+++ b/src/tr2/game/objects/effects/splash.c
@@ -10,7 +10,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/water_sprite.c
+++ b/src/tr2/game/objects/effects/water_sprite.c
@@ -9,7 +9,7 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = 1;
+    obj->semi_transparent = true;
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/general/alarm_sound.c
+++ b/src/tr2/game/objects/general/alarm_sound.c
@@ -7,7 +7,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/bell.c
+++ b/src/tr2/game/objects/general/bell.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/bell.c
+++ b/src/tr2/game/objects/general/bell.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/big_bowl.c
+++ b/src/tr2/game/objects/general/big_bowl.c
@@ -34,7 +34,7 @@ static void M_CreateHotLiquid(const ITEM *const bowl_item)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/big_bowl.c
+++ b/src/tr2/game/objects/general/big_bowl.c
@@ -35,7 +35,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/clock_chimes.c
+++ b/src/tr2/game/objects/general/clock_chimes.c
@@ -21,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -110,7 +110,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->initialise_func = M_Initialise;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 
     m_BossTimer = 0;
     m_EnemyCount = 0;

--- a/src/tr2/game/objects/general/copter.c
+++ b/src/tr2/game/objects/general/copter.c
@@ -17,7 +17,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/copter.c
+++ b/src/tr2/game/objects/general/copter.c
@@ -18,7 +18,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -76,7 +76,7 @@ static void M_Setup2(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->bounds_func = Pickup_Bounds;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -75,7 +75,7 @@ static void M_Setup2(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
     obj->bounds_func = Pickup_Bounds;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/earthquake.c
+++ b/src/tr2/game/objects/general/earthquake.c
@@ -22,7 +22,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/final_cutscene.c
+++ b/src/tr2/game/objects/general/final_cutscene.c
@@ -8,7 +8,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/final_cutscene.c
+++ b/src/tr2/game/objects/general/final_cutscene.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/flare_item.c
+++ b/src/tr2/game/objects/general/flare_item.c
@@ -10,7 +10,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = Flare_Control;
     obj->draw_func = Flare_DrawInAir;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 REGISTER_OBJECT(O_FLARE_ITEM, M_Setup)

--- a/src/tr2/game/objects/general/flare_item.c
+++ b/src/tr2/game/objects/general/flare_item.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
     obj->bounds_func = Pickup_Bounds;
     obj->control_func = Flare_Control;
     obj->draw_func = Flare_DrawInAir;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -17,7 +17,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = General_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 void General_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = General_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/gong_bonger.c
+++ b/src/tr2/game/objects/general/gong_bonger.c
@@ -21,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/gong_bonger.c
+++ b/src/tr2/game/objects/general/gong_bonger.c
@@ -20,7 +20,7 @@ static void M_ActivateHeavyTriggers(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -35,7 +35,7 @@ static void M_Explode(int16_t grenade_item_num, const XYZ_32 pos)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -12,7 +12,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/keyhole.c
+++ b/src/tr2/game/objects/general/keyhole.c
@@ -69,7 +69,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Collision(

--- a/src/tr2/game/objects/general/lara_alarm.c
+++ b/src/tr2/game/objects/general/lara_alarm.c
@@ -8,7 +8,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -154,7 +154,7 @@ static void M_Setup(OBJECT *const obj)
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -153,7 +153,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/lift.c
+++ b/src/tr2/game/objects/general/lift.c
@@ -155,7 +155,7 @@ static void M_Setup(OBJECT *const obj)
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/general/mini_copter.c
+++ b/src/tr2/game/objects/general/mini_copter.c
@@ -11,7 +11,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/mini_copter.c
+++ b/src/tr2/game/objects/general/mini_copter.c
@@ -10,7 +10,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -203,7 +203,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = M_Draw;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->base_rot.y = true;
 }
 

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -202,7 +202,7 @@ static void M_Setup(OBJECT *const obj)
     obj->bounds_func = M_Bounds;
     obj->draw_func = M_Draw;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
     obj->base_rot.y = true;
 }

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -201,7 +201,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
     obj->draw_func = M_Draw;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
     obj->base_rot.y = true;

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -215,7 +215,7 @@ static void M_Setup(OBJECT *const obj)
     obj->bounds_func = Pickup_Bounds;
     obj->draw_func = M_Draw;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -214,7 +214,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Pickup_Collision;
     obj->bounds_func = Pickup_Bounds;
     obj->draw_func = M_Draw;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/general/puzzle_hole.c
+++ b/src/tr2/game/objects/general/puzzle_hole.c
@@ -82,12 +82,12 @@ static void M_SetupEmpty(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->handle_save_func = M_HandleSave;
     obj->bounds_func = M_Bounds;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_SetupDone(OBJECT *const obj)
 {
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)

--- a/src/tr2/game/objects/general/sphere_of_doom.c
+++ b/src/tr2/game/objects/general/sphere_of_doom.c
@@ -20,7 +20,7 @@ static void M_SetupBase(OBJECT *const obj, const bool transparent)
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->semi_transparent = transparent;
 }

--- a/src/tr2/game/objects/general/sphere_of_doom.c
+++ b/src/tr2/game/objects/general/sphere_of_doom.c
@@ -21,7 +21,7 @@ static void M_SetupBase(OBJECT *const obj, const bool transparent)
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->semi_transparent = transparent;
 }
 

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -133,7 +133,7 @@ static void M_SetupBase(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -132,7 +132,7 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
 static void M_SetupBase(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/waterfall.c
+++ b/src/tr2/game/objects/general/waterfall.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -22,7 +22,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -23,7 +23,7 @@ static void M_SetupBase(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Setup1(OBJECT *const obj)

--- a/src/tr2/game/objects/general/zipline.c
+++ b/src/tr2/game/objects/general/zipline.c
@@ -49,7 +49,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/general/zipline.c
+++ b/src/tr2/game/objects/general/zipline.c
@@ -50,7 +50,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/general/zipline.c
+++ b/src/tr2/game/objects/general/zipline.c
@@ -51,7 +51,7 @@ static void M_Setup(OBJECT *const obj)
     obj->bounds_func = M_Bounds;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -20,7 +20,7 @@ static void M_SetupLara(void)
 
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 
@@ -49,7 +49,7 @@ void Object_SetupAllObjects(void)
 
         obj->save_position = false;
         obj->save_hitpoints = false;
-        obj->save_flags = 0;
+        obj->save_flags = false;
         obj->save_anim = 0;
         obj->intelligent = false;
 

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -21,7 +21,7 @@ static void M_SetupLara(void)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_SetupLaraExtra(void)
@@ -50,7 +50,7 @@ void Object_SetupAllObjects(void)
         obj->save_position = false;
         obj->save_hitpoints = false;
         obj->save_flags = false;
-        obj->save_anim = 0;
+        obj->save_anim = false;
         obj->intelligent = false;
 
         if (obj->setup_func != nullptr) {

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -19,7 +19,7 @@ static void M_SetupLara(void)
     obj->draw_func = Object_DrawDummyItem;
 
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }
@@ -48,7 +48,7 @@ void Object_SetupAllObjects(void)
         obj->lot_setup = g_LOT_Default;
 
         obj->save_position = false;
-        obj->save_hitpoints = 0;
+        obj->save_hitpoints = false;
         obj->save_flags = 0;
         obj->save_anim = 0;
         obj->intelligent = false;

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -18,7 +18,7 @@ static void M_SetupLara(void)
     obj->hit_points = LARA_MAX_HITPOINTS;
     obj->draw_func = Object_DrawDummyItem;
 
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;
@@ -47,7 +47,7 @@ void Object_SetupAllObjects(void)
         obj->enable_interpolation = true;
         obj->lot_setup = g_LOT_Default;
 
-        obj->save_position = 0;
+        obj->save_position = false;
         obj->save_hitpoints = 0;
         obj->save_flags = 0;
         obj->save_anim = 0;

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -51,7 +51,7 @@ void Object_SetupAllObjects(void)
         obj->save_hitpoints = 0;
         obj->save_flags = 0;
         obj->save_anim = 0;
-        obj->intelligent = 0;
+        obj->intelligent = false;
 
         if (obj->setup_func != nullptr) {
             obj->setup_func(obj);

--- a/src/tr2/game/objects/traps/blade.c
+++ b/src/tr2/game/objects/traps/blade.c
@@ -35,7 +35,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/traps/blade.c
+++ b/src/tr2/game/objects/traps/blade.c
@@ -34,7 +34,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/dart_emitter.c
+++ b/src/tr2/game/objects/traps/dart_emitter.c
@@ -57,7 +57,7 @@ static void M_CreateDart(ITEM *const item)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/dying_monk.c
+++ b/src/tr2/game/objects/traps/dying_monk.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/traps/ember_emitter.c
+++ b/src/tr2/game/objects/traps/ember_emitter.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/falling_block.c
+++ b/src/tr2/game/objects/traps/falling_block.c
@@ -44,7 +44,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/falling_block.c
+++ b/src/tr2/game/objects/traps/falling_block.c
@@ -46,7 +46,7 @@ static void M_Setup(OBJECT *const obj)
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/falling_block.c
+++ b/src/tr2/game/objects/traps/falling_block.c
@@ -45,7 +45,7 @@ static void M_Setup(OBJECT *const obj)
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/falling_ceiling.c
+++ b/src/tr2/game/objects/traps/falling_ceiling.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/flame_emitter.c
+++ b/src/tr2/game/objects/traps/flame_emitter.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawDummyItem;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -12,7 +12,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
     obj->save_position = true;
 }
 

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -13,7 +13,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_flags = 1;
     obj->save_anim = 1;
-    obj->save_position = 1;
+    obj->save_position = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -11,7 +11,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
     obj->save_position = true;
 }

--- a/src/tr2/game/objects/traps/hook.c
+++ b/src/tr2/game/objects/traps/hook.c
@@ -14,7 +14,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/hook.c
+++ b/src/tr2/game/objects/traps/hook.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -21,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -19,7 +19,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/icicle.c
+++ b/src/tr2/game/objects/traps/icicle.c
@@ -20,7 +20,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/killer_statue.c
+++ b/src/tr2/game/objects/traps/killer_statue.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/traps/killer_statue.c
+++ b/src/tr2/game/objects/traps/killer_statue.c
@@ -36,7 +36,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -89,7 +89,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->enable_interpolation = false;
 
     m_DetonateAllMines = false;

--- a/src/tr2/game/objects/traps/pendulum.c
+++ b/src/tr2/game/objects/traps/pendulum.c
@@ -16,7 +16,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->shadow_size = 128;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/pendulum.c
+++ b/src/tr2/game/objects/traps/pendulum.c
@@ -15,7 +15,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->shadow_size = 128;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/power_saw.c
+++ b/src/tr2/game/objects/traps/power_saw.c
@@ -7,7 +7,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = Propeller_Control;
     obj->collision_func = Object_Collision;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/power_saw.c
+++ b/src/tr2/game/objects/traps/power_saw.c
@@ -8,7 +8,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = Propeller_Control;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 REGISTER_OBJECT(O_POWER_SAW, M_Setup)

--- a/src/tr2/game/objects/traps/propeller.c
+++ b/src/tr2/game/objects/traps/propeller.c
@@ -22,7 +22,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = Propeller_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 void Propeller_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/propeller.c
+++ b/src/tr2/game/objects/traps/propeller.c
@@ -21,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = Propeller_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -26,7 +26,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -24,7 +24,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/spike_ceiling.c
+++ b/src/tr2/game/objects/traps/spike_ceiling.c
@@ -46,7 +46,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/traps/spike_ceiling.c
+++ b/src/tr2/game/objects/traps/spike_ceiling.c
@@ -47,7 +47,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/spike_wall.c
+++ b/src/tr2/game/objects/traps/spike_wall.c
@@ -85,7 +85,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
 }
 

--- a/src/tr2/game/objects/traps/spike_wall.c
+++ b/src/tr2/game/objects/traps/spike_wall.c
@@ -86,7 +86,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/spinning_blade.c
+++ b/src/tr2/game/objects/traps/spinning_blade.c
@@ -35,7 +35,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/traps/spinning_blade.c
+++ b/src/tr2/game/objects/traps/spinning_blade.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/traps/spinning_blade.c
+++ b/src/tr2/game/objects/traps/spinning_blade.c
@@ -36,7 +36,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -17,7 +17,7 @@ static void M_Control(int16_t item_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -18,7 +18,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/teeth_trap.c
+++ b/src/tr2/game/objects/traps/teeth_trap.c
@@ -38,7 +38,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/tr2/game/objects/traps/teeth_trap.c
+++ b/src/tr2/game/objects/traps/teeth_trap.c
@@ -37,7 +37,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -558,7 +558,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -559,7 +559,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Initialise(const int16_t item_num)

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -557,7 +557,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -26,7 +26,7 @@ static void M_Setup(OBJECT *const obj)
     obj->lot_setup = g_LOT_Jumper;
 
     obj->intelligent = true;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;
     obj->save_anim = 1;

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -25,7 +25,7 @@ static void M_Setup(OBJECT *const obj)
     obj->pivot_length = 0;
     obj->lot_setup = g_LOT_Jumper;
 
-    obj->intelligent = 1;
+    obj->intelligent = true;
     obj->save_position = 1;
     obj->save_hitpoints = 1;
     obj->save_flags = 1;

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -29,7 +29,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 static void M_Collision(

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -27,7 +27,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
-    obj->save_hitpoints = 1;
+    obj->save_hitpoints = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -28,7 +28,7 @@ static void M_Setup(OBJECT *const obj)
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 

--- a/src/tr2/game/objects/vehicles/skidoo_fast.c
+++ b/src/tr2/game/objects/vehicles/skidoo_fast.c
@@ -9,7 +9,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Skidoo_Collision;
     obj->save_position = true;
     obj->save_flags = true;
-    obj->save_anim = 1;
+    obj->save_anim = true;
 }
 
 REGISTER_OBJECT(O_SKIDOO_FAST, M_Setup)

--- a/src/tr2/game/objects/vehicles/skidoo_fast.c
+++ b/src/tr2/game/objects/vehicles/skidoo_fast.c
@@ -7,7 +7,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = Skidoo_Initialise;
     obj->draw_func = Skidoo_Draw;
     obj->collision_func = Skidoo_Collision;
-    obj->save_position = 1;
+    obj->save_position = true;
     obj->save_flags = 1;
     obj->save_anim = 1;
 }

--- a/src/tr2/game/objects/vehicles/skidoo_fast.c
+++ b/src/tr2/game/objects/vehicles/skidoo_fast.c
@@ -8,7 +8,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = Skidoo_Draw;
     obj->collision_func = Skidoo_Collision;
     obj->save_position = true;
-    obj->save_flags = 1;
+    obj->save_flags = true;
     obj->save_anim = 1;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Similar to #3069, this reorganises the `OBJECT` struct to replace bit flags with bool values. No logical changes, so it should be fine with a general test of behaviour.
