### PR TITLE
inject: support embedded level injections

### DIFF
--- a/src/libtrx/game/inject/common.c
+++ b/src/libtrx/game/inject/common.c
@@ -7,13 +7,12 @@
 #include "game/level.h"
 #include "game/rooms.h"
 #include "memory.h"
-#include "utils.h"
 
 #include <string.h>
 #include <zlib.h>
 
-#define INJECTION_MAGIC MKTAG('T', 'R', 'X', 'J')
-#define INJECTION_CURRENT_VERSION 2
+#define M_INJECTION_CURRENT_VERSION 2
+#define M_VIRTUAL_NAME "virtual_injection"
 
 static bool (*m_Testers[ITT_NUMBER_OF])(const INJECTION *injection) = {};
 static void (*m_Handlers[ICT_NUMBER_OF])(INJECTION_CHUNK chunk) = {};
@@ -27,40 +26,50 @@ static INJECTION_MESH_META *m_RoomMeta = nullptr;
 static LEVEL_INFO m_CachedInfo = {};
 static uint16_t *m_PaletteMap = nullptr;
 
-static void M_LoadFromFile(INJECTION *injection, const char *filename);
+static void M_LoadFromFile(INJECTION *injection, const char *file_name);
+static void M_ReadVFile(
+    INJECTION *injection, VFILE *file, const char *file_name);
 static INJECTION_CHUNK M_ReadChunk(const INJECTION *injection);
 static void M_InitialiseBlock(VFILE *file);
 static bool M_IsRelevant(INJECTION_FILE_TYPE type);
 static bool M_IsApplicable(const INJECTION *injection);
 
 static void M_LoadFromFile(
-    INJECTION *const injection, const char *const filename)
+    INJECTION *const injection, const char *const file_name)
 {
-    VFILE *const file = VFile_CreateFromPath(filename);
+    VFILE *const file = VFile_CreateFromPath(file_name);
     if (file == nullptr) {
-        LOG_WARNING("Could not open %s", filename);
+        LOG_WARNING("Could not open %s", file_name);
         return;
     }
 
+    M_ReadVFile(injection, file, file_name);
+}
+
+static void M_ReadVFile(
+    INJECTION *const injection, VFILE *const file, const char *const file_name)
+{
+    const char *const inj_name =
+        file_name == nullptr ? M_VIRTUAL_NAME : file_name;
     char *payload = nullptr;
 
     const uint32_t magic = VFile_ReadU32(file);
     if (magic != INJECTION_MAGIC) {
-        LOG_WARNING("Invalid injection magic in %s", filename);
+        LOG_WARNING("Invalid injection magic in %s", inj_name);
         goto cleanup;
     }
 
     injection->version = VFile_ReadS32(file);
     if (injection->version < INJ_VERSION_2
-        || injection->version > INJECTION_CURRENT_VERSION) {
+        || injection->version > M_INJECTION_CURRENT_VERSION) {
         LOG_WARNING(
-            "%s uses unsupported version %d", filename, injection->version);
+            "%s uses unsupported version %d", inj_name, injection->version);
         goto cleanup;
     }
 
     injection->type = VFile_ReadS32(file);
     if (injection->type < 0 || injection->type >= IFT_NUMBER_OF) {
-        LOG_WARNING("%s is of unknown type %d", filename, injection->type);
+        LOG_WARNING("%s is of unknown type %d", inj_name, injection->type);
         goto cleanup;
     }
 
@@ -103,7 +112,7 @@ static void M_LoadFromFile(
     }
 
     VFile_SetPos(injection->fp, 0);
-    LOG_INFO("%s queued for injection", filename);
+    LOG_INFO("%s queued for injection", inj_name);
 
 cleanup:
     Memory_FreePointer(&payload);
@@ -266,6 +275,14 @@ void Inject_InitLevel(const GF_LEVEL *const level)
     }
 
     Benchmark_End(&benchmark, nullptr);
+}
+
+void Inject_AppendInjection(VFILE *const file)
+{
+    m_Injections =
+        Memory_Realloc(m_Injections, sizeof(INJECTION) * (m_NumInjections + 1));
+    INJECTION *const injection = &m_Injections[m_NumInjections++];
+    M_ReadVFile(injection, file, nullptr);
 }
 
 void Inject_AllInjections(void)

--- a/src/libtrx/include/libtrx/game/inject/common.h
+++ b/src/libtrx/include/libtrx/game/inject/common.h
@@ -1,8 +1,12 @@
+#include "../../utils.h"
 #include "../game_flow.h"
 #include "../level.h"
 #include "./types.h"
 
+#define INJECTION_MAGIC MKTAG('T', 'R', 'X', 'J')
+
 void Inject_InitLevel(const GF_LEVEL *level);
+void Inject_AppendInjection(VFILE *file);
 void Inject_AllInjections(void);
 void Inject_Cleanup(void);
 

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -39,6 +39,7 @@
 
 typedef enum {
     LEVEL_LAYOUT_UNKNOWN = -1,
+    LEVEL_LAYOUT_TR1X,
     LEVEL_LAYOUT_TR1,
     LEVEL_LAYOUT_TR1_DEMO_PC,
     LEVEL_LAYOUT_NUMBER_OF,
@@ -147,6 +148,12 @@ static bool M_TryLayout(VFILE *const file, const LEVEL_LAYOUT layout)
     TRY_OR_FAIL_ARR_S32(1); // sample data
     TRY_OR_FAIL_ARR_S32(4); // samples
 
+    if (layout == LEVEL_LAYOUT_TR1X) {
+        uint32_t inj_magic;
+        TRY_OR_FAIL(VFile_TryReadU32(file, &inj_magic));
+        TRY_OR_FAIL((inj_magic == INJECTION_MAGIC));
+    }
+
 #undef TRY_OR_FAIL
 #undef TRY_OR_FAIL_ARR_U16
 #undef TRY_OR_FAIL_ARR_S32
@@ -246,6 +253,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadCinematicFrames(file);
     Level_ReadDemoData(file);
     Level_ReadSamples(file);
+
+    if (layout == LEVEL_LAYOUT_TR1X) {
+        VFILE *const embedded_injection = VFile_CreateFromBuffer(
+            file->cur_ptr, file->size - VFile_GetPos(file));
+        Inject_AppendInjection(embedded_injection);
+    }
 
     VFile_SetPos(file, 4);
     Level_ReadTexturePages(file);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -47,14 +47,15 @@ typedef enum {
     LEVEL_LAYOUT_NUMBER_OF,
 } M_LAYOUT;
 
+static bool M_TryLayout(VFILE *file, M_LAYOUT layout);
+static void M_SkimLevel(VFILE *file, M_LAYOUT layout);
+static M_LAYOUT M_GuessLayout(VFILE *file);
 static int32_t M_CompareSampleOffsets(const void *a, const void *b);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_InitialiseSoundEffects(const char *const file_name);
 static void M_CompleteSetup(const GF_LEVEL *level);
-static bool M_SkimLevel(VFILE *file, M_LAYOUT layout, bool read_items);
 
-static bool M_SkimLevel(
-    VFILE *const file, const M_LAYOUT layout, const bool read_items)
+static bool M_TryLayout(VFILE *const file, const M_LAYOUT layout)
 {
 #define TRY_OR_FAIL(call)                                                      \
     if (!call) {                                                               \
@@ -128,11 +129,7 @@ static bool M_SkimLevel(
     TRY_OR_FAIL(VFile_TrySkip(file, box_count * 20)); // zones
 
     TRY_OR_FAIL_ARR_S32(2); // animated texture ranges
-    if (read_items) {
-        Level_ReadItems(file);
-    } else {
-        TRY_OR_FAIL_ARR_S32(24); // items
-    }
+    TRY_OR_FAIL_ARR_S32(24); // items
 
     TRY_OR_FAIL(VFile_TrySkip(file, 32 * 256)); // light table
     TRY_OR_FAIL_ARR_U16(16); // cinematic frames
@@ -154,12 +151,77 @@ static bool M_SkimLevel(
     return true;
 }
 
+static void M_SkimLevel(VFILE *const file, M_LAYOUT layout)
+{
+#define SKIP_ARR_S32(size)                                                     \
+    {                                                                          \
+        const int32_t num = VFile_ReadS32(file);                               \
+        VFile_Skip(file, num *size);                                           \
+    }
+#define SKIP_ARR_U16(size)                                                     \
+    {                                                                          \
+        const uint16_t num = VFile_ReadU16(file);                              \
+        VFile_Skip(file, num *size);                                           \
+    }
+
+    ASSERT(layout != LEVEL_LAYOUT_UNKNOWN);
+    VFile_SetPos(file, 4); // start after version number
+    VFile_Skip(file, 1792); // palettes
+    SKIP_ARR_S32(TEXTURE_PAGE_SIZE * 3); // texture pages
+    VFile_Skip(file, 4); // unused version number
+
+    const uint16_t room_count = VFile_ReadU16(file);
+    for (int32_t i = 0; i < room_count; i++) {
+        VFile_Skip(file, 16);
+        SKIP_ARR_S32(2); // meshes
+        SKIP_ARR_U16(32); // portals
+
+        const int16_t size_z = VFile_ReadS16(file);
+        const int16_t size_x = VFile_ReadS16(file);
+        VFile_Skip(file, size_z * size_x * 8); // sectors
+
+        VFile_Skip(file, 6); // lighting
+        SKIP_ARR_U16(24); // lights
+        SKIP_ARR_U16(20); // static meshes
+        VFile_Skip(file, 4);
+    }
+
+    SKIP_ARR_S32(2); // floor data
+    SKIP_ARR_S32(2); // object meshes
+    SKIP_ARR_S32(4); // object mesh pointers
+    SKIP_ARR_S32(32); // animations
+    SKIP_ARR_S32(6); // animation changes
+    SKIP_ARR_S32(8); // animation ranges
+    SKIP_ARR_S32(2); // animation commands
+    SKIP_ARR_S32(4); // animation bones
+    SKIP_ARR_S32(2); // animation frames
+    SKIP_ARR_S32(18); // objects
+    SKIP_ARR_S32(32); // static objects
+    SKIP_ARR_S32(20); // object textures
+    SKIP_ARR_S32(16); // sprite textures
+    SKIP_ARR_S32(8); // sprites sequences
+    SKIP_ARR_S32(16); // cameras/sinks
+    SKIP_ARR_S32(16); // sound sources
+
+    const int32_t box_count = VFile_ReadS32(file);
+    VFile_Skip(file, box_count * 8);
+    SKIP_ARR_S32(2); // overlaps
+    VFile_Skip(file, box_count * 20); // zones
+
+    SKIP_ARR_S32(2); // animated texture ranges
+
+    Level_ReadItems(file);
+
+#undef SKIP_ARR_S32
+#undef SKIP_ARR_U16
+}
+
 static M_LAYOUT M_GuessLayout(VFILE *const file)
 {
     M_LAYOUT result = LEVEL_LAYOUT_UNKNOWN;
     BENCHMARK benchmark = Benchmark_Start();
     for (M_LAYOUT layout = 0; layout < LEVEL_LAYOUT_NUMBER_OF; layout++) {
-        if (M_SkimLevel(file, layout, false)) {
+        if (M_TryLayout(file, layout)) {
             result = layout;
             break;
         }
@@ -258,13 +320,7 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
         Shell_ExitSystemFmt("Failed to load %s", level->path);
     }
 
-    VFile_SetPos(file, 0);
-    const int32_t version = VFile_ReadS32(file);
-    if (version != 45) {
-        Shell_ExitSystemFmt(
-            "Unexpected level version (%d, expected: %d, path: %s)", level->num,
-            45, level->path);
-    }
+    VFile_SetPos(file, 4);
 
     Level_ReadPalettes(file);
     Level_ReadTexturePages(file);
@@ -427,16 +483,16 @@ void Level_Init(void)
             continue;
         }
 
-        const bool result = M_SkimLevel(file, LEVEL_LAYOUT_TR2, true);
-        VFile_Close(file);
-
-        if (result) {
+        const M_LAYOUT layout = M_GuessLayout(file);
+        if (layout != LEVEL_LAYOUT_UNKNOWN) {
+            M_SkimLevel(file, layout);
             Stats_CalculateStats();
             STATS_COMMON stats = {};
             stats.max_secret_count = Stats_GetSecrets();
             Savegame_SetDefaultStats(level, stats);
         }
         GameBuf_Reset();
+        VFile_Close(file);
     }
 
     Benchmark_End(&benchmark, nullptr);

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -40,13 +40,21 @@ typedef struct {
     int32_t file_index;
 } SAMPLE_ENTRY;
 
+typedef enum {
+    LEVEL_LAYOUT_UNKNOWN = -1,
+    LEVEL_LAYOUT_TR2X,
+    LEVEL_LAYOUT_TR2,
+    LEVEL_LAYOUT_NUMBER_OF,
+} M_LAYOUT;
+
 static int32_t M_CompareSampleOffsets(const void *a, const void *b);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_InitialiseSoundEffects(const char *const file_name);
 static void M_CompleteSetup(const GF_LEVEL *level);
-static bool M_SkimLevel(VFILE *file);
+static bool M_SkimLevel(VFILE *file, M_LAYOUT layout, bool read_items);
 
-static bool M_SkimLevel(VFILE *const file)
+static bool M_SkimLevel(
+    VFILE *const file, const M_LAYOUT layout, const bool read_items)
 {
 #define TRY_OR_FAIL(call)                                                      \
     if (!call) {                                                               \
@@ -120,13 +128,44 @@ static bool M_SkimLevel(VFILE *const file)
     TRY_OR_FAIL(VFile_TrySkip(file, box_count * 20)); // zones
 
     TRY_OR_FAIL_ARR_S32(2); // animated texture ranges
-    Level_ReadItems(file);
+    if (read_items) {
+        Level_ReadItems(file);
+    } else {
+        TRY_OR_FAIL_ARR_S32(24); // items
+    }
+
+    TRY_OR_FAIL(VFile_TrySkip(file, 32 * 256)); // light table
+    TRY_OR_FAIL_ARR_U16(16); // cinematic frames
+    TRY_OR_FAIL_ARR_U16(1); // demo data
+    TRY_OR_FAIL(VFile_TrySkip(file, 2 * SFX_NUMBER_OF)); // sample lut
+    TRY_OR_FAIL_ARR_S32(8); // sample infos
+    TRY_OR_FAIL_ARR_S32(4); // samples
+
+    if (layout == LEVEL_LAYOUT_TR2X) {
+        uint32_t inj_magic;
+        TRY_OR_FAIL(VFile_TryReadU32(file, &inj_magic));
+        TRY_OR_FAIL((inj_magic == INJECTION_MAGIC));
+    }
 
 #undef TRY_OR_FAIL
 #undef TRY_OR_FAIL_ARR_U16
 #undef TRY_OR_FAIL_ARR_S32
 
     return true;
+}
+
+static M_LAYOUT M_GuessLayout(VFILE *const file)
+{
+    M_LAYOUT result = LEVEL_LAYOUT_UNKNOWN;
+    BENCHMARK benchmark = Benchmark_Start();
+    for (M_LAYOUT layout = 0; layout < LEVEL_LAYOUT_NUMBER_OF; layout++) {
+        if (M_SkimLevel(file, layout, false)) {
+            result = layout;
+            break;
+        }
+    }
+    Benchmark_End(&benchmark, nullptr);
+    return result;
 }
 
 static int32_t M_CompareSampleOffsets(const void *const a, const void *const b)
@@ -214,6 +253,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     VFILE *const file = VFile_CreateFromPath(full_path);
     Memory_FreePointer(&full_path);
 
+    const M_LAYOUT layout = M_GuessLayout(file);
+    if (layout == LEVEL_LAYOUT_UNKNOWN) {
+        Shell_ExitSystemFmt("Failed to load %s", level->path);
+    }
+
+    VFile_SetPos(file, 0);
     const int32_t version = VFile_ReadS32(file);
     if (version != 45) {
         Shell_ExitSystemFmt(
@@ -251,6 +296,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
     Level_ReadCinematicFrames(file);
     Level_ReadDemoData(file);
     Level_ReadSamples(file);
+
+    if (layout == LEVEL_LAYOUT_TR2X) {
+        VFILE *const embedded_injection = VFile_CreateFromBuffer(
+            file->cur_ptr, file->size - VFile_GetPos(file));
+        Inject_AppendInjection(embedded_injection);
+    }
 
     VFile_Close(file);
     Benchmark_End(&benchmark, nullptr);
@@ -376,7 +427,7 @@ void Level_Init(void)
             continue;
         }
 
-        const bool result = M_SkimLevel(file);
+        const bool result = M_SkimLevel(file, LEVEL_LAYOUT_TR2, true);
         VFile_Close(file);
 
         if (result) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds support to the injection framework to accept a virtual file, which is put to use in level reading to detect when injections have been embedded at the end of regular level data.

I'm not particularly happy with `M_SkimLevel` in TR2 as it now has two purposes (initial secret loading count and to guess the layout), but equally I didn't want to duplicate the code here. WDYT? An alternative option is not to define a TRX version and just have the detection look for the additional data during `M_LoadFromFile`. Perhaps this is better as the "OG version" is technically the same.

I've uploaded a pair of test levels (`te-embedded-injections.zip`) generated from the linked TE PR. Lara should be able to traverse the vertical rooms there.

Ref: https://github.com/MontyTRC89/Tomb-Editor/pull/1038
