### PR TITLE
tr1/objects/save_crystal: increase vertical collision range

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -16,6 +16,7 @@
 - changed photo mode help dialog to show icons for inputs
 - changed settings to retain their active position until exiting to title or starting a new level (#3271)
 - changed the dev console to accept compound characters (#2938)
+- changed save crystal collision to be more lenient for custom levels (#3343)
 - removed config tool (we have ingame setting dialogs now)
 - fixed Lara not saying 'no' near receptacles if she doesn't carry any items (#3337, regression from 4.0)
 - fixed Lara not saying 'no' near complete receptacles (#3337, regression from 4.0)

--- a/src/tr1/game/objects/general/save_crystal.c
+++ b/src/tr1/game/objects/general/save_crystal.c
@@ -8,8 +8,8 @@
 
 static const OBJECT_BOUNDS m_SaveCrystal_Bounds = {
     .shift = {
-        .min = { .x = -256, .y = -100, .z = -256, },
-        .max = { .x = +256, .y = +100, .z = +256, },
+        .min = { .x = -STEP_L, .y = -100, .z = -STEP_L, },
+        .max = { .x = +STEP_L, .y = +WALL_L, .z = +STEP_L, },
     },
     .rot = {
         .min = { .x = -10 * DEG_1, .y = 0, .z = 0, },
@@ -102,6 +102,14 @@ static void M_Collision(
     item->rot.z = 0;
     item->rot.x = 0;
     if (!Lara_TestPosition(item, obj->bounds_func())) {
+        return;
+    }
+
+    int16_t room_num = lara_item->room_num;
+    const XYZ_32 pos = lara_item->pos;
+    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
+    if (ceiling >= item->pos.y) {
         return;
     }
 


### PR DESCRIPTION
Resolves #3343.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This increases the vertical range for save crystal collision, but adds an additional check where collision should be blocked by the ceiling. So they can now be up to 4 clicks above Lara, but any ceiling in the way will block collision.

<details><summary>Ceiling block e.g.</summary>

![image](https://github.com/user-attachments/assets/019a0788-e4ec-4b00-9059-1aa447d5a66c)
</details>

Test level available with crystals at various heights.

One thing I've noticed is that they don't work underwater (OG), that could be a nice feature to include as well.
