### PR TITLE
lara/common: fix cutscene Lara animation object getter

### DIFF
--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "game/const.h"
+#include "game/game_flow.h"
 #include "game/item_actions.h"
 #include "game/lara/const.h"
 #include "game/matrix.h"
@@ -29,13 +30,16 @@ GAME_OBJECT_ID Lara_GetAnimationObject(void)
     if (lara_info->extra_anim) {
         return O_LARA_EXTRA;
     }
-#if TR_VERSION >= 2
+#if TR_VERSION == 1
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    return level->lara_type;
+#else
     if (lara_info->vehicle_item_num != NO_ITEM) {
         const ITEM *const vehicle = Item_Get(lara_info->vehicle_item_num);
         return vehicle->object_id == O_BOAT ? O_LARA_BOAT : O_LARA_SKIDOO;
     }
-#endif
     return O_LARA;
+#endif
 }
 
 void Lara_Animate(ITEM *const item)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

An oversight on my part in #3192. For TR1 cutscenes, Lara's type is defined in the game flow as she is a cutscene actor there, so this ensures the relevant object type is returned based on the current level. TR1 cutscenes should display object 77 in the anim debug info.
