### PR TITLE
objects/door: fix doors on non-portal sectors

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -30,6 +30,7 @@
     - added the ability for stacks of movable blocks to fall and land on trapdoors, drawbridges, bridges, sliding pillars, and falling blocks
     - added the ability for stacks of movable blocks to fall when on opened trapdoors and drawbridges
     - fixed various bugs with falling movable blocks
+- fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal (#3814)
 - fixed recordings replaying commands twice (regression from 4.14)
 - fixed the fix for the sticky corner glitch not being optional - now linked to Gameplay → Fixes → Wall glitch mode (#3957, regression from 4.14)
 

--- a/docs/tr1/IMPROVEMENTS.md
+++ b/docs/tr1/IMPROVEMENTS.md
@@ -132,6 +132,7 @@ Not all options are turned on by default. Refer to the ingame settings for detai
 - fixed the collision box on the tall statues in Tomb of Qualopec e.g. room 20
 - fixed Lara walking backwards off ledges into lava
 - fixed a missing transition animation between Lara jumping forward and entering freefall
+- fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal
 
 ## Cheats
 - added a fly cheat

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -43,6 +43,7 @@
     - added the ability for movable blocks to travel up and down lifts
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece (#3828)
+- fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal (#3814)
 - fixed a rare crash if the t-rex is killed with a grenade and many other enemies are active (#3938)
 - fixed dead skidoo drivers not registering with combat end after loading a save (#3966)
 - fixed recordings replaying commands twice (regression from 1.4)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -148,6 +148,7 @@
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece
 - fixed dead skidoo drivers not registering with combat end after loading a save
+- fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal
 - improved the animation of Lara's braid
 - improved handling of items that are dropped by enemies
     - added the ability for any enemy type to drop items, excluding eels

--- a/src/libtrx/game/objects/general/door.c
+++ b/src/libtrx/game/objects/general/door.c
@@ -19,6 +19,18 @@ typedef struct {
     DOORPOS_DATA d2flip;
 } DOOR_DATA;
 
+static const SECTOR m_BlockedSector = {
+    .idx = 0,
+    .box = NO_BOX,
+    .ceiling.height = NO_HEIGHT,
+    .floor.height = NO_HEIGHT,
+    .ceiling.tilt = 0,
+    .floor.tilt = 0,
+    .portal_room.sky = NO_ROOM,
+    .portal_room.pit = NO_ROOM,
+    .portal_room.wall = NO_ROOM,
+};
+
 static SECTOR *M_GetRoomRelSector(
     const ROOM *room, const ITEM *item, int32_t sector_dx, int32_t sector_dz);
 static void M_InitialisePortal(
@@ -26,6 +38,8 @@ static void M_InitialisePortal(
     DOORPOS_DATA *door_pos);
 static bool M_LaraDoorCollision(const SECTOR *sector);
 static void M_Check(DOORPOS_DATA *d);
+static void M_CopySectorProperties(
+    const SECTOR *source_sector, SECTOR *target_sector);
 static void M_Shut(DOORPOS_DATA *d);
 static void M_Open(DOORPOS_DATA *d);
 static void M_Setup(OBJECT *obj);
@@ -68,22 +82,27 @@ static void M_Check(DOORPOS_DATA *const d)
     }
 }
 
+static void M_CopySectorProperties(
+    const SECTOR *const source_sector, SECTOR *const target_sector)
+{
+    target_sector->idx = source_sector->idx;
+    target_sector->box = source_sector->box;
+    target_sector->ceiling.height = source_sector->ceiling.height;
+    target_sector->floor.height = source_sector->floor.height;
+    target_sector->floor.tilt = source_sector->floor.tilt;
+    target_sector->ceiling.tilt = source_sector->ceiling.tilt;
+    target_sector->portal_room.sky = source_sector->portal_room.sky;
+    target_sector->portal_room.pit = source_sector->portal_room.pit;
+    target_sector->portal_room.wall = source_sector->portal_room.wall;
+}
+
 static void M_Shut(DOORPOS_DATA *const d)
 {
-    SECTOR *const sector = d->sector;
     if (d->sector == nullptr) {
         return;
     }
 
-    sector->idx = 0;
-    sector->box = NO_BOX;
-    sector->ceiling.height = NO_HEIGHT;
-    sector->floor.height = NO_HEIGHT;
-    sector->floor.tilt = 0;
-    sector->ceiling.tilt = 0;
-    sector->portal_room.sky = NO_ROOM;
-    sector->portal_room.pit = NO_ROOM;
-    sector->portal_room.wall = NO_ROOM;
+    M_CopySectorProperties(&m_BlockedSector, d->sector);
 
     const int16_t box_num = d->box_num;
     if (box_num != NO_BOX) {
@@ -97,7 +116,7 @@ static void M_Open(DOORPOS_DATA *const d)
         return;
     }
 
-    *d->sector = d->old_sector;
+    M_CopySectorProperties(&d->old_sector, d->sector);
 
     const int16_t box_num = d->box_num;
     if (box_num != NO_BOX) {


### PR DESCRIPTION
Resolves #3814.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the door open/shut logic to only copy the parts of a sector that are relevant to wall collision.
`non-portal-doors.zip` is available to test in addition to the level in the ticket.