### PR TITLE
Improve muting on focus loss, add to TR2

### DIFF
--- a/data/common/ship/cfg/TRX_common_strings-fr.json5
+++ b/data/common/ship/cfg/TRX_common_strings-fr.json5
@@ -563,6 +563,8 @@
         "SOUND_SETTINGS_MUSIC_LOAD_CONDITION_NON_AMBIENT": "Pistes musicales",
         "SOUND_SETTINGS_MUSIC_VOLUME": "\\{icon sound} Volume de la musique",
         "SOUND_SETTINGS_MUSIC_VOLUME_DESCRIPTION": "Ajuste le volume de la musique et de l'ambiance.",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS": "\\{review}Couper le son lorsque la fenêtre perd le focus",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS_DESCRIPTION": "\\{review}Coupe toute la musique et les effets sonores lorsque la fenêtre du jeu n'est pas au premier plan.",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY": "Suspendre la musique dans l'inventaire",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY_DESCRIPTION": "Suspend les effets sonores du jeu, l'ambiance et la musique dans l'écran d'inventaire.",
         "SOUND_SETTINGS_PS_UZI_SFX": "Sons uzis PS1",

--- a/data/common/ship/cfg/TRX_common_strings-it.json5
+++ b/data/common/ship/cfg/TRX_common_strings-it.json5
@@ -563,6 +563,8 @@
         "SOUND_SETTINGS_MUSIC_LOAD_CONDITION_NON_AMBIENT": "Non ambientale",
         "SOUND_SETTINGS_MUSIC_VOLUME": "\\{icon sound} Volume musica",
         "SOUND_SETTINGS_MUSIC_VOLUME_DESCRIPTION": "Regola il volume della musica e dei suoni ambientali.",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS": "\\{review}Disattiva audio quando la finestra perde il focus",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS_DESCRIPTION": "\\{review}Disattiva tutta la musica e gli effetti sonori quando la finestra del gioco non è in focus.",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY": "Ferma musica nell'inventario",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY_DESCRIPTION": "Mette in pausa i suoni di gioco, la musica e i suoni ambientali nella schermata dell'inventario.",
         "SOUND_SETTINGS_PS_UZI_SFX": "Suono uzi PS1",

--- a/data/common/ship/cfg/TRX_common_strings-pl.json5
+++ b/data/common/ship/cfg/TRX_common_strings-pl.json5
@@ -563,6 +563,8 @@
         "SOUND_SETTINGS_MUSIC_LOAD_CONDITION_NON_AMBIENT": "Tylko muzyka",
         "SOUND_SETTINGS_MUSIC_VOLUME": "\\{icon sound} Głośność muzyki",
         "SOUND_SETTINGS_MUSIC_VOLUME_DESCRIPTION": "Dostosowuje głośność muzyki i dźwięków otoczenia.",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS": "Wycisz dźwięk po zminimalizowaniu",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS_DESCRIPTION": "Wycisza muzykę i efekty dźwiękowe, kiedy okno gry jest nieaktywne.",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY": "Wstrzymaj muzykę w ekwipunku",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY_DESCRIPTION": "Wstrzymuje dźwięki gry, dźwięki otoczenia i muzykę na ekranie ekwipunku.",
         "SOUND_SETTINGS_PS_UZI_SFX": "Dźwięk uzi z PS1",

--- a/data/common/ship/cfg/TRX_common_strings.json5
+++ b/data/common/ship/cfg/TRX_common_strings.json5
@@ -563,6 +563,8 @@
         "SOUND_SETTINGS_MUSIC_LOAD_CONDITION_NON_AMBIENT": "Non-ambient",
         "SOUND_SETTINGS_MUSIC_VOLUME": "\\{icon sound} Music volume",
         "SOUND_SETTINGS_MUSIC_VOLUME_DESCRIPTION": "Adjusts music and ambient volume.",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS": "Mute audio when focus lost",
+        "SOUND_SETTINGS_MUTE_OUT_OF_FOCUS_DESCRIPTION": "Mutes all music and sound effects when the game window is not focused.",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY": "Pause music in inventory",
         "SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY_DESCRIPTION": "Pauses game sounds, ambient and music in the inventory screen.",
         "SOUND_SETTINGS_PS_UZI_SFX": "PS1 uzi sound",

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -20,6 +20,7 @@
 - added an option to control responsive jumping lock behaviour (Gameplay settings → Controls → Jump lock mode) (#3389)
 - added an option to display level counter in the statistics dialog (Graphic options → UI → Level counter) (#1087)
 - added an option to control playing of certain animation sound effects such as doors when underwater (Sound options → Underwater animation SFX) (#3385)
+- added an option to allow the audio to play when the game is out of focus (Sound options → Mute audio when focus lost, #3333)
 - changed statistics details mode to be placed in the UI section
 - changed controls dialog to remember the player's preferred input method
 - changed UI to show icons relevant to the chosen input method

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed the camera resetting if Lara is looking and then draws her guns (OG behaviour retained when using restricted look mode) (#3406)
 - fixed game window getting misplaced in windowed mode between game relaunches on certain systems (#3418)
 - fixed Lara using the wrong hit animation under certain scenarios based on her hit angle (#3424)
+- fixed already playing samples not getting muted when the game window goes out of focus
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)
 - improved performance when resizing the window

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added the ability to cycle UI tabs with sidestep keys (#3272)
 - added the ability to change the health bar color for allies, defaulting to green (#3005)
 - added the ability to skip consecutive credit images by holding the action / escape keys
+- added muting of game audio when the game window is not in focus
 - added dedicated British English translation (#3212)
 - added a new easter egg command
 - added a `/lighting` console command to let the player turn lighting system on/off

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -7,7 +7,6 @@
 - added the ability to cycle UI tabs with sidestep keys (#3272)
 - added the ability to change the health bar color for allies, defaulting to green (#3005)
 - added the ability to skip consecutive credit images by holding the action / escape keys
-- added muting of game audio when the game window is not in focus
 - added dedicated British English translation (#3212)
 - added a new easter egg command
 - added a `/lighting` console command to let the player turn lighting system on/off
@@ -21,6 +20,7 @@
 - added an option to display level counter in the statistics dialog (Graphic options → UI → Level counter) (#1087)
 - added an option to control playing of certain animation sound effects such as doors when underwater (Sound options → Underwater animation SFX) (#3385)
 - added an option to choose between original TR1, original TR2 or unrestricted look modes (Gameplay settings → Controls → Look mode) (#3403)
+- added an option to allow the audio to mute when the game is out of focus (Sound options → Mute audio when focus lost, #3333)
 - added an option to set the upscaling filter (Graqphic settings → Rendering → Upscaling filter)
 - added an inverted look camera option (Gameplay settings → Controls → Inverted look) (#3403)
 - added missing end of level statistic screens to Home Sweet Home and Kingdom (#2682)

--- a/docs/tr2/README.md
+++ b/docs/tr2/README.md
@@ -376,6 +376,7 @@ However, you can easily download them manually from these urls:
 - added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves
 - added an option to continue playing music while in the inventory
 - added an option to control playing of certain animation sound effects such as doors when underwater
+- fixed game audio not muting when game is minimized
 - fixed music not playing with certain game versions
 - fixed the audio not being in sync when Lara strikes the gong in Ice Palace
 - fixed sound settings resuming the music

--- a/src/libtrx/config/map.def
+++ b/src/libtrx/config/map.def
@@ -7,6 +7,7 @@
 
 X_CFG_BOOL(audio.enable_music_in_inventory,          true)
 X_CFG_BOOL(audio.enable_underwater_anim_sfx,         true)
+X_CFG_BOOL(audio.mute_out_of_focus,                  true)
 X_CFG_BOOL(debug.enable_debug_pos,                   false)
 X_CFG_BOOL(debug.enable_invulnerability,             false)
 X_CFG_BOOL(debug.enable_review_markers,              false)

--- a/src/libtrx/engine/audio.c
+++ b/src/libtrx/engine/audio.c
@@ -14,6 +14,7 @@ static int32_t m_RefCount = 0;
 static size_t m_MixBufferCapacity = 0;
 static float *m_MixBuffer = nullptr;
 static Uint8 m_Silence = 0;
+static bool m_Muted = false;
 
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len);
 
@@ -22,6 +23,9 @@ static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
     memset(m_MixBuffer, m_Silence, len);
     Audio_Stream_Mix(m_MixBuffer, len);
     Audio_Sample_Mix(m_MixBuffer, len);
+    if (m_Muted) {
+        memset(m_MixBuffer, m_Silence, len);
+    }
     memcpy(stream_data, m_MixBuffer, len);
 }
 
@@ -88,6 +92,21 @@ bool Audio_Shutdown(void)
     Audio_Sample_Shutdown();
     Audio_Stream_Shutdown();
     return true;
+}
+
+void Audio_Mute(void)
+{
+    m_Muted = true;
+}
+
+void Audio_Unmute(void)
+{
+    m_Muted = false;
+}
+
+bool Audio_IsMuted(void)
+{
+    return m_Muted;
 }
 
 int32_t Audio_GetAVChannelLayout(const int32_t channels)

--- a/src/libtrx/game/music/common.c
+++ b/src/libtrx/game/music/common.c
@@ -18,7 +18,6 @@ static MUSIC_TRACK_ID m_TrackLooped = MX_INACTIVE;
 static MUSIC_TRACK_ID m_TrackLastPlayed = MX_INACTIVE;
 static MUSIC_TRACK_ID m_TrackLastLooped = MX_INACTIVE;
 
-static bool m_Muted = false;
 static float m_MusicVolume = 0.0f;
 static int32_t m_AudioStreamID = -1;
 static const MUSIC_BACKEND *m_Backend = nullptr;
@@ -117,7 +116,7 @@ static void M_SyncVolume(const int32_t audio_stream_id)
     if (audio_stream_id < 0) {
         return;
     }
-    Audio_Stream_SetVolume(audio_stream_id, m_Muted ? 0.0f : m_MusicVolume);
+    Audio_Stream_SetVolume(audio_stream_id, m_MusicVolume);
 }
 
 bool Music_Init(void)
@@ -304,18 +303,6 @@ void Music_SetVolume(const float volume)
         m_MusicVolume = volume;
         M_SyncVolume(m_AudioStreamID);
     }
-}
-
-void Music_Mute(void)
-{
-    m_Muted = true;
-    M_SyncVolume(m_AudioStreamID);
-}
-
-void Music_Unmute(void)
-{
-    m_Muted = false;
-    M_SyncVolume(m_AudioStreamID);
 }
 
 void Music_ResetTrackFlags(void)

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -57,12 +57,16 @@ static void M_HandleKeyUp(const SDL_Event *const event)
 
 static void M_HandleFocusGained(void)
 {
-    Audio_Unmute();
+    if (g_Config.audio.mute_out_of_focus) {
+        Audio_Unmute();
+    }
 }
 
 static void M_HandleFocusLost(void)
 {
-    Audio_Mute();
+    if (g_Config.audio.mute_out_of_focus) {
+        Audio_Mute();
+    }
 }
 
 static void M_HandleWindowShown(void)

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -1,10 +1,9 @@
 #include "config.h"
 #include "debug.h"
+#include "engine/audio.h"
 #include "game/console/common.h"
 #include "game/fmv.h"
-#include "game/music.h"
 #include "game/shell.h"
-#include "game/sound.h"
 #include "game/ui.h"
 
 // If true, next SDL_TEXT* event should be zeroed out.
@@ -58,16 +57,12 @@ static void M_HandleKeyUp(const SDL_Event *const event)
 
 static void M_HandleFocusGained(void)
 {
-    FMV_Unmute();
-    Music_Unmute();
-    Sound_SetMasterVolume(g_Config.audio.sound_volume);
+    Audio_Unmute();
 }
 
 static void M_HandleFocusLost(void)
 {
-    FMV_Mute();
-    Music_Mute();
-    Sound_SetMasterVolume(0);
+    Audio_Mute();
 }
 
 static void M_HandleWindowShown(void)

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -2,7 +2,9 @@
 #include "debug.h"
 #include "game/console/common.h"
 #include "game/fmv.h"
+#include "game/music.h"
 #include "game/shell.h"
+#include "game/sound.h"
 #include "game/ui.h"
 
 // If true, next SDL_TEXT* event should be zeroed out.
@@ -19,7 +21,7 @@ static void M_HandleWindowMinimized(void);
 static void M_HandleWindowMaximized(void);
 static void M_HandleWindowMoved(int32_t x, int32_t y);
 static void M_HandleWindowResized(int32_t width, int32_t height);
-static bool M_CreateGameWindow(void);
+static bool M_ProcessEvent(const SDL_Event *event);
 
 static void M_HandleQuit(void)
 {
@@ -56,10 +58,16 @@ static void M_HandleKeyUp(const SDL_Event *const event)
 
 static void M_HandleFocusGained(void)
 {
+    FMV_Unmute();
+    Music_Unmute();
+    Sound_SetMasterVolume(g_Config.audio.sound_volume);
 }
 
 static void M_HandleFocusLost(void)
 {
+    FMV_Mute();
+    Music_Mute();
+    Sound_SetMasterVolume(0);
 }
 
 static void M_HandleWindowShown(void)
@@ -92,7 +100,7 @@ static void M_HandleWindowResized(int32_t width, int32_t height)
     Shell_SyncFromWindow(true);
 }
 
-bool Shell_ProcessCommonEvent(const SDL_Event *const event)
+static bool M_ProcessEvent(const SDL_Event *const event)
 {
     switch (event->type) {
     case SDL_QUIT:
@@ -168,4 +176,14 @@ bool Shell_ProcessCommonEvent(const SDL_Event *const event)
     }
 
     return false;
+}
+
+void Shell_ProcessEvents(void)
+{
+    SDL_Event event;
+    while (SDL_PollEvent(&event) != 0) {
+        if (M_ProcessEvent(&event)) {
+            continue;
+        }
+    }
 }

--- a/src/libtrx/game/ui/dialogs/setting_tabs/sound_settings.def
+++ b/src/libtrx/game/ui/dialogs/setting_tabs/sound_settings.def
@@ -14,6 +14,7 @@ X_UI_CFG_FLOAT_PERCENT(audio.underwater_ambient_volume, SOUND_SETTINGS_UNDERWATE
 X_UI_CFG_FLOAT_PERCENT(audio.underwater_music_volume,   SOUND_SETTINGS_UNDERWATER_MUSIC_VOLUME, .min_value = 0, .max_value = 100, .delta_slow = 10, .delta_fast = 10)
 X_UI_CFG_ENUM(audio.music_load_condition,               SOUND_SETTINGS_MUSIC_LOAD_CONDITION, .misc = UI_Settings_MusicLoadConditionEnumEntries)
 X_UI_CFG_BOOL(audio.enable_underwater_anim_sfx,         SOUND_SETTINGS_ENABLE_UNDERWATER_ANIM_SFX)
+X_UI_CFG_BOOL(audio.mute_out_of_focus,                  SOUND_SETTINGS_MUTE_OUT_OF_FOCUS)
 
 #if TR_VERSION == 1
 X_UI_CFG_BOOL(audio.enable_pitched_sounds,              SOUND_SETTINGS_ENABLE_PITCHED_SOUNDS)

--- a/src/libtrx/include/libtrx/config/types_tr1.h
+++ b/src/libtrx/include/libtrx/config/types_tr1.h
@@ -105,6 +105,7 @@ typedef struct {
         bool enable_pitched_sounds;
         bool load_music_triggers;
         bool enable_underwater_anim_sfx;
+        bool mute_out_of_focus;
         float inventory_ambient_volume;
         float inventory_music_volume;
         float underwater_ambient_volume;

--- a/src/libtrx/include/libtrx/config/types_tr2.h
+++ b/src/libtrx/include/libtrx/config/types_tr2.h
@@ -97,6 +97,7 @@ typedef struct {
         bool enable_lara_mic;
         bool enable_underwater_anim_sfx;
         bool enable_music_in_inventory;
+        bool mute_out_of_focus;
         float inventory_ambient_volume;
         float inventory_music_volume;
         float underwater_ambient_volume;

--- a/src/libtrx/include/libtrx/engine/audio.h
+++ b/src/libtrx/include/libtrx/engine/audio.h
@@ -12,6 +12,10 @@
 bool Audio_Init(void);
 bool Audio_Shutdown(void);
 
+void Audio_Mute(void);
+void Audio_Unmute(void);
+bool Audio_IsMuted(void);
+
 bool Audio_Stream_Pause(int32_t sound_id);
 bool Audio_Stream_Unpause(int32_t sound_id);
 int32_t Audio_Stream_CreateFromFile(const char *path);

--- a/src/libtrx/include/libtrx/game/fmv.h
+++ b/src/libtrx/include/libtrx/game/fmv.h
@@ -2,6 +2,3 @@
 
 extern bool FMV_Play(const char *path);
 extern bool FMV_IsPlaying(void);
-
-extern void FMV_Mute(void);
-extern void FMV_Unmute(void);

--- a/src/libtrx/include/libtrx/game/fmv.h
+++ b/src/libtrx/include/libtrx/game/fmv.h
@@ -2,3 +2,6 @@
 
 extern bool FMV_Play(const char *path);
 extern bool FMV_IsPlaying(void);
+
+extern void FMV_Mute(void);
+extern void FMV_Unmute(void);

--- a/src/libtrx/include/libtrx/game/game_string.def
+++ b/src/libtrx/include/libtrx/game/game_string.def
@@ -234,6 +234,8 @@ GS_DEFINE(SOUND_SETTINGS_MUSIC_LOAD_CONDITION,             "Restore music on loa
 GS_DEFINE(SOUND_SETTINGS_ENABLE_MUSIC_IN_MENU,             "Main menu music")
 GS_DEFINE(SOUND_SETTINGS_ENABLE_PITCHED_SOUNDS,            "Pitched sounds")
 GS_DEFINE(SOUND_SETTINGS_ENABLE_UNDERWATER_ANIM_SFX,       "Underwater animation SFX")
+GS_DEFINE(SOUND_SETTINGS_MUTE_OUT_OF_FOCUS,                "Mute audio when focus lost")
+GS_DEFINE(SOUND_SETTINGS_MUTE_OUT_OF_FOCUS_DESCRIPTION,    "Mutes all music and sound effects when the game window is not focused.")
 GS_DEFINE(SOUND_SETTINGS_PAUSE_MUSIC_IN_INVENTORY,         "Pause music in inventory")
 GS_DEFINE(SOUND_SETTINGS_FIX_SECRETS_KILLING_MUSIC,        "Layered secret music")
 GS_DEFINE(SOUND_SETTINGS_FIX_SPEECHES_KILLING_MUSIC,       "Layered enemy speech")

--- a/src/libtrx/include/libtrx/game/music/common.h
+++ b/src/libtrx/include/libtrx/game/music/common.h
@@ -52,12 +52,6 @@ MUSIC_TRACK_ID Music_GetCurrentLoopedTrack(void);
 // Sets the game volume.
 void Music_SetVolume(float volume);
 
-// Mutes the game music. Doesn't change the music volume.
-void Music_Mute(void);
-
-// Unmutes the game music. Doesn't change the music volume.
-void Music_Unmute(void);
-
 // Resets all track trigger mask flags.
 void Music_ResetTrackFlags(void);
 

--- a/src/libtrx/include/libtrx/game/shell.h
+++ b/src/libtrx/include/libtrx/game/shell.h
@@ -32,7 +32,6 @@ SHELL_SIZE Shell_GetCurrentDisplaySize(void);
 void Shell_LoadConfig(void);
 void Shell_InitCommonModules(void);
 void Shell_ShutdownCommonModules(void);
-bool Shell_ProcessCommonEvent(const SDL_Event *event);
 
 void Shell_HandleCommonConfigChange(const CONFIG *old, const CONFIG *new);
 extern void Shell_HandleConfigChange(const CONFIG *old, const CONFIG *new);

--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -17,7 +17,6 @@
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 
-static bool m_Muted = false;
 static bool m_IsPlaying = false;
 static const char *m_Extensions[] = {
     ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", nullptr,
@@ -105,7 +104,8 @@ static bool M_Play(const char *const file_path)
 
     Video_Start(video);
     while (video->is_playing) {
-        Video_SetVolume(video, m_Muted ? 0.0f : g_Config.audio.sound_volume);
+        Video_SetVolume(
+            video, Audio_IsMuted() ? 0.0f : g_Config.audio.sound_volume);
         Video_SetSurfaceSize(
             video, Viewport_GetWidth(VIEWPORT_GAME),
             Viewport_GetHeight(VIEWPORT_GAME));
@@ -130,16 +130,6 @@ static bool M_Play(const char *const file_path)
     Output_ApplyRenderSettings();
 
     return true;
-}
-
-void FMV_Mute(void)
-{
-    m_Muted = true;
-}
-
-void FMV_Unmute(void)
-{
-    m_Muted = false;
 }
 
 bool FMV_IsPlaying(void)

--- a/src/tr1/game/fmv.h
+++ b/src/tr1/game/fmv.h
@@ -1,6 +1,3 @@
 #pragma once
 
 #include <libtrx/game/fmv.h>
-
-void FMV_Mute(void);
-void FMV_Unmute(void);

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -3,13 +3,11 @@
 #include "game/output.h"
 #include "game/savegame.h"
 #include "game/shell.h"
-#include "game/sound.h"
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/enum_map.h>
 #include <libtrx/game/game_string_manager.h>
-#include <libtrx/game/music.h>
 #include <libtrx/memory.h>
 #include <libtrx/strings.h>
 
@@ -150,34 +148,6 @@ static void M_SetGLBackend(const GFX_GL_BACKEND backend)
     case GFX_GL_INVALID_BACKEND:
         ASSERT_FAIL();
         break;
-    }
-}
-
-void Shell_ProcessEvents(void)
-{
-    SDL_Event event;
-    while (SDL_PollEvent(&event) != 0) {
-        if (Shell_ProcessCommonEvent(&event)) {
-            continue;
-        }
-
-        switch (event.type) {
-        case SDL_WINDOWEVENT:
-            switch (event.window.event) {
-            case SDL_WINDOWEVENT_FOCUS_GAINED:
-                FMV_Unmute();
-                Music_Unmute();
-                Sound_SetMasterVolume(g_Config.audio.sound_volume);
-                break;
-
-            case SDL_WINDOWEVENT_FOCUS_LOST:
-                FMV_Mute();
-                Music_Mute();
-                Sound_SetMasterVolume(0);
-                break;
-            }
-            break;
-        }
     }
 }
 

--- a/src/tr2/game/fmv.c
+++ b/src/tr2/game/fmv.c
@@ -8,6 +8,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/engine/audio.h>
 #include <libtrx/engine/video.h>
 #include <libtrx/filesystem.h>
 #include <libtrx/game/music.h>
@@ -16,7 +17,6 @@
 
 #include <string.h>
 
-static bool m_Muted = false;
 static bool m_IsFMVPlaying = false;
 static const char *m_Extensions[] = {
     ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", nullptr,
@@ -120,7 +120,8 @@ static bool M_Play(const char *const file_name)
 
     Video_Start(video);
     while (video->is_playing) {
-        Video_SetVolume(video, m_Muted ? 0.0f : g_Config.audio.sound_volume);
+        Video_SetVolume(
+            video, Audio_IsMuted() ? 0.0f : g_Config.audio.sound_volume);
 
         const SHELL_SIZE display_size = Shell_GetCurrentDisplaySize();
         Video_SetSurfaceSize(video, display_size.w, display_size.h);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -336,16 +336,6 @@ const char *Shell_GetGameFlowPath(void)
     return m_ModPaths[m_Args.mod].game_flow_path;
 }
 
-void Shell_ProcessEvents(void)
-{
-    SDL_Event event;
-    while (SDL_PollEvent(&event) != 0) {
-        if (Shell_ProcessCommonEvent(&event)) {
-            continue;
-        }
-    }
-}
-
 SDL_Window *Shell_GetWindow(void)
 {
     return m_Window;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Makes the muting when the window loses focus optional in TR1
- Adds the same option to TR2
- Fixes sound effects not being muted (alt+tab while any sound effect is playing – on develop, it'll continue to play, on this branch, it'll get muted immediately)