### PR TITLE
tr2/objects: avoid testing windows as creatures

### DIFF
--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -82,13 +82,14 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (target_item->object_id != O_WINDOW_1
+        const bool is_window = target_item->object_id == O_WINDOW_1;
+        if (!is_window
             && (!target_obj->intelligent || target_item->status == IS_INVISIBLE
                 || target_obj->collision_func == nullptr)) {
             continue;
         }
 
-        if (!Creature_IsTargetable(target_item)) {
+        if (!is_window && !Creature_IsTargetable(target_item)) {
             continue;
         }
 
@@ -121,7 +122,7 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (target_item->object_id == O_WINDOW_1) {
+        if (is_window) {
             Window_Smash(target_item_num);
         } else {
             explode = true;

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -51,13 +51,14 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (target_item->object_id != O_WINDOW_1
+        const bool is_window = target_item->object_id == O_WINDOW_1;
+        if (is_window
             && (target_item->status == IS_INVISIBLE
                 || target_obj->collision_func == nullptr)) {
             continue;
         }
 
-        if (!Creature_IsTargetable(target_item)) {
+        if (!is_window && !Creature_IsTargetable(target_item)) {
             continue;
         }
 
@@ -93,7 +94,7 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (target_item->object_id == O_WINDOW_1) {
+        if (is_window) {
             Window_Smash(target_num);
         } else {
             if (target_obj->intelligent && target_item->status == IS_ACTIVE) {


### PR DESCRIPTION
Resolves #3375.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures windows aren't tested as targetable creatures for flying harpoons and grenades.

@aredfan you mentioned about this being OG if Lara is facing the opposite way, but also I don't think these projectiles work on bells, do they? Is that also OG? Would be good to sort that out eventually too.
