### PR TITLE
Improve bilinear filter blending

### DIFF
--- a/data/tr1/ship/shaders/common.glsl
+++ b/data/tr1/ship/shaders/common.glsl
@@ -7,6 +7,7 @@
 #define VERT_REFLECTIVE  0x04u
 #define VERT_NO_LIGHTING 0x08u
 #define VERT_BILLBOARD   0x10u
+#define VERT_CAUSTICS    0x20u
 
 #define LIGHTING_MODE_OFF         0
 #define LIGHTING_MODE_ONLY_SHADES 1

--- a/data/tr1/ship/shaders/meshes.glsl
+++ b/data/tr1/ship/shaders/meshes.glsl
@@ -38,9 +38,12 @@ void main(void) {
     gl_Position = uMatProjection * eyePos;
 
     // apply water wibble effect only to non-sprite vertices
-    if (uWibbleEffect && (inFlags & VERT_NO_CAUSTICS) == 0u && (inFlags & VERT_BILLBOARD) == 0u) {
-        gl_Position.xyz =
-            waterWibble(gl_Position, uViewportSize, uTime);
+    if (((inFlags & VERT_CAUSTICS) != 0u)
+        || (uWibbleEffect
+            && (inFlags & VERT_NO_CAUSTICS) == 0u
+            && (inFlags & VERT_BILLBOARD) == 0u)
+    ) {
+        gl_Position.xyz = waterWibble(gl_Position, uViewportSize, uTime);
     }
 
     gFlags = inFlags;
@@ -61,11 +64,9 @@ uniform int uTime;
 uniform sampler2DArray uTexAtlas;
 uniform sampler2D uTexEnvMap;
 uniform bool uSmoothingEnabled;
-uniform bool uAlphaDiscardEnabled;
 uniform bool uTrapezoidFilterEnabled;
 uniform int uLightingMode;
 uniform bool uReflectionsEnabled;
-uniform float uAlphaThreshold;
 uniform float uBrightnessMultiplier;
 uniform vec3 uGlobalTint;
 uniform vec2 uFog; // x = fog start, y = fog end
@@ -97,15 +98,10 @@ void main(void) {
         }
         texCoords.xy = clampTexAtlas(texCoords.xy, gAtlasSize);
 
-        if (uAlphaDiscardEnabled && uSmoothingEnabled && discardTranslucent(uTexAtlas, texCoords)) {
+        texColor *= texture(uTexAtlas, texCoords);
+        if (texColor.a <= 0.0) {
             discard;
         }
-
-        texColor = texture(uTexAtlas, texCoords);
-        if (uAlphaThreshold >= 0.0 && texColor.a <= uAlphaThreshold) {
-            discard;
-        }
-        texColor.a *= gColor.a;
     }
     if ((gFlags & VERT_REFLECTIVE) != 0u && uReflectionsEnabled) {
         texColor *= texture(uTexEnvMap, (normalize(gNormal) * 0.5 + 0.5).xy) * 2;

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -50,6 +50,7 @@
 - improved PS1 menu style border offsets and frames to match PC style
 - improved drawing shadows in no-clip camera mode (they're no longer double-sided)
 - improved wireframe mode to show text and UI normally
+- improved bilinear filter edge blending (#587)
 - removed the option in Unfinished Business to fix animated sprites as it is irrelevant there
 
 ## [4.13.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.13.1...tr1-4.13.2) - 2025-07-20

--- a/src/tr1/game/output.c
+++ b/src/tr1/game/output.c
@@ -59,6 +59,7 @@ bool Output_Init(void)
 
     m_Shader = Output_Shader_Create("shaders/meshes.glsl");
     m_Batcher = MeshBatcher_Create();
+    SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
     OutputSource_Rooms_Init(m_Batcher);
     OutputSource_RoomsDebug_Init();
     OutputSource_Objects_Init(m_Batcher);
@@ -66,7 +67,6 @@ bool Output_Init(void)
     OutputSource_Lightnings_Init();
     OutputSource_Misc_Init();
     OutputSource_UI_Init();
-    SceneCompositor_AddSource(MeshBatcher_AsSource(m_Batcher));
 
     Output_InitLight();
     return true;

--- a/src/tr1/game/output/mesh_batcher/batcher.c
+++ b/src/tr1/game/output/mesh_batcher/batcher.c
@@ -7,8 +7,10 @@
 
 #include <libtrx/debug.h>
 #include <libtrx/game/level/const.h>
+#include <libtrx/gfx/gl/track.h>
 #include <libtrx/memory.h>
 
+#include <stdlib.h>
 #include <uthash.h>
 
 typedef OUTPUT_SHORT M_MESH_SHADE;
@@ -26,6 +28,12 @@ typedef struct {
     float trapezoid_ratio[2];
 } M_MESH_TEXTURE;
 
+typedef struct {
+    M_MESH_GEOM geom;
+    M_MESH_TEXTURE tex;
+    M_MESH_SHADE shade;
+} M_MESH_FULL;
+
 typedef struct M_MESH_BUF_BINDING {
     OUTPUT_MESH *mesh;
     M_MESH_GEOM *geom_data;
@@ -35,6 +43,13 @@ typedef struct M_MESH_BUF_BINDING {
     int32_t vertex_count;
     UT_hash_handle hh;
 } M_MESH_BUF_BINDING;
+
+typedef struct {
+    int32_t sort_key;
+    const MESH_INSTANCE *inst;
+    const OUTPUT_MESH_FACE *face;
+    int32_t vertex_start;
+} M_FACE_SORT;
 
 typedef struct MESH_BATCHER {
     SCENE_SOURCE source;
@@ -46,10 +61,15 @@ typedef struct MESH_BATCHER {
     VECTOR *staged[SCENE_PASS_COUNT];
 
     OUTPUT_SHADER *shader;
-    GLuint vao;
+    GLuint partial_vao;
     GLuint geom_vbo;
     GLuint tex_vbo;
     GLuint shade_vbo;
+
+    VECTOR *transparent_sort; // M_FACE_SORT
+    VECTOR *transparent_vertices; // M_MESH_FULL
+    GLuint full_vao;
+    GLuint full_vbo;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -59,10 +79,21 @@ static void M_FillGeometry(M_MESH_GEOM *tex, const OUTPUT_MESH_VERTEX *vertex);
 static void M_FillTexture(
     M_MESH_TEXTURE *tex, const OUTPUT_MESH_VERTEX *vertex);
 static void M_FillShade(M_MESH_SHADE *shade, const OUTPUT_MESH_VERTEX *vertex);
-
-static void M_DrawInstance(const MESH_BATCHER *batcher, MESH_INSTANCE *inst);
 static void M_AnimateBinding(
     const MESH_BATCHER *batcher, const M_MESH_BUF_BINDING *bind);
+static void M_UpdateMeshGeometry(
+    const MESH_BATCHER *batcher, const OUTPUT_MESH *mesh);
+
+static int M_CompareFaceDepth(const void *a, const void *b);
+static void M_SortTransparentFaces(const MESH_BATCHER *batcher);
+
+static void M_OpaquePass(const MESH_BATCHER *batcher, SCENE_PASS pass);
+static void M_TransparentPass(const MESH_BATCHER *batcher);
+
+static void M_DrawOpaqueVertices(
+    const MESH_BATCHER *batcher, const MESH_INSTANCE *inst);
+static void M_DrawOpaqueInstance(
+    const MESH_BATCHER *batcher, MESH_INSTANCE *inst);
 
 static void M_RenderBegin(const SCENE_SOURCE *source);
 static void M_RenderPass(const SCENE_SOURCE *source, SCENE_PASS pass);
@@ -123,7 +154,181 @@ static void M_AnimateBinding(
     }
 }
 
-static void M_DrawInstance(
+static void M_UpdateMeshGeometry(
+    const MESH_BATCHER *const batcher, const OUTPUT_MESH *const mesh)
+{
+    M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, mesh);
+    const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
+    for (int32_t i = 0; i < bind->vertex_count; i++) {
+        M_FillGeometry(&bind->geom_data[i], &vertices[i]);
+    }
+    GFX_TRACK_SUBDATA(
+        glBufferSubData, GL_ARRAY_BUFFER,
+        bind->vertex_start * sizeof(M_MESH_GEOM),
+        bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
+}
+
+// Compare two faces by camera-space depth.
+static int M_CompareFaceDepth(const void *const a, const void *const b)
+{
+    const M_FACE_SORT *const face_a = a;
+    const M_FACE_SORT *const face_b = b;
+    return face_b->sort_key - face_a->sort_key;
+}
+
+// Compute per-face view depth and sort the mesh's transparent ranges
+// back-to-front.
+static void M_SortTransparentFaces(const MESH_BATCHER *const batcher)
+{
+    const int n = batcher->transparent_sort->count;
+    if (n == 0) {
+        return;
+    }
+    M_FACE_SORT *const buf = Vector_GetData(batcher->transparent_sort);
+    M_FACE_SORT *bptr = buf;
+    for (int32_t i = 0; i < n; i++) {
+        // clang-format off
+        bptr->sort_key = (
+            bptr->inst->matrix._20 * (int32_t)bptr->face->mesh_centroid.x +
+            bptr->inst->matrix._21 * (int32_t)bptr->face->mesh_centroid.y +
+            bptr->inst->matrix._22 * (int32_t)bptr->face->mesh_centroid.z +
+            bptr->inst->matrix._23);
+        // clang-format on
+        bptr++;
+    }
+    qsort(buf, n, sizeof(*buf), M_CompareFaceDepth);
+}
+
+static void M_OpaquePass(
+    const MESH_BATCHER *const batcher, const SCENE_PASS pass)
+{
+    VECTOR *const staged = batcher->staged[pass];
+
+    glBindVertexArray(batcher->partial_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->shade_vbo);
+    for (int32_t i = 0; i < staged->count; i++) {
+        MESH_INSTANCE *const inst = Vector_Get(staged, i);
+        const MATRIX *const m = &inst->matrix;
+        const M_MESH_BUF_BINDING *const bind =
+            M_GetBinding(batcher, inst->mesh);
+
+        // Update lighting data. The updates are done on the models rather than
+        // instances, so that we do not have to allocate vertex data memory for
+        // instances on every stage.
+        if (inst->update_light_func != nullptr) {
+            inst->update_light_func(inst, inst->update_light_func_data);
+            const OUTPUT_MESH_VERTEX *const vertices =
+                Vector_GetData(inst->mesh->vertices);
+            for (int32_t j = 0; j < bind->vertex_count; j++) {
+                M_FillShade(&bind->shade_data[j], &vertices[j]);
+            }
+            GFX_TRACK_SUBDATA(
+                glBufferSubData, GL_ARRAY_BUFFER,
+                bind->vertex_start * sizeof(M_MESH_SHADE),
+                bind->vertex_count * sizeof(M_MESH_SHADE), bind->shade_data);
+        }
+
+        if (inst->mesh->opaque_vertex_indices->count != 0) {
+            M_DrawOpaqueInstance(batcher, inst);
+        }
+
+        // Accumulate transparent polygons and faces.
+        for (int32_t j = 0; j < inst->mesh->transparent_faces->count; j++) {
+            const OUTPUT_MESH_FACE *const face =
+                Vector_Get(inst->mesh->transparent_faces, j);
+
+            const int32_t vertex_start = batcher->transparent_vertices->count;
+            for (int32_t k = 0; k < face->vertex_count; k++) {
+                const int32_t l = face->vertex_start + k;
+                M_MESH_FULL v = {
+                    .geom = bind->geom_data[l],
+                    .tex = bind->tex_data[l],
+                    .shade = bind->shade_data[l],
+                };
+
+                // Since we're ripping faces apart from individual model
+                // instances, we no longer are able to use per-instance uniforms
+                // – we need to bake the uniforms into vertex attributes.
+                // XXX: this technique might've been possible to avoid by using
+                // UBOs.
+
+                // clang-format off
+                v.geom.pos = (XYZ_F) {
+                    .x = (
+                        m->_00 * v.geom.pos.x +
+                        m->_01 * v.geom.pos.y +
+                        m->_02 * v.geom.pos.z +
+                        m->_03
+                     ),
+                    .y = (
+                        m->_10 * v.geom.pos.x +
+                        m->_11 * v.geom.pos.y +
+                        m->_12 * v.geom.pos.z +
+                        m->_13
+                     ),
+                    .z = (
+                        m->_20 * v.geom.pos.x +
+                        m->_21 * v.geom.pos.y +
+                        m->_22 * v.geom.pos.z +
+                        m->_23
+                     ),
+                };
+                // clang-format on
+                v.geom.color.r *= inst->tint.r;
+                v.geom.color.g *= inst->tint.g;
+                v.geom.color.b *= inst->tint.b;
+                v.geom.flags |= inst->wibble ? VERT_CAUSTICS : 0;
+
+                Vector_Add(batcher->transparent_vertices, &v);
+            }
+
+            Vector_Add(
+                batcher->transparent_sort,
+                &(M_FACE_SORT) {
+                    .inst = inst,
+                    .face = face,
+                    .vertex_start = vertex_start,
+                });
+        }
+    }
+}
+
+static void M_TransparentPass(const MESH_BATCHER *const batcher)
+{
+    const MATRIX id_matrix = {
+        // clang-format off
+        ._00 = 1, ._01 = 0, ._02 = 0, ._03 = 0,
+        ._10 = 0, ._11 = 1, ._12 = 0, ._13 = 0,
+        ._20 = 0, ._21 = 0, ._22 = 1, ._23 = 0,
+        // clang-format on
+    };
+    Output_Shader_UploadViewModelMatrix(batcher->shader, &id_matrix);
+    Output_Shader_UploadTint(batcher->shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
+    glBindVertexArray(batcher->full_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->full_vbo);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        batcher->transparent_vertices->count * sizeof(M_MESH_FULL),
+        Vector_GetData(batcher->transparent_vertices), GL_STATIC_DRAW);
+    for (int32_t i = 0; i < batcher->transparent_sort->count; i++) {
+        const M_FACE_SORT *const sort_ptr =
+            Vector_Get(batcher->transparent_sort, i);
+        glDrawArrays(
+            GL_TRIANGLES, sort_ptr->vertex_start, sort_ptr->face->vertex_count);
+        g_GFX_Metrics.trans_vert_count += sort_ptr->face->vertex_count;
+    }
+}
+
+static void M_DrawOpaqueVertices(
+    const MESH_BATCHER *const batcher, const MESH_INSTANCE *const inst)
+{
+    glDrawElements(
+        GL_TRIANGLES, inst->mesh->opaque_vertex_indices->count, GL_UNSIGNED_INT,
+        Vector_GetData(inst->mesh->opaque_vertex_indices));
+    g_GFX_Metrics.opaque_vert_count += inst->mesh->opaque_vertex_indices->count;
+}
+
+static void M_DrawOpaqueInstance(
     const MESH_BATCHER *const batcher, MESH_INSTANCE *const inst)
 {
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
@@ -138,24 +343,16 @@ static void M_DrawInstance(
             inst->scissor.height);
     }
 
-    if (inst->update_light_func != nullptr) {
-        inst->update_light_func(inst, inst->update_light_func_data);
-        MeshBatcher_UpdateMeshShades(batcher, inst->mesh);
-    }
-
     if (inst->wibble) {
         Output_Shader_UploadWibbleEffect(batcher->shader, false);
         glDepthMask(GL_FALSE);
-        glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
-        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
+        M_DrawOpaqueVertices(batcher, inst);
         glDepthMask(GL_TRUE);
         Output_Shader_UploadWibbleEffect(batcher->shader, true);
-        glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
-        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
+        M_DrawOpaqueVertices(batcher, inst);
     } else {
         Output_Shader_UploadWibbleEffect(batcher->shader, false);
-        glDrawArrays(GL_TRIANGLES, bind->vertex_start, bind->vertex_count);
-        g_GFX_Metrics.opaque_vert_count += bind->vertex_count;
+        M_DrawOpaqueVertices(batcher, inst);
     }
 
     if (inst->enable_scissor) {
@@ -169,17 +366,20 @@ static void M_RenderBegin(const SCENE_SOURCE *const source)
     for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
         Vector_Clear(batcher->staged[pass]);
     }
+    Vector_Clear(batcher->transparent_vertices);
+    Vector_Clear(batcher->transparent_sort);
 }
 
 static void M_RenderPass(
     const SCENE_SOURCE *const source, const SCENE_PASS pass)
 {
     MESH_BATCHER *const batcher = source->priv;
-    glBindVertexArray(batcher->vao);
 
-    for (int32_t i = 0; i < batcher->staged[pass]->count; i++) {
-        MESH_INSTANCE *const inst = Vector_Get(batcher->staged[pass], i);
-        M_DrawInstance(batcher, inst);
+    if (pass == SCENE_PASS_MESHES || pass == SCENE_PASS_BACKGROUND) {
+        M_OpaquePass(batcher, pass);
+    } else if (pass == SCENE_PASS_TRANSPARENT) {
+        M_SortTransparentFaces(batcher);
+        M_TransparentPass(batcher);
     }
 }
 
@@ -214,13 +414,16 @@ MESH_BATCHER *MeshBatcher_Create(void)
     batcher->source.animate_textures = M_AnimateTextures;
     batcher->source.priv = batcher;
 
-    glGenVertexArrays(1, &batcher->vao);
+    batcher->transparent_sort = Vector_Create(sizeof(M_FACE_SORT));
+    batcher->transparent_vertices = Vector_Create(sizeof(M_MESH_FULL));
+
+    glGenVertexArrays(1, &batcher->partial_vao);
     glGenBuffers(1, &batcher->geom_vbo);
     glGenBuffers(1, &batcher->tex_vbo);
     glGenBuffers(1, &batcher->shade_vbo);
+    glGenBuffers(1, &batcher->full_vbo);
 
-    glBindVertexArray(batcher->vao);
-
+    glBindVertexArray(batcher->partial_vao);
     glBindBuffer(GL_ARRAY_BUFFER, batcher->geom_vbo);
 
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_POS);
@@ -261,6 +464,46 @@ MESH_BATCHER *MeshBatcher_Create(void)
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_SHADE, 1, OUTPUT_SHORT_GL, GL_FALSE,
         sizeof(M_MESH_SHADE), 0);
+
+    glGenVertexArrays(1, &batcher->full_vao);
+    glBindVertexArray(batcher->full_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->full_vbo);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_POS);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_NORMAL);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_COLOR);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_UVW);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TEXTURE_SIZE);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO);
+    glEnableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, geom.pos));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, geom.normal));
+    glVertexAttribIPointer(
+        OUTPUT_MESH_ATTR_FLAGS, 1, OUTPUT_USHORT_GL, sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, geom.flags));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE,
+        sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, geom.color));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_UVW, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, tex.uvw));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_TEXTURE_SIZE, 4, GL_FLOAT, GL_FALSE,
+        sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, tex.texture_size));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_TRAPEZOID_RATIO, 2, GL_FLOAT, GL_FALSE,
+        sizeof(M_MESH_FULL),
+        (void *)(intptr_t)offsetof(M_MESH_FULL, tex.trapezoid_ratio));
+    glVertexAttribPointer(
+        OUTPUT_MESH_ATTR_SHADE, 1, OUTPUT_SHORT_GL, GL_FALSE,
+        sizeof(M_MESH_FULL), (void *)(intptr_t)offsetof(M_MESH_FULL, shade));
+
     return batcher;
 }
 
@@ -268,9 +511,13 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
 {
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
-    if (batcher->vao != 0) {
-        glDeleteVertexArrays(1, &batcher->vao);
-        batcher->vao = 0;
+    if (batcher->partial_vao != 0) {
+        glDeleteVertexArrays(1, &batcher->partial_vao);
+        batcher->partial_vao = 0;
+    }
+    if (batcher->full_vao != 0) {
+        glDeleteVertexArrays(1, &batcher->full_vao);
+        batcher->full_vao = 0;
     }
     if (batcher->geom_vbo != 0) {
         glDeleteBuffers(1, &batcher->geom_vbo);
@@ -284,10 +531,22 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
         glDeleteBuffers(1, &batcher->shade_vbo);
         batcher->shade_vbo = 0;
     }
+    if (batcher->full_vbo != 0) {
+        glDeleteBuffers(1, &batcher->full_vbo);
+        batcher->full_vbo = 0;
+    }
     ASSERT(batcher->bindings->count == 0);
     if (batcher->bindings != nullptr) {
         Vector_Free(batcher->bindings);
         batcher->bindings = nullptr;
+    }
+    if (batcher->transparent_sort != nullptr) {
+        Vector_Free(batcher->transparent_sort);
+        batcher->transparent_sort = nullptr;
+    }
+    if (batcher->transparent_vertices != nullptr) {
+        Vector_Free(batcher->transparent_vertices);
+        batcher->transparent_vertices = nullptr;
     }
     for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
         if (batcher->staged[pass] != nullptr) {
@@ -338,6 +597,14 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
     bind->vertex_start = batcher->vertex_count;
     batcher->vertex_count += bind->vertex_count;
 
+    // TODO: improve sealing api
+    {
+        int32_t *const vert_idx = Vector_GetData(mesh->opaque_vertex_indices);
+        for (int32_t i = 0; i < mesh->opaque_vertex_indices->count; i++) {
+            vert_idx[i] += bind->vertex_start;
+        }
+    }
+
     Vector_Add(batcher->bindings, &bind);
     HASH_ADD_PTR(batcher->binding_map, mesh, bind);
 }
@@ -383,34 +650,11 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
     }
 }
 
-void MeshBatcher_UpdateMeshShades(
-    const MESH_BATCHER *const batcher, const OUTPUT_MESH *const mesh)
-{
-    M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, mesh);
-    const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
-    for (int32_t i = 0; i < bind->vertex_count; i++) {
-        M_FillShade(&bind->shade_data[i], &vertices[i]);
-    }
-    glBindBuffer(GL_ARRAY_BUFFER, batcher->shade_vbo);
-    GFX_TRACK_SUBDATA(
-        glBufferSubData, GL_ARRAY_BUFFER,
-        bind->vertex_start * sizeof(M_MESH_SHADE),
-        bind->vertex_count * sizeof(M_MESH_SHADE), bind->shade_data);
-}
-
 void MeshBatcher_UpdateMeshGeometry(
     const MESH_BATCHER *const batcher, const OUTPUT_MESH *const mesh)
 {
-    M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, mesh);
-    const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
-    for (int32_t i = 0; i < bind->vertex_count; i++) {
-        M_FillGeometry(&bind->geom_data[i], &vertices[i]);
-    }
     glBindBuffer(GL_ARRAY_BUFFER, batcher->geom_vbo);
-    GFX_TRACK_SUBDATA(
-        glBufferSubData, GL_ARRAY_BUFFER,
-        bind->vertex_start * sizeof(M_MESH_GEOM),
-        bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
+    M_UpdateMeshGeometry(batcher, mesh);
 }
 
 void MeshBatcher_Stage(

--- a/src/tr1/game/output/mesh_batcher/batcher.c
+++ b/src/tr1/game/output/mesh_batcher/batcher.c
@@ -49,6 +49,7 @@ typedef struct {
     const MESH_INSTANCE *inst;
     const OUTPUT_MESH_FACE *face;
     int32_t vertex_start;
+    int32_t vertex_count;
 } M_FACE_SORT;
 
 typedef struct MESH_BATCHER {
@@ -239,7 +240,7 @@ static void M_OpaquePass(
 
             const int32_t vertex_start = batcher->transparent_vertices->count;
             for (int32_t k = 0; k < face->vertex_count; k++) {
-                const int32_t l = face->vertex_start + k;
+                const int32_t l = face->vertex_indices[k];
                 M_MESH_FULL v = {
                     .geom = bind->geom_data[l],
                     .tex = bind->tex_data[l],
@@ -281,6 +282,8 @@ static void M_OpaquePass(
 
                 Vector_Add(batcher->transparent_vertices, &v);
             }
+            const int32_t vertex_count =
+                batcher->transparent_vertices->count - vertex_start;
 
             Vector_Add(
                 batcher->transparent_sort,
@@ -288,6 +291,7 @@ static void M_OpaquePass(
                     .inst = inst,
                     .face = face,
                     .vertex_start = vertex_start,
+                    .vertex_count = vertex_count,
                 });
         }
     }
@@ -314,7 +318,7 @@ static void M_TransparentPass(const MESH_BATCHER *const batcher)
         const M_FACE_SORT *const sort_ptr =
             Vector_Get(batcher->transparent_sort, i);
         glDrawArrays(
-            GL_TRIANGLES, sort_ptr->vertex_start, sort_ptr->face->vertex_count);
+            GL_TRIANGLES, sort_ptr->vertex_start, sort_ptr->vertex_count);
         g_GFX_Metrics.trans_vert_count += sort_ptr->face->vertex_count;
     }
 }

--- a/src/tr1/game/output/mesh_batcher/batcher.h
+++ b/src/tr1/game/output/mesh_batcher/batcher.h
@@ -37,7 +37,5 @@ const SCENE_SOURCE *MeshBatcher_AsSource(const struct MESH_BATCHER *batcher);
 
 void MeshBatcher_Stage(
     struct MESH_BATCHER *batcher, const MESH_INSTANCE *inst, SCENE_PASS pass);
-void MeshBatcher_UpdateMeshShades(
-    const struct MESH_BATCHER *batcher, const OUTPUT_MESH *mesh);
 void MeshBatcher_UpdateMeshGeometry(
     const struct MESH_BATCHER *batcher, const OUTPUT_MESH *mesh);

--- a/src/tr1/game/output/mesh_batcher/mesh.c
+++ b/src/tr1/game/output/mesh_batcher/mesh.c
@@ -9,6 +9,11 @@
 #include <libtrx/game/level/const.h>
 #include <libtrx/memory.h>
 
+static XYZ_F M_GetWorldCentroid(
+    const OUTPUT_MESH *mesh, int32_t vertex_start, int32_t vertex_count);
+static void M_AddFaceCommon(
+    OUTPUT_MESH *mesh, int32_t vertex_start, int32_t vertex_count,
+    bool is_transparent);
 static void M_AddRoomVert(
     OUTPUT_MESH *mesh, const ROOM_VERTEX *room_vert, int32_t uvw_idx,
     const TEXTURE_ZW_F *texture_ratio);
@@ -16,6 +21,43 @@ static void M_AddObjectVert(
     OUTPUT_MESH *mesh, const XYZ_16 *pos, int32_t uvw_idx,
     const TEXTURE_ZW_F *texture_ratio, uint16_t flags, XYZ_16 normal,
     int16_t palette_idx);
+
+static XYZ_F M_GetMeshCentroid(
+    const OUTPUT_MESH *const mesh, const int32_t vertex_start,
+    const int32_t vertex_count)
+{
+    const OUTPUT_MESH_VERTEX *const vbuf = Vector_GetData(mesh->vertices);
+    XYZ_F wc = { 0.0f, 0.0f, 0.0f };
+    for (int32_t i = 0; i < vertex_count; i++) {
+        wc.x += vbuf[vertex_start + i].pos.x;
+        wc.y += vbuf[vertex_start + i].pos.y;
+        wc.z += vbuf[vertex_start + i].pos.z;
+    }
+    wc.x /= vertex_count;
+    wc.y /= vertex_count;
+    wc.z /= vertex_count;
+    return wc;
+}
+
+static void M_AddFaceCommon(
+    OUTPUT_MESH *const mesh, const int32_t vertex_start,
+    const int32_t vertex_count, const bool is_transparent)
+{
+    XYZ_F mesh_centroid = M_GetMeshCentroid(mesh, vertex_start, vertex_count);
+    const OUTPUT_MESH_FACE face = {
+        .vertex_start = vertex_start,
+        .vertex_count = vertex_count,
+        .mesh_centroid = mesh_centroid,
+    };
+    if (is_transparent) {
+        Vector_Add(mesh->transparent_faces, &face);
+    } else {
+        for (int32_t i = 0; i < vertex_count; i++) {
+            Vector_Add(
+                mesh->opaque_vertex_indices, &(int32_t) { vertex_start + i });
+        }
+    }
+}
 
 static void M_AddRoomVert(
     OUTPUT_MESH *const mesh, const ROOM_VERTEX *const room_vert,
@@ -91,40 +133,54 @@ OUTPUT_MESH *Output_Mesh_Create(void)
     OUTPUT_MESH *const mesh = Memory_Alloc(sizeof(OUTPUT_MESH));
     mesh->vertices = Vector_Create(sizeof(OUTPUT_MESH_VERTEX));
     mesh->animated_vertices = Vector_Create(sizeof(OUTPUT_VERTEX_RANGE));
+    mesh->transparent_faces = Vector_Create(sizeof(OUTPUT_MESH_FACE));
+    mesh->opaque_vertex_indices = Vector_Create(sizeof(int32_t));
+    mesh->sealed = false;
     return mesh;
 }
 
 void Output_Mesh_AddRoomFace4(
-    OUTPUT_MESH *const mesh, const FACE4 *const face,
-    const ROOM_VERTEX *const verts)
+    OUTPUT_MESH *const mesh, const FACE4 *const face, const ROOM *const room)
 {
     ASSERT(!mesh->sealed);
+    const int32_t vertex_start = mesh->vertices->count;
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
-        const ROOM_VERTEX *const room_vert = &verts[face->vertices[j]];
+        const ROOM_VERTEX *const room_vert =
+            &room->mesh.vertices[face->vertices[j]];
         M_AddRoomVert(mesh, room_vert, uvw_idx, &face->texture_zw[j]);
     }
+    const int32_t vertex_count = mesh->vertices->count - vertex_start;
+    M_AddFaceCommon(
+        mesh, vertex_start, vertex_count,
+        Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
 void Output_Mesh_AddRoomFace3(
-    OUTPUT_MESH *const mesh, const FACE3 *const face,
-    const ROOM_VERTEX *const verts)
+    OUTPUT_MESH *const mesh, const FACE3 *const face, const ROOM *const room)
 {
     ASSERT(!mesh->sealed);
+    const int32_t vertex_start = mesh->vertices->count;
     for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
         const int32_t j = OUTPUT_TRI_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
-        const ROOM_VERTEX *const room_vert = &verts[face->vertices[j]];
+        const ROOM_VERTEX *const room_vert =
+            &room->mesh.vertices[face->vertices[j]];
         M_AddRoomVert(mesh, room_vert, uvw_idx, nullptr);
     }
+    const int32_t vertex_count = mesh->vertices->count - vertex_start;
+    M_AddFaceCommon(
+        mesh, vertex_start, vertex_count,
+        Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
 void Output_Mesh_AddRoomSprite(
     OUTPUT_MESH *const mesh, const ROOM_SPRITE *const room_sprite,
-    const ROOM_VERTEX *const verts)
+    const ROOM *const room)
 {
     ASSERT(!mesh->sealed);
+    const int32_t vertex_start = mesh->vertices->count;
     struct {
         struct {
             float x, y;
@@ -142,7 +198,8 @@ void Output_Mesh_AddRoomSprite(
     quad[3].displacement.y = sprite->y1;
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
-        const ROOM_VERTEX *const room_vert = &verts[room_sprite->vertex];
+        const ROOM_VERTEX *const room_vert =
+            &room->mesh.vertices[room_sprite->vertex];
         if (Output_Textures_IsSpriteTextureAnimated(room_sprite->texture)) {
             Vector_Add(
                 mesh->animated_vertices,
@@ -171,6 +228,8 @@ void Output_Mesh_AddRoomSprite(
         };
         Vector_Add(mesh->vertices, &vertex);
     }
+    const int32_t vertex_count = mesh->vertices->count - vertex_start;
+    M_AddFaceCommon(mesh, vertex_start, vertex_count, true);
 }
 
 void Output_Mesh_AddObjectFace4(
@@ -178,6 +237,7 @@ void Output_Mesh_AddObjectFace4(
     const FACE4 *const face, const uint16_t flags)
 {
     ASSERT(!mesh->sealed);
+    const int32_t vertex_start = mesh->vertices->count;
     for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
         const int32_t j = OUTPUT_QUAD_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
@@ -187,6 +247,10 @@ void Output_Mesh_AddObjectFace4(
             mesh, pos, uvw_idx, &face->texture_zw[j], flags, normal,
             face->palette_idx);
     }
+    const int32_t vertex_count = mesh->vertices->count - vertex_start;
+    M_AddFaceCommon(
+        mesh, vertex_start, vertex_count,
+        Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
 void Output_Mesh_AddObjectFace3(
@@ -194,6 +258,7 @@ void Output_Mesh_AddObjectFace3(
     const FACE3 *const face, const uint16_t flags)
 {
     ASSERT(!mesh->sealed);
+    const int32_t vertex_start = mesh->vertices->count;
     for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
         const int32_t j = OUTPUT_TRI_TO_FAN(i);
         const int32_t uvw_idx = face->texture_idx * 4 + j;
@@ -202,6 +267,10 @@ void Output_Mesh_AddObjectFace3(
         M_AddObjectVert(
             mesh, pos, uvw_idx, nullptr, flags, normal, face->palette_idx);
     }
+    const int32_t vertex_count = mesh->vertices->count - vertex_start;
+    M_AddFaceCommon(
+        mesh, vertex_start, vertex_count,
+        Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
 void Output_Mesh_Seal(OUTPUT_MESH *const mesh)
@@ -216,5 +285,11 @@ void Output_Mesh_Destroy(OUTPUT_MESH *const mesh)
         Vector_Free(mesh->animated_vertices);
     }
     Vector_Free(mesh->vertices);
+    if (mesh->transparent_faces != nullptr) {
+        Vector_Free(mesh->transparent_faces);
+    }
+    if (mesh->opaque_vertex_indices != nullptr) {
+        Vector_Free(mesh->opaque_vertex_indices);
+    }
     Memory_Free(mesh);
 }

--- a/src/tr1/game/output/mesh_batcher/mesh.c
+++ b/src/tr1/game/output/mesh_batcher/mesh.c
@@ -9,11 +9,14 @@
 #include <libtrx/game/level/const.h>
 #include <libtrx/memory.h>
 
+static int32_t m_Vertices3[] = { 0, 2, 1 };
+static int32_t m_Vertices4[] = { 0, 2, 1, 0, 3, 2 };
+
 static XYZ_F M_GetWorldCentroid(
     const OUTPUT_MESH *mesh, int32_t vertex_start, int32_t vertex_count);
 static void M_AddFaceCommon(
     OUTPUT_MESH *mesh, int32_t vertex_start, int32_t vertex_count,
-    bool is_transparent);
+    const int32_t *prim_vert_indices, bool is_transparent);
 static void M_AddRoomVert(
     OUTPUT_MESH *mesh, const ROOM_VERTEX *room_vert, int32_t uvw_idx,
     const TEXTURE_ZW_F *texture_ratio);
@@ -41,20 +44,26 @@ static XYZ_F M_GetMeshCentroid(
 
 static void M_AddFaceCommon(
     OUTPUT_MESH *const mesh, const int32_t vertex_start,
-    const int32_t vertex_count, const bool is_transparent)
+    const int32_t vertex_count, const int32_t *const prim_vert_indices,
+    const bool is_transparent)
 {
-    XYZ_F mesh_centroid = M_GetMeshCentroid(mesh, vertex_start, vertex_count);
-    const OUTPUT_MESH_FACE face = {
-        .vertex_start = vertex_start,
-        .vertex_count = vertex_count,
-        .mesh_centroid = mesh_centroid,
-    };
+    const XYZ_F mesh_centroid =
+        M_GetMeshCentroid(mesh, vertex_start, vertex_count);
+    const int32_t real_vertex_count = vertex_count == 3 ? 3 : 6;
     if (is_transparent) {
+        OUTPUT_MESH_FACE face = {
+            .vertex_count = real_vertex_count,
+            .mesh_centroid = mesh_centroid,
+        };
+        for (int32_t i = 0; i < real_vertex_count; i++) {
+            face.vertex_indices[i] = vertex_start + prim_vert_indices[i];
+        }
         Vector_Add(mesh->transparent_faces, &face);
     } else {
-        for (int32_t i = 0; i < vertex_count; i++) {
+        for (int32_t i = 0; i < real_vertex_count; i++) {
             Vector_Add(
-                mesh->opaque_vertex_indices, &(int32_t) { vertex_start + i });
+                mesh->opaque_vertex_indices,
+                &(int32_t) { vertex_start + prim_vert_indices[i] });
         }
     }
 }
@@ -144,16 +153,15 @@ void Output_Mesh_AddRoomFace4(
 {
     ASSERT(!mesh->sealed);
     const int32_t vertex_start = mesh->vertices->count;
-    for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
-        const int32_t j = OUTPUT_QUAD_TO_FAN(i);
-        const int32_t uvw_idx = face->texture_idx * 4 + j;
+    for (int32_t i = 0; i < 4; i++) {
+        const int32_t uvw_idx = face->texture_idx * 4 + i;
         const ROOM_VERTEX *const room_vert =
-            &room->mesh.vertices[face->vertices[j]];
-        M_AddRoomVert(mesh, room_vert, uvw_idx, &face->texture_zw[j]);
+            &room->mesh.vertices[face->vertices[i]];
+        M_AddRoomVert(mesh, room_vert, uvw_idx, &face->texture_zw[i]);
     }
     const int32_t vertex_count = mesh->vertices->count - vertex_start;
     M_AddFaceCommon(
-        mesh, vertex_start, vertex_count,
+        mesh, vertex_start, vertex_count, m_Vertices4,
         Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
@@ -162,16 +170,15 @@ void Output_Mesh_AddRoomFace3(
 {
     ASSERT(!mesh->sealed);
     const int32_t vertex_start = mesh->vertices->count;
-    for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
-        const int32_t j = OUTPUT_TRI_TO_FAN(i);
-        const int32_t uvw_idx = face->texture_idx * 4 + j;
+    for (int32_t i = 0; i < 3; i++) {
+        const int32_t uvw_idx = face->texture_idx * 4 + i;
         const ROOM_VERTEX *const room_vert =
-            &room->mesh.vertices[face->vertices[j]];
+            &room->mesh.vertices[face->vertices[i]];
         M_AddRoomVert(mesh, room_vert, uvw_idx, nullptr);
     }
     const int32_t vertex_count = mesh->vertices->count - vertex_start;
     M_AddFaceCommon(
-        mesh, vertex_start, vertex_count,
+        mesh, vertex_start, vertex_count, m_Vertices3,
         Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
@@ -196,8 +203,7 @@ void Output_Mesh_AddRoomSprite(
     quad[2].displacement.y = sprite->y1;
     quad[3].displacement.x = sprite->x0;
     quad[3].displacement.y = sprite->y1;
-    for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
-        const int32_t j = OUTPUT_QUAD_TO_FAN(i);
+    for (int32_t i = 0; i < 4; i++) {
         const ROOM_VERTEX *const room_vert =
             &room->mesh.vertices[room_sprite->vertex];
         if (Output_Textures_IsSpriteTextureAnimated(room_sprite->texture)) {
@@ -215,21 +221,21 @@ void Output_Mesh_AddRoomSprite(
                 .z = room_vert->pos.z,
             },
             .normal = {
-                .x = quad[j].displacement.x,
-                .y = quad[j].displacement.y,
+                .x = quad[i].displacement.x,
+                .y = quad[i].displacement.y,
                 .z = 0.0f,
             },
             .flags = VERT_BILLBOARD,
             .color = { 255, 255, 255, 255 },
             .uvw_idx = Output_Textures_GetSpritesUVWsBase()
-                + room_sprite->texture * 4 + j,
+                + room_sprite->texture * 4 + i,
             .shade = room_vert->light_adder,
             .trapezoid_ratio = { 1.0f, 1.0f },
         };
         Vector_Add(mesh->vertices, &vertex);
     }
     const int32_t vertex_count = mesh->vertices->count - vertex_start;
-    M_AddFaceCommon(mesh, vertex_start, vertex_count, true);
+    M_AddFaceCommon(mesh, vertex_start, vertex_count, m_Vertices4, true);
 }
 
 void Output_Mesh_AddObjectFace4(
@@ -238,18 +244,17 @@ void Output_Mesh_AddObjectFace4(
 {
     ASSERT(!mesh->sealed);
     const int32_t vertex_start = mesh->vertices->count;
-    for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
-        const int32_t j = OUTPUT_QUAD_TO_FAN(i);
-        const int32_t uvw_idx = face->texture_idx * 4 + j;
-        const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[j]];
-        const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[j]];
+    for (int32_t i = 0; i < 4; i++) {
+        const int32_t uvw_idx = face->texture_idx * 4 + i;
+        const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[i]];
+        const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[i]];
         M_AddObjectVert(
-            mesh, pos, uvw_idx, &face->texture_zw[j], flags, normal,
+            mesh, pos, uvw_idx, &face->texture_zw[i], flags, normal,
             face->palette_idx);
     }
     const int32_t vertex_count = mesh->vertices->count - vertex_start;
     M_AddFaceCommon(
-        mesh, vertex_start, vertex_count,
+        mesh, vertex_start, vertex_count, m_Vertices4,
         Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 
@@ -259,17 +264,16 @@ void Output_Mesh_AddObjectFace3(
 {
     ASSERT(!mesh->sealed);
     const int32_t vertex_start = mesh->vertices->count;
-    for (int32_t i = 0; i < OUTPUT_TRI_VERTICES; i++) {
-        const int32_t j = OUTPUT_TRI_TO_FAN(i);
-        const int32_t uvw_idx = face->texture_idx * 4 + j;
-        const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[j]];
-        const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[j]];
+    for (int32_t i = 0; i < 3; i++) {
+        const int32_t uvw_idx = face->texture_idx * 4 + i;
+        const XYZ_16 normal = obj_mesh->lighting.normals[face->vertices[i]];
+        const XYZ_16 *const pos = &obj_mesh->vertices[face->vertices[i]];
         M_AddObjectVert(
             mesh, pos, uvw_idx, nullptr, flags, normal, face->palette_idx);
     }
     const int32_t vertex_count = mesh->vertices->count - vertex_start;
     M_AddFaceCommon(
-        mesh, vertex_start, vertex_count,
+        mesh, vertex_start, vertex_count, m_Vertices3,
         Output_Textures_IsObjectTextureTransparent(face->texture_idx));
 }
 

--- a/src/tr1/game/output/mesh_batcher/mesh.h
+++ b/src/tr1/game/output/mesh_batcher/mesh.h
@@ -27,24 +27,33 @@ typedef struct {
     RGBA_8888 color;
 } OUTPUT_MESH_VERTEX;
 
+// Describes a contiguous block of vertices belonging to one face,
+// with sort keys.
+typedef struct {
+    int32_t vertex_start;
+    int32_t vertex_count;
+    XYZ_F mesh_centroid;
+} OUTPUT_MESH_FACE;
+
 typedef struct {
     VECTOR *vertices;
 
     bool sealed;
     VECTOR *animated_vertices; // OUTPUT_VERTEX_RANGE
-    VECTOR *transparent_vertices; // OUTPUT_VERTEX_RANGE
+    VECTOR *transparent_faces; // OUTPUT_MESH_FACE
+
+    VECTOR *opaque_vertex_indices; // int32_t
 } OUTPUT_MESH;
 
 OUTPUT_MESH *Output_Mesh_Create(void);
 void Output_Mesh_Destroy(OUTPUT_MESH *mesh);
 
 void Output_Mesh_AddRoomFace4(
-    OUTPUT_MESH *mesh, const FACE4 *face, const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const FACE4 *face, const ROOM *room);
 void Output_Mesh_AddRoomFace3(
-    OUTPUT_MESH *mesh, const FACE3 *face, const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const FACE3 *face, const ROOM *room);
 void Output_Mesh_AddRoomSprite(
-    OUTPUT_MESH *mesh, const ROOM_SPRITE *room_sprite,
-    const ROOM_VERTEX *verts);
+    OUTPUT_MESH *mesh, const ROOM_SPRITE *room_sprite, const ROOM *room);
 
 void Output_Mesh_AddObjectFace4(
     OUTPUT_MESH *mesh, const OBJECT_MESH *obj_mesh, const FACE4 *face,

--- a/src/tr1/game/output/mesh_batcher/mesh.h
+++ b/src/tr1/game/output/mesh_batcher/mesh.h
@@ -30,8 +30,8 @@ typedef struct {
 // Describes a contiguous block of vertices belonging to one face,
 // with sort keys.
 typedef struct {
-    int32_t vertex_start;
     int32_t vertex_count;
+    int32_t vertex_indices[6]; // Maximum 6 indices per face
     XYZ_F mesh_centroid;
 } OUTPUT_MESH_FACE;
 

--- a/src/tr1/game/output/shader.c
+++ b/src/tr1/game/output/shader.c
@@ -14,8 +14,6 @@ typedef enum {
     M_UNIFORM_TEX_ATLAS,
     M_UNIFORM_TEX_ENV_MAP,
     M_UNIFORM_SMOOTHING_ENABLED,
-    M_UNIFORM_ALPHA_DISCARD_ENABLED,
-    M_UNIFORM_ALPHA_THRESHOLD,
     M_UNIFORM_TRAPEZOID_FILTER_ENABLED,
     M_UNIFORM_LIGHTING_MODE,
     M_UNIFORM_REFLECTIONS_ENABLED,
@@ -52,8 +50,6 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
         [M_UNIFORM_TEX_ATLAS] = "uTexAtlas",
         [M_UNIFORM_TEX_ENV_MAP] = "uTexEnvMap",
         [M_UNIFORM_SMOOTHING_ENABLED] = "uSmoothingEnabled",
-        [M_UNIFORM_ALPHA_DISCARD_ENABLED] = "uAlphaDiscardEnabled",
-        [M_UNIFORM_ALPHA_THRESHOLD] = "uAlphaThreshold",
         [M_UNIFORM_TRAPEZOID_FILTER_ENABLED] = "uTrapezoidFilterEnabled",
         [M_UNIFORM_LIGHTING_MODE] = "uLightingMode",
         [M_UNIFORM_REFLECTIONS_ENABLED] = "uReflectionsEnabled",
@@ -91,12 +87,6 @@ void Output_Shader_Bind(const OUTPUT_SHADER *const shader)
 
 void Output_Shader_UploadCommonUniforms(const OUTPUT_SHADER *const shader)
 {
-    GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_ALPHA_THRESHOLD],
-        g_Config.rendering.enable_wireframe ? -1.0f : 0.0f);
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_ALPHA_DISCARD_ENABLED],
-        !g_Config.rendering.enable_wireframe);
     GFX_TRACK_UNIFORM(
         glUniform1i, shader->uniforms[M_UNIFORM_TRAPEZOID_FILTER_ENABLED],
         g_Config.rendering.enable_trapezoid_filter);

--- a/src/tr1/game/output/shader.h
+++ b/src/tr1/game/output/shader.h
@@ -10,6 +10,7 @@
 #define VERT_REFLECTIVE  0b0000'0100 // = 0x04
 #define VERT_NO_LIGHTING 0b0000'1000 // = 0x08
 #define VERT_BILLBOARD   0b0001'0000 // = 0x10
+#define VERT_CAUSTICS    0b0010'0000 // = 0x20
 // clang-format on
 
 // GL attribute mapping in the shader

--- a/src/tr1/game/output/sources/objects.c
+++ b/src/tr1/game/output/sources/objects.c
@@ -226,6 +226,7 @@ static void M_Stage(const OBJECT_MESH *const mesh, const bool background)
     MeshBatcher_Stage(
         p->batcher, &inst,
         background ? SCENE_PASS_BACKGROUND : SCENE_PASS_MESHES);
+    MeshBatcher_Stage(p->batcher, &inst, SCENE_PASS_TRANSPARENT);
 }
 
 void OutputSource_Objects_Init(MESH_BATCHER *const batcher)

--- a/src/tr1/game/output/sources/objects.c
+++ b/src/tr1/game/output/sources/objects.c
@@ -35,29 +35,29 @@ static int32_t *M_PrepareLightIndexMap(
 #define L_SET(v, j) light_idx_map[v] = face->vertices[j];
     for (int32_t i = 0; i < obj_mesh->num_tex_face4s; i++) {
         const FACE4 *const face = &obj_mesh->tex_face4s[i];
-        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
-            L_SET(v, OUTPUT_QUAD_TO_FAN(j));
+        for (int32_t j = 0; j < 4; j++) {
+            L_SET(v, j);
             v++;
         }
     }
     for (int32_t i = 0; i < obj_mesh->num_tex_face3s; i++) {
         const FACE3 *const face = &obj_mesh->tex_face3s[i];
-        for (int32_t j = 0; j < OUTPUT_TRI_VERTICES; j++) {
-            L_SET(v, OUTPUT_TRI_TO_FAN(j));
+        for (int32_t j = 0; j < 3; j++) {
+            L_SET(v, j);
             v++;
         }
     }
     for (int32_t i = 0; i < obj_mesh->num_flat_face4s; i++) {
         const FACE4 *const face = &obj_mesh->flat_face4s[i];
-        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
-            L_SET(v, OUTPUT_QUAD_TO_FAN(j));
+        for (int32_t j = 0; j < 4; j++) {
+            L_SET(v, j);
             v++;
         }
     }
     for (int32_t i = 0; i < obj_mesh->num_flat_face3s; i++) {
         const FACE3 *const face = &obj_mesh->flat_face3s[i];
-        for (int32_t j = 0; j < OUTPUT_TRI_VERTICES; j++) {
-            L_SET(v, OUTPUT_TRI_TO_FAN(j));
+        for (int32_t j = 0; j < 3; j++) {
+            L_SET(v, j);
             v++;
         }
     }

--- a/src/tr1/game/output/sources/rooms.c
+++ b/src/tr1/game/output/sources/rooms.c
@@ -59,8 +59,8 @@ static void M_UpdateShades(MESH_INSTANCE *const inst, void *const user_data)
     // Quads
     for (int32_t i = 0; i < room->mesh.num_face4s; i++) {
         const FACE4 *const face = &room->mesh.face4s[i];
-        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
-            const int32_t k = OUTPUT_QUAD_TO_FAN(j);
+        for (int32_t j = 0; j < 4; j++) {
+            const int32_t k = j;
             vertex->shade = room->mesh.vertices[face->vertices[k]].light_adder;
             vertex->shade = M_ShadeCaustics(
                 p, room, inst->water_effect, vertex->shade, face->vertices[k]);
@@ -71,8 +71,8 @@ static void M_UpdateShades(MESH_INSTANCE *const inst, void *const user_data)
     // Triangles
     for (int32_t i = 0; i < room->mesh.num_face3s; i++) {
         const FACE3 *const face = &room->mesh.face3s[i];
-        for (int32_t j = 0; j < OUTPUT_TRI_VERTICES; j++) {
-            const int32_t k = OUTPUT_TRI_TO_FAN(j);
+        for (int32_t j = 0; j < 3; j++) {
+            const int32_t k = j;
             vertex->shade = room->mesh.vertices[face->vertices[k]].light_adder;
             vertex->shade = M_ShadeCaustics(
                 p, room, inst->water_effect, vertex->shade, face->vertices[k]);
@@ -83,7 +83,7 @@ static void M_UpdateShades(MESH_INSTANCE *const inst, void *const user_data)
     // Sprites
     for (int32_t i = 0; i < room->mesh.num_sprites; i++) {
         const ROOM_SPRITE *const room_sprite = &room->mesh.sprites[i];
-        for (int32_t j = 0; j < OUTPUT_QUAD_VERTICES; j++) {
+        for (int32_t j = 0; j < 4; j++) {
             vertex->shade =
                 room->mesh.vertices[room_sprite->vertex].light_adder;
             vertex++;

--- a/src/tr1/game/output/sources/rooms.c
+++ b/src/tr1/game/output/sources/rooms.c
@@ -99,17 +99,14 @@ static void M_PrepareMeshes(M_PRIV *const p)
         const ROOM *const room = Room_Get(i);
         OUTPUT_MESH *const mesh = Output_Mesh_Create();
 
-        for (int32_t i = 0; i < room->mesh.num_face4s; i++) {
-            Output_Mesh_AddRoomFace4(
-                mesh, &room->mesh.face4s[i], room->mesh.vertices);
+        for (int32_t j = 0; j < room->mesh.num_face4s; j++) {
+            Output_Mesh_AddRoomFace4(mesh, &room->mesh.face4s[j], room);
         }
-        for (int32_t i = 0; i < room->mesh.num_face3s; i++) {
-            Output_Mesh_AddRoomFace3(
-                mesh, &room->mesh.face3s[i], room->mesh.vertices);
+        for (int32_t j = 0; j < room->mesh.num_face3s; j++) {
+            Output_Mesh_AddRoomFace3(mesh, &room->mesh.face3s[j], room);
         }
-        for (int32_t i = 0; i < room->mesh.num_sprites; i++) {
-            Output_Mesh_AddRoomSprite(
-                mesh, &room->mesh.sprites[i], room->mesh.vertices);
+        for (int32_t j = 0; j < room->mesh.num_sprites; j++) {
+            Output_Mesh_AddRoomSprite(mesh, &room->mesh.sprites[j], room);
         }
         Output_Mesh_Seal(mesh);
         MeshBatcher_AddMesh(p->batcher, mesh);
@@ -189,4 +186,5 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .update_light_func_data = (void *)room,
     };
     MeshBatcher_Stage(p->batcher, &inst, SCENE_PASS_MESHES);
+    MeshBatcher_Stage(p->batcher, &inst, SCENE_PASS_TRANSPARENT);
 }

--- a/src/tr1/game/output/sources/sprites.c
+++ b/src/tr1/game/output/sources/sprites.c
@@ -68,8 +68,9 @@ static void M_PrepareMeshes(M_PRIV *p)
     for (int32_t i = 0; i < (int32_t)p->mesh_count; i++) {
         OUTPUT_MESH *mesh = Output_Mesh_Create();
         ROOM_VERTEX fake_vert = {};
+        const ROOM fake_room = { .mesh = { .vertices = &fake_vert } };
         ROOM_SPRITE fake_sprite = { .texture = (uint16_t)i, .vertex = 0 };
-        Output_Mesh_AddRoomSprite(mesh, &fake_sprite, &fake_vert);
+        Output_Mesh_AddRoomSprite(mesh, &fake_sprite, &fake_room);
         Output_Mesh_Seal(mesh);
         MeshBatcher_AddMesh(p->batcher, mesh);
         p->meshes[i] = mesh;

--- a/src/tr1/game/output/sources/sprites.c
+++ b/src/tr1/game/output/sources/sprites.c
@@ -1,16 +1,8 @@
 #include "game/output/sources/sprites.h"
 
-#include "game/output/mesh_batcher/batcher.h"
-#include "game/output/mesh_batcher/mesh.h"
-#include "game/output/textures.h"
-#include "game/output/utils.h"
-
 #include <libtrx/game/output/textures.h>
 #include <libtrx/memory.h>
 #include <libtrx/utils.h>
-#include <libtrx/vector.h>
-
-#include <stdint.h>
 
 typedef struct {
     MESH_BATCHER *batcher;

--- a/src/tr1/game/output/sources/ui.c
+++ b/src/tr1/game/output/sources/ui.c
@@ -135,6 +135,8 @@ static void M_Draw3DPickups(const M_PRIV *const p)
         // Immediately flush scheduled object, so that it gets rendered
         // in the target viewport
         p->objects_source->render_pass(p->objects_source, SCENE_PASS_MESHES);
+        p->objects_source->render_pass(
+            p->objects_source, SCENE_PASS_TRANSPARENT);
         if (p->objects_source->render_end != nullptr) {
             p->objects_source->render_end(p->objects_source);
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds alpha blending to bilinear filter textures which causes a slight slow down (but well around 1 ms per frame), and slightly reduces overhead by no longer uploading duplicated quad vertices, instead opting to upload vertex indices.

#### Technical background

To achieve seamless blending without any visual artifacts, we need to arrange polygons containing partially transparent pixels in a particular order. We should first render all the fully opaque geometry, and then render the translucent polygons, starting from the back and moving forward.

The challenge with implementing this is that the mesh batcher statically uploads each model mesh and then instances them through transformation matrices submitted as uniforms. One approach I considered was to sort the meshes based on their centroids, and then sort the faces within each mesh. However, this led to noticeable artifacts, especially around rooms; elements like windows or Atlantean vines could mix up with normal objects also having translucent polygons, causing a disorderly rendering. So this technique was out.

In other words, it's necessary to gather all transparent faces and sort them collectively. The complication here, again, is that some data is uploaded per-mesh instance via uniforms, and ripping certain faces from their collective meshes means we lose access to this data. To make things simple, I encode the uniform data directly into the vertices by applying the transformation matrix to vertex positions and coloring the vertices with the water tint on the CPU. This method makes vertices independent of uniform data, though it slightly increases CPU-bound calculations. Finally, I render all the geometry in one batch using a single call by referencing the faces through their indices, which are meticulously sorted using some clever techniques borrowed from TR2 (`M_FACE_SORT`).

Overall the slowdown is there, but it's acceptable IMO.

Possible improvements:
- 🟢 Disable uploading of room lighting data when it's unchanged
- 🟠 Instead of uploading the entire vertex data as a separate VBO, reuse texture and shade VBOs
- ⚫ Disable sorting of color key faces when the bilinear filter is off

----

Benchmark data – comparing against develop

### Colosseum Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg   │ Change %   ┃
┠──────────────────────┼──────────┼───────────┼────────────┨
┃ Opaque vertices      │ 23576.68 │ 23357.81  │ ⚪ 99.07%  ┃
┃ Transparent vertices │ 0.00     │ 1175.99   │ ⚫ ?       ┃
┃ Transfers            │ 196.57   │ 198.55    │ ⚪ 101.01% ┃
┃ Uniforms             │ 226.28   │ 222.68    │ ⚪ 98.41%  ┃
┃ Throughput           │ 92.37 KB │ 151.20 KB │ 🔴 163.69% ┃
┃ Time                 │ 0.52 ms  │ 0.61 ms   │ 🟠 116.94% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Colosseum
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg   │ Change %   ┃
┠──────────────────────┼──────────┼───────────┼────────────┨
┃ Opaque vertices      │ 24533.64 │ 23357.65  │ ⚪ 95.21%  ┃
┃ Transparent vertices │ 0.00     │ 1175.99   │ ⚫ ?       ┃
┃ Transfers            │ 197.16   │ 198.16    │ ⚪ 100.51% ┃
┃ Uniforms             │ 220.55   │ 217.25    │ ⚪ 98.51%  ┃
┃ Throughput           │ 96.08 KB │ 151.17 KB │ 🔴 157.34% ┃
┃ Time                 │ 0.90 ms  │ 1.18 ms   │ 🔴 130.07% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Inventory Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg   │ Change %   ┃
┠──────────────────────┼──────────┼───────────┼────────────┨
┃ Opaque vertices      │ 24794.11 │ 23621.57  │ ⚪ 95.27%  ┃
┃ Transparent vertices │ 0.00     │ 1724.37   │ ⚫ ?       ┃
┃ Transfers            │ 199.38   │ 205.35    │ ⚪ 103.00% ┃
┃ Uniforms             │ 253.08   │ 247.96    │ ⚪ 97.98%  ┃
┃ Throughput           │ 97.27 KB │ 192.25 KB │ 🔴 197.64% ┃
┃ Time                 │ 0.49 ms  │ 0.55 ms   │ 🟠 112.75% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Inventory
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg   │ New avg   │ Change %   ┃
┠──────────────────────┼───────────┼───────────┼────────────┨
┃ Opaque vertices      │ 25694.53  │ 24268.54  │ ⚪ 94.45%  ┃
┃ Transparent vertices │ 0.00      │ 1425.99   │ ⚫ ?       ┃
┃ Transfers            │ 205.81    │ 207.81    │ ⚪ 100.97% ┃
┃ Uniforms             │ 267.72    │ 259.76    │ ⚪ 97.03%  ┃
┃ Throughput           │ 210.59 KB │ 281.82 KB │ 🔴 133.82% ┃
┃ Time                 │ 1.16 ms   │ 1.30 ms   │ 🟠 112.38% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Midas Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg   │ Change %   ┃
┠──────────────────────┼──────────┼───────────┼────────────┨
┃ Opaque vertices      │ 13081.86 │ 12665.09  │ ⚪ 96.81%  ┃
┃ Transparent vertices │ 0.00     │ 1090.61   │ ⚫ ?       ┃
┃ Transfers            │ 126.00   │ 133.40    │ ⚪ 105.87% ┃
┃ Uniforms             │ 167.51   │ 166.08    │ ⚪ 99.15%  ┃
┃ Throughput           │ 66.09 KB │ 128.02 KB │ 🔴 193.71% ┃
┃ Time                 │ 0.30 ms  │ 0.40 ms   │ 🔴 131.84% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Midas
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 14970.38 │ 14282.86 │ ⚪ 95.41%  ┃
┃ Transparent vertices │ 0.00     │ 570.36   │ ⚫ ?       ┃
┃ Transfers            │ 141.65   │ 142.71   │ ⚪ 100.75% ┃
┃ Uniforms             │ 177.72   │ 173.99   │ ⚪ 97.90%  ┃
┃ Throughput           │ 61.36 KB │ 82.31 KB │ 🔴 134.15% ┃
┃ Time                 │ 0.61 ms  │ 0.71 ms  │ 🟠 116.30% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
