### PR TITLE
Fix select level and play level features in TR1

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed the underwater music volume setting to separate ambient and music volume sliders
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
 - fixed the `/play` command crashing when the game has only ATI saves (#3137, regression from 4.10)
+- fixed the `/play` command taking resume information from the highlighted slot (#3137, regression from 4.10)
 - fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 4.11)
 - fixed vertical FOV option not working properly (#3120, regression from 4.10)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -14,6 +14,7 @@
 - changed text kerning to a smaller value
 - changed the underwater music volume setting to separate ambient and music volume sliders
 - fixed 3D pickups misplacing or hiding UI elements with render mode set to window size and the game windowed (#3067, regression from 4.10)
+- fixed the `/play` command crashing when the game has only ATI saves (#3137, regression from 4.10)
 - fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 4.11)
 - fixed vertical FOV option not working properly (#3120, regression from 4.10)

--- a/src/libtrx/include/libtrx/game/savegame/common.h
+++ b/src/libtrx/include/libtrx/game/savegame/common.h
@@ -36,10 +36,12 @@ void Savegame_UnbindSlot(void);
 // Returns the currently bound slot number. If there is none, returns -1.
 int32_t Savegame_GetBoundSlot(void);
 
-// Returns the most recently created slot number. If there is none, returns -1.
+// Returns the most recently created save slot number. If there is none,
+// returns -1.
 int32_t Savegame_GetMostRecentlyCreatedSlot(void);
 
-// Returns the most recently created slot number. If there is none, returns -1.
+// Returns the most recently used slot save number. If there is none, returns
+// -1.
 int32_t Savegame_GetMostRecentlyUsedSlot(void);
 
 void Savegame_ProcessItemsBeforeLoad(void);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -83,12 +83,13 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         }
         break;
 
-    case GFSC_SELECT:
-        if (g_GameInfo.select_save_slot != -1) {
+    case GFSC_SELECT: {
+        const int16_t slot_num = Savegame_GetBoundSlot();
+        if (slot_num != -1) {
             // select level feature
             Savegame_InitCurrentInfo();
             if (level->num > GF_GetFirstLevel()->num) {
-                Savegame_LoadOnlyResumeInfo(g_GameInfo.select_save_slot);
+                Savegame_LoadOnlyResumeInfo(slot_num);
                 const GF_LEVEL *tmp_level = level;
                 while (tmp_level != nullptr) {
                     Savegame_ResetCurrentInfo(tmp_level);
@@ -112,6 +113,7 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
             }
         }
         break;
+    }
 
     default:
         if (level->type == GFL_GYM) {

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -77,7 +77,6 @@ static void M_ReadArm(LARA_ARM *arm);
 static void M_ReadAmmoInfo(AMMO_INFO *ammo_info);
 static void M_ReadLara(LARA_INFO *lara);
 static void M_ReadLOT(LOT_INFO *lot);
-static void M_SetCurrentPosition(int32_t level_num);
 static void M_ReadResumeInfo(MYFILE *fp);
 
 static const char *M_GetSaveFilePattern(void);
@@ -332,18 +331,6 @@ static void M_ReadLOT(LOT_INFO *const lot)
     lot->target.z = M_ReadS32();
 }
 
-static void M_SetCurrentPosition(const int32_t level_num)
-{
-    const GF_LEVEL *const current_level = Game_GetCurrentLevel();
-    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
-    for (int32_t i = 0; i < level_table->count; i++) {
-        const GF_LEVEL *const level = &level_table->levels[i];
-        if (level->type == GFL_CURRENT) {
-            Savegame_SetCurrentInfo(current_level->num, i);
-        }
-    }
-}
-
 static void M_ReadResumeInfo(MYFILE *const fp)
 {
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
@@ -379,7 +366,6 @@ static void M_ReadResumeInfo(MYFILE *const fp)
     const uint32_t temp_kill_count = M_ReadU32();
     const uint16_t temp_secret_flags = M_ReadU16();
     const uint16_t current_level = M_ReadU16();
-    M_SetCurrentPosition(current_level);
 
     RESUME_INFO *const resume_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -77,7 +77,8 @@ static void M_ReadArm(LARA_ARM *arm);
 static void M_ReadAmmoInfo(AMMO_INFO *ammo_info);
 static void M_ReadLara(LARA_INFO *lara);
 static void M_ReadLOT(LOT_INFO *lot);
-static void M_ReadResumeInfo(MYFILE *fp);
+static void M_ReadResumeInfo(RESUME_INFO *resume);
+static void M_ReadResumeInfos(MYFILE *fp);
 
 static const char *M_GetSaveFilePattern(void);
 static bool M_FillInfo(MYFILE *fp, SAVEGAME_INFO *savegame_info);
@@ -239,6 +240,7 @@ static void M_Skip(const size_t size)
 static void M_Read(void *const ptr, const size_t size)
 {
     ASSERT(m_SGBufPos + size <= SAVEGAME_LEGACY_MAX_BUFFER_SIZE);
+    ASSERT(m_SGBufPtr != nullptr);
     m_SGBufPos += size;
     memcpy(ptr, m_SGBufPtr, size);
     m_SGBufPtr += size;
@@ -331,54 +333,69 @@ static void M_ReadLOT(LOT_INFO *const lot)
     lot->target.z = M_ReadS32();
 }
 
-static void M_ReadResumeInfo(MYFILE *const fp)
+static void M_ReadResumeInfo(RESUME_INFO *const resume)
+{
+    resume->pistol_ammo = M_ReadU16();
+    resume->magnum_ammo = M_ReadU16();
+    resume->uzi_ammo = M_ReadU16();
+    resume->shotgun_ammo = M_ReadU16();
+    resume->small_medipacks = M_ReadU8();
+    resume->large_medipacks = M_ReadU8();
+    resume->num_scions = M_ReadU8();
+    resume->gun_status = M_ReadS8();
+    resume->equipped_gun_type = M_ReadS8();
+    resume->holsters_gun_type = LGT_UNKNOWN;
+    resume->back_gun_type = LGT_UNKNOWN;
+
+    const uint16_t flags = M_ReadU16();
+    resume->flags.available = flags & 1 ? 1 : 0;
+    resume->flags.has_pistols = flags & 2 ? 1 : 0;
+    resume->flags.has_magnums = flags & 4 ? 1 : 0;
+    resume->flags.has_uzis = flags & 8 ? 1 : 0;
+    resume->flags.has_shotgun = flags & 16 ? 1 : 0;
+    resume->flags.costume = flags & 32 ? 1 : 0;
+}
+
+static void M_ReadResumeInfos(MYFILE *const fp)
 {
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
-    for (int32_t i = 0; i < level_table->count; i++) {
-        const GF_LEVEL *const level = &level_table->levels[i];
-        RESUME_INFO *const current = Savegame_GetCurrentInfo(level);
-        current->pistol_ammo = M_ReadU16();
-        current->magnum_ammo = M_ReadU16();
-        current->uzi_ammo = M_ReadU16();
-        current->shotgun_ammo = M_ReadU16();
-        current->small_medipacks = M_ReadU8();
-        current->large_medipacks = M_ReadU8();
-        current->num_scions = M_ReadU8();
-        current->gun_status = M_ReadS8();
-        current->equipped_gun_type = M_ReadS8();
-        current->holsters_gun_type = LGT_UNKNOWN;
-        current->back_gun_type = LGT_UNKNOWN;
+    for (int32_t i = 0; i < 22; i++) {
+        if (i < level_table->count) {
+            const GF_LEVEL *const level = &level_table->levels[i];
+            M_ReadResumeInfo(Savegame_GetCurrentInfo(level));
 
-        const uint16_t flags = M_ReadU16();
-        current->flags.available = flags & 1 ? 1 : 0;
-        current->flags.has_pistols = flags & 2 ? 1 : 0;
-        current->flags.has_magnums = flags & 4 ? 1 : 0;
-        current->flags.has_uzis = flags & 8 ? 1 : 0;
-        current->flags.has_shotgun = flags & 16 ? 1 : 0;
-        current->flags.costume = flags & 32 ? 1 : 0;
-        // Gym and first level have special starting items.
-        if (level == GF_GetFirstLevel() || level == GF_GetGymLevel()) {
-            Savegame_ApplyLogicToCurrentInfo(level);
+            // Gym and first level have special starting items.
+            if (level == GF_GetFirstLevel() || level == GF_GetGymLevel()) {
+                Savegame_ApplyLogicToCurrentInfo(level);
+            }
+        } else {
+            RESUME_INFO dummy_resume_info;
+            M_ReadResumeInfo(&dummy_resume_info);
         }
     }
 
     const uint32_t temp_timer = M_ReadU32();
     const uint32_t temp_kill_count = M_ReadU32();
     const uint16_t temp_secret_flags = M_ReadU16();
-    const uint16_t current_level = M_ReadU16();
+    const uint16_t current_level_num = M_ReadU16();
+    const uint8_t temp_pickup_count = M_ReadU8();
+    const uint8_t temp_flags = M_ReadU8();
 
-    RESUME_INFO *const resume_info =
-        Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    resume_info->stats.timer = temp_timer;
-    resume_info->stats.kill_count = temp_kill_count;
-    resume_info->stats.secret_flags = temp_secret_flags;
-    Stats_UpdateSecrets(&resume_info->stats);
-    resume_info->stats.pickup_count = M_ReadU8();
-    const bool is_ng_plus = M_ReadU8() != 0;
+    const GF_LEVEL *current_level = Game_GetCurrentLevel();
+    if (current_level != nullptr) {
+        RESUME_INFO *const resume_info = Savegame_GetCurrentInfo(current_level);
+        resume_info->stats.timer = temp_timer;
+        resume_info->stats.kill_count = temp_kill_count;
+        resume_info->stats.secret_flags = temp_secret_flags;
+        Stats_UpdateSecrets(&resume_info->stats);
+        resume_info->stats.pickup_count = temp_pickup_count;
+        resume_info->stats.death_count = -1;
+    }
+
+    const bool is_ng_plus = temp_flags != 0;
     if (is_ng_plus) {
         Game_SetBonusFlag(GBF_NGPLUS);
     }
-    resume_info->stats.death_count = -1;
 }
 
 static const char *M_GetSaveFilePattern(void)
@@ -439,7 +456,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
     M_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
     M_Skip(sizeof(int32_t)); // save counter
 
-    M_ReadResumeInfo(fp);
+    M_ReadResumeInfos(fp);
     g_Lara.holsters_gun_type = LGT_UNKNOWN;
     g_Lara.back_gun_type = LGT_UNKNOWN;
 
@@ -561,10 +578,11 @@ static bool M_LoadOnlyResumeInfo(MYFILE *const fp)
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, buffer, File_Size(fp));
 
+    M_Reset(buffer);
     M_Skip(SAVEGAME_LEGACY_TITLE_SIZE); // level title
     M_Skip(sizeof(int32_t)); // save counter
 
-    M_ReadResumeInfo(fp);
+    M_ReadResumeInfos(fp);
 
     Memory_FreePointer(&buffer);
     return true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3137.

We actually had two bugs:
1) The legacy save would load messed up information from the resume infos because it never reset its internal buffer. This is what led to the game crashing. Fixing this triggered a cascade of other crashes which I fixed as well.
2) The `/play` command would restore inventory from the highlighted save slot, which is wrong – it should only get Lara her default equipment (so just the pistols in all levels except Natla's Mines).

I'd appreciate heavier testing around the select level feature, the `/play` feature (which ATI and TRX saves present and not) and the same kind of scenarios for `/play` in TR2.