### PR TITLE
More love for videos

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -70,6 +70,7 @@
 - fixed certain secrets not registering (#3252, regression from 4.12)
 
 ## [4.12](https://github.com/LostArtefacts/TRX/compare/tr1-4.11.2...tr1-4.12) - 2025-06-17
+Showcase: https://www.youtube.com/watch?v=IqjVuXTVI4A
 - added builtin support for ingame string translations
     - changed duplicate game strings between TR1 and TR2 to be placed in a single file TRX_common_strings.json5
     - added a new setting, `enable_review_markers`, which display which text requires review (only available via `/set`)
@@ -139,6 +140,7 @@
 - fixed crashes in the save dialog on Linux (#3046, regression from 4.11)
 
 ## [4.11](https://github.com/LostArtefacts/TRX/compare/tr1-4.10.2...tr1-4.11) - 2025-05-21
+Showcase: https://www.youtube.com/watch?v=JVtcZoNoeRM
 - added the ability to trigger a flip effect without having to also trigger the flip map, in line with TR2 (#2921)
 - added a /help command (#2917)
 - added an option to toggle between TR1 and TR2 camera modes (#2990)
@@ -180,6 +182,7 @@
 - fixed water caustics appearance (#2896, regression from 4.10)
 
 ## [4.10](https://github.com/LostArtefacts/TRX/compare/tr1-4.9...tr1-4.10) - 2025-04-30
+Showcase: https://www.youtube.com/watch?v=qJPq9obD6Cc
 - added an ability to customize the fog distances (#634)
 - added an ability to customize the water color [see the reference](/docs/GAME_FLOW.md#water-color-table) (#1532)  
 - added support for a hex water color notation (eg. `#80FFFF`) in the game flow file
@@ -234,6 +237,7 @@
 - removed the pretty pixels options (it's now always enabled, #2258)
 
 ## [4.9](https://github.com/LostArtefacts/TRX/compare/tr1-4.8.3...tr1-4.9) - 2025-03-31
+Showcase: https://www.youtube.com/watch?v=AYVpnsYQNno
 - added quadrilateral interpolation (#354)
 - added `/flood` and `/drain` console commands
 - added support for `-l`/`--level` argument to play a single level
@@ -293,6 +297,7 @@
 - fixed loading non-Caves saves triggering a new save prompt when save crystals are enabled (#2498, regression from 4.8)
 
 ## [4.8](https://github.com/LostArtefacts/TRX/compare/tr1-4.7.1...tr1-4.8) - 2025-02-14
+Showcase: https://www.youtube.com/watch?v=td2Qz3nbRVo
 >[!WARNING]
 >Attention level builders: this version introduces backwards incompatible changes to the game flow file.
 >Please refer to the following documents to see how to update your levels:
@@ -370,6 +375,7 @@
 - fixed hiding game UI causing the reset progressbar UI element to not show (regression from 4.7)
 
 ## [4.7](https://github.com/LostArtefacts/TRX/compare/tr1-4.6.1...tr1-4.7) - 2024-12-20
+Showcase: https://www.youtube.com/watch?v=ThXt0I2j_QI
 - added support for Wayland in binary Linux builds (#1927)
 - added support for Unicode in gameflow JSON (#386, #636, #1919 and #1928)
     Expanding on the 4.6's added support for named sequences, we now support
@@ -421,6 +427,7 @@
 - fixed game crashing when changing the save slot with `/set` when in passport (#1954, regression from 4.2)
 
 ## [4.6](https://github.com/LostArtefacts/TRX/compare/tr1-4.5.1...tr1-4.6) - 2024-11-18
+Showcase: https://www.youtube.com/watch?v=raSzSAu7kLI
 - added support for wading, similar to TR2+ (#1537)
 - added the ability to pause during cutscenes (#1673)
 - added an option to enable responsive swim cancellation, similar to TR2+ (#1004)
@@ -495,6 +502,7 @@
 - fixed mac builds missing embedded resources (#1710, regression from 4.5)
 
 ## [4.5](https://github.com/LostArtefacts/TRX/compare/tr1-4.4...tr1-4.5) - 2024-10-08
+Showcase: https://www.youtube.com/watch?v=eMnVYbB4QBc
 - added a photo mode feature (#1669)
 - added `/sfx` command
 - added `/nextlevel` alias to `/endlevel` console command
@@ -526,6 +534,7 @@
 - removed dedicated camera reset button in favor of pressing the look button (#1658)
 
 ## [4.4](https://github.com/LostArtefacts/TRX/compare/tr1-4.3...tr1-4.4) - 2024-09-20
+Showcase: https://www.youtube.com/watch?v=3XOSl9WqH3A
 - added `/exit` command (#1462)
 - added reflections to Midas Hand death animation and savegame crystals (#154)
 - added an option to use PS1 tinted savegame crystals (#1506)
@@ -568,6 +577,7 @@
 - improved skybox appearance (#1520)
 
 ## [4.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.2...tr1-4.3) - 2024-08-15
+Showcase: https://www.youtube.com/watch?v=kc2oo-pSMh0
 - added deadly water feature from TR2+ for custom levels (#1404)
 - added skybox support, with a default option provided for Lost Valley, Colosseum and Obelisk of Khamoon (#94)
 - added an option for Lara to use her underwater swimming physics from TR2+ (#1003)
@@ -588,6 +598,7 @@
 - improved initial level load time by lazy-loading audio samples (LostArtefacts/TR2X#114)
 
 ## [4.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.1.2...tr1-4.2) - 2024-07-14
+Showcase: https://www.youtube.com/watch?v=gV7oz0wEzWk
 - added creating minidump files on crashes
 - added new console commands:
     - `/hp`
@@ -620,6 +631,7 @@
 - fixed reading animated texture data in levels (#1346, regression from 4.1)
 
 ## [4.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.0.3...tr1-4.1) - 2024-04-26
+Showcase: https://www.youtube.com/watch?v=ioo2P0FuFWU
 - added ability to show enemy healthbars only for bosses (#1300)
 - added ability to kill specific enemy types (#1313)
 - added ability to teleport to nearest specific object (#1312)
@@ -665,6 +677,7 @@
 - fixed trying to pick up a lead bar crashing the game (#1293, regression from 4.0)
 
 ## [4.0](https://github.com/LostArtefacts/TRX/compare/tr1-3.1.1...tr1-4.0) - 2024-04-09
+Showcase: https://www.youtube.com/watch?v=-ED8HSHdHHQ&t=63s
 - added experimental support for 60 FPS, available from the in-game graphics menu
 - added ability to slow the game down using the turbo cheat (#1215)
 - added /speed command to control the turbo cheat (#1215)
@@ -745,6 +758,7 @@
 - fixed installer not detecting old Tomb1Main installations (#1071)
 
 ## [3.0](https://github.com/LostArtefacts/TRX/compare/tr1-2.16...tr1-3.0) - 2023-11-09
+Showcase: https://www.youtube.com/watch?v=vqvOkZzHx6M
 - renamed the project from Tomb1Main to TR1X in an effort to establish our own unique identity, while respectfully disassociating from TR2Main.
 - added developer console (accessible with `/`, see [COMMANDS.md] for details)
 - added Linux builds and toolchain

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -85,6 +85,7 @@
 - reverted the partial fix for wrong audio device reinitialization (#3251, regression from 1.2)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.1...tr2-1.2) - 2025-06-17
+Showcase: https://www.youtube.com/watch?v=yG82_Lt6v9M
 - added builtin support for ingame string translations
     - changed duplicate game strings between TR1 and TR2 to be placed in a single file TRX_common_strings.json5
     - added a new setting, `enable_review_markers`, which display which text requires review (only available via `/set`)
@@ -158,6 +159,7 @@
 - improved the dev console commands documentation
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.0.2...tr2-1.1) - 2025-05-23
+Showcase: https://www.youtube.com/watch?v=g5lrrDXDYKo
 - added a /help command (#2917)
 - added a flashing Demo Mode caption to demos (#1556)
 - added arrows to the passport text like in TR1X (#2926)
@@ -231,6 +233,7 @@
 - improved graphic settings dialog sizing (#2841)
 
 ## [1.0](https://github.com/LostArtefacts/TRX/compare/tr2-0.10...tr2-1.0) - 2025-04-23
+Showcase: https://www.youtube.com/watch?v=iUNUJda6QCU
 - added support for The Golden Mask (#1621)
 - added ability to turn off legal screen and FMVs (#2740)
 - added ability to turn off ingame cutscenes (#2127)
@@ -297,6 +300,7 @@
 - removed the FPS and aspect mode options from the config tool (now available in-game in the graphics options)
 
 ## [0.10](https://github.com/LostArtefacts/TRX/compare/tr2-0.9.2...tr2-0.10) - 2025-03-18
+Showcase: https://www.youtube.com/watch?v=s41hznpTJkY
 - added support for 60 FPS rendering
 - added support for more accented characters (#2356)
 - added quadrilateral interpolation (#354)
@@ -353,6 +357,7 @@
 - improved memory usage by shedding ca. 100-110 MB on average
 
 ## [0.9](https://github.com/LostArtefacts/TRX/compare/tr2-0.8...tr2-0.9) - 2025-02-14
+Showcase: https://www.youtube.com/watch?v=FrBSW35ZPKY
 - added Linux builds and toolchain (#1598)
 - added macOS builds (for both Apple Silicon and Intel) (#2226)
 - added pause dialog (#1638)

--- a/tools/output_current_changelog
+++ b/tools/output_current_changelog
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
 import argparse
 
+from shared.changelog import Changelog, get_current_version_changelog
 from shared.git import Git
-from shared.versioning import generate_version
-from shared.changelog import get_current_version_changelog
 from shared.paths import PROJECT_PATHS
+from shared.versioning import generate_version
+
+
+def output_changelog(
+    changelog: Changelog, commit_hash: str | None = None
+) -> None:
+    print(f"**{changelog.release_name}** – ", end="")
+    if changelog.release_date:
+        print(f"{changelog.release_date:%Y-%m-%d}", end=" - ")
+    print(f"[Diff]({changelog.diff_url})", end=" · ")
+    print(f"[History]({changelog.commits_url})")
+    print()
+    print("### Changes:")
+    print(changelog.body)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("version", choices=['1', '2', 'all'])
+    parser.add_argument("version", choices=["1", "2", "all"])
     return parser.parse_args()
 
 
@@ -18,25 +31,22 @@ def main() -> None:
 
     commit_hash = Git().get_current_commit_hash()
 
-    if args.version == 'all':
+    if args.version == "all":
         print(f"**Commit: {commit_hash}**  ")
         print()
         for version, project_paths in PROJECT_PATHS.items():
             commit_tag = generate_version(version)
-            print(f'### TR{version}X changes')
+            changelog = get_current_version_changelog(
+                project_paths.changelog_path
+            )
+            print(f"### TR{version}X changes")
             print()
-            print(f'**Tag: {commit_tag}**')
-            print()
-            print(get_current_version_changelog(project_paths.changelog_path))
-            print()
+            output_changelog(changelog)
     else:
         project_paths = PROJECT_PATHS.get(int(args.version))
         commit_tag = generate_version(int(args.version))
-        print(f"**Commit: {commit_hash}**  ")
-        print(f"**Tag: {commit_tag}**")
-        print()
-        print("### Changes")
-        print(get_current_version_changelog(project_paths.changelog_path))
+        changelog = get_current_version_changelog(project_paths.changelog_path)
+        output_changelog(changelog, commit_hash=commit_hash)
 
 
 if __name__ == "__main__":

--- a/tools/output_current_changelog
+++ b/tools/output_current_changelog
@@ -16,6 +16,14 @@ def output_changelog(
     print(f"[Diff]({changelog.diff_url})", end=" · ")
     print(f"[History]({changelog.commits_url})")
     print()
+    if changelog.video_id:
+        print("### Video preview:")
+        print()
+        print(
+            f"[![Video](https://i.ytimg.com/vi/{changelog.video_id}/maxresdefault.jpg)]"
+            f"(https://www.youtube.com/watch?v={changelog.video_id})"
+        )
+        print()
     print("### Changes:")
     print(changelog.body)
 

--- a/tools/release
+++ b/tools/release
@@ -37,6 +37,12 @@ class CommitCommand(BaseCommand):
     def decorate_parser(self, parser: argparse.ArgumentParser) -> None:
         super().decorate_parser(parser)
         parser.add_argument(
+            "--video-url",
+            "--video",
+            "--yt",
+            help="link to the release video URL",
+        )
+        parser.add_argument(
             "-d",
             "--dry-run",
             action="store_true",
@@ -60,6 +66,7 @@ class CommitCommand(BaseCommand):
             new_version_name=args.version,
             stable_branch=options.stable_branch,
             develop_branch=options.develop_branch,
+            video_url=args.video_url,
         )
         if old_changelog == new_changelog:
             return

--- a/tools/release
+++ b/tools/release
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import difflib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -72,7 +73,16 @@ class CommitCommand(BaseCommand):
             return
 
         if args.dry_run:
-            print(new_changelog, end="")
+            print(
+                "".join(
+                    difflib.unified_diff(
+                        old_changelog.splitlines(keepends=True),
+                        new_changelog.splitlines(keepends=True),
+                        fromfile=str(changelog_path),
+                        tofile=str(changelog_path),
+                    )
+                )
+            )
             return
 
         changelog_path.write_text(new_changelog)

--- a/tools/shared/changelog.py
+++ b/tools/shared/changelog.py
@@ -11,6 +11,7 @@ BASE_URL = "https://github.com/LostArtefacts/TRX"
 @dataclass
 class Changelog:
     release_name: str
+    video_id: str | None
     body: str
     commit_tag: str
     diff_url: str
@@ -19,6 +20,14 @@ class Changelog:
     @property
     def commits_url(self):
         return f"{BASE_URL}/commits/{self.commit_tag}/"
+
+
+def get_youtube_id(url: str) -> str | None:
+    if match := re.match(
+        r"https://(?:www\.)?youtube\.com/watch\?v=(\w+)", url
+    ):
+        return match.group(1)
+    return None
 
 
 def get_current_version_changelog(changelog_path: Path) -> Changelog:
@@ -32,7 +41,17 @@ def get_current_version_changelog(changelog_path: Path) -> Changelog:
     if sections:
         section_lines = sections[0].splitlines()
         header = section_lines.pop(0)
+
+        video_id: str | None = None
+        for i, line in reversed(list(enumerate(section_lines))):
+            if "youtube.com" in line:
+                video_id = get_youtube_id(
+                    re.search(r"\S+youtube\.com\S+", line).group(0)
+                )
+                section_lines.pop(i)
+
         return Changelog(
+            video_id=video_id,
             release_name=re.search(r"## \[([^\]]+?)\]", header).group(1),
             commit_tag=re.search(r"\.\.\.([^\)]+?)\)", header).group(1),
             diff_url=re.search(r"\(([^\)]+?)\)", header).group(1),
@@ -54,15 +73,18 @@ def update_changelog_to_new_version(
     new_version_name: str,
     stable_branch: str | None = "stable",
     develop_branch: str = "develop",
+    video_url: str | None = None,
 ) -> str:
     if f"[{new_version_name}]" in changelog:
         return changelog
     today = date.today().strftime("%Y-%m-%d")
     repo_url = "https://github.com/LostArtefacts/TRX"
+
+    header = f"## [Unreleased]({repo_url}/compare/{new_tag}...{develop_branch}) - ××××-××-××\n\n"
+    header += f"## [{new_version_name}]({repo_url}/compare/{old_tag}...{new_tag}) - {today}\n"
+    if video_url:
+        header += f"Showcase: {video_url}\n"
+
     changelog = re.sub(r"^## \[Unreleased\].*\n*", "", changelog, flags=re.M)
-    changelog = (
-        f"## [Unreleased]({repo_url}/compare/{new_tag}...{develop_branch}) - ××××-××-××\n\n"
-        f"## [{new_version_name}]({repo_url}/compare/{old_tag}...{new_tag}) - {today}\n"
-        + changelog
-    )
+    changelog = header + changelog
     return changelog

--- a/tools/shared/changelog.py
+++ b/tools/shared/changelog.py
@@ -1,18 +1,49 @@
 import re
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
+from dateutil.parser import parse as parse_date
 
-def get_current_version_changelog(changelog_path: Path) -> str:
+BASE_URL = "https://github.com/LostArtefacts/TRX"
+
+
+@dataclass
+class Changelog:
+    release_name: str
+    body: str
+    commit_tag: str
+    diff_url: str
+    release_date: date | None
+
+    @property
+    def commits_url(self):
+        return f"{BASE_URL}/commits/{self.commit_tag}/"
+
+
+def get_current_version_changelog(changelog_path: Path) -> Changelog:
     sections = [
         section.strip()
-        for section in re.split("^##", changelog_path.read_text(), flags=re.M)
+        for section in re.split(
+            "^(?=##)", changelog_path.read_text(), flags=re.M
+        )
         if re.search(r"- \w", section)
     ]
     if sections:
-        section = sections[0]
-        return "\n".join(
-            line for line in section.splitlines() if not line.startswith("#")
+        section_lines = sections[0].splitlines()
+        header = section_lines.pop(0)
+        return Changelog(
+            release_name=re.search(r"## \[([^\]]+?)\]", header).group(1),
+            commit_tag=re.search(r"\.\.\.([^\)]+?)\)", header).group(1),
+            diff_url=re.search(r"\(([^\)]+?)\)", header).group(1),
+            release_date=(
+                parse_date(match.group(1))
+                if (match := re.search(r" - (\d{4}-\d{2}-\d{2})", header))
+                else None
+            ),
+            body="\n".join(
+                line for line in section_lines if not line.startswith("#")
+            ),
         )
 
 
@@ -26,9 +57,9 @@ def update_changelog_to_new_version(
 ) -> str:
     if f"[{new_version_name}]" in changelog:
         return changelog
-    today = datetime.now().strftime('%Y-%m-%d')
-    repo_url = 'https://github.com/LostArtefacts/TRX'
-    changelog = re.sub(r'^## \[Unreleased\].*\n*', '', changelog, flags=re.M)
+    today = date.today().strftime("%Y-%m-%d")
+    repo_url = "https://github.com/LostArtefacts/TRX"
+    changelog = re.sub(r"^## \[Unreleased\].*\n*", "", changelog, flags=re.M)
     changelog = (
         f"## [Unreleased]({repo_url}/compare/{new_tag}...{develop_branch}) - ××××-××-××\n\n"
         f"## [{new_version_name}]({repo_url}/compare/{old_tag}...{new_tag}) - {today}\n"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Adds showcase videos to the changelog for historic releases of both games
- Updates the `tools/release` script to embed this URL when preparing the changelog, provided with an optional `--video` argument
- Updates the `tools/output_current_changelog` script to use this information when preparing release notes on GitHub
- Updates the internal plumbing to use strongly typed changelog information rather treating it as a lump of text
- Updates the format of the GitHub release notes

    Previous format:

    > **Commit: d8c427581e6b448f3aa31181cabffb9c9ff360b9**  
    > **Tag: 4.12.3-217-gd8c4275-dirty**
    > 
    > ### Changes
    > [4.12.3](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.2...tr1-4.12.3) - 2025-06-24
    > - fixed game crashing when the expected resources are missing (`#3310`, regression from 4.12.2)
    > - fixed restore default pop-up requiring all 3 water color options to be adjusted instead of just one (`#3314`, regression from 4.12)
    > - fixed pause screen rendered without background overlay if fade effects are disabled (`#3316`, regression from 4.11)
    > - fixed `/pos` command crashing when the level title is not set (regression from 4.12)

    New format:

    > **4.12.3** – 2025-06-24 - [Diff](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.2...tr1-4.12.3) · [History](https://github.com/LostArtefacts/TRX/commits/tr1-4.12.3/)
    > 
    > ### Changes:
    > - fixed game crashing when the expected resources are missing (`#3310`, regression from 4.12.2)
    > - fixed restore default pop-up requiring all 3 water color options to be adjusted instead of just one (`#3314`, regression from 4.12)
    > - fixed pause screen rendered without background overlay if fade effects are disabled (`#3316`, regression from 4.11)
    > - fixed `/pos` command crashing when the level title is not set (regression from 4.12)
