### PR TITLE
music: fix starting ambient track

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...develop) - ××××-××-××
 - fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 4.11)
+- fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 4.14)
 
 ## [4.15](https://github.com/LostArtefacts/TRX/compare/tr1-4.14.2...tr1-4.15) - 2025-10-04
 Showcase: https://youtu.be/BwZXWL0WULg

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...develop) - ××××-××-××
 - fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 1.1)
+- fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 1.4)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.2...tr2-1.5) - 2025-10-04
 Showcase: https://youtu.be/ClkbvsENSvc

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -69,10 +69,10 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     Interpolation_Remember();
 
     Sound_StopAll();
-    if (level->music_track != MX_INACTIVE) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    const bool is_cutscene = level->type == GFL_CUTSCENE;
+    if (level->music_track != MX_INACTIVE
+        && (is_cutscene || Music_GetCurrentLoopedTrack() == MX_INACTIVE)) {
+        Music_Play(level->music_track, is_cutscene ? MPM_ALWAYS : MPM_LOOPED);
     }
 
     return true;

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -56,6 +56,10 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         Lara_Initialise(level);
     }
 
+    if (level->music_track != MX_INACTIVE) {
+        Music_Stop();
+    }
+
     Lua_FireEvent(LUA_EVENT_LEVEL_LOAD, level->num);
 
     // post load

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -32,10 +32,10 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     Camera_Initialise();
     Interpolation_Remember();
 
-    if (level->music_track != MX_INACTIVE) {
-        Music_Play(
-            level->music_track,
-            level->type == GFL_CUTSCENE ? MPM_ALWAYS : MPM_LOOPED);
+    const bool is_cutscene = level->type == GFL_CUTSCENE;
+    if (level->music_track != MX_INACTIVE
+        && (is_cutscene || Music_GetCurrentLoopedTrack() == MX_INACTIVE)) {
+        Music_Play(level->music_track, is_cutscene ? MPM_ALWAYS : MPM_LOOPED);
     }
 
     return true;

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -38,6 +38,10 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
         Lara_Initialise(level);
     }
 
+    if (level->music_track != MX_INACTIVE) {
+        Music_Stop();
+    }
+
     Lua_FireEvent(LUA_EVENT_LEVEL_LOAD, level->num);
 
     switch (seq_ctx) {


### PR DESCRIPTION
Resolves #3997.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that if the savegame logic has started an ambient track, that the level's default track is not then started when the game itself starts.

The `ambient-triggers` test level can be used for checking. I've double-checked the following too, but would appreciate a second glance.

- Cutscenes
- TR2 going from GW cutscene to Venice (end of level music should continue)
