### PR TITLE
tr2/savegame: fix secrets mask not cleared between levels

### DIFF
--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -602,6 +602,7 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
     const STATS_COMMON default_stats = Savegame_GetDefaultStats(level);
     resume->stats.max_secret_count = default_stats.max_secret_count;
     resume->stats.all_secrets_mask = default_stats.all_secrets_mask;
+    resume->stats.secret_flags = 0;
 #endif
 
     M_DetermineLegacyGunTypes(resume);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the following bug present in the develop snapshots:

- `/play 1`
- `/tp secret`, pick it up, repeat 3 times to get all secrets,
- `l` to finish the level,
- `/tp secret`, pick it up. Lara gets rewarded with secret rewards
