### PR TITLE
objects: fix mesh locating

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed changing FPS after advancing frames in photo mode causing the game to speed up (#3605, regression from 4.13)
 - fixed CPU spike during playing FMVs (#3908, regression from 4.6)
 - fixed `/play` command likely to skip opening FMVs when inventory buffering is enabled (#3910, regression from 3.0)
+- fixed loading a save made in the gym with the item cheat resulting in Lara's meshes appearing broken (#3917, regression from 4.7)
 
 ## [4.14.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.14.1...tr1-4.14.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 4.14)

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -640,13 +640,42 @@ void Level_ReadObjectMeshes(VFILE *const file)
 void Level_AppendObjectMeshes(
     const int32_t num_offsets, const int32_t *const offsets, VFILE *const file)
 {
+#define L_ALIGN 2
+
+    // Savegames identify meshes by their file pointer values divided by 2.
+    // (Historically, meshes were stored in int16_t[] arrays, so the so-called
+    // "pointers" are really just array indices into that layout.)
+    //
+    // Original level meshes work fine under this scheme, but injected meshes
+    // are different, as they come from separate VFiles and bring their own
+    // pointer values. To prevent conflicts, calling Level_AppendObjectMeshes()
+    // for injected content must assign unique pseudo-pointers.
+    //
+    // Rules for injected meshes:
+    // - Pointers do not need to match real file offsets.
+    // - They only need to be unique and preserve ordering.
+    //
+    // Only the original level data requires true offset congruence so that old
+    // savegames remain compatible. For everything else, simple linear indexing
+    // is sufficient.
+    int32_t base_index = 0;
+    if (Object_GetMeshCount() > 0) {
+        // NOTE(Dash): Not assuming offsets are strictly increasing, so we scan
+        // all meshes and pick the max.
+        for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
+            base_index =
+                MAX(base_index, Object_GetMeshOffset(Object_GetMesh(i)));
+        }
+        base_index += L_ALIGN;
+    }
+
     // Construct and store distinct meshes only e.g. Lara's hips are referenced
     // by several pointers as a dummy mesh.
     VECTOR *const unique_offsets =
         Vector_CreateAtCapacity(sizeof(int32_t), num_offsets);
     int32_t pointer_map[num_offsets];
     for (int32_t i = 0; i < num_offsets; i++) {
-        const int32_t pointer = offsets[i];
+        const int32_t pointer = offsets[i] + base_index;
         const int32_t index = Vector_IndexOf(unique_offsets, (void *)&pointer);
         if (index == -1) {
             pointer_map[i] = unique_offsets->count;
@@ -661,17 +690,18 @@ void Level_AppendObjectMeshes(
     size_t start_pos = VFile_GetPos(file);
     for (int i = 0; i < unique_offsets->count; i++) {
         const int32_t pointer = *(const int32_t *)Vector_Get(unique_offsets, i);
-        VFile_SetPos(file, start_pos + pointer);
+        VFile_SetPos(file, start_pos + pointer - base_index);
         M_ReadObjectMesh(&meshes[i], file);
 
         // The original data position is required for backward compatibility
         // with savegame files, specifically for Lara's mesh pointers.
-        Object_SetMeshOffset(&meshes[i], pointer / 2);
+        Object_SetMeshOffset(&meshes[i], pointer / L_ALIGN);
     }
 
     for (int32_t i = 0; i < num_offsets; i++) {
         Object_StoreMesh(&meshes[pointer_map[i]]);
     }
+#undef L_ALIGN
 
     LOG_INFO("%d unique meshes constructed", unique_offsets->count);
 

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -619,48 +619,48 @@ void Level_ReadObjectMeshes(VFILE *const file)
     VFile_Skip(file, num_meshes * sizeof(int16_t));
 
     m_Info.mesh_ptr_count = VFile_ReadS32(file);
-    LOG_INFO("object mesh indices: %d", m_Info.mesh_ptr_count);
+    LOG_INFO("object mesh offsets: %d", m_Info.mesh_ptr_count);
     const int32_t alloc_size = m_Info.mesh_ptr_count * sizeof(int32_t);
-    int32_t *mesh_indices = Memory_Alloc(alloc_size);
-    VFile_Read(file, mesh_indices, alloc_size);
+    int32_t *mesh_offsets = Memory_Alloc(alloc_size);
+    VFile_Read(file, mesh_offsets, alloc_size);
 
     const size_t end_pos = VFile_GetPos(file);
     VFile_SetPos(file, data_start_pos);
 
     Object_InitialiseMeshes(
         m_Info.mesh_ptr_count + Inject_GetDataCount(IDT_MESH_POINTERS));
-    Level_AppendObjectMeshes(m_Info.mesh_ptr_count, mesh_indices, file);
+    Level_AppendObjectMeshes(m_Info.mesh_ptr_count, mesh_offsets, file);
 
     VFile_SetPos(file, end_pos);
-    Memory_FreePointer(&mesh_indices);
+    Memory_FreePointer(&mesh_offsets);
 
     Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_AppendObjectMeshes(
-    const int32_t num_indices, const int32_t *const indices, VFILE *const file)
+    const int32_t num_offsets, const int32_t *const offsets, VFILE *const file)
 {
     // Construct and store distinct meshes only e.g. Lara's hips are referenced
     // by several pointers as a dummy mesh.
-    VECTOR *const unique_indices =
-        Vector_CreateAtCapacity(sizeof(int32_t), num_indices);
-    int32_t pointer_map[num_indices];
-    for (int32_t i = 0; i < num_indices; i++) {
-        const int32_t pointer = indices[i];
-        const int32_t index = Vector_IndexOf(unique_indices, (void *)&pointer);
+    VECTOR *const unique_offsets =
+        Vector_CreateAtCapacity(sizeof(int32_t), num_offsets);
+    int32_t pointer_map[num_offsets];
+    for (int32_t i = 0; i < num_offsets; i++) {
+        const int32_t pointer = offsets[i];
+        const int32_t index = Vector_IndexOf(unique_offsets, (void *)&pointer);
         if (index == -1) {
-            pointer_map[i] = unique_indices->count;
-            Vector_Add(unique_indices, (void *)&pointer);
+            pointer_map[i] = unique_offsets->count;
+            Vector_Add(unique_offsets, (void *)&pointer);
         } else {
             pointer_map[i] = index;
         }
     }
 
     OBJECT_MESH *const meshes =
-        GameBuf_Alloc(sizeof(OBJECT_MESH) * unique_indices->count, GBUF_MESHES);
+        GameBuf_Alloc(sizeof(OBJECT_MESH) * unique_offsets->count, GBUF_MESHES);
     size_t start_pos = VFile_GetPos(file);
-    for (int i = 0; i < unique_indices->count; i++) {
-        const int32_t pointer = *(const int32_t *)Vector_Get(unique_indices, i);
+    for (int i = 0; i < unique_offsets->count; i++) {
+        const int32_t pointer = *(const int32_t *)Vector_Get(unique_offsets, i);
         VFile_SetPos(file, start_pos + pointer);
         M_ReadObjectMesh(&meshes[i], file);
 
@@ -669,13 +669,13 @@ void Level_AppendObjectMeshes(
         Object_SetMeshOffset(&meshes[i], pointer / 2);
     }
 
-    for (int32_t i = 0; i < num_indices; i++) {
+    for (int32_t i = 0; i < num_offsets; i++) {
         Object_StoreMesh(&meshes[pointer_map[i]]);
     }
 
-    LOG_INFO("%d unique meshes constructed", unique_indices->count);
+    LOG_INFO("%d unique meshes constructed", unique_offsets->count);
 
-    Vector_Free(unique_indices);
+    Vector_Free(unique_offsets);
 }
 
 void Level_ReadAnims(VFILE *const file)

--- a/src/libtrx/include/libtrx/game/level/common.h
+++ b/src/libtrx/include/libtrx/game/level/common.h
@@ -32,7 +32,7 @@ void Level_ReadSoundSources(VFILE *file);
 void Level_ReadSamples(VFILE *file);
 
 void Level_AppendObjectMeshes(
-    int32_t num_indices, const int32_t *indices, VFILE *file);
+    int32_t num_offsets, const int32_t *offsets, VFILE *file);
 void Level_AppendAnims(int32_t base_idx, int32_t num_anims, VFILE *file);
 void Level_AppendAnimChanges(
     int32_t base_idx, int32_t num_changes, VFILE *file);

--- a/src/tr1/game/savegame/savegame_bson.c
+++ b/src/tr1/game/savegame/savegame_bson.c
@@ -847,6 +847,8 @@ static bool M_LoadLara(
         OBJECT_MESH *const mesh = Object_FindMesh(idx);
         if (mesh != nullptr) {
             lara->mesh_ptrs[i] = mesh;
+        } else {
+            LOG_WARNING("can't find mesh %d", idx);
         }
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #3917.
Needs robust testing around mesh swaps and savegames in both games (Midas, gym outfits, injected content such as gym weapons, maybe Bacon Lara, maybe t-rex Lara's skin, etc.) Ideally it should also test legacy saves around these scenarios.

Most of the change is just renaming `indices` to `offsets` for readability (it tripped me up big-time), the actual fix is much less intimidating so it sits in its own commit.