### PR TITLE
ui/prompt: fix crash when editing short prompts

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed unbind key option being available when it shouldn't (#3111, regression from 4.11)
 - fixed vertical FOV option not working properly (#3120, regression from 4.10)
 - fixed Lara's position on a ledge after grabbing it extremely late (#3132, regression from 2.2.1)
+- fixed a rare crash when editing certain dev console history entries (#2913, regression from 4.10)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed Lara dropping flares after certain special animations, such as pulling the dagger from the dragon (#3084, regression from 1.1)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 1.1)
 - fixed the sizer option accepting values above 1 which made no sense (#3123, regression from 1.0)
+- fixed a rare crash when editing certain dev console history entries (#2913, regression from 1.0)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/src/libtrx/game/ui/elements/prompt.c
+++ b/src/libtrx/game/ui/elements/prompt.c
@@ -249,6 +249,6 @@ void UI_Prompt_ChangeText(UI_PROMPT_STATE *const s, const char *const new_text)
 {
     Memory_FreePointer(&s->current_text);
     s->current_text = Memory_DupStr(new_text);
-    s->current_text_capacity = strlen(new_text);
+    s->current_text_capacity = strlen(new_text) + 1;
     s->caret_pos = strlen(new_text);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

#2913 wasn't fully fixed, unfortunately – 1-letter long history entries would still trip the allocators up.
