### PR TITLE
savegame: fix music resuming

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -90,6 +90,7 @@
 - fixed Lara walking backwards off ledges into lava (#3745)
 - fixed room scheduling algorithm sometimes drawing overlapping rooms (#3774, regression from 4.1)
 - fixed exiting photo mode on a controller conflicting with the roll input (#3842, regression from 4.8)
+- fixed resuming non-ambient music tracks when loading a savegame (#3845, regression from 4.13)
 
 ## [4.13.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.13.1...tr1-4.13.2) - 2025-07-20
 - fixed savegame scanner only seeing all-lowercase file names (#3518, regression from 4.9)

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -933,8 +933,8 @@ static bool M_LoadCurrentMusic(
     JSON_OBJECT *music_obj, const uint16_t header_version)
 {
     if (music_obj == nullptr) {
-        LOG_WARNING("Malformed save: invalid or missing current music");
-        return true;
+        LOG_ERROR("Malformed save: invalid or missing music info");
+        return false;
     }
 
     const MUSIC_TRACK_ID current_track =
@@ -951,6 +951,7 @@ static bool M_LoadCurrentMusic(
         }
     }
 
+    Music_Stop();
     if (ambient_track != MX_INACTIVE) {
         // Always restart the ambient as it may have changed based on the
         // current position in the level.

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -393,6 +393,7 @@ static bool M_LoadMusic(
     current_track = M_ConvertMusicTrack(current_track, header_version);
     ambient_track = M_ConvertMusicTrack(ambient_track, header_version);
 
+    Music_Stop();
     if (ambient_track != MX_INACTIVE) {
         // Always restart the ambient as it may have changed based on the
         // current position in the level.


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3845.

Need updating changelog with the version at which this is broken.

#### Testing

Testing needs to check all 3 modes of resuming active music track on load, and verify if this bug is present in TR2.
I imagine Venice may be problematic as normally it does not have an ambient track.