### PR TITLE
tr2/objects/skidoo_driver: restore hitpoints on load

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -44,6 +44,7 @@
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece (#3828)
 - fixed a rare crash if the t-rex is killed with a grenade and many other enemies are active (#3938)
+- fixed dead skidoo drivers not registering with combat end after loading a save (#3966)
 - fixed recordings replaying commands twice (regression from 1.4)
 - fixed the fix for the sticky corner glitch not being optional - now linked to Gameplay → Fixes → Wall glitch mode (#3957, regression from 1.4)
 

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -147,6 +147,7 @@
     - added the ability for movable blocks to travel up and down lifts
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece
+- fixed dead skidoo drivers not registering with combat end after loading a save
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/tr2/game/objects/creatures/skidoo_driver.c
+++ b/src/tr2/game/objects/creatures/skidoo_driver.c
@@ -214,6 +214,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->status == IS_DEACTIVATED) {
+            item->hit_points = DONT_TARGET;
             const int16_t skidoo_num = (int16_t)(intptr_t)item->data;
             ITEM *const skidoo = Item_Get(skidoo_num);
             skidoo->object_id = O_SKIDOO_FAST;


### PR DESCRIPTION
Resolves #3966.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures dead skidoo drivers' hitpoints are set to `DONT_TARGET` after loading a save.
