### PR TITLE
savegame: adjust Lara animation shift on load

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed incorrect wet footstep sounds in some of Lara's climb-up animations (#3607, regression from 4.6)
 - fixed the `/kill` command potentially causing a crash if used in a level with pods that don't hatch creatures (#3628, regression from 4.12)
 - fixed wireframe mode rendering as mostly white (#3649, regression from 4.13.2)
+- fixed Lara's animation not being restored correctly on load if a save was made during a special animation, such as using the Midas Hand (#3625, regression from 4.9)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - removed the option in Unfinished Business to fix animated sprites as it is irrelevant there

--- a/src/libtrx/include/libtrx/game/lara/const.h
+++ b/src/libtrx/include/libtrx/game/lara/const.h
@@ -3,6 +3,12 @@
 #include "../const.h"
 #include "../rooms/const.h"
 
+#if TR_VERSION == 1
+    #define LARA_ORIGINAL_ANIM_COUNT 160
+#elif TR_VERSION == 2
+    #define LARA_ORIGINAL_ANIM_COUNT 218
+#endif
+
 #define LARA_MAX_HITPOINTS 1000
 #define LARA_MAX_AIR 1800
 #define LARA_DIVE_WAIT 10

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -560,7 +560,8 @@ static bool M_LoadItems(JSON_ARRAY *items_arr, uint16_t header_version)
 
             // Prevent issues with pre-injection saves and Lara's enhanced
             // animation set.
-            if (item->object_id == O_LARA && item->anim_num < obj->anim_idx) {
+            if (item->object_id == O_LARA
+                && item->anim_num < LARA_ORIGINAL_ANIM_COUNT) {
                 item->anim_num += obj->anim_idx;
             }
         }

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -518,7 +518,8 @@ static bool M_LoadFromFile(MYFILE *const fp)
             item->anim_num = M_ReadS16();
             item->frame_num = M_ReadS16();
 
-            if (item->object_id == O_LARA && item->anim_num < obj->anim_idx) {
+            if (item->object_id == O_LARA
+                && item->anim_num < LARA_ORIGINAL_ANIM_COUNT) {
                 item->anim_num += obj->anim_idx;
             }
         }

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -913,7 +913,8 @@ static bool M_LoadItems(JSON_ARRAY *const items_arr)
             item->frame_num =
                 JSON_ObjectGetInt(item_obj, "frame_num", item->frame_num);
 
-            if (item->object_id == O_LARA && item->anim_num < obj->anim_idx) {
+            if (item->object_id == O_LARA
+                && item->anim_num < LARA_ORIGINAL_ANIM_COUNT) {
                 item->anim_num += obj->anim_idx;
             }
         }

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -233,7 +233,8 @@ static void M_ReadItems(void)
             item->anim_num = M_ReadS16();
             item->frame_num = M_ReadS16();
 
-            if (item->object_id == O_LARA && item->anim_num < obj->anim_idx) {
+            if (item->object_id == O_LARA
+                && item->anim_num < LARA_ORIGINAL_ANIM_COUNT) {
                 item->anim_num += obj->anim_idx;
             }
         }


### PR DESCRIPTION
Resolves #3625.
Resolves #3648.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents shifting Lara's animation if she is in a state beyond her regular animation control such as extra animations. No changelog for TR2 as it's unreleased there.

The camera still reverts to `CAM_CHASE` in these cases, and cinematic frame position is not restored on load. I started looking into it but it's pretty complex with the sequence of events. It can be tackled on its own under #3459.
