### PR TITLE
Fix various headless mode rendering problems

### DIFF
--- a/docs/1-COMMAND_LINE.md
+++ b/docs/1-COMMAND_LINE.md
@@ -32,7 +32,11 @@ Currently the following command line interface options are available:
   Runs the game in command line only. Only available with `--test-replay`.
 
 - `--headless-fps <num>`:  
-  In headless mode, force the simulation to run at a constant FPS (frames per second). If omitted or zero, uses the FPS from the configuration.
+  In headless mode, forces the simulation to run at a constant FPS. If omitted
+  or zero, uses the FPS from the configuration.
+
+- `--debug-render-performance`:  
+  Outputs diagnostic information related to GPU usage and throughput.
 
 - `-q`, `--quiet`  
   Suppresses most of output to the standard output, keeping only errors.

--- a/src/libtrx/game/fader.c
+++ b/src/libtrx/game/fader.c
@@ -65,9 +65,6 @@ bool Fader_IsActive(const FADER *const fader)
     if (fader->args.duration <= 0.0) {
         return false;
     }
-    if (Shell_GetArgs()->headless) {
-        return Fader_GetCurrentValue(fader) != fader->args.target;
-    }
     return !fader->target_drawn;
 }
 

--- a/src/libtrx/game/output/common.c
+++ b/src/libtrx/game/output/common.c
@@ -1,6 +1,7 @@
 #include "game/const.h"
 #include "game/matrix.h"
 #include "game/output.h"
+#include "game/shell.h"
 #include "utils.h"
 #include "vector.h"
 
@@ -317,4 +318,9 @@ int32_t Output_GetFogStart(void)
 void Output_SetFogStart(const int32_t dist)
 {
     m_FogStart = dist;
+}
+
+bool Output_IsHeadless(void)
+{
+    return Shell_GetArgs()->headless;
 }

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -18,8 +18,6 @@
 #include "gfx/context.h"
 #include "gfx/gl/track.h"
 
-#define M_DEBUG_CONTROL_WAIT 0
-#define M_DEBUG_DRAW_PERF 0
 #define M_MAX_PHASES 10
 
 static bool m_Exiting;
@@ -86,9 +84,7 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
 
 static void M_Draw(PHASE *const phase)
 {
-#if M_DEBUG_DRAW_PERF > 0
     BENCHMARK benchmark = Benchmark_Start();
-#endif
 
     Output_BeginScene();
     Output_SwitchViewport(VIEWPORT_GAME);
@@ -110,20 +106,19 @@ static void M_Draw(PHASE *const phase)
     Output_Flush();
     Output_EndScene();
 
-#if M_DEBUG_DRAW_PERF > 0
-    char buffer[80];
-    const GFX_METRICS metrics = GFX_Track_GetMetrics();
-    sprintf(
-        buffer, "%.03f KB T:%d U:%d Vo:%d Vt:%d",
-        metrics.buffer_total_bytes / 1024.0f, metrics.buffer_transfer_count,
-        metrics.uniform_changes, metrics.opaque_vert_count,
-        metrics.trans_vert_count);
-    Benchmark_End(&benchmark, buffer);
-#endif
+    if (Shell_GetArgs()->debug_render_performance) {
+        char buffer[80];
+        const GFX_METRICS metrics = GFX_Track_GetMetrics();
+        sprintf(
+            buffer, "%.03f KB T:%d U:%d Vo:%d Vt:%d",
+            metrics.buffer_total_bytes / 1024.0f, metrics.buffer_transfer_count,
+            metrics.uniform_changes, metrics.opaque_vert_count,
+            metrics.trans_vert_count);
+        Benchmark_End(&benchmark, buffer);
+    }
 
     if (!Output_IsHeadless()
-        || GFX_Context_GetScheduledScreenshotPath() != nullptr
-        || M_DEBUG_DRAW_PERF == 2) {
+        || GFX_Context_GetScheduledScreenshotPath() != nullptr) {
         Output_FlipScreen();
     } else {
         GFX_Track_Reset();
@@ -160,13 +155,7 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
     }
 
     while (true) {
-#if M_DEBUG_CONTROL_WAIT
-        BENCHMARK benchmark = Benchmark_Start();
-#endif
         int32_t nframes = Clock_WaitTick();
-#if M_DEBUG_CONTROL_WAIT
-        Benchmark_End(&benchmark, "");
-#endif
         int32_t frame = 0;
         while (true) {
             const PHASE_CONTROL control = M_Control(phase);

--- a/src/libtrx/game/phase/executor.c
+++ b/src/libtrx/game/phase/executor.c
@@ -90,29 +90,24 @@ static void M_Draw(PHASE *const phase)
     BENCHMARK benchmark = Benchmark_Start();
 #endif
 
-    const bool skip = Shell_GetArgs()->headless && M_DEBUG_DRAW_PERF < 2
-        && GFX_Context_GetScheduledScreenshotPath() == nullptr;
-
     Output_BeginScene();
-    if (!skip) {
-        Output_SwitchViewport(VIEWPORT_GAME);
-        UI_BeginScene();
-        UI_BeginFade(&m_ExitFader, true);
-        if (phase != nullptr && phase->draw != nullptr) {
-            phase->draw(phase);
-        }
-
-        Overlay_Draw();
-        Console_Draw();
-        UI_EndFade();
-        UI_EndScene();
-
-        Output_SwitchViewport(VIEWPORT_UI);
-        UI_Draw();
-        Output_DrawPolyList();
-
-        Output_Flush();
+    Output_SwitchViewport(VIEWPORT_GAME);
+    UI_BeginScene();
+    UI_BeginFade(&m_ExitFader, true);
+    if (phase != nullptr && phase->draw != nullptr) {
+        phase->draw(phase);
     }
+
+    Overlay_Draw();
+    Console_Draw();
+    UI_EndFade();
+    UI_EndScene();
+
+    Output_SwitchViewport(VIEWPORT_UI);
+    UI_Draw();
+    Output_DrawPolyList();
+
+    Output_Flush();
     Output_EndScene();
 
 #if M_DEBUG_DRAW_PERF > 0
@@ -126,10 +121,12 @@ static void M_Draw(PHASE *const phase)
     Benchmark_End(&benchmark, buffer);
 #endif
 
-    if (skip && M_DEBUG_DRAW_PERF < 2) {
-        GFX_Track_Reset();
-    } else {
+    if (!Output_IsHeadless()
+        || GFX_Context_GetScheduledScreenshotPath() != nullptr
+        || M_DEBUG_DRAW_PERF == 2) {
         Output_FlipScreen();
+    } else {
+        GFX_Track_Reset();
     }
 }
 

--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -49,7 +49,6 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
     out_args->mod = M_BASE_MOD;
     out_args->save_to_load = -1;
     out_args->original_args = args;
-    out_args->headless_fps = 0;
     if (args == nullptr) {
         return out_args;
     }
@@ -106,6 +105,9 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                 out_args->headless_fps = fps;
             }
             i++;
+        }
+        if (!strcmp(arg, "--debug-render-performance")) {
+            out_args->debug_render_performance = true;
         }
         if (!strcmp(arg, "-q") || !strcmp(arg, "--quiet")) {
             out_args->quiet = true;

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -99,13 +99,17 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
 
     // Record original arguments passed to the game
     if (original_args->count > 0) {
-        // Skip record test recording-related arguments.
+        // Skip tracking irrelevant arguments.
         VECTOR *const filtered_args = Vector_Create(sizeof(char *));
         for (int32_t i = 0; i < original_args->count; i++) {
             const char *const arg = *(char **)Vector_Get(original_args, i);
             if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
-                || !strcmp(arg, "--test-play")) {
+                || !strcmp(arg, "--test-play")
+                || !strcmp(arg, "--headless-fps")) {
                 i++; // Also skip the path argument.
+                continue;
+            }
+            if (!strcmp(arg, "--debug-render-performance")) {
                 continue;
             }
             Vector_Add(filtered_args, &arg);

--- a/src/libtrx/gfx/renderer.c
+++ b/src/libtrx/gfx/renderer.c
@@ -176,7 +176,7 @@ static void M_Render(GFX_RENDERER *renderer)
     M_Blit(p, &p->ui_fbo);
     glDisable(GL_BLEND);
 
-    if (GFX_Context_GetScheduledScreenshotPath()) {
+    if (GFX_Context_GetScheduledScreenshotPath() != nullptr) {
         GFX_Context_SwitchToViewport(VIEWPORT_TARGET);
         GFX_Screenshot_CaptureToFile(GFX_Context_GetScheduledScreenshotPath());
         GFX_Context_ClearScheduledScreenshotPath();

--- a/src/libtrx/include/libtrx/game/output/common.h
+++ b/src/libtrx/include/libtrx/game/output/common.h
@@ -6,6 +6,7 @@
 
 extern bool Output_Init(void);
 extern void Output_Shutdown(void);
+extern bool Output_IsHeadless(void);
 
 extern void Output_DispatchLevelLoad(void);
 extern void Output_DispatchLevelUnload(void);

--- a/src/libtrx/include/libtrx/game/shell/args.h
+++ b/src/libtrx/include/libtrx/game/shell/args.h
@@ -21,6 +21,7 @@ typedef struct {
     const char *test_record_path;
     const char *test_replay_path;
     bool headless;
+    bool debug_render_performance;
     int32_t headless_fps; // in headless mode, force fixed fps (0 = unlocked)
     bool quiet;
 } SHELL_ARGS;

--- a/src/tr1/game/output/scene_compositor.c
+++ b/src/tr1/game/output/scene_compositor.c
@@ -6,6 +6,7 @@
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
+#include <libtrx/gfx/context.h>
 #include <libtrx/vector.h>
 
 #define M_PROCESS_SOURCES(p, func, ...)                                        \
@@ -206,9 +207,18 @@ void SceneCompositor_Shutdown(void)
     }
 }
 
+bool M_IsActive(void)
+{
+    return !Output_IsHeadless()
+        || GFX_Context_GetScheduledScreenshotPath() != nullptr;
+}
+
 void SceneCompositor_BeginScene(void)
 {
     M_PRIV *const p = &m_Priv;
+    if (!M_IsActive()) {
+        return;
+    }
     M_PrepareScene(p);
     M_PROCESS_SOURCES(p, render_begin);
 }
@@ -216,6 +226,9 @@ void SceneCompositor_BeginScene(void)
 void SceneCompositor_Flush(void)
 {
     M_PRIV *const p = &m_Priv;
+    if (!M_IsActive()) {
+        return;
+    }
     M_RenderScenePasses(p);
     M_PROCESS_SOURCES(p, render_end);
     M_PROCESS_SOURCES(p, render_begin);
@@ -225,6 +238,9 @@ void SceneCompositor_Flush(void)
 void SceneCompositor_EndScene(void)
 {
     M_PRIV *const p = &m_Priv;
+    if (!M_IsActive()) {
+        return;
+    }
     M_RenderScenePasses(p);
     M_PROCESS_SOURCES(p, render_end);
 }

--- a/src/tr1/game/output/textures.c
+++ b/src/tr1/game/output/textures.c
@@ -255,6 +255,28 @@ static void M_PrepareEnvMap(void)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     GFX_GL_CheckError();
+
+    if (Output_IsHeadless()) {
+        const int32_t pattern_size = 256;
+        RGB_888 *test_pattern =
+            Memory_Alloc(pattern_size * pattern_size * sizeof(RGB_888));
+        RGB_888 *pixel = test_pattern;
+        for (int32_t i = 0; i < pattern_size; i++) {
+            for (int32_t j = 0; j < pattern_size; j++) {
+                pixel->r = i % 256;
+                pixel->g = j % 256;
+                pixel->b = ((i / 32) % 2 == (j / 32) % 2) ? 255 : 0;
+                pixel++;
+            }
+        }
+
+        glBindTexture(GL_TEXTURE_2D, m_Priv.tex_env_map);
+        glTexImage2D(
+            GL_TEXTURE_2D, 0, GL_RGB, pattern_size, pattern_size, 0, GL_RGB,
+            GL_UNSIGNED_BYTE, test_pattern);
+        GFX_GL_CheckError();
+        Memory_FreePointer(&test_pattern);
+    }
 }
 
 static void M_PrepareAtlasSizes(void)
@@ -357,6 +379,10 @@ void Output_Textures_ObserveLevelLoad(void)
 
 void Output_Textures_UpdateEnvironmentMap(void)
 {
+    if (Output_IsHeadless()) {
+        return;
+    }
+
     GLint viewport[4];
     glGetIntegerv(GL_VIEWPORT, viewport);
     GFX_GL_CheckError();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Skipping the draw phase led to multiple inconsistencies around the UI and the game. I changed the skip logic to work on the scene compositor level, so that we execute all the drawing logic, but skip only the actual rendering. (Doesn't apply to TR2 which uses the old renderer still.)
Additionally I've added a mock texture to display reflections, as normally these are dependent on what we've drawn in the previous frame, and in the headless mode we don't draw anything (unless we're about to take a screenshot).

Finally, the macro `M_DEBUG_DRAW_PERF` is no longer, and this functionality is now available as a CLI switch `--debug-render-performance`. I also got rid of `M_DEBUG_CONTROL_WAIT`,  it was added 1-2 days ago and it wasn't all that useful.

![test_photo_mode_poses-cur](https://github.com/user-attachments/assets/c98d1706-7cc7-45bb-9dff-0df4c1eb8a21)
<img width="256" height="256" alt="test_pattern" src="https://github.com/user-attachments/assets/27b7e66b-92a5-492f-b704-0eb28ee5f911" />
