### PR TITLE
Let players use the console during FMVs

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -25,6 +25,7 @@
 - added an option to display level counter in the statistics dialog (Graphic options → UI → Level counter) (#1087)
 - added an option to control playing of certain animation sound effects such as doors when underwater (Sound options → Underwater animation SFX) (#3385)
 - added an option to allow the audio to play when the game is out of focus (Sound options → Mute audio when focus lost, #3333)
+- added the ability to use the dev console during FMVs played after showing the title ring
 - changed statistics details mode to be placed in the UI section
 - changed controls dialog to remember the player's preferred input method
 - changed UI to show icons relevant to the chosen input method

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -25,7 +25,7 @@
 - added an option to display level counter in the statistics dialog (Graphic options → UI → Level counter) (#1087)
 - added an option to control playing of certain animation sound effects such as doors when underwater (Sound options → Underwater animation SFX) (#3385)
 - added an option to allow the audio to play when the game is out of focus (Sound options → Mute audio when focus lost, #3333)
-- added the ability to use the dev console during FMVs played after showing the title ring
+- added the ability to use the dev console during FMVs
 - changed statistics details mode to be placed in the UI section
 - changed controls dialog to remember the player's preferred input method
 - changed UI to show icons relevant to the chosen input method

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -49,9 +49,9 @@
 - fixed game window getting misplaced in windowed mode between game relaunches on certain systems (#3418)
 - fixed Lara using the wrong hit animation under certain scenarios based on her hit angle (#3424)
 - fixed already playing samples not getting muted when the game window goes out of focus
+- fixed the `/play` command starting the level with wrong items sometimes (#3147, regression from 4.11)
 - fixed the `/tp` command breaking the photo mode
 - fixed the `/tp` command misbehaving when giving fractional coordinates
-- fixed carrying over items from the first level when the player issues `/play` command
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)
 - improved performance when resizing the window

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -74,6 +74,7 @@
 - fixed support for >3 secret dragons in custom levels (#3415, regression from 1.2)
 - fixed level select picking one level ahead of the one chosen if the gym is disabled (#3446, regression from 1.0)
 - fixed Lara's holsters resetting at times to incorrect meshes when using the fly cheat (#3451, regression from 0.3)
+- fixed the `/play` command starting the level with wrong items sometimes (#3147, regression from 1.1)
 - fixed the `/tp` command breaking the photo mode
 - fixed the `/tp` command misbehaving when giving fractional coordinates
 - improved support for >3 secret dragons in custom levels up to 16 dragons

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -18,6 +18,7 @@
 - added the ability to change the health bar color for allies, defaulting to green (#3005)
 - added the ability to skip consecutive credit images by holding the action / escape keys
 - added the ability to cycle between a list of predefined Lara poses in the photo mode
+- added the ability to use the dev console during FMVs
 - added a new easter egg command
 - added a `/lighting` console command to let the player turn lighting system on/off
 - added an `/immune` console command to make Lara impervious to damage

--- a/src/libtrx/game/console/cmd/flipmap.c
+++ b/src/libtrx/game/console/cmd/flipmap.c
@@ -1,5 +1,6 @@
 #include "game/console/common.h"
 #include "game/console/registry.h"
+#include "game/game.h"
 #include "game/game_flow.h"
 #include "game/game_string.h"
 #include "game/rooms.h"
@@ -11,6 +12,10 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
     if (GF_GetCurrentLevel() == nullptr
         || GF_GetCurrentLevel()->type == GFL_TITLE) {
+        return CR_UNAVAILABLE;
+    }
+
+    if (!Game_IsLoaded()) {
         return CR_UNAVAILABLE;
     }
 

--- a/src/libtrx/game/console/cmd/kill.c
+++ b/src/libtrx/game/console/cmd/kill.c
@@ -2,6 +2,7 @@
 #include "game/console/registry.h"
 #include "game/const.h"
 #include "game/creature.h"
+#include "game/game.h"
 #include "game/game_string.h"
 #include "game/items.h"
 #include "game/lara/cheat.h"
@@ -169,6 +170,10 @@ static COMMAND_RESULT M_KillEnemyType(const char *const enemy_name)
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!Game_IsLoaded()) {
+        return CR_UNAVAILABLE;
+    }
+
     if (String_Equivalent(ctx->args, "all")) {
         return M_KillAllEnemies();
     }

--- a/src/libtrx/game/console/cmd/pos.c
+++ b/src/libtrx/game/console/cmd/pos.c
@@ -16,6 +16,10 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx);
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
+    if (!Game_IsLoaded()) {
+        return CR_UNAVAILABLE;
+    }
+
     if (!String_IsEmpty(ctx->args)) {
         return CR_BAD_INVOCATION;
     }

--- a/src/libtrx/game/game.c
+++ b/src/libtrx/game/game.c
@@ -1,5 +1,6 @@
 #include "game/game.h"
 
+#include "game/fmv.h"
 #include "game/game_flow.h"
 #include "game/lara/common.h"
 #include "game/random.h"
@@ -36,8 +37,24 @@ bool Game_IsInGym(void)
     return current_level != nullptr && current_level->type == GFL_GYM;
 }
 
+bool Game_IsLoaded(void)
+{
+    if (FMV_IsPlaying()) {
+        return false;
+    }
+    const GF_LEVEL *const current_level = GF_GetCurrentLevel();
+    if (current_level == nullptr || current_level->type == GFL_TITLE) {
+        return false;
+    }
+    return true;
+}
+
 bool Game_IsPlayable(void)
 {
+    if (FMV_IsPlaying()) {
+        return false;
+    }
+
     const GF_LEVEL *const current_level = GF_GetCurrentLevel();
     if (current_level == nullptr || current_level->type == GFL_TITLE
         || current_level->type == GFL_DEMO

--- a/src/libtrx/game/game_flow/inventory.c
+++ b/src/libtrx/game/game_flow/inventory.c
@@ -13,13 +13,132 @@ static bool m_RemoveFlares = false;
 static bool m_RemoveMedipacks = false;
 static bool m_RemoveScions = false;
 
-static void M_ModifyInventory_GunOrAmmo(
-    RESUME_INFO *resume, GF_INV_TYPE type, LARA_GUN_TYPE gun_type);
-static void M_ModifyInventory_Item(GF_INV_TYPE type, GAME_OBJECT_ID obj_id);
+static bool M_ResumeInfo_HasWeapon(
+    const RESUME_INFO *resume, LARA_GUN_TYPE gun_type);
+static void M_ResumeInfo_SetWeapon(
+    RESUME_INFO *resume, LARA_GUN_TYPE gun_type, bool has_weapon);
+static void M_ResumeInfo_AddAmmo(
+    RESUME_INFO *resume, LARA_GUN_TYPE gun_type, int32_t ammo_qty);
+static void M_ResumeInfo_AddItem(
+    RESUME_INFO *resume, GAME_OBJECT_ID object_id, int32_t qty);
+
+static void M_ModifyResumeInfo_GunOrAmmo(
+    RESUME_INFO *resume, LARA_GUN_TYPE gun_type);
+static void M_ModifyResumeInfo_Item(
+    RESUME_INFO *resume, GAME_OBJECT_ID object_id);
 
 static void M_ModifyInventory_GunOrAmmo(
-    RESUME_INFO *const resume, const GF_INV_TYPE type,
-    const LARA_GUN_TYPE gun_type)
+    GF_INV_TYPE type, LARA_GUN_TYPE gun_type);
+static void M_ModifyInventory_Item(GF_INV_TYPE type, GAME_OBJECT_ID obj_id);
+
+static bool M_ResumeInfo_HasWeapon(
+    const RESUME_INFO *const resume, const LARA_GUN_TYPE gun_type)
+{
+    switch (gun_type) {
+        // clang-format off
+    case LGT_PISTOLS: return resume->flags.has_pistols;
+    case LGT_MAGNUMS: return resume->flags.has_magnums;
+    case LGT_UZIS:    return resume->flags.has_uzis;
+    case LGT_SHOTGUN: return resume->flags.has_shotgun;
+#if TR_VERSION >= 2
+    case LGT_HARPOON: return resume->flags.has_harpoon;
+    case LGT_M16:     return resume->flags.has_m16;
+    case LGT_GRENADE: return resume->flags.has_grenade;
+#endif
+    default: return false;
+        // clang-format on
+    }
+}
+
+static void M_ResumeInfo_SetWeapon(
+    RESUME_INFO *const resume, const LARA_GUN_TYPE gun_type,
+    const bool has_weapon)
+{
+    switch (gun_type) {
+        // clang-format off
+    case LGT_PISTOLS: resume->flags.has_pistols = has_weapon; break;
+    case LGT_MAGNUMS: resume->flags.has_magnums = has_weapon; break;
+    case LGT_UZIS:    resume->flags.has_uzis = has_weapon; break;
+    case LGT_SHOTGUN: resume->flags.has_shotgun = has_weapon; break;
+#if TR_VERSION >= 2
+    case LGT_HARPOON: resume->flags.has_harpoon = has_weapon; break;
+    case LGT_M16:     resume->flags.has_m16 = has_weapon; break;
+    case LGT_GRENADE: resume->flags.has_grenade = has_weapon; break;
+#endif
+    default: break;
+        // clang-format on
+    }
+}
+
+static void M_ResumeInfo_AddAmmo(
+    RESUME_INFO *const resume, const LARA_GUN_TYPE gun_type,
+    const int32_t ammo_qty)
+{
+    switch (gun_type) {
+        // clang-format off
+    case LGT_MAGNUMS: resume->magnum_ammo += ammo_qty; break;
+    case LGT_UZIS:    resume->uzi_ammo += ammo_qty; break;
+    case LGT_SHOTGUN: resume->shotgun_ammo += ammo_qty; break;
+#if TR_VERSION >= 2
+    case LGT_HARPOON: resume->harpoon_ammo += ammo_qty; break;
+    case LGT_M16:     resume->m16_ammo += ammo_qty; break;
+    case LGT_GRENADE: resume->grenade_ammo += ammo_qty; break;
+#endif
+    default: break;
+        // clang-format on
+    }
+}
+
+static void M_ResumeInfo_AddItem(
+    RESUME_INFO *const resume, const GAME_OBJECT_ID object_id,
+    const int32_t qty)
+{
+    switch (object_id) {
+    case O_SMALL_MEDIPACK_ITEM:
+    case O_SMALL_MEDIPACK_OPTION:
+        resume->small_medipacks += qty;
+        break;
+    case O_LARGE_MEDIPACK_ITEM:
+    case O_LARGE_MEDIPACK_OPTION:
+        resume->large_medipacks += qty;
+        break;
+#if TR_VERSION >= 2
+    case O_FLARES_ITEM:
+    case O_FLARES_OPTION:
+    case O_FLARE_ITEM:
+        resume->flares += qty;
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+static void M_ModifyResumeInfo_GunOrAmmo(
+    RESUME_INFO *const resume, const LARA_GUN_TYPE gun_type)
+{
+    const GAME_OBJECT_ID gun_item = Gun_GetGunObject(gun_type);
+    const GAME_OBJECT_ID ammo_item = Gun_GetAmmoObject(gun_type);
+    const int32_t ammo_qty = Gun_GetAmmoQuantity(gun_type);
+    AMMO_INFO *const ammo_info = Gun_GetAmmoInfo(gun_type);
+
+    M_ResumeInfo_AddAmmo(
+        resume, gun_type, ammo_qty * m_Add2InvItems[ammo_item]);
+    if (!M_ResumeInfo_HasWeapon(resume, gun_type)
+        && m_Add2InvItems[gun_item] > 0) {
+        M_ResumeInfo_SetWeapon(resume, gun_type, true);
+        M_ResumeInfo_AddAmmo(resume, gun_type, ammo_qty);
+    }
+}
+
+static void M_ModifyResumeInfo_Item(
+    RESUME_INFO *const resume, const GAME_OBJECT_ID object_id)
+{
+    M_ResumeInfo_AddItem(resume, object_id, m_Add2InvItems[object_id]);
+}
+
+static void M_ModifyInventory_GunOrAmmo(
+    const GF_INV_TYPE type, const LARA_GUN_TYPE gun_type)
 {
     const GAME_OBJECT_ID gun_item = Gun_GetGunObject(gun_type);
     const GAME_OBJECT_ID ammo_item = Gun_GetAmmoObject(gun_type);
@@ -36,24 +155,8 @@ static void M_ModifyInventory_GunOrAmmo(
             ammo_info->ammo += ammo_qty * m_Add2InvItems[ammo_item];
         }
     } else if (
-        (type == GF_INV_REGULAR && m_Add2InvItems[gun_item])
-        || (type == GF_INV_SECRET && m_SecretInvItems[gun_item])) {
-
-        // clang-format off
-        // TODO: consider moving this to Inv_AddItem
-        switch (gun_type) {
-        case LGT_PISTOLS: resume->flags.has_pistols = true; break;
-        case LGT_MAGNUMS: resume->flags.has_magnums = true; break;
-        case LGT_UZIS:    resume->flags.has_uzis = true;    break;
-        case LGT_SHOTGUN: resume->flags.has_shotgun = true; break;
-#if TR_VERSION >= 2
-        case LGT_HARPOON: resume->flags.has_harpoon = true; break;
-        case LGT_M16:     resume->flags.has_m16 = true;     break;
-        case LGT_GRENADE: resume->flags.has_grenade = true; break;
-#endif
-        default: break;
-        }
-        // clang-format on
+        (type == GF_INV_REGULAR && m_Add2InvItems[gun_item] > 0)
+        || (type == GF_INV_SECRET && m_SecretInvItems[gun_item] > 0)) {
 
         Inv_AddItem(gun_item);
 
@@ -138,8 +241,7 @@ void GF_InventoryModifier_Scan(const GF_LEVEL *const level)
     }
 }
 
-void GF_InventoryModifier_Apply(
-    const GF_LEVEL *const level, const GF_INV_TYPE type)
+void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *const level)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
 
@@ -161,7 +263,6 @@ void GF_InventoryModifier_Apply(
 
     if (!resume->flags.has_pistols && m_Add2InvItems[O_PISTOL_ITEM]) {
         resume->flags.has_pistols = true;
-        Inv_AddItem(O_PISTOL_ITEM);
         if (resume->equipped_gun_type == LGT_UNARMED) {
             resume->equipped_gun_type = LGT_PISTOLS;
         }
@@ -197,12 +298,50 @@ void GF_InventoryModifier_Apply(
         m_RemoveMedipacks = false;
     }
 
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_MAGNUMS);
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_UZIS);
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_SHOTGUN);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_PISTOLS);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_MAGNUMS);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_UZIS);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_SHOTGUN);
+#if TR_VERSION == 2
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_HARPOON);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_M16);
+    M_ModifyResumeInfo_GunOrAmmo(resume, LGT_GRENADE);
+#endif
 
-    M_ModifyInventory_Item(type, O_SMALL_MEDIPACK_ITEM);
-    M_ModifyInventory_Item(type, O_LARGE_MEDIPACK_ITEM);
+    M_ModifyResumeInfo_Item(resume, O_SMALL_MEDIPACK_ITEM);
+    M_ModifyResumeInfo_Item(resume, O_LARGE_MEDIPACK_ITEM);
+#if TR_VERSION == 2
+    M_ModifyResumeInfo_Item(resume, O_FLARE_ITEM);
+#endif
+}
+
+void GF_InventoryModifier_Apply(
+    const GF_LEVEL *const level, const GF_INV_TYPE type)
+{
+    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+
+    // For GF_INV_REGULAR, we must ignore weapons, ammo, medpacks and flares,
+    // as these are handled by RESUME_INFO and
+    // GF_InventoryModifier_ApplyToResumeInfo and Lara_InitialiseInventory.
+
+    if (type == GF_INV_SECRET) {
+        if (m_Add2InvItems[O_PISTOL_ITEM]) {
+            Inv_AddItem(O_PISTOL_ITEM);
+            if (resume->equipped_gun_type == LGT_UNARMED) {
+                resume->equipped_gun_type = LGT_PISTOLS;
+            }
+        }
+
+        M_ModifyInventory_GunOrAmmo(type, LGT_MAGNUMS);
+        M_ModifyInventory_GunOrAmmo(type, LGT_UZIS);
+        M_ModifyInventory_GunOrAmmo(type, LGT_SHOTGUN);
+#if TR_VERSION == 2
+        M_ModifyInventory_GunOrAmmo(type, LGT_HARPOON);
+        M_ModifyInventory_GunOrAmmo(type, LGT_M16);
+        M_ModifyInventory_GunOrAmmo(type, LGT_GRENADE);
+#endif
+    }
+
     M_ModifyInventory_Item(type, O_PICKUP_ITEM_1);
     M_ModifyInventory_Item(type, O_PICKUP_ITEM_2);
     M_ModifyInventory_Item(type, O_PUZZLE_ITEM_1);
@@ -213,16 +352,18 @@ void GF_InventoryModifier_Apply(
     M_ModifyInventory_Item(type, O_KEY_ITEM_2);
     M_ModifyInventory_Item(type, O_KEY_ITEM_3);
     M_ModifyInventory_Item(type, O_KEY_ITEM_4);
-
 #if TR_VERSION == 1
     M_ModifyInventory_Item(type, O_LEADBAR_ITEM);
     M_ModifyInventory_Item(type, O_SCION_ITEM_1);
     M_ModifyInventory_Item(type, O_SCION_ITEM_2);
-#else
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_HARPOON);
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_M16);
-    M_ModifyInventory_GunOrAmmo(resume, type, LGT_GRENADE);
-
-    M_ModifyInventory_Item(type, O_FLARE_ITEM);
 #endif
+
+    if (type == GF_INV_SECRET) {
+        M_ModifyInventory_Item(type, O_SMALL_MEDIPACK_ITEM);
+        M_ModifyInventory_Item(type, O_LARGE_MEDIPACK_ITEM);
+
+#if TR_VERSION == 2
+        M_ModifyInventory_Item(type, O_FLARE_ITEM);
+#endif
+    }
 }

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -7,11 +7,6 @@ static GF_LEVEL_SETTINGS m_DefaultSettings = {
     .sfx_path = nullptr,
 };
 
-static GF_SEQUENCE_EVENT_TYPE m_LevelArgSequenceEvents[] = {
-    GFS_LOOP_GAME,
-    (GF_SEQUENCE_EVENT_TYPE)-1,
-};
-
 static M_SEQUENCE_EVENT_HANDLER m_SequenceEventHandlers[] = {
     // clang-format off
     // Events without arguments

--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -2,7 +2,11 @@
 
 #include "debug.h"
 #include "enum_map.h"
+#include "game/game.h"
 #include "game/game_flow/sequencer_priv.h"
+#include "game/lara/common.h"
+#include "game/level.h"
+#include "game/savegame.h"
 
 #define M_MAX_QUEUE_SIZE 10
 
@@ -74,9 +78,109 @@ GF_COMMAND GF_InterpretSequence(
         "running sequence for level=%d type=%d seq_ctx=%d", level->num,
         level->type, seq_ctx);
 
+#if TR_VERSION == 1
+    if (level->type == GFL_DUMMY || level->type == GFL_CURRENT) {
+        return (GF_COMMAND) { .action = GF_NOOP };
+    }
+#endif
+
     GF_PreSequenceHook(seq_ctx, seq_ctx_arg);
 
     GF_COMMAND gf_cmd = { .action = GF_EXIT_TO_TITLE };
+
+    const GF_LEVEL *const prev_level = GF_GetLevelBefore(level);
+
+    // before load
+    switch (seq_ctx) {
+    case GFSC_STORY:
+        break;
+
+    case GFSC_SAVED:
+        GF_InventoryModifier_Scan(level);
+        // reset current info to the defaults so that we do not do
+        // Item_GlobalReplace in the inventory initialization routines too early
+        Savegame_InitCurrentInfo();
+        break;
+
+    case GFSC_RESTART:
+        if (level == GF_GetGymLevel() || level == GF_GetFirstLevel()) {
+            Savegame_InitCurrentInfo();
+        } else {
+            Savegame_ResetCurrentInfo(level);
+            Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
+            Savegame_ApplyLogicToCurrentInfo(level);
+        }
+        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+            GF_InventoryModifier_Scan(level);
+            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+        }
+        break;
+
+    case GFSC_SELECT: {
+        const int16_t slot_num = Savegame_GetBoundSlot();
+        if (slot_num != -1) {
+            // select level feature
+            Savegame_InitCurrentInfo();
+            if (level->num > GF_GetFirstLevel()->num) {
+                Savegame_LoadOnlyResumeInfo(slot_num);
+                const GF_LEVEL *tmp_level = level;
+                while (tmp_level != nullptr) {
+                    Savegame_ResetCurrentInfo(tmp_level);
+                    tmp_level = GF_GetLevelAfter(tmp_level);
+                }
+                Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
+                Savegame_ApplyLogicToCurrentInfo(level);
+                GF_InventoryModifier_Scan(level);
+                GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+            }
+        } else {
+            // console /play level feature
+            Savegame_InitCurrentInfo();
+            const GF_LEVEL *tmp_level = GF_GetFirstLevel();
+            while (tmp_level != nullptr && tmp_level <= level) {
+                Savegame_ApplyLogicToCurrentInfo(tmp_level);
+                GF_InventoryModifier_Scan(tmp_level);
+                GF_InventoryModifier_Apply(tmp_level, GF_INV_REGULAR);
+                if (tmp_level == level) {
+                    break;
+                }
+                const GF_LEVEL *const next_level = GF_GetLevelAfter(tmp_level);
+                if (next_level != nullptr) {
+                    Savegame_CarryCurrentInfoToNextLevel(tmp_level, next_level);
+                }
+                tmp_level = next_level;
+            }
+        }
+        break;
+    }
+
+    default:
+#if TR_VERSION == 1
+        if (level->type == GFL_GYM) {
+            Savegame_ResetCurrentInfo(level);
+        } else if (level->type == GFL_BONUS) {
+            Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
+        }
+#endif
+        Savegame_ApplyLogicToCurrentInfo(level);
+        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+            GF_InventoryModifier_Scan(level);
+            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+        }
+    }
+
+    // load the level
+    if (seq_ctx != GFSC_STORY || level->type == GFL_CUTSCENE) {
+        if (!Level_Initialise(level, seq_ctx)) {
+            Game_SetCurrentLevel(nullptr);
+            GF_SetCurrentLevel(nullptr);
+            if (level->type == GFL_TITLE) {
+                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
+            } else {
+                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+            }
+        }
+    }
 
     const GF_SEQUENCE *const sequence = &level->sequence;
     for (int32_t i = 0; i < sequence->length; i++) {

--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -4,6 +4,7 @@
 #include "enum_map.h"
 #include "game/game.h"
 #include "game/game_flow/sequencer_priv.h"
+#include "game/inventory.h"
 #include "game/lara/common.h"
 #include "game/level.h"
 #include "game/savegame.h"
@@ -112,7 +113,7 @@ GF_COMMAND GF_InterpretSequence(
         }
         if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
             GF_InventoryModifier_Scan(level);
-            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+            GF_InventoryModifier_ApplyToResumeInfo(level);
         }
         break;
 
@@ -131,24 +132,34 @@ GF_COMMAND GF_InterpretSequence(
                 Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
                 Savegame_ApplyLogicToCurrentInfo(level);
                 GF_InventoryModifier_Scan(level);
-                GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+                GF_InventoryModifier_ApplyToResumeInfo(level);
             }
         } else {
             // console /play level feature
-            Savegame_InitCurrentInfo();
-            const GF_LEVEL *tmp_level = GF_GetFirstLevel();
-            while (tmp_level != nullptr && tmp_level <= level) {
-                Savegame_ApplyLogicToCurrentInfo(tmp_level);
-                GF_InventoryModifier_Scan(tmp_level);
-                GF_InventoryModifier_Apply(tmp_level, GF_INV_REGULAR);
-                if (tmp_level == level) {
-                    break;
+            Inv_RemoveAllItems();
+            if (level == GF_GetGymLevel()) {
+                Savegame_InitCurrentInfo();
+                GF_InventoryModifier_Scan(level);
+                GF_InventoryModifier_ApplyToResumeInfo(level);
+            } else {
+                const GF_LEVEL *tmp_level = GF_GetFirstLevel();
+                Savegame_ResetCurrentInfo(tmp_level);
+                while (tmp_level != nullptr && tmp_level <= level) {
+                    Savegame_ApplyLogicToCurrentInfo(tmp_level);
+                    GF_InventoryModifier_Scan(tmp_level);
+                    GF_InventoryModifier_ApplyToResumeInfo(tmp_level);
+                    if (tmp_level == level) {
+                        break;
+                    }
+
+                    const GF_LEVEL *const next_level =
+                        GF_GetLevelAfter(tmp_level);
+                    if (next_level != nullptr) {
+                        Savegame_CarryCurrentInfoToNextLevel(
+                            tmp_level, next_level);
+                    }
+                    tmp_level = next_level;
                 }
-                const GF_LEVEL *const next_level = GF_GetLevelAfter(tmp_level);
-                if (next_level != nullptr) {
-                    Savegame_CarryCurrentInfoToNextLevel(tmp_level, next_level);
-                }
-                tmp_level = next_level;
             }
         }
         break;
@@ -165,7 +176,7 @@ GF_COMMAND GF_InterpretSequence(
         Savegame_ApplyLogicToCurrentInfo(level);
         if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
             GF_InventoryModifier_Scan(level);
-            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
+            GF_InventoryModifier_ApplyToResumeInfo(level);
         }
     }
 

--- a/src/libtrx/game/gun/common.c
+++ b/src/libtrx/game/gun/common.c
@@ -26,6 +26,7 @@ GAME_OBJECT_ID Gun_GetWeaponAnim(const LARA_GUN_TYPE gun_type)
 {
     // clang-format off
     switch (gun_type) {
+    case LGT_UNKNOWN: return O_LARA;
     case LGT_UNARMED: return O_LARA;
     case LGT_PISTOLS: return O_LARA_PISTOLS;
     case LGT_MAGNUMS: return O_LARA_MAGNUMS;

--- a/src/libtrx/game/gun/common.c
+++ b/src/libtrx/game/gun/common.c
@@ -117,6 +117,9 @@ int32_t Gun_GetAmmoQuantity(const LARA_GUN_TYPE gun_type)
 AMMO_INFO *Gun_GetAmmoInfo(const LARA_GUN_TYPE gun_type)
 {
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info == nullptr) {
+        return nullptr;
+    }
     // clang-format off
     switch (gun_type) {
     case LGT_PISTOLS: return &lara_info->pistol_ammo;

--- a/src/libtrx/game/matrix.c
+++ b/src/libtrx/game/matrix.c
@@ -6,14 +6,14 @@
 #define MAX_MATRICES 40
 #define MAX_NESTED_MATRICES 32
 
-MATRIX *g_MatrixPtr = nullptr;
-MATRIX g_W2VMatrix = {};
-
 static MATRIX m_MatrixStack[MAX_MATRICES] = {};
 static int32_t m_IMRate = 0;
 static int32_t m_IMFrac = 0;
 static MATRIX *m_IMMatrixPtr = nullptr;
 static MATRIX m_IMMatrixStack[MAX_NESTED_MATRICES] = {};
+
+MATRIX *g_MatrixPtr = &m_MatrixStack[0];
+MATRIX g_W2VMatrix = {};
 
 static void M_RotYXZ(const int16_t ry, const int16_t rx, const int16_t rz)
 {

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -27,11 +27,8 @@ static PHASE *m_PhaseStack[MAX_PHASES] = {};
 static PHASE_CONTROL M_Control(PHASE *phase, int32_t nframes);
 static void M_Draw(PHASE *phase);
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
+static GF_COMMAND M_HandleOverride(void)
 {
-    Console_Control();
-    Overlay_Control();
-
     const GF_COMMAND gf_override_cmd = GF_GetOverrideCommand();
     if (gf_override_cmd.action != GF_NOOP) {
         const GF_COMMAND gf_cmd = gf_override_cmd;
@@ -43,6 +40,18 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
         // This flag needs to be cleared as well.
         Game_SetIsPlaying(false);
 
+        return gf_cmd;
+    }
+    return (GF_COMMAND) { .action = GF_NOOP };
+}
+
+static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
+{
+    Console_Control();
+    Overlay_Control();
+
+    const GF_COMMAND gf_cmd = M_HandleOverride();
+    if (gf_cmd.action != GF_NOOP) {
         return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .gf_cmd = gf_cmd };
     }
 
@@ -102,6 +111,11 @@ static void M_Draw(PHASE *const phase)
 GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
+
+    gf_cmd = M_HandleOverride();
+    if (gf_cmd.action != GF_NOOP) {
+        return gf_cmd;
+    }
 
     PHASE *const prev_phase =
         m_PhaseStackSize > 0 ? m_PhaseStack[m_PhaseStackSize - 1] : nullptr;

--- a/src/libtrx/game/phase/phase_inventory.c
+++ b/src/libtrx/game/phase/phase_inventory.c
@@ -1,7 +1,10 @@
 #include "game/phase/phase_inventory.h"
 
+#include "config.h"
 #include "debug.h"
+#include "game/game_flow.h"
 #include "game/inventory_ring.h"
+#include "game/music.h"
 #include "game/output.h"
 #include "game/overlay.h"
 #include "memory.h"
@@ -19,6 +22,17 @@ static void M_Draw(PHASE *phase);
 static PHASE_CONTROL M_Start(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
+
+    const GF_LEVEL *const level = GF_GetTitleLevel();
+#if TR_VERSION == 1
+    const bool enable = g_Config.audio.enable_music_in_menu;
+#else
+    const bool enable = true;
+#endif
+    if (p->mode == INV_TITLE_MODE && enable && level->music_track >= 0) {
+        Music_Play(level->music_track, MPM_LOOPED);
+    }
+
     p->ring = InvRing_Open(p->mode);
     if (p->ring == nullptr) {
         return (PHASE_CONTROL) {
@@ -44,6 +58,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, int32_t num_frames)
 static void M_End(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
+    Music_Stop();
     if (p->ring != nullptr) {
         InvRing_Close(p->ring);
         p->ring = nullptr;

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -392,8 +392,11 @@ void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    const ITEM *const lara_item = Lara_GetItem();
 
-    resume->lara_hitpoints = Lara_GetItem()->hit_points;
+    if (lara_item != nullptr) {
+        resume->lara_hitpoints = lara_item->hit_points;
+    }
     resume->flags.available = true;
     resume->small_medipacks = Inv_RequestItem(O_SMALL_MEDIPACK_ITEM);
     resume->large_medipacks = Inv_RequestItem(O_LARGE_MEDIPACK_ITEM);

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -32,11 +32,15 @@ static void M_HandleKeyDown(const SDL_Event *const event)
     // NOTE: Opening the console normally would get handled by Input_Update,
     // but by the time Input_Update gets ran, we may already have lost some
     // keypresses if the player types really fast, so we need to react sooner.
-    if (!FMV_IsPlaying() && g_Config.gameplay.enable_console
-        && !Console_IsOpened() && !Input_IsInListenMode()
+    if (g_Config.gameplay.enable_console && !Console_IsOpened()
+        && !Input_IsInListenMode()
         && Input_IsPressed(
             INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
             INPUT_ROLE_ENTER_CONSOLE)) {
+        // TODO: let this through once we rewrite rendering in TR2
+        if (TR_VERSION == 2 && FMV_IsPlaying()) {
+            return;
+        }
         Console_Open();
         // Zero out the next text event so the console-open glyph never
         // shows up.

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -37,10 +37,6 @@ static void M_HandleKeyDown(const SDL_Event *const event)
         && Input_IsPressed(
             INPUT_BACKEND_KEYBOARD, g_Config.input.keyboard_layout,
             INPUT_ROLE_ENTER_CONSOLE)) {
-        // TODO: let this through once we rewrite rendering in TR2
-        if (TR_VERSION == 2 && FMV_IsPlaying()) {
-            return;
-        }
         Console_Open();
         // Zero out the next text event so the console-open glyph never
         // shows up.

--- a/src/libtrx/include/libtrx/game/game.h
+++ b/src/libtrx/include/libtrx/game/game.h
@@ -10,6 +10,7 @@ const GF_LEVEL *Game_GetCurrentLevel(void);
 void Game_SetCurrentLevel(const GF_LEVEL *level);
 
 bool Game_IsInGym(void);
+bool Game_IsLoaded(void);
 bool Game_IsPlayable(void);
 
 GAME_BONUS_FLAG Game_GetBonusFlag(void);

--- a/src/libtrx/include/libtrx/game/game_flow/enum.h
+++ b/src/libtrx/include/libtrx/game/game_flow/enum.h
@@ -28,9 +28,7 @@ typedef enum {
 typedef enum {
     GFSC_NORMAL,
     GFSC_SAVED,
-#if TR_VERSION == 1
     GFSC_RESTART,
-#endif
     GFSC_SELECT,
     GFSC_STORY,
 } GF_SEQUENCE_CONTEXT;
@@ -90,7 +88,6 @@ typedef enum {
 
 typedef enum {
     GF_EVENT_QUEUE_NONE = -1,
-    GF_EVENT_QUEUE_BEFORE_LEVEL_INIT,
     GF_EVENT_QUEUE_AFTER_LEVEL_INIT,
     GF_EVENT_QUEUE_NUMBER_OF,
 } GF_EVENT_QUEUE_TYPE;

--- a/src/libtrx/include/libtrx/game/game_flow/inventory.h
+++ b/src/libtrx/include/libtrx/game/game_flow/inventory.h
@@ -4,3 +4,4 @@
 
 void GF_InventoryModifier_Scan(const GF_LEVEL *level);
 void GF_InventoryModifier_Apply(const GF_LEVEL *level, GF_INV_TYPE type);
+void GF_InventoryModifier_ApplyToResumeInfo(const GF_LEVEL *level);

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../virtual_file.h"
+#include "../game_flow/types.h"
 #include "./types.h"
 
 #define ANIM_BONE_SIZE 4
@@ -54,3 +55,6 @@ void Level_LoadAnimFrames(void);
 void Level_LoadObjectsAndItems(void);
 
 LEVEL_INFO *Level_GetInfo(void);
+
+extern bool Level_Initialise(
+    const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);

--- a/src/tr1/game/cutscene.c
+++ b/src/tr1/game/cutscene.c
@@ -89,6 +89,13 @@ bool Cutscene_Start(const int32_t level_num)
     }
 
     Camera_GetCineData()->frame_idx = 0;
+
+    if (level->music_track != MX_INACTIVE) {
+        Music_Play(
+            level->music_track,
+            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    }
+
     return true;
 }
 

--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -12,6 +12,8 @@
 #include <libtrx/engine/audio.h>
 #include <libtrx/engine/video.h>
 #include <libtrx/filesystem.h>
+#include <libtrx/game/console.h>
+#include <libtrx/game/game_flow.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/ui.h>
 #include <libtrx/gfx/context.h>
@@ -85,6 +87,9 @@ static void M_UploadSurface(void *const surface, void *const user_data)
 
     Output_SwitchViewport(VIEWPORT_UI);
     UI_BeginScene();
+    Console_Draw();
+    Console_Control();
+    Console_Control();
     UI_EndScene();
     UI_Draw();
 }
@@ -122,7 +127,7 @@ static bool M_Play(const char *const file_path)
         Input_Update();
         Shell_ProcessInput();
         if (g_InputDB.menu_confirm || g_InputDB.menu_back
-            || Shell_IsExiting()) {
+            || GF_GetOverrideCommand().action != GF_NOOP || Shell_IsExiting()) {
             Video_Stop(video);
         }
     }

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -81,6 +81,14 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     Camera_Initialise();
     Interpolation_Remember();
     Stats_StartTimer();
+
+    Sound_ResetEffects();
+    if (level->music_track != MX_INACTIVE) {
+        Music_Play(
+            level->music_track,
+            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    }
+
     return true;
 }
 

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -1,11 +1,5 @@
-#include "game/fmv.h"
 #include "game/game.h"
-#include "game/game_flow/common.h"
-#include "game/game_flow/sequencer.h"
-#include "game/game_flow/vars.h"
-#include "game/inventory.h"
 #include "game/lara.h"
-#include "game/level.h"
 #include "game/objects/creatures/bacon_lara.h"
 #include "game/savegame.h"
 #include "game/stats.h"
@@ -15,7 +9,6 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/music.h>
-#include <libtrx/game/phase.h>
 
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel);
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayMusic);
@@ -46,86 +39,12 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
     const GF_LEVEL *const prev_level = GF_GetLevelBefore(level);
 
-    // before load
-    switch (seq_ctx) {
-    case GFSC_STORY:
+    if (seq_ctx == GFSC_STORY) {
         const int32_t savegame_level_num = (int32_t)(intptr_t)seq_ctx_arg;
         if (savegame_level_num == level->num) {
             return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
         } else {
             return (GF_COMMAND) { .action = GF_NOOP };
-        }
-        break;
-
-    case GFSC_SAVED:
-        GF_InventoryModifier_Scan(level);
-        // reset current info to the defaults so that we do not do
-        // Item_GlobalReplace in the inventory initialization routines too early
-        Savegame_InitCurrentInfo();
-        break;
-
-    case GFSC_RESTART:
-        if (level == GF_GetGymLevel() || level == GF_GetFirstLevel()) {
-            Savegame_InitCurrentInfo();
-        } else {
-            Savegame_ResetCurrentInfo(level);
-            Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
-            Savegame_ApplyLogicToCurrentInfo(level);
-        }
-        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
-            GF_InventoryModifier_Scan(level);
-            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
-        }
-        break;
-
-    case GFSC_SELECT: {
-        const int16_t slot_num = Savegame_GetBoundSlot();
-        if (slot_num != -1) {
-            // select level feature
-            Savegame_InitCurrentInfo();
-            if (level->num > GF_GetFirstLevel()->num) {
-                Savegame_LoadOnlyResumeInfo(slot_num);
-                const GF_LEVEL *tmp_level = level;
-                while (tmp_level != nullptr) {
-                    Savegame_ResetCurrentInfo(tmp_level);
-                    tmp_level = GF_GetLevelAfter(tmp_level);
-                }
-                Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
-                Savegame_ApplyLogicToCurrentInfo(level);
-                GF_InventoryModifier_Scan(level);
-                GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
-            }
-        } else {
-            // console /play level feature
-            Savegame_InitCurrentInfo();
-            const GF_LEVEL *tmp_level = GF_GetFirstLevel();
-            while (tmp_level != nullptr && tmp_level <= level) {
-                Savegame_ApplyLogicToCurrentInfo(tmp_level);
-                GF_InventoryModifier_Scan(tmp_level);
-                GF_InventoryModifier_Apply(tmp_level, GF_INV_REGULAR);
-                if (tmp_level == level) {
-                    break;
-                }
-                const GF_LEVEL *const next_level = GF_GetLevelAfter(tmp_level);
-                if (next_level != nullptr) {
-                    Savegame_CarryCurrentInfoToNextLevel(tmp_level, next_level);
-                }
-                tmp_level = next_level;
-            }
-        }
-        break;
-    }
-
-    default:
-        if (level->type == GFL_GYM) {
-            Savegame_ResetCurrentInfo(level);
-        } else if (level->type == GFL_BONUS) {
-            Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
-        }
-        Savegame_ApplyLogicToCurrentInfo(level);
-        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
-            GF_InventoryModifier_Scan(level);
-            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
         }
     }
 
@@ -133,26 +52,13 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
     g_GameInfo.select_save_slot = -1;
 
     gf_cmd = GF_RunSequencerQueue(
-        GF_EVENT_QUEUE_BEFORE_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
-    if (gf_cmd.action != GF_NOOP) {
-        return gf_cmd;
-    }
-
-    // load the level
-    if (!Level_Initialise(level, seq_ctx)) {
-        Game_SetCurrentLevel(nullptr);
-        GF_SetCurrentLevel(nullptr);
-        if (level->type == GFL_TITLE) {
-            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
-        } else {
-            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-        }
-    }
-
-    gf_cmd = GF_RunSequencerQueue(
         GF_EVENT_QUEUE_AFTER_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
     if (gf_cmd.action != GF_NOOP) {
         return gf_cmd;
+    }
+
+    if (Lara_GetItem() != nullptr) {
+        Lara_Initialise(level);
     }
 
     // post load

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -345,6 +345,7 @@ void Level_Load(const GF_LEVEL *const level)
 
 void Level_Unload(void)
 {
+    Lara_InitialiseLoad(NO_ITEM);
     Output_ObserveLevelUnload();
 }
 
@@ -388,14 +389,9 @@ bool Level_Initialise(
     Camera_Reset();
     Pierre_Reset();
 
-    Lara_InitialiseLoad(NO_ITEM);
     Level_Unload();
     Level_Load(level);
     GameStringTable_Apply(level);
-
-    if (g_Lara.item_num != NO_ITEM) {
-        Lara_Initialise(level);
-    }
 
     if (seq_ctx != GFSC_SAVED) {
         // Avoid initialising the floor before movable block positions have

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -410,17 +410,8 @@ bool Level_Initialise(
     Overlay_Reset();
     Overlay_SetHealthBarTimer(100);
 
-    Music_Stop();
     Music_SetVolume(g_Config.audio.music_volume);
     Sound_ResetEffects();
-
-    const bool disable_music =
-        level->type == GFL_TITLE && !g_Config.audio.enable_music_in_menu;
-    if (level->music_track >= 0 && !disable_music) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
-    }
 
     Viewport_AlterFOV(-1);
 

--- a/src/tr2/game/cutscene.c
+++ b/src/tr2/game/cutscene.c
@@ -44,6 +44,13 @@ bool Cutscene_Start(const int32_t level_num)
 
     Music_SetVolume(1.0f);
     cine_data->frame_idx = 0;
+
+    if (level->music_track != MX_INACTIVE) {
+        Music_Play(
+            level->music_track,
+            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    }
+
     return true;
 }
 

--- a/src/tr2/game/fmv.c
+++ b/src/tr2/game/fmv.c
@@ -11,6 +11,8 @@
 #include <libtrx/engine/audio.h>
 #include <libtrx/engine/video.h>
 #include <libtrx/filesystem.h>
+#include <libtrx/game/console.h>
+#include <libtrx/game/game_flow.h>
 #include <libtrx/game/music.h>
 #include <libtrx/game/ui.h>
 #include <libtrx/log.h>
@@ -84,6 +86,8 @@ static void M_UnlockSurface(void *const surface, void *const user_data)
 
 static void M_UploadSurface(void *const surface, void *const user_data)
 {
+    Render_BeginScene();
+
     GFX_2D_RENDERER *renderer_2d = user_data;
     GFX_2D_SURFACE *surface_ = surface;
     GFX_2D_Renderer_Upload(renderer_2d, &surface_->desc, surface_->buffer);
@@ -91,8 +95,12 @@ static void M_UploadSurface(void *const surface, void *const user_data)
 
     Output_SwitchViewport(VIEWPORT_UI);
     UI_BeginScene();
+    Console_Draw();
+    Console_Control();
+    Console_Control();
     UI_EndScene();
     UI_Draw();
+    Render_EndScene();
 }
 
 static bool M_Play(const char *const file_name)
@@ -145,7 +153,7 @@ static bool M_Play(const char *const file_name)
         Input_Update();
         Shell_ProcessInput();
         if (g_InputDB.menu_back || g_InputDB.menu_confirm
-            || Shell_IsExiting()) {
+            || GF_GetOverrideCommand().action != GF_NOOP || Shell_IsExiting()) {
             Video_Stop(video);
             break;
         }

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -32,6 +32,13 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     Camera_Initialise();
     Interpolation_Remember();
     Stats_StartTimer();
+
+    if (level->music_track != MX_INACTIVE) {
+        Music_Play(
+            level->music_track,
+            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    }
+
     return true;
 }
 

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -1,14 +1,8 @@
-#include "decomp/decomp.h"
-#include "game/fmv.h"
 #include "game/game.h"
-#include "game/game_flow.h"
-#include "game/game_flow/sequencer.h"
 #include "game/lara.h"
-#include "game/level.h"
 #include "game/output.h"
 #include "game/savegame.h"
 #include "game/stats.h"
-#include "global/vars.h"
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
@@ -38,62 +32,6 @@ static DECLARE_GF_EVENT_HANDLER((*m_EventHandlers[GFS_NUMBER_OF])) = {
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
-    switch (seq_ctx) {
-    case GFSC_STORY:
-        return gf_cmd;
-
-    case GFSC_SAVED:
-        GF_InventoryModifier_Scan(level);
-        // reset current info to the defaults so that we do not do
-        // Item_GlobalReplace in the inventory initialization routines too early
-        Savegame_InitCurrentInfo();
-        break;
-
-    case GFSC_SELECT: {
-        // console /play level feature
-        Savegame_InitCurrentInfo();
-        const GF_LEVEL *tmp_level = GF_GetFirstLevel();
-        while (tmp_level != nullptr && tmp_level <= level) {
-            Savegame_ApplyLogicToCurrentInfo(tmp_level);
-            GF_InventoryModifier_Scan(tmp_level);
-            GF_InventoryModifier_Apply(tmp_level, GF_INV_REGULAR);
-            if (tmp_level == level) {
-                break;
-            }
-            const GF_LEVEL *const next_level = GF_GetLevelAfter(tmp_level);
-            if (next_level != nullptr) {
-                Savegame_CarryCurrentInfoToNextLevel(tmp_level, next_level);
-            }
-            tmp_level = next_level;
-        }
-        break;
-    }
-
-    default:
-        Savegame_ApplyLogicToCurrentInfo(level);
-        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
-            GF_InventoryModifier_Scan(level);
-            GF_InventoryModifier_Apply(level, GF_INV_REGULAR);
-        }
-        break;
-    }
-
-    gf_cmd = GF_RunSequencerQueue(
-        GF_EVENT_QUEUE_BEFORE_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
-    if (gf_cmd.action != GF_NOOP) {
-        return gf_cmd;
-    }
-
-    // load the level
-    if (!Level_Initialise(level, seq_ctx)) {
-        Game_SetCurrentLevel(nullptr);
-        GF_SetCurrentLevel(nullptr);
-        if (level->type == GFL_TITLE) {
-            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
-        } else {
-            gf_cmd = (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-        }
-    }
 
     gf_cmd = GF_RunSequencerQueue(
         GF_EVENT_QUEUE_AFTER_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
@@ -101,14 +39,21 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         return gf_cmd;
     }
 
+    if (Lara_GetItem() != nullptr) {
+        Lara_Initialise(level);
+    }
+
     switch (seq_ctx) {
-    case GFSC_SAVED:
+    case GFSC_SAVED: {
         const int16_t slot_num = Savegame_GetBoundSlot();
         if (!Savegame_Load(slot_num)) {
             LOG_ERROR("Failed to load save file!");
+            Game_SetCurrentLevel(nullptr);
+            GF_SetCurrentLevel(nullptr);
             return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
         }
         break;
+    }
 
     default:
         if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -26,7 +26,6 @@
 #include <libtrx/game/gym.h>
 #include <libtrx/game/inject.h>
 #include <libtrx/game/level.h>
-#include <libtrx/game/music.h>
 #include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/game/option.h>
 #include <libtrx/log.h>
@@ -459,12 +458,6 @@ bool Level_Initialise(
     Option_Reset();
     Overlay_Reset();
     Overlay_SetHealthBarTimer(100);
-
-    if (level->music_track != MX_INACTIVE) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
-    }
 
     Gym_ResetAssault();
     return true;

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -443,9 +443,6 @@ bool Level_Initialise(
     }
     GameStringTable_Apply(level);
 
-    if (g_Lara.item_num != NO_ITEM) {
-        Lara_Initialise(level);
-    }
     Carrier_InitialiseLevel(level);
 
     if (seq_ctx != GFSC_SAVED) {

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -677,6 +677,7 @@ void Output_BeginScene(void)
 void Output_EndScene(void)
 {
     Render_EndScene();
+    GFX_Context_SwapBuffers();
     Shell_ProcessEvents();
 }
 

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -199,7 +199,6 @@ void Render_EndScene(void)
 {
     RENDERER *const r = M_GetRenderer();
     r->EndScene(r);
-    GFX_Context_SwapBuffers();
 }
 
 void Render_LoadBackgroundFromTexture(

--- a/src/tr2/game/render/hwr.c
+++ b/src/tr2/game/render/hwr.c
@@ -1325,6 +1325,8 @@ static void M_BeginScene(RENDERER *const renderer)
 
 static void M_EndScene(RENDERER *const renderer)
 {
+    M_PRIV *const priv = renderer->priv;
+    GFX_3D_Renderer_Flush(priv->renderer_3d);
 }
 
 static void M_Reset(RENDERER *const renderer, const RENDER_RESET_FLAGS flags)

--- a/src/tr2/game/render/swr.c
+++ b/src/tr2/game/render/swr.c
@@ -165,6 +165,17 @@ static void M_DrawScaledSpriteC(
     const int16_t *obj_ptr, GFX_2D_SURFACE *target_surface,
     GFX_2D_SURFACE *alpha_surface);
 
+static void M_Init(RENDERER *renderer);
+static void M_Open(RENDERER *renderer);
+static void M_Close(RENDERER *renderer);
+static void M_Shutdown(RENDERER *renderer);
+static void M_Reset(RENDERER *renderer, RENDER_RESET_FLAGS flags);
+static void M_BeginScene(RENDERER *renderer);
+static void M_EndScene(RENDERER *renderer);
+static void M_ResetPolyList(RENDERER *renderer);
+static void M_DrawPolyList(RENDERER *renderer);
+static void M_SetWet(RENDERER *renderer, bool is_wet);
+
 static void M_InsertFlatFace3s(
     RENDERER *const renderer, const FACE3 *faces, int32_t num,
     SORT_TYPE sort_type);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This builds on top of #3453 to let the players interact with the dev console even when an FMV is playing. 
Also, resolves #3147.

#### Technical considerations and testing

In develop we do not have the font injected until we actually load the title inventory ring. To circumvent this, I changed the game flow sequencer to always load the level at the start of a sequence (unless we're playing "story so far", then it'll skip loading the level file for non-cutscene levels for performance reasons), and merged TR1 and TR2 loading routines. As such it'd be good to test that this reordering didn't break anything (especially when it comes to the inventory management):

- Save/load
- Select level (TR1)
- Play any level (TR2)
- Restart level × new game/savegame
- Story so far
- Secret rewards in TR2
- Inventory modifiers
    - Starting without pistols in Natla's Mines
    - Saving with pistols in Natla's Mines and reloading the game does not remove pistols
    - Advancing to The Great Pyramid without pistols gives Lara pistols
    - Saving and reloading in The Great Pyramid doesn't mess with Lara's items
- Save crystals continue to ask for a save at a start of a level
- Save/load dialog row preselection works as expected
- Bonus levels trigger as expected and do not trigger as expected
- Cutscenes shouldn't crash, and Lara's braid should operate as normal