### PR TITLE
Simplify collision side probes and cleanup movable block

### DIFF
--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -7,6 +7,8 @@
 #include "game/rooms.h"
 #include "utils.h"
 
+#define M_HEADROOM 160 // Additional collision space above Lara's head.
+
 static bool M_IsOnWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);
 
@@ -166,7 +168,7 @@ void Collide_GetCollisionInfo(
     int32_t x = x_pos;
     int32_t z = z_pos;
     const int32_t y = y_pos - obj_height;
-    const int32_t y_top = y - 160;
+    const int32_t y_top = y - M_HEADROOM;
 
     const SECTOR *sector = Room_GetSector(x, y_top, z, &room_num);
     int32_t height = Room_GetHeight(sector, x, y_top, z);

--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -9,6 +9,9 @@
 
 #define M_HEADROOM 160 // Additional collision space above Lara's head.
 
+static void M_FillSide(
+    const COLL_INFO *coll, COLL_SIDE *side, int32_t x_pos, int32_t z_pos,
+    int32_t y_pos, int32_t obj_height, int16_t room_num);
 static bool M_IsOnWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);
 
@@ -18,6 +21,52 @@ static bool M_IsOnWalkable(
 {
     return g_Config.gameplay.fix_bridge_collision
         && Room_IsOnWalkable(sector, x, y, z, room_height);
+}
+
+// Probes the front, left, and right of Lara and fills in the collision info for
+// each side. The collision info depends on Lara's state. Her state determines
+// how big slope and lava pit sectors are treated. For example, in the walk
+// state, Lara won't walk up big slopes or walk down into lava pits.
+static void M_FillSide(
+    const COLL_INFO *const coll, COLL_SIDE *const side, const int32_t x_pos,
+    const int32_t z_pos, const int32_t y_pos, const int32_t obj_height,
+    int16_t room_num)
+{
+    const int32_t y = y_pos - obj_height;
+    const int32_t y_top = y - M_HEADROOM;
+
+    const SECTOR *const sector = Room_GetSector(x_pos, y_top, z_pos, &room_num);
+    int32_t height = Room_GetHeight(sector, x_pos, y_top, z_pos);
+    int32_t ceiling = Room_GetCeiling(sector, x_pos, y_top, z_pos);
+    const int32_t room_height = height;
+    const int32_t room_ceiling = ceiling;
+    if (height != NO_HEIGHT) {
+        height -= y_pos;
+    }
+    if (ceiling != NO_HEIGHT) {
+        ceiling -= y;
+    }
+
+    side->floor = height;
+    side->ceiling = ceiling;
+    side->type = Room_GetHeightType();
+
+    const bool is_on_walkable =
+        M_IsOnWalkable(sector, x_pos, y_top, z_pos, room_height);
+    if (!is_on_walkable) {
+        if (coll->slopes_are_walls && side->type == HT_BIG_SLOPE
+            && side->floor < 0) {
+            side->floor = -32767;
+        } else if (
+            coll->slopes_are_pits && side->type == HT_BIG_SLOPE
+            && side->floor > 0) {
+            side->floor = STEP_L * 2;
+        } else if (
+            coll->lava_is_pit && side->floor > 0
+            && Room_GetPitSector(sector, x_pos, z_pos)->is_death_sector) {
+            side->floor = STEP_L * 2;
+        }
+    }
 }
 
 int32_t Collide_GetSpheres(
@@ -249,107 +298,15 @@ void Collide_GetCollisionInfo(
         break;
     }
 
-    // Front.
-    x = x_pos + x_front;
-    z = z_pos + z_front;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_front.floor = height;
-    coll->side_front.ceiling = ceiling;
-    coll->side_front.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_front.type == HT_BIG_SLOPE
-            && coll->side_front.floor < 0) {
-            coll->side_front.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_front.type == HT_BIG_SLOPE
-            && coll->side_front.floor > 0) {
-            coll->side_front.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_front.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_front.floor = 512;
-        }
-    }
-
-    // Left.
-    x = x_pos + x_left;
-    z = z_pos + z_left;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_left.floor = height;
-    coll->side_left.ceiling = ceiling;
-    coll->side_left.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_left.type == HT_BIG_SLOPE
-            && coll->side_left.floor < 0) {
-            coll->side_left.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_left.type == HT_BIG_SLOPE
-            && coll->side_left.floor > 0) {
-            coll->side_left.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_left.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_left.floor = 512;
-        }
-    }
-
-    // Right.
-    x = x_pos + x_right;
-    z = z_pos + z_right;
-    sector = Room_GetSector(x, y_top, z, &room_num);
-    height = Room_GetHeight(sector, x, y_top, z);
-    room_height = height;
-    if (height != NO_HEIGHT) {
-        height -= y_pos;
-    }
-    ceiling = Room_GetCeiling(sector, x, y_top, z);
-    if (ceiling != NO_HEIGHT) {
-        ceiling -= y;
-    }
-
-    coll->side_right.floor = height;
-    coll->side_right.ceiling = ceiling;
-    coll->side_right.type = Room_GetHeightType();
-
-    is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
-    if (!is_on_walkable) {
-        if (coll->slopes_are_walls && coll->side_right.type == HT_BIG_SLOPE
-            && coll->side_right.floor < 0) {
-            coll->side_right.floor = -32767;
-        } else if (
-            coll->slopes_are_pits && coll->side_right.type == HT_BIG_SLOPE
-            && coll->side_right.floor > 0) {
-            coll->side_right.floor = 512;
-        } else if (
-            coll->lava_is_pit && coll->side_right.floor > 0
-            && Room_GetPitSector(sector, x, z)->is_death_sector) {
-            coll->side_right.floor = 512;
-        }
-    }
+    M_FillSide(
+        coll, &coll->side_front, x_pos + x_front, z_pos + z_front, y_pos,
+        obj_height, room_num);
+    M_FillSide(
+        coll, &coll->side_left, x_pos + x_left, z_pos + z_left, y_pos,
+        obj_height, room_num);
+    M_FillSide(
+        coll, &coll->side_right, x_pos + x_right, z_pos + z_right, y_pos,
+        obj_height, room_num);
 
     if (Collide_CollideStaticObjects(
             coll, x_pos, y_pos, z_pos, room_num, obj_height)) {

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -37,7 +37,7 @@ static const OBJECT_BOUNDS m_MovableBlock_Bounds = {
 
 static const OBJECT_BOUNDS *M_Bounds(void);
 static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll);
-static bool M_TestDestination(ITEM *item, int32_t block_height);
+static bool M_TestCurrentSector(ITEM *item, int32_t block_height);
 static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant);
 static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant);
 static bool M_TestDeathCollision(ITEM *item, const ITEM *lara);
@@ -81,16 +81,19 @@ static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll)
     return false;
 }
 
-static bool M_TestDestination(ITEM *item, int32_t block_height)
+static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
 {
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+
+    // Check if there is a hard wall above.
     if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
         == NO_HEIGHT) {
         return true;
     }
 
+    // Make sure there is nothing on top of the block.
     if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
         != item->pos.y - block_height) {
         return false;
@@ -101,7 +104,7 @@ static bool M_TestDestination(ITEM *item, int32_t block_height)
 
 static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
 {
-    if (!M_TestDestination(item, block_height)) {
+    if (!M_TestCurrentSector(item, block_height)) {
         return false;
     }
 
@@ -149,7 +152,7 @@ static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
 
 static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
 {
-    if (!M_TestDestination(item, block_height)) {
+    if (!M_TestCurrentSector(item, block_height)) {
         return false;
     }
 

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -175,11 +175,12 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
         break;
     }
 
+    // Test block destination sector.
     int32_t x = item->pos.x + x_add;
     int32_t y = item->pos.y;
     int32_t z = item->pos.z + z_add;
-
     int16_t room_num = item->room_num;
+
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
     COLL_INFO coll;
     coll.quadrant = quadrant;
@@ -197,6 +198,7 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
         return false;
     }
 
+    // Test Lara destination sector.
     x += x_add;
     z += z_add;
     room_num = item->room_num;

--- a/src/tr1/game/objects/traps/movable_block.c
+++ b/src/tr1/game/objects/traps/movable_block.c
@@ -40,7 +40,7 @@ static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll);
 static bool M_TestCurrentSector(ITEM *item, int32_t block_height);
 static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant);
 static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant);
-static bool M_TestDeathCollision(ITEM *item, const ITEM *lara);
+static bool M_TestDeathCollision(const ITEM *item, const ITEM *lara);
 static void M_KillLara(const ITEM *item, ITEM *lara);
 static void M_Setup(OBJECT *obj);
 static void M_HandleSave(ITEM *item, SAVEGAME_STAGE stage);
@@ -225,7 +225,7 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
     return true;
 }
 
-static bool M_TestDeathCollision(ITEM *const item, const ITEM *const lara)
+static bool M_TestDeathCollision(const ITEM *const item, const ITEM *const lara)
 {
     return g_GameFlow.enable_killer_pushblocks
         && !g_Config.debug.enable_invulnerability && item->gravity


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Internal changes to prepare for #3671. Thanks to @lahm86 for the collision fill sides function! :partying_face: 

The only testing will need to be making sure Lara moves as normal around ledges, lava, and slopes. From my testing, everything seems ok. This should be only cosmetic changes.