### PR TITLE
tr2/docs: add wading wall hit documentation

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -258,6 +258,7 @@
 - fixed scale of secret icons on level complete summary (#1631)
 - fixed showing inventory ring up/down arrows when uncalled for (#2225)
 - fixed Lara never stepping backwards off a step using her right foot (#1602)
+- fixed flawed frame number checks which prevented Lara's wall hit animation while wading
 - fixed blood spawning on Lara from gunshots using incorrect positioning data (#2253)
 - fixed ghost meshes appearing near statics in custom levels (#2310)
 - fixed potential memory corruption when reading a custom level with more than 512 sprite textures (#2338)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -225,6 +225,7 @@ However, you can easily download them manually from these urls:
 - fixed several instances of the camera going out of bounds
 - fixed the camera behaving erratically in rooms/sectors that have no pathfinding data
 - fixed Lara never stepping backwards off a step using her right foot
+- fixed flawed frame number checks which prevented Lara's wall hit animation while wading
 - fixed the following floor data issues:
     - **Opera House**: fixed the trigger under item 203 to trigger it rather than item 204
     - **Wreck of the Maria Doria**: fixed room 98 not having water


### PR DESCRIPTION
Resolves #3138.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The fix was implemented in #2224. The OG frame checks were numbered as though they were relative to the animations, when we moved to controlled anim/frame switching per TR1, this resolved itself.
