### PR TITLE
output: flip the depth adjustment axis

### DIFF
--- a/src/libtrx/game/output/sources/objects.c
+++ b/src/libtrx/game/output/sources/objects.c
@@ -179,7 +179,7 @@ static void M_PrepareMeshes(M_PRIV *const p)
                 flags | VERT_FLAT_SHADED);
         }
 
-        MeshBuilder_AdjustDepth(builder, -0.005);
+        MeshBuilder_AdjustDepth(builder, 0.005);
         OUTPUT_MESH *const mesh = MeshBuilder_Seal(builder);
         if (mesh != nullptr) {
             MeshBatcher_AddMesh(p->batcher, mesh);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3766 – instead of nudging the items slightly towards the camera, it nudges them slightly outwards.
The consequence is that the door frames will now get embedded in walls, as demonstrated below. But I think that might actually be a desirable outcome.

**Develop**
<img width="3840" height="2160" alt="20250808_101058_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/e0f23f00-39cb-45ef-b8de-5b6185a10eca" />
**PR**
<img width="3840" height="2160" alt="20250808_101049_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/f31d901f-0ffe-4fcd-97c2-93ac70186dfe" />
