### PR TITLE
inject/data/sound: skip existing TR2 SFX injection

### DIFF
--- a/src/libtrx/game/inject/data/sound.c
+++ b/src/libtrx/game/inject/data/sound.c
@@ -16,6 +16,12 @@ static void M_HandleSFXData(const INJECTION_CHUNK chunk)
     int16_t *const sample_lut = Sound_GetSampleLUT();
     for (int32_t i = 0; i < data_count; i++) {
         const int16_t sfx_id = VFile_ReadS16(chunk.injection->fp);
+        if (TR_VERSION == 2 && sample_lut[sfx_id] != -1) {
+            // TODO: resolve properly: currently replacing existing sounds in
+            // TR2 alone badly affects others, e.g. making them silent.
+            VFile_Skip(chunk.injection->fp, 10);
+            continue;
+        }
         sample_lut[sfx_id] = level_info->samples.info_count;
 
         SAMPLE_INFO *const sample_info = Sound_GetSampleInfo(sfx_id);


### PR DESCRIPTION
Resolves #3857.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids replacing existing SFX in TR2 as doing so badly affects other slots. While injections have been crafted carefully to target OG levels, using ones such as the photo mode shutter sound in levels that already have it will cause problems (it's similar to the problem we had initially with Winston injection). I'd like to resolve this properly during #3284 (or perhaps on its own) but as that's very involved, for the time being this workaround should be sufficient; in none of our existing TR2 injection cases do we intentionally overwrite SFX anyway.
