### PR TITLE
tr2/option_passport: prevent deselection in death mode

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed the Bartoli's Hideout sunset effect being reset after reloading a save (#1617)
 - fixed the shotgun sound at the end of the shower cutscene in Home Sweet Home being cut off when the credits start (#1579)
 - fixed the camera being partially inside the wall at the end of the Home Sweet Home shower cutscene (#3370)
+- fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
 - improved the `/tp` command to orient Lara towards keyholes and doors
 
 ## [1.2.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.2.1...tr2-1.2.2) - 2025-06-24

--- a/src/tr2/game/option/option_passport.c
+++ b/src/tr2/game/option/option_passport.c
@@ -256,7 +256,8 @@ static void M_ShowSaves(INVENTORY_ITEM *const inv_item)
         break;
 
     case UI_SAVE_SLOT_DIALOG_CANCEL:
-        if (g_Inv_Mode != INV_SAVE_MODE && g_Inv_Mode != INV_LOAD_MODE) {
+        if (g_Inv_Mode != INV_SAVE_MODE && g_Inv_Mode != INV_LOAD_MODE
+            && g_Inv_Mode != INV_DEATH_MODE) {
             M_Close(inv_item);
         }
         break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3381.
