### PR TITLE
viewport: consolidate fov apis

### DIFF
--- a/src/libtrx/game/camera/cinematic.c
+++ b/src/libtrx/game/camera/cinematic.c
@@ -46,11 +46,7 @@ static void M_UpdateCutscene(const XYZ_32 base_pos, const int16_t angle)
     g_Camera.roll = frame->roll;
     g_Camera.shift = 0;
 
-#if TR_VERSION == 1
-    Viewport_SetFOV(frame->fov);
-#else
     Viewport_AlterFOV(frame->fov);
-#endif
 }
 
 void Camera_InitialiseCineFrames(const int32_t num_frames)

--- a/src/libtrx/game/camera/photo_mode.c
+++ b/src/libtrx/game/camera/photo_mode.c
@@ -38,7 +38,6 @@ static struct {
 } m_PreviousState;
 static BOUNDS_32 m_WorldBounds = {};
 
-static int32_t M_GetFOV(void);
 static void M_SetFOV(int32_t fov);
 
 static void M_ResetCamera(bool exiting);
@@ -58,23 +57,11 @@ static bool M_HandleFOVInputs();
 static void M_UpdatePhotoMode(void);
 
 // TODO: remove this wrapper when consolidating the viewport API
-static int32_t M_GetFOV(void)
-{
-#if TR_VERSION == 1
-    return Viewport_GetFOV();
-#elif TR_VERSION == 2
-    return Viewport_GetFOV(true);
-#endif
-}
-
-// TODO: remove this wrapper when consolidating the viewport API
 static void M_SetFOV(const int32_t fov)
 {
-#if TR_VERSION == 1
-    Viewport_SetFOV(fov);
-    Output_ApplyFOV();
-#elif TR_VERSION == 2
     Viewport_AlterFOV(fov);
+#if TR_VERSION == 1
+    Output_ApplyFOV();
 #endif
 }
 
@@ -316,7 +303,7 @@ void Camera_EnterPhotoMode(void)
 
     m_StartingCamera = g_Camera;
 
-    m_OriginalFOV = M_GetFOV();
+    m_OriginalFOV = Viewport_GetEffectiveFOV();
     m_CurrentFOV = m_OriginalFOV / DEG_1;
     g_Camera.type = CAM_PHOTO_MODE;
     const int32_t border = WALL_L * 5;
@@ -368,7 +355,7 @@ void Camera_PausePhotoMode(void)
 {
     m_PreviousState.camera = g_Camera;
     m_PreviousState.is_chunky = Camera_IsChunky();
-    m_PreviousState.fov = M_GetFOV();
+    m_PreviousState.fov = Viewport_GetSystemFOV();
     g_Camera = m_OriginalCamera;
 }
 

--- a/src/libtrx/game/lara/cheat.c
+++ b/src/libtrx/game/lara/cheat.c
@@ -235,15 +235,15 @@ bool Lara_Cheat_EnterFlyMode(void)
         return false;
     }
 
+    Viewport_AlterFOV(-1);
+
 #if TR_VERSION == 1
-    Viewport_SetFOV(-1);
     lara_info->request_gun_type = LGT_UNARMED;
     if (lara_item->hit_points <= 0) {
         lara_info->gun_status = LGS_ARMLESS;
         Lara_InitialiseMeshes(GF_GetCurrentLevel());
     }
 #else
-    Viewport_AlterFOV(-1);
     if (lara_info->extra_anim) {
         M_ResetGunStatus();
     }
@@ -400,11 +400,7 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
     lara_info->mesh_effects = 0;
 
     g_Camera.type = CAM_CHASE;
-#if TR_VERSION == 1
-    Viewport_SetFOV(-1);
-#else
     Viewport_AlterFOV(-1);
-#endif
     Camera_ResetPosition();
 
     return true;

--- a/src/libtrx/game/viewport.c
+++ b/src/libtrx/game/viewport.c
@@ -1,0 +1,7 @@
+#include "game/viewport.h"
+
+int16_t Viewport_GetEffectiveFOV(void)
+{
+    return Viewport_GetSystemFOV() != -1 ? Viewport_GetSystemFOV()
+                                         : Viewport_GetUserFOV();
+}

--- a/src/libtrx/include/libtrx/game/viewport.h
+++ b/src/libtrx/include/libtrx/game/viewport.h
@@ -2,16 +2,21 @@
 
 #include <stdint.h>
 
-// TODO: consolidate this API
-#if TR_VERSION == 1
-extern int16_t Viewport_GetFOV(void);
-extern void Viewport_SetFOV(int16_t view_angle);
-#elif TR_VERSION == 2
-extern int16_t Viewport_GetFOV(bool resolve_user_fov);
-extern void Viewport_AlterFOV(int16_t view_angle);
-#endif
-
 extern int32_t Viewport_GetWidth(void);
 extern int32_t Viewport_GetHeight(void);
 extern int32_t Viewport_GetMaxX(void);
 extern int32_t Viewport_GetMaxY(void);
+
+// Return the current FOV as overriden by the game mechanics, such as special
+// cameras or cutscenes. If the FOV is not overriden, returns -1.
+extern int16_t Viewport_GetSystemFOV(void);
+
+// Returns preferred player FOV.
+extern int16_t Viewport_GetUserFOV(void);
+
+// Returns the current effective FOV – eg system FOV if it's defined, otherwise
+// the player choice.
+int16_t Viewport_GetEffectiveFOV(void);
+
+// Sets the system FOV. Set to -1 to fallback to player FOV.
+extern void Viewport_AlterFOV(int16_t view_angle);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -306,6 +306,7 @@ sources = [
   'game/ui/hud/overlay.c',
   'game/ui/scrollable.c',
   'game/ui/text.c',
+  'game/viewport.c',
   'gfx/2d/2d_renderer.c',
   'gfx/2d/2d_surface.c',
   'gfx/3d/3d_renderer.c',

--- a/src/tr1/game/inventory_ring/draw.c
+++ b/src/tr1/game/inventory_ring/draw.c
@@ -140,8 +140,8 @@ void InvRing_Draw(INV_RING *const ring)
         Viewport_Init(0, 0, width, height);
     }
 
-    const int16_t old_fov = Viewport_GetFOV();
-    Viewport_SetFOV(M_PASSPORT_FOV * DEG_1);
+    const int16_t old_fov = Viewport_GetSystemFOV();
+    Viewport_AlterFOV(M_PASSPORT_FOV * DEG_1);
     Output_ApplyFOV();
 
     XYZ_32 view_pos;
@@ -194,7 +194,7 @@ void InvRing_Draw(INV_RING *const ring)
     }
 
     Matrix_Pop();
-    Viewport_SetFOV(old_fov);
+    Viewport_AlterFOV(old_fov);
     Output_DrawPolyList();
 
     if (ring->motion.status == RNG_SELECTED) {

--- a/src/tr1/game/item_actions/lara_effects.c
+++ b/src/tr1/game/item_actions/lara_effects.c
@@ -15,7 +15,7 @@ void ItemAction_LaraNormal(ITEM *item)
     item->goal_anim_state = LS_STOP;
     Item_SwitchToAnim(item, LA_STAND_STILL, 0);
     g_Camera.type = CAM_CHASE;
-    Viewport_SetFOV(-1);
+    Viewport_AlterFOV(-1);
 }
 
 void ItemAction_LaraHandsFree(ITEM *item)

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -422,7 +422,7 @@ bool Level_Initialise(
             level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
     }
 
-    Viewport_SetFOV(-1);
+    Viewport_AlterFOV(-1);
 
     Benchmark_End(&benchmark, nullptr);
     return true;

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -855,7 +855,7 @@ void Output_DrawPolyList(void)
 
 void Output_ApplyFOV(void)
 {
-    int32_t fov = Viewport_GetFOV();
+    int32_t fov = Viewport_GetEffectiveFOV();
 
     // In places that use GAME_FOV, it can be safely changed to user's choice.
     // But for cinematics, the FOV value chosen by devs needs to stay

--- a/src/tr1/game/output/func.c
+++ b/src/tr1/game/output/func.c
@@ -65,7 +65,7 @@ void Output_GetProjectionMatrix(GLfloat output[][4])
     const float near = Output_GetNearZ() / (float)(1 << W2V_SHIFT);
     const float far = Output_GetFarZ() / (float)(1 << W2V_SHIFT);
     const float aspect = (float)(right - left) / (float)(bottom - top);
-    const float fov = Viewport_GetFOV() * M_PI / (float)DEG_180;
+    const float fov = Viewport_GetEffectiveFOV() * M_PI / (float)DEG_180;
 
     float f_x, f_y;
     if (g_Config.visuals.fov_vertical) {

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -262,9 +262,9 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
     // camera (when picking up the Scion). Move the viewport rather than
     // translating the object in order to avoid perspective distortion in the
     // screen corners.
-    int16_t old_fov = Viewport_GetFOV();
+    const int16_t old_fov = Viewport_GetSystemFOV();
     Viewport_Init(new_vp.x, new_vp.y, new_vp.w, new_vp.h);
-    Viewport_SetFOV(M_PICKUPS_FOV * DEG_1);
+    Viewport_AlterFOV(M_PICKUPS_FOV * DEG_1);
     glViewport(new_vp.x, new_vp.y, new_vp.w, new_vp.h);
     Output_ApplyFOV();
 
@@ -311,7 +311,7 @@ static void M_DrawPickup3D(DISPLAY_PICKUP *pu)
 
     Matrix_Pop();
     Viewport_Init(0, 0, Screen_GetResWidth(), Screen_GetResHeight());
-    Viewport_SetFOV(old_fov);
+    Viewport_AlterFOV(old_fov);
     glViewport(old_vp.x, old_vp.y, old_vp.w, old_vp.h);
     Output_ApplyFOV();
 }

--- a/src/tr1/game/screen.c
+++ b/src/tr1/game/screen.c
@@ -42,7 +42,7 @@ static void M_ApplyResolution(void)
     Output_ApplyRenderSettings();
 
     Matrix_ResetStack();
-    Viewport_SetFOV(-1);
+    Viewport_AlterFOV(-1);
 }
 
 static int32_t M_GetRenderScaleBase(

--- a/src/tr1/game/viewport.c
+++ b/src/tr1/game/viewport.c
@@ -76,9 +76,9 @@ int32_t Viewport_GetHeight(void)
     return m_Height;
 }
 
-int16_t Viewport_GetFOV(void)
+int16_t Viewport_GetSystemFOV(void)
 {
-    return m_CurrentFOV == -1 ? Viewport_GetUserFOV() : m_CurrentFOV;
+    return m_CurrentFOV;
 }
 
 int16_t Viewport_GetUserFOV(void)
@@ -86,7 +86,7 @@ int16_t Viewport_GetUserFOV(void)
     return g_Config.visuals.fov_value * DEG_1;
 }
 
-void Viewport_SetFOV(int16_t fov)
+void Viewport_AlterFOV(int16_t fov)
 {
     m_CurrentFOV = fov;
     Output_ObserveFOVChange();

--- a/src/tr1/game/viewport.h
+++ b/src/tr1/game/viewport.h
@@ -10,9 +10,3 @@ int32_t Viewport_GetMinX(void);
 int32_t Viewport_GetMinY(void);
 int32_t Viewport_GetCenterX(void);
 int32_t Viewport_GetCenterY(void);
-int32_t Viewport_GetWidth(void);
-int32_t Viewport_GetHeight(void);
-
-int16_t Viewport_GetFOV(void);
-int16_t Viewport_GetUserFOV(void);
-void Viewport_SetFOV(int16_t fov);

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -821,7 +821,7 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
 
     INV_RING *const ring = Memory_Alloc(sizeof(INV_RING));
     ring->mode = mode;
-    ring->old_fov = Viewport_GetFOV(false);
+    ring->old_fov = Viewport_GetSystemFOV();
     m_NoInputCounter = 0;
 
     switch (mode) {

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -414,7 +414,7 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
     }
 
     if (L_CHANGED(visuals.fov) || L_CHANGED(visuals.use_psx_fov)) {
-        if (Viewport_GetFOV(false) == -1) {
+        if (Viewport_GetSystemFOV() == -1) {
             Viewport_AlterFOV(-1);
         }
     }

--- a/src/tr2/game/viewport.c
+++ b/src/tr2/game/viewport.c
@@ -182,11 +182,14 @@ void Viewport_Restore(const VIEWPORT *ref_vp)
     M_ApplyGameVars(&m_Viewport);
 }
 
-int16_t Viewport_GetFOV(bool resolve_user_fov)
+int16_t Viewport_GetSystemFOV(void)
 {
-    return resolve_user_fov && m_Viewport.view_angle < 0
-        ? g_Config.visuals.fov * DEG_1
-        : m_Viewport.view_angle;
+    return m_Viewport.view_angle;
+}
+
+int16_t Viewport_GetUserFOV(void)
+{
+    return g_Config.visuals.fov * DEG_1;
 }
 
 void Viewport_AlterFOV(const int16_t view_angle)

--- a/src/tr2/game/viewport.h
+++ b/src/tr2/game/viewport.h
@@ -54,7 +54,4 @@ void Viewport_Reset(void);
 
 void Viewport_Restore(const VIEWPORT *ref_vp);
 
-int16_t Viewport_GetFOV(bool resolve_user_fov);
-void Viewport_AlterFOV(int16_t view_angle);
-
 const VIEWPORT *Viewport_Get(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Preparation for #3332.
This brings the viewport API a bit closer, at least in terms of FOV management. While the 3 getters might appear like an overkill, I do believe that they bring clarity about usage.

#### Testing

Nothing should change, but I'd appreciate a sanity check around FOVs: cutscenes, special cameras, and fiddling with settings in these contexts (including the vertical FOV option in TR1 / PSX FOV option in TR2).
