### PR TITLE
Midas fix

### DIFF
--- a/src/libtrx/game/lara/cheat.c
+++ b/src/libtrx/game/lara/cheat.c
@@ -281,6 +281,9 @@ bool Lara_Cheat_EnterFlyMode(void)
     lara_info->mesh_effects = 0;
     lara_item->enable_shadow = true;
     lara_item->hit_points = LARA_MAX_HITPOINTS;
+    lara_info->interact_target.item_num = NO_ITEM;
+    lara_info->interact_target.is_moving = false;
+    lara_info->interact_target.move_count = 0;
 
     M_ReinitialiseGunMeshes();
     g_Camera.type = CAM_CHASE;

--- a/src/libtrx/game/lara/state/extra.c
+++ b/src/libtrx/game/lara/state/extra.c
@@ -62,6 +62,7 @@ static void M_UseMidas(ITEM *const item, COLL_INFO *const coll)
 
     if (Item_TestFrameEqual(item, M_LF_PICKUP_GOLD_BAR)) {
         Overlay_AddDisplayPickup(O_PUZZLE_ITEM_1);
+        Inv_RemoveItem(O_LEADBAR_ITEM);
         Inv_AddItem(O_PUZZLE_ITEM_1);
         LARA_INFO *const lara = Lara_GetLaraInfo();
         lara->interact_target.item_num = NO_ITEM;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes Midas Hand not consuming lead bars (scope limited to interactions with the Midas Hand), and using the fly cheat in the middle of interaction with the Midas Hand breaking it indefinitely (scope covers entering the fly cheat during any interactive item animation).