### PR TITLE
statue: fix game crash if statues explode with no centaur object

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed vertical FOV option not working properly (#3120, regression from 4.10)
 - fixed Lara's position on a ledge after grabbing it extremely late (#3132, regression from 2.2.1)
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 4.10)
+- fixed a game crash in custom levels if centaur statues exploded without having centaur objects in the level file (#3155)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/src/tr1/game/objects/creatures/statue.c
+++ b/src/tr1/game/objects/creatures/statue.c
@@ -28,6 +28,11 @@ static void M_Setup(OBJECT *const obj)
 
 static void M_Initialise(const int16_t item_num)
 {
+    OBJECT *const obj = Object_Get(O_CENTAUR);
+    if (!obj->loaded) {
+        return;
+    }
+
     ITEM *const item = Item_Get(item_num);
 
     const int16_t centaur_item_num = Item_CreateLevelItem();
@@ -69,14 +74,17 @@ static void M_Control(const int16_t item_num)
         Item_Kill(item_num);
         item->status = IS_DEACTIVATED;
 
-        const int16_t centaur_item_num = (intptr_t)item->data;
-        ITEM *const centaur = Item_Get(centaur_item_num);
-        centaur->touch_bits = 0;
-        Item_AddActive(centaur_item_num);
-        LOT_EnableBaddieAI(centaur_item_num, 1);
-        centaur->status = IS_ACTIVE;
-
-        Sound_Effect(SFX_ATLANTEAN_EXPLODE, &centaur->pos, SPM_NORMAL);
+        if (item->data != nullptr) {
+            const int16_t centaur_item_num = (intptr_t)item->data;
+            ITEM *const centaur = Item_Get(centaur_item_num);
+            centaur->touch_bits = 0;
+            Item_AddActive(centaur_item_num);
+            LOT_EnableBaddieAI(centaur_item_num, 1);
+            centaur->status = IS_ACTIVE;
+            Sound_Effect(SFX_ATLANTEAN_EXPLODE, &centaur->pos, SPM_NORMAL);
+        } else {
+            Sound_Effect(SFX_ATLANTEAN_EXPLODE, &item->pos, SPM_NORMAL);
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #3155.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Fixed a game crash in custom levels if centaur statues exploded without having centaur objects in the level file. Test with Sabatu's Gold level 1: (don't use the save, it was made from 4.9 and doesn't seem to load on current TR1X 😢 `/tp statue` works to get to the room, `/give 3 key` to get all the keys, and then place them all and return to the statue room)

[StatueCrash.zip](https://github.com/user-attachments/files/20678744/StatueCrash.zip)