### PR TITLE
lara/vehicle: create vehicle API

### DIFF
--- a/src/libtrx/game/interpolation.c
+++ b/src/libtrx/game/interpolation.c
@@ -4,8 +4,7 @@
 #include "debug.h"
 #include "game/camera.h"
 #include "game/effects.h"
-#include "game/lara/common.h"
-#include "game/lara/hair.h"
+#include "game/lara.h"
 #include "game/rooms.h"
 #include "utils.h"
 
@@ -117,12 +116,11 @@ static XYZ_32 M_GetItemMaxDelta(const ITEM *const item)
 
     case O_LARA:
     case O_LARA_EXTRA: {
-        LARA_INFO *const lara = Lara_GetLaraInfo();
-        if (lara == nullptr || lara->item_num == NO_ITEM
-            || lara->vehicle_item_num == NO_ITEM) {
+        const ITEM *const vehicle = Lara_Vehicle_GetItem();
+        if (vehicle == nullptr) {
             break;
         }
-        return M_GetItemMaxDelta(Item_Get(lara->vehicle_item_num));
+        return M_GetItemMaxDelta(vehicle);
     }
 #endif
 
@@ -348,17 +346,11 @@ static void M_RememberItems(void)
 
 static void M_InterpolateItems(const double ratio)
 {
+    const int16_t lara_vehicle_num = Lara_Vehicle_GetIndex();
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
         ITEM *const item = Item_Get(i);
-#if TR_VERSION == 2
-        const LARA_INFO *const lara = Lara_GetLaraInfo();
-        const bool is_mounted =
-            lara != nullptr && (i == lara->vehicle_item_num);
-#else
-        const bool is_mounted = false;
-#endif
         if (((item->flags & IF_KILLED) || item->status == IS_INACTIVE)
-            && !is_mounted) {
+            && i != lara_vehicle_num) {
             M_CommitItem(item);
         } else {
             M_InterpolateItem(item, ratio);

--- a/src/libtrx/game/lara/cheat.c
+++ b/src/libtrx/game/lara/cheat.c
@@ -257,7 +257,7 @@ bool Lara_Cheat_EnterFlyMode(void)
 #endif
 
     lara_info->extra_anim = false;
-    Lara_DismountVehicle();
+    Lara_Vehicle_Dismount();
     if (lara_info->water_status != LWS_UNDERWATER
         || lara_item->hit_points <= 0) {
         lara_item->pos.y -= STEP_L;
@@ -364,7 +364,7 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
         lara_info->gun_status = LGS_ARMLESS;
     }
 
-    Lara_DismountVehicle();
+    Lara_Vehicle_Dismount();
     if (lara_info->extra_anim) {
         const ROOM *const room = Room_Get(lara_item->room_num);
         const bool room_submerged = (room->flags & RF_UNDERWATER) != 0;

--- a/src/libtrx/game/lara/common.c
+++ b/src/libtrx/game/lara/common.c
@@ -46,8 +46,8 @@ GAME_OBJECT_ID Lara_GetAnimationObject(void)
     const GF_LEVEL *const level = GF_GetCurrentLevel();
     return level->lara_type;
 #else
-    if (lara_info->vehicle_item_num != NO_ITEM) {
-        const ITEM *const vehicle = Item_Get(lara_info->vehicle_item_num);
+    const ITEM *const vehicle = Lara_Vehicle_GetItem();
+    if (vehicle != nullptr) {
         return vehicle->object_id == O_BOAT ? O_LARA_BOAT : O_LARA_SKIDOO;
     }
     return O_LARA;

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -62,8 +62,7 @@ static void M_UpdateEnvironment(void)
     const bool wading_enabled = g_Config.gameplay.enable_wading;
 #else
     const bool wading_enabled = true;
-
-    if (lara_info->vehicle_item_num != NO_ITEM || lara_info->extra_anim) {
+    if (Lara_Vehicle_IsMounted() || lara_info->extra_anim) {
         return;
     }
 #endif
@@ -323,12 +322,10 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
 
     Lara_Look_Update();
 
-#if TR_VERSION == 1
-    const bool on_vehicle = false;
-#else
-    bool on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
-    if (on_vehicle) {
-        if (Item_Get(lara_info->vehicle_item_num)->object_id == O_SKIDOO_FAST) {
+    const ITEM *const vehicle = Lara_Vehicle_GetItem();
+#if TR_VERSION >= 2
+    if (vehicle != nullptr) {
+        if (vehicle->object_id == O_SKIDOO_FAST) {
             // TODO: make this Object_Get(O_SKIDOO_FAST)->control
             if (Skidoo_Control()) {
                 return;
@@ -365,10 +362,7 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
     if ((TR_VERSION == 1 || !lara_info->extra_anim)
         && lara_info->water_status != LWS_CHEAT) {
         M_ObjectCollision(coll);
-#if TR_VERSION >= 2
-        on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
-#endif
-        if (!on_vehicle) {
+        if (!Lara_Vehicle_IsMounted()) {
             Lara_Col_Update(item, coll);
         }
     }
@@ -511,12 +505,7 @@ static void M_HandleSurface(COLL_INFO *const coll)
     const SECTOR *const sector = M_GetCurrentSector();
 
     M_ObjectCollision(coll);
-#if TR_VERSION == 1
-    const bool on_vehicle = false;
-#else
-    const bool on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
-#endif
-    if (!on_vehicle) {
+    if (!Lara_Vehicle_IsMounted()) {
         Lara_Col_Update(item, coll);
     }
 
@@ -705,25 +694,4 @@ void Lara_Control(void)
 
     Stats_AddDistanceTravelled(item->pos, lara_info->last_pos);
     lara_info->last_pos = item->pos;
-}
-
-void Lara_DismountVehicle(void)
-{
-#if TR_VERSION >= 2
-    ITEM *const lara_item = Lara_GetItem();
-    LARA_INFO *const lara_info = Lara_GetLaraInfo();
-
-    if (lara_info->vehicle_item_num != NO_ITEM) {
-        ITEM *const vehicle = Item_Get(lara_info->vehicle_item_num);
-        Item_SwitchToAnim(vehicle, 0, 0);
-        lara_info->vehicle_item_num = NO_ITEM;
-
-        lara_item->current_anim_state = LS_STOP;
-        lara_item->goal_anim_state = LS_STOP;
-        Item_SwitchToAnim(lara_item, LA_STAND_STILL, 0);
-
-        lara_item->rot.x = 0;
-        lara_item->rot.z = 0;
-    }
-#endif
 }

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -326,7 +326,7 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
 #if TR_VERSION == 1
     const bool on_vehicle = false;
 #else
-    const bool on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
+    bool on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
     if (on_vehicle) {
         if (Item_Get(lara_info->vehicle_item_num)->object_id == O_SKIDOO_FAST) {
             // TODO: make this Object_Get(O_SKIDOO_FAST)->control
@@ -365,6 +365,9 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
     if ((TR_VERSION == 1 || !lara_info->extra_anim)
         && lara_info->water_status != LWS_CHEAT) {
         M_ObjectCollision(coll);
+#if TR_VERSION >= 2
+        on_vehicle = lara_info->vehicle_item_num != NO_ITEM;
+#endif
         if (!on_vehicle) {
             Lara_Col_Update(item, coll);
         }

--- a/src/libtrx/game/lara/look.c
+++ b/src/libtrx/game/lara/look.c
@@ -78,13 +78,10 @@ static void M_Reset(void)
 
 static bool M_IsLaraIdle(void)
 {
-#if TR_VERSION >= 2
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_info->vehicle_item_num != NO_ITEM) {
-        const ITEM *const vehicle = Item_Get(lara_info->vehicle_item_num);
+    const ITEM *const vehicle = Lara_Vehicle_GetItem();
+    if (vehicle != nullptr) {
         return vehicle->speed == 0;
     }
-#endif
     return Lara_HasState(m_StopStates);
 }
 
@@ -122,12 +119,7 @@ void Lara_Look_LeftRight(void)
         }
     }
 
-#if TR_VERSION == 1
-    const bool on_vehicle = false;
-#else
-    const bool on_vehicle = lara->vehicle_item_num != NO_ITEM;
-#endif
-    if (lara->gun_status != LGS_HANDS_BUSY && !on_vehicle) {
+    if (lara->gun_status != LGS_HANDS_BUSY && !Lara_Vehicle_IsMounted()) {
         lara->torso_rot.y =
             on_surface ? (lara->head_rot.y / 2) : lara->head_rot.y;
     }

--- a/src/libtrx/game/lara/vehicle.c
+++ b/src/libtrx/game/lara/vehicle.c
@@ -1,0 +1,44 @@
+#include "game/lara/vehicle.h"
+
+#include "game/lara.h"
+
+static int16_t m_VehicleItemNum = NO_ITEM;
+
+bool Lara_Vehicle_IsMounted(void)
+{
+    return m_VehicleItemNum != NO_ITEM;
+}
+
+void Lara_Vehicle_SetIndex(const int16_t item_num)
+{
+    m_VehicleItemNum = item_num;
+}
+
+int16_t Lara_Vehicle_GetIndex(void)
+{
+    return m_VehicleItemNum;
+}
+
+ITEM *Lara_Vehicle_GetItem(void)
+{
+    return m_VehicleItemNum == NO_ITEM ? nullptr : Item_Get(m_VehicleItemNum);
+}
+
+void Lara_Vehicle_Dismount(void)
+{
+    if (!Lara_Vehicle_IsMounted()) {
+        return;
+    }
+
+    ITEM *const lara_item = Lara_GetItem();
+    ITEM *const vehicle = Lara_Vehicle_GetItem();
+    Item_SwitchToAnim(vehicle, 0, 0);
+    Lara_Vehicle_SetIndex(NO_ITEM);
+
+    lara_item->current_anim_state = LS_STOP;
+    lara_item->goal_anim_state = LS_STOP;
+    Item_SwitchToAnim(lara_item, LA_STAND_STILL, 0);
+
+    lara_item->rot.x = 0;
+    lara_item->rot.z = 0;
+}

--- a/src/libtrx/game/ui/hud/overlay.c
+++ b/src/libtrx/game/ui/hud/overlay.c
@@ -5,7 +5,7 @@
 #include "game/const.h"
 #include "game/game.h"
 #include "game/game_string.h"
-#include "game/lara/common.h"
+#include "game/lara.h"
 #include "game/scaler.h"
 #include "game/ui/elements/ammo_label.h"
 #include "game/ui/elements/bar.h"
@@ -147,14 +147,7 @@ static void M_DebugPosTopLeft(void)
     }
 
     const GAME_OBJECT_ID obj_id = Lara_GetAnimationObject();
-#if TR_VERSION == 1
-    const ITEM *const vehicle = nullptr;
-#else
-    const ITEM *const vehicle =
-        lara_info != nullptr && lara_info->vehicle_item_num != NO_ITEM
-        ? Item_Get(lara_info->vehicle_item_num)
-        : nullptr;
-#endif
+    const ITEM *const vehicle = Lara_Vehicle_GetItem();
     UI_BeginStack(UI_STACK_HORIZONTAL);
     UI_BeginStack(UI_STACK_VERTICAL);
     UI_Label(GS(OVERLAY_DEBUG_POSITION));

--- a/src/libtrx/include/libtrx/game/lara.h
+++ b/src/libtrx/include/libtrx/game/lara.h
@@ -13,3 +13,4 @@
 #include "lara/misc.h"
 #include "lara/state.h"
 #include "lara/types.h"
+#include "lara/vehicle.h"

--- a/src/libtrx/include/libtrx/game/lara/control.h
+++ b/src/libtrx/include/libtrx/game/lara/control.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "../collision.h"
 #include "../game_flow.h"
 
 extern void Lara_InitialiseMeshes(const GF_LEVEL *level);
 
 void Lara_Control(void);
-void Lara_DismountVehicle(void);

--- a/src/libtrx/include/libtrx/game/lara/types.h
+++ b/src/libtrx/include/libtrx/game/lara/types.h
@@ -91,7 +91,6 @@ typedef struct {
     LARA_GUN_TYPE last_gun_type;
     GAME_OBJECT_ID back_gun_obj_id;
     int16_t gun_item_num;
-    int16_t vehicle_item_num;
 
     bool climb_status;
 

--- a/src/libtrx/include/libtrx/game/lara/vehicle.h
+++ b/src/libtrx/include/libtrx/game/lara/vehicle.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "../items/types.h"
+
+bool Lara_Vehicle_IsMounted(void);
+void Lara_Vehicle_SetIndex(int16_t item_num);
+int16_t Lara_Vehicle_GetIndex(void);
+ITEM *Lara_Vehicle_GetItem(void);
+
+void Lara_Vehicle_Dismount(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -192,6 +192,7 @@ sources = [
   'game/lara/state/jump.c',
   'game/lara/state/land.c',
   'game/lara/state/swim.c',
+  'game/lara/vehicle.c',
   'game/level/common.c',
   'game/level/faces.c',
   'game/level/settings.c',

--- a/src/tr1/game/lara/common.c
+++ b/src/tr1/game/lara/common.c
@@ -182,6 +182,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     g_Lara.head_rot.z = 0;
     g_Lara.calc_fall_speed = 0;
     g_Lara.extra_anim = false;
+    Lara_Vehicle_SetIndex(NO_ITEM);
     g_Lara.burn = false;
     g_Lara.mesh_effects = 0;
     g_Lara.hit_frame = 0;

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -199,7 +199,7 @@ int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
 void Skidoo_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
-    if (lara_item->hit_points < 0 || g_Lara.vehicle_item_num != NO_ITEM) {
+    if (lara_item->hit_points < 0 || Lara_Vehicle_IsMounted()) {
         return;
     }
 
@@ -209,7 +209,7 @@ void Skidoo_Collision(
         return;
     }
 
-    g_Lara.vehicle_item_num = item_num;
+    Lara_Vehicle_SetIndex(item_num);
     if (g_Lara.gun_type == LGT_FLARE) {
         Lara_Flare_Dispose(false);
         g_Lara.gun_type = LGT_UNARMED;
@@ -430,7 +430,7 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
         const int32_t dz = skidoo->pos.z - old.z;
         const int32_t new_speed = (s * dx + c * dz) >> W2V_SHIFT;
 
-        if (skidoo == Item_Get(g_Lara.vehicle_item_num)
+        if (skidoo == Lara_Vehicle_GetItem()
             && skidoo->speed > SKIDOO_MAX_SPEED + SKIDOO_ACCELERATION
             && new_speed < skidoo->speed - SKIDOO_ACCELERATION) {
             Lara_TakeDamage((skidoo->speed - new_speed) / 2, true);
@@ -527,7 +527,7 @@ int32_t Skidoo_UserControl(
 
 int32_t Skidoo_CheckGetOffOK(int32_t direction)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
+    ITEM *const skidoo = Lara_Vehicle_GetItem();
 
     int16_t rot;
     if (direction == LARA_STATE_SKIDOO_GET_OFF_L) {
@@ -685,14 +685,14 @@ void Skidoo_Explode(const ITEM *const skidoo)
         effect->object_id = O_EXPLOSION_1;
     }
 
-    Item_Explode(g_Lara.vehicle_item_num, ~(SKIDOO_GUN_MESH - 1), 0);
+    Item_Explode(Item_GetIndex(skidoo), ~(SKIDOO_GUN_MESH - 1), 0);
     Sound_Effect(SFX_EXPLOSION_1, nullptr, SPM_NORMAL);
-    g_Lara.vehicle_item_num = NO_ITEM;
+    Lara_Vehicle_SetIndex(NO_ITEM);
 }
 
 bool Skidoo_CheckGetOff(void)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
+    ITEM *const skidoo = Lara_Vehicle_GetItem();
 
     if ((g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_GET_OFF_R
          || g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_GET_OFF_L)
@@ -711,7 +711,7 @@ bool Skidoo_CheckGetOff(void)
             (SKIDOO_GET_OFF_DIST * Math_Cos(g_LaraItem->rot.y)) >> W2V_SHIFT;
         g_LaraItem->rot.x = 0;
         g_LaraItem->rot.z = 0;
-        g_Lara.vehicle_item_num = NO_ITEM;
+        Lara_Vehicle_SetIndex(NO_ITEM);
         g_Lara.gun_status = LGS_ARMLESS;
         return true;
     }
@@ -768,14 +768,14 @@ void Skidoo_Guns(void)
     Sound_Effect(winfo->sample_num, &g_LaraItem->pos, SPM_NORMAL);
     Gun_AddDynamicLight();
 
-    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
+    ITEM *const skidoo = Lara_Vehicle_GetItem();
     Creature_Effect(skidoo, &g_Skidoo_LeftGun, Spawn_GunShot);
     Creature_Effect(skidoo, &g_Skidoo_RightGun, Spawn_GunShot);
 }
 
 bool Skidoo_Control(void)
 {
-    ITEM *const skidoo = Item_Get(g_Lara.vehicle_item_num);
+    ITEM *const skidoo = Lara_Vehicle_GetItem();
     SKIDOO_INFO *const skidoo_data = skidoo->data;
     int32_t collide = Skidoo_Dynamics(skidoo);
 
@@ -860,7 +860,7 @@ bool Skidoo_Control(void)
 
     if (skidoo->flags & IF_ONE_SHOT) {
         Room_TestTriggers(g_LaraItem);
-        Item_UpdateRoom(g_Lara.vehicle_item_num, room_num);
+        Item_UpdateRoom(Item_GetIndex(skidoo), room_num);
         if (skidoo->pos.y == skidoo->floor) {
             Skidoo_Explode(skidoo);
         }
@@ -868,7 +868,7 @@ bool Skidoo_Control(void)
     }
 
     Skidoo_Animation(skidoo, collide, dead);
-    Item_UpdateRoom(g_Lara.vehicle_item_num, room_num);
+    Item_UpdateRoom(Item_GetIndex(skidoo), room_num);
     Item_UpdateRoom(g_Lara.item_num, room_num);
 
     if (g_LaraItem->current_anim_state == LARA_STATE_SKIDOO_FALLOFF) {

--- a/src/tr2/game/gun/gun.c
+++ b/src/tr2/game/gun/gun.c
@@ -5,14 +5,14 @@
 #include "game/gun/gun_rifle.h"
 #include "game/input.h"
 #include "game/inventory.h"
-#include "game/lara/control.h"
-#include "game/lara/flare.h"
+#include "game/lara.h"
 #include "game/sound.h"
 #include "global/vars.h"
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
+#include <libtrx/game/lara.h>
 
 void Gun_Control(void)
 {
@@ -47,7 +47,7 @@ void Gun_Control(void)
 
         if (g_Lara.request_gun_type != g_Lara.gun_type || g_Input.draw) {
             if (g_Lara.request_gun_type == LGT_FLARE
-                || (g_Lara.vehicle_item_num == NO_ITEM
+                || (!Lara_Vehicle_IsMounted()
                     && g_Lara.water_status != LWS_CHEAT
                     && (g_Lara.request_gun_type == LGT_HARPOON
                         || g_Lara.water_status == LWS_ABOVE_WATER

--- a/src/tr2/game/lara/control.c
+++ b/src/tr2/game/lara/control.c
@@ -135,7 +135,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     }
 
     g_Lara.hit_direction = -1;
-    g_Lara.vehicle_item_num = NO_ITEM;
+    Lara_Vehicle_SetIndex(NO_ITEM);
     g_Lara.gun_item_num = NO_ITEM;
     g_Lara.calc_fall_speed = 0;
     g_Lara.climb_status = false;

--- a/src/tr2/game/lara/draw.c
+++ b/src/tr2/game/lara/draw.c
@@ -57,7 +57,7 @@ void Lara_Draw(const ITEM *const item)
         hit_frame == nullptr ? frames[0] : hit_frame;
 
     const OBJECT *const obj = Object_Get(item->object_id);
-    if (g_Lara.vehicle_item_num == NO_ITEM) {
+    if (!Lara_Vehicle_IsMounted()) {
         Output_InsertShadow(obj->shadow_size, &frame->bounds, item);
     }
 
@@ -295,7 +295,7 @@ void Lara_Draw_I(
     const OBJECT *const obj = Object_Get(item->object_id);
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
 
-    if (g_Lara.vehicle_item_num == NO_ITEM) {
+    if (!Lara_Vehicle_IsMounted()) {
         Output_InsertShadow(obj->shadow_size, bounds, item);
     }
 

--- a/src/tr2/game/lara/flare.c
+++ b/src/tr2/game/lara/flare.c
@@ -123,7 +123,7 @@ static void M_ControlArmless(void)
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
 
     const bool is_mounted_or_armed =
-        lara_info->vehicle_item_num != NO_ITEM || Lara_HasState(m_HoldStates);
+        Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
 
     if (is_mounted_or_armed) {
         if (!lara_info->flare.control) {
@@ -148,7 +148,7 @@ static void M_ControlBusyHands(void)
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     lara_info->flare.control =
-        lara_info->vehicle_item_num != NO_ITEM || Lara_HasState(m_HoldStates);
+        Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
     M_ControlInHand(lara_info->flare.age);
     M_SetArm(lara_info->left_arm.frame_num);
 }
@@ -238,8 +238,7 @@ void Lara_Flare_Undraw(void)
 
     lara_info->flare.control = true;
 
-    if (lara_item->goal_anim_state == LS_STOP
-        && lara_info->vehicle_item_num == NO_ITEM) {
+    if (lara_item->goal_anim_state == LS_STOP && !Lara_Vehicle_IsMounted()) {
         if (Item_TestAnimEqual(lara_item, LA_STAND_IDLE)) {
             Item_SwitchToAnim(lara_item, LA_FLARE_THROW, frame_num_1);
             lara_info->flare.frame_num = lara_item->frame_num;
@@ -267,8 +266,7 @@ void Lara_Flare_Undraw(void)
             lara_info->flare.frame_num = frame_num_2 + 1;
         }
     } else if (
-        lara_item->current_anim_state == LS_STOP
-        && lara_info->vehicle_item_num == -1) {
+        lara_item->current_anim_state == LS_STOP && !Lara_Vehicle_IsMounted()) {
         Item_SwitchToAnim(lara_item, LA_STAND_STILL, 0);
     }
 

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -7,6 +7,7 @@
 
 #include <libtrx/debug.h>
 #include <libtrx/game/carrier.h>
+#include <libtrx/game/lara.h>
 #include <libtrx/utils.h>
 
 #define SKIDOO_DRIVER_MIN_TURN (SKIDOO_MAX_TURN / 3) // = 364
@@ -148,7 +149,7 @@ static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
         if (driver_data->flags == 0
             && ABS(info.angle) < SKIDOO_DRIVER_TARGET_ANGLE
             && g_LaraItem->hit_points > 0) {
-            const int32_t damage = g_Lara.vehicle_item_num != NO_ITEM
+            const int32_t damage = Lara_Vehicle_IsMounted()
                 ? SKIDOO_DRIVER_SHOT_DAMAGE
                 : SKIDOO_DRIVER_LARA_DAMAGE;
 

--- a/src/tr2/game/objects/general/window.c
+++ b/src/tr2/game/objects/general/window.c
@@ -4,7 +4,7 @@
 #include "game/sound.h"
 #include "global/vars.h"
 
-#include <libtrx/game/lara/common.h>
+#include <libtrx/game/lara.h>
 #include <libtrx/game/math.h>
 #include <libtrx/utils.h>
 
@@ -64,7 +64,7 @@ static void M_Control1(const int16_t item_num)
         return;
     }
 
-    if (g_Lara.vehicle_item_num != NO_ITEM) {
+    if (Lara_Vehicle_IsMounted()) {
         if (Lara_IsNearItem(&item->pos, 512)) {
             Window_Smash(item_num);
         }

--- a/src/tr2/game/objects/traps/mine.c
+++ b/src/tr2/game/objects/traps/mine.c
@@ -5,6 +5,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/game/lara.h>
 #include <libtrx/utils.h>
 
 static bool m_DetonateAllMines = false;
@@ -42,7 +43,7 @@ static void M_DetonateAll(
     int16_t boat_room_num)
 {
     ITEM *const boat_item = Item_Get(boat_item_num);
-    if (g_Lara.vehicle_item_num == boat_item_num) {
+    if (Lara_Vehicle_GetIndex() == boat_item_num) {
         Item_Explode(g_Lara.item_num, -1, 0);
         g_LaraItem->hit_points = 0;
         g_LaraItem->flags |= IF_ONE_SHOT;

--- a/src/tr2/game/objects/traps/springboard.c
+++ b/src/tr2/game/objects/traps/springboard.c
@@ -2,7 +2,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
-#include <libtrx/game/lara/common.h>
+#include <libtrx/game/lara.h>
 
 typedef enum {
     // clang-format off
@@ -34,16 +34,15 @@ static void M_Control(const int16_t item_num)
             return;
         }
 
-        const LARA_INFO *const lara = Lara_GetLaraInfo();
-        if (lara->vehicle_item_num != NO_ITEM) {
-            ITEM *const skidoo = Item_Get(lara->vehicle_item_num);
-            if (skidoo->object_id != O_SKIDOO_FAST
-                && skidoo->object_id != O_SKIDOO_ARMED) {
+        ITEM *const vehicle = Lara_Vehicle_GetItem();
+        if (vehicle != nullptr) {
+            if (vehicle->object_id != O_SKIDOO_FAST
+                && vehicle->object_id != O_SKIDOO_ARMED) {
                 return;
             }
 
-            skidoo->fall_speed = -200;
-            skidoo->pos.y -= STEP_L;
+            vehicle->fall_speed = -200;
+            vehicle->pos.y -= STEP_L;
         } else {
             if (lara_item->current_anim_state == LS_WALK_BACK
                 || lara_item->current_anim_state == LS_FAST_BACK) {

--- a/src/tr2/game/objects/vehicles/boat.c
+++ b/src/tr2/game/objects/vehicles/boat.c
@@ -218,7 +218,7 @@ static void M_DoShift(const int32_t boat_num)
         ITEM *const item = Item_Get(item_num);
 
         if (item->object_id == O_BOAT && item_num != boat_num
-            && g_Lara.vehicle_item_num != item_num) {
+            && Lara_Vehicle_GetIndex() != item_num) {
             const int32_t dx = item->pos.x - boat->pos.x;
             const int32_t dz = item->pos.z - boat->pos.z;
             const int32_t dist = SQUARE(dx) + SQUARE(dz);
@@ -387,7 +387,7 @@ static int32_t M_Dynamics(const int16_t boat_num)
         ) >> W2V_SHIFT;
         // clang-format on
 
-        if (g_Lara.vehicle_item_num == boat_num) {
+        if (Lara_Vehicle_GetIndex() == boat_num) {
             if (boat->speed > BOAT_MAX_SPEED + BOAT_ACCELERATION
                 && new_speed < boat->speed - 10) {
                 g_LaraItem->hit_points -= (boat->speed - new_speed) / 2;
@@ -585,7 +585,7 @@ static void M_Initialise(const int16_t item_num)
 static void M_Collision(
     const int16_t item_num, ITEM *const lara, COLL_INFO *const coll)
 {
-    if (lara->hit_points < 0 || g_Lara.vehicle_item_num != NO_ITEM) {
+    if (lara->hit_points < 0 || Lara_Vehicle_IsMounted()) {
         return;
     }
 
@@ -596,7 +596,7 @@ static void M_Collision(
         return;
     }
 
-    g_Lara.vehicle_item_num = item_num;
+    Lara_Vehicle_SetIndex(item_num);
 
     int16_t boat_anim_idx;
     switch (get_on) {
@@ -669,7 +669,7 @@ static void M_Control(const int16_t item_num)
         Room_GetWaterHeight(boat->pos.x, boat->pos.y, boat->pos.z, room_num);
     boat_data->water = water_height;
 
-    if (g_Lara.vehicle_item_num == item_num && lara->hit_points > 0) {
+    if (Lara_Vehicle_GetIndex() == item_num && lara->hit_points > 0) {
         switch (lara->current_anim_state) {
         case BOAT_STATE_GET_ON:
         case BOAT_STATE_JUMP_R:
@@ -725,7 +725,7 @@ static void M_Control(const int16_t item_num)
         boat->rot.z = 0;
     }
 
-    if (g_Lara.vehicle_item_num == item_num) {
+    if (Lara_Vehicle_GetIndex() == item_num) {
         M_Animation(boat, collide);
 
         Item_UpdateRoom(item_num, room_num);
@@ -784,7 +784,7 @@ static void M_Control(const int16_t item_num)
         M_DoWakeEffect(boat);
     }
 
-    if (g_Lara.vehicle_item_num != item_num) {
+    if (Lara_Vehicle_GetIndex() != item_num) {
         return;
     }
 
@@ -805,7 +805,7 @@ static void M_Control(const int16_t item_num)
         lara->rot.z = 0;
         lara->speed = 20;
         lara->fall_speed = -40;
-        g_Lara.vehicle_item_num = NO_ITEM;
+        Lara_Vehicle_SetIndex(NO_ITEM);
 
         const XYZ_32 pos = {
             .x = lara->pos.x + ((360 * Math_Sin(lara->rot.y)) >> W2V_SHIFT),

--- a/src/tr2/game/objects/vehicles/skidoo_armed.c
+++ b/src/tr2/game/objects/vehicles/skidoo_armed.c
@@ -3,7 +3,7 @@
 #include "global/vars.h"
 
 #include <libtrx/game/collision.h>
-#include <libtrx/game/lara/common.h>
+#include <libtrx/game/lara.h>
 #include <libtrx/game/math.h>
 
 #define SKIDOO_ARMED_RADIUS (WALL_L / 3) // = 341
@@ -49,7 +49,7 @@ static void M_Collision(
             item, coll, item->speed > 0 ? coll->enable_hit : false, false);
     }
 
-    if (g_Lara.vehicle_item_num == NO_ITEM && item->speed > 0) {
+    if (!Lara_Vehicle_IsMounted() && item->speed > 0) {
         Lara_TakeDamage(100, true);
     }
 }

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -13,6 +13,7 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/carrier.h>
+#include <libtrx/game/lara.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/savegame/bson.h>
 #include <libtrx/game/shell.h>
@@ -1252,7 +1253,7 @@ static JSON_OBJECT *M_DumpLara(void)
     JSON_ObjectAppendInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
     JSON_ObjectAppendInt(lara_obj, "flare_age", lara->flare.age);
     JSON_ObjectAppendInt(
-        lara_obj, "vehicle_item_number", lara->vehicle_item_num);
+        lara_obj, "vehicle_item_number", Lara_Vehicle_GetIndex());
     JSON_ObjectAppendInt(
         lara_obj, "back_gun_obj_id", Object_MakeGameID(lara->back_gun_obj_id));
     JSON_ObjectAppendInt(lara_obj, "flare_frame", lara->flare.frame_num);
@@ -1358,8 +1359,6 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
     lara->hit_effect_count =
         JSON_ObjectGetInt(lara_obj, "hit_effect_count", lara->hit_effect_count);
     lara->flare.age = JSON_ObjectGetInt(lara_obj, "flare_age", lara->flare.age);
-    lara->vehicle_item_num = JSON_ObjectGetInt(
-        lara_obj, "vehicle_item_number", lara->vehicle_item_num);
     lara->back_gun_obj_id = Object_UnmapGameID(
         JSON_ObjectGetInt(lara_obj, "back_gun_obj_id", lara->back_gun_obj_id));
     lara->flare.frame_num =
@@ -1368,6 +1367,10 @@ static bool M_LoadLara(JSON_OBJECT *const lara_obj)
         JSON_ObjectGetInt(lara_obj, "mesh_effects", lara->mesh_effects);
     lara->water_surface_dist = JSON_ObjectGetInt(
         lara_obj, "water_surface_dist", lara->water_surface_dist);
+
+    const int16_t vehicle_index = JSON_ObjectGetInt(
+        lara_obj, "vehicle_item_number", Lara_Vehicle_GetIndex());
+    Lara_Vehicle_SetIndex(vehicle_index);
 
     lara->flare.control =
         JSON_ObjectGetBool(lara_obj, "flare_control_left", lara->flare.control);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -11,6 +11,7 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/carrier.h>
+#include <libtrx/game/lara.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/stats.h>
 #include <libtrx/memory.h>
@@ -324,7 +325,7 @@ static void M_ReadLara(LARA_INFO *const lara)
     lara->current_active = M_ReadS16();
     lara->hit_effect_count = M_ReadS16();
     lara->flare.age = M_ReadS16();
-    lara->vehicle_item_num = M_ReadS16();
+    Lara_Vehicle_SetIndex(M_ReadS16());
     lara->gun_item_num = M_ReadS16();
     lara->back_gun_obj_id = Object_UnmapGameID(M_ReadS16());
     lara->flare.frame_num = M_ReadS16();
@@ -580,7 +581,7 @@ static void M_WriteLara(const LARA_INFO *const lara)
     M_WriteS16(lara->current_active);
     M_WriteS16(lara->hit_effect_count);
     M_WriteS16(lara->flare.age);
-    M_WriteS16(lara->vehicle_item_num);
+    M_WriteS16(Lara_Vehicle_GetIndex());
     M_WriteS16(lara->gun_item_num);
     M_WriteS16(Object_MakeGameID(lara->back_gun_obj_id));
     M_WriteS16(lara->flare.frame_num);


### PR DESCRIPTION
Resolves #3433.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This introduces a lightweight API for checking if Lara is on a vehicle, and retrieving that vehicle to reduce some of the noise in the codebase where game version checks are otherwise required. It also fixes the linked issue, by ensuring we don't run normal collision routines after object collision when above water and Lara's vehicle number is set - there was caching introduced in 4aec26c that caused this.
