### PR TITLE
Further sound module refactors before final merge

### DIFF
--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -361,20 +361,15 @@ bool Sound_Effect(
         break;
 
     case SAMPLE_MODE_LOOPED:
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-            if (sound->sample != nullptr
-                && sound->sample->mode == SAMPLE_MODE_LOOPED
-                && sound->sample_id == sample_id) {
-                if (sound->distance == -1 || distance < sound->distance) {
-                    sound->distance = distance;
-                    sound->volume = volume;
-                    sound->pan = pan;
-                    sound->pitch = pitch;
-                    return true;
-                }
-                return false;
+        sound = M_SelectUsedSound(sample_id);
+        if (sound != nullptr) {
+            if (sound->distance == -1 || distance < sound->distance) {
+                sound->distance = distance;
+                sound->volume = volume;
+                sound->pan = pan;
+                sound->pitch = pitch;
             }
+            return true;
         }
 
         sound = M_SelectUnusedSound();

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -26,15 +26,10 @@ typedef struct {
     int16_t volume;
     int16_t pan;
     int32_t pitch;
-    int16_t flags;
 
     int32_t distance;
     const XYZ_32 *pos;
 } M_ACTIVE_SOUND;
-
-typedef enum {
-    SOUND_FLAG_RESTARTED = 1 << 1,
-} M_SOUND_FLAG;
 
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 
@@ -42,7 +37,7 @@ static float M_ConvertPitch(int32_t pitch);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
 static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id);
-static M_ACTIVE_SOUND *M_SelectBoundSound(
+static M_ACTIVE_SOUND *M_SelectUsedSoundWithPos(
     SAMPLE_ID sample_id, const XYZ_32 *pos);
 
 static void M_ClearAllActiveSounds(void);
@@ -93,13 +88,12 @@ static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id)
     return nullptr;
 }
 
-static M_ACTIVE_SOUND *M_SelectBoundSound(
+static M_ACTIVE_SOUND *M_SelectUsedSoundWithPos(
     const SAMPLE_ID sample_id, const XYZ_32 *const pos)
 {
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
         if (result->sample_id == sample_id && result->pos == pos) {
-            result->flags |= SOUND_FLAG_RESTARTED;
             return result;
         }
     }
@@ -146,7 +140,6 @@ static bool M_Play(
     sound->pitch = pitch;
     sound->sample_id = sample_id;
     sound->handle = handle;
-    sound->flags = 0;
     sound->distance = distance;
     sound->pos = pos;
     return true;
@@ -344,15 +337,14 @@ bool Sound_Effect(
         break;
 
     case SAMPLE_MODE_WAIT: {
-        M_ACTIVE_SOUND *sound = M_SelectBoundSound(sample_id, pos);
+        M_ACTIVE_SOUND *sound = M_SelectUsedSoundWithPos(sample_id, pos);
         if (sound == nullptr) {
             sound = M_SelectUnusedSound();
         }
         if (sound == nullptr) {
             return false;
         }
-        if (sound->flags & SOUND_FLAG_RESTARTED) {
-            sound->flags &= ~SOUND_FLAG_RESTARTED;
+        if (Audio_Sample_IsPlaying(sound->handle)) {
             return true;
         }
         if (!M_Play(

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -46,7 +46,7 @@ static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
 static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
 
 static bool M_Play(
-    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *info, int32_t sample_id,
+    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *sample, int32_t sample_id,
     int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
     int32_t distance, const XYZ_32 *pos);
 
@@ -137,7 +137,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
 }
 
 static bool M_Play(
-    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
+    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const sample,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
     const int32_t pitch, const int32_t pan, const int32_t distance,
     const XYZ_32 *const pos)
@@ -145,11 +145,11 @@ static bool M_Play(
     M_CloseActiveSound(sound);
     const int32_t handle = Audio_Sample_Play(
         track_id, Sound_ConvertVolumeToDecibel(volume), M_ConvertPitch(pitch),
-        Sound_ConvertPanToDecibel(pan), info->mode == SAMPLE_MODE_LOOPED);
+        Sound_ConvertPanToDecibel(pan), sample->mode == SAMPLE_MODE_LOOPED);
     if (handle == AUDIO_NO_SOUND) {
         return false;
     }
-    sound->sample = info;
+    sound->sample = sample;
     sound->sample_id = sample_id;
     sound->handle = handle;
     sound->volume = volume;
@@ -171,7 +171,7 @@ static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 {
-    const SAMPLE_INFO *const info = Sound_GetSampleInfo(sound->sample_id);
+    const SAMPLE_INFO *const sample = Sound_GetSampleInfo(sound->sample_id);
 
     const int32_t x = sound->pos->x - g_Camera.target.x;
     const int32_t y = sound->pos->y - g_Camera.target.y;
@@ -184,7 +184,7 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 
     const int32_t distance = SQUARE(x) + SQUARE(y) + SQUARE(z);
     int32_t volume =
-        info->volume - Math_Sqrt(distance) * M_SOUND_RANGE_MULT_CONSTANT;
+        sample->volume - Math_Sqrt(distance) * M_SOUND_RANGE_MULT_CONSTANT;
     if (volume < 0) {
         sound->volume = 0;
         return;
@@ -194,7 +194,7 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 
     sound->volume = volume;
 
-    if (distance == 0 || info->flags.no_pan) {
+    if (distance == 0 || sample->flags.no_pan) {
         sound->pan = 0;
         return;
     }
@@ -231,15 +231,13 @@ void Sound_UpdateEffects(void)
     if (!Sound_IsInitialised()) {
         return;
     }
-
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
         if (sound->sample == nullptr) {
             continue;
         }
 
-        const SAMPLE_INFO *const info = Sound_GetSampleInfo(sound->sample_id);
-        if (info->mode == SAMPLE_MODE_LOOPED) {
+        if (sound->sample->mode == SAMPLE_MODE_LOOPED) {
             if (sound->volume <= 0) {
                 M_ClearActiveSound(sound);
             } else {
@@ -311,12 +309,12 @@ bool Sound_Effect(
         return false;
     }
 
-    const SAMPLE_INFO *const info = Sound_GetSampleInfo(sample_id);
-    if (info == nullptr || info->number < 0) {
+    const SAMPLE_INFO *const sample = Sound_GetSampleInfo(sample_id);
+    if (sample == nullptr || sample->number < 0) {
         return false;
     }
 
-    if (info->randomness && Random_GetDraw() > info->randomness) {
+    if (sample->randomness && Random_GetDraw() > sample->randomness) {
         return false;
     }
 
@@ -325,20 +323,20 @@ bool Sound_Effect(
         return false;
     }
 
-    const int32_t pan = Sound_GetPan(info, pos);
-    const int32_t volume = Sound_GetVolume(info, distance);
+    const int32_t pan = Sound_GetPan(sample, pos);
+    const int32_t volume = Sound_GetVolume(sample, distance);
     if (volume <= 0) {
         return false;
     }
 
-    const int32_t pitch = Sound_GetPitch(info);
-    const int32_t num_samples = info->flags.num_samples;
+    const int32_t pitch = Sound_GetPitch(sample);
+    const int32_t num_samples = sample->flags.num_samples;
     const int32_t track_id = num_samples == 1
-        ? info->number
-        : info->number + ((num_samples * Random_GetDraw()) / 0x8000);
+        ? sample->number
+        : sample->number + ((num_samples * Random_GetDraw()) / 0x8000);
 
     M_ACTIVE_SOUND *sound = nullptr;
-    switch (info->mode) {
+    switch (sample->mode) {
     case SAMPLE_MODE_NORMAL:
         sound = M_SelectUnusedSound();
         break;
@@ -371,7 +369,6 @@ bool Sound_Effect(
             }
             return true;
         }
-
         sound = M_SelectUnusedSound();
         break;
     }
@@ -380,7 +377,7 @@ bool Sound_Effect(
         return false;
     }
     return M_Play(
-        sound, info, sample_id, track_id, volume, pitch, pan, distance, pos);
+        sound, sample, sample_id, track_id, volume, pitch, pan, distance, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -267,6 +267,7 @@ void Sound_UpdateEffects(void)
                 M_ClearActiveSound(sound);
             } else {
                 M_SyncActiveSoundHandle(sound);
+                sound->volume = 0;
             }
         } else if (!Audio_Sample_IsPlaying(sound->handle)) {
             M_ClearActiveSound(sound);
@@ -347,7 +348,7 @@ bool Sound_Effect(
     case SAMPLE_MODE_LOOPED:
         sound = M_SelectUsedSound(sample_id);
         if (sound != nullptr) {
-            if (sound->distance == -1 || distance < sound->distance) {
+            if (volume > sound->volume) {
                 sound->distance = distance;
                 sound->volume = volume;
                 sound->pan = pan;

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -25,7 +25,6 @@ typedef struct {
     int32_t pitch;
     int16_t pan;
 
-    int32_t distance;
     const XYZ_32 *pos;
 } M_ACTIVE_SOUND;
 
@@ -50,7 +49,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
 static bool M_Play(
     M_ACTIVE_SOUND *sound, const SAMPLE_INFO *sample, int32_t sample_id,
     int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
-    int32_t distance, const XYZ_32 *pos);
+    const XYZ_32 *pos);
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
@@ -183,8 +182,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
 static bool M_Play(
     M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const sample,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
-    const int32_t pitch, const int32_t pan, const int32_t distance,
-    const XYZ_32 *const pos)
+    const int32_t pitch, const int32_t pan, const XYZ_32 *const pos)
 {
     M_CloseActiveSound(sound);
     const int32_t handle = Audio_Sample_Play(
@@ -199,7 +197,6 @@ static bool M_Play(
     sound->volume = volume;
     sound->pitch = pitch;
     sound->pan = pan;
-    sound->distance = distance;
     sound->pos = pos;
     M_ClearActiveSoundHandles(sound);
     return true;
@@ -232,7 +229,11 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 
 bool Sound_Init(void)
 {
-    return Sound_InitialiseCommon();
+    const bool result = Sound_InitialiseCommon();
+    if (result) {
+        M_ClearAllActiveSounds();
+    }
+    return result;
 }
 
 void Sound_ResetAmbient(void)
@@ -241,14 +242,6 @@ void Sound_ResetAmbient(void)
         return;
     }
     Sound_ResetSources();
-
-    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-        M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-        if (sound->sample != nullptr
-            && sound->sample->mode == SAMPLE_MODE_LOOPED) {
-            sound->distance = -1;
-        }
-    }
 }
 
 void Sound_UpdateEffects(void)
@@ -264,7 +257,7 @@ void Sound_UpdateEffects(void)
 
         if (sound->sample->mode == SAMPLE_MODE_LOOPED) {
             if (sound->volume <= 0) {
-                M_ClearActiveSound(sound);
+                M_CloseActiveSound(sound);
             } else {
                 M_SyncActiveSoundHandle(sound);
                 sound->volume = 0;
@@ -349,7 +342,6 @@ bool Sound_Effect(
         sound = M_SelectUsedSound(sample_id);
         if (sound != nullptr) {
             if (volume > sound->volume) {
-                sound->distance = distance;
                 sound->volume = volume;
                 sound->pan = pan;
                 sound->pitch = pitch;
@@ -363,8 +355,7 @@ bool Sound_Effect(
     if (sound == nullptr) {
         return false;
     }
-    return M_Play(
-        sound, sample, sample_id, track_id, volume, pitch, pan, distance, pos);
+    return M_Play(sound, sample, sample_id, track_id, volume, pitch, pan, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -13,10 +13,10 @@
 #include <math.h>
 
 #define M_MAX_ACTIVE_SOUNDS AUDIO_MAX_ACTIVE_SAMPLES
-#define M_SOUND_RANGE 8
 #define M_SOUND_RANGE_MULT_CONSTANT 4
-#define M_SOUND_RADIUS (M_SOUND_RANGE * WALL_L)
-#define M_SOUND_MAX_VOLUME ((M_SOUND_RADIUS * M_SOUND_RANGE_MULT_CONSTANT) - 1)
+#define M_SOUND_FAR_RANGE (8 * WALL_L)
+#define M_SOUND_MAX_VOLUME                                                     \
+    ((M_SOUND_FAR_RANGE * M_SOUND_RANGE_MULT_CONSTANT) - 1)
 #define M_SOUND_MAX_VOLUME_CHANGE 0x2000
 
 typedef struct {
@@ -50,10 +50,10 @@ static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
 static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
 static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
 
-static void M_UpdateActiveSound(M_ACTIVE_SOUND *sound);
+static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
 
-static float M_ConvertPitch(int32_t pitch)
+static float M_ConvertPitch(const int32_t pitch)
 {
     return pitch / 0x10000.p0;
 }
@@ -158,7 +158,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
     }
 }
 
-static void M_UpdateActiveSound(M_ACTIVE_SOUND *const sound)
+static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 {
     Audio_Sample_SetPan(sound->handle, Sound_ConvertPanToDecibel(sound->pan));
     Audio_Sample_SetPitch(sound->handle, M_ConvertPitch(sound->pitch));
@@ -173,8 +173,8 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
     const int32_t x = sound->pos->x - g_Camera.target.x;
     const int32_t y = sound->pos->y - g_Camera.target.y;
     const int32_t z = sound->pos->z - g_Camera.target.z;
-    if (ABS(x) > M_SOUND_RADIUS || ABS(y) > M_SOUND_RADIUS
-        || ABS(z) > M_SOUND_RADIUS) {
+    if (ABS(x) > M_SOUND_FAR_RANGE || ABS(y) > M_SOUND_FAR_RANGE
+        || ABS(z) > M_SOUND_FAR_RANGE) {
         sound->volume = 0;
         return;
     }
@@ -240,7 +240,7 @@ void Sound_UpdateEffects(void)
             if (sound->volume <= 0) {
                 M_ClearActiveSound(sound);
             } else {
-                M_UpdateActiveSound(sound);
+                M_SyncActiveSoundHandle(sound);
             }
         } else if (!Audio_Sample_IsPlaying(sound->handle)) {
             M_ClearActiveSound(sound);
@@ -249,7 +249,7 @@ void Sound_UpdateEffects(void)
             if (sound->volume <= 0) {
                 M_CloseActiveSound(sound);
             } else {
-                M_UpdateActiveSound(sound);
+                M_SyncActiveSoundHandle(sound);
             }
         }
     }
@@ -263,8 +263,8 @@ int32_t Sound_GetDistance(const XYZ_32 *const pos)
     const int32_t dx = pos->x - g_Camera.target.x;
     const int32_t dy = pos->y - g_Camera.target.y;
     const int32_t dz = pos->z - g_Camera.target.z;
-    if (ABS(dx) > M_SOUND_RADIUS || ABS(dy) > M_SOUND_RADIUS
-        || ABS(dz) > M_SOUND_RADIUS) {
+    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
+        || ABS(dz) > M_SOUND_FAR_RANGE) {
         return INT32_MAX;
     }
     const uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -24,8 +24,8 @@ typedef struct {
     SAMPLE_ID sample_id;
     const SAMPLE_INFO *sample;
     int16_t volume;
-    int16_t pan;
     int32_t pitch;
+    int16_t pan;
 
     int32_t distance;
     const XYZ_32 *pos;
@@ -36,7 +36,7 @@ static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 static float M_ConvertPitch(int32_t pitch);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
-static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id);
+static M_ACTIVE_SOUND *M_SelectUsedSound(SAMPLE_ID sample_id);
 static M_ACTIVE_SOUND *M_SelectUsedSoundWithPos(
     SAMPLE_ID sample_id, const XYZ_32 *pos);
 
@@ -44,6 +44,11 @@ static void M_ClearAllActiveSounds(void);
 static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
 static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
 static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
+
+static bool M_Play(
+    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *info, int32_t sample_id,
+    int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
+    int32_t distance, const XYZ_32 *pos);
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
@@ -121,6 +126,16 @@ static void M_CloseActiveSound(M_ACTIVE_SOUND *const sound)
     M_ClearActiveSound(sound);
 }
 
+static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
+{
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const rsound = &m_ActiveSounds[i];
+        if (rsound != sound && rsound->handle == sound->handle) {
+            rsound->handle = AUDIO_NO_SOUND;
+        }
+    }
+}
+
 static bool M_Play(
     M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
@@ -135,25 +150,15 @@ static bool M_Play(
         return false;
     }
     sound->sample = info;
-    sound->volume = volume;
-    sound->pan = pan;
-    sound->pitch = pitch;
     sound->sample_id = sample_id;
     sound->handle = handle;
+    sound->volume = volume;
+    sound->pitch = pitch;
+    sound->pan = pan;
     sound->distance = distance;
     sound->pos = pos;
     M_ClearActiveSoundHandles(sound);
     return true;
-}
-
-static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
-{
-    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-        M_ACTIVE_SOUND *const rsound = &m_ActiveSounds[i];
-        if (rsound != sound && rsound->handle == sound->handle) {
-            rsound->handle = AUDIO_NO_SOUND;
-        }
-    }
 }
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
@@ -284,8 +289,7 @@ int32_t Sound_GetPan(const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
     return 0;
 }
 
-int32_t Sound_GetVolume(
-    const SAMPLE_INFO *const sample, const uint32_t distance)
+int32_t Sound_GetVolume(const SAMPLE_INFO *const sample, const int32_t distance)
 {
     int32_t volume = sample->volume - distance * M_SOUND_RANGE_MULT_CONSTANT;
     if (sample->flags.randomize_volume) {
@@ -333,46 +337,30 @@ bool Sound_Effect(
         ? info->number
         : info->number + ((num_samples * Random_GetDraw()) / 0x8000);
 
+    M_ACTIVE_SOUND *sound = nullptr;
     switch (info->mode) {
     case SAMPLE_MODE_NORMAL:
-        M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
-        if (sound == nullptr) {
-            return false;
-        }
-        return M_Play(
-            sound, info, sample_id, track_id, volume, pitch, pan, distance,
-            pos);
+        sound = M_SelectUnusedSound();
+        break;
 
-    case SAMPLE_MODE_WAIT: {
-        M_ACTIVE_SOUND *sound = M_SelectUsedSoundWithPos(sample_id, pos);
-        if (sound == nullptr) {
-            sound = M_SelectUnusedSound();
-        }
-        if (sound == nullptr) {
-            return false;
-        }
-        if (Audio_Sample_IsPlaying(sound->handle)) {
+    case SAMPLE_MODE_WAIT:
+        sound = M_SelectUsedSoundWithPos(sample_id, pos);
+        if (sound != nullptr && Audio_Sample_IsPlaying(sound->handle)) {
             return true;
         }
-        return M_Play(
-            sound, info, sample_id, track_id, volume, pitch, pan, distance,
-            pos);
-    }
-
-    case SAMPLE_MODE_RESTART: {
-        M_ACTIVE_SOUND *sound = M_SelectUsedSound(sample_id);
         if (sound == nullptr) {
             sound = M_SelectUnusedSound();
         }
-        if (sound == nullptr) {
-            return false;
-        }
-        return M_Play(
-            sound, info, sample_id, track_id, volume, pitch, pan, distance,
-            pos);
-    }
+        break;
 
-    case SAMPLE_MODE_LOOPED: {
+    case SAMPLE_MODE_RESTART:
+        sound = M_SelectUsedSound(sample_id);
+        if (sound == nullptr) {
+            sound = M_SelectUnusedSound();
+        }
+        break;
+
+    case SAMPLE_MODE_LOOPED:
         for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
             M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
             if (sound->sample != nullptr
@@ -389,17 +377,15 @@ bool Sound_Effect(
             }
         }
 
-        M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
-        if (sound == nullptr) {
-            return false;
-        }
-        return M_Play(
-            sound, info, sample_id, track_id, volume, pitch, pan, distance,
-            pos);
-    }
+        sound = M_SelectUnusedSound();
+        break;
     }
 
-    return false;
+    if (sound == nullptr) {
+        return false;
+    }
+    return M_Play(
+        sound, info, sample_id, track_id, volume, pitch, pan, distance, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)
@@ -407,14 +393,10 @@ void Sound_StopEffect(const SAMPLE_ID sample_id)
     if (!Sound_IsInitialised()) {
         return;
     }
-
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-        if (sound->sample_id == sample_id
-            && Audio_Sample_IsPlaying(sound->handle)) {
-            Audio_Sample_Close(sound->handle);
-            M_ClearActiveSound(sound);
-            break;
+        if (sound->sample_id == sample_id) {
+            M_CloseActiveSound(sound);
         }
     }
 }
@@ -426,6 +408,7 @@ void Sound_Reset(void)
     }
     Audio_Sample_CloseAll();
     Audio_Sample_UnloadAll();
+    M_ClearAllActiveSounds();
 }
 
 void Sound_StopAll(void)

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -15,8 +15,6 @@
 #define M_MAX_ACTIVE_SOUNDS AUDIO_MAX_ACTIVE_SAMPLES
 #define M_SOUND_RANGE_MULT_CONSTANT 4
 #define M_SOUND_FAR_RANGE (8 * WALL_L)
-#define M_SOUND_MAX_VOLUME                                                     \
-    ((M_SOUND_FAR_RANGE * M_SOUND_RANGE_MULT_CONSTANT) - 1)
 #define M_SOUND_MAX_VOLUME_CHANGE 0x2000
 
 typedef struct {
@@ -34,6 +32,10 @@ typedef struct {
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 
 static float M_ConvertPitch(int32_t pitch);
+static int32_t M_GetDistance(const XYZ_32 *pos);
+static int32_t M_GetVolume(
+    const SAMPLE_INFO *sample, int32_t distance, bool random);
+static int32_t M_GetPan(const SAMPLE_INFO *sample, const XYZ_32 *pos);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
 static M_ACTIVE_SOUND *M_SelectUsedSound(SAMPLE_ID sample_id);
@@ -56,6 +58,48 @@ static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
 static float M_ConvertPitch(const int32_t pitch)
 {
     return pitch / 0x10000.p0;
+}
+
+static int32_t M_GetDistance(const XYZ_32 *const pos)
+{
+    if (pos == nullptr) {
+        return 0;
+    }
+    const int32_t dx = pos->x - g_Camera.target.x;
+    const int32_t dy = pos->y - g_Camera.target.y;
+    const int32_t dz = pos->z - g_Camera.target.z;
+    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
+        || ABS(dz) > M_SOUND_FAR_RANGE) {
+        return INT32_MAX;
+    }
+    const uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
+    return Math_Sqrt(distance);
+}
+
+static int32_t M_GetVolume(
+    const SAMPLE_INFO *const sample, const int32_t distance, const bool random)
+{
+    int32_t volume = sample->volume - distance * M_SOUND_RANGE_MULT_CONSTANT;
+    if (random && sample->flags.randomize_volume) {
+        volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
+    }
+    return volume;
+}
+
+static int32_t M_GetPan(
+    const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
+{
+    if (pos == nullptr) {
+        return 0;
+    }
+    const int32_t distance = M_GetDistance(pos);
+    if (distance > 0 && !sample->flags.no_pan) {
+        int16_t angle =
+            Math_Atan(pos->z - g_LaraItem->pos.z, pos->x - g_LaraItem->pos.x);
+        angle -= g_LaraItem->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
+        return angle;
+    }
+    return 0;
 }
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
@@ -171,38 +215,19 @@ static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 {
-    const SAMPLE_INFO *const sample = Sound_GetSampleInfo(sound->sample_id);
-
-    const int32_t x = sound->pos->x - g_Camera.target.x;
-    const int32_t y = sound->pos->y - g_Camera.target.y;
-    const int32_t z = sound->pos->z - g_Camera.target.z;
-    if (ABS(x) > M_SOUND_FAR_RANGE || ABS(y) > M_SOUND_FAR_RANGE
-        || ABS(z) > M_SOUND_FAR_RANGE) {
+    const int32_t distance = M_GetDistance(sound->pos);
+    if (distance == INT32_MAX) {
         sound->volume = 0;
         return;
     }
-
-    const int32_t distance = SQUARE(x) + SQUARE(y) + SQUARE(z);
-    int32_t volume =
-        sample->volume - Math_Sqrt(distance) * M_SOUND_RANGE_MULT_CONSTANT;
+    int32_t volume = M_GetVolume(sound->sample, distance, false);
     if (volume < 0) {
         sound->volume = 0;
         return;
     }
 
-    CLAMPG(volume, M_SOUND_MAX_VOLUME);
-
     sound->volume = volume;
-
-    if (distance == 0 || sample->flags.no_pan) {
-        sound->pan = 0;
-        return;
-    }
-
-    int16_t angle = Math_Atan(
-        sound->pos->z - g_LaraItem->pos.z, sound->pos->x - g_LaraItem->pos.x);
-    angle -= g_LaraItem->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
-    sound->pan = angle;
+    sound->pan = M_GetPan(sound->sample, sound->pos);
 }
 
 bool Sound_Init(void)
@@ -245,7 +270,7 @@ void Sound_UpdateEffects(void)
             }
         } else if (!Audio_Sample_IsPlaying(sound->handle)) {
             M_ClearActiveSound(sound);
-        } else if (sound->pos != nullptr) {
+        } else if (TR_VERSION == 1 && sound->pos != nullptr) {
             M_UpdateActiveSoundParams(sound);
             if (sound->volume <= 0) {
                 M_CloseActiveSound(sound);
@@ -254,46 +279,6 @@ void Sound_UpdateEffects(void)
             }
         }
     }
-}
-
-int32_t Sound_GetDistance(const XYZ_32 *const pos)
-{
-    if (pos == nullptr) {
-        return 0;
-    }
-    const int32_t dx = pos->x - g_Camera.target.x;
-    const int32_t dy = pos->y - g_Camera.target.y;
-    const int32_t dz = pos->z - g_Camera.target.z;
-    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
-        || ABS(dz) > M_SOUND_FAR_RANGE) {
-        return INT32_MAX;
-    }
-    const uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    return Math_Sqrt(distance);
-}
-
-int32_t Sound_GetPan(const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
-{
-    if (pos == nullptr) {
-        return 0;
-    }
-    const int32_t distance = Sound_GetDistance(pos);
-    if (distance > 0 && !sample->flags.no_pan) {
-        int16_t angle =
-            Math_Atan(pos->z - g_LaraItem->pos.z, pos->x - g_LaraItem->pos.x);
-        angle -= g_LaraItem->rot.y + g_Lara.torso_rot.y + g_Lara.head_rot.y;
-        return angle;
-    }
-    return 0;
-}
-
-int32_t Sound_GetVolume(const SAMPLE_INFO *const sample, const int32_t distance)
-{
-    int32_t volume = sample->volume - distance * M_SOUND_RANGE_MULT_CONSTANT;
-    if (sample->flags.randomize_volume) {
-        volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
-    }
-    return volume;
 }
 
 bool Sound_Effect(
@@ -318,13 +303,13 @@ bool Sound_Effect(
         return false;
     }
 
-    const int32_t distance = Sound_GetDistance(pos);
+    const int32_t distance = M_GetDistance(pos);
     if (distance == INT32_MAX) {
         return false;
     }
 
-    const int32_t pan = Sound_GetPan(sample, pos);
-    const int32_t volume = Sound_GetVolume(sample, distance);
+    const int32_t pan = M_GetPan(sample, pos);
+    const int32_t volume = M_GetVolume(sample, distance, true);
     if (volume <= 0) {
         return false;
     }
@@ -342,7 +327,8 @@ bool Sound_Effect(
         break;
 
     case SAMPLE_MODE_WAIT:
-        sound = M_SelectUsedSoundWithPos(sample_id, pos);
+        sound = TR_VERSION == 1 ? M_SelectUsedSoundWithPos(sample_id, pos)
+                                : M_SelectUsedSound(sample_id);
         if (sound != nullptr && Audio_Sample_IsPlaying(sound->handle)) {
             return true;
         }

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -85,40 +85,17 @@ static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
 static M_ACTIVE_SOUND *M_GetActiveSound(
     const SAMPLE_ID sample_id, const XYZ_32 *const pos, const SAMPLE_MODE mode)
 {
-    switch (mode) {
-    case SAMPLE_MODE_NORMAL:
-    case SAMPLE_MODE_WAIT:
-    case SAMPLE_MODE_RESTART: {
-        M_ACTIVE_SOUND *last_free_sound = nullptr;
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
-            if (result->sample_id == sample_id && result->pos == pos) {
-                result->flags |= SOUND_FLAG_RESTARTED;
-                return result;
-            } else if (result->sample == nullptr) {
-                last_free_sound = result;
-            }
+    M_ACTIVE_SOUND *last_free_sound = nullptr;
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
+        if (result->sample_id == sample_id && result->pos == pos) {
+            result->flags |= SOUND_FLAG_RESTARTED;
+            return result;
+        } else if (result->sample == nullptr) {
+            last_free_sound = result;
         }
-        return last_free_sound;
     }
-
-    case SAMPLE_MODE_LOOPED:
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
-            if (result->sample_id == sample_id) {
-                return result;
-            }
-        }
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
-            if (result->sample == nullptr) {
-                return result;
-            }
-        }
-        break;
-    }
-
-    return nullptr;
+    return last_free_sound;
 }
 
 static void M_ClearAllActiveSounds(void)
@@ -134,18 +111,37 @@ static void M_ClearActiveSound(M_ACTIVE_SOUND *const sound)
     sound->sample = nullptr;
     sound->sample_id = SFX_INVALID;
     sound->handle = AUDIO_NO_SOUND;
-    sound->flags = 0;
-    sound->volume = 0;
-    sound->pan = 0;
-    sound->pitch = 0;
-    sound->pos = nullptr;
-    sound->distance = -1;
 }
 
 static void M_CloseActiveSound(M_ACTIVE_SOUND *const sound)
 {
     Audio_Sample_Close(sound->handle);
     M_ClearActiveSound(sound);
+}
+
+static bool M_Play(
+    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
+    const int32_t sample_id, const int32_t track_id, const int32_t volume,
+    const int32_t pitch, const int32_t pan, const int32_t distance,
+    const XYZ_32 *const pos)
+{
+    M_CloseActiveSound(sound);
+    const int32_t handle = Audio_Sample_Play(
+        track_id, Sound_ConvertVolumeToDecibel(volume), M_ConvertPitch(pitch),
+        Sound_ConvertPanToDecibel(pan), info->mode == SAMPLE_MODE_LOOPED);
+    if (handle == AUDIO_NO_SOUND) {
+        return false;
+    }
+    sound->sample = info;
+    sound->volume = volume;
+    sound->pan = pan;
+    sound->pitch = pitch;
+    sound->sample_id = sample_id;
+    sound->handle = handle;
+    sound->flags = 0;
+    sound->distance = distance;
+    sound->pos = pos;
+    return true;
 }
 
 static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
@@ -345,24 +341,16 @@ bool Sound_Effect(
         if (sound == nullptr) {
             return false;
         }
-        if (sound->flags & SOUND_FLAG_RESTARTED) {
-            sound->flags &= ~SOUND_FLAG_RESTARTED;
-            return true;
-        }
-        sound->handle = Audio_Sample_Play(
-            track_id, Sound_ConvertVolumeToDecibel(volume),
-            M_ConvertPitch(pitch), Sound_ConvertPanToDecibel(pan), false);
-        if (sound->handle == AUDIO_NO_SOUND) {
+        // if (sound->flags & SOUND_FLAG_RESTARTED) {
+        // sound->flags &= ~SOUND_FLAG_RESTARTED;
+        // return true;
+        //}
+        if (!M_Play(
+                sound, info, sample_id, track_id, volume, pitch, pan, distance,
+                pos)) {
             return false;
         }
         M_ClearActiveSoundHandles(sound);
-        sound->flags = 0;
-        sound->sample = info;
-        sound->sample_id = sample_id;
-        sound->volume = volume;
-        sound->pan = pan;
-        sound->pitch = pitch;
-        sound->pos = pos;
         return true;
     }
 
@@ -372,28 +360,11 @@ bool Sound_Effect(
         if (sound == nullptr) {
             return false;
         }
-        if (sound->flags & SOUND_FLAG_RESTARTED) {
-            Audio_Sample_Close(sound->handle);
-            sound->handle = Audio_Sample_Play(
-                track_id, Sound_ConvertVolumeToDecibel(volume),
-                M_ConvertPitch(pitch), Sound_ConvertPanToDecibel(pan), false);
-            M_ClearActiveSoundHandles(sound);
-            return true;
-        }
-        sound->handle = Audio_Sample_Play(
-            track_id, Sound_ConvertVolumeToDecibel(volume),
-            M_ConvertPitch(pitch), Sound_ConvertPanToDecibel(pan), false);
-        if (sound->handle == AUDIO_NO_SOUND) {
-            return false;
-        }
+        Audio_Sample_Close(sound->handle);
+        M_Play(
+            sound, info, sample_id, track_id, volume, pitch, pan, distance,
+            pos);
         M_ClearActiveSoundHandles(sound);
-        sound->flags = 0;
-        sound->sample = info;
-        sound->sample_id = sample_id;
-        sound->volume = volume;
-        sound->pan = pan;
-        sound->pitch = pitch;
-        sound->pos = pos;
         return true;
     }
 
@@ -418,23 +389,9 @@ bool Sound_Effect(
         if (sound == nullptr) {
             return false;
         }
-
-        sound->handle = Audio_Sample_Play(
-            track_id, Sound_ConvertVolumeToDecibel(volume),
-            M_ConvertPitch(pitch), Sound_ConvertPanToDecibel(pan), true);
-        if (sound->handle == AUDIO_NO_SOUND) {
-            M_ClearActiveSound(sound);
-            return false;
-        }
-        M_ClearActiveSoundHandles(sound);
-        sound->sample = info;
-        sound->sample_id = sample_id;
-        sound->pan = pan;
-        sound->pitch = pitch;
-        sound->volume = volume;
-        sound->distance = distance;
-        sound->pos = pos;
-        return true;
+        return M_Play(
+            sound, info, sample_id, track_id, volume, pitch, pan, distance,
+            pos);
     }
     }
 

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -142,6 +142,7 @@ static bool M_Play(
     sound->handle = handle;
     sound->distance = distance;
     sound->pos = pos;
+    M_ClearActiveSoundHandles(sound);
     return true;
 }
 
@@ -334,7 +335,13 @@ bool Sound_Effect(
 
     switch (info->mode) {
     case SAMPLE_MODE_NORMAL:
-        break;
+        M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
+        if (sound == nullptr) {
+            return false;
+        }
+        return M_Play(
+            sound, info, sample_id, track_id, volume, pitch, pan, distance,
+            pos);
 
     case SAMPLE_MODE_WAIT: {
         M_ACTIVE_SOUND *sound = M_SelectUsedSoundWithPos(sample_id, pos);
@@ -347,13 +354,9 @@ bool Sound_Effect(
         if (Audio_Sample_IsPlaying(sound->handle)) {
             return true;
         }
-        if (!M_Play(
-                sound, info, sample_id, track_id, volume, pitch, pan, distance,
-                pos)) {
-            return false;
-        }
-        M_ClearActiveSoundHandles(sound);
-        return true;
+        return M_Play(
+            sound, info, sample_id, track_id, volume, pitch, pan, distance,
+            pos);
     }
 
     case SAMPLE_MODE_RESTART: {
@@ -364,11 +367,9 @@ bool Sound_Effect(
         if (sound == nullptr) {
             return false;
         }
-        M_Play(
+        return M_Play(
             sound, info, sample_id, track_id, volume, pitch, pan, distance,
             pos);
-        M_ClearActiveSoundHandles(sound);
-        return true;
     }
 
     case SAMPLE_MODE_LOOPED: {

--- a/src/tr1/game/sound.c
+++ b/src/tr1/game/sound.c
@@ -23,10 +23,10 @@ typedef struct {
     int32_t handle;
     SAMPLE_ID sample_id;
     const SAMPLE_INFO *sample;
-    int16_t flags;
     int16_t volume;
     int16_t pan;
     int32_t pitch;
+    int16_t flags;
 
     int32_t distance;
     const XYZ_32 *pos;
@@ -41,9 +41,9 @@ static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 static float M_ConvertPitch(int32_t pitch);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
-
-static M_ACTIVE_SOUND *M_GetActiveSound(
-    SAMPLE_ID sample_id, const XYZ_32 *pos, SAMPLE_MODE mode);
+static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id);
+static M_ACTIVE_SOUND *M_SelectBoundSound(
+    SAMPLE_ID sample_id, const XYZ_32 *pos);
 
 static void M_ClearAllActiveSounds(void);
 static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
@@ -82,20 +82,28 @@ static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
     return best_sound;
 }
 
-static M_ACTIVE_SOUND *M_GetActiveSound(
-    const SAMPLE_ID sample_id, const XYZ_32 *const pos, const SAMPLE_MODE mode)
+static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id)
 {
-    M_ACTIVE_SOUND *last_free_sound = nullptr;
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
+        if (result->sample_id == sample_id) {
+            return result;
+        }
+    }
+    return nullptr;
+}
+
+static M_ACTIVE_SOUND *M_SelectBoundSound(
+    const SAMPLE_ID sample_id, const XYZ_32 *const pos)
+{
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
         if (result->sample_id == sample_id && result->pos == pos) {
             result->flags |= SOUND_FLAG_RESTARTED;
             return result;
-        } else if (result->sample == nullptr) {
-            last_free_sound = result;
         }
     }
-    return last_free_sound;
+    return nullptr;
 }
 
 static void M_ClearAllActiveSounds(void)
@@ -336,15 +344,17 @@ bool Sound_Effect(
         break;
 
     case SAMPLE_MODE_WAIT: {
-        M_ACTIVE_SOUND *const sound =
-            M_GetActiveSound(sample_id, pos, info->mode);
+        M_ACTIVE_SOUND *sound = M_SelectBoundSound(sample_id, pos);
+        if (sound == nullptr) {
+            sound = M_SelectUnusedSound();
+        }
         if (sound == nullptr) {
             return false;
         }
-        // if (sound->flags & SOUND_FLAG_RESTARTED) {
-        // sound->flags &= ~SOUND_FLAG_RESTARTED;
-        // return true;
-        //}
+        if (sound->flags & SOUND_FLAG_RESTARTED) {
+            sound->flags &= ~SOUND_FLAG_RESTARTED;
+            return true;
+        }
         if (!M_Play(
                 sound, info, sample_id, track_id, volume, pitch, pan, distance,
                 pos)) {
@@ -355,12 +365,13 @@ bool Sound_Effect(
     }
 
     case SAMPLE_MODE_RESTART: {
-        M_ACTIVE_SOUND *const sound =
-            M_GetActiveSound(sample_id, pos, info->mode);
+        M_ACTIVE_SOUND *sound = M_SelectUsedSound(sample_id);
+        if (sound == nullptr) {
+            sound = M_SelectUnusedSound();
+        }
         if (sound == nullptr) {
             return false;
         }
-        Audio_Sample_Close(sound->handle);
         M_Play(
             sound, info, sample_id, track_id, volume, pitch, pan, distance,
             pos);

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -14,37 +14,61 @@
 
 typedef struct {
     SAMPLE_ID sample_id;
+    const SAMPLE_INFO *sample;
     int32_t handle;
     int32_t volume;
     int32_t pan;
     int32_t pitch;
 } M_ACTIVE_SOUND;
 
-#define M_SOUND_RANGE 10
-#define M_SOUND_RADIUS (M_SOUND_RANGE * WALL_L) // = 0x2800 = 10240
-#define M_SOUND_RADIUS_SQRD SQUARE(M_SOUND_RADIUS) // = 0x6400000
-
 #define M_MAX_ACTIVE_SOUNDS 32
 // sample volume ranges from 0..32767
 #define M_SOUND_MAX_VOLUME_CHANGE 0x2000
 
-#define M_SOUND_MAXVOL_RANGE 1
-#define M_SOUND_MAXVOL_RADIUS (M_SOUND_MAXVOL_RANGE * WALL_L) // = 0x400 = 1024
-#define M_SOUND_MAXVOL_RADIUS_SQRD SQUARE(M_SOUND_MAXVOL_RADIUS) // = 0x100000
+#define M_SOUND_CLOSE_RANGE WALL_L // = 0x400 = 1024
+#define M_SOUND_FAR_RANGE (10 * WALL_L) // = 0x2800 = 10240
 
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 
 static float M_ConvertPitch(float pitch);
 
+static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
 static void M_ClearAllActiveSounds(void);
 static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
 static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
-
-static void M_UpdateActiveSound(M_ACTIVE_SOUND *sound);
+static bool M_Play(
+    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
+    const int32_t sample_id, const int32_t track_id, const int32_t volume,
+    const int32_t pitch, const int32_t pan);
+static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 
 static float M_ConvertPitch(const float pitch)
 {
     return pitch / 0x10000.p0;
+}
+
+static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
+{
+    // Try to get an unused slot
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
+        if (sound->sample == nullptr) {
+            return sound;
+        }
+    }
+
+    // No sound found - try to find the most quiet track, and use this one
+    M_ACTIVE_SOUND *best_sound = nullptr;
+    int32_t min_volume = INT32_MAX;
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
+        if (sound->sample != nullptr && sound->volume < min_volume) {
+            min_volume = sound->volume;
+            best_sound = sound;
+        }
+    }
+
+    return best_sound;
 }
 
 static void M_ClearAllActiveSounds(void)
@@ -57,6 +81,7 @@ static void M_ClearAllActiveSounds(void)
 
 static void M_ClearActiveSound(M_ACTIVE_SOUND *const sound)
 {
+    sound->sample = nullptr;
     sound->sample_id = SFX_INVALID;
     sound->handle = AUDIO_NO_SOUND;
 }
@@ -67,7 +92,28 @@ static void M_CloseActiveSound(M_ACTIVE_SOUND *const sound)
     M_ClearActiveSound(sound);
 }
 
-static void M_UpdateActiveSound(M_ACTIVE_SOUND *const sound)
+static bool M_Play(
+    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
+    const int32_t sample_id, const int32_t track_id, const int32_t volume,
+    const int32_t pitch, const int32_t pan)
+{
+    M_CloseActiveSound(sound);
+    const int32_t handle = Audio_Sample_Play(
+        track_id, Sound_ConvertVolumeToDecibel(volume), M_ConvertPitch(pitch),
+        Sound_ConvertPanToDecibel(pan), info->mode == SAMPLE_MODE_LOOPED);
+    if (handle == AUDIO_NO_SOUND) {
+        return false;
+    }
+    sound->sample = info;
+    sound->volume = volume;
+    sound->pan = pan;
+    sound->pitch = pitch;
+    sound->sample_id = sample_id;
+    sound->handle = handle;
+    return true;
+}
+
+static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 {
     Audio_Sample_SetPan(sound->handle, Sound_ConvertPanToDecibel(sound->pan));
     Audio_Sample_SetPitch(sound->handle, M_ConvertPitch(sound->pitch));
@@ -102,7 +148,7 @@ void Sound_UpdateEffects(void)
             if (sound->volume == 0) {
                 M_CloseActiveSound(sound);
             } else {
-                M_UpdateActiveSound(sound);
+                M_SyncActiveSoundHandle(sound);
                 sound->volume = 0;
             }
         } else if (!Audio_Sample_IsPlaying(sound->handle)) {
@@ -119,17 +165,17 @@ uint32_t Sound_GetDistance(const XYZ_32 *const pos)
     const int32_t dx = pos->x - g_Camera.mic_pos.x;
     const int32_t dy = pos->y - g_Camera.mic_pos.y;
     const int32_t dz = pos->z - g_Camera.mic_pos.z;
-    if (ABS(dx) > M_SOUND_RADIUS || ABS(dy) > M_SOUND_RADIUS
-        || ABS(dz) > M_SOUND_RADIUS) {
+    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
+        || ABS(dz) > M_SOUND_FAR_RANGE) {
         return INT32_MAX;
     }
     uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    if (distance > M_SOUND_RADIUS_SQRD) {
+    if (distance > SQUARE(M_SOUND_FAR_RANGE)) {
         return INT32_MAX;
-    } else if (distance < M_SOUND_MAXVOL_RADIUS_SQRD) {
+    } else if (distance < SQUARE(M_SOUND_CLOSE_RANGE)) {
         distance = 0;
     } else {
-        distance = Math_Sqrt(distance) - M_SOUND_MAXVOL_RADIUS;
+        distance = Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
     }
     return distance;
 }
@@ -156,7 +202,7 @@ int32_t Sound_GetVolume(
         volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
     }
     const int32_t attenuation =
-        SQUARE(distance) / (M_SOUND_RADIUS_SQRD / 0x10000);
+        SQUARE(distance) / (SQUARE(M_SOUND_FAR_RANGE) / 0x10000);
     return (volume * (0x10000 - attenuation)) / 0x10000;
 }
 
@@ -240,45 +286,11 @@ bool Sound_Effect(
         break;
     }
 
-    int32_t free_sound_idx = -1;
-    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-        M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-        if (sound->sample_id < 0) {
-            free_sound_idx = i;
-            break;
-        }
+    M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
+    if (sound == nullptr) {
+        return false;
     }
-
-    if (free_sound_idx == -1) {
-        // No sound found - try to find the most quiet track, and use this one
-        int32_t min_volume = INT32_MAX;
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-            if (sound->sample_id >= 0 && sound->volume < min_volume) {
-                min_volume = sound->volume;
-                free_sound_idx = i;
-            }
-        }
-
-        if (free_sound_idx == -1) {
-            // No sound found - give up
-            return false;
-        }
-    }
-
-    M_ACTIVE_SOUND *const sound = &m_ActiveSounds[free_sound_idx];
-    M_CloseActiveSound(sound);
-
-    const int32_t handle = Audio_Sample_Play(
-        track_id, Sound_ConvertVolumeToDecibel(volume), M_ConvertPitch(pitch),
-        Sound_ConvertPanToDecibel(pan), info->mode == SAMPLE_MODE_LOOPED);
-    if (handle != AUDIO_NO_SOUND) {
-        sound->volume = volume;
-        sound->pan = pan;
-        sound->pitch = pitch;
-        sound->sample_id = sample_id;
-        sound->handle = handle;
-    }
+    M_Play(sound, info, sample_id, track_id, volume, pitch, pan);
 
     return true;
 }

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -44,7 +44,7 @@ static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
 static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
 
 static bool M_Play(
-    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *info, int32_t sample_id,
+    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *sample, int32_t sample_id,
     int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
     int32_t distance, const XYZ_32 *pos);
 
@@ -122,7 +122,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
 }
 
 static bool M_Play(
-    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
+    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const sample,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
     const int32_t pitch, const int32_t pan, const int32_t distance,
     const XYZ_32 *const pos)
@@ -130,11 +130,11 @@ static bool M_Play(
     M_CloseActiveSound(sound);
     const int32_t handle = Audio_Sample_Play(
         track_id, Sound_ConvertVolumeToDecibel(volume), M_ConvertPitch(pitch),
-        Sound_ConvertPanToDecibel(pan), info->mode == SAMPLE_MODE_LOOPED);
+        Sound_ConvertPanToDecibel(pan), sample->mode == SAMPLE_MODE_LOOPED);
     if (handle == AUDIO_NO_SOUND) {
         return false;
     }
-    sound->sample = info;
+    sound->sample = sample;
     sound->sample_id = sample_id;
     sound->handle = handle;
     sound->volume = volume;
@@ -170,15 +170,17 @@ void Sound_ResetAmbient(void)
 
 void Sound_UpdateEffects(void)
 {
+    if (!Sound_IsInitialised()) {
+        return;
+    }
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-        const SAMPLE_INFO *const info = Sound_GetSampleInfo(sound->sample_id);
-        if (info == nullptr) {
+        if (sound->sample == nullptr) {
             continue;
         }
 
-        if (info->mode == SAMPLE_MODE_LOOPED) {
-            if (sound->volume == 0) {
+        if (sound->sample->mode == SAMPLE_MODE_LOOPED) {
+            if (sound->volume <= 0) {
                 M_CloseActiveSound(sound);
             } else {
                 M_SyncActiveSoundHandle(sound);
@@ -251,12 +253,12 @@ bool Sound_Effect(
         return false;
     }
 
-    const SAMPLE_INFO *const info = Sound_GetSampleInfo(sample_id);
-    if (info == nullptr || info->number < 0) {
+    const SAMPLE_INFO *const sample = Sound_GetSampleInfo(sample_id);
+    if (sample == nullptr || sample->number < 0) {
         return false;
     }
 
-    if (info->randomness && Random_GetDraw() > info->randomness) {
+    if (sample->randomness && Random_GetDraw() > sample->randomness) {
         return false;
     }
 
@@ -265,20 +267,20 @@ bool Sound_Effect(
         return false;
     }
 
-    const int32_t pan = Sound_GetPan(info, pos);
-    const int32_t volume = Sound_GetVolume(info, distance);
+    const int32_t pan = Sound_GetPan(sample, pos);
+    const int32_t volume = Sound_GetVolume(sample, distance);
     if (volume <= 0) {
         return false;
     }
 
-    const int32_t pitch = Sound_GetPitch(info);
-    const int32_t num_samples = info->flags.num_samples;
+    const int32_t pitch = Sound_GetPitch(sample);
+    const int32_t num_samples = sample->flags.num_samples;
     const int32_t track_id = num_samples == 1
-        ? info->number
-        : info->number + ((num_samples * Random_GetDraw()) / 0x8000);
+        ? sample->number
+        : sample->number + ((num_samples * Random_GetDraw()) / 0x8000);
 
     M_ACTIVE_SOUND *sound = nullptr;
-    switch (info->mode) {
+    switch (sample->mode) {
     case SAMPLE_MODE_NORMAL:
         sound = M_SelectUnusedSound();
         break;
@@ -300,34 +302,26 @@ bool Sound_Effect(
         }
         break;
 
-    case SAMPLE_MODE_LOOPED: {
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-            if (sound->sample_id == sample_id) {
-                if (volume > sound->volume) {
-                    sound->distance = distance;
-                    sound->volume = volume;
-                    sound->pan = pan;
-                    sound->pitch = pitch;
-                }
-                return true;
+    case SAMPLE_MODE_LOOPED:
+        sound = M_SelectUsedSound(sample_id);
+        if (sound != nullptr) {
+            if (volume > sound->volume) {
+                sound->distance = distance;
+                sound->volume = volume;
+                sound->pan = pan;
+                sound->pitch = pitch;
             }
+            return true;
         }
-        M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
-        if (sound == nullptr) {
-            return false;
-        }
-        return M_Play(
-            sound, info, sample_id, track_id, volume, pitch, pan, distance,
-            pos);
-    }
+        sound = M_SelectUnusedSound();
+        break;
     }
 
     if (sound == nullptr) {
         return false;
     }
     return M_Play(
-        sound, info, sample_id, track_id, volume, pitch, pan, distance, pos);
+        sound, sample, sample_id, track_id, volume, pitch, pan, distance, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -17,8 +17,11 @@ typedef struct {
     const SAMPLE_INFO *sample;
     int32_t handle;
     int32_t volume;
-    int32_t pan;
     int32_t pitch;
+    int32_t pan;
+
+    int32_t distance;
+    const XYZ_32 *pos;
 } M_ACTIVE_SOUND;
 
 #define M_MAX_ACTIVE_SOUNDS 32
@@ -33,13 +36,18 @@ static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 static float M_ConvertPitch(float pitch);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
+static M_ACTIVE_SOUND *M_SelectUsedSound(SAMPLE_ID sample_id);
+
 static void M_ClearAllActiveSounds(void);
 static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
 static void M_CloseActiveSound(M_ACTIVE_SOUND *sound);
+static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
+
 static bool M_Play(
-    M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
-    const int32_t sample_id, const int32_t track_id, const int32_t volume,
-    const int32_t pitch, const int32_t pan);
+    M_ACTIVE_SOUND *sound, const SAMPLE_INFO *info, int32_t sample_id,
+    int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
+    int32_t distance, const XYZ_32 *pos);
+
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 
 static float M_ConvertPitch(const float pitch)
@@ -71,6 +79,17 @@ static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
     return best_sound;
 }
 
+static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id)
+{
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
+        if (result->sample_id == sample_id) {
+            return result;
+        }
+    }
+    return nullptr;
+}
+
 static void M_ClearAllActiveSounds(void)
 {
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
@@ -92,10 +111,21 @@ static void M_CloseActiveSound(M_ACTIVE_SOUND *const sound)
     M_ClearActiveSound(sound);
 }
 
+static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
+{
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const rsound = &m_ActiveSounds[i];
+        if (rsound != sound && rsound->handle == sound->handle) {
+            rsound->handle = AUDIO_NO_SOUND;
+        }
+    }
+}
+
 static bool M_Play(
     M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const info,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
-    const int32_t pitch, const int32_t pan)
+    const int32_t pitch, const int32_t pan, const int32_t distance,
+    const XYZ_32 *const pos)
 {
     M_CloseActiveSound(sound);
     const int32_t handle = Audio_Sample_Play(
@@ -105,11 +135,14 @@ static bool M_Play(
         return false;
     }
     sound->sample = info;
-    sound->volume = volume;
-    sound->pan = pan;
-    sound->pitch = pitch;
     sound->sample_id = sample_id;
     sound->handle = handle;
+    sound->volume = volume;
+    sound->pitch = pitch;
+    sound->pan = pan;
+    sound->distance = distance;
+    sound->pos = pos;
+    M_ClearActiveSoundHandles(sound);
     return true;
 }
 
@@ -185,7 +218,7 @@ int32_t Sound_GetPan(const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
     if (pos == nullptr) {
         return 0;
     }
-    const uint32_t distance = Sound_GetDistance(pos);
+    const int32_t distance = Sound_GetDistance(pos);
     if (distance > 0 && !sample->flags.no_pan) {
         const int32_t dx = pos->x - g_Camera.mic_pos.x;
         const int32_t dz = pos->z - g_Camera.mic_pos.z;
@@ -194,8 +227,7 @@ int32_t Sound_GetPan(const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
     return 0;
 }
 
-int32_t Sound_GetVolume(
-    const SAMPLE_INFO *const sample, const uint32_t distance)
+int32_t Sound_GetVolume(const SAMPLE_INFO *const sample, const int32_t distance)
 {
     int32_t volume = sample->volume;
     if (sample->flags.randomize_volume) {
@@ -228,7 +260,7 @@ bool Sound_Effect(
         return false;
     }
 
-    const uint32_t distance = Sound_GetDistance(pos);
+    const int32_t distance = Sound_GetDistance(pos);
     if (distance == INT32_MAX) {
         return false;
     }
@@ -245,37 +277,35 @@ bool Sound_Effect(
         ? info->number
         : info->number + ((num_samples * Random_GetDraw()) / 0x8000);
 
+    M_ACTIVE_SOUND *sound = nullptr;
     switch (info->mode) {
     case SAMPLE_MODE_NORMAL:
+        sound = M_SelectUnusedSound();
         break;
 
     case SAMPLE_MODE_WAIT:
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-            if (sound->sample_id == sample_id) {
-                if (Audio_Sample_IsPlaying(sound->handle)) {
-                    return true;
-                }
-                M_ClearActiveSound(sound);
-            }
+        sound = M_SelectUsedSound(sample_id);
+        if (sound != nullptr && Audio_Sample_IsPlaying(sound->handle)) {
+            return true;
+        }
+        if (sound == nullptr) {
+            sound = M_SelectUnusedSound();
         }
         break;
 
     case SAMPLE_MODE_RESTART:
-        for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
-            M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
-            if (sound->sample_id == sample_id) {
-                M_CloseActiveSound(sound);
-                break;
-            }
+        sound = M_SelectUsedSound(sample_id);
+        if (sound == nullptr) {
+            sound = M_SelectUnusedSound();
         }
         break;
 
-    case SAMPLE_MODE_LOOPED:
+    case SAMPLE_MODE_LOOPED: {
         for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
             M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
             if (sound->sample_id == sample_id) {
                 if (volume > sound->volume) {
+                    sound->distance = distance;
                     sound->volume = volume;
                     sound->pan = pan;
                     sound->pitch = pitch;
@@ -283,20 +313,28 @@ bool Sound_Effect(
                 return true;
             }
         }
-        break;
+        M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
+        if (sound == nullptr) {
+            return false;
+        }
+        return M_Play(
+            sound, info, sample_id, track_id, volume, pitch, pan, distance,
+            pos);
+    }
     }
 
-    M_ACTIVE_SOUND *const sound = M_SelectUnusedSound();
     if (sound == nullptr) {
         return false;
     }
-    M_Play(sound, info, sample_id, track_id, volume, pitch, pan);
-
-    return true;
+    return M_Play(
+        sound, info, sample_id, track_id, volume, pitch, pan, distance, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)
 {
+    if (!Sound_IsInitialised()) {
+        return;
+    }
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const sound = &m_ActiveSounds[i];
         if (sound->sample_id == sample_id) {

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -20,7 +20,6 @@ typedef struct {
     int32_t pitch;
     int32_t pan;
 
-    int32_t distance;
     const XYZ_32 *pos;
 } M_ACTIVE_SOUND;
 
@@ -52,7 +51,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *sound);
 static bool M_Play(
     M_ACTIVE_SOUND *sound, const SAMPLE_INFO *sample, int32_t sample_id,
     int32_t track_id, int32_t volume, int32_t pitch, int32_t pan,
-    int32_t distance, const XYZ_32 *pos);
+    const XYZ_32 *pos);
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
@@ -193,8 +192,7 @@ static void M_ClearActiveSoundHandles(const M_ACTIVE_SOUND *const sound)
 static bool M_Play(
     M_ACTIVE_SOUND *const sound, const SAMPLE_INFO *const sample,
     const int32_t sample_id, const int32_t track_id, const int32_t volume,
-    const int32_t pitch, const int32_t pan, const int32_t distance,
-    const XYZ_32 *const pos)
+    const int32_t pitch, const int32_t pan, const XYZ_32 *const pos)
 {
     M_CloseActiveSound(sound);
     const int32_t handle = Audio_Sample_Play(
@@ -209,7 +207,6 @@ static bool M_Play(
     sound->volume = volume;
     sound->pitch = pitch;
     sound->pan = pan;
-    sound->distance = distance;
     sound->pos = pos;
     M_ClearActiveSoundHandles(sound);
     return true;
@@ -251,6 +248,9 @@ bool Sound_Init(void)
 
 void Sound_ResetAmbient(void)
 {
+    if (!Sound_IsInitialised()) {
+        return;
+    }
     Sound_ResetSources();
 }
 
@@ -352,7 +352,6 @@ bool Sound_Effect(
         sound = M_SelectUsedSound(sample_id);
         if (sound != nullptr) {
             if (volume > sound->volume) {
-                sound->distance = distance;
                 sound->volume = volume;
                 sound->pan = pan;
                 sound->pitch = pitch;
@@ -366,8 +365,7 @@ bool Sound_Effect(
     if (sound == nullptr) {
         return false;
     }
-    return M_Play(
-        sound, sample, sample_id, track_id, volume, pitch, pan, distance, pos);
+    return M_Play(sound, sample, sample_id, track_id, volume, pitch, pan, pos);
 }
 
 void Sound_StopEffect(const SAMPLE_ID sample_id)

--- a/src/tr2/game/sound.c
+++ b/src/tr2/game/sound.c
@@ -34,9 +34,15 @@ typedef struct {
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
 
 static float M_ConvertPitch(float pitch);
+static int32_t M_GetDistance(const XYZ_32 *pos);
+static int32_t M_GetVolume(
+    const SAMPLE_INFO *sample, int32_t distance, bool random);
+static int32_t M_GetPan(const SAMPLE_INFO *sample, const XYZ_32 *pos);
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void);
 static M_ACTIVE_SOUND *M_SelectUsedSound(SAMPLE_ID sample_id);
+static M_ACTIVE_SOUND *M_SelectUsedSoundWithPos(
+    SAMPLE_ID sample_id, const XYZ_32 *pos);
 
 static void M_ClearAllActiveSounds(void);
 static void M_ClearActiveSound(M_ACTIVE_SOUND *sound);
@@ -49,10 +55,61 @@ static bool M_Play(
     int32_t distance, const XYZ_32 *pos);
 
 static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *sound);
+static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *sound);
 
 static float M_ConvertPitch(const float pitch)
 {
     return pitch / 0x10000.p0;
+}
+
+static int32_t M_GetDistance(const XYZ_32 *const pos)
+{
+    if (pos == nullptr) {
+        return 0;
+    }
+    const int32_t dx = pos->x - g_Camera.mic_pos.x;
+    const int32_t dy = pos->y - g_Camera.mic_pos.y;
+    const int32_t dz = pos->z - g_Camera.mic_pos.z;
+    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
+        || ABS(dz) > M_SOUND_FAR_RANGE) {
+        return INT32_MAX;
+    }
+    uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
+    if (distance > SQUARE(M_SOUND_FAR_RANGE)) {
+        return INT32_MAX;
+    } else if (distance < SQUARE(M_SOUND_CLOSE_RANGE)) {
+        distance = 0;
+    } else {
+        distance = Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
+    }
+    return distance;
+}
+
+static int32_t M_GetVolume(
+    const SAMPLE_INFO *const sample, const int32_t distance, const bool random)
+{
+    int32_t volume = sample->volume;
+    if (random && sample->flags.randomize_volume) {
+        volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
+    }
+    const int32_t attenuation =
+        SQUARE(distance) / (SQUARE(M_SOUND_FAR_RANGE) / 0x10000);
+    return (volume * (0x10000 - attenuation)) / 0x10000;
+}
+
+static int32_t M_GetPan(
+    const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
+{
+    if (pos == nullptr) {
+        return 0;
+    }
+    const int32_t distance = M_GetDistance(pos);
+    if (distance > 0 && !sample->flags.no_pan) {
+        const int32_t dx = pos->x - g_Camera.mic_pos.x;
+        const int32_t dz = pos->z - g_Camera.mic_pos.z;
+        return (int16_t)Math_Atan(dz, dx) - g_Camera.actual_angle;
+    }
+    return 0;
 }
 
 static M_ACTIVE_SOUND *M_SelectUnusedSound(void)
@@ -84,6 +141,18 @@ static M_ACTIVE_SOUND *M_SelectUsedSound(const SAMPLE_ID sample_id)
     for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
         M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
         if (result->sample_id == sample_id) {
+            return result;
+        }
+    }
+    return nullptr;
+}
+
+static M_ACTIVE_SOUND *M_SelectUsedSoundWithPos(
+    const SAMPLE_ID sample_id, const XYZ_32 *const pos)
+{
+    for (int32_t i = 0; i < M_MAX_ACTIVE_SOUNDS; i++) {
+        M_ACTIVE_SOUND *const result = &m_ActiveSounds[i];
+        if (result->sample_id == sample_id && result->pos == pos) {
             return result;
         }
     }
@@ -154,6 +223,23 @@ static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
         sound->handle, Sound_ConvertVolumeToDecibel(sound->volume));
 }
 
+static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
+{
+    const int32_t distance = M_GetDistance(sound->pos);
+    if (distance == INT32_MAX) {
+        sound->volume = 0;
+        return;
+    }
+    int32_t volume = M_GetVolume(sound->sample, distance, false);
+    if (volume < 0) {
+        sound->volume = 0;
+        return;
+    }
+
+    sound->volume = volume;
+    sound->pan = M_GetPan(sound->sample, sound->pos);
+}
+
 bool Sound_Init(void)
 {
     const bool result = Sound_InitialiseCommon();
@@ -188,56 +274,15 @@ void Sound_UpdateEffects(void)
             }
         } else if (!Audio_Sample_IsPlaying(sound->handle)) {
             M_ClearActiveSound(sound);
+        } else if (TR_VERSION == 1 && sound->pos != nullptr) {
+            M_UpdateActiveSoundParams(sound);
+            if (sound->volume <= 0) {
+                M_CloseActiveSound(sound);
+            } else {
+                M_SyncActiveSoundHandle(sound);
+            }
         }
     }
-}
-
-uint32_t Sound_GetDistance(const XYZ_32 *const pos)
-{
-    if (pos == nullptr) {
-        return 0;
-    }
-    const int32_t dx = pos->x - g_Camera.mic_pos.x;
-    const int32_t dy = pos->y - g_Camera.mic_pos.y;
-    const int32_t dz = pos->z - g_Camera.mic_pos.z;
-    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
-        || ABS(dz) > M_SOUND_FAR_RANGE) {
-        return INT32_MAX;
-    }
-    uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    if (distance > SQUARE(M_SOUND_FAR_RANGE)) {
-        return INT32_MAX;
-    } else if (distance < SQUARE(M_SOUND_CLOSE_RANGE)) {
-        distance = 0;
-    } else {
-        distance = Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
-    }
-    return distance;
-}
-
-int32_t Sound_GetPan(const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
-{
-    if (pos == nullptr) {
-        return 0;
-    }
-    const int32_t distance = Sound_GetDistance(pos);
-    if (distance > 0 && !sample->flags.no_pan) {
-        const int32_t dx = pos->x - g_Camera.mic_pos.x;
-        const int32_t dz = pos->z - g_Camera.mic_pos.z;
-        return (int16_t)Math_Atan(dz, dx) - g_Camera.actual_angle;
-    }
-    return 0;
-}
-
-int32_t Sound_GetVolume(const SAMPLE_INFO *const sample, const int32_t distance)
-{
-    int32_t volume = sample->volume;
-    if (sample->flags.randomize_volume) {
-        volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
-    }
-    const int32_t attenuation =
-        SQUARE(distance) / (SQUARE(M_SOUND_FAR_RANGE) / 0x10000);
-    return (volume * (0x10000 - attenuation)) / 0x10000;
 }
 
 bool Sound_Effect(
@@ -262,13 +307,13 @@ bool Sound_Effect(
         return false;
     }
 
-    const int32_t distance = Sound_GetDistance(pos);
+    const int32_t distance = M_GetDistance(pos);
     if (distance == INT32_MAX) {
         return false;
     }
 
-    const int32_t pan = Sound_GetPan(sample, pos);
-    const int32_t volume = Sound_GetVolume(sample, distance);
+    const int32_t pan = M_GetPan(sample, pos);
+    const int32_t volume = M_GetVolume(sample, distance, true);
     if (volume <= 0) {
         return false;
     }
@@ -286,7 +331,8 @@ bool Sound_Effect(
         break;
 
     case SAMPLE_MODE_WAIT:
-        sound = M_SelectUsedSound(sample_id);
+        sound = TR_VERSION == 1 ? M_SelectUsedSoundWithPos(sample_id, pos)
+                                : M_SelectUsedSound(sample_id);
         if (sound != nullptr && Audio_Sample_IsPlaying(sound->handle)) {
             return true;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This hammers the TR1 and TR2 sound modules into rough alignment, but stops shy of the final merge. The biggest remaining differences:
- `SAMPLE_MODE_WAIT` in TR1 requires `pos`, as some samples (eg explosions) are not using `SAMPLE_MODE_RESTART`
- the way distances and volume are calculated

Please LMK if there are any regressions – we focus on sound repeating, different sources etc. just like in #3890.

The commits are not spectacular in terms of their descriptions, but if we hit regressions, they'll allow me to find out which part of the refactoring went south. I mean to squash everything into a single commit later.