### PR TITLE
game-buf: allow resetting individual buffers

### DIFF
--- a/src/libtrx/game/game_buf.c
+++ b/src/libtrx/game/game_buf.c
@@ -3,26 +3,36 @@
 #include "enum_map.h"
 #include "memory.h"
 
-static MEMORY_ARENA_ALLOCATOR m_Allocator = {
-    .default_chunk_size = 1024 * 1024 * 5,
-};
+static MEMORY_ARENA_ALLOCATOR m_Allocator[GBUF_NUM_MALLOC_TYPES] = {};
 
 void GameBuf_Init(void)
 {
+    for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
+        m_Allocator[i].default_chunk_size = 2048;
+    }
 }
 
 void GameBuf_Reset(void)
 {
-    Memory_ArenaReset(&m_Allocator);
+    for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
+        Memory_ArenaReset(&m_Allocator[i]);
+    }
+}
+
+void GameBuf_ResetSingle(const GAME_BUFFER buffer)
+{
+    Memory_ArenaReset(&m_Allocator[buffer]);
 }
 
 void GameBuf_Shutdown(void)
 {
-    Memory_ArenaFree(&m_Allocator);
+    for (int32_t i = 0; i < GBUF_NUM_MALLOC_TYPES; i++) {
+        Memory_ArenaFree(&m_Allocator[i]);
+    }
 }
 
 void *GameBuf_Alloc(const size_t alloc_size, const GAME_BUFFER buffer)
 {
     const size_t aligned_size = (alloc_size + 3) & ~3;
-    return Memory_ArenaAlloc(&m_Allocator, aligned_size);
+    return Memory_ArenaAlloc(&m_Allocator[buffer], aligned_size);
 }

--- a/src/libtrx/include/libtrx/game/game_buf.h
+++ b/src/libtrx/include/libtrx/game/game_buf.h
@@ -53,6 +53,7 @@ typedef enum {
 
 void GameBuf_Init(void);
 void GameBuf_Shutdown(void);
+void GameBuf_ResetSingle(GAME_BUFFER buffer);
 void GameBuf_Reset(void);
 
 void *GameBuf_Alloc(size_t alloc_size, GAME_BUFFER buffer);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

From my benchmarks against develop that include 180 samples of level loads:

Develop: 33.87 ms
This PR: 34.04 ms

I'd say the difference is negligible.