### PR TITLE
ui/settings: respect wraparound setting

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.2...develop) - ××××-××-××
 - added an optional breeze effect for Lara's braid in appropriate outside rooms (#3090)
 - changed the graphic settings dialog to use tabs
+- changed the setting dialogs to respect the UI wraparound setting
 - changed the `/tp` command to align Lara to switches and pickups
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added an option to disable the breeze effect on Lara's braid (#3090)
 - changed the `/tp` command to align Lara to switches and pickups
 - changed the graphic settings dialog to use tabs
+- changed the setting dialogs to respect the UI wraparound setting
 - changed the combat end logic (used in Home Sweet Home) to allow using any regular enemy type aside from the boss
 - changed the rotation of some pickups in The Golden Mask to better suit the 3D pickups option (#1973)
 - fixed a missing collapsible tile trigger in The Cold War room 82 (#3058)

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -148,7 +148,6 @@ static int32_t M_GetVisibleRows(void);
 static INPUT_ROLE M_GetInputRole(
     const UI_CONTROLS_EDITOR_GROUP *group, int32_t row);
 static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *group);
-static bool M_CycleLayout(UI_CONTROLS_EDITOR_STATE *s, int32_t dir);
 static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *s);
 static void M_UnbindKey(const UI_CONTROLS_EDITOR_STATE *s);
 static bool M_HandleHoldAction(
@@ -216,27 +215,6 @@ static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *const group)
     return row;
 }
 
-static bool M_CycleLayout(UI_CONTROLS_EDITOR_STATE *const s, const int32_t dir)
-{
-    if (!g_Config.ui.enable_wraparound
-        && (s->active_layout + dir < INPUT_LAYOUT_DEFAULT
-            || s->active_layout + dir >= INPUT_LAYOUT_NUMBER_OF)) {
-        return false;
-    }
-
-    s->active_layout += dir;
-    s->active_layout += INPUT_LAYOUT_NUMBER_OF;
-    s->active_layout %= INPUT_LAYOUT_NUMBER_OF;
-
-    const EVENT event = {
-        .name = "layout_change",
-        .sender = nullptr,
-        .data = nullptr,
-    };
-    EventManager_Fire(s->events, &event);
-    return true;
-}
-
 static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)
 {
 #if TR_VERSION == 1
@@ -299,10 +277,14 @@ static UI_CONTROLS_CHOICE M_NavigateLayout(UI_CONTROLS_EDITOR_STATE *const s)
         return UI_CONTROLS_CHOICE_EXIT;
     } else if (g_InputDB.menu_back) {
         return UI_CONTROLS_CHOICE_GO_BACK;
-    } else if (g_InputDB.menu_left) {
-        M_CycleLayout(s, -1);
-    } else if (g_InputDB.menu_right) {
-        M_CycleLayout(s, 1);
+    } else if (UI_TabSwitch_Control(s->layout_tab_switch)) {
+        s->active_layout = s->layout_tab_switch->active_tab_idx;
+        const EVENT event = {
+            .name = "layout_change",
+            .sender = nullptr,
+            .data = nullptr,
+        };
+        EventManager_Fire(s->events, &event);
     } else if (g_InputDB.menu_down) {
         s->phase = M_PHASE_NAVIGATE_GROUP;
     } else if (
@@ -325,8 +307,8 @@ static UI_CONTROLS_CHOICE M_NavigateGroup(UI_CONTROLS_EDITOR_STATE *const s)
         return UI_CONTROLS_CHOICE_EXIT;
     } else if (g_InputDB.menu_back) {
         return UI_CONTROLS_CHOICE_GO_BACK;
-    } else if (UI_TabSwitch_Control(s->tab_switch)) {
-        s->active_group = &m_Groups[s->tab_switch->active_tab_idx];
+    } else if (UI_TabSwitch_Control(s->controls_tab_switch)) {
+        s->active_group = &m_Groups[s->controls_tab_switch->active_tab_idx];
         UI_Scrollable_SetMaxItems(
             &s->scroll, M_GetInputRoleCount(s->active_group));
     } else if (g_InputDB.menu_down && s->active_layout != 0) {
@@ -347,8 +329,8 @@ static UI_CONTROLS_CHOICE M_NavigateInputs(UI_CONTROLS_EDITOR_STATE *const s)
         s->phase = M_PHASE_NAVIGATE_INPUTS_DEBOUNCE;
     } else if (g_InputDB.menu_back) {
         return UI_CONTROLS_CHOICE_GO_BACK;
-    } else if (UI_TabSwitch_Control(s->tab_switch)) {
-        s->active_group = &m_Groups[s->tab_switch->active_tab_idx];
+    } else if (UI_TabSwitch_Control(s->controls_tab_switch)) {
+        s->active_group = &m_Groups[s->controls_tab_switch->active_tab_idx];
         UI_Scrollable_SetMaxItems(
             &s->scroll, M_GetInputRoleCount(s->active_group));
     } else if (g_InputDB.menu_up) {
@@ -410,32 +392,13 @@ static UI_CONTROLS_CHOICE M_ListenDebounce(UI_CONTROLS_EDITOR_STATE *const s)
 
 static void M_CurrentLayout(const UI_CONTROLS_EDITOR_STATE *const s)
 {
-    const bool is_focused = s->phase == M_PHASE_NAVIGATE_LAYOUT;
-    UI_BeginAnchor(0.5f, 0.5f);
-    UI_BeginRowArrows(
-        is_focused
-            && (g_Config.ui.enable_wraparound
-                || s->active_layout != INPUT_LAYOUT_DEFAULT),
-        is_focused
-            && (g_Config.ui.enable_wraparound
-                || s->active_layout + 1 < INPUT_LAYOUT_NUMBER_OF),
-        UI_ROW_ARROWS_MEDIUM);
-    if (is_focused) {
-        UI_BeginFrame(UI_FRAME_SELECTED_OPTION);
-    }
-    UI_BeginPad(2.0f, 1.0f);
-    UI_Label(Input_GetLayoutName(s->active_layout));
-    UI_EndPad();
-    if (is_focused) {
-        UI_EndFrame();
-    }
-    UI_EndRowArrows();
-    UI_EndAnchor();
+    UI_TabSwitchSingle(
+        s->layout_tab_switch, s->phase == M_PHASE_NAVIGATE_LAYOUT);
 }
 
 static void M_GroupsHeader(const UI_CONTROLS_EDITOR_STATE *const s)
 {
-    UI_TabSwitch(s->tab_switch, s->phase == M_PHASE_NAVIGATE_GROUP);
+    UI_TabSwitch(s->controls_tab_switch, s->phase == M_PHASE_NAVIGATE_GROUP);
 }
 
 static void M_InputLabel(
@@ -562,15 +525,26 @@ void UI_ControlsEditor_Init(
     s->hold_timer = 0;
     UI_Flash_Init(&s->flash, LOGIC_FPS * 2 / 3);
 
-    int32_t tab_count = 0;
-    for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
-        tab_count++;
+    {
+        UI_TAB_SWITCH_TAB layout_tabs[INPUT_LAYOUT_NUMBER_OF];
+        for (INPUT_LAYOUT i = 0; i < INPUT_LAYOUT_NUMBER_OF; i++) {
+            layout_tabs[i].header = Input_GetLayoutName(i);
+        }
+        s->layout_tab_switch =
+            UI_TabSwitch_Init(INPUT_LAYOUT_NUMBER_OF, layout_tabs);
     }
-    UI_TAB_SWITCH_TAB tabs[tab_count];
-    for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
-        tabs[i].header = m_Groups[i].header;
+
+    {
+        int32_t tab_count = 0;
+        for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
+            tab_count++;
+        }
+        UI_TAB_SWITCH_TAB controls_tabs[tab_count];
+        for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
+            controls_tabs[i].header = GameString_Get(m_Groups[i].header);
+        }
+        s->controls_tab_switch = UI_TabSwitch_Init(tab_count, controls_tabs);
     }
-    s->tab_switch = UI_TabSwitch_Init(tab_count, tabs);
 
     s->max_group_items = 0;
     for (const UI_CONTROLS_EDITOR_GROUP *group = m_Groups;
@@ -597,15 +571,19 @@ void UI_ControlsEditor_Init(
 void UI_ControlsEditor_Free(UI_CONTROLS_EDITOR_STATE *const s)
 {
     UI_Flash_Free(&s->flash);
-    UI_TabSwitch_Free(s->tab_switch);
-    s->tab_switch = nullptr;
+    UI_TabSwitch_Free(s->layout_tab_switch);
+    s->layout_tab_switch = nullptr;
+    UI_TabSwitch_Free(s->controls_tab_switch);
+    s->controls_tab_switch = nullptr;
 }
 
 void UI_ControlsEditor_Reinit(
-    UI_CONTROLS_EDITOR_STATE *s, INPUT_BACKEND backend, int32_t layout)
+    UI_CONTROLS_EDITOR_STATE *const s, const INPUT_BACKEND backend,
+    const INPUT_LAYOUT layout)
 {
     s->backend = backend;
     s->active_layout = layout;
+    s->layout_tab_switch->active_tab_idx = s->active_layout;
     s->scroll.sel_item = 0;
     s->active_role = M_GetInputRole(s->active_group, s->scroll.sel_item);
     s->phase = M_PHASE_NAVIGATE_LAYOUT;

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -148,7 +148,7 @@ static int32_t M_GetVisibleRows(void);
 static INPUT_ROLE M_GetInputRole(
     const UI_CONTROLS_EDITOR_GROUP *group, int32_t row);
 static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *group);
-static void M_CycleLayout(UI_CONTROLS_EDITOR_STATE *s, int32_t dir);
+static bool M_CycleLayout(UI_CONTROLS_EDITOR_STATE *s, int32_t dir);
 static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *s);
 static void M_UnbindKey(const UI_CONTROLS_EDITOR_STATE *s);
 static bool M_HandleHoldAction(
@@ -216,8 +216,14 @@ static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *const group)
     return row;
 }
 
-static void M_CycleLayout(UI_CONTROLS_EDITOR_STATE *const s, const int32_t dir)
+static bool M_CycleLayout(UI_CONTROLS_EDITOR_STATE *const s, const int32_t dir)
 {
+    if (!g_Config.ui.enable_wraparound
+        && (s->active_layout + dir < INPUT_LAYOUT_DEFAULT
+            || s->active_layout + dir >= INPUT_LAYOUT_NUMBER_OF)) {
+        return false;
+    }
+
     s->active_layout += dir;
     s->active_layout += INPUT_LAYOUT_NUMBER_OF;
     s->active_layout %= INPUT_LAYOUT_NUMBER_OF;
@@ -228,6 +234,7 @@ static void M_CycleLayout(UI_CONTROLS_EDITOR_STATE *const s, const int32_t dir)
         .data = nullptr,
     };
     EventManager_Fire(s->events, &event);
+    return true;
 }
 
 static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)
@@ -298,7 +305,9 @@ static UI_CONTROLS_CHOICE M_NavigateLayout(UI_CONTROLS_EDITOR_STATE *const s)
         M_CycleLayout(s, 1);
     } else if (g_InputDB.menu_down) {
         s->phase = M_PHASE_NAVIGATE_GROUP;
-    } else if (g_InputDB.menu_up && s->active_layout != 0) {
+    } else if (
+        g_InputDB.menu_up && s->active_layout != 0
+        && g_Config.ui.enable_wraparound) {
         s->phase = M_PHASE_NAVIGATE_INPUTS;
         UI_Scrollable_SelectLastItem(&s->scroll);
         s->active_role = M_GetInputRole(s->active_group, s->scroll.sel_item);
@@ -347,7 +356,8 @@ static UI_CONTROLS_CHOICE M_NavigateInputs(UI_CONTROLS_EDITOR_STATE *const s)
             s->phase = M_PHASE_NAVIGATE_GROUP;
         }
     } else if (g_InputDB.menu_down) {
-        if (!UI_Scrollable_SelectNext(&s->scroll, false)) {
+        if (!UI_Scrollable_SelectNext(&s->scroll, false)
+            && g_Config.ui.enable_wraparound) {
             s->phase = M_PHASE_NAVIGATE_LAYOUT;
         }
     } else {
@@ -402,7 +412,14 @@ static void M_CurrentLayout(const UI_CONTROLS_EDITOR_STATE *const s)
 {
     const bool is_focused = s->phase == M_PHASE_NAVIGATE_LAYOUT;
     UI_BeginAnchor(0.5f, 0.5f);
-    UI_BeginRowArrows(is_focused, is_focused, UI_ROW_ARROWS_MEDIUM);
+    UI_BeginRowArrows(
+        is_focused
+            && (g_Config.ui.enable_wraparound
+                || s->active_layout != INPUT_LAYOUT_DEFAULT),
+        is_focused
+            && (g_Config.ui.enable_wraparound
+                || s->active_layout + 1 < INPUT_LAYOUT_NUMBER_OF),
+        UI_ROW_ARROWS_MEDIUM);
     if (is_focused) {
         UI_BeginFrame(UI_FRAME_SELECTED_OPTION);
     }

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -448,7 +448,7 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
         } else if (g_InputDB.menu_down) {
             s->phase = UI_SETTINGS_PHASE_EDIT_SETTINGS;
             UI_Scrollable_SelectFirstItem(&s->scroll);
-        } else if (g_InputDB.menu_up) {
+        } else if (g_InputDB.menu_up && g_Config.ui.enable_wraparound) {
             s->phase = UI_SETTINGS_PHASE_EDIT_SETTINGS;
             UI_Scrollable_SelectLastItem(&s->scroll);
         }
@@ -457,12 +457,13 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
             if (!UI_Scrollable_SelectPrev(&s->scroll, false)) {
                 if (s->tab_switch != nullptr) {
                     s->phase = UI_SETTINGS_PHASE_NAVIGATE_TABS;
-                } else {
+                } else if (g_Config.ui.enable_wraparound) {
                     UI_Scrollable_SelectLastItem(&s->scroll);
                 }
             }
         } else if (g_InputDB.menu_down) {
-            if (!UI_Scrollable_SelectNext(&s->scroll, false)) {
+            if (!UI_Scrollable_SelectNext(&s->scroll, false)
+                && g_Config.ui.enable_wraparound) {
                 if (s->tab_switch != nullptr) {
                     s->phase = UI_SETTINGS_PHASE_NAVIGATE_TABS;
                 } else {

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -415,7 +415,7 @@ void UI_Settings_InitWithTabs(
     s->max_group_items = 0;
     UI_TAB_SWITCH_TAB tab_switch_tabs[tab_count];
     for (int32_t i = 0; i < tab_count; i++) {
-        tab_switch_tabs[i].header = tabs[i].header;
+        tab_switch_tabs[i].header = GameString_Get(tabs[i].header);
         int32_t tab_items = 0;
         for (int32_t j = 0; tabs[i].options[j].label_id != nullptr; j++) {
             tab_items++;

--- a/src/libtrx/game/ui/elements/tab_switch.c
+++ b/src/libtrx/game/ui/elements/tab_switch.c
@@ -1,6 +1,6 @@
 #include "game/ui/elements/tab_switch.h"
 
-#include "game/game_string.h"
+#include "config.h"
 #include "game/input/common.h"
 #include "game/ui/elements/anchor.h"
 #include "game/ui/elements/frame.h"
@@ -8,8 +8,6 @@
 #include "game/ui/elements/pad.h"
 #include "game/ui/elements/row_arrows.h"
 #include "game/ui/elements/stack.h"
-#include "game/ui/helpers.h"
-#include "game/ui/scrollable.h"
 #include "memory.h"
 
 UI_TAB_SWITCH_STATE *UI_TabSwitch_Init(
@@ -28,24 +26,31 @@ void UI_TabSwitch_Free(UI_TAB_SWITCH_STATE *const s)
     Memory_Free(s);
 }
 
-void UI_TabSwitch_Cycle(UI_TAB_SWITCH_STATE *const s, const int32_t dir)
+bool UI_TabSwitch_Cycle(UI_TAB_SWITCH_STATE *const s, const int32_t dir)
 {
-    s->active_tab_idx += dir;
-    if (s->active_tab_idx < 0) {
-        s->active_tab_idx = s->tab_count - 1;
-    } else if (s->active_tab_idx >= s->tab_count) {
-        s->active_tab_idx = 0;
+    if (s->active_tab_idx + dir < 0) {
+        if (g_Config.ui.enable_wraparound) {
+            s->active_tab_idx = s->tab_count - 1;
+            return true;
+        }
+    } else if (s->active_tab_idx + dir >= s->tab_count) {
+        if (g_Config.ui.enable_wraparound) {
+            s->active_tab_idx = 0;
+            return true;
+        }
+    } else {
+        s->active_tab_idx += dir;
+        return true;
     }
+    return false;
 }
 
 bool UI_TabSwitch_Control(UI_TAB_SWITCH_STATE *const s)
 {
     if (g_InputDB.menu_left) {
-        UI_TabSwitch_Cycle(s, -1);
-        return true;
+        return UI_TabSwitch_Cycle(s, -1);
     } else if (g_InputDB.menu_right) {
-        UI_TabSwitch_Cycle(s, 1);
-        return true;
+        return UI_TabSwitch_Cycle(s, 1);
     }
     return false;
 }
@@ -53,7 +58,12 @@ bool UI_TabSwitch_Control(UI_TAB_SWITCH_STATE *const s)
 void UI_TabSwitch(const UI_TAB_SWITCH_STATE *const s, const bool is_focused)
 {
     UI_BeginAnchor(0.5f, 0.5f);
-    UI_BeginRowArrows(is_focused, is_focused, UI_ROW_ARROWS_MEDIUM);
+    UI_BeginRowArrows(
+        is_focused && (g_Config.ui.enable_wraparound || s->active_tab_idx > 0),
+        is_focused
+            && (g_Config.ui.enable_wraparound
+                || s->active_tab_idx + 1 < s->tab_count),
+        UI_ROW_ARROWS_MEDIUM);
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_HORIZONTAL,
         .align = { .h = UI_STACK_H_ALIGN_CENTER },

--- a/src/libtrx/game/ui/elements/tab_switch.c
+++ b/src/libtrx/game/ui/elements/tab_switch.c
@@ -10,6 +10,47 @@
 #include "game/ui/elements/stack.h"
 #include "memory.h"
 
+static void M_Draw(const UI_TAB_SWITCH_STATE *s, bool is_focused, bool single);
+
+static void M_Draw(
+    const UI_TAB_SWITCH_STATE *const s, const bool is_focused,
+    const bool single)
+{
+    UI_BeginAnchor(0.5f, 0.5f);
+    UI_BeginRowArrows(
+        is_focused && (g_Config.ui.enable_wraparound || s->active_tab_idx > 0),
+        is_focused
+            && (g_Config.ui.enable_wraparound
+                || s->active_tab_idx + 1 < s->tab_count),
+        UI_ROW_ARROWS_MEDIUM);
+    UI_BeginStackEx((UI_STACK_SETTINGS) {
+        .orientation = UI_STACK_HORIZONTAL,
+        .align = { .h = UI_STACK_H_ALIGN_CENTER },
+        .spacing = { .h = 10.0f },
+    });
+    for (int32_t i = 0; i < s->tab_count; i++) {
+        if (single && i != s->active_tab_idx) {
+            continue;
+        }
+        const UI_TAB_SWITCH_TAB *const tab = &s->tabs[i];
+        UI_BeginAnchor(0.5f, 0.5f);
+        if (i == s->active_tab_idx) {
+            UI_BeginFrame(
+                is_focused ? UI_FRAME_SELECTED_OPTION : UI_FRAME_OUTLINE_ONLY);
+        }
+        UI_BeginPad(2.0f, 1.0f);
+        UI_Label(tab->header);
+        UI_EndPad();
+        if (i == s->active_tab_idx) {
+            UI_EndFrame();
+        }
+        UI_EndAnchor();
+    }
+    UI_EndStack();
+    UI_EndRowArrows();
+    UI_EndAnchor();
+}
+
 UI_TAB_SWITCH_STATE *UI_TabSwitch_Init(
     const int32_t tab_count, const UI_TAB_SWITCH_TAB *const tabs)
 {
@@ -57,34 +98,11 @@ bool UI_TabSwitch_Control(UI_TAB_SWITCH_STATE *const s)
 
 void UI_TabSwitch(const UI_TAB_SWITCH_STATE *const s, const bool is_focused)
 {
-    UI_BeginAnchor(0.5f, 0.5f);
-    UI_BeginRowArrows(
-        is_focused && (g_Config.ui.enable_wraparound || s->active_tab_idx > 0),
-        is_focused
-            && (g_Config.ui.enable_wraparound
-                || s->active_tab_idx + 1 < s->tab_count),
-        UI_ROW_ARROWS_MEDIUM);
-    UI_BeginStackEx((UI_STACK_SETTINGS) {
-        .orientation = UI_STACK_HORIZONTAL,
-        .align = { .h = UI_STACK_H_ALIGN_CENTER },
-        .spacing = { .h = 10.0f },
-    });
-    for (int32_t i = 0; i < s->tab_count; i++) {
-        const UI_TAB_SWITCH_TAB *const tab = &s->tabs[i];
-        UI_BeginAnchor(0.5f, 0.5f);
-        if (i == s->active_tab_idx) {
-            UI_BeginFrame(
-                is_focused ? UI_FRAME_SELECTED_OPTION : UI_FRAME_OUTLINE_ONLY);
-        }
-        UI_BeginPad(2.0f, 1.0f);
-        UI_Label(GameString_Get(tab->header));
-        UI_EndPad();
-        if (i == s->active_tab_idx) {
-            UI_EndFrame();
-        }
-        UI_EndAnchor();
-    }
-    UI_EndStack();
-    UI_EndRowArrows();
-    UI_EndAnchor();
+    M_Draw(s, is_focused, false);
+}
+
+void UI_TabSwitchSingle(
+    const UI_TAB_SWITCH_STATE *const s, const bool is_focused)
+{
+    M_Draw(s, is_focused, true);
 }

--- a/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
@@ -19,7 +19,7 @@ typedef struct {
 typedef struct {
     int32_t phase;
     INPUT_BACKEND backend;
-    int32_t active_layout;
+    INPUT_LAYOUT active_layout;
     INPUT_ROLE active_role;
     const UI_CONTROLS_EDITOR_GROUP *active_group;
     UI_FLASH_STATE flash;
@@ -33,7 +33,8 @@ typedef struct {
     int32_t max_group_items;
     int32_t input_size;
     int32_t label_size;
-    UI_TAB_SWITCH_STATE *tab_switch;
+    UI_TAB_SWITCH_STATE *layout_tab_switch;
+    UI_TAB_SWITCH_STATE *controls_tab_switch;
 } UI_CONTROLS_EDITOR_STATE;
 
 typedef enum {
@@ -46,7 +47,7 @@ typedef enum {
 void UI_ControlsEditor_Init(UI_CONTROLS_EDITOR_STATE *s, EVENT_MANAGER *events);
 void UI_ControlsEditor_Free(UI_CONTROLS_EDITOR_STATE *s);
 void UI_ControlsEditor_Reinit(
-    UI_CONTROLS_EDITOR_STATE *s, INPUT_BACKEND backend, int32_t layout);
+    UI_CONTROLS_EDITOR_STATE *s, INPUT_BACKEND backend, INPUT_LAYOUT layout);
 UI_CONTROLS_CHOICE UI_ControlsEditor_Control(UI_CONTROLS_EDITOR_STATE *s);
 
 // draw functions

--- a/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
+++ b/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
@@ -9,7 +9,7 @@
 
 // Represents a single tab page for use with UI_TabSwitch_Control.
 typedef struct {
-    GAME_STRING_ID header;
+    const char *header;
 } UI_TAB_SWITCH_TAB;
 
 typedef struct {
@@ -33,3 +33,4 @@ bool UI_TabSwitch_Cycle(UI_TAB_SWITCH_STATE *state, int32_t dir);
 
 // draw functions
 void UI_TabSwitch(const UI_TAB_SWITCH_STATE *state, bool is_focused);
+void UI_TabSwitchSingle(const UI_TAB_SWITCH_STATE *state, bool is_focused);

--- a/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
+++ b/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
@@ -29,7 +29,7 @@ bool UI_TabSwitch_Control(UI_TAB_SWITCH_STATE *state);
 
 // Advances the active tab by dir (-1 for previous, +1 for next), wrapping
 // around.
-void UI_TabSwitch_Cycle(UI_TAB_SWITCH_STATE *state, int32_t dir);
+bool UI_TabSwitch_Cycle(UI_TAB_SWITCH_STATE *state, int32_t dir);
 
 // draw functions
 void UI_TabSwitch(const UI_TAB_SWITCH_STATE *state, bool is_focused);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Changes the setting dialogs to respect the UI wraparound setting. Affects all settings dialog - sounds, graphic settings and controls; both horizontal and vertical navigation.
Also, updates the controls dialog to use the new TabSwitch component for the layout navigation as well, adding a `TabSwitchSingle` element which only draws the active tab rather than all of them.