### PR TITLE
Improved handling of broken language files

### DIFF
--- a/src/libtrx/game/game_string_table/common.c
+++ b/src/libtrx/game/game_string_table/common.c
@@ -124,14 +124,16 @@ void GameStringTable_Shutdown(void)
     }
 }
 
-void GameStringTable_Load(const char *const path, const bool load_levels)
+bool GameStringTable_Load(const char *const path, const bool load_levels)
 {
     char *data = nullptr;
     if (!File_Load(path, &data, nullptr)) {
-        Shell_ExitSystemFmt("failed to open strings file (path: %d)", path);
+        LOG_ERROR("failed to open strings file (path: %d)", path);
+        return false;
     }
     GS_FILE *gs_file = GS_File_CreateFromString(data, load_levels);
     ASSERT(m_GST_Layers != nullptr);
     Vector_Add(m_GST_Layers, &gs_file);
     Memory_FreePointer(&data);
+    return true;
 }

--- a/src/libtrx/game/ui/dialogs/graphic_settings.c
+++ b/src/libtrx/game/ui/dialogs/graphic_settings.c
@@ -238,11 +238,13 @@ static bool M_Language_CanChangeValue(
     const UI_SETTINGS_OPTION *const option, const int32_t dir)
 {
     const VECTOR *const langs = M_Language_GetLanguages();
-    if (langs->count < 2) {
-        return false;
-    }
     const int32_t idx = M_Language_FindIndex(option);
     if (idx < 0) {
+        // If the language from the user config somehow is no longer on the list
+        // (the file was deleted), let the player return to the default language
+        return true;
+    }
+    if (langs->count < 2) {
         return false;
     }
     return idx + dir >= 0 && idx + dir < langs->count;
@@ -255,8 +257,15 @@ static bool M_Language_RequestChangeValue(
     if (!M_Language_CanChangeValue(option, dir)) {
         return false;
     }
-    int32_t idx = M_Language_FindIndex(option);
-    const char *const new_lang = *(char **)Vector_Get(langs, idx + dir);
+    const char *new_lang;
+    const int32_t idx = M_Language_FindIndex(option);
+    if (idx != -1) {
+        new_lang = *(char **)Vector_Get(langs, idx + dir);
+    } else {
+        // If the language from the user config somehow is no longer on the list
+        // (the file was deleted), default to the first entry, which is English
+        new_lang = *(char **)Vector_Get(langs, 0);
+    }
     Config_SetOptionValueFromString(Config_GetOption(option->target), new_lang);
     GameStringManager_ReloadLanguage(new_lang);
     return true;

--- a/src/libtrx/include/libtrx/game/game_string_table.h
+++ b/src/libtrx/include/libtrx/game/game_string_table.h
@@ -7,5 +7,5 @@
 void GameStringTable_Init(void);
 void GameStringTable_Shutdown(void);
 
-void GameStringTable_Load(const char *path, bool load_levels);
+bool GameStringTable_Load(const char *path, bool load_levels);
 void GameStringTable_Apply(const GF_LEVEL *level);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Setting the language to something other than English, then removing the relevant file would cause the player to be unable to change the language at all. Now the game will let the player exit of such state by switching back to English.

Also in the event the strings file was inaccessible, the game would exit with a fatal error. This error is not fatal, as we'll just show the builtin English strings in such events, so I changed this to be just a log message.
