### PR TITLE
Refactor event processing

### DIFF
--- a/src/libtrx/game/input/backends/controller.c
+++ b/src/libtrx/game/input/backends/controller.c
@@ -99,6 +99,10 @@ static SDL_GameControllerType m_ControllerType = SDL_CONTROLLER_TYPE_UNKNOWN;
 
 static bool m_Conflicts[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF] = {};
 
+// Internal controller state tables updated via SDL events
+static bool m_ButtonState[SDL_CONTROLLER_BUTTON_MAX] = {};
+static int16_t m_AxisState[SDL_CONTROLLER_AXIS_MAX] = {};
+
 static const char *M_GetButtonName(SDL_GameControllerButton button);
 static const char *M_GetAxisName(SDL_GameControllerAxis axis, int16_t axis_dir);
 
@@ -122,6 +126,7 @@ static void M_CheckConflicts(INPUT_LAYOUT layout);
 static SDL_GameController *M_FindController(void);
 
 static void M_Init(void);
+static void M_ProcessEvent(const SDL_Event *event);
 static void M_Shutdown(void);
 static void M_Discover(void);
 static bool M_CustomUpdate(INPUT_STATE *result, INPUT_LAYOUT layout);
@@ -226,27 +231,47 @@ static const char *M_GetButtonName(const SDL_GameControllerButton button)
     }
 }
 
+// Update internal controller button/axis state from SDL events.
+// @param event     Event to process.
+static void M_ProcessEvent(const SDL_Event *const event)
+{
+    switch (event->type) {
+    case SDL_CONTROLLERBUTTONDOWN:
+        m_ButtonState[event->cbutton.button] = true;
+        break;
+    case SDL_CONTROLLERBUTTONUP:
+        m_ButtonState[event->cbutton.button] = false;
+        break;
+    case SDL_CONTROLLERAXISMOTION: {
+        const Sint16 value = event->caxis.value;
+        if (value < -SDL_JOYSTICK_AXIS_MAX / 2) {
+            m_AxisState[event->caxis.axis] = -1;
+        } else if (value > SDL_JOYSTICK_AXIS_MAX / 2) {
+            m_AxisState[event->caxis.axis] = 1;
+        } else {
+            m_AxisState[event->caxis.axis] = 0;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
 static bool M_JoyBtn(const SDL_GameControllerButton button)
 {
-    if (m_Controller == nullptr) {
+    if (m_Controller == nullptr || button == SDL_CONTROLLER_BUTTON_INVALID) {
         return false;
     }
-    return SDL_GameControllerGetButton(m_Controller, button);
+    return m_ButtonState[button];
 }
 
 static int16_t M_JoyAxis(const SDL_GameControllerAxis axis)
 {
-    if (m_Controller == nullptr) {
+    if (m_Controller == nullptr || axis == SDL_CONTROLLER_AXIS_INVALID) {
         return false;
     }
-    const Sint16 value = SDL_GameControllerGetAxis(m_Controller, axis);
-    if (value < -SDL_JOYSTICK_AXIS_MAX / 2) {
-        return -1;
-    }
-    if (value > SDL_JOYSTICK_AXIS_MAX / 2) {
-        return 1;
-    }
-    return 0;
+    return m_AxisState[axis];
 }
 
 static bool M_GetBindState(const INPUT_LAYOUT layout, const INPUT_ROLE role)
@@ -575,6 +600,7 @@ INPUT_BACKEND_IMPL g_Input_Controller = {
     .init = M_Init,
     .shutdown = M_Shutdown,
     .discover = M_Discover,
+    .process_event = M_ProcessEvent,
     .custom_update = M_CustomUpdate,
     .is_pressed = M_IsPressed,
     .is_role_conflicted = M_IsRoleConflicted,

--- a/src/libtrx/game/input/backends/keyboard.c
+++ b/src/libtrx/game/input/backends/keyboard.c
@@ -4,6 +4,7 @@
 
 #include <SDL2/SDL_keyboard.h>
 
+// Key state table updated via SDL events.
 #define KEY_DOWN(a) (m_KeyboardState[(a)])
 
 typedef struct {
@@ -11,7 +12,7 @@ typedef struct {
     SDL_Scancode scancode;
 } BUILTIN_KEYBOARD_LAYOUT;
 
-const Uint8 *m_KeyboardState = nullptr;
+static bool m_KeyboardState[SDL_NUM_SCANCODES] = {};
 static bool m_Conflicts[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF] = {};
 
 static BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayout[] = {
@@ -37,6 +38,7 @@ static void M_AssignConflict(
 static void M_CheckConflicts(INPUT_LAYOUT layout);
 
 static void M_Init(void);
+static void M_ProcessEvent(const SDL_Event *event);
 static bool M_CustomUpdate(INPUT_STATE *result, INPUT_LAYOUT layout);
 static bool M_IsPressed(INPUT_LAYOUT layout, INPUT_ROLE role);
 static bool M_IsRoleConflicted(INPUT_LAYOUT layout, INPUT_ROLE role);
@@ -48,6 +50,24 @@ static bool M_AssignToJSONObject(
     INPUT_LAYOUT layout, INPUT_ROLE role, JSON_OBJECT *bind_obj);
 static void M_ResetLayout(INPUT_LAYOUT layout);
 static bool M_ReadAndAssign(INPUT_LAYOUT layout, INPUT_ROLE role);
+
+// Update internal controller button/axis state from SDL events.
+// @param event     Event to process.
+static void M_ProcessEvent(const SDL_Event *const event)
+{
+    switch (event->type) {
+    case SDL_KEYDOWN:
+        if (!event->key.repeat) {
+            m_KeyboardState[event->key.keysym.scancode] = true;
+        }
+        break;
+    case SDL_KEYUP:
+        m_KeyboardState[event->key.keysym.scancode] = false;
+        break;
+    default:
+        break;
+    }
+}
 
 static const char *M_GetScancodeName(SDL_Scancode scancode)
 {
@@ -362,8 +382,6 @@ static void M_CheckConflicts(const INPUT_LAYOUT layout)
 
 static void M_Init(void)
 {
-    m_KeyboardState = SDL_GetKeyboardState(nullptr);
-
     // first, reset the roles to null
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
         m_Layout[INPUT_LAYOUT_DEFAULT][role] = SDL_SCANCODE_UNKNOWN;
@@ -463,6 +481,7 @@ INPUT_BACKEND_IMPL g_Input_Keyboard = {
     .init = M_Init,
     .shutdown = nullptr,
     .discover = nullptr,
+    .process_event = M_ProcessEvent,
     .custom_update = M_CustomUpdate,
     .is_pressed = M_IsPressed,
     .is_role_conflicted = M_IsRoleConflicted,

--- a/src/libtrx/game/input/common.c
+++ b/src/libtrx/game/input/common.c
@@ -242,6 +242,16 @@ bool Input_IsInListenMode(void)
     return m_ListenMode;
 }
 
+void Input_ProcessEvent(const SDL_Event *event)
+{
+    if (g_Input_Keyboard.process_event) {
+        g_Input_Keyboard.process_event(event);
+    }
+    if (g_Input_Controller.process_event) {
+        g_Input_Controller.process_event(event);
+    }
+}
+
 bool Input_AssignFromJSONObject(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
     JSON_OBJECT *const bind_obj)

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -52,6 +52,7 @@ static GF_COMMAND M_HandleOverride(void)
 
 static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
 {
+    Shell_ProcessEvents();
     Console_Control();
     Overlay_Control();
 

--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -117,7 +117,6 @@ static void M_End(PHASE *const phase)
 static PHASE_CONTROL M_Control(PHASE *const phase, int32_t const num_frames)
 {
     M_PRIV *const p = phase->priv;
-
     Input_Update();
     Shell_ProcessInput();
 

--- a/src/libtrx/game/phase/phase_picture.c
+++ b/src/libtrx/game/phase/phase_picture.c
@@ -49,7 +49,6 @@ static void M_End(PHASE *const phase)
 static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
 {
     M_PRIV *const p = phase->priv;
-
     Input_Update();
     Shell_ProcessInput();
 

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -3,6 +3,7 @@
 #include "engine/audio.h"
 #include "game/console/common.h"
 #include "game/fmv.h"
+#include "game/input/common.h"
 #include "game/shell.h"
 #include "game/ui.h"
 
@@ -181,6 +182,7 @@ void Shell_ProcessEvents(void)
 {
     SDL_Event event;
     while (SDL_PollEvent(&event) != 0) {
+        Input_ProcessEvent(&event);
         if (M_ProcessEvent(&event)) {
             continue;
         }

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -354,7 +354,6 @@ static UI_CONTROLS_CHOICE M_NavigateInputs(UI_CONTROLS_EDITOR_STATE *const s)
 static UI_CONTROLS_CHOICE M_NavigateInputsDebounce(
     UI_CONTROLS_EDITOR_STATE *const s)
 {
-    Shell_ProcessEvents();
     Input_Update();
     if (g_Input.any) {
         return UI_CONTROLS_CHOICE_NOOP;

--- a/src/libtrx/include/libtrx/game/input/backends/base.h
+++ b/src/libtrx/include/libtrx/game/input/backends/base.h
@@ -2,11 +2,14 @@
 
 #include "../common.h"
 
+#include <SDL2/SDL.h>
+
 typedef struct {
     void (*init)(void);
     void (*shutdown)(void);
     void (*discover)(void);
     bool (*custom_update)(INPUT_STATE *result, INPUT_LAYOUT layout);
+    void (*process_event)(const SDL_Event *event);
     bool (*is_pressed)(INPUT_LAYOUT layout, INPUT_ROLE role);
     bool (*is_role_conflicted)(INPUT_LAYOUT layout, INPUT_ROLE role);
     const char *(*get_name)(INPUT_LAYOUT layout, INPUT_ROLE role);

--- a/src/libtrx/include/libtrx/game/input/common.h
+++ b/src/libtrx/include/libtrx/game/input/common.h
@@ -2,6 +2,7 @@
 
 #include "../../json.h"
 
+#include <SDL2/SDL.h>
 #include <stdint.h>
 
 typedef enum {
@@ -42,6 +43,10 @@ void Input_Init(void);
 void Input_Shutdown(void);
 void Input_Discover(void);
 void Input_Update(void);
+
+// Processes a SDL event to update global input state before polling.
+// @param event     Event to process.
+void Input_ProcessEvent(const SDL_Event *event);
 
 // Checks whether the given role can be assigned to by the player.
 // Hard-coded roles are exempt from conflict checks (eg will never flash in the

--- a/src/tr1/game/fmv.c
+++ b/src/tr1/game/fmv.c
@@ -115,6 +115,7 @@ static bool M_Play(const char *const file_path)
 
     Video_Start(video);
     while (video->is_playing) {
+        Shell_ProcessEvents();
         Video_SetVolume(
             video, Audio_IsMuted() ? 0.0f : g_Config.audio.sound_volume);
         Video_SetSurfaceSize(
@@ -122,7 +123,6 @@ static bool M_Play(const char *const file_path)
             Viewport_GetHeight(VIEWPORT_GAME));
         Video_SetSurfacePixelFormat(video, AV_PIX_FMT_BGRA);
         Video_PumpEvents(video);
-        Shell_ProcessEvents();
 
         Input_Update();
         Shell_ProcessInput();

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -26,6 +26,7 @@
 
 #define FRAME_BUFFER(key)                                                      \
     do {                                                                       \
+        Shell_ProcessEvents();                                                 \
         Output_BeginScene();                                                   \
         Game_Draw(true);                                                       \
         Input_Update();                                                        \

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -547,7 +547,6 @@ void Output_EndScene(void)
     M_EnableDepthTest();
     GFX_3D_Renderer_RenderEnd(m_Renderer3D);
     M_FlipScreen();
-    Shell_ProcessEvents();
 }
 
 void Output_ClearDepthBuffer(void)

--- a/src/tr2/game/fmv.c
+++ b/src/tr2/game/fmv.c
@@ -134,6 +134,7 @@ static bool M_Play(const char *const file_name)
 
     Video_Start(video);
     while (video->is_playing) {
+        Shell_ProcessEvents();
         Video_SetVolume(
             video, Audio_IsMuted() ? 0.0f : g_Config.audio.sound_volume);
 
@@ -148,7 +149,6 @@ static bool M_Play(const char *const file_name)
         }
 
         Video_PumpEvents(video);
-        Shell_ProcessEvents();
 
         Input_Update();
         Shell_ProcessInput();

--- a/src/tr2/game/input.c
+++ b/src/tr2/game/input.c
@@ -134,7 +134,7 @@ void Input_Update(void)
     g_InputDB = Input_GetDebounced(g_Input);
 
     if (Input_IsInListenMode()) {
-        g_Input = (INPUT_STATE) {};
-        g_InputDB = (INPUT_STATE) {};
+        g_Input.any = 0;
+        g_InputDB.any = 0;
     }
 }

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -347,7 +347,6 @@ static GF_COMMAND M_Control(INV_RING *const ring)
     }
 
     InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-    Shell_ProcessEvents();
     Input_Update();
     Shell_ProcessInput();
     Game_ProcessInput();

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -672,7 +672,6 @@ void Output_EndScene(void)
 {
     Render_EndScene();
     GFX_Context_SwapBuffers();
-    Shell_ProcessEvents();
 }
 
 BACKGROUND_TYPE Output_GetBackgroundType(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR refactors event processing so that it has fewer call sites – the event pumping happens just before calling the control routine in a phase.
I can't think of any regression this might create, but it's good to test the game for weird scenarios.

Another big part is that we no longer update the inputs via SDL calls, and instead source the inputs from event processing. Again, this shouldn't affect anything, but it's good to test weird inputs – frame buffering, forbidden QWOP techniques, remapping the inputs, keyboard and controller control methods and anything that comes to your mind that goes beyond basic playing.

The purpose of all this is to make it easier to implement automated test playthroughs which I'm planning to work on next.