### PR TITLE
tr1/cutscene: fix audio drift

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -5,6 +5,7 @@
 - changed death timer skip to only trigger with Action and Inventory keys
 - fixed depth buffer problems when closing the inventory ring with fade effects disabled (#3267, regression from 4.8)
 - fixed Lara's braid not being reflective (on Midas' hand) (#3257, regression from 4.9)
+- fixed turbo cheat causing audio desync in cutscenes (#3263)
 - removed config tool (we have ingame setting dialogs now)
 
 ## [4.12.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.12...tr1-4.12.1) - 2025-06-18

--- a/src/tr1/game/cutscene.c
+++ b/src/tr1/game/cutscene.c
@@ -19,7 +19,19 @@
 #include <libtrx/game/music.h>
 #include <libtrx/memory.h>
 
+static void M_FixAudioDrift(void);
 static void M_InitialiseLara(const GF_LEVEL *level);
+
+static void M_FixAudioDrift(void)
+{
+    const int32_t audio_frame_idx = Music_GetTimestamp() * LOGIC_FPS;
+    const int32_t game_frame_idx = Camera_GetCineData()->frame_idx;
+    const int32_t audio_drift = ABS(audio_frame_idx - game_frame_idx);
+    if (audio_drift >= LOGIC_FPS * 0.2) {
+        LOG_DEBUG("Detected audio drift: %d frames", audio_drift);
+        Music_SeekTimestamp(game_frame_idx / (double)LOGIC_FPS);
+    }
+}
 
 static void M_InitialiseLara(const GF_LEVEL *const level)
 {
@@ -89,6 +101,7 @@ void Cutscene_End(void)
 GF_COMMAND Cutscene_Control(void)
 {
     Interpolation_Remember();
+    M_FixAudioDrift();
 
     Input_Update();
     Shell_ProcessInput();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3263.

