### PR TITLE
Fix glitchy playback

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -36,6 +36,7 @@
 - fixed a desync in the Vilcabamba demo if the wall glitch fix option was enabled (#3172, regression from 1.3)
 - fixed demos being affected if Lara's starting HP has been altered (#3180, regression from 2.6)
 - fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 4.11)
+- fixed broken playback of mono music tracks (regression from 2.0)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed demos being affected if Lara's starting HP has been altered (#3180, regression from 2.6)
 - fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 4.11)
 - fixed broken playback of mono music tracks (regression from 2.0)
+- fixed hot-plugging certain audio devices causing glitchy playback (partial fix; regression from 2.0)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed the sizer option accepting values above 1 which made no sense (#3123, regression from 1.0)
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 1.0)
 - fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 1.1)
+- fixed broken playback of mono music tracks (regression from 0.2)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 1.0)
 - fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 1.1)
 - fixed broken playback of mono music tracks (regression from 0.2)
+- fixed hot-plugging certain audio devices causing glitchy playback (partial fix; regression from 0.2)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/src/libtrx/engine/audio.c
+++ b/src/libtrx/engine/audio.c
@@ -9,26 +9,100 @@
 #include <stdint.h>
 #include <string.h>
 
+SDL_AudioSpec g_AudioDeviceParms = {};
 SDL_AudioDeviceID g_AudioDeviceID = 0;
+
 static int32_t m_RefCount = 0;
 static size_t m_MixBufferCapacity = 0;
 static float *m_MixBuffer = nullptr;
 static Uint8 m_Silence = 0;
+static Uint64 m_ReopenDebounce = 0;
 
+static int M_HandleSDLEvent(void *userdata, SDL_Event *event);
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len);
+static bool M_OpenDevice(void);
+static void M_CloseDevice(void);
+static bool M_ReopenDevice(void);
+
+void Audio_HandleSDLEvent(const SDL_Event *const event)
+{
+    if (event->type == SDL_AUDIODEVICEADDED) {
+        if ((SDL_GetTicks() - m_ReopenDebounce) > 500) {
+            M_ReopenDevice();
+        }
+    }
+}
 
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
 {
+    if (m_MixBuffer == nullptr) {
+        return;
+    }
     memset(m_MixBuffer, m_Silence, len);
     Audio_Stream_Mix(m_MixBuffer, len);
     Audio_Sample_Mix(m_MixBuffer, len);
     memcpy(stream_data, m_MixBuffer, len);
 }
 
+static bool M_OpenDevice(void)
+{
+    if (g_AudioDeviceID != 0) {
+        return true;
+    }
+
+    Memory_FreePointer(&m_MixBuffer);
+    SDL_AudioSpec desired;
+    SDL_memset(&desired, 0, sizeof(desired));
+    desired.freq = AUDIO_WORKING_RATE;
+    desired.format = AUDIO_WORKING_FORMAT;
+    desired.channels = AUDIO_WORKING_CHANNELS;
+    desired.samples = AUDIO_SAMPLES;
+    desired.callback = M_MixerCallback;
+    desired.userdata = nullptr;
+
+    g_AudioDeviceID = SDL_OpenAudioDevice(
+        nullptr, 0, &desired, &g_AudioDeviceParms,
+        SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+
+    if (g_AudioDeviceID == 0) {
+        LOG_ERROR("Failed to open audio device: %s", SDL_GetError());
+        return false;
+    }
+
+    LOG_INFO("Opened audio device (%x)", g_AudioDeviceID);
+    m_ReopenDebounce = SDL_GetTicks();
+    m_Silence = desired.silence;
+    m_MixBufferCapacity = desired.samples * desired.channels
+        * SDL_AUDIO_BITSIZE(desired.format) / 8;
+    m_MixBuffer = Memory_Alloc(m_MixBufferCapacity);
+    SDL_PauseAudioDevice(g_AudioDeviceID, 0);
+    return true;
+}
+
+static void M_CloseDevice(void)
+{
+    if (g_AudioDeviceID != 0) {
+        LOG_INFO("Closing audio device (%x)", g_AudioDeviceID);
+        SDL_PauseAudioDevice(g_AudioDeviceID, 1);
+        SDL_CloseAudioDevice(g_AudioDeviceID);
+        g_AudioDeviceID = 0;
+    }
+}
+
+static bool M_ReopenDevice(void)
+{
+    M_CloseDevice();
+    if (M_OpenDevice()) {
+        Audio_Stream_Reload();
+        return true;
+    }
+    return false;
+}
+
 bool Audio_Init(void)
 {
     m_RefCount++;
-    if (g_AudioDeviceID) {
+    if (g_AudioDeviceID != 0) {
         // already initialized
         return true;
     }
@@ -39,34 +113,12 @@ bool Audio_Init(void)
         return false;
     }
 
-    SDL_AudioSpec desired;
-    SDL_memset(&desired, 0, sizeof(desired));
-    desired.freq = AUDIO_WORKING_RATE;
-    desired.format = AUDIO_WORKING_FORMAT;
-    desired.channels = AUDIO_WORKING_CHANNELS;
-    desired.samples = AUDIO_SAMPLES;
-    desired.callback = M_MixerCallback;
-    desired.userdata = nullptr;
-
-    SDL_AudioSpec delivered;
-    g_AudioDeviceID = SDL_OpenAudioDevice(nullptr, 0, &desired, &delivered, 0);
-
-    if (!g_AudioDeviceID) {
-        LOG_ERROR("Failed to open audio device: %s", SDL_GetError());
+    if (!M_OpenDevice()) {
         return false;
     }
 
-    m_Silence = desired.silence;
-    m_MixBufferCapacity = desired.samples * desired.channels
-        * SDL_AUDIO_BITSIZE(desired.format) / 8;
-
-    m_MixBuffer = Memory_Alloc(m_MixBufferCapacity);
-
-    SDL_PauseAudioDevice(g_AudioDeviceID, 0);
-
     Audio_Sample_Init();
     Audio_Stream_Init();
-
     return true;
 }
 
@@ -77,14 +129,11 @@ bool Audio_Shutdown(void)
         return false;
     }
 
-    if (g_AudioDeviceID) {
-        SDL_PauseAudioDevice(g_AudioDeviceID, 1);
-        SDL_CloseAudioDevice(g_AudioDeviceID);
-        g_AudioDeviceID = 0;
+    if (g_AudioDeviceID != 0) {
+        M_CloseDevice();
     }
 
     Memory_FreePointer(&m_MixBuffer);
-
     Audio_Sample_Shutdown();
     Audio_Stream_Shutdown();
     return true;

--- a/src/libtrx/engine/audio_internal.h
+++ b/src/libtrx/engine/audio_internal.h
@@ -10,6 +10,7 @@
 #define AUDIO_SAMPLES 500
 #define AUDIO_WORKING_CHANNELS 2
 
+extern SDL_AudioSpec g_AudioDeviceParms;
 extern SDL_AudioDeviceID g_AudioDeviceID;
 
 int32_t Audio_GetAVChannelLayout(int32_t sample_fmt);
@@ -23,3 +24,4 @@ void Audio_Sample_Mix(float *dst_buffer, size_t len);
 void Audio_Stream_Init(void);
 void Audio_Stream_Shutdown(void);
 void Audio_Stream_Mix(float *dst_buffer, size_t len);
+void Audio_Stream_Reload(void);

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -630,32 +630,9 @@ void Audio_Stream_Mix(float *dst_buffer, size_t len)
             const float *src_ptr = &m_MixBuffer[0];
             float *dst_ptr = dst_buffer;
 
-            const int32_t channels =
-                stream->av.codec_ctx->ch_layout.nb_channels;
-            if (channels == AUDIO_WORKING_CHANNELS) {
-                for (int32_t s = 0; s < samples_gotten; s++) {
-                    for (int32_t c = 0; c < AUDIO_WORKING_CHANNELS; c++) {
-                        *dst_ptr++ += *src_ptr++ * stream->volume;
-                    }
-                }
-            } else if (channels == 1) {
-                for (int32_t s = 0; s < samples_gotten; s++) {
-                    for (int32_t c = 0; c < AUDIO_WORKING_CHANNELS; c++) {
-                        *dst_ptr++ += *src_ptr * stream->volume;
-                    }
-                    src_ptr++;
-                }
-            } else {
-                for (int32_t s = 0; s < samples_gotten; s++) {
-                    // downmix to mono
-                    float src_sample = 0.0f;
-                    for (int32_t i = 0; i < channels; i++) {
-                        src_sample += *src_ptr++;
-                    }
-                    src_sample /= (float)channels;
-                    for (int32_t c = 0; c < AUDIO_WORKING_CHANNELS; c++) {
-                        *dst_ptr++ += src_sample * stream->volume;
-                    }
+            for (int32_t s = 0; s < samples_gotten; s++) {
+                for (int32_t c = 0; c < AUDIO_WORKING_CHANNELS; c++) {
+                    *dst_ptr++ += *src_ptr++ * stream->volume;
                 }
             }
         }

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -359,7 +359,8 @@ static bool M_InitialiseFromPath(int32_t sound_id, const char *file_path)
 
     stream->sdl.stream = SDL_NewAudioStream(
         AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE,
-        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE);
+        g_AudioDeviceParms.format, g_AudioDeviceParms.channels,
+        g_AudioDeviceParms.freq);
     if (!stream->sdl.stream) {
         LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());
         goto cleanup;
@@ -742,4 +743,28 @@ bool Audio_Stream_SetStopTimestamp(int32_t sound_id, double timestamp)
 
     m_Streams[sound_id].stop_at = timestamp;
     return true;
+}
+
+void Audio_Stream_Reload(void)
+{
+    SDL_LockAudioDevice(g_AudioDeviceID);
+    for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
+         sound_id++) {
+        AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+        if (!stream->is_used) {
+            continue;
+        }
+        SDL_FreeAudioStream(stream->sdl.stream);
+        const int32_t sdl_channels =
+            stream->av.codec_ctx->ch_layout.nb_channels;
+        stream->sdl.stream = SDL_NewAudioStream(
+            AUDIO_WORKING_FORMAT, AUDIO_WORKING_CHANNELS, AUDIO_WORKING_RATE,
+            g_AudioDeviceParms.format, g_AudioDeviceParms.channels,
+            g_AudioDeviceParms.freq);
+        if (stream->sdl.stream == nullptr) {
+            LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());
+            Audio_Stream_Close(sound_id);
+        }
+    }
+    SDL_UnlockAudioDevice(g_AudioDeviceID);
 }

--- a/src/libtrx/include/libtrx/engine/audio.h
+++ b/src/libtrx/include/libtrx/engine/audio.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL2/SDL_audio.h>
+#include <SDL2/SDL_events.h>
 #include <libavutil/samplefmt.h>
 #include <stdint.h>
 
@@ -11,6 +12,8 @@
 
 bool Audio_Init(void);
 bool Audio_Shutdown(void);
+
+void Audio_HandleSDLEvent(const SDL_Event *event);
 
 bool Audio_Stream_Pause(int32_t sound_id);
 bool Audio_Stream_Unpause(int32_t sound_id);

--- a/src/tr1/specific/s_shell.c
+++ b/src/tr1/specific/s_shell.c
@@ -10,6 +10,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/engine/audio.h>
 #include <libtrx/filesystem.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/ui.h>
@@ -205,6 +206,11 @@ void Shell_ProcessEvents(void)
 
         case SDL_TEXTINPUT:
             UI_HandleTextEdit(event.text.text);
+            break;
+
+        case SDL_AUDIODEVICEADDED:
+        case SDL_AUDIODEVICEREMOVED:
+            Audio_HandleSDLEvent(&event);
             break;
 
         case SDL_CONTROLLERDEVICEADDED:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Some findings: the FMV playback code, which is tangentially faithful to ffprobe.c from ffmpeg, is working as it should. And while it does include output renegotiation, in reality, it never is called (!). Its SDL usage is akin to ours: open the device once, mix the decoded data, and close the device once. It never tries to reopen the device, or does it reconfigure its SWR context (SoftWare Resampler) at any point. On the other hand, it uses `memcpy` and `SDL_MixAudioFormat` (which is only used to achieve volume control and is otherwise the same as `memcpy`) paired with manual queues and clock syncing, whereas we use `SDL_AudioStream*` family of functions out of convenience (they allow us to enqueue and consume sample data at our leisure without worrying about overflows or underruns). At the same time, we open the audio device with `flags=0`, whereas video.c opens it with `SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_CHANNELS_CHANGE`. 

I tried moving our decoding (which currently happens in a "just in time" manner inside the mixer callback) to a separate thread and decode eagerly the entire file, which means the samples should always arrive in time without any sort of hiccups. It didn't help.

I tried replacing `SDL_AudioStream*` API with our own buffer that is sure not to do any resampling. It didn't help either.

While VSync may influence the "speed" at which the main thread runs, I have it off, and we're doing decoding in the mixer callback which is in its own separate thread, anyway.

I'm out of ideas.

I've added some code to recreate the streams on device change for simplicity's sake. Seems to work, though it's a bit of a cannonball approach as the device removal/add events cannot be trusted really and this means we recreate the streams on any configuration change, even if the connected/disconnected devices are not in use and of no interest to the game. Plus I'm not entirely understanding why we have to do this and how video.c gets away without it.