### PR TITLE
input: allow skipping credits faster

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -11,6 +11,7 @@
 - added the ability to skip end game credits (#3266)
 - added the ability to hide specific game settings (#3242)
 - added the ability to cycle UI tabs with sidestep keys (#3272)
+- added the ability to skip consecutive credit images by holding the action / escape keys
 - added dedicated British English translation (#3212)
 - added a `/lighting` console command to let the player turn lighting system on/off
 - added an `/immune` console command to make Lara impervious to damage

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added the ability to hide specific game settings (#3242)
 - added the ability to cycle UI tabs with sidestep keys (#3272)
 - added the ability to change the health bar color for allies, defaulting to green (#3005)
+- added the ability to skip consecutive credit images by holding the action / escape keys
 - added dedicated British English translation (#3212)
 - added a new easter egg command
 - added a `/lighting` console command to let the player turn lighting system on/off

--- a/src/libtrx/game/input/backends/controller.c
+++ b/src/libtrx/game/input/backends/controller.c
@@ -413,6 +413,7 @@ static bool M_CustomUpdate(INPUT_STATE *const result, const INPUT_LAYOUT layout)
         return false;
     }
     result->menu_back |= M_JoyBtn(SDL_CONTROLLER_BUTTON_Y);
+    result->menu_skip = result->menu_confirm || result->menu_back;
     return true;
 }
 

--- a/src/libtrx/game/input/backends/keyboard.c
+++ b/src/libtrx/game/input/backends/keyboard.c
@@ -387,6 +387,7 @@ static bool M_CustomUpdate(INPUT_STATE *const result, const INPUT_LAYOUT layout)
     result->menu_confirm |= result->action;
     result->toggle_fullscreen =
         KEY_DOWN(SDL_SCANCODE_RETURN) && KEY_DOWN(SDL_SCANCODE_LALT);
+    result->menu_skip = result->menu_confirm || result->menu_back;
     return true;
 }
 

--- a/src/libtrx/game/input/common.c
+++ b/src/libtrx/game/input/common.c
@@ -34,6 +34,7 @@ static M_HOLD_CHECK m_HoldChecks[] = {
     { .role = INPUT_ROLE_MENU_DOWN, .delay_time = 0.4, .hold_time = 0.1 },
     { .role = INPUT_ROLE_MENU_LEFT, .delay_time = 0.4, .hold_time = 0.2 },
     { .role = INPUT_ROLE_MENU_RIGHT, .delay_time = 0.4, .hold_time = 0.2 },
+    { .role = INPUT_ROLE_MENU_SKIP, .delay_time = 0.4, .hold_time = 0.1 },
     { .role = (INPUT_ROLE)-1 }, // sentinel
 };
 

--- a/src/libtrx/game/phase/phase_picture.c
+++ b/src/libtrx/game/phase/phase_picture.c
@@ -55,7 +55,8 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
 
     switch (p->state) {
     case STATE_FADE_IN:
-        if (g_InputDB.menu_confirm || g_InputDB.menu_back) {
+        if (g_InputDB.menu_confirm || g_InputDB.menu_back
+            || g_InputDB.menu_skip) {
             M_FadeOut(p);
         } else if (!Fader_IsActive(&p->fader)) {
             p->state = STATE_DISPLAY;
@@ -64,7 +65,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
         break;
 
     case STATE_DISPLAY:
-        if (g_InputDB.menu_confirm || g_InputDB.menu_back
+        if (g_InputDB.menu_confirm || g_InputDB.menu_back || g_InputDB.menu_skip
             || ClockTimer_CheckElapsed(
                 &p->timer,
                 p->args.display_time
@@ -76,7 +77,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
         break;
 
     case STATE_FADE_OUT:
-        if (g_InputDB.menu_confirm || g_InputDB.menu_back
+        if (g_InputDB.menu_confirm || g_InputDB.menu_back || g_InputDB.menu_skip
             || !Fader_IsActive(&p->fader)) {
             return (PHASE_CONTROL) {
                 .action = PHASE_ACTION_END,

--- a/src/libtrx/include/libtrx/game/input/roles.def
+++ b/src/libtrx/include/libtrx/game/input/roles.def
@@ -19,6 +19,7 @@ INPUT_ROLE_DEFINE(MENU_LEFT,               menu_left)
 INPUT_ROLE_DEFINE(MENU_UP,                 menu_up)
 INPUT_ROLE_DEFINE(MENU_DOWN,               menu_down)
 INPUT_ROLE_DEFINE(MENU_RIGHT,              menu_right)
+INPUT_ROLE_DEFINE(MENU_SKIP,               menu_skip)
 
 INPUT_ROLE_DEFINE(FLY_CHEAT,               fly_cheat)
 INPUT_ROLE_DEFINE(ITEM_CHEAT,              item_cheat)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Allows the player to hold the Action or Escape keys to skip through the credits faster, including fade effects. The skip will stop at the final stats screen. A side effect of the way I implemented this is that you can hold the Action key on the final level statistics, and it'll skip the images altogether, but I think it's actually desirable.