### PR TITLE
ui: do not retain game string content

### DIFF
--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -36,7 +36,7 @@ typedef enum {
 
 static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     {
-        .header = GS_ID(CONTROLS_SECTION_BASICS),
+        .header_gs = GS_ID(CONTROLS_SECTION_BASICS),
         .roles =
             (INPUT_ROLE[]) {
                 INPUT_ROLE_UP,
@@ -56,7 +56,7 @@ static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     },
 
     {
-        .header = GS_ID(CONTROLS_SECTION_ITEMS),
+        .header_gs = GS_ID(CONTROLS_SECTION_ITEMS),
         .roles =
             (INPUT_ROLE[]) {
 #if TR_VERSION == 2
@@ -78,7 +78,7 @@ static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     },
 
     {
-        .header = GS_ID(CONTROLS_SECTION_MISC),
+        .header_gs = GS_ID(CONTROLS_SECTION_MISC),
         .roles =
             (INPUT_ROLE[]) {
 #if TR_VERSION == 1
@@ -99,7 +99,7 @@ static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     },
 
     {
-        .header = GS_ID(CONTROLS_SECTION_SYSTEM),
+        .header_gs = GS_ID(CONTROLS_SECTION_SYSTEM),
         .roles =
             (INPUT_ROLE[]) {
                 INPUT_ROLE_OPTION,
@@ -129,7 +129,8 @@ static const UI_CONTROLS_EDITOR_GROUP m_Groups[] = {
     },
 
     {
-        .header = nullptr,
+        .header_gs = nullptr,
+        .roles = nullptr,
     },
 };
 
@@ -485,7 +486,8 @@ void UI_ControlsEditor_Init(
     {
         UI_TAB_SWITCH_TAB layout_tabs[INPUT_LAYOUT_NUMBER_OF];
         for (INPUT_LAYOUT i = 0; i < INPUT_LAYOUT_NUMBER_OF; i++) {
-            layout_tabs[i].header = Input_GetLayoutName(i);
+            layout_tabs[i].header_str = Input_GetLayoutName(i);
+            layout_tabs[i].header_gs = nullptr;
         }
         s->layout_tab_switch =
             UI_TabSwitch_Init(INPUT_LAYOUT_NUMBER_OF, layout_tabs);
@@ -493,19 +495,20 @@ void UI_ControlsEditor_Init(
 
     {
         int32_t tab_count = 0;
-        for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
+        for (int32_t i = 0; m_Groups[i].roles != nullptr; i++) {
             tab_count++;
         }
         UI_TAB_SWITCH_TAB controls_tabs[tab_count];
-        for (int32_t i = 0; m_Groups[i].header != nullptr; i++) {
-            controls_tabs[i].header = GameString_Get(m_Groups[i].header);
+        for (int32_t i = 0; m_Groups[i].roles != nullptr; i++) {
+            controls_tabs[i].header_gs = m_Groups[i].header_gs;
+            controls_tabs[i].header_str = nullptr;
         }
         s->controls_tab_switch = UI_TabSwitch_Init(tab_count, controls_tabs);
     }
 
     s->max_group_items = 0;
     for (const UI_CONTROLS_EDITOR_GROUP *group = m_Groups;
-         group->header != nullptr; group++) {
+         group->roles != nullptr; group++) {
         s->max_group_items =
             MAX(s->max_group_items, M_GetInputRoleCount(group));
     }

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -458,7 +458,7 @@ void UI_Settings_InitWithTabs(
     s->max_group_items = 0;
     UI_TAB_SWITCH_TAB tab_switch_tabs[tab_count];
     for (int32_t i = 0; i < tab_count; i++) {
-        tab_switch_tabs[i].header = GameString_Get(tabs[i].header);
+        tab_switch_tabs[i].header_gs = tabs[i].header_gs;
         int32_t tab_items = 0;
         for (int32_t j = 0; tabs[i].options[j].label_id != nullptr; j++) {
             tab_items++;

--- a/src/libtrx/game/ui/elements/tab_switch.c
+++ b/src/libtrx/game/ui/elements/tab_switch.c
@@ -39,7 +39,9 @@ static void M_Draw(
                 is_focused ? UI_FRAME_SELECTED_OPTION : UI_FRAME_OUTLINE_ONLY);
         }
         UI_BeginPad(2.0f, 1.0f);
-        UI_Label(tab->header);
+        UI_Label(
+            tab->header_gs != nullptr ? GameString_Get(tab->header_gs)
+                                      : tab->header_str);
         UI_EndPad();
         if (i == s->active_tab_idx) {
             UI_EndFrame();

--- a/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/controls_editor.h
@@ -13,7 +13,7 @@
 #include "../scrollable.h"
 
 typedef struct {
-    GAME_STRING_ID header;
+    GAME_STRING_ID header_gs;
     INPUT_ROLE *roles;
 } UI_CONTROLS_EDITOR_GROUP;
 

--- a/src/libtrx/include/libtrx/game/ui/dialogs/settings.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/settings.h
@@ -50,7 +50,7 @@ typedef enum {
 // A tab for grouping settings into separate, labeled pages.
 // Each tab has its own nullptr-terminated UI_SETTINGS_OPTION array.
 typedef struct UI_SETTINGS_TAB {
-    GAME_STRING_ID header;
+    GAME_STRING_ID header_gs;
     const UI_SETTINGS_OPTION *options;
 } UI_SETTINGS_TAB;
 

--- a/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
+++ b/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
@@ -9,7 +9,8 @@
 
 // Represents a single tab page for use with UI_TabSwitch_Control.
 typedef struct {
-    const char *header;
+    GAME_STRING_ID header_gs;
+    const char *header_str;
 } UI_TAB_SWITCH_TAB;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Isolated from #3159. Modifies UI elements to not hold onto pointers to GAME_STRINGs, as these may change at runtime, invalidating the content.

The only element that continues to retain the `char*` pointers internally is the text dialog (examine item / settings description), but it clones them on initialization, so it never ends up accessing invalid memory – even if the original text passed to it is freed.