### PR TITLE
level/common: improve object error messages

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 4.9)
 - fixed drawing UI text with bilinear filter and PS1 UI (#3548, regression from 4.13)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 4.13)
+- improved object loading error messages when an invalid object ID is detected
 
 ## [4.13.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.13...tr1-4.13.1) - 2025-07-18
 - fixed Lara's first pose in photo mode at times being skipped (#3522, regression from 4.13)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 1.0)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 1.3)
+- improved object loading error messages when an invalid object ID is detected
 
 ## [1.3.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.3...tr2-1.3.1) - 2025-07-18
 - fixed Lara's first pose in photo mode at times being skipped (#3522, regression from 1.3)

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -828,13 +828,14 @@ void Level_ReadObjects(VFILE *const file)
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_INFO("objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
-        const GAME_OBJECT_ID obj_id = Object_UnmapGameID(VFile_ReadS32(file));
-        if (obj_id < O_FIRST || obj_id >= O_NUMBER_OF) {
+        const int32_t obj_id = VFile_ReadS32(file);
+        const GAME_OBJECT_ID game_obj_id = Object_UnmapGameID(obj_id);
+        if (game_obj_id < O_FIRST || game_obj_id >= O_NUMBER_OF) {
             Shell_ExitSystemFmt(
                 "Invalid object ID: %d (max=%d)", obj_id, O_NUMBER_OF);
         }
 
-        OBJECT *const obj = Object_Get(obj_id);
+        OBJECT *const obj = Object_Get(game_obj_id);
         obj->mesh_count = VFile_ReadS16(file);
         obj->mesh_idx = VFile_ReadS16(file);
         obj->bone_idx = VFile_ReadS32(file) / ANIM_BONE_SIZE;
@@ -1104,17 +1105,18 @@ void Level_ReadItems(VFILE *const file)
     Item_InitialiseItems(num_items);
     for (int32_t i = 0; i < num_items; i++) {
         ITEM *const item = Item_Get(i);
-        item->object_id = Object_UnmapGameID(VFile_ReadS16(file));
+        const int16_t obj_id = VFile_ReadS16(file);
+        item->object_id = Object_UnmapGameID(obj_id);
+        if (item->object_id < O_FIRST || item->object_id >= O_NUMBER_OF) {
+            Shell_ExitSystemFmt("Bad object number (%d) on item %d", obj_id, i);
+            goto finish;
+        }
+
         item->room_num = VFile_ReadS16(file);
         M_ReadPosition(&item->pos, file);
         item->rot.y = VFile_ReadS16(file);
         M_ReadShade(&item->shade, file);
         item->flags = VFile_ReadS16(file);
-        if (item->object_id < O_FIRST || item->object_id >= O_NUMBER_OF) {
-            Shell_ExitSystemFmt(
-                "Bad object number (%d) on item %d", item->object_id, i);
-            goto finish;
-        }
     }
 
 finish:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates level loading to show the object IDs from the level file rather than the unmapped IDs, as failures will have unmapped to `NO_OBJECT`, so will always show the same error.

<img width="256" height="141" alt="image" src="https://github.com/user-attachments/assets/83acaec6-6358-4351-955a-e2264f850ffe" />

