### PR TITLE
tr2/gun: fix extra anim gun reset

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity (#3062)
 - fixed transparent eyes on Lara's model in the gym and Home Sweet Home levels (#3072)
 - fixed transparent eyes on the wolf model in Furnace of the Gods (#3073)
+- fixed Lara dropping flares after certain special animations, such as pulling the dagger from the dragon (#3084, regression from 1.1)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -16,7 +16,7 @@
 
 void Gun_Control(void)
 {
-    if (g_Lara.extra_anim) {
+    if (g_Lara.extra_anim && g_Lara.gun_status != LGS_HANDS_BUSY) {
         g_Lara.request_gun_type = LGT_UNARMED;
         return;
     }


### PR DESCRIPTION
Resolves #3084.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara dropping flares once extra animations have completed. I think this could have also affected air lock doors, the Bartoli's detonator and the gong in Ice Palace, so worth checking those too.
