### PR TITLE
lara: reorganise Lara structs

### DIFF
--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -954,7 +954,7 @@ void Creature_SpecialKill(
     lara_item->goal_anim_state = lara_kill_state;
     lara_item->current_anim_state = lara_kill_state;
 #if TR_VERSION == 2
-    lara->extra_anim = 1;
+    lara->extra_anim = true;
 #endif
     lara->gun_status = LGS_HANDS_BUSY;
     lara->gun_type = LGT_UNARMED;

--- a/src/libtrx/game/interpolation.c
+++ b/src/libtrx/game/interpolation.c
@@ -116,10 +116,10 @@ static XYZ_32 M_GetItemMaxDelta(const ITEM *const item)
     case O_LARA_EXTRA: {
         LARA_INFO *const lara = Lara_GetLaraInfo();
         if (lara == nullptr || lara->item_num == NO_ITEM
-            || lara->skidoo == NO_ITEM) {
+            || lara->vehicle_item_num == NO_ITEM) {
             break;
         }
-        return M_GetItemMaxDelta(Item_Get(lara->skidoo));
+        return M_GetItemMaxDelta(Item_Get(lara->vehicle_item_num));
     }
 #endif
 
@@ -314,7 +314,8 @@ static void M_InterpolateItems(const double ratio)
         ITEM *const item = Item_Get(i);
 #if TR_VERSION == 2
         const LARA_INFO *const lara = Lara_GetLaraInfo();
-        const bool is_mounted = lara != nullptr && (i == lara->skidoo);
+        const bool is_mounted =
+            lara != nullptr && (i == lara->vehicle_item_num);
 #else
         const bool is_mounted = false;
 #endif

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -153,7 +153,7 @@ static void M_LoadPostprocess(void)
     LOT_ClearLOT(&lara->lot);
 #else
     if (lara->burn) {
-        lara->burn = 0;
+        lara->burn = false;
         Lara_CatchFire();
     }
 #endif

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -97,12 +97,9 @@ typedef struct {
     int16_t death_timer;
     int16_t current_active;
     int16_t hit_effect_count;
-    int16_t flare_age;
     int16_t vehicle_item_num;
     int16_t gun_item_num;
     GAME_OBJECT_ID back_gun;
-    int16_t flare_frame;
-    bool flare_control;
     bool extra_anim;
     bool enable_look;
     bool burn;
@@ -127,6 +124,12 @@ typedef struct {
     AMMO_INFO grenade_ammo;
     AMMO_INFO m16_ammo;
     LOT_INFO lot;
+
+    struct {
+        bool control;
+        int16_t age;
+        int16_t frame_num;
+    } flare;
 
     struct {
         struct {

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -29,16 +29,19 @@ typedef struct {
     int32_t ammo;
 } AMMO_INFO;
 
-#if TR_VERSION == 1
 typedef struct {
     int16_t item_num;
     LARA_GUN_STATE gun_status;
     LARA_GUN_TYPE gun_type;
     LARA_GUN_TYPE request_gun_type;
-    LARA_GUN_TYPE holsters_gun_type;
-    LARA_GUN_TYPE back_gun_type;
-    int16_t calc_fall_speed;
+
     LARA_WATER_STATE water_status;
+    int32_t water_surface_dist;
+    int16_t turn_rate;
+    int16_t move_angle;
+    XYZ_16 head_rot;
+    XYZ_16 torso_rot;
+    int16_t calc_fall_speed;
     int16_t pose_count;
     int16_t hit_frame;
     int16_t hit_direction;
@@ -46,30 +49,23 @@ typedef struct {
     int16_t dive_timer;
     int16_t death_timer;
     int16_t current_active;
-    int32_t water_surface_dist;
+    LOT_INFO lot;
     XYZ_32 last_pos;
+
     int16_t hit_effect_count;
     EFFECT *hit_effect;
     int32_t mesh_effects;
     OBJECT_MESH *mesh_ptrs[LM_NUMBER_OF];
+
     ITEM *target;
     int16_t target_angles[2];
-    int16_t turn_rate;
-    int16_t move_angle;
-    XYZ_16 head_rot;
-    XYZ_16 torso_rot;
+
     LARA_ARM left_arm;
     LARA_ARM right_arm;
     AMMO_INFO pistol_ammo;
     AMMO_INFO magnum_ammo;
     AMMO_INFO uzi_ammo;
     AMMO_INFO shotgun_ammo;
-    LOT_INFO lot;
-    struct {
-        int32_t item_num;
-        int32_t move_count;
-        bool is_moving;
-    } interact_target;
 
     struct {
         struct {
@@ -77,66 +73,35 @@ typedef struct {
             XYZ_16 torso_rot;
         } result, prev;
     } interp;
-} LARA_INFO;
 
-#elif TR_VERSION == 2
-typedef struct {
-    int16_t item_num;
-    LARA_GUN_STATE gun_status;
-    LARA_GUN_TYPE gun_type;
-    LARA_GUN_TYPE request_gun_type;
+#if TR_VERSION == 1
+    LARA_GUN_TYPE holsters_gun_type;
+    LARA_GUN_TYPE back_gun_type;
+
+    struct {
+        int32_t item_num;
+        int32_t move_count;
+        bool is_moving;
+    } interact_target;
+#else
     LARA_GUN_TYPE last_gun_type;
-    int16_t calc_fall_speed;
-    int16_t water_status;
-    int16_t pose_count;
-    int16_t hit_frame;
-    int16_t hit_direction;
-    int16_t air;
-    int16_t dive_timer;
-    int16_t death_timer;
-    int16_t current_active;
-    int16_t hit_effect_count;
-    int16_t vehicle_item_num;
-    int16_t gun_item_num;
     GAME_OBJECT_ID back_gun_obj_id;
+    int16_t gun_item_num;
+    int16_t vehicle_item_num;
+
     bool climb_status;
     bool extra_anim;
     bool enable_look;
     bool burn;
-    int32_t water_surface_dist;
-    XYZ_32 last_pos;
-    EFFECT *hit_effect;
-    uint32_t mesh_effects;
-    OBJECT_MESH *mesh_ptrs[LM_NUMBER_OF];
-    ITEM *target;
-    int16_t target_angles[2];
-    int16_t turn_rate;
-    int16_t move_angle;
-    XYZ_16 head_rot;
-    XYZ_16 torso_rot;
-    LARA_ARM left_arm;
-    LARA_ARM right_arm;
-    AMMO_INFO pistol_ammo;
-    AMMO_INFO magnum_ammo;
-    AMMO_INFO uzi_ammo;
-    AMMO_INFO shotgun_ammo;
+
     AMMO_INFO harpoon_ammo;
     AMMO_INFO grenade_ammo;
     AMMO_INFO m16_ammo;
-    LOT_INFO lot;
 
     struct {
         bool control;
         int16_t age;
         int16_t frame_num;
     } flare;
-
-    struct {
-        struct {
-            XYZ_16 head_rot;
-            XYZ_16 torso_rot;
-        } result, prev;
-    } interp;
-} LARA_INFO;
-
 #endif
+} LARA_INFO;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -88,7 +88,6 @@ typedef struct {
     int16_t last_gun_type;
     int16_t calc_fall_speed;
     int16_t water_status;
-    int16_t climb_status;
     int16_t pose_count;
     int16_t hit_frame;
     int16_t hit_direction;
@@ -100,6 +99,7 @@ typedef struct {
     int16_t vehicle_item_num;
     int16_t gun_item_num;
     GAME_OBJECT_ID back_gun;
+    bool climb_status;
     bool extra_anim;
     bool enable_look;
     bool burn;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -98,7 +98,7 @@ typedef struct {
     int16_t current_active;
     int16_t hit_effect_count;
     int16_t flare_age;
-    int16_t skidoo;
+    int16_t vehicle_item_num;
     int16_t gun_item_num;
     GAME_OBJECT_ID back_gun;
     int16_t flare_frame;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -32,7 +32,7 @@ typedef struct {
 #if TR_VERSION == 1
 typedef struct {
     int16_t item_num;
-    int16_t gun_status;
+    LARA_GUN_STATE gun_status;
     LARA_GUN_TYPE gun_type;
     LARA_GUN_TYPE request_gun_type;
     LARA_GUN_TYPE holsters_gun_type;
@@ -82,7 +82,7 @@ typedef struct {
 #elif TR_VERSION == 2
 typedef struct {
     int16_t item_num;
-    int16_t gun_status;
+    LARA_GUN_STATE gun_status;
     int16_t gun_type;
     int16_t request_gun_type;
     int16_t last_gun_type;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -103,12 +103,12 @@ typedef struct {
     GAME_OBJECT_ID back_gun;
     int16_t flare_frame;
     // clang-format off
-    uint16_t flare_control_left:  1; // 0x01 1
-    uint16_t flare_control_right: 1; // 0x02 2
-    uint16_t extra_anim:          1; // 0x04 4
-    uint16_t look:                1; // 0x08 8
-    uint16_t burn:                1; // 0x10 16
-    uint16_t pad:                 11;
+    uint16_t flare_control: 1; // 0x01 1
+    uint16_t pad_1:         1; // 0x02 2
+    uint16_t extra_anim:    1; // 0x04 4
+    uint16_t look:          1; // 0x08 8
+    uint16_t burn:          1; // 0x10 16
+    uint16_t pad:           11;
     // clang-format on
     int32_t water_surface_dist;
     XYZ_32 last_pos;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -105,14 +105,7 @@ typedef struct {
     bool flare_control;
     bool extra_anim;
     bool enable_look;
-    // clang-format off
-    uint16_t pad_0:         1; // 0x01 1
-    uint16_t pad_1:         1; // 0x02 2
-    uint16_t pad_2:         1; // 0x04 4
-    uint16_t pad_3:         1; // 0x08 8
-    uint16_t burn:          1; // 0x10 16
-    uint16_t pad:           11;
-    // clang-format on
+    bool burn;
     int32_t water_surface_dist;
     XYZ_32 last_pos;
     EFFECT *hit_effect;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -93,7 +93,7 @@ typedef struct {
     int16_t hit_frame;
     int16_t hit_direction;
     int16_t air;
-    int16_t dive_count;
+    int16_t dive_timer;
     int16_t death_timer;
     int16_t current_active;
     int16_t hit_effect_count;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -83,9 +83,9 @@ typedef struct {
 typedef struct {
     int16_t item_num;
     LARA_GUN_STATE gun_status;
-    int16_t gun_type;
-    int16_t request_gun_type;
-    int16_t last_gun_type;
+    LARA_GUN_TYPE gun_type;
+    LARA_GUN_TYPE request_gun_type;
+    LARA_GUN_TYPE last_gun_type;
     int16_t calc_fall_speed;
     int16_t water_status;
     int16_t pose_count;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -99,7 +99,7 @@ typedef struct {
     int16_t hit_effect_count;
     int16_t flare_age;
     int16_t skidoo;
-    int16_t weapon_item;
+    int16_t gun_item_num;
     GAME_OBJECT_ID back_gun;
     int16_t flare_frame;
     // clang-format off

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -104,11 +104,12 @@ typedef struct {
     int16_t flare_frame;
     bool flare_control;
     bool extra_anim;
+    bool enable_look;
     // clang-format off
     uint16_t pad_0:         1; // 0x01 1
     uint16_t pad_1:         1; // 0x02 2
     uint16_t pad_2:         1; // 0x04 4
-    uint16_t look:          1; // 0x08 8
+    uint16_t pad_3:         1; // 0x08 8
     uint16_t burn:          1; // 0x10 16
     uint16_t pad:           11;
     // clang-format on

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -98,7 +98,7 @@ typedef struct {
     int16_t hit_effect_count;
     int16_t vehicle_item_num;
     int16_t gun_item_num;
-    GAME_OBJECT_ID back_gun;
+    GAME_OBJECT_ID back_gun_obj_id;
     bool climb_status;
     bool extra_anim;
     bool enable_look;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -103,10 +103,11 @@ typedef struct {
     GAME_OBJECT_ID back_gun;
     int16_t flare_frame;
     bool flare_control;
+    bool extra_anim;
     // clang-format off
     uint16_t pad_0:         1; // 0x01 1
     uint16_t pad_1:         1; // 0x02 2
-    uint16_t extra_anim:    1; // 0x04 4
+    uint16_t pad_2:         1; // 0x04 4
     uint16_t look:          1; // 0x08 8
     uint16_t burn:          1; // 0x10 16
     uint16_t pad:           11;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -25,13 +25,11 @@ typedef struct {
     } interp;
 } LARA_ARM;
 
-#if TR_VERSION == 1
 typedef struct {
     int32_t ammo;
-    int32_t hit;
-    int32_t miss;
 } AMMO_INFO;
 
+#if TR_VERSION == 1
 typedef struct {
     int16_t item_num;
     int16_t gun_status;
@@ -82,10 +80,6 @@ typedef struct {
 } LARA_INFO;
 
 #elif TR_VERSION == 2
-typedef struct {
-    int32_t ammo;
-} AMMO_INFO;
-
 typedef struct {
     int16_t item_num;
     int16_t gun_status;

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -102,8 +102,9 @@ typedef struct {
     int16_t gun_item_num;
     GAME_OBJECT_ID back_gun;
     int16_t flare_frame;
+    bool flare_control;
     // clang-format off
-    uint16_t flare_control: 1; // 0x01 1
+    uint16_t pad_0:         1; // 0x01 1
     uint16_t pad_1:         1; // 0x02 2
     uint16_t extra_anim:    1; // 0x04 4
     uint16_t look:          1; // 0x08 8

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -8,13 +8,15 @@
 #include "../types.h"
 #include "enum.h"
 
-#if TR_VERSION == 1
 typedef struct {
     ANIM_FRAME *frame_base;
     int16_t frame_num;
+#if TR_VERSION >= 2
+    int16_t anim_num;
+#endif
     int16_t lock;
     XYZ_16 rot;
-    uint16_t flash_gun;
+    int16_t flash_gun;
 
     struct {
         struct {
@@ -23,6 +25,7 @@ typedef struct {
     } interp;
 } LARA_ARM;
 
+#if TR_VERSION == 1
 typedef struct {
     int32_t ammo;
     int32_t hit;
@@ -82,21 +85,6 @@ typedef struct {
 typedef struct {
     int32_t ammo;
 } AMMO_INFO;
-
-typedef struct {
-    ANIM_FRAME *frame_base;
-    int16_t frame_num;
-    int16_t anim_num;
-    int16_t lock;
-    XYZ_16 rot;
-    int16_t flash_gun;
-
-    struct {
-        struct {
-            XYZ_16 rot;
-        } result, prev;
-    } interp;
-} LARA_ARM;
 
 typedef struct {
     int16_t item_num;

--- a/src/tr1/game/gun/gun.c
+++ b/src/tr1/game/gun/gun.c
@@ -181,6 +181,9 @@ void Gun_Control(void)
             break;
         }
         break;
+
+    default:
+        break;
     }
 }
 

--- a/src/tr1/game/gun/gun_misc.c
+++ b/src/tr1/game/gun/gun_misc.c
@@ -471,7 +471,6 @@ int32_t Gun_FireWeapon(
 
     GAME_VECTOR vdest;
     if (best >= 0) {
-        ammo->hit++;
         Stats_AddAmmoHits();
         vdest.x = vsrc.x + ((bestdist * g_MatrixPtr->_20) >> W2V_SHIFT);
         vdest.y = vsrc.y + ((bestdist * g_MatrixPtr->_21) >> W2V_SHIFT);
@@ -482,7 +481,6 @@ int32_t Gun_FireWeapon(
         return 1;
     }
 
-    ammo->miss++;
     vdest.x = vsrc.x + g_MatrixPtr->_20;
     vdest.y = vsrc.y + g_MatrixPtr->_21;
     vdest.z = vsrc.z + g_MatrixPtr->_22;

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -755,8 +755,6 @@ static bool M_LoadAmmo(JSON_OBJECT *ammo_obj, AMMO_INFO *ammo)
     }
 
     ammo->ammo = JSON_ObjectGetInt(ammo_obj, "ammo", ammo->ammo);
-    ammo->hit = JSON_ObjectGetInt(ammo_obj, "hit", ammo->hit);
-    ammo->miss = JSON_ObjectGetInt(ammo_obj, "miss", ammo->miss);
     return true;
 }
 
@@ -1258,8 +1256,6 @@ static JSON_OBJECT *M_DumpAmmo(AMMO_INFO *ammo)
     ASSERT(ammo != nullptr);
     JSON_OBJECT *ammo_obj = JSON_ObjectNew();
     JSON_ObjectAppendInt(ammo_obj, "ammo", ammo->ammo);
-    JSON_ObjectAppendInt(ammo_obj, "hit", ammo->hit);
-    JSON_ObjectAppendInt(ammo_obj, "miss", ammo->miss);
     return ammo_obj;
 }
 

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -311,8 +311,8 @@ static void M_ReadArm(LARA_ARM *const arm)
 static void M_ReadAmmoInfo(AMMO_INFO *const ammo_info)
 {
     ammo_info->ammo = M_ReadS32();
-    ammo_info->hit = M_ReadS32();
-    ammo_info->miss = M_ReadS32();
+    M_Skip(sizeof(int32_t)); // Legacy hits value
+    M_Skip(sizeof(int32_t)); // Legacy miss value
 }
 
 static void M_ReadLOT(LOT_INFO *const lot)

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -259,7 +259,7 @@ void Flare_Draw(void)
     if (g_LaraItem->current_anim_state == LS_FLARE_PICKUP
         || g_LaraItem->current_anim_state == LS_PICKUP) {
         Flare_DoInHand(g_Lara.flare_age);
-        g_Lara.flare_control = 0;
+        g_Lara.flare_control = false;
         g_Lara.left_arm.frame_num = LF_FL_2_HOLD - 2;
         Flare_SetArm(g_Lara.left_arm.frame_num);
         return;
@@ -267,7 +267,7 @@ void Flare_Draw(void)
 
     int32_t frame_num = g_Lara.left_arm.frame_num + 1;
 
-    g_Lara.flare_control = 1;
+    g_Lara.flare_control = true;
 
     if (frame_num < LF_FL_DRAW || frame_num > LF_FL_2_HOLD - 1) {
         frame_num = LF_FL_DRAW;
@@ -296,7 +296,7 @@ void Flare_Undraw(void)
     int16_t frame_num_1 = g_Lara.left_arm.frame_num;
     int16_t frame_num_2 = g_Lara.flare_frame;
 
-    g_Lara.flare_control = 1;
+    g_Lara.flare_control = true;
 
     if (g_LaraItem->goal_anim_state == LS_STOP
         && g_Lara.vehicle_item_num == NO_ITEM) {
@@ -307,7 +307,7 @@ void Flare_Undraw(void)
         }
 
         if (Item_TestAnimEqual(g_LaraItem, LA_FLARE_THROW)) {
-            g_Lara.flare_control = 0;
+            g_Lara.flare_control = false;
 
             if (frame_num_2 >= Anim_GetAnim(LA_FLARE_THROW)->frame_base
                     + LF_FL_THROW_FT - 1) {
@@ -351,7 +351,7 @@ void Flare_Undraw(void)
             g_Lara.gun_status = LGS_ARMLESS;
             Gun_InitialiseNewWeapon();
             g_Lara.target = nullptr;
-            g_Lara.flare_control = 0;
+            g_Lara.flare_control = false;
             g_Lara.right_arm.lock = 0;
             g_Lara.left_arm.lock = 0;
             g_Lara.flare_frame = 0;

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -125,8 +125,8 @@ void Flare_DoInHand(const int32_t flare_age)
 
     g_Lara.left_arm.flash_gun = Flare_DoLight(&vec, flare_age);
 
-    if (g_Lara.flare_age < MAX_FLARE_AGE) {
-        g_Lara.flare_age++;
+    if (g_Lara.flare.age < MAX_FLARE_AGE) {
+        g_Lara.flare.age++;
         M_DoBurnEffects(g_LaraItem->pos, vec, g_LaraItem->room_num);
     } else if (M_CanThrowFlare()) {
         g_Lara.gun_status = LGS_UNDRAW;
@@ -223,10 +223,10 @@ void Flare_Create(const bool thrown)
         item->fall_speed = g_LaraItem->fall_speed + 50;
     }
 
-    if (Flare_DoLight(&item->pos, g_Lara.flare_age)) {
-        item->data = (void *)(intptr_t)(g_Lara.flare_age | 0x8000);
+    if (Flare_DoLight(&item->pos, g_Lara.flare.age)) {
+        item->data = (void *)(intptr_t)(g_Lara.flare.age | 0x8000);
     } else {
-        item->data = (void *)(intptr_t)(g_Lara.flare_age & ~0x8000);
+        item->data = (void *)(intptr_t)(g_Lara.flare.age & ~0x8000);
     }
 
     Item_AddActive(item_num);
@@ -258,8 +258,8 @@ void Flare_Draw(void)
 {
     if (g_LaraItem->current_anim_state == LS_FLARE_PICKUP
         || g_LaraItem->current_anim_state == LS_PICKUP) {
-        Flare_DoInHand(g_Lara.flare_age);
-        g_Lara.flare_control = false;
+        Flare_DoInHand(g_Lara.flare.age);
+        g_Lara.flare.control = false;
         g_Lara.left_arm.frame_num = LF_FL_2_HOLD - 2;
         Flare_SetArm(g_Lara.left_arm.frame_num);
         return;
@@ -267,7 +267,7 @@ void Flare_Draw(void)
 
     int32_t frame_num = g_Lara.left_arm.frame_num + 1;
 
-    g_Lara.flare_control = true;
+    g_Lara.flare.control = true;
 
     if (frame_num < LF_FL_DRAW || frame_num > LF_FL_2_HOLD - 1) {
         frame_num = LF_FL_DRAW;
@@ -278,12 +278,12 @@ void Flare_Draw(void)
         }
     } else if (frame_num >= LF_FL_IGNITE && frame_num <= LF_FL_2_HOLD - 2) {
         if (frame_num == LF_FL_IGNITE) {
-            g_Lara.flare_age = 0;
+            g_Lara.flare.age = 0;
         }
-        Flare_DoInHand(g_Lara.flare_age);
+        Flare_DoInHand(g_Lara.flare.age);
     } else if (frame_num == LF_FL_2_HOLD - 1) {
         Flare_Ready();
-        Flare_DoInHand(g_Lara.flare_age);
+        Flare_DoInHand(g_Lara.flare.age);
         frame_num = LF_FL_HOLD;
     }
 
@@ -294,20 +294,20 @@ void Flare_Draw(void)
 void Flare_Undraw(void)
 {
     int16_t frame_num_1 = g_Lara.left_arm.frame_num;
-    int16_t frame_num_2 = g_Lara.flare_frame;
+    int16_t frame_num_2 = g_Lara.flare.frame_num;
 
-    g_Lara.flare_control = true;
+    g_Lara.flare.control = true;
 
     if (g_LaraItem->goal_anim_state == LS_STOP
         && g_Lara.vehicle_item_num == NO_ITEM) {
         if (Item_TestAnimEqual(g_LaraItem, LA_STAND_IDLE)) {
             Item_SwitchToAnim(g_LaraItem, LA_FLARE_THROW, frame_num_1);
-            g_Lara.flare_frame = g_LaraItem->frame_num;
+            g_Lara.flare.frame_num = g_LaraItem->frame_num;
             frame_num_2 = g_LaraItem->frame_num;
         }
 
         if (Item_TestAnimEqual(g_LaraItem, LA_FLARE_THROW)) {
-            g_Lara.flare_control = false;
+            g_Lara.flare.control = false;
 
             if (frame_num_2 >= Anim_GetAnim(LA_FLARE_THROW)->frame_base
                     + LF_FL_THROW_FT - 1) {
@@ -319,12 +319,12 @@ void Flare_Undraw(void)
                 g_Lara.right_arm.lock = 0;
                 g_Lara.left_arm.lock = 0;
                 Item_SwitchToAnim(g_LaraItem, LA_STAND_STILL, 0);
-                g_Lara.flare_frame = g_LaraItem->frame_num;
+                g_Lara.flare.frame_num = g_LaraItem->frame_num;
                 g_LaraItem->current_anim_state = LS_STOP;
                 g_LaraItem->goal_anim_state = LS_STOP;
                 return;
             }
-            g_Lara.flare_frame = frame_num_2 + 1;
+            g_Lara.flare.frame_num = frame_num_2 + 1;
         }
     } else if (
         g_LaraItem->current_anim_state == LS_STOP
@@ -351,10 +351,10 @@ void Flare_Undraw(void)
             g_Lara.gun_status = LGS_ARMLESS;
             Gun_InitialiseNewWeapon();
             g_Lara.target = nullptr;
-            g_Lara.flare_control = false;
+            g_Lara.flare.control = false;
             g_Lara.right_arm.lock = 0;
             g_Lara.left_arm.lock = 0;
-            g_Lara.flare_frame = 0;
+            g_Lara.flare.frame_num = 0;
         }
     } else if (frame_num_1 >= LF_FL_2_HOLD && frame_num_1 < LF_FL_END) {
         frame_num_1++;
@@ -364,7 +364,7 @@ void Flare_Undraw(void)
     }
 
     if (frame_num_1 >= LF_FL_THROW && frame_num_1 < LF_FL_THROW_RELEASE) {
-        Flare_DoInHand(g_Lara.flare_age);
+        Flare_DoInHand(g_Lara.flare.age);
     }
 
     g_Lara.left_arm.frame_num = frame_num_1;

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -298,7 +298,8 @@ void Flare_Undraw(void)
 
     g_Lara.flare_control_left = 1;
 
-    if (g_LaraItem->goal_anim_state == LS_STOP && g_Lara.skidoo == NO_ITEM) {
+    if (g_LaraItem->goal_anim_state == LS_STOP
+        && g_Lara.vehicle_item_num == NO_ITEM) {
         if (Item_TestAnimEqual(g_LaraItem, LA_STAND_IDLE)) {
             Item_SwitchToAnim(g_LaraItem, LA_FLARE_THROW, frame_num_1);
             g_Lara.flare_frame = g_LaraItem->frame_num;
@@ -326,7 +327,8 @@ void Flare_Undraw(void)
             g_Lara.flare_frame = frame_num_2 + 1;
         }
     } else if (
-        g_LaraItem->current_anim_state == LS_STOP && g_Lara.skidoo == -1) {
+        g_LaraItem->current_anim_state == LS_STOP
+        && g_Lara.vehicle_item_num == -1) {
         Item_SwitchToAnim(g_LaraItem, LA_STAND_STILL, 0);
     }
 

--- a/src/tr2/decomp/flares.c
+++ b/src/tr2/decomp/flares.c
@@ -259,7 +259,7 @@ void Flare_Draw(void)
     if (g_LaraItem->current_anim_state == LS_FLARE_PICKUP
         || g_LaraItem->current_anim_state == LS_PICKUP) {
         Flare_DoInHand(g_Lara.flare_age);
-        g_Lara.flare_control_left = 0;
+        g_Lara.flare_control = 0;
         g_Lara.left_arm.frame_num = LF_FL_2_HOLD - 2;
         Flare_SetArm(g_Lara.left_arm.frame_num);
         return;
@@ -267,7 +267,7 @@ void Flare_Draw(void)
 
     int32_t frame_num = g_Lara.left_arm.frame_num + 1;
 
-    g_Lara.flare_control_left = 1;
+    g_Lara.flare_control = 1;
 
     if (frame_num < LF_FL_DRAW || frame_num > LF_FL_2_HOLD - 1) {
         frame_num = LF_FL_DRAW;
@@ -296,7 +296,7 @@ void Flare_Undraw(void)
     int16_t frame_num_1 = g_Lara.left_arm.frame_num;
     int16_t frame_num_2 = g_Lara.flare_frame;
 
-    g_Lara.flare_control_left = 1;
+    g_Lara.flare_control = 1;
 
     if (g_LaraItem->goal_anim_state == LS_STOP
         && g_Lara.vehicle_item_num == NO_ITEM) {
@@ -307,7 +307,7 @@ void Flare_Undraw(void)
         }
 
         if (Item_TestAnimEqual(g_LaraItem, LA_FLARE_THROW)) {
-            g_Lara.flare_control_left = 0;
+            g_Lara.flare_control = 0;
 
             if (frame_num_2 >= Anim_GetAnim(LA_FLARE_THROW)->frame_base
                     + LF_FL_THROW_FT - 1) {
@@ -351,7 +351,7 @@ void Flare_Undraw(void)
             g_Lara.gun_status = LGS_ARMLESS;
             Gun_InitialiseNewWeapon();
             g_Lara.target = nullptr;
-            g_Lara.flare_control_left = 0;
+            g_Lara.flare_control = 0;
             g_Lara.right_arm.lock = 0;
             g_Lara.left_arm.lock = 0;
             g_Lara.flare_frame = 0;

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -209,7 +209,7 @@ int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
 void Skidoo_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
-    if (lara_item->hit_points < 0 || g_Lara.skidoo != NO_ITEM) {
+    if (lara_item->hit_points < 0 || g_Lara.vehicle_item_num != NO_ITEM) {
         return;
     }
 
@@ -219,7 +219,7 @@ void Skidoo_Collision(
         return;
     }
 
-    g_Lara.skidoo = item_num;
+    g_Lara.vehicle_item_num = item_num;
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Create(false);
         Flare_UndrawMeshes();
@@ -442,7 +442,7 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
         const int32_t dz = skidoo->pos.z - old.z;
         const int32_t new_speed = (s * dx + c * dz) >> W2V_SHIFT;
 
-        if (skidoo == Item_Get(g_Lara.skidoo)
+        if (skidoo == Item_Get(g_Lara.vehicle_item_num)
             && skidoo->speed > SKIDOO_MAX_SPEED + SKIDOO_ACCELERATION
             && new_speed < skidoo->speed - SKIDOO_ACCELERATION) {
             Lara_TakeDamage((skidoo->speed - new_speed) / 2, true);
@@ -539,7 +539,7 @@ int32_t Skidoo_UserControl(
 
 int32_t Skidoo_CheckGetOffOK(int32_t direction)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.skidoo);
+    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
 
     int16_t rot;
     if (direction == LARA_STATE_SKIDOO_GET_OFF_L) {
@@ -697,14 +697,14 @@ void Skidoo_Explode(const ITEM *const skidoo)
         effect->object_id = O_EXPLOSION_1;
     }
 
-    Item_Explode(g_Lara.skidoo, ~(SKIDOO_GUN_MESH - 1), 0);
+    Item_Explode(g_Lara.vehicle_item_num, ~(SKIDOO_GUN_MESH - 1), 0);
     Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
-    g_Lara.skidoo = NO_ITEM;
+    g_Lara.vehicle_item_num = NO_ITEM;
 }
 
 int32_t Skidoo_CheckGetOff(void)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.skidoo);
+    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
 
     if ((g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_GET_OFF_R
          || g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_GET_OFF_L)
@@ -723,7 +723,7 @@ int32_t Skidoo_CheckGetOff(void)
             (SKIDOO_GET_OFF_DIST * Math_Cos(g_LaraItem->rot.y)) >> W2V_SHIFT;
         g_LaraItem->rot.x = 0;
         g_LaraItem->rot.z = 0;
-        g_Lara.skidoo = NO_ITEM;
+        g_Lara.vehicle_item_num = NO_ITEM;
         g_Lara.gun_status = LGS_ARMLESS;
         return true;
     }
@@ -780,14 +780,14 @@ void Skidoo_Guns(void)
     Sound_Effect(winfo->sample_num, &g_LaraItem->pos, SPM_NORMAL);
     Gun_AddDynamicLight();
 
-    ITEM *const skidoo = Item_Get(g_Lara.skidoo);
+    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
     Creature_Effect(skidoo, &g_Skidoo_LeftGun, Spawn_GunShot);
     Creature_Effect(skidoo, &g_Skidoo_RightGun, Spawn_GunShot);
 }
 
 int32_t Skidoo_Control(void)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.skidoo);
+    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
     SKIDOO_INFO *const skidoo_data = skidoo->data;
     int32_t collide = Skidoo_Dynamics(skidoo);
 
@@ -872,7 +872,7 @@ int32_t Skidoo_Control(void)
 
     if (skidoo->flags & IF_ONE_SHOT) {
         Room_TestTriggers(g_LaraItem);
-        Item_UpdateRoom(g_Lara.skidoo, room_num);
+        Item_UpdateRoom(g_Lara.vehicle_item_num, room_num);
         if (skidoo->pos.y == skidoo->floor) {
             Skidoo_Explode(skidoo);
         }
@@ -880,7 +880,7 @@ int32_t Skidoo_Control(void)
     }
 
     Skidoo_Animation(skidoo, collide, dead);
-    Item_UpdateRoom(g_Lara.skidoo, room_num);
+    Item_UpdateRoom(g_Lara.vehicle_item_num, room_num);
     Item_UpdateRoom(g_Lara.item_num, room_num);
 
     if (g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_FALLOFF) {

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -223,7 +223,7 @@ void Skidoo_Collision(
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Create(false);
         Flare_UndrawMeshes();
-        g_Lara.flare_control = 0;
+        g_Lara.flare_control = false;
         g_Lara.gun_type = LGT_UNARMED;
         g_Lara.request_gun_type = LGT_UNARMED;
     }

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -223,7 +223,7 @@ void Skidoo_Collision(
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Create(false);
         Flare_UndrawMeshes();
-        g_Lara.flare_control = false;
+        g_Lara.flare.control = false;
         g_Lara.gun_type = LGT_UNARMED;
         g_Lara.request_gun_type = LGT_UNARMED;
     }

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -223,7 +223,7 @@ void Skidoo_Collision(
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Create(false);
         Flare_UndrawMeshes();
-        g_Lara.flare_control_left = 0;
+        g_Lara.flare_control = 0;
         g_Lara.gun_type = LGT_UNARMED;
         g_Lara.request_gun_type = LGT_UNARMED;
     }

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -59,7 +59,7 @@ void Gun_Control(void)
                 if (g_Lara.gun_type == LGT_FLARE) {
                     Flare_Create(0);
                     Flare_UndrawMeshes();
-                    g_Lara.flare_control = 0;
+                    g_Lara.flare_control = false;
                 }
                 g_Lara.gun_type = g_Lara.request_gun_type;
                 Gun_InitialiseNewWeapon();
@@ -103,7 +103,7 @@ void Gun_Control(void)
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state)) {
                 if (!g_Lara.flare_control) {
                     g_Lara.left_arm.frame_num = LF_FL_2_HOLD;
-                    g_Lara.flare_control = 1;
+                    g_Lara.flare_control = true;
                 } else if (g_Lara.left_arm.frame_num != LF_FL_HOLD) {
                     g_Lara.left_arm.frame_num++;
                     if (g_Lara.left_arm.frame_num == LF_FL_END) {
@@ -111,7 +111,7 @@ void Gun_Control(void)
                     }
                 }
             } else {
-                g_Lara.flare_control = 0;
+                g_Lara.flare_control = false;
             }
             Flare_DoInHand(g_Lara.flare_age);
             Flare_SetArm(g_Lara.left_arm.frame_num);

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -59,7 +59,7 @@ void Gun_Control(void)
                 if (g_Lara.gun_type == LGT_FLARE) {
                     Flare_Create(0);
                     Flare_UndrawMeshes();
-                    g_Lara.flare_control = false;
+                    g_Lara.flare.control = false;
                 }
                 g_Lara.gun_type = g_Lara.request_gun_type;
                 Gun_InitialiseNewWeapon();
@@ -101,9 +101,9 @@ void Gun_Control(void)
         if (g_Lara.gun_type == LGT_FLARE) {
             if (g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state)) {
-                if (!g_Lara.flare_control) {
+                if (!g_Lara.flare.control) {
                     g_Lara.left_arm.frame_num = LF_FL_2_HOLD;
-                    g_Lara.flare_control = true;
+                    g_Lara.flare.control = true;
                 } else if (g_Lara.left_arm.frame_num != LF_FL_HOLD) {
                     g_Lara.left_arm.frame_num++;
                     if (g_Lara.left_arm.frame_num == LF_FL_END) {
@@ -111,18 +111,18 @@ void Gun_Control(void)
                     }
                 }
             } else {
-                g_Lara.flare_control = false;
+                g_Lara.flare.control = false;
             }
-            Flare_DoInHand(g_Lara.flare_age);
+            Flare_DoInHand(g_Lara.flare.age);
             Flare_SetArm(g_Lara.left_arm.frame_num);
         }
         break;
 
     case LGS_HANDS_BUSY:
         if (g_Lara.gun_type == LGT_FLARE) {
-            g_Lara.flare_control = g_Lara.vehicle_item_num != NO_ITEM
+            g_Lara.flare.control = g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state);
-            Flare_DoInHand(g_Lara.flare_age);
+            Flare_DoInHand(g_Lara.flare.age);
             Flare_SetArm(g_Lara.left_arm.frame_num);
         }
         break;

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -47,7 +47,8 @@ void Gun_Control(void)
 
         if (g_Lara.request_gun_type != g_Lara.gun_type || g_Input.draw) {
             if (g_Lara.request_gun_type == LGT_FLARE
-                || (g_Lara.skidoo == NO_ITEM && g_Lara.water_status != LWS_CHEAT
+                || (g_Lara.vehicle_item_num == NO_ITEM
+                    && g_Lara.water_status != LWS_CHEAT
                     && (g_Lara.request_gun_type == LGT_HARPOON
                         || g_Lara.water_status == LWS_ABOVE_WATER
                         || (g_Lara.water_status == LWS_WADE
@@ -98,7 +99,7 @@ void Gun_Control(void)
     switch (g_Lara.gun_status) {
     case LGS_ARMLESS:
         if (g_Lara.gun_type == LGT_FLARE) {
-            if (g_Lara.skidoo != NO_ITEM
+            if (g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state)) {
                 if (!g_Lara.flare_control_left) {
                     g_Lara.left_arm.frame_num = LF_FL_2_HOLD;
@@ -119,7 +120,7 @@ void Gun_Control(void)
 
     case LGS_HANDS_BUSY:
         if (g_Lara.gun_type == LGT_FLARE) {
-            g_Lara.flare_control_left = g_Lara.skidoo != NO_ITEM
+            g_Lara.flare_control_left = g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state);
             Flare_DoInHand(g_Lara.flare_age);
             Flare_SetArm(g_Lara.left_arm.frame_num);

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -408,7 +408,7 @@ void Gun_SetLaraBackMesh(const LARA_GUN_TYPE weapon_type)
     const GAME_OBJECT_ID obj_id = Gun_GetWeaponAnim(weapon_type);
     ASSERT(obj_id != NO_OBJECT);
     Lara_SwapSingleMesh(LM_TORSO, obj_id);
-    g_Lara.back_gun = obj_id;
+    g_Lara.back_gun_obj_id = obj_id;
 }
 
 void Gun_SetLaraHolsterLMesh(const LARA_GUN_TYPE weapon_type)

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -59,7 +59,7 @@ void Gun_Control(void)
                 if (g_Lara.gun_type == LGT_FLARE) {
                     Flare_Create(0);
                     Flare_UndrawMeshes();
-                    g_Lara.flare_control_left = 0;
+                    g_Lara.flare_control = 0;
                 }
                 g_Lara.gun_type = g_Lara.request_gun_type;
                 Gun_InitialiseNewWeapon();
@@ -101,9 +101,9 @@ void Gun_Control(void)
         if (g_Lara.gun_type == LGT_FLARE) {
             if (g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state)) {
-                if (!g_Lara.flare_control_left) {
+                if (!g_Lara.flare_control) {
                     g_Lara.left_arm.frame_num = LF_FL_2_HOLD;
-                    g_Lara.flare_control_left = 1;
+                    g_Lara.flare_control = 1;
                 } else if (g_Lara.left_arm.frame_num != LF_FL_HOLD) {
                     g_Lara.left_arm.frame_num++;
                     if (g_Lara.left_arm.frame_num == LF_FL_END) {
@@ -111,7 +111,7 @@ void Gun_Control(void)
                     }
                 }
             } else {
-                g_Lara.flare_control_left = 0;
+                g_Lara.flare_control = 0;
             }
             Flare_DoInHand(g_Lara.flare_age);
             Flare_SetArm(g_Lara.left_arm.frame_num);
@@ -120,7 +120,7 @@ void Gun_Control(void)
 
     case LGS_HANDS_BUSY:
         if (g_Lara.gun_type == LGT_FLARE) {
-            g_Lara.flare_control_left = g_Lara.vehicle_item_num != NO_ITEM
+            g_Lara.flare_control = g_Lara.vehicle_item_num != NO_ITEM
                 || Gun_CheckForHoldingState(g_LaraItem->current_anim_state);
             Flare_DoInHand(g_Lara.flare_age);
             Flare_SetArm(g_Lara.left_arm.frame_num);

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -37,13 +37,13 @@ static void M_AnimateGun(ITEM *const item)
 void Gun_Rifle_DrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
     Gun_SetLaraHandRMesh(weapon_type);
-    g_Lara.back_gun = O_LARA;
+    g_Lara.back_gun_obj_id = O_LARA;
 }
 
 void Gun_Rifle_UndrawMeshes(const LARA_GUN_TYPE weapon_type)
 {
     Gun_SetLaraHandRMesh(LGT_UNARMED);
-    g_Lara.back_gun = Gun_GetWeaponAnim(weapon_type);
+    g_Lara.back_gun_obj_id = Gun_GetWeaponAnim(weapon_type);
 }
 
 void Gun_Rifle_Ready(const LARA_GUN_TYPE weapon_type)

--- a/src/tr2/game/gun/gun_rifle.c
+++ b/src/tr2/game/gun/gun_rifle.c
@@ -245,11 +245,11 @@ void Gun_Rifle_FireGrenade(void)
 void Gun_Rifle_Draw(const LARA_GUN_TYPE weapon_type)
 {
     ITEM *item;
-    if (g_Lara.weapon_item != NO_ITEM) {
-        item = Item_Get(g_Lara.weapon_item);
+    if (g_Lara.gun_item_num != NO_ITEM) {
+        item = Item_Get(g_Lara.gun_item_num);
     } else {
-        g_Lara.weapon_item = Item_Create();
-        item = Item_Get(g_Lara.weapon_item);
+        g_Lara.gun_item_num = Item_Create();
+        item = Item_Get(g_Lara.gun_item_num);
         item->object_id = Gun_GetWeaponAnim(weapon_type);
         if (weapon_type == LGT_GRENADE) {
             Item_SwitchToObjAnim(item, 0, 0, O_LARA_GRENADE);
@@ -285,7 +285,7 @@ void Gun_Rifle_Draw(const LARA_GUN_TYPE weapon_type)
 
 void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
 {
-    ITEM *const item = Item_Get(g_Lara.weapon_item);
+    ITEM *const item = Item_Get(g_Lara.gun_item_num);
     if (g_Lara.water_status == LWS_SURFACE) {
         item->goal_anim_state = LA_G_SURF_UNDRAW;
     } else {
@@ -294,8 +294,8 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
     M_AnimateGun(item);
 
     if (item->status == IS_DEACTIVATED) {
-        Item_Kill(g_Lara.weapon_item);
-        g_Lara.weapon_item = NO_ITEM;
+        Item_Kill(g_Lara.gun_item_num);
+        g_Lara.gun_item_num = NO_ITEM;
         g_Lara.gun_status = LGS_ARMLESS;
         g_Lara.target = nullptr;
         g_Lara.left_arm.frame_num = 0;
@@ -319,7 +319,7 @@ void Gun_Rifle_Undraw(const LARA_GUN_TYPE weapon_type)
 void Gun_Rifle_Animate(const LARA_GUN_TYPE weapon_type)
 {
     const bool running = weapon_type == LGT_M16 && g_LaraItem->speed != 0;
-    ITEM *const item = Item_Get(g_Lara.weapon_item);
+    ITEM *const item = Item_Get(g_Lara.gun_item_num);
 
     switch (item->current_anim_state) {
     case LA_G_AIM:

--- a/src/tr2/game/inventory.c
+++ b/src/tr2/game/inventory.c
@@ -65,8 +65,8 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
         if (g_Lara.last_gun_type == LGT_UNARMED) {
             g_Lara.last_gun_type = LGT_SHOTGUN;
         }
-        if (g_Lara.back_gun == O_LARA) {
-            g_Lara.back_gun = O_LARA_SHOTGUN;
+        if (g_Lara.back_gun_obj_id == O_LARA) {
+            g_Lara.back_gun_obj_id = O_LARA_SHOTGUN;
         }
         Item_GlobalReplace(O_SHOTGUN_ITEM, O_SHOTGUN_AMMO_ITEM);
         return false;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -156,7 +156,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.death_timer = 0;
     g_Lara.mesh_effects = 0;
     g_Lara.burn = 0;
-    g_Lara.extra_anim = 0;
+    g_Lara.extra_anim = false;
     g_LaraItem->enable_shadow = true;
     g_LaraItem->hit_points = LARA_MAX_HITPOINTS;
 
@@ -412,7 +412,7 @@ bool Lara_Cheat_Teleport(int32_t x, int32_t y, int32_t z, int16_t room_num)
             g_Lara.torso_rot.y = 0;
         }
 
-        g_Lara.extra_anim = 0;
+        g_Lara.extra_anim = false;
         M_ResetGunStatus();
         M_ReinitialiseGunMeshes();
     }

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -155,7 +155,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     g_Lara.air = LARA_MAX_AIR;
     g_Lara.death_timer = 0;
     g_Lara.mesh_effects = 0;
-    g_Lara.burn = 0;
+    g_Lara.burn = false;
     g_Lara.extra_anim = false;
     g_LaraItem->enable_shadow = true;
     g_LaraItem->hit_points = LARA_MAX_HITPOINTS;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -91,7 +91,7 @@ static void M_ResetGunStatus(void)
     g_Lara.gun_status = LGS_ARMLESS;
     g_Lara.gun_type = LGT_UNARMED;
     g_Lara.request_gun_type = LGT_UNARMED;
-    g_Lara.weapon_item = NO_ITEM;
+    g_Lara.gun_item_num = NO_ITEM;
     g_Lara.gun_status = LGS_ARMLESS;
     g_Lara.left_arm.frame_num = 0;
     g_Lara.left_arm.lock = 0;
@@ -193,7 +193,7 @@ bool Lara_Cheat_ExitFlyMode(void)
         g_Lara.torso_rot.y = 0;
     }
 
-    if (g_Lara.weapon_item != NO_ITEM) {
+    if (g_Lara.gun_item_num != NO_ITEM) {
         g_Lara.gun_status = LGS_UNDRAW;
     } else {
         g_Lara.gun_status = LGS_ARMLESS;

--- a/src/tr2/game/lara/cheat.c
+++ b/src/tr2/game/lara/cheat.c
@@ -127,7 +127,8 @@ bool Lara_Cheat_EnterFlyMode(void)
     }
 
     if (g_Lara.gun_status == LGS_HANDS_BUSY
-        || (g_Lara.gun_status == LGS_UNDRAW && g_Lara.back_gun != O_LARA)) {
+        || (g_Lara.gun_status == LGS_UNDRAW
+            && g_Lara.back_gun_obj_id != O_LARA)) {
         g_Lara.gun_status = LGS_ARMLESS;
     }
 

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -227,8 +227,8 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
     }
     g_Lara.look = 1;
 
-    if (g_Lara.skidoo != NO_ITEM) {
-        if (Item_Get(g_Lara.skidoo)->object_id == O_SKIDOO_FAST) {
+    if (g_Lara.vehicle_item_num != NO_ITEM) {
+        if (Item_Get(g_Lara.vehicle_item_num)->object_id == O_SKIDOO_FAST) {
             // TODO: make this Object_Get(O_SKIDOO_FAST)->control
             if (Skidoo_Control()) {
                 return;
@@ -267,7 +267,7 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
     const SECTOR *const sector = M_GetCurrentSector(item);
     if (!g_Lara.extra_anim && g_Lara.water_status != LWS_CHEAT) {
         Lara_BaddieCollision(item, coll);
-        if (g_Lara.skidoo == NO_ITEM) {
+        if (g_Lara.vehicle_item_num == NO_ITEM) {
             m_CollisionRoutines[item->current_anim_state](item, coll);
         }
     }
@@ -329,7 +329,7 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
 
     Lara_BaddieCollision(item, coll);
 
-    if (g_Lara.skidoo == NO_ITEM) {
+    if (g_Lara.vehicle_item_num == NO_ITEM) {
         m_CollisionRoutines[item->current_anim_state](item, coll);
     }
 
@@ -456,7 +456,7 @@ void Lara_Control(const int16_t item_num)
 
     g_Lara.water_surface_dist = -water_height_diff;
 
-    if (g_Lara.skidoo == NO_ITEM && !g_Lara.extra_anim) {
+    if (g_Lara.vehicle_item_num == NO_ITEM && !g_Lara.extra_anim) {
         switch (g_Lara.water_status) {
         case LWS_ABOVE_WATER:
             if (water_height_diff == NO_HEIGHT
@@ -780,7 +780,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     item->hit_points = LARA_MAX_HITPOINTS;
 
     g_Lara.hit_direction = -1;
-    g_Lara.skidoo = NO_ITEM;
+    g_Lara.vehicle_item_num = NO_ITEM;
     g_Lara.gun_item_num = NO_ITEM;
     g_Lara.calc_fall_speed = 0;
     g_Lara.climb_status = 0;
@@ -1001,10 +1001,10 @@ void Lara_InitialiseMeshes(const GF_LEVEL *const level)
 
 void Lara_GetOffVehicle(void)
 {
-    if (g_Lara.skidoo != NO_ITEM) {
-        ITEM *const vehicle = Item_Get(g_Lara.skidoo);
+    if (g_Lara.vehicle_item_num != NO_ITEM) {
+        ITEM *const vehicle = Item_Get(g_Lara.vehicle_item_num);
         Item_SwitchToAnim(vehicle, 0, 0);
-        g_Lara.skidoo = NO_ITEM;
+        g_Lara.vehicle_item_num = NO_ITEM;
 
         g_LaraItem->current_anim_state = LS_STOP;
         g_LaraItem->goal_anim_state = LS_STOP;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -793,7 +793,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.flare_age = 0;
     g_Lara.back_gun = O_LARA;
     g_Lara.flare_frame = 0;
-    g_Lara.flare_control = 0;
+    g_Lara.flare_control = false;
     g_Lara.extra_anim = 0;
     g_Lara.look = 1;
     g_Lara.burn = 0;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -790,10 +790,10 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.dive_timer = 0;
     g_Lara.death_timer = 0;
     g_Lara.hit_effect_count = 0;
-    g_Lara.flare_age = 0;
+    g_Lara.flare.age = 0;
     g_Lara.back_gun = O_LARA;
-    g_Lara.flare_frame = 0;
-    g_Lara.flare_control = false;
+    g_Lara.flare.frame_num = 0;
+    g_Lara.flare.control = false;
     g_Lara.extra_anim = false;
     g_Lara.enable_look = true;
     g_Lara.burn = false;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -783,7 +783,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.vehicle_item_num = NO_ITEM;
     g_Lara.gun_item_num = NO_ITEM;
     g_Lara.calc_fall_speed = 0;
-    g_Lara.climb_status = 0;
+    g_Lara.climb_status = false;
     g_Lara.pose_count = 0;
     g_Lara.hit_frame = 0;
     g_Lara.air = LARA_MAX_AIR;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -531,7 +531,7 @@ void Lara_Control(const int16_t item_num)
                 item->pos.y += 1 - water_height_diff;
                 item->rot.z = 0;
                 item->rot.x = 0;
-                g_Lara.dive_count = 11;
+                g_Lara.dive_timer = 11;
                 g_Lara.torso_rot.y = 0;
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
@@ -610,7 +610,7 @@ void Lara_Control(const int16_t item_num)
                 item->rot.x = 0;
                 item->gravity = false;
                 item->fall_speed = 0;
-                g_Lara.dive_count = 0;
+                g_Lara.dive_timer = 0;
                 g_Lara.torso_rot.y = 0;
                 g_Lara.torso_rot.x = 0;
                 g_Lara.head_rot.y = 0;
@@ -787,7 +787,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.pose_count = 0;
     g_Lara.hit_frame = 0;
     g_Lara.air = LARA_MAX_AIR;
-    g_Lara.dive_count = 0;
+    g_Lara.dive_timer = 0;
     g_Lara.death_timer = 0;
     g_Lara.hit_effect_count = 0;
     g_Lara.flare_age = 0;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -220,12 +220,12 @@ void Lara_HandleAboveWater(ITEM *const item, COLL_INFO *const coll)
     coll->enable_baddie_push = 1;
     coll->enable_hit = 1;
 
-    if (g_Input.look && !g_Lara.extra_anim && g_Lara.look) {
+    if (g_Input.look && !g_Lara.extra_anim && g_Lara.enable_look) {
         Lara_LookLeftRight();
     } else {
         Lara_ResetLook();
     }
-    g_Lara.look = 1;
+    g_Lara.enable_look = true;
 
     if (g_Lara.vehicle_item_num != NO_ITEM) {
         if (Item_Get(g_Lara.vehicle_item_num)->object_id == O_SKIDOO_FAST) {
@@ -296,12 +296,12 @@ void Lara_HandleSurface(ITEM *const item, COLL_INFO *const coll)
     coll->enable_baddie_push = 0;
     coll->enable_hit = 0;
 
-    if (g_Input.look && g_Lara.look) {
+    if (g_Input.look && g_Lara.enable_look) {
         Lara_LookLeftRight();
     } else {
         Lara_ResetLook();
     }
-    g_Lara.look = 1;
+    g_Lara.enable_look = true;
 
     m_ControlRoutines[item->current_anim_state](item, coll);
 
@@ -355,12 +355,12 @@ void Lara_HandleUnderwater(ITEM *const item, COLL_INFO *const coll)
     coll->enable_baddie_push = 1;
     coll->enable_hit = 0;
 
-    if (g_Input.look && g_Lara.look) {
+    if (g_Input.look && g_Lara.enable_look) {
         Lara_LookLeftRight();
     } else {
         Lara_ResetLook();
     }
-    g_Lara.look = 1;
+    g_Lara.enable_look = true;
 
     if (g_Lara.extra_anim) {
         m_ExtraControlRoutines[item->current_anim_state](item, coll);
@@ -795,7 +795,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.flare_frame = 0;
     g_Lara.flare_control = false;
     g_Lara.extra_anim = false;
-    g_Lara.look = 1;
+    g_Lara.enable_look = true;
     g_Lara.burn = 0;
     g_Lara.water_surface_dist = 100;
     g_Lara.last_pos = item->pos;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -791,7 +791,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.death_timer = 0;
     g_Lara.hit_effect_count = 0;
     g_Lara.flare.age = 0;
-    g_Lara.back_gun = O_LARA;
+    g_Lara.back_gun_obj_id = O_LARA;
     g_Lara.flare.frame_num = 0;
     g_Lara.flare.control = false;
     g_Lara.extra_anim = false;
@@ -972,15 +972,15 @@ void Lara_InitialiseMeshes(const GF_LEVEL *const level)
 
     switch (resume->equipped_gun_type) {
     case LGT_M16:
-        g_Lara.back_gun = O_LARA_M16;
+        g_Lara.back_gun_obj_id = O_LARA_M16;
         return;
 
     case LGT_GRENADE:
-        g_Lara.back_gun = O_LARA_GRENADE;
+        g_Lara.back_gun_obj_id = O_LARA_GRENADE;
         return;
 
     case LGT_HARPOON:
-        g_Lara.back_gun = O_LARA_HARPOON;
+        g_Lara.back_gun_obj_id = O_LARA_HARPOON;
         return;
 
     default:
@@ -988,13 +988,13 @@ void Lara_InitialiseMeshes(const GF_LEVEL *const level)
     }
 
     if (resume->flags.has_shotgun) {
-        g_Lara.back_gun = O_LARA_SHOTGUN;
+        g_Lara.back_gun_obj_id = O_LARA_SHOTGUN;
     } else if (resume->flags.has_m16) {
-        g_Lara.back_gun = O_LARA_M16;
+        g_Lara.back_gun_obj_id = O_LARA_M16;
     } else if (resume->flags.has_grenade) {
-        g_Lara.back_gun = O_LARA_GRENADE;
+        g_Lara.back_gun_obj_id = O_LARA_GRENADE;
     } else if (resume->flags.has_harpoon) {
-        g_Lara.back_gun = O_LARA_HARPOON;
+        g_Lara.back_gun_obj_id = O_LARA_HARPOON;
     }
 }
 

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -793,8 +793,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.flare_age = 0;
     g_Lara.back_gun = O_LARA;
     g_Lara.flare_frame = 0;
-    g_Lara.flare_control_left = 0;
-    g_Lara.flare_control_right = 0;
+    g_Lara.flare_control = 0;
     g_Lara.extra_anim = 0;
     g_Lara.look = 1;
     g_Lara.burn = 0;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -796,7 +796,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.flare_control = false;
     g_Lara.extra_anim = false;
     g_Lara.enable_look = true;
-    g_Lara.burn = 0;
+    g_Lara.burn = false;
     g_Lara.water_surface_dist = 100;
     g_Lara.last_pos = item->pos;
     g_Lara.hit_effect = nullptr;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -794,7 +794,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.back_gun = O_LARA;
     g_Lara.flare_frame = 0;
     g_Lara.flare_control = false;
-    g_Lara.extra_anim = 0;
+    g_Lara.extra_anim = false;
     g_Lara.look = 1;
     g_Lara.burn = 0;
     g_Lara.water_surface_dist = 100;
@@ -830,7 +830,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
         item->current_anim_state = LA_EXTRA_BREATH;
         item->goal_anim_state = g_GF_LaraStartAnim;
         Lara_Animate(item);
-        g_Lara.extra_anim = 1;
+        g_Lara.extra_anim = true;
         Camera_InvokeCinematic(item, 0, 0);
     } else if ((Room_Get(item->room_num)->flags & RF_UNDERWATER)) {
         g_Lara.water_status = LWS_UNDERWATER;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -781,7 +781,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
 
     g_Lara.hit_direction = -1;
     g_Lara.skidoo = NO_ITEM;
-    g_Lara.weapon_item = NO_ITEM;
+    g_Lara.gun_item_num = NO_ITEM;
     g_Lara.calc_fall_speed = 0;
     g_Lara.climb_status = 0;
     g_Lara.pose_count = 0;

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -120,9 +120,9 @@ void Lara_Draw(const ITEM *const item)
 
     Matrix_Pop();
 
-    if (g_Lara.back_gun != O_LARA) {
+    if (g_Lara.back_gun_obj_id != O_LARA) {
         Matrix_Push();
-        const OBJECT *const back_obj = Object_Get(g_Lara.back_gun);
+        const OBJECT *const back_obj = Object_Get(g_Lara.back_gun_obj_id);
         const ANIM_BONE *const bone_c = Object_GetBone(back_obj, 0);
         Matrix_TranslateRel32(bone_c[13].pos);
         mesh_rots_c = back_obj->frame_base->mesh_rots;
@@ -357,9 +357,9 @@ void Lara_Draw_I(
     Lara_Hair_Draw();
     Matrix_Pop_I();
 
-    if (g_Lara.back_gun != O_LARA) {
+    if (g_Lara.back_gun_obj_id != O_LARA) {
         Matrix_Push_I();
-        const OBJECT *const back_obj = Object_Get(g_Lara.back_gun);
+        const OBJECT *const back_obj = Object_Get(g_Lara.back_gun_obj_id);
         const ANIM_BONE *const bone_c = Object_GetBone(back_obj, 0);
         Matrix_TranslateRel32_I(bone_c[13].pos);
         mesh_rots_1_c = back_obj->frame_base->mesh_rots;

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -148,7 +148,7 @@ void Lara_Draw(const ITEM *const item)
 
         Matrix_Push();
         Matrix_TranslateRel32(bone[10].pos);
-        if (g_Lara.flare_control_left) {
+        if (g_Lara.flare_control) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots =
                 g_Lara.left_arm
@@ -386,7 +386,7 @@ void Lara_Draw_I(
 
         Matrix_Push_I();
         Matrix_TranslateRel32_I(bone[10].pos);
-        if (g_Lara.flare_control_left) {
+        if (g_Lara.flare_control) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots_1 =
                 g_Lara.left_arm

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -58,7 +58,7 @@ void Lara_Draw(const ITEM *const item)
         hit_frame == nullptr ? frames[0] : hit_frame;
 
     const OBJECT *const obj = Object_Get(item->object_id);
-    if (g_Lara.skidoo == NO_ITEM) {
+    if (g_Lara.vehicle_item_num == NO_ITEM) {
         Output_InsertShadow(obj->shadow_size, &frame->bounds, item);
     }
 
@@ -289,7 +289,7 @@ void Lara_Draw_I(
     const OBJECT *const obj = Object_Get(item->object_id);
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
 
-    if (g_Lara.skidoo == NO_ITEM) {
+    if (g_Lara.vehicle_item_num == NO_ITEM) {
         Output_InsertShadow(obj->shadow_size, bounds, item);
     }
 

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -148,7 +148,7 @@ void Lara_Draw(const ITEM *const item)
 
         Matrix_Push();
         Matrix_TranslateRel32(bone[10].pos);
-        if (g_Lara.flare_control) {
+        if (g_Lara.flare.control) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots =
                 g_Lara.left_arm
@@ -386,7 +386,7 @@ void Lara_Draw_I(
 
         Matrix_Push_I();
         Matrix_TranslateRel32_I(bone[10].pos);
-        if (g_Lara.flare_control) {
+        if (g_Lara.flare.control) {
             const ANIM *const anim = Anim_GetAnim(g_Lara.left_arm.anim_num);
             mesh_rots_1 =
                 g_Lara.left_arm

--- a/src/tr2/game/lara/look.c
+++ b/src/tr2/game/lara/look.c
@@ -41,7 +41,8 @@ void Lara_LookLeftRight(void)
             g_Lara.head_rot.y += HEAD_TURN;
     }
 
-    if (g_Lara.gun_status != LGS_HANDS_BUSY && g_Lara.skidoo == NO_ITEM) {
+    if (g_Lara.gun_status != LGS_HANDS_BUSY
+        && g_Lara.vehicle_item_num == NO_ITEM) {
         g_Lara.torso_rot.y = g_Lara.head_rot.y;
     }
 }

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1690,11 +1690,11 @@ void Lara_Extinguish(void)
 
 bool Lara_IsM16Active(void)
 {
-    if (g_Lara.weapon_item == NO_ITEM || g_Lara.gun_type != LGT_M16) {
+    if (g_Lara.gun_item_num == NO_ITEM || g_Lara.gun_type != LGT_M16) {
         return false;
     }
 
-    const ITEM *const item = Item_Get(g_Lara.weapon_item);
+    const ITEM *const item = Item_Get(g_Lara.gun_item_num);
     return item->current_anim_state == 0 || item->current_anim_state == 2
         || item->current_anim_state == 4;
 }

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -839,7 +839,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
 
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
-        if (g_Lara.flare_control_left) {
+        if (g_Lara.flare_control) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             mesh_rots =
@@ -909,7 +909,7 @@ void Lara_GetJointAbsPosition_I(
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_Interpolate();
         Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
-        if (g_Lara.flare_control_left) {
+        if (g_Lara.flare_control) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             mesh_rots_1 =

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -1664,7 +1664,7 @@ void Lara_CatchFire(void)
     effect->frame_num = 0;
     effect->object_id = O_FLAME;
     effect->counter = -1;
-    g_Lara.burn = 1;
+    g_Lara.burn = true;
 }
 
 void Lara_Extinguish(void)
@@ -1673,7 +1673,7 @@ void Lara_Extinguish(void)
         return;
     }
 
-    g_Lara.burn = 0;
+    g_Lara.burn = false;
 
     // put out flame objects
     int16_t effect_num = Effect_GetActiveNum();

--- a/src/tr2/game/lara/misc.c
+++ b/src/tr2/game/lara/misc.c
@@ -839,7 +839,7 @@ void Lara_GetJointAbsPosition(XYZ_32 *vec, int32_t joint)
 
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
-        if (g_Lara.flare_control) {
+        if (g_Lara.flare.control) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             mesh_rots =
@@ -909,7 +909,7 @@ void Lara_GetJointAbsPosition_I(
     if (g_Lara.gun_type == LGT_FLARE) {
         Matrix_Interpolate();
         Matrix_TranslateRel32(bone[LM_UARM_L - 1].pos);
-        if (g_Lara.flare_control) {
+        if (g_Lara.flare.control) {
             const LARA_ARM *const arm = &g_Lara.left_arm;
             const ANIM *const anim = Anim_GetAnim(arm->anim_num);
             mesh_rots_1 =

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -828,7 +828,7 @@ void Lara_State_Extra_FinalAnim(ITEM *item, COLL_INFO *coll)
     item->hit_points = 1000;
 
     if (Item_TestFrameEqual(item, LF_SHOWER_START)) {
-        g_Lara.back_gun = O_LARA;
+        g_Lara.back_gun_obj_id = O_LARA;
         Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
         Lara_SwapSingleMesh(LM_HEAD, O_LARA);
         Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -311,7 +311,7 @@ void Lara_State_TurnLeft(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Death(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
 }
@@ -351,7 +351,7 @@ void Lara_State_Reach(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Splat(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
 }
 
 void Lara_State_Compress(ITEM *item, COLL_INFO *coll)
@@ -437,7 +437,7 @@ void Lara_State_FastTurn(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_StepRight(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     if (item->hit_points <= 0) {
         item->goal_anim_state = LS_STOP;
         return;
@@ -458,7 +458,7 @@ void Lara_State_StepRight(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_StepLeft(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     if (item->hit_points <= 0) {
         item->goal_anim_state = LS_STOP;
         return;
@@ -504,7 +504,7 @@ void Lara_State_BackJump(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_RightJump(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     if (item->fall_speed > LARA_FAST_FALL_SPEED) {
         item->goal_anim_state = LS_FAST_FALL;
         return;
@@ -517,7 +517,7 @@ void Lara_State_RightJump(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_LeftJump(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     if (item->fall_speed > LARA_FAST_FALL_SPEED) {
         item->goal_anim_state = LS_FAST_FALL;
         return;
@@ -578,7 +578,7 @@ void Lara_State_SlideBack(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_PushBlock(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
     g_Camera.flags = CF_FOLLOW_CENTRE;
@@ -598,7 +598,7 @@ void Lara_State_PPReady(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Pickup(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
     g_Camera.target_angle = CAM_PICKUP_ANGLE;
@@ -619,7 +619,7 @@ void Lara_State_PickupFlare(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_SwitchOn(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
     g_Camera.target_angle = CAM_SWITCH_ON_ANGLE;
@@ -630,7 +630,7 @@ void Lara_State_SwitchOn(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_UseKey(ITEM *item, COLL_INFO *coll)
 {
-    g_Lara.look = 0;
+    g_Lara.enable_look = false;
     coll->enable_hit = 0;
     coll->enable_baddie_push = 0;
     g_Camera.target_angle = CAM_USE_KEY_ANGLE;

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -722,7 +722,7 @@ void Lara_State_Extra_Breath(ITEM *item, COLL_INFO *coll)
     Item_SwitchToAnim(item, LA_STAND_IDLE, 0);
     item->goal_anim_state = LS_STOP;
     item->current_anim_state = LS_STOP;
-    g_Lara.extra_anim = 0;
+    g_Lara.extra_anim = false;
     g_Lara.gun_status = LGS_ARMLESS;
     if (g_Camera.type != CAM_HEAVY) {
         g_Camera.type = CAM_CHASE;

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -254,7 +254,7 @@ void Lara_State_TurnRight(ITEM *item, COLL_INFO *coll)
 
     g_Lara.turn_rate += LARA_TURN_RATE;
 
-    if (g_Lara.gun_status == LWS_WADE) {
+    if (g_Lara.gun_status == LGS_READY) {
         item->goal_anim_state = LS_FAST_TURN;
     } else if (g_Lara.turn_rate > LARA_SLOW_TURN) {
         if (g_Input.slow) {

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -912,7 +912,7 @@ void Lara_State_SurfSwim(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    g_Lara.dive_count = 0;
+    g_Lara.dive_timer = 0;
     if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
         if (g_Input.left) {
             item->rot.y -= LARA_SLOW_TURN;
@@ -934,7 +934,7 @@ void Lara_State_SurfBack(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    g_Lara.dive_count = 0;
+    g_Lara.dive_timer = 0;
     if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
         if (g_Input.left) {
             item->rot.y -= LARA_SURF_TURN;
@@ -956,7 +956,7 @@ void Lara_State_SurfLeft(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    g_Lara.dive_count = 0;
+    g_Lara.dive_timer = 0;
     if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
         if (g_Input.left) {
             item->rot.y -= LARA_SURF_TURN;
@@ -978,7 +978,7 @@ void Lara_State_SurfRight(ITEM *item, COLL_INFO *coll)
         return;
     }
 
-    g_Lara.dive_count = 0;
+    g_Lara.dive_timer = 0;
     if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
         if (g_Input.left) {
             item->rot.y -= LARA_SURF_TURN;
@@ -1026,8 +1026,8 @@ void Lara_State_SurfTread(ITEM *item, COLL_INFO *coll)
     }
 
     if (g_Input.jump) {
-        g_Lara.dive_count++;
-        if (g_Lara.dive_count == 10) {
+        g_Lara.dive_timer++;
+        if (g_Lara.dive_timer == 10) {
             Item_SwitchToAnim(item, LA_ONWATER_DIVE, 0);
             item->goal_anim_state = LS_SWIM;
             item->current_anim_state = LS_DIVE;
@@ -1036,7 +1036,7 @@ void Lara_State_SurfTread(ITEM *item, COLL_INFO *coll)
             g_Lara.water_status = LWS_UNDERWATER;
         }
     } else {
-        g_Lara.dive_count = 0;
+        g_Lara.dive_timer = 0;
     }
 }
 

--- a/src/tr2/game/objects/creatures/dragon.c
+++ b/src/tr2/game/objects/creatures/dragon.c
@@ -121,7 +121,7 @@ static void M_PullDagger(ITEM *const lara_item, ITEM *const dragon_back_item)
 
     Item_Animate(g_LaraItem);
 
-    g_Lara.extra_anim = 1;
+    g_Lara.extra_anim = true;
     g_Lara.gun_status = LGS_HANDS_BUSY;
     g_Lara.hit_direction = -1;
 

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -148,7 +148,7 @@ static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
         if (driver_data->flags == 0
             && ABS(info.angle) < SKIDOO_DRIVER_TARGET_ANGLE
             && g_LaraItem->hit_points > 0) {
-            const int32_t damage = g_Lara.skidoo != NO_ITEM
+            const int32_t damage = g_Lara.vehicle_item_num != NO_ITEM
                 ? SKIDOO_DRIVER_SHOT_DAMAGE
                 : SKIDOO_DRIVER_LARA_DAMAGE;
 

--- a/src/tr2/game/objects/effects/flame.c
+++ b/src/tr2/game/objects/effects/flame.c
@@ -61,11 +61,11 @@ static void M_Control(const int16_t effect_num)
             || g_Lara.water_status == LWS_CHEAT) {
             effect->counter = 0;
             Effect_Kill(effect_num);
-            g_Lara.burn = 0;
+            g_Lara.burn = false;
         } else {
             Sound_Effect(SFX_LOOP_FOR_SMALL_FIRES, &effect->pos, SPM_ALWAYS);
             Lara_TakeDamage(7, false);
-            g_Lara.burn = 1;
+            g_Lara.burn = true;
         }
     }
 }

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -90,7 +90,7 @@ static void M_PrepareCutscene(const int16_t item_num)
 {
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Undraw();
-        g_Lara.flare_control = false;
+        g_Lara.flare.control = false;
         g_Lara.left_arm.lock = false;
     }
 

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -90,7 +90,7 @@ static void M_PrepareCutscene(const int16_t item_num)
 {
     if (g_Lara.gun_type == LGT_FLARE) {
         Flare_Undraw();
-        g_Lara.flare_control_left = false;
+        g_Lara.flare_control = false;
         g_Lara.left_arm.lock = false;
     }
 

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -151,7 +151,7 @@ static void M_Collision(
 
     Item_Animate(lara_item);
 
-    g_Lara.extra_anim = 1;
+    g_Lara.extra_anim = true;
     g_Lara.gun_status = LGS_HANDS_BUSY;
 
     if (item->object_id == O_DETONATOR_2) {

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -86,7 +86,7 @@ static void M_DoFlarePickup(const int16_t item_num)
     g_Lara.gun_type = LGT_FLARE;
     Gun_InitialiseNewWeapon();
     g_Lara.gun_status = LGS_SPECIAL;
-    g_Lara.flare_age = ((int32_t)(intptr_t)item->data) & 0x7FFF;
+    g_Lara.flare.age = ((int32_t)(intptr_t)item->data) & 0x7FFF;
     Item_Kill(item_num);
 }
 

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -110,7 +110,7 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
         lara_item->current_anim_state = LA_EXTRA_BREATH;
         lara_item->goal_anim_state = LA_EXTRA_AIRLOCK;
         Item_Animate(lara_item);
-        g_Lara.extra_anim = 1;
+        g_Lara.extra_anim = true;
         break;
 
     case O_SWITCH_TYPE_SMALL:

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -64,7 +64,7 @@ static void M_Control1(const int16_t item_num)
         return;
     }
 
-    if (g_Lara.skidoo != NO_ITEM) {
+    if (g_Lara.vehicle_item_num != NO_ITEM) {
         if (Lara_IsNearItem(&item->pos, 512)) {
             Window_Smash(item_num);
         }

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -42,7 +42,7 @@ static void M_DetonateAll(
     int16_t boat_room_num)
 {
     ITEM *const boat_item = Item_Get(boat_item_num);
-    if (g_Lara.skidoo == boat_item_num) {
+    if (g_Lara.vehicle_item_num == boat_item_num) {
         Item_Explode(g_Lara.item_num, -1, 0);
         g_LaraItem->hit_points = 0;
         g_LaraItem->flags |= IF_ONE_SHOT;

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -35,8 +35,8 @@ static void M_Control(const int16_t item_num)
         }
 
         const LARA_INFO *const lara = Lara_GetLaraInfo();
-        if (lara->skidoo != NO_ITEM) {
-            ITEM *const skidoo = Item_Get(lara->skidoo);
+        if (lara->vehicle_item_num != NO_ITEM) {
+            ITEM *const skidoo = Item_Get(lara->vehicle_item_num);
             if (skidoo->object_id != O_SKIDOO_FAST
                 && skidoo->object_id != O_SKIDOO_ARMED) {
                 return;

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -217,7 +217,7 @@ static void M_DoShift(const int32_t boat_num)
         ITEM *const item = Item_Get(item_num);
 
         if (item->object_id == O_BOAT && item_num != boat_num
-            && g_Lara.skidoo != item_num) {
+            && g_Lara.vehicle_item_num != item_num) {
             const int32_t dx = item->pos.x - boat->pos.x;
             const int32_t dz = item->pos.z - boat->pos.z;
             const int32_t dist = SQUARE(dx) + SQUARE(dz);
@@ -386,7 +386,7 @@ static int32_t M_Dynamics(const int16_t boat_num)
         ) >> W2V_SHIFT;
         // clang-format on
 
-        if (g_Lara.skidoo == boat_num) {
+        if (g_Lara.vehicle_item_num == boat_num) {
             if (boat->speed > BOAT_MAX_SPEED + BOAT_ACCELERATION
                 && new_speed < boat->speed - 10) {
                 g_LaraItem->hit_points -= (boat->speed - new_speed) / 2;
@@ -580,7 +580,7 @@ static void M_Initialise(const int16_t item_num)
 static void M_Collision(
     const int16_t item_num, ITEM *const lara, COLL_INFO *const coll)
 {
-    if (lara->hit_points < 0 || g_Lara.skidoo != NO_ITEM) {
+    if (lara->hit_points < 0 || g_Lara.vehicle_item_num != NO_ITEM) {
         return;
     }
 
@@ -591,7 +591,7 @@ static void M_Collision(
         return;
     }
 
-    g_Lara.skidoo = item_num;
+    g_Lara.vehicle_item_num = item_num;
 
     int16_t boat_anim_idx;
     switch (get_on) {
@@ -664,7 +664,7 @@ static void M_Control(const int16_t item_num)
         Room_GetWaterHeight(boat->pos.x, boat->pos.y, boat->pos.z, room_num);
     boat_data->water = water_height;
 
-    if (g_Lara.skidoo == item_num && lara->hit_points > 0) {
+    if (g_Lara.vehicle_item_num == item_num && lara->hit_points > 0) {
         switch (lara->current_anim_state) {
         case BOAT_STATE_GET_ON:
         case BOAT_STATE_JUMP_R:
@@ -720,7 +720,7 @@ static void M_Control(const int16_t item_num)
         boat->rot.z = 0;
     }
 
-    if (g_Lara.skidoo == item_num) {
+    if (g_Lara.vehicle_item_num == item_num) {
         M_Animation(boat, collide);
 
         Item_UpdateRoom(item_num, room_num);
@@ -779,7 +779,7 @@ static void M_Control(const int16_t item_num)
         M_DoWakeEffect(boat);
     }
 
-    if (g_Lara.skidoo != item_num) {
+    if (g_Lara.vehicle_item_num != item_num) {
         return;
     }
 
@@ -800,7 +800,7 @@ static void M_Control(const int16_t item_num)
         lara->rot.z = 0;
         lara->speed = 20;
         lara->fall_speed = -40;
-        g_Lara.skidoo = NO_ITEM;
+        g_Lara.vehicle_item_num = NO_ITEM;
 
         const XYZ_32 pos = {
             .x = lara->pos.x + ((360 * Math_Sin(lara->rot.y)) >> W2V_SHIFT),

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -49,7 +49,7 @@ static void M_Collision(
             item, coll, item->speed > 0 ? coll->enable_hit : false, false);
     }
 
-    if (g_Lara.skidoo == NO_ITEM && item->speed > 0) {
+    if (g_Lara.vehicle_item_num == NO_ITEM && item->speed > 0) {
         Lara_TakeDamage(100, true);
     }
 }

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1146,9 +1146,9 @@ static JSON_OBJECT *M_DumpLara(void)
         lara_obj, "grenade", M_DumpAmmo(&lara->grenade_ammo));
     JSON_ObjectAppendObject(lara_obj, "m16", M_DumpAmmo(&lara->m16_ammo));
 
-    if (lara->weapon_item != NO_ITEM) {
+    if (lara->gun_item_num != NO_ITEM) {
         JSON_OBJECT *const weapon_obj = JSON_ObjectNew();
-        const ITEM *const weapon_item = Item_Get(lara->weapon_item);
+        const ITEM *const weapon_item = Item_Get(lara->gun_item_num);
         JSON_ObjectAppendInt(
             weapon_obj, "obj_id", Object_MakeGameID(weapon_item->object_id));
         JSON_ObjectAppendInt(weapon_obj, "anim_num", weapon_item->anim_num);
@@ -1302,8 +1302,8 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     const JSON_OBJECT *const weapon_obj =
         JSON_ObjectGetObject(lara_obj, "weapon");
     if (weapon_obj != nullptr) {
-        lara->weapon_item = Item_Create();
-        ITEM *const weapon_item = Item_Get(lara->weapon_item);
+        lara->gun_item_num = Item_Create();
+        ITEM *const weapon_item = Item_Get(lara->gun_item_num);
         weapon_item->object_id = Object_UnmapGameID(
             JSON_ObjectGetInt(weapon_obj, "obj_id", weapon_item->object_id));
         weapon_item->anim_num =

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1095,7 +1095,7 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(lara_obj, "hit_frame", lara->hit_frame);
     JSON_ObjectAppendInt(lara_obj, "hit_direction", lara->hit_direction);
     JSON_ObjectAppendInt(lara_obj, "air", lara->air);
-    JSON_ObjectAppendInt(lara_obj, "dive_count", lara->dive_count);
+    JSON_ObjectAppendInt(lara_obj, "dive_count", lara->dive_timer);
     JSON_ObjectAppendInt(lara_obj, "death_count", lara->death_timer);
     JSON_ObjectAppendInt(lara_obj, "current_active", lara->current_active);
     JSON_ObjectAppendInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
@@ -1194,8 +1194,8 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     lara->hit_direction =
         JSON_ObjectGetInt(lara_obj, "hit_direction", lara->hit_direction);
     lara->air = JSON_ObjectGetInt(lara_obj, "air", lara->air);
-    lara->dive_count =
-        JSON_ObjectGetInt(lara_obj, "dive_count", lara->dive_count);
+    lara->dive_timer =
+        JSON_ObjectGetInt(lara_obj, "dive_count", lara->dive_timer);
     lara->death_timer =
         JSON_ObjectGetInt(lara_obj, "death_count", lara->death_timer);
     lara->current_active =

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1100,7 +1100,8 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(lara_obj, "current_active", lara->current_active);
     JSON_ObjectAppendInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
     JSON_ObjectAppendInt(lara_obj, "flare_age", lara->flare_age);
-    JSON_ObjectAppendInt(lara_obj, "vehicle_item_number", lara->skidoo);
+    JSON_ObjectAppendInt(
+        lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     JSON_ObjectAppendInt(
         lara_obj, "back_gun_obj_id", Object_MakeGameID(lara->back_gun));
     JSON_ObjectAppendInt(lara_obj, "flare_frame", lara->flare_frame);
@@ -1202,8 +1203,8 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     lara->hit_effect_count =
         JSON_ObjectGetInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
     lara->flare_age = JSON_ObjectGetInt(lara_obj, "flare_age", lara->flare_age);
-    lara->skidoo =
-        JSON_ObjectGetInt(lara_obj, "vehicle_item_number", lara->skidoo);
+    lara->vehicle_item_num = JSON_ObjectGetInt(
+        lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     lara->back_gun = Object_UnmapGameID(
         JSON_ObjectGetInt(lara_obj, "back_gun_obj_id", lara->back_gun));
     lara->flare_frame =

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1109,7 +1109,7 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
-    JSON_ObjectAppendBool(lara_obj, "flare_control", lara->flare.control);
+    JSON_ObjectAppendBool(lara_obj, "flare_control_left", lara->flare.control);
     JSON_ObjectAppendBool(lara_obj, "extra_anim", lara->extra_anim);
     JSON_ObjectAppendBool(lara_obj, "look", lara->enable_look);
     JSON_ObjectAppendBool(lara_obj, "burn", lara->burn);
@@ -1212,7 +1212,7 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
     lara->flare.control =
-        JSON_ObjectGetBool(lara_obj, "flare_control", lara->flare.control);
+        JSON_ObjectGetBool(lara_obj, "flare_control_left", lara->flare.control);
     lara->extra_anim =
         JSON_ObjectGetBool(lara_obj, "extra_anim", lara->extra_anim);
     lara->enable_look = JSON_ObjectGetBool(lara_obj, "look", lara->enable_look);

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1103,7 +1103,7 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(
         lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     JSON_ObjectAppendInt(
-        lara_obj, "back_gun_obj_id", Object_MakeGameID(lara->back_gun));
+        lara_obj, "back_gun_obj_id", Object_MakeGameID(lara->back_gun_obj_id));
     JSON_ObjectAppendInt(lara_obj, "flare_frame", lara->flare.frame_num);
     JSON_ObjectAppendInt(lara_obj, "mesh_effects", lara->mesh_effects);
     JSON_ObjectAppendInt(
@@ -1202,8 +1202,8 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     lara->flare.age = JSON_ObjectGetInt(lara_obj, "flare_age", lara->flare.age);
     lara->vehicle_item_num = JSON_ObjectGetInt(
         lara_obj, "vehicle_item_number", lara->vehicle_item_num);
-    lara->back_gun = Object_UnmapGameID(
-        JSON_ObjectGetInt(lara_obj, "back_gun_obj_id", lara->back_gun));
+    lara->back_gun_obj_id = Object_UnmapGameID(
+        JSON_ObjectGetInt(lara_obj, "back_gun_obj_id", lara->back_gun_obj_id));
     lara->flare.frame_num =
         JSON_ObjectGetInt(lara_obj, "flare_frame", lara->flare.frame_num);
     lara->mesh_effects =

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1111,7 +1111,7 @@ static JSON_OBJECT *M_DumpLara(void)
 
     JSON_ObjectAppendBool(lara_obj, "flare_control", lara->flare_control);
     JSON_ObjectAppendBool(lara_obj, "extra_anim", lara->extra_anim);
-    JSON_ObjectAppendBool(lara_obj, "look", lara->look);
+    JSON_ObjectAppendBool(lara_obj, "look", lara->enable_look);
     JSON_ObjectAppendBool(lara_obj, "burn", lara->burn);
 
     JSON_ARRAY *const lara_meshes_arr = JSON_ArrayNew();
@@ -1215,7 +1215,7 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
         JSON_ObjectGetBool(lara_obj, "flare_control", lara->flare_control);
     lara->extra_anim =
         JSON_ObjectGetBool(lara_obj, "extra_anim", lara->extra_anim);
-    lara->look = JSON_ObjectGetBool(lara_obj, "look", lara->look);
+    lara->enable_look = JSON_ObjectGetBool(lara_obj, "look", lara->enable_look);
     lara->burn = JSON_ObjectGetBool(lara_obj, "burn", lara->burn);
 
     const JSON_ARRAY *const lara_meshes_arr =

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1109,10 +1109,7 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
-    JSON_ObjectAppendBool(
-        lara_obj, "flare_control_left", lara->flare_control_left);
-    JSON_ObjectAppendBool(
-        lara_obj, "flare_control_right", lara->flare_control_right);
+    JSON_ObjectAppendBool(lara_obj, "flare_control", lara->flare_control);
     JSON_ObjectAppendBool(lara_obj, "extra_anim", lara->extra_anim);
     JSON_ObjectAppendBool(lara_obj, "look", lara->look);
     JSON_ObjectAppendBool(lara_obj, "burn", lara->burn);
@@ -1214,10 +1211,8 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     lara->water_surface_dist = JSON_ObjectGetInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
-    lara->flare_control_left = JSON_ObjectGetBool(
-        lara_obj, "flare_control_left", lara->flare_control_left);
-    lara->flare_control_right = JSON_ObjectGetBool(
-        lara_obj, "flare_control_right", lara->flare_control_right);
+    lara->flare_control =
+        JSON_ObjectGetBool(lara_obj, "flare_control", lara->flare_control);
     lara->extra_anim =
         JSON_ObjectGetBool(lara_obj, "extra_anim", lara->extra_anim);
     lara->look = JSON_ObjectGetBool(lara_obj, "look", lara->look);

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1099,17 +1099,17 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(lara_obj, "death_count", lara->death_timer);
     JSON_ObjectAppendInt(lara_obj, "current_active", lara->current_active);
     JSON_ObjectAppendInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
-    JSON_ObjectAppendInt(lara_obj, "flare_age", lara->flare_age);
+    JSON_ObjectAppendInt(lara_obj, "flare_age", lara->flare.age);
     JSON_ObjectAppendInt(
         lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     JSON_ObjectAppendInt(
         lara_obj, "back_gun_obj_id", Object_MakeGameID(lara->back_gun));
-    JSON_ObjectAppendInt(lara_obj, "flare_frame", lara->flare_frame);
+    JSON_ObjectAppendInt(lara_obj, "flare_frame", lara->flare.frame_num);
     JSON_ObjectAppendInt(lara_obj, "mesh_effects", lara->mesh_effects);
     JSON_ObjectAppendInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
-    JSON_ObjectAppendBool(lara_obj, "flare_control", lara->flare_control);
+    JSON_ObjectAppendBool(lara_obj, "flare_control", lara->flare.control);
     JSON_ObjectAppendBool(lara_obj, "extra_anim", lara->extra_anim);
     JSON_ObjectAppendBool(lara_obj, "look", lara->enable_look);
     JSON_ObjectAppendBool(lara_obj, "burn", lara->burn);
@@ -1199,20 +1199,20 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
         JSON_ObjectGetInt(lara_obj, "current_active", lara->current_active);
     lara->hit_effect_count =
         JSON_ObjectGetInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
-    lara->flare_age = JSON_ObjectGetInt(lara_obj, "flare_age", lara->flare_age);
+    lara->flare.age = JSON_ObjectGetInt(lara_obj, "flare_age", lara->flare.age);
     lara->vehicle_item_num = JSON_ObjectGetInt(
         lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     lara->back_gun = Object_UnmapGameID(
         JSON_ObjectGetInt(lara_obj, "back_gun_obj_id", lara->back_gun));
-    lara->flare_frame =
-        JSON_ObjectGetInt(lara_obj, "flare_frame", lara->flare_frame);
+    lara->flare.frame_num =
+        JSON_ObjectGetInt(lara_obj, "flare_frame", lara->flare.frame_num);
     lara->mesh_effects =
         JSON_ObjectGetInt(lara_obj, "mesh_effects", lara->mesh_effects);
     lara->water_surface_dist = JSON_ObjectGetInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
 
-    lara->flare_control =
-        JSON_ObjectGetBool(lara_obj, "flare_control", lara->flare_control);
+    lara->flare.control =
+        JSON_ObjectGetBool(lara_obj, "flare_control", lara->flare.control);
     lara->extra_anim =
         JSON_ObjectGetBool(lara_obj, "extra_anim", lara->extra_anim);
     lara->enable_look = JSON_ObjectGetBool(lara_obj, "look", lara->enable_look);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -323,7 +323,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->current_active = M_ReadS16();
     lara->hit_effect_count = M_ReadS16();
     lara->flare_age = M_ReadS16();
-    lara->skidoo = M_ReadS16();
+    lara->vehicle_item_num = M_ReadS16();
     lara->gun_item_num = M_ReadS16();
     lara->back_gun = Object_UnmapGameID(M_ReadS16());
     lara->flare_frame = M_ReadS16();
@@ -581,7 +581,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->current_active);
     M_WriteS16(lara->hit_effect_count);
     M_WriteS16(lara->flare_age);
-    M_WriteS16(lara->skidoo);
+    M_WriteS16(lara->vehicle_item_num);
     M_WriteS16(lara->gun_item_num);
     M_WriteS16(Object_MakeGameID(lara->back_gun));
     M_WriteS16(lara->flare_frame);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -318,7 +318,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->hit_frame = M_ReadS16();
     lara->hit_direction = M_ReadS16();
     lara->air = M_ReadS16();
-    lara->dive_count = M_ReadS16();
+    lara->dive_timer = M_ReadS16();
     lara->death_timer = M_ReadS16();
     lara->current_active = M_ReadS16();
     lara->hit_effect_count = M_ReadS16();
@@ -576,7 +576,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->hit_frame);
     M_WriteS16(lara->hit_direction);
     M_WriteS16(lara->air);
-    M_WriteS16(lara->dive_count);
+    M_WriteS16(lara->dive_timer);
     M_WriteS16(lara->death_timer);
     M_WriteS16(lara->current_active);
     M_WriteS16(lara->hit_effect_count);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -324,7 +324,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->hit_effect_count = M_ReadS16();
     lara->flare_age = M_ReadS16();
     lara->skidoo = M_ReadS16();
-    lara->weapon_item = M_ReadS16();
+    lara->gun_item_num = M_ReadS16();
     lara->back_gun = Object_UnmapGameID(M_ReadS16());
     lara->flare_frame = M_ReadS16();
 
@@ -582,7 +582,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->hit_effect_count);
     M_WriteS16(lara->flare_age);
     M_WriteS16(lara->skidoo);
-    M_WriteS16(lara->weapon_item);
+    M_WriteS16(lara->gun_item_num);
     M_WriteS16(Object_MakeGameID(lara->back_gun));
     M_WriteS16(lara->flare_frame);
 
@@ -784,8 +784,8 @@ static void M_SaveToFile(MYFILE *const fp, SAVEGAME_INFO *const info)
     M_WriteItems();
     M_WriteLara(&g_Lara);
 
-    if (g_Lara.weapon_item != NO_ITEM) {
-        const ITEM *const weapon_item = Item_Get(g_Lara.weapon_item);
+    if (g_Lara.gun_item_num != NO_ITEM) {
+        const ITEM *const weapon_item = Item_Get(g_Lara.gun_item_num);
         M_WriteS16(weapon_item->object_id);
         M_WriteS16(weapon_item->anim_num);
         M_WriteS16(weapon_item->frame_num);
@@ -864,10 +864,10 @@ static bool M_LoadFromFile(MYFILE *const fp)
     M_ReadItems();
     M_ReadLara(&g_Lara);
 
-    if (g_Lara.weapon_item != NO_ITEM) {
-        g_Lara.weapon_item = Item_Create();
+    if (g_Lara.gun_item_num != NO_ITEM) {
+        g_Lara.gun_item_num = Item_Create();
 
-        ITEM *const weapon_item = Item_Get(g_Lara.weapon_item);
+        ITEM *const weapon_item = Item_Get(g_Lara.gun_item_num);
         weapon_item->object_id = Object_UnmapGameID(M_ReadS16());
         weapon_item->anim_num = M_ReadS16();
         weapon_item->frame_num = M_ReadS16();

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -325,7 +325,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->flare.age = M_ReadS16();
     lara->vehicle_item_num = M_ReadS16();
     lara->gun_item_num = M_ReadS16();
-    lara->back_gun = Object_UnmapGameID(M_ReadS16());
+    lara->back_gun_obj_id = Object_UnmapGameID(M_ReadS16());
     lara->flare.frame_num = M_ReadS16();
 
     const uint16_t flags = M_ReadU16();
@@ -582,7 +582,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->flare.age);
     M_WriteS16(lara->vehicle_item_num);
     M_WriteS16(lara->gun_item_num);
-    M_WriteS16(Object_MakeGameID(lara->back_gun));
+    M_WriteS16(Object_MakeGameID(lara->back_gun_obj_id));
     M_WriteS16(lara->flare.frame_num);
 
     uint16_t flags = 0;

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -322,15 +322,15 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->death_timer = M_ReadS16();
     lara->current_active = M_ReadS16();
     lara->hit_effect_count = M_ReadS16();
-    lara->flare_age = M_ReadS16();
+    lara->flare.age = M_ReadS16();
     lara->vehicle_item_num = M_ReadS16();
     lara->gun_item_num = M_ReadS16();
     lara->back_gun = Object_UnmapGameID(M_ReadS16());
-    lara->flare_frame = M_ReadS16();
+    lara->flare.frame_num = M_ReadS16();
 
     const uint16_t flags = M_ReadU16();
     // clang-format off
-    lara->flare_control = flags >> 0;
+    lara->flare.control = flags >> 0;
     lara->extra_anim    = flags >> 2;
     lara->enable_look   = flags >> 3;
     lara->burn          = flags >> 4;
@@ -579,15 +579,15 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->death_timer);
     M_WriteS16(lara->current_active);
     M_WriteS16(lara->hit_effect_count);
-    M_WriteS16(lara->flare_age);
+    M_WriteS16(lara->flare.age);
     M_WriteS16(lara->vehicle_item_num);
     M_WriteS16(lara->gun_item_num);
     M_WriteS16(Object_MakeGameID(lara->back_gun));
-    M_WriteS16(lara->flare_frame);
+    M_WriteS16(lara->flare.frame_num);
 
     uint16_t flags = 0;
     // clang-format off
-    if (lara->flare_control) { flags |= 1 << 0; }
+    if (lara->flare.control) { flags |= 1 << 0; }
     if (lara->extra_anim)    { flags |= 1 << 2; }
     if (lara->enable_look)   { flags |= 1 << 3; }
     if (lara->burn)          { flags |= 1 << 4; }

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -332,7 +332,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     // clang-format off
     lara->flare_control = flags >> 0;
     lara->extra_anim    = flags >> 2;
-    lara->look          = flags >> 3;
+    lara->enable_look   = flags >> 3;
     lara->burn          = flags >> 4;
     // clang-format on
 
@@ -589,7 +589,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     // clang-format off
     if (lara->flare_control) { flags |= 1 << 0; }
     if (lara->extra_anim)    { flags |= 1 << 2; }
-    if (lara->look)          { flags |= 1 << 3; }
+    if (lara->enable_look)   { flags |= 1 << 3; }
     if (lara->burn)          { flags |= 1 << 4; }
     // clang-format on
     M_WriteU16(flags);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -330,11 +330,10 @@ static void M_ReadLara(LARA_INFO *const lara)
 
     const uint16_t flags = M_ReadU16();
     // clang-format off
-    lara->flare_control_left  = flags >> 0;
-    lara->flare_control_right = flags >> 1;
-    lara->extra_anim          = flags >> 2;
-    lara->look                = flags >> 3;
-    lara->burn                = flags >> 4;
+    lara->flare_control = flags >> 0;
+    lara->extra_anim    = flags >> 2;
+    lara->look          = flags >> 3;
+    lara->burn          = flags >> 4;
     // clang-format on
 
     lara->water_surface_dist = M_ReadS32();
@@ -588,11 +587,10 @@ static void M_WriteLara(const LARA_INFO *const lara)
 
     uint16_t flags = 0;
     // clang-format off
-    if (lara->flare_control_left)  { flags |= 1 << 0; }
-    if (lara->flare_control_right) { flags |= 1 << 1; }
-    if (lara->extra_anim)          { flags |= 1 << 2; }
-    if (lara->look)                { flags |= 1 << 3; }
-    if (lara->burn)                { flags |= 1 << 4; }
+    if (lara->flare_control) { flags |= 1 << 0; }
+    if (lara->extra_anim)    { flags |= 1 << 2; }
+    if (lara->look)          { flags |= 1 << 3; }
+    if (lara->burn)          { flags |= 1 << 4; }
     // clang-format on
     M_WriteU16(flags);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reorganises `LARA_ARM`, `AMMO_INFO` and `LARA_INFO` to mark common properties for each, and renames some other properties and changes types to better match their purpose.

Only Lara is affected here so it'd be good to test save/load in various states, such as climbing, holding a flare, a different back gun being holstered and equipped, etc.
