### PR TITLE
lara: adjust neutral jump twist

### DIFF
--- a/src/libtrx/game/lara/col/jump.c
+++ b/src/libtrx/game/lara/col/jump.c
@@ -333,6 +333,25 @@ static void M_Compress(ITEM *const item, COLL_INFO *const coll)
     }
 }
 
+static void M_NeutralJumpRoll(ITEM *const item, COLL_INFO *const coll)
+{
+    item->gravity = false;
+    item->fall_speed = 0;
+    coll->bad_pos = NO_BAD_POS;
+    coll->bad_neg = NO_BAD_NEG;
+    coll->bad_ceiling = 0;
+
+    Lara_Col_GetInfo(item, coll);
+
+    if (coll->side_mid.ceiling > -100) {
+        Item_SwitchToAnim(item, LA_STAND_STILL, 0);
+        item->goal_anim_state = LS_STOP;
+        item->current_anim_state = LS_STOP;
+        item->speed = 0;
+        item->pos = coll->old;
+    }
+}
+
 static void M_UpJump(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -588,6 +607,7 @@ static void M_FastFall(ITEM *const item, COLL_INFO *const coll)
 
 // clang-format off
 REGISTER_LARA_COL(LS_COMPRESS,     M_Compress)
+REGISTER_LARA_COL(LS_NEUTRAL_ROLL, M_NeutralJumpRoll)
 REGISTER_LARA_COL(LS_JUMP_UP,      M_UpJump)
 REGISTER_LARA_COL(LS_JUMP_FORWARD, M_ForwardJump)
 REGISTER_LARA_COL(LS_JUMP_BACK,    M_SideBackJump)

--- a/src/libtrx/game/lara/state/land.c
+++ b/src/libtrx/game/lara/state/land.c
@@ -175,6 +175,7 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
 
     if (g_Input.roll && lara->water_status != LWS_WADE) {
         if (g_Input.jump && g_Config.gameplay.enable_neutral_twists
+            && Item_TestAnimEqual(item, LA_STAND_IDLE)
             && Lara_State_IsResponsive(LA_STAND_TO_JUMP)) {
             item->current_anim_state = LS_NEUTRAL_ROLL;
             item->goal_anim_state = LS_STOP;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara being able to neutral jump twist on a slope, after falling from a height, and when she is standing with a ceiling touching her head. So basically the move can be performed only when she is standing still and she has enough gap overhead where she would normally be able to jump.
