### PR TITLE
tr2/savegame_bson: restore arm animation on load

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed `/play` command likely to skip opening FMVs (#3910, regression from 0.8)
 - fixed resumed music tracks playing briefly track start upon savegame load (#3916)
 - fixed highlight size in health and air bars
+- fixed a potential crash when loading a save where Lara is holding a flare (#3924, regression from 1.0)
 
 ## [1.4.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.1...tr2-1.4.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 1.4)

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -1522,6 +1522,7 @@ static bool M_LoadArm(JSON_OBJECT *const arm_obj, LARA_ARM *const arm)
         return false;
     }
 
+    arm->anim_num = JSON_ObjectGetInt(arm_obj, "anim_num", arm->anim_num);
     arm->frame_num = JSON_ObjectGetInt(arm_obj, "frame_num", arm->frame_num);
     arm->lock = JSON_ObjectGetInt(arm_obj, "lock", arm->lock);
     arm->flash_gun = JSON_ObjectGetInt(arm_obj, "flash_gun", arm->flash_gun);


### PR DESCRIPTION
Resolves #3924.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores the animation number of Lara's arms when loading a save. I think this has been lurking since 1.0 when bson saves were introduced, although something in 1.4 made it more prevalent - I've marked it as 1.0 in the changelog given the potential it had.
