### PR TITLE
option/examine: let it be closed with look key

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the ability to advance individual frames to the photo mode
 - added the ability to skip end game credits (#3266)
 - changed death timer skip to only trigger with Action and Inventory keys
+- changed the examine dialog to be close-able with Look button (#3225)
 - fixed turbo cheat causing audio desync in cutscenes (#3263)
 - fixed depth buffer problems when closing the inventory ring with fade effects disabled (#3267, regression from 4.8)
 - fixed Lara's braid not being reflective (on Midas' hand) (#3257, regression from 4.9)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added the ability to skip end game credits (#3266)
 - added a new easter egg command
 - changed death timer skip to only trigger with Action and Inventory keys
+- changed the examine dialog to be close-able with Look button (#3225)
 - removed config tool (we have ingame setting dialogs now)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.1...tr2-1.2) - 2025-06-17

--- a/src/libtrx/game/option/examine.c
+++ b/src/libtrx/game/option/examine.c
@@ -73,6 +73,9 @@ void Option_Examine_Control(const GAME_OBJECT_ID obj_id, const bool is_busy)
     }
     UI_TextDialog_Control(p->ui.state);
 
+    if (g_InputDB.look) {
+        g_InputDB.menu_back = true;
+    }
     if (g_InputDB.menu_back || g_InputDB.menu_confirm) {
         M_Shutdown(p);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3225.

The weird `g_Input` assignment is because we specifically need to fall-through outside `Option_Control` to hit the conditions that go after, which check for `menu_back` and `menu_confirm`.

Ideally `Option_Control` should communicate this via return codes instead of meddling with the player inputs, but I didn't want the diff to grow hair and legs.