### PR TITLE
game: improve skipping death timer

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.1...develop) - ××××-××-××
 - added French translation
+- changed death timer skip to only trigger with Action and Inventory keys
 - removed config tool (we have ingame setting dialogs now)
 
 ## [4.12.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.12...tr1-4.12.1) - 2025-06-18

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.2...develop) - ××××-××-××
 - added French translation
 - added a new easter egg command
+- changed death timer skip to only trigger with Action and Inventory keys
 - removed config tool (we have ingame setting dialogs now)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.1...tr2-1.2) - 2025-06-17

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -125,7 +125,8 @@ GF_COMMAND Game_Control(const bool demo_mode)
     Game_ProcessInput();
 
     if (g_Lara.death_timer > DEATH_WAIT
-        || (g_Lara.death_timer > DEATH_WAIT_INPUT && g_Input.any
+        || (g_Lara.death_timer > DEATH_WAIT_INPUT
+            && (g_InputDB.menu_confirm || g_InputDB.menu_back)
             && !g_Input.fly_cheat)
         || g_OverlayFlag == 2) {
         if (g_OverlayFlag == 2) {

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -85,7 +85,8 @@ GF_COMMAND Game_Control(const bool demo_mode)
     }
 
     if (g_Lara.death_timer > DEATH_WAIT
-        || (g_Lara.death_timer > DEATH_WAIT_INPUT && g_Input.any)
+        || (g_Lara.death_timer > DEATH_WAIT_INPUT
+            && (g_InputDB.menu_confirm || g_InputDB.menu_back))
         || g_OverlayStatus == 2) {
         if (demo_mode) {
             return g_GameFlow.cmd_death_demo_mode;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This gives the players more chances to press meaningful inputs, such as the turbo cheat and whatnot, after Lara dies.