### PR TITLE
tr2/objects/combat_end: dismount vehicle on completion

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.1...develop) - ××××-××-××
+- fixed the combat end logic not completing properly if Lara is on a vehicle (#3885)
 
 ## [1.4.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.4...tr2-1.4.1) - 2025-08-30
 - fixed missing shader and configuration files from MacOS releases (#3870, regression from 1.4)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -137,6 +137,7 @@
 - fixed Lara walking backwards off ledges into lava
 - fixed Lara being able to get on a skidoo while underwater and consequently dying
 - fixed a missing transition animation between Lara jumping forward and entering freefall
+- fixed the combat end logic not completing properly if Lara is on a vehicle
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -7,6 +7,7 @@
 #include "global/vars.h"
 
 #include <libtrx/game/camera.h>
+#include <libtrx/game/lara/vehicle.h>
 #include <libtrx/game/objects/vars.h>
 #include <libtrx/utils.h>
 
@@ -116,6 +117,7 @@ static void M_PrepareCutscene(const int16_t item_num)
         g_Lara.left_arm.lock = false;
     }
 
+    Lara_Vehicle_Dismount();
     Gun_SetLaraHandLMesh(LGT_UNARMED);
     Gun_SetLaraHandRMesh(LGT_UNARMED);
     g_Lara.water_status = LWS_ABOVE_WATER;


### PR DESCRIPTION
Resolves #3885.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara dismounts any vehicle she may be on before triggering the death call for the cutscene.
