### PR TITLE
sound: add option to disable random pitch in tr2

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added an option to use Lara's barefoot sound effects in appropriate levels (Sound options → Barefoot SFX) (#2643)
 - added dev console gradient backdrop, similar to TR1X (#2150)
 - added smooth bars (needs to be explicitly enabled in the settings)
+- added an option to turn off sound effect pitching (#625)
 - fixed trapdoor type 3 (object #116) not functioning (#3895)
 - fixed camera stutter when shimmying on ladders to the left (#3904, regression from 1.3)
 - fixed gameplay settings UI displaying eagerly after the first use (#3583, regression from 1.3)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -270,6 +270,7 @@
 
 ## Audio
 - added an option to control how music is played while underwater rather than simply muting it
+- added an option to turn off sound effect pitching
 - added the current music track and timestamp to the savegame so they now persist on load
 - added the ability to trigger different ambient tracks in custom levels, which will loop and be remembered between saves
 - added an option to continue playing music while in the inventory

--- a/src/libtrx/config/map.def
+++ b/src/libtrx/config/map.def
@@ -6,6 +6,7 @@
 #endif
 
 X_CFG_BOOL(audio.enable_music_in_inventory,          true)
+X_CFG_BOOL(audio.enable_pitched_sounds,              true)
 X_CFG_BOOL(audio.enable_underwater_anim_sfx,         true)
 X_CFG_BOOL(audio.mute_out_of_focus,                  true)
 X_CFG_BOOL(debug.enable_debug_portals,               false)

--- a/src/libtrx/config/map_tr1.def
+++ b/src/libtrx/config/map_tr1.def
@@ -1,5 +1,4 @@
 X_CFG_BOOL(audio.enable_music_in_menu,         true)
-X_CFG_BOOL(audio.enable_pitched_sounds,        true)
 X_CFG_BOOL(audio.enable_ps_uzi_sfx,            false)
 X_CFG_BOOL(audio.fix_secrets_killing_music,    true)
 X_CFG_BOOL(audio.fix_speeches_killing_music,   true)

--- a/src/libtrx/game/sound/common.c
+++ b/src/libtrx/game/sound/common.c
@@ -186,11 +186,9 @@ static int32_t M_GetVolume(
 static int32_t M_GetPitch(const SAMPLE_INFO *const sample)
 {
     int32_t pitch = SOUND_DEFAULT_PITCH;
-#if TR_VERSION == 1
     if (!g_Config.audio.enable_pitched_sounds) {
         return pitch;
     }
-#endif
     if (sample->flags.randomize_pitch) {
         pitch += ((Random_GetDraw() * M_SOUND_MAX_PITCH_CHANGE) / 0x4000)
             - M_SOUND_MAX_PITCH_CHANGE;

--- a/src/libtrx/game/ui/dialogs/setting_tabs/sound_settings.def
+++ b/src/libtrx/game/ui/dialogs/setting_tabs/sound_settings.def
@@ -16,8 +16,8 @@ X_UI_CFG_ENUM(audio.music_load_condition,               SETTING_MUSIC_LOAD_CONDI
 X_UI_CFG_BOOL(audio.enable_underwater_anim_sfx,         SETTING_ENABLE_UNDERWATER_ANIM_SFX)
 X_UI_CFG_BOOL(audio.mute_out_of_focus,                  SETTING_MUTE_OUT_OF_FOCUS)
 
-#if TR_VERSION == 1
 X_UI_CFG_BOOL(audio.enable_pitched_sounds,              SETTING_ENABLE_PITCHED_SOUNDS)
+#if TR_VERSION == 1
 X_UI_CFG_BOOL(audio.enable_ps_uzi_sfx,                  SETTING_PS_UZI_SFX)
 #elif TR_VERSION >= 2
 X_UI_CFG_BOOL(audio.enable_lara_mic,                    SETTING_ENABLE_LARA_MIC)

--- a/src/libtrx/include/libtrx/config/types_tr2.h
+++ b/src/libtrx/include/libtrx/config/types_tr2.h
@@ -103,6 +103,7 @@ typedef struct {
         float sound_volume;
         float music_volume;
         bool enable_lara_mic;
+        bool enable_pitched_sounds;
         bool enable_underwater_anim_sfx;
         bool enable_music_in_inventory;
         bool mute_out_of_focus;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This just adds a feature that existed in TR1 for a while.