### PR TITLE
game-flow: fix potential crash on exiting the game

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...develop) - ××××-××-××
+- fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 4.11)
 
 ## [4.15](https://github.com/LostArtefacts/TRX/compare/tr1-4.14.2...tr1-4.15) - 2025-10-04
 Showcase: https://youtu.be/BwZXWL0WULg

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...develop) - ××××-××-××
+- fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 1.1)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.2...tr2-1.5) - 2025-10-04
 Showcase: https://youtu.be/ClkbvsENSvc

--- a/src/libtrx/game/game_flow/reader.c
+++ b/src/libtrx/game/game_flow/reader.c
@@ -57,6 +57,22 @@ static void M_LoadCommonSettings(
     #include "./reader_tr2.def.c"
 #endif
 
+static void M_CopyRootSettingsIntoLevel(
+    const M_CONTEXT *const ctx, GF_LEVEL_SETTINGS *const dst,
+    const GF_LEVEL_SETTINGS *const src)
+{
+    *dst = *src;
+#if TR_VERSION == 2
+    dst->sfx_path = nullptr;
+#endif
+    if (src->ambient_tracks.is_present) {
+        const GF_AMBIENT_DATA *const root = &src->ambient_tracks;
+        GF_AMBIENT_DATA *const lvl = &dst->ambient_tracks;
+        lvl->ids = Memory_Alloc(sizeof(*lvl->ids) * root->count);
+        memcpy(lvl->ids, root->ids, sizeof(*lvl->ids) * root->count);
+    }
+}
+
 static bool M_ParseRGB888(JSON_VALUE *const value, RGB_888 *const target)
 {
     if (value != nullptr && value->type == JSON_TYPE_ARRAY) {
@@ -520,6 +536,7 @@ static void M_LoadLevel(
         }
     }
 
+    M_CopyRootSettingsIntoLevel(ctx, &level->settings, &ctx->gf->settings);
     M_LoadLevelGameSpecifics(ctx, jlvl_obj, level);
 
     M_LoadLevelSequence(ctx, jlvl_obj, level);

--- a/src/libtrx/game/game_flow/reader_tr1.def.c
+++ b/src/libtrx/game/game_flow/reader_tr1.def.c
@@ -160,7 +160,6 @@ static void M_LoadLevelGameSpecifics(
     const M_CONTEXT *const ctx, JSON_OBJECT *const jlvl_obj,
     GF_LEVEL *const level)
 {
-    level->settings = ctx->gf->settings;
     M_LoadSettings(ctx, jlvl_obj, &level->settings);
 
     level->unobtainable.pickups =

--- a/src/libtrx/game/game_flow/reader_tr2.def.c
+++ b/src/libtrx/game/game_flow/reader_tr2.def.c
@@ -56,10 +56,6 @@ static void M_LoadLevelGameSpecifics(
     const M_CONTEXT *const ctx, JSON_OBJECT *const jlvl_obj,
     GF_LEVEL *const level)
 {
-    level->settings = ctx->gf->settings;
-#if TR_VERSION == 2
-    level->settings.sfx_path = nullptr;
-#endif
     M_LoadSettings(ctx, jlvl_obj, &level->settings);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

To see the crash, you have to declare `"ambient_tracks"` at the root, instead of a specific level, and then exit the game.