### PR TITLE
tr1/game: adjust item action call order

### DIFF
--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -173,8 +173,8 @@ GF_COMMAND Game_Control(const bool demo_mode)
 
         Camera_Update();
         Sound_ResetAmbient();
-        Sound_UpdateEffects();
         ItemAction_RunActive();
+        Sound_UpdateEffects();
         Overlay_Animate(1);
         Output_AnimateTextures(1);
     }

--- a/src/tr1/game/objects/vars.c
+++ b/src/tr1/game/objects/vars.c
@@ -126,6 +126,7 @@ const GAME_OBJECT_ID g_SwitchObjects[] = {
     // clang-format off
     O_SWITCH_TYPE_NORMAL,
     O_SWITCH_TYPE_UW,
+    NO_OBJECT,
     // clang-format on
 };
 
@@ -171,6 +172,7 @@ const GAME_OBJECT_ID g_AnimObjects[] = {
     O_LARA_UZIS,
     O_LARA_HAIR,
     O_LARA_EXTRA,
+    NO_OBJECT,
     // clang-format on
 };
 
@@ -201,6 +203,7 @@ const GAME_OBJECT_ID g_NullObjects[] = {
     O_SKYBOX,
     O_PICKUP_AID,
     O_ALPHABET,
+    NO_OBJECT,
     // clang-format on
 };
 

--- a/src/tr2/game/objects/vars.c
+++ b/src/tr2/game/objects/vars.c
@@ -129,6 +129,7 @@ const GAME_OBJECT_ID g_SwitchObjects[] = {
     O_SWITCH_TYPE_NORMAL,
     O_SWITCH_TYPE_SMALL,
     O_SWITCH_TYPE_UW,
+    NO_OBJECT,
     // clang-format on
 };
 
@@ -206,6 +207,7 @@ const GAME_OBJECT_ID g_AnimObjects[] = {
     O_LARA_SKIDOO,
     O_LARA_BOAT,
     O_LARA_EXTRA,
+    NO_OBJECT,
     // clang-format on
 };
 
@@ -248,6 +250,7 @@ const GAME_OBJECT_ID g_NullObjects[] = {
     O_COMBAT_END,
     O_CUT_SHOTGUN,
     O_EARTHQUAKE,
+    NO_OBJECT,
     // clang-format on
 };
 
@@ -296,6 +299,7 @@ const GAME_OBJECT_ID g_WaterSpriteObjects[] = {
     O_WATERFALL,
     O_SPLASH_1,
     O_BUBBLE_1,
+    NO_OBJECT,
     // clang-format on
 };
 


### PR DESCRIPTION
Resolves #3768.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`ItemAction_RunActive` seemingly needs to run before `Sound_UpdateEffects` in TR1 for sounds whose positions change each frame, like flooding in The Cistern or sand in Egypt. More fun ahead with SFX merging.

I also noticed some object arrays were missing sentinel values so have fixed that (I initially thought it might be an issue with teleporting to a switch as that array was part of this).
