### PR TITLE
phase: simplify frame management

### DIFF
--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -25,7 +25,7 @@ static FADER m_ExitFader;
 static int32_t m_PhaseStackSize = 0;
 static PHASE *m_PhaseStack[MAX_PHASES] = {};
 
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t nframes);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static GF_COMMAND M_HandleOverride(void)
@@ -50,7 +50,7 @@ static GF_COMMAND M_HandleOverride(void)
     return (GF_COMMAND) { .action = GF_NOOP };
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     Shell_ProcessEvents();
     Console_Control();
@@ -74,7 +74,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t nframes)
     }
 
     if (phase != nullptr && phase->control != nullptr) {
-        return phase->control(phase, nframes);
+        return phase->control(phase);
     }
     return (PHASE_CONTROL) {
         .action = PHASE_ACTION_END,
@@ -144,32 +144,36 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
         }
     }
 
-    int32_t nframes = Clock_WaitTick();
     while (true) {
-        const PHASE_CONTROL control = M_Control(phase, nframes);
-
-        if (control.action == PHASE_ACTION_END) {
-            if (Shell_IsExiting()) {
-                gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
-            } else {
-                gf_cmd = control.gf_cmd;
-            }
-            goto finish;
-        } else if (control.action == PHASE_ACTION_NO_WAIT) {
-            nframes = 0;
-            continue;
-        } else {
-            nframes = 0;
-            if (Interpolation_IsEnabled()) {
-                Interpolation_SetRate(0.5);
-                M_Draw(phase);
-                Clock_WaitTick();
+        int32_t nframes = Clock_WaitTick();
+        int32_t frame = 0;
+        while (true) {
+            const PHASE_CONTROL control = M_Control(phase);
+            if (control.action == PHASE_ACTION_END) {
+                if (Shell_IsExiting()) {
+                    gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
+                } else {
+                    gf_cmd = control.gf_cmd;
+                }
+                goto finish;
+            } else if (control.action == PHASE_ACTION_NO_WAIT) {
+                continue;
             }
 
-            Interpolation_SetRate(1.0);
-            M_Draw(phase);
-            nframes += Clock_WaitTick();
+            frame++;
+            if (frame >= nframes) {
+                break;
+            }
         }
+
+        if (Interpolation_IsEnabled()) {
+            Interpolation_SetRate(0.5);
+            M_Draw(phase);
+            Clock_WaitTick();
+        }
+
+        Interpolation_SetRate(1.0);
+        M_Draw(phase);
     }
 
 finish:

--- a/src/libtrx/game/phase/phase_cutscene.c
+++ b/src/libtrx/game/phase/phase_cutscene.c
@@ -14,7 +14,7 @@ static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
 static void M_Suspend(PHASE *phase);
 static void M_Resume(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t n_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
@@ -48,17 +48,15 @@ static void M_Resume(PHASE *const phase)
     Game_SetIsPlaying(true);
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
-    for (int32_t i = 0; i < num_frames; i++) {
-        const GF_COMMAND gf_cmd = Cutscene_Control();
-        if (gf_cmd.action != GF_NOOP) {
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .gf_cmd = gf_cmd,
-            };
-        }
+    const GF_COMMAND gf_cmd = Cutscene_Control();
+    if (gf_cmd.action != GF_NOOP) {
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END,
+            .gf_cmd = gf_cmd,
+        };
     }
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }

--- a/src/libtrx/game/phase/phase_demo.c
+++ b/src/libtrx/game/phase/phase_demo.c
@@ -26,7 +26,7 @@ static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
 static void M_Suspend(PHASE *const phase);
 static void M_Resume(PHASE *const phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t n_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
@@ -69,22 +69,19 @@ static void M_Resume(PHASE *const phase)
     Demo_Unpause();
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
 
     switch (p->state) {
     case STATE_RUN:
-        for (int32_t i = 0; i < num_frames; i++) {
-            const GF_COMMAND gf_cmd = Demo_Control();
-            if (gf_cmd.action != GF_NOOP) {
-                p->state = STATE_FADE_OUT;
-                p->exit_gf_cmd = gf_cmd;
-                Fader_Init(&p->top_fader, FADER_ANY, FADER_BLACK, 0.5);
-                return (PHASE_CONTROL) { .action = PHASE_ACTION_NO_WAIT };
-            }
+        const GF_COMMAND gf_cmd = Demo_Control();
+        if (gf_cmd.action != GF_NOOP) {
+            p->state = STATE_FADE_OUT;
+            p->exit_gf_cmd = gf_cmd;
+            Fader_Init(&p->top_fader, FADER_ANY, FADER_BLACK, 0.5);
+            return (PHASE_CONTROL) { .action = PHASE_ACTION_NO_WAIT };
         }
-
         break;
 
     case STATE_FADE_OUT:

--- a/src/libtrx/game/phase/phase_game.c
+++ b/src/libtrx/game/phase/phase_game.c
@@ -12,7 +12,7 @@ typedef struct {
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
 static void M_Resume(PHASE *const phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t n_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
@@ -48,16 +48,14 @@ static void M_Resume(PHASE *const phase)
     Game_SetIsPlaying(true);
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
-    for (int32_t i = 0; i < num_frames; i++) {
-        const GF_COMMAND gf_cmd = Game_Control(false);
-        if (gf_cmd.action != GF_NOOP) {
-            return (PHASE_CONTROL) {
-                .action = PHASE_ACTION_END,
-                .gf_cmd = gf_cmd,
-            };
-        }
+    const GF_COMMAND gf_cmd = Game_Control(false);
+    if (gf_cmd.action != GF_NOOP) {
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END,
+            .gf_cmd = gf_cmd,
+        };
     }
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }

--- a/src/libtrx/game/phase/phase_inventory.c
+++ b/src/libtrx/game/phase/phase_inventory.c
@@ -16,7 +16,7 @@ typedef struct {
 
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t num_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
@@ -43,11 +43,11 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     ASSERT(p->ring != nullptr);
-    const GF_COMMAND gf_cmd = InvRing_Control(p->ring, num_frames);
+    const GF_COMMAND gf_cmd = InvRing_Control(p->ring);
     return (PHASE_CONTROL) {
         .action = p->ring->motion.status == RNG_DONE ? PHASE_ACTION_END
                                                      : PHASE_ACTION_CONTINUE,

--- a/src/libtrx/game/phase/phase_pause.c
+++ b/src/libtrx/game/phase/phase_pause.c
@@ -44,7 +44,7 @@ static void M_RemoveText(M_PRIV *p);
 
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t nframes);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static void M_FadeIn(M_PRIV *const p)
@@ -114,7 +114,7 @@ static void M_End(PHASE *const phase)
     UI_Pause_Free(&p->ui.state);
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, int32_t const num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     Input_Update();

--- a/src/libtrx/game/phase/phase_photo_mode.c
+++ b/src/libtrx/game/phase/phase_photo_mode.c
@@ -28,7 +28,7 @@ typedef struct {
 
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t num_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static PHASE_CONTROL M_Start(PHASE *phase)
@@ -42,7 +42,7 @@ static void M_End(PHASE *const phase)
     PhotoMode_End();
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     Input_Update();

--- a/src/libtrx/game/phase/phase_picture.c
+++ b/src/libtrx/game/phase/phase_picture.c
@@ -23,7 +23,7 @@ static void M_FadeOut(M_PRIV *p);
 
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t num_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static void M_FadeOut(M_PRIV *const p)
@@ -46,7 +46,7 @@ static void M_End(PHASE *const phase)
     Output_UnloadBackground();
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, const int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     Input_Update();

--- a/src/libtrx/game/phase/phase_stats.c
+++ b/src/libtrx/game/phase/phase_stats.c
@@ -33,7 +33,7 @@ static void M_FadeOut(M_PRIV *p, bool force);
 
 static PHASE_CONTROL M_Start(PHASE *phase);
 static void M_End(PHASE *phase);
-static PHASE_CONTROL M_Control(PHASE *phase, int32_t num_frames);
+static PHASE_CONTROL M_Control(PHASE *phase);
 static void M_Draw(PHASE *phase);
 
 static bool M_IsFading(M_PRIV *const p)
@@ -114,7 +114,7 @@ static void M_End(PHASE *const phase)
     Output_UnloadBackground();
 }
 
-static PHASE_CONTROL M_Control(PHASE *const phase, int32_t num_frames)
+static PHASE_CONTROL M_Control(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     Input_Update();

--- a/src/libtrx/game/photo_mode.c
+++ b/src/libtrx/game/photo_mode.c
@@ -100,7 +100,7 @@ static PHASE_CONTROL M_AdvanceFrame(M_PRIV *const p)
     if (p->rate >= 1.0) {
         g_Input.any = 0;
         g_InputDB.any = 0;
-        result = phase->control(phase, 1);
+        result = phase->control(phase);
         g_Input.any = 0;
         g_InputDB.any = 0;
         p->rate = 0.0;

--- a/src/libtrx/include/libtrx/game/inventory_ring/control.h
+++ b/src/libtrx/include/libtrx/game/inventory_ring/control.h
@@ -7,7 +7,7 @@
 extern INV_RING *InvRing_Open(INVENTORY_MODE mode);
 extern void InvRing_Close(INV_RING *ring);
 
-extern GF_COMMAND InvRing_Control(INV_RING *ring, int32_t num_frames);
+extern GF_COMMAND InvRing_Control(INV_RING *ring);
 extern bool InvRing_IsRingAvailable(RING_TYPE ring_type);
 
 void InvRing_AdjustMusicVolume(const INV_RING *ring);

--- a/src/libtrx/include/libtrx/game/phase/types.h
+++ b/src/libtrx/include/libtrx/game/phase/types.h
@@ -8,7 +8,7 @@ typedef PHASE_CONTROL (*PHASE_START_FUNC)(PHASE *phase);
 typedef void (*PHASE_END_FUNC)(PHASE *phase);
 typedef void (*PHASE_SUSPEND_FUNC)(PHASE *phase);
 typedef void (*PHASE_RESUME_FUNC)(PHASE *phase);
-typedef PHASE_CONTROL (*PHASE_CONTROL_FUNC)(PHASE *phase, int32_t num_frames);
+typedef PHASE_CONTROL (*PHASE_CONTROL_FUNC)(PHASE *phase);
 typedef void (*PHASE_DRAW_FUNC)(PHASE *phase);
 
 typedef struct PHASE {

--- a/src/tr1/game/inventory_ring/control.c
+++ b/src/tr1/game/inventory_ring/control.c
@@ -901,18 +901,10 @@ void InvRing_Close(INV_RING *const ring)
     Memory_Free(ring);
 }
 
-GF_COMMAND InvRing_Control(INV_RING *const ring, const int32_t num_frames)
+GF_COMMAND InvRing_Control(INV_RING *const ring)
 {
     InvRing_AdjustMusicVolume(ring);
-    GF_COMMAND gf_cmd = { .action = GF_NOOP };
-    for (int32_t i = 0; i < num_frames; i++) {
-        gf_cmd = M_Control(ring);
-        if (gf_cmd.action != GF_NOOP) {
-            break;
-        }
-    }
-
-    return gf_cmd;
+    return M_Control(ring);
 }
 
 bool InvRing_IsRingAvailable(const RING_TYPE ring_type)

--- a/src/tr2/game/inventory_ring/control.c
+++ b/src/tr2/game/inventory_ring/control.c
@@ -908,19 +908,12 @@ void InvRing_Close(INV_RING *const ring)
     Memory_Free(ring);
 }
 
-GF_COMMAND InvRing_Control(INV_RING *const ring, const int32_t num_frames)
+GF_COMMAND InvRing_Control(INV_RING *const ring)
 {
     InvRing_AdjustMusicVolume(ring);
-    GF_COMMAND gf_cmd = { .action = GF_NOOP };
-    for (int32_t i = 0; i < num_frames; i++) {
-        gf_cmd = M_Control(ring);
-        if (gf_cmd.action != GF_NOOP) {
-            break;
-        }
-    }
-
-    Overlay_Animate(num_frames);
-    Output_AnimateTextures(num_frames * TICKS_PER_FRAME);
+    GF_COMMAND gf_cmd = M_Control(ring);
+    Overlay_Animate(1);
+    Output_AnimateTextures(TICKS_PER_FRAME);
     return gf_cmd;
 }
 

--- a/src/tr2/game/inventory_ring/control.h
+++ b/src/tr2/game/inventory_ring/control.h
@@ -7,7 +7,6 @@
 #include <libtrx/game/objects/types.h>
 
 INV_RING *InvRing_Open(INVENTORY_MODE mode);
-GF_COMMAND InvRing_Control(INV_RING *ring, int32_t num_frames);
 void InvRing_Close(INV_RING *ring);
 
 void InvRing_RemoveAllText(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The goal of this PR is to fix timing-related issues in #3601.

The old two‑level timing loop is hoisted into the phase executor; each phase's `control()` now just does a single‐frame pass, and the outer code in `PhaseExecutor_Run` drives the multi‑frame loop. All forward declarations and calls to `M_Control` have been updated to drop the old `nframes` argument.

This change is invasive, and needs additional testing around:

- fade effects speed
- animated textures speed
- turbo cheat
- vsync on/off
- all phases simulation speeds
    - game
    - cutscenes
    - demos
    - fmvs
    - pictures
    - stats
    - pause mode
    - photo mode
    - ingame inventory ring
    - title inventory ring
    - assault course timer
    - compass / stopwatch inventory timer and ingame timer (both TRs)
- game flow overrides (issuing `/play` or `/title` in different contexts)