### PR TITLE
savegame: initialise block info from legacy saves

### DIFF
--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -4,6 +4,8 @@
 #include "game/inventory.h"
 #include "game/lara.h"
 #include "game/level.h"
+#include "game/objects/traps/sliding_pillar.h"
+#include "game/objects/vars.h"
 #include "game/savegame.h"
 #include "game/shell.h"
 #include "game/stats.h"
@@ -11,6 +13,7 @@
 #include <libtrx/debug.h>
 #include <libtrx/game/camera.h>
 #include <libtrx/game/carrier.h>
+#include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/log.h>
 #include <libtrx/memory.h>
 #include <libtrx/utils.h>
@@ -582,6 +585,16 @@ static bool M_LoadFromFile(MYFILE *const fp)
             } else if (obj->intelligent) {
                 item->data = nullptr;
             }
+        }
+
+        if (Object_IsType(item->object_id, g_MovableBlockObjects)) {
+            MOVABLE_BLOCK_INFO *const data = item->data;
+            data->linked.pos = item->pos;
+            data->linked.room_num = item->room_num;
+        } else if (item->object_id == O_SLIDING_PILLAR) {
+            SLIDING_PILLAR_INFO *const data = item->data;
+            data->linked.pos = item->pos;
+            data->linked.room_num = item->room_num;
         }
 
         Carrier_TestLegacyDrops(i);

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -4,6 +4,7 @@
 #include "game/inventory.h"
 #include "game/lara.h"
 #include "game/objects/general/lift.h"
+#include "game/objects/vars.h"
 #include "game/savegame.h"
 #include "game/shell.h"
 
@@ -12,6 +13,7 @@
 #include <libtrx/game/carrier.h>
 #include <libtrx/game/lara.h>
 #include <libtrx/game/music.h>
+#include <libtrx/game/objects/traps/movable_block.h>
 #include <libtrx/game/stats.h>
 #include <libtrx/memory.h>
 
@@ -304,6 +306,12 @@ static void M_ReadItems(void)
 
         default:
             break;
+        }
+
+        if (Object_IsType(item->object_id, g_MovableBlockObjects)) {
+            MOVABLE_BLOCK_INFO *const data = item->data;
+            data->linked.pos = item->pos;
+            data->linked.room_num = item->room_num;
         }
 
         if (obj->handle_save_func != nullptr) {


### PR DESCRIPTION
Resolves #3960.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds similar logic for legacy saves as for pre-V12 bson saves to initialise block and pillar info.
