### PR TITLE
tr1/game-flow: fix inventory modifier with level 1

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fixed already playing samples not getting muted when the game window goes out of focus
 - fixed the `/tp` command breaking the photo mode
 - fixed the `/tp` command misbehaving when giving fractional coordinates
+- fixed carrying over items from the first level when the player issues `/play` command
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)
 - improved performance when resizing the window

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -98,17 +98,19 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         } else {
             // console /play level feature
             Savegame_InitCurrentInfo();
-            const GF_LEVEL *tmp_level = GF_GetLevelAfter(GF_GetFirstLevel());
-            while (tmp_level != nullptr) {
-                Savegame_CarryCurrentInfoToNextLevel(
-                    GF_GetLevelBefore(tmp_level), tmp_level);
+            const GF_LEVEL *tmp_level = GF_GetFirstLevel();
+            while (tmp_level != nullptr && tmp_level <= level) {
                 Savegame_ApplyLogicToCurrentInfo(tmp_level);
                 GF_InventoryModifier_Scan(tmp_level);
                 GF_InventoryModifier_Apply(tmp_level, GF_INV_REGULAR);
                 if (tmp_level == level) {
                     break;
                 }
-                tmp_level = GF_GetLevelAfter(tmp_level);
+                const GF_LEVEL *const next_level = GF_GetLevelAfter(tmp_level);
+                if (next_level != nullptr) {
+                    Savegame_CarryCurrentInfoToNextLevel(tmp_level, next_level);
+                }
+                tmp_level = next_level;
             }
         }
         break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

While this doesn't solve #3147 it does improve the situation when the builder tries to give Lara some items:
```patch
diff --git a/data/tr1/ship/cfg/TR1X_gameflow.json5 b/data/tr1/ship/cfg/TR1X_gameflow.json5
index 28807173c..86aa885a3 100644
--- a/data/tr1/ship/cfg/TR1X_gameflow.json5
+++ b/data/tr1/ship/cfg/TR1X_gameflow.json5
@@ -76,6 +76,10 @@
             "sequence": [
                 {"type": "play_fmv", "fmv_id": 4},
                 {"type": "loading_screen", "path": "data/images/peru.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
+                {"type": "give_item", "object_id": "pistols"},
+                {"type": "give_item", "object_id": "shotgun"},
+                {"type": "give_item", "object_id": "small_medipack"},
+                {"type": "give_item", "object_id": "large_medipack"},
                 {"type": "loop_game"},
                 {"type": "level_stats"},
                 {"type": "level_complete"},
```