### PR TITLE
game-strings: fix cheats formatting

### DIFF
--- a/data/common/ship/cfg/TRX_common_strings-it.json5
+++ b/data/common/ship/cfg/TRX_common_strings-it.json5
@@ -76,7 +76,7 @@
         "GAMEPLAY_SETTINGS_ENABLE_BUFFERING": "Buffering comandi",
         "GAMEPLAY_SETTINGS_ENABLE_BUFFERING_DESCRIPTION": "Abilita il buffering dei tasti funzione (1 fotogramma) e dell'inventario (2 fotogrammi) per ottenere un controllo preciso dei movimenti di Lara.",
         "GAMEPLAY_SETTINGS_ENABLE_CHEATS": "Trucchi",
-        "GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION": "Abilita vari trucchi:\n\n- L: termina immediatamente il livello.\n- I: dà a Lara tutte le armi; maggior quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n     - tasto CAMMINA: disabilita il trucco DOZY.\n     - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi).",
+        "GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION": "Abilita vari trucchi:\n\n- L: termina immediatamente il livello.\n- I: dà a Lara tutte le armi; maggior quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n  - tasto CAMMINA: disabilita il trucco DOZY.\n  - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi).",
         "GAMEPLAY_SETTINGS_ENABLE_COMPASS_STATS": "Statistiche livello bussola",
         "GAMEPLAY_SETTINGS_ENABLE_COMPASS_STATS_DESCRIPTION": "Abilita la visualizzazione delle statistiche del livello quando è selezionata la bussola.",
         "GAMEPLAY_SETTINGS_ENABLE_CONSOLE": "Console",

--- a/data/common/ship/cfg/TRX_common_strings.json5
+++ b/data/common/ship/cfg/TRX_common_strings.json5
@@ -76,7 +76,7 @@
         "GAMEPLAY_SETTINGS_ENABLE_BUFFERING": "Input buffering",
         "GAMEPLAY_SETTINGS_ENABLE_BUFFERING_DESCRIPTION": "Enables F-key (1-frame) and inventory (2-frame) buffering to achieve precise control of Lara's movement.",
         "GAMEPLAY_SETTINGS_ENABLE_CHEATS": "Cheats",
-        "GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION": "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable DOZY cheat (swimming midair).\n     - WALK key: exit DOZY.\n     - GUN key: open the closest door (doesn't work in certain places).",
+        "GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION": "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).",
         "GAMEPLAY_SETTINGS_ENABLE_COMPASS_STATS": "Level statistics in compass",
         "GAMEPLAY_SETTINGS_ENABLE_COMPASS_STATS_DESCRIPTION": "Enables showing level statistics when the compass is selected.",
         "GAMEPLAY_SETTINGS_ENABLE_CONSOLE": "Console",

--- a/src/libtrx/include/libtrx/game/game_string.def
+++ b/src/libtrx/include/libtrx/game/game_string.def
@@ -436,7 +436,7 @@ GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_ALLY_TARGETING_DESCRIPTION,          "Allows 
 GS_DEFINE(GAMEPLAY_SETTINGS_DISABLE_UZIS_DESCRIPTION,                   "Removes all uzi guns and uzi ammo pickups from the game.")
 GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_AUTO_ITEM_SELECTION_DESCRIPTION,     "When Lara presses action against a keyhole or puzzle slot, and she has the corresponding item in the inventory, that item will be pre-selected.")
 GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_BUFFERING_DESCRIPTION,               "Enables F-key (1-frame) and inventory (2-frame) buffering to achieve precise control of Lara's movement.")
-GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION,                  "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable DOZY cheat (swimming midair).\n     - WALK key: exit DOZY.\n     - GUN key: open the closest door (doesn't work in certain places).")
+GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_CHEATS_DESCRIPTION,                  "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).")
 GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_COMPASS_STATS_DESCRIPTION,           "Enables showing level statistics when the compass is selected.")
 GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_CONSOLE_DESCRIPTION,                 "Enables the developer console.")
 GS_DEFINE(GAMEPLAY_SETTINGS_ENABLE_CUTSCENES_DESCRIPTION,               "Enables cutscenes playing.")


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the second list not being formatted well due to stripping preceding spaces. Chose to go with non-breakable spaces.
