### PR TITLE
game_flow: block Lara control on load

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -64,6 +64,7 @@
     - fixed Bacon Lara shadow rendered transparent when she's standing on a trapdoor (#3666)
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 4.13)
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 4.13)
+- fixed being able to issue certain console commands that target Lara during loading screens (#3662, regression from 4.13)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - improved lighting, projection and sizing of 3D pickups in the UI

--- a/src/libtrx/game/console/cmd/die.c
+++ b/src/libtrx/game/console/cmd/die.c
@@ -1,4 +1,5 @@
 #include "game/console/registry.h"
+#include "game/game.h"
 #include "game/items.h"
 #include "game/lara/common.h"
 #include "game/objects/common.h"
@@ -14,7 +15,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         return CR_BAD_INVOCATION;
     }
 
-    if (!Object_Get(O_LARA)->loaded) {
+    if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
     }
 

--- a/src/libtrx/game/game.c
+++ b/src/libtrx/game/game.c
@@ -65,7 +65,8 @@ bool Game_IsPlayable(void)
         return false;
     }
 
-    if (!Object_Get(O_LARA)->loaded || Lara_GetItem() == nullptr) {
+    if (!Object_Get(O_LARA)->loaded || Lara_GetItem() == nullptr
+        || !Lara_IsControllable()) {
         return false;
     }
 

--- a/src/libtrx/include/libtrx/game/game.h
+++ b/src/libtrx/include/libtrx/game/game.h
@@ -3,14 +3,21 @@
 #include "./game/enum.h"
 #include "./game_flow/types.h"
 
+// Sets the game's playing state, which in turn toggles random draw lock, and
+// certain overlay displays/animations, such as bars and pickups.
 void Game_SetIsPlaying(bool is_playing);
+// Returns true if the game is in a playing state - i.e. not suspended, such as
+// during pause, photo mode, or while the inventory is open.
 bool Game_IsPlaying(void);
 
 const GF_LEVEL *Game_GetCurrentLevel(void);
 void Game_SetCurrentLevel(const GF_LEVEL *level);
 
 bool Game_IsInGym(void);
+// Returns true if an FMV is not playing and the current level is not the title.
 bool Game_IsLoaded(void);
+// Returns true if an FMV is not playing, if the level type is neither the
+// title, a demo or a cutscene, and if Lara is loaded and controllable.
 bool Game_IsPlayable(void);
 
 GAME_BONUS_FLAG Game_GetBonusFlag(void);

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -225,6 +225,7 @@ void GF_PreSequenceHook(
     const GF_SEQUENCE_CONTEXT seq_ctx, void *const seq_ctx_arg)
 {
     Room_SetAbyssHeight(0);
+    Lara_SetControllable(false);
     if (seq_ctx == GFSC_SAVED) {
         Game_SetBonusFlag(GBF_NONE);
     }

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -164,6 +164,7 @@ void GF_PreSequenceHook(
 {
     Room_SetAbyssHeight(0);
     Output_SetSunsetEnabled(false);
+    Lara_SetControllable(false);
     Lara_SetStartAnimState(LS_EXTRA_BREATH);
     Camera_GetCineData()->position.target_angle = DEG_90;
     if (seq_ctx == GFSC_SAVED) {


### PR DESCRIPTION
Resolves #3662.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This blocks Lara from being controllable when a level is started, and the lock is only lifted once `Lara_Initialise` has run i.e. via the loop game sequence. This avoids being able to perform certain console commands on Lara before she is ready.

Commands affected:
- die (Lara blowing up)
- fly
- give
- heal
- hp
- save/load
- secret
- tp
