### PR TITLE
test-replay: improve syntax

### DIFF
--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -49,6 +49,9 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
     out_args->mod = M_BASE_MOD;
     out_args->save_to_load = -1;
     out_args->original_args = args;
+    if (args == nullptr) {
+        return out_args;
+    }
 
     for (int32_t i = 0; i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "debug.h"
 #include "enum_map.h"
 #include "game/clock.h"
 #include "game/console.h"
@@ -133,6 +134,7 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
     if (args->test_replay_path != nullptr) {
         SHELL_ARGS *tmp_args = TestReplay_Open(args->test_replay_path);
         // original args not needed, free immediately.
+        ASSERT(tmp_args != nullptr);
         if (tmp_args->original_args != nullptr) {
             Vector_Free(tmp_args->original_args);
             tmp_args->original_args = nullptr;

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -94,12 +94,12 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
         LOG_ERROR("Cannot open record file '%s'", path);
         return;
     }
-    File_WriteString(p->file, "# seed_control %d\n", Random_GetControlSeed());
-    File_WriteString(p->file, "# seed_draw %d\n", Random_GetDrawSeed());
+    File_WriteString(p->file, "seed_control %d\n", Random_GetControlSeed());
+    File_WriteString(p->file, "seed_draw %d\n", Random_GetDrawSeed());
 
     // Record original arguments passed to the game
     if (original_args->count > 0) {
-        File_WriteString(p->file, "# args");
+        File_WriteString(p->file, "args");
         for (int32_t i = 0; i < original_args->count; i++) {
             const char *const arg = *(char **)Vector_Get(original_args, i);
             if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
@@ -117,7 +117,7 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
          opt++) {
         if (!Config_IsOptionAtDefault(opt->target)) {
             File_WriteString(
-                p->file, "# config %s %s\n", opt->name,
+                p->file, "config %s %s\n", opt->name,
                 Config_GetOptionValueAsString(opt));
         }
     }
@@ -129,7 +129,7 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
         if (g_Input_Keyboard.assign_to_json_object(
                 g_Config.input.keyboard_layout, role, bind)) {
             const int32_t sc = JSON_ObjectGetInt(bind, "scancode", -1);
-            File_WriteString(p->file, "# bind keyboard %d %d\n", role, sc);
+            File_WriteString(p->file, "bind keyboard %d %d\n", role, sc);
         }
         JSON_ObjectFree(bind);
     }
@@ -142,7 +142,7 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
             const int32_t b = JSON_ObjectGetInt(bind, "bind", 0);
             const int32_t ad = JSON_ObjectGetInt(bind, "axis_dir", 0);
             File_WriteString(
-                p->file, "# bind controller %d %d %d %d\n", role, bt, b, ad);
+                p->file, "bind controller %d %d %d %d\n", role, bt, b, ad);
         }
         JSON_ObjectFree(bind);
     }

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -264,7 +264,7 @@ static void M_RunQueue(M_PRIV *const p)
 static bool M_ParseSeedControl(const char *const line, M_PARSE_CTX *const ctx)
 {
     int32_t val;
-    if (sscanf(line, "# seed_control %d", &val) == 1) {
+    if (sscanf(line, "seed_control %d", &val) == 1) {
         Random_SeedControl(val);
         return true;
     }
@@ -274,7 +274,7 @@ static bool M_ParseSeedControl(const char *const line, M_PARSE_CTX *const ctx)
 static bool M_ParseSeedDraw(const char *const line, M_PARSE_CTX *const ctx)
 {
     int32_t val;
-    if (sscanf(line, "# seed_draw %d", &val) == 1) {
+    if (sscanf(line, "seed_draw %d", &val) == 1) {
         Random_SeedDraw(val);
         return true;
     }
@@ -285,7 +285,7 @@ static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
 {
     int32_t role;
     int32_t scancode;
-    if (sscanf(line, "# bind keyboard %d %d", &role, &scancode) == 2) {
+    if (sscanf(line, "bind keyboard %d %d", &role, &scancode) == 2) {
         JSON_OBJECT *bind = JSON_ObjectNew();
         JSON_ObjectAppendInt(bind, "scancode", scancode);
         g_Input_Keyboard.assign_from_json_object(
@@ -303,8 +303,7 @@ static bool M_ParseBindController(
     int32_t bt;
     int32_t b;
     int32_t ad;
-    if (sscanf(line, "# bind controller %d %d %d %d", &role, &bt, &b, &ad)
-        == 4) {
+    if (sscanf(line, "bind controller %d %d %d %d", &role, &bt, &b, &ad) == 4) {
         JSON_OBJECT *bind = JSON_ObjectNew();
         JSON_ObjectAppendInt(bind, "button_type", bt);
         JSON_ObjectAppendInt(bind, "bind", b);
@@ -319,12 +318,12 @@ static bool M_ParseBindController(
 
 static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
 {
-    if (strncmp(line, "# args", 6) != 0) {
+    if (strncmp(line, "args", 4) != 0) {
         return false;
     }
 
     ctx->raw_args = Vector_Create(sizeof(const char *));
-    const char *p = line + 6;
+    const char *p = line + 4;
     while (*p != '\0') {
         while (isspace((unsigned char)*p)) {
             p++;
@@ -355,7 +354,7 @@ static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
 {
     char keybuf[64];
     char valbuf[128];
-    if (sscanf(line, "# config %63s %127s", keybuf, valbuf) == 2) {
+    if (sscanf(line, "config %63s %127s", keybuf, valbuf) == 2) {
         const CONFIG_OPTION *opt = Config_GetOptionByPath(keybuf);
         if (opt) {
             Config_SetOptionValueFromString(opt, valbuf);
@@ -375,8 +374,14 @@ static void M_ReadHeaders(M_PRIV *const p, M_PARSE_CTX *const ctx)
             break;
         }
 
+        // Skip comments and blank lines
+        if (line[0] == '\n' || line[0] == '#') {
+            continue;
+        }
+
         // Stop when a non-comment is encountered
-        if (line[0] != '#') {
+        int32_t frame = 0;
+        if (sscanf(line, "frame %d:", &frame) == 1) {
             File_Skip(p->file, -strlen(line));
             break;
         }
@@ -409,8 +414,7 @@ SHELL_ARGS *TestReplay_Open(const char *path)
     // Read header for initialization stuff
     M_PARSE_CTX ctx;
     M_ReadHeaders(p, &ctx);
-    SHELL_ARGS *new_args =
-        ctx.raw_args != nullptr ? Shell_ParseArgs(ctx.raw_args) : nullptr;
+    SHELL_ARGS *const new_args = Shell_ParseArgs(ctx.raw_args);
 
     p->next_frame_idx = -1;
     p->queue = Vector_Create(sizeof(char *));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Drops the `#` prefix from the header commands
- Adds support for `#` prefix for comments (ignores them silently)
- Adds support for blank lines (ignores them silently)
- Fix missing `args` line causing the game to crash

#### Testing

Record a macro with `-l` and replay it – it should start in a level of user choice