### PR TITLE
Fix overriding game flow commands not working while in the key use inventory ring

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -19,6 +19,7 @@
 - removed config tool (we have ingame setting dialogs now)
 - fixed Lara not saying 'no' near receptacles if she doesn't carry any items (#3337, regression from 4.0)
 - fixed Lara not saying 'no' near complete receptacles (#3337, regression from 4.0)
+- fixed certain commands (such as `/load` or `/play`) not working as expected while in the key use inventory screen (#3338)
 
 ## [4.12.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.2...tr1-4.12.3) - 2025-06-24
 - fixed game crashing when the expected resources are missing (#3310, regression from 4.12.2)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed missing zipline sound in Home Sweet Home (#3102)
 - fixed flare count getting corrupt on save/load if Lara had more than 255 flares (#1592)
 - fixed title screen background not updating aspect ratio when moving fullscreen window between monitors (#2842)
+- fixed certain commands (such as `/load` or `/play`) not working as expected while in the key use inventory screen (#3338)
 
 ## [1.2.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.2.1...tr2-1.2.2) - 2025-06-24
 - fixed underwater hum not playing properly (#3305, regression from 0.10)

--- a/src/libtrx/game/game_flow/sequencer_misc.c
+++ b/src/libtrx/game/game_flow/sequencer_misc.c
@@ -42,7 +42,10 @@ bool GF_ShowInventoryKeys(const GAME_OBJECT_ID receptacle_type_id)
             receptacle_type_id, g_KeyItemToReceptacleMap);
         InvRing_SetRequestedObjectID(obj_id);
     }
-    GF_ShowInventory(INV_KEYS_MODE);
+    const GF_COMMAND gf_cmd = GF_ShowInventory(INV_KEYS_MODE);
+    if (gf_cmd.action != GF_NOOP) {
+        GF_OverrideCommand(gf_cmd);
+    }
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Builds on top of #3339. Resolves #3338.
