### PR TITLE
test-replay: add game recorder and replay modules

### DIFF
--- a/docs/1-COMMAND_LINE.md
+++ b/docs/1-COMMAND_LINE.md
@@ -18,6 +18,16 @@ Currently the following command line interface options are available:
   should be absolute. Internally, this option uses `TR*X_gameflow_level.json5`
   as a template instructing it how to run the game.
 
-- `-s <num>`, `--save <num>`:
+- `-s <num>`, `--save <num>`:  
   Runs the game immediately loading a specific save slot. The first save starts
   at `num=1`. This option can be combined with `-l`/`--level`.
+
+- `--test-record <PATH>`:  
+  Records gameplay events to an external text file.
+
+  `--test-replay <PATH>`, `--test-play <PATH>`:  
+  Replays gameplay events from an external text file.
+
+> [!NOTE]
+> Gameplay capture is considered an internal testing tool, and may be
+> subject to breaking changes without warnings.

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,6 +3,7 @@
 >Attention level builders: this version introduces backwards incompatible changes to the file structure.
 >Please refer to the [migration guide](../3-MIGRATING.md) to see how to update your levels.
 
+- added support for automated playthroughs with `--test-record` and `--test-replay` (internal tool – the recording file format may be subject to changes)
 - added ability to move Lara around in photo mode
 - added an option to use Lara's slide-to-run animation from TR3+ (Gameplay → Controls → Slide-to-run) (#1089)
 - added German translation

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,6 +3,7 @@
 >Attention level builders: this version introduces backwards incompatible changes to the file structure.
 >Please refer to the [migration guide](../3-MIGRATING.md) to see how to update your levels.
 
+- added support for automated playthroughs with `--test-record` and `--test-replay` (internal tool – the recording file format may be subject to changes)
 - added ability to move Lara around in photo mode (use sidestep keys to switch modes)
 - added an option to use Lara's slide-to-run animation from TR3+ (Gameplay → Controls → Slide-to-run) (#1089)
 - added German translation

--- a/src/libtrx/game/input/common.c
+++ b/src/libtrx/game/input/common.c
@@ -244,10 +244,10 @@ bool Input_IsInListenMode(void)
 
 void Input_ProcessEvent(const SDL_Event *event)
 {
-    if (g_Input_Keyboard.process_event) {
+    if (g_Input_Keyboard.process_event != nullptr) {
         g_Input_Keyboard.process_event(event);
     }
-    if (g_Input_Controller.process_event) {
+    if (g_Input_Controller.process_event != nullptr) {
         g_Input_Controller.process_event(event);
     }
 }

--- a/src/libtrx/game/random.c
+++ b/src/libtrx/game/random.c
@@ -45,6 +45,16 @@ int32_t Random_GetDraw(void)
     return (m_RandDraw >> 10) & 0x7FFF;
 }
 
+int32_t Random_GetControlSeed(void)
+{
+    return m_RandControl;
+}
+
+int32_t Random_GetDrawSeed(void)
+{
+    return m_RandDraw;
+}
+
 void Random_FreezeDraw(bool is_frozen)
 {
     m_IsDrawFrozen = is_frozen;

--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -39,6 +39,8 @@ static void M_ShowHelp(void)
 #endif
     puts("-l/--level <PATH>: launch a specific level file.");
     puts("-s/--save <NUM>: launch from a specific save slot (starts at 1).");
+    puts("--test-record <PATH>: record gameplay events to file.");
+    puts("--test-replay <PATH>: replay gameplay events from file.");
 }
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
@@ -80,6 +82,15 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             if (String_ParseInteger(next_arg, &out_args->save_to_load)) {
                 out_args->save_to_load--;
             }
+            i++;
+        }
+        if (!strcmp(arg, "--test-record") && next_arg != nullptr) {
+            out_args->test_record_path = next_arg;
+            i++;
+        }
+        if ((!strcmp(arg, "--test-play") || !strcmp(arg, "--test-replay"))
+            && next_arg != nullptr) {
+            out_args->test_replay_path = next_arg;
             i++;
         }
     }

--- a/src/libtrx/game/shell/config.c
+++ b/src/libtrx/game/shell/config.c
@@ -4,6 +4,7 @@
 #include "game/output.h"
 #include "game/shell.h"
 #include "game/sound.h"
+#include "game/test_replay.h"
 #include "game/viewport.h"
 #include "log.h"
 
@@ -136,7 +137,9 @@ void Shell_SyncFromWindow(const bool update_viewport)
 void Shell_HandleCommonConfigChange(
     const CONFIG *const old, const CONFIG *const new)
 {
-    Config_Write();
+    if (!TestReplay_IsOpened()) {
+        Config_Write();
+    }
 
 #define L_CHANGED(subject) (old->subject != new->subject)
 

--- a/src/libtrx/game/shell/events.c
+++ b/src/libtrx/game/shell/events.c
@@ -5,6 +5,8 @@
 #include "game/fmv.h"
 #include "game/input/common.h"
 #include "game/shell.h"
+#include "game/test_recorder.h"
+#include "game/test_replay.h"
 #include "game/ui.h"
 
 // If true, next SDL_TEXT* event should be zeroed out.
@@ -21,7 +23,7 @@ static void M_HandleWindowMinimized(void);
 static void M_HandleWindowMaximized(void);
 static void M_HandleWindowMoved(int32_t x, int32_t y);
 static void M_HandleWindowResized(int32_t width, int32_t height);
-static bool M_ProcessEvent(const SDL_Event *event);
+static bool M_ProcessReplayEvent(const SDL_Event *event);
 
 static void M_HandleQuit(void)
 {
@@ -100,8 +102,20 @@ static void M_HandleWindowResized(int32_t width, int32_t height)
     Shell_SyncFromWindow(true);
 }
 
-static bool M_ProcessEvent(const SDL_Event *const event)
+static bool M_ProcessReplayEvent(const SDL_Event *const event)
 {
+    switch (event->type) {
+    case SDL_QUIT:
+        M_HandleQuit();
+        return true;
+    }
+    return false;
+}
+
+bool Shell_ProcessEvent(const SDL_Event *const event)
+{
+    Input_ProcessEvent(event);
+
     switch (event->type) {
     case SDL_QUIT:
         M_HandleQuit();
@@ -113,14 +127,6 @@ static bool M_ProcessEvent(const SDL_Event *const event)
 
     case SDL_KEYUP:
         M_HandleKeyUp(event);
-        return true;
-
-    case SDL_TEXTEDITING:
-        if (m_ConsoleJustOpened) {
-            m_ConsoleJustOpened = false;
-        } else {
-            UI_HandleTextEdit(event->text.text);
-        }
         return true;
 
     case SDL_TEXTINPUT:
@@ -181,10 +187,22 @@ static bool M_ProcessEvent(const SDL_Event *const event)
 void Shell_ProcessEvents(void)
 {
     SDL_Event event;
-    while (SDL_PollEvent(&event) != 0) {
-        Input_ProcessEvent(&event);
-        if (M_ProcessEvent(&event)) {
-            continue;
+    if (TestReplay_IsOpened()) {
+        TestReplay_RunFrame();
+        while (SDL_PollEvent(&event) != 0) {
+            M_ProcessReplayEvent(&event);
         }
+        return;
+    }
+
+    if (TestRecorder_IsOpened()) {
+        TestRecorder_BeginFrame();
+    }
+    while (SDL_PollEvent(&event) != 0) {
+        TestRecorder_RecordEvent(&event);
+        Shell_ProcessEvent(&event);
+    }
+    if (TestRecorder_IsOpened()) {
+        TestRecorder_EndFrame();
     }
 }

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -18,6 +18,8 @@
 #include "game/shell.h"
 #include "game/shell/platform.h"
 #include "game/sound.h"
+#include "game/test_recorder.h"
+#include "game/test_replay.h"
 #include "log.h"
 #include "utils.h"
 
@@ -57,15 +59,7 @@ const char *Shell_GetConfigDir(void)
     return "cfg";
 }
 
-void Shell_InstallConfig(void)
-{
-    Config_SubscribeChanges(M_HandleConfigChange, nullptr);
-    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
-    Sound_SetMasterVolume(g_Config.audio.sound_volume);
-    Music_SetVolume(g_Config.audio.music_volume);
-}
-
-void Shell_CommonInit(const SHELL_ARGS *const args)
+void Shell_InitCommonModules(void)
 {
     Shell_SetupHiDPI();
     Shell_SetupLibAV();
@@ -90,15 +84,17 @@ void Shell_CommonInit(const SHELL_ARGS *const args)
 
     Clock_Init();
     LUA_Init();
-
-    Config_Read(
-        String_FormatStatic("%s/%s.json5", Shell_GetConfigDir(), PROJECT_NAME),
-        Shell_GetGameFlowPath(args->mod));
-    Shell_InstallConfig();
 }
 
 void Shell_ShutdownCommonModules(void)
 {
+    if (TestReplay_IsOpened()) {
+        TestReplay_Close();
+    }
+    if (TestRecorder_IsOpened()) {
+        TestRecorder_Close();
+    }
+
     Lara_Pose_Shutdown();
 
     Console_Shutdown();
@@ -122,4 +118,40 @@ void Shell_ShutdownCommonModules(void)
     Config_Shutdown();
     EnumMap_Shutdown();
     Log_Shutdown();
+}
+
+const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
+{
+    const SHELL_ARGS *new_args = args;
+
+    if (args->test_record_path != nullptr
+        && args->test_replay_path != nullptr) {
+        Shell_ExitSystem("Cannot use both --test-record and --test-replay");
+        return new_args;
+    }
+
+    if (args->test_replay_path != nullptr) {
+        SHELL_ARGS *tmp_args = TestReplay_Open(args->test_replay_path);
+        // original args not needed, free immediately.
+        if (tmp_args->original_args != nullptr) {
+            Vector_Free(tmp_args->original_args);
+            tmp_args->original_args = nullptr;
+        }
+        new_args = tmp_args;
+    } else {
+        Config_Read(
+            String_FormatStatic(
+                "%s/%s.json5", Shell_GetConfigDir(), PROJECT_NAME),
+            Shell_GetGameFlowPath(args->mod));
+
+        if (args->test_record_path != nullptr) {
+            TestRecorder_Open(args->test_record_path, args->original_args);
+        }
+    }
+    Config_SubscribeChanges(M_HandleConfigChange, nullptr);
+
+    Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
+    Sound_SetMasterVolume(g_Config.audio.sound_volume);
+    Music_SetVolume(g_Config.audio.music_volume);
+    return new_args;
 }

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -1,0 +1,207 @@
+#include "game/test_recorder.h"
+
+#include "config.h"
+#include "debug.h"
+#include "filesystem.h"
+#include "game/console/common.h"
+#include "game/input/backends/controller.h"
+#include "game/input/backends/keyboard.h"
+#include "game/lara.h"
+#include "game/random.h"
+
+#define M_DEBUG 0
+#define M_MAX_EVENTS 64 // Maximum SDL or custom events per frame
+
+typedef struct {
+    MYFILE *file;
+    int32_t frame_idx;
+    SDL_Event queue[M_MAX_EVENTS];
+    int32_t queue_size;
+} M_PRIV;
+
+static M_PRIV m_Priv = {};
+
+static const char *M_DumpEvent(const SDL_Event *event);
+static void M_DumpQueue(M_PRIV *p);
+
+static const char *M_DumpEvent(const SDL_Event *const event)
+{
+    switch (event->type) {
+    case SDL_KEYDOWN:
+        return String_FormatStatic(
+            "keydown %d %hu", event->key.keysym.scancode,
+            event->key.keysym.mod);
+    case SDL_TEXTINPUT:
+        return String_FormatStatic("text-input \"%s\"", event->text.text);
+    case SDL_KEYUP:
+        return String_FormatStatic(
+            "keyup %d %hu", event->key.keysym.scancode, event->key.keysym.mod);
+    case SDL_QUIT:
+        return String_FormatStatic("quit");
+    }
+    return nullptr;
+}
+
+static void M_DumpQueue(M_PRIV *const p)
+{
+#if !M_DEBUG
+    if (p->queue_size == 0) {
+        return;
+    }
+#endif
+    File_WriteString(p->file, "frame %d:", p->frame_idx);
+    for (int32_t i = 0; i < p->queue_size; i++) {
+        const SDL_Event *const event = &p->queue[i];
+        const char *const event_str = M_DumpEvent(event);
+        if (event_str == nullptr) {
+            continue;
+        }
+        File_WriteString(p->file, " ");
+        File_WriteString(p->file, event_str);
+        if (i < p->queue_size - 1) {
+            File_WriteString(p->file, ";");
+        }
+    }
+#if M_DEBUG
+    const ITEM *const lara_item = Lara_GetItem();
+    const GAME_OBJECT_ID obj_id = Lara_GetAnimationObject();
+    const ITEM *const vehicle_item = Lara_Vehicle_GetItem();
+    if (lara_item != nullptr) {
+        File_WriteString(
+            p->file, "; assert lara.pos=%d,%d,%d", lara_item->pos.x,
+            lara_item->pos.y, lara_item->pos.z);
+        File_WriteString(
+            p->file, "; assert lara.rot=%d,%d,%d", lara_item->rot.x,
+            lara_item->rot.y, lara_item->rot.z);
+        File_WriteString(
+            p->file, "; assert lara.anim=%d,%d,%d", obj_id,
+            Item_GetRelativeObjAnim(lara_item, obj_id),
+            Item_GetRelativeFrame(lara_item));
+        File_WriteString(
+            p->file, "; assert lara.speed=%d,%d",
+            (vehicle_item != nullptr ? vehicle_item : lara_item)->speed,
+            (vehicle_item != nullptr ? vehicle_item : lara_item)->fall_speed);
+    }
+#endif
+    File_WriteString(p->file, "\n");
+}
+
+void TestRecorder_Open(const char *path, VECTOR *const original_args)
+{
+    M_PRIV *const p = &m_Priv;
+    p->file = File_Open(path, FILE_OPEN_WRITE);
+    if (p->file == nullptr) {
+        LOG_ERROR("Cannot open record file '%s'", path);
+        return;
+    }
+    File_WriteString(p->file, "# seed_control %d\n", Random_GetControlSeed());
+    File_WriteString(p->file, "# seed_draw %d\n", Random_GetDrawSeed());
+
+    // Record original arguments passed to the game
+    if (original_args->count > 0) {
+        File_WriteString(p->file, "# args");
+        for (int32_t i = 0; i < original_args->count; i++) {
+            const char *const arg = *(char **)Vector_Get(original_args, i);
+            if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
+                || !strcmp(arg, "--test-play")) {
+                i++; // skip path argument
+                continue;
+            }
+            File_WriteString(p->file, " \"%s\"", arg);
+        }
+        File_WriteString(p->file, "\n");
+    }
+
+    // Record any non-default config options for later replay
+    for (const CONFIG_OPTION *opt = Config_GetOptionMap(); opt->name != nullptr;
+         opt++) {
+        if (!Config_IsOptionAtDefault(opt->target)) {
+            File_WriteString(
+                p->file, "# config %s %s\n", opt->name,
+                Config_GetOptionValueAsString(opt));
+        }
+    }
+
+    // Record any non-default key/controller bindings for later replay.
+    // Keyboard binds
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        JSON_OBJECT *bind = JSON_ObjectNew();
+        if (g_Input_Keyboard.assign_to_json_object(
+                g_Config.input.keyboard_layout, role, bind)) {
+            const int32_t sc = JSON_ObjectGetInt(bind, "scancode", -1);
+            File_WriteString(p->file, "# bind keyboard %d %d\n", role, sc);
+        }
+        JSON_ObjectFree(bind);
+    }
+    // Controller binds
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        JSON_OBJECT *bind = JSON_ObjectNew();
+        if (g_Input_Controller.assign_to_json_object(
+                g_Config.input.controller_layout, role, bind)) {
+            const int32_t bt = JSON_ObjectGetInt(bind, "button_type", 0);
+            const int32_t b = JSON_ObjectGetInt(bind, "bind", 0);
+            const int32_t ad = JSON_ObjectGetInt(bind, "axis_dir", 0);
+            File_WriteString(
+                p->file, "# bind controller %d %d %d %d\n", role, bt, b, ad);
+        }
+        JSON_ObjectFree(bind);
+    }
+
+    LOG_INFO("Starting recording");
+}
+
+bool TestRecorder_IsOpened(void)
+{
+    M_PRIV *const p = &m_Priv;
+    return p->file != nullptr;
+}
+
+void TestRecorder_Close(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file != nullptr) {
+        File_Close(p->file);
+        p->file = nullptr;
+    }
+}
+
+void TestRecorder_BeginFrame(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file != nullptr) {
+        p->queue_size = 0;
+    }
+}
+
+void TestRecorder_EndFrame(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file != nullptr) {
+        M_DumpQueue(p);
+    }
+    p->frame_idx++;
+}
+
+void TestRecorder_RecordEvent(const SDL_Event *const event)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file == nullptr) {
+        return;
+    }
+
+    // Only record eligible events
+    if (event->type != SDL_KEYDOWN && event->type != SDL_KEYUP
+        && event->type != SDL_QUIT && event->type != SDL_TEXTINPUT) {
+        return;
+    }
+    if (event->type == SDL_KEYDOWN && event->key.repeat) {
+        return;
+    }
+    if (event->type == SDL_TEXTINPUT && !Console_IsOpened()) {
+        return;
+    }
+
+    if (p->queue_size < M_MAX_EVENTS) {
+        p->queue[p->queue_size++] = *event;
+    }
+}

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -1,0 +1,450 @@
+#include "game/test_replay.h"
+
+#include "config.h"
+#include "debug.h"
+#include "filesystem.h"
+#include "game/console/common.h"
+#include "game/input/backends/controller.h"
+#include "game/input/backends/keyboard.h"
+#include "game/lara.h"
+#include "game/random.h"
+#include "game/shell/events.h"
+#include "memory.h"
+#include "vector.h"
+
+#define M_DEBUG 0
+
+typedef struct {
+    VECTOR *raw_args;
+} M_PARSE_CTX;
+
+typedef struct {
+    MYFILE *file;
+    int32_t frame_idx;
+    int32_t next_frame_idx;
+    VECTOR *queue;
+} M_PRIV;
+
+static M_PRIV m_Priv = {};
+
+typedef bool (*M_EVENT_HANDLER)(const char *token);
+typedef bool (*M_HEADER_HANDLER)(const char *line, M_PARSE_CTX *ctx);
+
+// Event parsers
+static bool M_ParseQuitEvent(const char *event_str);
+static bool M_ParseKeyDownEvent(const char *event_str);
+static bool M_ParseKeyUpEvent(const char *event_str);
+static bool M_ParseTextInputEvent(const char *event_str);
+static bool M_ParseCommandEvent(const char *event_str);
+static bool M_ParseAssertEvent(const char *event_str);
+
+// Header parsers
+static bool M_ParseSeedControl(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseSeedDraw(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseBindKeyboard(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseBindController(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseBindController(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseArgs(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseConfig(const char *line, M_PARSE_CTX *ctx);
+
+static bool M_ParseEvent(const char *event_str);
+static void M_ReadHeaders(M_PRIV *p, M_PARSE_CTX *ctx);
+static void M_ClearEventQueue(M_PRIV *p);
+static void M_ReadQueue(M_PRIV *p);
+static void M_RunQueue(M_PRIV *p);
+
+static const M_HEADER_HANDLER m_HeaderHandlers[] = {
+    M_ParseSeedControl,
+    M_ParseSeedDraw,
+    M_ParseBindKeyboard,
+    M_ParseBindController,
+    M_ParseArgs,
+    M_ParseConfig,
+    nullptr,
+};
+
+static const M_EVENT_HANDLER m_EventHandlers[] = {
+    M_ParseQuitEvent,
+    M_ParseKeyDownEvent,
+    M_ParseKeyUpEvent,
+    M_ParseTextInputEvent,
+    M_ParseCommandEvent,
+#if M_DEBUG
+    M_ParseAssertEvent,
+#endif
+    nullptr,
+};
+
+static bool M_ParseQuitEvent(const char *const event_str)
+{
+    if (strcmp(event_str, "quit") != 0) {
+        return false;
+    }
+    SDL_Event event = { .type = SDL_QUIT };
+    Shell_ProcessEvent(&event);
+    return true;
+}
+
+static bool M_ParseKeyDownEvent(const char *const event_str)
+{
+    SDL_Event event = { .type = SDL_KEYDOWN };
+    if (sscanf(
+            event_str, "keydown %hu %hu",
+            (uint16_t *)&event.key.keysym.scancode, &event.key.keysym.mod)
+        != 2) {
+        return false;
+    }
+    event.key.keysym.sym = SDL_GetKeyFromScancode(event.key.keysym.scancode);
+    Shell_ProcessEvent(&event);
+    return true;
+}
+
+static bool M_ParseKeyUpEvent(const char *const event_str)
+{
+    SDL_Event event = { .type = SDL_KEYUP };
+    if (sscanf(
+            event_str, "keyup %hu %hu", (uint16_t *)&event.key.keysym.scancode,
+            &event.key.keysym.mod)
+        != 2) {
+        return false;
+    }
+    event.key.keysym.sym = SDL_GetKeyFromScancode(event.key.keysym.scancode);
+    Shell_ProcessEvent(&event);
+    return true;
+}
+
+static bool M_ParseTextInputEvent(const char *const event_str)
+{
+    SDL_Event event = { .type = SDL_TEXTINPUT };
+    const char *const fmt = String_FormatStatic(
+        "text-input \"%%%d[^\"]\"", SDL_TEXTEDITINGEVENT_TEXT_SIZE - 1);
+    if (sscanf(event_str, fmt, &event.text.text) != 1) {
+        return false;
+    }
+    Shell_ProcessEvent(&event);
+    return true;
+}
+
+static bool M_ParseCommandEvent(const char *const event_str)
+{
+    if (strncmp(event_str, "cmd ", 4) != 0) {
+        return false;
+    }
+
+    const char *const start = strchr(event_str + 4, '"');
+    const char *const end = start ? strrchr(start + 1, '"') : nullptr;
+    if (start == nullptr || end == nullptr || end <= start + 1) {
+        LOG_WARNING("Malformed cmd instruction: %s", event_str);
+        return false;
+    }
+    const size_t len = (size_t)(end - (start + 1));
+    char *const cmd_str = Memory_DupStr(start + 1);
+    if (strlen(cmd_str) > len) {
+        cmd_str[len] = '\0';
+    }
+    Console_Eval(cmd_str);
+    return true;
+}
+
+static bool M_ParseAssertEvent(const char *const event_str)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    const GAME_OBJECT_ID obj_id = Lara_GetAnimationObject();
+    const ITEM *const vehicle_item = Lara_Vehicle_GetItem();
+    int32_t x, y, z;
+    if (sscanf(event_str, "assert lara.pos=%d,%d,%d", &x, &y, &z) == 3) {
+        ASSERT(lara_item->pos.x == x);
+        ASSERT(lara_item->pos.y == y);
+        ASSERT(lara_item->pos.z == z);
+        return true;
+    } else if (sscanf(event_str, "assert lara.rot=%d,%d,%d", &x, &y, &z) == 3) {
+        ASSERT(lara_item->rot.x == x);
+        ASSERT(lara_item->rot.y == y);
+        ASSERT(lara_item->rot.z == z);
+        return true;
+    } else if (
+        sscanf(event_str, "assert lara.anim=%d,%d,%d", &x, &y, &z) == 3) {
+        ASSERT(x == obj_id);
+        ASSERT(y == Item_GetRelativeObjAnim(lara_item, obj_id));
+        ASSERT(z == Item_GetRelativeFrame(lara_item));
+        return true;
+    } else if (sscanf(event_str, "assert lara.speed=%d,%d", &x, &y) == 2) {
+        ASSERT(
+            x == (vehicle_item != nullptr ? vehicle_item : lara_item)->speed);
+        ASSERT(
+            y
+            == (vehicle_item != nullptr ? vehicle_item : lara_item)
+                   ->fall_speed);
+        return true;
+    }
+    return false;
+}
+
+static bool M_ParseEvent(const char *const event_str)
+{
+    for (int32_t i = 0; m_EventHandlers[i] != nullptr; i++) {
+        if (m_EventHandlers[i](event_str)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void M_ClearQueue(M_PRIV *const p)
+{
+    if (p->queue != nullptr) {
+        for (int32_t i = 0; i < p->queue->count; i++) {
+            char *event_str = *(char **)Vector_Get(p->queue, i);
+            Memory_Free(event_str);
+        }
+        Vector_Clear(p->queue);
+    }
+}
+
+static void M_ReadQueue(M_PRIV *const p)
+{
+    M_ClearQueue(p);
+    while (true) {
+        char *const line = (char *)File_ReadLine(p->file);
+        if (line == nullptr) {
+            break;
+        }
+        if (line[0] == '#' || line[0] == '\n') {
+            continue;
+        }
+        if (line[strlen(line) - 1] == '\n') {
+            line[strlen(line) - 1] = '\0';
+        }
+
+        char *const colon = strchr(line, ':');
+        if (colon == nullptr) {
+            LOG_ERROR("Malformed input line: %s", line);
+            continue; // Malformed line
+        }
+        *colon = '\0';
+
+        int32_t frame = -1;
+        if (sscanf(line, "frame %d", &frame) != 1) {
+            LOG_ERROR("Malformed input line: %s", line);
+            continue;
+        }
+
+        p->next_frame_idx = frame;
+
+        char *const events_str = colon + 1;
+        const char *token = strtok(events_str, ";");
+        while (token != nullptr) {
+            while (*token == ' ' || *token == '\t') {
+                token++; // trim leading space
+            }
+
+            char *const event_str = Memory_DupStr(token);
+            Vector_Add(p->queue, &event_str);
+
+            token = strtok(nullptr, ";");
+        }
+        return;
+    }
+
+    // no more frames
+    p->next_frame_idx = -1;
+}
+
+static void M_RunQueue(M_PRIV *const p)
+{
+#if M_DEBUG
+    LOG_INFO("%d", p->frame_idx);
+#endif
+    for (int32_t i = 0; i < p->queue->count; i++) {
+        const char *const event_str = *(char **)Vector_Get(p->queue, i);
+        M_ParseEvent(event_str);
+    }
+}
+
+static bool M_ParseSeedControl(const char *const line, M_PARSE_CTX *const ctx)
+{
+    int32_t val;
+    if (sscanf(line, "# seed_control %d", &val) == 1) {
+        Random_SeedControl(val);
+        return true;
+    }
+    return false;
+}
+
+static bool M_ParseSeedDraw(const char *const line, M_PARSE_CTX *const ctx)
+{
+    int32_t val;
+    if (sscanf(line, "# seed_draw %d", &val) == 1) {
+        Random_SeedDraw(val);
+        return true;
+    }
+    return false;
+}
+
+static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
+{
+    int32_t role;
+    int32_t scancode;
+    if (sscanf(line, "# bind keyboard %d %d", &role, &scancode) == 2) {
+        JSON_OBJECT *bind = JSON_ObjectNew();
+        JSON_ObjectAppendInt(bind, "scancode", scancode);
+        g_Input_Keyboard.assign_from_json_object(
+            g_Config.input.keyboard_layout, role, bind);
+        JSON_ObjectFree(bind);
+        return true;
+    }
+    return false;
+}
+
+static bool M_ParseBindController(
+    const char *const line, M_PARSE_CTX *const ctx)
+{
+    int32_t role;
+    int32_t bt;
+    int32_t b;
+    int32_t ad;
+    if (sscanf(line, "# bind controller %d %d %d %d", &role, &bt, &b, &ad)
+        == 4) {
+        JSON_OBJECT *bind = JSON_ObjectNew();
+        JSON_ObjectAppendInt(bind, "button_type", bt);
+        JSON_ObjectAppendInt(bind, "bind", b);
+        JSON_ObjectAppendInt(bind, "axis_dir", ad);
+        g_Input_Controller.assign_from_json_object(
+            g_Config.input.controller_layout, role, bind);
+        JSON_ObjectFree(bind);
+        return true;
+    }
+    return false;
+}
+
+static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
+{
+    if (strncmp(line, "# args", 6) != 0) {
+        return false;
+    }
+
+    ctx->raw_args = Vector_Create(sizeof(const char *));
+    const char *p = line + 6;
+    while (*p != '\0') {
+        while (isspace((unsigned char)*p)) {
+            p++;
+        }
+        if (*p != '"') {
+            break;
+        }
+
+        p++;
+        const char *start = p;
+        while (*p != '\0' && *p != '"') {
+            p++;
+        }
+        const ptrdiff_t len = p - start;
+        char tmp[len + 1];
+        memcpy(tmp, start, len);
+        tmp[len] = '\0';
+        char *arg = Memory_DupStr(tmp);
+        Vector_Add(ctx->raw_args, &arg);
+        if (*p == '"') {
+            p++;
+        }
+    }
+    return true;
+}
+
+static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
+{
+    char keybuf[64];
+    char valbuf[128];
+    if (sscanf(line, "# config %63s %127s", keybuf, valbuf) == 2) {
+        const CONFIG_OPTION *opt = Config_GetOptionByPath(keybuf);
+        if (opt) {
+            Config_SetOptionValueFromString(opt, valbuf);
+        } else {
+            LOG_WARNING("Unknown option: %s", keybuf);
+        }
+        return true;
+    }
+    return false;
+}
+
+static void M_ReadHeaders(M_PRIV *const p, M_PARSE_CTX *const ctx)
+{
+    while (true) {
+        const char *const line = File_ReadLine(p->file);
+        if (line == nullptr) {
+            break;
+        }
+
+        // Stop when a non-comment is encountered
+        if (line[0] != '#') {
+            File_Skip(p->file, -strlen(line));
+            break;
+        }
+
+        // Dispatch based on matching prefix
+        bool handled = false;
+        for (int32_t i = 0; m_HeaderHandlers[i] != nullptr; i++) {
+            if (m_HeaderHandlers[i](line, ctx)) {
+                handled = true;
+                break;
+            }
+        }
+
+        // Unknown #comment? Just ignore
+        if (!handled) {
+            LOG_WARNING("Unknown line: %s", line);
+        }
+    }
+}
+
+SHELL_ARGS *TestReplay_Open(const char *path)
+{
+    M_PRIV *const p = &m_Priv;
+    p->file = File_Open(path, FILE_OPEN_READ);
+    if (p->file == nullptr) {
+        LOG_ERROR("Cannot open replay file '%s'", path);
+        return nullptr;
+    }
+
+    // Read header for initialization stuff
+    M_PARSE_CTX ctx;
+    M_ReadHeaders(p, &ctx);
+    SHELL_ARGS *new_args =
+        ctx.raw_args != nullptr ? Shell_ParseArgs(ctx.raw_args) : nullptr;
+
+    p->next_frame_idx = -1;
+    p->queue = Vector_Create(sizeof(char *));
+    M_ReadQueue(p);
+    LOG_INFO("Starting playback");
+    return new_args;
+}
+
+void TestReplay_Close(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file != nullptr) {
+        File_Close(p->file);
+        p->file = nullptr;
+    }
+    if (p->queue != nullptr) {
+        M_ClearQueue(p);
+        Vector_Free(p->queue);
+        p->queue = nullptr;
+    }
+}
+
+bool TestReplay_IsOpened(void)
+{
+    M_PRIV *const p = &m_Priv;
+    return p->file != nullptr;
+}
+
+void TestReplay_RunFrame(void)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->next_frame_idx == p->frame_idx) {
+        M_RunQueue(p);
+        M_ReadQueue(p);
+    }
+    p->frame_idx++;
+}

--- a/src/libtrx/include/libtrx/game/random.h
+++ b/src/libtrx/include/libtrx/game/random.h
@@ -8,5 +8,7 @@ void Random_SeedDraw(int32_t seed);
 
 int32_t Random_GetControl(void);
 int32_t Random_GetDraw(void);
+int32_t Random_GetControlSeed(void);
+int32_t Random_GetDrawSeed(void);
 
 void Random_FreezeDraw(bool is_frozen);

--- a/src/libtrx/include/libtrx/game/shell/args.h
+++ b/src/libtrx/include/libtrx/game/shell/args.h
@@ -18,6 +18,8 @@ typedef struct {
     SHELL_MOD mod;
     const char *level_to_play;
     int32_t save_to_load;
+    const char *test_record_path;
+    const char *test_replay_path;
 } SHELL_ARGS;
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *raw_args);

--- a/src/libtrx/include/libtrx/game/shell/events.h
+++ b/src/libtrx/include/libtrx/game/shell/events.h
@@ -1,3 +1,6 @@
 #pragma once
 
-extern void Shell_ProcessEvents(void);
+#include <SDL2/SDL.h>
+
+bool Shell_ProcessEvent(const SDL_Event *event);
+void Shell_ProcessEvents(void);

--- a/src/libtrx/include/libtrx/game/shell/flow.h
+++ b/src/libtrx/include/libtrx/game/shell/flow.h
@@ -2,7 +2,7 @@
 
 #include "./args.h"
 
-// TODO: inline these once we get common shell code
-void Shell_InstallConfig(void);
-void Shell_CommonInit(const SHELL_ARGS *args);
+void Shell_InitCommonModules(void);
 void Shell_ShutdownCommonModules(void);
+
+const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *args);

--- a/src/libtrx/include/libtrx/game/test_recorder.h
+++ b/src/libtrx/include/libtrx/game/test_recorder.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../vector.h"
+#include "./shell/args.h"
+
+#include <SDL2/SDL.h>
+
+// Test replay: a module to record game playthroughs.
+// ============================================================================
+
+// Initialize test recorder for recording mode.
+// @param path  Path to the recording to write to.
+void TestRecorder_Open(const char *path, VECTOR *original_args);
+
+// Close the recorder.
+void TestRecorder_Close(void);
+
+// Return whether the recording mode is currently active.
+bool TestRecorder_IsOpened(void);
+
+// Should be called at the start of each frame to handle skip logic.
+void TestRecorder_BeginFrame(void);
+
+// Record a single SDL_Event. Called for each event polled. Only essential
+// events are recorded.
+// @param event     Event to record
+void TestRecorder_RecordEvent(const SDL_Event *event);
+
+// Should be called after processing events each frame to update skip counters.
+void TestRecorder_EndFrame(void);

--- a/src/libtrx/include/libtrx/game/test_replay.h
+++ b/src/libtrx/include/libtrx/game/test_replay.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "./shell/args.h"
+
+#include <SDL2/SDL.h>
+
+// Test replay: a module to simulate game playthroughs.
+// ============================================================================
+
+// Initialize test replay for playback mode.
+// @param path  Path to the recording to play from.
+// @return      Parsed shell arguments from the replay file, or nullptr on
+//              error.
+SHELL_ARGS *TestReplay_Open(const char *path);
+
+// Shutdown test replay.
+void TestReplay_Close(void);
+
+// Return whether the replay mode is currently active.
+bool TestReplay_IsOpened(void);
+
+// Run all events associated with the given frame.
+void TestReplay_RunFrame(void);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -271,6 +271,8 @@ sources = [
   'game/sound/common.c',
   'game/spawn.c',
   'game/stats.c',
+  'game/test_recorder.c',
+  'game/test_replay.c',
   'game/ui/common.c',
   'game/ui/dialogs/base_passport.c',
   'game/ui/dialogs/controls.c',

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -107,13 +107,13 @@ SDL_Window *Shell_GetWindow(void)
     return m_Window;
 }
 
-int32_t Shell_Main(const SHELL_ARGS *const args)
+int32_t Shell_Main(const SHELL_ARGS *args)
 {
     ASSERT(args != nullptr);
     LOG_INFO("Game directory: %s", File_GetGameDirectory());
 
-    Shell_CommonInit(args);
-
+    Shell_InitCommonModules();
+    args = Shell_CommonInit(args);
     M_CreateGameWindow();
 
     if (!Output_Init()) {

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -88,13 +88,13 @@ static void M_ShowWindow(void)
     Render_Reset(RENDER_RESET_PARAMS);
 }
 
-int32_t Shell_Main(const SHELL_ARGS *const args)
+int32_t Shell_Main(const SHELL_ARGS *args)
 {
     ASSERT(args != nullptr);
     LOG_INFO("Game directory: %s", File_GetGameDirectory());
 
-    Shell_CommonInit(args);
-
+    Shell_InitCommonModules();
+    args = Shell_CommonInit(args);
     if (!M_CreateGameWindow()) {
         Shell_ExitSystem("Failed to create game window");
         return 1;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR offers a way to record and play back player input at the shell level, making it possible to automate testing of gameplay sessions. At its foundation, it introduces two new run modes: a recording mode that captures key SDL events to a text file, and a replay mode that retrieves and sends those events back into the engine. These modes are optional and can be activated using new command-line flags.

From a development angle, the patch hooks into the SDL event-polling loop to call `TestRecorder` or `TestReplay` callbacks around each frame. In recording mode, every event is processed using `TestRecorder_RecordEvent`, surrounded by `TestRecorder_BeginFrame` and `EndFrame`, which lets the recorder eliminate unnecessary frames or group writes. In replay mode, `TestReplay_PollEvent` manages the game's input system, and actual SDL events during playback are filtered to handle only most essential events (currently only SDL_QUIT). 

I took care to try and make the test recordings as config-agnostic as possible. To achieve this, the recorded text files contain deviations from the game's default config, random seeds, passed CLI arguments (so that it works with `-l` and `-s`) and current input bindings (so that a capture can work between machines and user configurations). Configuration writes are paused during replay to prevent unwanted changes to config files.

Future improvements can include:

- adding dedicated inputs during the playback mode – for example, to make a screenshot, or skip some frames;
- adding a way to run automated assertions – likely through LUA `eval()`-like mechanism;
- introducing a headless mode so that the simulation can run in immediate mode, rather than in real time.

LMK your thoughts.