### PR TITLE
scaler: fix behavior with upscaling-factor

### DIFF
--- a/src/libtrx/game/scaler.c
+++ b/src/libtrx/game/scaler.c
@@ -2,22 +2,20 @@
 
 #include "config.h"
 #include "game/viewport.h"
-#include "log.h"
 #include "utils.h"
 
 static int32_t M_DoCalc(
-    int32_t unit, int32_t base_width, int32_t base_height, double factor)
+    const int32_t unit, const int32_t base_width, const int32_t base_height,
+    const double factor)
 {
-    const int32_t win_width = Viewport_GetWidth(VIEWPORT_GAME);
-    const int32_t win_height = Viewport_GetHeight(VIEWPORT_GAME);
+    const int32_t vp_width = Viewport_GetWidth(VIEWPORT_GAME);
+    const int32_t vp_height = Viewport_GetHeight(VIEWPORT_GAME);
     const int32_t sign = unit < 0 ? -1 : 1;
-    const int32_t scale_x = win_width > base_width
-        ? ((double)win_width * ABS(unit) * factor) / MAX(1, base_width)
-        : ABS(unit) * factor;
-    const int32_t scale_y = win_height > base_height
-        ? ((double)win_height * ABS(unit) * factor) / MAX(1, base_height)
-        : ABS(unit) * factor;
-    return MIN(scale_x, scale_y) * sign;
+    const int32_t sx =
+        ((double)vp_width * ABS(unit) * factor) / MAX(1, base_width);
+    const int32_t sy =
+        ((double)vp_height * ABS(unit) * factor) / MAX(1, base_height);
+    return MIN(sx, sy) * sign;
 }
 
 double Scaler_GetScale(const SCALER_TARGET target)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Playing the game in windowed mode with a small window and a large upscaling factor would cause the text to reposition and become larger, which is an unwelcome effect considering we have a separate text-scale option.

I thought it was important to address this before releasing a version with the upscaling factor option introduced properly to both games.

#### Testing

I recommend comparing screenshots between develop and this version with various combinations of viewport aspect ratios and text scales. The text scale shouldn't change. It does become smaller on aspect ratios more squarish than 4:3, but we're not really interested in maintaining 100% compatibility with this use case.
Where the fix kicks in is when the upscaling factor is set to values bigger than 1 – develop would rescale the text making it bigger than expected, whereas this branch just makes it more pixelated.