### PR TITLE
ui: delay draw operations; draw all ui at once

### DIFF
--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -82,6 +82,7 @@ static void M_Draw(PHASE *const phase)
     Overlay_Draw();
     Console_Draw();
     UI_EndScene();
+    UI_Draw();
     Output_DrawPolyList();
     Fader_Draw(&m_ExitFader);
 

--- a/src/libtrx/game/ui/common.c
+++ b/src/libtrx/game/ui/common.c
@@ -5,6 +5,7 @@
 #include "game/console/common.h"
 #include "game/game_string.h"
 #include "game/scaler.h"
+#include "game/ui/draw.h"
 #include "game/ui/elements/anchor.h"
 #include "game/ui/events.h"
 #include "game/ui/text.h"
@@ -16,11 +17,6 @@
 
 static struct {
     MEMORY_ARENA_ALLOCATOR alloc;
-
-    int32_t node_count;
-    int32_t node_capacity;
-    UI_NODE *nodes;
-
     UI_NODE *root; // The top-level container
     UI_NODE *current; // The current container into which we attach nodes
 } m_Priv = {
@@ -104,7 +100,6 @@ UI_NODE *UI_AllocNode(
     memset(node, 0, size);
     node->ops = ops;
     node->data = (char *)node + sizeof(UI_NODE);
-    m_Priv.node_count++;
     return node;
 }
 
@@ -153,10 +148,7 @@ const UI_NODE *UI_GetCurrent(void)
 void UI_BeginScene(void)
 {
     Memory_ArenaReset(&m_Priv.alloc);
-    m_Priv.node_count = 0;
-
-    // Make a root node.
-    UI_BeginAnchor(0.5f, 0.5f);
+    UI_BeginAnchor(0.5f, 0.5f); // Make a root node.
 }
 
 void UI_EndScene(void)
@@ -172,10 +164,12 @@ void UI_Init(void)
 {
     UI_InitEvents();
     UI_InitText();
+    UI_InitDraw();
 }
 
 void UI_Shutdown(void)
 {
+    UI_ShutdownDraw();
     UI_ShutdownText();
     Memory_ArenaFree(&m_Priv.alloc);
     UI_ShutdownEvents();

--- a/src/libtrx/game/ui/draw.c
+++ b/src/libtrx/game/ui/draw.c
@@ -1,0 +1,181 @@
+#include "game/ui/draw.h"
+
+#include "game/output/common.h"
+#include "memory.h"
+#include "vector.h"
+
+#include <string.h>
+
+// Draw operation types for deferred UI rendering.
+typedef enum {
+    UI_DRAW_OP_TEXT_BACKGROUND,
+    UI_DRAW_OP_TEXT_OUTLINE,
+    UI_DRAW_OP_SCREEN_SPRITE,
+    UI_DRAW_OP_FLUSH,
+    UI_DRAW_OP_FADER_DRAW,
+} M_DRAW_OP_TYPE;
+
+// Deferred draw operation node.
+typedef struct {
+    M_DRAW_OP_TYPE type;
+    union {
+        struct {
+            UI_STYLE ui_style;
+            int32_t sx, sy, w, h, z;
+            TEXT_STYLE text_style;
+        } text;
+        struct {
+            int32_t sx, sy, sz, scale_h, scale_v, sprite_idx;
+            int16_t shade;
+        } sprite;
+        struct {
+            FADER *fader;
+        } fader;
+    } data;
+} M_DRAW_OP;
+
+typedef struct {
+    MEMORY_ARENA_ALLOCATOR alloc;
+    VECTOR *ops;
+} M_PRIV;
+
+static M_PRIV m_Priv = {
+    .alloc = {
+        .default_chunk_size = 1024 * 4,
+    },
+};
+
+// Allocate a new deferred draw operation in the arena.
+static M_DRAW_OP *M_AllocDrawOp(void)
+{
+    M_DRAW_OP *const op = Memory_ArenaAlloc(&m_Priv.alloc, sizeof(*op));
+    memset(op, 0, sizeof(*op));
+    return op;
+}
+
+static void M_ScheduleOp(M_DRAW_OP *const op)
+{
+    M_PRIV *const p = &m_Priv;
+    Vector_Add(p->ops, &op);
+}
+
+void UI_ScheduleDrawTextBackground(
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t w, const int32_t h, const int32_t z,
+    const TEXT_STYLE text_style)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_TEXT_BACKGROUND;
+    op->data.text.ui_style = ui_style;
+    op->data.text.sx = sx;
+    op->data.text.sy = sy;
+    op->data.text.w = w;
+    op->data.text.h = h;
+    op->data.text.z = z;
+    op->data.text.text_style = text_style;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleDrawTextOutline(
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t w, const int32_t h, const int32_t z,
+    const TEXT_STYLE text_style)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_TEXT_OUTLINE;
+    op->data.text.ui_style = ui_style;
+    op->data.text.sx = sx;
+    op->data.text.sy = sy;
+    op->data.text.w = w;
+    op->data.text.h = h;
+    op->data.text.z = z;
+    op->data.text.text_style = text_style;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleDrawScreenSprite(
+    const int32_t sx, const int32_t sy, const int32_t sz, const int32_t scale_h,
+    const int32_t scale_v, const int32_t sprite_idx, const int16_t shade)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_SCREEN_SPRITE;
+    op->data.sprite.sx = sx;
+    op->data.sprite.sy = sy;
+    op->data.sprite.sz = sz;
+    op->data.sprite.scale_h = scale_h;
+    op->data.sprite.scale_v = scale_v;
+    op->data.sprite.sprite_idx = sprite_idx;
+    op->data.sprite.shade = shade;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleFlush(void)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_FLUSH;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleFaderDraw(FADER *const fader)
+{
+    UI_ScheduleFlush();
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_FADER_DRAW;
+    op->data.fader.fader = fader;
+    M_ScheduleOp(op);
+}
+
+void UI_InitDraw(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->ops == nullptr) {
+        p->ops = Vector_Create(sizeof(M_DRAW_OP));
+    }
+}
+
+void UI_ShutdownDraw(void)
+{
+    M_PRIV *const p = &m_Priv;
+    Memory_ArenaFree(&p->alloc);
+    if (p->ops == nullptr) {
+        Vector_Free(p->ops);
+        p->ops = nullptr;
+    }
+}
+
+void UI_Draw(void)
+{
+    M_PRIV *const p = &m_Priv;
+    for (int32_t i = 0; i < p->ops->count; i++) {
+        const M_DRAW_OP *const op = *(M_DRAW_OP **)Vector_Get(p->ops, i);
+        switch (op->type) {
+        case UI_DRAW_OP_TEXT_BACKGROUND:
+            Output_DrawTextBackground(
+                op->data.text.ui_style, op->data.text.sx, op->data.text.sy,
+                op->data.text.w, op->data.text.h, op->data.text.z,
+                op->data.text.text_style);
+            break;
+        case UI_DRAW_OP_TEXT_OUTLINE:
+            Output_DrawTextOutline(
+                op->data.text.ui_style, op->data.text.sx, op->data.text.sy,
+                op->data.text.w, op->data.text.h, op->data.text.z,
+                op->data.text.text_style);
+            break;
+        case UI_DRAW_OP_SCREEN_SPRITE:
+            Output_DrawScreenSprite(
+                op->data.sprite.sx, op->data.sprite.sy, op->data.sprite.sz,
+                op->data.sprite.scale_h, op->data.sprite.scale_v,
+                op->data.sprite.sprite_idx, op->data.sprite.shade);
+            break;
+        case UI_DRAW_OP_FLUSH:
+            Output_DrawPolyList();
+            break;
+        case UI_DRAW_OP_FADER_DRAW:
+            Fader_Draw(op->data.fader.fader);
+            break;
+        }
+    }
+
+    Vector_Clear(p->ops);
+    Memory_ArenaReset(&p->alloc);
+}

--- a/src/libtrx/game/ui/elements/fade.c
+++ b/src/libtrx/game/ui/elements/fade.c
@@ -1,6 +1,7 @@
 #include "game/ui/elements/fade.h"
 
 #include "game/output.h"
+#include "game/ui/draw.h"
 #include "game/ui/helpers.h"
 
 typedef struct {
@@ -21,10 +22,9 @@ static void M_Draw(const UI_NODE *const node)
     const M_DATA *const data = node->data;
     if (data->is_on_top) {
         UI_DrawWrapper(node);
-        Output_DrawPolyList(); // flush geometry
-        Fader_Draw(data->fader);
+        UI_ScheduleFaderDraw(data->fader);
     } else {
-        Fader_Draw(data->fader);
+        UI_ScheduleFaderDraw(data->fader);
         UI_DrawWrapper(node);
     }
 }

--- a/src/libtrx/game/ui/elements/frame.c
+++ b/src/libtrx/game/ui/elements/frame.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "game/output.h"
+#include "game/ui/draw.h"
 #include "game/ui/helpers.h"
 
 typedef struct {
@@ -23,13 +24,13 @@ static void M_Draw(const UI_NODE *node)
 {
     const M_DATA *const data = node->data;
     if (data->background_z >= 0) {
-        Output_DrawTextBackground(
+        UI_ScheduleDrawTextBackground(
             data->ui_style, UI_ScaleX(node->x), UI_ScaleY(node->y),
             UI_ScaleX(node->w), UI_ScaleY(node->h), data->background_z,
             data->text_style);
     }
     if (data->outline_z >= 0) {
-        Output_DrawTextOutline(
+        UI_ScheduleDrawTextOutline(
             data->ui_style, UI_ScaleX(node->x), UI_ScaleY(node->y),
             UI_ScaleX(node->w), UI_ScaleY(node->h), data->outline_z,
             data->text_style);

--- a/src/libtrx/game/ui/elements/modal.c
+++ b/src/libtrx/game/ui/elements/modal.c
@@ -1,6 +1,7 @@
 #include "game/ui/elements/modal.h"
 
 #include "game/output.h"
+#include "game/ui/draw.h"
 #include "game/ui/elements/anchor.h"
 #include "game/ui/helpers.h"
 
@@ -21,7 +22,7 @@ static void M_Measure(UI_NODE *const node)
 
 static void M_Draw(const UI_NODE *const node)
 {
-    Output_DrawPolyList();
+    UI_ScheduleFlush();
     UI_DrawWrapper(node);
 }
 

--- a/src/libtrx/game/ui/text.c
+++ b/src/libtrx/game/ui/text.c
@@ -7,6 +7,8 @@
 #include "game/objects.h"
 #include "game/output.h"
 #include "game/scaler.h"
+#include "game/ui/common.h"
+#include "game/ui/draw.h"
 #include "log.h"
 #include "memory.h"
 #include "strings.h"
@@ -553,7 +555,7 @@ void UI_Text_Draw(
     M_Process(
         text, nullptr, nullptr, settings, base_x,
         base_y - g_Config.ui.text_scale, M_ScaleScreen,
-        Output_DrawScreenSprite);
+        UI_ScheduleDrawScreenSprite);
 }
 
 char *UI_Text_WordWrap(

--- a/src/libtrx/include/libtrx/game/ui/common.h
+++ b/src/libtrx/include/libtrx/game/ui/common.h
@@ -73,3 +73,6 @@ void UI_ToggleState(bool *config_setting);
 void UI_HandleKeyDown(uint32_t key);
 void UI_HandleKeyUp(uint32_t key);
 void UI_HandleTextEdit(const char *text);
+
+// Execute all scheduled UI draw operations in order.
+void UI_Draw(void);

--- a/src/libtrx/include/libtrx/game/ui/draw.h
+++ b/src/libtrx/include/libtrx/game/ui/draw.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../fader.h"
+#include "../output/draw.h"
+
+// Schedule deferred UI draw operations to be executed by UI_Draw().
+// These record drawing commands during UI_EndScene instead of issuing them
+// immediately.
+void UI_ScheduleDrawTextBackground(
+    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t w, int32_t h, int32_t z,
+    TEXT_STYLE text_style);
+void UI_ScheduleDrawTextOutline(
+    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t w, int32_t h, int32_t z,
+    TEXT_STYLE text_style);
+void UI_ScheduleDrawScreenSprite(
+    int32_t sx, int32_t sy, int32_t sz, int32_t scale_h, int32_t scale_v,
+    int32_t sprite_idx, int16_t shade);
+void UI_ScheduleFlush(void);
+void UI_ScheduleFaderDraw(FADER *fader);
+
+void UI_InitDraw(void);
+void UI_ShutdownDraw(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -278,6 +278,7 @@ sources = [
   'game/ui/dialogs/sound_settings.c',
   'game/ui/dialogs/stats.c',
   'game/ui/dialogs/text.c',
+  'game/ui/draw.c',
   'game/ui/elements/ammo_label.c',
   'game/ui/elements/anchor.c',
   'game/ui/elements/bar_enemy_hp.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The PR makes the UI accumulate output calls in a vector, that later get fired all at once with a single draw to `UI_Draw()`. Currently it's interleaved with geometry calls. The idea with this isolation is to eventually render the UI to a separate framebuffer so that it looks better when integer upscaling is on.
