### PR TITLE
Fix wireframe mode rendering as white mesh

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -36,6 +36,7 @@
 - fixed the collision box on some static meshes in Egypt to prevent the camera shaking when Lara walks by them (#762)
 - fixed incorrect wet footstep sounds in some of Lara's climb-up animations (#3607, regression from 4.6)
 - fixed the `/kill` command potentially causing a crash if used in a level with pods that don't hatch creatures (#3628, regression from 4.12)
+- fixed wireframe mode rendering as mostly white (#3649, regression from 4.13.2)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - removed the option in Unfinished Business to fix animated sprites as it is irrelevant there

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fixed incorrect push button object positions in all levels where it appears (#3596)
 - fixed persistent damage resetting Lara's HP after cutscenes (#3595, regression from 1.2)
 - fixed Lara not being able to look when look mode is set to unrestricted and she is using an airlock door (#3645, regression from 1.3)
+- fixed wireframe mode rendering as mostly white (#3649, regression from 1.3.2)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/gfx/2d/2d_renderer.c
+++ b/src/libtrx/gfx/2d/2d_renderer.c
@@ -140,9 +140,9 @@ GFX_2D_RENDERER *GFX_2D_Renderer_Create(void)
 
     GFX_GL_Program_Init(&r->program);
     GFX_GL_Program_AttachShader(
-        &r->program, GL_VERTEX_SHADER, "shaders/2d.glsl", config->backend);
+        &r->program, GL_VERTEX_SHADER, "shaders/2d.glsl");
     GFX_GL_Program_AttachShader(
-        &r->program, GL_FRAGMENT_SHADER, "shaders/2d.glsl", config->backend);
+        &r->program, GL_FRAGMENT_SHADER, "shaders/2d.glsl");
     GFX_GL_Program_FragmentData(&r->program, "outColor");
     GFX_GL_Program_Link(&r->program);
 

--- a/src/libtrx/gfx/3d/3d_renderer.c
+++ b/src/libtrx/gfx/3d/3d_renderer.c
@@ -154,11 +154,9 @@ GFX_3D_RENDERER *GFX_3D_Renderer_Create(void)
 
     GFX_GL_Program_Init(&renderer->program);
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_VERTEX_SHADER, "shaders/3d.glsl",
-        renderer->config->backend);
+        &renderer->program, GL_VERTEX_SHADER, "shaders/3d.glsl");
     GFX_GL_Program_AttachShader(
-        &renderer->program, GL_FRAGMENT_SHADER, "shaders/3d.glsl",
-        renderer->config->backend);
+        &renderer->program, GL_FRAGMENT_SHADER, "shaders/3d.glsl");
     GFX_GL_Program_FragmentData(&renderer->program, "outColor");
     GFX_GL_Program_Link(&renderer->program);
 

--- a/src/libtrx/gfx/context.c
+++ b/src/libtrx/gfx/context.c
@@ -74,7 +74,7 @@ void GFX_Context_SwitchToViewport(const VIEWPORT_SPACE space)
     GFX_GL_CheckError();
 }
 
-bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend)
+bool GFX_Context_Attach(void *window_handle)
 {
     const char *shading_ver;
 
@@ -90,7 +90,6 @@ bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend)
         return false;
     }
 
-    m_Context.config.backend = backend;
     m_Context.config.line_width = 1;
     m_Context.config.enable_wireframe = false;
     SDL_GetWindowSize(

--- a/src/libtrx/gfx/context.c
+++ b/src/libtrx/gfx/context.c
@@ -15,6 +15,7 @@
 typedef struct {
     SDL_GLContext context;
     SDL_Window *window_handle;
+    VIEWPORT_SPACE space;
 
     GFX_CONFIG config;
 
@@ -70,6 +71,7 @@ static GLvoid GLAPIENTRY M_GLDebug(
 void GFX_Context_SwitchToViewport(const VIEWPORT_SPACE space)
 {
     const VIEWPORT_RECT rect = Viewport_GetRect(space);
+    m_Context.space = space;
     glViewport(rect.x, rect.y, rect.width, rect.height);
     GFX_GL_CheckError();
 }
@@ -195,12 +197,13 @@ void *GFX_Context_GetWindowHandle(void)
 
 void GFX_Context_Clear(void)
 {
-    if (m_Context.config.enable_wireframe) {
-        glClearColor(1.0, 1.0, 1.0, 0.0);
-    } else {
-        glClearColor(0.0, 0.0, 0.0, 0.0);
-    }
-    glClear(GL_COLOR_BUFFER_BIT);
+    const RGBA_F white = { 1.0f, 1.0f, 1.0f, 0.0f };
+    const RGBA_F black = { 0.0f, 0.0f, 0.0f, 0.0f };
+    const RGBA_F color =
+        m_Context.space == VIEWPORT_GAME && m_Context.config.enable_wireframe
+        ? white
+        : black;
+    glClearBufferfv(GL_COLOR, 0, &color.r);
 }
 
 void GFX_Context_SwapBuffers(void)

--- a/src/libtrx/gfx/fade/fade_renderer.c
+++ b/src/libtrx/gfx/fade/fade_renderer.c
@@ -41,9 +41,9 @@ GFX_FADE_RENDERER *GFX_FadeRenderer_Create(void)
 
     GFX_GL_Program_Init(&r->program);
     GFX_GL_Program_AttachShader(
-        &r->program, GL_VERTEX_SHADER, "shaders/fade.glsl", config->backend);
+        &r->program, GL_VERTEX_SHADER, "shaders/fade.glsl");
     GFX_GL_Program_AttachShader(
-        &r->program, GL_FRAGMENT_SHADER, "shaders/fade.glsl", config->backend);
+        &r->program, GL_FRAGMENT_SHADER, "shaders/fade.glsl");
     GFX_GL_Program_FragmentData(&r->program, "outColor");
     GFX_GL_Program_Link(&r->program);
 

--- a/src/libtrx/gfx/gl/program.c
+++ b/src/libtrx/gfx/gl/program.c
@@ -39,18 +39,13 @@ void GFX_GL_Program_Bind(const GFX_GL_PROGRAM *const program)
     GFX_GL_CheckError();
 }
 
-char *GFX_GL_Program_PreprocessShader(
-    const char *content, GLenum type, GFX_GL_BACKEND backend)
+char *GFX_GL_Program_PreprocessShader(const char *content, GLenum type)
 {
     ASSERT(content != nullptr);
 
     char *common = nullptr;
     File_Load("shaders/common.glsl", &common, nullptr);
 
-    const char *version_ogl21 =
-        "#version 120\n"
-        "#extension GL_ARB_explicit_attrib_location: enable\n"
-        "#extension GL_EXT_gpu_shader4: enable\n";
     const char *version_ogl33c = "#version 330 core\n";
     const char *define_vertex = "#define VERTEX\n";
     const char *define_fragment = "#define FRAGMENT\n";
@@ -61,10 +56,8 @@ char *GFX_GL_Program_PreprocessShader(
         bufsize += strlen(common);
     }
 
-    if (backend == GFX_GL_33C) {
-        bufsize += strlen(version_ogl33c);
-        bufsize += strlen(define_ogl33c);
-    }
+    bufsize += strlen(version_ogl33c);
+    bufsize += strlen(define_ogl33c);
 
     if (type == GL_VERTEX_SHADER) {
         bufsize += strlen(define_vertex);
@@ -73,10 +66,8 @@ char *GFX_GL_Program_PreprocessShader(
     }
 
     char *processed_content = Memory_Alloc(bufsize);
-    if (backend == GFX_GL_33C) {
-        strcpy(processed_content, version_ogl33c);
-        strcat(processed_content, define_ogl33c);
-    }
+    strcpy(processed_content, version_ogl33c);
+    strcat(processed_content, define_ogl33c);
 
     if (common != nullptr) {
         strcat(processed_content, common);
@@ -95,8 +86,7 @@ char *GFX_GL_Program_PreprocessShader(
 }
 
 void GFX_GL_Program_AttachShader(
-    GFX_GL_PROGRAM *program, GLenum type, const char *path,
-    const GFX_GL_BACKEND backend)
+    GFX_GL_PROGRAM *program, GLenum type, const char *path)
 {
     ASSERT(program != nullptr);
     ASSERT(path != nullptr);
@@ -112,8 +102,7 @@ void GFX_GL_Program_AttachShader(
         Shell_ExitSystemFmt("Unable to find shader file: %s", path);
     }
 
-    char *processed_content =
-        GFX_GL_Program_PreprocessShader(content, type, backend);
+    char *processed_content = GFX_GL_Program_PreprocessShader(content, type);
     Memory_FreePointer(&content);
     if (!processed_content) {
         Shell_ExitSystemFmt("Failed to pre-process shader source:  %s", path);

--- a/src/libtrx/gfx/renderer.c
+++ b/src/libtrx/gfx/renderer.c
@@ -104,9 +104,9 @@ static void M_Init(GFX_RENDERER *const renderer, const GFX_CONFIG *const config)
 
     GFX_GL_Program_Init(&p->program);
     GFX_GL_Program_AttachShader(
-        &p->program, GL_VERTEX_SHADER, "shaders/fbo.glsl", config->backend);
+        &p->program, GL_VERTEX_SHADER, "shaders/fbo.glsl");
     GFX_GL_Program_AttachShader(
-        &p->program, GL_FRAGMENT_SHADER, "shaders/fbo.glsl", config->backend);
+        &p->program, GL_FRAGMENT_SHADER, "shaders/fbo.glsl");
     GFX_GL_Program_FragmentData(&p->program, "outColor");
     GFX_GL_Program_Link(&p->program);
     GFX_GL_Program_Bind(&p->program);

--- a/src/libtrx/include/libtrx/colors.h
+++ b/src/libtrx/include/libtrx/colors.h
@@ -3,20 +3,17 @@
 #include <stdint.h>
 
 typedef struct {
-    float r;
-    float g;
-    float b;
+    float r, g, b;
 } RGB_F;
 
 typedef struct {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
+    float r, g, b, a;
+} RGBA_F;
+
+typedef struct {
+    uint8_t r, g, b;
 } RGB_888;
 
 typedef struct {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-    uint8_t a;
+    uint8_t r, g, b, a;
 } RGBA_8888;

--- a/src/libtrx/include/libtrx/gfx/common.h
+++ b/src/libtrx/include/libtrx/gfx/common.h
@@ -7,8 +7,3 @@ typedef enum {
     GFX_TF_LAST = GFX_TF_BILINEAR,
     GFX_TF_NUMBER_OF,
 } GFX_TEXTURE_FILTER;
-
-typedef enum {
-    GFX_GL_INVALID_BACKEND,
-    GFX_GL_33C,
-} GFX_GL_BACKEND;

--- a/src/libtrx/include/libtrx/gfx/config.h
+++ b/src/libtrx/include/libtrx/gfx/config.h
@@ -5,8 +5,6 @@
 #include <stdint.h>
 
 typedef struct {
-    GFX_GL_BACKEND backend;
-
     GFX_TEXTURE_FILTER display_filter;
     bool enable_wireframe;
     int32_t line_width;

--- a/src/libtrx/include/libtrx/gfx/context.h
+++ b/src/libtrx/include/libtrx/gfx/context.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-bool GFX_Context_Attach(void *window_handle, GFX_GL_BACKEND backend);
+bool GFX_Context_Attach(void *window_handle);
 void GFX_Context_Detach(void);
 
 void GFX_Context_SetDisplayFilter(GFX_TEXTURE_FILTER filter);

--- a/src/libtrx/include/libtrx/gfx/gl/program.h
+++ b/src/libtrx/include/libtrx/gfx/gl/program.h
@@ -13,11 +13,9 @@ bool GFX_GL_Program_Init(GFX_GL_PROGRAM *program);
 void GFX_GL_Program_Close(GFX_GL_PROGRAM *program);
 
 void GFX_GL_Program_Bind(const GFX_GL_PROGRAM *program);
-char *GFX_GL_Program_PreprocessShader(
-    const char *content, GLenum type, GFX_GL_BACKEND backend);
+char *GFX_GL_Program_PreprocessShader(const char *content, GLenum type);
 void GFX_GL_Program_AttachShader(
-    GFX_GL_PROGRAM *program, GLenum type, const char *path,
-    GFX_GL_BACKEND backend);
+    GFX_GL_PROGRAM *program, GLenum type, const char *path);
 void GFX_GL_Program_Link(GFX_GL_PROGRAM *program);
 void GFX_GL_Program_FragmentData(GFX_GL_PROGRAM *program, const char *name);
 GLint GFX_GL_Program_UniformLocation(GFX_GL_PROGRAM *program, const char *name);

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -528,6 +528,7 @@ void Output_BeginScene(void)
     GFX_3D_Renderer_SetTextureFilter(
         m_Renderer3D, g_Config.rendering.texture_filter);
     GFX_3D_Renderer_SetBlendingMode(m_Renderer3D, GFX_BLEND_MODE_OFF);
+    GFX_Context_SetWireframeMode(g_Config.rendering.enable_wireframe);
     m_LightningCount = 0;
 }
 
@@ -963,8 +964,8 @@ void Output_SwitchViewport(const VIEWPORT_SPACE space)
         GFX_Renderer_BindUiFbo();
         GFX_3D_Renderer_SetTextureFilter(
             m_Renderer3D, g_Config.rendering.ui_filter);
-        GFX_Context_Clear();
     }
     GFX_Context_SwitchToViewport(space);
     GFX_3D_Renderer_SetProjectionMatrix(m_Renderer3D, space);
+    GFX_Context_Clear();
 }

--- a/src/tr1/game/output/shader.c
+++ b/src/tr1/game/output/shader.c
@@ -39,12 +39,8 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
     OUTPUT_SHADER *const shader = Memory_Alloc(sizeof(OUTPUT_SHADER));
 
     GFX_GL_Program_Init(&shader->program);
-    GFX_GL_Program_AttachShader(
-        &shader->program, GL_VERTEX_SHADER, path,
-        GFX_Context_GetConfig()->backend);
-    GFX_GL_Program_AttachShader(
-        &shader->program, GL_FRAGMENT_SHADER, path,
-        GFX_Context_GetConfig()->backend);
+    GFX_GL_Program_AttachShader(&shader->program, GL_VERTEX_SHADER, path);
+    GFX_GL_Program_AttachShader(&shader->program, GL_FRAGMENT_SHADER, path);
     GFX_GL_Program_FragmentData(&shader->program, "outColor");
     GFX_GL_Program_Link(&shader->program);
 

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -35,7 +35,7 @@ static void M_CreateGLContext(void)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(
         SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    if (!GFX_Context_Attach(m_Window, GFX_GL_33C)) {
+    if (!GFX_Context_Attach(m_Window)) {
         Shell_ExitSystem("System Error: cannot attach opengl context");
     }
 }

--- a/src/tr2/game/output.c
+++ b/src/tr2/game/output.c
@@ -1093,8 +1093,8 @@ void Output_SwitchViewport(const VIEWPORT_SPACE space)
 {
     if (space == VIEWPORT_UI) {
         GFX_Renderer_BindUiFbo();
-        GFX_Context_Clear();
     }
     GFX_Context_SwitchToViewport(space);
     Render_SwitchViewport(space);
+    GFX_Context_Clear();
 }

--- a/src/tr2/game/render/common.c
+++ b/src/tr2/game/render/common.c
@@ -35,7 +35,6 @@ static struct {
 static RENDERER *M_GetRenderer(void);
 static void M_ReuploadBackground(void);
 static void M_ResetPolyList(void);
-static void M_SetGLBackend(GFX_GL_BACKEND backend);
 
 static RENDERER *M_GetRenderer(void)
 {
@@ -72,52 +71,21 @@ static void M_ResetPolyList(void)
     }
 }
 
-static void M_SetGLBackend(const GFX_GL_BACKEND backend)
-{
-    switch (backend) {
-    case GFX_GL_33C:
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-        SDL_GL_SetAttribute(
-            SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-        break;
-
-    case GFX_GL_INVALID_BACKEND:
-        ASSERT_FAIL();
-        break;
-    }
-}
-
 void Render_Init(void)
 {
-    // TODO Move to libtrx later and combine with S_Shell_CreateWindow.
-    const GFX_GL_BACKEND backends_to_try[] = {
-        // clang-format off
-        GFX_GL_33C,
-        GFX_GL_INVALID_BACKEND, // guard
-        // clang-format on
-    };
-
-    for (int32_t i = 0; backends_to_try[i] != GFX_GL_INVALID_BACKEND; i++) {
-        const GFX_GL_BACKEND backend = backends_to_try[i];
-
-        M_SetGLBackend(backend);
-
-        int32_t major;
-        int32_t minor;
-        SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &major);
-        SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minor);
-        LOG_DEBUG("Trying GL backend %d.%d", major, minor);
-        if (GFX_Context_Attach(Shell_GetWindow(), backend)) {
-            m_FadeRenderer = GFX_FadeRenderer_Create();
-            m_BackgroundRenderer = GFX_2D_Renderer_Create();
-            Renderer_SW_Prepare(&m_Renderer_SW);
-            Renderer_HW_Prepare(&m_Renderer_HW);
-            return;
-        }
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(
+        SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    if (!GFX_Context_Attach(Shell_GetWindow())) {
+        Shell_ExitSystem("System Error: cannot attach opengl context");
     }
 
-    Shell_ExitSystem("System Error: cannot attach opengl context");
+    m_FadeRenderer = GFX_FadeRenderer_Create();
+    m_BackgroundRenderer = GFX_2D_Renderer_Create();
+    Renderer_SW_Prepare(&m_Renderer_SW);
+    Renderer_HW_Prepare(&m_Renderer_HW);
+    return;
 }
 
 void Render_Shutdown(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3649.
Doesn't fix the inventory ring rendering opaque in TR1 which is a separate issue that's been out for a longer time.