### PR TITLE
screenshot: fix screenshot stripping accents

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed some settings to be hidden when they're only applicable to specific games or custom levels (#3242)
 - changed photo mode help dialog to show icons for inputs
 - changed settings to retain their active position until exiting to title or starting a new level (#3271)
+- fixed screenshots stripping accented characters (#3238)
 - fixed turbo cheat causing audio desync in cutscenes (#3263)
 - fixed depth buffer problems when closing the inventory ring with fade effects disabled (#3267, regression from 4.8)
 - fixed Lara's braid not being reflective (on Midas' hand) (#3257, regression from 4.9)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed some settings to be hidden when they're only applicable to specific games or custom levels (#3242)
 - changed photo mode help dialog to show icons for inputs
 - changed settings to retain their active position until exiting to title or starting a new level (#3271)
+- fixed screenshots stripping accented characters (#3238)
 - fixed some secrets in some levels incorrectly registering by standing on specific tiles (#3280, regression from 1.2)
 - fixed movable blocks getting stuck in midair if the game is saved and loaded while they are falling (#3274)
 - fixed PS touchpad input missing an icon (#3288, regression from 4.12)

--- a/src/libtrx/filesystem.c
+++ b/src/libtrx/filesystem.c
@@ -29,9 +29,46 @@ const char *m_GameDir = nullptr;
 static void M_PathAppendSeparator(char *path);
 static void M_PathAppendPart(char *path, const char *part);
 static char *M_CasePath(const char *path);
+static FILE *M_UTF8Fopen(const char *path, const char *mode);
 static FILE *M_ResolveAndOpen(
     const char *path, const char *mode, char **out_full_path);
 static bool M_ExistsRaw(const char *path);
+
+#if defined(_WIN32)
+    #include <wchar.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #include <windows.h>
+
+static wchar_t *M_UTF8ToWide(const char *utf8_str);
+
+static wchar_t *M_UTF8ToWide(const char *const utf8_str)
+{
+    const size_t len = strlen(utf8_str);
+    const size_t wide_len =
+        MultiByteToWideChar(CP_UTF8, 0, utf8_str, len, NULL, 0);
+    wchar_t *wide_str = Memory_Alloc((wide_len + 1) * sizeof(wchar_t));
+    MultiByteToWideChar(CP_UTF8, 0, utf8_str, len, wide_str, wide_len);
+    wide_str[wide_len] = L'\0';
+    return wide_str;
+}
+
+static FILE *M_UTF8Fopen(const char *path, const char *mode)
+{
+    wchar_t *const wide_title = M_UTF8ToWide(path);
+    wchar_t *const wide_mode = M_UTF8ToWide(mode);
+    FILE *const file = _wfopen(wide_title, wide_mode);
+    Memory_Free(wide_title);
+    Memory_Free(wide_mode);
+    return file;
+}
+
+#else
+static FILE *M_UTF8Fopen(const char *path, const char *mode)
+{
+    return fopen(path, mode);
+}
+#endif
 
 static void M_PathAppendSeparator(char *const path)
 {
@@ -133,7 +170,7 @@ static FILE *M_ResolveAndOpen(
         abs_path = Memory_DupStr(path);
     }
 
-    FILE *fp = fopen(abs_path, mode);
+    FILE *fp = M_UTF8Fopen(abs_path, mode);
     char *resolved_path = nullptr;
     if (fp != nullptr) {
         resolved_path = Memory_DupStr(abs_path);
@@ -141,7 +178,7 @@ static FILE *M_ResolveAndOpen(
     } else {
         resolved_path = M_CasePath(abs_path);
         if (resolved_path != nullptr) {
-            fp = fopen(resolved_path, mode);
+            fp = M_UTF8Fopen(resolved_path, mode);
         }
     }
 
@@ -157,7 +194,7 @@ finish:
 
 static bool M_ExistsRaw(const char *path)
 {
-    FILE *fp = fopen(path, "rb");
+    FILE *fp = M_UTF8Fopen(path, "rb");
     if (fp) {
         fclose(fp);
         return true;

--- a/src/libtrx/screenshot.c
+++ b/src/libtrx/screenshot.c
@@ -22,12 +22,13 @@ static char *M_GetScreenshotPath(SCREENSHOT_FORMAT format);
 static char *M_CleanScreenshotTitle(const char *const source)
 {
     // Sanitize screenshot title.
+    // - Remove filesystem-sensitive characters
     // - Replace spaces with underscores
-    // - Remove all non-alphanumeric characters
     // - Merge consecutive underscores together
     // - Remove leading underscores
     // - Remove trailing underscores
     char *result = Memory_Alloc(strlen(source) + 1);
+    const char *const sensitive_characters = "/\\:*?\"<>|";
 
     bool last_was_underscore = false;
     char *out = result;
@@ -37,10 +38,15 @@ static char *M_CleanScreenshotTitle(const char *const source)
                 *out++ = '_';
                 last_was_underscore = true;
             }
-        } else if (((source[i] >= 'A' && source[i] <= 'Z')
-                    || (source[i] >= 'a' && source[i] <= 'z')
-                    || (source[i] >= '0' && source[i] <= '9'))) {
-            *out++ = source[i];
+            continue;
+        }
+
+        const size_t char_size = String_GetCharByteSize(out);
+        if (char_size != 1
+            || strchr(sensitive_characters, source[i]) == nullptr) {
+            memcpy(out, source + i, char_size);
+            out += char_size;
+            i += char_size - 1;
             last_was_underscore = false;
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3238. This PR restores proper support for accented (and other non‑ASCII) characters in screenshot titles.

Previously, we've been removing any characters that aren't alphanumeric, but with the recently added official support for accented characters in level titles, this approach has become problematic.

We were doing this for two reasons - first, to remove sensitive characters such as `/` which can be interpreted as directory separators. The other reason was the challenge of dealing with Unicode support on Windows systems. Unlike other platforms, Windows' "narrow" C `fopen()` does not recognize UTF-8 as it relies on the current ANSI code-page, leading to mishandling or rejection of non-ASCII characters. To accurately open a path containing arbitrary Unicode elements, we need to convert the UTF-8 path to UTF-16LE using `MultiByteToWideChar(CP_UTF8…)` and utilize the wide-char variant `_wfopen()`, which directly engages with the Win32 UTF-16 APIs.

As such I would be grateful to find out if there's any effect on running the game from directories with accented characters, CJK symbols, or paths with spaces.
