### PR TITLE
camera/common: update camera on initialise

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 4.9)
 - fixed drawing UI text with bilinear filter and PS1 UI (#3548, regression from 4.13)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 4.13)
+- fixed the first camera frame when starting or loading a level being inaccurate (#3537, regression from 4.12.3)
 - improved object loading error messages when an invalid object ID is detected
 
 ## [4.13.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.13...tr1-4.13.1) - 2025-07-18

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 1.0)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 1.3)
 - fixed harpoons disappearing if used near inactive/invisible enemies (#3546, regression from 1.3)
+- fixed the first camera frame when starting or loading a level being inaccurate (#3537, regression from 1.2.2)
 - improved object loading error messages when an invalid object ID is detected
 
 ## [1.3.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.3...tr2-1.3.1) - 2025-07-18

--- a/src/libtrx/game/camera/common.c
+++ b/src/libtrx/game/camera/common.c
@@ -71,6 +71,7 @@ static const double m_ManualCameraMultiplier[11] = {
 
 static BOX_INFO m_FixedBox = {};
 static bool m_IsChunky = false;
+static bool m_IsInitialised = false;
 #if TR_VERSION == 2
 // TODO: consolidate with Viewport API
 extern int32_t g_PhdPersp;
@@ -763,6 +764,7 @@ void Camera_SetChunky(const bool is_chunky)
 
 void Camera_Initialise(void)
 {
+    m_IsInitialised = false;
     Matrix_ResetStack();
     g_Camera.last = NO_CAMERA;
     g_Camera.underwater = false;
@@ -770,6 +772,8 @@ void Camera_Initialise(void)
 #if TR_VERSION == 2
     Viewport_AlterFOV(-1);
 #endif
+    Camera_Update();
+    m_IsInitialised = true;
 }
 
 void Camera_ResetPosition(void)
@@ -1091,7 +1095,9 @@ void Camera_Update(void)
 #endif
     }
     Camera_SetChunky(false);
-    Camera_EnsureEnvironment();
+    if (m_IsInitialised) {
+        Camera_EnsureEnvironment();
+    }
 }
 
 void Camera_UpdateMicPosition(void)


### PR DESCRIPTION
Resolves #3537.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores updating the camera when it is initialised, but holds back on updating the environment until the second frame to avoid introducing SFX issues such as at the start of Palace Midas (we need to wait until triggers are tested there to apply the fixed camera). The relevant commit is 008a2f0 where the logic was changed to ensure updating the environment in the control phase.
