### PR TITLE
col: fix Lara walking backwards off ledges into lava pits

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -70,6 +70,7 @@
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 4.13)
 - fixed being able to issue certain console commands that target Lara during loading screens (#3662, regression from 4.13)
 - fixed z-fighting of doors near walls
+- fixed Lara walking backwards off ledges into lava (#3745)
 - improved object loading error messages when an invalid object ID is detected
 - improved frames in Lara's jump-twist animations
 - improved lighting, projection and sizing of 3D pickups in the UI

--- a/docs/tr1/IMPROVEMENTS.md
+++ b/docs/tr1/IMPROVEMENTS.md
@@ -124,6 +124,7 @@ Not all options are turned on by default. Refer to the ingame settings for detai
 - fixed Lara not catching fire after reloading a save made when she was on fire
 - fixed the camera resetting if Lara is looking and then draws her guns (OG behaviour retained when using restricted look mode)
 - fixed the collision box on the tall statues in Tomb of Qualopec e.g. room 20
+- fixed Lara walking backwards off ledges into lava
 
 ## Cheats
 - added a fly cheat

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -72,6 +72,7 @@
 - fixed a crash when the level file was missing
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 1.3)
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 1.3)
+- fixed Lara walking backwards off ledges into lava (#3745)
 - improved frames in Lara's jump-twist animations
 - improved object loading error messages when an invalid object ID is detected
 - improved window resize performance in the title inventory ring

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -134,6 +134,7 @@
 - fixed the boat veering if Lara looks left or right when driving
 - fixed Lara not equipping a weapon chosen from inventory if it is the last weapon used
 - fixed being unable to hang off bridges in Barkhang Monastery and Temple of Xian
+- fixed Lara walking backwards off ledges into lava
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/libtrx/game/lara/col/land.c
+++ b/src/libtrx/game/lara/col/land.c
@@ -387,6 +387,7 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_walls = 1;
     coll->bad_neg = -STEPUP_HEIGHT;
     coll->bad_ceiling = 0;
+    coll->lava_is_pit = 1;
 
     Lara_Col_GetInfo(item, coll);
     if (M_TestCeiling(item, coll)) {
@@ -436,6 +437,7 @@ static void M_SideStep(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_walls = 1;
     coll->bad_neg = -STEP_L / 2;
     coll->bad_ceiling = 0;
+    coll->lava_is_pit = 1;
 
     Lara_Col_GetInfo(item, coll);
     if (M_TestCeiling(item, coll)) {


### PR DESCRIPTION
Resolves #3745.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Fixed Lara backwards walking off ledges into lava sectors. Walk sidesteps don't actually set `lava_is_pit` either, but the `bad_neg` for the sidestep state is `coll->bad_neg = -STEP_L / 2` which is extremely small. That means Lara won't even sidestep off tiny 1/2 click (128 height) steps. I set `lava_is_pit` for both sidesteps and backwards walking to be consistent.