### PR TITLE
lara/state/extra: combine Lara extra routines

### DIFF
--- a/src/libtrx/game/lara/state/extra.c
+++ b/src/libtrx/game/lara/state/extra.c
@@ -1,0 +1,200 @@
+#include "game/camera.h"
+#include "game/game.h"
+#include "game/inventory.h"
+#include "game/lara.h"
+#include "game/lara/util.h"
+#include "game/music.h"
+#include "game/overlay.h"
+#include "game/rooms.h"
+#include "game/viewport.h"
+
+// clang-format off
+#define M_LF_SHARK_DEATH_END           56
+#define M_LF_SHARK_DEATH_TIMER_DELAY   25
+#define M_LF_TREX_DEATH_TIMER_DELAY    45
+#define M_LF_YETI_DEATH_TIMER_DELAY    70
+#define M_LF_DRAGON_DAGGER_PULLED      1
+#define M_LF_DRAGON_DAGGER_STORED      180
+#define M_LF_DRAGON_DAGGER_DISPLAY     210
+#define M_LF_DRAGON_DAGGER_ANIM_END    239
+#define M_LF_START_HOUSE_BEGIN         1
+#define M_LF_START_HOUSE_DAGGER_STORED 401
+#define M_LF_START_HOUSE_END           427
+#define M_LF_SHOWER_START              1
+#define M_LF_SHOWER_SHOTGUN_PICKUP     316
+#define M_LF_SHOWER_END                349
+#define M_CAM_YETI_KILL_ANGLE         (160 * DEG_1) // = 29120
+#define M_CAM_YETI_KILL_DISTANCE      (3 * WALL_L)  // = 3072
+#define M_CAM_SHARK_KILL_ANGLE        (160 * DEG_1) // = 29120
+#define M_CAM_SHARK_KILL_DISTANCE     (3 * WALL_L)  // = 3072
+#define M_CAM_AIRLOCK_ANGLE           (80 * DEG_1)  // = 14560
+#define M_CAM_AIRLOCK_ELEVATION       (-25 * DEG_1) // = -4550
+#define M_CAM_GONG_BONG_ANGLE         (-25 * DEG_1) // = -4550
+#define M_CAM_GONG_BONG_ELEVATION     (-20 * DEG_1) // = -3640
+#define M_CAM_GONG_BONG_DISTANCE      (3 * WALL_L)  // = 3072
+#define M_CAM_TREX_KILL_ANGLE         (170 * DEG_1) // = 30940
+#define M_CAM_TREX_KILL_ELEVATION     (-25 * DEG_1) // = -4550
+// clang-format on
+
+static void M_Breath(ITEM *item, COLL_INFO *coll);
+static void M_YetiKill(ITEM *item, COLL_INFO *coll);
+static void M_SharkKill(ITEM *item, COLL_INFO *coll);
+static void M_Airlock(ITEM *item, COLL_INFO *coll);
+static void M_GongBong(ITEM *item, COLL_INFO *coll);
+static void M_DinoKill(ITEM *item, COLL_INFO *coll);
+static void M_PullDagger(ITEM *item, COLL_INFO *coll);
+static void M_StartAnim(ITEM *item, COLL_INFO *coll);
+static void M_StartHouse(ITEM *item, COLL_INFO *coll);
+static void M_FinalAnim(ITEM *item, COLL_INFO *coll);
+
+static void M_Breath(ITEM *const item, COLL_INFO *const coll)
+{
+    Item_SwitchToAnim(item, LA_STAND_IDLE, 0);
+    item->goal_anim_state = LS_STOP;
+    item->current_anim_state = LS_STOP;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->extra_anim = false;
+    lara->gun_status = LGS_ARMLESS;
+    if (g_Camera.type != CAM_HEAVY) {
+        g_Camera.type = CAM_CHASE;
+    }
+#if TR_VERSION == 2
+    Viewport_AlterFOV(-1);
+#endif
+}
+
+static void M_YetiKill(ITEM *const item, COLL_INFO *const coll)
+{
+    g_Camera.target_angle = M_CAM_YETI_KILL_ANGLE;
+    g_Camera.target_distance = M_CAM_YETI_KILL_DISTANCE;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->hit_direction = -1;
+    if (Item_TestFrameRange(item, 0, M_LF_YETI_DEATH_TIMER_DELAY)) {
+        lara->death_timer = 1;
+    }
+}
+
+static void M_SharkKill(ITEM *const item, COLL_INFO *const coll)
+{
+    g_Camera.target_angle = M_CAM_SHARK_KILL_ANGLE;
+    g_Camera.target_distance = M_CAM_SHARK_KILL_DISTANCE;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->hit_direction = -1;
+
+    if (Item_TestFrameEqual(item, M_LF_SHARK_DEATH_END)) {
+        const int32_t water_height = Room_GetWaterHeight(
+            item->pos.x, item->pos.y, item->pos.z, item->room_num);
+        if (water_height != NO_HEIGHT && water_height < item->pos.y - 100) {
+            item->pos.y -= 5;
+        }
+    }
+
+    if (Item_TestFrameRange(item, 0, M_LF_SHARK_DEATH_TIMER_DELAY)) {
+        lara->death_timer = 1;
+    }
+}
+
+static void M_Airlock(ITEM *const item, COLL_INFO *const coll)
+{
+    g_Camera.target_angle = M_CAM_AIRLOCK_ANGLE;
+    g_Camera.target_elevation = M_CAM_AIRLOCK_ELEVATION;
+}
+
+static void M_GongBong(ITEM *const item, COLL_INFO *const coll)
+{
+    g_Camera.target_angle = M_CAM_GONG_BONG_ANGLE;
+    g_Camera.target_elevation = M_CAM_GONG_BONG_ELEVATION;
+    g_Camera.target_distance = M_CAM_GONG_BONG_DISTANCE;
+}
+
+static void M_DinoKill(ITEM *const item, COLL_INFO *const coll)
+{
+    g_Camera.flags = CF_FOLLOW_CENTRE;
+    g_Camera.target_angle = M_CAM_TREX_KILL_ANGLE;
+    g_Camera.target_elevation = M_CAM_TREX_KILL_ELEVATION;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->hit_direction = -1;
+    if (Item_TestFrameRange(item, 0, M_LF_TREX_DEATH_TIMER_DELAY)) {
+        lara->death_timer = 1;
+    }
+}
+
+static void M_PullDagger(ITEM *const item, COLL_INFO *const coll)
+{
+#if TR_VERSION == 2
+    if (Item_TestFrameEqual(item, M_LF_DRAGON_DAGGER_PULLED)) {
+        Music_Play(MX_DAGGER_PULL, MPM_ALWAYS);
+    } else if (Item_TestFrameEqual(item, M_LF_DRAGON_DAGGER_STORED)) {
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
+        Inv_AddItem(O_PUZZLE_ITEM_2);
+    } else if (Item_TestFrameEqual(item, M_LF_DRAGON_DAGGER_DISPLAY)) {
+        Overlay_AddDisplayPickup(O_PUZZLE_ITEM_2);
+    } else if (Item_TestFrameEqual(item, M_LF_DRAGON_DAGGER_ANIM_END)) {
+        item->rot.y += DEG_90;
+
+        const ITEM *const dragon_bones = Item_Find(O_DRAGON_BONES_2);
+        if (dragon_bones != nullptr) {
+            Room_TestTriggers(dragon_bones);
+        }
+    }
+#endif
+}
+
+static void M_StartAnim(ITEM *const item, COLL_INFO *const coll)
+{
+    Room_TestTriggers(item);
+}
+
+static void M_StartHouse(ITEM *const item, COLL_INFO *const coll)
+{
+#if TR_VERSION == 2
+    if (Item_TestFrameEqual(item, M_LF_START_HOUSE_BEGIN)) {
+        Music_Play(MX_REVEAL_2, MPM_ALWAYS);
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_EXTRA);
+        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
+    } else if (Item_TestFrameEqual(item, M_LF_START_HOUSE_DAGGER_STORED)) {
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
+        Lara_SwapSingleMesh(LM_HIPS, O_LARA);
+        Inv_AddItem(O_PUZZLE_ITEM_1);
+    } else if (Item_TestFrameEqual(item, M_LF_START_HOUSE_END)) {
+        g_Camera.type = CAM_CHASE;
+        Viewport_AlterFOV(-1);
+    }
+#endif
+}
+
+static void M_FinalAnim(ITEM *const item, COLL_INFO *const coll)
+{
+#if TR_VERSION == 2
+    item->hit_points = LARA_MAX_HITPOINTS;
+    Lara_SetControllable(false);
+
+    if (Item_TestFrameEqual(item, M_LF_SHOWER_START)) {
+        LARA_INFO *const lara = Lara_GetLaraInfo();
+        lara->back_gun_obj_id = O_LARA;
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
+        Lara_SwapSingleMesh(LM_HEAD, O_LARA);
+        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
+        Music_Play(MX_CUTSCENE_BATH, MPM_ALWAYS);
+    } else if (Item_TestFrameEqual(item, M_LF_SHOWER_SHOTGUN_PICKUP)) {
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_SHOTGUN);
+    } else if (Item_TestFrameEqual(item, M_LF_SHOWER_END)) {
+        Game_SetIsLevelComplete(true);
+    }
+#endif
+}
+
+#if TR_VERSION == 2
+// clang-format off
+REGISTER_LARA_EXTRA(LS_EXTRA_BREATH,      M_Breath)
+REGISTER_LARA_EXTRA(LS_EXTRA_YETI_KILL,   M_YetiKill)
+REGISTER_LARA_EXTRA(LS_EXTRA_SHARK_KILL,  M_SharkKill)
+REGISTER_LARA_EXTRA(LS_EXTRA_AIRLOCK,     M_Airlock)
+REGISTER_LARA_EXTRA(LS_EXTRA_GONG_BONG,   M_GongBong)
+REGISTER_LARA_EXTRA(LS_EXTRA_TREX_KILL,   M_DinoKill)
+REGISTER_LARA_EXTRA(LS_EXTRA_PULL_DAGGER, M_PullDagger)
+REGISTER_LARA_EXTRA(LS_EXTRA_START_ANIM,  M_StartAnim)
+REGISTER_LARA_EXTRA(LS_EXTRA_START_HOUSE, M_StartHouse)
+REGISTER_LARA_EXTRA(LS_EXTRA_FINAL_ANIM,  M_FinalAnim)
+// clang-format on
+#endif

--- a/src/libtrx/game/lara/state/extra.c
+++ b/src/libtrx/game/lara/state/extra.c
@@ -9,6 +9,7 @@
 #include "game/viewport.h"
 
 // clang-format off
+#define M_LF_PICKUP_GOLD_BAR           113
 #define M_LF_SHARK_DEATH_END           56
 #define M_LF_SHARK_DEATH_TIMER_DELAY   25
 #define M_LF_TREX_DEATH_TIMER_DELAY    45
@@ -36,6 +37,12 @@
 #define M_CAM_TREX_KILL_ELEVATION     (-25 * DEG_1) // = -4550
 // clang-format on
 
+#if TR_VERSION == 1
+extern void Twinkle_SparkleItem(ITEM *item, uint32_t mesh_mask);
+#endif
+
+static void M_UseMidas(ITEM *item, COLL_INFO *coll);
+static void M_DieMidas(ITEM *item, COLL_INFO *coll);
 static void M_Breath(ITEM *item, COLL_INFO *coll);
 static void M_YetiKill(ITEM *item, COLL_INFO *coll);
 static void M_SharkKill(ITEM *item, COLL_INFO *coll);
@@ -46,6 +53,109 @@ static void M_PullDagger(ITEM *item, COLL_INFO *coll);
 static void M_StartAnim(ITEM *item, COLL_INFO *coll);
 static void M_StartHouse(ITEM *item, COLL_INFO *coll);
 static void M_FinalAnim(ITEM *item, COLL_INFO *coll);
+
+static void M_UseMidas(ITEM *const item, COLL_INFO *const coll)
+{
+#if TR_VERSION == 1
+    coll->enable_hit = 0;
+    coll->enable_baddie_push = 0;
+    Twinkle_SparkleItem(item, (1 << LM_HAND_L) | (1 << LM_HAND_R));
+
+    if (Item_TestFrameEqual(item, M_LF_PICKUP_GOLD_BAR)) {
+        Overlay_AddDisplayPickup(O_PUZZLE_ITEM_1);
+        Inv_AddItem(O_PUZZLE_ITEM_1);
+        LARA_INFO *const lara = Lara_GetLaraInfo();
+        lara->interact_target.item_num = NO_OBJECT;
+    }
+#endif
+}
+
+static void M_DieMidas(ITEM *const item, COLL_INFO *const coll)
+{
+#if TR_VERSION == 1
+    item->gravity = false;
+    coll->enable_hit = 0;
+    coll->enable_baddie_push = 0;
+
+    Object_SetReflective(O_LARA_EXTRA, true);
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const int32_t frame_num = Item_GetRelativeFrame(item);
+    switch (frame_num) {
+    case 5:
+        lara->mesh_effects |= (1 << LM_FOOT_L);
+        lara->mesh_effects |= (1 << LM_FOOT_R);
+        Lara_SwapSingleMesh(LM_FOOT_L, O_LARA_EXTRA);
+        Lara_SwapSingleMesh(LM_FOOT_R, O_LARA_EXTRA);
+        break;
+
+    case 70:
+        lara->mesh_effects |= (1 << LM_CALF_L);
+        Lara_SwapSingleMesh(LM_CALF_L, O_LARA_EXTRA);
+        break;
+
+    case 90:
+        lara->mesh_effects |= (1 << LM_THIGH_L);
+        Lara_SwapSingleMesh(LM_THIGH_L, O_LARA_EXTRA);
+        break;
+
+    case 100:
+        lara->mesh_effects |= (1 << LM_CALF_R);
+        Lara_SwapSingleMesh(LM_CALF_R, O_LARA_EXTRA);
+        break;
+
+    case 120:
+        lara->mesh_effects |= (1 << LM_HIPS);
+        lara->mesh_effects |= (1 << LM_THIGH_R);
+        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
+        Lara_SwapSingleMesh(LM_THIGH_R, O_LARA_EXTRA);
+        break;
+
+    case 135:
+        lara->mesh_effects |= (1 << LM_TORSO);
+        Lara_SwapSingleMesh(LM_TORSO, O_LARA_EXTRA);
+        break;
+
+    case 150:
+        lara->mesh_effects |= (1 << LM_UARM_L);
+        Lara_SwapSingleMesh(LM_UARM_L, O_LARA_EXTRA);
+        break;
+
+    case 163:
+        lara->mesh_effects |= (1 << LM_LARM_L);
+        Lara_SwapSingleMesh(LM_LARM_L, O_LARA_EXTRA);
+        break;
+
+    case 174:
+        lara->mesh_effects |= (1 << LM_HAND_L);
+        Lara_SwapSingleMesh(LM_HAND_L, O_LARA_EXTRA);
+        break;
+
+    case 186:
+        lara->mesh_effects |= (1 << LM_UARM_R);
+        Lara_SwapSingleMesh(LM_UARM_R, O_LARA_EXTRA);
+        break;
+
+    case 195:
+        lara->mesh_effects |= (1 << LM_LARM_R);
+        Lara_SwapSingleMesh(LM_LARM_R, O_LARA_EXTRA);
+        break;
+
+    case 218:
+        lara->mesh_effects |= (1 << LM_HAND_R);
+        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_EXTRA);
+        break;
+
+    case 225:
+        Object_SetReflective(O_LARA_HAIR, true);
+        lara->mesh_effects |= (1 << LM_HEAD);
+        Lara_SwapSingleMesh(LM_HEAD, O_LARA_EXTRA);
+        break;
+    }
+
+    Twinkle_SparkleItem(item, lara->mesh_effects);
+#endif
+}
 
 static void M_Breath(ITEM *const item, COLL_INFO *const coll)
 {
@@ -184,8 +294,11 @@ static void M_FinalAnim(ITEM *const item, COLL_INFO *const coll)
 #endif
 }
 
-#if TR_VERSION == 2
 // clang-format off
+#if TR_VERSION == 1
+REGISTER_LARA_STATE(LS_USE_MIDAS,         M_UseMidas)
+REGISTER_LARA_STATE(LS_DIE_MIDAS,         M_DieMidas)
+#else
 REGISTER_LARA_EXTRA(LS_EXTRA_BREATH,      M_Breath)
 REGISTER_LARA_EXTRA(LS_EXTRA_YETI_KILL,   M_YetiKill)
 REGISTER_LARA_EXTRA(LS_EXTRA_SHARK_KILL,  M_SharkKill)
@@ -196,5 +309,5 @@ REGISTER_LARA_EXTRA(LS_EXTRA_PULL_DAGGER, M_PullDagger)
 REGISTER_LARA_EXTRA(LS_EXTRA_START_ANIM,  M_StartAnim)
 REGISTER_LARA_EXTRA(LS_EXTRA_START_HOUSE, M_StartHouse)
 REGISTER_LARA_EXTRA(LS_EXTRA_FINAL_ANIM,  M_FinalAnim)
-// clang-format on
 #endif
+// clang-format on

--- a/src/libtrx/include/libtrx/game/lara/const.h
+++ b/src/libtrx/include/libtrx/game/lara/const.h
@@ -108,17 +108,6 @@
 
 #if TR_VERSION == 2
     #define CAM_ZIPLINE_ANGLE (70 * DEG_1) // = 12740
-    #define CAM_YETI_KILL_ANGLE (160 * DEG_1) // = 29120
-    #define CAM_YETI_KILL_DISTANCE (3 * WALL_L) // = 3072
-    #define CAM_SHARK_KILL_ANGLE (160 * DEG_1) // = 29120
-    #define CAM_SHARK_KILL_DISTANCE (3 * WALL_L) // = 3072
-    #define CAM_AIRLOCK_ANGLE (80 * DEG_1) // = 14560
-    #define CAM_AIRLOCK_ELEVATION (-25 * DEG_1) // = -4550
-    #define CAM_GONG_BONG_ANGLE (-25 * DEG_1) // = -4550
-    #define CAM_GONG_BONG_ELEVATION (-20 * DEG_1) // = -3640
-    #define CAM_GONG_BONG_DISTANCE (3 * WALL_L) // = 3072
-    #define CAM_TREX_KILL_ANGLE (170 * DEG_1) // = 30940
-    #define CAM_TREX_KILL_ELEVATION (-25 * DEG_1) // = -4550
     #define CAM_CLIMB_LEFT_ANGLE (-30 * DEG_1) // = -5460
     #define CAM_CLIMB_LEFT_ELEVATION (-15 * DEG_1) // = -2730
     #define CAM_CLIMB_RIGHT_ANGLE (-CAM_CLIMB_LEFT_ANGLE) // = 5460

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -69,6 +69,7 @@ int16_t Object_FindReceptacle(GAME_OBJECT_ID obj_id);
 
 extern void Object_DrawUnclippedItem(const ITEM *item);
 extern void Object_DrawMesh(int32_t mesh_idx, int32_t clip, bool interpolated);
+extern void Object_SetReflective(GAME_OBJECT_ID obj_id, bool enabled);
 
 void Object_DrawInterpolatedObject(
     const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,

--- a/src/libtrx/include/libtrx/game/overlay.h
+++ b/src/libtrx/include/libtrx/game/overlay.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "./objects/types.h"
 #include "./ui/hud/overlay.h"
 
 void Overlay_Init(void);
@@ -10,6 +11,7 @@ void Overlay_Control(void);
 void Overlay_Draw(void);
 
 extern void Overlay_HideGameInfo(void);
+extern void Overlay_AddDisplayPickup(GAME_OBJECT_ID obj_id);
 
 void Overlay_ForceHealthBar(bool show);
 void Overlay_SetHealthBarTimer(int16_t health_bar_timer);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -183,6 +183,7 @@ sources = [
   'game/lara/hair.c',
   'game/lara/misc.c',
   'game/lara/state.c',
+  'game/lara/state/extra.c',
   'game/level/common.c',
   'game/level/faces.c',
   'game/level/settings.c',

--- a/src/tr1/game/lara/state.c
+++ b/src/tr1/game/lara/state.c
@@ -62,8 +62,6 @@ static void M_Special(ITEM *item, COLL_INFO *coll);
 static void M_SurfBack(ITEM *item, COLL_INFO *coll);
 static void M_SurfLeft(ITEM *item, COLL_INFO *coll);
 static void M_SurfRight(ITEM *item, COLL_INFO *coll);
-static void M_UseMidas(ITEM *item, COLL_INFO *coll);
-static void M_DieMidas(ITEM *item, COLL_INFO *coll);
 static void M_SwanDive(ITEM *item, COLL_INFO *coll);
 static void M_FastDive(ITEM *item, COLL_INFO *coll);
 static void M_WaterOut(ITEM *item, COLL_INFO *coll);
@@ -683,97 +681,6 @@ static void M_Special(ITEM *item, COLL_INFO *coll)
     g_Camera.target_elevation = CAM_SPECIAL_ELEVATION;
 }
 
-static void M_UseMidas(ITEM *item, COLL_INFO *coll)
-{
-    coll->enable_hit = 0;
-    coll->enable_baddie_push = 0;
-    Twinkle_SparkleItem(item, (1 << LM_HAND_L) | (1 << LM_HAND_R));
-}
-
-static void M_DieMidas(ITEM *item, COLL_INFO *coll)
-{
-    item->gravity = false;
-    coll->enable_hit = 0;
-    coll->enable_baddie_push = 0;
-
-    Object_SetReflective(O_LARA_EXTRA, true);
-
-    const int32_t frame_num = Item_GetRelativeFrame(item);
-    switch (frame_num) {
-    case 5:
-        g_Lara.mesh_effects |= (1 << LM_FOOT_L);
-        g_Lara.mesh_effects |= (1 << LM_FOOT_R);
-        Lara_SwapSingleMesh(LM_FOOT_L, O_LARA_EXTRA);
-        Lara_SwapSingleMesh(LM_FOOT_R, O_LARA_EXTRA);
-        break;
-
-    case 70:
-        g_Lara.mesh_effects |= (1 << LM_CALF_L);
-        Lara_SwapSingleMesh(LM_CALF_L, O_LARA_EXTRA);
-        break;
-
-    case 90:
-        g_Lara.mesh_effects |= (1 << LM_THIGH_L);
-        Lara_SwapSingleMesh(LM_THIGH_L, O_LARA_EXTRA);
-        break;
-
-    case 100:
-        g_Lara.mesh_effects |= (1 << LM_CALF_R);
-        Lara_SwapSingleMesh(LM_CALF_R, O_LARA_EXTRA);
-        break;
-
-    case 120:
-        g_Lara.mesh_effects |= (1 << LM_HIPS);
-        g_Lara.mesh_effects |= (1 << LM_THIGH_R);
-        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
-        Lara_SwapSingleMesh(LM_THIGH_R, O_LARA_EXTRA);
-        break;
-
-    case 135:
-        g_Lara.mesh_effects |= (1 << LM_TORSO);
-        Lara_SwapSingleMesh(LM_TORSO, O_LARA_EXTRA);
-        break;
-
-    case 150:
-        g_Lara.mesh_effects |= (1 << LM_UARM_L);
-        Lara_SwapSingleMesh(LM_UARM_L, O_LARA_EXTRA);
-        break;
-
-    case 163:
-        g_Lara.mesh_effects |= (1 << LM_LARM_L);
-        Lara_SwapSingleMesh(LM_LARM_L, O_LARA_EXTRA);
-        break;
-
-    case 174:
-        g_Lara.mesh_effects |= (1 << LM_HAND_L);
-        Lara_SwapSingleMesh(LM_HAND_L, O_LARA_EXTRA);
-        break;
-
-    case 186:
-        g_Lara.mesh_effects |= (1 << LM_UARM_R);
-        Lara_SwapSingleMesh(LM_UARM_R, O_LARA_EXTRA);
-        break;
-
-    case 195:
-        g_Lara.mesh_effects |= (1 << LM_LARM_R);
-        Lara_SwapSingleMesh(LM_LARM_R, O_LARA_EXTRA);
-        break;
-
-    case 218:
-        g_Lara.mesh_effects |= (1 << LM_HAND_R);
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_EXTRA);
-        break;
-
-    case 225:
-        Object_SetReflective(O_LARA_HAIR, true);
-        g_Lara.mesh_effects |= (1 << LM_HEAD);
-        Lara_SwapSingleMesh(LM_HEAD, O_LARA_EXTRA);
-        break;
-    }
-
-    Twinkle_SparkleItem(item, g_Lara.mesh_effects);
-}
-
 static void M_SwanDive(ITEM *item, COLL_INFO *coll)
 {
     coll->enable_hit = 0;
@@ -1272,8 +1179,6 @@ REGISTER_LARA_STATE(LS_SPECIAL,       M_Special)
 REGISTER_LARA_STATE(LS_SURF_BACK,     M_SurfBack)
 REGISTER_LARA_STATE(LS_SURF_LEFT,     M_SurfLeft)
 REGISTER_LARA_STATE(LS_SURF_RIGHT,    M_SurfRight)
-REGISTER_LARA_STATE(LS_USE_MIDAS,     M_UseMidas)
-REGISTER_LARA_STATE(LS_DIE_MIDAS,     M_DieMidas)
 REGISTER_LARA_STATE(LS_SWAN_DIVE,     M_SwanDive)
 REGISTER_LARA_STATE(LS_FAST_DIVE,     M_FastDive)
 REGISTER_LARA_STATE(LS_GYMNAST,       M_Null)

--- a/src/tr1/game/objects/common.h
+++ b/src/tr1/game/objects/common.h
@@ -13,4 +13,3 @@ void Object_DrawPickupItem(const ITEM *item);
 void Object_DrawAnimatingItem(const ITEM *item);
 void Object_SetMeshReflective(
     GAME_OBJECT_ID obj_id, int32_t mesh_idx, bool enabled);
-void Object_SetReflective(GAME_OBJECT_ID obj_id, bool enabled);

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -102,7 +102,7 @@ static void M_SpawnPickupAid(const ITEM *const item)
 
 static void M_GetItem(int16_t item_num, ITEM *item, ITEM *lara_item)
 {
-    Overlay_AddPickup(item->object_id);
+    Overlay_AddDisplayPickup(item->object_id);
     Inv_AddItem(item->object_id);
 
     item->status = IS_INVISIBLE;

--- a/src/tr1/game/objects/general/scion1.c
+++ b/src/tr1/game/objects/general/scion1.c
@@ -77,7 +77,7 @@ static void M_Collision(
 
     if (lara_item->current_anim_state == LS_PICKUP) {
         if (Item_TestFrameEqual(lara_item, LF_PICKUPSCION)) {
-            Overlay_AddPickup(item->object_id);
+            Overlay_AddDisplayPickup(item->object_id);
             Inv_AddItem(item->object_id);
             item->status = IS_INVISIBLE;
             Item_RemoveDrawn(item_num);

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -76,7 +76,7 @@ static void M_Collision(
     if (lara_item->current_anim_state == LS_USE_MIDAS
         && g_Lara.interact_target.item_num == item_num
         && Item_TestFrameEqual(lara_item, LF_PICKUP_GOLD_BAR)) {
-        Overlay_AddPickup(O_PUZZLE_ITEM_1);
+        Overlay_AddDisplayPickup(O_PUZZLE_ITEM_1);
         Inv_AddItem(O_PUZZLE_ITEM_1);
         g_Lara.interact_target.item_num = NO_OBJECT;
     }

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -9,11 +9,13 @@
 
 #include <libtrx/game/camera.h>
 
-#define EXTRA_ANIM_PLACE_BAR 0
-#define EXTRA_ANIM_DIE_GOLD 1
-#define LF_PICKUP_GOLD_BAR 113
-#define MIDAS_RANGE_H (STEP_L * 2)
-#define MIDAS_RANGE_V (STEP_L * 3)
+#define M_RANGE_H (STEP_L * 2)
+#define M_RANGE_V (STEP_L * 3)
+
+typedef enum {
+    M_ANIM_USE = 0,
+    M_ANIM_DIE = 1,
+} M_EXTRA_ANIM;
 
 static const OBJECT_BOUNDS m_MidasTouch_Bounds = {
     .shift = {
@@ -55,7 +57,7 @@ static void M_Collision(
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
 
-    DIRECTION quadrant = (uint16_t)(lara_item->rot.y + DEG_45) / DEG_90;
+    const DIRECTION quadrant = (uint16_t)(lara_item->rot.y + DEG_45) / DEG_90;
     switch (quadrant) {
     case DIR_NORTH:
         item->rot.y = 0;
@@ -73,24 +75,16 @@ static void M_Collision(
         break;
     }
 
-    if (lara_item->current_anim_state == LS_USE_MIDAS
-        && g_Lara.interact_target.item_num == item_num
-        && Item_TestFrameEqual(lara_item, LF_PICKUP_GOLD_BAR)) {
-        Overlay_AddDisplayPickup(O_PUZZLE_ITEM_1);
-        Inv_AddItem(O_PUZZLE_ITEM_1);
-        g_Lara.interact_target.item_num = NO_OBJECT;
-    }
-
     if (!lara_item->gravity && lara_item->current_anim_state == LS_STOP
-        && lara_item->pos.x > item->pos.x - MIDAS_RANGE_H
-        && lara_item->pos.x < item->pos.x + MIDAS_RANGE_H
-        && lara_item->pos.y > item->pos.y - MIDAS_RANGE_V
-        && lara_item->pos.y < item->pos.y + MIDAS_RANGE_V
-        && lara_item->pos.z > item->pos.z - MIDAS_RANGE_H
-        && lara_item->pos.z < item->pos.z + MIDAS_RANGE_H) {
+        && lara_item->pos.x > item->pos.x - M_RANGE_H
+        && lara_item->pos.x < item->pos.x + M_RANGE_H
+        && lara_item->pos.y > item->pos.y - M_RANGE_V
+        && lara_item->pos.y < item->pos.y + M_RANGE_V
+        && lara_item->pos.z > item->pos.z - M_RANGE_H
+        && lara_item->pos.z < item->pos.z + M_RANGE_H) {
         lara_item->current_anim_state = LS_DIE_MIDAS;
         lara_item->goal_anim_state = LS_DIE_MIDAS;
-        Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_DIE_GOLD, 0, O_LARA_EXTRA);
+        Item_SwitchToObjAnim(lara_item, M_ANIM_DIE, 0, O_LARA_EXTRA);
         lara_item->hit_points = -1;
         lara_item->gravity = 0;
         g_Lara.extra_anim = true;
@@ -105,7 +99,7 @@ static void M_Collision(
         && g_Lara.interact_target.item_num == item_num) {
         lara_item->current_anim_state = LS_USE_MIDAS;
         lara_item->goal_anim_state = LS_USE_MIDAS;
-        Item_SwitchToObjAnim(lara_item, EXTRA_ANIM_PLACE_BAR, 0, O_LARA_EXTRA);
+        Item_SwitchToObjAnim(lara_item, M_ANIM_USE, 0, O_LARA_EXTRA);
         g_Lara.extra_anim = true;
         g_Lara.gun_status = LGS_HANDS_BUSY;
         g_Lara.interact_target.is_moving = false;

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -421,7 +421,7 @@ void Overlay_DrawGameInfo(void)
     }
 }
 
-void Overlay_AddPickup(const GAME_OBJECT_ID obj_id)
+void Overlay_AddDisplayPickup(const GAME_OBJECT_ID obj_id)
 {
     int32_t grid_x = -1;
     int32_t grid_y = -1;

--- a/src/tr1/game/overlay.h
+++ b/src/tr1/game/overlay.h
@@ -27,5 +27,3 @@ typedef struct {
 void Overlay_BarDraw(BAR_INFO *bar_info, RENDER_SCALE_REF scale_func);
 
 void Overlay_DrawGameInfo(void);
-
-void Overlay_AddPickup(GAME_OBJECT_ID obj_id);

--- a/src/tr2/game/lara/state.c
+++ b/src/tr2/game/lara/state.c
@@ -20,20 +20,6 @@
 #define LF_JUMP_READY 4
 #define LF_FLARE_PICKUP_END 89
 #define LF_UW_FLARE_PICKUP_END 35
-#define LF_SHARK_DEATH_END 56
-#define LF_SHARK_DEATH_TIMER_DELAY 25
-#define LF_TREX_DEATH_TIMER_DELAY 45
-#define LF_YETI_DEATH_TIMER_DELAY 70
-#define LF_DRAGON_DAGGER_PULLED 1
-#define LF_DRAGON_DAGGER_STORED 180
-#define LF_DRAGON_DAGGER_DISPLAY 210
-#define LF_DRAGON_DAGGER_ANIM_END 239
-#define LF_START_HOUSE_BEGIN 1
-#define LF_START_HOUSE_DAGGER_STORED 401
-#define LF_START_HOUSE_END 427
-#define LF_SHOWER_START 1
-#define LF_SHOWER_SHOTGUN_PICKUP 316
-#define LF_SHOWER_END 349
 
 static bool m_JumpPermitted = true;
 
@@ -78,16 +64,6 @@ static void M_FastDive(ITEM *item, COLL_INFO *coll);
 static void M_WaterOut(ITEM *item, COLL_INFO *coll);
 static void M_Wade(ITEM *item, COLL_INFO *coll);
 static void M_Zipline(ITEM *item, COLL_INFO *coll);
-static void M_Extra_Breath(ITEM *item, COLL_INFO *coll);
-static void M_Extra_YetiKill(ITEM *item, COLL_INFO *coll);
-static void M_Extra_SharkKill(ITEM *item, COLL_INFO *coll);
-static void M_Extra_Airlock(ITEM *item, COLL_INFO *coll);
-static void M_Extra_GongBong(ITEM *item, COLL_INFO *coll);
-static void M_Extra_DinoKill(ITEM *item, COLL_INFO *coll);
-static void M_Extra_PullDagger(ITEM *item, COLL_INFO *coll);
-static void M_Extra_StartAnim(ITEM *item, COLL_INFO *coll);
-static void M_Extra_StartHouse(ITEM *item, COLL_INFO *coll);
-static void M_Extra_FinalAnim(ITEM *item, COLL_INFO *coll);
 static void M_ClimbLeft(ITEM *item, COLL_INFO *coll);
 static void M_ClimbRight(ITEM *item, COLL_INFO *coll);
 static void M_ClimbStance(ITEM *item, COLL_INFO *coll);
@@ -783,130 +759,6 @@ static void M_Zipline(ITEM *item, COLL_INFO *coll)
     }
 }
 
-static void M_Extra_Breath(ITEM *item, COLL_INFO *coll)
-{
-    Item_SwitchToAnim(item, LA_STAND_IDLE, 0);
-    item->goal_anim_state = LS_STOP;
-    item->current_anim_state = LS_STOP;
-    g_Lara.extra_anim = false;
-    g_Lara.gun_status = LGS_ARMLESS;
-    if (g_Camera.type != CAM_HEAVY) {
-        g_Camera.type = CAM_CHASE;
-    }
-    Viewport_AlterFOV(-1);
-}
-
-static void M_Extra_YetiKill(ITEM *item, COLL_INFO *coll)
-{
-    g_Camera.target_angle = CAM_YETI_KILL_ANGLE;
-    g_Camera.target_distance = CAM_YETI_KILL_DISTANCE;
-    g_Lara.hit_direction = -1;
-    if (Item_TestFrameRange(item, 0, LF_YETI_DEATH_TIMER_DELAY)) {
-        g_Lara.death_timer = 1;
-    }
-}
-
-static void M_Extra_SharkKill(ITEM *item, COLL_INFO *coll)
-{
-    g_Camera.target_angle = CAM_SHARK_KILL_ANGLE;
-    g_Camera.target_distance = CAM_SHARK_KILL_DISTANCE;
-    g_Lara.hit_direction = -1;
-
-    if (Item_TestFrameEqual(item, LF_SHARK_DEATH_END)) {
-        const int32_t water_height = Room_GetWaterHeight(
-            item->pos.x, item->pos.y, item->pos.z, item->room_num);
-        if (water_height != NO_HEIGHT && water_height < item->pos.y - 100) {
-            item->pos.y -= 5;
-        }
-    }
-
-    if (Item_TestFrameRange(item, 0, LF_SHARK_DEATH_TIMER_DELAY)) {
-        g_Lara.death_timer = 1;
-    }
-}
-
-static void M_Extra_Airlock(ITEM *item, COLL_INFO *coll)
-{
-    g_Camera.target_angle = CAM_AIRLOCK_ANGLE;
-    g_Camera.target_elevation = CAM_AIRLOCK_ELEVATION;
-}
-
-static void M_Extra_GongBong(ITEM *item, COLL_INFO *coll)
-{
-    g_Camera.target_angle = CAM_GONG_BONG_ANGLE;
-    g_Camera.target_elevation = CAM_GONG_BONG_ELEVATION;
-    g_Camera.target_distance = CAM_GONG_BONG_DISTANCE;
-}
-
-static void M_Extra_DinoKill(ITEM *item, COLL_INFO *coll)
-{
-    g_Camera.flags = CF_FOLLOW_CENTRE;
-    g_Camera.target_angle = CAM_TREX_KILL_ANGLE;
-    g_Camera.target_elevation = CAM_TREX_KILL_ELEVATION;
-    g_Lara.hit_direction = -1;
-    if (Item_TestFrameRange(item, 0, LF_TREX_DEATH_TIMER_DELAY)) {
-        g_Lara.death_timer = 1;
-    }
-}
-
-static void M_Extra_PullDagger(ITEM *item, COLL_INFO *coll)
-{
-    if (Item_TestFrameEqual(item, LF_DRAGON_DAGGER_PULLED)) {
-        Music_Play(MX_DAGGER_PULL, MPM_ALWAYS);
-    } else if (Item_TestFrameEqual(item, LF_DRAGON_DAGGER_STORED)) {
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
-        Inv_AddItem(O_PUZZLE_ITEM_2);
-    } else if (Item_TestFrameEqual(item, LF_DRAGON_DAGGER_DISPLAY)) {
-        Overlay_AddDisplayPickup(O_PUZZLE_ITEM_2);
-    } else if (Item_TestFrameEqual(item, LF_DRAGON_DAGGER_ANIM_END)) {
-        item->rot.y += DEG_90;
-
-        const ITEM *const dragon_bones = Item_Find(O_DRAGON_BONES_2);
-        if (dragon_bones != nullptr) {
-            Room_TestTriggers(dragon_bones);
-        }
-    }
-}
-
-static void M_Extra_StartAnim(ITEM *item, COLL_INFO *coll)
-{
-    Room_TestTriggers(item);
-}
-
-static void M_Extra_StartHouse(ITEM *item, COLL_INFO *coll)
-{
-    if (Item_TestFrameEqual(item, LF_START_HOUSE_BEGIN)) {
-        Music_Play(MX_REVEAL_2, MPM_ALWAYS);
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_EXTRA);
-        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
-    } else if (Item_TestFrameEqual(item, LF_START_HOUSE_DAGGER_STORED)) {
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
-        Lara_SwapSingleMesh(LM_HIPS, O_LARA);
-        Inv_AddItem(O_PUZZLE_ITEM_1);
-    } else if (Item_TestFrameEqual(item, LF_START_HOUSE_END)) {
-        g_Camera.type = CAM_CHASE;
-        Viewport_AlterFOV(-1);
-    }
-}
-
-static void M_Extra_FinalAnim(ITEM *item, COLL_INFO *coll)
-{
-    item->hit_points = LARA_MAX_HITPOINTS;
-    Lara_SetControllable(false);
-
-    if (Item_TestFrameEqual(item, LF_SHOWER_START)) {
-        g_Lara.back_gun_obj_id = O_LARA;
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA);
-        Lara_SwapSingleMesh(LM_HEAD, O_LARA);
-        Lara_SwapSingleMesh(LM_HIPS, O_LARA_EXTRA);
-        Music_Play(MX_CUTSCENE_BATH, MPM_ALWAYS);
-    } else if (Item_TestFrameEqual(item, LF_SHOWER_SHOTGUN_PICKUP)) {
-        Lara_SwapSingleMesh(LM_HAND_R, O_LARA_SHOTGUN);
-    } else if (Item_TestFrameEqual(item, LF_SHOWER_END)) {
-        Game_SetIsLevelComplete(true);
-    }
-}
-
 static void M_ClimbLeft(ITEM *item, COLL_INFO *coll)
 {
     coll->enable_hit = 0;
@@ -1273,15 +1125,4 @@ REGISTER_LARA_STATE(LS_WADE,         M_Wade)
 REGISTER_LARA_STATE(LS_WATER_ROLL,   M_UWTwist)
 REGISTER_LARA_STATE(LS_FLARE_PICKUP, M_PickupFlare)
 REGISTER_LARA_STATE(LS_ZIPLINE,      M_Zipline)
-
-REGISTER_LARA_EXTRA(LS_EXTRA_BREATH,      M_Extra_Breath)
-REGISTER_LARA_EXTRA(LS_EXTRA_YETI_KILL,   M_Extra_YetiKill)
-REGISTER_LARA_EXTRA(LS_EXTRA_SHARK_KILL,  M_Extra_SharkKill)
-REGISTER_LARA_EXTRA(LS_EXTRA_AIRLOCK,     M_Extra_Airlock)
-REGISTER_LARA_EXTRA(LS_EXTRA_GONG_BONG,   M_Extra_GongBong)
-REGISTER_LARA_EXTRA(LS_EXTRA_TREX_KILL,   M_Extra_DinoKill)
-REGISTER_LARA_EXTRA(LS_EXTRA_PULL_DAGGER, M_Extra_PullDagger)
-REGISTER_LARA_EXTRA(LS_EXTRA_START_ANIM,  M_Extra_StartAnim)
-REGISTER_LARA_EXTRA(LS_EXTRA_START_HOUSE, M_Extra_StartHouse)
-REGISTER_LARA_EXTRA(LS_EXTRA_FINAL_ANIM,  M_Extra_FinalAnim)
 // clang-format on

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -4,6 +4,7 @@
 #include "game/viewport.h"
 #include "global/vars.h"
 
+#include <libtrx/debug.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara.h>
 #include <libtrx/game/matrix.h>
@@ -206,4 +207,9 @@ void Object_DrawMesh(
     } else {
         Output_DrawObjectMesh(mesh, clip);
     }
+}
+
+void Object_SetReflective(const GAME_OBJECT_ID obj_id, const bool enabled)
+{
+    ASSERT_FAIL();
 }

--- a/src/tr2/game/overlay.h
+++ b/src/tr2/game/overlay.h
@@ -4,9 +4,6 @@
 
 #include <libtrx/game/overlay.h>
 
-void Overlay_HideGameInfo(void);
 void Overlay_DrawGameInfo(void);
-
-void Overlay_AddDisplayPickup(GAME_OBJECT_ID obj_id);
 
 void Overlay_Animate(int32_t frames);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is not so much a merger as none of these functions are shared, but it gets them all into the same module for some clarity. TR1's two Midas routines are the only extras that have special behaviour. I've adjusted this too so that the gold bar pickup display is triggered from the state routine rather than object collision, similar to how it's done in TR2 for the dagger.
