### PR TITLE
tr2/skidoo: test water status on mount

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -75,6 +75,7 @@
 - fixed wireframe mode rendering as mostly white (#3649, regression from 1.3.2)
 - fixed shadows Y component not interpolated in 60 FPS (#1314)
 - fixed a crash when the level file was missing
+- fixed Lara being able to get on a skidoo while underwater and consequently dying (#3810)
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 1.3)
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 1.3)
 - fixed Lara walking backwards off ledges into lava (#3745)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -135,6 +135,7 @@
 - fixed Lara not equipping a weapon chosen from inventory if it is the last weapon used
 - fixed being unable to hang off bridges in Barkhang Monastery and Temple of Xian
 - fixed Lara walking backwards off ledges into lava
+- fixed Lara being able to get on a skidoo while underwater and consequently dying
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/tr2/decomp/skidoo.c
+++ b/src/tr2/decomp/skidoo.c
@@ -161,7 +161,9 @@ void Skidoo_Initialise(const int16_t item_num)
 int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
 {
     if (!g_Input.action || g_Lara.gun_status != LGS_ARMLESS
-        || g_LaraItem->gravity) {
+        || g_LaraItem->gravity
+        || (g_Lara.water_status != LWS_ABOVE_WATER
+            && g_Lara.water_status != LWS_WADE)) {
         return SKIDOO_GET_ON_NONE;
     }
 


### PR DESCRIPTION
Resolves #3810.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restricts Lara to being able to mount a skidoo only when on land or wading. Updated `spring-skidoo.zip` test level.
