### PR TITLE
misc: enhance Lara's immunity

### DIFF
--- a/src/libtrx/game/lara/col/jump.c
+++ b/src/libtrx/game/lara/col/jump.c
@@ -549,7 +549,7 @@ static void M_FastDive(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    if (item->fall_speed > 133) {
+    if (item->fall_speed > 133 && !g_Config.debug.enable_invulnerability) {
         item->goal_anim_state = LS_DEATH;
     } else {
         item->goal_anim_state = LS_STOP;

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -36,11 +36,6 @@ void Lara_TakeHit(ITEM *const lara_item, const int32_t dx, const int32_t dz)
 
 void Lara_TouchLava(void)
 {
-    if (g_Config.debug.enable_invulnerability) {
-        Lara_CatchFire();
-        return;
-    }
-
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     if (lara_item->hit_points < 0 || lara_info->water_status == LWS_CHEAT) {
@@ -53,6 +48,11 @@ void Lara_TouchLava(void)
     const int32_t height =
         Room_GetHeight(sector, lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z);
     if (lara_item->floor != height) {
+        return;
+    }
+
+    if (g_Config.debug.enable_invulnerability) {
+        Lara_CatchFire();
         return;
     }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -9,6 +9,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/lara/const.h>
@@ -223,7 +224,8 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
 
 static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
 {
-    return g_GameFlow.enable_killer_pushblocks && item->gravity
+    return g_GameFlow.enable_killer_pushblocks
+        && !g_Config.debug.enable_invulnerability && item->gravity
         && Lara_TestBoundsCollide(item, 0);
 }
 

--- a/src/tr1/game/objects/traps/rolling_ball.c
+++ b/src/tr1/game/objects/traps/rolling_ball.c
@@ -4,6 +4,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/game_buf.h>
@@ -128,11 +129,13 @@ static void M_Collision(
     }
 
     int32_t x, y, z, d;
-    if (lara_item->gravity) {
+    if (lara_item->gravity || g_Config.debug.enable_invulnerability) {
         if (coll->enable_baddie_push) {
             Lara_Push(item, coll, coll->enable_hit, true);
         }
-        lara_item->hit_points -= ROLLINGBALL_DAMAGE_AIR;
+        if (!g_Config.debug.enable_invulnerability) {
+            lara_item->hit_points -= ROLLINGBALL_DAMAGE_AIR;
+        }
         x = lara_item->pos.x - item->pos.x;
         z = lara_item->pos.z - item->pos.z;
         y = (lara_item->pos.y - 350) - (item->pos.y - WALL_L / 2);

--- a/src/tr1/game/objects/traps/spikes.c
+++ b/src/tr1/game/objects/traps/spikes.c
@@ -2,6 +2,7 @@
 #include "game/random.h"
 #include "game/spawn.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/collision.h>
 
 #define SPIKE_DAMAGE 15
@@ -31,7 +32,8 @@ static void M_Collision(
 
     int32_t num = Random_GetControl() / 24576;
     if (lara_item->gravity) {
-        if (lara_item->fall_speed > 0) {
+        if (lara_item->fall_speed > 0
+            && !g_Config.debug.enable_invulnerability) {
             lara_item->hit_points = -1;
             num = 20;
         }

--- a/src/tr1/game/objects/traps/thors_hammer.c
+++ b/src/tr1/game/objects/traps/thors_hammer.c
@@ -2,6 +2,7 @@
 #include "game/objects/common.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/debug.h>
 
 typedef enum {
@@ -88,9 +89,10 @@ static void M_ControlHandle(const int16_t item_num)
                 break;
             }
 
-            if (g_LaraItem->hit_points >= 0 && g_LaraItem->pos.x > x - 520
-                && g_LaraItem->pos.x < x + 520 && g_LaraItem->pos.z > z - 520
-                && g_LaraItem->pos.z < z + 520) {
+            if (g_LaraItem->hit_points >= 0
+                && !g_Config.debug.enable_invulnerability
+                && g_LaraItem->pos.x > x - 520 && g_LaraItem->pos.x < x + 520
+                && g_LaraItem->pos.z > z - 520 && g_LaraItem->pos.z < z + 520) {
                 g_LaraItem->hit_points = -1;
                 g_LaraItem->pos.y = item->pos.y;
                 g_LaraItem->gravity = 0;

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -4,6 +4,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/collision.h>
 #include <libtrx/game/game_buf.h>
@@ -161,11 +162,13 @@ static void M_Collision(
         return;
     }
 
-    if (lara_item->gravity) {
+    if (lara_item->gravity || g_Config.debug.enable_invulnerability) {
         if (coll->enable_baddie_push) {
             Lara_Push(item, coll, coll->enable_hit, true);
         }
-        lara_item->hit_points -= ROLLING_BALL_DAMAGE_AIR;
+        if (!g_Config.debug.enable_invulnerability) {
+            lara_item->hit_points -= ROLLING_BALL_DAMAGE_AIR;
+        }
 
         // TODO: handle overflows
         const int32_t dx = lara_item->pos.x - item->pos.x;

--- a/src/tr2/game/objects/traps/spikes.c
+++ b/src/tr2/game/objects/traps/spikes.c
@@ -2,6 +2,7 @@
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/collision.h>
 
 #define SPIKE_DAMAGE 15
@@ -31,7 +32,8 @@ static void M_Collision(
 
     int32_t num = Random_GetControl() / 24576;
     if (lara_item->gravity) {
-        if (lara_item->fall_speed > GRAVITY) {
+        if (lara_item->fall_speed > GRAVITY
+            && !g_Config.debug.enable_invulnerability) {
             lara_item->hit_points = -1;
             num = 20;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

While immune, Lara can now survive jumping into spikes; boulders/barrels; Thor's hammer; killer pushblocks and swan-diving onto land from any height. This also resolves catching fire when walking across a bridge.

I think the only one-shot deaths left are: T-rex, Torso and Midas hand. Should we just exclude these too?
