### PR TITLE
Rework replay format

### DIFF
--- a/src/libtrx/game/events.c
+++ b/src/libtrx/game/events.c
@@ -1,0 +1,40 @@
+#include "game/events.h"
+
+#include "config/common.h"
+#include "debug.h"
+
+static EVENT_MANAGER *m_GameEventManager = nullptr;
+
+void GameEvent_Init(void)
+{
+    m_GameEventManager = EventManager_Create();
+}
+
+void GameEvent_Shutdown(void)
+{
+    EventManager_Free(m_GameEventManager);
+    m_GameEventManager = nullptr;
+}
+
+int32_t GameEvent_Subscribe(
+    const char *const event_name, const void *const sender,
+    const GAME_EVENT_LISTENER listener, void *const user_data)
+{
+    ASSERT(m_GameEventManager != nullptr);
+    return EventManager_Subscribe(
+        m_GameEventManager, event_name, sender, listener, user_data);
+}
+
+void GameEvent_Unsubscribe(const int32_t listener_id)
+{
+    if (m_GameEventManager != nullptr) {
+        EventManager_Unsubscribe(m_GameEventManager, listener_id);
+    }
+}
+
+void GameEvent_Fire(const EVENT event)
+{
+    if (m_GameEventManager != nullptr) {
+        EventManager_Fire(m_GameEventManager, &event);
+    }
+}

--- a/src/libtrx/game/input/common.c
+++ b/src/libtrx/game/input/common.c
@@ -5,8 +5,13 @@
 #include "game/game_string.h"
 #include "game/input/backends/controller.h"
 #include "game/input/backends/keyboard.h"
+#include "strings.h"
 
+#include <SDL2/SDL_keyboard.h>
+#include <ctype.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 typedef enum {
     HOLD_INACTIVE,
@@ -379,4 +384,59 @@ INPUT_STATE Input_GetDebounced(const INPUT_STATE input)
 const char *Input_GetRoleName(const INPUT_ROLE role)
 {
     return GS_ENUM(INPUT_ROLE, role);
+}
+
+const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod)
+{
+    // clang-format off
+    const char *mods = "";
+    if (mod & KMOD_CTRL)  { mods = String_FormatStatic("%sctrl+",  mods); }
+    if (mod & KMOD_SHIFT) { mods = String_FormatStatic("%sshift+", mods); }
+    if (mod & KMOD_ALT)   { mods = String_FormatStatic("%salt+",   mods); }
+    if (mod & KMOD_GUI)   { mods = String_FormatStatic("%sgui+",   mods); }
+    // clang-format on
+
+    const char *const name = SDL_GetScancodeName(scancode);
+    if (name == nullptr || name[0] == '\0') {
+        return nullptr;
+    }
+
+    char *const full = (char *)String_FormatStatic("%s%s", mods, name);
+    for (size_t i = 0; i < strlen(full); i++) {
+        full[i] = (char)tolower((unsigned char)full[i]);
+    }
+    return full;
+}
+
+bool Input_ParseKeyDesc(
+    const char *const desc, SDL_Scancode *const scancode, SDL_Keymod *const mod)
+{
+    if (desc == nullptr || scancode == nullptr || mod == nullptr) {
+        return false;
+    }
+
+    SDL_Keymod m = KMOD_NONE;
+    const char *keystr = desc;
+    const char *last = strrchr(desc, '+');
+
+    if (last != nullptr) {
+        for (const char *tok = desc; tok < last; tok = strchr(tok, '+') + 1) {
+            const size_t len =
+                strchr(tok, '+') ? strchr(tok, '+') - tok : last - tok;
+            if (strncmp(tok, "ctrl", len) == 0) {
+                m |= KMOD_CTRL;
+            } else if (strncmp(tok, "shift", len) == 0) {
+                m |= KMOD_SHIFT;
+            } else if (strncmp(tok, "alt", len) == 0) {
+                m |= KMOD_ALT;
+            } else if (strncmp(tok, "gui", len) == 0) {
+                m |= KMOD_GUI;
+            }
+        }
+        keystr = last + 1;
+    }
+
+    *scancode = SDL_GetScancodeFromName(keystr);
+    *mod = m;
+    return *scancode != SDL_SCANCODE_UNKNOWN;
 }

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -3,6 +3,7 @@
 #include "enum_map.h"
 #include "game/clock.h"
 #include "game/console.h"
+#include "game/events.h"
 #include "game/fmv.h"
 #include "game/game_buf.h"
 #include "game/game_flow.h"
@@ -82,6 +83,7 @@ void Shell_InitCommonModules(void)
     UI_Init();
     Console_Init();
     Overlay_Init();
+    GameEvent_Init();
 
     Input_Init();
 
@@ -117,6 +119,7 @@ void Shell_ShutdownCommonModules(void)
     Music_Shutdown();
     Sound_Shutdown();
     UI_Shutdown();
+    GameEvent_Shutdown();
 
     GameStringManager_Shutdown();
     GameString_Shutdown();

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -6,6 +6,7 @@
 #include "game/console/common.h"
 #include "game/input/backends/controller.h"
 #include "game/input/backends/keyboard.h"
+#include "game/input/common.h"
 #include "game/lara.h"
 #include "game/random.h"
 
@@ -56,14 +57,19 @@ static const char *M_DumpEvent(const SDL_Event *const event)
 {
     switch (event->type) {
     case SDL_KEYDOWN:
+        // NOTE: we do not serialize the modifiers to avoid noise, as currently
+        // they are unused by the engine. In the future, once we add support
+        // for compound keybindings, it may become necessary to either
+        // serialize them, or simulate them in the replay module.
         return String_FormatStatic(
-            "keydown %d %hu", event->key.keysym.scancode,
-            event->key.keysym.mod);
-    case SDL_TEXTINPUT:
-        return String_FormatStatic("text-input \"%s\"", event->text.text);
+            "keydown \"%s\"",
+            Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
     case SDL_KEYUP:
         return String_FormatStatic(
-            "keyup %d %hu", event->key.keysym.scancode, event->key.keysym.mod);
+            "keyup \"%s\"",
+            Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
+    case SDL_TEXTINPUT:
+        return String_FormatStatic("text-input \"%s\"", event->text.text);
     case SDL_QUIT:
         return String_FormatStatic("quit");
     }
@@ -203,7 +209,9 @@ static void M_DumpBindings(MYFILE *const fp)
                 g_Config.input.keyboard_layout, role, bind)) {
             const SDL_Scancode sc =
                 JSON_ObjectGetInt(bind, "scancode", SDL_SCANCODE_UNKNOWN);
-            File_WriteString(fp, "bind keyboard %d %d\n", role, sc);
+            File_WriteString(
+                fp, "bind keyboard %d \"%s\"\n", role,
+                Input_KeyDescFromSDL(sc, 0));
         }
         JSON_ObjectFree(bind);
     }

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -9,6 +9,9 @@
 #include "game/lara.h"
 #include "game/random.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 #define M_DEBUG 0
 #define M_MAX_EVENTS 64 // Maximum SDL or custom events per frame
 
@@ -22,8 +25,20 @@ typedef struct {
 
 static M_PRIV m_Priv = {};
 
+static int M_CompareConfigOption(const void *a, const void *b);
 static const char *M_DumpEvent(const SDL_Event *event);
 static void M_DumpQueue(M_PRIV *p);
+static void M_DumpHeader(MYFILE *fp);
+static void M_DumpArguments(MYFILE *fp, VECTOR *original_args);
+static void M_DumpConfig(MYFILE *fp);
+static void M_DumpBindings(MYFILE *fp);
+
+static int M_CompareConfigOption(const void *a, const void *b)
+{
+    const CONFIG_OPTION *const *opt_a = a;
+    const CONFIG_OPTION *const *opt_b = b;
+    return strcmp((*opt_a)->name, (*opt_b)->name);
+}
 
 static const char *M_DumpEvent(const SDL_Event *const event)
 {
@@ -97,59 +112,74 @@ static void M_DumpQueue(M_PRIV *const p)
     p->prev_frame_idx = p->frame_idx;
 }
 
-void TestRecorder_Open(const char *path, VECTOR *const original_args)
+static void M_DumpHeader(MYFILE *const fp)
 {
-    M_PRIV *const p = &m_Priv;
-    p->file = File_Open(path, FILE_OPEN_WRITE);
-    if (p->file == nullptr) {
-        LOG_ERROR("Cannot open record file '%s'", path);
+    File_WriteString(fp, "seed_control %d\n", Random_GetControlSeed());
+    File_WriteString(fp, "seed_draw %d\n", Random_GetDrawSeed());
+}
+
+static void M_DumpArguments(MYFILE *const fp, VECTOR *const original_args)
+{
+    // Record original arguments passed to the game
+    if (original_args->count <= 0) {
         return;
     }
-    File_WriteString(p->file, "seed_control %d\n", Random_GetControlSeed());
-    File_WriteString(p->file, "seed_draw %d\n", Random_GetDrawSeed());
 
-    // Record original arguments passed to the game
-    if (original_args->count > 0) {
-        // Skip tracking irrelevant arguments.
-        VECTOR *const filtered_args = Vector_Create(sizeof(char *));
-        for (int32_t i = 0; i < original_args->count; i++) {
-            const char *const arg = *(char **)Vector_Get(original_args, i);
-            if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
-                || !strcmp(arg, "--test-play")
-                || !strcmp(arg, "--headless-fps")) {
-                i++; // Also skip the path argument.
-                continue;
-            }
-            if (!strcmp(arg, "--debug-render-performance")) {
-                continue;
-            }
-            Vector_Add(filtered_args, &arg);
+    // Skip tracking irrelevant arguments.
+    VECTOR *const filtered_args = Vector_Create(sizeof(char *));
+    for (int32_t i = 0; i < original_args->count; i++) {
+        const char *const arg = *(char **)Vector_Get(original_args, i);
+        if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
+            || !strcmp(arg, "--test-play") || !strcmp(arg, "--headless-fps")) {
+            i++; // Also skip the path argument.
+            continue;
         }
-
-        if (filtered_args->count > 0) {
-            File_WriteString(p->file, "args");
-            for (int32_t i = 0; i < filtered_args->count; i++) {
-                const char *const arg = *(char **)Vector_Get(filtered_args, i);
-                File_WriteString(p->file, " \"%s\"", arg);
-            }
-            File_WriteString(p->file, "\n");
+        if (!strcmp(arg, "--debug-render-performance")) {
+            continue;
         }
-        Vector_Free(filtered_args);
+        Vector_Add(filtered_args, &arg);
     }
 
+    if (filtered_args->count > 0) {
+        File_WriteString(fp, "args");
+        for (int32_t i = 0; i < filtered_args->count; i++) {
+            const char *const arg = *(char **)Vector_Get(filtered_args, i);
+            File_WriteString(fp, " \"%s\"", arg);
+        }
+        File_WriteString(fp, "\n");
+    }
+    Vector_Free(filtered_args);
+}
+
+static void M_DumpConfig(MYFILE *const fp)
+{
     // Record any non-default config options for later replay
-    for (const CONFIG_OPTION *opt = Config_GetOptionMap(); opt->name != nullptr;
-         opt++) {
+    const CONFIG_OPTION *const map = Config_GetOptionMap();
+    VECTOR *opts = Vector_Create(sizeof(CONFIG_OPTION *));
+
+    for (const CONFIG_OPTION *opt = map; opt->name != nullptr; opt++) {
         if (Config_IsOptionAtDefault(opt->target)) {
             continue;
         }
+        Vector_Add(opts, &opt);
+    }
+
+    CONFIG_OPTION **raw_opts = Vector_GetData(opts);
+    qsort(
+        raw_opts, opts->count, sizeof(CONFIG_OPTION *), M_CompareConfigOption);
+    for (int32_t i = 0; i < opts->count; i++) {
+        const CONFIG_OPTION *opt = raw_opts[i];
         const char *const fmt = opt->type == COT_ENUM || opt->type == COT_STRING
             ? "config %s \"%s\"\n"
             : "config %s %s\n";
         File_WriteString(
-            p->file, fmt, opt->name, Config_GetOptionValueAsString(opt));
+            fp, fmt, opt->name, Config_GetOptionValueAsString(opt));
     }
+    Vector_Free(opts);
+}
 
+static void M_DumpBindings(MYFILE *const fp)
+{
     // Record any non-default key/controller bindings for later replay.
     // Keyboard binds
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
@@ -157,7 +187,7 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
         if (g_Input_Keyboard.assign_to_json_object(
                 g_Config.input.keyboard_layout, role, bind)) {
             const int32_t sc = JSON_ObjectGetInt(bind, "scancode", -1);
-            File_WriteString(p->file, "bind keyboard %d %d\n", role, sc);
+            File_WriteString(fp, "bind keyboard %d %d\n", role, sc);
         }
         JSON_ObjectFree(bind);
     }
@@ -170,12 +200,26 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
             const int32_t b = JSON_ObjectGetInt(bind, "bind", 0);
             const int32_t ad = JSON_ObjectGetInt(bind, "axis_dir", 0);
             File_WriteString(
-                p->file, "bind controller %d %d %d %d\n", role, bt, b, ad);
+                fp, "bind controller %d %d %d %d\n", role, bt, b, ad);
         }
         JSON_ObjectFree(bind);
     }
-    File_WriteString(p->file, "\n");
+    File_WriteString(fp, "\n");
+}
 
+void TestRecorder_Open(const char *path, VECTOR *const original_args)
+{
+    M_PRIV *const p = &m_Priv;
+    p->file = File_Open(path, FILE_OPEN_WRITE);
+    if (p->file == nullptr) {
+        LOG_ERROR("Cannot open record file '%s'", path);
+        return;
+    }
+
+    M_DumpHeader(p->file);
+    M_DumpArguments(p->file, original_args);
+    M_DumpConfig(p->file);
+    M_DumpBindings(p->file);
     LOG_INFO("Starting recording");
 }
 

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -14,6 +14,7 @@
 
 typedef struct {
     MYFILE *file;
+    int32_t prev_frame_idx;
     int32_t frame_idx;
     SDL_Event queue[M_MAX_EVENTS];
     int32_t queue_size;
@@ -49,41 +50,51 @@ static void M_DumpQueue(M_PRIV *const p)
         return;
     }
 #endif
-    File_WriteString(p->file, "frame %d:", p->frame_idx);
+    const size_t indent = 8;
+    File_WriteString(
+        p->file, "%-*s", indent,
+        String_FormatStatic("@+%d:", p->frame_idx - p->prev_frame_idx));
     for (int32_t i = 0; i < p->queue_size; i++) {
         const SDL_Event *const event = &p->queue[i];
         const char *const event_str = M_DumpEvent(event);
         if (event_str == nullptr) {
             continue;
         }
-        File_WriteString(p->file, " ");
         File_WriteString(p->file, event_str);
         if (i < p->queue_size - 1) {
-            File_WriteString(p->file, ";");
+            File_WriteString(p->file, "\n%*s", indent, "");
         }
     }
 #if M_DEBUG
+    if (p->queue_size == 0) {
+        File_WriteString(p->file, "noop");
+    }
     const ITEM *const lara_item = Lara_GetItem();
     const GAME_OBJECT_ID obj_id = Lara_GetAnimationObject();
     const ITEM *const vehicle_item = Lara_Vehicle_GetItem();
     if (lara_item != nullptr) {
+        File_WriteString(p->file, "\n%*s", indent, "");
         File_WriteString(
-            p->file, "; assert lara.pos=%d,%d,%d", lara_item->pos.x,
+            p->file, "assert lara.pos=%d,%d,%d", lara_item->pos.x,
             lara_item->pos.y, lara_item->pos.z);
+        File_WriteString(p->file, "\n%*s", indent, "");
         File_WriteString(
-            p->file, "; assert lara.rot=%d,%d,%d", lara_item->rot.x,
+            p->file, "assert lara.rot=%d,%d,%d", lara_item->rot.x,
             lara_item->rot.y, lara_item->rot.z);
+        File_WriteString(p->file, "\n%*s", indent, "");
         File_WriteString(
-            p->file, "; assert lara.anim=%d,%d,%d", obj_id,
+            p->file, "assert lara.anim=%d,%d,%d", obj_id,
             Item_GetRelativeObjAnim(lara_item, obj_id),
             Item_GetRelativeFrame(lara_item));
+        File_WriteString(p->file, "\n%*s", indent, "");
         File_WriteString(
-            p->file, "; assert lara.speed=%d,%d",
+            p->file, "assert lara.speed=%d,%d",
             (vehicle_item != nullptr ? vehicle_item : lara_item)->speed,
             (vehicle_item != nullptr ? vehicle_item : lara_item)->fall_speed);
     }
 #endif
     File_WriteString(p->file, "\n");
+    p->prev_frame_idx = p->frame_idx;
 }
 
 void TestRecorder_Open(const char *path, VECTOR *const original_args)

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -201,7 +201,8 @@ static void M_DumpBindings(MYFILE *const fp)
         JSON_OBJECT *bind = JSON_ObjectNew();
         if (g_Input_Keyboard.assign_to_json_object(
                 g_Config.input.keyboard_layout, role, bind)) {
-            const int32_t sc = JSON_ObjectGetInt(bind, "scancode", -1);
+            const SDL_Scancode sc =
+                JSON_ObjectGetInt(bind, "scancode", SDL_SCANCODE_UNKNOWN);
             File_WriteString(fp, "bind keyboard %d %d\n", role, sc);
         }
         JSON_ObjectFree(bind);

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -5,11 +5,13 @@
 #include "enum_map.h"
 #include "filesystem.h"
 #include "game/console/common.h"
+#include "game/events.h"
 #include "game/input/backends/controller.h"
 #include "game/input/backends/keyboard.h"
 #include "game/input/common.h"
 #include "game/lara.h"
 #include "game/random.h"
+#include "memory.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -17,12 +19,21 @@
 #define M_DEBUG 0
 #define M_MAX_EVENTS 64 // Maximum SDL or custom events per frame
 
+static void M_HandleGameEvent(const EVENT *event, void *user_data);
+
+// Internal event codes for recorder swimlane
+typedef enum {
+    M_CUSTOM_EVENT_SCREENSHOT,
+    M_CUSTOM_EVENT_COMMAND,
+} M_CUSTOM_EVENT;
+
 typedef struct {
     MYFILE *file;
     int32_t prev_frame_idx;
     int32_t frame_idx;
     SDL_Event queue[M_MAX_EVENTS];
     int32_t queue_size;
+    int32_t listeners[2];
 } M_PRIV;
 
 static const struct {
@@ -57,6 +68,19 @@ static int M_CompareConfigOption(const void *a, const void *b)
 static const char *M_DumpEvent(const SDL_Event *const event)
 {
     switch (event->type) {
+    case SDL_USEREVENT:
+        const char *result = nullptr;
+        if (event->user.code == M_CUSTOM_EVENT_SCREENSHOT) {
+            char *path = event->user.data1;
+            result = String_FormatStatic("noop  # cmd \"screenshot %s\"", path);
+            Memory_FreePointer(&path);
+        } else if (event->user.code == M_CUSTOM_EVENT_COMMAND) {
+            char *cmd = event->user.data1;
+            result = String_FormatStatic("noop  # cmd \"%s\"", cmd);
+            Memory_FreePointer(&cmd);
+        }
+        return result;
+
     case SDL_KEYDOWN:
         // NOTE: we do not serialize the modifiers to avoid noise, as currently
         // they are unused by the engine. In the future, once we add support
@@ -64,14 +88,18 @@ static const char *M_DumpEvent(const SDL_Event *const event)
         // serialize them, or simulate them in the replay module.
         return String_FormatStatic(
             "● \"%s\"", Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
+
     case SDL_KEYUP:
         return String_FormatStatic(
             "○ \"%s\"", Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
+
     case SDL_TEXTINPUT:
         return String_FormatStatic("text-input \"%s\"", event->text.text);
+
     case SDL_QUIT:
         return String_FormatStatic("quit");
     }
+
     return nullptr;
 }
 
@@ -245,6 +273,12 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
     M_DumpArguments(p->file, original_args);
     M_DumpConfig(p->file);
     M_DumpBindings(p->file);
+
+    p->listeners[0] = GameEvent_Subscribe(
+        GAME_EVENT_SCREENSHOT, nullptr, M_HandleGameEvent, nullptr);
+    p->listeners[1] = GameEvent_Subscribe(
+        GAME_EVENT_COMMAND, nullptr, M_HandleGameEvent, nullptr);
+
     LOG_INFO("Starting recording");
 }
 
@@ -261,6 +295,9 @@ void TestRecorder_Close(void)
         File_Close(p->file);
         p->file = nullptr;
     }
+
+    GameEvent_Unsubscribe(p->listeners[0]);
+    GameEvent_Unsubscribe(p->listeners[1]);
 }
 
 void TestRecorder_BeginFrame(void)
@@ -280,6 +317,22 @@ void TestRecorder_EndFrame(void)
     p->frame_idx++;
 }
 
+// Callback for game events: inject synthetic SDL_USEREVENT into queue
+static void M_HandleGameEvent(const EVENT *const event, void *const user_data)
+{
+    M_PRIV *const p = &m_Priv;
+    if (p->file == nullptr || p->queue_size >= M_MAX_EVENTS) {
+        return;
+    }
+    SDL_Event ev = { .type = SDL_USEREVENT };
+    ev.user.code = (strcmp(event->name, GAME_EVENT_SCREENSHOT) == 0)
+        ? M_CUSTOM_EVENT_SCREENSHOT
+        : M_CUSTOM_EVENT_COMMAND;
+    ev.user.data1 = Memory_DupStr(event->data);
+    ev.user.data2 = nullptr;
+    p->queue[p->queue_size++] = ev;
+}
+
 void TestRecorder_RecordEvent(const SDL_Event *const event)
 {
     M_PRIV *const p = &m_Priv;
@@ -289,7 +342,8 @@ void TestRecorder_RecordEvent(const SDL_Event *const event)
 
     // Only record eligible events
     if (event->type != SDL_KEYDOWN && event->type != SDL_KEYUP
-        && event->type != SDL_QUIT && event->type != SDL_TEXTINPUT) {
+        && event->type != SDL_QUIT && event->type != SDL_TEXTINPUT
+        && event->type != SDL_USEREVENT) {
         return;
     }
     if (event->type == SDL_KEYDOWN && event->key.repeat) {

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -23,6 +23,18 @@ typedef struct {
     int32_t queue_size;
 } M_PRIV;
 
+static const struct {
+    const char *arg;
+    bool takes_value;
+} m_SkipArgs[] = {
+    { "--debug-render-performance", false },
+    { "--test-record", true },
+    { "--test-replay", true },
+    { "--test-play", true },
+    { "--headless-fps", true },
+    { nullptr, false },
+};
+
 static M_PRIV m_Priv = {};
 
 static int M_CompareConfigOption(const void *a, const void *b);
@@ -129,15 +141,18 @@ static void M_DumpArguments(MYFILE *const fp, VECTOR *const original_args)
     VECTOR *const filtered_args = Vector_Create(sizeof(char *));
     for (int32_t i = 0; i < original_args->count; i++) {
         const char *const arg = *(char **)Vector_Get(original_args, i);
-        if (!strcmp(arg, "--test-record") || !strcmp(arg, "--test-replay")
-            || !strcmp(arg, "--test-play") || !strcmp(arg, "--headless-fps")) {
-            i++; // Also skip the path argument.
-            continue;
+        int32_t skip = 0;
+        for (size_t j = 0; m_SkipArgs[j].arg != nullptr; j++) {
+            if (strcmp(arg, m_SkipArgs[j].arg) == 0) {
+                skip = 1 + m_SkipArgs[j].takes_value;
+                break;
+            }
         }
-        if (!strcmp(arg, "--debug-render-performance")) {
-            continue;
+        if (skip) {
+            i += skip - 1;
+        } else {
+            Vector_Add(filtered_args, &arg);
         }
-        Vector_Add(filtered_args, &arg);
     }
 
     if (filtered_args->count > 0) {

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -63,12 +63,10 @@ static const char *M_DumpEvent(const SDL_Event *const event)
         // for compound keybindings, it may become necessary to either
         // serialize them, or simulate them in the replay module.
         return String_FormatStatic(
-            "keydown \"%s\"",
-            Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
+            "● \"%s\"", Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
     case SDL_KEYUP:
         return String_FormatStatic(
-            "keyup \"%s\"",
-            Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
+            "○ \"%s\"", Input_KeyDescFromSDL(event->key.keysym.scancode, 0));
     case SDL_TEXTINPUT:
         return String_FormatStatic("text-input \"%s\"", event->text.text);
     case SDL_QUIT:

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -140,11 +140,14 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
     // Record any non-default config options for later replay
     for (const CONFIG_OPTION *opt = Config_GetOptionMap(); opt->name != nullptr;
          opt++) {
-        if (!Config_IsOptionAtDefault(opt->target)) {
-            File_WriteString(
-                p->file, "config %s %s\n", opt->name,
-                Config_GetOptionValueAsString(opt));
+        if (Config_IsOptionAtDefault(opt->target)) {
+            continue;
         }
+        const char *const fmt = opt->type == COT_ENUM || opt->type == COT_STRING
+            ? "config %s \"%s\"\n"
+            : "config %s %s\n";
+        File_WriteString(
+            p->file, fmt, opt->name, Config_GetOptionValueAsString(opt));
     }
 
     // Record any non-default key/controller bindings for later replay.

--- a/src/libtrx/game/test_recorder.c
+++ b/src/libtrx/game/test_recorder.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "debug.h"
+#include "enum_map.h"
 #include "filesystem.h"
 #include "game/console/common.h"
 #include "game/input/backends/controller.h"
@@ -210,7 +211,8 @@ static void M_DumpBindings(MYFILE *const fp)
             const SDL_Scancode sc =
                 JSON_ObjectGetInt(bind, "scancode", SDL_SCANCODE_UNKNOWN);
             File_WriteString(
-                fp, "bind keyboard %d \"%s\"\n", role,
+                fp, "bind keyboard %s \"%s\"\n",
+                ENUM_MAP_TO_STRING(INPUT_ROLE, role),
                 Input_KeyDescFromSDL(sc, 0));
         }
         JSON_ObjectFree(bind);
@@ -224,7 +226,8 @@ static void M_DumpBindings(MYFILE *const fp)
             const int32_t b = JSON_ObjectGetInt(bind, "bind", 0);
             const int32_t ad = JSON_ObjectGetInt(bind, "axis_dir", 0);
             File_WriteString(
-                fp, "bind controller %d %d %d %d\n", role, bt, b, ad);
+                fp, "bind controller %s %d %d %d\n",
+                ENUM_MAP_TO_STRING(INPUT_ROLE, role), bt, b, ad);
         }
         JSON_ObjectFree(bind);
     }

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -435,6 +435,12 @@ static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
     char keybuf[64];
     char valbuf[128];
     if (sscanf(line, "config %63s %127s", keybuf, valbuf) == 2) {
+        // Strip surrounding quotes from the value, if present
+        size_t vlen = strlen(valbuf);
+        if (vlen >= 2 && valbuf[0] == '"' && valbuf[vlen - 1] == '"') {
+            valbuf[vlen - 1] = '\0';
+            memmove(valbuf, valbuf + 1, vlen - 1);
+        }
         const CONFIG_OPTION *opt = Config_GetOptionByPath(keybuf);
         if (opt) {
             Config_SetOptionValueFromString(opt, valbuf);

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -43,6 +43,7 @@ static bool M_ParseKeyDownEvent(const char *event_str);
 static bool M_ParseKeyUpEvent(const char *event_str);
 static bool M_ParseTextInputEvent(const char *event_str);
 static bool M_ParseCommandEvent(const char *event_str);
+static bool M_ParseNoopEvent(const char *event_str);
 static bool M_ParseLuaEvent(const char *event_str);
 static bool M_ParseAssertEvent(const char *event_str);
 
@@ -77,6 +78,7 @@ static const M_EVENT_HANDLER m_EventHandlers[] = {
     M_ParseKeyDownEvent,
     M_ParseKeyUpEvent,
     M_ParseTextInputEvent,
+    M_ParseNoopEvent,
     M_ParseCommandEvent,
     M_ParseLuaEvent,
 #if M_DEBUG
@@ -141,6 +143,15 @@ static bool M_ParseTextInputEvent(const char *const event_str)
         return false;
     }
     Shell_ProcessEvent(&event);
+    return true;
+}
+
+static bool M_ParseNoopEvent(const char *const event_str)
+{
+    // No-op event for inline comments and empty frame markers
+    if (strncmp(event_str, "noop", 4) != 0) {
+        return false;
+    }
     return true;
 }
 

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -6,6 +6,7 @@
 #include "game/console/common.h"
 #include "game/input/backends/controller.h"
 #include "game/input/backends/keyboard.h"
+#include "game/input/common.h"
 #include "game/lara.h"
 #include "game/lua.h"
 #include "game/random.h"
@@ -93,32 +94,44 @@ static bool M_ParseQuitEvent(const char *const event_str)
     return true;
 }
 
-static bool M_ParseKeyDownEvent(const char *const event_str)
+// Consolidate keydown/keyup parsing into a single helper
+static bool M_ParseKeyEvent(
+    const char *event_str, SDL_EventType type, const char *prefix)
 {
-    SDL_Event event = { .type = SDL_KEYDOWN };
-    if (sscanf(
-            event_str, "keydown %hu %hu",
-            (uint16_t *)&event.key.keysym.scancode, &event.key.keysym.mod)
-        != 2) {
+    if (strncmp(event_str, prefix, strlen(prefix)) != 0) {
         return false;
     }
+    SDL_Event event = { .type = type };
+    const char *p = event_str + strlen(prefix);
+    const char *start = strchr(p, '"');
+    const char *end = start ? strrchr(start + 1, '"') : nullptr;
+    if (!start || !end || end <= start + 1) {
+        LOG_WARNING("Malformed %s instruction: %s", prefix, event_str);
+        return false;
+    }
+    char desc[64];
+    int slen = (int)(end - (start + 1));
+    const char *substr = String_FormatStatic("%.*s", slen, start + 1);
+    strncpy(desc, substr, sizeof(desc));
+    desc[sizeof(desc) - 1] = '\0';
+    SDL_Keymod mod;
+    if (!Input_ParseKeyDesc(desc, &event.key.keysym.scancode, &mod)) {
+        return false;
+    }
+    event.key.keysym.mod = mod;
     event.key.keysym.sym = SDL_GetKeyFromScancode(event.key.keysym.scancode);
     Shell_ProcessEvent(&event);
     return true;
 }
 
-static bool M_ParseKeyUpEvent(const char *const event_str)
+static bool M_ParseKeyDownEvent(const char *event_str)
 {
-    SDL_Event event = { .type = SDL_KEYUP };
-    if (sscanf(
-            event_str, "keyup %hu %hu", (uint16_t *)&event.key.keysym.scancode,
-            &event.key.keysym.mod)
-        != 2) {
-        return false;
-    }
-    event.key.keysym.sym = SDL_GetKeyFromScancode(event.key.keysym.scancode);
-    Shell_ProcessEvent(&event);
-    return true;
+    return M_ParseKeyEvent(event_str, SDL_KEYDOWN, "keydown");
+}
+
+static bool M_ParseKeyUpEvent(const char *event_str)
+{
+    return M_ParseKeyEvent(event_str, SDL_KEYUP, "keyup");
 }
 
 static bool M_ParseTextInputEvent(const char *const event_str)
@@ -363,17 +376,35 @@ static bool M_ParseSeedDraw(const char *const line, M_PARSE_CTX *const ctx)
 
 static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
 {
-    int32_t role;
-    int32_t scancode;
-    if (sscanf(line, "bind keyboard %d %d", &role, &scancode) == 2) {
-        JSON_OBJECT *bind = JSON_ObjectNew();
-        JSON_ObjectAppendInt(bind, "scancode", scancode);
-        g_Input_Keyboard.assign_from_json_object(
-            g_Config.input.keyboard_layout, role, bind);
-        JSON_ObjectFree(bind);
-        return true;
+    const char *prefix = "bind keyboard ";
+    if (strncmp(line, prefix, strlen(prefix)) != 0) {
+        return false;
     }
-    return false;
+    const char *p = line + strlen(prefix);
+    int32_t role;
+    if (sscanf(p, "%d", &role) != 1) {
+        return false;
+    }
+    const char *const start = strchr(p, '"');
+    const char *const end = start ? strrchr(start + 1, '"') : nullptr;
+    if (start == nullptr || end == nullptr || end <= start + 1) {
+        LOG_WARNING("Malformed bind keyboard instruction: %s", line);
+        return false;
+    }
+    const size_t slen = end - (start + 1);
+    const char *desc = String_FormatStatic("%.*s", slen, start + 1);
+    SDL_Scancode sc;
+    SDL_Keymod mod;
+    if (!Input_ParseKeyDesc(desc, &sc, &mod)) {
+        return false;
+    }
+    JSON_OBJECT *const bind = JSON_ObjectNew();
+    JSON_ObjectAppendInt(bind, "scancode", sc);
+    JSON_ObjectAppendInt(bind, "mod", mod);
+    g_Input_Keyboard.assign_from_json_object(
+        g_Config.input.keyboard_layout, role, bind);
+    JSON_ObjectFree(bind);
+    return true;
 }
 
 static bool M_ParseBindController(

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -14,6 +14,9 @@
 #include "memory.h"
 #include "vector.h"
 
+#include <ctype.h>
+#include <string.h>
+
 #define M_DEBUG 0
 
 typedef struct {
@@ -53,6 +56,7 @@ static bool M_ParseConfig(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseEvent(const char *event_str);
 static void M_ReadHeaders(M_PRIV *p, M_PARSE_CTX *ctx);
 static void M_ClearEventQueue(M_PRIV *p);
+static void M_StripInlineComment(char *const line);
 static void M_ReadQueue(M_PRIV *p);
 static void M_RunQueue(M_PRIV *p);
 
@@ -227,6 +231,28 @@ static void M_ClearQueue(M_PRIV *const p)
     }
 }
 
+static void M_StripInlineComment(char *const line)
+{
+    bool in_quote = false;
+    char *p;
+    for (p = line; *p != '\0'; ++p) {
+        if (*p == '"') {
+            in_quote = !in_quote;
+        } else if (*p == '#' && !in_quote) {
+            *p = '\0';
+            break;
+        }
+    }
+    // Trim trailing whitespace
+    {
+        char *end = line + strlen(line);
+        while (end > line && (end[-1] == ' ' || end[-1] == '\t')) {
+            end[-1] = '\0';
+            end--;
+        }
+    }
+}
+
 static void M_ReadQueue(M_PRIV *const p)
 {
     M_ClearQueue(p);
@@ -242,6 +268,7 @@ static void M_ReadQueue(M_PRIV *const p)
         if (line[strlen(line) - 1] == '\n') {
             line[strlen(line) - 1] = '\0';
         }
+        M_StripInlineComment(line);
 
         // Expect a frame marker: @+<delta>:
         char *const colon = strchr(line, ':');
@@ -285,6 +312,7 @@ static void M_ReadQueue(M_PRIV *const p)
             if (len > 0 && cont[len - 1] == '\n') {
                 cont[len - 1] = '\0';
             }
+            M_StripInlineComment(cont);
             if (cont[0] != ' ' && cont[0] != '\t') {
                 File_Skip(p->file, -strlen(cont));
                 break;
@@ -421,13 +449,14 @@ static bool M_ParseConfig(const char *const line, M_PARSE_CTX *const ctx)
 static void M_ReadHeaders(M_PRIV *const p, M_PARSE_CTX *const ctx)
 {
     while (true) {
-        const char *const line = File_ReadLine(p->file);
+        char *const line = (char *)File_ReadLine(p->file);
         if (line == nullptr) {
             break;
         }
+        M_StripInlineComment(line);
 
         // Skip comments and blank lines
-        if (line[0] == '\n' || line[0] == '#') {
+        if (line[0] == '\n') {
             continue;
         }
 

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "debug.h"
+#include "enum_map.h"
 #include "filesystem.h"
 #include "game/console/common.h"
 #include "game/input/backends/controller.h"
@@ -109,11 +110,8 @@ static bool M_ParseKeyEvent(
         LOG_WARNING("Malformed %s instruction: %s", prefix, event_str);
         return false;
     }
-    char desc[64];
-    int slen = (int)(end - (start + 1));
-    const char *substr = String_FormatStatic("%.*s", slen, start + 1);
-    strncpy(desc, substr, sizeof(desc));
-    desc[sizeof(desc) - 1] = '\0';
+    const size_t slen = end - (start + 1);
+    const char *desc = String_FormatStatic("%.*s", slen, start + 1);
     SDL_Keymod mod;
     if (!Input_ParseKeyDesc(desc, &event.key.keysym.scancode, &mod)) {
         return false;
@@ -381,8 +379,13 @@ static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
         return false;
     }
     const char *p = line + strlen(prefix);
-    int32_t role;
-    if (sscanf(p, "%d", &role) != 1) {
+    const char *q = strchr(p, ' ');
+    if (q == nullptr) {
+        return false;
+    }
+    const char *role_str = String_FormatStatic("%.*s", (int)(q - p), p);
+    const INPUT_ROLE role = ENUM_MAP_GET(INPUT_ROLE, role_str, -1);
+    if (role == (INPUT_ROLE)-1) {
         return false;
     }
     const char *const start = strchr(p, '"');
@@ -410,11 +413,23 @@ static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
 static bool M_ParseBindController(
     const char *const line, M_PARSE_CTX *const ctx)
 {
-    int32_t role;
-    int32_t bt;
-    int32_t b;
-    int32_t ad;
-    if (sscanf(line, "bind controller %d %d %d %d", &role, &bt, &b, &ad) == 4) {
+    const char *prefix = "bind controller ";
+    if (strncmp(line, prefix, strlen(prefix)) != 0) {
+        return false;
+    }
+    const char *p = line + strlen(prefix);
+    const char *q = strchr(p, ' ');
+    if (q == nullptr) {
+        return false;
+    }
+    const char *role_str = String_FormatStatic("%.*s", (int)(q - p), p);
+    const INPUT_ROLE role =
+        (INPUT_ROLE)ENUM_MAP_GET(INPUT_ROLE, role_str, (int32_t)(INPUT_ROLE)-1);
+    if (role == (INPUT_ROLE)-1) {
+        return false;
+    }
+    int32_t bt, b, ad;
+    if (sscanf(q + 1, "%d %d %d", &bt, &b, &ad) == 3) {
         JSON_OBJECT *bind = JSON_ObjectNew();
         JSON_ObjectAppendInt(bind, "button_type", bt);
         JSON_ObjectAppendInt(bind, "bind", b);

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -230,6 +230,7 @@ static void M_ClearQueue(M_PRIV *const p)
 static void M_ReadQueue(M_PRIV *const p)
 {
     M_ClearQueue(p);
+
     while (true) {
         char *const line = (char *)File_ReadLine(p->file);
         if (line == nullptr) {
@@ -242,32 +243,60 @@ static void M_ReadQueue(M_PRIV *const p)
             line[strlen(line) - 1] = '\0';
         }
 
+        // Expect a frame marker: @+<delta>:
         char *const colon = strchr(line, ':');
         if (colon == nullptr) {
             LOG_ERROR("Malformed input line: %s", line);
-            continue; // Malformed line
-        }
-        *colon = '\0';
-
-        int32_t frame = -1;
-        if (sscanf(line, "frame %d", &frame) != 1) {
-            LOG_ERROR("Malformed input line: %s", line);
             continue;
         }
-
-        p->next_frame_idx = frame;
-
-        char *const events_str = colon + 1;
-        const char *token = strtok(events_str, ";");
-        while (token != nullptr) {
-            while (*token == ' ' || *token == '\t') {
-                token++; // trim leading space
+        int32_t delta = 0;
+        {
+            char *marker = line;
+            if (*marker == '@') {
+                marker++;
             }
+            if (*marker != '+' || sscanf(marker + 1, "%d", &delta) != 1) {
+                LOG_ERROR("Malformed input line: %s", line);
+                continue;
+            }
+        }
+        p->next_frame_idx = p->frame_idx + delta;
 
-            char *const event_str = Memory_DupStr(token);
+        // First event on this line (after colon)
+        char *p_event = colon + 1;
+        while (*p_event == ' ' || *p_event == '\t') {
+            p_event++;
+        }
+        if (*p_event != '\0') {
+            char *const event_str = Memory_DupStr(p_event);
             Vector_Add(p->queue, &event_str);
+        }
 
-            token = strtok(nullptr, ";");
+        // Continuation lines for this frame
+        while (true) {
+            char *const cont = (char *)File_ReadLine(p->file);
+            if (cont == nullptr) {
+                break;
+            }
+            if (cont[0] == '#' || cont[0] == '\n') {
+                continue;
+            }
+            size_t len = strlen(cont);
+            if (len > 0 && cont[len - 1] == '\n') {
+                cont[len - 1] = '\0';
+            }
+            if (cont[0] != ' ' && cont[0] != '\t') {
+                File_Skip(p->file, -strlen(cont));
+                break;
+            }
+            char *p_cont = cont;
+            while (*p_cont == ' ' || *p_cont == '\t') {
+                p_cont++;
+            }
+            if (*p_cont != '\0') {
+                char *const event_str = Memory_DupStr(p_cont);
+                Vector_Add(p->queue, &event_str);
+            }
         }
         return;
     }
@@ -278,9 +307,6 @@ static void M_ReadQueue(M_PRIV *const p)
 
 static void M_RunQueue(M_PRIV *const p)
 {
-#if M_DEBUG
-    LOG_INFO("%d", p->frame_idx);
-#endif
     for (int32_t i = 0; i < p->queue->count; i++) {
         const char *const event_str = *(char **)Vector_Get(p->queue, i);
         M_ParseEvent(event_str);
@@ -405,11 +431,14 @@ static void M_ReadHeaders(M_PRIV *const p, M_PARSE_CTX *const ctx)
             continue;
         }
 
-        // Stop when a non-comment is encountered
-        int32_t frame = 0;
-        if (sscanf(line, "frame %d:", &frame) == 1) {
-            File_Skip(p->file, -strlen(line));
-            break;
+        // Stop at first replay frame marker (@+<delta>:), rewind to allow its
+        // parsing
+        {
+            int32_t rel = 0;
+            if (sscanf(line, "@+%d:", &rel) == 1) {
+                File_Skip(p->file, -strlen(line));
+                break;
+            }
         }
 
         // Dispatch based on matching prefix

--- a/src/libtrx/game/test_replay.c
+++ b/src/libtrx/game/test_replay.c
@@ -124,12 +124,12 @@ static bool M_ParseKeyEvent(
 
 static bool M_ParseKeyDownEvent(const char *event_str)
 {
-    return M_ParseKeyEvent(event_str, SDL_KEYDOWN, "keydown");
+    return M_ParseKeyEvent(event_str, SDL_KEYDOWN, "●");
 }
 
 static bool M_ParseKeyUpEvent(const char *event_str)
 {
-    return M_ParseKeyEvent(event_str, SDL_KEYUP, "keyup");
+    return M_ParseKeyEvent(event_str, SDL_KEYUP, "○");
 }
 
 static bool M_ParseTextInputEvent(const char *const event_str)

--- a/src/libtrx/game/ui/hud/console.c
+++ b/src/libtrx/game/ui/hud/console.c
@@ -1,6 +1,7 @@
 #include "game/ui/hud/console.h"
 
 #include "game/console.h"
+#include "game/events.h"
 #include "game/ui/elements/modal.h"
 #include "game/ui/elements/pad.h"
 #include "game/ui/elements/prompt.h"
@@ -10,6 +11,7 @@
 #include "game/ui/helpers.h"
 #include "game/ui/hud/console_logs.h"
 #include "game/ui/text.h"
+#include "memory.h"
 #include "utils.h"
 
 static void M_Draw(const UI_NODE *node);
@@ -86,6 +88,10 @@ static void M_HandleConfirm(const EVENT *event, void *user_data)
     const char *text = event->data;
     Console_History_Append(text);
     Console_Eval(text);
+    GameEvent_Fire((EVENT) {
+        .name = GAME_EVENT_COMMAND,
+        .data = text,
+    });
     Console_Close();
     s->history_idx = Console_History_GetLength();
 }

--- a/src/libtrx/include/libtrx/event_manager.h
+++ b/src/libtrx/include/libtrx/event_manager.h
@@ -5,7 +5,7 @@
 typedef struct {
     const char *name;
     const void *sender;
-    void *data;
+    const void *data;
 } EVENT;
 
 typedef void (*EVENT_LISTENER)(const EVENT *, void *user_data);

--- a/src/libtrx/include/libtrx/game/events.h
+++ b/src/libtrx/include/libtrx/game/events.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../event_manager.h"
+
+// Game-level event names
+#define GAME_EVENT_SCREENSHOT "screenshot"
+#define GAME_EVENT_COMMAND "console_command"
+
+typedef void (*GAME_EVENT_LISTENER)(const EVENT *event, void *user_data);
+
+void GameEvent_Init(void);
+void GameEvent_Shutdown(void);
+
+int32_t GameEvent_Subscribe(
+    const char *event_name, const void *sender, GAME_EVENT_LISTENER listener,
+    void *user_data);
+void GameEvent_Unsubscribe(int32_t listener_id);
+
+void GameEvent_Fire(const EVENT event);

--- a/src/libtrx/include/libtrx/game/input/common.h
+++ b/src/libtrx/include/libtrx/game/input/common.h
@@ -116,3 +116,13 @@ bool Input_AssignToJSONObject(
 INPUT_STATE Input_GetDebounced(const INPUT_STATE input);
 
 extern const char *Input_GetRoleName(INPUT_ROLE role);
+
+// Serialize a scancode and modifier mask into a human-readable key
+// description, e.g. "ctrl+shift+up". The returned string must not be held onto.
+const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod);
+
+// Parse a human-readable key description into scancode and modifier mask.
+// e.g. "ctrl+shift+up" → scancode SDL_SCANCODE_UP, mod KMOD_CTRL|KMOD_SHIFT.
+// Returns true if parsing succeeded, false otherwise.
+bool Input_ParseKeyDesc(
+    const char *desc, SDL_Scancode *scancode, SDL_Keymod *mod);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -131,6 +131,7 @@ sources = [
   'game/console/registry.c',
   'game/creature/common.c',
   'game/demo/common.c',
+  'game/events.c',
   'game/fader.c',
   'game/game.c',
   'game/game_buf.c',

--- a/src/libtrx/screenshot.c
+++ b/src/libtrx/screenshot.c
@@ -2,6 +2,7 @@
 
 #include "filesystem.h"
 #include "game/clock.h"
+#include "game/events.h"
 #include "game/game.h"
 #include "game/game_flow/common.h"
 #include "game/output.h"
@@ -136,6 +137,10 @@ void Screenshot_Make(const SCREENSHOT_FORMAT format)
 {
     char *full_path = M_GetScreenshotPath(format);
     Output_MakeScreenshot(full_path);
+    GameEvent_Fire((EVENT) {
+        .name = GAME_EVENT_SCREENSHOT,
+        .data = full_path,
+    });
     Memory_FreePointer(&full_path);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Changes the format of the replays in a backwards incompatible way to be more readable and editable.

- Frame numbers are now relative instead of absolute, which allows compositing multiple scenarios without having to offset the entire file
- Commands are now separated with newlines instead of `;`
- Key up and key down events, and bindings use readable strings rather than numbers, so that it's easier to find out what's happening
- Key up and key down events are logged with short ● and ○ to reduce input spam noise
- Important events (currently, console commands and screenshots) emit a comment so that it's easier to merge manual command input into a single `cmd` statement
- New event: `noop` that does nothing, but is useful when cleaning the source from unnecessary inputs without having to adjust the frame numbers
- The config section is now sorted and uses quoted strings around string values

Before:

```js
seed_control 77365
seed_draw 75265
config audio.music_volume 10%
config audio.sound_volume 10%
config visuals.fov_value 95
config gameplay.enable_fmv 0
config gameplay.enable_legal 0
config gameplay.look_mode unrestricted
config rendering.screenshot_format png
config input.controller_layout 2
config input.keyboard_layout 2
bind keyboard 4 47
bind keyboard 5 48
bind keyboard 10 29
bind keyboard 52 23

frame 11: keydown 56 0; text-input "/"
frame 16: keydown 6 0; text-input "c"; keyup 56 0
frame 19: keyup 6 0; keydown 24 0; text-input "u"
frame 22: keydown 23 0; text-input "t"; keyup 24 0
frame 25: keydown 44 0; text-input " "
frame 26: keyup 23 0
frame 27: keyup 44 0
frame 32: keydown 31 0; text-input "2"
frame 36: keydown 40 0; keyup 31 0
frame 39: keyup 40 0
frame 200: cmd "screenshot test_results/cutscene-cur.jpg"
frame 201: quit
```

After – exact same scenario and inputs with the new syntax:

```js
seed_control 77365
seed_draw 75265
config audio.music_volume 10%
config audio.sound_volume 10%
config gameplay.enable_fmv 0
config gameplay.enable_legal 0
config gameplay.look_mode "unrestricted"
config input.controller_layout 2
config input.keyboard_layout 2
config rendering.screenshot_format "png"
config visuals.fov_value 95
bind keyboard step_left "["
bind keyboard step_right "]"
bind keyboard look "z"
bind keyboard change_target "t"

@+11:   ● "/"
        text-input "/"
@+5:    ● "c"
        text-input "c"
        ○ "/"
@+3:    ○ "c"
        ● "u"
        text-input "u"
@+3:    ● "t"
        text-input "t"
        ○ "u"
@+3:    ● " "
        text-input " "
@+1:    ○ "t"
@+1:    ○ " "
@+5:    ● "2"
        text-input "2"
@+4:    ● "return"
        noop  # cmd "cut 2"
        ○ "2"
@+3:    ○ "return"
@+161:  cmd "screenshot test_results/cutscene-cur.jpg"
@+1:    quit
```