### PR TITLE
UI upscaling prep work

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -26,7 +26,7 @@
 - added an inverted look camera option (Gameplay settings → Controls → Inverted look) (#3403)
 - added missing end of level statistic screens to Home Sweet Home and Kingdom (#2682)
 - changed statistics details mode to be placed in the UI section
-- changed the "sizer" option name to "Upscaling factor" (Graphic settings → Rendering → Upscaling factor)
+- changed the "sizer" option name to "Upscaling factor" and its max value to 8× (Graphic settings → Rendering → Upscaling factor)
 - changed the "scaler" option name to "Borders" (Graphic settings → Rendering → Borders)
 - changed controls dialog to remember the player's preferred input method
 - changed UI to show icons relevant to the chosen input method

--- a/src/libtrx/config/priv.c
+++ b/src/libtrx/config/priv.c
@@ -21,7 +21,7 @@ void Config_SanitizeCommon(void)
     CLAMP(g_Config.gameplay.start_lara_hitpoints, 1, LARA_MAX_HITPOINTS);
     CLAMP(g_Config.gameplay.camera_speed, 1, 10);
     CLAMP(g_Config.rendering.wireframe_width, 1.0, 100.0);
-    CLAMP(g_Config.rendering.upscaling_factor, 1, 4);
+    CLAMP(g_Config.rendering.upscaling_factor, 1, 8);
     CLAMP(g_Config.rendering.borders, 0.0, 0.45);
     CLAMP(g_Config.ui.bar_scale, 0.5, 2.0);
     CLAMP(g_Config.ui.text_scale, 0.5, 2.0);

--- a/src/libtrx/game/stats.c
+++ b/src/libtrx/game/stats.c
@@ -32,7 +32,6 @@ bool Stats_HasSecret(const int16_t secret_idx)
 
 bool Stats_TakeSecret(const int16_t secret_idx)
 {
-    LOG_INFO("Removing secret %d", secret_idx);
     RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
     if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
@@ -45,6 +44,7 @@ bool Stats_TakeSecret(const int16_t secret_idx)
     if (!(current_info->stats.secret_flags & secret_mask)) {
         return false;
     }
+    LOG_INFO("Removing secret %d", secret_idx);
     current_info->stats.secret_flags &= ~secret_mask;
     current_info->stats.secret_count--;
     return true;
@@ -52,7 +52,6 @@ bool Stats_TakeSecret(const int16_t secret_idx)
 
 bool Stats_AddSecret(const int16_t secret_idx)
 {
-    LOG_INFO("Adding secret %d", secret_idx);
     RESUME_INFO *const current_info =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
     if (secret_idx < 0 || secret_idx >= STATS_MAX_SECRETS) {
@@ -65,6 +64,7 @@ bool Stats_AddSecret(const int16_t secret_idx)
     if (current_info->stats.secret_flags & secret_mask) {
         return false;
     }
+    LOG_INFO("Adding secret %d", secret_idx);
     current_info->stats.secret_flags |= secret_mask;
     current_info->stats.secret_count++;
     return true;

--- a/src/libtrx/game/ui/dialogs/setting_tabs/graphic_rendering.def
+++ b/src/libtrx/game/ui/dialogs/setting_tabs/graphic_rendering.def
@@ -16,7 +16,7 @@ X_UI_CFG_ENUM(rendering.render_mode,             GRAPHIC_SETTINGS_RENDER_MODE, .
 #endif
 X_UI_CFG_ENUM(rendering.aspect_mode,             GRAPHIC_SETTINGS_ASPECT_MODE, .misc = UI_Settings_AspectModeEnumEntries)
 X_UI_CFG_ENUM(rendering.upscaling_filter,        GRAPHIC_SETTINGS_UPSCALING_FILTER, .misc = UI_Settings_TextureFilterEnumEntries)
-X_UI_CFG_INT32(rendering.upscaling_factor,       GRAPHIC_SETTINGS_UPSCALING_FACTOR, .min_value = 1, .max_value = 4, .delta_slow = 1, .delta_fast = 1)
+X_UI_CFG_INT32(rendering.upscaling_factor,       GRAPHIC_SETTINGS_UPSCALING_FACTOR, .min_value = 1, .max_value = 8, .delta_slow = 1, .delta_fast = 1)
 X_UI_CFG_FLOAT_PERCENT(rendering.borders,        GRAPHIC_SETTINGS_BORDERS, .min_value = 0, .max_value = 45, .delta_slow = 1, .delta_fast = 5)
 
 X_UI_CFG_ENUM(rendering.screenshot_format,       GRAPHIC_SETTINGS_SCREENSHOT_FORMAT, .misc = UI_Settings_ScreenshotFormatEnumEntries)

--- a/src/libtrx/game/ui/draw.c
+++ b/src/libtrx/game/ui/draw.c
@@ -11,6 +11,8 @@ typedef enum {
     UI_DRAW_OP_TEXT_BACKGROUND,
     UI_DRAW_OP_TEXT_OUTLINE,
     UI_DRAW_OP_SCREEN_SPRITE,
+    UI_DRAW_OP_FLAT_QUAD,
+    UI_DRAW_OP_GRADIENT_QUAD,
     UI_DRAW_OP_FLUSH,
     UI_DRAW_OP_FADER_DRAW,
 } M_DRAW_OP_TYPE;
@@ -21,16 +23,24 @@ typedef struct {
     union {
         struct {
             UI_STYLE ui_style;
-            int32_t sx, sy, w, h, z;
+            int32_t sx, sy, z, w, h;
             TEXT_STYLE text_style;
         } text;
         struct {
-            int32_t sx, sy, sz, scale_h, scale_v, sprite_idx;
+            int32_t sx, sy, z, scale_h, scale_v, sprite_idx;
             int16_t shade;
         } sprite;
         struct {
             FADER *fader;
         } fader;
+        struct {
+            int32_t sx, sy, z, w, h;
+            RGBA_8888 color;
+        } flat_quad;
+        struct {
+            int32_t sx, sy, z, w, h;
+            RGBA_8888 tl, tr, bl, br;
+        } gradient_quad;
     } data;
 } M_DRAW_OP;
 
@@ -61,7 +71,7 @@ static void M_ScheduleOp(M_DRAW_OP *const op)
 
 void UI_ScheduleDrawTextBackground(
     const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
-    const int32_t w, const int32_t h, const int32_t z,
+    const int32_t z, const int32_t w, const int32_t h,
     const TEXT_STYLE text_style)
 {
     M_DRAW_OP *const op = M_AllocDrawOp();
@@ -69,16 +79,16 @@ void UI_ScheduleDrawTextBackground(
     op->data.text.ui_style = ui_style;
     op->data.text.sx = sx;
     op->data.text.sy = sy;
+    op->data.text.z = z;
     op->data.text.w = w;
     op->data.text.h = h;
-    op->data.text.z = z;
     op->data.text.text_style = text_style;
     M_ScheduleOp(op);
 }
 
 void UI_ScheduleDrawTextOutline(
     const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
-    const int32_t w, const int32_t h, const int32_t z,
+    const int32_t z, const int32_t w, const int32_t h,
     const TEXT_STYLE text_style)
 {
     M_DRAW_OP *const op = M_AllocDrawOp();
@@ -94,18 +104,52 @@ void UI_ScheduleDrawTextOutline(
 }
 
 void UI_ScheduleDrawScreenSprite(
-    const int32_t sx, const int32_t sy, const int32_t sz, const int32_t scale_h,
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t scale_h,
     const int32_t scale_v, const int32_t sprite_idx, const int16_t shade)
 {
     M_DRAW_OP *const op = M_AllocDrawOp();
     op->type = UI_DRAW_OP_SCREEN_SPRITE;
     op->data.sprite.sx = sx;
     op->data.sprite.sy = sy;
-    op->data.sprite.sz = sz;
+    op->data.sprite.z = z;
     op->data.sprite.scale_h = scale_h;
     op->data.sprite.scale_v = scale_v;
     op->data.sprite.sprite_idx = sprite_idx;
     op->data.sprite.shade = shade;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleDrawScreenFlatQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 color)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_FLAT_QUAD;
+    op->data.flat_quad.sx = sx;
+    op->data.flat_quad.sy = sy;
+    op->data.flat_quad.z = z;
+    op->data.flat_quad.w = w;
+    op->data.flat_quad.h = h;
+    op->data.flat_quad.color = color;
+    M_ScheduleOp(op);
+}
+
+void UI_ScheduleDrawScreenGradientQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
+    const RGBA_8888 br)
+{
+    M_DRAW_OP *const op = M_AllocDrawOp();
+    op->type = UI_DRAW_OP_GRADIENT_QUAD;
+    op->data.gradient_quad.sx = sx;
+    op->data.gradient_quad.sy = sy;
+    op->data.gradient_quad.z = z;
+    op->data.gradient_quad.w = w;
+    op->data.gradient_quad.h = h;
+    op->data.gradient_quad.tl = tl;
+    op->data.gradient_quad.tr = tr;
+    op->data.gradient_quad.bl = bl;
+    op->data.gradient_quad.br = br;
     M_ScheduleOp(op);
 }
 
@@ -152,20 +196,34 @@ void UI_Draw(void)
         case UI_DRAW_OP_TEXT_BACKGROUND:
             Output_DrawTextBackground(
                 op->data.text.ui_style, op->data.text.sx, op->data.text.sy,
-                op->data.text.w, op->data.text.h, op->data.text.z,
+                op->data.text.z, op->data.text.w, op->data.text.h,
                 op->data.text.text_style);
             break;
         case UI_DRAW_OP_TEXT_OUTLINE:
             Output_DrawTextOutline(
                 op->data.text.ui_style, op->data.text.sx, op->data.text.sy,
-                op->data.text.w, op->data.text.h, op->data.text.z,
+                op->data.text.z, op->data.text.w, op->data.text.h,
                 op->data.text.text_style);
             break;
         case UI_DRAW_OP_SCREEN_SPRITE:
             Output_DrawScreenSprite(
-                op->data.sprite.sx, op->data.sprite.sy, op->data.sprite.sz,
+                op->data.sprite.sx, op->data.sprite.sy, op->data.sprite.z,
                 op->data.sprite.scale_h, op->data.sprite.scale_v,
                 op->data.sprite.sprite_idx, op->data.sprite.shade);
+            break;
+        case UI_DRAW_OP_FLAT_QUAD:
+            Output_DrawScreenFlatQuad(
+                op->data.flat_quad.sx, op->data.flat_quad.sy,
+                op->data.flat_quad.z, op->data.flat_quad.w,
+                op->data.flat_quad.h, op->data.flat_quad.color);
+            break;
+        case UI_DRAW_OP_GRADIENT_QUAD:
+            Output_DrawScreenGradientQuad(
+                op->data.gradient_quad.sx, op->data.gradient_quad.sy,
+                op->data.gradient_quad.z, op->data.gradient_quad.w,
+                op->data.gradient_quad.h, op->data.gradient_quad.tl,
+                op->data.gradient_quad.tr, op->data.gradient_quad.bl,
+                op->data.gradient_quad.br);
             break;
         case UI_DRAW_OP_FLUSH:
             Output_DrawPolyList();

--- a/src/libtrx/game/ui/elements/frame.c
+++ b/src/libtrx/game/ui/elements/frame.c
@@ -26,13 +26,13 @@ static void M_Draw(const UI_NODE *node)
     if (data->background_z >= 0) {
         UI_ScheduleDrawTextBackground(
             data->ui_style, UI_ScaleX(node->x), UI_ScaleY(node->y),
-            UI_ScaleX(node->w), UI_ScaleY(node->h), data->background_z,
+            data->background_z, UI_ScaleX(node->w), UI_ScaleY(node->h),
             data->text_style);
     }
     if (data->outline_z >= 0) {
         UI_ScheduleDrawTextOutline(
             data->ui_style, UI_ScaleX(node->x), UI_ScaleY(node->y),
-            UI_ScaleX(node->w), UI_ScaleY(node->h), data->outline_z,
+            data->outline_z, UI_ScaleX(node->w), UI_ScaleY(node->h),
             data->text_style);
     }
     UI_DrawWrapper(node);

--- a/src/libtrx/include/libtrx/game/output/draw.h
+++ b/src/libtrx/include/libtrx/game/output/draw.h
@@ -20,3 +20,8 @@ extern void Output_DrawTextOutline(
 extern void Output_DrawScreenSprite(
     int32_t sx, int32_t sy, int32_t sz, int32_t scale_h, int32_t scale_v,
     int32_t sprite_idx, int16_t shade);
+extern void Output_DrawScreenFlatQuad(
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 color);
+extern void Output_DrawScreenGradientQuad(
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 tl,
+    RGBA_8888 tr, RGBA_8888 bl, RGBA_8888 br);

--- a/src/libtrx/include/libtrx/game/ui/draw.h
+++ b/src/libtrx/include/libtrx/game/ui/draw.h
@@ -7,14 +7,19 @@
 // These record drawing commands during UI_EndScene instead of issuing them
 // immediately.
 void UI_ScheduleDrawTextBackground(
-    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t w, int32_t h, int32_t z,
+    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h,
     TEXT_STYLE text_style);
 void UI_ScheduleDrawTextOutline(
-    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t w, int32_t h, int32_t z,
+    UI_STYLE ui_style, int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h,
     TEXT_STYLE text_style);
 void UI_ScheduleDrawScreenSprite(
-    int32_t sx, int32_t sy, int32_t sz, int32_t scale_h, int32_t scale_v,
+    int32_t sx, int32_t sy, int32_t z, int32_t scale_h, int32_t scale_v,
     int32_t sprite_idx, int16_t shade);
+void UI_ScheduleDrawScreenFlatQuad(
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 color);
+void UI_ScheduleDrawScreenGradientQuad(
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 tl,
+    RGBA_8888 tr, RGBA_8888 bl, RGBA_8888 br);
 void UI_ScheduleFlush(void);
 void UI_ScheduleFaderDraw(FADER *fader);
 

--- a/src/tr1/game/console/common.c
+++ b/src/tr1/game/console/common.c
@@ -19,5 +19,5 @@ void Console_DrawBackdrop(void)
     RGBA_8888 bottom = { 0, 0, 0, 196 };
 
     Output_DrawPolyList();
-    Output_DrawScreenGradientQuad(sx, sy, sw, sh, top, top, bottom, bottom);
+    Output_DrawScreenGradientQuad(sx, sy, 0, sw, sh, top, top, bottom, bottom);
 }

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -544,15 +544,15 @@ void Output_ClearDepthBuffer(void)
 }
 
 void Output_DrawScreenFlatQuad(
-    const int32_t sx, const int32_t sy, const int32_t w, const int32_t h,
-    const RGBA_8888 color)
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 color)
 {
     M_Draw2DQuad(sx, sy, sx + w, sy + h, color, color, color, color);
 }
 
 void Output_DrawScreenGradientQuad(
-    const int32_t sx, const int32_t sy, const int32_t w, const int32_t h,
-    const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
     const RGBA_8888 br)
 {
     M_Draw2DQuad(sx, sy, sx + w, sy + h, tl, tr, bl, br);
@@ -831,7 +831,7 @@ void Output_DrawBlackRectangle(const int32_t opacity)
     const RGBA_8888 background = { 0, 0, 0, opacity };
     M_DisableDepthTest();
     Output_ClearDepthBuffer();
-    Output_DrawScreenFlatQuad(sx, sy, sw, sh, background);
+    Output_DrawScreenFlatQuad(sx, sy, 0, sw, sh, background);
     M_EnableDepthTest();
 }
 
@@ -875,8 +875,8 @@ void Output_ApplyFOV(void)
 }
 
 void Output_DrawTextBackground(
-    const UI_STYLE ui_style, const int32_t sx, const int32_t sy, int32_t w,
-    int32_t h, const int32_t z, const TEXT_STYLE text_style)
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t z, int32_t w, int32_t h, const TEXT_STYLE text_style)
 {
     if (ui_style == UI_STYLE_PC) {
         Output_DrawScreenFBox(sx, sy, w, h, text_style);
@@ -898,25 +898,25 @@ void Output_DrawTextBackground(
     if (text_style == TS_HEADING) {
         for (int i = 0; i < 4; i++) {
             Output_DrawScreenGradientQuad(
-                gradient_quads[i].x, gradient_quads[i].y, gradient_quads[i].w,
-                gradient_quads[i].h, M_GetMenuColor(MC_BROWN_E),
+                gradient_quads[i].x, gradient_quads[i].y, 0,
+                gradient_quads[i].w, gradient_quads[i].h,
                 M_GetMenuColor(MC_BROWN_E), M_GetMenuColor(MC_BROWN_E),
-                M_GetMenuColor(MC_BROWN_C));
+                M_GetMenuColor(MC_BROWN_E), M_GetMenuColor(MC_BROWN_C));
         }
     } else if (text_style == TS_REQUESTED) {
         for (int i = 0; i < 4; i++) {
             Output_DrawScreenGradientQuad(
-                gradient_quads[i].x, gradient_quads[i].y, gradient_quads[i].w,
-                gradient_quads[i].h, M_GetMenuColor(MC_PURPLE_E),
+                gradient_quads[i].x, gradient_quads[i].y, 0,
+                gradient_quads[i].w, gradient_quads[i].h,
                 M_GetMenuColor(MC_PURPLE_E), M_GetMenuColor(MC_PURPLE_E),
-                M_GetMenuColor(MC_PURPLE_C));
+                M_GetMenuColor(MC_PURPLE_E), M_GetMenuColor(MC_PURPLE_C));
         }
     }
 }
 
 void Output_DrawTextOutline(
-    const UI_STYLE ui_style, const int32_t sx, const int32_t sy, int32_t w,
-    int32_t h, const int32_t z, const TEXT_STYLE text_style)
+    const UI_STYLE ui_style, const int32_t sx, const int32_t sy,
+    const int32_t z, int32_t w, int32_t h, const TEXT_STYLE text_style)
 {
     if (ui_style == UI_STYLE_PC) {
         Output_DrawScreenFrame(

--- a/src/tr1/game/output.h
+++ b/src/tr1/game/output.h
@@ -34,12 +34,12 @@ void Output_DrawLightningSegment(XYZ_32 pos_0, XYZ_32 pos_1, int32_t thickness);
 void Output_FlushTranslucentObjects(void);
 
 void Output_DrawScreenFlatQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA_8888 color);
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 color);
 void Output_DrawScreenTranslucentQuad(
     int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA_8888 color);
 void Output_DrawScreenGradientQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA_8888 tl, RGBA_8888 tr,
-    RGBA_8888 bl, RGBA_8888 br);
+    int32_t sx, int32_t sy, int32_t z, int32_t w, int32_t h, RGBA_8888 tl,
+    RGBA_8888 tr, RGBA_8888 bl, RGBA_8888 br);
 void Output_DrawScreenFrame(
     int32_t sx, int32_t sy, int32_t w, int32_t h, RGBA_8888 colDark,
     RGBA_8888 colLight, int32_t thickness);

--- a/src/tr1/game/overlay.c
+++ b/src/tr1/game/overlay.c
@@ -6,6 +6,7 @@
 #include "game/viewport.h"
 
 #include <libtrx/config.h>
+#include <libtrx/game/ui/draw.h>
 
 #define M_MAX_PICKUP_COLUMNS 4
 #define M_MAX_PICKUP_DURATION_DISPLAY 2.0 // seconds
@@ -225,7 +226,8 @@ static void M_DrawPickupsSprites(void)
             - sprite_height * pu->grid_y;
         const int32_t scale = 12288 * Viewport_GetWidth(VIEWPORT_GAME) / 640;
         const int16_t sprite_num = Object_Get(pu->object_id)->mesh_idx;
-        Output_DrawUISprite(x, y, scale, sprite_num, SHADE_NEUTRAL);
+        UI_ScheduleDrawScreenSprite(
+            x, y, 0, scale, scale, sprite_num, SHADE_NEUTRAL);
     }
 }
 

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -114,7 +114,11 @@ void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
 
 #define L_CHANGED(subject) (old->subject != new->subject)
 
-    if (L_CHANGED(rendering.upscaling_filter)) {
+    if (L_CHANGED(rendering.upscaling_filter)
+        || L_CHANGED(rendering.enable_wireframe)
+        || L_CHANGED(rendering.wireframe_width)
+        || L_CHANGED(rendering.enable_vsync)
+        || L_CHANGED(rendering.anisotropy_filter)) {
         Output_ApplyRenderSettings();
     }
 

--- a/src/tr1/game/ui/elements/bar.c
+++ b/src/tr1/game/ui/elements/bar.c
@@ -4,6 +4,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/game/scaler.h>
+#include <libtrx/game/ui/draw.h>
 #include <libtrx/game/ui/helpers.h>
 #include <libtrx/utils.h>
 
@@ -101,12 +102,12 @@ static void M_Draw(const UI_NODE *const node)
     };
 
     // Draw border
-    Output_DrawScreenFlatQuad(
-        outer_rect.x, outer_rect.y, outer_rect.w, outer_rect.h, rgb_border);
+    UI_ScheduleDrawScreenFlatQuad(
+        outer_rect.x, outer_rect.y, 0, outer_rect.w, outer_rect.h, rgb_border);
 
     // Draw background
-    Output_DrawScreenFlatQuad(
-        inner_rect.x, inner_rect.y, inner_rect.w, inner_rect.h, rgb_bgnd);
+    UI_ScheduleDrawScreenFlatQuad(
+        inner_rect.x, inner_rect.y, 0, inner_rect.w, inner_rect.h, rgb_bgnd);
 
     if (percent == 0.0f) {
         return;
@@ -121,8 +122,8 @@ static void M_Draw(const UI_NODE *const node)
                 bar_rect.y + i * bar_rect.h / (M_COLOR_STEPS - 1);
             const int32_t lsh =
                 bar_rect.y + (i + 1) * bar_rect.h / (M_COLOR_STEPS - 1) - lsy;
-            Output_DrawScreenGradientQuad(
-                bar_rect.x, lsy, bar_rect.w, lsh, c1, c1, c2, c2);
+            UI_ScheduleDrawScreenGradientQuad(
+                bar_rect.x, lsy, 0, bar_rect.w, lsh, c1, c1, c2, c2);
         }
     } else {
         for (int32_t i = 0; i < M_COLOR_STEPS; i++) {
@@ -130,7 +131,8 @@ static void M_Draw(const UI_NODE *const node)
             const int32_t lsy = bar_rect.y + i * bar_rect.h / M_COLOR_STEPS;
             const int32_t lsh =
                 bar_rect.y + (i + 1) * bar_rect.h / M_COLOR_STEPS - lsy;
-            Output_DrawScreenFlatQuad(bar_rect.x, lsy, bar_rect.w, lsh, color);
+            UI_ScheduleDrawScreenFlatQuad(
+                bar_rect.x, lsy, 0, bar_rect.w, lsh, color);
         }
     }
 }

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -644,21 +644,6 @@ void Output_DrawSprite(
     Render_InsertSprite(zv, x0, y0, x1, y1, sprite_idx, shade);
 }
 
-void Output_DrawPickup(
-    const int32_t sx, const int32_t sy, const int32_t scale,
-    const int16_t sprite_idx, const int16_t shade)
-{
-    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
-    ASSERT(sprite != nullptr);
-    const int32_t x0 = sx + ((sprite->x0 * scale) / PHD_ONE);
-    const int32_t y0 = sy + ((sprite->y0 * scale) / PHD_ONE);
-    const int32_t x1 = sx + ((sprite->x1 * scale) / PHD_ONE);
-    const int32_t y1 = sy + ((sprite->y1 * scale) / PHD_ONE);
-    if (x1 >= 0 && y1 >= 0 && x0 < g_PhdWinWidth && y0 < g_PhdWinHeight) {
-        Render_InsertSprite(200, x0, y0, x1, y1, sprite_idx, shade);
-    }
-}
-
 void Output_DrawScreenSprite(
     const int32_t sx, const int32_t sy, const int32_t sz, const int32_t scale_h,
     const int32_t scale_v, const int32_t sprite_idx, const int16_t shade)

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -791,10 +791,20 @@ void Output_DrawScreenFrame(
 }
 
 void Output_DrawScreenFlatQuad(
-    const int32_t sx, const int32_t sy, const int32_t w, const int32_t h,
-    int32_t z, const RGB_888 color)
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 color)
 {
-    Render_InsertFlatRect(sx, sy, sx + w, sy + h, z, Output_FindColor8(color));
+    Render_InsertFlatRect(
+        sx, sy, sx + w, sy + h, z,
+        Output_FindColor8((RGB_888) { color.r, color.g, color.b }));
+}
+
+void Output_DrawScreenGradientQuad(
+    const int32_t sx, const int32_t sy, const int32_t z, const int32_t w,
+    const int32_t h, const RGBA_8888 tl, const RGBA_8888 tr, const RGBA_8888 bl,
+    const RGBA_8888 br)
+{
+    // TODO: not implemented
 }
 
 void Output_InsertShadow(
@@ -1058,9 +1068,8 @@ void Output_LightRoomVertices(const ROOM *const room)
 }
 
 void Output_DrawTextOutline(
-    const UI_STYLE ui_style, const int32_t x, const int32_t y,
-    const int32_t width, const int32_t height, const int32_t z,
-    const TEXT_STYLE text_style)
+    const UI_STYLE ui_style, const int32_t x, const int32_t y, const int32_t z,
+    const int32_t width, const int32_t height, const TEXT_STYLE text_style)
 {
     const int32_t mesh_idx = Object_Get(O_TEXT_BOX)->mesh_idx;
 
@@ -1091,8 +1100,8 @@ void Output_DrawTextOutline(
 }
 
 void Output_DrawTextBackground(
-    const UI_STYLE ui_style, const int32_t x, const int32_t y, const int32_t w,
-    const int32_t h, const int32_t z, const TEXT_STYLE text_style)
+    const UI_STYLE ui_style, const int32_t x, const int32_t y, const int32_t z,
+    const int32_t w, const int32_t h, const TEXT_STYLE text_style)
 {
     Render_InsertTransQuad(
         x, y, w + 1, h + 1, g_PhdNearZ + 8 * z,

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -49,9 +49,6 @@ void Output_DrawSprite(
     uint32_t flags, int32_t x, int32_t y, int32_t z, int16_t sprite_idx,
     int16_t shade, int16_t scale);
 
-void Output_DrawPickup(
-    int32_t sx, int32_t sy, int32_t scale, int16_t sprite_idx, int16_t shade);
-
 void Output_DrawScreenSprite(
     int32_t sx, int32_t sy, int32_t sz, int32_t scale_h, int32_t scale_v,
     int32_t sprite_idx, int16_t shade);

--- a/src/tr2/game/output.h
+++ b/src/tr2/game/output.h
@@ -70,9 +70,6 @@ void Output_DrawScreenFrame(
     int32_t sx, int32_t sy, int32_t z, int32_t width, int32_t height,
     uint8_t color_idx, const void *gour, uint16_t flags);
 
-void Output_DrawScreenFlatQuad(
-    int32_t sx, int32_t sy, int32_t w, int32_t h, int32_t z, RGB_888 color);
-
 void Output_LoadBackgroundFromObject(void);
 
 void Output_InsertShadow(

--- a/src/tr2/game/overlay.c
+++ b/src/tr2/game/overlay.c
@@ -17,6 +17,7 @@
 #include <libtrx/game/matrix.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/scaler.h>
+#include <libtrx/game/ui/draw.h>
 #include <libtrx/utils.h>
 
 #include <stdio.h>
@@ -354,7 +355,8 @@ static void M_DrawPickupSprite(const DISPLAY_PICKUP *const pickup)
     // TODO: use proper scaling
     const int32_t scale = 12288 * g_PhdWinWidth / 640;
     const int16_t sprite_num = pickup->object->mesh_idx;
-    Output_DrawPickup(x, y, scale, sprite_num, SHADE_NEUTRAL);
+    UI_ScheduleDrawScreenSprite(
+        x, y, 0, scale, scale, sprite_num, SHADE_NEUTRAL);
 }
 
 static void M_DrawPickups(void)

--- a/src/tr2/game/ui/elements/bar.c
+++ b/src/tr2/game/ui/elements/bar.c
@@ -5,6 +5,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/game/scaler.h>
+#include <libtrx/game/ui/draw.h>
 #include <libtrx/game/ui/helpers.h>
 #include <libtrx/utils.h>
 
@@ -43,15 +44,16 @@ static const UI_WIDGET_OPS m_Ops = {
     .draw = M_Draw,
 };
 
-static RGB_888 M_GetColor(BAR_COLOR color, int32_t idx);
+static RGBA_8888 M_GetColor(BAR_COLOR color, int32_t idx);
 
-static RGB_888 M_GetColor(const BAR_COLOR color, const int32_t idx)
+static RGBA_8888 M_GetColor(const BAR_COLOR color, const int32_t idx)
 {
     const int32_t value = m_ColorMap[color][idx];
-    return (RGB_888) {
+    return (RGBA_8888) {
         .r = (value >> 16) & 0xFF,
         .g = (value >> 8) & 0xFF,
         .b = (value) & 0xFF,
+        .a = 0xFF,
     };
 }
 
@@ -68,9 +70,9 @@ static void M_Draw(const UI_NODE *const node)
     M_DATA *const data = node->data;
     const UI_BAR_SETTINGS *const settings = &data->settings;
 
-    const RGB_888 rgb_bgnd = { 0, 0, 0 };
-    const RGB_888 rgb_border_highlight = { 0xFF, 0xFF, 0xFF };
-    const RGB_888 rgb_border_dark = { 0x40, 0x40, 0x40 };
+    const RGBA_8888 rgb_bgnd = { 0, 0, 0, 0xFF };
+    const RGBA_8888 rgb_border_highlight = { 0xFF, 0xFF, 0xFF, 0xFF };
+    const RGBA_8888 rgb_border_dark = { 0x40, 0x40, 0x40, 0xFF };
 
     float percent = settings->value / (float)MAX(1, settings->max_value);
     CLAMP(percent, 0.0f, 1.0f);
@@ -103,17 +105,18 @@ static void M_Draw(const UI_NODE *const node)
     };
 
     // Draw border
-    Output_DrawScreenFlatQuad(
-        outer_rect.x, outer_rect.y, outer_rect.w, outer_rect.h,
-        g_PhdNearZ + M_COLOR_STEPS * 4, rgb_border_highlight);
-    Output_DrawScreenFlatQuad(
-        outer_rect.x + border, outer_rect.y + border, outer_rect.w - border,
-        outer_rect.h - border, g_PhdNearZ + M_COLOR_STEPS * 3, rgb_border_dark);
+    UI_ScheduleDrawScreenFlatQuad(
+        outer_rect.x, outer_rect.y, g_PhdNearZ + M_COLOR_STEPS * 4,
+        outer_rect.w, outer_rect.h, rgb_border_highlight);
+    UI_ScheduleDrawScreenFlatQuad(
+        outer_rect.x + border, outer_rect.y + border,
+        g_PhdNearZ + M_COLOR_STEPS * 3, outer_rect.w - border,
+        outer_rect.h - border, rgb_border_dark);
 
     // Draw background
-    Output_DrawScreenFlatQuad(
-        inner_rect.x, inner_rect.y, inner_rect.w, inner_rect.h,
-        g_PhdNearZ + M_COLOR_STEPS * 2, rgb_bgnd);
+    UI_ScheduleDrawScreenFlatQuad(
+        inner_rect.x, inner_rect.y, g_PhdNearZ + M_COLOR_STEPS * 2,
+        inner_rect.w, inner_rect.h, rgb_bgnd);
 
     if (percent == 0.0f) {
         return;
@@ -121,12 +124,12 @@ static void M_Draw(const UI_NODE *const node)
 
     // Draw fill
     for (int32_t i = 0; i < M_COLOR_STEPS; i++) {
-        const RGB_888 color = M_GetColor(settings->color, i);
+        const RGBA_8888 color = M_GetColor(settings->color, i);
         const int32_t lsy = bar_rect.y + i * bar_rect.h / M_COLOR_STEPS;
         const int32_t lsh =
             bar_rect.y + (i + 1) * bar_rect.h / M_COLOR_STEPS - lsy;
-        Output_DrawScreenFlatQuad(
-            bar_rect.x, lsy, bar_rect.w, lsh, g_PhdNearZ + M_COLOR_STEPS - i,
+        UI_ScheduleDrawScreenFlatQuad(
+            bar_rect.x, lsy, g_PhdNearZ + M_COLOR_STEPS - i, bar_rect.w, lsh,
             color);
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Miscellaneous preparations for the upcoming UI upscaling rework.

- Increases the upscaling limit to 8
- Fixes logs constantly firing on secret tiles in TR1
- Fixes TR1 not updating some changes (`/wireframe 1` etc.)
- Fixes bars being drawn eagerly, rather than using deferred rendering
- Fixes pickup sprites being drawn eagerly, rather than using deferred rendering
- Ensures common order of arguments across `Output_*` function family – X, Y, Z, W, H.