### PR TITLE
lara/control: use debounced input to exit fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -62,6 +62,7 @@
     - fixed shadows being rendered partially opaque near room portals (#879)
     - fixed Bacon Lara shadow rendered transparent when she's standing on a trapdoor (#3666)
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 4.13)
+- fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 4.13)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - improved lighting, projection and sizing of 3D pickups in the UI

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -66,6 +66,7 @@
 - fixed shadows Y component not interpolated in 60 FPS (#1314)
 - fixed a crash when the level file was missing
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 1.3)
+- fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 1.3)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved projectiles

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -323,7 +323,7 @@ static void M_HandleEnvironment(void)
         item->hit_points = LARA_MAX_HITPOINTS;
         lara_info->death_timer = 0;
         M_HandleUnderwater(&coll);
-        if (g_Input.slow && !g_Input.look && !g_Input.fly_cheat) {
+        if (g_InputDB.slow && !g_Input.look && !g_Input.fly_cheat) {
             Lara_Cheat_ExitFlyMode();
         }
         break;


### PR DESCRIPTION
Resolves #3753.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids the walk input taking Lara out of the fly cheat if used during photo mode.
