### PR TITLE
Small rendering refactors + fix rendering lightnings

### DIFF
--- a/data/tr1/ship/shaders/meshes.glsl
+++ b/data/tr1/ship/shaders/meshes.glsl
@@ -69,7 +69,6 @@ uniform float uAlphaThreshold;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;
 uniform vec2 uFog; // x = fog start, y = fog end
-uniform bool uWaterEffect;
 
 in vec4 gWorldPos;
 in vec3 gNormal;

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -112,8 +112,10 @@ static void M_Draw(PHASE *const phase)
     char buffer[80];
     const GFX_METRICS metrics = GFX_Track_GetMetrics();
     sprintf(
-        buffer, "%.03f KB T:%d U:%d", metrics.buffer_total_bytes / 1024.0f,
-        metrics.buffer_transfer_count, metrics.uniform_changes);
+        buffer, "%.03f KB T:%d U:%d Vo:%d Vt:%d",
+        metrics.buffer_total_bytes / 1024.0f, metrics.buffer_transfer_count,
+        metrics.uniform_changes, metrics.opaque_vert_count,
+        metrics.trans_vert_count);
     Benchmark_End(&benchmark, buffer);
 #endif
 

--- a/src/libtrx/include/libtrx/game/output/types.h
+++ b/src/libtrx/include/libtrx/game/output/types.h
@@ -18,6 +18,11 @@ typedef enum {
     TS_REQUESTED,
 } TEXT_STYLE;
 
+typedef enum {
+    DRAW_OPAQUE = 0,
+    DRAW_COLOR_KEY = 1,
+} DRAW_TYPE;
+
 typedef struct {
     int16_t value_1;
     int16_t value_2;

--- a/src/libtrx/include/libtrx/gfx/gl/track.h
+++ b/src/libtrx/include/libtrx/gfx/gl/track.h
@@ -6,6 +6,8 @@ typedef struct {
     int32_t buffer_transfer_count;
     int32_t buffer_total_bytes;
     int32_t uniform_changes;
+    int32_t opaque_vert_count;
+    int32_t trans_vert_count;
 } GFX_METRICS;
 
 extern GFX_METRICS g_GFX_Metrics;

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -62,7 +62,7 @@ bool Output_Init(void)
     OutputSource_Rooms_Init(m_Batcher);
     OutputSource_RoomsDebug_Init();
     OutputSource_Objects_Init(m_Batcher);
-    OutputSource_Sprites_Init();
+    OutputSource_Sprites_Init(m_Batcher);
     OutputSource_Lightnings_Init();
     OutputSource_Misc_Init();
     OutputSource_UI_Init();

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -1,6 +1,7 @@
 #include "game/output.h"
 
 #include "game/level.h"
+#include "game/output/mesh_batcher/batcher.h"
 #include "game/output/scene_compositor.h"
 #include "game/output/sources/lightnings.h"
 #include "game/output/sources/misc.h"
@@ -16,6 +17,7 @@
 
 #include <libtrx/config.h>
 
+static MESH_BATCHER *m_Batcher = nullptr;
 static OUTPUT_SHADER *m_Shader = nullptr;
 static GFX_2D_RENDERER *m_Renderer2D = nullptr;
 
@@ -56,13 +58,15 @@ bool Output_Init(void)
     Output_Textures_Init();
 
     m_Shader = Output_Shader_Create("shaders/meshes.glsl");
-    OutputSource_Rooms_Init();
+    m_Batcher = MeshBatcher_Create();
+    OutputSource_Rooms_Init(m_Batcher);
     OutputSource_RoomsDebug_Init();
-    OutputSource_Objects_Init();
+    OutputSource_Objects_Init(m_Batcher);
     OutputSource_Sprites_Init();
     OutputSource_Lightnings_Init();
     OutputSource_Misc_Init();
     OutputSource_UI_Init();
+    SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
 
     Output_InitLight();
     return true;
@@ -77,8 +81,11 @@ void Output_Shutdown(void)
     OutputSource_Sprites_Shutdown();
     OutputSource_Lightnings_Shutdown();
     OutputSource_Misc_Shutdown();
+
     Output_Shader_Free(m_Shader);
     m_Shader = nullptr;
+    MeshBatcher_Destroy(m_Batcher);
+    m_Batcher = nullptr;
 
     Output_Textures_Shutdown();
     Output_ShutdownLight();
@@ -138,6 +145,8 @@ void Output_DispatchLevelLoad(void)
     OutputSource_Rooms_ObserveLevelLoad();
     OutputSource_RoomsDebug_ObserveLevelLoad();
     OutputSource_Sprites_ObserveLevelLoad();
+
+    MeshBatcher_Seal(m_Batcher);
 
     Output_ApplyLevelSettings();
 }

--- a/src/tr1/game/output/mesh_batcher/batcher.c
+++ b/src/tr1/game/output/mesh_batcher/batcher.c
@@ -130,7 +130,6 @@ static void M_DrawInstance(
 
     Output_Shader_UploadViewModelMatrix(batcher->shader, &inst->matrix);
     Output_Shader_UploadTint(batcher->shader, inst->tint);
-    Output_Shader_UploadWaterEffect(batcher->shader, inst->water_effect);
 
     if (inst->enable_scissor) {
         Output_EnableScissor(

--- a/src/tr1/game/output/mesh_batcher/batcher.c
+++ b/src/tr1/game/output/mesh_batcher/batcher.c
@@ -147,12 +147,15 @@ static void M_DrawInstance(
         Output_Shader_UploadWibbleEffect(batcher->shader, false);
         glDepthMask(GL_FALSE);
         glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
+        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
         glDepthMask(GL_TRUE);
         Output_Shader_UploadWibbleEffect(batcher->shader, true);
         glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
+        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
     } else {
         Output_Shader_UploadWibbleEffect(batcher->shader, false);
         glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
+        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
     }
 
     if (inst->enable_scissor) {

--- a/src/tr1/game/output/mesh_batcher/batcher.c
+++ b/src/tr1/game/output/mesh_batcher/batcher.c
@@ -18,7 +18,7 @@ typedef struct {
     XYZ_F normal;
     OUTPUT_USHORT flags;
     RGBA_8888 color;
-} M_MESH_VERTEX;
+} M_MESH_GEOM;
 
 typedef struct {
     OUTPUT_UVW uvw;
@@ -28,7 +28,7 @@ typedef struct {
 
 typedef struct M_MESH_BUF_BINDING {
     OUTPUT_MESH *mesh;
-    M_MESH_VERTEX *geom_data;
+    M_MESH_GEOM *geom_data;
     M_MESH_TEXTURE *tex_data;
     M_MESH_SHADE *shade_data;
     int32_t vertex_start;
@@ -52,13 +52,14 @@ typedef struct MESH_BATCHER {
     GLuint shade_vbo;
 } MESH_BATCHER;
 
-static void M_FillGeometry(
-    M_MESH_VERTEX *tex, const OUTPUT_MESH_VERTEX *vertex);
+static M_MESH_BUF_BINDING *M_GetBinding(
+    const MESH_BATCHER *batcher, const OUTPUT_MESH *mesh);
+
+static void M_FillGeometry(M_MESH_GEOM *tex, const OUTPUT_MESH_VERTEX *vertex);
 static void M_FillTexture(
     M_MESH_TEXTURE *tex, const OUTPUT_MESH_VERTEX *vertex);
 static void M_FillShade(M_MESH_SHADE *shade, const OUTPUT_MESH_VERTEX *vertex);
-static M_MESH_BUF_BINDING *M_GetBinding(
-    const MESH_BATCHER *batcher, const OUTPUT_MESH *mesh);
+
 static void M_DrawInstance(const MESH_BATCHER *batcher, MESH_INSTANCE *inst);
 static void M_AnimateBinding(
     const MESH_BATCHER *batcher, const M_MESH_BUF_BINDING *bind);
@@ -68,8 +69,16 @@ static void M_RenderPass(const SCENE_SOURCE *source, SCENE_PASS pass);
 static bool M_IsDirty(const SCENE_SOURCE *source, SCENE_PASS pass);
 static void M_AnimateTextures(const SCENE_SOURCE *source);
 
+static M_MESH_BUF_BINDING *M_GetBinding(
+    const MESH_BATCHER *const batcher, const OUTPUT_MESH *const mesh)
+{
+    M_MESH_BUF_BINDING *bind = nullptr;
+    HASH_FIND_PTR(batcher->binding_map, &mesh, bind);
+    return bind;
+}
+
 static void M_FillGeometry(
-    M_MESH_VERTEX *const geom, const OUTPUT_MESH_VERTEX *const vertex)
+    M_MESH_GEOM *const geom, const OUTPUT_MESH_VERTEX *const vertex)
 {
     geom->pos = vertex->pos;
     geom->normal = vertex->normal;
@@ -90,14 +99,6 @@ static void M_FillShade(
     M_MESH_SHADE *const shade, const OUTPUT_MESH_VERTEX *const vertex)
 {
     *shade = vertex->shade;
-}
-
-static M_MESH_BUF_BINDING *M_GetBinding(
-    const MESH_BATCHER *const batcher, const OUTPUT_MESH *const mesh)
-{
-    M_MESH_BUF_BINDING *bind = nullptr;
-    HASH_FIND_PTR(batcher->binding_map, &mesh, bind);
-    return bind;
 }
 
 static void M_AnimateBinding(
@@ -227,18 +228,17 @@ MESH_BATCHER *MeshBatcher_Create(void)
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_COLOR);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, pos));
+        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_GEOM),
+        (void *)(intptr_t)offsetof(M_MESH_GEOM, pos));
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, normal));
+        OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_GEOM),
+        (void *)(intptr_t)offsetof(M_MESH_GEOM, normal));
     glVertexAttribIPointer(
-        OUTPUT_MESH_ATTR_FLAGS, 1, OUTPUT_USHORT_GL, sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, flags));
+        OUTPUT_MESH_ATTR_FLAGS, 1, OUTPUT_USHORT_GL, sizeof(M_MESH_GEOM),
+        (void *)(intptr_t)offsetof(M_MESH_GEOM, flags));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE,
-        sizeof(M_MESH_VERTEX),
-        (void *)(intptr_t)offsetof(M_MESH_VERTEX, color));
+        sizeof(M_MESH_GEOM), (void *)(intptr_t)offsetof(M_MESH_GEOM, color));
 
     glBindBuffer(GL_ARRAY_BUFFER, batcher->tex_vbo);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_UVW);
@@ -326,7 +326,7 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
     bind->vertex_count = mesh->vertices->count;
     const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
 
-    bind->geom_data = Memory_Alloc(sizeof(M_MESH_VERTEX) * bind->vertex_count);
+    bind->geom_data = Memory_Alloc(sizeof(M_MESH_GEOM) * bind->vertex_count);
     bind->tex_data = Memory_Alloc(sizeof(M_MESH_TEXTURE) * bind->vertex_count);
     bind->shade_data = Memory_Alloc(sizeof(M_MESH_SHADE) * bind->vertex_count);
     for (int32_t i = 0; i < bind->vertex_count; i++) {
@@ -347,7 +347,7 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
     glBindBuffer(GL_ARRAY_BUFFER, batcher->geom_vbo);
     GFX_TRACK_DATA(
         glBufferData, GL_ARRAY_BUFFER,
-        batcher->vertex_count * sizeof(M_MESH_VERTEX), nullptr,
+        batcher->vertex_count * sizeof(M_MESH_GEOM), nullptr,
         GL_DYNAMIC_DRAW); // allow updating mesh flags
 
     glBindBuffer(GL_ARRAY_BUFFER, batcher->tex_vbo);
@@ -368,8 +368,8 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
         glBindBuffer(GL_ARRAY_BUFFER, batcher->geom_vbo);
         GFX_TRACK_SUBDATA(
             glBufferSubData, GL_ARRAY_BUFFER,
-            bind->vertex_start * sizeof(M_MESH_VERTEX),
-            bind->vertex_count * sizeof(M_MESH_VERTEX), bind->geom_data);
+            bind->vertex_start * sizeof(M_MESH_GEOM),
+            bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
         glBindBuffer(GL_ARRAY_BUFFER, batcher->tex_vbo);
         GFX_TRACK_SUBDATA(
             glBufferSubData, GL_ARRAY_BUFFER,
@@ -409,8 +409,8 @@ void MeshBatcher_UpdateMeshGeometry(
     glBindBuffer(GL_ARRAY_BUFFER, batcher->geom_vbo);
     GFX_TRACK_SUBDATA(
         glBufferSubData, GL_ARRAY_BUFFER,
-        bind->vertex_start * sizeof(M_MESH_VERTEX),
-        bind->vertex_count * sizeof(M_MESH_VERTEX), bind->geom_data);
+        bind->vertex_start * sizeof(M_MESH_GEOM),
+        bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
 }
 
 void MeshBatcher_Stage(

--- a/src/tr1/game/output/mesh_batcher/batcher.h
+++ b/src/tr1/game/output/mesh_batcher/batcher.h
@@ -11,7 +11,6 @@ typedef struct MESH_INSTANCE {
     MATRIX matrix;
     RGB_F tint;
     bool wibble;
-    bool water_effect;
 
     // TODO: remove these
     int32_t ls_adder;
@@ -23,6 +22,7 @@ typedef struct MESH_INSTANCE {
 
     void (*update_light_func)(struct MESH_INSTANCE *inst, void *user_data);
     void *update_light_func_data;
+    bool water_effect; // helper for the update_light_func
 } MESH_INSTANCE;
 
 typedef struct MESH_BATCHER MESH_BATCHER;

--- a/src/tr1/game/output/mesh_batcher/mesh.c
+++ b/src/tr1/game/output/mesh_batcher/mesh.c
@@ -10,27 +10,27 @@
 #include <libtrx/memory.h>
 
 static void M_AddRoomVert(
-    OUTPUT_MESH *b, const ROOM_VERTEX *room_vert, int32_t uvw_idx,
+    OUTPUT_MESH *mesh, const ROOM_VERTEX *room_vert, int32_t uvw_idx,
     const TEXTURE_ZW_F *texture_ratio);
 static void M_AddObjectVert(
-    OUTPUT_MESH *b, const XYZ_16 *pos, int32_t uvw_idx,
+    OUTPUT_MESH *mesh, const XYZ_16 *pos, int32_t uvw_idx,
     const TEXTURE_ZW_F *texture_ratio, uint16_t flags, XYZ_16 normal,
     int16_t palette_idx);
 
 static void M_AddRoomVert(
-    OUTPUT_MESH *const b, const ROOM_VERTEX *const room_vert,
+    OUTPUT_MESH *const mesh, const ROOM_VERTEX *const room_vert,
     const int32_t uvw_idx, const TEXTURE_ZW_F *const texture_ratio)
 {
     if (Output_Textures_IsObjectTextureAnimated(uvw_idx / 4)) {
         Vector_Add(
-            b->animated_vertices,
+            mesh->animated_vertices,
             &(OUTPUT_VERTEX_RANGE) {
-                .vertex_start = b->vertices->count,
+                .vertex_start = mesh->vertices->count,
                 .vertex_count = 1,
             });
     }
     OUTPUT_MESH_VERTEX vertex = {
-        .pos = (XYZ_F) {
+        .pos = {
             .x = room_vert->pos.x,
             .y = room_vert->pos.y,
             .z = room_vert->pos.z,
@@ -38,36 +38,36 @@ static void M_AddRoomVert(
         .flags = room_vert->flags & NO_VERT_MOVE ? VERT_NO_CAUSTICS : 0,
         .uvw_idx = uvw_idx,
         .shade = room_vert->light_adder,
-        .color = (RGBA_8888) { 255, 255, 255, 255 },
+        .color = { 255, 255, 255, 255 },
         .trapezoid_ratio = {
             [0] = texture_ratio != nullptr ? texture_ratio->z : 1.0f,
             [1] = texture_ratio != nullptr ? texture_ratio->w : 1.0f,
         },
     };
-    Vector_Add(b->vertices, &vertex);
+    Vector_Add(mesh->vertices, &vertex);
 }
 
 static void M_AddObjectVert(
-    OUTPUT_MESH *const b, const XYZ_16 *const pos, const int32_t uvw_idx,
+    OUTPUT_MESH *const mesh, const XYZ_16 *const pos, const int32_t uvw_idx,
     const TEXTURE_ZW_F *const texture_ratio, const uint16_t flags,
     const XYZ_16 normal, const int16_t palette_idx)
 {
     if (!(flags & VERT_FLAT_SHADED)
         && Output_Textures_IsObjectTextureAnimated(uvw_idx / 4)) {
         Vector_Add(
-            b->animated_vertices,
+            mesh->animated_vertices,
             &(OUTPUT_VERTEX_RANGE) {
-                .vertex_start = b->vertices->count,
+                .vertex_start = mesh->vertices->count,
                 .vertex_count = 1,
             });
     }
     OUTPUT_MESH_VERTEX vertex = {
-        .pos = (XYZ_F) {
+        .pos = {
             .x = pos->x,
             .y = pos->y,
             .z = pos->z,
         },
-        .normal = (XYZ_F) {
+        .normal = {
             .x = normal.x,
             .y = normal.y,
             .z = normal.z,
@@ -77,54 +77,54 @@ static void M_AddObjectVert(
         .shade = SHADE_NEUTRAL,
         .color = (flags & VERT_FLAT_SHADED) ?
             Output_RGB2RGBA(Output_GetPaletteColor8(palette_idx))
-            :  (RGBA_8888) { 255, 255, 255, 255 },
+            : (RGBA_8888) { 255, 255, 255, 255 },
         .trapezoid_ratio = {
             [0] = texture_ratio != nullptr ? texture_ratio->z : 1.0f,
             [1] = texture_ratio != nullptr ? texture_ratio->w : 1.0f,
         },
     };
-    Vector_Add(b->vertices, &vertex);
+    Vector_Add(mesh->vertices, &vertex);
 }
 
 OUTPUT_MESH *Output_Mesh_Create(void)
 {
-    OUTPUT_MESH *const b = Memory_Alloc(sizeof(OUTPUT_MESH));
-    b->vertices = Vector_Create(sizeof(OUTPUT_MESH_VERTEX));
-    b->animated_vertices = Vector_Create(sizeof(OUTPUT_VERTEX_RANGE));
-    return b;
+    OUTPUT_MESH *const mesh = Memory_Alloc(sizeof(OUTPUT_MESH));
+    mesh->vertices = Vector_Create(sizeof(OUTPUT_MESH_VERTEX));
+    mesh->animated_vertices = Vector_Create(sizeof(OUTPUT_VERTEX_RANGE));
+    return mesh;
 }
 
 void Output_Mesh_AddRoomFace4(
-    OUTPUT_MESH *const b, const FACE4 *const face,
+    OUTPUT_MESH *const mesh, const FACE4 *const face,
     const ROOM_VERTEX *const verts)
 {
-    ASSERT(!b->sealed);
+    ASSERT(!mesh->sealed);
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
         const ROOM_VERTEX *const room_vert = &verts[face->vertices[j]];
-        M_AddRoomVert(b, room_vert, uvw_idx, &face->texture_zw[j]);
+        M_AddRoomVert(mesh, room_vert, uvw_idx, &face->texture_zw[j]);
     }
 }
 
 void Output_Mesh_AddRoomFace3(
-    OUTPUT_MESH *const b, const FACE3 *const face,
+    OUTPUT_MESH *const mesh, const FACE3 *const face,
     const ROOM_VERTEX *const verts)
 {
-    ASSERT(!b->sealed);
+    ASSERT(!mesh->sealed);
     for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
         const int32_t j = OUTPUT_TRI_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
         const ROOM_VERTEX *const room_vert = &verts[face->vertices[j]];
-        M_AddRoomVert(b, room_vert, uvw_idx, nullptr);
+        M_AddRoomVert(mesh, room_vert, uvw_idx, nullptr);
     }
 }
 
 void Output_Mesh_AddRoomSprite(
-    OUTPUT_MESH *const b, const ROOM_SPRITE *const room_sprite,
+    OUTPUT_MESH *const mesh, const ROOM_SPRITE *const room_sprite,
     const ROOM_VERTEX *const verts)
 {
-    ASSERT(!b->sealed);
+    ASSERT(!mesh->sealed);
     struct {
         struct {
             float x, y;
@@ -145,78 +145,76 @@ void Output_Mesh_AddRoomSprite(
         const ROOM_VERTEX *const room_vert = &verts[room_sprite->vertex];
         if (Output_Textures_IsSpriteTextureAnimated(room_sprite->texture)) {
             Vector_Add(
-                b->animated_vertices,
+                mesh->animated_vertices,
                 &(OUTPUT_VERTEX_RANGE) {
-                    .vertex_start = b->vertices->count,
+                    .vertex_start = mesh->vertices->count,
                     .vertex_count = 1,
                 });
         }
         OUTPUT_MESH_VERTEX vertex = {
-            .pos =
-                (XYZ_F) {
-                    .x = room_vert->pos.x,
-                    .y = room_vert->pos.y,
-                    .z = room_vert->pos.z,
-                },
-            .normal =
-                (XYZ_F) {
-                    .x = quad[j].displacement.x,
-                    .y = quad[j].displacement.y,
-                    .z = 0.0f,
-                },
+            .pos = {
+                .x = room_vert->pos.x,
+                .y = room_vert->pos.y,
+                .z = room_vert->pos.z,
+            },
+            .normal = {
+                .x = quad[j].displacement.x,
+                .y = quad[j].displacement.y,
+                .z = 0.0f,
+            },
             .flags = VERT_BILLBOARD,
-            .color = (RGBA_8888) { 255, 255, 255, 255 },
+            .color = { 255, 255, 255, 255 },
             .uvw_idx = Output_Textures_GetSpritesUVWsBase()
                 + room_sprite->texture * 4 + j,
             .shade = room_vert->light_adder,
             .trapezoid_ratio = { 1.0f, 1.0f },
         };
-        Vector_Add(b->vertices, &vertex);
+        Vector_Add(mesh->vertices, &vertex);
     }
 }
 
 void Output_Mesh_AddObjectFace4(
-    OUTPUT_MESH *const b, const OBJECT_MESH *const obj_mesh,
+    OUTPUT_MESH *const mesh, const OBJECT_MESH *const obj_mesh,
     const FACE4 *const face, const uint16_t flags)
 {
-    ASSERT(!b->sealed);
+    ASSERT(!mesh->sealed);
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
         const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[j]];
         const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[j]];
         M_AddObjectVert(
-            b, pos, uvw_idx, &face->texture_zw[j], flags, normal,
+            mesh, pos, uvw_idx, &face->texture_zw[j], flags, normal,
             face->palette_idx);
     }
 }
 
 void Output_Mesh_AddObjectFace3(
-    OUTPUT_MESH *const b, const OBJECT_MESH *const obj_mesh,
+    OUTPUT_MESH *const mesh, const OBJECT_MESH *const obj_mesh,
     const FACE3 *const face, const uint16_t flags)
 {
-    ASSERT(!b->sealed);
+    ASSERT(!mesh->sealed);
     for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
         const int32_t j = OUTPUT_TRI_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
         const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[j]];
         const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[j]];
         M_AddObjectVert(
-            b, pos, uvw_idx, nullptr, flags, normal, face->palette_idx);
+            mesh, pos, uvw_idx, nullptr, flags, normal, face->palette_idx);
     }
 }
 
-void Output_Mesh_Seal(OUTPUT_MESH *const b)
+void Output_Mesh_Seal(OUTPUT_MESH *const mesh)
 {
-    Output_GlueVertexRanges(b->animated_vertices);
-    b->sealed = true;
+    Output_GlueVertexRanges(mesh->animated_vertices);
+    mesh->sealed = true;
 }
 
-void Output_Mesh_Destroy(OUTPUT_MESH *const b)
+void Output_Mesh_Destroy(OUTPUT_MESH *const mesh)
 {
-    if (b->animated_vertices != nullptr) {
-        Vector_Free(b->animated_vertices);
+    if (mesh->animated_vertices != nullptr) {
+        Vector_Free(mesh->animated_vertices);
     }
-    Vector_Free(b->vertices);
-    Memory_Free(b);
+    Vector_Free(mesh->vertices);
+    Memory_Free(mesh);
 }

--- a/src/tr1/game/output/mesh_batcher/mesh.h
+++ b/src/tr1/game/output/mesh_batcher/mesh.h
@@ -36,23 +36,24 @@ typedef struct {
 } OUTPUT_MESH;
 
 OUTPUT_MESH *Output_Mesh_Create(void);
-void Output_Mesh_Destroy(OUTPUT_MESH *b);
+void Output_Mesh_Destroy(OUTPUT_MESH *mesh);
 
 void Output_Mesh_AddRoomFace4(
-    OUTPUT_MESH *b, const FACE4 *face, const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const FACE4 *face, const ROOM_VERTEX *verts);
 void Output_Mesh_AddRoomFace3(
-    OUTPUT_MESH *b, const FACE3 *face, const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const FACE3 *face, const ROOM_VERTEX *verts);
 void Output_Mesh_AddRoomSprite(
-    OUTPUT_MESH *b, const ROOM_SPRITE *room_sprite, const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const ROOM_SPRITE *room_sprite,
+    const ROOM_VERTEX *verts);
 
 void Output_Mesh_AddObjectFace4(
-    OUTPUT_MESH *b, const OBJECT_MESH *obj_mesh, const FACE4 *face,
+    OUTPUT_MESH *mesh, const OBJECT_MESH *obj_mesh, const FACE4 *face,
     uint16_t flags);
 void Output_Mesh_AddObjectFace3(
-    OUTPUT_MESH *b, const OBJECT_MESH *obj_mesh, const FACE3 *face,
+    OUTPUT_MESH *mesh, const OBJECT_MESH *obj_mesh, const FACE3 *face,
     uint16_t flags);
 
 // Done streaming faces. This seals the batch (vertex_count is final), and
 // immediately uploads the CPU‐side vertex & UV data to the GPU.
 // (Later calls to UpdateTextures/UpdateShades will do incremental sub‑data.)
-void Output_Mesh_Seal(OUTPUT_MESH *b);
+void Output_Mesh_Seal(OUTPUT_MESH *mesh);

--- a/src/tr1/game/output/scene_compositor.c
+++ b/src/tr1/game/output/scene_compositor.c
@@ -94,9 +94,9 @@ static void M_RenderSourcePass(const M_PRIV *const p, const SCENE_PASS pass)
     for (int32_t i = 0; i < p->sources->count; i++) {
         const SCENE_SOURCE *const source =
             *(SCENE_SOURCE **)Vector_Get(p->sources, i);
-        Output_Shader_UploadTint(shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
-        Output_Shader_UploadWibbleEffect(shader, false);
         if (source->is_dirty(source, pass)) {
+            Output_Shader_UploadTint(shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
+            Output_Shader_UploadWibbleEffect(shader, false);
             source->render_pass(source, pass);
         }
     }

--- a/src/tr1/game/output/scene_compositor.c
+++ b/src/tr1/game/output/scene_compositor.c
@@ -95,7 +95,6 @@ static void M_RenderSourcePass(const M_PRIV *const p, const SCENE_PASS pass)
         const SCENE_SOURCE *const source =
             *(SCENE_SOURCE **)Vector_Get(p->sources, i);
         Output_Shader_UploadTint(shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
-        Output_Shader_UploadWaterEffect(shader, false);
         Output_Shader_UploadWibbleEffect(shader, false);
         if (source->is_dirty(source, pass)) {
             source->render_pass(source, pass);

--- a/src/tr1/game/output/shader.c
+++ b/src/tr1/game/output/shader.c
@@ -26,7 +26,6 @@ typedef enum {
     M_UNIFORM_PROJECTION_MATRIX,
     M_UNIFORM_MODEL_MATRIX,
     M_UNIFORM_WIBBLE_EFFECT,
-    M_UNIFORM_WATER_EFFECT,
     M_UNIFORM_NUMBER_OF,
 } M_UNIFORM;
 
@@ -35,7 +34,6 @@ struct OUTPUT_SHADER {
     GLint uniforms[M_UNIFORM_NUMBER_OF];
 
     bool is_wibble_effect;
-    bool is_water_effect;
     RGB_F tint;
 };
 
@@ -66,7 +64,6 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
         [M_UNIFORM_PROJECTION_MATRIX] = "uMatProjection",
         [M_UNIFORM_MODEL_MATRIX] = "uMatModelView",
         [M_UNIFORM_WIBBLE_EFFECT] = "uWibbleEffect",
-        [M_UNIFORM_WATER_EFFECT] = "uWaterEffect",
     };
     for (int32_t i = 0; i < M_UNIFORM_NUMBER_OF; i++) {
         shader->uniforms[i] =
@@ -180,17 +177,6 @@ void Output_Shader_UploadWibbleEffect(
     GFX_TRACK_UNIFORM(
         glUniform1i, shader->uniforms[M_UNIFORM_WIBBLE_EFFECT], is_enabled);
     shader->is_wibble_effect = is_enabled;
-}
-
-void Output_Shader_UploadWaterEffect(
-    OUTPUT_SHADER *const shader, const bool is_enabled)
-{
-    if (is_enabled == shader->is_water_effect) {
-        return;
-    }
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_WATER_EFFECT], is_enabled);
-    shader->is_water_effect = is_enabled;
 }
 
 void Output_Shader_UploadTint(OUTPUT_SHADER *const shader, const RGB_F tint)

--- a/src/tr1/game/output/shader.h
+++ b/src/tr1/game/output/shader.h
@@ -44,5 +44,4 @@ void Output_Shader_UploadSmoothingEnabled(
 void Output_Shader_UploadViewModelMatrix(
     const OUTPUT_SHADER *shader, const MATRIX *source);
 void Output_Shader_UploadWibbleEffect(OUTPUT_SHADER *shader, bool is_enabled);
-void Output_Shader_UploadWaterEffect(OUTPUT_SHADER *shader, bool is_enabled);
 void Output_Shader_UploadTint(OUTPUT_SHADER *shader, RGB_F tint);

--- a/src/tr1/game/output/sources/lightnings.c
+++ b/src/tr1/game/output/sources/lightnings.c
@@ -56,7 +56,9 @@ static void M_GenerateLightningSegment(
     };
     Matrix_Pop();
 
-    const M_VERTEX vertices[2][4] = {
+    // 2 quads side-to-side (blue-white) (white-blue);
+    // double-sided so that visible from both sides
+    const M_VERTEX vertices[4][4] = {
         // clang-format off
         {
             { .pos = pos_0, .normal = { 0, 0, 0 }, .color = white },
@@ -70,10 +72,22 @@ static void M_GenerateLightningSegment(
             { .pos = pos_1, .normal = { -w, 0, 0 }, .color = blue },
             { .pos = pos_0, .normal = { -w, 0, 0 }, .color = blue },
         },
+        {
+            { .pos = pos_0, .normal = { 0, 0, 0 }, .color = white },
+            { .pos = pos_0, .normal = { w, 0, 0 }, .color = blue },
+            { .pos = pos_1, .normal = { w, 0, 0 }, .color = blue },
+            { .pos = pos_1, .normal = { 0, 0, 0 }, .color = white },
+        },
+        {
+            { .pos = pos_0, .normal = { 0, 0, 0 }, .color = white },
+            { .pos = pos_0, .normal = { -w, 0, 0 }, .color = blue },
+            { .pos = pos_1, .normal = { -w, 0, 0 }, .color = blue },
+            { .pos = pos_1, .normal = { 0, 0, 0 }, .color = white },
+        },
         // clang-format on
     };
 
-    for (int32_t quad = 0; quad < 2; quad++) {
+    for (int32_t quad = 0; quad < 4; quad++) {
         for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
             const int32_t j = OUTPUT_QUAD_TO_FAN(i);
             Vector_Add(p->vertices, &vertices[quad][j]);

--- a/src/tr1/game/output/sources/objects.c
+++ b/src/tr1/game/output/sources/objects.c
@@ -1,7 +1,6 @@
 #include "game/output/sources/objects.h"
 
 #include "game/output.h"
-#include "game/output/mesh_batcher/batcher.h"
 #include "game/output/scene_compositor.h"
 #include "game/output/utils.h"
 
@@ -108,7 +107,6 @@ static void M_PrepareMeshes(M_PRIV *const p)
         new_batch->light_idx_map =
             M_PrepareLightIndexMap(obj_mesh, batch->vertices->count);
     }
-    MeshBatcher_Seal(p->batcher);
 }
 
 static void M_FreeMeshes(M_PRIV *const p)
@@ -230,18 +228,16 @@ static void M_Stage(const OBJECT_MESH *const mesh, const bool background)
         background ? SCENE_PASS_BACKGROUND : SCENE_PASS_MESHES);
 }
 
-void OutputSource_Objects_Init(void)
+void OutputSource_Objects_Init(MESH_BATCHER *const batcher)
 {
     M_PRIV *const p = &m_Priv;
-    p->batcher = MeshBatcher_Create();
-    SceneCompositor_AddSource(MeshBatcher_AsSource(p->batcher));
+    p->batcher = batcher;
 }
 
 void OutputSource_Objects_Shutdown(void)
 {
     M_PRIV *const p = &m_Priv;
     M_FreeMeshes(p);
-    MeshBatcher_Destroy(p->batcher);
 }
 
 void OutputSource_Objects_ObserveLevelLoad(void)

--- a/src/tr1/game/output/sources/objects.h
+++ b/src/tr1/game/output/sources/objects.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "game/output/mesh_batcher/batcher.h"
 #include "game/output/scene_source.h"
 
 #include <libtrx/game/objects/types.h>
 
-void OutputSource_Objects_Init(void);
+void OutputSource_Objects_Init(MESH_BATCHER *batcher);
 void OutputSource_Objects_Shutdown(void);
 void OutputSource_Objects_ObserveLevelLoad(void);
 void OutputSource_Objects_ObserveLevelUnload(void);

--- a/src/tr1/game/output/sources/rooms.c
+++ b/src/tr1/game/output/sources/rooms.c
@@ -1,7 +1,6 @@
 #include "game/output/sources/rooms.h"
 
 #include "game/output.h"
-#include "game/output/mesh_batcher/batcher.h"
 #include "game/output/scene_compositor.h"
 #include "game/output/utils.h"
 #include "game/random.h"
@@ -117,7 +116,6 @@ static void M_PrepareMeshes(M_PRIV *const p)
 
         p->meshes[i] = mesh;
     }
-    MeshBatcher_Seal(p->batcher);
 }
 
 static void M_FreeMeshes(M_PRIV *const p)
@@ -131,23 +129,21 @@ static void M_FreeMeshes(M_PRIV *const p)
     }
 }
 
-void OutputSource_Rooms_Init(void)
+void OutputSource_Rooms_Init(MESH_BATCHER *const batcher)
 {
     M_PRIV *const p = &m_Priv;
-    p->batcher = MeshBatcher_Create();
+    p->batcher = batcher;
     for (int32_t i = 0; i < WIBBLE_SIZE; i++) {
         const int16_t angle = (i * DEG_360) / WIBBLE_SIZE;
         p->shade_table[i] = Math_Sin(angle) * SHADE_CAUSTICS >> W2V_SHIFT;
         p->caustics_table[i] = (Random_GetDraw() >> 5) - 0x01FF;
     }
-    SceneCompositor_AddSource(MeshBatcher_AsSource(p->batcher));
 }
 
 void OutputSource_Rooms_Shutdown(void)
 {
     M_PRIV *const p = &m_Priv;
     M_FreeMeshes(p);
-    MeshBatcher_Destroy(p->batcher);
 }
 
 void OutputSource_Rooms_ObserveLevelLoad(void)

--- a/src/tr1/game/output/sources/rooms.h
+++ b/src/tr1/game/output/sources/rooms.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "game/output/mesh_batcher/batcher.h"
+
 #include <libtrx/game/rooms/types.h>
 
-void OutputSource_Rooms_Init(void);
+void OutputSource_Rooms_Init(MESH_BATCHER *batcher);
 void OutputSource_Rooms_Shutdown(void);
 void OutputSource_Rooms_ObserveLevelLoad(void);
 void OutputSource_Rooms_ObserveLevelUnload(void);

--- a/src/tr1/game/output/sources/sprites.c
+++ b/src/tr1/game/output/sources/sprites.c
@@ -1,297 +1,98 @@
 #include "game/output/sources/sprites.h"
 
-#include "game/output.h"
-#include "game/output/scene_compositor.h"
+#include "game/output/mesh_batcher/batcher.h"
+#include "game/output/mesh_batcher/mesh.h"
 #include "game/output/textures.h"
 #include "game/output/utils.h"
 
-#include <libtrx/gfx/gl/utils.h>
+#include <libtrx/game/output/textures.h>
 #include <libtrx/memory.h>
+#include <libtrx/utils.h>
 #include <libtrx/vector.h>
 
-#pragma pack(push, 1)
-typedef struct {
-    XYZ_F pos;
-    struct {
-        float x, y;
-    } displacement;
-    OUTPUT_UVW uvw;
-    OUTPUT_TEXTURE_SIZE texture_size;
-} M_SPRITE_VERTEX;
-
-typedef OUTPUT_USHORT M_SPRITE_SHADE;
-#pragma pack(pop)
+#include <stdint.h>
 
 typedef struct {
-    MATRIX matrix;
-    XYZ_32 pos;
-    int32_t sprite_idx;
-    RGB_F tint;
-    int16_t shade;
-} M_INSTANCE;
-
-typedef struct {
-    GLuint vao;
-    GLuint geom_vbo;
-    GLuint shade_vbo;
-    size_t vertex_capacity;
-    size_t vertex_count;
-    M_SPRITE_VERTEX *geom_vbo_data;
-    M_SPRITE_SHADE *shade_vbo_data;
-} M_SPRITE_BUFFER;
-
-typedef struct {
-    const ROOM *room;
-    MATRIX matrix;
-    RGB_F tint;
-    bool wibble;
-    bool water_effect;
-} M_ROOM;
-
-typedef struct {
-    SCENE_SOURCE source;
-    OUTPUT_SHADER *shader;
-    VECTOR *scheduled;
-    M_SPRITE_BUFFER sprite_buf;
+    MESH_BATCHER *batcher;
+    OUTPUT_MESH **meshes;
+    size_t mesh_count;
 } M_PRIV;
 
-static M_PRIV m_Priv = {};
+static M_PRIV m_Priv;
 
-static void M_MakeQuad(
-    M_SPRITE_VERTEX out_quad[4], int32_t sprite_idx, XYZ_16 pos);
-static void M_BufferReallocGPU(M_SPRITE_BUFFER *buffer);
-static void M_PrepareBuffer(void);
-static void M_FreeBuffer(void);
+static void M_PrepareMeshes(M_PRIV *p);
+static void M_FreeMeshes(M_PRIV *p);
+static void M_UpdateShades(MESH_INSTANCE *inst, void *user_data);
 
-static void M_RenderBegin(const SCENE_SOURCE *source);
-static void M_RenderPass(const SCENE_SOURCE *source, SCENE_PASS pass);
-static bool M_IsDirty(const SCENE_SOURCE *source, SCENE_PASS pass);
-
-static void M_MakeQuad(
-    M_SPRITE_VERTEX out_quad[4], const int32_t sprite_idx, const XYZ_16 pos)
+void OutputSource_Sprites_Init(MESH_BATCHER *batcher)
 {
-    const SPRITE_TEXTURE *const sprite = Output_GetSpriteTexture(sprite_idx);
-
-    for (int32_t k = 0; k < 4; k++) {
-        const int32_t uvw_idx =
-            Output_Textures_GetSpritesUVWsBase() + sprite_idx * 4 + k;
-        out_quad[k].pos = (XYZ_F) { .x = pos.x, .y = pos.y, .z = pos.z };
-        out_quad[k].uvw = Output_Textures_GetUVW(uvw_idx);
-        out_quad[k].texture_size = Output_Textures_GetAtlasSize(uvw_idx / 4);
-    }
-
-    out_quad[0].displacement.x = sprite->x0;
-    out_quad[0].displacement.y = sprite->y0;
-    out_quad[1].displacement.x = sprite->x1;
-    out_quad[1].displacement.y = sprite->y0;
-    out_quad[2].displacement.x = sprite->x1;
-    out_quad[2].displacement.y = sprite->y1;
-    out_quad[3].displacement.x = sprite->x0;
-    out_quad[3].displacement.y = sprite->y1;
-}
-
-static void M_BufferReallocGPU(M_SPRITE_BUFFER *const buffer)
-{
-    // This triggers a reallocation on the GPU and should be used sparingly,
-    // even when swapping the entire buffer data.
-    glBindBuffer(GL_ARRAY_BUFFER, buffer->geom_vbo);
-    GFX_TRACK_DATA(
-        glBufferData, GL_ARRAY_BUFFER,
-        buffer->vertex_capacity * sizeof(M_SPRITE_VERTEX),
-        buffer->geom_vbo_data, GL_DYNAMIC_DRAW);
-
-    glBindBuffer(GL_ARRAY_BUFFER, buffer->shade_vbo);
-    GFX_TRACK_DATA(
-        glBufferData, GL_ARRAY_BUFFER,
-        buffer->vertex_capacity * sizeof(M_SPRITE_SHADE),
-        buffer->shade_vbo_data, GL_DYNAMIC_DRAW); // shades are always dynamic
-}
-
-static void M_PrepareBuffer(void)
-{
-    M_PRIV *const p = &m_Priv;
-    M_SPRITE_BUFFER *const buffer = &p->sprite_buf;
-    buffer->vertex_capacity = 500;
-    buffer->vertex_count = 0;
-
-    buffer->geom_vbo_data =
-        Memory_Alloc(buffer->vertex_capacity * sizeof(M_SPRITE_VERTEX));
-    buffer->shade_vbo_data =
-        Memory_Alloc(buffer->vertex_capacity * sizeof(M_SPRITE_SHADE));
-
-    glGenVertexArrays(1, &buffer->vao);
-    glGenBuffers(1, &buffer->geom_vbo);
-    glGenBuffers(1, &buffer->shade_vbo);
-
-    M_BufferReallocGPU(buffer);
-
-    glBindVertexArray(buffer->vao);
-
-    glBindBuffer(GL_ARRAY_BUFFER, buffer->geom_vbo);
-    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_POS);
-    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_NORMAL);
-    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_UVW);
-    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TEXTURE_SIZE);
-    glDisableVertexAttribArray(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO);
-    glDisableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
-    glDisableVertexAttribArray(OUTPUT_MESH_ATTR_COLOR);
-    glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_SPRITE_VERTEX),
-        (void *)(intptr_t)offsetof(M_SPRITE_VERTEX, pos));
-    glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_NORMAL, 2, GL_FLOAT, GL_FALSE, sizeof(M_SPRITE_VERTEX),
-        (void *)(intptr_t)offsetof(M_SPRITE_VERTEX, displacement));
-    glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_UVW, 3, GL_FLOAT, GL_FALSE, sizeof(M_SPRITE_VERTEX),
-        (void *)(intptr_t)offsetof(M_SPRITE_VERTEX, uvw));
-    glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_TEXTURE_SIZE, 4, GL_FLOAT, GL_FALSE,
-        sizeof(M_SPRITE_VERTEX),
-        (void *)(intptr_t)offsetof(M_SPRITE_VERTEX, texture_size));
-
-    glBindBuffer(GL_ARRAY_BUFFER, buffer->shade_vbo);
-    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
-    glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_SHADE, 1, OUTPUT_USHORT_GL, GL_FALSE,
-        sizeof(M_SPRITE_SHADE), 0);
-}
-
-static void M_FreeBuffer(void)
-{
-    M_PRIV *const p = &m_Priv;
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    if (p->sprite_buf.vao != 0) {
-        glDeleteVertexArrays(1, &p->sprite_buf.vao);
-        p->sprite_buf.vao = 0;
-    }
-    if (p->sprite_buf.geom_vbo != 0) {
-        glDeleteBuffers(1, &p->sprite_buf.geom_vbo);
-        p->sprite_buf.geom_vbo = 0;
-    }
-    if (p->sprite_buf.shade_vbo != 0) {
-        glDeleteBuffers(1, &p->sprite_buf.shade_vbo);
-        p->sprite_buf.shade_vbo = 0;
-    }
-    Memory_FreePointer(&p->sprite_buf.geom_vbo_data);
-    Memory_FreePointer(&p->sprite_buf.shade_vbo_data);
-}
-
-static void M_RenderBegin(const SCENE_SOURCE *const source)
-{
-    M_PRIV *const p = &m_Priv;
-    Vector_Clear(p->scheduled);
-    p->sprite_buf.vertex_count = 0;
-}
-
-static void M_RenderPass(
-    const SCENE_SOURCE *const source, const SCENE_PASS pass)
-{
-    M_PRIV *const p = &m_Priv;
-    if (pass != SCENE_PASS_MESHES) {
-        return;
-    }
-    if (p->scheduled->count == 0) {
-        return;
-    }
-
-    glBindVertexArray(p->sprite_buf.vao);
-    GFX_GL_CheckError();
-
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D_ARRAY, Output_Textures_GetAtlasTexture());
-    glActiveTexture(GL_TEXTURE1);
-    glBindTexture(GL_TEXTURE_2D, Output_Textures_GetEnvMapTexture());
-    GFX_GL_CheckError();
-
-    M_SPRITE_BUFFER *const buffer = &p->sprite_buf;
-    if ((size_t)p->scheduled->count * OUTPUT_QUAD_VERTICES
-        > buffer->vertex_capacity) {
-        buffer->vertex_capacity =
-            (p->scheduled->count + 50) * OUTPUT_QUAD_VERTICES;
-        buffer->geom_vbo_data = Memory_Realloc(
-            buffer->geom_vbo_data,
-            buffer->vertex_capacity * sizeof(M_SPRITE_VERTEX));
-        buffer->shade_vbo_data = Memory_Realloc(
-            buffer->shade_vbo_data,
-            buffer->vertex_capacity * sizeof(M_SPRITE_SHADE));
-    }
-
-    for (int32_t i = 0; i < p->scheduled->count; i++) {
-        const M_INSTANCE *const sprite = Vector_Get(p->scheduled, i);
-        M_SPRITE_VERTEX quad[4];
-        M_MakeQuad(
-            quad, sprite->sprite_idx,
-            (XYZ_16) { sprite->pos.x, sprite->pos.y, sprite->pos.z });
-        for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
-            buffer->geom_vbo_data[buffer->vertex_count] =
-                quad[OUTPUT_QUAD_TO_FAN(i)];
-            buffer->shade_vbo_data[buffer->vertex_count] = sprite->shade;
-            buffer->vertex_count++;
-        }
-    }
-    M_BufferReallocGPU(buffer);
-    glVertexAttribI1ui(OUTPUT_MESH_ATTR_FLAGS, VERT_BILLBOARD);
-    glVertexAttrib4f(OUTPUT_MESH_ATTR_TEXTURE_SIZE, 0.0f, 0.0f, 1.0f, 1.0f);
-    glVertexAttrib2f(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO, 1.0f, 1.0f);
-    glVertexAttrib4f(OUTPUT_MESH_ATTR_COLOR, 1.0f, 1.0f, 1.0f, 1.0f);
-
-    Output_Shader_UploadWibbleEffect(p->shader, Output_GetWibbleEffect());
-    for (int32_t i = 0; i < p->scheduled->count; i++) {
-        const M_INSTANCE *const sprite = Vector_Get(p->scheduled, i);
-        Output_Shader_UploadTint(p->shader, sprite->tint);
-        Output_Shader_UploadViewModelMatrix(p->shader, &sprite->matrix);
-        glDrawArrays(
-            GL_TRIANGLES, i * OUTPUT_QUAD_VERTICES, OUTPUT_QUAD_VERTICES);
-        GFX_GL_CheckError();
-    }
-}
-
-static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
-{
-    const M_PRIV *const p = &m_Priv;
-    return pass == SCENE_PASS_MESHES && p->scheduled->count > 0;
-}
-
-void OutputSource_Sprites_Init(void)
-{
-    M_PRIV *const p = &m_Priv;
-    p->shader = Output_GetMeshShader();
-    p->scheduled = Vector_CreateAtCapacity(sizeof(M_INSTANCE), 50);
-    p->source.render_begin = M_RenderBegin;
-    p->source.render_pass = M_RenderPass;
-    p->source.is_dirty = M_IsDirty;
-    SceneCompositor_AddSource(&p->source);
+    m_Priv.batcher = batcher;
 }
 
 void OutputSource_Sprites_Shutdown(void)
 {
-    M_PRIV *const p = &m_Priv;
-    Vector_Free(p->scheduled);
-    M_FreeBuffer();
+    M_FreeMeshes(&m_Priv);
 }
 
 void OutputSource_Sprites_ObserveLevelLoad(void)
 {
-    M_FreeBuffer();
-    M_PrepareBuffer();
+    M_FreeMeshes(&m_Priv);
+    M_PrepareMeshes(&m_Priv);
 }
 
 void OutputSource_Sprites_ObserveLevelUnload(void)
 {
-    M_FreeBuffer();
+    M_FreeMeshes(&m_Priv);
 }
 
-void OutputSource_Sprites_Stage(
-    const int32_t sprite_idx, const int16_t shade, const RGB_F tint)
+void OutputSource_Sprites_Stage(int32_t sprite_idx, int16_t shade, RGB_F tint)
 {
-    M_PRIV *const p = &m_Priv;
-    const M_INSTANCE sprite = {
+    OUTPUT_MESH *mesh = m_Priv.meshes[sprite_idx];
+    const MESH_INSTANCE inst = {
+        .mesh = mesh,
         .matrix = *g_MatrixPtr,
         .tint = tint,
-        .pos = (XYZ_32) { 0, 0, 0 },
-        .sprite_idx = sprite_idx,
-        .shade = shade,
+        .wibble = false,
+        .water_effect = false,
+        .update_light_func = M_UpdateShades,
+        .update_light_func_data = (void *)(intptr_t)shade,
     };
-    Vector_Add(p->scheduled, &sprite);
+    MeshBatcher_Stage(m_Priv.batcher, &inst, SCENE_PASS_MESHES);
+    MeshBatcher_Stage(m_Priv.batcher, &inst, SCENE_PASS_TRANSPARENT);
+}
+
+static void M_PrepareMeshes(M_PRIV *p)
+{
+    p->mesh_count = Output_GetSpriteTextureCount();
+    p->meshes = Memory_Alloc(sizeof(*p->meshes) * p->mesh_count);
+    for (int32_t i = 0; i < (int32_t)p->mesh_count; i++) {
+        OUTPUT_MESH *mesh = Output_Mesh_Create();
+        ROOM_VERTEX fake_vert = {};
+        ROOM_SPRITE fake_sprite = { .texture = (uint16_t)i, .vertex = 0 };
+        Output_Mesh_AddRoomSprite(mesh, &fake_sprite, &fake_vert);
+        Output_Mesh_Seal(mesh);
+        MeshBatcher_AddMesh(p->batcher, mesh);
+        p->meshes[i] = mesh;
+    }
+}
+
+static void M_FreeMeshes(M_PRIV *const p)
+{
+    if (p->meshes != nullptr) {
+        for (size_t i = 0; i < p->mesh_count; i++) {
+            MeshBatcher_RemoveMesh(p->batcher, p->meshes[i]);
+            Output_Mesh_Destroy(p->meshes[i]);
+        }
+        Memory_FreePointer(&p->meshes);
+    }
+}
+
+static void M_UpdateShades(MESH_INSTANCE *inst, void *user_data)
+{
+    int16_t shade = (int16_t)(intptr_t)user_data;
+    CLAMP(shade, 0, SHADE_MAX);
+    OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(inst->mesh->vertices);
+    for (int32_t i = 0; i < inst->mesh->vertices->count; i++) {
+        vertices[i].shade = shade;
+    }
 }

--- a/src/tr1/game/output/sources/sprites.h
+++ b/src/tr1/game/output/sources/sprites.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "game/output/mesh_batcher/batcher.h"
+#include "game/output/scene_source.h"
+
 #include <libtrx/game/rooms/types.h>
 
-void OutputSource_Sprites_Init(void);
+void OutputSource_Sprites_Init(MESH_BATCHER *batcher);
 void OutputSource_Sprites_Shutdown(void);
 void OutputSource_Sprites_ObserveLevelLoad(void);
 void OutputSource_Sprites_ObserveLevelUnload(void);

--- a/src/tr1/game/output/textures.c
+++ b/src/tr1/game/output/textures.c
@@ -418,6 +418,11 @@ bool Output_Textures_IsSpriteTextureAnimated(const int32_t uvw_idx)
     return m_Priv.uvws.animated_sprites[uvw_idx];
 }
 
+bool Output_Textures_IsObjectTextureTransparent(const int32_t texture_idx)
+{
+    return Output_GetObjectTexture(texture_idx)->draw_type == DRAW_COLOR_KEY;
+}
+
 void Output_Textures_ApplyRenderSettings(void)
 {
     // re-adjust UVs when the bilinear filter is toggled.

--- a/src/tr1/game/output/textures.h
+++ b/src/tr1/game/output/textures.h
@@ -30,4 +30,5 @@ int32_t Output_Textures_GetSpritesUVWsBase(void);
 OUTPUT_UVW Output_Textures_GetUVW(int32_t uvw_idx);
 OUTPUT_TEXTURE_SIZE Output_Textures_GetAtlasSize(int32_t uvw_idx);
 bool Output_Textures_IsObjectTextureAnimated(int32_t texture_idx);
+bool Output_Textures_IsObjectTextureTransparent(int32_t texture_idx);
 bool Output_Textures_IsSpriteTextureAnimated(int32_t sprite_idx);

--- a/src/tr2/global/types_decomp.h
+++ b/src/tr2/global/types_decomp.h
@@ -72,11 +72,6 @@ typedef struct {
 } SORT_ITEM;
 
 typedef enum {
-    DRAW_OPAQUE    = 0,
-    DRAW_COLOR_KEY = 1,
-} DRAW_TYPE;
-
-typedef enum {
     GFE_PICTURE          = 0,
     GFE_LIST_START       = 1,
     GFE_LIST_END         = 2,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes lightnings rendering where only one side of the lightnings would be drawn.
Other improvements are internal and are best viewed on a commit-by-commit basis.

No performance gains from this PR:

### Colosseum Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 23576.68 │ 23576.73 │ ⚪ 100.00% ┃
┃ Transparent vertices │ 0.00     │ 0.00     │ ⚫ ?       ┃
┃ Transfers            │ 196.57   │ 196.56   │ ⚪ 100.00% ┃
┃ Uniforms             │ 226.28   │ 226.15   │ ⚪ 99.94%  ┃
┃ Throughput           │ 92.37 KB │ 92.37 KB │ ⚪ 100.00% ┃
┃ Time                 │ 0.52 ms  │ 0.53 ms  │ ⚪ 102.06% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Inventory Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 24794.11 │ 24794.12 │ ⚪ 100.00% ┃
┃ Transparent vertices │ 0.00     │ 0.00     │ ⚫ ?       ┃
┃ Transfers            │ 199.38   │ 199.38   │ ⚪ 100.00% ┃
┃ Uniforms             │ 253.08   │ 253.11   │ ⚪ 100.01% ┃
┃ Throughput           │ 97.27 KB │ 97.28 KB │ ⚪ 100.00% ┃
┃ Time                 │ 0.49 ms  │ 0.49 ms  │ ⚪ 99.37%  ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Midas Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 13081.86 │ 13084.07 │ ⚪ 100.02% ┃
┃ Transparent vertices │ 0.00     │ 0.00     │ ⚫ ?       ┃
┃ Transfers            │ 126.00   │ 126.21   │ ⚪ 100.17% ┃
┃ Uniforms             │ 167.51   │ 167.82   │ ⚪ 100.18% ┃
┃ Throughput           │ 66.09 KB │ 64.08 KB │ ⚪ 96.96%  ┃
┃ Time                 │ 0.30 ms  │ 0.31 ms  │ ⚪ 102.37% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
