### PR TITLE
objects/movable_block: use default floor/ceiling when falling

### DIFF
--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -742,9 +742,10 @@ static void M_Control(const int16_t item_num)
 }
 
 static int16_t M_GetFloorHeight(
-    const ITEM *const item, int32_t x, int32_t y, int32_t z, int16_t height)
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
-    if (item->status == IS_INVISIBLE) {
+    if (item->status == IS_INVISIBLE || item->gravity) {
         return height;
     }
 
@@ -791,9 +792,10 @@ static int16_t M_GetFloorHeight(
 }
 
 static int16_t M_GetCeilingHeight(
-    const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height)
+    const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
+    const int16_t height)
 {
-    if (item->status == IS_INVISIBLE) {
+    if (item->status == IS_INVISIBLE || item->gravity) {
         return height;
     }
 


### PR DESCRIPTION
Resolves #3981.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This alters the movable block floor and ceiling functions to return the default provided heights if the block is falling, which is effectively equivalent to OG in this state. This avoids Lara being col shifted on top of the block too early during her own collision routines, and hence the killer check not being able to run in time.
