### PR TITLE
Fix Winston crash

### DIFF
--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -1107,7 +1107,8 @@ bool Creature_IsTargetable(const ITEM *const item)
 #if TR_VERSION == 1
     return true;
 #else
-    return g_Config.gameplay.enable_ally_targeting || !Creature_IsAlly(item);
+    return item->hit_points != DONT_TARGET
+        && (g_Config.gameplay.enable_ally_targeting || !Creature_IsAlly(item));
 #endif
 }
 

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -50,6 +50,9 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const item = Item_Get(item_num);
     CREATURE *const creature = item->data;
+    if (creature == nullptr) {
+        return;
+    }
 
     AI_INFO info;
     Creature_AIInfo(item, &info);


### PR DESCRIPTION
Resolves #3367.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Ensures Winston's control is exited early if his creature data is null, but also ensures Lara doesn't target him in the first place in any case. Would be good to check running him over with the skidoo too, and a general ally/foe test.
