### PR TITLE
Add ability to restore defaults in the settings dialogs

### DIFF
--- a/data/tr1/ship/cfg/TR1X_strings.json5
+++ b/data/tr1/ship/cfg/TR1X_strings.json5
@@ -345,6 +345,7 @@
         "ACTION_UNBIND": "Unbind",
         "ACTION_USE_ITEM": "Use",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "This setting is enforced by the level builder and cannot be changed.",
+        "COMMON_SETTINGS_RESTORE_DEFAULT": "Restore default",
         "COMMON_SETTINGS_TOGGLE_HELP": "Toggle help",
         "CONSOLE_CMD_HELP_LIST": "Available commands:",
         "CONSOLE_HELP_BRAID": "Toggles Lara's braid.",

--- a/data/tr2/ship/cfg/TR2X_strings.json5
+++ b/data/tr2/ship/cfg/TR2X_strings.json5
@@ -469,6 +469,7 @@
         "ACTION_UNBIND": "Unbind",
         "ACTION_USE_ITEM": "Use",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "This setting is enforced by the level builder and cannot be changed.",
+        "COMMON_SETTINGS_RESTORE_DEFAULT": "Restore default",
         "COMMON_SETTINGS_TOGGLE_HELP": "Toggle help",
         "CONSOLE_CMD_HELP_LIST": "Available commands:",
         "CONSOLE_HELP_BRAID": "Toggles Lara's braid.",

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -24,9 +24,6 @@
 #include "game/viewport.h"
 #include "utils.h"
 
-#define M_HOLD_TIMER_DEBUFF (LOGIC_FPS / 3)
-#define M_HOLD_TIMER_MAX LOGIC_FPS
-
 typedef enum {
     M_PHASE_NAVIGATE_LAYOUT,
     M_PHASE_NAVIGATE_GROUP,
@@ -36,8 +33,6 @@ typedef enum {
     M_PHASE_LISTEN_DEBOUNCE,
     M_PHASE_EXIT,
 } M_PHASE;
-
-typedef void (*M_HOLD_ACTION_FUNC)(const UI_CONTROLS_EDITOR_STATE *);
 
 static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     {
@@ -143,11 +138,8 @@ static int32_t M_GetVisibleRows(void);
 static INPUT_ROLE M_GetInputRole(
     const UI_CONTROLS_EDITOR_GROUP *group, int32_t row);
 static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *group);
-static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *s);
-static void M_UnbindKey(const UI_CONTROLS_EDITOR_STATE *s);
-static bool M_HandleHoldAction(
-    UI_CONTROLS_EDITOR_STATE *s, INPUT_ROLE role,
-    M_HOLD_ACTION_FUNC action_func);
+static void M_ResetLayout(void *s);
+static void M_UnbindKey(void *s);
 static bool M_CanResetLayout(const UI_CONTROLS_EDITOR_STATE *s);
 static bool M_CanUnbindKey(const UI_CONTROLS_EDITOR_STATE *s);
 static void M_CheckResetKeys(UI_CONTROLS_EDITOR_STATE *s);
@@ -162,8 +154,6 @@ static void M_CurrentLayout(const UI_CONTROLS_EDITOR_STATE *s);
 static void M_GroupsHeader(const UI_CONTROLS_EDITOR_STATE *s);
 static void M_InputChoice(UI_CONTROLS_EDITOR_STATE *s, INPUT_ROLE role);
 static void M_InputLabel(const UI_CONTROLS_EDITOR_STATE *s, INPUT_ROLE role);
-static void M_FooterButton(
-    UI_CONTROLS_EDITOR_STATE *s, INPUT_ROLE role, const char *role_label);
 static void M_Group(
     UI_CONTROLS_EDITOR_STATE *s, const UI_CONTROLS_EDITOR_GROUP *group);
 static void M_Footer(UI_CONTROLS_EDITOR_STATE *s);
@@ -212,8 +202,9 @@ static int32_t M_GetInputRoleCount(const UI_CONTROLS_EDITOR_GROUP *const group)
     return row;
 }
 
-static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)
+static void M_ResetLayout(void *const arg)
 {
+    const UI_CONTROLS_EDITOR_STATE *const s = arg;
 #if TR_VERSION == 1
     Sound_Effect(SFX_MENU_GAMEBOY, nullptr, SPM_NORMAL);
 #else
@@ -223,8 +214,9 @@ static void M_ResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)
     Config_Write();
 }
 
-static void M_UnbindKey(const UI_CONTROLS_EDITOR_STATE *const s)
+static void M_UnbindKey(void *const arg)
 {
+    const UI_CONTROLS_EDITOR_STATE *const s = arg;
 #if TR_VERSION == 1
     Sound_Effect(SFX_MENU_GAMEBOY, nullptr, SPM_NORMAL);
 #else
@@ -232,24 +224,6 @@ static void M_UnbindKey(const UI_CONTROLS_EDITOR_STATE *const s)
 #endif
     Input_UnassignRole(s->backend, s->active_layout, s->active_role);
     Config_Write();
-}
-
-static bool M_HandleHoldAction(
-    UI_CONTROLS_EDITOR_STATE *const s, const INPUT_ROLE role,
-    const M_HOLD_ACTION_FUNC action_func)
-{
-    if (!Input_IsPressed(s->backend, s->active_layout, role)) {
-        return false;
-    }
-    if (s->hold_timer != -1) {
-        s->hold_timer++;
-        s->hold_role = role;
-        if (s->hold_timer - M_HOLD_TIMER_DEBUFF > M_HOLD_TIMER_MAX) {
-            action_func(s);
-            s->hold_timer = -1; // Debounce the key
-        }
-    }
-    return true;
 }
 
 static bool M_CanResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)
@@ -271,15 +245,11 @@ static bool M_CanUnbindKey(const UI_CONTROLS_EDITOR_STATE *const s)
 
 static void M_CheckResetKeys(UI_CONTROLS_EDITOR_STATE *const s)
 {
-    bool held = false;
     if (M_CanResetLayout(s)) {
-        held |= M_HandleHoldAction(s, INPUT_ROLE_RESET_BINDINGS, M_ResetLayout);
+        UI_ProgressButton_Control(s->reset_bindings_button);
     }
     if (M_CanUnbindKey(s)) {
-        held |= M_HandleHoldAction(s, INPUT_ROLE_UNBIND_KEY, M_UnbindKey);
-    }
-    if (!held) {
-        s->hold_timer = 0;
+        UI_ProgressButton_Control(s->unbind_key_button);
     }
 }
 
@@ -453,32 +423,6 @@ static void M_InputChoice(
     }
 }
 
-static void M_FooterButton(
-    UI_CONTROLS_EDITOR_STATE *const s, const INPUT_ROLE role,
-    const char *const role_label)
-{
-    const char *const value_label = String_FormatStatic(
-        GS(MISC_HOLD_FMT),
-        Input_GetKeyName(s->backend, s->active_layout, role));
-
-    const float pad[2] = { 6.0f, 3.0f };
-
-    UI_BeginSpan();
-    UI_BeginPad(pad[0], pad[1]);
-    UI_LabelFmt("%s: %s", role_label, value_label);
-    UI_EndPad();
-    if (s->hold_role == role && s->hold_timer >= M_HOLD_TIMER_DEBUFF) {
-        UI_Bar((UI_BAR_SETTINGS) {
-            .color = TR_VERSION == 2 ? BC_GREEN : BC_GOLD,
-            .value = s->hold_timer - M_HOLD_TIMER_DEBUFF,
-            .max_value = M_HOLD_TIMER_MAX,
-            .w = 0.0, // Span will make it expand anyway!
-            .h = 0.0,
-        });
-    }
-    UI_EndSpan();
-}
-
 static void M_Group(
     UI_CONTROLS_EDITOR_STATE *const s,
     const UI_CONTROLS_EDITOR_GROUP *const group)
@@ -516,11 +460,11 @@ static void M_Footer(UI_CONTROLS_EDITOR_STATE *const s)
         .spacing = { .h = 40.0f },
     });
     UI_BeginHide(!M_CanResetLayout(s));
-    M_FooterButton(s, INPUT_ROLE_RESET_BINDINGS, GS(ACTION_RESET_DEFAULTS));
+    UI_ProgressButton(s->reset_bindings_button);
     UI_EndHide();
 
     UI_BeginHide(!M_CanUnbindKey(s));
-    M_FooterButton(s, INPUT_ROLE_UNBIND_KEY, GS(ACTION_UNBIND));
+    UI_ProgressButton(s->unbind_key_button);
     UI_EndHide();
     UI_EndStack();
 }
@@ -529,8 +473,14 @@ void UI_ControlsEditor_Init(
     UI_CONTROLS_EDITOR_STATE *const s, EVENT_MANAGER *events)
 {
     s->events = events;
-    s->hold_timer = 0;
     UI_Flash_Init(&s->flash, LOGIC_FPS * 2 / 3);
+
+    s->reset_bindings_button = UI_ProgressButton_Init(
+        s->backend, INPUT_ROLE_RESET_BINDINGS, GS_ID(ACTION_RESET_DEFAULTS),
+        M_ResetLayout, s);
+    s->unbind_key_button = UI_ProgressButton_Init(
+        s->backend, INPUT_ROLE_UNBIND_KEY, GS_ID(ACTION_UNBIND), M_UnbindKey,
+        s);
 
     {
         UI_TAB_SWITCH_TAB layout_tabs[INPUT_LAYOUT_NUMBER_OF];
@@ -582,6 +532,10 @@ void UI_ControlsEditor_Free(UI_CONTROLS_EDITOR_STATE *const s)
     s->layout_tab_switch = nullptr;
     UI_TabSwitch_Free(s->controls_tab_switch);
     s->controls_tab_switch = nullptr;
+    UI_ProgressButton_Free(s->reset_bindings_button);
+    s->reset_bindings_button = nullptr;
+    UI_ProgressButton_Free(s->unbind_key_button);
+    s->unbind_key_button = nullptr;
 }
 
 void UI_ControlsEditor_Reinit(

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "debug.h"
+#include "game/const.h"
 #include "game/input.h"
 #include "game/scaler.h"
 #include "game/ui/elements/anchor.h"
@@ -24,6 +25,9 @@
 
 #include <math.h>
 
+#define M_HOLD_TIMER_DEBUFF (LOGIC_FPS / 3)
+#define M_HOLD_TIMER_MAX LOGIC_FPS
+
 typedef struct {
     const UI_SETTINGS_ENUM_ENTRY *entry;
     int32_t position;
@@ -42,8 +46,12 @@ static bool M_RequestChangeValue(
     const UI_SETTINGS_STATE *s, int32_t row_idx, int32_t dir);
 static float M_GetMaxLabelWidth(const UI_SETTINGS_STATE *s);
 static float M_GetMaxValueWidth(const UI_SETTINGS_STATE *s);
-static bool M_CanExamine(const UI_SETTINGS_STATE *s);
+static bool M_CanExamine(const UI_SETTINGS_STATE *s, int32_t row_idx);
+static bool M_CanRestoreDefault(const UI_SETTINGS_STATE *s, int32_t row_idx);
+static void M_RestoreDefault(const UI_SETTINGS_STATE *s, int32_t row_idx);
 static void M_OptionsChanged(UI_SETTINGS_STATE *s);
+static void M_Footer(const UI_SETTINGS_STATE *s);
+static void M_InitCommon(UI_SETTINGS_STATE *s, GAME_STRING_ID title);
 
 static int32_t M_GetVisibleRows(void)
 {
@@ -324,19 +332,99 @@ static float M_GetMaxValueWidth(const UI_SETTINGS_STATE *const s)
     return result;
 }
 
-static bool M_CanExamine(const UI_SETTINGS_STATE *const s)
+static bool M_CanExamine(
+    const UI_SETTINGS_STATE *const s, const int32_t row_idx)
 {
     if (s->phase != UI_SETTINGS_PHASE_EDIT_SETTINGS) {
         return false;
     }
-    const int32_t sel_row = UI_Scrollable_GetSelectedItem(&s->scroll);
-    if (sel_row < 0 || s->options[sel_row].description_id == nullptr) {
+    if (row_idx < 0 || s->options[row_idx].description_id == nullptr) {
         return false;
     }
-    const UI_SETTINGS_OPTION *const option = &s->options[sel_row];
+    const UI_SETTINGS_OPTION *const option = &s->options[row_idx];
     const char *const title = GameString_Get(option->label_id);
     const char *const text = GameString_Get(option->description_id);
     return title != nullptr && text != nullptr;
+}
+
+// Returns whether the selected setting may be reset to its default.
+static bool M_CanRestoreDefault(
+    const UI_SETTINGS_STATE *const s, const int32_t row_idx)
+{
+    if (s->phase != UI_SETTINGS_PHASE_EDIT_SETTINGS) {
+        return false;
+    }
+    if (row_idx < 0) {
+        return false;
+    }
+    const UI_SETTINGS_OPTION *const option = &s->options[row_idx];
+    if (option->target == nullptr || Config_IsOptionEnforced(option->target)) {
+        return false;
+    }
+    const CONFIG_OPTION *cfg = Config_GetOptionMap();
+    while (cfg->target != nullptr) {
+        if (cfg->target == option->target) {
+            switch (cfg->type) {
+            case COT_BOOL:
+            case COT_INVERTED_BOOL:
+                return *(bool *)cfg->target != *(bool *)cfg->default_value;
+            case COT_INT32:
+                return *(int32_t *)cfg->target
+                    != *(int32_t *)cfg->default_value;
+            case COT_FLOAT:
+                return *(float *)cfg->target != *(float *)cfg->default_value;
+            case COT_DOUBLE:
+                return *(double *)cfg->target != *(double *)cfg->default_value;
+            case COT_RGB888: {
+                const RGB_888 src = *(RGB_888 *)cfg->target;
+                const RGB_888 dst = *(RGB_888 *)cfg->default_value;
+                return src.r != dst.r || src.g != dst.g || src.b != dst.b;
+            }
+            case COT_ENUM:
+                return *(int32_t *)cfg->target
+                    != *(int32_t *)cfg->default_value;
+            }
+            break;
+        }
+        cfg++;
+    }
+    return true;
+}
+
+// Reset the selected setting back to its compiled-in default value.
+static void M_RestoreDefault(
+    const UI_SETTINGS_STATE *const s, const int32_t row_idx)
+{
+    const UI_SETTINGS_OPTION *const option = &s->options[row_idx];
+    const CONFIG_OPTION *cfg = Config_GetOptionMap();
+    while (cfg->target != nullptr) {
+        if (cfg->target == option->target) {
+            switch (cfg->type) {
+            case COT_BOOL:
+            case COT_INVERTED_BOOL:
+                *(bool *)cfg->target = *(bool *)cfg->default_value;
+                break;
+            case COT_INT32:
+                *(int32_t *)cfg->target = *(int32_t *)cfg->default_value;
+                break;
+            case COT_FLOAT:
+                *(float *)cfg->target = *(float *)cfg->default_value;
+                break;
+            case COT_DOUBLE:
+                *(double *)cfg->target = *(double *)cfg->default_value;
+                break;
+            case COT_RGB888:
+                *(RGB_888 *)cfg->target = *(RGB_888 *)cfg->default_value;
+                break;
+            case COT_ENUM:
+                *(int32_t *)cfg->target = *(int32_t *)cfg->default_value;
+                break;
+            }
+            break;
+        }
+        cfg++;
+    }
+    Config_Write();
 }
 
 static void M_OptionsChanged(UI_SETTINGS_STATE *const s)
@@ -350,11 +438,43 @@ static void M_OptionsChanged(UI_SETTINGS_STATE *const s)
     s->max_value_w = M_GetMaxValueWidth(s) / g_Config.ui.text_scale;
 }
 
+static void M_Footer(const UI_SETTINGS_STATE *const s)
+{
+    const int32_t row_idx = UI_Scrollable_GetSelectedItem(&s->scroll);
+    UI_BeginStackEx((UI_STACK_SETTINGS) {
+        .orientation = UI_STACK_HORIZONTAL,
+        .align = { .h = UI_STACK_H_ALIGN_DISTRIBUTE },
+        .spacing = { .h = 20 },
+    });
+    UI_BeginHide(!M_CanExamine(s, row_idx));
+    UI_LabelFmt(
+        "%s %s",
+        Input_GetKeyName(
+            INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
+            INPUT_ROLE_LOOK),
+        GS(COMMON_SETTINGS_TOGGLE_HELP));
+    UI_EndHide();
+    UI_BeginHide(!M_CanRestoreDefault(s, row_idx));
+    UI_LabelFmt(
+        "%s %s",
+        Input_GetKeyName(
+            INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
+            INPUT_ROLE_UNBIND_KEY),
+        GS(COMMON_SETTINGS_RESTORE_DEFAULT));
+    UI_EndHide();
+    UI_EndStack();
+}
+
+static void M_InitCommon(UI_SETTINGS_STATE *const s, const GAME_STRING_ID title)
+{
+    s->title = title;
+}
+
 void UI_Settings_Init(
     UI_SETTINGS_STATE *const s, const GAME_STRING_ID title,
     const UI_SETTINGS_OPTION *const options)
 {
-    s->title = title;
+    M_InitCommon(s, title);
     s->options = options;
     s->max_group_items = 0;
     for (int32_t i = 0; s->options[i].label_id != nullptr; i++) {
@@ -372,7 +492,7 @@ void UI_Settings_InitWithTabs(
     const UI_SETTINGS_TAB *const tabs)
 {
     ASSERT(tabs != nullptr);
-    s->title = title;
+    M_InitCommon(s, title);
     s->options = tabs[0].options;
     s->tab_count = tab_count;
     s->tabs = tabs;
@@ -433,7 +553,7 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
         }
     } else if (s->phase == UI_SETTINGS_PHASE_EDIT_SETTINGS) {
         const int32_t sel_row = UI_Scrollable_GetSelectedItem(&s->scroll);
-        if (g_InputDB.look && M_CanExamine(s)) {
+        if (g_InputDB.look && M_CanExamine(s, sel_row)) {
             const UI_SETTINGS_OPTION *const option = &s->options[sel_row];
             const char *title = GameString_Get(option->label_id);
             const char *text = GameString_Get(option->description_id);
@@ -472,12 +592,14 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
             }
         } else if (g_InputDB.menu_back) {
             return true;
-        } else {
-            if (g_InputDB.menu_left && sel_row >= 0) {
-                M_RequestChangeValue(s, sel_row, -1);
-            } else if (g_InputDB.menu_right && sel_row >= 0) {
-                M_RequestChangeValue(s, sel_row, +1);
-            }
+        } else if (
+            g_InputDB.unbind_key && sel_row >= 0
+            && M_CanRestoreDefault(s, sel_row)) {
+            M_RestoreDefault(s, sel_row);
+        } else if (g_InputDB.menu_left && sel_row >= 0) {
+            M_RequestChangeValue(s, sel_row, -1);
+        } else if (g_InputDB.menu_right && sel_row >= 0) {
+            M_RequestChangeValue(s, sel_row, +1);
         }
     }
     return false;
@@ -628,16 +750,9 @@ void UI_Settings(UI_SETTINGS_STATE *const s)
     UI_EndWindow();
 
     // Button hint strip
-    UI_BeginHide(!M_CanExamine(s));
-    UI_LabelFmt(
-        "%s %s",
-        Input_GetKeyName(
-            INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
-            INPUT_ROLE_LOOK),
-        GS(COMMON_SETTINGS_TOGGLE_HELP));
-    UI_EndHide();
-    UI_EndStack();
+    M_Footer(s);
 
+    UI_EndStack();
     UI_EndModal();
 
     if (s->description.show) {

--- a/src/libtrx/game/ui/elements/progress_button.c
+++ b/src/libtrx/game/ui/elements/progress_button.c
@@ -1,0 +1,80 @@
+#include "game/ui/elements/progress_button.h"
+
+#include "game/const.h"
+#include "game/ui/elements/bar.h"
+#include "game/ui/elements/label.h"
+#include "game/ui/elements/pad.h"
+#include "game/ui/elements/span.h"
+#include "memory.h"
+#include "strings.h"
+
+#define M_HOLD_TIMER_DEBUFF (LOGIC_FPS / 3)
+#define M_HOLD_TIMER_MAX LOGIC_FPS
+
+struct UI_PROGRESS_BUTTON_STATE {
+    GAME_STRING_ID text;
+    INPUT_BACKEND backend;
+    INPUT_ROLE role;
+    UI_PROGRESS_BUTTON_CALLBACK func;
+    void *func_arg;
+    int32_t hold_timer;
+};
+
+UI_PROGRESS_BUTTON_STATE *UI_ProgressButton_Init(
+    INPUT_BACKEND backend, INPUT_ROLE role, GAME_STRING_ID text,
+    UI_PROGRESS_BUTTON_CALLBACK func, void *func_arg)
+{
+    UI_PROGRESS_BUTTON_STATE *const s =
+        Memory_Alloc(sizeof(UI_PROGRESS_BUTTON_STATE));
+    s->backend = backend;
+    s->role = role;
+    s->text = text;
+    s->func = func;
+    s->func_arg = func_arg;
+    s->hold_timer = 0;
+    return s;
+}
+
+void UI_ProgressButton_Control(UI_PROGRESS_BUTTON_STATE *const s)
+{
+    if (!Input_IsPressed(s->backend, INPUT_LAYOUT_DEFAULT, s->role)) {
+        s->hold_timer = 0;
+        return;
+    }
+    if (s->hold_timer != -1) {
+        s->hold_timer++;
+        if (s->hold_timer - M_HOLD_TIMER_DEBUFF > M_HOLD_TIMER_MAX) {
+            s->func(s->func_arg);
+            s->hold_timer = -1; // Debounce the key
+        }
+    }
+}
+
+void UI_ProgressButton_Free(UI_PROGRESS_BUTTON_STATE *s)
+{
+    Memory_Free(s);
+}
+
+void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
+{
+    const char *const value_label = String_FormatStatic(
+        GS(MISC_HOLD_FMT),
+        Input_GetKeyName(s->backend, INPUT_LAYOUT_DEFAULT, s->role));
+
+    const float pad[2] = { 6.0f, 3.0f };
+
+    UI_BeginSpan();
+    UI_BeginPad(pad[0], pad[1]);
+    UI_LabelFmt("%s: %s", GameString_Get(s->text), value_label);
+    UI_EndPad();
+    if (s->hold_timer >= M_HOLD_TIMER_DEBUFF) {
+        UI_Bar((UI_BAR_SETTINGS) {
+            .color = TR_VERSION == 2 ? BC_GREEN : BC_GOLD,
+            .value = s->hold_timer - M_HOLD_TIMER_DEBUFF,
+            .max_value = M_HOLD_TIMER_MAX,
+            .w = 0.0, // Span will make it expand anyway!
+            .h = 0.0,
+        });
+    }
+    UI_EndSpan();
+}

--- a/src/libtrx/game/ui/elements/progress_button.c
+++ b/src/libtrx/game/ui/elements/progress_button.c
@@ -63,6 +63,7 @@ void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
 
     const float pad[2] = { 6.0f, 3.0f };
 
+    UI_BeginPad(0.0f, -pad[1]);
     UI_BeginSpan();
     UI_BeginPad(pad[0], pad[1]);
     UI_LabelFmt("%s: %s", GameString_Get(s->text), value_label);
@@ -77,4 +78,5 @@ void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
         });
     }
     UI_EndSpan();
+    UI_EndPad();
 }

--- a/src/libtrx/include/libtrx/game/game_string.def
+++ b/src/libtrx/include/libtrx/game/game_string.def
@@ -202,6 +202,7 @@ GS_DEFINE(CONSOLE_HELP_DEBUG, "Toggles visual debug information.")
 
 GS_DEFINE(COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER, "This setting is enforced by the level builder and cannot be changed.")
 GS_DEFINE(COMMON_SETTINGS_TOGGLE_HELP, "Toggle help")
+GS_DEFINE(COMMON_SETTINGS_RESTORE_DEFAULT, "Restore default")
 
 GS_DEFINE(SOUND_SETTINGS_TITLE,                            "Sound Options")
 

--- a/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
@@ -7,6 +7,7 @@
 #include "../../input.h"
 #include "../common.h"
 #include "../elements/flash.h"
+#include "../elements/progress_button.h"
 #include "../elements/requester.h"
 #include "../elements/tab_switch.h"
 #include "../scrollable.h"
@@ -25,9 +26,6 @@ typedef struct {
     UI_FLASH_STATE flash;
     EVENT_MANAGER *events;
 
-    INPUT_ROLE hold_role;
-    int32_t hold_timer;
-
     UI_SCROLLABLE scroll;
 
     int32_t max_group_items;
@@ -35,6 +33,8 @@ typedef struct {
     int32_t label_size;
     UI_TAB_SWITCH_STATE *layout_tab_switch;
     UI_TAB_SWITCH_STATE *controls_tab_switch;
+    UI_PROGRESS_BUTTON_STATE *reset_bindings_button;
+    UI_PROGRESS_BUTTON_STATE *unbind_key_button;
 } UI_CONTROLS_EDITOR_STATE;
 
 typedef enum {

--- a/src/libtrx/include/libtrx/game/ui/elements/progress_button.h
+++ b/src/libtrx/include/libtrx/game/ui/elements/progress_button.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../game_string.h"
+#include "../../input.h"
+#include "../common.h"
+
+typedef void (*UI_PROGRESS_BUTTON_CALLBACK)(void *);
+
+typedef struct UI_PROGRESS_BUTTON_STATE UI_PROGRESS_BUTTON_STATE;
+
+UI_PROGRESS_BUTTON_STATE *UI_ProgressButton_Init(
+    INPUT_BACKEND backend, INPUT_ROLE role, GAME_STRING_ID text,
+    UI_PROGRESS_BUTTON_CALLBACK func, void *func_arg);
+void UI_ProgressButton_Control(UI_PROGRESS_BUTTON_STATE *s);
+void UI_ProgressButton_Free(UI_PROGRESS_BUTTON_STATE *s);
+
+void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *s);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -263,6 +263,7 @@ sources = [
   'game/ui/elements/modal.c',
   'game/ui/elements/offset.c',
   'game/ui/elements/pad.c',
+  'game/ui/elements/progress_button.c',
   'game/ui/elements/prompt.c',
   'game/ui/elements/requester.c',
   'game/ui/elements/resize.c',

--- a/src/tr1/game/input.c
+++ b/src/tr1/game/input.c
@@ -66,6 +66,8 @@ static void M_UpdateFromBackend(
     s->menu_right                |= backend->is_pressed(layout, INPUT_ROLE_MENU_RIGHT);
     s->menu_confirm              |= backend->is_pressed(layout, INPUT_ROLE_MENU_CONFIRM);
     s->menu_back                 |= backend->is_pressed(layout, INPUT_ROLE_MENU_BACK);
+    s->reset_bindings            |= backend->is_pressed(layout, INPUT_ROLE_RESET_BINDINGS);
+    s->unbind_key                |= backend->is_pressed(layout, INPUT_ROLE_UNBIND_KEY);
 
     s->screenshot                |= backend->is_pressed(layout, INPUT_ROLE_SCREENSHOT);
     s->toggle_fps_counter        |= backend->is_pressed(layout, INPUT_ROLE_FPS);

--- a/src/tr2/game/input.c
+++ b/src/tr2/game/input.c
@@ -71,6 +71,8 @@ static void M_UpdateFromBackend(
     s->menu_right                  |= backend->is_pressed(layout, INPUT_ROLE_MENU_RIGHT);
     s->menu_confirm                |= backend->is_pressed(layout, INPUT_ROLE_MENU_CONFIRM);
     s->menu_back                   |= backend->is_pressed(layout, INPUT_ROLE_MENU_BACK);
+    s->reset_bindings              |= backend->is_pressed(layout, INPUT_ROLE_RESET_BINDINGS);
+    s->unbind_key                  |= backend->is_pressed(layout, INPUT_ROLE_UNBIND_KEY);
 
     s->screenshot                  |= backend->is_pressed(layout, INPUT_ROLE_SCREENSHOT);
     s->switch_resolution           |= backend->is_pressed(layout, INPUT_ROLE_SWITCH_RESOLUTION);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds a button that lets us immediately restore default settings. Only available if a row is selected and its value is different from the defaults. For compound setting (e.g. water color) resetting affects all components at once.

![20250609_134229_Level_0](https://github.com/user-attachments/assets/1cdf1ca9-9800-41b6-bc16-b9e3c97b673c)
![20250609_134155_Level_0](https://github.com/user-attachments/assets/6c9b5caa-180a-4108-b4f2-29b297faec7e)

#### Technical considerations

I've extracted the ProgressButton element from the controls editor dialog intending to reuse it for this function. However, it performed poorly in practice, and the delay for reset was frustrating, so I opted for instant feedback instead. I did leave the ProgressButton isolated, though, in case we need it in the future (though it costs some LOC).