### PR TITLE
output: fix mesh swaps

### DIFF
--- a/src/libtrx/game/objects/common.c
+++ b/src/libtrx/game/objects/common.c
@@ -269,14 +269,12 @@ void Object_SwapMesh(
     const OBJECT *const obj1 = Object_Get(object1_id);
     const OBJECT *const obj2 = Object_Get(object2_id);
 
-    OBJECT_MESH *const temp = m_MeshPointers[obj1->mesh_idx + mesh_num];
-    m_MeshPointers[obj1->mesh_idx + mesh_num] =
-        m_MeshPointers[obj2->mesh_idx + mesh_num];
-    m_MeshPointers[obj2->mesh_idx + mesh_num] = temp;
-
-    Output_DispatchObjectMeshSwap(
+    SWAP(
         m_MeshPointers[obj1->mesh_idx + mesh_num],
         m_MeshPointers[obj2->mesh_idx + mesh_num]);
+
+    Output_DispatchObjectMeshSwap(
+        obj1->mesh_idx + mesh_num, obj2->mesh_idx + mesh_num);
 }
 
 ANIM *Object_GetAnim(const OBJECT *const obj, const int32_t anim_idx)

--- a/src/libtrx/game/output/common.c
+++ b/src/libtrx/game/output/common.c
@@ -176,12 +176,12 @@ void Output_DispatchRoomFlip(const ROOM *room)
 }
 
 void Output_DispatchObjectMeshSwap(
-    const OBJECT_MESH *const mesh_1, const OBJECT_MESH *const mesh_2)
+    const int32_t mesh_idx_1, const int32_t mesh_idx_2)
 {
-    OutputSource_Objects_ObserveObjectMeshSwap(mesh_1, mesh_2);
+    OutputSource_Objects_ObserveObjectMeshSwap(mesh_idx_1, mesh_idx_2);
 }
 
-void Output_DispatchObjectMeshUpdate(const OBJECT_MESH *const mesh)
+void Output_DispatchObjectMeshUpdate(const int32_t mesh_idx)
 {
-    OutputSource_Objects_ObserveObjectMeshUpdate(mesh);
+    OutputSource_Objects_ObserveObjectMeshUpdate(mesh_idx);
 }

--- a/src/libtrx/game/output/sources/objects.c
+++ b/src/libtrx/game/output/sources/objects.c
@@ -354,28 +354,26 @@ void OutputSource_Objects_ObserveLevelUnload(void)
 }
 
 void OutputSource_Objects_ObserveObjectMeshSwap(
-    const OBJECT_MESH *const mesh_1, const OBJECT_MESH *const mesh_2)
+    const int32_t mesh_idx_1, const int32_t mesh_idx_2)
 {
     M_PRIV *const p = &m_Priv;
     if (p->meshes == nullptr) {
         return;
     }
 
-    const int16_t mesh_num_1 = Object_GetMeshIndex(mesh_1);
-    const int16_t mesh_num_2 = Object_GetMeshIndex(mesh_2);
-    SWAP(p->meshes[mesh_num_1], p->meshes[mesh_num_2]);
-    OutputSource_Objects_ObserveObjectMeshUpdate(mesh_1);
-    OutputSource_Objects_ObserveObjectMeshUpdate(mesh_2);
+    SWAP(p->meshes[mesh_idx_1], p->meshes[mesh_idx_2]);
+    OutputSource_Objects_ObserveObjectMeshUpdate(mesh_idx_1);
+    OutputSource_Objects_ObserveObjectMeshUpdate(mesh_idx_2);
 }
 
-void OutputSource_Objects_ObserveObjectMeshUpdate(const OBJECT_MESH *const mesh)
+void OutputSource_Objects_ObserveObjectMeshUpdate(const int32_t mesh_idx)
 {
     M_PRIV *const p = &m_Priv;
     if (p->meshes == nullptr) {
         return;
     }
-    M_MESH *const batch = &p->meshes[Object_GetMeshIndex(mesh)];
-    M_UpdateFlags(mesh, batch);
+    M_MESH *const batch = &p->meshes[mesh_idx];
+    M_UpdateFlags(Object_GetMesh(mesh_idx), batch);
     MeshBatcher_UpdateMeshGeometry(p->batcher, batch->mesh_batch);
 }
 

--- a/src/libtrx/include/libtrx/game/output/common.h
+++ b/src/libtrx/include/libtrx/game/output/common.h
@@ -23,6 +23,5 @@ void Output_ApplyLevelSettings(void);
 void Output_DispatchLevelLoad(void);
 void Output_DispatchLevelUnload(void);
 void Output_DispatchRoomFlip(const ROOM *room);
-void Output_DispatchObjectMeshUpdate(const OBJECT_MESH *mesh);
-void Output_DispatchObjectMeshSwap(
-    const OBJECT_MESH *mesh_1, const OBJECT_MESH *mesh_2);
+void Output_DispatchObjectMeshUpdate(int32_t mesh_idx);
+void Output_DispatchObjectMeshSwap(int32_t mesh_idx_0, int32_t mesh_idx_1);

--- a/src/libtrx/include/libtrx/game/output/sources/objects.h
+++ b/src/libtrx/include/libtrx/game/output/sources/objects.h
@@ -9,8 +9,8 @@ void OutputSource_Objects_Shutdown(void);
 void OutputSource_Objects_ObserveLevelLoad(void);
 void OutputSource_Objects_ObserveLevelUnload(void);
 void OutputSource_Objects_ObserveObjectMeshSwap(
-    const OBJECT_MESH *mesh_1, const OBJECT_MESH *mesh_2);
-void OutputSource_Objects_ObserveObjectMeshUpdate(const OBJECT_MESH *mesh);
+    int32_t mesh_idx_1, int32_t mesh_idx_2);
+void OutputSource_Objects_ObserveObjectMeshUpdate(int32_t mesh_idx);
 
 void OutputSource_Objects_StageSkyboxMesh(
     const OBJECT_MESH *mesh, int16_t shade);

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -267,7 +267,7 @@ void Object_SetMeshReflective(
     for (int32_t i = 0; i < mesh->num_flat_face3s; i++) {
         mesh->flat_face3s[i].enable_reflections = enabled;
     }
-    Output_DispatchObjectMeshUpdate(mesh);
+    Output_DispatchObjectMeshUpdate(obj->mesh_idx + mesh_idx);
 }
 
 void Object_SetReflective(const GAME_OBJECT_ID obj_id, const bool enabled)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the issue in TR2 cutscene 3 where the mesh swap would swap the wrong mesh, as meshes 116 and 15 shared the same pointer (?)