### PR TITLE
Improve z fighting situation

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -8,7 +8,7 @@ uniform mat4 uMatModelView;
 uniform bool uTrapezoidFilterEnabled;
 uniform bool uWibbleEffect;
 
-layout(location = 0) in vec3 inPosition;
+layout(location = 0) in vec4 inPosition;
 layout(location = 1) in vec3 inNormal;
 layout(location = 2) in vec3 inUVW;
 layout(location = 3) in vec4 inTextureSize;
@@ -37,6 +37,7 @@ void main(void) {
     gWorldPos = eyePos;
     gNormal = inNormal;
     gl_Position = uMatProjection * eyePos;
+    gl_Position.z += inPosition.w;
 
     // apply water wibble effect only to non-sprite vertices
     if (((inFlags & VERT_CAUSTICS) != 0u)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 4.13)
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 4.13)
 - fixed being able to issue certain console commands that target Lara during loading screens (#3662, regression from 4.13)
+- fixed z-fighting of doors near walls
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - improved lighting, projection and sizing of 3D pickups in the UI

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -17,6 +17,7 @@
     - added support for 60 fps in 3D UI pickups
     - fixed trapezoid textures warping at the edge of the screen (#2629)
     - fixed certain polygons disappearing in some objects (#3699)
+    - fixed z-fighting of doors near walls
     - removed software rendering mode
     - removed the z-buffer option, which is now always enabled
     - removed undocumented linear and nearest texel adjustment options

--- a/src/libtrx/game/output/mesh_batcher/batcher.c
+++ b/src/libtrx/game/output/mesh_batcher/batcher.c
@@ -12,7 +12,7 @@
 typedef OUTPUT_SHORT M_MESH_SHADE;
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     XYZ_F normal;
     OUTPUT_USHORT flags;
     RGBA_8888 color;
@@ -108,7 +108,10 @@ static M_MESH_BUF_BINDING *M_GetBinding(
 static void M_FillGeometry(
     M_MESH_GEOM *const geom, const OUTPUT_MESH_VERTEX *const vertex)
 {
-    geom->pos = vertex->pos;
+    geom->pos.x = vertex->pos.x;
+    geom->pos.y = vertex->pos.y;
+    geom->pos.z = vertex->pos.z;
+    geom->pos.w = vertex->pos.w;
     geom->normal = vertex->normal;
     geom->color = vertex->color;
     geom->flags = vertex->flags;
@@ -258,7 +261,7 @@ static void M_OpaquePass(
                 // UBOs.
 
                 // clang-format off
-                v.geom.pos = (XYZ_F) {
+                v.geom.pos = (XYZW_F) {
                     .x = (
                         m->_00 * v.geom.pos.x +
                         m->_01 * v.geom.pos.y +
@@ -277,6 +280,7 @@ static void M_OpaquePass(
                         m->_22 * v.geom.pos.z +
                         m->_23
                      ),
+                     .w = v.geom.pos.w,
                 };
                 // clang-format on
                 v.geom.color.r *= inst->tint.r;
@@ -441,7 +445,7 @@ MESH_BATCHER *MeshBatcher_Create(void)
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_COLOR);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_GEOM),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_MESH_GEOM),
         (void *)(intptr_t)offsetof(M_MESH_GEOM, pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_GEOM),
@@ -487,7 +491,7 @@ MESH_BATCHER *MeshBatcher_Create(void)
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),
         (void *)(intptr_t)offsetof(M_MESH_FULL, geom.pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_MESH_FULL),

--- a/src/libtrx/game/output/mesh_batcher/batcher.c
+++ b/src/libtrx/game/output/mesh_batcher/batcher.c
@@ -394,7 +394,9 @@ static void M_RenderPass(
 static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
 {
     const MESH_BATCHER *const batcher = source->priv;
-    return batcher->staged[pass]->count > 0;
+    return batcher->staged[pass]->count > 0
+        || (batcher->transparent_vertices->count > 0
+            && pass == SCENE_PASS_TRANSPARENT);
 }
 
 static void M_AnimateTextures(const SCENE_SOURCE *const source)

--- a/src/libtrx/game/output/mesh_batcher/mesh_builder.c
+++ b/src/libtrx/game/output/mesh_batcher/mesh_builder.c
@@ -160,7 +160,7 @@ void MeshBuilder_AddRoomSprite(
     };
     for (int32_t j = 0; j < 4; j++) {
         const OUTPUT_MESH_VERTEX vertex = {
-            .pos = { .x = pos->x, .y = pos->y, .z = pos->z },
+            .pos = { .x = pos->x, .y = pos->y, .z = pos->z, .w = 0.0f, },
             .normal = { .x = normal[j].x, .y = normal[j].y, .z = 0.0f },
             .flags = VERT_BILLBOARD,
             .color = { 255, 255, 255, 255 },
@@ -171,6 +171,14 @@ void MeshBuilder_AddRoomSprite(
         MeshBuilder_AddVertex(builder, &vertex);
     }
     MeshBuilder_AddFace4(builder, true);
+}
+
+void MeshBuilder_AdjustDepth(MESH_BUILDER *const builder, const float depth)
+{
+    OUTPUT_MESH_VERTEX *const vbuf = Vector_GetData(builder->mesh->vertices);
+    for (int32_t i = 0; i < builder->mesh->vertices->count; i++) {
+        vbuf[i].pos.w = depth;
+    }
 }
 
 OUTPUT_MESH *MeshBuilder_Seal(MESH_BUILDER *const builder)

--- a/src/libtrx/game/output/sources/lightnings.c
+++ b/src/libtrx/game/output/sources/lightnings.c
@@ -7,7 +7,7 @@
 #include "gfx/gl/utils.h"
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     XYZ_F normal;
     RGBA_8888 color;
 } M_VERTEX;
@@ -39,19 +39,21 @@ static void M_GenerateLightningSegment(
 
     Matrix_Push();
     Matrix_TranslateAbs32(segment->from);
-    const XYZ_F pos_0 = {
+    const XYZW_F pos_0 = {
         .x = g_MatrixPtr->_03 >> W2V_SHIFT,
         .y = g_MatrixPtr->_13 >> W2V_SHIFT,
         .z = g_MatrixPtr->_23 >> W2V_SHIFT,
+        .w = 0.0f,
     };
     Matrix_Pop();
 
     Matrix_Push();
     Matrix_TranslateAbs32(segment->to);
-    const XYZ_F pos_1 = {
+    const XYZW_F pos_1 = {
         .x = g_MatrixPtr->_03 >> W2V_SHIFT,
         .y = g_MatrixPtr->_13 >> W2V_SHIFT,
         .z = g_MatrixPtr->_23 >> W2V_SHIFT,
+        .w = 0.0f,
     };
     Matrix_Pop();
 
@@ -166,7 +168,7 @@ void OutputSource_Lightnings_Init(void)
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_COLOR);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
         (void *)(intptr_t)offsetof(M_VERTEX, pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_NORMAL, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),

--- a/src/libtrx/game/output/sources/misc.c
+++ b/src/libtrx/game/output/sources/misc.c
@@ -10,7 +10,7 @@
 #include "utils.h"
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     RGBA_8888 color;
 } M_VERTEX;
 
@@ -63,7 +63,7 @@ static void M_GenerateSphere(
     // More subdivisions means smoother spheres.
     const RGBA_8888 color = { 255, 0, 0, 255 };
     const int32_t position_count = SQUARE(subdivisions + 1);
-    XYZ_F positions[position_count];
+    XYZW_F positions[position_count];
     int32_t index = 0;
 
     for (int32_t i = 0; i <= subdivisions; i++) {
@@ -77,10 +77,11 @@ static void M_GenerateSphere(
             const float cos_phi = cosf(phi);
 
             // Convert spherical coordinates to 3D points.
-            positions[index] = (XYZ_F) {
-                .x = 1 * cos_phi * sin_theta,
-                .y = 1 * cos_theta,
-                .z = 1 * sin_phi * sin_theta,
+            positions[index] = (XYZW_F) {
+                .x = cos_phi * sin_theta,
+                .y = cos_theta,
+                .z = sin_phi * sin_theta,
+                .w = 0.0f,
             };
             index++;
         }
@@ -100,15 +101,19 @@ static void M_GenerateSphere(
                 const int32_t l = OUTPUT_QUAD_TO_FAN(k);
                 Vector_Add(
                     p->vertices,
-                    &(M_VERTEX) { .pos = positions[indices[l]],
-                                  .color = color });
+                    &(M_VERTEX) {
+                        .pos = positions[indices[l]],
+                        .color = color,
+                    });
             }
             for (int32_t k = 0; k < OUTPUT_QUAD_VERTICES; k++) {
                 const int32_t l = OUTPUT_QUAD_TO_FAN_CW(k);
                 Vector_Add(
                     p->vertices,
-                    &(M_VERTEX) { .pos = positions[indices[l]],
-                                  .color = color });
+                    &(M_VERTEX) {
+                        .pos = positions[indices[l]],
+                        .color = color,
+                    });
             }
         }
     }
@@ -203,7 +208,7 @@ void OutputSource_Misc_Init(void)
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
         (void *)(intptr_t)offsetof(M_VERTEX, pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(M_VERTEX),

--- a/src/libtrx/game/output/sources/objects.c
+++ b/src/libtrx/game/output/sources/objects.c
@@ -177,6 +177,7 @@ static void M_PrepareMeshes(M_PRIV *const p)
                 flags | VERT_FLAT_SHADED);
         }
 
+        MeshBuilder_AdjustDepth(builder, -0.005);
         OUTPUT_MESH *const mesh = MeshBuilder_Seal(builder);
         if (mesh != nullptr) {
             MeshBatcher_AddMesh(p->batcher, mesh);

--- a/src/libtrx/game/output/sources/rooms_debug.c
+++ b/src/libtrx/game/output/sources/rooms_debug.c
@@ -11,7 +11,7 @@
 #include "vector.h"
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     RGBA_8888 color;
 } M_VERTEX;
 
@@ -82,7 +82,12 @@ static void M_PrepareRoomTriggers(
                     + (Output_GetWaterEffect() ? -16 : -2);
 
                 M_VERTEX vertex = {
-                    .pos = { vertex_pos.x, vertex_pos.y, vertex_pos.z },
+                    .pos = {
+                        .x = vertex_pos.x,
+                        .y = vertex_pos.y,
+                        .z = vertex_pos.z,
+                        .w = 0.0f,
+                    },
                     .color = color,
                 };
                 Vector_Add(p->vertices, &vertex);
@@ -103,12 +108,12 @@ static void M_PrepareRoomPortals(
         return;
     }
     for (int32_t i = 0; i < room->portals->count; i++) {
-        const PORTAL *const portal = &room->portals->portal[i];
-        const XYZ_F positions[4] = {
-            { portal->vertex[0].x, portal->vertex[0].y, portal->vertex[0].z },
-            { portal->vertex[1].x, portal->vertex[1].y, portal->vertex[1].z },
-            { portal->vertex[2].x, portal->vertex[2].y, portal->vertex[2].z },
-            { portal->vertex[3].x, portal->vertex[3].y, portal->vertex[3].z },
+        const XYZ_16 *const portal = room->portals->portal[i].vertex;
+        const XYZW_F positions[4] = {
+            { portal[0].x, portal[0].y, portal[0].z, 0.0f },
+            { portal[1].x, portal[1].y, portal[1].z, 0.0f },
+            { portal[2].x, portal[2].y, portal[2].z, 0.0f },
+            { portal[3].x, portal[3].y, portal[3].z, 0.0f },
         };
         const int32_t indices[8] = { 0, 1, 1, 2, 2, 3, 3, 0 };
         for (int32_t j = 0; j < 8; j++) {
@@ -241,7 +246,7 @@ void OutputSource_RoomsDebug_Init(void)
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
         (void *)(intptr_t)offsetof(M_VERTEX, pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(M_VERTEX),

--- a/src/libtrx/game/output/sources/ui.c
+++ b/src/libtrx/game/output/sources/ui.c
@@ -13,7 +13,7 @@
 #define M_PICKUPS_FOV 65
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     OUTPUT_UVW uvw;
     OUTPUT_TEXTURE_SIZE texture_size;
     OUTPUT_USHORT flags;
@@ -246,7 +246,7 @@ void OutputSource_UI_Init(void)
     glDisableVertexAttribArray(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_FLAGS);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_POS, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
+        OUTPUT_MESH_ATTR_POS, 4, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
         (void *)(intptr_t)offsetof(M_VERTEX, pos));
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_UVW, 3, GL_FLOAT, GL_FALSE, sizeof(M_VERTEX),
@@ -293,6 +293,7 @@ void OutputSource_UI_StageSprite(const OUTPUT_UI_SPRITE sprite)
     M_VERTEX vertices[4];
     for (int32_t i = 0; i < 4; i++) {
         vertices[i].pos.z = sprite.z;
+        vertices[i].pos.w = 0.0f;
         vertices[i].color.r = sprite.color.r;
         vertices[i].color.g = sprite.color.g;
         vertices[i].color.b = sprite.color.b;
@@ -330,6 +331,7 @@ void OutputSource_UI_StageQuad(const OUTPUT_UI_QUAD quad)
     M_VERTEX vertices[4];
     for (int32_t i = 0; i < 4; i++) {
         vertices[i].pos.z = quad.z;
+        vertices[i].pos.w = 0.0f;
         vertices[i].shade = SHADE_NEUTRAL;
         vertices[i].flags =
             VERT_NO_LIGHTING | VERT_FLAT_SHADED | VERT_NO_CAUSTICS;

--- a/src/libtrx/include/libtrx/game/math/types.h
+++ b/src/libtrx/include/libtrx/game/math/types.h
@@ -36,6 +36,10 @@ typedef struct {
     float x, y, z;
 } XYZ_F;
 
+typedef struct {
+    float x, y, z, w;
+} XYZW_F;
+
 typedef enum {
     DIR_UNKNOWN = -1,
     DIR_NORTH = 0,

--- a/src/libtrx/include/libtrx/game/output/mesh_batcher/batcher.h
+++ b/src/libtrx/include/libtrx/game/output/mesh_batcher/batcher.h
@@ -17,6 +17,8 @@ typedef struct MESH_INSTANCE {
     XYZ_32 ls_vector_view;
 
     bool enable_scissor;
+    bool disable_z_writes;
+    float z_offset;
     VIEWPORT_RECT scissor;
 
     int32_t (*transparent_sort_func)(

--- a/src/libtrx/include/libtrx/game/output/mesh_batcher/mesh.h
+++ b/src/libtrx/include/libtrx/game/output/mesh_batcher/mesh.h
@@ -16,7 +16,7 @@ typedef struct {
 } OUTPUT_MESH_TEXTURE;
 
 typedef struct {
-    XYZ_F pos;
+    XYZW_F pos;
     XYZ_F normal;
     uint16_t flags;
     int16_t uvw_idx;

--- a/src/libtrx/include/libtrx/game/output/mesh_batcher/mesh_builder.h
+++ b/src/libtrx/include/libtrx/game/output/mesh_batcher/mesh_builder.h
@@ -34,6 +34,9 @@ void MeshBuilder_AddFace4(MESH_BUILDER *builder, bool transparent);
 // ring vertices.
 void MeshBuilder_AddFan(MESH_BUILDER *builder, bool transparent);
 
+// Applies invisible z offset to all vertices that helps with the z-fighting.
+void MeshBuilder_AdjustDepth(MESH_BUILDER *builder, float depth);
+
 // Finalize all pending vertices and faces into the OUTPUT_MESH and seal it.
 // Returns the sealed mesh; builder must still be destroyed via
 // MeshBuilder_Destroy().


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reduces z fighting by updating the XYZ to include a small depth offset component.
This has a chance of causing unexpected regressions so I'd appreciate a general lookaround.

Before:

<img width="3840" height="2160" alt="20250807_192440_City_of_Khamoon" src="https://github.com/user-attachments/assets/0ee3e5a4-06fe-4df2-9466-a51d55f46fca" />

After:

<img width="3840" height="2160" alt="20250807_192429_City_of_Khamoon" src="https://github.com/user-attachments/assets/0d1ac1c2-a6c2-4fb7-b1ce-c640eb0fa181" />