### PR TITLE
ui/dialogs/settings: show disclaimer when all settings hidden

### DIFF
--- a/data/common/ship/cfg/base_strings-de.json5
+++ b/data/common/ship/cfg/base_strings-de.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Unzulässiges Geheimnis: #%d (zulässige Geheimnisse: %s)",
         "CMD_LUA_RUNTIME_ERROR": "\\{review}Lua-Laufzeitfehler: %s",
         "CMD_LUA_SYNTAX_ERROR": "\\{review}Lua-Syntaxfehler: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "\\{review}Die Einstellungen sind für dieses Level-Set deaktiviert.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "Diese Einstellung ist vom Ersteller des Levels erzwungen und kann nicht geändert werden.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Standard wiederherstellen",
         "COMMON_SETTINGS_TOGGLE_HELP": "Hilfe Ein/Aus",

--- a/data/common/ship/cfg/base_strings-fr.json5
+++ b/data/common/ship/cfg/base_strings-fr.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "\\{review}Secret invalide : %s (secrets valides : %s)",
         "CMD_LUA_RUNTIME_ERROR": "\\{review}Erreur d'exécution Lua : %s",
         "CMD_LUA_SYNTAX_ERROR": "\\{review}Erreur de syntaxe Lua : %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "\\{review}Les paramètres sont désactivés pour cet ensemble de niveaux.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "Ce paramètre est imposé par le créateur du niveau et ne peut pas être modifié.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Restaurer",
         "COMMON_SETTINGS_TOGGLE_HELP": "Active l'aide",

--- a/data/common/ship/cfg/base_strings-gd.json5
+++ b/data/common/ship/cfg/base_strings-gd.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Dìomhaireachd mì-dhligheach: %s (dìomhaireachdan dligheach: %s)",
         "CMD_LUA_RUNTIME_ERROR": "Mearachd a' ruith Lua: %s",
         "CMD_LUA_SYNTAX_ERROR": "Mearachd sìntacs Lua: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "Tha na roghainnean ciorramach airson nan ìrean seo.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "Tha an suidheachadh seo air a chur an gnìomh le ùghdar nan ìrean agus chan urrainnear ga atharrachadh.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Ath-shuidhich",
         "COMMON_SETTINGS_TOGGLE_HELP": "Tionndaidh cuideachadh",

--- a/data/common/ship/cfg/base_strings-it.json5
+++ b/data/common/ship/cfg/base_strings-it.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Segreto non valido: %s (segreti validi: %s)",
         "CMD_LUA_RUNTIME_ERROR": "\\{review}Errore di runtime Lua: %s",
         "CMD_LUA_SYNTAX_ERROR": "\\{review}Errore di sintassi Lua: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "\\{review}Le impostazioni sono disabilitate per questo set di livelli.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "Questa impostazione è applicata dal generatore di livelli e non può essere modificata.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Ripristina predefiniti",
         "COMMON_SETTINGS_TOGGLE_HELP": "Visualizza guida",

--- a/data/common/ship/cfg/base_strings-pl.json5
+++ b/data/common/ship/cfg/base_strings-pl.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Nieprawidłowy sekret: %s (prawidłowe sekrety: %s)",
         "CMD_LUA_RUNTIME_ERROR": "Błąd wykonania: %s",
         "CMD_LUA_SYNTAX_ERROR": "Błąd składni: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "\\{review}Ustawienia są wyłączone dla tego zestawu poziomów.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "To ustawienie jest wymuszane przez twórcę poziomu i nie może być zmienione.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Przywróć domyślne",
         "COMMON_SETTINGS_TOGGLE_HELP": "Pokaż pomoc",

--- a/data/common/ship/cfg/base_strings-ru.json5
+++ b/data/common/ship/cfg/base_strings-ru.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Невалидный секрет: %s (валидные секреты: %s)",
         "CMD_LUA_RUNTIME_ERROR": "Ошибка выполнения Lua: %s",
         "CMD_LUA_SYNTAX_ERROR": "Ошибка синтаксиса Lua: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "\\{review}Настройки отключены для этого набора уровней.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "Этот параметр принудительно установлен редактором уровней и не может быть изменён.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "По умолчанию",
         "COMMON_SETTINGS_TOGGLE_HELP": "Показать помощь",

--- a/data/common/ship/cfg/base_strings.json5
+++ b/data/common/ship/cfg/base_strings.json5
@@ -18,6 +18,7 @@
         "CMD_INVALID_SECRET": "Invalid secret: %s (valid secrets: %s)",
         "CMD_LUA_RUNTIME_ERROR": "Lua runtime error: %s",
         "CMD_LUA_SYNTAX_ERROR": "Lua syntax error: %s",
+        "COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER": "Settings are disabled for this level set.",
         "COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER": "This setting is enforced by the level builder and cannot be changed.",
         "COMMON_SETTINGS_RESTORE_DEFAULT": "Restore default",
         "COMMON_SETTINGS_TOGGLE_HELP": "Toggle help",

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -29,6 +29,7 @@
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - changed `-l`/`--level` switch to accept the level number on top of the level path
+- changed settings dialogs to show a suitable message if a level builder has hidden all options within that dialog (#3637)
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
 - fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -42,6 +42,7 @@
 - changed the `/set` console command to report boolean values as `0` or `1`, language-agnostic
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - changed `-l`/`--level` switch to accept the level number on top of the level path
+- changed settings dialogs to show a suitable message if a level builder has hidden all options within that dialog (#3637)
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)

--- a/src/libtrx/game/ui/dialogs/settings.c
+++ b/src/libtrx/game/ui/dialogs/settings.c
@@ -769,13 +769,27 @@ void UI_Settings(UI_SETTINGS_STATE *const s)
         .orientation = UI_STACK_VERTICAL,
         .align = { .h = UI_STACK_H_ALIGN_SPAN },
     });
-    if (s->tab_switch != nullptr) {
+    if (s->tab_switch != nullptr && s->tab_count > 0) {
         UI_TabSwitch(
             s->tab_switch, s->phase == UI_SETTINGS_PHASE_NAVIGATE_TABS);
         UI_Spacer(0.0f, 8.0f);
     }
 
     UI_BeginScrollableArea(&s->scroll, s->tab_count > 0);
+
+    if (s->scroll.vis_items == 0) {
+        UI_BeginResize(-1.0f, -1.0f);
+        UI_BeginPad(
+            TR_VERSION == 1 ? -1.0f : 0.0f, TR_VERSION == 1 ? -1.0f : 0.0f);
+        UI_BeginStackEx((UI_STACK_SETTINGS) {
+            .orientation = UI_STACK_VERTICAL,
+            .align = { .h = UI_STACK_H_ALIGN_CENTER },
+        });
+        UI_Label(GS(COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER));
+        UI_EndStack();
+        UI_EndPad();
+        UI_EndResize();
+    }
 
     for (int32_t i = 0; i < s->scroll.vis_items; i++) {
         const int32_t row = s->scroll.first_item + i;

--- a/src/libtrx/include/libtrx/game/game_string.def
+++ b/src/libtrx/include/libtrx/game/game_string.def
@@ -617,8 +617,9 @@ GS_DEFINE(CONSOLE_HELP_INF_SPRINT,    "Toggles infinite sprint.")
 GS_DEFINE(CONSOLE_HELP_LUA,           "Executes the given Lua code string.")
 
 GS_DEFINE(COMMON_SETTINGS_FROZEN_OPTION_DISCLAIMER, "This setting is enforced by the level builder and cannot be changed.")
-GS_DEFINE(COMMON_SETTINGS_TOGGLE_HELP, "Toggle help")
-GS_DEFINE(COMMON_SETTINGS_RESTORE_DEFAULT, "Restore default")
+GS_DEFINE(COMMON_SETTINGS_ALL_HIDDEN_DISCLAIMER,    "Settings are disabled for this level set.")
+GS_DEFINE(COMMON_SETTINGS_TOGGLE_HELP,              "Toggle help")
+GS_DEFINE(COMMON_SETTINGS_RESTORE_DEFAULT,          "Restore default")
 
 GS_DEFINE(SOUND_SETTINGS_TITLE,                            "Sound Options")
 


### PR DESCRIPTION
Resolves #3637.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

If a level builder has hidden all settings for a particular dialog, a suitable message will be shown to the player rather than an empty window.

Adapted config below from Gizzy's post to include some of the latest settings - this will result in the gameplay and sound dialogs being empty, while graphics will have a few remaining.
[hidden.txt](https://github.com/user-attachments/files/21671635/hidden.txt)

