### PR TITLE
lara/look: fix extra anim state test

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed resumed music tracks playing briefly track start upon savegame load (#3916)
 - fixed highlight size in health and air bars
 - fixed a potential crash when loading a save where Lara is holding a flare (#3924, regression from 1.0)
+- fixed unrestricted look mode allowing cinematic cameras to be broken out of (#3926, regression from 1.4)
 
 ## [1.4.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.1...tr2-1.4.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 1.4)

--- a/src/libtrx/game/lara/look.c
+++ b/src/libtrx/game/lara/look.c
@@ -104,8 +104,10 @@ static bool M_IsStatePermitted(void)
         return false;
     }
 
-    if (Lara_HasExtraState(m_PermittedExtraStates)) {
-        return g_Config.gameplay.look_mode == LOOK_MODE_UNRESTRICTED;
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->extra_anim) {
+        return g_Config.gameplay.look_mode == LOOK_MODE_UNRESTRICTED
+            && Lara_HasExtraState(m_PermittedExtraStates);
     }
 
     return g_Config.gameplay.look_mode == LOOK_MODE_UNRESTRICTED


### PR DESCRIPTION
Resolves #3926.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that look is not permitted if Lara has extra state and her actual state is not a permitted one.
