### PR TITLE
Output: preserve original view model matrix in the transparent pass

### DIFF
--- a/src/libtrx/game/output/mesh_batcher/batcher.c
+++ b/src/libtrx/game/output/mesh_batcher/batcher.c
@@ -248,46 +248,11 @@ static void M_OpaquePass(
             const int32_t vertex_start = batcher->transparent_vertices->count;
             for (int32_t k = 0; k < face->vertex_count; k++) {
                 const int32_t l = face->vertex_indices[k];
-                M_MESH_FULL v = {
+                const M_MESH_FULL v = {
                     .geom = bind->geom_data[l],
                     .tex = bind->tex_data[l],
                     .shade = bind->shade_data[l],
                 };
-
-                // Since we're ripping faces apart from individual model
-                // instances, we no longer are able to use per-instance uniforms
-                // – we need to bake the uniforms into vertex attributes.
-                // XXX: this technique might've been possible to avoid by using
-                // UBOs.
-
-                // clang-format off
-                v.geom.pos = (XYZW_F) {
-                    .x = (
-                        m->_00 * v.geom.pos.x +
-                        m->_01 * v.geom.pos.y +
-                        m->_02 * v.geom.pos.z +
-                        m->_03
-                     ),
-                    .y = (
-                        m->_10 * v.geom.pos.x +
-                        m->_11 * v.geom.pos.y +
-                        m->_12 * v.geom.pos.z +
-                        m->_13
-                     ),
-                    .z = (
-                        m->_20 * v.geom.pos.x +
-                        m->_21 * v.geom.pos.y +
-                        m->_22 * v.geom.pos.z +
-                        m->_23
-                     ),
-                     .w = v.geom.pos.w,
-                };
-                // clang-format on
-                v.geom.color.r *= inst->tint.r;
-                v.geom.color.g *= inst->tint.g;
-                v.geom.color.b *= inst->tint.b;
-                v.geom.flags |= inst->wibble ? VERT_CAUSTICS : 0;
-
                 Vector_Add(batcher->transparent_vertices, &v);
             }
             const int32_t vertex_count =
@@ -307,24 +272,26 @@ static void M_OpaquePass(
 
 static void M_TransparentPass(const MESH_BATCHER *const batcher)
 {
-    const MATRIX id_matrix = {
-        // clang-format off
-        ._00 = 1, ._01 = 0, ._02 = 0, ._03 = 0,
-        ._10 = 0, ._11 = 1, ._12 = 0, ._13 = 0,
-        ._20 = 0, ._21 = 0, ._22 = 1, ._23 = 0,
-        // clang-format on
-    };
-    Output_Shader_UploadViewModelMatrix(batcher->shader, &id_matrix);
-    Output_Shader_UploadTint(batcher->shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
     glBindVertexArray(batcher->full_vao);
     glBindBuffer(GL_ARRAY_BUFFER, batcher->full_vbo);
     GFX_TRACK_DATA(
         glBufferData, GL_ARRAY_BUFFER,
         batcher->transparent_vertices->count * sizeof(M_MESH_FULL),
         Vector_GetData(batcher->transparent_vertices), GL_STATIC_DRAW);
+
+    const MESH_INSTANCE *inst = nullptr;
     for (int32_t i = 0; i < batcher->transparent_sort->count; i++) {
         const M_FACE_SORT *const sort_ptr =
             Vector_Get(batcher->transparent_sort, i);
+        if (sort_ptr->face->vertex_count == 0) {
+            continue;
+        }
+        if (sort_ptr->inst != inst) {
+            inst = sort_ptr->inst;
+            Output_Shader_UploadViewModelMatrix(batcher->shader, &inst->matrix);
+            Output_Shader_UploadTint(batcher->shader, inst->tint);
+            Output_Shader_UploadWibbleEffect(batcher->shader, inst->wibble);
+        }
         glDrawArrays(
             GL_TRIANGLES, sort_ptr->vertex_start, sort_ptr->vertex_count);
         g_GFX_Metrics.trans_vert_count += sort_ptr->face->vertex_count;

--- a/src/libtrx/game/output/scene_compositor.c
+++ b/src/libtrx/game/output/scene_compositor.c
@@ -5,6 +5,7 @@
 #include "game/output.h"
 #include "game/output/shader.h"
 #include "game/output/textures.h"
+#include "game/shell.h"
 #include "gfx/context.h"
 #include "vector.h"
 
@@ -206,7 +207,7 @@ void SceneCompositor_Shutdown(void)
 
 bool M_IsActive(void)
 {
-    return !Output_IsHeadless()
+    return !Output_IsHeadless() || Shell_GetArgs()->debug_render_performance
         || GFX_Context_GetScheduledScreenshotPath() != nullptr;
 }
 

--- a/src/libtrx/game/shell/flow.c
+++ b/src/libtrx/game/shell/flow.c
@@ -151,6 +151,7 @@ const SHELL_ARGS *Shell_CommonInit(const SHELL_ARGS *const args)
                 tmp_args->original_args = nullptr;
             }
             tmp_args->headless = args->headless;
+            tmp_args->debug_render_performance = args->debug_render_performance;
             new_args = tmp_args;
         }
     } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Reduces GPU throughput at the cost of increased uniforms churn.
Should let me do some cool things with sprites.

### Folly Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 7780.86  │ 7780.86  │ ⚪ 100.00% ┃
┃ Transparent vertices │ 173.86   │ 173.86   │ ⚪ 100.00% ┃
┃ Transfers            │ 53.37    │ 52.38    │ ⚪ 98.14%  ┃
┃ Uniforms             │ 78.15    │ 91.02    │ 🟠 116.46% ┃
┃ Throughput           │ 52.07 KB │ 39.17 KB │ 🟢 75.22%  ┃
┃ Time                 │ 0.20 ms  │ 0.20 ms  │ ⚪ 98.42%  ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
### Midas Headless
```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 10336.23 │ 10336.23 │ ⚪ 100.00% ┃
┃ Transparent vertices │ 402.83   │ 402.83   │ ⚪ 100.00% ┃
┃ Transfers            │ 65.93    │ 64.94    │ ⚪ 98.49%  ┃
┃ Uniforms             │ 94.02    │ 165.48   │ 🔴 176.00% ┃
┃ Throughput           │ 63.06 KB │ 33.16 KB │ 💚 52.59%  ┃
┃ Time                 │ 0.21 ms  │ 0.21 ms  │ ⚪ 101.18% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```
