### PR TITLE
tr2/savegame_legacy: fix reading Lara flags

### DIFF
--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -329,10 +329,10 @@ static void M_ReadLara(LARA_INFO *const lara)
 
     const uint16_t flags = M_ReadU16();
     // clang-format off
-    lara->flare.control = flags >> 0;
-    lara->extra_anim    = flags >> 2;
-    lara->enable_look   = flags >> 3;
-    lara->burn          = flags >> 4;
+    lara->flare.control = (flags & (1 << 0)) != 0;
+    lara->extra_anim    = (flags & (1 << 2)) != 0;
+    lara->enable_look   = (flags & (1 << 3)) != 0;
+    lara->burn          = (flags & (1 << 4)) != 0;
     // clang-format on
 
     lara->water_surface_dist = M_ReadS32();


### PR DESCRIPTION
Resolves #3083.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes interpreting Lara's saved status flags as bools in legacy save files.
