### PR TITLE
build: add lua dependency

### DIFF
--- a/.github/actions/prepare_macos_tooling/action.yml
+++ b/.github/actions/prepare_macos_tooling/action.yml
@@ -71,6 +71,11 @@ runs:
       shell: bash
       run: sudo port -N install libsdl2 +universal
 
+    - name: "Build dependency: luajit (universal)"
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo port -N install luajit +universal
+
     - name: "Build dependency: uthash (universal)"
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/src/libtrx/game/lua/common.c
+++ b/src/libtrx/game/lua/common.c
@@ -1,0 +1,26 @@
+#include "game/lua/common.h"
+
+#include <debug.h>
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+
+typedef struct {
+    lua_State *state;
+} M_PRIV;
+
+static M_PRIV m_Priv = {};
+
+void LUA_Init(void)
+{
+    M_PRIV *const p = &m_Priv;
+    p->state = luaL_newstate();
+    ASSERT(p->state != nullptr);
+    luaL_openlibs(p->state);
+}
+
+void LUA_Shutdown(void)
+{
+    M_PRIV *const p = &m_Priv;
+    lua_close(p->state);
+}

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -8,6 +8,7 @@
 #include "game/game_string.h"
 #include "game/game_string_manager.h"
 #include "game/lara/pose.h"
+#include "game/lua.h"
 #include "game/music.h"
 #include "game/option.h"
 #include "game/output.h"
@@ -85,6 +86,7 @@ void Shell_CommonInit(void)
 
     Shell_LoadConfig();
     Clock_Init();
+    LUA_Init();
 }
 
 void Shell_ShutdownCommonModules(void)
@@ -95,6 +97,7 @@ void Shell_ShutdownCommonModules(void)
     Savegame_Shutdown();
 
     GF_Shutdown();
+    LUA_Shutdown();
     Overlay_Shutdown();
     Option_Shutdown();
     Output_Shutdown();

--- a/src/libtrx/include/libtrx/game/lua.h
+++ b/src/libtrx/include/libtrx/game/lua.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "./lua/common.h"

--- a/src/libtrx/include/libtrx/game/lua/common.h
+++ b/src/libtrx/include/libtrx/game/lua/common.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void LUA_Init(void);
+void LUA_Shutdown(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -54,6 +54,7 @@ dep_pcre2 = dependency('libpcre2-8', static: staticdeps)
 dep_backtrace = c_compiler.find_library('backtrace', static: true, required: false)
 dep_swscale = dependency('libswscale', static: staticdeps)
 dep_swresample = dependency('libswresample', static: staticdeps)
+dep_luajit = dependency('luajit', static: staticdeps)
 c_compiler.check_header('uthash.h', required: true)
 
 dep_zlib = null_dep
@@ -202,6 +203,7 @@ sources = [
   'game/level/common.c',
   'game/level/faces.c',
   'game/level/settings.c',
+  'game/lua/common.c',
   'game/math/trig.c',
   'game/math/util.c',
   'game/matrix.c',
@@ -256,10 +258,10 @@ sources = [
   'game/savegame/common.c',
   'game/scaler.c',
   'game/shell/common.c',
-  'game/shell/input.c',
   'game/shell/config.c',
   'game/shell/events.c',
   'game/shell/flow.c',
+  'game/shell/input.c',
   'game/shell/main.c',
   'game/shell/platform.c',
   'game/sound/common.c',
@@ -362,6 +364,7 @@ dependencies = [
   dep_backtrace,
   dep_swresample,
   dep_swscale,
+  dep_luajit,
   dep_zlib,
   dep_opengl,
 ]

--- a/tools/shared/docker/game-linux/Dockerfile
+++ b/tools/shared/docker/game-linux/Dockerfile
@@ -122,6 +122,16 @@ RUN sed -i "s/Cflags: .*/\\0 -DGLEW_STATIC /" /ext/lib/pkgconfig/glew.pc
 
 
 
+# LuaJIT
+FROM base AS luajit
+RUN apt-get install -y git gcc \
+    && git clone https://github.com/LuaJIT/LuaJIT.git \
+    && cd LuaJIT \
+    && make PREFIX=/ext -j4 \
+    && make install PREFIX=/ext
+
+
+
 # TRX
 FROM base
 
@@ -158,6 +168,7 @@ COPY --from=sdl /ext/ /ext/
 COPY --from=backtrace /ext/ /ext/
 COPY --from=pcre2 /ext/ /ext/
 COPY --from=glew /ext/ /ext/
+COPY --from=luajit /ext/ /ext/
 
 ENV PYTHONPATH=/app/tools/
 ENTRYPOINT ["/app/tools/shared/docker/game-linux/entrypoint.sh"]

--- a/tools/shared/docker/game-win/Dockerfile
+++ b/tools/shared/docker/game-win/Dockerfile
@@ -130,7 +130,7 @@ RUN cp -rL uthash-2.3.0/* /ext/
 
 
 # GLEW
-FROM mingw as glew
+FROM mingw AS glew
 RUN git clone https://github.com/nigels-com/glew.git
 RUN apt-get install -y \
     build-essential \
@@ -149,6 +149,32 @@ RUN mkdir -p /ext/lib \
     && make \
     && make install
 RUN sed -i "s/Cflags: .*/\\0 -DGLEW_STATIC/" /ext/lib/pkgconfig/glew.pc
+
+
+
+# LuaJIT
+FROM mingw AS luajit
+RUN apt-get update && apt-get install -y gcc-multilib
+RUN git clone https://github.com/LuaJIT/LuaJIT.git \
+    && cd LuaJIT \
+    && make amalg PREFIX=/ext HOST_CC='gcc -m32' CROSS=i686-w64-mingw32- TARGET_SYS=Windows BUILDMODE=static -j4
+RUN cd LuaJIT \
+    && mkdir -p /ext/bin \
+    && mkdir -p /ext/lib \
+    && mkdir -p /ext/include/luajit-2.1 \
+    && mkdir -p /ext/lib/pkgconfig \
+    && cp src/libluajit.a /ext/lib/libluajit-5.1.a \
+    && cp src/lauxlib.h /ext/include/luajit-2.1/ \
+    && cp src/lua.h /ext/include/luajit-2.1/ \
+    && cp src/lua.hpp /ext/include/luajit-2.1/ \
+    && cp src/luaconf.h /ext/include/luajit-2.1/ \
+    && cp src/luajit.h /ext/include/luajit-2.1/ \
+    && cp src/lualib.h /ext/include/luajit-2.1/ \
+    && cp etc/luajit.pc /ext/lib/pkgconfig/ \
+    && sed -i 's/\/usr\/local/\/ext/' /ext/lib/pkgconfig/luajit.pc \
+    && sed -i '/Libs\.private/d' /ext/lib/pkgconfig/luajit.pc
+# COPY luajit.pc /ext/lib/pkgconfig/luajit.pc
+ENTRYPOINT /bin/bash
 
 
 
@@ -178,6 +204,7 @@ COPY --from=libav /ext/ /ext/
 COPY --from=sdl /ext/ /ext/
 COPY --from=uthash /ext/ /ext/
 COPY --from=glew /ext/ /ext/
+COPY --from=luajit /ext/ /ext/
 
 ENV PKG_CONFIG_LIBDIR=/ext/lib/
 ENV PKG_CONFIG_PATH=/ext/lib/pkgconfig/


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds a dependency on LUA for future fun and profit – for now no functionality at all, only hooking it into our toolchain. Requires a manual rebuild of Docker Images. The CI will fail at first, but after I rebuild and upload the images to DockerHub, it should work.
Mac plumbing is a shot in the dark, it may work, it may not work. 
Example patch to show it's working:

```patch
diff --git a/src/libtrx/game/lua/common.c b/src/libtrx/game/lua/common.c
index 8029a1724..5a243994d 100644
--- a/src/libtrx/game/lua/common.c
+++ b/src/libtrx/game/lua/common.c
@@ -17,6 +17,8 @@ void LUA_Init(void)
     p->state = luaL_newstate();
     ASSERT(p->state != nullptr);
     luaL_openlibs(p->state);
+
+    luaL_dostring(p->state, "print('Hello from LuaJIT!')");
 }
 
 void LUA_Shutdown(void)
```
