### PR TITLE
rooms/floor_data: pass secret number to stats

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.12...develop) - ××××-××-××
 - added French translation
+- fixed certain secrets not registering (#3252, regression from 4.12)
 - removed config tool (we have ingame setting dialogs now)
 
 ## [4.12](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.2...tr1-4.12) - 2025-06-17

--- a/src/libtrx/game/rooms/floor_data.c
+++ b/src/libtrx/game/rooms/floor_data.c
@@ -561,7 +561,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_SECRET: {
             // TODO: implement support for TR1-style secrets as an option
             // in TR2, see #2047
-            const int16_t secret_num = 1 << (int16_t)(intptr_t)cmd->parameter;
+            const int16_t secret_num = (int16_t)(intptr_t)cmd->parameter;
             if (Stats_AddSecret(secret_num)) {
                 Music_Play(MX_SECRET, MPM_ALWAYS);
             }


### PR DESCRIPTION
Resolves #3252.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Stats_AddSecret` handles secret index shifting so the floor data caller need only pass the number directly.
