### PR TITLE
creature/common: test targetable item status

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed sprites having thick borders depending on viewing angle (#3549, regression from 1.3)
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 1.0)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 1.3)
+- fixed harpoons disappearing if used near inactive/invisible enemies (#3546, regression from 1.3)
 - improved object loading error messages when an invalid object ID is detected
 
 ## [1.3.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.3...tr2-1.3.1) - 2025-07-18

--- a/src/libtrx/game/creature/common.c
+++ b/src/libtrx/game/creature/common.c
@@ -1103,6 +1103,8 @@ bool Creature_IsTargetable(const ITEM *const item)
     return true;
 #else
     return item->hit_points != DONT_TARGET
+        && (!Object_Get(item->object_id)->intelligent
+            || item->status == IS_ACTIVE)
         && (g_Config.gameplay.enable_ally_targeting || !Creature_IsAlly(item));
 #endif
 }


### PR DESCRIPTION
Resolves #3546.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that a creature is only treated as targetable if their status is active.

Worth checking kill commands, winston, etc too with this change.
