### PR TITLE
tr1/objects/lava_wedge: set camera only when vulnerable

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed the texture page limit from 128 to unlimited (#3517)
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
+- fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)
 - improved object loading error messages when an invalid object ID is detected
 - removed the option in Unfinished Business to fix animated sprites as it is irrelevant there
 

--- a/src/tr1/game/objects/traps/lava_wedge.c
+++ b/src/tr1/game/objects/traps/lava_wedge.c
@@ -1,6 +1,7 @@
 #include "game/objects/common.h"
 #include "global/vars.h"
 
+#include <libtrx/config.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/lara.h>
 
@@ -65,6 +66,9 @@ static void M_Control(const int16_t item_num)
             Lara_TouchLava();
         }
 
+        if (g_Config.debug.enable_invulnerability) {
+            return;
+        }
         g_Camera.item = item;
         g_Camera.flags = CF_CHASE_OBJECT;
         g_Camera.type = CAM_FIXED;


### PR DESCRIPTION
Resolves #3578.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the camera doesn't stay locked on moving lava when Lara touches it while immune.
