### PR TITLE
Config API updates

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -8,6 +8,7 @@
 - changed the game flow and game strings file placement
 - changed the skybox option to allow toggling in-game without the need to reload the level
 - changed the texture page limit from 128 to unlimited (#3517)
+- changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
 - fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added an option to animate the algae in 40 Fathoms, Wreck of the Maria Doria and The Deck (Gameplay settings → Fixes → Fix sprite animations) (#3141)
 - changed the game flow and game strings file placement
 - changed the texture page limit from 128 to unlimited (#3517)
+- changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -4,11 +4,11 @@
 #include "config/priv.h"
 #include "config/vars.h"
 #include "debug.h"
+#include "enum_map.h"
 #include "game/shell.h"
 #include "memory.h"
+#include "strings.h"
 #include "vector.h"
-
-#include <string.h>
 
 typedef enum {
     CFT_DEFAULT,
@@ -217,6 +217,40 @@ bool Config_RestoreOptionDefault(const void *const target)
     }
     }
     return false;
+}
+
+const char *Config_GetOptionValueAsString(const CONFIG_OPTION *const option)
+{
+    if (option == nullptr) {
+        return nullptr;
+    }
+    switch (option->type) {
+    case COT_BOOL:
+        return String_FormatStatic("%d", *(bool *)option->target);
+    case COT_INVERTED_BOOL:
+        return String_FormatStatic("%d", !*(bool *)option->target);
+    case COT_INT32:
+        return String_FormatStatic("%d", *(int32_t *)option->target);
+    case COT_FLOAT:
+        return String_FormatStatic("%.2f", *(float *)option->target);
+    case COT_FLOAT_PERCENT:
+        return String_FormatStatic(
+            "%.0f%%", (*(float *)option->target) * 100.0f);
+    case COT_DOUBLE:
+        return String_FormatStatic("%.2f", *(double *)option->target);
+    case COT_ENUM:
+        return String_FormatStatic(
+            "%s", EnumMap_ToString(option->param, *(int32_t *)option->target));
+    case COT_RGB888: {
+        const RGB_888 *color = option->target;
+        return String_FormatStatic(
+            "%02hhx%02hhx%02hhx", color->r, color->g, color->b);
+    }
+    case COT_STRING:
+        return String_FormatStatic("%s", *(char **)option->target);
+    default:
+        return nullptr;
+    }
 }
 
 bool Config_SetOptionValueFromString(

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -90,6 +90,7 @@ bool Config_Update(void)
         return false;
     }
 
+    g_Config.dirty = false;
     if (m_EventManager != nullptr) {
         const EVENT event = {
             .name = "change",

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -86,9 +86,11 @@ bool Config_Read(void)
 bool Config_Update(void)
 {
     Config_Sanitize();
-    if (!Config_Write()) {
+    if (memcmp(&g_Config, &g_SavedConfig, sizeof(CONFIG)) == 0) {
         return false;
     }
+
+    Config_Write();
 
     if (m_EventManager != nullptr) {
         const EVENT event = {

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -90,8 +90,6 @@ bool Config_Update(void)
         return false;
     }
 
-    Config_Write();
-
     if (m_EventManager != nullptr) {
         const EVENT event = {
             .name = "change",

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -83,27 +83,33 @@ bool Config_Read(void)
     return result;
 }
 
-bool Config_Write(void)
+bool Config_Update(void)
 {
     Config_Sanitize();
+    if (!Config_Write()) {
+        return false;
+    }
+
+    if (m_EventManager != nullptr) {
+        const EVENT event = {
+            .name = "change",
+            .sender = nullptr,
+            .data = nullptr,
+        };
+        EventManager_Fire(m_EventManager, &event);
+    }
+    g_SavedConfig = g_Config;
+    return true;
+}
+
+bool Config_Write(void)
+{
     const CONFIG_IO_ARGS args = {
         .default_path = M_GetPath(CFT_DEFAULT),
         .enforced_path = M_GetPath(CFT_ENFORCED),
         .action = &Config_DumpToJSON,
     };
-    const bool updated = ConfigFile_Write(&args);
-    if (updated) {
-        if (m_EventManager != nullptr) {
-            const EVENT event = {
-                .name = "change",
-                .sender = nullptr,
-                .data = nullptr,
-            };
-            EventManager_Fire(m_EventManager, &event);
-        }
-        g_SavedConfig = g_Config;
-    }
-    return updated;
+    return ConfigFile_Write(&args);
 }
 
 int32_t Config_SubscribeChanges(

--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -33,6 +33,12 @@ static const char *M_GetPath(const CONFIG_FILE_TYPE file_type)
 void Config_Init(void)
 {
     m_EventManager = EventManager_Create();
+
+    const CONFIG_OPTION *option = Config_GetOptionMap();
+    while (option->target != nullptr) {
+        Config_RestoreOptionDefault(option->target);
+        option++;
+    }
 }
 
 void Config_Shutdown(void)

--- a/src/libtrx/config/file.c
+++ b/src/libtrx/config/file.c
@@ -26,7 +26,6 @@ static void M_PreserveEnforcedState(
 static char *M_WriteToJSON(
     void (*dump)(JSON_OBJECT *root_obj), const char *old_data,
     const char *enf_data);
-static const char *M_ResolveOptionName(const char *option_name);
 
 static JSON_VALUE *M_ReadRoot(const char *const cfg_data)
 {
@@ -74,13 +73,9 @@ static bool M_ReadFromJSON(
         const JSON_OBJECT_ELEMENT *elem = enforced_config->start;
         while (elem != nullptr) {
             const char *const name = elem->name->string;
-            const CONFIG_OPTION *opt = Config_GetOptionMap();
-            while (opt->target != nullptr) {
-                if (strcmp(M_ResolveOptionName(opt->name), name) == 0) {
-                    Vector_Add(enforced_targets, &opt->target);
-                    break;
-                }
-                opt++;
+            const CONFIG_OPTION *const opt = Config_GetOptionByPath(name);
+            if (opt != nullptr) {
+                Vector_Add(enforced_targets, &opt->target);
             }
             elem = elem->next;
         }
@@ -103,13 +98,9 @@ static bool M_ReadFromJSON(
                     M_HIDDEN_KEY);
                 continue;
             }
-            const CONFIG_OPTION *opt = Config_GetOptionMap();
-            while (opt->target != nullptr) {
-                if (strcmp(M_ResolveOptionName(opt->name), name) == 0) {
-                    Vector_Add(hidden_targets, &opt->target);
-                    break;
-                }
-                opt++;
+            const CONFIG_OPTION *const opt = Config_GetOptionByPath(name);
+            if (opt != nullptr) {
+                Vector_Add(hidden_targets, &opt->target);
             }
         }
     }
@@ -181,15 +172,6 @@ static char *M_WriteToJSON(
     return data;
 }
 
-static const char *M_ResolveOptionName(const char *option_name)
-{
-    const char *dot = strrchr(option_name, '.');
-    if (dot) {
-        return dot + 1;
-    }
-    return option_name;
-}
-
 bool ConfigFile_Read(const CONFIG_IO_ARGS *const args)
 {
     char *default_data = nullptr;
@@ -257,19 +239,19 @@ void ConfigFile_LoadOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
         switch (opt->type) {
         case COT_BOOL:
             *(bool *)opt->target = JSON_ObjectGetBool(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(bool *)opt->default_value);
             break;
 
         case COT_INVERTED_BOOL:
             *(bool *)opt->target = !JSON_ObjectGetBool(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(bool *)opt->default_value);
             break;
 
         case COT_INT32: {
-            JSON_VALUE *const value =
-                JSON_ObjectGetValue(root_obj, M_ResolveOptionName(opt->name));
+            JSON_VALUE *const value = JSON_ObjectGetValue(
+                root_obj, Config_ResolveOptionName(opt->name));
             bool success = false;
             if (value != nullptr && value->type == JSON_TYPE_NUMBER) {
                 *(int32_t *)opt->target =
@@ -288,25 +270,25 @@ void ConfigFile_LoadOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
         case COT_FLOAT:
         case COT_FLOAT_PERCENT:
             *(float *)opt->target = JSON_ObjectGetDouble(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(float *)opt->default_value);
             break;
 
         case COT_DOUBLE:
             *(double *)opt->target = JSON_ObjectGetDouble(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(double *)opt->default_value);
             break;
 
         case COT_ENUM:
             *(int *)opt->target = ConfigFile_ReadEnum(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(int *)opt->default_value, opt->param);
             break;
 
         case COT_STRING: {
             const char *const val = JSON_ObjectGetString(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 (const char *)opt->default_value);
             char **const p = (char **)opt->target;
             Memory_FreePointer(p);
@@ -316,8 +298,8 @@ void ConfigFile_LoadOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
 
         case COT_RGB888: {
             RGB_888 *const target = (RGB_888 *)opt->target;
-            JSON_VALUE *const value =
-                JSON_ObjectGetValue(root_obj, M_ResolveOptionName(opt->name));
+            JSON_VALUE *const value = JSON_ObjectGetValue(
+                root_obj, Config_ResolveOptionName(opt->name));
             bool success = false;
             if (value != nullptr && value->type == JSON_TYPE_NUMBER) {
                 const uint32_t rgb_value =
@@ -350,43 +332,44 @@ void ConfigFile_DumpOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
         switch (opt->type) {
         case COT_BOOL:
             JSON_ObjectAppendBool(
-                root_obj, M_ResolveOptionName(opt->name), *(bool *)opt->target);
+                root_obj, Config_ResolveOptionName(opt->name),
+                *(bool *)opt->target);
             break;
 
         case COT_INVERTED_BOOL:
             JSON_ObjectAppendBool(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 !*(bool *)opt->target);
             break;
 
         case COT_INT32:
             JSON_ObjectAppendInt(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(int32_t *)opt->target);
             break;
 
         case COT_FLOAT:
         case COT_FLOAT_PERCENT:
             JSON_ObjectAppendDouble(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(float *)opt->target);
             break;
 
         case COT_DOUBLE:
             JSON_ObjectAppendDouble(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(double *)opt->target);
             break;
 
         case COT_ENUM:
             ConfigFile_WriteEnum(
-                root_obj, M_ResolveOptionName(opt->name), *(int *)opt->target,
-                (const char *)opt->param);
+                root_obj, Config_ResolveOptionName(opt->name),
+                *(int *)opt->target, (const char *)opt->param);
             break;
 
         case COT_STRING:
             JSON_ObjectAppendString(
-                root_obj, M_ResolveOptionName(opt->name),
+                root_obj, Config_ResolveOptionName(opt->name),
                 *(char **)opt->target);
             break;
 
@@ -395,7 +378,7 @@ void ConfigFile_DumpOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
             char tmp[10];
             sprintf(tmp, "#%02X%02X%02X", color->r, color->g, color->b);
             JSON_ObjectAppendString(
-                root_obj, M_ResolveOptionName(opt->name), tmp);
+                root_obj, Config_ResolveOptionName(opt->name), tmp);
             break;
         }
         }

--- a/src/libtrx/config/map.c
+++ b/src/libtrx/config/map.c
@@ -83,3 +83,27 @@ const CONFIG_OPTION *Config_GetOptionMap(void)
 {
     return m_ConfigOptionMap;
 }
+
+const char *Config_ResolveOptionName(const char *option_name)
+{
+    const char *dot = strrchr(option_name, '.');
+    if (dot) {
+        return dot + 1;
+    }
+    return option_name;
+}
+
+const CONFIG_OPTION *Config_GetOptionByPath(const char *const path)
+{
+    if (path == nullptr) {
+        return nullptr;
+    }
+    for (const CONFIG_OPTION *opt = Config_GetOptionMap(); opt->name != nullptr;
+         opt++) {
+        if (strcmp(opt->name, path) == 0
+            || strcmp(Config_ResolveOptionName(opt->name), path) == 0) {
+            return opt;
+        }
+    }
+    return nullptr;
+}

--- a/src/libtrx/game/clock/common.c
+++ b/src/libtrx/game/clock/common.c
@@ -32,7 +32,6 @@ void Clock_Init(void)
 {
     m_Frequency = SDL_GetPerformanceFrequency();
     m_InitCounter = SDL_GetPerformanceCounter();
-    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
 }
 
 size_t Clock_GetDateTime(char *const buffer, const size_t size)

--- a/src/libtrx/game/clock/turbo.c
+++ b/src/libtrx/game/clock/turbo.c
@@ -26,7 +26,7 @@ void Clock_SetTurboSpeed(int32_t value)
         return;
     }
     g_Config.gameplay.turbo_speed = value;
-    Config_Write();
+    Config_Update();
     Console_Log(GS(OSD_SPEED_SET), value);
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
 }

--- a/src/libtrx/game/console/cmd/config.c
+++ b/src/libtrx/game/console/cmd/config.c
@@ -220,7 +220,7 @@ COMMAND_RESULT Console_Cmd_Config_Helper(
     if ((strcmp(new_value, "-") == 0
          && Config_RestoreOptionDefault(option->target))
         || Config_SetOptionValueFromString(option, new_value)) {
-        Config_Write();
+        Config_Update();
         const char *const value_str = Config_GetOptionValueAsString(option);
         ASSERT(value_str != nullptr);
         Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, value_str);

--- a/src/libtrx/game/console/cmd/config.c
+++ b/src/libtrx/game/console/cmd/config.c
@@ -187,58 +187,6 @@ char *Console_Cmd_Config_NormalizeKey(const char *key)
     return result;
 }
 
-bool Console_Cmd_Config_GetCurrentValue(
-    const CONFIG_OPTION *const option, char *target, const size_t target_size)
-{
-    if (option == nullptr) {
-        return false;
-    }
-
-    ASSERT(option->target != nullptr);
-    switch (option->type) {
-    case COT_BOOL:
-        snprintf(
-            target, target_size, "%s",
-            *(bool *)option->target ? GS(MISC_ON) : GS(MISC_OFF));
-        break;
-    case COT_INVERTED_BOOL:
-        snprintf(
-            target, target_size, "%s",
-            *(bool *)option->target ? GS(MISC_OFF) : GS(MISC_ON));
-        break;
-    case COT_INT32:
-        snprintf(target, target_size, "%d", *(int32_t *)option->target);
-        break;
-    case COT_FLOAT:
-        snprintf(target, target_size, "%.2f", *(float *)option->target);
-        break;
-    case COT_FLOAT_PERCENT:
-        snprintf(
-            target, target_size, "%.00f%%",
-            (*(float *)option->target) * 100.0f);
-        break;
-    case COT_DOUBLE:
-        snprintf(target, target_size, "%.2f", *(double *)option->target);
-        break;
-    case COT_ENUM:
-        snprintf(
-            target, target_size, "%s",
-            EnumMap_ToString(option->param, *(int32_t *)option->target));
-        break;
-    case COT_RGB888: {
-        const RGB_888 *color = option->target;
-        snprintf(
-            target, target_size, "%02hhx%02hhx%02hhx", color->r, color->g,
-            color->b);
-        break;
-    }
-    case COT_STRING:
-        snprintf(target, target_size, "%s", *(char **)option->target);
-        break;
-    }
-    return true;
-}
-
 const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromTarget(
     const void *const target)
 {
@@ -260,27 +208,22 @@ COMMAND_RESULT Console_Cmd_Config_Helper(
     char *normalized_name = Console_Cmd_Config_NormalizeKey(option->name);
 
     if (new_value == nullptr || String_IsEmpty(new_value)) {
-        char cur_value[128];
-        if (Console_Cmd_Config_GetCurrentValue(option, cur_value, 128)) {
-            Console_Log(GS(OSD_CONFIG_OPTION_GET), normalized_name, cur_value);
-            return CR_SUCCESS;
+        const char *const value_str = Config_GetOptionValueAsString(option);
+        if (value_str == nullptr) {
+            return CR_FAILURE;
         }
-        return CR_FAILURE;
+        Console_Log(GS(OSD_CONFIG_OPTION_GET), normalized_name, value_str);
+        return CR_SUCCESS;
     }
 
     COMMAND_RESULT result;
-    if (strcmp(new_value, "-") == 0
-        && Config_RestoreOptionDefault(option->target)) {
+    if ((strcmp(new_value, "-") == 0
+         && Config_RestoreOptionDefault(option->target))
+        || Config_SetOptionValueFromString(option, new_value)) {
         Config_Write();
-        char final_value[128];
-        ASSERT(Console_Cmd_Config_GetCurrentValue(option, final_value, 128));
-        Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, final_value);
-        result = CR_SUCCESS;
-    } else if (Config_SetOptionValueFromString(option, new_value)) {
-        Config_Write();
-        char final_value[128];
-        ASSERT(Console_Cmd_Config_GetCurrentValue(option, final_value, 128));
-        Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, final_value);
+        const char *const value_str = Config_GetOptionValueAsString(option);
+        ASSERT(value_str != nullptr);
+        Console_Log(GS(OSD_CONFIG_OPTION_SET), normalized_name, value_str);
         result = CR_SUCCESS;
     } else {
         // Report bad invocation on the provided new value

--- a/src/libtrx/game/console/cmd/debug.c
+++ b/src/libtrx/game/console/cmd/debug.c
@@ -54,7 +54,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_SUCCESS;
     } else if (String_Match(ctx->args, "^(off|false|0)$")) {
         M_Toggle(false);
-        Config_Write();
+        Config_Update();
         return CR_SUCCESS;
     } else if (String_IsEmpty(ctx->args)) {
         M_ShowStatus();

--- a/src/libtrx/game/console/cmd/debug.c
+++ b/src/libtrx/game/console/cmd/debug.c
@@ -26,9 +26,9 @@ static void M_Toggle(const bool enable)
             Console_Cmd_Config_GetOptionFromTarget(target);
         char *const name = Console_Cmd_Config_NormalizeKey(option->name);
         *(bool *)target = enable;
-        char value_repr[128];
-        ASSERT(Console_Cmd_Config_GetCurrentValue(option, value_repr, 128));
-        Console_Log(GS(OSD_CONFIG_OPTION_SET), name, value_repr);
+        const char *const value_str = Config_GetOptionValueAsString(option);
+        ASSERT(value_str != nullptr);
+        Console_Log(GS(OSD_CONFIG_OPTION_SET), name, value_str);
         Memory_Free(name);
     }
 }
@@ -40,9 +40,9 @@ static void M_ShowStatus(void)
         const CONFIG_OPTION *const option =
             Console_Cmd_Config_GetOptionFromTarget(target);
         char *const name = Console_Cmd_Config_NormalizeKey(option->name);
-        char value_repr[128];
-        ASSERT(Console_Cmd_Config_GetCurrentValue(option, value_repr, 128));
-        Console_Log(GS(OSD_CONFIG_OPTION_GET), name, value_repr);
+        const char *const value_str = Config_GetOptionValueAsString(option);
+        ASSERT(value_str != nullptr);
+        Console_Log(GS(OSD_CONFIG_OPTION_GET), name, value_str);
         Memory_Free(name);
     }
 }

--- a/src/libtrx/game/console/cmd/immune.c
+++ b/src/libtrx/game/console/cmd/immune.c
@@ -12,11 +12,13 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     bool enable;
     if (String_ParseBool(ctx->args, &enable)) {
         g_Config.debug.enable_invulnerability = enable;
+        Config_Update();
     } else if (!String_IsEmpty(ctx->args)) {
         return CR_BAD_INVOCATION;
     } else {
         g_Config.debug.enable_invulnerability =
             !g_Config.debug.enable_invulnerability;
+        Config_Update();
     }
 
     Console_Log(

--- a/src/libtrx/game/gym.c
+++ b/src/libtrx/game/gym.c
@@ -47,7 +47,7 @@ static bool M_StoreAssaultTime(const uint32_t time)
     assault->total_attempts++;
     assault->entries[insert_idx].time = time;
     assault->entries[insert_idx].attempt_num = assault->total_attempts;
-    Config_Write();
+    Config_Update();
     return true;
 }
 

--- a/src/libtrx/game/option/controls.c
+++ b/src/libtrx/game/option/controls.c
@@ -48,6 +48,7 @@ static void M_HandleLayoutChange(const EVENT *event, void *user_data)
 
 static void M_HandleKeyChange(const EVENT *event, void *user_data)
 {
+    g_Config.dirty = true;
     Config_Update();
 }
 

--- a/src/libtrx/game/option/controls.c
+++ b/src/libtrx/game/option/controls.c
@@ -43,12 +43,12 @@ static void M_HandleLayoutChange(const EVENT *event, void *user_data)
     const M_PRIV *const p = user_data;
     g_Config.input.layout[p->ui.state.backend] =
         p->ui.state.editor_state[p->ui.state.backend].active_layout;
-    Config_Write();
+    Config_Update();
 }
 
 static void M_HandleKeyChange(const EVENT *event, void *user_data)
 {
-    Config_Write();
+    Config_Update();
 }
 
 void Option_Controls_Control(INVENTORY_ITEM *const inv_item, const bool is_busy)

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -164,6 +164,7 @@ static void M_LoadPostprocess(void)
 #if TR_VERSION == 1
     if (Game_GetBonusFlag() != GBF_NONE) {
         g_Config.profile.new_game_plus_unlock = true;
+        Config_Update();
     }
     LOT_ClearLOT(&lara->lot);
 #endif

--- a/src/libtrx/game/shell/config.c
+++ b/src/libtrx/game/shell/config.c
@@ -122,7 +122,7 @@ void Shell_SyncFromWindow(const bool update_viewport)
         }
         if (g_Config.loaded) {
             m_IgnoreConfigChanges = true;
-            Config_Write();
+            Config_Update();
             m_IgnoreConfigChanges = false;
         }
     }

--- a/src/libtrx/game/shell/config.c
+++ b/src/libtrx/game/shell/config.c
@@ -136,6 +136,8 @@ void Shell_SyncFromWindow(const bool update_viewport)
 void Shell_HandleCommonConfigChange(
     const CONFIG *const old, const CONFIG *const new)
 {
+    Config_Write();
+
 #define L_CHANGED(subject) (old->subject != new->subject)
 
     if (L_CHANGED(audio.sound_volume)) {

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -52,11 +52,10 @@ static void M_SetupGL(void)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 }
 
-void Shell_LoadConfig(void)
+void Shell_InstallConfig(void)
 {
-    Config_Read();
     Config_SubscribeChanges(M_HandleConfigChange, nullptr);
-
+    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
     Sound_SetMasterVolume(g_Config.audio.sound_volume);
     Music_SetVolume(g_Config.audio.music_volume);
 }
@@ -84,9 +83,11 @@ void Shell_CommonInit(void)
     Random_Seed();
     Lara_Pose_Init();
 
-    Shell_LoadConfig();
     Clock_Init();
     LUA_Init();
+
+    Config_Read();
+    Shell_InstallConfig();
 }
 
 void Shell_ShutdownCommonModules(void)

--- a/src/libtrx/game/shell/input.c
+++ b/src/libtrx/game/shell/input.c
@@ -15,7 +15,7 @@ static void M_IncreaseUpscaling(void);
 static void M_ToggleFullscreen(void)
 {
     g_Config.window.is_fullscreen = !g_Config.window.is_fullscreen;
-    Config_Write();
+    Config_Update();
 }
 
 static void M_IncreaseBorders(void)
@@ -39,14 +39,14 @@ static void M_DecreaseBorders(void)
 static void M_DecreaseUpscaling(void)
 {
     g_Config.rendering.upscaling_factor--;
-    Config_Write();
+    Config_Update();
     Console_Log(GS(OSD_UPSCALING_FACTOR), g_Config.rendering.upscaling_factor);
 }
 
 static void M_IncreaseUpscaling(void)
 {
     g_Config.rendering.upscaling_factor++;
-    Config_Write();
+    Config_Update();
     Console_Log(GS(OSD_UPSCALING_FACTOR), g_Config.rendering.upscaling_factor);
 }
 

--- a/src/libtrx/game/ui/common.c
+++ b/src/libtrx/game/ui/common.c
@@ -179,7 +179,7 @@ void UI_Shutdown(void)
 void UI_ToggleState(bool *const config_setting)
 {
     *config_setting ^= true;
-    Config_Write();
+    Config_Update();
     Console_Log(*config_setting ? GS(OSD_UI_ON) : GS(OSD_UI_OFF));
 }
 

--- a/src/libtrx/game/ui/dialogs/controls.c
+++ b/src/libtrx/game/ui/dialogs/controls.c
@@ -53,7 +53,7 @@ bool UI_Controls_Control(UI_CONTROLS_STATE *const s)
             s->backend = choice;
             s->phase = M_PHASE_EDITOR;
             g_Config.input.backend = s->backend;
-            Config_Write();
+            Config_Update();
             break;
         }
         break;

--- a/src/libtrx/game/ui/dialogs/controls_editor.c
+++ b/src/libtrx/game/ui/dialogs/controls_editor.c
@@ -227,7 +227,7 @@ static void M_ResetLayout(void *const arg)
     Sound_Effect(SFX_MENU_SPINOUT, nullptr, SPM_NORMAL);
 #endif
     Input_ResetLayout(s->backend, s->active_layout);
-    Config_Write();
+    Config_Update();
 }
 
 static void M_UnbindKey(void *const arg)
@@ -239,7 +239,7 @@ static void M_UnbindKey(void *const arg)
     Sound_Effect(SFX_MENU_SPINOUT, nullptr, SPM_NORMAL);
 #endif
     Input_UnassignRole(s->backend, s->active_layout, s->active_role);
-    Config_Write();
+    Config_Update();
 }
 
 static bool M_CanResetLayout(const UI_CONTROLS_EDITOR_STATE *const s)

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -351,7 +351,7 @@ static bool M_RequestChangeValue(
 
     UI_Settings_RequestChange(option, dir);
 changed:
-    Config_Write();
+    Config_Update();
     return true;
 }
 
@@ -447,7 +447,7 @@ static void M_RestoreDefault(
     const UI_SETTINGS_OPTION *const option = M_GetOptionByRow(s, row_idx);
     if (option != nullptr) {
         Config_RestoreOptionDefault(option->target);
-        Config_Write();
+        Config_Update();
     }
 }
 

--- a/src/libtrx/include/libtrx/config/common.h
+++ b/src/libtrx/include/libtrx/config/common.h
@@ -11,6 +11,7 @@ void Config_Shutdown(void);
 
 bool Config_Read(void);
 bool Config_Write(void);
+bool Config_Update(void);
 
 const CONFIG_OPTION *Config_GetOptionMap(void);
 

--- a/src/libtrx/include/libtrx/config/common.h
+++ b/src/libtrx/include/libtrx/config/common.h
@@ -33,6 +33,10 @@ bool Config_IsOptionAtDefault(const void *target);
 // Restores the given setting's default value.
 bool Config_RestoreOptionDefault(const void *target);
 
+// Formats the current value of a config option as a static string.
+// The string must not be freed and is short lived.
+const char *Config_GetOptionValueAsString(const CONFIG_OPTION *option);
+
 // Updates the given setting's value from string.
 bool Config_SetOptionValueFromString(
     const CONFIG_OPTION *option, const char *new_value);

--- a/src/libtrx/include/libtrx/config/common.h
+++ b/src/libtrx/include/libtrx/config/common.h
@@ -33,6 +33,12 @@ bool Config_IsOptionAtDefault(const void *target);
 // Restores the given setting's default value.
 bool Config_RestoreOptionDefault(const void *target);
 
+// Get a flat string name of an option.
+const char *Config_ResolveOptionName(const char *option_name);
+
+// Retrieve an option given a string path.
+const CONFIG_OPTION *Config_GetOptionByPath(const char *path);
+
 // Formats the current value of a config option as a static string.
 // The string must not be freed and is short lived.
 const char *Config_GetOptionValueAsString(const CONFIG_OPTION *option);

--- a/src/libtrx/include/libtrx/config/types_tr1.h
+++ b/src/libtrx/include/libtrx/config/types_tr1.h
@@ -26,6 +26,10 @@ typedef struct {
     bool loaded;
     char *language;
 
+    // This field is used to force trigger a change event for fields that are
+    // not stored in the CONFIG struct.
+    bool dirty;
+
     struct {
         INPUT_BACKEND backend; // Not decisive - mostly for UI visuals
         union {

--- a/src/libtrx/include/libtrx/config/types_tr2.h
+++ b/src/libtrx/include/libtrx/config/types_tr2.h
@@ -30,6 +30,10 @@ typedef struct {
     bool loaded;
     char *language;
 
+    // This field is used to force trigger a change event for fields that are
+    // not stored in the CONFIG struct.
+    bool dirty;
+
     struct {
         INPUT_BACKEND backend; // Not decisive - mostly for UI visuals
         union {

--- a/src/libtrx/include/libtrx/game/console/cmd/config.h
+++ b/src/libtrx/include/libtrx/game/console/cmd/config.h
@@ -6,8 +6,6 @@
 #include <stddef.h>
 
 char *Console_Cmd_Config_NormalizeKey(const char *key);
-bool Console_Cmd_Config_GetCurrentValue(
-    const CONFIG_OPTION *option, char *target, size_t target_size);
 bool Console_Cmd_Config_SetCurrentValue(
     const CONFIG_OPTION *option, const char *new_value);
 const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromKey(const char *key);

--- a/src/libtrx/include/libtrx/game/shell/flow.h
+++ b/src/libtrx/include/libtrx/game/shell/flow.h
@@ -1,6 +1,6 @@
 #pragma once
 
 // TODO: inline these once we get common shell code
-void Shell_LoadConfig(void);
+void Shell_InstallConfig(void);
 void Shell_CommonInit(void);
 void Shell_ShutdownCommonModules(void);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -129,7 +129,7 @@ static DECLARE_GF_EVENT_HANDLER(M_HandleLevelComplete)
 
     if (current_level == GF_GetLastLevel()) {
         g_Config.profile.new_game_plus_unlock = true;
-        Config_Write();
+        Config_Update();
     }
     const bool bonus_level_unlock = Stats_CheckAllSecretsCollected(GFL_NORMAL);
 

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -309,8 +309,6 @@ int32_t Shell_Main(void)
         }
     }
 
-    Config_Write();
-
     if (m_Args.level_to_play != nullptr) {
         Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
     }

--- a/src/tr1/game/shell/input.c
+++ b/src/tr1/game/shell/input.c
@@ -24,7 +24,7 @@ void Shell_ProcessInput(void)
             break;
         }
 
-        Config_Write();
+        Config_Update();
     }
 
     if (g_InputDB.toggle_trapezoid_filter) {
@@ -33,7 +33,7 @@ void Shell_ProcessInput(void)
             g_Config.rendering.enable_trapezoid_filter
                 ? GS(OSD_TRAPEZOID_FILTER_ON)
                 : GS(OSD_TRAPEZOID_FILTER_OFF));
-        Config_Write();
+        Config_Update();
     }
 
     if (g_InputDB.toggle_fps_counter) {
@@ -41,6 +41,6 @@ void Shell_ProcessInput(void)
         Console_Log(
             g_Config.ui.enable_fps_counter ? GS(OSD_FPS_COUNTER_ON)
                                            : GS(OSD_FPS_COUNTER_OFF));
-        Config_Write();
+        Config_Update();
     }
 }

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -100,7 +100,7 @@ static DECLARE_GF_EVENT_HANDLER(M_HandleLevelComplete)
 
     if (current_level == GF_GetLastLevel()) {
         g_Config.profile.new_game_plus_unlock = true;
-        Config_Write();
+        Config_Update();
     }
 
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -292,6 +292,7 @@ int32_t Shell_Main(void)
     }
 
     Config_Write();
+
     if (m_Args.level_to_play != nullptr) {
         Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
     }

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -291,8 +291,6 @@ int32_t Shell_Main(void)
         }
     }
 
-    Config_Write();
-
     if (m_Args.level_to_play != nullptr) {
         Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
     }

--- a/src/tr2/game/shell/input.c
+++ b/src/tr2/game/shell/input.c
@@ -27,7 +27,7 @@ static void M_ToggleRenderingMode(void);
 static void M_ToggleFPSCounter(void)
 {
     g_Config.ui.enable_fps_counter = !g_Config.ui.enable_fps_counter;
-    Config_Write();
+    Config_Update();
     Console_Log(
         "%s",
         g_Config.ui.enable_fps_counter ? GS(OSD_FPS_COUNTER_ON)
@@ -39,7 +39,7 @@ static void M_ToggleBilinearFiltering(void)
     g_Config.rendering.texture_filter =
         g_Config.rendering.texture_filter == GFX_TF_BILINEAR ? GFX_TF_NN
                                                              : GFX_TF_BILINEAR;
-    Config_Write();
+    Config_Update();
     Console_Log(
         "%s",
         g_Config.rendering.texture_filter == GFX_TF_BILINEAR
@@ -54,7 +54,7 @@ static void M_TogglePerspectiveCorrection(void)
     g_PerspectiveDistance = g_Config.rendering.enable_perspective_filter
         ? SW_DETAIL_HIGH
         : SW_DETAIL_MEDIUM;
-    Config_Write();
+    Config_Update();
     Console_Log(
         "%s",
         g_Config.rendering.enable_perspective_filter
@@ -66,7 +66,7 @@ static void M_ToggleTrapezoidFilter(void)
 {
     g_Config.rendering.enable_trapezoid_filter =
         !g_Config.rendering.enable_trapezoid_filter;
-    Config_Write();
+    Config_Update();
     Console_Log(
         "%s",
         g_Config.rendering.enable_trapezoid_filter
@@ -79,14 +79,14 @@ static void M_ToggleZBuffer(void)
     if (g_Input.slow) {
         g_Config.rendering.enable_wireframe =
             !g_Config.rendering.enable_wireframe;
-        Config_Write();
+        Config_Update();
         Console_Log(
             "%s",
             g_Config.rendering.enable_wireframe ? GS(OSD_WIREFRAME_MODE_ON)
                                                 : GS(OSD_WIREFRAME_MODE_OFF));
     } else {
         g_Config.rendering.enable_zbuffer = !g_Config.rendering.enable_zbuffer;
-        Config_Write();
+        Config_Update();
         Console_Log(
             "%s",
             g_Config.rendering.enable_zbuffer ? GS(OSD_DEPTH_BUFFER_ON)
@@ -102,7 +102,7 @@ static void M_CycleLightingContrast(void)
     value += LIGHTING_CONTRAST_NUMBER_OF;
     value %= LIGHTING_CONTRAST_NUMBER_OF;
     g_Config.rendering.lighting_contrast = value;
-    Config_Write();
+    Config_Update();
     Console_Log(
         GS(OSD_LIGHTNING_CONTRAST_FMT),
         ENUM_MAP_TO_STRING(LIGHTING_CONTRAST, value));
@@ -113,7 +113,7 @@ static void M_ToggleRenderingMode(void)
     g_Config.rendering.render_mode =
         g_Config.rendering.render_mode == RM_HARDWARE ? RM_SOFTWARE
                                                       : RM_HARDWARE;
-    Config_Write();
+    Config_Update();
     Console_Log(
         "%s",
         g_Config.rendering.render_mode == RM_HARDWARE


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

First, a couple of new functions. I want to use them to interact with external human-readable files in an upcoming PR.

- Introduces `const CONFIG_OPTION *Config_GetOptionByPath(const char *path)`.
- Introduces `const char *Config_ResolveOptionName(const char *name)` although it's more of a side effect to the refactor than a intended change. (It strips the tree prefix so `"gameplay.fix_bear_ai"` becomes `"fix_bear_ai"`).
- Introduces `const char *Config_GetOptionValueAsString(const CONFIG_OPTION *opt)`. It was mostly taken from the `/set` console command, although it got simplified a lot thanks to `String_FormatStatic`. I had to drop `GS()` conversion for boolean values to be able to use it without relying on the player's chosen language. And in order to avoid duplication, I decided to drop the `/set` string serializer specialization in favor of this new simpler function.

**Now onto the big thing**: We no longer call `Config_Write()` after changing options. Instead, we call `Config_Update()`. Underneath it works pretty much the same, except these key differences:

- `Config_Update()` no longer writes to disk. This job is done in a distilled `Config_Write()` and calling this is a responsibility of subscribers to config change events. Specifically, it's now done by the main shell subscriber in libtrx.
- `Config_Update()` no longer consults the disk for whether the config has changed, and instead operates solely by comparing `g_Config` against `g_SavedConfig`.

Additionally, we no longer write the config prior to game exit – persisting the config to disk is supposed to be handled in reaction to events in all cases. And that's what we need to focus with testing here – if all unique ways for changing the config trigger the save properly:
- `/set` (OK to test just one setting)
- UI setting dialogs (OK to test just one setting in the normal dialogs)
- UI key binding dialogs (both game and controller, resetting to defaults, unbinding)
- Hotkeys (need to test all of them separately)
- ?

The idea behind this change is to be able to easily disable saving the config to disk if the game is ran in a special way.
I'm not sure if removing of `Config_Write()` prior to game exit is the right call – it's a good safe guard and we'd have only two places to mock rather than one, both within shell.c, so maybe it's not that bad. LMK WDYT.

Additionally we should check if saving the config works well with enforced options by the builder – enforced settings shouldn't influence the saved settings, which should be kind of "frozen".