### PR TITLE
ui/settings: fix not updating size after /strings

### DIFF
--- a/src/libtrx/game/game_string_manager.c
+++ b/src/libtrx/game/game_string_manager.c
@@ -25,6 +25,7 @@ typedef struct {
 
 static VECTOR *m_SourceFiles = nullptr;
 static VECTOR *m_LangEntries = nullptr;
+static EVENT_MANAGER *m_EventManager = nullptr;
 
 static void M_ClearFileEntries(VECTOR *files);
 static void M_ClearManager(void);
@@ -175,12 +176,17 @@ static void M_ReorderLanguages(void)
 
 void GameStringManager_Init(void)
 {
+    m_EventManager = EventManager_Create();
     M_ClearManager();
     m_SourceFiles = Vector_Create(sizeof(M_FILE_ENTRY));
 }
 
 void GameStringManager_Shutdown(void)
 {
+    if (m_EventManager != nullptr) {
+        EventManager_Free(m_EventManager);
+        m_EventManager = nullptr;
+    }
     GameStringTable_Shutdown();
     M_ClearManager();
 }
@@ -199,11 +205,11 @@ void GameStringManager_ClearSourceFiles(void)
 void GameStringManager_AddSourceFile(
     const char *const base_path, const bool load_levels)
 {
-    if (m_SourceFiles == nullptr) {
-        GameStringManager_Init();
-    }
-    M_FILE_ENTRY fe = { .path = Memory_DupStr(base_path),
-                        .load_levels = load_levels };
+    ASSERT(m_SourceFiles != nullptr);
+    const M_FILE_ENTRY fe = {
+        .path = Memory_DupStr(base_path),
+        .load_levels = load_levels,
+    };
     Vector_Add(m_SourceFiles, &fe);
 }
 
@@ -303,6 +309,10 @@ bool GameStringManager_ReloadLanguage(const char *const lang)
             }
         }
         GameStringTable_Apply(GF_GetCurrentLevel());
+        if (m_EventManager != nullptr) {
+            EVENT event = { "reload_language", nullptr, (void *)lang };
+            EventManager_Fire(m_EventManager, &event);
+        }
     }
     return success;
 }
@@ -314,4 +324,18 @@ const char *GameStringManager_GetLanguageName(const char *const code)
     }
     const M_LANG_ENTRY *const ent = M_FindLangEntry(code);
     return ent != nullptr ? ent->display_name : nullptr;
+}
+
+int32_t GameStringManager_SubscribeReload(
+    const EVENT_LISTENER listener, void *const user_data)
+{
+    ASSERT(m_EventManager != nullptr);
+    return EventManager_Subscribe(
+        m_EventManager, "reload_language", nullptr, listener, user_data);
+}
+
+void GameStringManager_UnsubscribeReload(const int32_t listener_id)
+{
+    ASSERT(m_EventManager != nullptr);
+    EventManager_Unsubscribe(m_EventManager, listener_id);
 }

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "debug.h"
 #include "game/const.h"
+#include "game/game_string_manager.h"
 #include "game/input.h"
 #include "game/scaler.h"
 #include "game/ui/elements/anchor.h"
@@ -438,7 +439,7 @@ static void M_Footer(const UI_SETTINGS_STATE *const s)
     UI_EndStack();
 }
 
-static void M_HandleConfigChange(const EVENT *const event, void *const data)
+static void M_HandleLanguageReload(const EVENT *const event, void *const data)
 {
     UI_SETTINGS_STATE *const s = data;
     M_RecomputeSizes(s);
@@ -447,7 +448,8 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
 static void M_InitCommon(UI_SETTINGS_STATE *const s, const GAME_STRING_ID title)
 {
     s->title = title;
-    s->listener_id = Config_SubscribeChanges(M_HandleConfigChange, s);
+    s->listener_id =
+        GameStringManager_SubscribeReload(M_HandleLanguageReload, s);
 }
 
 void UI_Settings_Init(
@@ -496,7 +498,7 @@ void UI_Settings_InitWithTabs(
 void UI_Settings_Free(UI_SETTINGS_STATE *const s)
 {
     if (s->listener_id >= 0) {
-        Config_UnsubscribeChanges(s->listener_id);
+        GameStringManager_UnsubscribeReload(s->listener_id);
         s->listener_id = -1;
     }
     if (s->tab_switch != nullptr) {

--- a/src/libtrx/include/libtrx/game/game_string_manager.h
+++ b/src/libtrx/include/libtrx/game/game_string_manager.h
@@ -2,6 +2,7 @@
 // mod/OG fallback.
 #pragma once
 
+#include "../event_manager.h"
 #include "../vector.h"
 
 #include <stdbool.h>
@@ -40,3 +41,12 @@ const char *GameStringManager_GetLanguageName(const char *code);
 // lang: language code (e.g. "en", "fr"). Must be one returned by
 // GetAvailableLanguages.
 bool GameStringManager_ReloadLanguage(const char *lang);
+
+// Subscribe to be notified when the game strings language is reloaded.
+// The listener will receive an EVENT with name "reload_language",
+// and .data pointing to the language code (const char *).
+int32_t GameStringManager_SubscribeReload(
+    EVENT_LISTENER listener, void *user_data);
+
+// Unsubscribe from language reload events.
+void GameStringManager_UnsubscribeReload(int32_t listener_id);

--- a/src/tr1/game/shell.c
+++ b/src/tr1/game/shell.c
@@ -199,6 +199,7 @@ bool Shell_ParseArgs(const int32_t arg_count, const char **args)
 int32_t Shell_Main(void)
 {
     GameString_Init();
+    GameStringManager_Init();
     EnumMap_Init();
     Config_Init();
 

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -467,6 +467,7 @@ int32_t Shell_Main(void)
     }
 
     GameString_Init();
+    GameStringManager_Init();
     EnumMap_Init();
     Config_Init();
     UI_Init();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The size of the setting dialogs would update when we changed the language, but failed to update if we issued `/strings` which technically did not change the active language, and the translated content required the sizes to be recomputed.