### PR TITLE
items/utils: test object loaded state on explode

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed being unable to activate waterfall objects with code bits (#3589)
 - fixed skippable triggers for waterfall objects in Lost Valley (#3593)
 - fixed incorrect wet footstep sounds in some of Lara's climb-up animations (#3607, regression from 4.6)
+- fixed the `/kill` command potentially causing a crash if used in a level with pods that don't hatch creatures (#3628, regression from 4.12)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - removed the option in Unfinished Business to fix animated sprites as it is irrelevant there

--- a/src/libtrx/game/items/utils.c
+++ b/src/libtrx/game/items/utils.c
@@ -29,6 +29,9 @@ int32_t Item_Explode(
 {
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
+    if (!obj->loaded) {
+        return 0;
+    }
 
     Output_CalculateLight(item->pos, item->room_num);
 


### PR DESCRIPTION
Resolves #3628.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that an item of a type that isn't loaded is not exploded, as doing so yields null frames.
