### PR TITLE
objects/general: allow interactive fly cheat

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -32,6 +32,7 @@
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - changed `-l`/`--level` switch to accept the level number on top of the level path
 - changed settings dialogs to show a suitable message if a level builder has hidden all options within that dialog (#3637)
+- changed the fly cheat to allow Lara to interact with switches and pickups (#3665)
 - fixed glide camera behaviour and position in room 101 in Temple of the Cat (#3533)
 - fixed French translations containing Italian text in some cases (#3567)
 - fixed the camera remaining locked on moving lava if it touches Lara when she is immune (#3578)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -47,6 +47,7 @@
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range (#3598)
 - changed `-l`/`--level` switch to accept the level number on top of the level path
 - changed settings dialogs to show a suitable message if a level builder has hidden all options within that dialog (#3637)
+- changed the fly cheat to allow Lara to interact with switches and pickups (#3665)
 - fixed audio in the shower cutscene in Home Sweet Home not being sync with the turbo cheat (#3541)
 - fixed projectiles sometimes not shattering breakable windows (#3378, #3551)
 - fixed flat/opaque window shards in Lara's Home and Home Sweet Home (#3512)

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -467,8 +467,7 @@ static void M_HandleUnderwater(COLL_INFO *const coll)
         >> W2V_SHIFT;
 
     const SECTOR *const sector = M_GetCurrentSector();
-    if (lara_info->water_status != LWS_CHEAT
-        && (TR_VERSION == 1 || !lara_info->extra_anim)) {
+    if (TR_VERSION == 1 || !lara_info->extra_anim) {
         M_ObjectCollision(coll);
     }
 

--- a/src/tr1/game/objects/general/pickup.c
+++ b/src/tr1/game/objects/general/pickup.c
@@ -205,7 +205,8 @@ static void M_Control(int16_t item_num)
 
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
-    if (g_Lara.water_status == LWS_UNDERWATER) {
+    if (g_Lara.water_status == LWS_UNDERWATER
+        || g_Lara.water_status == LWS_CHEAT) {
         return &m_PickUpBoundsUW;
     } else if (g_Config.gameplay.enable_walk_to_items) {
         return &m_PickUpBoundsControlled;
@@ -254,7 +255,9 @@ static void M_Collision(
             g_Lara.gun_status = LGS_HANDS_BUSY;
             goto cleanup;
         }
-    } else if (g_Lara.water_status == LWS_UNDERWATER) {
+    } else if (
+        g_Lara.water_status == LWS_UNDERWATER
+        || g_Lara.water_status == LWS_CHEAT) {
         item->rot.x = -25 * DEG_1;
         if (!Lara_TestPosition(item, obj->bounds_func())) {
             goto cleanup;
@@ -342,7 +345,9 @@ static void M_CollisionControlled(
                 g_Lara.interact_target.item_num = NO_ITEM;
             }
         }
-    } else if (g_Lara.water_status == LWS_UNDERWATER) {
+    } else if (
+        g_Lara.water_status == LWS_UNDERWATER
+        || g_Lara.water_status == LWS_CHEAT) {
         item->rot.x = -25 * DEG_1;
 
         if ((g_Input.action && lara_item->current_anim_state == LS_TREAD

--- a/src/tr1/game/objects/general/save_crystal.c
+++ b/src/tr1/game/objects/general/save_crystal.c
@@ -45,10 +45,10 @@ static void M_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 static const OBJECT_BOUNDS *M_Bounds(void)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
-    return lara->water_status == LWS_SURFACE
-            || lara->water_status == LWS_UNDERWATER
-        ? &m_UW_Bounds
-        : &m_SaveCrystal_Bounds;
+    return lara->water_status == LWS_ABOVE_WATER
+            || lara->water_status == LWS_WADE
+        ? &m_SaveCrystal_Bounds
+        : &m_UW_Bounds;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -203,7 +203,8 @@ static void M_CollisionUW(
     const OBJECT *const obj = Object_Get(item->object_id);
 
     if (!g_Input.action || item->status != IS_INACTIVE
-        || g_Lara.water_status != LWS_UNDERWATER) {
+        || (g_Lara.water_status != LWS_UNDERWATER
+            && g_Lara.water_status != LWS_CHEAT)) {
         return;
     }
 

--- a/src/tr2/game/objects/general/pickup.c
+++ b/src/tr2/game/objects/general/pickup.c
@@ -332,7 +332,8 @@ static void M_Draw(const ITEM *const item)
 
 const OBJECT_BOUNDS *Pickup_Bounds(void)
 {
-    if (g_Lara.water_status == LWS_UNDERWATER) {
+    if (g_Lara.water_status == LWS_UNDERWATER
+        || g_Lara.water_status == LWS_CHEAT) {
         return &m_PickUpBoundsUW;
     } else {
         return &m_PickUpBounds;
@@ -350,7 +351,9 @@ void Pickup_Collision(
     if (g_Lara.water_status == LWS_ABOVE_WATER
         || g_Lara.water_status == LWS_WADE) {
         M_DoAboveWater(item_num, lara_item);
-    } else if (g_Lara.water_status == LWS_UNDERWATER) {
+    } else if (
+        g_Lara.water_status == LWS_UNDERWATER
+        || g_Lara.water_status == LWS_CHEAT) {
         M_DoUnderwater(item_num, lara_item);
     }
 }

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -200,7 +200,8 @@ static void M_CollisionUW(
     const OBJECT *const obj = Object_Get(item->object_id);
 
     if (!g_Input.action || item->status != IS_INACTIVE
-        || g_Lara.water_status != LWS_UNDERWATER
+        || (g_Lara.water_status != LWS_UNDERWATER
+            && g_Lara.water_status != LWS_CHEAT)
         || g_Lara.gun_status != LGS_ARMLESS
         || lara_item->current_anim_state != LS_TREAD) {
         return;


### PR DESCRIPTION
Resolves #3665.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows Lara to interact with (underwater type) switches and pickups while in the fly cheat. I dabbled with gun control, but her arms behave too erratically, and she misses 9/10 shots.
