### PR TITLE
game-strings: use stable pointers

### DIFF
--- a/src/libtrx/game/game_string.c
+++ b/src/libtrx/game/game_string.c
@@ -4,43 +4,55 @@
 
 #include <uthash.h>
 
+// One-slot-per-string for stable indirection on reload.
+typedef struct M_SLOT {
+    const char *value;
+} M_SLOT;
+
 typedef struct {
     char *key;
-    char *value;
+    M_SLOT *slot;
     UT_hash_handle hh;
 } M_STRING_ENTRY;
 
 static M_STRING_ENTRY *m_StringTable = nullptr;
 
-void GameString_Define(const char *key, const char *value)
+void GameString_Define(const char *const key, const char *value)
 {
     M_STRING_ENTRY *entry;
 
     HASH_FIND_STR(m_StringTable, key, entry);
     if (entry == nullptr) {
-        entry = (M_STRING_ENTRY *)Memory_Alloc(sizeof(M_STRING_ENTRY));
+        entry = Memory_Alloc(sizeof(*entry));
         entry->key = Memory_DupStr(key);
-        entry->value = Memory_DupStr(value);
+        entry->slot = Memory_Alloc(sizeof(*entry->slot));
+        entry->slot->value = nullptr;
         HASH_ADD_KEYPTR(
             hh, m_StringTable, entry->key, strlen(entry->key), entry);
-    } else {
-        Memory_Free(entry->value);
-        entry->value = Memory_DupStr(value);
     }
+    Memory_Free((void *)entry->slot->value);
+    entry->slot->value = Memory_DupStr(value);
 }
 
-bool GameString_IsKnown(const char *key)
+bool GameString_IsKnown(const char *const key)
 {
     M_STRING_ENTRY *entry;
     HASH_FIND_STR(m_StringTable, key, entry);
     return entry != nullptr;
 }
 
-const char *GameString_Get(const char *key)
+const char *GameString_Get(const char *const key)
 {
     M_STRING_ENTRY *entry;
     HASH_FIND_STR(m_StringTable, key, entry);
-    return entry ? entry->value : nullptr;
+    return entry ? entry->slot->value : nullptr;
+}
+
+const char *const *GameString_GetPtr(const char *const key)
+{
+    M_STRING_ENTRY *entry;
+    HASH_FIND_STR(m_StringTable, key, entry);
+    return entry ? &entry->slot->value : nullptr;
 }
 
 void GameString_Clear(void)
@@ -51,7 +63,8 @@ void GameString_Clear(void)
     {
         HASH_DEL(m_StringTable, entry);
         Memory_Free(entry->key);
-        Memory_Free(entry->value);
+        Memory_Free((void *)entry->slot->value);
+        Memory_Free(entry->slot);
         Memory_Free(entry);
     }
 }

--- a/src/libtrx/game/inventory_ring/priv.c
+++ b/src/libtrx/game/inventory_ring/priv.c
@@ -418,7 +418,7 @@ void InvRing_ShowItemName(const INVENTORY_ITEM *const inv_item)
     if (inv_item->object_id == O_PASSPORT_OPTION) {
         return;
     }
-    Overlay_SetBottomText(Object_GetName(inv_item->object_id), false);
+    Overlay_SetBottomTextPtr(Object_GetNamePtr(inv_item->object_id), false);
 }
 
 void InvRing_ShowItemQuantity(const char *const fmt, const int32_t qty)
@@ -464,17 +464,17 @@ void InvRing_ShowHeader(INV_RING *const ring)
 
     switch (ring->type) {
     case RT_MAIN:
-        Overlay_SetTopText(GS(HEADING_INVENTORY), false);
+        Overlay_SetTopTextPtr(GS_PTR(HEADING_INVENTORY), false);
         break;
     case RT_OPTION:
         if (ring->mode == INV_DEATH_MODE) {
-            Overlay_SetTopText(GS(HEADING_GAME_OVER), false);
+            Overlay_SetTopTextPtr(GS_PTR(HEADING_GAME_OVER), false);
         } else {
-            Overlay_SetTopText(GS(HEADING_OPTION), false);
+            Overlay_SetTopTextPtr(GS_PTR(HEADING_OPTION), false);
         }
         break;
     case RT_KEYS:
-        Overlay_SetTopText(GS(HEADING_ITEMS), false);
+        Overlay_SetTopTextPtr(GS_PTR(HEADING_ITEMS), false);
         break;
     case RT_NUMBER_OF:
         break;

--- a/src/libtrx/game/objects/names.c
+++ b/src/libtrx/game/objects/names.c
@@ -24,6 +24,7 @@ typedef struct {
 typedef struct {
     VECTOR *names;
     char *description;
+    const char *slot; // stable first-name slot for this object
 } M_NAME_ENTRY;
 
 static M_NAME_ENTRY m_NamesTable[O_NUMBER_OF] = {};
@@ -91,6 +92,7 @@ static void M_ClearAllNames(void)
             entry->names = nullptr;
         }
         Memory_FreePointer(&entry->description);
+        entry->slot = nullptr;
     }
 }
 
@@ -105,6 +107,7 @@ void Object_ClearNames(const GAME_OBJECT_ID obj_id)
         }
         Vector_Clear(entry->names);
     }
+    entry->slot = nullptr;
 }
 
 void Object_AddName(const GAME_OBJECT_ID obj_id, const char *const name)
@@ -117,6 +120,10 @@ void Object_AddName(const GAME_OBJECT_ID obj_id, const char *const name)
     }
     char *const dup = Memory_DupStr(name);
     Vector_Add(entry->names, &dup);
+    // on first insertion, update stable slot
+    if (entry->names->count == 1) {
+        entry->slot = dup;
+    }
 }
 
 void Object_SetDescription(
@@ -132,11 +139,13 @@ void Object_SetDescription(
 const char *Object_GetName(const GAME_OBJECT_ID obj_id)
 {
     M_NAME_ENTRY *const entry = M_ResolveNameEntry(obj_id);
-    if (entry != nullptr && entry->names != nullptr
-        && entry->names->count > 0) {
-        return *(char **)Vector_Get(entry->names, 0);
-    }
-    return nullptr;
+    return entry ? entry->slot : nullptr;
+}
+
+const char *const *Object_GetNamePtr(const GAME_OBJECT_ID obj_id)
+{
+    M_NAME_ENTRY *entry = M_ResolveNameEntry(obj_id);
+    return entry ? &entry->slot : nullptr;
 }
 
 const char *Object_GetDescription(GAME_OBJECT_ID obj_id)

--- a/src/libtrx/game/overlay.c
+++ b/src/libtrx/game/overlay.c
@@ -70,3 +70,17 @@ void Overlay_SetBottomText(const char *const text, const bool flash)
         UI_Overlay_SetBottomText(m_UI, text, flash);
     }
 }
+
+void Overlay_SetTopTextPtr(const char *const *const ptr, const bool flash)
+{
+    if (m_UI != nullptr) {
+        UI_Overlay_SetTopTextPtr(m_UI, ptr, flash);
+    }
+}
+
+void Overlay_SetBottomTextPtr(const char *const *const ptr, const bool flash)
+{
+    if (m_UI != nullptr) {
+        UI_Overlay_SetBottomTextPtr(m_UI, ptr, flash);
+    }
+}

--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -89,7 +89,7 @@ static void M_ExitToTitle(M_PRIV *const p)
 
 static void M_CreateText(M_PRIV *const p)
 {
-    Overlay_SetBottomText(GS(PAUSE_PAUSED), false);
+    Overlay_SetBottomTextPtr(GS_PTR(PAUSE_PAUSED), false);
 }
 
 static void M_RemoveText(M_PRIV *const p)

--- a/src/libtrx/game/ui/hud/overlay.c
+++ b/src/libtrx/game/ui/hud/overlay.c
@@ -36,7 +36,8 @@ typedef struct UI_OVERLAY_STATE {
     bool show_arrows[6];
     bool show_version;
     struct {
-        const char *text;
+        const char *one_off;
+        const char *const *live_ptr;
         bool flash_enabled;
     } top_text, bottom_text;
     UI_FLASH_STATE flash_state;
@@ -227,13 +228,17 @@ static void M_TopCenterRegion(const UI_OVERLAY_STATE *const s)
     M_LaraHealthBar(s, BL_TOP_CENTER);
     M_LaraAirBar(s, BL_TOP_CENTER);
     M_EnemyHealthBar(BL_TOP_CENTER);
-    if (s->top_text.text != nullptr) {
-        if (s->top_text.flash_enabled) {
-            UI_BeginFlash(&s->flash_state);
-        }
-        UI_Label(s->top_text.text);
-        if (s->top_text.flash_enabled) {
-            UI_EndFlash();
+    {
+        const char *const txt =
+            s->top_text.live_ptr ? *s->top_text.live_ptr : s->top_text.one_off;
+        if (txt != nullptr) {
+            if (s->top_text.flash_enabled) {
+                UI_BeginFlash(&s->flash_state);
+            }
+            UI_Label(txt);
+            if (s->top_text.flash_enabled) {
+                UI_EndFlash();
+            }
         }
     }
     UI_EndOverlayRegion();
@@ -274,17 +279,22 @@ static void M_BottomLeftRegion(const UI_OVERLAY_STATE *const s)
 static void M_BottomCenterRegion(const UI_OVERLAY_STATE *const s)
 {
     UI_BeginOverlayRegion(0.5f, 1.0f);
-    if (s->bottom_text.text != nullptr) {
-        if (s->bottom_text.flash_enabled) {
-            UI_BeginFlash(&s->flash_state);
-        }
-        UI_BeginRowArrows(
-            s->show_arrows[UI_OVERLAY_ARROW_BCL],
-            s->show_arrows[UI_OVERLAY_ARROW_BCR], UI_ROW_ARROWS_WIDE);
-        UI_Label(s->bottom_text.text);
-        UI_EndRowArrows();
-        if (s->bottom_text.flash_enabled) {
-            UI_EndFlash();
+    {
+        const char *const txt = s->bottom_text.live_ptr
+            ? *s->bottom_text.live_ptr
+            : s->bottom_text.one_off;
+        if (txt != nullptr) {
+            if (s->bottom_text.flash_enabled) {
+                UI_BeginFlash(&s->flash_state);
+            }
+            UI_BeginRowArrows(
+                s->show_arrows[UI_OVERLAY_ARROW_BCL],
+                s->show_arrows[UI_OVERLAY_ARROW_BCR], UI_ROW_ARROWS_WIDE);
+            UI_Label(txt);
+            UI_EndRowArrows();
+            if (s->bottom_text.flash_enabled) {
+                UI_EndFlash();
+            }
         }
     }
     M_LaraHealthBar(s, BL_BOTTOM_CENTER);
@@ -396,13 +406,31 @@ void UI_Overlay_ShowVersion(UI_OVERLAY_STATE *const s, const bool show)
 void UI_Overlay_SetTopText(
     UI_OVERLAY_STATE *const s, const char *const text, const bool flash)
 {
-    s->top_text.text = text;
+    s->top_text.one_off = text;
+    s->top_text.live_ptr = nullptr;
     s->top_text.flash_enabled = flash;
 }
 
 void UI_Overlay_SetBottomText(
     UI_OVERLAY_STATE *const s, const char *const text, const bool flash)
 {
-    s->bottom_text.text = text;
+    s->bottom_text.one_off = text;
+    s->bottom_text.live_ptr = nullptr;
+    s->bottom_text.flash_enabled = flash;
+}
+
+void UI_Overlay_SetTopTextPtr(
+    UI_OVERLAY_STATE *const s, const char *const *const ptr, const bool flash)
+{
+    s->top_text.one_off = nullptr;
+    s->top_text.live_ptr = ptr;
+    s->top_text.flash_enabled = flash;
+}
+
+void UI_Overlay_SetBottomTextPtr(
+    UI_OVERLAY_STATE *const s, const char *const *const ptr, const bool flash)
+{
+    s->bottom_text.one_off = nullptr;
+    s->bottom_text.live_ptr = ptr;
     s->bottom_text.flash_enabled = flash;
 }

--- a/src/libtrx/include/libtrx/game/game_string.h
+++ b/src/libtrx/include/libtrx/game/game_string.h
@@ -13,3 +13,10 @@ bool GameString_IsKnown(const char *key);
 const char *GameString_Get(const char *key);
 void GameString_Clear(void);
 void GameString_Shutdown(void);
+
+// Like GameString_Get(), but returns a stable slot pointer that always
+// reflects the current value for this key (updates automatically on reload).
+const char *const *GameString_GetPtr(const char *key);
+
+// Macro to get the slot pointer for a compile-time string ID.
+#define GS_PTR(id) GameString_GetPtr(#id)

--- a/src/libtrx/include/libtrx/game/objects/names.h
+++ b/src/libtrx/include/libtrx/game/objects/names.h
@@ -9,7 +9,12 @@ typedef struct {
     const char *matched_name;
 } OBJECT_NAME_MATCH;
 
+// Get the current name for an object (may change on language reload).
 const char *Object_GetName(GAME_OBJECT_ID obj_id);
+
+// Get a stable pointer-to-pointer for the object name, content of which
+// automatically udpates on each language reload.
+const char *const *Object_GetNamePtr(GAME_OBJECT_ID obj_id);
 const char *Object_GetDescription(GAME_OBJECT_ID obj_id);
 
 void Object_ResetAllNames(void);

--- a/src/libtrx/include/libtrx/game/overlay.h
+++ b/src/libtrx/include/libtrx/game/overlay.h
@@ -15,5 +15,11 @@ void Overlay_ForceHealthBar(bool show);
 void Overlay_SetHealthBarTimer(int16_t health_bar_timer);
 void Overlay_ShowArrow(UI_OVERLAY_ARROW arrow, bool show);
 void Overlay_ShowVersion(bool show);
+
 void Overlay_SetTopText(const char *text, bool flash);
 void Overlay_SetBottomText(const char *text, bool flash);
+
+// Like Overlay_SetTopText(), but takes a stable indirect pointer.
+void Overlay_SetTopTextPtr(const char *const *ptr, bool flash);
+// Like Overlay_SetBottomText(), but takes a stable indirect pointer.
+void Overlay_SetBottomTextPtr(const char *const *ptr, bool flash);

--- a/src/libtrx/include/libtrx/game/ui/hud/overlay.h
+++ b/src/libtrx/include/libtrx/game/ui/hud/overlay.h
@@ -30,5 +30,13 @@ void UI_Overlay_ShowArrow(
     UI_OVERLAY_STATE *s, UI_OVERLAY_ARROW arrow, bool show);
 void UI_Overlay_ShowVersion(UI_OVERLAY_STATE *s, bool show);
 void UI_Overlay_SetTopText(UI_OVERLAY_STATE *s, const char *text, bool flash);
+
 void UI_Overlay_SetBottomText(
     UI_OVERLAY_STATE *s, const char *text, bool flash);
+
+// Like UI_Overlay_SetTopText(), but takes a stable indirect pointer.
+void UI_Overlay_SetTopTextPtr(
+    UI_OVERLAY_STATE *s, const char *const *ptr, bool flash);
+// Like UI_Overlay_SetBottomText(), but takes a stable indirect pointer.
+void UI_Overlay_SetBottomTextPtr(
+    UI_OVERLAY_STATE *s, const char *const *ptr, bool flash);

--- a/src/tr1/game/demo.c
+++ b/src/tr1/game/demo.c
@@ -175,7 +175,7 @@ bool Demo_Start(const int32_t level_num)
     // https://github.com/LostArtefacts/TRX/issues/36
     g_Lara.request_gun_type = LGT_UNARMED;
 
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), true);
     return true;
 }
 
@@ -197,7 +197,7 @@ void Demo_Unpause(void)
 {
     M_PRIV *const p = &m_Priv;
     M_PrepareConfig(p);
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), true);
 }
 
 int32_t Demo_ChooseLevel(const int32_t demo_num)
@@ -272,5 +272,5 @@ GF_COMMAND Demo_Control(void)
 
 void Demo_StopFlashing(void)
 {
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), false);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), false);
 }

--- a/src/tr2/game/demo.c
+++ b/src/tr2/game/demo.c
@@ -171,7 +171,7 @@ bool Demo_Start(const int32_t level_num)
     Camera_Initialise();
     Stats_StartTimer();
 
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), true);
     return true;
 }
 
@@ -198,7 +198,7 @@ void Demo_Unpause(void)
     M_PRIV *const p = &m_Priv;
     M_PrepareConfig(p);
     Stats_StartTimer();
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), true);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), true);
 }
 
 int32_t Demo_ChooseLevel(const int32_t demo_num)
@@ -221,5 +221,5 @@ GF_COMMAND Demo_Control(void)
 
 void Demo_StopFlashing(void)
 {
-    Overlay_SetBottomText(GS(MISC_DEMO_MODE), false);
+    Overlay_SetBottomTextPtr(GS_PTR(MISC_DEMO_MODE), false);
 }

--- a/tools/shared/linting.py
+++ b/tools/shared/linting.py
@@ -27,7 +27,7 @@ RE_GAME_STRING_DEFINE = re.compile(r"GS_DEFINE\(([A-Z0-9_]+),\s*\"(.*)\"\)")
 RE_GAME_STRING_DEFINE_VAL = re.compile(
     r'GS_DEFINE\(\s*([A-Z0-9_]+)\s*,\s*"([^"]*)"\)'
 )
-RE_GAME_STRING_USAGE = re.compile(r"GS(?:_ID)?\(([A-Z0-9_]+)\)")
+RE_GAME_STRING_USAGE = re.compile(r"GS(?:_ID|_PTR)?\(([A-Z0-9_]+)\)")
 
 
 @dataclass
@@ -96,7 +96,7 @@ def lint_const_primitives(
     for i, line in enumerate(path.open("r"), 1):
         if re.search(r"const (int[a-z0-9_]*|bool)\b\s*[a-z]", line):
             yield LintWarning(path, "useless const", line=i)
-        if re.search(r"\*\s*const", line):
+        if re.search(r"\*\s*const(?!\s?\*)", line):
             yield LintWarning(path, "useless const", line=i)
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Unfortunately #3161 didn't catch all instances, and we still had parts of the UI that were holding onto pointers which would become invalid whenever the language was changed. This problem affected the text on the top and bottom of the inventory ring.

To address this, I've introduced a system of stable pointers – specific memory locations that store actual text. Rather than pointing directly to the text, we pass around pointers to the slots instead, which remain constant even if their content changes. When changing the language setting, we simply update the slots' content. We dereference the slot at the last minute to access the current content, just prior to drawing it via `UI_Label`.