### PR TITLE
tr1/data: remove PC demo injections

### DIFF
--- a/data/tr1/ship/cfg/tr1-demo-pc/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-demo-pc/gameflow.json5
@@ -50,10 +50,6 @@
                 {"type": "level_stats"},
                 {"type": "level_complete"},
             ],
-            "injections": [
-                "data/injections/vilcabamba_itemrots.bin",
-                "data/injections/vilcabamba_textures.bin",
-            ],
             "demo": true,
         },
     ],


### PR DESCRIPTION
Resolves #3587.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes targeted retail injections from being loaded in the PC demo as they do not apply anyway given there are fundamental differences between the levels.
