### PR TITLE
Make -l/--level accept level numbers

### DIFF
--- a/docs/1-COMMAND_LINE.md
+++ b/docs/1-COMMAND_LINE.md
@@ -13,10 +13,12 @@ Currently the following command line interface options are available:
 - `--demo-pc` (legacy: `-demo_pc`) (TR1X only)  
   Runs the PC demo level.
 
-- `-l <path>`, `--level <path>`  
-  Runs the game immediately launching it into the specified level. The path
+- `-l <path|num>`, `--level <path|num>`  
+  Runs the game immediately launching it into the specified level. If `<path>`
+  is provided, runs the custom level located in the specified location, which
   should be absolute. Internally, this option uses `TR*X_gameflow_level.json5`
-  as a template instructing it how to run the game.
+  as a template instructing it how to run the game. If `<num>` is an integer,
+  plays the level with the given number within the main game flow (1-based).
 
 - `-s <num>`, `--save <num>`:  
   Runs the game immediately loading a specific save slot. The first save starts

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -22,6 +22,7 @@
 - changed the texture page limit from 128 to unlimited (#3517)
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
+- changed `-l`/`--level` switch to accept the level number on top of the level path
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
 - fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - changed the texture page limit from 128 to unlimited (#3517)
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
+- changed `-l`/`--level` switch to accept the level number on top of the level path
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -44,6 +44,7 @@
 - fixed Lara not being able to look when look mode is set to unrestricted and she is using an airlock door (#3645, regression from 1.3)
 - fixed wireframe mode rendering as mostly white (#3649, regression from 1.3.2)
 - fixed shadows Y component not interpolated in 60 FPS (#1314)
+- fixed a crash when the level file was missing
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/game/game_flow/sequencer_misc.c
+++ b/src/libtrx/game/game_flow/sequencer_misc.c
@@ -7,7 +7,9 @@
 #include "game/inventory_ring/control.h"
 #include "game/objects/vars.h"
 #include "game/phase.h"
+#include "game/shell/common.h"
 #include "log.h"
+#include "memory.h"
 
 GF_COMMAND GF_EnterPhotoMode(void)
 {
@@ -79,6 +81,39 @@ GF_COMMAND GF_RunGame(
 
 GF_COMMAND GF_DoFrontendSequence(void)
 {
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    if (args != nullptr) {
+        if (args->save_to_load >= 0) {
+            return (GF_COMMAND) {
+                .action = GF_START_SAVED_GAME,
+                .param = args->save_to_load,
+            };
+        }
+
+        if (args->level_to_select >= 0) {
+            const GF_LEVEL *const level =
+                GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
+            if (level == nullptr) {
+                Shell_ExitSystemFmt(
+                    "Invalid level number: %d", args->level_to_select);
+            }
+            return (GF_COMMAND) {
+                .action = GF_SELECT_GAME,
+                .param = level->num,
+            };
+        }
+
+        if (args->level_to_play != nullptr) {
+            Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
+            g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
+                Memory_DupStr(args->level_to_play);
+            return (GF_COMMAND) {
+                .action = GF_START_GAME,
+                .param = 0,
+            };
+        }
+    }
+
     if (g_GameFlow.title_level == nullptr) {
         return (GF_COMMAND) { .action = GF_NOOP };
     }

--- a/src/libtrx/game/shell/args.c
+++ b/src/libtrx/game/shell/args.c
@@ -48,6 +48,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
     SHELL_ARGS *out_args = Memory_Alloc(sizeof(SHELL_ARGS));
     out_args->mod = M_BASE_MOD;
     out_args->save_to_load = -1;
+    out_args->level_to_select = -1;
     out_args->original_args = args;
     if (args == nullptr) {
         return out_args;
@@ -75,9 +76,14 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 #endif
         if ((!strcmp(arg, "-l") || !strcmp(arg, "--level"))
             && next_arg != nullptr) {
-            out_args->level_to_play = next_arg;
-            out_args->mod = TR_VERSION == 1 ? SHELL_MOD_TR1_CUSTOM_LEVEL
-                                            : SHELL_MOD_TR2_CUSTOM_LEVEL;
+            int32_t lvnum = -1;
+            if (String_ParseInteger(next_arg, &lvnum)) {
+                out_args->level_to_select = lvnum;
+            } else {
+                out_args->level_to_play = next_arg;
+                out_args->mod = TR_VERSION == 1 ? SHELL_MOD_TR1_CUSTOM_LEVEL
+                                                : SHELL_MOD_TR2_CUSTOM_LEVEL;
+            }
             i++;
         }
         if ((!strcmp(arg, "-s") || !strcmp(arg, "--save"))

--- a/src/libtrx/include/libtrx/game/shell/args.h
+++ b/src/libtrx/include/libtrx/game/shell/args.h
@@ -16,6 +16,7 @@ typedef struct {
     VECTOR *original_args;
 
     SHELL_MOD mod;
+    int32_t level_to_select;
     const char *level_to_play;
     int32_t save_to_load;
     const char *test_record_path;

--- a/src/tr1/game/level.c
+++ b/src/tr1/game/level.c
@@ -43,16 +43,16 @@ typedef enum {
     LEVEL_LAYOUT_TR1,
     LEVEL_LAYOUT_TR1_DEMO_PC,
     LEVEL_LAYOUT_NUMBER_OF,
-} LEVEL_LAYOUT;
+} M_LAYOUT;
 
-static bool M_TryLayout(VFILE *file, LEVEL_LAYOUT layout);
-static LEVEL_LAYOUT M_GuessLayout(VFILE *file);
+static bool M_TryLayout(VFILE *file, M_LAYOUT layout);
+static M_LAYOUT M_GuessLayout(VFILE *file);
 static void M_InitialiseSoundEffects(void);
 static void M_LoadFromFile(const GF_LEVEL *level);
 static void M_CompleteSetup(const GF_LEVEL *level);
 static void M_MarkWaterEdgeVertices(void);
 
-static bool M_TryLayout(VFILE *const file, const LEVEL_LAYOUT layout)
+static bool M_TryLayout(VFILE *const file, const M_LAYOUT layout)
 {
     // TODO: clang-format <20 formats this wrongly
     // clang-format off
@@ -163,11 +163,11 @@ static bool M_TryLayout(VFILE *const file, const LEVEL_LAYOUT layout)
     return true;
 }
 
-static LEVEL_LAYOUT M_GuessLayout(VFILE *const file)
+static M_LAYOUT M_GuessLayout(VFILE *const file)
 {
-    LEVEL_LAYOUT result = LEVEL_LAYOUT_UNKNOWN;
+    M_LAYOUT result = LEVEL_LAYOUT_UNKNOWN;
     BENCHMARK benchmark = Benchmark_Start();
-    for (LEVEL_LAYOUT layout = 0; layout < LEVEL_LAYOUT_NUMBER_OF; layout++) {
+    for (M_LAYOUT layout = 0; layout < LEVEL_LAYOUT_NUMBER_OF; layout++) {
         if (M_TryLayout(file, layout)) {
             result = layout;
             break;
@@ -204,12 +204,12 @@ static void M_LoadFromFile(const GF_LEVEL *const level)
 {
     GameBuf_Reset();
 
-    VFILE *file = VFile_CreateFromPath(level->path);
-    if (!file) {
+    VFILE *const file = VFile_CreateFromPath(level->path);
+    if (file == nullptr) {
         Shell_ExitSystemFmt("Could not open %s", level->path);
     }
 
-    const LEVEL_LAYOUT layout = M_GuessLayout(file);
+    const M_LAYOUT layout = M_GuessLayout(file);
     if (layout == LEVEL_LAYOUT_UNKNOWN) {
         Shell_ExitSystemFmt("Failed to load %s", level->path);
     }

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -113,12 +113,23 @@ int32_t Shell_Main(const SHELL_ARGS *args)
             Memory_DupStr(args->level_to_play);
     }
 
-    GF_COMMAND gf_cmd = args->save_to_load != -1
-        ? (GF_COMMAND) { .action = GF_START_SAVED_GAME,
-                         .param = args->save_to_load }
-        : args->level_to_play != nullptr
-        ? (GF_COMMAND) { .action = GF_START_GAME, .param = 0 }
-        : GF_DoFrontendSequence();
+    GF_COMMAND gf_cmd;
+    if (args->save_to_load != -1) {
+        gf_cmd = (GF_COMMAND) { .action = GF_START_SAVED_GAME,
+                                .param = args->save_to_load };
+    } else if (args->level_to_select >= 0) {
+        const GF_LEVEL *level =
+            GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
+        if (level == nullptr) {
+            Shell_ExitSystemFmt(
+                "Invalid level number: %d", args->level_to_select);
+        }
+        gf_cmd = (GF_COMMAND) { .action = GF_SELECT_GAME, .param = level->num };
+    } else if (args->level_to_play != nullptr) {
+        gf_cmd = (GF_COMMAND) { .action = GF_START_GAME, .param = 0 };
+    } else {
+        gf_cmd = GF_DoFrontendSequence();
+    }
 
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -107,29 +107,7 @@ int32_t Shell_Main(const SHELL_ARGS *args)
     Savegame_ScanSavedGames();
     Savegame_HighlightNewestSlot();
 
-    if (args->level_to_play != nullptr) {
-        Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
-        g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
-            Memory_DupStr(args->level_to_play);
-    }
-
-    GF_COMMAND gf_cmd;
-    if (args->save_to_load != -1) {
-        gf_cmd = (GF_COMMAND) { .action = GF_START_SAVED_GAME,
-                                .param = args->save_to_load };
-    } else if (args->level_to_select >= 0) {
-        const GF_LEVEL *level =
-            GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
-        if (level == nullptr) {
-            Shell_ExitSystemFmt(
-                "Invalid level number: %d", args->level_to_select);
-        }
-        gf_cmd = (GF_COMMAND) { .action = GF_SELECT_GAME, .param = level->num };
-    } else if (args->level_to_play != nullptr) {
-        gf_cmd = (GF_COMMAND) { .action = GF_START_GAME, .param = 0 };
-    } else {
-        gf_cmd = GF_DoFrontendSequence();
-    }
+    GF_COMMAND gf_cmd = GF_DoFrontendSequence();
 
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {

--- a/src/tr2/game/level.c
+++ b/src/tr2/game/level.c
@@ -312,20 +312,19 @@ finish:
 
 static void M_LoadFromFile(const GF_LEVEL *const level)
 {
-    LOG_DEBUG("%s (num=%d)", level->title, level->num);
     GameBuf_Reset();
 
     BENCHMARK benchmark = Benchmark_Start();
 
-    const char *full_path = File_GetFullPath(level->path);
-    VFILE *const file = VFile_CreateFromPath(full_path);
-    Memory_FreePointer(&full_path);
+    VFILE *const file = VFile_CreateFromPath(level->path);
+    if (file == nullptr) {
+        Shell_ExitSystemFmt("Could not open %s", level->path);
+    }
 
     const M_LAYOUT layout = M_GuessLayout(file);
     if (layout == LEVEL_LAYOUT_UNKNOWN) {
         Shell_ExitSystemFmt("Failed to load %s", level->path);
     }
-
     VFile_SetPos(file, 4);
 
     Level_ReadPalettes(file);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -129,12 +129,23 @@ int32_t Shell_Main(const SHELL_ARGS *args)
             Memory_DupStr(args->level_to_play);
     }
 
-    GF_COMMAND gf_cmd = args->save_to_load != -1
-        ? (GF_COMMAND) { .action = GF_START_SAVED_GAME,
-                         .param = args->save_to_load }
-        : args->level_to_play != nullptr
-        ? (GF_COMMAND) { .action = GF_START_GAME, .param = 0 }
-        : GF_DoFrontendSequence();
+    GF_COMMAND gf_cmd;
+    if (args->save_to_load != -1) {
+        gf_cmd = (GF_COMMAND) { .action = GF_START_SAVED_GAME,
+                                .param = args->save_to_load };
+    } else if (args->level_to_select >= 0) {
+        const GF_LEVEL *level =
+            GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
+        if (level == nullptr) {
+            Shell_ExitSystemFmt(
+                "Invalid level number: %d", args->level_to_select);
+        }
+        gf_cmd = (GF_COMMAND) { .action = GF_SELECT_GAME, .param = level->num };
+    } else if (args->level_to_play != nullptr) {
+        gf_cmd = (GF_COMMAND) { .action = GF_START_GAME, .param = 0 };
+    } else {
+        gf_cmd = GF_DoFrontendSequence();
+    }
 
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -123,29 +123,7 @@ int32_t Shell_Main(const SHELL_ARGS *args)
 
     Level_Init();
 
-    if (args->level_to_play != nullptr) {
-        Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
-        g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
-            Memory_DupStr(args->level_to_play);
-    }
-
-    GF_COMMAND gf_cmd;
-    if (args->save_to_load != -1) {
-        gf_cmd = (GF_COMMAND) { .action = GF_START_SAVED_GAME,
-                                .param = args->save_to_load };
-    } else if (args->level_to_select >= 0) {
-        const GF_LEVEL *level =
-            GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
-        if (level == nullptr) {
-            Shell_ExitSystemFmt(
-                "Invalid level number: %d", args->level_to_select);
-        }
-        gf_cmd = (GF_COMMAND) { .action = GF_SELECT_GAME, .param = level->num };
-    } else if (args->level_to_play != nullptr) {
-        gf_cmd = (GF_COMMAND) { .action = GF_START_GAME, .param = 0 };
-    } else {
-        gf_cmd = GF_DoFrontendSequence();
-    }
+    GF_COMMAND gf_cmd = GF_DoFrontendSequence();
 
     bool loop_continue = !Shell_IsExiting();
     while (loop_continue) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Usage: `TR1X -l 1`, `TR2X -l 0` for gym. Compatible with `--gold`. Passing `-s` overrides this choice. Exits with a fatal error if the level does not exist, just like the path-specific variant.
