### PR TITLE
lara/cheat: set animation state post fly cheat

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -45,6 +45,7 @@
 - fixed the shotgun sound at the end of the shower cutscene in Home Sweet Home being cut off when the credits start (#1579)
 - fixed the camera being partially inside the wall at the end of the Home Sweet Home shower cutscene (#3370)
 - fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
+- fixed Lara getting stuck in the fly cheat in rare circumstances (#3392, regression from 0.3)
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - removed config tool (we have ingame setting dialogs now)
 - removed default bindings for the "sizer" and the "scaler" options (#2853)

--- a/src/libtrx/game/lara/cheat.c
+++ b/src/libtrx/game/lara/cheat.c
@@ -308,6 +308,8 @@ bool Lara_Cheat_ExitFlyMode(void)
     } else {
         lara_info->water_status = LWS_ABOVE_WATER;
         Item_SwitchToAnim(lara_item, LA_STAND_STILL, 0);
+        lara_item->goal_anim_state = LS_STOP;
+        lara_item->current_anim_state = LS_STOP;
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;
         lara_info->head_rot.x = 0;


### PR DESCRIPTION
Resolves #3392.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I'll admit I wasn't able to reproduce this, but logically this should be the fix. I think what was happening was there was a one frame window where Lara could continue in her twist state and with the roll key detected there, she would become stuck yet not have a cheat water status. TR2 doesn't have state changes for underwater roll, whereas TR1 does because we inject it; so the merging of the state routine introduced it to TR1.
