### PR TITLE
game-flow: fix music not stopping

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -78,6 +78,7 @@
 - fixed the `/play` command starting the level with wrong items sometimes (#3147, regression from 1.1)
 - fixed the `/tp` command breaking the photo mode
 - fixed the `/tp` command misbehaving when giving fractional coordinates
+- fixed the `/play` command not stopping active music when used to play Venice (#3469, regression from 0.8)
 - improved support for >3 secret dragons in custom levels up to 16 dragons
 - improved the `/tp` command to orient Lara towards keyholes and doors
 - improved handling of animation sound effects when in shallow water (#3385)

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -9,6 +9,7 @@
 #include "game/game_flow.h"
 #include "game/input.h"
 #include "game/interpolation.h"
+#include "game/music.h"
 #include "game/output.h"
 #include "game/overlay.h"
 #include "game/savegame.h"
@@ -39,6 +40,10 @@ static GF_COMMAND M_HandleOverride(void)
         Savegame_UnbindSlot();
         // This flag needs to be cleared as well.
         Game_SetIsPlaying(false);
+        // Usually, sequences permit music to flow through - for instance, the
+        // end of level screen in The Great Wall transitioning to Venice.
+        // We must stop it manually here when derailing the sequence (#3469).
+        Music_Stop();
 
         return gf_cmd;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a bug on develop found by Lahm:

> There is another music bug :ohmygod: 
> But I love it.
> `/play 18`
> end level
> `/play 2`
> Epic Venice