### PR TITLE
lara/look: permit look during airlock action

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -33,6 +33,7 @@
 - fixed incorrect frames in Lara's underwater roll animation (#1589)
 - fixed incorrect push button object positions in all levels where it appears (#3596)
 - fixed persistent damage resetting Lara's HP after cutscenes (#3595, regression from 1.2)
+- fixed Lara not being able to look when look mode is set to unrestricted and she is using an airlock door (#3645, regression from 1.3)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/game/lara/look.c
+++ b/src/libtrx/game/lara/look.c
@@ -50,9 +50,19 @@ static const LARA_STATE m_BlockingStates[] = {
     // clang-format on
 };
 
+static const LARA_EXTRA_STATE m_PermittedExtraStates[] = {
+    // clang-format off
+    LS_EXTRA_BREATH,
+#if TR_VERSION == 2
+    LS_EXTRA_AIRLOCK,
+#endif
+    (LARA_EXTRA_STATE)-1,
+    // clang-format on
+};
+
 static void M_Reset(void);
 static bool M_IsLaraIdle(void);
-static bool M_IsCurrentStateBlocked(void);
+static bool M_IsStatePermitted(void);
 
 static void M_Reset(void)
 {
@@ -86,16 +96,19 @@ static bool M_IsLaraIdle(void)
     return Lara_HasState(m_StopStates);
 }
 
-static bool M_IsCurrentStateBlocked(void)
+static bool M_IsStatePermitted(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_item->hit_points <= 0 || lara_info->extra_anim) {
-        return true;
+    if (lara_item->hit_points <= 0) {
+        return false;
     }
 
-    return g_Config.gameplay.look_mode != LOOK_MODE_UNRESTRICTED
-        && Lara_HasState(m_BlockingStates);
+    if (Lara_HasExtraState(m_PermittedExtraStates)) {
+        return g_Config.gameplay.look_mode == LOOK_MODE_UNRESTRICTED;
+    }
+
+    return g_Config.gameplay.look_mode == LOOK_MODE_UNRESTRICTED
+        || !Lara_HasState(m_BlockingStates);
 }
 
 void Lara_Look_LeftRight(void)
@@ -171,7 +184,7 @@ void Lara_Look_Update(void)
         return;
     }
 
-    if (g_Input.look && !M_IsCurrentStateBlocked()) {
+    if (g_Input.look && M_IsStatePermitted()) {
         Lara_Look_LeftRight();
     } else {
         M_Reset();

--- a/src/libtrx/game/lara/misc.c
+++ b/src/libtrx/game/lara/misc.c
@@ -241,3 +241,19 @@ bool Lara_HasState(const LARA_STATE *const test_arr)
     }
     return false;
 }
+
+bool Lara_HasExtraState(const LARA_EXTRA_STATE *const test_arr)
+{
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (!lara_info->extra_anim) {
+        return false;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    for (int32_t i = 0; test_arr[i] != (LARA_EXTRA_STATE)-1; i++) {
+        if (test_arr[i] == (LARA_EXTRA_STATE)lara_item->current_anim_state) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/libtrx/include/libtrx/game/lara/misc.h
+++ b/src/libtrx/include/libtrx/game/lara/misc.h
@@ -18,3 +18,4 @@ int32_t Lara_GetWaterDepth(int32_t x, int32_t y, int32_t z, int16_t room_num);
 // (start aim); 2 (firing); or 4 (stopping firing).
 bool Lara_IsM16Active(void);
 bool Lara_HasState(const LARA_STATE *test_arr);
+bool Lara_HasExtraState(const LARA_EXTRA_STATE *test_arr);


### PR DESCRIPTION
Resolves #3645.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This permits Lara to look when she is using an airlock door, provided the look mode option is set to unrestricted.

I've flipped the state check function here for better readability, so it'll be worth a check that this hasn't introduced any issues elsewhere re look.
