### PR TITLE
tr1/fmv: process input in FMVs

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fixed Lara's health bar showing at the start of cutscenes (#3182, regression from 4.11)
 - fixed broken playback of mono music tracks (regression from 2.0)
 - fixed hot-plugging certain audio devices causing glitchy playback (partial fix; regression from 2.0)
+- fixed being unable to toggle fullscreen mode during FMV sequences (#3188, regression from 4.6)
 - improved the teleport cheat if used when Lara is in a special animation, such as grabbing the Scion
 
 ## [4.11.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.1...tr1-4.11.2) - 2025-05-24

--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -115,7 +115,7 @@ static bool M_Play(const char *const file_path)
         Shell_ProcessEvents();
 
         Input_Update();
-
+        Shell_ProcessInput();
         if (g_InputDB.menu_confirm || g_InputDB.menu_back
             || Shell_IsExiting()) {
             Video_Stop(video);


### PR DESCRIPTION
Resolves #3188.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes being unable to toggle fullscreen mode during FMVs in TR1.