### PR TITLE
ui/overlay: show Lara bars only when controllable

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 4.10)
 - fixed a desync in the Vilcabamba demo if the wall glitch fix option was enabled (#3172, regression from 1.3)
 - fixed demos being affected if Lara's starting HP has been altered (#3180, regression from 2.6)
+- fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 4.11)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed transparent eyes on the wolf model in Furnace of the Gods (#3073)
 - fixed Lara getting stuck in her hit animation if she is hit while using an airlock door, the detonator or the gong (#3092)
 - fixed Lara behaving erratically if she is killed while hanging from a ledge (#3134)
+- fixed Lara's health bar showing in the Home Sweet Home shower cutscene (#1564)
 - fixed Lara dropping flares after certain special animations, such as pulling the dagger from the dragon (#3084, regression from 1.1)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 1.1)
 - fixed the sizer option accepting values above 1 which made no sense (#3123, regression from 1.0)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fixed unbind key option being available when it shouldn't (#3111, regression from 1.1)
 - fixed the sizer option accepting values above 1 which made no sense (#3123, regression from 1.0)
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 1.0)
+- fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 1.1)
 - improved word wrapping algorithm in the dev console
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -357,6 +357,7 @@ However, you can easily download them manually from these urls:
 - fixed texture and visibility issues with the skyboxes in The Cold War and Kingdom
 - fixed transparent eyes on Lara's model in the gym and Home Sweet Home levels
 - fixed transparent eyes on the wolf model in Furnace of the Gods
+- fixed Lara's health bar showing in the Home Sweet Home shower cutscene
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -11,6 +11,18 @@
 #define M_MOVE_SPEED 16
 #define M_MOVE_ANGLE (2 * DEG_1) // = 364
 
+static bool m_Controllable = false;
+
+bool Lara_IsControllable(void)
+{
+    return m_Controllable;
+}
+
+void Lara_SetControllable(const bool controllable)
+{
+    m_Controllable = controllable;
+}
+
 void Lara_Animate(ITEM *const item)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();

--- a/src/libtrx/game/phase/phase_cutscene.c
+++ b/src/libtrx/game/phase/phase_cutscene.c
@@ -2,6 +2,7 @@
 
 #include "game/cutscene.h"
 #include "game/game.h"
+#include "game/lara/common.h"
 #include "game/output.h"
 #include "memory.h"
 
@@ -26,6 +27,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
         };
     }
     Game_SetIsPlaying(true);
+    Lara_SetControllable(false);
     return (PHASE_CONTROL) {};
 }
 

--- a/src/libtrx/game/ui/hud/overlay.c
+++ b/src/libtrx/game/ui/hud/overlay.c
@@ -73,7 +73,8 @@ static bool M_LaraHealthBar(
     if (location != g_Config.ui.lara_health_bar.location) {
         return false;
     }
-    if (!Game_IsPlaying() && !s->force_show_healthbar) {
+    if (!Lara_IsControllable()
+        || (!Game_IsPlaying() && !s->force_show_healthbar)) {
         return false;
     }
     if (!g_Config.ui.enable_game_ui) {
@@ -91,7 +92,7 @@ static bool M_LaraAirBar(
     if (location != g_Config.ui.lara_air_bar.location) {
         return false;
     }
-    if (!Game_IsPlaying()) {
+    if (!Lara_IsControllable() || !Game_IsPlaying()) {
         return false;
     }
     if (!g_Config.ui.enable_game_ui) {

--- a/src/libtrx/include/libtrx/game/lara/common.h
+++ b/src/libtrx/include/libtrx/game/lara/common.h
@@ -6,6 +6,8 @@
 
 LARA_INFO *Lara_GetLaraInfo(void);
 ITEM *Lara_GetItem(void);
+bool Lara_IsControllable(void);
+void Lara_SetControllable(bool controllable);
 void Lara_Animate(ITEM *item);
 void Lara_SwapSingleMesh(LARA_MESH mesh, GAME_OBJECT_ID obj_id);
 OBJECT_MESH *Lara_GetMesh(LARA_MESH mesh);

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -467,6 +467,7 @@ void Lara_InitialiseLoad(int16_t item_num)
 
 void Lara_Initialise(const GF_LEVEL *const level)
 {
+    Lara_SetControllable(true);
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
 
     g_LaraItem->collidable = 0;

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -696,6 +696,7 @@ void Lara_InitialiseLoad(const int16_t item_num)
 
 void Lara_Initialise(const GF_LEVEL *const level)
 {
+    Lara_SetControllable(true);
     const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
     ITEM *const item = g_LaraItem;
 

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -827,7 +827,8 @@ void Lara_State_Extra_StartHouse(ITEM *item, COLL_INFO *coll)
 
 void Lara_State_Extra_FinalAnim(ITEM *item, COLL_INFO *coll)
 {
-    item->hit_points = 1000;
+    item->hit_points = LARA_MAX_HITPOINTS;
+    Lara_SetControllable(false);
 
     if (Item_TestFrameEqual(item, LF_SHOWER_START)) {
         g_Lara.back_gun_obj_id = O_LARA;


### PR DESCRIPTION
Resolves #3182.
Resolves #1564.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Overlay_DrawGameInfo` used to perform a check on `g_OverlayStatus` to test whether or not to draw Lara's health and air bars, but since cd1e338 that's no longer the case. I've added the ability to mark Lara as controllable rather than exposing the overlay status in TRX (which I'm hoping we can make private eventually to `game.c`). This also lets us fix the HSH shower cutscene (OG bug).
