### PR TITLE
tr2/vehicles/boat: ignore side inputs when looking

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -52,6 +52,7 @@
 - fixed the Bartoli's Hideout sunset effect being reset after reloading a save (#1617)
 - fixed the shotgun sound at the end of the shower cutscene in Home Sweet Home being cut off when the credits start (#1579)
 - fixed the camera being partially inside the wall at the end of the Home Sweet Home shower cutscene (#3370)
+- fixed the boat veering if Lara looks left or right when driving (#3409)
 - fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
 - fixed Lara getting stuck in the fly cheat in rare circumstances (#3392, regression from 0.3)
 - fixed support for >3 secret dragons in custom levels (#3415, regression from 1.2)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -281,6 +281,7 @@ However, you can easily download them manually from these urls:
 - fixed Lara being able to equip guns and flares during in-game cutscenes
 - fixed the same boss item always being selected in Home Sweet Home, regardless of Lara's proximity
 - fixed Lara behaving erratically if she is killed while hanging from a ledge
+- fixed the boat veering if Lara looks left or right when driving
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -9,6 +9,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/game_buf.h>
@@ -432,7 +433,12 @@ static int32_t M_UserControl(ITEM *const boat)
         return no_turn;
     }
 
-    if ((g_Input.left && !g_Input.back) || (g_Input.right && g_Input.back)) {
+    const bool look =
+        g_Input.look && g_Config.gameplay.look_mode != LOOK_MODE_RESTRICTED;
+    const bool left_input = g_Input.left && !look;
+    const bool right_input = g_Input.right && !look;
+
+    if ((left_input && !g_Input.back) || (right_input && g_Input.back)) {
         if (boat_data->boat_turn > 0) {
             boat_data->boat_turn -= BOAT_UNDO_TURN;
         } else {
@@ -440,8 +446,7 @@ static int32_t M_UserControl(ITEM *const boat)
             CLAMPL(boat_data->boat_turn, -BOAT_MAX_TURN);
         }
         no_turn = 0;
-    } else if (
-        (g_Input.right && !g_Input.back) || (g_Input.left && g_Input.back)) {
+    } else if ((right_input && !g_Input.back) || (left_input && g_Input.back)) {
         if (boat_data->boat_turn < 0) {
             boat_data->boat_turn += BOAT_UNDO_TURN;
         } else {
@@ -473,7 +478,7 @@ static int32_t M_UserControl(ITEM *const boat)
         }
     } else if (
         boat->speed >= 0 && boat->speed < BOAT_MIN_SPEED
-        && (g_Input.left || g_Input.right)) {
+        && (left_input || right_input)) {
         boat->speed = BOAT_MIN_SPEED;
     } else if (boat->speed > BOAT_SLOWDOWN) {
         boat->speed -= BOAT_SLOWDOWN;


### PR DESCRIPTION
Resolves #3409.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the boat isn't steered if Lara is looking left or right. If look mode is restricted, holding look and a direction will let you steer, similar to the skidoo.
