### PR TITLE
tr2/console/cmd/winston: test object presence

### DIFF
--- a/src/tr2/game/console/cmd/winston.c
+++ b/src/tr2/game/console/cmd/winston.c
@@ -24,6 +24,11 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx)
         return CR_UNAVAILABLE;
     }
 
+    const OBJECT *const obj = Object_Get(O_WINSTON);
+    if (!obj->loaded) {
+        return CR_UNAVAILABLE;
+    }
+
     int16_t target_room_num = lara_item->room_num;
     XYZ_32 target_pos = {
         .x = lara_item->pos.x + STEP_L,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids a crash if trying to spawn Winston when the object isn't loaded. The crash only happens on develop (I think because of the rendering changes), hence no changelog.
