### PR TITLE
tools: do not mark dialects for review

### DIFF
--- a/tools/shared/linting.py
+++ b/tools/shared/linting.py
@@ -123,10 +123,6 @@ def lint_untranslated_game_strings(
     except Exception as exc:
         yield LintWarning(path, f"unable to parse JSON5: {exc}")
         return
-    # Skip missing translation warnings if using 'extends' inheritance
-    if isinstance(trans_data, dict) and "extends" in trans_data:
-        return
-
     base_ptr = JSONPointers(base_data)
     trans_ptr = JSONPointers(trans_data)
     base_paths = list(base_ptr)
@@ -134,11 +130,16 @@ def lint_untranslated_game_strings(
     for ptr in base_paths:
         if should_skip_object_name(ptr, trans_data):
             continue
+        # Only warn for missing translations in dialects if they're already present
+        if "extends" in trans_data and ptr not in trans_ptr:
+            continue
         if not clean(trans_ptr.get(ptr)):
             yield LintWarning(path, f"untranslated key '{ptr}'")
     # Warn about extra translation keys not present in the base file (unused by the game)
     base_set = set(base_paths)
     for ptr in trans_ptr:
+        if ptr == "/extends":
+            continue
         if should_skip_object_name(ptr, trans_data):
             continue
         if ptr not in base_set:

--- a/tools/update_game_strings
+++ b/tools/update_game_strings
@@ -105,6 +105,8 @@ class ReviewTracker:
                 trans_data = load_json5_from_string(self.vfs.get(trans_path))
                 trans_ptr = JSONPointers(trans_data)
                 for ptr in ptrs:
+                    if "extends" in trans_data and ptr not in trans_ptr:
+                        continue
                     trans_ptr[ptr] = REVIEW_MARKER
                 self.vfs.put(
                     trans_path, write_json_to_string(trans_data) + "\n"


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`pre-commit run -a` will not put empty review markers in the dialect files, and we'll now get warnings if there are empty or invalid values in the dialects (whereas they used to be completely ignored).