### PR TITLE
Fix audio drift in HSH shower cutscene with turbo speed

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.3.1...develop) - ××××-××-××
 - added German translation
 - changed the texture page limit from 128 to unlimited (#3517)
+- fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)
 
 ## [1.3.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.3...tr2-1.3.1) - 2025-07-18

--- a/src/libtrx/engine/audio_stream.c
+++ b/src/libtrx/engine/audio_stream.c
@@ -424,6 +424,26 @@ void Audio_Stream_Shutdown(void)
     }
 }
 
+bool Audio_Stream_SyncTimestamp(const int32_t sound_id, const double timestamp)
+{
+    if (!g_AudioDeviceID || sound_id < 0
+        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+        return false;
+    }
+
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+    double drift = stream->timestamp - timestamp;
+    if (drift < 0) {
+        drift = -drift;
+    }
+    if (drift >= AUDIO_DRIFT_THRESHOLD) {
+        LOG_DEBUG("Detected audio drift: %f s", drift);
+        Audio_Stream_SeekTimestamp(sound_id, timestamp);
+        return true;
+    }
+    return false;
+}
+
 bool Audio_Stream_Pause(int32_t sound_id)
 {
     if (!g_AudioDeviceID || sound_id < 0
@@ -431,9 +451,10 @@ bool Audio_Stream_Pause(int32_t sound_id)
         return false;
     }
 
-    if (m_Streams[sound_id].is_playing) {
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+    if (stream->is_playing) {
         SDL_LockAudioDevice(g_AudioDeviceID);
-        m_Streams[sound_id].is_playing = false;
+        stream->is_playing = false;
         SDL_UnlockAudioDevice(g_AudioDeviceID);
     }
 
@@ -447,9 +468,10 @@ bool Audio_Stream_Unpause(int32_t sound_id)
         return false;
     }
 
-    if (!m_Streams[sound_id].is_playing) {
+    AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
+    if (!stream->is_playing) {
         SDL_LockAudioDevice(g_AudioDeviceID);
-        m_Streams[sound_id].is_playing = true;
+        stream->is_playing = true;
         SDL_UnlockAudioDevice(g_AudioDeviceID);
     }
 
@@ -596,7 +618,7 @@ void Audio_Stream_Mix(float *dst_buffer, size_t len)
 {
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
          sound_id++) {
-        AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+        AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
         if (!stream->is_playing) {
             continue;
         }

--- a/src/libtrx/game/lara/state/extra.c
+++ b/src/libtrx/game/lara/state/extra.c
@@ -291,6 +291,12 @@ static void M_FinalAnim(ITEM *const item, COLL_INFO *const coll)
     } else if (Item_TestFrameEqual(item, -1)) {
         Game_SetIsLevelComplete(true);
     }
+
+    if (Music_GetCurrentPlayingTrack() == MX_CUTSCENE_BATH) {
+        const int32_t frame_num = Item_GetRelativeFrame(item);
+        const double ts = (frame_num - M_LF_SHOWER_START) / (double)LOGIC_FPS;
+        Music_SyncTimestamp(ts);
+    }
 #endif
 }
 

--- a/src/libtrx/game/music/common.c
+++ b/src/libtrx/game/music/common.c
@@ -282,6 +282,14 @@ bool Music_SeekTimestamp(const double timestamp)
     return Audio_Stream_SeekTimestamp(m_AudioStreamID, timestamp);
 }
 
+bool Music_SyncTimestamp(const double timestamp)
+{
+    if (m_AudioStreamID < 0) {
+        return false;
+    }
+    return Audio_Stream_SyncTimestamp(m_AudioStreamID, timestamp);
+}
+
 MUSIC_TRACK_ID Music_GetDelayedTrack(void)
 {
     return m_TrackDelayed;

--- a/src/libtrx/include/libtrx/engine/audio.h
+++ b/src/libtrx/include/libtrx/engine/audio.h
@@ -7,6 +7,7 @@
 #define AUDIO_MAX_SAMPLES 1000
 #define AUDIO_MAX_ACTIVE_SAMPLES 50
 #define AUDIO_MAX_ACTIVE_STREAMS 10
+#define AUDIO_DRIFT_THRESHOLD 0.2
 #define AUDIO_NO_SOUND (-1)
 
 bool Audio_Init(void);
@@ -23,6 +24,10 @@ bool Audio_Stream_Close(int32_t sound_id);
 bool Audio_Stream_IsLooped(int32_t sound_id);
 bool Audio_Stream_SetVolume(int32_t sound_id, float volume);
 bool Audio_Stream_SetIsLooped(int32_t sound_id, bool is_looped);
+
+// Sync the audio against specific timestamp (seek if the drift is too large).
+bool Audio_Stream_SyncTimestamp(int32_t sound_id, double timestamp);
+
 bool Audio_Stream_SetFinishCallback(
     int32_t sound_id, void (*callback)(int32_t sound_id, void *user_data),
     void *user_data);

--- a/src/libtrx/include/libtrx/game/music/common.h
+++ b/src/libtrx/include/libtrx/game/music/common.h
@@ -40,6 +40,9 @@ double Music_GetTimestamp(void);
 // Seek to timestamp of current stream.
 bool Music_SeekTimestamp(double timestamp);
 
+// Seeks to the given timestamp if the drift is too big.
+bool Music_SyncTimestamp(double timestamp);
+
 // Returns the delayed track. Ignores looped tracks.
 MUSIC_TRACK_ID Music_GetDelayedTrack(void);
 

--- a/src/tr1/game/cutscene.c
+++ b/src/tr1/game/cutscene.c
@@ -19,19 +19,7 @@
 #include <libtrx/game/music.h>
 #include <libtrx/memory.h>
 
-static void M_FixAudioDrift(void);
 static void M_InitialiseLara(const GF_LEVEL *level);
-
-static void M_FixAudioDrift(void)
-{
-    const int32_t audio_frame_idx = Music_GetTimestamp() * LOGIC_FPS;
-    const int32_t game_frame_idx = Camera_GetCineData()->frame_idx;
-    const int32_t audio_drift = ABS(audio_frame_idx - game_frame_idx);
-    if (audio_drift >= LOGIC_FPS * 0.2) {
-        LOG_DEBUG("Detected audio drift: %d frames", audio_drift);
-        Music_SeekTimestamp(game_frame_idx / (double)LOGIC_FPS);
-    }
-}
 
 static void M_InitialiseLara(const GF_LEVEL *const level)
 {
@@ -91,9 +79,7 @@ bool Cutscene_Start(const int32_t level_num)
     Camera_GetCineData()->frame_idx = 0;
 
     if (level->music_track != MX_INACTIVE) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+        Music_Play(level->music_track, MPM_ALWAYS);
     }
 
     return true;
@@ -108,7 +94,7 @@ void Cutscene_End(void)
 GF_COMMAND Cutscene_Control(void)
 {
     Interpolation_Remember();
-    M_FixAudioDrift();
+    Music_SyncTimestamp(Camera_GetCineData()->frame_idx / (double)LOGIC_FPS);
 
     Input_Update();
     Shell_ProcessInput();

--- a/src/tr2/game/cutscene.c
+++ b/src/tr2/game/cutscene.c
@@ -20,19 +20,6 @@
 
 static CAMERA_INFO m_LocalCamera = {};
 
-static void M_FixAudioDrift(void);
-
-static void M_FixAudioDrift(void)
-{
-    const int32_t audio_frame_idx = Music_GetTimestamp() * LOGIC_FPS;
-    const int32_t game_frame_idx = Camera_GetCineData()->frame_idx;
-    const int32_t audio_drift = ABS(audio_frame_idx - game_frame_idx);
-    if (audio_drift >= LOGIC_FPS * 0.2) {
-        LOG_DEBUG("Detected audio drift: %d frames", audio_drift);
-        Music_SeekTimestamp(game_frame_idx / (double)LOGIC_FPS);
-    }
-}
-
 bool Cutscene_Start(const int32_t level_num)
 {
     const GF_LEVEL *const level = GF_GetLevel(GFLT_CUTSCENES, level_num);
@@ -46,9 +33,7 @@ bool Cutscene_Start(const int32_t level_num)
     cine_data->frame_idx = 0;
 
     if (level->music_track != MX_INACTIVE) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+        Music_Play(level->music_track, MPM_ALWAYS);
     }
 
     return true;
@@ -64,7 +49,7 @@ void Cutscene_End(void)
 GF_COMMAND Cutscene_Control(void)
 {
     Interpolation_Remember();
-    M_FixAudioDrift();
+    Music_SyncTimestamp(Camera_GetCineData()->frame_idx / (double)LOGIC_FPS);
 
     Input_Update();
     Shell_ProcessInput();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3541.
Affects cutscenes and has potential to affect pausing in the cutscenes. Affects TR1 too.