### PR TITLE
objects/waterfall: remove draw distance constraint

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed the skybox option to allow toggling in-game without the need to reload the level
 - changed the texture page limit from 128 to unlimited (#3517)
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
+- changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
 - fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)

--- a/docs/tr1/IMPROVEMENTS.md
+++ b/docs/tr1/IMPROVEMENTS.md
@@ -188,6 +188,7 @@ Not all options are turned on by default. Refer to the ingame settings for detai
 - added optional dynamic lighting for flames
 - added an option to toggle between TR1 and TR2 camera modes
 - changed the Scion in The Great Pyramid from spawning blood when hit to a ricochet effect
+- changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range
 - fixed thin black lines between polygons
 - fixed black screen flashing when navigating the inventory
 - fixed detail levels text flashing with any option change

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -11,6 +11,7 @@
 - changed the game flow and game strings file placement
 - changed the texture page limit from 128 to unlimited (#3517)
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
+- changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -183,6 +183,7 @@
 - changed fullscreen behavior to use windowed desktop mode
 - changed dynamic lighting for gun flashes and explosions to be optional
 - changed the Bartoli's Hideout sunset effect to also apply to skybox lighting
+- changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range
 - fixed fullscreen issues
 - fixed black borders in windowed mode
 - fixed "Failed to create device" when toggling fullscreen

--- a/src/libtrx/game/objects/general/waterfall.c
+++ b/src/libtrx/game/objects/general/waterfall.c
@@ -24,12 +24,8 @@ static void M_Control(const int16_t item_num)
     }
 
     const ITEM *const lara_item = Lara_GetItem();
-    if (!Item_IsNearby(item, lara_item, M_RANGE)) {
-        return;
-    }
-
     Output_CalculateLight(item->pos, item->room_num);
-    if (TR_VERSION == 2) {
+    if (TR_VERSION == 2 && Item_IsNearby(item, lara_item, M_RANGE)) {
         Sound_Effect(SFX_WATERFALL_LOOP, &item->pos, SPM_NORMAL);
     }
 


### PR DESCRIPTION
Resolves #3598.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the 10 sector draw constraint on waterfall objects. The constraint is retained for TR2 sound effects however, to avoid flooding the sound system.
