### PR TITLE
game-flow: fix applying resume info across cutscenes

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed missing door sound effects in Lara's Home, Bartoli's Hideout, Opera House, Living Quarters, Catacombs of the Talion, Ice Palace, Home Sweet Home, Fool's Gold, Kingdom and Nightmare in Vegas (#3363)
 - fixed being unable to antitrigger waterfall objects (#3589)
 - fixed incorrect frames in Lara's underwater roll animation (#1589)
+- fixed persistent damage resetting Lara's HP after cutscenes (#3595, regression from 1.2)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -133,13 +133,11 @@ GF_COMMAND GF_InterpretSequence(
     }
 
     default:
-#if TR_VERSION == 1
         if (level->type == GFL_GYM) {
             Savegame_ResetCurrentInfo(level);
-        } else if (level->type == GFL_BONUS) {
+        } else if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
             Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
         }
-#endif
         Savegame_ApplyLogicToCurrentInfo(level);
         if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
             GF_InventoryModifier_Scan(level);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -137,9 +137,6 @@ static DECLARE_GF_EVENT_HANDLER(M_HandleLevelComplete)
     if (g_GameInfo.select_level_num != -1) {
         const GF_LEVEL *const select_level =
             GF_GetLevel(GFLT_MAIN, g_GameInfo.select_level_num);
-        if (current_level != nullptr && select_level != nullptr) {
-            Savegame_CarryCurrentInfoToNextLevel(current_level, select_level);
-        }
         return (GF_COMMAND) {
             .action = GF_SELECT_GAME,
             .param = g_GameInfo.select_level_num,
@@ -149,10 +146,6 @@ static DECLARE_GF_EVENT_HANDLER(M_HandleLevelComplete)
     if (next_level == nullptr) {
         return (GF_COMMAND) { .action = GF_NOOP };
     }
-
-    // carry info to the next level
-    Savegame_CarryCurrentInfoToNextLevel(current_level, next_level);
-    Savegame_ApplyLogicToCurrentInfo(next_level);
 
     if (next_level->type == GFL_BONUS && !bonus_level_unlock) {
         return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -45,6 +45,7 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
 
 void Game_End(void)
 {
+    Savegame_PersistGameToCurrentInfo(Game_GetCurrentLevel());
     Overlay_HideGameInfo();
     Sound_StopAll();
     Music_Stop();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3595.

Needs tests for equipment carryover in TR1.