### PR TITLE
tr2/option/option_compass: fix ticking SFX

### DIFF
--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -453,7 +453,6 @@ static GF_COMMAND M_Control(INV_RING *const ring)
 
             switch (inv_item->object_id) {
             case O_COMPASS_OPTION:
-                Sound_Effect(SFX_MENU_STOPWATCH, nullptr, SPM_ALWAYS);
                 break;
 
             case O_PHOTO_OPTION:

--- a/src/tr2/game/option/option_compass.c
+++ b/src/tr2/game/option/option_compass.c
@@ -56,9 +56,10 @@ void Option_Compass_Control(INVENTORY_ITEM *const inv_item, const bool is_busy)
         M_Shutdown(p);
         inv_item->anim_direction = 1;
         inv_item->goal_frame = inv_item->frames_total - 1;
+        Sound_StopEffect(SFX_MENU_STOPWATCH);
+    } else {
+        Sound_Effect(SFX_MENU_STOPWATCH, 0, SPM_ALWAYS);
     }
-
-    Sound_Effect(SFX_MENU_STOPWATCH, 0, SPM_ALWAYS);
 }
 
 void Option_Compass_Draw(void)


### PR DESCRIPTION
Resolves #3243.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the stopwatch SFX doesn't start until it is open and that it stops when the option is closed.
