### PR TITLE
ui/dialogs/text: support hot reloading strings

### DIFF
--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -504,7 +504,8 @@ void UI_Settings_Free(UI_SETTINGS_STATE *const s)
         s->tab_switch = nullptr;
     }
     if (s->description.show) {
-        UI_TextDialog_Free(&s->description.state);
+        UI_TextDialog_Free(s->description.state);
+        s->description.state = nullptr;
         s->description.show = false;
     }
 }
@@ -514,9 +515,10 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
     UI_Scrollable_SetVisibleItems(
         &s->scroll, MIN(s->max_group_items, M_GetVisibleRows()));
     if (s->description.show) {
-        UI_TextDialog_Control(&s->description.state);
+        UI_TextDialog_Control(s->description.state);
         if (g_InputDB.menu_back || g_InputDB.look) {
-            UI_TextDialog_Free(&s->description.state);
+            UI_TextDialog_Free(s->description.state);
+            s->description.state = nullptr;
             s->description.show = false;
             return false;
         }
@@ -540,23 +542,11 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
     } else if (s->phase == UI_SETTINGS_PHASE_EDIT_SETTINGS) {
         const int32_t sel_row = UI_Scrollable_GetSelectedItem(&s->scroll);
         if (g_InputDB.look && M_CanExamine(s, sel_row)) {
-            const UI_SETTINGS_OPTION *const option = &s->options[sel_row];
-            const char *title = GameString_Get(option->label_id);
-            const char *text = GameString_Get(option->description_id);
-            if (title != nullptr && text != nullptr) {
-                if (Config_IsOptionEnforced(option->target)) {
-                    title = String_FormatStatic("%s*", title);
-                    text = String_FormatStatic(
-                        "* %s\n\n%s",
-                        GS(COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER), text);
-                }
-                UI_TextDialog_Init(
-                    &s->description.state, title, text,
-                    MIN(UI_GetCanvasWidth() * 2.0 / 3.0f,
-                        s->max_label_w + s->max_value_w + 10),
-                    (size_t)M_GetVisibleRows(), true);
-                s->description.show = true;
-            }
+            s->description.show = true;
+            s->description.state = UI_TextDialog_Init(
+                MIN(UI_GetCanvasWidth() * 2.0 / 3.0f,
+                    s->max_label_w + s->max_value_w + 10),
+                (size_t)M_GetVisibleRows(), true);
             return false;
         }
         if (g_InputDB.menu_up) {
@@ -746,6 +736,18 @@ void UI_Settings(UI_SETTINGS_STATE *const s)
     UI_EndModal();
 
     if (s->description.show) {
-        UI_TextDialog(&s->description.state);
+        const int32_t sel_row = UI_Scrollable_GetSelectedItem(&s->scroll);
+        const UI_SETTINGS_OPTION *const option = &s->options[sel_row];
+        const char *title = GameString_Get(option->label_id);
+        const char *text = GameString_Get(option->description_id);
+        if (title != nullptr && text != nullptr) {
+            if (Config_IsOptionEnforced(option->target)) {
+                title = String_FormatStatic("%s*", title);
+                text = String_FormatStatic(
+                    "* %s\n\n%s",
+                    *GS_PTR(COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER), text);
+            }
+            UI_TextDialog(s->description.state, title, text);
+        }
     }
 }

--- a/src/libtrx/game/ui/dialogs/text.c
+++ b/src/libtrx/game/ui/dialogs/text.c
@@ -1,5 +1,6 @@
 #include "game/ui/dialogs/text.h"
 
+#include "debug.h"
 #include "game/game_string.h"
 #include "game/input.h"
 #include "game/sound.h"
@@ -16,123 +17,178 @@
 #include "utils.h"
 
 #include <stdio.h>
+#include <string.h>
 
-#define TITLE_MARGIN 5.0f
-#define DIALOG_PADDING 8.0f
+#define M_TITLE_MARGIN 5.0f
+#define M_DIALOG_PADDING 8.0f
 
-static bool M_SelectPage(UI_TEXT_DIALOG_STATE *state, int32_t new_page);
+typedef struct UI_TEXT_DIALOG_STATE {
+    char *title; // uppercase working title string
+    char *last_raw_title; // last raw title (duplicate for strcmp)
+    char *last_raw_text; // last raw text (duplicate for strcmp)
 
-static bool M_SelectPage(
-    UI_TEXT_DIALOG_STATE *const state, const int32_t new_page)
+    size_t wrap_width;
+    size_t wrap_max_lines;
+    bool is_heavy;
+
+    size_t max_vis_lines; // maximum visible lines in pagination
+    VECTOR *page_content; // paginated wrapped pages
+    int32_t current_page;
+} UI_TEXT_DIALOG_STATE;
+
+static bool M_SelectPage(UI_TEXT_DIALOG_STATE *s, int32_t new_page);
+static void M_UpdateTitle(UI_TEXT_DIALOG_STATE *s, const char *title_raw);
+static void M_UpdateText(UI_TEXT_DIALOG_STATE *s, const char *text_raw);
+
+static void M_UpdateTitle(
+    UI_TEXT_DIALOG_STATE *const s, const char *const title_raw)
 {
-    if (new_page == state->current_page || new_page < 0
-        || new_page >= state->page_content->count) {
+    // Title update on change (strcmp to handle static ring buffers)
+    if (title_raw != nullptr
+        && (s->last_raw_title == nullptr
+            || strcmp(s->last_raw_title, title_raw) != 0)) {
+        Memory_FreePointer(&s->title);
+        s->title = String_ToUpper(title_raw);
+        Memory_FreePointer(&s->last_raw_title);
+        s->last_raw_title = Memory_DupStr(title_raw);
+    }
+}
+
+static void M_UpdateText(
+    UI_TEXT_DIALOG_STATE *const s, const char *const text_raw)
+{
+    // Text update on change (strcmp to in case the pointers does not change)
+    if (!s->last_raw_text || strcmp(s->last_raw_text, text_raw) != 0) {
+        if (s->page_content != nullptr) {
+            for (int32_t i = 0; i < s->page_content->count; i++) {
+                char *page = *(char **)Vector_Get(s->page_content, i);
+                Memory_Free(page);
+            }
+            Vector_Free(s->page_content);
+        }
+
+        const char *wrapped = UI_Text_WordWrap(text_raw, 1.0f, s->wrap_width);
+        s->page_content = String_Paginate(wrapped, s->wrap_max_lines);
+        Memory_FreePointer(&wrapped);
+
+        s->max_vis_lines = 0;
+        for (int32_t i = 0; i < s->page_content->count; ++i) {
+            size_t page_lines = 1;
+            const char *c = *(char **)Vector_Get(s->page_content, i);
+            while (*c != '\0') {
+                page_lines += *c++ == '\n';
+            }
+            CLAMPL(s->max_vis_lines, page_lines);
+        }
+        Memory_FreePointer(&s->last_raw_text);
+        s->last_raw_text = Memory_DupStr(text_raw);
+        s->current_page = 0;
+    }
+}
+static bool M_SelectPage(UI_TEXT_DIALOG_STATE *const s, const int32_t new_page)
+{
+    if (s->page_content == nullptr) {
         return false;
     }
-    state->current_page = new_page;
+    if (new_page == s->current_page || new_page < 0
+        || new_page >= s->page_content->count) {
+        return false;
+    }
+    s->current_page = new_page;
     return true;
 }
 
-void UI_TextDialog_Init(
-    UI_TEXT_DIALOG_STATE *const state, const char *const title,
-    const char *const text, const size_t width, const size_t max_lines,
-    const bool is_heavy)
+UI_TEXT_DIALOG_STATE *UI_TextDialog_Init(
+    size_t wrap_width, size_t wrap_max_lines, bool is_heavy)
 {
-    state->current_page = 0;
-    state->title = String_ToUpper(title);
-    state->is_heavy = is_heavy;
-
-    const char *wrapped = UI_Text_WordWrap(text, 1.0f, width);
-    state->page_content = String_Paginate(wrapped, max_lines);
-    state->is_empty = String_IsEmpty(text);
-    Memory_FreePointer(&wrapped);
-
-    // Compute actual maximum number of lines on any single page, which can be
-    // less than the line cap.
-    size_t max_vis_lines = 0;
-    for (int32_t i = 0; i < state->page_content->count; i++) {
-        size_t page_lines = 1;
-        const char *c = *(char **)Vector_Get(state->page_content, i);
-        while (*c != '\0') {
-            page_lines += *c++ == '\n';
-        }
-        CLAMPL(max_vis_lines, page_lines);
-    }
-    state->max_lines = max_vis_lines;
+    UI_TEXT_DIALOG_STATE *s = Memory_Alloc(sizeof(*s));
+    s->wrap_width = wrap_width;
+    s->wrap_max_lines = wrap_max_lines;
+    s->is_heavy = is_heavy;
+    return s;
 }
 
-void UI_TextDialog_Control(UI_TEXT_DIALOG_STATE *const state)
+void UI_TextDialog_Free(UI_TEXT_DIALOG_STATE *const s)
 {
+    ASSERT(s != nullptr);
+    Memory_FreePointer(&s->title);
+    Memory_FreePointer(&s->last_raw_title);
+    Memory_FreePointer(&s->last_raw_text);
+    if (s->page_content != nullptr) {
+        for (int32_t i = s->page_content->count - 1; i >= 0; --i) {
+            Memory_Free(*(char **)Vector_Get(s->page_content, i));
+        }
+        Vector_Free(s->page_content);
+        s->page_content = nullptr;
+    }
+}
+
+void UI_TextDialog_Control(UI_TEXT_DIALOG_STATE *const s)
+{
+    ASSERT(s != nullptr);
     const int32_t page_shift =
         g_InputDB.menu_left ? -1 : (g_InputDB.menu_right ? 1 : 0);
-    if (M_SelectPage(state, state->current_page + page_shift)) {
+    if (M_SelectPage(s, s->current_page + page_shift)) {
         Sound_Effect(SFX_MENU_PASSPORT, nullptr, SPM_ALWAYS);
     }
 }
 
-void UI_TextDialog_Free(UI_TEXT_DIALOG_STATE *const state)
+void UI_TextDialog(
+    UI_TEXT_DIALOG_STATE *const s, const char *const title_raw,
+    const char *const text_raw)
 {
-    Memory_FreePointer(&state->title);
-    for (int32_t i = state->page_content->count - 1; i >= 0; i--) {
-        char *const page = *(char **)Vector_Get(state->page_content, i);
-        Memory_Free(page);
-    }
-    Vector_Free(state->page_content);
-}
+    ASSERT(s != nullptr);
 
-void UI_TextDialog(UI_TEXT_DIALOG_STATE *const state)
-{
-    if (state->is_empty) {
+    if (text_raw == nullptr || String_IsEmpty(text_raw)) {
         return;
     }
 
+    M_UpdateTitle(s, title_raw);
+    M_UpdateText(s, text_raw);
+
     UI_BeginModal(0.5f, 0.5f);
     UI_BeginFrame(
-        state->is_heavy ? UI_FRAME_DIALOG_BACKGROUND_HEAVY
-                        : UI_FRAME_DIALOG_BACKGROUND);
-    UI_BeginPad(DIALOG_PADDING, DIALOG_PADDING);
+        s->is_heavy ? UI_FRAME_DIALOG_BACKGROUND_HEAVY
+                    : UI_FRAME_DIALOG_BACKGROUND);
+    UI_BeginPad(M_DIALOG_PADDING, M_DIALOG_PADDING);
     UI_BeginStackEx((UI_STACK_SETTINGS) {
         .orientation = UI_STACK_VERTICAL,
-        .align = { .h = UI_STACK_H_ALIGN_SPAN },
+        { .h = UI_STACK_H_ALIGN_SPAN },
     });
 
     UI_BeginAnchor(0.5f, 0.5f);
-    UI_Label(state->title);
+    UI_Label(s->title != nullptr ? s->title : "");
     UI_EndAnchor();
-    UI_Spacer(TITLE_MARGIN, TITLE_MARGIN);
+    UI_Spacer(M_TITLE_MARGIN, M_TITLE_MARGIN);
 
-    for (int32_t i = 0; i < state->page_content->count; i++) {
-        if (i != state->current_page) {
+    for (int32_t i = 0; i < s->page_content->count; ++i) {
+        if (i != s->current_page) {
             UI_BeginResize(-1.0f, 0.0f);
-        } else if (state->page_content->count == 1) {
+        } else if (s->page_content->count == 1) {
             UI_BeginResize(-1.0f, -1.0f);
         } else {
-            UI_BeginResize(-1.0f, UI_TEXT_HEIGHT * state->max_lines);
+            UI_BeginResize(-1.0f, UI_TEXT_HEIGHT * s->max_vis_lines);
         }
-        UI_Label(*(char **)Vector_Get(state->page_content, i));
+        UI_Label(*(char **)Vector_Get(s->page_content, i));
         UI_EndResize();
     }
 
-    if (state->page_content->count > 1) {
-        UI_Spacer(TITLE_MARGIN, TITLE_MARGIN * 3);
+    if (s->page_content->count > 1) {
+        UI_Spacer(M_TITLE_MARGIN, M_TITLE_MARGIN * 3);
 
         UI_BeginAnchor(1.0f, 0.5f);
         UI_BeginStack(UI_STACK_HORIZONTAL);
-
-        if (state->current_page > 0) {
+        if (s->current_page > 0) {
             UI_Label("\\{button left} ");
         }
-
         char page_indicator[100];
         sprintf(
-            page_indicator, GS(PAGINATION_NAV), state->current_page + 1,
-            state->page_content->count);
+            page_indicator, *GS_PTR(PAGINATION_NAV), s->current_page + 1,
+            s->page_content->count);
         UI_Label(page_indicator);
-
-        if (state->current_page < state->page_content->count - 1) {
+        if (s->current_page < s->page_content->count - 1) {
             UI_Label(" \\{button right}");
         }
-
         UI_EndStack();
         UI_EndAnchor();
     }

--- a/src/libtrx/include/libtrx/game/ui/dialogs/settings.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/settings.h
@@ -73,7 +73,7 @@ typedef struct {
 
     struct {
         bool show;
-        UI_TEXT_DIALOG_STATE state;
+        UI_TEXT_DIALOG_STATE *state;
     } description;
 
     int32_t listener_id;

--- a/src/libtrx/include/libtrx/game/ui/dialogs/text.h
+++ b/src/libtrx/include/libtrx/game/ui/dialogs/text.h
@@ -5,19 +5,21 @@
 
 // A widget to cycle through several pages of a text content.
 
-typedef struct {
-    char *title;
-    size_t max_lines;
-    int32_t current_page;
-    VECTOR *page_content;
-    bool is_empty;
-    bool is_heavy;
-} UI_TEXT_DIALOG_STATE;
+typedef struct UI_TEXT_DIALOG_STATE UI_TEXT_DIALOG_STATE;
 
-void UI_TextDialog_Init(
-    UI_TEXT_DIALOG_STATE *state, const char *title, const char *text,
-    size_t width, size_t max_lines, bool is_heavy);
+// state functions
+UI_TEXT_DIALOG_STATE *UI_TextDialog_Init(
+    size_t wrap_width, size_t wrap_max_lines, bool is_heavy);
+
+// Handle page-left/right input.  Call before UI_TextDialog().
 void UI_TextDialog_Control(UI_TEXT_DIALOG_STATE *state);
+
+// Free any allocated buffers.  Call when dialog is dismissed.
 void UI_TextDialog_Free(UI_TEXT_DIALOG_STATE *state);
 
-void UI_TextDialog(UI_TEXT_DIALOG_STATE *state);
+// draw functions
+
+// Draw and manage a text dialog in one call.  Rewraps/recapitalizes only
+// when title_raw/text_raw differ (compared via strcmp).  Call every frame.
+void UI_TextDialog(
+    UI_TEXT_DIALOG_STATE *state, const char *title_raw, const char *text_raw);

--- a/src/tr1/game/option/option_examine.c
+++ b/src/tr1/game/option/option_examine.c
@@ -8,9 +8,10 @@
 #include <libtrx/game/ui.h>
 
 typedef struct {
+    GAME_OBJECT_ID object_id;
     struct {
         bool is_ready;
-        UI_TEXT_DIALOG_STATE state;
+        UI_TEXT_DIALOG_STATE *state;
     } ui;
 } M_PRIV;
 
@@ -35,16 +36,17 @@ static int32_t M_GetMaxRows(void)
 
 static void M_Init(M_PRIV *const p, const GAME_OBJECT_ID obj_id)
 {
+    p->object_id = obj_id;
     p->ui.is_ready = true;
-    UI_TextDialog_Init(
-        &p->ui.state, Object_GetName(obj_id), Object_GetDescription(obj_id),
+    p->ui.state = UI_TextDialog_Init(
         UI_GetCanvasWidth() * 2.0 / 3.0f, M_GetMaxRows(), false);
 }
 
 static void M_Shutdown(M_PRIV *const p)
 {
     if (p->ui.is_ready) {
-        UI_TextDialog_Free(&p->ui.state);
+        UI_TextDialog_Free(p->ui.state);
+        p->ui.state = nullptr;
         p->ui.is_ready = false;
     }
 }
@@ -70,7 +72,7 @@ void Option_Examine_Control(const GAME_OBJECT_ID obj_id, const bool is_busy)
     if (!p->ui.is_ready) {
         M_Init(p, obj_id);
     }
-    UI_TextDialog_Control(&p->ui.state);
+    UI_TextDialog_Control(p->ui.state);
 
     if (g_InputDB.menu_back || g_InputDB.menu_confirm) {
         M_Shutdown(p);
@@ -81,7 +83,9 @@ void Option_Examine_Draw(void)
 {
     M_PRIV *const p = &m_Priv;
     if (p->ui.is_ready) {
-        UI_TextDialog(&p->ui.state);
+        UI_TextDialog(
+            p->ui.state, Object_GetName(p->object_id),
+            Object_GetDescription(p->object_id));
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Changes the text dialogs (examine item, option settings) to support hot reload.
Changes the architecture to pass the title and the description to the draw function. The function caches the contents, and if it detects a change, it re-paginates the content.

I also spotted a bug where `/strings` will wrongfully clear some item names, taking them from the wrong layer. I'll tackle that separately. Edit: fix in #3229 