### PR TITLE
tr2/output: fix Bartoli sunset effect

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -19,6 +19,7 @@
 - changed settings to retain their active position until exiting to title or starting a new level (#3271)
 - changed the dev console to accept compound characters (#2938)
 - changed the item duplication glitch fix to be on by default
+- changed the Bartoli's Hideout sunset effect to also apply to skybox lighting (#1617)
 - removed config tool (we have ingame setting dialogs now)
 - removed default bindings for the "sizer" and the "scaler" options (#2853)
 - fixed inventory screen carpet background texture stretched on non-4:3 aspect ratios (#2022)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fixed Lara not saying 'no' near gong or detonator when applicable (#3337)
 - fixed Lara saying 'no' near receptacles after loading a game (#1603)
 - fixed Lara saying 'no' near receptacles when using guns, medikits or flares (#1601)
+- fixed the Bartoli's Hideout sunset effect being reset after reloading a save (#1617)
 - improved the `/tp` command to orient Lara towards keyholes and doors
 
 ## [1.2.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.2.1...tr2-1.2.2) - 2025-06-24

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -354,6 +354,7 @@ fixed flare count getting corrupt on save/load if Lara had more than 255 flares
 - fixed transparent eyes on Lara's model in the gym and Home Sweet Home levels
 - fixed transparent eyes on the wolf model in Furnace of the Gods
 - fixed Lara's health bar showing in the Home Sweet Home shower cutscene
+- fixed the Bartoli's Hideout sunset effect being reset after reloading a save
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -324,6 +324,7 @@ fixed flare count getting corrupt on save/load if Lara had more than 255 flares
 - changed the software renderer to use the picture's palette for the background pictures
 - changed fullscreen behavior to use windowed desktop mode
 - changed dynamic lighting for gun flashes and explosions to be optional
+- changed the Bartoli's Hideout sunset effect to also apply to skybox lighting
 - fixed fullscreen issues
 - fixed black borders in windowed mode
 - fixed "Failed to create device" when toggling fullscreen

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -341,7 +341,7 @@ static void M_CalcVerticeLight(const OBJECT_MESH *const mesh)
 static void M_CalcSkyboxLight(const OBJECT_MESH *const mesh)
 {
     for (int32_t i = 0; i < ABS(mesh->num_lights); i++) {
-        g_PhdVBuf[i].g = 0xFFF;
+        g_PhdVBuf[i].g = 0xFFF + 0x400 * m_SunsetTimer / M_SUNSET_TIMEOUT;
     }
 }
 

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -960,6 +960,11 @@ void Output_SetSunsetTimer(const int32_t timer)
     m_SunsetTimer = timer;
 }
 
+int32_t Output_GetSunsetTimer(void)
+{
+    return m_SunsetTimer;
+}
+
 void Output_AnimateTextures(const int32_t ticks)
 {
     m_WibbleOffset = (m_WibbleOffset + (ticks / TICKS_PER_FRAME)) % WIBBLE_SIZE;

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -87,6 +87,7 @@ void Output_SetShadeEffect(bool shade_effect);
 bool Output_IsShadeEffect(void);
 void Output_SetSunsetEnabled(bool enabled);
 void Output_SetSunsetTimer(int32_t timer);
+int32_t Output_GetSunsetTimer(void);
 
 int32_t Output_GetNearZ(void);
 int32_t Output_GetFarZ(void);

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -4,6 +4,7 @@
 #include "game/inventory.h"
 #include "game/lara/control.h"
 #include "game/objects/general/lift.h"
+#include "game/output.h"
 #include "game/savegame.h"
 #include "global/vars.h"
 
@@ -299,6 +300,7 @@ static JSON_OBJECT *M_DumpMisc(void)
     JSON_ObjectAppendInt(misc_obj, "bonus_flag", Game_GetBonusFlag());
     JSON_ObjectAppendBool(
         misc_obj, "are_monks_angry", Creature_AreAlliesHostile());
+    JSON_ObjectAppendInt(misc_obj, "sunset_timer", Output_GetSunsetTimer());
     return misc_obj;
 }
 
@@ -313,6 +315,8 @@ static bool M_LoadMisc(JSON_OBJECT *const misc_obj)
     Game_SetBonusFlag(bonus_flag);
     const bool hostile = JSON_ObjectGetBool(misc_obj, "are_monks_angry", false);
     Creature_SetAlliesHostile(hostile);
+    const int32_t sunset_timer = JSON_ObjectGetInt(misc_obj, "sunset_timer", 0);
+    Output_SetSunsetTimer(sunset_timer);
     return true;
 }
 


### PR DESCRIPTION
Resolves #1617.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This gets the sunset timer added to the savegame so lighting can be restored on load, and it also applies sunset lighting to the skybox. Example below after ~30mins.

<details><summary>Screenshots</summary>

![a](https://github.com/user-attachments/assets/e6a6a09b-4c5c-42cf-88c8-72fa81cfdf62)
![b](https://github.com/user-attachments/assets/f9cfbde4-b193-4de1-bd54-ab53cbb26e04)
</details>
