### PR TITLE
tr1/ui: fix ps1-style setting descriptions missing borders

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -33,6 +33,7 @@
     - fixed the cameras for doors 81 in Tomb of Tihocan and 1 in Sanctuary of the Scion only showing once (#3661)
 - fixed the passport having an invisible back page, noticeable when opening/closing it (#2051)
 - fixed z-fighting on the front of the passport (#3584)
+- fixed setting description dialog missing borders with PS1 UI style (#3714, regression from 4.12)
 - fixed being unable to activate waterfall objects with code bits (#3589)
 - fixed skippable triggers for waterfall objects in Lost Valley (#3593)
 - fixed incorrectly rotated 3D pickup items in several levels (#2147)

--- a/src/tr1/game/output/draw.c
+++ b/src/tr1/game/output/draw.c
@@ -193,7 +193,8 @@ void Output_DrawTextOutline(
             sx, sy, w, h, M_GetMenuColor(MC_BLACK), M_GetMenuColor(MC_BLACK),
             M_GetMenuColor(MC_BLACK), M_GetMenuColor(MC_BLACK),
             M_TEXT_OUTLINE_THICKNESS);
-    } else if (text_style == TS_BACKGROUND) {
+    } else if (
+        text_style == TS_BACKGROUND || text_style == TS_BACKGROUND_HEAVY) {
         Output_DrawScreenGradientBox(
             sx, sy, w, h, M_GetMenuColor(MC_GREY_TL),
             M_GetMenuColor(MC_GREY_TR), M_GetMenuColor(MC_GREY_BL),


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3714.

