### PR TITLE
tr1/output: fix vertical fov option not working

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
 - fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 4.11)
+- fixed vertical FOV option not working properly (#3120, regression from 4.10)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -139,7 +139,7 @@ void InvRing_Draw(INV_RING *const ring)
         Viewport_Init(0, 0, width, height);
     }
 
-    int16_t old_fov = Viewport_GetFOV();
+    const int16_t old_fov = Viewport_GetFOV();
     Viewport_SetFOV(M_PASSPORT_FOV * DEG_1);
     Output_ApplyFOV();
 

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -865,9 +865,8 @@ void Output_ApplyFOV(void)
         fov = round((fov_rad_v / M_PI) * (180 * DEG_1));
     }
 
-    int16_t c = Math_Cos(fov / 2);
-    int16_t s = Math_Sin(fov / 2);
-
+    const int16_t c = Math_Cos(fov / 2);
+    const int16_t s = Math_Sin(fov / 2);
     g_PhdPersp = Screen_GetResWidth() / 2;
     if (s != 0) {
         g_PhdPersp *= c;

--- a/src/tr1/game/output/func.c
+++ b/src/tr1/game/output/func.c
@@ -4,6 +4,7 @@
 #include "game/viewport.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/gfx/gl/utils.h>
 
@@ -63,17 +64,25 @@ void Output_GetProjectionMatrix(GLfloat output[][4])
     const float bottom = Viewport_GetHeight();
     const float near = Output_GetNearZ() / (float)(1 << W2V_SHIFT);
     const float far = Output_GetFarZ() / (float)(1 << W2V_SHIFT);
-    const float aspect = (float)right / (float)bottom;
+    const float aspect = (float)(right - left) / (float)(bottom - top);
     const float fov = Viewport_GetFOV() * M_PI / (float)DEG_180;
-    const float f = 1.0f / tan(fov / 2.0f);
 
-    output[0][0] = f / aspect;
+    float f_x, f_y;
+    if (g_Config.visuals.fov_vertical) {
+        f_y = 1.0f / tanf(fov * 0.5f);
+        f_x = f_y / aspect;
+    } else {
+        f_x = 1.0f / tanf(fov * 0.5f);
+        f_y = f_x * aspect;
+    }
+
+    output[0][0] = f_x;
     output[0][1] = 0.0f;
     output[0][2] = 0.0f;
     output[0][3] = 0.0f;
 
     output[1][0] = 0.0f;
-    output[1][1] = -f;
+    output[1][1] = -f_y;
     output[1][2] = 0.0f;
     output[1][3] = 0.0f;
 

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -263,8 +263,8 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     // translating the object in order to avoid perspective distortion in the
     // screen corners.
     int16_t old_fov = Viewport_GetFOV();
-    Viewport_SetFOV(M_PICKUPS_FOV * DEG_1);
     Viewport_Init(new_vp.x, new_vp.y, new_vp.w, new_vp.h);
+    Viewport_SetFOV(M_PICKUPS_FOV * DEG_1);
     glViewport(new_vp.x, new_vp.y, new_vp.w, new_vp.h);
     Output_ApplyFOV();
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3120.