### PR TITLE
lara/control: test cheat option and inputs together

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -61,6 +61,7 @@
     - fixed Y component not interpolated in 60 FPS (#1314)
     - fixed shadows being rendered partially opaque near room portals (#879)
     - fixed Bacon Lara shadow rendered transparent when she's standing on a trapdoor (#3666)
+- fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 4.13)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - improved lighting, projection and sizing of 3D pickups in the UI

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed wireframe mode rendering as mostly white (#3649, regression from 1.3.2)
 - fixed shadows Y component not interpolated in 60 FPS (#1314)
 - fixed a crash when the level file was missing
+- fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 1.3)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -34,6 +34,7 @@
 static int32_t m_OpenDoorsCheatCooldown = 0;
 
 static SECTOR *M_GetCurrentSector(void);
+static void M_Cheat(void);
 static void M_UpdateEnvironment(void);
 static void M_HandleEnvironment(void);
 static void M_HandleAboveWater(COLL_INFO *coll);
@@ -52,6 +53,26 @@ static SECTOR *M_GetCurrentSector(void)
     int16_t room_num = lara_item->room_num;
     return Room_GetSector(
         lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z, &room_num);
+}
+
+static void M_Cheat(void)
+{
+    if (!g_Config.gameplay.enable_cheats) {
+        return;
+    }
+
+    if (g_InputDB.level_skip_cheat) {
+        Lara_Cheat_EndLevel();
+    }
+
+    if (g_InputDB.item_cheat) {
+        Lara_Cheat_GiveAllItems();
+    }
+
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->water_status != LWS_CHEAT && g_InputDB.fly_cheat) {
+        Lara_Cheat_EnterFlyMode();
+    }
 }
 
 static void M_UpdateEnvironment(void)
@@ -687,17 +708,7 @@ void Lara_Control(void)
         item->hit_points = LARA_MAX_HITPOINTS;
     }
 
-    if (g_InputDB.level_skip_cheat) {
-        Lara_Cheat_EndLevel();
-    }
-
-    if (g_InputDB.item_cheat) {
-        Lara_Cheat_GiveAllItems();
-    }
-
-    if (lara_info->water_status != LWS_CHEAT && g_InputDB.fly_cheat) {
-        Lara_Cheat_EnterFlyMode();
-    }
+    M_Cheat();
 
     if (TR_VERSION == 1 && lara_info->interact_target.is_moving
         && lara_info->interact_target.move_count++ > M_MOVE_TIMEOUT) {

--- a/src/libtrx/game/shell/input.c
+++ b/src/libtrx/game/shell/input.c
@@ -76,7 +76,7 @@ void Shell_ProcessCommonInput(void)
         M_ToggleFullscreen();
     }
 
-    if (g_InputDB.turbo_cheat) {
+    if (g_InputDB.turbo_cheat && g_Config.gameplay.enable_cheats) {
         Clock_CycleTurboSpeed(!g_Input.slow);
     }
 }

--- a/src/tr1/game/input.c
+++ b/src/tr1/game/input.c
@@ -103,13 +103,6 @@ void Input_Update(void)
         g_Input.right = 0;
     }
 
-    if (!g_Config.gameplay.enable_cheats) {
-        g_Input.item_cheat = 0;
-        g_Input.fly_cheat = 0;
-        g_Input.level_skip_cheat = 0;
-        g_Input.turbo_cheat = 0;
-    }
-
     if (g_Config.input.enable_tr3_sidesteps) {
         if (g_Input.slow && !g_Input.forward && !g_Input.back
             && !g_Input.step_left && !g_Input.step_right) {

--- a/src/tr2/game/input.c
+++ b/src/tr2/game/input.c
@@ -110,13 +110,6 @@ void Input_Update(void)
         g_Input.right = 0;
     }
 
-    if (!g_Config.gameplay.enable_cheats) {
-        g_Input.item_cheat = 0;
-        g_Input.fly_cheat = 0;
-        g_Input.level_skip_cheat = 0;
-        g_Input.turbo_cheat = 0;
-    }
-
     if (g_Config.input.enable_tr3_sidesteps) {
         if (g_Input.slow && !g_Input.forward && !g_Input.back
             && !g_Input.step_left && !g_Input.step_right) {


### PR DESCRIPTION
Resolves #3726.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This alters the way that cheat inputs are handled by no longer overriding them to be `false` and instead the target actions are responsible for checking that the config option is enabled. It therefore allows the use of cheat input keys elsewhere, such as for posing in photo mode.

Just a sanity test needed around the `L`, `O`, `I` and turbo cheats with the overall option on/off, as well as photo posing itself.
