### PR TITLE
tr2/gun: improve projectiles handling

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,10 +3,11 @@
 - added German translation
 - added PS1 fade-out to final cutscene (#3521)
 - changed the texture page limit from 128 to unlimited (#3517)
-- changed projectiles to smash all shatterable objects simultaneously instead of 1 for rifles and 2 for pistols (#3378)
+- changed projectiles to smash all shatterable objects simultaneously instead of 1 for rifles and 2 for pistols (#3378, #3551)
 - fixed audio playback with CDAudio backend in cutscenes (#2593)
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
-- fixed projectiles sometimes not shattering breakable windows (#3378)
+- fixed harpoons/grenades having no effect on bells (#3379)
+- fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 1.0)
 - fixed dynamic fire light being generated despite the flame object not being present in the level (#3539, regression from 1.3)

--- a/src/libtrx/game/gun/rifle.c
+++ b/src/libtrx/game/gun/rifle.c
@@ -95,11 +95,10 @@ static void M_FireHarpoon(void)
     }
 
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_HARPOON];
-    const GAME_VECTOR origin = {
+    const XYZ_32 origin = {
         .x = lara_item->pos.x,
         .y = lara_item->pos.y - weapon->gun_height,
         .z = lara_item->pos.z,
-        .room_num = lara_item->room_num,
     };
 
     ITEM *const projectile_item = Item_Get(item_num);
@@ -141,13 +140,7 @@ static void M_FireHarpoon(void)
     Item_AddActive(item_num);
     projectile_item->status = IS_ACTIVE;
 
-    const GAME_VECTOR target = {
-        .x = projectile_item->pos.x,
-        .y = projectile_item->pos.y,
-        .z = projectile_item->pos.z,
-        .room_num = projectile_item->room_num,
-    };
-    Gun_SmashItems(origin, target);
+    Gun_SmashItems(origin, projectile_item->pos);
 
     lara->harpoon_ammo.ammo--;
     Stats_AddAmmoUsed();
@@ -175,11 +168,10 @@ static void M_FireGrenade(void)
         return;
     }
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_GRENADE];
-    const GAME_VECTOR origin = {
+    const XYZ_32 origin = {
         .x = lara_item->pos.x,
         .y = lara_item->pos.y - weapon->gun_height,
         .z = lara_item->pos.z,
-        .room_num = lara_item->room_num,
     };
 
     const int16_t item_num = Item_Create();
@@ -210,13 +202,7 @@ static void M_FireGrenade(void)
     Item_AddActive(item_num);
     projectile_item->status = IS_ACTIVE;
 
-    const GAME_VECTOR target = {
-        .x = projectile_item->pos.x,
-        .y = projectile_item->pos.y,
-        .z = projectile_item->pos.z,
-        .room_num = projectile_item->room_num,
-    };
-    Gun_SmashItems(origin, target);
+    Gun_SmashItems(origin, projectile_item->pos);
 
     if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
         lara->grenade_ammo.ammo--;

--- a/src/libtrx/game/gun/rifle.c
+++ b/src/libtrx/game/gun/rifle.c
@@ -94,9 +94,17 @@ static void M_FireHarpoon(void)
         goto finish;
     }
 
-    ITEM *const item = Item_Get(item_num);
-    item->object_id = O_HARPOON_BOLT;
-    item->room_num = lara_item->room_num;
+    const WEAPON_INFO *const weapon = &g_Weapons[LGT_HARPOON];
+    const GAME_VECTOR origin = {
+        .x = lara_item->pos.x,
+        .y = lara_item->pos.y - weapon->gun_height,
+        .z = lara_item->pos.z,
+        .room_num = lara_item->room_num,
+    };
+
+    ITEM *const projectile_item = Item_Get(item_num);
+    projectile_item->object_id = O_HARPOON_BOLT;
+    projectile_item->room_num = lara_item->room_num;
 
     XYZ_32 offset = {
         .x = -2,
@@ -105,32 +113,41 @@ static void M_FireHarpoon(void)
     };
 
     Lara_GetJointAbsPosition(&offset, LM_HAND_R);
-    item->pos.x = offset.x;
-    item->pos.y = offset.y;
-    item->pos.z = offset.z;
+    projectile_item->pos.x = offset.x;
+    projectile_item->pos.y = offset.y;
+    projectile_item->pos.z = offset.z;
     Item_Initialise(item_num);
 
     if (lara->target != nullptr) {
         GAME_VECTOR lara_vec;
         Gun_FindTargetPoint(lara->target, &lara_vec);
-        const int32_t dx = lara_vec.pos.x - item->pos.x;
-        const int32_t dz = lara_vec.pos.z - item->pos.z;
-        const int32_t dy = lara_vec.pos.y - item->pos.y;
+        const int32_t dx = lara_vec.pos.x - projectile_item->pos.x;
+        const int32_t dz = lara_vec.pos.z - projectile_item->pos.z;
+        const int32_t dy = lara_vec.pos.y - projectile_item->pos.y;
         const int32_t dxz = Math_Sqrt(SQUARE(dx) + SQUARE(dz));
-        item->rot.y = Math_Atan(dz, dx);
-        item->rot.x = -Math_Atan(dxz, dy);
-        item->rot.z = 0;
+        projectile_item->rot.y = Math_Atan(dz, dx);
+        projectile_item->rot.x = -Math_Atan(dxz, dy);
+        projectile_item->rot.z = 0;
     } else {
-        item->rot.x = lara->left_arm.rot.x + lara_item->rot.x;
-        item->rot.y = lara->left_arm.rot.y + lara_item->rot.y;
-        item->rot.z = 0;
+        projectile_item->rot.x = lara->left_arm.rot.x + lara_item->rot.x;
+        projectile_item->rot.y = lara->left_arm.rot.y + lara_item->rot.y;
+        projectile_item->rot.z = 0;
     }
 
-    item->fall_speed =
-        (-HARPOON_BOLT_SPEED * Math_Sin(item->rot.x)) >> W2V_SHIFT;
-    item->speed = (HARPOON_BOLT_SPEED * Math_Cos(item->rot.x)) >> W2V_SHIFT;
+    projectile_item->fall_speed =
+        (-HARPOON_BOLT_SPEED * Math_Sin(projectile_item->rot.x)) >> W2V_SHIFT;
+    projectile_item->speed =
+        (HARPOON_BOLT_SPEED * Math_Cos(projectile_item->rot.x)) >> W2V_SHIFT;
     Item_AddActive(item_num);
-    item->status = IS_ACTIVE;
+    projectile_item->status = IS_ACTIVE;
+
+    const GAME_VECTOR target = {
+        .x = projectile_item->pos.x,
+        .y = projectile_item->pos.y,
+        .z = projectile_item->pos.z,
+        .room_num = projectile_item->room_num,
+    };
+    Gun_SmashItems(origin, target);
 
     lara->harpoon_ammo.ammo--;
     Stats_AddAmmoUsed();
@@ -157,15 +174,22 @@ static void M_FireGrenade(void)
     if (lara->grenade_ammo.ammo <= 0) {
         return;
     }
+    const WEAPON_INFO *const weapon = &g_Weapons[LGT_GRENADE];
+    const GAME_VECTOR origin = {
+        .x = lara_item->pos.x,
+        .y = lara_item->pos.y - weapon->gun_height,
+        .z = lara_item->pos.z,
+        .room_num = lara_item->room_num,
+    };
 
     const int16_t item_num = Item_Create();
     if (item_num == NO_ITEM) {
         return;
     }
 
-    ITEM *const item = Item_Get(item_num);
-    item->object_id = O_GRENADE;
-    item->room_num = lara_item->room_num;
+    ITEM *const projectile_item = Item_Get(item_num);
+    projectile_item->object_id = O_GRENADE;
+    projectile_item->room_num = lara_item->room_num;
 
     XYZ_32 offset = {
         .x = -2,
@@ -173,18 +197,26 @@ static void M_FireGrenade(void)
         .z = 77,
     };
     Lara_GetJointAbsPosition(&offset, LM_HAND_R);
-    item->pos.x = offset.x;
-    item->pos.y = offset.y;
-    item->pos.z = offset.z;
+    projectile_item->pos.x = offset.x;
+    projectile_item->pos.y = offset.y;
+    projectile_item->pos.z = offset.z;
     Item_Initialise(item_num);
 
-    item->rot.x = lara->left_arm.rot.x + lara_item->rot.x;
-    item->rot.y = lara->left_arm.rot.y + lara_item->rot.y;
-    item->rot.z = 0;
-    item->speed = GRENADE_SPEED;
-    item->fall_speed = 0;
+    projectile_item->rot.x = lara->left_arm.rot.x + lara_item->rot.x;
+    projectile_item->rot.y = lara->left_arm.rot.y + lara_item->rot.y;
+    projectile_item->rot.z = 0;
+    projectile_item->speed = GRENADE_SPEED;
+    projectile_item->fall_speed = 0;
     Item_AddActive(item_num);
-    item->status = IS_ACTIVE;
+    projectile_item->status = IS_ACTIVE;
+
+    const GAME_VECTOR target = {
+        .x = projectile_item->pos.x,
+        .y = projectile_item->pos.y,
+        .z = projectile_item->pos.z,
+        .room_num = projectile_item->room_num,
+    };
+    Gun_SmashItems(origin, target);
 
     if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
         lara->grenade_ammo.ammo--;

--- a/src/libtrx/include/libtrx/game/gun/misc.h
+++ b/src/libtrx/include/libtrx/game/gun/misc.h
@@ -16,5 +16,5 @@ void Gun_AimWeapon(const WEAPON_INFO *weapon, LARA_ARM *arm);
 void Gun_TargetInfo(const WEAPON_INFO *weapon);
 
 #if TR_VERSION >= 2
-extern PROJECTILE_HIT Gun_SmashItems(GAME_VECTOR start, GAME_VECTOR target);
+extern PROJECTILE_HIT Gun_SmashItems(XYZ_32 start, XYZ_32 target);
 #endif

--- a/src/libtrx/include/libtrx/game/gun/misc.h
+++ b/src/libtrx/include/libtrx/game/gun/misc.h
@@ -5,6 +5,16 @@
 #include "../types.h"
 #include "./types.h"
 
+typedef enum {
+    PROJECTILE_HIT_NONE,
+    PROJECTILE_HIT_SHATTER, // some objects were shattered
+    PROJECTILE_HIT_STOP, // a hard object (eg a bell) has been hit
+} PROJECTILE_HIT;
+
 void Gun_FindTargetPoint(const ITEM *item, GAME_VECTOR *target);
 void Gun_AimWeapon(const WEAPON_INFO *weapon, LARA_ARM *arm);
 void Gun_TargetInfo(const WEAPON_INFO *weapon);
+
+#if TR_VERSION >= 2
+extern PROJECTILE_HIT Gun_SmashItems(GAME_VECTOR start, GAME_VECTOR target);
+#endif

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -63,24 +63,17 @@ bool Creature_ShootAtLara(
         Effect_Get(effect_num)->rot.y += extra_rotation;
     }
 
-    GAME_VECTOR start = {
-        .pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - STEP_L * 3,
-            .z = item->pos.z,
-        },
-        .room_num = item->room_num,
+    const XYZ_32 start = {
+        .x = item->pos.x,
+        .y = item->pos.y - STEP_L * 3,
+        .z = item->pos.z,
     };
-
-    GAME_VECTOR target = {
-        .pos = {
-            .x = target_item->pos.x,
-            .y = target_item->pos.y - STEP_L * 3,
-            .z = target_item->pos.z,
-        },
-        .room_num = target_item->room_num,
+    const XYZ_32 target = {
+        .x = target_item->pos.x,
+        .y = target_item->pos.y - STEP_L * 3,
+        .z = target_item->pos.z,
     };
-
     Gun_SmashItems(start, target);
+
     return is_targetable;
 }

--- a/src/tr2/game/gun/gun_misc.c
+++ b/src/tr2/game/gun/gun_misc.c
@@ -3,6 +3,7 @@
 #include "game/gun/gun.h"
 #include "game/los.h"
 #include "game/objects/general/window.h"
+#include "game/objects/vars.h"
 #include "game/output.h"
 #include "game/random.h"
 #include "game/spawn.h"
@@ -181,7 +182,8 @@ int32_t Gun_FireWeapon(
         hit_pos.room_num =
             Room_GetIndexFromPos(hit_pos.pos.x, hit_pos.pos.y, hit_pos.pos.z);
         const bool object_on_los = LOS_Check(&start, &hit_pos);
-        if (!Gun_SmashItems(start, hit_pos) && !object_on_los) {
+        if (Gun_SmashItems(start, hit_pos) == PROJECTILE_HIT_NONE
+            && !object_on_los) {
             Spawn_Ricochet(&hit_pos);
         }
         return -1;
@@ -204,9 +206,9 @@ int32_t Gun_FireWeapon(
     }
 }
 
-bool Gun_SmashItems(const GAME_VECTOR start, const GAME_VECTOR target)
+PROJECTILE_HIT Gun_SmashItems(const GAME_VECTOR start, const GAME_VECTOR target)
 {
-    bool broken = false;
+    int32_t hits = 0;
     int16_t last_item_num = NO_ITEM;
     while (true) {
         const int16_t item_num = LOS_CheckSmashable(&start, &target);
@@ -215,14 +217,14 @@ bool Gun_SmashItems(const GAME_VECTOR start, const GAME_VECTOR target)
         }
         last_item_num = item_num;
         M_SmashItem(item_num);
-        broken = true;
+        hits++;
 
         const ITEM *const item = Item_Get(item_num);
-        if (item->object_id == O_BELL) {
-            break;
+        if (Object_IsType(item->object_id, g_SmashableObjects)) {
+            return PROJECTILE_HIT_STOP;
         }
     }
-    return broken;
+    return hits > 0 ? PROJECTILE_HIT_SHATTER : PROJECTILE_HIT_NONE;
 }
 
 void Gun_HitTarget(

--- a/src/tr2/game/gun/gun_misc.c
+++ b/src/tr2/game/gun/gun_misc.c
@@ -182,7 +182,7 @@ int32_t Gun_FireWeapon(
         hit_pos.room_num =
             Room_GetIndexFromPos(hit_pos.pos.x, hit_pos.pos.y, hit_pos.pos.z);
         const bool object_on_los = LOS_Check(&start, &hit_pos);
-        if (Gun_SmashItems(start, hit_pos) == PROJECTILE_HIT_NONE
+        if (Gun_SmashItems(start.pos, hit_pos.pos) == PROJECTILE_HIT_NONE
             && !object_on_los) {
             Spawn_Ricochet(&hit_pos);
         }
@@ -198,7 +198,7 @@ int32_t Gun_FireWeapon(
             view_pos.z + ((best_dist * g_MatrixPtr->_22) >> W2V_SHIFT);
         hit_pos.room_num =
             Room_GetIndexFromPos(hit_pos.pos.x, hit_pos.pos.y, hit_pos.pos.z);
-        Gun_SmashItems(start, hit_pos);
+        Gun_SmashItems(start.pos, hit_pos.pos);
         Gun_HitTarget(
             target, &hit_pos,
             winfo->damage * (Game_IsBonusFlagSet(GBF_JAPANESE) ? 2 : 1));
@@ -206,12 +206,12 @@ int32_t Gun_FireWeapon(
     }
 }
 
-PROJECTILE_HIT Gun_SmashItems(const GAME_VECTOR start, const GAME_VECTOR target)
+PROJECTILE_HIT Gun_SmashItems(const XYZ_32 target, const XYZ_32 start)
 {
     int32_t hits = 0;
     int16_t last_item_num = NO_ITEM;
     while (true) {
-        const int16_t item_num = LOS_CheckSmashable(&start, &target);
+        const int16_t item_num = LOS_CheckSmashable(start, target);
         if (item_num == NO_ITEM || item_num == last_item_num) {
             break;
         }

--- a/src/tr2/game/gun/gun_misc.h
+++ b/src/tr2/game/gun/gun_misc.h
@@ -19,5 +19,4 @@ typedef enum {
 
 void Gun_GetNewTarget(const WEAPON_INFO *winfo);
 void Gun_HitTarget(ITEM *item, const GAME_VECTOR *hit_pos, int32_t damage);
-bool Gun_SmashItems(GAME_VECTOR start, GAME_VECTOR target);
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, int32_t clip);

--- a/src/tr2/game/los.c
+++ b/src/tr2/game/los.c
@@ -10,6 +10,107 @@
 static int32_t m_LOSRooms[200] = {};
 static int32_t m_LOSNumRooms = 0;
 
+static bool M_ItemIntersectSegment(
+    XYZ_32 start, XYZ_32 target, const ITEM *item);
+
+// This routine transforms the world-space LOS segment [start,target] into the
+// object's local coordinates (undoing its translation and Y-rotation), then
+// performs a slab intersection test against that local AABB. The first
+// smashable item hit is returned, or NO_ITEM if none.
+//
+// (AABB = Axis-Aligned Bounding Box. It's the rectangular box defined by
+// bounds->min/max along X,Y,Z in the object's local space (no rotation).)
+//
+// @param start  World-space ray origin
+// @param target World-space ray end
+// @param item   Item to check
+// @return       Whether the item collides with the segment
+static bool M_ItemIntersectSegment(
+    const XYZ_32 start, const XYZ_32 target, const ITEM *const item)
+{
+    const double dx = target.x - start.x;
+    const double dy = target.y - start.y;
+    const double dz = target.z - start.z;
+
+    // Translate into object-local space
+    const double ox = start.x - item->pos.x;
+    const double oy = start.y - item->pos.y;
+    const double oz = start.z - item->pos.z;
+
+    // Unrotate by -rot.y around Y axis
+    const float c = cosf(-item->rot.y * M_PI / DEG_180);
+    const float s = sinf(-item->rot.y * M_PI / DEG_180);
+    const double lx = ox * c + oz * s;
+    const double ly = oy;
+    const double lz = oz * c - ox * s;
+    const double ldx = dx * c + dz * s;
+    const double ldy = dy;
+    const double ldz = dz * c - dx * s;
+
+    // Local AABB extents from item's bounds
+    const BOUNDS_16 *const orig_bounds = Item_GetBoundsAccurate(item);
+    BOUNDS_16 patched_bounds = *orig_bounds;
+
+    const BOUNDS_16 *const bounds = &patched_bounds;
+
+    // Parametric interval [t0..t1] in Q14 fixed-point
+    double t0 = 0.0;
+    double t1 = 1.0;
+
+    // X slab
+    if (ldx != 0) {
+        double tmp;
+        double t_near = (double)(bounds->min.x - lx) / ldx;
+        double t_far = (double)(bounds->max.x - lx) / ldx;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far, tmp);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (lx < bounds->min.x || lx > bounds->max.x) {
+        return false;
+    }
+
+    // Y slab
+    if (ldy != 0) {
+        double tmp;
+        double t_near = (double)(bounds->min.y - ly) / ldy;
+        double t_far = (double)(bounds->max.y - ly) / ldy;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far, tmp);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (ly < bounds->min.y || ly > bounds->max.y) {
+        return false;
+    }
+
+    // Z slab
+    if (ldz != 0) {
+        double tmp;
+        double t_near = (double)(bounds->min.z - lz) / ldz;
+        double t_far = (double)(bounds->max.z - lz) / ldz;
+        if (t_near > t_far) {
+            SWAP(t_near, t_far, tmp);
+        }
+        if (t_near > t1 || t_far < t0) {
+            return false;
+        }
+        CLAMPL(t0, t_near);
+        CLAMPG(t1, t_far);
+    } else if (lz < bounds->min.z || lz > bounds->max.z) {
+        return false;
+    }
+
+    return true;
+}
+
 int32_t LOS_CheckX(const GAME_VECTOR *const start, GAME_VECTOR *const target)
 {
     const int32_t dx = target->x - start->x;
@@ -287,25 +388,15 @@ bool LOS_Check(const GAME_VECTOR *const start, GAME_VECTOR *const target)
     return false;
 }
 
-// This routine transforms the world-space LOS segment [start,target] into the
-// object's local coordinates (undoing its translation and Y-rotation), then
-// performs a slab intersection test against that local AABB. The first
-// smashable item hit is returned, or NO_ITEM if none.
-//
-// (AABB = Axis-Aligned Bounding Box. It's the rectangular box defined by
-// bounds->min/max along X,Y,Z in the object's local space (no rotation).)
+// Smashes all objects along the ray path.
 //
 // @param start  World-space ray origin
 // @param target World-space ray end
 // @return       First smashable item's index, or NO_ITEM if none hit
-int32_t LOS_CheckSmashable(
-    const GAME_VECTOR *const start, const GAME_VECTOR *const target)
+int32_t LOS_CheckSmashable(const XYZ_32 start, const XYZ_32 target)
 {
     int32_t best_dist;
     int16_t best_item_num = NO_ITEM;
-    const int32_t dx = target->x - start->x;
-    const int32_t dy = target->y - start->y;
-    const int32_t dz = target->z - start->z;
 
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
         const ITEM *const item = Item_Get(item_num);
@@ -317,80 +408,12 @@ int32_t LOS_CheckSmashable(
             continue;
         }
 
-        // Translate into object-local space
-        const int32_t ox = start->x - item->pos.x;
-        const int32_t oy = start->y - item->pos.y;
-        const int32_t oz = start->z - item->pos.z;
-        // Unrotate by -rot.y around Y axis
-        const int32_t c = Math_Cos(item->rot.y);
-        const int32_t s = Math_Sin(item->rot.y);
-        const int32_t lx = ((ox * c) + (oz * s)) >> W2V_SHIFT;
-        const int32_t ly = oy;
-        const int32_t lz = ((-ox * s) + (oz * c)) >> W2V_SHIFT;
-        const int32_t ldx = ((dx * c) + (dz * s)) >> W2V_SHIFT;
-        const int32_t ldy = dy;
-        const int32_t ldz = (((-dx * s) + (dz * c))) >> W2V_SHIFT;
-
-        // Local AABB extents from item's bounds
-        const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
-
-        // Parametric interval [t0..t1] in Q14 fixed-point
-        int32_t t0 = 0;
-        int32_t t1 = 1 << W2V_SHIFT;
-
-        // X slab
-        if (ldx != 0) {
-            int32_t tmp;
-            int32_t t_near = ((bounds->min.x - lx) << W2V_SHIFT) / ldx;
-            int32_t t_far = ((bounds->max.x - lx) << W2V_SHIFT) / ldx;
-            if (t_near > t_far) {
-                SWAP(t_near, t_far, tmp);
-            }
-            if (t_near > t1 || t_far < t0) {
-                continue;
-            }
-            CLAMPL(t0, t_near);
-            CLAMPG(t1, t_far);
-        } else if (lx < bounds->min.x || lx > bounds->max.x) {
-            continue;
-        }
-
-        // Y slab
-        if (ldy != 0) {
-            int32_t tmp;
-            int32_t t_near = ((bounds->min.y - ly) << W2V_SHIFT) / ldy;
-            int32_t t_far = ((bounds->max.y - ly) << W2V_SHIFT) / ldy;
-            if (t_near > t_far) {
-                SWAP(t_near, t_far, tmp);
-            }
-            if (t_near > t1 || t_far < t0) {
-                continue;
-            }
-            CLAMPL(t0, t_near);
-            CLAMPG(t1, t_far);
-        } else if (ly < bounds->min.y || ly > bounds->max.y) {
-            continue;
-        }
-
-        // Z slab
-        if (ldz != 0) {
-            int32_t tmp;
-            int32_t t_near = ((bounds->min.z - lz) << W2V_SHIFT) / ldz;
-            int32_t t_far = ((bounds->max.z - lz) << W2V_SHIFT) / ldz;
-            if (t_near > t_far) {
-                SWAP(t_near, t_far, tmp);
-            }
-            if (t_near > t1 || t_far < t0) {
-                continue;
-            }
-            CLAMPL(t0, t_near);
-            CLAMPG(t1, t_far);
-        } else if (lz < bounds->min.z || lz > bounds->max.z) {
+        if (!M_ItemIntersectSegment(start, target, item)) {
             continue;
         }
 
         // Ray segment intersects the object's local AABB
-        const int32_t dist = Item_GetDistance(item, &start->pos);
+        const int32_t dist = Item_GetDistance(item, &start);
         if (best_item_num == NO_ITEM || dist < best_dist) {
             best_dist = dist;
             best_item_num = item_num;

--- a/src/tr2/game/los.c
+++ b/src/tr2/game/los.c
@@ -312,7 +312,8 @@ int32_t LOS_CheckSmashable(
         if (item->status == IS_DEACTIVATED) {
             continue;
         }
-        if (!Object_IsType(item->object_id, g_SmashableObjects)) {
+        if (!Object_IsType(item->object_id, g_SmashableObjects)
+            && !Object_IsType(item->object_id, g_ShatterableObjects)) {
             continue;
         }
 

--- a/src/tr2/game/los.h
+++ b/src/tr2/game/los.h
@@ -7,4 +7,4 @@ int32_t LOS_CheckX(const GAME_VECTOR *start, GAME_VECTOR *target);
 int32_t LOS_CheckZ(const GAME_VECTOR *start, GAME_VECTOR *target);
 int32_t LOS_ClipTarget(
     const GAME_VECTOR *start, GAME_VECTOR *target, const SECTOR *sector);
-int32_t LOS_CheckSmashable(const GAME_VECTOR *start, const GAME_VECTOR *target);
+int32_t LOS_CheckSmashable(XYZ_32 start, XYZ_32 target);

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -42,7 +42,10 @@ static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
 
-    const XYZ_32 old_pos = item->pos;
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     item->speed--;
     if (item->speed < M_FALL_SPEED) {
@@ -70,6 +73,14 @@ static void M_Control(const int16_t item_num)
         explode = true;
     }
 
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+    if (Gun_SmashItems(old_pos, new_pos) == PROJECTILE_HIT_STOP) {
+        explode = true;
+    }
+
     for (int16_t target_item_num = Room_Get(item->room_num)->item_num;
          target_item_num != NO_ITEM;
          target_item_num = Item_Get(target_item_num)->next_item) {
@@ -82,14 +93,12 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        const bool is_window = target_item->object_id == O_WINDOW_1;
-        if (!is_window
-            && (!target_obj->intelligent || target_item->status == IS_INVISIBLE
-                || target_obj->collision_func == nullptr)) {
+        if ((!target_obj->intelligent || target_item->status == IS_INVISIBLE
+             || target_obj->collision_func == nullptr)) {
             continue;
         }
 
-        if (!is_window && !Creature_IsTargetable(target_item)) {
+        if (!Creature_IsTargetable(target_item)) {
             continue;
         }
 
@@ -122,29 +131,25 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (is_window) {
-            Window_Smash(target_item_num);
-        } else {
-            explode = true;
+        explode = true;
 
-            if (!target_obj->intelligent || target_item->status != IS_ACTIVE) {
-                continue;
-            }
+        if (!target_obj->intelligent || target_item->status != IS_ACTIVE) {
+            continue;
+        }
 
-            Gun_HitTarget(target_item, nullptr, 30);
-            Stats_AddAmmoHits();
+        Gun_HitTarget(target_item, nullptr, 30);
+        Stats_AddAmmoHits();
 
-            if (target_item->hit_points <= 0) {
-                if (target_item->object_id != O_DRAGON_FRONT
-                    && target_item->object_id != O_BIRD_GUARDIAN) {
-                    Creature_Die(target_item_num, true);
-                }
+        if (target_item->hit_points <= 0) {
+            if (target_item->object_id != O_DRAGON_FRONT
+                && target_item->object_id != O_BIRD_GUARDIAN) {
+                Creature_Die(target_item_num, true);
             }
         }
     }
 
     if (explode) {
-        M_Explode(item_num, old_pos);
+        M_Explode(item_num, old_pos.pos);
     }
 }
 

--- a/src/tr2/game/objects/general/grenade.c
+++ b/src/tr2/game/objects/general/grenade.c
@@ -41,11 +41,7 @@ static void M_Setup(OBJECT *const obj)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-
-    const GAME_VECTOR old_pos = {
-        .pos = item->pos,
-        .room_num = item->room_num,
-    };
+    const XYZ_32 old_pos = item->pos;
 
     item->speed--;
     if (item->speed < M_FALL_SPEED) {
@@ -73,11 +69,7 @@ static void M_Control(const int16_t item_num)
         explode = true;
     }
 
-    const GAME_VECTOR new_pos = {
-        .pos = item->pos,
-        .room_num = item->room_num,
-    };
-    if (Gun_SmashItems(old_pos, new_pos) == PROJECTILE_HIT_STOP) {
+    if (Gun_SmashItems(old_pos, item->pos) == PROJECTILE_HIT_STOP) {
         explode = true;
     }
 
@@ -149,7 +141,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (explode) {
-        M_Explode(item_num, old_pos.pos);
+        M_Explode(item_num, old_pos);
     }
 }
 

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -1,5 +1,6 @@
 #include "game/gun/gun_misc.h"
 #include "game/objects/general/window.h"
+#include "game/objects/vars.h"
 #include "game/spawn.h"
 #include "game/stats.h"
 #include "global/vars.h"
@@ -18,15 +19,14 @@ static void M_Setup(OBJECT *const obj)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     if (!(Room_Get(item->room_num)->flags & RF_UNDERWATER)) {
         item->fall_speed += GRAVITY / 2;
     }
-
-    const XZ_32 old_pos = {
-        .x = item->pos.x,
-        .z = item->pos.z,
-    };
 
     item->pos.x += (item->speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
     item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
@@ -37,6 +37,15 @@ static void M_Control(const int16_t item_num)
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
     Item_UpdateRoom(item_num, room_num);
+
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+    bool hit = false;
+    if (Gun_SmashItems(old_pos, new_pos) == PROJECTILE_HIT_STOP) {
+        hit = true;
+    }
 
     for (int16_t target_num = Room_Get(item->room_num)->item_num;
          target_num != NO_ITEM; target_num = Item_Get(target_num)->next_item) {
@@ -51,14 +60,7 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        const bool is_window = target_item->object_id == O_WINDOW_1;
-        if (is_window
-            && (target_item->status == IS_INVISIBLE
-                || target_obj->collision_func == nullptr)) {
-            continue;
-        }
-
-        if (!is_window && !Creature_IsTargetable(target_item)) {
+        if (!Creature_IsTargetable(target_item)) {
             continue;
         }
 
@@ -94,25 +96,25 @@ static void M_Control(const int16_t item_num)
             continue;
         }
 
-        if (is_window) {
-            Window_Smash(target_num);
-        } else {
-            if (target_obj->intelligent && target_item->status == IS_ACTIVE) {
-                Spawn_BloodBath(
-                    item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,
-                    5);
-                Gun_HitTarget(
-                    target_item, nullptr, g_Weapons[LGT_HARPOON].damage);
-                Stats_AddAmmoHits();
-            }
-            Item_Kill(item_num);
-            return;
+        if (target_obj->intelligent && target_item->status == IS_ACTIVE) {
+            Spawn_BloodBath(
+                item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num, 5);
+            Gun_HitTarget(target_item, nullptr, g_Weapons[LGT_HARPOON].damage);
+            Stats_AddAmmoHits();
+        }
+        hit = true;
+        break;
+    }
+
+    if (!hit) {
+        const int32_t ceiling =
+            Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+        if (item->pos.y >= item->floor || item->pos.y <= ceiling) {
+            hit = true;
         }
     }
 
-    const int32_t ceiling =
-        Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
-    if (item->pos.y >= item->floor || item->pos.y <= ceiling) {
+    if (hit) {
         Item_Kill(item_num);
     } else if (Room_Get(item->room_num)->flags & RF_UNDERWATER) {
         Spawn_Bubble(&item->pos, item->room_num);

--- a/src/tr2/game/objects/general/harpoon_bolt.c
+++ b/src/tr2/game/objects/general/harpoon_bolt.c
@@ -19,10 +19,7 @@ static void M_Setup(OBJECT *const obj)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const GAME_VECTOR old_pos = {
-        .pos = item->pos,
-        .room_num = item->room_num,
-    };
+    const XYZ_32 old_pos = item->pos;
 
     if (!(Room_Get(item->room_num)->flags & RF_UNDERWATER)) {
         item->fall_speed += GRAVITY / 2;
@@ -38,12 +35,8 @@ static void M_Control(const int16_t item_num)
     item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
     Item_UpdateRoom(item_num, room_num);
 
-    const GAME_VECTOR new_pos = {
-        .pos = item->pos,
-        .room_num = item->room_num,
-    };
     bool hit = false;
-    if (Gun_SmashItems(old_pos, new_pos) == PROJECTILE_HIT_STOP) {
+    if (Gun_SmashItems(old_pos, item->pos) == PROJECTILE_HIT_STOP) {
         hit = true;
     }
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -154,9 +154,15 @@ const GAME_OBJECT_ID g_SecretObjects[] = {
     // clang-format on
 };
 
-const GAME_OBJECT_ID g_SmashableObjects[] = {
+const GAME_OBJECT_ID g_ShatterableObjects[] = {
     // clang-format off
     O_WINDOW_1,
+    NO_OBJECT,
+    // clang-format on
+};
+
+const GAME_OBJECT_ID g_SmashableObjects[] = {
+    // clang-format off
     O_BELL,
     NO_OBJECT,
     // clang-format on

--- a/src/tr2/game/objects/vars.h
+++ b/src/tr2/game/objects/vars.h
@@ -3,4 +3,5 @@
 #include <libtrx/game/objects/vars.h>
 
 extern const GAME_OBJECT_ID g_SecretObjects[];
+extern const GAME_OBJECT_ID g_ShatterableObjects[];
 extern const GAME_OBJECT_ID g_SmashableObjects[];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3551. Resolves #3379.

The grenades and harpoons will stop at the bell and go through all windows just like regular guns.

#### Testing

Windows on portals and not on portals, both sides, and the testing level
Trying to shoot through windows is something I had to provide a specific fix too.


https://github.com/user-attachments/assets/0fab3d42-80e0-4547-b4ab-9292e62d5df6

