### PR TITLE
tr2/fmv: support additional file types

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
     - added Italian translation
 - added UI for all config tool settings
 - added ingame help for all settings
+- added the ability to use `.avi`, `.mkv`, `.mp4`, `.mpeg`, and `.webm` files for FMVs, as well as the default `.rpl` (#3190)
 - added support for object name aliases; added aliases for dev commands
 - added a pickup overlay display when Lara pulls the dagger from the dragon (#1830)
 - added an option to disable Lara's braid (#3089)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -324,6 +324,7 @@ However, you can easily download them manually from these urls:
 - added the ability for custom levels to have up to two of each secret type per level
 - added an option to toggle between TR1 and TR2 camera modes
 - added an option to disable Lara's braid
+- added the ability to use `.avi`, `.mkv`, `.mp4`, `.mpeg`, and `.webm` files for FMVs
 - changed the hardware renderer to always use 16-bit textures
 - changed the software renderer to use the picture's palette for the background pictures
 - changed fullscreen behavior to use windowed desktop mode

--- a/src/tr2/game/fmv.c
+++ b/src/tr2/game/fmv.c
@@ -18,6 +18,9 @@
 
 static bool m_Muted = false;
 static bool m_IsFMVPlaying = false;
+static const char *m_Extensions[] = {
+    ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", nullptr,
+};
 
 static void *M_AllocateSurface(int32_t width, int32_t height, void *user_data);
 static void M_DeallocateSurface(void *surface, void *user_data);
@@ -154,7 +157,9 @@ bool FMV_Play(const char *const file_name)
         return false;
     }
 
-    const bool result = M_Play(file_name);
+    char *final_path = File_GuessExtension(file_name, m_Extensions);
+    const bool result = M_Play(final_path);
+    Memory_FreePointer(&final_path);
     if (!Shell_IsExiting()) {
         Render_Reset(RENDER_RESET_ALL);
     }


### PR DESCRIPTION
Resolves #3190.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This gets TR2 FMV support into line with TR1 in terms of the file types supported.
