### PR TITLE
output: fix shadows occluding transparent tiles

### DIFF
--- a/src/libtrx/game/output/mesh_batcher/batcher.c
+++ b/src/libtrx/game/output/mesh_batcher/batcher.c
@@ -187,13 +187,18 @@ static void M_SortTransparentFaces(const MESH_BATCHER *const batcher)
     M_FACE_SORT *const buf = Vector_GetData(batcher->transparent_sort);
     M_FACE_SORT *bptr = buf;
     for (int32_t i = 0; i < n; i++) {
-        // clang-format off
-        bptr->sort_key = (
-            bptr->inst->matrix._20 * (int32_t)bptr->face->mesh_centroid.x +
-            bptr->inst->matrix._21 * (int32_t)bptr->face->mesh_centroid.y +
-            bptr->inst->matrix._22 * (int32_t)bptr->face->mesh_centroid.z +
-            bptr->inst->matrix._23);
-        // clang-format on
+        if (bptr->inst->transparent_sort_func != nullptr) {
+            bptr->sort_key =
+                bptr->inst->transparent_sort_func(bptr->inst, bptr->face);
+        } else {
+            // clang-format off
+            bptr->sort_key = (
+                bptr->inst->matrix._20 * (int32_t)bptr->face->mesh_centroid.x +
+                bptr->inst->matrix._21 * (int32_t)bptr->face->mesh_centroid.y +
+                bptr->inst->matrix._22 * (int32_t)bptr->face->mesh_centroid.z +
+                bptr->inst->matrix._23);
+            // clang-format on
+        }
         bptr++;
     }
     qsort(buf, n, sizeof(*buf), M_CompareFaceDepth);

--- a/src/libtrx/game/output/sources/shadows.c
+++ b/src/libtrx/game/output/sources/shadows.c
@@ -13,7 +13,12 @@ typedef struct {
 
 static M_PRIV m_Priv;
 
-static OUTPUT_MESH *M_GenerateShadow(MESH_BUILDER *builder, int32_t fidelity)
+static OUTPUT_MESH *M_GenerateShadow(MESH_BUILDER *builder, int32_t fidelity);
+static int32_t M_TransparentSort(
+    const MESH_INSTANCE *inst, const OUTPUT_MESH_FACE *face);
+
+static OUTPUT_MESH *M_GenerateShadow(
+    MESH_BUILDER *const builder, const int32_t fidelity)
 {
     const int32_t y = -5;
     const RGBA_8888 color = { 0, 0, 0, 128 };
@@ -40,6 +45,12 @@ static OUTPUT_MESH *M_GenerateShadow(MESH_BUILDER *builder, int32_t fidelity)
     }
     MeshBuilder_AddFan(builder, true);
     return MeshBuilder_Seal(builder);
+}
+
+static int32_t M_TransparentSort(
+    const MESH_INSTANCE *const inst, const OUTPUT_MESH_FACE *const face)
+{
+    return 0; // Always draw shadows last.
 }
 
 void OutputSource_Shadows_Init(MESH_BATCHER *const batcher)
@@ -79,6 +90,7 @@ void OutputSource_Shadows_StageShadow(void)
         .mesh = mesh,
         .matrix = *g_MatrixPtr,
         .tint = { 1.0f, 1.0f, 1.0f },
+        .transparent_sort_func = M_TransparentSort,
     };
     // XXX: Mesh batcher currently collects the transparent faces for the
     // transparent pass in the opaque pass, so the shadow, even though

--- a/src/libtrx/include/libtrx/game/output/mesh_batcher/batcher.h
+++ b/src/libtrx/include/libtrx/game/output/mesh_batcher/batcher.h
@@ -19,6 +19,8 @@ typedef struct MESH_INSTANCE {
     bool enable_scissor;
     VIEWPORT_RECT scissor;
 
+    int32_t (*transparent_sort_func)(
+        const struct MESH_INSTANCE *inst, const OUTPUT_MESH_FACE *face);
     void (*update_light_func)(struct MESH_INSTANCE *inst, void *user_data);
     void *update_light_func_data;
     bool water_effect; // helper for the update_light_func


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3750.

<img width="1793" height="1009" alt="image" src="https://github.com/user-attachments/assets/73f909fc-0f18-48aa-add6-442b896b884a" />

The issue visible in the screenshot above stems from depth sorting – technically the tile under the shadow is closer to the camera (because we sort by centroids), so it gets rendered later. And when we draw the shadows first, it occludes the buffer.
This PR ensures that shadows are always drawn last. It results in a different class of artifacts, when the shadows are occluded by near-camera objects, like this:

<img width="2820" height="1587" alt="image" src="https://github.com/user-attachments/assets/fe850137-3ff4-420a-9f9a-9696a21a239e" />

But this happens much rarer.