### PR TITLE
tr2/objects: reset hit pose in extra anims

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity (#3062)
 - fixed transparent eyes on Lara's model in the gym and Home Sweet Home levels (#3072)
 - fixed transparent eyes on the wolf model in Furnace of the Gods (#3073)
+- fixed Lara getting stuck in her hit animation if she is hit while using an airlock door, the detonator or the gong (#3092)
 - fixed Lara dropping flares after certain special animations, such as pulling the dagger from the dragon (#3084, regression from 1.1)
 - improved word wrapping algorithm in the dev console
 

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -211,7 +211,7 @@ However, you can easily download them manually from these urls:
 - fixed harpoon bolts damaging inactive enemies
 - fixed the distorted skybox in room 5 of Barkhang Monastery
 - fixed new saves not displaying the save count in the passport
-- fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo
+- fixed Lara getting stuck in her hit animation if she is hit while mounting the boat or skidoo, or when using an airlock door, the detonator or the gong
 - fixed the detonator key and gong hammer not activating their target items when manually selected from the inventory
 - fixed a potential crash if Lara is on the skidoo in a room with many other adjoining rooms
 - fixed a softlock in Home Sweet Home if the final cutscene is triggered while Lara is on water surface

--- a/src/tr2/game/objects/general/detonator.c
+++ b/src/tr2/game/objects/general/detonator.c
@@ -153,6 +153,7 @@ static void M_Collision(
 
     g_Lara.extra_anim = true;
     g_Lara.gun_status = LGS_HANDS_BUSY;
+    g_Lara.hit_direction = -1;
 
     if (item->object_id == O_DETONATOR_2) {
         item->status = IS_ACTIVE;

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -111,6 +111,7 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
         lara_item->goal_anim_state = LA_EXTRA_AIRLOCK;
         Item_Animate(lara_item);
         g_Lara.extra_anim = true;
+        g_Lara.hit_direction = -1;
         break;
 
     case O_SWITCH_TYPE_SMALL:


### PR DESCRIPTION
Resolves #3092.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resets Lara's hit pose when she uses the detonator, gong or an air lock. I've uploaded `tr2-hit-pose.zip` with some saves for the detonator and gong (hold action on load). The airlock one is easier to replicate than these.
