### PR TITLE
shell: move window manipulation events to trx

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -33,6 +33,7 @@
 - fixed key items getting consumed at the start of the interaction with receptacles (#3399)
 - fixed certain commands (such as `/load` or `/play`) not working as expected while in the key use inventory screen (#3338)
 - fixed the camera resetting if Lara is looking and then draws her guns (OG behaviour retained when using restricted look mode) (#3406)
+- fixed game window getting misplaced in windowed mode between game relaunches on certain systems (#3418)
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)
 - removed "window size" rendering mode, enforcing the FBO rendering method (#3332)

--- a/src/libtrx/game/shell/config.c
+++ b/src/libtrx/game/shell/config.c
@@ -1,0 +1,175 @@
+#include "config.h"
+#include "game/game_string_manager.h"
+#include "game/music.h"
+#include "game/output.h"
+#include "game/shell.h"
+#include "game/sound.h"
+#include "game/viewport.h"
+#include "log.h"
+
+static Uint64 m_UpdateDebounce = 0;
+static bool m_IgnoreConfigChanges = false;
+static SHELL_SIZE m_ViewportSize = { .w = -1, .h = -1 };
+
+static bool M_MustUpdateRendererViewport(void);
+
+static bool M_MustUpdateRendererViewport(void)
+{
+    const SHELL_SIZE size = Shell_GetCurrentSize();
+    return m_ViewportSize.w != size.w || m_ViewportSize.h != size.h;
+}
+
+void Shell_RefreshRendererViewport(void)
+{
+    Viewport_Reset();
+    m_ViewportSize = Shell_GetCurrentSize();
+}
+
+void Shell_SyncToWindow(void)
+{
+    m_UpdateDebounce = SDL_GetTicks();
+
+    LOG_DEBUG(
+        "is_fullscreen=%d is_maximized=%d x=%d y=%d width=%d height=%d",
+        g_Config.window.is_fullscreen, g_Config.window.is_maximized,
+        g_Config.window.x, g_Config.window.y, g_Config.window.width,
+        g_Config.window.height);
+
+    SDL_Window *const window = Shell_GetWindow();
+    if (g_Config.window.is_fullscreen) {
+        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_ShowCursor(SDL_DISABLE);
+    } else if (g_Config.window.is_maximized) {
+        SDL_SetWindowFullscreen(window, 0);
+        SDL_MaximizeWindow(window);
+        SDL_ShowCursor(SDL_ENABLE);
+    } else {
+        int32_t x = g_Config.window.x;
+        int32_t y = g_Config.window.y;
+        int32_t width = g_Config.window.width;
+        int32_t height = g_Config.window.height;
+        if (width <= 0 || height <= 0) {
+            width = 1280;
+            height = 720;
+        }
+
+        // Handle default position
+        if (x == -1 && y == -1) {
+            SDL_DisplayMode display_mode;
+            SDL_GetCurrentDisplayMode(0, &display_mode);
+            x = (display_mode.w - width) / 2;
+            y = (display_mode.h - height) / 2;
+        } else {
+            // Adjust window position if completely offscreen
+            bool on_screen = false;
+            const int32_t num_displays = SDL_GetNumVideoDisplays();
+            for (int32_t i = 0; i < num_displays; i++) {
+                SDL_Rect bounds;
+                SDL_GetDisplayBounds(i, &bounds);
+                if (x + width > bounds.x && x < bounds.x + bounds.w
+                    && y + height > bounds.y && y < bounds.y + bounds.h) {
+                    on_screen = true;
+                    break;
+                }
+            }
+            if (!on_screen) {
+                x = 0;
+                y = 0;
+                // Find the first display to reposition the window
+                SDL_Rect bounds;
+                SDL_GetDisplayBounds(0, &bounds);
+                x = bounds.x + (bounds.w - width) / 2;
+                y = bounds.y + (bounds.h - height) / 2;
+            }
+        }
+
+        SDL_SetWindowFullscreen(window, 0);
+        SDL_SetWindowPosition(window, x, y);
+        SDL_SetWindowSize(window, width, height);
+        SDL_ShowCursor(SDL_ENABLE);
+    }
+}
+
+void Shell_SyncFromWindow(const bool update_viewport)
+{
+    // Determine if this call should sync config, i.e., skip immediate
+    // programmatic events
+    const Uint32 now = SDL_GetTicks();
+    const bool skip_config = (now - m_UpdateDebounce) < 500;
+
+    // Always pull current window state for logging and viewport reset
+    SDL_Window *const window = Shell_GetWindow();
+    const Uint32 window_flags = SDL_GetWindowFlags(window);
+    const bool is_maximized = window_flags & SDL_WINDOW_MAXIMIZED;
+    int32_t x, y;
+    int32_t width, height;
+    SDL_GetWindowSize(window, &width, &height);
+    SDL_GetWindowPosition(window, &x, &y);
+    LOG_INFO("%dx%d+%d,%d (maximized: %d)", width, height, x, y, is_maximized);
+
+    // Update config only when not in debounce window
+    if (!skip_config) {
+        g_Config.window.is_maximized = is_maximized;
+        if (!is_maximized && !g_Config.window.is_fullscreen) {
+            g_Config.window.x = x;
+            g_Config.window.y = y;
+            g_Config.window.width = width;
+            g_Config.window.height = height;
+        } else {
+            g_Config.window.fs_width = width;
+            g_Config.window.fs_height = height;
+        }
+        if (g_Config.loaded) {
+            m_IgnoreConfigChanges = true;
+            Config_Write();
+            m_IgnoreConfigChanges = false;
+        }
+    }
+
+    if (update_viewport || M_MustUpdateRendererViewport()) {
+        // Refresh viewport to reflect the actual window size
+        Shell_RefreshRendererViewport();
+    }
+}
+
+void Shell_HandleCommonConfigChange(
+    const CONFIG *const old, const CONFIG *const new)
+{
+#define L_CHANGED(subject) (old->subject != new->subject)
+
+    if (L_CHANGED(audio.sound_volume)) {
+        Sound_SetMasterVolume(g_Config.audio.sound_volume);
+    }
+    if (L_CHANGED(audio.music_volume)) {
+        Music_SetVolume(g_Config.audio.music_volume);
+    }
+
+    if (L_CHANGED(language)) {
+        GameStringManager_ReloadLanguage(g_Config.language);
+    }
+
+    if (L_CHANGED(window.is_fullscreen) || L_CHANGED(window.is_maximized)
+        || L_CHANGED(window.width) || L_CHANGED(window.height)
+        || L_CHANGED(window.fs_width) || L_CHANGED(window.fs_height)
+#if TR_VERSION >= 2
+        || L_CHANGED(rendering.scaler) || L_CHANGED(rendering.sizer)
+        || L_CHANGED(rendering.aspect_mode) || L_CHANGED(visuals.use_psx_fov)
+#endif
+    ) {
+        LOG_DEBUG("Change in settings detected");
+        if (!m_IgnoreConfigChanges) {
+            Shell_SyncToWindow();
+        }
+        Shell_RefreshRendererViewport();
+    }
+
+    if (
+#if TR_VERSION >= 2
+        L_CHANGED(rendering.aspect_mode) ||
+#endif
+        L_CHANGED(window.width) || L_CHANGED(window.height)
+        || L_CHANGED(window.fs_width) || L_CHANGED(window.fs_height)) {
+        Output_ReloadBackgroundImage();
+    }
+#undef L_CHANGED
+}

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -11,6 +11,15 @@ static bool m_ConsoleJustOpened = false;
 static void M_HandleQuit(void);
 static void M_HandleKeyDown(const SDL_Event *event);
 static void M_HandleKeyUp(const SDL_Event *event);
+static void M_HandleFocusGained(void);
+static void M_HandleFocusLost(void);
+static void M_HandleWindowShown(void);
+static void M_HandleWindowRestored(void);
+static void M_HandleWindowMinimized(void);
+static void M_HandleWindowMaximized(void);
+static void M_HandleWindowMoved(int32_t x, int32_t y);
+static void M_HandleWindowResized(int32_t width, int32_t height);
+static bool M_CreateGameWindow(void);
 
 static void M_HandleQuit(void)
 {
@@ -43,6 +52,44 @@ static void M_HandleKeyUp(const SDL_Event *const event)
     if (event->key.keysym.sym == SDLK_PRINTSCREEN) {
         Screenshot_Make(g_Config.rendering.screenshot_format);
     }
+}
+
+static void M_HandleFocusGained(void)
+{
+}
+
+static void M_HandleFocusLost(void)
+{
+}
+
+static void M_HandleWindowShown(void)
+{
+    LOG_DEBUG("");
+}
+
+static void M_HandleWindowRestored(void)
+{
+    Shell_SyncFromWindow(true);
+}
+
+static void M_HandleWindowMinimized(void)
+{
+    LOG_DEBUG("");
+}
+
+static void M_HandleWindowMaximized(void)
+{
+    Shell_SyncFromWindow(true);
+}
+
+static void M_HandleWindowMoved(const int32_t x, const int32_t y)
+{
+    Shell_SyncFromWindow(false);
+}
+
+static void M_HandleWindowResized(int32_t width, int32_t height)
+{
+    Shell_SyncFromWindow(true);
 }
 
 bool Shell_ProcessCommonEvent(const SDL_Event *const event)
@@ -82,6 +129,42 @@ bool Shell_ProcessCommonEvent(const SDL_Event *const event)
     case SDL_JOYDEVICEREMOVED:
         Input_Discover();
         return true;
+
+    case SDL_WINDOWEVENT:
+        switch (event->window.event) {
+        case SDL_WINDOWEVENT_SHOWN:
+            M_HandleWindowShown();
+            break;
+
+        case SDL_WINDOWEVENT_FOCUS_GAINED:
+            M_HandleFocusGained();
+            break;
+
+        case SDL_WINDOWEVENT_FOCUS_LOST:
+            M_HandleFocusLost();
+            break;
+
+        case SDL_WINDOWEVENT_RESTORED:
+            M_HandleWindowRestored();
+            break;
+
+        case SDL_WINDOWEVENT_MINIMIZED:
+            M_HandleWindowMinimized();
+            break;
+
+        case SDL_WINDOWEVENT_MAXIMIZED:
+            M_HandleWindowMaximized();
+            break;
+
+        case SDL_WINDOWEVENT_MOVED:
+            M_HandleWindowMoved(event->window.data1, event->window.data2);
+            break;
+
+        case SDL_WINDOWEVENT_RESIZED:
+            M_HandleWindowResized(event->window.data1, event->window.data2);
+            break;
+        }
+        break;
     }
 
     return false;

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -32,6 +32,13 @@ static void M_SetupSDL(void)
     }
 }
 
+void M_HandleConfigChange(const EVENT *const event, void *const data)
+{
+    const CONFIG *const old = &g_Config;
+    const CONFIG *const new = &g_SavedConfig;
+    Shell_HandleConfigChange(old, new);
+}
+
 static void M_SetupGL(void)
 {
     // Setup minimum properties of GL context
@@ -46,7 +53,7 @@ static void M_SetupGL(void)
 void Shell_LoadConfig(void)
 {
     Config_Read();
-    Config_SubscribeChanges(Shell_HandleConfigChange, nullptr);
+    Config_SubscribeChanges(M_HandleConfigChange, nullptr);
 
     Sound_SetMasterVolume(g_Config.audio.sound_volume);
     Music_SetVolume(g_Config.audio.music_volume);

--- a/src/libtrx/include/libtrx/game/shell.h
+++ b/src/libtrx/include/libtrx/game/shell.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../config/types.h"
 #include "../event_manager.h"
 
 #include <SDL2/SDL.h>
@@ -33,7 +34,12 @@ void Shell_InitCommonModules(void);
 void Shell_ShutdownCommonModules(void);
 bool Shell_ProcessCommonEvent(const SDL_Event *event);
 
-extern void Shell_HandleConfigChange(const EVENT *event, void *data);
+void Shell_HandleCommonConfigChange(const CONFIG *old, const CONFIG *new);
+extern void Shell_HandleConfigChange(const CONFIG *old, const CONFIG *new);
+
+extern void Shell_RefreshRendererViewport(void);
+extern void Shell_SyncToWindow(void);
+extern void Shell_SyncFromWindow(bool update_viewport);
 
 extern const char *Shell_GetConfigPath(void);
 extern const char *Shell_GetGameFlowPath(void);

--- a/src/libtrx/include/libtrx/game/viewport.h
+++ b/src/libtrx/include/libtrx/game/viewport.h
@@ -20,3 +20,6 @@ int16_t Viewport_GetEffectiveFOV(void);
 
 // Sets the system FOV. Set to -1 to fallback to player FOV.
 extern void Viewport_AlterFOV(int16_t view_angle);
+
+// TODO: decide what to do with this function
+void Viewport_Reset(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -248,6 +248,7 @@ sources = [
   'game/savegame/common.c',
   'game/scaler.c',
   'game/shell/common.c',
+  'game/shell/config.c',
   'game/shell/events.c',
   'game/shell/flow.c',
   'game/shell/main.c',

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -442,11 +442,6 @@ void Output_Shutdown(void)
     Output_ClearLastBackgroundPath();
 }
 
-void Output_SetWindowSize(int32_t width, int32_t height)
-{
-    GFX_Context_SetWindowSize(width, height);
-}
-
 void Output_ApplyLevelSettings(void)
 {
     Output_SetWaterColor(Level_GetWaterColor());

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -8,7 +8,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void Output_SetWindowSize(int32_t width, int32_t height);
 void Output_ApplyLevelSettings(void);
 void Output_ApplyRenderSettings(void);
 void Output_ObserveFOVChange(void);

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -59,38 +59,9 @@ static SHELL_ARGS m_Args = {
     .save_to_load = -1,
 };
 
-static void M_HandleWindowResized(void);
-static void M_SetWindowPos(int32_t x, int32_t y, bool update);
-static void M_SetWindowSize(int32_t width, int32_t height, bool update);
-static void M_SetWindowMaximized(bool is_enabled, bool update);
-static void M_SetFullscreen(bool is_enabled, bool update);
 static void M_SetGLBackend(GFX_GL_BACKEND backend);
 
 static void M_ShowHelp(void);
-
-static void M_HandleWindowResized(void)
-{
-    int x;
-    int y;
-    int width;
-    int height;
-    bool is_maximized;
-
-    Uint32 window_flags = SDL_GetWindowFlags(m_Window);
-    is_maximized = window_flags & SDL_WINDOW_MAXIMIZED;
-    SDL_GetWindowSize(m_Window, &width, &height);
-    SDL_GetWindowPosition(m_Window, &x, &y);
-    LOG_INFO("%dx%d+%d,%d (maximized: %d)", width, height, x, y, is_maximized);
-
-    M_SetWindowMaximized(is_maximized, false);
-    M_SetWindowPos(x, y, false);
-    M_SetWindowSize(width, height, false);
-
-    // save the updated config, but ensure it was loaded first
-    if (g_Config.loaded) {
-        Config_Write();
-    }
-}
 
 static void M_CreateGameWindow(void)
 {
@@ -123,7 +94,6 @@ static void M_CreateGameWindow(void)
         LOG_DEBUG("Trying GL backend %d.%d", major, minor);
         if (GFX_Context_Attach(window, backend)) {
             m_Window = window;
-            M_HandleWindowResized();
             return;
         }
     }
@@ -141,19 +111,11 @@ static void M_ShowHelp(void)
     puts("-s/--save <NUM>: launch from a specific save slot (starts at 1).");
 }
 
-void Shell_HandleConfigChange(const EVENT *const event, void *const data)
+void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
 {
-    const CONFIG *const old = &g_Config;
-    const CONFIG *const new = &g_SavedConfig;
+    Shell_HandleCommonConfigChange(old, new);
 
 #define L_CHANGED(subject) (old->subject != new->subject)
-
-    if (L_CHANGED(audio.sound_volume)) {
-        Sound_SetMasterVolume(g_Config.audio.sound_volume);
-    }
-    if (L_CHANGED(audio.music_volume)) {
-        Music_SetVolume(g_Config.audio.music_volume);
-    }
 
     if (L_CHANGED(gameplay.maximum_save_slots) && Savegame_IsInitialised()) {
         Savegame_Shutdown();
@@ -161,91 +123,15 @@ void Shell_HandleConfigChange(const EVENT *const event, void *const data)
         Savegame_ScanSavedGames();
         Savegame_HighlightNewestSlot();
     }
-
-    if (L_CHANGED(language)) {
-        GameStringManager_ReloadLanguage(g_Config.language);
-    }
-
-    if (L_CHANGED(window.is_fullscreen)) {
-        LOG_DEBUG("Change in settings detected");
-        SDL_SetWindowFullscreen(
-            m_Window,
-            g_Config.window.is_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-        SDL_ShowCursor(
-            g_Config.window.is_fullscreen ? SDL_DISABLE : SDL_ENABLE);
-    }
-
 #undef L_CHANGED
-
-    Output_ApplyRenderSettings();
 }
 
 static void M_ShowWindow(void)
 {
-    M_SetFullscreen(g_Config.window.is_fullscreen, true);
-    M_SetWindowPos(g_Config.window.x, g_Config.window.y, true);
-    M_SetWindowSize(g_Config.window.width, g_Config.window.height, true);
-    M_SetWindowMaximized(g_Config.window.is_maximized, true);
+    Shell_SyncToWindow();
     SDL_ShowWindow(m_Window);
-}
-
-static void M_SetWindowPos(int32_t x, int32_t y, bool update)
-{
-    if (x <= 0 || y <= 0) {
-        return;
-    }
-
-    // only save window position if it's in windowed state.
-    if (!g_Config.window.is_fullscreen && !g_Config.window.is_maximized) {
-        g_Config.window.x = x;
-        g_Config.window.y = y;
-    }
-
-    if (update) {
-        SDL_SetWindowPosition(m_Window, x, y);
-    }
-}
-
-static void M_SetWindowSize(int32_t width, int32_t height, bool update)
-{
-    if (width <= 0 || height <= 0) {
-        return;
-    }
-
-    // only save window size if it's in windowed state.
-    if (!g_Config.window.is_fullscreen && !g_Config.window.is_maximized) {
-        g_Config.window.width = width;
-        g_Config.window.height = height;
-    } else {
-        g_Config.window.fs_width = width;
-        g_Config.window.fs_height = height;
-    }
-
-    Output_SetWindowSize(width, height);
-
-    if (update) {
-        SDL_SetWindowSize(m_Window, width, height);
-    }
-}
-
-static void M_SetWindowMaximized(bool is_enabled, bool update)
-{
-    g_Config.window.is_maximized = is_enabled;
-
-    if (update && is_enabled) {
-        SDL_MaximizeWindow(m_Window);
-    }
-}
-
-static void M_SetFullscreen(bool is_enabled, bool update)
-{
-    g_Config.window.is_fullscreen = is_enabled;
-
-    if (update) {
-        SDL_SetWindowFullscreen(
-            m_Window, is_enabled ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-        SDL_ShowCursor(is_enabled ? SDL_DISABLE : SDL_ENABLE);
-    }
+    SDL_RaiseWindow(m_Window);
+    Shell_RefreshRendererViewport();
 }
 
 static void M_SetGLBackend(const GFX_GL_BACKEND backend)
@@ -285,11 +171,6 @@ void Shell_ProcessEvents(void)
                 FMV_Mute();
                 Music_Mute();
                 Sound_SetMasterVolume(0);
-                break;
-
-            case SDL_WINDOWEVENT_MOVED:
-            case SDL_WINDOWEVENT_RESIZED:
-                M_HandleWindowResized();
                 break;
             }
             break;

--- a/src/tr1/game/viewport.c
+++ b/src/tr1/game/viewport.c
@@ -2,6 +2,7 @@
 
 #include "game/output.h"
 #include "game/screen.h"
+#include "game/shell.h"
 #include "global/vars.h"
 
 #include <libtrx/config.h>
@@ -90,4 +91,10 @@ void Viewport_AlterFOV(int16_t fov)
 {
     m_CurrentFOV = fov;
     Output_ObserveFOVChange();
+}
+
+void Viewport_Reset(void)
+{
+    const SHELL_SIZE size = Shell_GetCurrentSize();
+    GFX_Context_SetWindowSize(size.w, size.h);
 }

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -62,26 +62,8 @@ static SHELL_ARGS m_Args = {
     .save_to_load = -1,
 };
 
-static SHELL_SIZE m_ViewportSize = { .w = -1, .h = -1 };
-static Uint64 m_UpdateDebounce = 0;
-static bool m_IgnoreConfigChanges = false;
-
-static void M_SyncToWindow(void);
-static void M_SyncFromWindow(bool update_viewport);
-static bool M_MustUpdateRendererViewport(void);
-static void M_RefreshRendererViewport(void);
-static void M_HandleFocusGained(void);
-static void M_HandleFocusLost(void);
-static void M_HandleWindowShown(void);
-static void M_HandleWindowRestored(void);
-static void M_HandleWindowMinimized(void);
-static void M_HandleWindowMaximized(void);
-static void M_HandleWindowMoved(int32_t x, int32_t y);
-static void M_HandleWindowResized(int32_t width, int32_t height);
 static bool M_CreateGameWindow(void);
-
 static void M_ShowHelp(void);
-static void M_HandleConfigChange(const EVENT *event, void *data);
 static void M_ShowWindow(void);
 
 static struct {
@@ -92,161 +74,6 @@ static struct {
     int32_t width;
     int32_t height;
 } m_LastWindowState = {};
-
-static void M_SyncToWindow(void)
-{
-    m_UpdateDebounce = SDL_GetTicks();
-
-    LOG_DEBUG(
-        "is_fullscreen=%d is_maximized=%d x=%d y=%d width=%d height=%d",
-        g_Config.window.is_fullscreen, g_Config.window.is_maximized,
-        g_Config.window.x, g_Config.window.y, g_Config.window.width,
-        g_Config.window.height);
-
-    if (g_Config.window.is_fullscreen) {
-        SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-        SDL_ShowCursor(SDL_DISABLE);
-    } else if (g_Config.window.is_maximized) {
-        SDL_SetWindowFullscreen(m_Window, 0);
-        SDL_MaximizeWindow(m_Window);
-        SDL_ShowCursor(SDL_ENABLE);
-    } else {
-        int32_t x = g_Config.window.x;
-        int32_t y = g_Config.window.y;
-        int32_t width = g_Config.window.width;
-        int32_t height = g_Config.window.height;
-        if (width <= 0 || height <= 0) {
-            width = 1280;
-            height = 720;
-        }
-
-        // Handle default position
-        if (x == -1 && y == -1) {
-            SDL_DisplayMode display_mode;
-            SDL_GetCurrentDisplayMode(0, &display_mode);
-            x = (display_mode.w - width) / 2;
-            y = (display_mode.h - height) / 2;
-        } else {
-            // Adjust window position if completely offscreen
-            bool on_screen = false;
-            const int32_t num_displays = SDL_GetNumVideoDisplays();
-            for (int32_t i = 0; i < num_displays; i++) {
-                SDL_Rect bounds;
-                SDL_GetDisplayBounds(i, &bounds);
-                if (x + width > bounds.x && x < bounds.x + bounds.w
-                    && y + height > bounds.y && y < bounds.y + bounds.h) {
-                    on_screen = true;
-                    break;
-                }
-            }
-            if (!on_screen) {
-                x = 0;
-                y = 0;
-                // Find the first display to reposition the window
-                SDL_Rect bounds;
-                SDL_GetDisplayBounds(0, &bounds);
-                x = bounds.x + (bounds.w - width) / 2;
-                y = bounds.y + (bounds.h - height) / 2;
-            }
-        }
-
-        SDL_SetWindowFullscreen(m_Window, 0);
-        SDL_SetWindowPosition(m_Window, x, y);
-        SDL_SetWindowSize(m_Window, width, height);
-        SDL_ShowCursor(SDL_ENABLE);
-    }
-}
-
-static void M_SyncFromWindow(const bool update_viewport)
-{
-    // Determine if this call should sync config, i.e., skip immediate
-    // programmatic events
-    const Uint32 now = SDL_GetTicks();
-    const bool skip_config = (now - m_UpdateDebounce) < 500;
-
-    // Always pull current window state for logging and viewport reset
-    const Uint32 window_flags = SDL_GetWindowFlags(m_Window);
-    const bool is_maximized = window_flags & SDL_WINDOW_MAXIMIZED;
-    int32_t x, y;
-    int32_t width, height;
-    SDL_GetWindowSize(m_Window, &width, &height);
-    SDL_GetWindowPosition(m_Window, &x, &y);
-    LOG_INFO("%dx%d+%d,%d (maximized: %d)", width, height, x, y, is_maximized);
-
-    // Update config only when not in debounce window
-    if (!skip_config) {
-        g_Config.window.is_maximized = is_maximized;
-        if (!is_maximized && !g_Config.window.is_fullscreen) {
-            g_Config.window.x = x;
-            g_Config.window.y = y;
-            g_Config.window.width = width;
-            g_Config.window.height = height;
-        } else {
-            g_Config.window.fs_width = width;
-            g_Config.window.fs_height = height;
-        }
-        if (g_Config.loaded) {
-            m_IgnoreConfigChanges = true;
-            Config_Write();
-            m_IgnoreConfigChanges = false;
-        }
-    }
-
-    if (update_viewport || M_MustUpdateRendererViewport()) {
-        // Refresh viewport to reflect the actual window size
-        M_RefreshRendererViewport();
-    }
-}
-
-static bool M_MustUpdateRendererViewport(void)
-{
-    const SHELL_SIZE size = Shell_GetCurrentSize();
-    return m_ViewportSize.w != size.w || m_ViewportSize.h != size.h;
-}
-
-static void M_RefreshRendererViewport(void)
-{
-    Viewport_Reset();
-    m_ViewportSize = Shell_GetCurrentSize();
-}
-
-static void M_HandleFocusGained(void)
-{
-}
-
-static void M_HandleFocusLost(void)
-{
-}
-
-static void M_HandleWindowShown(void)
-{
-    LOG_DEBUG("");
-}
-
-static void M_HandleWindowRestored(void)
-{
-    M_SyncFromWindow(true);
-}
-
-static void M_HandleWindowMinimized(void)
-{
-    LOG_DEBUG("");
-}
-
-static void M_HandleWindowMaximized(void)
-{
-    M_SyncFromWindow(true);
-}
-
-static void M_HandleWindowMoved(const int32_t x, const int32_t y)
-{
-    M_SyncFromWindow(false);
-}
-
-static void M_HandleWindowResized(int32_t width, int32_t height)
-{
-    M_SyncFromWindow(true);
-}
 
 static bool M_CreateGameWindow(void)
 {
@@ -282,35 +109,11 @@ static void M_ShowHelp(void)
     puts("-s/--save <NUM>: launch from a specific save slot (starts at 1).");
 }
 
-void Shell_HandleConfigChange(const EVENT *const event, void *const data)
+void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
 {
-    const CONFIG *const old = &g_Config;
-    const CONFIG *const new = &g_SavedConfig;
+    Shell_HandleCommonConfigChange(old, new);
 
 #define L_CHANGED(subject) (old->subject != new->subject)
-
-    if (L_CHANGED(audio.sound_volume)) {
-        Sound_SetMasterVolume(g_Config.audio.sound_volume);
-    }
-    if (L_CHANGED(audio.music_volume)) {
-        Music_SetVolume(g_Config.audio.music_volume);
-    }
-
-    if (L_CHANGED(language)) {
-        GameStringManager_ReloadLanguage(g_Config.language);
-    }
-
-    if (L_CHANGED(window.is_fullscreen) || L_CHANGED(window.is_maximized)
-        || L_CHANGED(window.width) || L_CHANGED(window.height)
-        || L_CHANGED(window.fs_width) || L_CHANGED(window.fs_height)
-        || L_CHANGED(rendering.scaler) || L_CHANGED(rendering.sizer)
-        || L_CHANGED(rendering.aspect_mode) || L_CHANGED(visuals.use_psx_fov)) {
-        LOG_DEBUG("Change in settings detected");
-        if (!m_IgnoreConfigChanges) {
-            M_SyncToWindow();
-        }
-        M_RefreshRendererViewport();
-    }
 
     if (L_CHANGED(rendering.render_mode)) {
         Render_Reset(RENDER_RESET_ALL);
@@ -335,23 +138,17 @@ void Shell_HandleConfigChange(const EVENT *const event, void *const data)
         || L_CHANGED(visuals.water_color.r)) {
         Output_ApplyLevelSettings();
     }
-
-    if (L_CHANGED(rendering.aspect_mode) || L_CHANGED(window.width)
-        || L_CHANGED(window.height) || L_CHANGED(window.fs_width)
-        || L_CHANGED(window.fs_height)) {
-        Output_ReloadBackgroundImage();
-    }
 #undef L_CHANGED
 }
 
 static void M_ShowWindow(void)
 {
     Render_Init();
-    M_SyncToWindow();
+    Shell_SyncToWindow();
 
     SDL_ShowWindow(m_Window);
     SDL_RaiseWindow(m_Window);
-    M_RefreshRendererViewport();
+    Shell_RefreshRendererViewport();
 
     Viewport_AlterFOV(-1);
     Viewport_Reset();
@@ -544,44 +341,6 @@ void Shell_ProcessEvents(void)
     while (SDL_PollEvent(&event) != 0) {
         if (Shell_ProcessCommonEvent(&event)) {
             continue;
-        }
-
-        switch (event.type) {
-        case SDL_WINDOWEVENT:
-            switch (event.window.event) {
-            case SDL_WINDOWEVENT_SHOWN:
-                M_HandleWindowShown();
-                break;
-
-            case SDL_WINDOWEVENT_FOCUS_GAINED:
-                M_HandleFocusGained();
-                break;
-
-            case SDL_WINDOWEVENT_FOCUS_LOST:
-                M_HandleFocusLost();
-                break;
-
-            case SDL_WINDOWEVENT_RESTORED:
-                M_HandleWindowRestored();
-                break;
-
-            case SDL_WINDOWEVENT_MINIMIZED:
-                M_HandleWindowMinimized();
-                break;
-
-            case SDL_WINDOWEVENT_MAXIMIZED:
-                M_HandleWindowMaximized();
-                break;
-
-            case SDL_WINDOWEVENT_MOVED:
-                M_HandleWindowMoved(event.window.data1, event.window.data2);
-                break;
-
-            case SDL_WINDOWEVENT_RESIZED:
-                M_HandleWindowResized(event.window.data1, event.window.data2);
-                break;
-            }
-            break;
         }
     }
 }

--- a/src/tr2/game/viewport.h
+++ b/src/tr2/game/viewport.h
@@ -50,8 +50,6 @@ typedef struct {
     } game_vars;
 } VIEWPORT;
 
-void Viewport_Reset(void);
-
 void Viewport_Restore(const VIEWPORT *ref_vp);
 
 const VIEWPORT *Viewport_Get(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3418.
Another bit for #3332.
Underneath, this takes the TR2 shell events code which is slightly better.

#### Testing

Everything related to window moving, full screen toggling etc. + relaunching the game.
The game in windowed mode should be positioned in the same spot between relaunches.
Furthermore an offscreen window (eg a window with ridiculous values in "x" or "y") should be brought back to the main monitor center.
Resizing the window should switch the background in both games to a variant with a fitting aspect ratio. Same with moving the game using hotkeys across monitors.