### PR TITLE
objects/flame: skip effects when object not present

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
 - changed the skybox option to allow toggling in-game without the need to reload the level
 - changed the texture page limit from 128 to unlimited (#3517)
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 4.9)
+- fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 4.13)
 
 ## [4.13.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.13...tr1-4.13.1) - 2025-07-18
 - fixed Lara's first pose in photo mode at times being skipped (#3522, regression from 4.13)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - changed the texture page limit from 128 to unlimited (#3517)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 1.0)
+- fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 1.3)
 
 ## [1.3.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.3...tr2-1.3.1) - 2025-07-18
 - fixed Lara's first pose in photo mode at times being skipped (#3522, regression from 1.3)

--- a/src/libtrx/game/objects/effects/flame.c
+++ b/src/libtrx/game/objects/effects/flame.c
@@ -26,6 +26,10 @@ static void M_Control(int16_t effect_num);
 
 static void M_DoEffects(const EFFECT *const effect)
 {
+    if (!Object_Get(O_FLAME)->loaded) {
+        return;
+    }
+
     Sound_Effect(SFX_LOOP_FOR_SMALL_FIRES, &effect->pos, SPM_ALWAYS);
     if (!g_Config.visuals.enable_fire_lighting) {
         return;


### PR DESCRIPTION
Resolves #3539.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids dynamic light being generated when the flame object is not present in the level.
