### PR TITLE
tr2/inventory_ring: fix play any level parameter

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -62,6 +62,7 @@
 - fixed being able to deselect the passport in the game over screen (#3381, regression from 1.0)
 - fixed Lara getting stuck in the fly cheat in rare circumstances (#3392, regression from 0.3)
 - fixed support for >3 secret dragons in custom levels (#3415, regression from 1.2)
+- fixed level select picking one level ahead of the one chosen if the gym is disabled (#3446, regression from 1.0)
 - fixed the `/tp` command breaking the photo mode
 - fixed the `/tp` command misbehaving when giving fractional coordinates
 - improved support for >3 secret dragons in custom levels up to 16 dragons

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -210,8 +210,7 @@ static GF_COMMAND M_Finish(INV_RING *const ring, const bool apply_changes)
                 if (g_GameFlow.play_any_level) {
                     return (GF_COMMAND) {
                         .action = GF_START_GAME,
-                        .param = g_Inv_ExtraData[1]
-                            + (GF_GetGymLevel() != nullptr ? 1 : 0),
+                        .param = g_Inv_ExtraData[1],
                     };
                 } else {
                     if (apply_changes) {
@@ -232,8 +231,7 @@ static GF_COMMAND M_Finish(INV_RING *const ring, const bool apply_changes)
                     if (g_GameFlow.play_any_level) {
                         return (GF_COMMAND) {
                             .action = GF_START_GAME,
-                            .param = g_Inv_ExtraData[1]
-                                + (GF_GetGymLevel() != nullptr ? 1 : 0),
+                            .param = g_Inv_ExtraData[1],
                         };
                     } else {
                         return (GF_COMMAND) {


### PR DESCRIPTION
Resolves #3446.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the parameter set by the play any level menu is passed as-is to the GF command that starts the level, as it deals with sequencing already based on the main level table.
