### PR TITLE
console/cmd/set: accept - to set default state

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed the graphic settings dialog to use tabs
 - changed the setting dialogs to respect the UI wraparound setting
 - changed the `/tp` command to align Lara to switches and pickups
+- changed the `/set` command to accept `-`, which will restore the given setting to its default state
 - changed the music track slot limit from 64 to 1024 (#3101)
 - changed text kerning to a smaller value
 - changed the underwater music volume setting to separate ambient and music volume sliders

--- a/docs/tr1/COMMANDS.md
+++ b/docs/tr1/COMMANDS.md
@@ -111,7 +111,10 @@ Currently supported commands:
 
 - `/set {option}`  
 - `/set {option} {value}`  
-  Retrieves or assigns a new value to the given configuration option. Some options need a game re-launch to apply. The option names use `-` rather than `_`.
+- `/set {option} -`  
+  Retrieves or assigns a new value to the given configuration option. Some
+  options need a game re-launch to apply. The option names use `-` rather than
+  `_`. Use `-` as `{value}` to restore the option to its default state.
 
 - `/music {track_id}`  
   Plays a given music track. It uses internal game IDs that for historic reasons don't align with the music folder's file names.

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -14,6 +14,7 @@
   - if building levels, use track numbers that correspond to the file names; previously built levels will need to be manually adjusted
 - changed sound and music volumes to be displayed as percentage instead of 0-10
 - changed the `/tp` command to align Lara to switches and pickups
+- changed the `/set` command to accept `-`, which will restore the given setting to its default state
 - changed the graphic settings dialog to use tabs
 - changed the setting dialogs to respect the UI wraparound setting
 - changed the combat end logic (used in Home Sweet Home) to allow using any regular enemy type aside from the boss

--- a/docs/tr2/COMMANDS.md
+++ b/docs/tr2/COMMANDS.md
@@ -101,7 +101,10 @@ Currently supported commands:
 
 - `/set {option}`  
 - `/set {option} {value}`  
-  Retrieves or assigns a new value to the given configuration option. Some options need a game re-launch to apply. The option names use `-` rather than `_`.
+- `/set {option} -`  
+  Retrieves or assigns a new value to the given configuration option. Some
+  options need a game re-launch to apply. The option names use `-` rather than
+  `_`. Use `-` as `{value}` to restore the option to its default state.
 
 - `/music {track_id}`  
   Plays a given music track. It uses internal game IDs that for historic reasons don't align with the music folder's file names.

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -99,8 +99,157 @@ void Config_UnsubscribeChanges(const int32_t listener_id)
     EventManager_Unsubscribe(m_EventManager, listener_id);
 }
 
+const CONFIG_OPTION *Config_GetOption(const void *const target)
+{
+    const CONFIG_OPTION *option = Config_GetOptionMap();
+    while (option->target != nullptr) {
+        if (option->target == target) {
+            return option;
+        }
+        option++;
+    }
+    return nullptr;
+}
+
 bool Config_IsOptionEnforced(const void *const target)
 {
     return m_EnforcedOptions != nullptr
         && Vector_Contains(m_EnforcedOptions, &target);
+}
+
+bool Config_IsOptionAtDefault(const void *const target)
+{
+    const CONFIG_OPTION *option = Config_GetOption(target);
+    if (target == nullptr) {
+        return true;
+    }
+    switch (option->type) {
+    case COT_BOOL:
+    case COT_INVERTED_BOOL:
+        return *(bool *)option->target == *(bool *)option->default_value;
+    case COT_INT32:
+        return *(int32_t *)option->target == *(int32_t *)option->default_value;
+    case COT_FLOAT:
+        return *(float *)option->target == *(float *)option->default_value;
+    case COT_DOUBLE:
+        return *(double *)option->target == *(double *)option->default_value;
+    case COT_RGB888: {
+        const RGB_888 src = *(RGB_888 *)option->target;
+        const RGB_888 dst = *(RGB_888 *)option->default_value;
+        return src.r == dst.r || src.g == dst.g || src.b == dst.b;
+    }
+    case COT_ENUM:
+        return *(int32_t *)option->target == *(int32_t *)option->default_value;
+        break;
+    }
+    return true;
+}
+
+bool Config_RestoreOptionDefault(const void *const target)
+{
+    const CONFIG_OPTION *option = Config_GetOption(target);
+    if (target == nullptr) {
+        return false;
+    }
+    switch (option->type) {
+    case COT_BOOL:
+    case COT_INVERTED_BOOL:
+        *(bool *)option->target = *(bool *)option->default_value;
+        return true;
+    case COT_INT32:
+        *(int32_t *)option->target = *(int32_t *)option->default_value;
+        return true;
+    case COT_FLOAT:
+        *(float *)option->target = *(float *)option->default_value;
+        return true;
+    case COT_DOUBLE:
+        *(double *)option->target = *(double *)option->default_value;
+        return true;
+    case COT_RGB888:
+        *(RGB_888 *)option->target = *(RGB_888 *)option->default_value;
+        return true;
+    case COT_ENUM:
+        *(int32_t *)option->target = *(int32_t *)option->default_value;
+        return true;
+    }
+    return false;
+}
+
+bool Config_SetOptionValueFromString(
+    const CONFIG_OPTION *const option, const char *const new_value)
+{
+    ASSERT(option != nullptr);
+    ASSERT(option->target != nullptr);
+    switch (option->type) {
+    case COT_BOOL:
+        if (String_Match(new_value, "^(on|true|1)$")) {
+            *(bool *)option->target = true;
+            return true;
+        } else if (String_Match(new_value, "^(off|false|0)$")) {
+            *(bool *)option->target = false;
+            return true;
+        }
+        break;
+
+    case COT_INVERTED_BOOL:
+        if (String_Match(new_value, "^(on|true|1)$")) {
+            *(bool *)option->target = false;
+            return true;
+        } else if (String_Match(new_value, "^(off|false|0)$")) {
+            *(bool *)option->target = true;
+            return true;
+        }
+        break;
+
+    case COT_INT32: {
+        int32_t new_value_typed;
+        if (sscanf(new_value, "%d", &new_value_typed) == 1) {
+            *(int32_t *)option->target = new_value_typed;
+            return true;
+        }
+        break;
+    }
+
+    case COT_FLOAT: {
+        float new_value_typed;
+        if (sscanf(new_value, "%f", &new_value_typed) == 1) {
+            *(float *)option->target = new_value_typed;
+            return true;
+        }
+        break;
+    }
+
+    case COT_DOUBLE: {
+        double new_value_typed;
+        if (sscanf(new_value, "%lf", &new_value_typed) == 1) {
+            *(double *)option->target = new_value_typed;
+            return true;
+        }
+        break;
+    }
+
+    case COT_ENUM: {
+        const int32_t new_value_typed =
+            EnumMap_Get(option->param, new_value, -1);
+        if (new_value_typed != -1) {
+            *(int32_t *)option->target = new_value_typed;
+            return true;
+        }
+        break;
+    }
+
+    case COT_RGB888: {
+        uint8_t r, g, b;
+        if (sscanf(new_value, "%02hhx%02hhx%02hhx", &r, &g, &b) == 3) {
+            RGB_888 *const color = (RGB_888 *)option->target;
+            color->r = r;
+            color->g = g;
+            color->b = b;
+            return true;
+        }
+        break;
+    }
+    }
+
+    return false;
 }

--- a/src/libtrx/game/console/cmd/config.c
+++ b/src/libtrx/game/console/cmd/config.c
@@ -15,6 +15,7 @@
 static const char *M_Resolve(const char *option_name);
 static bool M_SameKey(const char *key1, const char *key2);
 static char *M_GetAvailableOptions(const CONFIG_OPTION *option);
+static const CONFIG_OPTION *M_GetOptionFromKey(const char *key);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
@@ -64,8 +65,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         space[0] = '\0'; // nullptr-terminate the key
     }
 
-    const CONFIG_OPTION *const option =
-        Console_Cmd_Config_GetOptionFromKey(key);
+    const CONFIG_OPTION *const option = M_GetOptionFromKey(key);
     if (option == nullptr) {
         result = CR_FAILURE;
     } else {
@@ -130,6 +130,47 @@ static char *M_GetAvailableOptions(const CONFIG_OPTION *const option)
     }
 }
 
+static const CONFIG_OPTION *M_GetOptionFromKey(const char *const key)
+{
+    VECTOR *source = Vector_Create(sizeof(STRING_FUZZY_SOURCE));
+
+    for (const CONFIG_OPTION *option = Config_GetOptionMap();
+         option->name != nullptr; option++) {
+        STRING_FUZZY_SOURCE source_item = {
+            .key = (const char *)Console_Cmd_Config_NormalizeKey(option->name),
+            .value = (void *)option,
+            .weight = 1,
+        };
+        Vector_Add(source, &source_item);
+    }
+
+    VECTOR *matches = String_FuzzyMatch(key, source);
+    const CONFIG_OPTION *result = nullptr;
+    if (matches->count == 0) {
+        Console_Log(GS(OSD_CONFIG_OPTION_UNKNOWN_OPTION), key);
+    } else if (matches->count == 1) {
+        const STRING_FUZZY_MATCH *const match = Vector_Get(matches, 0);
+        result = match->value;
+    } else if (matches->count == 2) {
+        const STRING_FUZZY_MATCH *const match1 = Vector_Get(matches, 0);
+        const STRING_FUZZY_MATCH *const match2 = Vector_Get(matches, 1);
+        Console_Log(GS(OSD_AMBIGUOUS_INPUT_2), match1->key, match2->key);
+    } else if (matches->count >= 3) {
+        const STRING_FUZZY_MATCH *const match1 = Vector_Get(matches, 0);
+        const STRING_FUZZY_MATCH *const match2 = Vector_Get(matches, 1);
+        Console_Log(GS(OSD_AMBIGUOUS_INPUT_3), match1->key, match2->key);
+    }
+
+    for (int32_t i = 0; i < source->count; i++) {
+        const STRING_FUZZY_SOURCE *const source_item = Vector_Get(source, i);
+        Memory_Free((char *)source_item->key);
+    }
+
+    Vector_Free(matches);
+    Vector_Free(source);
+    return result;
+}
+
 char *Console_Cmd_Config_NormalizeKey(const char *key)
 {
     // TODO: Once we support arbitrary glyphs, this conversion should
@@ -187,129 +228,6 @@ bool Console_Cmd_Config_GetCurrentValue(
     return true;
 }
 
-bool Console_Cmd_Config_SetCurrentValue(
-    const CONFIG_OPTION *const option, const char *const new_value)
-{
-    if (option == nullptr) {
-        return CR_BAD_INVOCATION;
-    }
-
-    ASSERT(option->target != nullptr);
-    switch (option->type) {
-    case COT_BOOL:
-        if (String_Match(new_value, "^(on|true|1)$")) {
-            *(bool *)option->target = true;
-            return true;
-        } else if (String_Match(new_value, "^(off|false|0)$")) {
-            *(bool *)option->target = false;
-            return true;
-        }
-        break;
-
-    case COT_INVERTED_BOOL:
-        if (String_Match(new_value, "^(on|true|1)$")) {
-            *(bool *)option->target = false;
-            return true;
-        } else if (String_Match(new_value, "^(off|false|0)$")) {
-            *(bool *)option->target = true;
-            return true;
-        }
-        break;
-
-    case COT_INT32: {
-        int32_t new_value_typed;
-        if (sscanf(new_value, "%d", &new_value_typed) == 1) {
-            *(int32_t *)option->target = new_value_typed;
-            return true;
-        }
-        break;
-    }
-
-    case COT_FLOAT: {
-        float new_value_typed;
-        if (sscanf(new_value, "%f", &new_value_typed) == 1) {
-            *(float *)option->target = new_value_typed;
-            return true;
-        }
-        break;
-    }
-
-    case COT_DOUBLE: {
-        double new_value_typed;
-        if (sscanf(new_value, "%lf", &new_value_typed) == 1) {
-            *(double *)option->target = new_value_typed;
-            return true;
-        }
-        break;
-    }
-
-    case COT_ENUM: {
-        const int32_t new_value_typed =
-            EnumMap_Get(option->param, new_value, -1);
-        if (new_value_typed != -1) {
-            *(int32_t *)option->target = new_value_typed;
-            return true;
-        }
-        break;
-    }
-
-    case COT_RGB888: {
-        uint8_t r, g, b;
-        if (sscanf(new_value, "%02hhx%02hhx%02hhx", &r, &g, &b) == 3) {
-            RGB_888 *const color = (RGB_888 *)option->target;
-            color->r = r;
-            color->g = g;
-            color->b = b;
-            return true;
-        }
-        break;
-    }
-    }
-
-    return false;
-}
-
-const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromKey(const char *const key)
-{
-    VECTOR *source = Vector_Create(sizeof(STRING_FUZZY_SOURCE));
-
-    for (const CONFIG_OPTION *option = Config_GetOptionMap();
-         option->name != nullptr; option++) {
-        STRING_FUZZY_SOURCE source_item = {
-            .key = (const char *)Console_Cmd_Config_NormalizeKey(option->name),
-            .value = (void *)option,
-            .weight = 1,
-        };
-        Vector_Add(source, &source_item);
-    }
-
-    VECTOR *matches = String_FuzzyMatch(key, source);
-    const CONFIG_OPTION *result = nullptr;
-    if (matches->count == 0) {
-        Console_Log(GS(OSD_CONFIG_OPTION_UNKNOWN_OPTION), key);
-    } else if (matches->count == 1) {
-        const STRING_FUZZY_MATCH *const match = Vector_Get(matches, 0);
-        result = match->value;
-    } else if (matches->count == 2) {
-        const STRING_FUZZY_MATCH *const match1 = Vector_Get(matches, 0);
-        const STRING_FUZZY_MATCH *const match2 = Vector_Get(matches, 1);
-        Console_Log(GS(OSD_AMBIGUOUS_INPUT_2), match1->key, match2->key);
-    } else if (matches->count >= 3) {
-        const STRING_FUZZY_MATCH *const match1 = Vector_Get(matches, 0);
-        const STRING_FUZZY_MATCH *const match2 = Vector_Get(matches, 1);
-        Console_Log(GS(OSD_AMBIGUOUS_INPUT_3), match1->key, match2->key);
-    }
-
-    for (int32_t i = 0; i < source->count; i++) {
-        const STRING_FUZZY_SOURCE *const source_item = Vector_Get(source, i);
-        Memory_Free((char *)source_item->key);
-    }
-
-    Vector_Free(matches);
-    Vector_Free(source);
-    return result;
-}
-
 const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromTarget(
     const void *const target)
 {
@@ -340,9 +258,15 @@ COMMAND_RESULT Console_Cmd_Config_Helper(
     }
 
     COMMAND_RESULT result;
-    if (Console_Cmd_Config_SetCurrentValue(option, new_value)) {
+    if (strcmp(new_value, "-") == 0
+        && Config_RestoreOptionDefault(option->target)) {
         Config_Write();
-
+        char final_value[128];
+        ASSERT(Console_Cmd_Config_GetCurrentValue(option, final_value, 128));
+        Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, final_value);
+        result = CR_SUCCESS;
+    } else if (Config_SetOptionValueFromString(option, new_value)) {
+        Config_Write();
         char final_value[128];
         ASSERT(Console_Cmd_Config_GetCurrentValue(option, final_value, 128));
         Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, final_value);

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -361,34 +361,7 @@ static bool M_CanRestoreDefault(
     if (option->target == nullptr || Config_IsOptionEnforced(option->target)) {
         return false;
     }
-    const CONFIG_OPTION *cfg = Config_GetOptionMap();
-    while (cfg->target != nullptr) {
-        if (cfg->target == option->target) {
-            switch (cfg->type) {
-            case COT_BOOL:
-            case COT_INVERTED_BOOL:
-                return *(bool *)cfg->target != *(bool *)cfg->default_value;
-            case COT_INT32:
-                return *(int32_t *)cfg->target
-                    != *(int32_t *)cfg->default_value;
-            case COT_FLOAT:
-                return *(float *)cfg->target != *(float *)cfg->default_value;
-            case COT_DOUBLE:
-                return *(double *)cfg->target != *(double *)cfg->default_value;
-            case COT_RGB888: {
-                const RGB_888 src = *(RGB_888 *)cfg->target;
-                const RGB_888 dst = *(RGB_888 *)cfg->default_value;
-                return src.r != dst.r || src.g != dst.g || src.b != dst.b;
-            }
-            case COT_ENUM:
-                return *(int32_t *)cfg->target
-                    != *(int32_t *)cfg->default_value;
-            }
-            break;
-        }
-        cfg++;
-    }
-    return true;
+    return !Config_IsOptionAtDefault(option->target);
 }
 
 // Reset the selected setting back to its compiled-in default value.
@@ -396,34 +369,7 @@ static void M_RestoreDefault(
     const UI_SETTINGS_STATE *const s, const int32_t row_idx)
 {
     const UI_SETTINGS_OPTION *const option = &s->options[row_idx];
-    const CONFIG_OPTION *cfg = Config_GetOptionMap();
-    while (cfg->target != nullptr) {
-        if (cfg->target == option->target) {
-            switch (cfg->type) {
-            case COT_BOOL:
-            case COT_INVERTED_BOOL:
-                *(bool *)cfg->target = *(bool *)cfg->default_value;
-                break;
-            case COT_INT32:
-                *(int32_t *)cfg->target = *(int32_t *)cfg->default_value;
-                break;
-            case COT_FLOAT:
-                *(float *)cfg->target = *(float *)cfg->default_value;
-                break;
-            case COT_DOUBLE:
-                *(double *)cfg->target = *(double *)cfg->default_value;
-                break;
-            case COT_RGB888:
-                *(RGB_888 *)cfg->target = *(RGB_888 *)cfg->default_value;
-                break;
-            case COT_ENUM:
-                *(int32_t *)cfg->target = *(int32_t *)cfg->default_value;
-                break;
-            }
-            break;
-        }
-        cfg++;
-    }
+    Config_RestoreOptionDefault(option->target);
     Config_Write();
 }
 

--- a/src/libtrx/include/libtrx/config/common.h
+++ b/src/libtrx/include/libtrx/config/common.h
@@ -17,6 +17,19 @@ const CONFIG_OPTION *Config_GetOptionMap(void);
 int32_t Config_SubscribeChanges(EVENT_LISTENER listener, void *user_data);
 void Config_UnsubscribeChanges(int32_t listener_id);
 
-// Returns true if a given setting (a pointer into a g_Config member)
-// was forced by the game flow file.
+// Retrieves CONFIG_OPTION related to the target setting (a pointer into a
+// g_Config property).
+const CONFIG_OPTION *Config_GetOption(const void *target);
+
+// Returns true if a given setting was enforced by the game flow file.
 bool Config_IsOptionEnforced(const void *target);
+
+// Returns whether the given setting's current value is the same as its default.
+bool Config_IsOptionAtDefault(const void *target);
+
+// Restores the given setting's default value.
+bool Config_RestoreOptionDefault(const void *target);
+
+// Updates the given setting's value from string.
+bool Config_SetOptionValueFromString(
+    const CONFIG_OPTION *option, const char *new_value);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Extended the `/set` command to accept `-`, which will cause the option to use its default state.
Reuses the same routines as the settings dialog.