### PR TITLE
objects/movable_block: fix room number checks

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -31,6 +31,7 @@
     - added the ability for stacks of movable blocks to fall when on opened trapdoors and drawbridges
     - fixed various bugs with falling movable blocks
 - fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal (#3814)
+- fixed pushblocks that fall from a great height potentially causing a crash (#3969)
 - fixed recordings replaying commands twice (regression from 4.14)
 - fixed the fix for the sticky corner glitch not being optional - now linked to Gameplay → Fixes → Wall glitch mode (#3957, regression from 4.14)
 

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -44,6 +44,7 @@
     - fixed various bugs with falling movable blocks
 - fixed Lara hang climbing up a movable block used as a ladder piece (#3828)
 - fixed pushblocks becoming unusable when on the same sector as a door that does not sit on a room portal (#3814)
+- fixed pushblocks that fall from a great height potentially causing a crash (#3969)
 - fixed a rare crash if the t-rex is killed with a grenade and many other enemies are active (#3938)
 - fixed dead skidoo drivers not registering with combat end after loading a save (#3966)
 - fixed recordings replaying commands twice (regression from 1.4)

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -2,24 +2,17 @@
 
 #include "config.h"
 #include "game/camera.h"
-#include "game/const.h"
 #include "game/game_buf.h"
 #include "game/input.h"
 #include "game/item_actions.h"
 #include "game/items.h"
-#include "game/items/walkable.h"
 #include "game/lara.h"
-#include "game/lara/const.h"
-#include "game/objects/common.h"
-#include "game/objects/vars.h"
+#include "game/objects.h"
 #include "game/pathing.h"
 #include "game/random.h"
 #include "game/sound.h"
 #include "game/spawn.h"
-#include "log.h"
 #include "vector.h"
-
-#include <stdlib.h>
 
 #define LF_PPREADY 19
 
@@ -659,8 +652,12 @@ static void M_Control(const int16_t item_num)
     // Check if the block is floating, on a walkable, or on the pit floor.
     // ROUND_TO_HALF_CLICK because block can fall through floor to undefined
     // sector.
-    const ROOM *const room = Room_Get(Room_GetIndexFromPos(
-        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z));
+    int16_t room_num = Room_GetIndexFromPos(
+        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z);
+    if (room_num == NO_ROOM) {
+        room_num = item->room_num;
+    }
+    const ROOM *const room = Room_Get(room_num);
     const SECTOR *sector = Room_GetWorldSector(room, item->pos.x, item->pos.z);
     int32_t under_block_height = Room_GetHeightEx(
         sector, item->pos.x, item->pos.y, item->pos.z, false, item_num);
@@ -672,8 +669,12 @@ static void M_Control(const int16_t item_num)
         const int32_t y_prev = item->pos.y - item->fall_speed;
 
         // Query floor at previous y position.
-        const ROOM *const prev_room = Room_Get(Room_GetIndexFromPos(
-            item->pos.x, ROUND_TO_HALF_CLICK(y_prev), item->pos.z));
+        room_num = Room_GetIndexFromPos(
+            item->pos.x, ROUND_TO_HALF_CLICK(y_prev), item->pos.z);
+        if (room_num == NO_ROOM) {
+            room_num = item->room_num;
+        }
+        const ROOM *const prev_room = Room_Get(room_num);
         const SECTOR *prev_sector =
             Room_GetWorldSector(prev_room, item->pos.x, item->pos.z);
         int32_t prev_height = Room_GetHeightEx(
@@ -720,8 +721,8 @@ static void M_Control(const int16_t item_num)
     // Don't update room number if on a walkable because room number can fall
     // through to a pit room (e.g. trapdoors).
     if (update_room_num) {
-        int16_t room_num = item->room_num;
-        const SECTOR *const room_num_sector = Room_GetSectorOnWalkable(
+        room_num = item->room_num;
+        Room_GetSectorOnWalkable(
             item->pos.x, item->pos.y - WALL_L, item->pos.z, &room_num);
         Item_UpdateRoom(item_num, room_num);
     }


### PR DESCRIPTION
Resolves #3969.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that a falling pushblock that has tunnelled into the floor has its room number queried more safely to avoid acting on a null room for sector checks.

I've had a quick check of the recent pushblock overhaul test level and everything seems OK there still with this change, but would appreciate a second glance.
