### PR TITLE
Add --headless mode

### DIFF
--- a/docs/1-COMMAND_LINE.md
+++ b/docs/1-COMMAND_LINE.md
@@ -29,7 +29,11 @@ Currently the following command line interface options are available:
   Replays gameplay events from an external text file.
 
   `--headless`:  
-  Run the game in command line only. Only available with `--test-replay`.
+  Runs the game in command line only. Only available with `--test-replay`.
+
+- `-q`, `--quiet`  
+  Suppresses most of output to the standard output, keeping only errors.
+  The log file is written to normally.
 
 > [!NOTE]
 > Gameplay capture is considered an internal testing tool, and may be

--- a/docs/1-COMMAND_LINE.md
+++ b/docs/1-COMMAND_LINE.md
@@ -28,6 +28,9 @@ Currently the following command line interface options are available:
   `--test-replay <PATH>`, `--test-play <PATH>`:  
   Replays gameplay events from an external text file.
 
+  `--headless`:  
+  Run the game in command line only. Only available with `--test-replay`.
+
 > [!NOTE]
 > Gameplay capture is considered an internal testing tool, and may be
 > subject to breaking changes without warnings.

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -3,7 +3,10 @@
 >Attention level builders: this version introduces backwards incompatible changes to the file structure.
 >Please refer to the [migration guide](../3-MIGRATING.md) to see how to update your levels.
 
-- added support for automated playthroughs with `--test-record` and `--test-replay` (internal tool – the recording file format may be subject to changes)
+- added new command switches:
+    - `--test-record` and `--test-replay` for automated playthroughs with (internal tool – the recording file format may be subject to changes)
+    - `--headless`: runs the game offscreen with no audio and at unlocked simulation speed
+    - -q`, `--quiet`: outputs only error messages to the terminal, with log files being written to normally
 - added ability to move Lara around in photo mode
 - added an option to use Lara's slide-to-run animation from TR3+ (Gameplay → Controls → Slide-to-run) (#1089)
 - added a new `/lua` console command (for now, [it cannot do much](../8-LUA.md))

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -3,7 +3,10 @@
 >Attention level builders: this version introduces backwards incompatible changes to the file structure.
 >Please refer to the [migration guide](../3-MIGRATING.md) to see how to update your levels.
 
-- added support for automated playthroughs with `--test-record` and `--test-replay` (internal tool – the recording file format may be subject to changes)
+- added new command switches:
+    - `--test-record` and `--test-replay` for automated playthroughs with (internal tool – the recording file format may be subject to changes)
+    - `--headless`: runs the game offscreen with no audio and at unlocked simulation speed
+    - -q`, `--quiet`: outputs only error messages to the terminal, with log files being written to normally
 - added ability to move Lara around in photo mode (use sidestep keys to switch modes)
 - added a new `/lua` console command (for now, [it cannot do much](../8-LUA.md))
 - added an option to use Lara's slide-to-run animation from TR3+ (Gameplay → Controls → Slide-to-run) (#1089)

--- a/src/libtrx/game/clock/common.c
+++ b/src/libtrx/game/clock/common.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <time.h>
 
+static bool m_Disabled = false;
 static Uint64 m_LastCounter = 0;
 static Uint64 m_InitCounter = 0;
 static Uint64 m_Frequency = 0;
@@ -32,6 +33,11 @@ void Clock_Init(void)
 {
     m_Frequency = SDL_GetPerformanceFrequency();
     m_InitCounter = SDL_GetPerformanceCounter();
+}
+
+void Clock_DisableWait(void)
+{
+    m_Disabled = true;
 }
 
 size_t Clock_GetDateTime(char *const buffer, const size_t size)
@@ -63,6 +69,9 @@ void Clock_SyncTick(void)
 
 int32_t Clock_WaitTick(void)
 {
+    if (m_Disabled) {
+        return 1;
+    }
     const Uint64 current_counter = SDL_GetPerformanceCounter();
 
     // If this is the first call, just initialize and return a frame.

--- a/src/libtrx/game/music/common.c
+++ b/src/libtrx/game/music/common.c
@@ -9,6 +9,7 @@
 #include "game/sound.h"
 #include "log.h"
 
+static bool m_Initialised = false;
 static uint16_t m_MusicTrackFlags[MAX_MUSIC_TRACKS] = {};
 static MUSIC_TRACK_ID m_TrackCurrent = MX_INACTIVE;
 static MUSIC_TRACK_ID m_TrackDelayed = MX_INACTIVE;
@@ -121,8 +122,7 @@ static void M_SyncVolume(const int32_t audio_stream_id)
 
 bool Music_Init(void)
 {
-    bool result = false;
-
+    m_Initialised = true;
     m_Backend = M_FindBackend();
     if (m_Backend == nullptr) {
         LOG_ERROR("No music backend is available");
@@ -130,7 +130,6 @@ bool Music_Init(void)
     }
 
     LOG_INFO("Chosen music backend: %s", m_Backend->describe(m_Backend));
-    result = true;
     Music_SetVolume(g_Config.audio.music_volume);
 
 finish:
@@ -139,17 +138,22 @@ finish:
     m_TrackDelayed = MX_INACTIVE;
     m_TrackLooped = MX_INACTIVE;
     m_TrackLastLooped = MX_INACTIVE;
-    return result && Audio_Init();
+    return Audio_Init();
 }
 
 void Music_Shutdown(void)
 {
+    m_Initialised = false;
     M_StopActiveStream();
     Audio_Shutdown();
 }
 
 bool Music_Play(const MUSIC_TRACK_ID track_id, const MUSIC_PLAY_MODE mode)
 {
+    if (!m_Initialised) {
+        return false;
+    }
+
     if (M_IsBrokenTrack(track_id)) {
         return false;
     }

--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -96,6 +96,9 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             out_args->test_replay_path = next_arg;
             i++;
         }
+        if (!strcmp(arg, "--headless")) {
+            out_args->headless = true;
+        }
     }
     return out_args;
 }

--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -99,6 +99,9 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         if (!strcmp(arg, "--headless")) {
             out_args->headless = true;
         }
+        if (!strcmp(arg, "-q") || !strcmp(arg, "--quiet")) {
+            out_args->quiet = true;
+        }
     }
     return out_args;
 }

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -26,6 +26,8 @@
 
 #include <stdio.h>
 
+static const SHELL_ARGS *m_ShellArgs = nullptr;
+
 static void M_HandleConfigChange(const EVENT *const event, void *const data);
 static void M_SetupSDL(void);
 static void M_SetupGL(void);
@@ -58,6 +60,11 @@ static void M_SetupGL(void)
 const char *Shell_GetConfigDir(void)
 {
     return "cfg";
+}
+
+const SHELL_ARGS *Shell_GetArgs(void)
+{
+    return m_ShellArgs;
 }
 
 void Shell_InitCommonModules(void)
@@ -155,5 +162,7 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
     Sound_SetMasterVolume(g_Config.audio.sound_volume);
     Music_SetVolume(g_Config.audio.music_volume);
+
+    m_ShellArgs = new_args;
     return new_args;
 }

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -83,8 +83,6 @@ void Shell_InitCommonModules(void)
     Overlay_Init();
 
     Input_Init();
-    Sound_Init();
-    Music_Init();
 
     GameBuf_Init();
     Random_Seed();
@@ -135,7 +133,9 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
     if (args->test_record_path != nullptr
         && args->test_replay_path != nullptr) {
         Shell_ExitSystem("Cannot use both --test-record and --test-replay");
-        return new_args;
+    }
+    if (args->headless && args->test_replay_path == nullptr) {
+        Shell_ExitSystem("--headless can only be used with --test-replay");
     }
 
     if (args->test_replay_path != nullptr) {
@@ -146,6 +146,7 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
             Vector_Free(tmp_args->original_args);
             tmp_args->original_args = nullptr;
         }
+        tmp_args->headless = args->headless;
         new_args = tmp_args;
     } else {
         Config_Read(
@@ -162,6 +163,13 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
     Sound_SetMasterVolume(g_Config.audio.sound_volume);
     Music_SetVolume(g_Config.audio.music_volume);
+
+    if (!new_args->headless) {
+        Sound_Init();
+        Music_Init();
+    } else {
+        Clock_DisableWait();
+    }
 
     m_ShellArgs = new_args;
     return new_args;

--- a/src/libtrx/game/shell/main.c
+++ b/src/libtrx/game/shell/main.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
     }
 
     char *log_path = File_GetFullPath(PROJECT_NAME ".log");
-    Log_Init(log_path);
+    Log_Init(log_path, args->quiet ? LOG_LEVEL_ERROR : LOG_LEVEL_MAX);
     Memory_FreePointer(&log_path);
 
     LOG_INFO("Starting %s", g_TRXVersion);

--- a/src/libtrx/game/sound/common.c
+++ b/src/libtrx/game/sound/common.c
@@ -34,6 +34,9 @@ void Sound_InitialiseSampleInfos(const int32_t num_sample_infos)
 bool Sound_LoadSample(
     const int32_t sample_num, const char *const sample_data, const size_t size)
 {
+    if (!Sound_IsInitialised()) {
+        return false;
+    }
     return Audio_Sample_Load(sample_num, sample_data, size);
 }
 

--- a/src/libtrx/gfx/context.c
+++ b/src/libtrx/gfx/context.c
@@ -103,8 +103,14 @@ bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend)
             "Can't activate OpenGL context: %s", SDL_GetError());
     }
 
-    if (glewInit() != GLEW_OK) {
-        Shell_ExitSystem("Can't initialize GLEW for OpenGL extension loading");
+    const GLenum err = glewInit();
+    if (err != GLEW_OK) {
+        if (err != 4) {
+            Shell_ExitSystemFmt(
+                "Can't initialize GLEW for OpenGL extension loading: %d", err);
+        }
+        // https://github.com/nigels-com/glew/issues/417
+        LOG_WARNING("GLEW failed to init: %d", err);
     }
 
     LOG_INFO("OpenGL vendor string:   %s", glGetString(GL_VENDOR));

--- a/src/libtrx/include/libtrx/debug.h
+++ b/src/libtrx/include/libtrx/debug.h
@@ -5,19 +5,19 @@
 #define ASSERT(x)                                                              \
     do {                                                                       \
         if (!(x)) {                                                            \
-            LOG_DEBUG("Assertion failed: %s", #x);                             \
+            LOG_ERROR("Assertion failed: %s", #x);                             \
             __builtin_trap();                                                  \
         }                                                                      \
     } while (0)
 
 #define ASSERT_FAIL()                                                          \
     do {                                                                       \
-        LOG_DEBUG("Assertion failed");                                         \
+        LOG_ERROR("Assertion failed");                                         \
         __builtin_trap();                                                      \
     } while (0)
 
 #define ASSERT_FAIL_FMT(fmt, ...)                                              \
     do {                                                                       \
-        LOG_DEBUG("Assertion failed: " fmt __VA_OPT__(, ) __VA_ARGS__);        \
+        LOG_ERROR("Assertion failed: " fmt __VA_OPT__(, ) __VA_ARGS__);        \
         __builtin_trap();                                                      \
     } while (0)

--- a/src/libtrx/include/libtrx/game/clock/common.h
+++ b/src/libtrx/include/libtrx/game/clock/common.h
@@ -5,6 +5,9 @@
 
 void Clock_Init(void);
 
+// Disables any kind of waiting in Clock_WaitTick
+void Clock_DisableWait(void);
+
 void Clock_SyncTick(void);
 int32_t Clock_WaitTick(void);
 

--- a/src/libtrx/include/libtrx/game/shell/args.h
+++ b/src/libtrx/include/libtrx/game/shell/args.h
@@ -20,6 +20,7 @@ typedef struct {
     int32_t save_to_load;
     const char *test_record_path;
     const char *test_replay_path;
+    bool headless;
 } SHELL_ARGS;
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *raw_args);

--- a/src/libtrx/include/libtrx/game/shell/args.h
+++ b/src/libtrx/include/libtrx/game/shell/args.h
@@ -21,6 +21,7 @@ typedef struct {
     const char *test_record_path;
     const char *test_replay_path;
     bool headless;
+    bool quiet;
 } SHELL_ARGS;
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *raw_args);

--- a/src/libtrx/include/libtrx/game/shell/common.h
+++ b/src/libtrx/include/libtrx/game/shell/common.h
@@ -24,6 +24,7 @@ void Shell_ExitSystemFmt(const char *fmt, ...);
 
 void Shell_ScheduleExit(void);
 bool Shell_IsExiting(void);
+const SHELL_ARGS *Shell_GetArgs(void);
 
 bool Shell_IsFullscreen(void);
 SHELL_SIZE Shell_GetWindowSize(void);

--- a/src/libtrx/include/libtrx/game/sound/common.h
+++ b/src/libtrx/include/libtrx/game/sound/common.h
@@ -10,6 +10,7 @@
 
 extern bool Sound_Init(void);
 extern void Sound_Shutdown(void);
+extern bool Sound_IsInitialised(void);
 
 // Stops and unloads all samples
 extern void Sound_Reset(void);

--- a/src/libtrx/include/libtrx/log.h
+++ b/src/libtrx/include/libtrx/log.h
@@ -1,10 +1,12 @@
 #pragma once
 
 typedef enum {
+    // from least important to most important
+    LOG_LEVEL_DEBUG,
     LOG_LEVEL_INFO,
     LOG_LEVEL_WARNING,
     LOG_LEVEL_ERROR,
-    LOG_LEVEL_DEBUG,
+    LOG_LEVEL_MAX = -1,
 } LOG_LEVEL;
 
 #define LOG_INFO(...)                                                          \
@@ -34,7 +36,7 @@ typedef enum {
         const char *: LOG_DEBUG(#var ": %s", var),                             \
         default: LOG_DEBUG(#var ": %p", var))
 
-void Log_Init(const char *path);
+void Log_Init(const char *path, LOG_LEVEL min_level);
 void Log_Shutdown(void);
 void Log_Message(
     LOG_LEVEL level, const char *file, int line, const char *func,

--- a/src/libtrx/log.c
+++ b/src/libtrx/log.c
@@ -13,6 +13,7 @@
 #define M_ANSI_COLOR_CYAN "\x1b[36m"
 #define M_ANSI_COLOR_RESET "\x1b[0m"
 
+static LOG_LEVEL m_LogLevel = LOG_LEVEL_MAX;
 static FILE *m_LogHandle = nullptr;
 static const char *const m_LogLevelColors[] = {
     [LOG_LEVEL_INFO] = M_ANSI_COLOR_RESET,
@@ -27,8 +28,9 @@ static const char *const m_LogLevelStrings[] = {
     [LOG_LEVEL_DEBUG] = "DBG",
 };
 
-void Log_Init(const char *path)
+void Log_Init(const char *path, const LOG_LEVEL min_level)
 {
+    m_LogLevel = min_level;
     if (path != nullptr) {
         m_LogHandle = fopen(path, "w");
     }
@@ -70,11 +72,13 @@ void Log_Message(
     }
 
     // print to stdout
-    printf("%s", log_color);
-    printf(M_FORMAT, log_str, timestamp_str, file, line, func);
-    vprintf(fmt, va);
-    printf("%s", M_ANSI_COLOR_RESET "\n");
-    fflush(stdout);
+    if (level >= m_LogLevel) {
+        printf("%s", log_color);
+        printf(M_FORMAT, log_str, timestamp_str, file, line, func);
+        vprintf(fmt, va);
+        printf("%s", M_ANSI_COLOR_RESET "\n");
+        fflush(stdout);
+    }
 
     va_end(va);
 }

--- a/src/libtrx/log_linux.c
+++ b/src/libtrx/log_linux.c
@@ -22,11 +22,11 @@ static int M_StackTrace(
     const char *func_name)
 {
     if (filename) {
-        LOG_INFO(
+        LOG_ERROR(
             "0x%08X: %s (%s:%d)", pc, func_name ? func_name : "???",
             filename ? filename : "???", lineno);
     } else {
-        LOG_INFO("0x%08X: %s", pc, func_name ? func_name : "???");
+        LOG_ERROR("0x%08X: %s", pc, func_name ? func_name : "???");
     }
     return 0;
 }
@@ -34,8 +34,8 @@ static int M_StackTrace(
 static void M_SignalHandler(int sig)
 {
     LOG_ERROR("== CRASH REPORT ==");
-    LOG_INFO("SIGNAL: %d", sig);
-    LOG_INFO("STACK TRACE:");
+    LOG_ERROR("SIGNAL: %d", sig);
+    LOG_ERROR("STACK TRACE:");
     struct backtrace_state *state = backtrace_create_state(
         nullptr, BACKTRACE_SUPPORTS_THREADS, M_ErrorCallback, nullptr);
     backtrace_full(state, 0, M_StackTrace, M_ErrorCallback, nullptr);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -56,7 +56,6 @@ typedef struct {
     GFX_2D_SURFACE *surface;
 } M_TEXTURE;
 
-static bool m_Initialized = false;
 static int32_t m_LightningCount = 0;
 static LIGHTNING m_LightningTable[M_MAX_LIGHTNINGS];
 static VECTOR *m_Textures;
@@ -252,6 +251,9 @@ static void M_Flush(void)
 
 static void M_FlipScreen(void)
 {
+    if (Shell_GetArgs()->headless) {
+        return;
+    }
     GFX_Context_SwapBuffers();
     m_SelectedTexture = -1;
 }
@@ -402,11 +404,6 @@ static void M_DrawSprite(
 
 bool Output_Init(void)
 {
-    if (m_Initialized) {
-        return true;
-    }
-    m_Initialized = true;
-
     m_Textures = Vector_Create(sizeof(M_TEXTURE));
     m_Renderer2D = GFX_2D_Renderer_Create();
     m_Renderer3D = GFX_3D_Renderer_Create();
@@ -425,11 +422,6 @@ bool Output_Init(void)
 
 void Output_Shutdown(void)
 {
-    if (!m_Initialized) {
-        return;
-    }
-    m_Initialized = false;
-
     Output_Meshes_Shutdown();
     Output_Sprites_Shutdown();
     Output_Textures_Shutdown();
@@ -499,7 +491,6 @@ void Output_ObserveLevelLoad(void)
     Output_Textures_ObserveLevelLoad();
     Output_Sprites_ObserveLevelLoad();
     Output_Meshes_ObserveLevelLoad();
-
     Output_ApplyLevelSettings();
 }
 

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -13,46 +13,39 @@
 
 static SDL_Window *m_Window = nullptr;
 
-static void M_SetGLBackend(GFX_GL_BACKEND backend);
 static void M_CreateGameWindow(void);
+static void M_CreateGLContext(void);
 static void M_ShowWindow(void);
 
 static void M_CreateGameWindow(void)
 {
-    SDL_Window *const window = SDL_CreateWindow(
+    m_Window = SDL_CreateWindow(
         "TR1X", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 1280, 720,
         SDL_WINDOW_HIDDEN | SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_RESIZABLE
             | SDL_WINDOW_OPENGL);
 
-    if (window == nullptr) {
+    if (m_Window == nullptr) {
         Shell_ExitSystem("System Error: cannot create window");
-        return;
     }
+}
 
-    const GFX_GL_BACKEND backends_to_try[] = {
-        // clang-format off
-        GFX_GL_33C,
-        GFX_GL_INVALID_BACKEND, // guard
-        // clang-format on
-    };
-
-    for (int32_t i = 0; backends_to_try[i] != GFX_GL_INVALID_BACKEND; i++) {
-        const GFX_GL_BACKEND backend = backends_to_try[i];
-
-        M_SetGLBackend(backend);
-
-        int32_t major;
-        int32_t minor;
-        SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &major);
-        SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minor);
-        LOG_DEBUG("Trying GL backend %d.%d", major, minor);
-        if (GFX_Context_Attach(window, backend)) {
-            m_Window = window;
-            return;
-        }
+static void M_CreateGLContext(void)
+{
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(
+        SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    if (!GFX_Context_Attach(m_Window, GFX_GL_33C)) {
+        Shell_ExitSystem("System Error: cannot attach opengl context");
     }
+}
 
-    Shell_ExitSystem("System Error: cannot attach opengl context");
+static void M_ShowWindow(void)
+{
+    Shell_SyncToWindow();
+    SDL_ShowWindow(m_Window);
+    SDL_RaiseWindow(m_Window);
+    Shell_RefreshRendererViewport();
 }
 
 void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
@@ -78,30 +71,6 @@ void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
 #undef L_CHANGED
 }
 
-static void M_ShowWindow(void)
-{
-    Shell_SyncToWindow();
-    SDL_ShowWindow(m_Window);
-    SDL_RaiseWindow(m_Window);
-    Shell_RefreshRendererViewport();
-}
-
-static void M_SetGLBackend(const GFX_GL_BACKEND backend)
-{
-    switch (backend) {
-    case GFX_GL_33C:
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-        SDL_GL_SetAttribute(
-            SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-        break;
-
-    case GFX_GL_INVALID_BACKEND:
-        ASSERT_FAIL();
-        break;
-    }
-}
-
 SDL_Window *Shell_GetWindow(void)
 {
     return m_Window;
@@ -115,12 +84,14 @@ int32_t Shell_Main(const SHELL_ARGS *args)
     Shell_InitCommonModules();
     args = Shell_CommonInit(args);
     M_CreateGameWindow();
-
+    M_CreateGLContext();
     if (!Output_Init()) {
         Shell_ExitSystem("Could not initialise video system");
         return 1;
     }
-    M_ShowWindow();
+    if (!args->headless) {
+        M_ShowWindow();
+    }
 
     GF_Init();
     GF_LoadFromFile(Shell_GetGameFlowPath(args->mod));

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -46,6 +46,7 @@ typedef enum {
     SOUND_FLAG_RESTARTED = 1 << 2,
 } SOUND_FLAG;
 
+static bool m_Initialised = false;
 static SOUND_SLOT m_SFXPlaying[M_MAX_PLAYING_FX] = {};
 static int32_t m_MasterVolume = 0;
 static int32_t m_MasterVolumeDefault = 0;
@@ -197,6 +198,7 @@ static void M_ResetAmbientLoudness(void)
 
 bool Sound_Init(void)
 {
+    m_Initialised = true;
     m_DecibelLUT[0] = -10000;
     for (int i = 1; i < M_DECIBEL_LUT_SIZE; i++) {
         m_DecibelLUT[i] =
@@ -211,7 +213,13 @@ bool Sound_Init(void)
 
 void Sound_Shutdown(void)
 {
+    m_Initialised = false;
     Audio_Shutdown();
+}
+
+bool Sound_IsInitialised(void)
+{
+    return m_Initialised;
 }
 
 void Sound_UpdateEffects(void)
@@ -268,6 +276,9 @@ bool Sound_Effect(
     const SOUND_EFFECT_ID sfx_num, const XYZ_32 *const pos,
     const uint32_t flags)
 {
+    if (!m_Initialised) {
+        return false;
+    }
     if (!m_SoundIsActive) {
         return false;
     }
@@ -512,12 +523,18 @@ void Sound_StopAmbientSounds(void)
 
 void Sound_Reset(void)
 {
+    if (!m_Initialised) {
+        return;
+    }
     Audio_Sample_CloseAll();
     Audio_Sample_UnloadAll();
 }
 
 void Sound_StopAll(void)
 {
+    if (!m_Initialised) {
+        return;
+    }
     Audio_Sample_CloseAll();
 }
 

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -24,8 +24,6 @@
 #define M_MAX_ROOM_LIGHT_UNIT (0x2000 / (WIBBLE_SIZE / 2))
 #define M_SUNSET_TIMEOUT (40 * 60 * (LOGIC_FPS)) // = 72000
 
-static bool m_Initialized = false;
-
 static int32_t m_VBufCapacity = 0;
 static int32_t m_TickComp = 0;
 static int32_t m_LsAdder = 0;
@@ -401,11 +399,6 @@ static void M_ReserveVertexBuffer(void)
 
 bool Output_Init(void)
 {
-    if (m_Initialized) {
-        return true;
-    }
-    m_Initialized = true;
-
     M_CalculateWibbleTable();
     Output_InitLight();
     return true;
@@ -413,11 +406,6 @@ bool Output_Init(void)
 
 void Output_Shutdown(void)
 {
-    if (!m_Initialized) {
-        return;
-    }
-    m_Initialized = false;
-
     Output_ShutdownLight();
 }
 
@@ -671,6 +659,9 @@ void Output_BeginScene(void)
 void Output_EndScene(void)
 {
     Render_EndScene();
+    if (Shell_GetArgs()->headless) {
+        return;
+    }
     GFX_Context_SwapBuffers();
 }
 

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -76,7 +76,6 @@ void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
 
 static void M_ShowWindow(void)
 {
-    Render_Init();
     Shell_SyncToWindow();
 
     SDL_ShowWindow(m_Window);
@@ -100,7 +99,10 @@ int32_t Shell_Main(const SHELL_ARGS *args)
         return 1;
     }
     Output_Init();
-    M_ShowWindow();
+    Render_Init();
+    if (!args->headless) {
+        M_ShowWindow();
+    }
 
     GF_Init();
     GF_LoadFromFile(Shell_GetGameFlowPath(args->mod));

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -53,6 +53,7 @@ typedef enum {
 
 #define M_DECIBEL_LUT_SIZE 512
 
+static bool m_Initialised = false;
 static float m_MasterVolume = 0.0f;
 static int32_t m_DecibelLUT[M_DECIBEL_LUT_SIZE] = {};
 static M_SOUND_SLOT m_SoundSlots[M_SOUND_MAX_SLOTS] = {};
@@ -134,6 +135,7 @@ static void M_UpdateSlot(M_SOUND_SLOT *const slot)
 
 bool Sound_Init(void)
 {
+    m_Initialised = true;
     m_DecibelLUT[0] = -10000;
     for (int32_t i = 1; i < M_DECIBEL_LUT_SIZE; i++) {
         m_DecibelLUT[i] =
@@ -152,8 +154,14 @@ bool Sound_Init(void)
 
 void Sound_Shutdown(void)
 {
-    Audio_Shutdown();
+    m_Initialised = false;
     M_ClearAllSlots();
+    Audio_Shutdown();
+}
+
+bool Sound_IsInitialised(void)
+{
+    return m_Initialised;
 }
 
 void Sound_SetMasterVolume(const float volume)
@@ -170,6 +178,9 @@ bool Sound_Effect(
     const SOUND_EFFECT_ID sample_id, const XYZ_32 *const pos,
     const uint32_t flags)
 {
+    if (!m_Initialised) {
+        return false;
+    }
     if (flags != SPM_ALWAYS
         && ((flags & SPM_UNDERWATER)
             != (Room_Get(g_Camera.pos.room_num)->flags & RF_UNDERWATER))) {
@@ -328,6 +339,9 @@ void Sound_StopEffect(const SOUND_EFFECT_ID sample_id)
 
 void Sound_Reset(void)
 {
+    if (!m_Initialised) {
+        return;
+    }
     Audio_Sample_CloseAll();
     Audio_Sample_UnloadAll();
     M_ClearAllSlots();
@@ -335,6 +349,9 @@ void Sound_Reset(void)
 
 void Sound_StopAll(void)
 {
+    if (!m_Initialised) {
+        return;
+    }
     Audio_Sample_CloseAll();
     M_ClearAllSlots();
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:

1. Adds a `--headless` switch, which lets the game play test recordings without having to run the simulation in real time.

    - Disables master clock waiting
    - Disables visuals
        Keeps the OpenGL machinery to not strip us of the ability to take screenshots. This needs a window to work, though, so we keep creating the window, except we just never show it.
    - Disables buffer flips so that VSync doesn't slow us down
    - Disables music and sound systems

2. Adds a `-q` / `--quiet` switch which only shows errors in stdout (the log file contains all output as usual).

3. Changes stack traces and failed assertions to be logged as errors rather than information.

Results – given a recording `test.txt`:

<details><pre>
seed_control 91
seed_draw 77
args
config gameplay.enable_walk_to_items 1
config gameplay.restore_ps1_enemies 1
config window.is_maximized 0
config rendering.wireframe_width 1.00
config ui.menu_style ps1
config rendering.anisotropy_filter 5.00
config audio.music_volume 10%
config audio.sound_volume 10%
config gameplay.maximum_save_slots 30
config visuals.fov_value 95
config debug.enable_debug_pos 1
config gameplay.disable_healing_between_levels 1
config gameplay.enable_cheats 1
config gameplay.enable_fmv 0
config gameplay.enable_game_modes 0
config gameplay.enable_legal 0
config gameplay.fix_bear_ai 0
config gameplay.fix_item_duplication_glitch 0
config profile.new_game_plus_unlock 1
config ui.enable_photo_mode_ui 0
config gameplay.look_mode unrestricted
config rendering.screenshot_format png
config ui.enemy_healthbar_location bottom-center
config gameplay.start_lara_hitpoints 500
config input.controller_layout 2
config input.keyboard_layout 1
config window.fs_height 2160
config window.fs_width 3840
bind keyboard 4 47
bind keyboard 5 48
bind keyboard 7 226
bind keyboard 10 29
bind keyboard 52 21
frame 13: keydown 56 0; text-input "/"
frame 15: keydown 19 0; text-input "p"
frame 17: keyup 56 0; keydown 15 0; text-input "l"
frame 18: keydown 4 0; text-input "a"; keydown 28 0; text-input "y"
frame 19: keyup 19 0
frame 20: keyup 15 0
frame 21: keydown 44 0; text-input " "
frame 22: keyup 4 0
frame 23: keyup 28 0; keyup 44 0
frame 26: keydown 30 0; text-input "1"; keydown 40 0
frame 28: keyup 30 0; keyup 40 0
frame 33: keydown 82 0
frame 66: keydown 226 256
frame 142: keydown 80 256
frame 149: keyup 80 256
frame 197: keydown 80 256
frame 208: keyup 80 256
frame 218: keydown 79 256
frame 231: keyup 79 256
frame 274: keydown 80 256
frame 281: keyup 80 256
frame 284: keyup 82 256
frame 286: keyup 226 0
frame 296: keydown 56 0; text-input "/"
frame 297: keydown 19 0; text-input "p"
frame 299: keyup 56 0
frame 300: keydown 18 0; text-input "o"
frame 302: keyup 19 0; keydown 22 0; text-input "s"
frame 303: keyup 18 0
frame 306: keyup 22 0
frame 352: keydown 40 0
frame 358: keyup 40 0
frame 400: lua assert(lara.get_item().pos.x==74510)
frame 410: quit
</pre></details>

- `./TR1X --test-replay test.txt`:  
  1.38s user 0.46s system 12% cpu **14.430 total**
- `./TR1X --test-replay test.txt --headless`:  
  1.03s user 0.21s system 120% cpu **1.030 total**