### PR TITLE
Introduce JSONFile

### DIFF
--- a/src/libtrx/config/common.c
+++ b/src/libtrx/config/common.c
@@ -47,11 +47,17 @@ void Config_Shutdown(void)
 bool Config_Read(
     const char *const default_path, const char *const enforced_path)
 {
-    char *default_path_copy = Memory_DupStr(default_path);
-    char *enforced_path_copy = Memory_DupStr(enforced_path);
+    // Always initialize the config, even if the file is missing, so that
+    // the game can interact with these properties.
+    Memory_FreePointer(&g_Config.default_path);
+    Memory_FreePointer(&g_Config.enforced_path);
+    g_Config.default_path = Memory_DupStr(default_path);
+    g_Config.enforced_path = Memory_DupStr(enforced_path);
+    g_Config.loaded = true;
+
     LOG_DEBUG("Reading config");
-    LOG_DEBUG("  default_path=%s", default_path_copy);
-    LOG_DEBUG("  enforced_path=%s", enforced_path_copy);
+    LOG_DEBUG("  default_path=%s", g_Config.default_path);
+    LOG_DEBUG("  enforced_path=%s", g_Config.enforced_path);
     if (m_EnforcedOptions == nullptr) {
         m_EnforcedOptions = Vector_Create(sizeof(void *));
     } else {
@@ -63,25 +69,20 @@ bool Config_Read(
         Vector_Clear(m_HiddenOptions);
     }
     const CONFIG_IO_ARGS args = {
-        .default_path = default_path_copy,
-        .enforced_path = enforced_path_copy,
+        .default_path = g_Config.default_path,
+        .enforced_path = g_Config.enforced_path,
         .action = &Config_LoadFromJSON,
         .enforced_targets = m_EnforcedOptions,
         .hidden_targets = m_HiddenOptions,
     };
     const bool result = ConfigFile_Read(&args);
     if (result) {
-        g_Config.default_path = default_path_copy;
-        g_Config.enforced_path = enforced_path_copy;
-        g_Config.loaded = true;
-        Config_Sanitize();
-        g_SavedConfig = g_Config;
         LOG_DEBUG("Config loaded");
     } else {
-        Memory_FreePointer(default_path_copy);
-        Memory_FreePointer(enforced_path_copy);
-        LOG_WARNING("Errors while loading loaded");
+        LOG_WARNING("Errors while loading config");
     }
+    Config_Sanitize();
+    g_SavedConfig = g_Config;
     return result;
 }
 
@@ -107,6 +108,7 @@ bool Config_Update(void)
 
 bool Config_Write(void)
 {
+    ASSERT(g_Config.default_path != nullptr);
     const CONFIG_IO_ARGS args = {
         .default_path = g_Config.default_path,
         .enforced_path = g_Config.enforced_path,

--- a/src/libtrx/config/file.c
+++ b/src/libtrx/config/file.c
@@ -5,6 +5,7 @@
 #include "debug.h"
 #include "filesystem.h"
 #include "game/console/history.h"
+#include "json_file.h"
 #include "log.h"
 #include "memory.h"
 #include "strings.h"
@@ -23,44 +24,22 @@ static bool M_ReadFromJSON(
     VECTOR *const hidden_targets);
 static void M_PreserveEnforcedState(
     JSON_OBJECT *root_obj, JSON_VALUE *old_root, JSON_VALUE *enf_root);
-static char *M_WriteToJSON(
-    void (*dump)(JSON_OBJECT *root_obj), const char *old_data,
-    const char *enf_data);
-
-static JSON_VALUE *M_ReadRoot(const char *const cfg_data)
-{
-    if (cfg_data == nullptr) {
-        return nullptr;
-    }
-
-    JSON_PARSE_RESULT parse_result;
-    JSON_VALUE *root = JSON_ParseEx(
-        cfg_data, strlen(cfg_data), JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr,
-        nullptr, &parse_result);
-    if (root == nullptr) {
-        LOG_ERROR(
-            "failed to parse config file: %s in line %d, char %d",
-            JSON_GetErrorDescription(parse_result.error),
-            parse_result.error_line_no, parse_result.error_row_no);
-    }
-
-    return root;
-}
 
 static bool M_ReadFromJSON(
-    const char *const cfg_data, const char *const enf_data,
+    const char *const default_path, const char *const enforced_path,
     void (*load)(JSON_OBJECT *root_obj), VECTOR *const enforced_targets,
     VECTOR *const hidden_targets)
 {
     bool result = false;
 
-    JSON_VALUE *cfg_root =
-        M_ReadRoot(cfg_data == nullptr ? M_EMPTY_ROOT : cfg_data);
-    JSON_VALUE *enf_root =
-        M_ReadRoot(enf_data == nullptr ? M_EMPTY_ROOT : enf_data);
+    JSON_VALUE *cfg_root = JSONFile_Read(default_path);
     if (cfg_root != nullptr) {
         result = true;
+    } else {
+        cfg_root = JSON_ValueFromObject(JSON_ObjectNew());
     }
+    JSON_VALUE *const enf_root =
+        enforced_path != nullptr ? JSONFile_Read(enforced_path) : nullptr;
 
     JSON_OBJECT *cfg_root_obj = JSON_ValueAsObject(cfg_root);
     JSON_OBJECT *enf_root_obj = JSON_ValueAsObject(enf_root);
@@ -150,84 +129,32 @@ static void M_PreserveEnforcedState(
     }
 }
 
-static char *M_WriteToJSON(
-    void (*dump)(JSON_OBJECT *root_obj), const char *const old_data,
-    const char *const enf_data)
-{
-    JSON_OBJECT *root_obj = JSON_ObjectNew();
-
-    dump(root_obj);
-
-    JSON_VALUE *old_root = M_ReadRoot(old_data);
-    JSON_VALUE *enf_root = M_ReadRoot(enf_data);
-    M_PreserveEnforcedState(root_obj, old_root, enf_root);
-
-    JSON_VALUE *root = JSON_ValueFromObject(root_obj);
-    size_t size;
-    char *data = JSON_WritePretty(root, "  ", "\n", &size);
-    JSON_ValueFree(root);
-    JSON_ValueFree(old_root);
-    JSON_ValueFree(enf_root);
-
-    return data;
-}
-
 bool ConfigFile_Read(const CONFIG_IO_ARGS *const args)
 {
-    char *default_data = nullptr;
-    char *enforced_data = nullptr;
-
     ASSERT(args->default_path != nullptr);
-    if (!File_Load(args->default_path, &default_data, nullptr)) {
-        LOG_WARNING(
-            "'%s' not loaded - default settings will apply",
-            args->default_path);
-    }
-
-    if (args->enforced_path != nullptr) {
-        File_Load(args->enforced_path, &enforced_data, nullptr);
-    }
-
-    const bool result = M_ReadFromJSON(
-        default_data, enforced_data, args->action, args->enforced_targets,
-        args->hidden_targets);
-
-    Memory_FreePointer(&default_data);
-    Memory_FreePointer(&enforced_data);
-    return result;
+    return M_ReadFromJSON(
+        args->default_path, args->enforced_path, args->action,
+        args->enforced_targets, args->hidden_targets);
 }
 
 bool ConfigFile_Write(const CONFIG_IO_ARGS *const args)
 {
-    char *old_data = nullptr;
-    char *enforced_data = nullptr;
-
     ASSERT(args->default_path != nullptr);
-    File_Load(args->default_path, &old_data, nullptr);
+    JSON_VALUE *const old_root = JSONFile_Read(args->default_path);
+    JSON_VALUE *const enf_root = args->enforced_path != nullptr
+        ? JSONFile_Read(args->enforced_path)
+        : nullptr;
 
-    if (args->enforced_path != nullptr) {
-        File_Load(args->enforced_path, &enforced_data, nullptr);
-    }
+    JSON_OBJECT *const root_obj = JSON_ObjectNew();
+    args->action(root_obj);
+    M_PreserveEnforcedState(root_obj, old_root, enf_root);
 
-    bool updated = false;
-    char *data = M_WriteToJSON(args->action, old_data, enforced_data);
+    JSON_VALUE *const new_root = JSON_ValueFromObject(root_obj);
+    const bool updated = JSONFile_Write(args->default_path, new_root);
 
-    if (old_data == nullptr || strcmp(data, old_data) != 0) {
-        MYFILE *const fp = File_Open(args->default_path, FILE_OPEN_WRITE);
-        if (fp == nullptr) {
-            LOG_ERROR("Failed to write settings!");
-        } else {
-            LOG_INFO("Saving user settings to %s", args->default_path);
-            File_WriteData(fp, data, strlen(data));
-            File_Close(fp);
-            updated = true;
-        }
-    }
-
-    Memory_FreePointer(&data);
-    Memory_FreePointer(&old_data);
-    Memory_FreePointer(&enforced_data);
-
+    JSON_ValueFree(new_root);
+    JSON_ValueFree(old_root);
+    JSON_ValueFree(enf_root);
     return updated;
 }
 

--- a/src/libtrx/game/console/history.c
+++ b/src/libtrx/game/console/history.c
@@ -1,6 +1,6 @@
 #include "game/console/history.h"
 
-#include "config/file.h"
+#include "json_file.h"
 #include "memory.h"
 #include "utils.h"
 #include "vector.h"
@@ -12,8 +12,12 @@
 VECTOR *m_History = nullptr;
 static const char *m_Path = "cfg/" PROJECT_NAME "_console_history.json5";
 
-static void M_LoadFromJSON(JSON_OBJECT *const root_obj)
+static void M_LoadFromJSON(JSON_VALUE *doc);
+static JSON_VALUE *M_DumpToJSON(void);
+
+static void M_LoadFromJSON(JSON_VALUE *const doc)
 {
+    JSON_OBJECT *const root_obj = JSON_ValueAsObject(doc);
     JSON_ARRAY *const arr = JSON_ObjectGetArray(root_obj, "entries");
     if (arr == nullptr) {
         return;
@@ -28,48 +32,50 @@ static void M_LoadFromJSON(JSON_OBJECT *const root_obj)
     }
 }
 
-static void M_DumpToJSON(JSON_OBJECT *const root_obj)
+static JSON_VALUE *M_DumpToJSON(void)
 {
     JSON_ARRAY *const arr = JSON_ArrayNew();
-
-    bool has_elements = false;
     for (int32_t i = 0; i < Console_History_GetLength(); i++) {
         JSON_ArrayAppendString(arr, Console_History_Get(i));
-        has_elements = true;
     }
 
-    if (has_elements) {
-        JSON_ObjectAppendArray(root_obj, "entries", arr);
-    } else {
+    if (arr->length == 0) {
         JSON_ArrayFree(arr);
+        return nullptr;
     }
+    JSON_OBJECT *root_obj = JSON_ObjectNew();
+    JSON_ObjectAppendArray(root_obj, "entries", arr);
+    return JSON_ValueFromObject(root_obj);
 }
 
 void Console_History_Init(void)
 {
     m_History = Vector_Create(sizeof(char *));
-    ConfigFile_Read(&(CONFIG_IO_ARGS) {
-        .default_path = m_Path,
-        .enforced_path = nullptr,
-        .action = &M_LoadFromJSON,
-    });
+    JSON_VALUE *const doc = JSONFile_Read(m_Path);
+    if (doc != nullptr) {
+        M_LoadFromJSON(doc);
+        JSON_ValueFree(doc);
+    }
 }
 
 void Console_History_Shutdown(void)
 {
-    if (m_History != nullptr) {
-        ConfigFile_Write(&(CONFIG_IO_ARGS) {
-            .default_path = m_Path,
-            .enforced_path = nullptr,
-            .action = &M_DumpToJSON,
-        });
-        for (int32_t i = m_History->count - 1; i >= 0; i--) {
-            char *const prompt = *(char **)Vector_Get(m_History, i);
-            Memory_Free(prompt);
-        }
-        Vector_Free(m_History);
-        m_History = nullptr;
+    if (m_History == nullptr) {
+        return;
     }
+
+    JSON_VALUE *const doc = M_DumpToJSON();
+    if (doc != nullptr) {
+        JSONFile_Write(m_Path, doc);
+        JSON_ValueFree(doc);
+    }
+
+    for (int32_t i = m_History->count - 1; i >= 0; i--) {
+        char *const prompt = *(char **)Vector_Get(m_History, i);
+        Memory_Free(prompt);
+    }
+    Vector_Free(m_History);
+    m_History = nullptr;
 }
 
 int32_t Console_History_GetLength(void)

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -9,7 +9,7 @@
 #include "game/objects/common.h"
 #include "game/objects/names.h"
 #include "game/shell.h"
-#include "json.h"
+#include "json_file.h"
 #include "log.h"
 #include "memory.h"
 #include "strings.h"
@@ -625,17 +625,9 @@ void GF_LoadFromString(
     ctx.gf->path = Memory_DupStr(script_path);
     ctx.script_path = g_GameFlow.path;
 
-    JSON_PARSE_RESULT parse_result;
-    JSON_VALUE *const root = JSON_ParseEx(
-        script_data, strlen(script_data), JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr,
-        nullptr, &parse_result);
-    if (root == nullptr) {
-        Shell_ExitSystemFmt(
-            "Failed to parse script file %s: %s in line %d, char %d",
-            script_path, JSON_GetErrorDescription(parse_result.error),
-            parse_result.error_line_no, parse_result.error_row_no);
-    }
-    JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
+    JSON_VALUE *const doc = JSONFile_ReadEx(
+        script_path, (JSON_FILE_OPTIONS) { .exit_on_error = true });
+    JSON_OBJECT *const root_obj = JSON_ValueAsObject(doc);
 
     M_LoadCommonRoot(&ctx, root_obj);
     M_LoadRoot(&ctx, root_obj);
@@ -645,7 +637,5 @@ void GF_LoadFromString(
     M_LoadFMVs(&ctx, root_obj);
     M_LoadTitleLevel(&ctx, root_obj);
 
-    if (root != nullptr) {
-        JSON_ValueFree(root);
-    }
+    JSON_ValueFree(doc);
 }

--- a/src/libtrx/game/game_string_table/priv.c
+++ b/src/libtrx/game/game_string_table/priv.c
@@ -51,20 +51,6 @@ static void M_FreeLevelsTable(GS_LEVEL_TABLE *const levels)
     levels->count = 0;
 }
 
-GS_FILE *GS_File_CreateFromPath(const char *const path, const bool load_levels)
-{
-    char *data = nullptr;
-    if (!File_Load(path, &data, nullptr)) {
-        LOG_ERROR("failed to open strings file (path: %d)", path);
-        return nullptr;
-    }
-    GS_FILE *file = Memory_Alloc(sizeof(*file));
-    file->path = Memory_DupStr(path);
-    GS_File_LoadFromString(file, data, load_levels);
-    Memory_FreePointer(&data);
-    return file;
-}
-
 void GS_File_Free(GS_FILE *const gs_file)
 {
     if (gs_file == nullptr) {

--- a/src/libtrx/game/game_string_table/priv.h
+++ b/src/libtrx/game/game_string_table/priv.h
@@ -40,5 +40,4 @@ typedef struct {
 void GS_Table_Free(GS_TABLE *gs_table);
 
 GS_FILE *GS_File_CreateFromPath(const char *path, bool load_levels);
-void GS_File_LoadFromString(GS_FILE *file, const char *data, bool load_levels);
 void GS_File_Free(GS_FILE *gs_file);

--- a/src/libtrx/game/game_string_table/reader.c
+++ b/src/libtrx/game/game_string_table/reader.c
@@ -2,7 +2,7 @@
 #include "game/game_string_table.h"
 #include "game/game_string_table/priv.h"
 #include "game/shell.h"
-#include "json.h"
+#include "json_file.h"
 #include "log.h"
 #include "memory.h"
 
@@ -156,30 +156,21 @@ static void M_LoadLevelsFromJSON(
     }
 }
 
-void GS_File_LoadFromString(
-    GS_FILE *const gs_file, const char *const data, const bool load_levels)
+GS_FILE *GS_File_CreateFromPath(const char *const path, const bool load_levels)
 {
-    JSON_PARSE_RESULT parse_result;
+    GS_FILE *const gs_file = Memory_Alloc(sizeof(*gs_file));
+    gs_file->path = Memory_DupStr(path);
 
-    JSON_VALUE *root = JSON_ParseEx(
-        data, strlen(data), JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr, nullptr,
-        &parse_result);
-    if (root == nullptr) {
-        Shell_ExitSystemFmt(
-            "%s: Failed to parse strings table: %s in line %d, char %d",
-            gs_file->path, JSON_GetErrorDescription(parse_result.error),
-            parse_result.error_line_no, parse_result.error_row_no);
-    }
-
-    JSON_OBJECT *root_obj = JSON_ValueAsObject(root);
+    JSON_VALUE *const doc =
+        JSONFile_ReadEx(path, (JSON_FILE_OPTIONS) { .exit_on_error = true });
+    JSON_OBJECT *root_obj = JSON_ValueAsObject(doc);
     M_LoadTableFromJSON(root_obj, &gs_file->global);
     if (load_levels) {
         M_LoadLevelsFromJSON(root_obj, gs_file, "levels", GFLT_MAIN);
         M_LoadLevelsFromJSON(root_obj, gs_file, "demos", GFLT_DEMOS);
         M_LoadLevelsFromJSON(root_obj, gs_file, "cutscenes", GFLT_CUTSCENES);
     }
-    if (root != nullptr) {
-        JSON_ValueFree(root);
-        root = nullptr;
-    }
+
+    JSON_ValueFree(doc);
+    return gs_file;
 }

--- a/src/libtrx/game/lara/pose.c
+++ b/src/libtrx/game/lara/pose.c
@@ -7,7 +7,7 @@
 #include "game/items.h"
 #include "game/lara/hair.h"
 #include "game/objects.h"
-#include "json.h"
+#include "json_file.h"
 #include "memory.h"
 #include "vector.h"
 
@@ -44,26 +44,8 @@ static void M_LoadPoses(void)
     m_Poses = Vector_Create(sizeof(LARA_POSE));
     ASSERT(m_Poses != nullptr);
 
-    char *json_data = nullptr;
-    size_t json_size = 0;
-    if (!File_Load(m_Path, &json_data, &json_size)) {
-        LOG_ERROR("Failed to load poses from %s", m_Path);
-        return;
-    }
-
-    JSON_PARSE_RESULT parse_result;
-    JSON_VALUE *const root = JSON_ParseEx(
-        json_data, json_size, JSON_PARSE_FLAGS_ALLOW_JSON5, nullptr, nullptr,
-        &parse_result);
-    if (root == nullptr) {
-        LOG_ERROR(
-            "Failed to parse %s: %s at line %zu char %zu", m_Path,
-            JSON_GetErrorDescription(parse_result.error),
-            parse_result.error_line_no, parse_result.error_row_no);
-        goto cleanup;
-    }
-
-    JSON_ARRAY *const poses = JSON_ValueAsArray(root);
+    JSON_VALUE *const doc = JSONFile_Read(m_Path);
+    JSON_ARRAY *const poses = JSON_ValueAsArray(doc);
     if (poses == nullptr) {
         LOG_WARNING("Error while reading poses: root object must be an array");
         goto cleanup;
@@ -105,10 +87,7 @@ static void M_LoadPoses(void)
     }
 
 cleanup:
-    if (root != nullptr) {
-        JSON_ValueFree(root);
-    }
-    Memory_FreePointer(&json_data);
+    JSON_ValueFree(doc);
 }
 
 void Lara_Pose_Init(void)

--- a/src/libtrx/include/libtrx/json_file.h
+++ b/src/libtrx/include/libtrx/json_file.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "json.h"
+
+// Read and parse a JSON5 file. Missing files will return nullptr.
+// @param path  Path to read.
+// @return      The root JSON_VALUE, or nullptr on I/O/parse failure. Caller
+//              must free the result with JSON_ValueFree().
+JSON_VALUE *JSONFile_Read(const char *path);
+
+// Write a JSON_VALUE to disk (pretty-printed), overwriting only if changed.
+// @param path  Path to read.
+// @param root  Value to write to the file.
+// @return      Returns true if the file was written; false on error or no-op.
+bool JSONFile_Write(const char *path, JSON_VALUE *root);

--- a/src/libtrx/include/libtrx/json_file.h
+++ b/src/libtrx/include/libtrx/json_file.h
@@ -2,11 +2,18 @@
 
 #include "json.h"
 
+typedef struct {
+    bool exit_on_error;
+} JSON_FILE_OPTIONS;
+
 // Read and parse a JSON5 file. Missing files will return nullptr.
 // @param path  Path to read.
 // @return      The root JSON_VALUE, or nullptr on I/O/parse failure. Caller
 //              must free the result with JSON_ValueFree().
 JSON_VALUE *JSONFile_Read(const char *path);
+
+// Like JSONFile_Read(), except with additional options.
+JSON_VALUE *JSONFile_ReadEx(const char *path, JSON_FILE_OPTIONS options);
 
 // Write a JSON_VALUE to disk (pretty-printed), overwriting only if changed.
 // @param path  Path to read.

--- a/src/libtrx/json_file.c
+++ b/src/libtrx/json_file.c
@@ -1,0 +1,56 @@
+#include "json_file.h"
+
+#include "filesystem.h"
+#include "json.h"
+#include "log.h"
+#include "memory.h"
+
+#include <string.h>
+
+#define M_PARSE_FLAGS JSON_PARSE_FLAGS_ALLOW_JSON5
+
+JSON_VALUE *JSONFile_Read(const char *path)
+{
+    char *file_data = nullptr;
+    if (!File_Load(path, &file_data, nullptr)) {
+        return nullptr;
+    }
+
+    JSON_PARSE_RESULT pr;
+    JSON_VALUE *const value = JSON_ParseEx(
+        file_data, strlen(file_data), M_PARSE_FLAGS, nullptr, nullptr, &pr);
+    if (value == nullptr) {
+        LOG_ERROR(
+            "parse error in '%s': %s (line %d, char %d)", path,
+            JSON_GetErrorDescription(pr.error), pr.error_line_no,
+            pr.error_row_no);
+    }
+    Memory_FreePointer(&file_data);
+    return value;
+}
+
+bool JSONFile_Write(const char *path, JSON_VALUE *const value)
+{
+    char *old_data = nullptr;
+    File_Load(path, &old_data, nullptr);
+
+    size_t out_len;
+    char *out_data = JSON_WritePretty(value, "  ", "\n", &out_len);
+
+    bool updated = false;
+    if (old_data == nullptr || strcmp(old_data, out_data) != 0) {
+        MYFILE *const fp = File_Open(path, FILE_OPEN_WRITE);
+        if (fp == nullptr) {
+            LOG_ERROR("unable to open '%s' for writing", path);
+        } else {
+            LOG_DEBUG("saving JSON to %s", path);
+            File_WriteData(fp, out_data, out_len);
+            File_Close(fp);
+            updated = true;
+        }
+    }
+
+    Memory_FreePointer(&old_data);
+    Memory_FreePointer(&out_data);
+    return updated;
+}

--- a/src/libtrx/json_file.c
+++ b/src/libtrx/json_file.c
@@ -1,15 +1,22 @@
 #include "json_file.h"
 
 #include "filesystem.h"
+#include "game/shell.h"
 #include "json.h"
 #include "log.h"
 #include "memory.h"
+#include "strings.h"
 
 #include <string.h>
 
 #define M_PARSE_FLAGS JSON_PARSE_FLAGS_ALLOW_JSON5
 
 JSON_VALUE *JSONFile_Read(const char *path)
+{
+    return JSONFile_ReadEx(path, (JSON_FILE_OPTIONS) {});
+}
+
+JSON_VALUE *JSONFile_ReadEx(const char *path, const JSON_FILE_OPTIONS options)
 {
     char *file_data = nullptr;
     if (!File_Load(path, &file_data, nullptr)) {
@@ -20,10 +27,14 @@ JSON_VALUE *JSONFile_Read(const char *path)
     JSON_VALUE *const value = JSON_ParseEx(
         file_data, strlen(file_data), M_PARSE_FLAGS, nullptr, nullptr, &pr);
     if (value == nullptr) {
-        LOG_ERROR(
+        const char *const error_msg = String_FormatStatic(
             "parse error in '%s': %s (line %d, char %d)", path,
             JSON_GetErrorDescription(pr.error), pr.error_line_no,
             pr.error_row_no);
+        LOG_ERROR("%s", error_msg);
+        if (options.exit_on_error) {
+            Shell_ExitSystemFmt("%s", error_msg);
+        }
     }
     Memory_FreePointer(&file_data);
     return value;

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -347,6 +347,7 @@ sources = [
   'json/json_base.c',
   'json/json_parse.c',
   'json/json_write.c',
+  'json_file.c',
   'log.c',
   'memory.c',
   'screenshot.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR introduces a standalone JSON file utility module and migrates the `ConfigFile`, `Console_History`, `GameFlow`, `GameString` and `Lara_Pose` modules to use it. The new module introduces the following functions with straightforward signatures:

- ```c
    JSON_VALUE *JSONFile_Read(const char *path);
    ```
- ```c
    JSON_VALUE *JSONFile_ReadEx(const char *path, JSON_FILE_OPTIONS options);
    ```
- ```c
    bool JSONFile_Write(const char *path, JSON_VALUE *root);
    ```

with `JSON_FILE_OPTIONS` having only one property, `bool exit_on_error`.

The logic no longer treats missing files as empty objects – instead, the decision on what to do in such cases is left to the caller.

The change is motivated by the `Console_History` module's use of `ConfigFile_Write`, which is an unsuitable dependency. `ConfigFile` is meant for managing configuration options, handling default vs. enforced paths, merging, and validating settings, which don't relate to a console-history list. Switching to `JSONFile` isolates the history array's persistence without tying it to configuration management.

#### Testing

- Booting the game with missing config file
- Booting the game with missing console history file
    - Exiting the game with no commands issues shouldn't create the history file
- Saving the config on config changes (any change will do)
- Saving the history file on exit
- Enforcing the config from the game flow
- Ignoring changes to enforced settings
- Game strings (very quick check for translations working, no need to test layers)
- Lara poses are working
- Errors in the files:
    - Config: non-fatal, carry on
    - Poses: non-fatal, carry on
    - Game flow: fatal, exit with a visible message
    - Game strings: fatal, exit with a visible message