### PR TITLE
game-flow: do not defer any events

### DIFF
--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -9,20 +9,9 @@
 #include "game/level.h"
 #include "game/savegame.h"
 
-#define M_MAX_QUEUE_SIZE 10
-
 static GF_COMMAND M_RunEvent(
     const GF_LEVEL *level, const GF_SEQUENCE_EVENT *event,
     GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg);
-static bool M_PostponeEvent(const GF_SEQUENCE_EVENT *event);
-static void M_ResetQueue(GF_EVENT_QUEUE_TYPE queue_type);
-
-typedef struct {
-    int32_t count;
-    const GF_SEQUENCE_EVENT *events[M_MAX_QUEUE_SIZE];
-} M_EVENT_QUEUE;
-
-static M_EVENT_QUEUE m_EventQueues[GF_EVENT_QUEUE_NUMBER_OF] = {};
 
 static GF_COMMAND M_RunEvent(
     const GF_LEVEL *const level, const GF_SEQUENCE_EVENT *const event,
@@ -48,26 +37,6 @@ static GF_COMMAND M_RunEvent(
         event->data, ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action),
         gf_cmd.param);
     return gf_cmd;
-}
-
-static bool M_PostponeEvent(const GF_SEQUENCE_EVENT *const event)
-{
-    const GF_EVENT_QUEUE_TYPE queue_type =
-        GF_ShouldDeferSequenceEvent(event->type);
-    if (queue_type == GF_EVENT_QUEUE_NONE) {
-        return false;
-    }
-    M_EVENT_QUEUE *const queue = &m_EventQueues[queue_type];
-    queue->events[queue->count] = event;
-    ASSERT(queue->count + 1 < M_MAX_QUEUE_SIZE);
-    queue->count++;
-    return true;
-}
-
-static void M_ResetQueue(const GF_EVENT_QUEUE_TYPE queue_type)
-{
-    M_EVENT_QUEUE *const queue = &m_EventQueues[queue_type];
-    queue->count = 0;
 }
 
 GF_COMMAND GF_InterpretSequence(
@@ -196,11 +165,6 @@ GF_COMMAND GF_InterpretSequence(
     const GF_SEQUENCE *const sequence = &level->sequence;
     for (int32_t i = 0; i < sequence->length; i++) {
         const GF_SEQUENCE_EVENT *const event = &sequence->events[i];
-        if (M_PostponeEvent(event)) {
-            continue;
-        }
-
-        // Handle the event
         gf_cmd = M_RunEvent(level, event, seq_ctx, seq_ctx_arg);
         if (gf_cmd.action != GF_NOOP) {
             return gf_cmd;
@@ -213,22 +177,5 @@ GF_COMMAND GF_InterpretSequence(
     LOG_DEBUG(
         "sequence finished: action=%s param=%d",
         ENUM_MAP_TO_STRING(GF_ACTION, gf_cmd.action), gf_cmd.param);
-    return gf_cmd;
-}
-
-GF_COMMAND GF_RunSequencerQueue(
-    const GF_EVENT_QUEUE_TYPE queue_type, const GF_LEVEL *const level,
-    GF_SEQUENCE_CONTEXT seq_ctx, void *const seq_ctx_arg)
-{
-    GF_COMMAND gf_cmd = { .action = GF_NOOP };
-    M_EVENT_QUEUE *const queue = &m_EventQueues[queue_type];
-    for (int32_t i = 0; i < queue->count; i++) {
-        const GF_SEQUENCE_EVENT *const event = queue->events[i];
-        gf_cmd = M_RunEvent(level, event, seq_ctx, seq_ctx_arg);
-        if (gf_cmd.action != GF_NOOP) {
-            return gf_cmd;
-        }
-    }
-    queue->count = 0;
     return gf_cmd;
 }

--- a/src/libtrx/game/game_flow/sequencer_priv.h
+++ b/src/libtrx/game/game_flow/sequencer_priv.h
@@ -4,10 +4,5 @@ extern void GF_PreSequenceHook(GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg);
 extern GF_SEQUENCE_CONTEXT GF_SwitchSequenceContext(
     const GF_SEQUENCE_EVENT *event, GF_SEQUENCE_CONTEXT seq_ctx);
 
-// Defer execution of certain events to run it at various stages of
-// GFS_LOOP_GAME.
-extern GF_EVENT_QUEUE_TYPE GF_ShouldDeferSequenceEvent(
-    GF_SEQUENCE_EVENT_TYPE event_type);
-
 GF_SEQUENCE_EVENT_HANDLER GF_GetSequenceEventHandler(
     GF_SEQUENCE_EVENT_TYPE event_type);

--- a/src/libtrx/include/libtrx/game/game_flow/enum.h
+++ b/src/libtrx/include/libtrx/game/game_flow/enum.h
@@ -85,9 +85,3 @@ typedef enum {
 #endif
     GFS_NUMBER_OF,
 } GF_SEQUENCE_EVENT_TYPE;
-
-typedef enum {
-    GF_EVENT_QUEUE_NONE = -1,
-    GF_EVENT_QUEUE_AFTER_LEVEL_INIT,
-    GF_EVENT_QUEUE_NUMBER_OF,
-} GF_EVENT_QUEUE_TYPE;

--- a/src/libtrx/include/libtrx/game/game_flow/sequencer.h
+++ b/src/libtrx/include/libtrx/game/game_flow/sequencer.h
@@ -30,7 +30,3 @@ extern GF_COMMAND GF_InterpretSequence(
 
 void GF_SetSequenceEventHandler(
     GF_SEQUENCE_EVENT_TYPE event_type, GF_SEQUENCE_EVENT_HANDLER);
-
-GF_COMMAND GF_RunSequencerQueue(
-    GF_EVENT_QUEUE_TYPE queue_type, const GF_LEVEL *level,
-    GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -51,12 +51,6 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
     // clear the save slot information so that /play starts with a fresh state
     g_GameInfo.select_save_slot = -1;
 
-    gf_cmd = GF_RunSequencerQueue(
-        GF_EVENT_QUEUE_AFTER_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
-    if (gf_cmd.action != GF_NOOP) {
-        return gf_cmd;
-    }
-
     if (Lara_GetItem() != nullptr) {
         Lara_Initialise(level);
     }
@@ -257,22 +251,6 @@ GF_SEQUENCE_CONTEXT GF_SwitchSequenceContext(
     default:
         return seq_ctx;
     }
-}
-
-GF_EVENT_QUEUE_TYPE GF_ShouldDeferSequenceEvent(
-    const GF_SEQUENCE_EVENT_TYPE event_type)
-{
-    switch (event_type) {
-    case GFS_SET_CAMERA_POS:
-    case GFS_SET_CAMERA_ANGLE:
-    case GFS_FLIP_MAP:
-    case GFS_MESH_SWAP:
-    case GFS_SETUP_BACON_LARA:
-        return GF_EVENT_QUEUE_AFTER_LEVEL_INIT;
-
-    default:
-        return GF_EVENT_QUEUE_NONE;
-    };
 }
 
 void GF_InitSequencer(void)

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -33,12 +33,6 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
 
-    gf_cmd = GF_RunSequencerQueue(
-        GF_EVENT_QUEUE_AFTER_LEVEL_INIT, level, seq_ctx, seq_ctx_arg);
-    if (gf_cmd.action != GF_NOOP) {
-        return gf_cmd;
-    }
-
     if (Lara_GetItem() != nullptr) {
         Lara_Initialise(level);
     }
@@ -191,12 +185,6 @@ GF_SEQUENCE_CONTEXT GF_SwitchSequenceContext(
     default:
         return seq_ctx;
     }
-}
-
-GF_EVENT_QUEUE_TYPE GF_ShouldDeferSequenceEvent(
-    const GF_SEQUENCE_EVENT_TYPE event_type)
-{
-    return GF_EVENT_QUEUE_NONE;
 }
 
 void GF_InitSequencer(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Now that the level is guaranteed to be initialized prior to launching the sequence events, postponing the events should be no longer needed.

#### Testing

Only TR1 cutscenes :relieved: flip maps, Lara's holsters, and starting cutscene angle.