### PR TITLE
tr2/stats: fix support for levels with >3 secrets

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -53,6 +53,8 @@
 - fixed the camera being partially inside the wall at the end of the Home Sweet Home shower cutscene (#3370)
 - fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
 - fixed Lara getting stuck in the fly cheat in rare circumstances (#3392, regression from 0.3)
+- fixed support for >3 secret dragons in custom levels (#3415, regression from 1.2)
+- improved support for >3 secret dragons in custom levels up to 16 dragons
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)
 - removed config tool (we have ingame setting dialogs now)

--- a/src/libtrx/game/stats.c
+++ b/src/libtrx/game/stats.c
@@ -2,29 +2,42 @@
 
 #include "game/game.h"
 #include "game/savegame.h"
+#include "log.h"
 
-bool Stats_HasSecret(const int16_t secret_num)
+bool Stats_IsSecretValid(const int16_t secret_idx)
 {
     RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    if (secret_num < 0 || secret_num >= STATS_MAX_SECRETS) {
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
-    const uint32_t secret_mask = 1 << secret_num;
+    const uint32_t secret_mask = 1 << secret_idx;
+    return (secret_mask & current_info->stats.all_secrets_mask) != 0;
+}
+
+bool Stats_HasSecret(const int16_t secret_idx)
+{
+    RESUME_INFO *const current_info =
+        Savegame_GetCurrentInfo(Game_GetCurrentLevel());
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
+        return false;
+    }
+    const uint32_t secret_mask = 1 << secret_idx;
     if ((secret_mask & current_info->stats.all_secrets_mask) == 0) {
         return false;
     }
     return (current_info->stats.secret_flags & secret_mask) != 0;
 }
 
-bool Stats_TakeSecret(const int16_t secret_num)
+bool Stats_TakeSecret(const int16_t secret_idx)
 {
+    LOG_INFO("Removing secret %d", secret_idx);
     RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    if (secret_num < 0 || secret_num >= STATS_MAX_SECRETS) {
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
-    const uint32_t secret_mask = 1 << secret_num;
+    const uint32_t secret_mask = 1 << secret_idx;
     if ((secret_mask & current_info->stats.all_secrets_mask) == 0) {
         return false;
     }
@@ -36,14 +49,15 @@ bool Stats_TakeSecret(const int16_t secret_num)
     return true;
 }
 
-bool Stats_AddSecret(const int16_t secret_num)
+bool Stats_AddSecret(const int16_t secret_idx)
 {
+    LOG_INFO("Adding secret %d", secret_idx);
     RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    if (secret_num < 0 || secret_num >= STATS_MAX_SECRETS) {
+    if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
         return false;
     }
-    const uint32_t secret_mask = 1 << secret_num;
+    const uint32_t secret_mask = 1 << secret_idx;
     if ((secret_mask & current_info->stats.all_secrets_mask) == 0) {
         return false;
     }

--- a/src/libtrx/include/libtrx/game/inventory.h
+++ b/src/libtrx/include/libtrx/game/inventory.h
@@ -18,3 +18,4 @@ void Inv_ClearSelection(void);
 void Inv_RemoveAllItems(void);
 
 extern bool Inv_AddItem(GAME_OBJECT_ID obj_id);
+extern bool Inv_AddPickup(const ITEM *item);

--- a/src/libtrx/include/libtrx/game/stats/common.h
+++ b/src/libtrx/include/libtrx/game/stats/common.h
@@ -5,9 +5,10 @@
 extern void Stats_StartTimer(void);
 extern void Stats_ObserveItemsLoad(void);
 
-bool Stats_HasSecret(int16_t secret_num);
-bool Stats_TakeSecret(int16_t secret_num);
-bool Stats_AddSecret(int16_t secret_num);
+bool Stats_HasSecret(int16_t secret_idx);
+bool Stats_IsSecretValid(int16_t secret_idx);
+bool Stats_TakeSecret(int16_t secret_idx);
+bool Stats_AddSecret(int16_t secret_idx);
 extern uint32_t Stats_GetMaxSecretFlags(void);
 
 void Stats_UpdateSecrets(LEVEL_STATS *stats);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -167,13 +167,15 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         break;
     }
 
-    Stats_CalculateStats();
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-    if (resume != nullptr) {
-        resume->stats.max_pickup_count = Stats_GetMaxPickups();
-        resume->stats.max_kill_count = Stats_GetMaxKillables();
-        resume->stats.max_secret_count = Stats_GetMaxSecrets();
-        resume->stats.all_secrets_mask = Stats_GetMaxSecretFlags();
+    if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+        Stats_CalculateStats();
+        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+        if (resume != nullptr) {
+            resume->stats.max_pickup_count = Stats_GetMaxPickups();
+            resume->stats.max_kill_count = Stats_GetMaxKillables();
+            resume->stats.max_secret_count = Stats_GetMaxSecrets();
+            resume->stats.all_secrets_mask = Stats_GetMaxSecretFlags();
+        }
     }
 
     g_GameInfo.ask_for_save = g_Config.gameplay.enable_save_crystals

--- a/src/tr1/game/inventory.c
+++ b/src/tr1/game/inventory.c
@@ -187,3 +187,8 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
 
     return false;
 }
+
+bool Inv_AddPickup(const ITEM *const item)
+{
+    return Inv_AddItem(item->object_id);
+}

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -103,7 +103,7 @@ static void M_SpawnPickupAid(const ITEM *const item)
 static void M_GetItem(int16_t item_num, ITEM *item, ITEM *lara_item)
 {
     Overlay_AddDisplayPickup(item->object_id);
-    Inv_AddItem(item->object_id);
+    Inv_AddPickup(item);
 
     item->status = IS_INVISIBLE;
     item->flags |= IF_KILLED;

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -131,11 +131,13 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         break;
     }
 
-    Stats_CalculateStats();
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-    if (resume != nullptr) {
-        resume->stats.max_secret_count = Stats_GetMaxSecrets();
-        resume->stats.all_secrets_mask = Stats_GetMaxSecretFlags();
+    if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+        Stats_CalculateStats();
+        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+        if (resume != nullptr) {
+            resume->stats.max_secret_count = Stats_GetMaxSecrets();
+            resume->stats.all_secrets_mask = Stats_GetMaxSecretFlags();
+        }
     }
 
     ASSERT(GF_GetCurrentLevel() == level);

--- a/src/tr2/game/inventory.c
+++ b/src/tr2/game/inventory.c
@@ -1,5 +1,6 @@
 #include "game/inventory.h"
 
+#include "game/game_flow.h"
 #include "game/gun.h"
 #include "game/inventory_ring.h"
 #include "game/objects/vars.h"
@@ -234,12 +235,6 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
         Inv_InsertItem(&g_InvRing_Item_Puzzle4);
         return true;
 
-    case O_SECRET_1:
-    case O_SECRET_2:
-    case O_SECRET_3:
-        Stats_MarkSecretCollected(obj_id);
-        return true;
-
     case O_KEY_ITEM_1:
     case O_KEY_OPTION_1:
         Inv_InsertItem(&g_InvRing_Item_Key1);
@@ -273,4 +268,22 @@ bool Inv_AddItem(const GAME_OBJECT_ID obj_id)
     default:
         return false;
     }
+}
+
+bool Inv_AddPickup(const ITEM *const item)
+{
+    switch (item->object_id) {
+    case O_SECRET_1:
+    case O_SECRET_2:
+    case O_SECRET_3:
+        Stats_MarkSecretCollected(item);
+        if (Stats_CheckAllLevelSecretsCollected()) {
+            GF_InventoryModifier_Apply(Game_GetCurrentLevel(), GF_INV_SECRET);
+        }
+        return true;
+    default:
+        break;
+    }
+
+    return Inv_AddItem(item->object_id);
 }

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -1,7 +1,6 @@
 #include "game/objects/general/pickup.h"
 
 #include "game/game.h"
-#include "game/game_flow.h"
 #include "game/gun/gun.h"
 #include "game/input.h"
 #include "game/inventory.h"
@@ -64,12 +63,7 @@ static void M_DoPickup(const int16_t item_num)
     }
 
     Overlay_AddDisplayPickup(item->object_id);
-    Inv_AddItem(item->object_id);
-
-    if (Object_IsType(item->object_id, g_SecretObjects)
-        && Stats_CheckAllLevelSecretsCollected()) {
-        GF_InventoryModifier_Apply(Game_GetCurrentLevel(), GF_INV_SECRET);
-    }
+    Inv_AddPickup(item);
 
     item->status = IS_INVISIBLE;
     item->flags |= IF_KILLED;

--- a/src/tr2/game/stats.c
+++ b/src/tr2/game/stats.c
@@ -5,8 +5,8 @@
 #include "game/game_flow.h"
 #include "game/objects/vars.h"
 #include "game/savegame.h"
-#include "global/vars.h"
 
+#include <libtrx/debug.h>
 #include <libtrx/log.h>
 #include <libtrx/utils.h>
 
@@ -14,13 +14,12 @@
 
 typedef struct {
     int32_t secret_count;
-    int32_t secret_flags;
+    uint32_t secret_flags;
+    GAME_OBJECT_ID secret_objects[STATS_MAX_SECRETS];
 } M_MAX_STATS;
 
 static int32_t m_CachedItemCount = 0;
 static M_MAX_STATS m_LevelMax = {};
-
-static bool M_SetSecretFlag(uint16_t *flags, GAME_OBJECT_ID obj_id);
 
 #if M_USE_REAL_CLOCK
 static CLOCK_TIMER m_StartCounter = { .type = CLOCK_TYPE_REAL };
@@ -55,19 +54,6 @@ void Stats_UpdateTimer(void)
 }
 #endif
 
-static bool M_SetSecretFlag(uint16_t *const flags, const GAME_OBJECT_ID obj_id)
-{
-    for (int32_t i = 0; i < 2; i++) {
-        const int32_t flag = 1 << ((obj_id - O_SECRET_1) + i * 3);
-        if ((*flags & flag) == 0) {
-            *flags |= flag;
-            return true;
-        }
-    }
-
-    return false;
-}
-
 FINAL_STATS Stats_ComputeFinalStats(const GF_LEVEL_TYPE level_type)
 {
     FINAL_STATS result = {};
@@ -101,21 +87,70 @@ void Stats_ObserveItemsLoad(void)
 
 void Stats_CalculateStats(void)
 {
+    LOG_INFO("Recalculating stats");
     m_LevelMax.secret_count = 0;
-    uint16_t secret_flags = 0;
+    m_LevelMax.secret_flags = 0;
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        m_LevelMax.secret_objects[i] = NO_OBJECT;
+    }
 
+    struct L_SECRET_ITEM {
+        GAME_OBJECT_ID object_id;
+        int32_t index;
+    } secrets[STATS_MAX_SECRETS];
+    int32_t secret_count = 0;
     for (int32_t i = 0; i < m_CachedItemCount; i++) {
-        const ITEM *const item = Item_Get(i);
+        ITEM *const item = Item_Get(i);
         if (item->object_id < O_FIRST || item->object_id >= O_NUMBER_OF) {
             LOG_ERROR("Bad Object number (%d) on Item %d", item->object_id, i);
             continue;
         }
-
-        if (Object_IsType(item->object_id, g_SecretObjects)
-            && M_SetSecretFlag(&secret_flags, item->object_id)) {
-            m_LevelMax.secret_count++;
+        if (Object_IsType(item->object_id, g_SecretObjects)) {
+            if (secret_count >= STATS_MAX_SECRETS) {
+                LOG_ERROR("Too many secrets, max %d", STATS_MAX_SECRETS);
+                break;
+            }
+            secrets[secret_count].object_id = item->object_id;
+            secrets[secret_count].index = i;
+            secret_count++;
         }
     }
+
+    for (int32_t i = 0; i < secret_count; i++) {
+        for (int32_t j = i + 1; j < secret_count; j++) {
+            if (secrets[i].object_id > secrets[j].object_id) {
+                struct L_SECRET_ITEM tmp;
+                SWAP(secrets[i], secrets[j], tmp);
+            }
+        }
+    }
+
+    for (int32_t k = 0; k < secret_count; k++) {
+        ITEM *const item = Item_Get(secrets[k].index);
+        item->data =
+            (void *)(intptr_t)Stats_ReserveSecretBit(secrets[k].object_id);
+    }
+}
+
+uint32_t Stats_ReserveSecretBit(const GAME_OBJECT_ID object_id)
+{
+    uint32_t n = m_LevelMax.secret_flags;
+    int32_t position = 0;
+    while ((n & 1) == 1) {
+        n >>= 1;
+        position++;
+    }
+    LOG_INFO("Reserving bit %d for secret %d", position, object_id);
+    m_LevelMax.secret_flags |= 1 << position;
+    m_LevelMax.secret_count++;
+    m_LevelMax.secret_objects[position] = object_id;
+    return 1 << position;
+}
+
+GAME_OBJECT_ID Stats_GetSecretObject(const int32_t secret_idx)
+{
+    ASSERT(secret_idx >= 0 && secret_idx < STATS_MAX_SECRETS);
+    return m_LevelMax.secret_objects[secret_idx];
 }
 
 int32_t Stats_GetMaxSecrets(void)
@@ -125,13 +160,13 @@ int32_t Stats_GetMaxSecrets(void)
 
 uint32_t Stats_GetMaxSecretFlags(void)
 {
-    return (1 << m_LevelMax.secret_count) - 1;
+    return m_LevelMax.secret_flags;
 }
 
-void Stats_MarkSecretCollected(const GAME_OBJECT_ID obj_id)
+void Stats_MarkSecretCollected(const ITEM *const item)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    M_SetSecretFlag(&resume->stats.secret_flags, obj_id);
+    resume->stats.secret_flags |= (uint32_t)(intptr_t)item->data;
     Stats_UpdateSecrets(&resume->stats);
 }
 

--- a/src/tr2/game/stats.h
+++ b/src/tr2/game/stats.h
@@ -7,11 +7,14 @@
 
 void Stats_UpdateTimer(void);
 void Stats_CalculateStats(void);
-int32_t Stats_GetMaxSecrets(void);
-void Stats_MarkSecretCollected(GAME_OBJECT_ID obj_id);
-bool Stats_CheckAllLevelSecretsCollected(void);
+void Stats_MarkSecretCollected(const ITEM *item);
 FINAL_STATS Stats_ComputeFinalStats(GF_LEVEL_TYPE level_type);
+
+int32_t Stats_GetMaxSecrets(void);
+bool Stats_CheckAllLevelSecretsCollected(void);
 bool Stats_CheckAllSecretsCollected(GF_LEVEL_TYPE level_type);
+uint32_t Stats_ReserveSecretBit(GAME_OBJECT_ID object_id);
+GAME_OBJECT_ID Stats_GetSecretObject(int32_t secret_idx);
 
 void Stats_AddKill(void);
 void Stats_AddAmmoHits(void);

--- a/src/tr2/game/ui/dialogs/stats.c
+++ b/src/tr2/game/ui/dialogs/stats.c
@@ -65,23 +65,29 @@ static void M_FormatSecrets(
     // TODO: implement optional support for TR1-style secrets in TR2, see #2047
     char *ptr = out;
     int32_t num_secrets = 0;
-    for (int32_t i = 1; i >= 0; i--) {
-        for (int32_t j = 0; j < 3; j++) {
-            const int32_t num = j + i * 3;
-            if (num >= level_stats->max_secret_count) {
-                // Do not reserve space for secrets that don't exist
-                continue;
-            }
-            if (Stats_HasSecret(num)) {
-                ptr += sprintf(ptr, "\\{secret %d}", j + 1);
-                num_secrets++;
-            } else {
-                ptr += sprintf(ptr, "\\{i}\\{secret %d}\\{/i}", j + 1);
-            }
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        if (!Stats_IsSecretValid(i)) {
+            continue;
+        }
+
+        const bool has_secret = Stats_HasSecret(i);
+        if (!has_secret && out == ptr) {
+            // Do not reserve space pointlessly.
+            // Good: [secret][ ][ ]
+            // Bad:  [ ][ ][secret] – should be just [secret]
+            continue;
+        }
+        const GAME_OBJECT_ID obj_id = Stats_GetSecretObject(i);
+        ASSERT(obj_id != NO_OBJECT);
+        ptr += sprintf(
+            ptr, has_secret ? "\\{secret %d}" : "\\{i}\\{secret %d}\\{/i}",
+            obj_id + 1 - O_SECRET_1);
+        if (has_secret) {
+            num_secrets++;
         }
     }
-
     *ptr++ = '\0';
+
     if (num_secrets == 0) {
         strcpy(out, GS(MISC_NONE));
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3415.

This is quite a heavy change. It requires `Stats_CalculateStats()` to be called only for regular levels, so we no longer call it for cutscenes – otherwise they'll mess the internal game state up. When loading a level, we iterate through all secret pickups and assign a unique bitmask to each via `item->data`, and calculate the combined flags and count for the level at large. This happens regardless of saves, but depending on the order of calls can influence carrying over statistics between levels, separately for saves and for normal playthrough. Going further, to identify which secret is picked up (and thus which bitmask we need to apply), I added an `Inv_AddPickup(ITEM *)` function which defaults to `Inv_AddItem(GAME_OBJECT_ID)` for all non-secret pickups. `Inv_AddItem` was not enough for this – I tried iterating through all pickups and find ones that weren't killed but the problem was that Lara would pick stone dragon A, and the game would think she picked stone dragon B. A potential fix would be to go with the recent receptacle approach, in which we check Lara's position and compare it with the item bounding box. LMK if that's preferred.

Despite the dragons having now essentially a random order, we still show empty space in the statistics UI for the missing pickups. To do this, I sort the dragons by their order, so that we always show them consistently. The consequence of this change is that for levels with >3 dragons the order will no longer be Gold, Jade, Stone, Gold, Jade, Stone but instead Gold, Gold, Jade, Jade, Stone, Stone.

### Testing

- **Saving/loading**
- **Carrying the stats** to the final stats
- `/secret` with >3 secrets
- Regular pickups with >3 secrets
- End level stats for all levels
- Requirements for Nightmare in Vegas (both meeting and not meeting them)
- Final final stats for Nightmare in Vegas
- Dialog sizes when reserving space for the secret sprites
- Dragon order – AFAIK it should be Gold → Jade → Stone
- Ideally, a level with more than 6 dragons – theoretically we now support up to 16 secrets
- TR1 sanity checks