### PR TITLE
output: exclude bubbles from upright transform

### DIFF
--- a/data/common/ship/shaders/common.glsl
+++ b/data/common/ship/shaders/common.glsl
@@ -8,7 +8,7 @@
 #define VERT_REFLECTIVE  0x04u
 #define VERT_NO_LIGHTING 0x08u
 #define VERT_BILLBOARD   0x10u
-#define VERT_CAUSTICS    0x20u
+#define VERT_ABS_SPRITE  0x20u
 
 #define LIGHTING_MODE_OFF         0
 #define LIGHTING_MODE_ONLY_SHADES 1

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -32,8 +32,12 @@ out vec4 gColor;
 void main(void) {
     vec4 eyePos;
 
-    if ((inFlags & VERT_BILLBOARD) != 0u) {
-        eyePos = offsetBillboard(inPosition.xyz, inNormal.xy, uMatView, uMatModelView, uMatProjection, uBillboardLockMode);
+    if ((inFlags & VERT_ABS_SPRITE) != 0u) {
+        eyePos = offsetBillboard(
+            inPosition.xyz, inNormal.xy, uMatView, uMatModelView, uMatProjection, BILLBOARD_LOCK_NONE);
+    } else if ((inFlags & VERT_BILLBOARD) != 0u) {
+        eyePos = offsetBillboard(
+            inPosition.xyz, inNormal.xy, uMatView, uMatModelView, uMatProjection, uBillboardLockMode);
     } else {
         eyePos = uMatModelView * vec4(inPosition.xyz, 1.0);
     }
@@ -44,10 +48,9 @@ void main(void) {
     gl_Position.z += inPosition.w;
 
     // apply water wibble effect only to non-sprite vertices
-    if (((inFlags & VERT_CAUSTICS) != 0u)
-        || (uWibbleEffect
-            && (inFlags & VERT_NO_CAUSTICS) == 0u
-            && (inFlags & VERT_BILLBOARD) == 0u)
+    if ((uWibbleEffect
+        && (inFlags & VERT_NO_CAUSTICS) == 0u
+        && (inFlags & VERT_BILLBOARD) == 0u)
     ) {
         gl_Position.xyz = waterWibble(gl_Position, uViewportSize, uTime);
     }

--- a/src/libtrx/game/output/mesh_batcher/mesh_builder.c
+++ b/src/libtrx/game/output/mesh_batcher/mesh_builder.c
@@ -162,7 +162,7 @@ void MeshBuilder_AddRoomSprite(
         const OUTPUT_MESH_VERTEX vertex = {
             .pos = { .x = pos->x, .y = pos->y, .z = pos->z, .w = 0.0f, },
             .normal = { .x = normal[j].x, .y = normal[j].y, .z = 0.0f },
-            .flags = VERT_BILLBOARD,
+            .flags = Output_Textures_GetSpriteTextureFlags(texture_idx),
             .color = { 255, 255, 255, 255 },
             .uvw_idx = Output_Textures_GetSpriteUVWIndex(texture_idx, j),
             .shade = room_vert->light_adder,

--- a/src/libtrx/game/output/textures.c
+++ b/src/libtrx/game/output/textures.c
@@ -38,6 +38,10 @@ static struct {
         bool *animated;
         bool *animated_objects;
         bool *animated_sprites;
+
+        uint16_t *flags;
+        uint16_t *flags_objects;
+        uint16_t *flags_sprites;
     } uvws;
 
     struct {
@@ -214,6 +218,7 @@ static void M_FillSpriteUVW(const int32_t i)
     corners[1].u = u1; corners[1].v = v0; corners[1].w = sprite->tex_page;
     corners[2].u = u1; corners[2].v = v1; corners[2].w = sprite->tex_page;
     corners[3].u = u0; corners[3].v = v1; corners[3].w = sprite->tex_page;
+    m_Priv.uvws.flags_sprites[i] = sprite->flags;
     // clang-format on
 }
 
@@ -265,6 +270,9 @@ static void M_PrepareUVWs(void)
     m_Priv.uvws.animated_objects = m_Priv.uvws.animated;
     m_Priv.uvws.animated_sprites =
         m_Priv.uvws.animated + m_Priv.uvws.count_objects;
+    m_Priv.uvws.flags = Memory_Alloc(m_Priv.uvws.count * sizeof(uint16_t));
+    m_Priv.uvws.flags_objects = m_Priv.uvws.flags;
+    m_Priv.uvws.flags_sprites = m_Priv.uvws.flags + m_Priv.uvws.count_objects;
     M_FillObjectUVWs();
     M_FillSpriteUVWs();
 }
@@ -364,6 +372,7 @@ static void M_FreeLevelData(void)
     }
     Memory_FreePointer(&m_Priv.uvws.data);
     Memory_FreePointer(&m_Priv.uvws.animated);
+    Memory_FreePointer(&m_Priv.uvws.flags);
     Memory_FreePointer(&m_Priv.atlas_sizes.data);
 }
 
@@ -470,9 +479,20 @@ bool Output_Textures_IsObjectTextureAnimated(const int32_t texture_idx)
     return m_Priv.uvws.animated_objects[texture_idx];
 }
 
-bool Output_Textures_IsSpriteTextureAnimated(const int32_t uvw_idx)
+bool Output_Textures_IsSpriteTextureAnimated(const int32_t texture_idx)
 {
-    return m_Priv.uvws.animated_sprites[uvw_idx];
+    return m_Priv.uvws.animated_sprites[texture_idx];
+}
+
+void Output_Textures_SetSpriteTextureFlags(
+    const int32_t texture_idx, const uint16_t flags)
+{
+    m_Priv.uvws.flags_sprites[texture_idx] = flags;
+}
+
+uint16_t Output_Textures_GetSpriteTextureFlags(const int32_t texture_idx)
+{
+    return VERT_BILLBOARD | m_Priv.uvws.flags_sprites[texture_idx];
 }
 
 bool Output_Textures_IsObjectTextureTransparent(const int32_t texture_idx)

--- a/src/libtrx/include/libtrx/game/output/shader.h
+++ b/src/libtrx/include/libtrx/game/output/shader.h
@@ -9,7 +9,7 @@
 #define VERT_REFLECTIVE  0b0000'0100 // = 0x04
 #define VERT_NO_LIGHTING 0b0000'1000 // = 0x08
 #define VERT_BILLBOARD   0b0001'0000 // = 0x10
-#define VERT_CAUSTICS    0b0010'0000 // = 0x20
+#define VERT_ABS_SPRITE  0b0010'0000 // = 0x20
 // clang-format on
 
 // GL attribute mapping in the shader

--- a/src/libtrx/include/libtrx/game/output/textures.h
+++ b/src/libtrx/include/libtrx/game/output/textures.h
@@ -37,6 +37,8 @@ OUTPUT_TEXTURE_SIZE Output_Textures_GetAtlasSize(int32_t uvw_idx);
 bool Output_Textures_IsObjectTextureAnimated(int32_t texture_idx);
 bool Output_Textures_IsObjectTextureTransparent(int32_t texture_idx);
 bool Output_Textures_IsSpriteTextureAnimated(int32_t sprite_idx);
+uint16_t Output_Textures_GetSpriteTextureFlags(int32_t sprite_idx);
+void Output_Textures_SetSpriteTextureFlags(int32_t sprite_idx, uint16_t flags);
 
 // Public utility methods =====================================================
 

--- a/src/libtrx/include/libtrx/game/output/types.h
+++ b/src/libtrx/include/libtrx/game/output/types.h
@@ -74,6 +74,7 @@ typedef struct {
     int16_t y0;
     int16_t x1;
     int16_t y1;
+    uint16_t flags;
 } SPRITE_TEXTURE;
 
 typedef struct ANIMATED_TEXTURE_RANGE {

--- a/src/tr1/game/objects/effects/bubble.c
+++ b/src/tr1/game/objects/effects/bubble.c
@@ -2,6 +2,7 @@
 
 #include <libtrx/game/math.h>
 #include <libtrx/game/objects.h>
+#include <libtrx/game/output.h>
 #include <libtrx/game/rooms.h>
 
 static void M_Setup(OBJECT *obj);
@@ -10,6 +11,9 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
+    for (int32_t i = 0; i < -obj->mesh_count; i++) {
+        Output_GetSpriteTexture(obj->mesh_idx + i)->flags = VERT_ABS_SPRITE;
+    }
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/tr2/game/objects/effects/bubble.c
+++ b/src/tr2/game/objects/effects/bubble.c
@@ -2,6 +2,7 @@
 #include "global/vars.h"
 
 #include <libtrx/game/math.h>
+#include <libtrx/game/output.h>
 
 static void M_Setup(OBJECT *obj);
 static void M_Control(int16_t effect_num);
@@ -9,6 +10,9 @@ static void M_Control(int16_t effect_num);
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
+    for (int32_t i = 0; i < -obj->mesh_count; i++) {
+        Output_GetSpriteTexture(obj->mesh_idx + i)->flags = VERT_ABS_SPRITE;
+    }
 }
 
 static void M_Control(const int16_t effect_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Forces bubbles to use normal billboarding.
