### PR TITLE
tr1/ui/settings: fix resolution not saved

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -33,6 +33,7 @@
 - fixed the `/play` command taking resume information from the highlighted slot (#3137, regression from 4.10)
 - fixed text glyphs having cut off right and bottom borders (regression from 4.7)
 - fixed unbind key option being available when it shouldn't (#3111, regression from 4.11)
+- fixed not saving screen resolution (regression from 4.11)
 - fixed vertical FOV option not working properly (#3120, regression from 4.10)
 - fixed Lara's position on a ledge after grabbing it extremely late (#3132, regression from 2.2.1)
 - fixed a rare crash when editing certain dev console history entries (#2913, regression from 4.10)

--- a/src/libtrx/game/ui/dialogs/graphic_settings.c
+++ b/src/libtrx/game/ui/dialogs/graphic_settings.c
@@ -170,10 +170,15 @@ static bool M_ScreenResolution_CanChangeValue(
 static bool M_ScreenResolution_RequestChangeValue(
     const UI_SETTINGS_OPTION *const option, const int32_t dir)
 {
+    bool result = false;
     if (dir < 0) {
-        Screen_SetPrevRes();
+        result = Screen_SetPrevRes();
     } else {
-        Screen_SetNextRes();
+        result = Screen_SetNextRes();
+    }
+    if (result) {
+        g_Config.rendering.resolution_width = Screen_GetResWidth();
+        g_Config.rendering.resolution_height = Screen_GetResHeight();
     }
     return true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the screen resolution not being saved across game relaunches.
I think this bug is limited only to develop, but I may be mistaken.
