### PR TITLE
rooms/floor_data: constrain gym music track check

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed Lara's position on a ledge after grabbing it extremely late (#3132, regression from 2.2.1)
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 4.10)
 - fixed a game crash in custom levels if centaur statues exploded without having centaur objects in the level file (#3155)
+- fixed being unable to re-purpose some gym music tracks in custom levels (#3164)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr1/README.md
+++ b/docs/tr1/README.md
@@ -629,6 +629,7 @@ Not all options are turned on by default. Refer to `TR1X_ConfigTool.exe` for det
     - **The Hive**: converted track 9 in room 8, track 6 in room 18, track 12 in room 30, track 18 in room 31, track 3 in room 32, and track 20 in room 35 to one shot
 - fixed being unable to load a level that contains no sound effect data
 - fixed the panther at times not making a sound when it dies
+- fixed being unable to re-purpose some gym music tracks in custom levels
 - restored Skate Kid's death SFX
 
 #### Mods

--- a/src/libtrx/game/rooms/floor_data.c
+++ b/src/libtrx/game/rooms/floor_data.c
@@ -129,7 +129,7 @@ static void M_TriggerMusicTrack(int16_t track, const TRIGGER *const trigger)
     }
 
     if (track <= MX_UNUSED_1 || track >= MAX_MUSIC_TRACKS
-        || !Gym_CanPlayMusicTrack(&track)) {
+        || (Game_IsInGym() && !Gym_CanPlayMusicTrack(&track))) {
         return;
     }
 


### PR DESCRIPTION
Resolves #3164.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that the check on whether or not to play a gym music track is done in the gym level only.
