### PR TITLE
savegame: fix overflows in flare count

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fixed room 136 in Opera House not having water (#3214)
 - fixed Lara not saying 'aha' when picking up the secret in Lara's Home (#3103)
 - fixed missing zipline sound in Home Sweet Home (#3102)
+- fixed flare count getting corrupt on save/load if Lara had more than 255 flares (#1592)
 - fixed underwater hum not playing properly (#3305, regression from 0.10)
 - fixed game crashing when the expected resources are missing (#3310, regression from 1.2.1)
 - fixed restore default pop-up requiring all 3 water color options to be adjusted instead of just one (#3314, regression from 1.2)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -197,6 +197,7 @@ However, you can easily download them manually from these urls:
 - added an option to toggle random enemy initial angle adjustment
 - added an option to prevent Lara targeting allies, either with weapons or the skidoo
 - changed inventory to pause the music rather than muting it
+fixed flare count getting corrupt on save/load if Lara had more than 255 flares
 - fixed killing the T-Rex with a grenade launcher crashing the game
 - fixed assault course best times not being retained between game relaunches
 - fixed secret rewards not displaying shotgun ammo

--- a/src/libtrx/include/libtrx/game/savegame/types.h
+++ b/src/libtrx/include/libtrx/game/savegame/types.h
@@ -23,7 +23,7 @@ typedef struct {
     uint16_t m16_ammo;
     uint16_t grenade_ammo;
     uint16_t harpoon_ammo;
-    uint8_t flares;
+    uint16_t flares;
 #endif
 
     union {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #1592. Doesn't get rid of the overflows entirely but makes it less likely to bump into in a normal playthrough.