### PR TITLE
Fix text sizing issues

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
 - changed the graphic settings dialog to use tabs
 - changed the `/tp` command to align Lara to switches and pickups
 - changed the music track slot limit from 64 to 1024 (#3101)
+- changed text kerning to a smaller value
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
 - fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -4,6 +4,7 @@
 - changed the `/tp` command to align Lara to switches and pickups
 - changed the music track slot limit from 64 to 1024 (#3101)
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
+- fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed the graphic settings dialog to use tabs
 - changed the combat end logic (used in Home Sweet Home) to allow using any regular enemy type aside from the boss
 - changed the rotation of some pickups in The Golden Mask to better suit the 3D pickups option (#1973)
+- changed text kerning to a smaller value
 - fixed a missing collapsible tile trigger in The Cold War room 82 (#3058)
 - fixed missing sound effects for collapsible tiles in Opera House, The Deck and Catacombs of the Talion (#2262, #2872, #3087)
 - fixed texture and visibility issues with the skyboxes in The Cold War and Kingdom (#3056)

--- a/src/libtrx/game/ui/text.c
+++ b/src/libtrx/game/ui/text.c
@@ -12,8 +12,8 @@
 #include <ctype.h>
 #include <uthash.h>
 
-#define M_LETTER_SPACING 1
-#define M_WORD_SPACING 6
+#define M_LETTER_SPACING 0.5f
+#define M_WORD_SPACING 6.0f
 
 typedef enum {
     // special non-printable glyph roles
@@ -225,8 +225,8 @@ void UI_Text_Measure(
     ASSERT(glyphs != nullptr);
 
     if (out_w != nullptr) {
-        int32_t width = 0;
-        int32_t max_width = 0;
+        float width = 0.0f;
+        float max_width = 0.0f;
         const M_GLYPH_INFO **glyph_ptr = glyphs;
         while (*glyph_ptr != nullptr) {
             if ((*glyph_ptr)->role == GLYPH_SPACE) {
@@ -281,12 +281,12 @@ void UI_Text_Draw(
 
     const int32_t scale = M_Scale(UI_TEXT_BASE_SCALE * settings.scale);
 
-    int32_t x = M_Scale(base_x / g_Config.ui.text_scale);
-    int32_t y = M_Scale(
+    float x = M_Scale(base_x / g_Config.ui.text_scale);
+    float y = M_Scale(
         base_y / g_Config.ui.text_scale + settings.scale * UI_TEXT_HEIGHT - 1);
     int32_t z = settings.z;
 
-    const int32_t start_x = x;
+    const float start_x = x;
 
     const M_GLYPH_INFO **glyph_ptr = glyphs;
     while (*glyph_ptr != nullptr) {
@@ -345,7 +345,7 @@ void UI_Text_Draw(
             SHADE_NEUTRAL);
 
         if (glyph->role != GLYPH_COMBINING) {
-            const int32_t spacing = glyph->width + M_LETTER_SPACING;
+            const float spacing = glyph->width + M_LETTER_SPACING;
             x += spacing * scale / UI_TEXT_BASE_SCALE;
         }
 

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -352,8 +352,8 @@ static void M_DrawSprite(
 
     const float u0 = (sprite->offset & 0xFF) / 256.0f;
     const float v0 = (sprite->offset >> 8) / 256.0f;
-    const float u1 = (sprite->width >> 8) / 256.0f + u0;
-    const float v1 = (sprite->height >> 8) / 256.0f + v0;
+    const float u1 = u0 + sprite->width / 65536.0f;
+    const float v1 = v0 + sprite->height / 65536.0f;
     const float vz = MAP_DEPTH(z);
     const float rhw = 1.0f / z;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes text glyphs missing rightmost and bottom-most edges in TR1, and reduces the letter spacing to half a pixel.
Technically this also covers pickup sprites in the UI screen corner.

@aredfan  I'd appreciate a check which version of TR1X broke text rendering so that we can update changelog accordingly. Thanks