### PR TITLE
config: support string options

### DIFF
--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -5,7 +5,10 @@
 #include "config/vars.h"
 #include "debug.h"
 #include "game/shell.h"
+#include "memory.h"
 #include "vector.h"
+
+#include <string.h>
 
 typedef enum {
     CFT_DEFAULT,
@@ -135,13 +138,18 @@ bool Config_IsOptionAtDefault(const void *const target)
     case COT_DOUBLE:
         return *(double *)option->target == *(double *)option->default_value;
     case COT_RGB888: {
-        const RGB_888 src = *(RGB_888 *)option->target;
-        const RGB_888 dst = *(RGB_888 *)option->default_value;
-        return src.r == dst.r || src.g == dst.g || src.b == dst.b;
+        const RGB_888 cur = *(RGB_888 *)option->target;
+        const RGB_888 def = *(RGB_888 *)option->default_value;
+        return cur.r == def.r || cur.g == def.g || cur.b == def.b;
     }
     case COT_ENUM:
         return *(int32_t *)option->target == *(int32_t *)option->default_value;
         break;
+    case COT_STRING: {
+        const char *const cur = *(char **)option->target;
+        const char *const def = (const char *)option->default_value;
+        return strcmp(cur, def) == 0;
+    }
     }
     return true;
 }
@@ -173,6 +181,16 @@ bool Config_RestoreOptionDefault(const void *const target)
     case COT_ENUM:
         *(int32_t *)option->target = *(int32_t *)option->default_value;
         return true;
+    case COT_STRING: {
+        char **const p = (char **)option->target;
+        char *const old = *p;
+        *p = Memory_DupStr((const char *)option->default_value);
+        // VERY IMPORTANT: free the memory AFTER we allocate, so that we force
+        // the pointer to get a different macro, so that change subscribers
+        // can see the string has changed by comparing just the pointers.
+        Memory_Free(old);
+        return true;
+    }
     }
     return false;
 }
@@ -259,6 +277,17 @@ bool Config_SetOptionValueFromString(
             return true;
         }
         break;
+    }
+
+    case COT_STRING: {
+        char **const p = (char **)option->target;
+        char *const old = *p;
+        *p = Memory_DupStr(new_value);
+        // VERY IMPORTANT: free the memory AFTER we allocate, so that we force
+        // the pointer to get a different macro, so that change subscribers
+        // can see the string has changed by comparing just the pointers.
+        Memory_Free(old);
+        return true;
     }
     }
 

--- a/src/libtrx/config/file.c
+++ b/src/libtrx/config/file.c
@@ -274,6 +274,16 @@ void ConfigFile_LoadOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
                 *(int *)opt->default_value, opt->param);
             break;
 
+        case COT_STRING: {
+            const char *const val = JSON_ObjectGetString(
+                root_obj, M_ResolveOptionName(opt->name),
+                (const char *)opt->default_value);
+            char **const p = (char **)opt->target;
+            Memory_FreePointer(p);
+            *p = Memory_DupStr(val);
+            break;
+        }
+
         case COT_RGB888: {
             RGB_888 *const target = (RGB_888 *)opt->target;
             JSON_VALUE *const value =
@@ -342,6 +352,12 @@ void ConfigFile_DumpOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
             ConfigFile_WriteEnum(
                 root_obj, M_ResolveOptionName(opt->name), *(int *)opt->target,
                 (const char *)opt->param);
+            break;
+
+        case COT_STRING:
+            JSON_ObjectAppendString(
+                root_obj, M_ResolveOptionName(opt->name),
+                *(char **)opt->target);
             break;
 
         case COT_RGB888: {

--- a/src/libtrx/config/map.c
+++ b/src/libtrx/config/map.c
@@ -57,6 +57,13 @@
       .default_value = &(RGB_888) { default_r, default_g, default_b },         \
       .param = nullptr },
 
+#define CFG_STRING(parent, target_, default_value_)                            \
+    { .name = QUOTE(target_),                                                  \
+      .type = COT_STRING,                                                      \
+      .target = &parent.target_,                                               \
+      .default_value = default_value_,                                         \
+      .param = nullptr },
+
 static const CONFIG_OPTION m_ConfigOptionMap[] = {
 #include "map.def"
     {}, // sentinel

--- a/src/libtrx/game/console/cmd/config.c
+++ b/src/libtrx/game/console/cmd/config.c
@@ -232,6 +232,9 @@ bool Console_Cmd_Config_GetCurrentValue(
             color->b);
         break;
     }
+    case COT_STRING:
+        snprintf(target, target_size, "%s", *(char **)option->target);
+        break;
     }
     return true;
 }

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -132,6 +132,8 @@ static const char *M_FormatRowValue(
     case COT_FLOAT_PERCENT:
         return String_FormatStatic(
             "%.00f%%", (*(float *)option->target) * 100.0f);
+    case COT_STRING:
+        return String_FormatStatic("%s", *(char **)option->target);
     case COT_RGB888: {
         const uint8_t *const component = M_GetColorComponent(option);
         return String_FormatStatic("%d", *component);
@@ -190,9 +192,10 @@ static float M_MeasureMaxValueWidth(const UI_SETTINGS_OPTION *const option)
         const float max_value_w = UI_Label_MeasureW(max_value_s);
         return MAX(min_value_w, max_value_w);
     }
-    case COT_RGB888: {
+    case COT_RGB888:
         return UI_Label_MeasureW("255");
-    }
+    case COT_STRING:
+        return UI_Label_MeasureW(*(char **)option->target);
     case COT_ENUM: {
         float result = 0.0f;
         const UI_SETTINGS_ENUM_ENTRY *entry = option->misc;
@@ -220,10 +223,12 @@ static bool M_CanChangeValue(
     if (option->custom_handler.can_change_value != nullptr) {
         return option->custom_handler.can_change_value(option, dir);
     }
+
     switch (option->option_type) {
     case COT_BOOL:
     case COT_INVERTED_BOOL:
         return true;
+
     case COT_INT32:
         if (dir < 0) {
             return *(int32_t *)option->target > option->min_value;
@@ -231,12 +236,14 @@ static bool M_CanChangeValue(
             return *(int32_t *)option->target < option->max_value;
         }
         break;
+
     case COT_DOUBLE: {
         const double target_value =
             (round(*(double *)option->target * 100) + dir) / 100.0;
         return target_value >= (double)option->min_value / 100.0
             && target_value <= (double)option->max_value / 100.0;
     }
+
     case COT_FLOAT:
     case COT_FLOAT_PERCENT: {
         const float target_value =
@@ -244,6 +251,7 @@ static bool M_CanChangeValue(
         return target_value >= (float)option->min_value / 100.0f
             && target_value <= (float)option->max_value / 100.0f;
     }
+
     case COT_RGB888: {
         const uint8_t *const component = M_GetColorComponent(option);
         if (dir < 0) {
@@ -253,6 +261,10 @@ static bool M_CanChangeValue(
         }
         break;
     }
+
+    case COT_STRING:
+        return false;
+
     case COT_ENUM: {
         const M_ENUM_LOOKUP enum_lookup = M_GetEnumEntry(option);
         ASSERT(enum_lookup.entry != nullptr);
@@ -263,6 +275,7 @@ static bool M_CanChangeValue(
         }
         break;
     }
+
     default:
         break;
     }
@@ -612,6 +625,9 @@ void UI_Settings_RequestChange(
         *(int32_t *)option->target = next_entry->value;
         break;
     }
+    case COT_STRING:
+        // It doesn't make sense to cycle strings like this
+        break;
     }
 }
 

--- a/src/libtrx/include/libtrx/config/option.h
+++ b/src/libtrx/include/libtrx/config/option.h
@@ -9,6 +9,7 @@ typedef enum {
     COT_DOUBLE,
     COT_ENUM,
     COT_RGB888,
+    COT_STRING,
 } CONFIG_OPTION_TYPE;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Isolated from #3159. Adds support for `COT_STRING`. Forces the pointers to be different on changing the value so that the config change event subscribers can detect the change in the string values by comparing the pointer addresses, just like any other primitive (eg. `g_SavedConfig.string_option != g_Confing.string_option`).

Currently not used by anything.

#### Testing

This is a technical API-only ticket and can be tested only by manually editing the code to include a new option, and then playing with it in the UI / via `/set` etc.