### PR TITLE
game_flow/sequencer: fix resume carry over

### DIFF
--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -135,7 +135,9 @@ GF_COMMAND GF_InterpretSequence(
     default:
         if (level->type == GFL_GYM) {
             Savegame_ResetCurrentInfo(level);
-        } else if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+        } else if (
+            prev_level != nullptr
+            && (level->type == GFL_NORMAL || level->type == GFL_BONUS)) {
             Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
         }
         Savegame_ApplyLogicToCurrentInfo(level);


### PR DESCRIPTION
Resolves #3635.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids attempting to carry over resume info when previous level is not set.
