### PR TITLE
tr2/output: fix the scissor test in windowed mode

### DIFF
--- a/src/libtrx/game/output/func.c
+++ b/src/libtrx/game/output/func.c
@@ -34,6 +34,8 @@ int32_t Output_CalcFogShade(const int32_t depth)
 void Output_ApplyFOV(void)
 {
     int32_t fov = Viewport_GetEffectiveFOV();
+    const int32_t sw = Viewport_GetWidth(VIEWPORT_GAME);
+    const int32_t sh = Viewport_GetHeight(VIEWPORT_GAME);
 
 #if TR_VERSION == 1
     // In places that use GAME_FOV, it can be safely changed to user's choice.
@@ -41,26 +43,17 @@ void Output_ApplyFOV(void)
     // unchanged, otherwise the game renders the low camera in the Lost Valley
     // cutscene wrong.
     if (g_Config.visuals.fov_vertical) {
-        double aspect_ratio = Viewport_GetWidth(VIEWPORT_GAME)
-            / (double)Viewport_GetHeight(VIEWPORT_GAME);
+        double aspect_ratio = sw / (float)sh;
         double fov_rad_h = fov * M_PI / (180 * DEG_1);
         double fov_rad_v = 2 * atan(aspect_ratio * tan(fov_rad_h / 2));
         fov = round((fov_rad_v / M_PI) * (180 * DEG_1));
     }
 
-    const int32_t fov_width = Viewport_GetWidth(VIEWPORT_GAME);
-
-    const int16_t c = Math_Cos(fov / 2);
-    const int16_t s = Math_Sin(fov / 2);
-    g_PhdPersp = fov_width / 2;
-    if (s != 0) {
-        g_PhdPersp *= c;
-        g_PhdPersp /= s;
-    }
-
+    const int32_t fov_width = sw;
 #else
-    const int32_t fov_width = Viewport_GetHeight(VIEWPORT_GAME) * 320
-        / (g_Config.visuals.use_psx_fov ? 200 : 240);
+    const int32_t adjust = g_Config.visuals.use_psx_fov ? 200 : 240;
+    const int32_t fov_width = sw * 240 / 320 * 240 / adjust;
+#endif
 
     const int16_t c = Math_Cos(fov / 2);
     const int16_t s = Math_Sin(fov / 2);
@@ -69,5 +62,4 @@ void Output_ApplyFOV(void)
         g_PhdPersp *= c;
         g_PhdPersp /= s;
     }
-#endif
 }

--- a/src/libtrx/game/output/state.c
+++ b/src/libtrx/game/output/state.c
@@ -150,13 +150,10 @@ void Output_GetPerspProjectionMatrix(GLfloat output[][4])
         f_y = f_x * aspect;
     }
 #else
-    const float og_ar = 240.0 / 320.0;
-    const float adjust =
-        240.0f / (g_Config.visuals.use_psx_fov ? 200.0 : 240.0);
-    const float width = og_ar * adjust;
-    const float persp = width * cos(fov * 0.5f) / sin(fov * 0.5f);
-    f_x = persp;
-    f_y = persp * aspect;
+    const float adjust = g_Config.visuals.use_psx_fov ? 200.0f : 240.0f;
+    const float persp = (240.0f / 320.0f) * (240.0f / adjust);
+    f_x = persp / tanf(fov * 0.5f);
+    f_y = f_x * aspect;
 #endif
 
     output[0][0] = f_x;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Playing TR2 in windowed mode would clip the rooms in the weirdest ways due to a mismatch between the projection matrices and the perspective factor.
