### PR TITLE
ui/text: fix game crashing on word-wrapping unknown glyphs

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
     - changed duplicate game strings between TR1 and TR2 to be placed in a single file TRX_common_strings.json5
     - added a new setting, `enable_review_markers`, which display which text requires review (only available via `/set`)
     - added Italian translation
+    - fixed game crashing when trying to word-wrap unknown characters
 - added UI for all config tool settings
 - added ingame help for all settings
 - added support for object name aliases; added aliases for dev commands

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
     - changed duplicate game strings between TR1 and TR2 to be placed in a single file TRX_common_strings.json5
     - added a new setting, `enable_review_markers`, which display which text requires review (only available via `/set`)
     - added Italian translation
+    - fixed game crashing when trying to word-wrap unknown characters
 - added UI for all config tool settings
 - added ingame help for all settings
 - added the ability to use `.avi`, `.mkv`, `.mp4`, `.mpeg`, and `.webm` files for FMVs, as well as the default `.rpl` (#3190)

--- a/src/libtrx/game/ui/text.c
+++ b/src/libtrx/game/ui/text.c
@@ -118,6 +118,7 @@ static const M_GLYPH_INFO **M_Decompose(
             *glyph_ptr++ = entry->glyph;
         } else {
             LOG_WARNING("Unknown glyph: %s", m_GlyphLookupKey);
+            glyph_count--;
         }
 
         content_ptr += glyph_size;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes game crashing when trying to use word-wrapping with text that contains unknown characters. (Example: description in examine item or settings descriptions)