### PR TITLE
cmd/kill: improve kill all behavior in HSH

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -67,6 +67,7 @@
 - fixed hot-plugging certain audio devices causing glitchy playback (partial fix; regression from 0.2)
 - fixed stats dialog reserving too much space for extra secrets (#3237, regression from 1.0)
 - fixed logging not outputting anything on Windows terminals
+- fixed `/kill all` command softlocking the game in Home Sweet Home
 - improved word wrapping algorithm in the dev console
 - improved the dev console commands documentation
 

--- a/src/libtrx/game/console/cmd/kill.c
+++ b/src/libtrx/game/console/cmd/kill.c
@@ -14,6 +14,11 @@
 #include "memory.h"
 #include "strings.h"
 
+#if TR_VERSION == 2
+extern bool CombatEnd_IsWaitingForBoss(void);
+extern GAME_OBJECT_ID CombatEnd_GetBossType(void);
+#endif
+
 static bool M_CanTargetObjectCreature(GAME_OBJECT_ID obj_id);
 static bool M_KillSingleEnemyInRange(int32_t max_dist);
 static int32_t M_KillAllEnemiesInRange(int32_t max_dist);
@@ -76,11 +81,18 @@ static int32_t M_KillAllEnemiesInRange(const int32_t max_dist)
 static COMMAND_RESULT M_KillAllEnemies(void)
 {
     int32_t num_killed = 0;
+
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
         const ITEM *const item = Item_Get(item_num);
         if (!Creature_IsHostile(item)) {
             continue;
         }
+#if TR_VERSION == 2
+        if (item->object_id == CombatEnd_GetBossType()
+            && CombatEnd_IsWaitingForBoss()) {
+            continue;
+        }
+#endif
         if (Lara_Cheat_KillEnemy(item_num)) {
             num_killed++;
         }

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -1085,6 +1085,11 @@ void Creature_SetAlliesHostile(bool enable)
     m_AlliesHostile = enable;
 }
 
+bool Creature_IsAlive(const ITEM *const item)
+{
+    return item->hit_points > 0;
+}
+
 bool Creature_IsHostile(const ITEM *const item)
 {
     return Object_IsType(item->object_id, g_EnemyObjects)

--- a/src/libtrx/include/libtrx/game/creature/common.h
+++ b/src/libtrx/include/libtrx/game/creature/common.h
@@ -31,6 +31,7 @@ int32_t Creature_Vault(
 
 bool Creature_AreAlliesHostile(void);
 void Creature_SetAlliesHostile(bool enable);
+bool Creature_IsAlive(const ITEM *item);
 bool Creature_IsHostile(const ITEM *item);
 bool Creature_IsAlly(const ITEM *item);
 bool Creature_IsTargetable(const ITEM *item);

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -15,14 +15,29 @@
 #define M_BOSS_TYPE O_CULT_3
 
 static int16_t m_BossTimer = 0;
-static uint16_t m_EnemyCount = 0;
+static uint16_t m_BossCount = 0;
 
+static int32_t M_CountAliveEnemies(bool include_boss);
 static int16_t M_FindBestBoss(void);
 static void M_ActivateLastBoss(void);
 static void M_PrepareCutscene(int16_t item_num);
 static void M_Setup(OBJECT *obj);
-static void M_Initialise(int16_t item_num);
 static void M_Control(int16_t item_num);
+
+static int32_t M_CountAliveEnemies(const bool include_boss)
+{
+    int32_t count = 0;
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        const ITEM *const item = Item_Get(i);
+        if (!include_boss && item->object_id == M_BOSS_TYPE) {
+            continue;
+        }
+        if (Creature_IsAlive(item) && Creature_IsHostile(item)) {
+            count++;
+        }
+    }
+    return count;
+}
 
 static int16_t M_FindBestBoss(void)
 {
@@ -108,40 +123,44 @@ static void M_PrepareCutscene(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->initialise_func = M_Initialise;
     obj->draw_func = Object_DrawDummyItem;
     obj->save_flags = true;
 
     m_BossTimer = 0;
-    m_EnemyCount = 0;
-}
-
-static void M_Initialise(const int16_t item_num)
-{
-    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
-        const ITEM *const item = Item_Get(i);
-        if (Object_IsType(item->object_id, g_EnemyObjects)
-            && item->object_id != M_BOSS_TYPE) {
-            m_EnemyCount++;
-        }
-    }
+    m_BossCount = 0;
 }
 
 static void M_Control(const int16_t item_num)
 {
     const RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    if (current_info->stats.kill_count == m_EnemyCount && m_BossTimer == 0) {
+    if (m_BossTimer == 0 && M_CountAliveEnemies(false) == 0) {
+        m_BossCount = M_CountAliveEnemies(true);
         M_ActivateLastBoss();
         return;
     }
 
-    if (current_info->stats.kill_count > m_EnemyCount) {
+    if (M_CountAliveEnemies(true) < m_BossCount) {
         m_BossTimer++;
         if (m_BossTimer == M_CUTSCENE_DELAY) {
             M_PrepareCutscene(item_num);
         }
     }
+}
+
+GAME_OBJECT_ID CombatEnd_GetBossType(void)
+{
+    return M_BOSS_TYPE;
+}
+
+bool CombatEnd_IsWaitingForBoss(void)
+{
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        if (Item_Get(i)->object_id == O_COMBAT_END) {
+            return m_BossTimer == 0;
+        }
+    }
+    return false;
 }
 
 bool CombatEnd_IsComplete(void)

--- a/src/tr2/game/objects/general/combat_end.h
+++ b/src/tr2/game/objects/general/combat_end.h
@@ -1,3 +1,7 @@
 #pragma once
 
+#include <libtrx/game/objects/types.h>
+
+GAME_OBJECT_ID CombatEnd_GetBossType(void);
+bool CombatEnd_IsWaitingForBoss(void);
 bool CombatEnd_IsComplete(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Running the command `/kill all` will now kill only non-boss enemies. Running it again after the boss gets activated will kill the boss enemies. It will log that it has 5 enemies - one for each possible boss spawn - which could be mitigated but I didn't want to dive in too much into the item flags necessary for this to work.

Furthermore, it will no longer cause a soft lock. To accomplish this, I had to refactor the combat end object to no longer depend on the kill count statistics, which are not updated when the player kills enemies with cheats.

