### PR TITLE
tr2/objects/trex: fix crash when AI is not set

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -27,6 +27,7 @@
     - added the ability for movable blocks to travel up and down lifts
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece (#3828)
+- fixed a rare crash if the t-rex is killed with a grenade and many other enemies are active (#3938)
 
 ## [1.4.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.1...tr2-1.4.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 1.4)

--- a/src/tr2/game/objects/creatures/trex.c
+++ b/src/tr2/game/objects/creatures/trex.c
@@ -164,7 +164,9 @@ static void M_Control(const int16_t item_num)
     }
 
     Creature_Head(item, head / 2);
-    creature->neck_rotation = creature->head_rotation;
+    if (creature != nullptr) {
+        creature->neck_rotation = creature->head_rotation;
+    }
 
     Creature_Animate(item_num, angle, tilt);
 }


### PR DESCRIPTION
Resolves #3938.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves a crash if a t-rex's control is run after it's been exploded, but its AI is not set.
The t-rex is the only creature that applies neck rotation like this, everything else uses `Creature_Neck` which tests for null as-is.
