### PR TITLE
cmd/pos: fix crash if no level title set

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fixed game crashing when the expected resources are missing (#3310, regression from 4.12.2)
 - fixed restore default pop-up requiring all 3 water color options to be adjusted instead of just one (#3314, regression from 4.12)
 - fixed pause screen rendered without background overlay if fade effects are disabled (#3316, regression from 4.11)
+- fixed `/pos` command crashing when the level title is not set (regression from 4.12)
 
 ## [4.12.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.1...tr1-4.12.2) - 2025-06-22
 - fixed depth buffer problems when closing the inventory ring with fade effects disabled (#3267, regression from 4.8)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed restore default pop-up requiring all 3 water color options to be adjusted instead of just one (#3314, regression from 1.2)
 - fixed pause screen rendered without background overlay if fade effects are disabled (#3316, regression from 1.1)
 - fixed title screen background not updating aspect ratio when moving fullscreen window between monitors (#2842)
+- fixed `/pos` command crashing when the level title is not set (regression from 1.2)
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.2...tr2-1.2.1) - 2025-06-22
 - fixed some secrets in some levels incorrectly registering by standing on specific tiles (#3280, regression from 1.2)

--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -42,8 +42,8 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         break;
     }
 
-    char *level_type =
-        String_Format(level_type_fmt, current_level->num + reindex);
+    const char *const level_type =
+        String_FormatStatic(level_type_fmt, current_level->num + reindex);
 
     const ITEM *const lara_item = Lara_GetItem();
     int16_t room_num = lara_item->room_num;
@@ -51,9 +51,9 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     if (Room_GetFlipStatus() && room->flipped_room != NO_ROOM) {
         room_num = room->flipped_room;
     }
-    char *details = lara_item == nullptr
-        ? String_Format("%s", GS(OSD_POS_LARA_MISSING))
-        : String_Format(
+    const char *const details = lara_item == nullptr
+        ? String_FormatStatic("%s", GS(OSD_POS_LARA_MISSING))
+        : String_FormatStatic(
               GS(OSD_POS_LARA_POS_FMT), room_num,
               lara_item->pos.x / (float)WALL_L,
               lara_item->pos.y / (float)WALL_L,
@@ -63,16 +63,13 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
               lara_item->rot.z * 360.0f / (float)DEG_360);
     const char *const glue = lara_item == nullptr ? "\n" : "  ";
 
-    char *message = strcmp(level_type, current_level->title) == 0
-        ? String_Format("%s%s%s", level_type, glue, details)
-        : String_Format(
+    const char *const message = current_level->title != nullptr
+            && strcmp(level_type, current_level->title) == 0
+        ? String_FormatStatic("%s%s%s", level_type, glue, details)
+        : String_FormatStatic(
               "%s (%s)%s%s", level_type, current_level->title, glue, details);
 
     Console_Log("%s", message);
-
-    Memory_FreePointer(&details);
-    Memory_FreePointer(&message);
-    Memory_FreePointer(&level_type);
 
     return CR_SUCCESS;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

To replicate the crash – `/set language nonsense`, relaunch the game, load any level and issue `/pos`. Prior to the language version this should be possible to replicate by deleting the strings file.

Regression – unknown