### PR TITLE
output: remove dynamic light limit

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -21,8 +21,6 @@
 - changed the dev console to accept compound characters (#2938)
 - changed the item duplication glitch fix to be on by default
 - changed the Bartoli's Hideout sunset effect to also apply to skybox lighting (#1617)
-- removed config tool (we have ingame setting dialogs now)
-- removed default bindings for the "sizer" and the "scaler" options (#2853)
 - fixed inventory screen carpet background texture stretched on non-4:3 aspect ratios (#2022)
 - fixed picked up guns not appearing in holsters / on Lara's back (#1588)
 - fixed room 134 in Opera House having wrong textures (#3142)
@@ -41,6 +39,9 @@
 - fixed the camera being partially inside the wall at the end of the Home Sweet Home shower cutscene (#3370)
 - fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
 - improved the `/tp` command to orient Lara towards keyholes and doors
+- removed config tool (we have ingame setting dialogs now)
+- removed default bindings for the "sizer" and the "scaler" options (#2853)
+- removed the limit of 10 dynamic lights per frame (#3384)
 
 ## [1.2.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.2.1...tr2-1.2.2) - 2025-06-24
 - fixed underwater hum not playing properly (#3305, regression from 0.10)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -360,6 +360,7 @@ fixed flare count getting corrupt on save/load if Lara had more than 255 flares
 - improved FMV mode behavior - stopped switching screen resolutions
 - improved vertex movement when looking through water portals
 - improved support for non-4:3 aspect ratios
+- removed the limit of 10 dynamic lights per frame
 
 #### Audio
 - added an option to control how music is played while underwater rather than simply muting it

--- a/src/libtrx/game/output/common.c
+++ b/src/libtrx/game/output/common.c
@@ -2,8 +2,7 @@
 #include "game/matrix.h"
 #include "game/output.h"
 #include "utils.h"
-
-#define MAX_DYNAMIC_LIGHTS 10
+#include "vector.h"
 
 typedef struct {
     XYZ_32 pos;
@@ -11,8 +10,7 @@ typedef struct {
 } COMMON_LIGHT;
 
 static int32_t m_FogStart = 0;
-static int32_t m_DynamicLightCount = 0;
-static LIGHT m_DynamicLights[MAX_DYNAMIC_LIGHTS] = {};
+static VECTOR *m_DynamicLights = nullptr;
 
 static void M_CalculateBrightestLight(
     XYZ_32 pos, const ROOM *room, COMMON_LIGHT *brightest_light);
@@ -73,8 +71,8 @@ static int32_t M_CalculateDynamicLight(
     const XYZ_32 pos, COMMON_LIGHT *const brightest_light)
 {
     int32_t adder = 0;
-    for (int32_t i = 0; i < m_DynamicLightCount; i++) {
-        const LIGHT *const light = &m_DynamicLights[i];
+    for (int32_t i = 0; i < m_DynamicLights->count; i++) {
+        const LIGHT *const light = Vector_Get(m_DynamicLights, i);
         const int32_t dx = pos.x - light->pos.x;
         const int32_t dy = pos.y - light->pos.y;
         const int32_t dz = pos.z - light->pos.z;
@@ -167,8 +165,8 @@ void Output_CalculateStaticMeshLight(
             (shade.value_2 - shade.value_1) * room_shade / (WIBBLE_SIZE - 1);
     }
 
-    for (int32_t i = 0; i < m_DynamicLightCount; i++) {
-        const LIGHT *const light = &m_DynamicLights[i];
+    for (int32_t i = 0; i < m_DynamicLights->count; i++) {
+        const LIGHT *const light = Vector_Get(m_DynamicLights, i);
         const int32_t dx = pos.x - light->pos.x;
         const int32_t dy = pos.y - light->pos.y;
         const int32_t dz = pos.z - light->pos.z;
@@ -239,8 +237,8 @@ void Output_LightRoom(ROOM *const room)
     const int32_t x_max = (room->size.x - 1) * WALL_L;
     const int32_t z_max = (room->size.z - 1) * WALL_L;
 
-    for (int32_t i = 0; i < m_DynamicLightCount; i++) {
-        const LIGHT *const light = &m_DynamicLights[i];
+    for (int32_t i = 0; i < m_DynamicLights->count; i++) {
+        const LIGHT *const light = Vector_Get(m_DynamicLights, i);
         const int32_t x = light->pos.x - room->pos.x;
         const int32_t y = light->pos.y;
         const int32_t z = light->pos.z - room->pos.z;
@@ -279,21 +277,36 @@ void Output_LightRoom(ROOM *const room)
     }
 }
 
+void Output_InitLight(void)
+{
+    // TODO: consolidate into Output_Init once common.
+    if (m_DynamicLights == nullptr) {
+        m_DynamicLights = Vector_Create(sizeof(LIGHT));
+    }
+}
+
+void Output_ShutdownLight(void)
+{
+    if (m_DynamicLights != nullptr) {
+        Vector_Free(m_DynamicLights);
+        m_DynamicLights = nullptr;
+    }
+}
+
 void Output_ResetDynamicLights(void)
 {
-    m_DynamicLightCount = 0;
+    Vector_Clear(m_DynamicLights);
 }
 
 void Output_AddDynamicLight(
     const XYZ_32 pos, const int32_t intensity, const int32_t falloff)
 {
-    const int32_t idx =
-        m_DynamicLightCount < MAX_DYNAMIC_LIGHTS ? m_DynamicLightCount++ : 0;
-
-    LIGHT *const light = &m_DynamicLights[idx];
-    light->pos = pos;
-    light->shade.value_1 = intensity;
-    light->falloff.value_1 = falloff;
+    const LIGHT light = {
+        .pos = pos,
+        .shade.value_1 = intensity,
+        .falloff.value_1 = falloff,
+    };
+    Vector_Add(m_DynamicLights, &light);
 }
 
 int32_t Output_GetFogStart(void)

--- a/src/libtrx/include/libtrx/game/output/common.h
+++ b/src/libtrx/include/libtrx/game/output/common.h
@@ -2,6 +2,9 @@
 
 #include "../rooms.h"
 
+extern bool Output_Init(void);
+extern void Output_Shutdown(void);
+
 extern void Output_ObserveLevelLoad(void);
 extern void Output_ObserveLevelUnload(void);
 extern void Output_ObserveRoomFlip(const ROOM *room);
@@ -27,6 +30,8 @@ extern int32_t Output_CalcFogShade(int32_t depth);
 extern int32_t Output_GetRoomLightShade(ROOM_LIGHT_MODE mode);
 extern void Output_LightRoomVertices(const ROOM *room);
 
+void Output_InitLight(void);
+void Output_ShutdownLight(void);
 void Output_CalculateLight(XYZ_32 pos, int16_t room_num);
 void Output_CalculateStaticLight(int16_t adder);
 void Output_CalculateStaticMeshLight(XYZ_32 pos, SHADE shade, const ROOM *room);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -410,6 +410,7 @@ bool Output_Init(void)
     Output_Textures_Init();
     Output_Meshes_Init();
     Output_Sprites_Init();
+    Output_InitLight();
     return true;
 }
 
@@ -423,6 +424,7 @@ void Output_Shutdown(void)
     Output_Meshes_Shutdown();
     Output_Sprites_Shutdown();
     Output_Textures_Shutdown();
+    Output_ShutdownLight();
 
     M_ReleaseTextures();
     M_ReleaseSurfaces();

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -8,9 +8,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-bool Output_Init(void);
-void Output_Shutdown(void);
-
 void Output_SetWindowSize(int32_t width, int32_t height);
 void Output_ApplyLevelSettings(void);
 void Output_ApplyRenderSettings(void);

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -25,6 +25,8 @@
 #define M_MAX_ROOM_LIGHT_UNIT (0x2000 / (WIBBLE_SIZE / 2))
 #define M_SUNSET_TIMEOUT (40 * 60 * (LOGIC_FPS)) // = 72000
 
+static bool m_Initialized = false;
+
 static int32_t m_VBufCapacity = 0;
 static int32_t m_TickComp = 0;
 static int32_t m_LsAdder = 0;
@@ -50,6 +52,7 @@ static int32_t m_SunsetTimer = 0;
 
 static int32_t m_DepthBias = 0;
 
+static void M_CalculateWibbleTable(void);
 static void M_CalcRoomVertices(const ROOM_MESH *mesh, int32_t far_clip);
 static void M_CalcRoomVerticesWibble(const ROOM_MESH *mesh);
 static void M_DrawRoomSprites(const ROOM_MESH *mesh);
@@ -57,6 +60,20 @@ static void M_DrawRoomSprites(const ROOM_MESH *mesh);
 static bool M_CalcObjectVertices(const XYZ_16 *vertices, int16_t count);
 static void M_CalcVerticeLight(const OBJECT_MESH *mesh);
 static void M_CalcSkyboxLight(const OBJECT_MESH *mesh);
+
+static void M_CalculateWibbleTable(void)
+{
+    for (int32_t i = 0; i < WIBBLE_SIZE; i++) {
+        const int32_t sine = Math_Sin(i * DEG_360 / WIBBLE_SIZE);
+        m_WibbleTable[i] = (sine * M_MAX_WIBBLE) >> W2V_SHIFT;
+        m_ShadesTable[i] = (sine * SHADE_CAUSTICS) >> W2V_SHIFT;
+        m_RandomTable[i] = (Random_GetDraw() >> 5) - 0x01FF;
+        for (int32_t j = 0; j < WIBBLE_SIZE; j++) {
+            m_RoomLightTables[i].table[j] = (j - (WIBBLE_SIZE / 2)) * i
+                * M_MAX_ROOM_LIGHT_UNIT / (WIBBLE_SIZE - 1);
+        }
+    }
+}
 
 static void M_CalcRoomVertices(const ROOM_MESH *const mesh, int32_t far_clip)
 {
@@ -381,6 +398,28 @@ static void M_ReserveVertexBuffer(void)
         g_PhdVBuf = Memory_Realloc(g_PhdVBuf, max_vertices * sizeof(PHD_VBUF));
         m_VBufCapacity = max_vertices;
     }
+}
+
+bool Output_Init(void)
+{
+    if (m_Initialized) {
+        return true;
+    }
+    m_Initialized = true;
+
+    M_CalculateWibbleTable();
+    Output_InitLight();
+    return true;
+}
+
+void Output_Shutdown(void)
+{
+    if (!m_Initialized) {
+        return;
+    }
+    m_Initialized = false;
+
+    Output_ShutdownLight();
 }
 
 void Output_ApplyLevelSettings(void)
@@ -808,20 +847,6 @@ void Output_InsertShadow(
         Render_InsertTransOctagon(g_PhdVBuf, 24);
     }
     Matrix_Pop();
-}
-
-void Output_CalculateWibbleTable(void)
-{
-    for (int32_t i = 0; i < WIBBLE_SIZE; i++) {
-        const int32_t sine = Math_Sin(i * DEG_360 / WIBBLE_SIZE);
-        m_WibbleTable[i] = (sine * M_MAX_WIBBLE) >> W2V_SHIFT;
-        m_ShadesTable[i] = (sine * SHADE_CAUSTICS) >> W2V_SHIFT;
-        m_RandomTable[i] = (Random_GetDraw() >> 5) - 0x01FF;
-        for (int32_t j = 0; j < WIBBLE_SIZE; j++) {
-            m_RoomLightTables[i].table[j] = (j - (WIBBLE_SIZE / 2)) * i
-                * M_MAX_ROOM_LIGHT_UNIT / (WIBBLE_SIZE - 1);
-        }
-    }
 }
 
 int32_t Output_GetObjectBounds(const BOUNDS_16 *const bounds)

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -78,7 +78,6 @@ void Output_LoadBackgroundFromObject(void);
 void Output_InsertShadow(
     int16_t radius, const BOUNDS_16 *bounds, const ITEM *item);
 
-void Output_CalculateWibbleTable(void);
 void Output_SetupBelowWater(bool is_underwater);
 void Output_SetupAboveWater(bool is_underwater);
 void Output_AnimateTextures(int32_t ticks);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -499,7 +499,7 @@ int32_t Shell_Main(void)
     }
 
     Random_Seed();
-    Output_CalculateWibbleTable();
+    Output_Init();
 
     Shell_Start();
     Viewport_AlterFOV(-1);
@@ -625,6 +625,7 @@ void Shell_Shutdown(void)
     GF_Shutdown();
     Overlay_Shutdown();
     Option_Shutdown();
+    Output_Shutdown();
     Render_Shutdown();
     UI_Shutdown();
 


### PR DESCRIPTION
Resolves #3384.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces the fixed size dynamic light array with a vector, so removing the limit of 10 per frame. I've updated the TR1 test level for fire light, and added one for TR2, both with a silly number of flame objects for testing performance. It behaves OK on my end, but LMK if you think we should retain an upper limit.
