### PR TITLE
collision: track room number when filling sides

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -21,6 +21,7 @@
     - added the ability for stacks of movable blocks to fall when on opened trapdoors and drawbridges
     - fixed various bugs with falling movable blocks
 - fixed recordings replaying commands twice (regression from 4.14)
+- fixed the fix for the sticky corner glitch not being optional - now linked to Gameplay → Fixes → Wall glitch mode (#3957, regression from 4.14)
 
 ## [4.14.2](https://github.com/LostArtefacts/TRX/compare/tr1-4.14.1...tr1-4.14.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 4.14)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -36,6 +36,7 @@
 - fixed Lara hang climbing up a movable block used as a ladder piece (#3828)
 - fixed a rare crash if the t-rex is killed with a grenade and many other enemies are active (#3938)
 - fixed recordings replaying commands twice (regression from 1.4)
+- fixed the fix for the sticky corner glitch not being optional - now linked to Gameplay → Fixes → Wall glitch mode (#3957, regression from 1.4)
 
 ## [1.4.2](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.1...tr2-1.4.2) - 2025-09-07
 - fixed broken rendering in MacOS releases (#3880, regression from 1.4)

--- a/src/libtrx/game/collision.c
+++ b/src/libtrx/game/collision.c
@@ -11,7 +11,7 @@
 
 static void M_FillSide(
     const COLL_INFO *coll, COLL_SIDE *side, int32_t x_pos, int32_t z_pos,
-    int32_t y_pos, int32_t obj_height, int16_t room_num);
+    int32_t y_pos, int32_t obj_height, int16_t *room_num);
 static bool M_IsOnWalkable(
     const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height);
 
@@ -30,12 +30,19 @@ static bool M_IsOnWalkable(
 static void M_FillSide(
     const COLL_INFO *const coll, COLL_SIDE *const side, const int32_t x_pos,
     const int32_t z_pos, const int32_t y_pos, const int32_t obj_height,
-    int16_t room_num)
+    int16_t *const room_num)
 {
     const int32_t y = y_pos - obj_height;
     const int32_t y_top = y - M_HEADROOM;
 
-    const SECTOR *const sector = Room_GetSector(x_pos, y_top, z_pos, &room_num);
+    int16_t local_room_num = *room_num;
+    int16_t *const test_room_num =
+        g_Config.gameplay.wall_glitch_mode == WALL_GLITCH_FIXED
+        ? &local_room_num
+        : room_num;
+
+    const SECTOR *const sector =
+        Room_GetSector(x_pos, y_top, z_pos, test_room_num);
     int32_t height = Room_GetHeight(sector, x_pos, y_top, z_pos);
     int32_t ceiling = Room_GetCeiling(sector, x_pos, y_top, z_pos);
     const int32_t room_height = height;
@@ -305,13 +312,13 @@ void Collide_GetCollisionInfo(
 
     M_FillSide(
         coll, &coll->side_front, x_pos + x_front, z_pos + z_front, y_pos,
-        obj_height, room_num);
+        obj_height, &room_num);
     M_FillSide(
         coll, &coll->side_left, x_pos + x_left, z_pos + z_left, y_pos,
-        obj_height, room_num);
+        obj_height, &room_num);
     M_FillSide(
         coll, &coll->side_right, x_pos + x_right, z_pos + z_right, y_pos,
-        obj_height, room_num);
+        obj_height, &room_num);
 
     if (Collide_CollideStaticObjects(
             coll, x_pos, y_pos, z_pos, room_num, obj_height)) {


### PR DESCRIPTION
Resolves #3957.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

In the original collision gathering routine, the room number could change on each call to `Room_GetSector`, and hence affect the next side being tested. Having moved this to a separate function, the base room number was always used. This in turn fixed sticky corners by default, and so the wall glitch mode option is now used to determine which room to use.
