### PR TITLE
ui/settings: fix jump on tab switch

### DIFF
--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -528,6 +528,7 @@ bool UI_Settings_Control(UI_SETTINGS_STATE *const s)
     if (s->phase == UI_SETTINGS_PHASE_NAVIGATE_TABS) {
         if (UI_TabSwitch_Control(s->tab_switch)) {
             s->options = s->tabs[s->tab_switch->active_tab_idx].options;
+            UI_Scrollable_SelectFirstItem(&s->scroll);
             M_RecomputeSizes(s);
             return false;
         } else if (g_InputDB.menu_down) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a small but noticeable and visually jarring jump when cycling between tabs under some circumstances.

Before fix:

https://github.com/user-attachments/assets/312f78bd-6286-4fb1-9037-722c4f1e97a8

After fix:

https://github.com/user-attachments/assets/53bd9ca1-253f-40e0-9f99-9a5bb717c131