### PR TITLE
lara/state/land: extend stop routine early exit

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -94,7 +94,8 @@
 - fixed Lara not throwing away a spent flare when swimming of flying (#3816, regression from 0.8)
 - fixed flame SFX being audible underwater (#3830, regression from 0.3)
 - fixed harpoon gun not working correctly in NG+ (#3837, regression from 1.3)
-- fixed exiting photo mode on a controller conflicting with the roll input (#3842, regression from 4.8)
+- fixed exiting photo mode on a controller conflicting with the roll input (#3842, regression from 0.9)
+- fixed Lara being able to move away from a keyhole/puzzle slot after selecting the key item from the inventory (#3866, regression from 1.3)
 
 ## [1.3.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.3.1...tr2-1.3.2) - 2025-07-20
 - fixed audio playback with CDAudio backend in cutscenes (#2593)

--- a/src/libtrx/game/lara/state/land.c
+++ b/src/libtrx/game/lara/state/land.c
@@ -214,11 +214,9 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-#if TR_VERSION == 1
     if (lara->interact_target.is_moving) {
         return;
     }
-#endif
 
     if (g_Input.roll && lara->water_status != LWS_WADE) {
         if (g_Input.jump && g_Config.gameplay.enable_neutral_twists


### PR DESCRIPTION
Resolves #3866.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This applies TR1's early exit in `M_Stop` for Lara's state control to TR2 when the interact target is active.
