### PR TITLE
tr1/output: allow skybox toggle in-game

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.13...develop) - ××××-××-××
 - added German translation
+- changed the skybox option to allow toggling in-game without the need to reload the level
 
 ## [4.13](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.3...tr1-4.13) - 2025-07-14
 Showcase: https://youtu.be/YKI7u2QOolU

--- a/src/libtrx/game/inject/common.c
+++ b/src/libtrx/game/inject/common.c
@@ -199,6 +199,7 @@ static bool M_IsRelevant(const INJECTION_FILE_TYPE type)
         return g_Config.visuals.fix_texture_issues;
 #if TR_VERSION == 1
     case IFT_LARA_ANIMS:
+    case IFT_SKYBOX:
         return true;
     case IFT_BRAID:
         return g_Config.visuals.enable_braid;
@@ -208,8 +209,6 @@ static bool M_IsRelevant(const INJECTION_FILE_TYPE type)
         return g_Config.gameplay.restore_ps1_enemies;
     case IFT_DISABLE_ANIM_SPRITE:
         return !g_Config.visuals.fix_animated_sprites;
-    case IFT_SKYBOX:
-        return g_Config.visuals.enable_skybox;
     case IFT_PS1_CRYSTAL:
         return g_Config.gameplay.enable_save_crystals
             && g_Config.visuals.enable_ps1_crystals;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -337,8 +337,7 @@ void Level_Load(const GF_LEVEL *const level)
 
     Inject_Cleanup();
 
-    Output_SetSkyboxEnabled(
-        g_Config.visuals.enable_skybox && Object_Get(O_SKYBOX)->loaded);
+    Output_SetSkyboxEnabled(Object_Get(O_SKYBOX)->loaded);
 
     Benchmark_End(&benchmark, nullptr);
 }

--- a/src/tr1/game/output/draw_misc.c
+++ b/src/tr1/game/output/draw_misc.c
@@ -91,7 +91,7 @@ void Output_SetSkyboxEnabled(const bool enabled)
 
 bool Output_IsSkyboxEnabled(void)
 {
-    return m_IsSkyboxEnabled;
+    return m_IsSkyboxEnabled && g_Config.visuals.enable_skybox;
 }
 
 void Output_DrawSkybox(const OBJECT_MESH *const mesh)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows the skybox to be toggled in-game without the need to reload.
