### PR TITLE
tr2/data: restore missing collapsible tile SFX

### DIFF
--- a/data/tr2/ship/cfg/TR2X_gameflow.json5
+++ b/data/tr2/ship/cfg/TR2X_gameflow.json5
@@ -248,6 +248,7 @@
                 {"type": "level_complete"},
             ],
             "injections": [
+                "data/injections/breakable_tile_sfx.bin",
                 "data/injections/deck_cameras.bin",
                 "data/injections/deck_fd.bin",
                 "data/injections/deck_itemrots.bin",

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,7 +4,7 @@
 - changed the combat end logic (used in Home Sweet Home) to allow using any regular enemy type aside from the boss
 - changed the rotation of some pickups in The Golden Mask to better suit the 3D pickups option (#1973)
 - fixed a missing collapsible tile trigger in The Cold War room 82 (#3058)
-- fixed missing sound effects for collapsible tiles in Opera House and Catacombs of the Talion (#2262, #2872)
+- fixed missing sound effects for collapsible tiles in Opera House, The Deck and Catacombs of the Talion (#2262, #2872, #3087)
 - fixed texture and visibility issues with the skyboxes in The Cold War and Kingdom (#3056)
 - fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity (#3062)
 - fixed transparent eyes on Lara's model in the gym and Home Sweet Home levels (#3072)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -361,7 +361,7 @@ However, you can easily download them manually from these urls:
 - fixed music not playing if triggered while the game is muted, but the volume is then increased
 - fixed being unable to load a level that contains no sound effect data
 - fixed missing enemy sound effects in the underwater levels
-- fixed missing sound effects for collapsible tiles in Opera House and Catacombs of the Talion
+- fixed missing sound effects for collapsible tiles in Opera House, The Deck and Catacombs of the Talion
 
 #### Mods
 - added developer console (accessible with `/`, see [COMMANDS.md](COMMANDS.md) for details)


### PR DESCRIPTION
Resolves #3087.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds the same fix from 5e31cb9c to The Deck to restore collapsible tile SFX.
