### PR TITLE
inventory: test object state before gun swap

### DIFF
--- a/src/tr1/game/inventory.c
+++ b/src/tr1/game/inventory.c
@@ -13,6 +13,13 @@
 
 bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
 {
+    const GAME_OBJECT_ID inv_obj_id = Inv_GetItemOption(obj_id);
+    const OBJECT *const object =
+        Object_Get(inv_obj_id == NO_OBJECT ? obj_id : inv_obj_id);
+    if (!object->loaded) {
+        return false;
+    }
+
     if (Object_IsType(obj_id, g_GunObjects)) {
         Gun_UpdateLaraMeshes(obj_id);
         if (g_Lara.gun_type == LGT_UNARMED) {
@@ -24,11 +31,6 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
                 g_Lara.gun_status = LGS_HANDS_BUSY;
             }
         }
-    }
-
-    const GAME_OBJECT_ID inv_obj_id = Inv_GetItemOption(obj_id);
-    if (!Object_Get(inv_obj_id)->loaded) {
-        return false;
     }
 
     for (RING_TYPE ring_type = 0; ring_type < RT_NUMBER_OF; ring_type++) {

--- a/src/tr2/game/inventory.c
+++ b/src/tr2/game/inventory.c
@@ -19,6 +19,13 @@ static int32_t M_GetFlareQuantity(void)
 
 bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
 {
+    const GAME_OBJECT_ID inv_obj_id = Inv_GetItemOption(obj_id);
+    const OBJECT *const object =
+        Object_Get(inv_obj_id == NO_OBJECT ? obj_id : inv_obj_id);
+    if (!object->loaded) {
+        return false;
+    }
+
     if (Object_IsType(obj_id, g_GunObjects)) {
         Gun_UpdateLaraMeshes(obj_id);
         if (g_Lara.gun_type == LGT_UNARMED) {
@@ -30,13 +37,6 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
                 g_Lara.gun_status = LGS_HANDS_BUSY;
             }
         }
-    }
-
-    const GAME_OBJECT_ID inv_obj_id = Inv_GetItemOption(obj_id);
-    const OBJECT *const object =
-        Object_Get(inv_obj_id == NO_OBJECT ? obj_id : inv_obj_id);
-    if (!object->loaded) {
-        return false;
     }
 
     for (RING_TYPE ring_type = 0; ring_type < RT_NUMBER_OF; ring_type++) {


### PR DESCRIPTION
Resolves #3358.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the object loaded state is tested before carrying out any gun mesh changes when an item is added to inventory. I've applied the same to TR1 so would be good to test things there too to make sure there are no problems.

As an aside, it would be nice to inject the guns in the gym, similar to TR1. WDYT? Not sure about in HSH though.
