### PR TITLE
tr1/objects/save_crystal: add underwater functionality

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added the ability to cycle UI tabs with sidestep keys (#3272)
 - added dedicated British English translation (#3212)
 - added a `/lighting` console command to let the player turn lighting system on/off
+- added support for underwater save crystals in custom levels (#3356)
 - changed controls dialog to remember the player's preferred input method
 - changed UI to show icons relevant to the chosen input method
 - changed death timer skip to only trigger with Action and Inventory keys

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -203,3 +203,19 @@ void Lara_Extinguish(void)
         effect_num = next_effect_num;
     }
 }
+
+bool Lara_HasState(const LARA_STATE *const test_arr)
+{
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->extra_anim) {
+        return false;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    for (int32_t i = 0; test_arr[i] != (LARA_STATE)-1; i++) {
+        if (test_arr[i] == (LARA_STATE)lara_item->current_anim_state) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../collision.h"
+#include "./enum.h"
 
 void Lara_RefuseInteraction(void);
 
@@ -16,3 +17,4 @@ int32_t Lara_GetWaterDepth(int32_t x, int32_t y, int32_t z, int16_t room_num);
 // Returns true if Lara has the M16 equipped and is in either anim state: 0
 // (start aim); 2 (firing); or 4 (stopping firing).
 bool Lara_IsM16Active(void);
+bool Lara_HasState(const LARA_STATE *test_arr);

--- a/src/tr1/game/objects/general/save_crystal.c
+++ b/src/tr1/game/objects/general/save_crystal.c
@@ -1,10 +1,10 @@
 #include "game/game_flow.h"
 #include "game/input.h"
-#include "game/lara/common.h"
 #include "game/objects/common.h"
 #include "global/vars.h"
 
 #include <libtrx/config.h>
+#include <libtrx/game/lara.h>
 
 static const OBJECT_BOUNDS m_SaveCrystal_Bounds = {
     .shift = {
@@ -17,6 +17,24 @@ static const OBJECT_BOUNDS m_SaveCrystal_Bounds = {
     },
 };
 
+static const OBJECT_BOUNDS m_UW_Bounds = {
+    .shift = {
+        .min = { .x = -STEP_L, .y = -WALL_L, .z = -STEP_L, },
+        .max = { .x = +STEP_L, .y = +WALL_L, .z = +STEP_L, },
+    },
+    .rot = {
+        .min = { .x = -DEG_90, .y = 0, .z = 0, },
+        .max = { .x = +DEG_90, .y = 0, .z = 0, },
+    },
+};
+
+static const LARA_STATE m_StopStates[] = {
+    LS_STOP,
+    LS_TREAD,
+    LS_SURF_TREAD,
+    (LARA_STATE)-1,
+};
+
 static const OBJECT_BOUNDS *M_Bounds(void);
 static void M_Setup(OBJECT *obj);
 static void M_Initialise(int16_t item_num);
@@ -26,7 +44,11 @@ static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    return &m_SaveCrystal_Bounds;
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    return lara->water_status == LWS_SURFACE
+            || lara->water_status == LWS_UNDERWATER
+        ? &m_UW_Bounds
+        : &m_SaveCrystal_Bounds;
 }
 
 static void M_Setup(OBJECT *const obj)
@@ -94,7 +116,7 @@ static void M_Collision(
         return;
     }
 
-    if (lara_item->current_anim_state != LS_STOP) {
+    if (!Lara_HasState(m_StopStates)) {
         return;
     }
 
@@ -109,7 +131,8 @@ static void M_Collision(
     const XYZ_32 pos = lara_item->pos;
     const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
     const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
-    if (ceiling >= item->pos.y) {
+    const int32_t floor = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    if (ceiling >= item->pos.y || floor < item->pos.y) {
         return;
     }
 

--- a/src/tr2/game/gun/gun_misc.c
+++ b/src/tr2/game/gun/gun_misc.c
@@ -19,28 +19,6 @@
 #define M_NEAR_ANGLE (DEG_1 * 15) // = 2730
 #define M_ALLY_FRIENDLY_FIRE_THRESHOLD 10
 
-static LARA_STATE m_HoldStates[] = {
-    LS_WALK,      LS_STOP,      LS_POSE,       LS_TURN_RIGHT,  LS_TURN_LEFT,
-    LS_WALK_BACK, LS_FAST_TURN, LS_STEP_LEFT,  LS_STEP_RIGHT,  LS_WADE,
-    LS_PICKUP,    LS_SWITCH_ON, LS_SWITCH_OFF, (LARA_STATE)-1,
-};
-
-int32_t Gun_CheckForHoldingState(const LARA_STATE state)
-{
-    if (g_Lara.extra_anim) {
-        return false;
-    }
-
-    const LARA_STATE *hold_state = m_HoldStates;
-    while (*hold_state != (LARA_STATE)-1) {
-        if (*hold_state == state) {
-            return true;
-        }
-        hold_state++;
-    }
-    return false;
-}
-
 void Gun_TargetInfo(const WEAPON_INFO *const winfo)
 {
     if (!g_Lara.target) {

--- a/src/tr2/game/gun/gun_misc.h
+++ b/src/tr2/game/gun/gun_misc.h
@@ -29,7 +29,6 @@ typedef enum {
     LA_G_SURF_UNDRAW = 9,
 } LARA_GUN_ANIMATION;
 
-int32_t Gun_CheckForHoldingState(const LARA_STATE state);
 void Gun_TargetInfo(const WEAPON_INFO *winfo);
 void Gun_GetNewTarget(const WEAPON_INFO *winfo);
 void Gun_AimWeapon(const WEAPON_INFO *winfo, LARA_ARM *arm);

--- a/src/tr2/game/lara/flare.c
+++ b/src/tr2/game/lara/flare.c
@@ -38,6 +38,12 @@ typedef enum {
     LF_FL_DRAW_GOT_IT = (LF_FL_DRAW + 13), // = 46
 } M_LARA_FLARE_FRAME;
 
+static const LARA_STATE m_HoldStates[] = {
+    LS_WALK,      LS_STOP,      LS_POSE,       LS_TURN_RIGHT,  LS_TURN_LEFT,
+    LS_WALK_BACK, LS_FAST_TURN, LS_STEP_LEFT,  LS_STEP_RIGHT,  LS_WADE,
+    LS_PICKUP,    LS_SWITCH_ON, LS_SWITCH_OFF, (LARA_STATE)-1,
+};
+
 static void M_InitialiseState(void);
 static void M_DoIgniteEffects(XYZ_32 flare_pos, int16_t room_num);
 static bool M_CanThrowFlare(void);
@@ -116,8 +122,8 @@ static void M_ControlArmless(void)
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
 
-    const bool is_mounted_or_armed = lara_info->vehicle_item_num != NO_ITEM
-        || Gun_CheckForHoldingState(lara_item->current_anim_state);
+    const bool is_mounted_or_armed =
+        lara_info->vehicle_item_num != NO_ITEM || Lara_HasState(m_HoldStates);
 
     if (is_mounted_or_armed) {
         if (!lara_info->flare.control) {
@@ -141,8 +147,8 @@ static void M_ControlBusyHands(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_info->flare.control = lara_info->vehicle_item_num != NO_ITEM
-        || Gun_CheckForHoldingState(lara_item->current_anim_state);
+    lara_info->flare.control =
+        lara_info->vehicle_item_num != NO_ITEM || Lara_HasState(m_HoldStates);
     M_ControlInHand(lara_info->flare.age);
     M_SetArm(lara_info->left_arm.frame_num);
 }


### PR DESCRIPTION
Resolves #3356.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Updates save crystals so they can work while Lara is underwater or on the surface. Test level from #3355 updated.

A quick test around Lara's left arm when using flares in TR2 would also be good, as I've merged a little logic for testing state. So when she's at a stop, sidestepping etc her arm should be in the flare position, whereas jumping around her arm will be in the relevant animation position.
