### PR TITLE
ui: fix input layout names hot reloading

### DIFF
--- a/src/libtrx/game/input/common.c
+++ b/src/libtrx/game/input/common.c
@@ -320,9 +320,9 @@ bool Input_AssignToJSONObject(
     return M_GetBackend(backend)->assign_to_json_object(layout, role, bind_obj);
 }
 
-const char *Input_GetLayoutName(const INPUT_LAYOUT layout)
+const char *const *Input_GetLayoutNamePtr(const INPUT_LAYOUT layout)
 {
-    return GameString_Get(m_LayoutMap[layout]);
+    return GameString_GetPtr(m_LayoutMap[layout]);
 }
 
 INPUT_STATE Input_GetDebounced(const INPUT_STATE input)

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -486,8 +486,8 @@ void UI_ControlsEditor_Init(
     {
         UI_TAB_SWITCH_TAB layout_tabs[INPUT_LAYOUT_NUMBER_OF];
         for (INPUT_LAYOUT i = 0; i < INPUT_LAYOUT_NUMBER_OF; i++) {
-            layout_tabs[i].header_str = Input_GetLayoutName(i);
-            layout_tabs[i].header_gs = nullptr;
+            layout_tabs[i].header.one_off = nullptr;
+            layout_tabs[i].header.live_ptr = Input_GetLayoutNamePtr(i);
         }
         s->layout_tab_switch =
             UI_TabSwitch_Init(INPUT_LAYOUT_NUMBER_OF, layout_tabs);
@@ -500,8 +500,9 @@ void UI_ControlsEditor_Init(
         }
         UI_TAB_SWITCH_TAB controls_tabs[tab_count];
         for (int32_t i = 0; m_Groups[i].roles != nullptr; i++) {
-            controls_tabs[i].header_gs = m_Groups[i].header_gs;
-            controls_tabs[i].header_str = nullptr;
+            controls_tabs[i].header.one_off = nullptr;
+            controls_tabs[i].header.live_ptr =
+                GameString_GetPtr(m_Groups[i].header_gs);
         }
         s->controls_tab_switch = UI_TabSwitch_Init(tab_count, controls_tabs);
     }

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -479,7 +479,9 @@ void UI_Settings_InitWithTabs(
     s->max_group_items = 0;
     UI_TAB_SWITCH_TAB tab_switch_tabs[tab_count];
     for (int32_t i = 0; i < tab_count; i++) {
-        tab_switch_tabs[i].header_gs = tabs[i].header_gs;
+        tab_switch_tabs[i].header.one_off = nullptr;
+        tab_switch_tabs[i].header.live_ptr =
+            GameString_GetPtr(tabs[i].header_gs);
         int32_t tab_items = 0;
         for (int32_t j = 0; tabs[i].options[j].label_id != nullptr; j++) {
             tab_items++;

--- a/src/libtrx/game/ui/elements/tab_switch.c
+++ b/src/libtrx/game/ui/elements/tab_switch.c
@@ -40,8 +40,8 @@ static void M_Draw(
         }
         UI_BeginPad(2.0f, 1.0f);
         UI_Label(
-            tab->header_gs != nullptr ? GameString_Get(tab->header_gs)
-                                      : tab->header_str);
+            tab->header.live_ptr != nullptr ? *tab->header.live_ptr
+                                            : tab->header.one_off);
         UI_EndPad();
         if (i == s->active_tab_idx) {
             UI_EndFrame();

--- a/src/libtrx/include/libtrx/game/input/common.h
+++ b/src/libtrx/include/libtrx/game/input/common.h
@@ -70,8 +70,8 @@ bool Input_ReadAndAssignRole(
 void Input_UnassignRole(
     INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role);
 
-// Get the layout human-readable name.
-const char *Input_GetLayoutName(const INPUT_LAYOUT layout);
+// Get a stable pointer to the layout human-readable name.
+const char *const *Input_GetLayoutNamePtr(const INPUT_LAYOUT layout);
 
 // Given the input layout and input key role, get the assigned key name.
 const char *Input_GetKeyName(

--- a/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
+++ b/src/libtrx/include/libtrx/game/ui/elements/tab_switch.h
@@ -9,8 +9,10 @@
 
 // Represents a single tab page for use with UI_TabSwitch_Control.
 typedef struct {
-    GAME_STRING_ID header_gs;
-    const char *header_str;
+    struct {
+        const char *one_off;
+        const char *const *live_ptr;
+    } header;
 } UI_TAB_SWITCH_TAB;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Yet another fix in the spirit of #3203 and #3161 – this time about input layout names (Default keys / User keys 1-3). Hopefully this really is the last one.