### PR TITLE
Fix TR2 underwater hum

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed photo mode help dialog to show icons for inputs
 - changed settings to retain their active position until exiting to title or starting a new level (#3271)
 - removed config tool (we have ingame setting dialogs now)
+- fixed underwater hum not playing properly (#3305, regression from 0.10)
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.2...tr2-1.2.1) - 2025-06-22
 - fixed some secrets in some levels incorrectly registering by standing on specific tiles (#3280, regression from 1.2)

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -526,6 +526,7 @@ bool Audio_Stream_Close(int32_t sound_id)
 
     if (stream->sdl.stream) {
         SDL_FreeAudioStream(stream->sdl.stream);
+        stream->sdl.stream = nullptr;
     }
 
     void (*finish_callback)(int32_t, void *) = stream->finish_callback;

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -929,6 +929,8 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
 
 void Camera_Update(void)
 {
+    M_EnsureEnvironment();
+
     if (g_Camera.type == CAM_PHOTO_MODE) {
         Camera_UpdatePhotoMode();
         return;
@@ -1137,7 +1139,6 @@ void Camera_MoveManual(void)
 
 void Camera_Apply(void)
 {
-    M_EnsureEnvironment();
     Matrix_LookAt(
         g_Camera.interp.result.pos.x,
         g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,

--- a/src/libtrx/game/sound/common.c
+++ b/src/libtrx/game/sound/common.c
@@ -57,6 +57,9 @@ int16_t *Sound_GetSampleLUT(void)
 
 SAMPLE_INFO *Sound_GetSampleInfo(const SOUND_EFFECT_ID sfx_num)
 {
+    if (sfx_num == SFX_INVALID) {
+        return nullptr;
+    }
     const int16_t info_idx = m_SampleLUT[sfx_num];
     return info_idx < 0 ? nullptr : &m_SampleInfos[info_idx];
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3305.

The underwater hum would play for at most 2 frames before getting reset on certain devices. The reason for this is because of how `Sound_EndScene()` works.

The idea is that looped sound sources need to `Sound_Effect()` their samples on every logical frame to achieve continuous playback, otherwise the samples will stop. Which is actually quite convenient. To achieve this behavior, `Sound_EndScene()` checks if the looped samples are silent. If they aren't, it syncs the parameters to the relevant output stream and updates the samples volume to be silent – but keeps the other parameters. In the following frame, the repeated call to `Sound_Effect()` will either reset the volume back to some non-silent value, or if there are no such calls, the second call to `Sound_EndScene()` will deem the sample as no longer in use, stop the playback, and fully close the slot.

At the same time the call to `Sound_Effect(SFX_UNDERWATER)` would happen inside M_EnsureEnvironment() which is part of the draw phase. Under normal circumstances this is fine, even if we have 60 FPS. But if we experience frame drops, this means the calls to `Sound_Effect()` and the calls to `Sound_EndScene()` can go out of order , and the samples will randomly restart. This is especially visible if the FPS is set to 60 but the display is only capable of rendering 30 FPS.

The fix ended up being simple and was to just move the camera environment sync to the control phase.

#### Testing

The only play is around the camera going into and out of water bodies.
I'd appreciate a version in which the regression occurred.