### PR TITLE
tr1/lara/common: check existing target before consuming item

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed movable blocks getting stuck in midair if the game is saved and loaded while they are falling (#3274)
 - fixed PS touchpad input missing an icon (#3288, regression from 4.12)
 - fixed inability to use unbind key / reset layout buttons with controllers (#3290, regression from 4.12)
+- fixed Lara potentially using too many key items if the turbo cheat is used while interacting with a key/puzzle hole (#3295, regression from 4.8)
 - removed config tool (we have ingame setting dialogs now)
 - reverted the partial fix for wrong audio device reinitialization (#3251, regression from 4.12)
 

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -433,14 +433,18 @@ void Lara_UseItem(const GAME_OBJECT_ID obj_id)
     case O_SCION_ITEM_3:
     case O_SCION_ITEM_4:
     case O_SCION_OPTION: {
-        int16_t receptacle_item_num = Object_FindReceptacle(obj_id);
+        LARA_INFO *const lara = Lara_GetLaraInfo();
+        const int16_t receptacle_item_num = Object_FindReceptacle(obj_id);
+        if (lara->interact_target.item_num == receptacle_item_num) {
+            return;
+        }
         if (receptacle_item_num == NO_OBJECT) {
             Sound_Effect(SFX_LARA_NO, nullptr, SPM_NORMAL);
             return;
         }
-        g_Lara.interact_target.item_num = receptacle_item_num;
-        g_Lara.interact_target.is_moving = true;
-        g_Lara.interact_target.move_count = 0;
+        lara->interact_target.item_num = receptacle_item_num;
+        lara->interact_target.is_moving = true;
+        lara->interact_target.move_count = 0;
         Inv_RemoveItem(obj_id);
         break;
     }


### PR DESCRIPTION
Resolves #3295.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's existing interact target is checked before proceeding to remove the item from inventory, for cases when turbo mode is used and requests to use the item are backed up.
