### PR TITLE
tr2/output: fix fog effect too strong on statics

### DIFF
--- a/src/libtrx/game/output/func.c
+++ b/src/libtrx/game/output/func.c
@@ -102,22 +102,6 @@ void Output_MakeScreenshot(const char *const path)
     GFX_Context_ScheduleScreenshot(path);
 }
 
-int32_t Output_CalcFogShade(const int32_t depth)
-{
-#if TR_VERSION == 1
-    return 0;
-#endif
-    const int32_t fog_start = Output_GetFogStart();
-    const int32_t fog_end = Output_GetFogEnd();
-    if (depth < fog_start) {
-        return 0;
-    }
-    if (depth >= fog_end) {
-        return SHADE_MAX;
-    }
-    return (depth - fog_start) * SHADE_MAX / (fog_end - fog_start);
-}
-
 void Output_ApplyFOV(void)
 {
     int32_t fov = Viewport_GetEffectiveFOV();

--- a/src/libtrx/game/output/lights.c
+++ b/src/libtrx/game/output/lights.c
@@ -147,8 +147,6 @@ void Output_CalculateLight(const XYZ_32 pos, const int16_t room_num)
         Output_RotateLight(angles[1], angles[0]);
     }
 
-    const int32_t depth = g_MatrixPtr->_23 >> W2V_SHIFT;
-    global_adder += Output_CalcFogShade(depth);
     CLAMPG(global_adder, SHADE_MAX);
 
     Output_SetLightAdder(global_adder);
@@ -159,8 +157,6 @@ void Output_CalculateStaticLight(const int16_t adder)
 {
     // TODO: use m_LsAdder
     int32_t global_adder = adder - SHADE_NEUTRAL;
-    const int32_t depth = g_MatrixPtr->_23 >> W2V_SHIFT;
-    global_adder += Output_CalcFogShade(depth);
     CLAMPG(global_adder, SHADE_MAX);
     Output_SetLightAdder(global_adder);
 }

--- a/src/libtrx/include/libtrx/game/output/func.h
+++ b/src/libtrx/include/libtrx/game/output/func.h
@@ -7,5 +7,3 @@ CLIP Output_CheckBoundsClip(const BOUNDS_16 *bounds);
 void Output_MakeScreenshot(const char *path);
 
 void Output_ApplyFOV(void);
-
-int32_t Output_CalcFogShade(int32_t depth);

--- a/src/libtrx/include/libtrx/game/output/lights.h
+++ b/src/libtrx/include/libtrx/game/output/lights.h
@@ -10,7 +10,6 @@ void Output_CalculateLight(XYZ_32 pos, int16_t room_num);
 void Output_CalculateStaticLight(int16_t adder);
 void Output_CalculateStaticMeshLight(XYZ_32 pos, SHADE shade, const ROOM *room);
 void Output_CalculateObjectLighting(const ITEM *item, const BOUNDS_16 *bounds);
-int32_t Output_CalcFogShade(int32_t depth);
 int32_t Output_GetRoomLightShade(ROOM_LIGHT_MODE mode);
 void Output_LightRoomVertices(const ROOM *room);
 void Output_LightRoom(ROOM *room);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Area of interest: window in the background

Develop:

<img width="3840" height="2160" alt="20250810_104335_Lara's_Home" src="https://github.com/user-attachments/assets/f7497b7e-8585-4f54-bf25-f56b2f7372ab" />

PR:

<img width="3840" height="2160" alt="20250810_104433_Lara's_Home" src="https://github.com/user-attachments/assets/537bf77e-4cea-431a-8c46-168642ffb45c" />