### PR TITLE
tr1/output: fix alpha blending

### DIFF
--- a/data/tr1/ship/shaders/meshes.glsl
+++ b/data/tr1/ship/shaders/meshes.glsl
@@ -102,7 +102,10 @@ void main(void) {
         if (texColor.a <= 0.0) {
             discard;
         }
+    } else {
+        texColor.rgb *= texColor.a;
     }
+
     if ((gFlags & VERT_REFLECTIVE) != 0u && uReflectionsEnabled) {
         texColor *= texture(uTexEnvMap, (normalize(gNormal) * 0.5 + 0.5).xy) * 2;
     }

--- a/src/tr1/game/output/scene_compositor.c
+++ b/src/tr1/game/output/scene_compositor.c
@@ -78,9 +78,7 @@ static void M_BindTextures(const M_PRIV *p)
 static void M_SetBlendModeForScene(bool wireframe)
 {
     glEnable(GL_BLEND);
-    glBlendFunc(
-        wireframe ? GL_ONE : GL_SRC_ALPHA,
-        wireframe ? GL_ZERO : GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFunc(GL_ONE, wireframe ? GL_ZERO : GL_ONE_MINUS_SRC_ALPHA);
 }
 
 static void M_SetBlendModeForUI(void)

--- a/src/tr1/game/output/sources/ui.c
+++ b/src/tr1/game/output/sources/ui.c
@@ -289,9 +289,9 @@ void OutputSource_UI_StageSprite(const OUTPUT_UI_SPRITE sprite)
     M_VERTEX vertices[4];
     for (int32_t i = 0; i < 4; i++) {
         vertices[i].pos.z = sprite.z;
-        vertices[i].color.r = sprite.color.r * sprite.color.a / 255;
-        vertices[i].color.g = sprite.color.g * sprite.color.a / 255;
-        vertices[i].color.b = sprite.color.b * sprite.color.a / 255;
+        vertices[i].color.r = sprite.color.r;
+        vertices[i].color.g = sprite.color.g;
+        vertices[i].color.b = sprite.color.b;
         vertices[i].color.a = sprite.color.a;
         vertices[i].shade = sprite.shade;
         vertices[i].uvw.w = sprite_tex->tex_page;
@@ -334,9 +334,9 @@ void OutputSource_UI_StageQuad(const OUTPUT_UI_QUAD quad)
 #define L_SET(vtx_idx, x_, y_, color_)                                         \
     vertices[vtx_idx].pos.x = x_;                                              \
     vertices[vtx_idx].pos.y = y_;                                              \
-    vertices[vtx_idx].color.r = color_.r * color_.a / 255;                     \
-    vertices[vtx_idx].color.g = color_.g * color_.a / 255;                     \
-    vertices[vtx_idx].color.b = color_.b * color_.a / 255;                     \
+    vertices[vtx_idx].color.r = color_.r;                                      \
+    vertices[vtx_idx].color.g = color_.g;                                      \
+    vertices[vtx_idx].color.b = color_.b;                                      \
     vertices[vtx_idx].color.a = color_.a;
     L_SET(0, quad.x0, quad.y0, quad.tl);
     L_SET(1, quad.x1, quad.y0, quad.tr);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the bleeding borders raised on Discord some time ago. Some before and after screenshots:

<img width="1280" height="720" alt="bilinear_filter_premultiply-cur" src="https://github.com/user-attachments/assets/95531219-4bd4-4d8e-acfc-98da1d7ae773" />
<img width="1280" height="720" alt="bilinear_filter_premultiply-ref" src="https://github.com/user-attachments/assets/84800274-16d5-4167-99e0-96960ece1ac1" />
<img width="1280" height="720" alt="bilinear_filter_premultiply2-cur" src="https://github.com/user-attachments/assets/ba58daa2-a449-4ab4-ab95-86d8ab743eb0" />
<img width="1280" height="720" alt="bilinear_filter_premultiply2-ref" src="https://github.com/user-attachments/assets/08d69cdb-922e-4c21-8384-14d6297ba6f3" />
<img width="1280" height="720" alt="bilinear_filter_sort-cur" src="https://github.com/user-attachments/assets/7df173ac-13a3-40d0-9b0a-d70a3540fc3a" />
<img width="1280" height="720" alt="bilinear_filter_sort-ref" src="https://github.com/user-attachments/assets/6559e14b-a184-4971-81fc-04c9eb93c568" />
<img width="1280" height="720" alt="bilinear_filter_sort2-cur" src="https://github.com/user-attachments/assets/d4e62caf-24a3-441b-bb37-e4b7295b3105" />
<img width="1280" height="720" alt="bilinear_filter_sort2-ref" src="https://github.com/user-attachments/assets/7455d481-463b-49f7-b578-4fb14cd64f2f" />
