### PR TITLE
movable_block: fix stuck blocks if game is saved while they fall

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed depth buffer problems when closing the inventory ring with fade effects disabled (#3267, regression from 4.8)
 - fixed Lara's braid not being reflective (on Midas' hand) (#3257, regression from 4.9)
 - fixed support for non-linear secret flags in custom levels (#3262, regression from 4.12)
+- fixed movable blocks getting stuck in midair if the game is saved and loaded while they are falling (#3274)
 - removed config tool (we have ingame setting dialogs now)
 
 ## [4.12.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.12...tr1-4.12.1) - 2025-06-18

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed the examine dialog to be close-able with Look button (#3225)
 - changed some settings to be hidden when they're only applicable to specific games or custom levels (#3242)
 - fixed some secrets in some levels incorrectly registering by standing on specific tiles (#3280, regression from 1.2)
+- fixed movable blocks getting stuck in midair if the game is saved and loaded while they are falling (#3274)
 - removed config tool (we have ingame setting dialogs now)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.1...tr2-1.2) - 2025-06-17

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -283,7 +283,7 @@ static void M_Setup(OBJECT *const obj)
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
-        if (item->status == IS_ACTIVE
+        if (item->status == IS_ACTIVE && !item->gravity
             && item->current_anim_state == MOVABLE_BLOCK_STATE_STILL) {
             Item_RemoveActive(Item_GetIndex(item));
             item->status = IS_INACTIVE;

--- a/src/tr2/game/objects/general/movable_block.c
+++ b/src/tr2/game/objects/general/movable_block.c
@@ -210,7 +210,7 @@ static void M_Setup(OBJECT *const obj)
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
-        if (item->status == IS_ACTIVE
+        if (item->status == IS_ACTIVE && !item->gravity
             && item->current_anim_state == MOVABLE_BLOCK_STATE_STILL) {
             Item_RemoveActive(Item_GetIndex(item));
             item->status = IS_INACTIVE;


### PR DESCRIPTION
Resolves #3274.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Fixed movable blocks getting stuck in midair if the game is saved and loaded while they are falling.