### PR TITLE
objects/puzzle_slot: alter status only when inactive

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -82,6 +82,7 @@
     - fixed Y component not interpolated in 60 FPS (#1314)
     - fixed shadows being rendered partially opaque near room portals (#879)
     - fixed Bacon Lara shadow rendered transparent when she's standing on a trapdoor (#3666)
+- fixed potentially being able to reactivate an already used puzzle slot's trigger (#3849, regression from 4.13)
 - fixed being unable to cycle poses in photo mode if cheats were disabled (#3726, regression from 4.13)
 - fixed Lara exiting the fly cheat if the walk key is used during photo mode (#3753, regression from 4.13)
 - fixed being able to issue certain console commands that target Lara during loading screens (#3662, regression from 4.13)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -84,6 +84,7 @@
 - fixed backslash/grave key/less-than character on some keyboards shown as ???? – now it's shown as backslash (#3713)
 - fixed Lara being able to get on a skidoo while underwater and consequently dying (#3810)
 - fixed a missing transition animation between Lara jumping forward and entering freefall (#3815)
+- fixed potentially being able to reactivate an already used puzzle slot's trigger (#3849, regression from 1.3)
 - fixed persistent damage resetting Lara's HP after cutscenes (#3595, regression from 1.2)
 - fixed Lara not being able to look when look mode is set to unrestricted and she is using an airlock door (#3645, regression from 1.3)
 - fixed wireframe mode rendering as mostly white (#3649, regression from 1.3.2)

--- a/src/libtrx/game/objects/general/puzzle_hole.c
+++ b/src/libtrx/game/objects/general/puzzle_hole.c
@@ -74,7 +74,9 @@ static void M_MarkDone(ITEM *const receptacle_item)
     if (done_obj_id != NO_OBJECT) {
         receptacle_item->object_id = done_obj_id;
     }
-    receptacle_item->status = IS_ACTIVE;
+    if (receptacle_item->status == IS_INACTIVE) {
+        receptacle_item->status = IS_ACTIVE;
+    }
 }
 
 static void M_SetupEmpty(OBJECT *const obj)


### PR DESCRIPTION
Resolves #3849.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids a deactivated puzzle slot becoming active again on loading a save, and hence avoids its triggers becoming active/re-triggerable.

Affects TR2 as well, although I can't think of anywhere in OG where a similar setup to Natla's Mines would be.
