### PR TITLE
tr1/pickup: reset interact target on pickup

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -4,6 +4,7 @@
 - changed the texture page limit from 128 to unlimited (#3517)
 - fixed Lara's first pose in photo mode at times being skipped (#3522, regression from 4.13)
 - fixed Lara's arms being drawn inaccurately when posing in photo mode with dual weapons equipped (#3520, regression from 4.13)
+- fixed Lara being unable to use key items at times with animated interactions enabled (#3524, regression from 4.13)
 
 ## [4.13](https://github.com/LostArtefacts/TRX/compare/tr1-4.12.3...tr1-4.13) - 2025-07-14
 Showcase: https://youtu.be/YKI7u2QOolU

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -339,6 +339,7 @@ static void M_CollisionControlled(
             && lara_item->current_anim_state == LS_PICKUP) {
             if (Item_TestFrameEqual(lara_item, LF_PICKUP_ERASE)) {
                 M_GetAllAtLaraPos(item, lara_item);
+                g_Lara.interact_target.item_num = NO_ITEM;
             }
         }
     } else if (g_Lara.water_status == LWS_UNDERWATER) {
@@ -373,6 +374,7 @@ static void M_CollisionControlled(
             && Item_TestFrameEqual(lara_item, LF_PICKUP_UW)) {
             M_GetAllAtLaraPos(item, lara_item);
             g_Lara.gun_status = LGS_ARMLESS;
+            g_Lara.interact_target.item_num = NO_ITEM;
         }
     }
     item->rot.x = rotx;


### PR DESCRIPTION
Resolves #3524.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures to reset the interact target after Lara picks up an item when animated interactions is enabled. For existing saves as in the issue, a resolution would be to go to a switch and use it, then return and try to use the keyhole.
