### PR TITLE
lara: adjust neutral twist and ledge jump checks

### DIFF
--- a/src/libtrx/game/lara/col/climb.c
+++ b/src/libtrx/game/lara/col/climb.c
@@ -515,6 +515,7 @@ static bool M_TestClimbStance(ITEM *const item, COLL_INFO *const coll)
 static bool M_TestLedgeJump(const ITEM *const item, const COLL_INFO *const coll)
 {
     if (!g_Input.jump || !(g_Input.forward ^ g_Input.back)
+        || (g_Input.forward && g_Input.slow)
         || !g_Config.gameplay.enable_ledge_jumps
         || !Lara_State_IsResponsive(LA_REACH_TO_HANG)) {
         return false;

--- a/src/libtrx/game/lara/state/land.c
+++ b/src/libtrx/game/lara/state/land.c
@@ -227,7 +227,7 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
             item->current_anim_state = LS_NEUTRAL_ROLL;
             item->goal_anim_state = LS_STOP;
             Item_SwitchToAnim(item, LA_JUMP_NEUTRAL_ROLL, 0);
-        } else {
+        } else if (!g_Input.jump || !g_Config.gameplay.enable_neutral_twists) {
             item->current_anim_state = LS_ROLL;
             item->goal_anim_state = LS_STOP;
             Item_SwitchToAnim(item, LA_ROLL_START, M_LF_ROLL);


### PR DESCRIPTION
Resolves #3731.
Resolves #3735.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Allows holding jump and roll while mid-air, and Lara will perform a neutral twist _after_ the landing animation. It can't be immediate as that caused the previous issue of being able to do the manoeuvre on slopes, and it cancelling stumbles.
The ledge jump fix is also quite straight-forward.
