### PR TITLE
items: support names

### DIFF
--- a/docs/6-lua/2-reference/4-ITEMS.md
+++ b/docs/6-lua/2-reference/4-ITEMS.md
@@ -21,12 +21,14 @@ Module for controlling all moveables behavior.
     - **`hit_points`**: Integer representing the item's hit points.
     - **`max_hit_points`**: Integer representing the item's hit points.
     - **`object_id`**: Integer ID of the item's object type.
+    - **`name`**: String name of the item, or `nil` if none.
 
     Writable properties:
     - `pos` (updating this also updates `room`)
     - `rot`
     - `hit_points` (updating this also may increase `max_hit_points`)
     - `max_hit_points`
+    - `name` (string identifier; setting duplicates raises an error)
 
 ### Functions
 
@@ -34,4 +36,11 @@ Module for controlling all moveables behavior.
   Returns the total number of allocated items.
 
 - [lua]`TRX.Items.Get(index)`  
-  Retrieves the [lua]`TRX.Items.ITEM` at the given zero-based index, or `nil` if out of range.
+  Retrieves the [lua]`TRX.Items.ITEM` at the given 1-based index, or `nil` if out of range.
+- [lua]`TRX.Items.GetByName(name)`  
+  Retrieves the [lua]`TRX.Items.ITEM` with the given `name`, or `nil` if not found.  
+  Example:
+  ```lua
+  TRX.Lara.GetItem().name = "lara"
+  TRX.Items.GetByName("lara") -- contains Lara item
+  ```

--- a/docs/6-lua/2-reference/9-MISC.md
+++ b/docs/6-lua/2-reference/9-MISC.md
@@ -6,3 +6,5 @@ title: Miscellaneous
 
 - [lua]`assert(condition)`  
     Logs a detailed error message to the console if something is not true.
+- [lua]`print(message)`  
+    Logs a basic string to the console without extra decorations like timestamp or the module name.

--- a/src/libtrx/game/items/common.c
+++ b/src/libtrx/game/items/common.c
@@ -8,7 +8,10 @@
 #include "game/objects/common.h"
 #include "game/output/const.h"
 #include "game/rooms.h"
+#include "memory.h"
 #include "utils.h"
+
+#include <string.h>
 
 static int32_t m_LevelItemCount = 0;
 static int16_t m_MaxUsedItemCount = 0;
@@ -56,6 +59,42 @@ ITEM *Item_Find(const GAME_OBJECT_ID obj_id)
         }
     }
 
+    return nullptr;
+}
+
+bool Item_SetName(const int16_t item_num, const char *const name)
+{
+    ITEM *const item = Item_Get(item_num);
+    if (item == nullptr) {
+        return false;
+    }
+    if (name != nullptr) {
+        ITEM *const existing = Item_GetByName(name);
+        if (existing != nullptr && existing != item) {
+            return false;
+        }
+    }
+    if (name != nullptr) {
+        item->name = GameBuf_Alloc(strlen(name) + 1, GBUF_ITEMS);
+        strcpy(item->name, name);
+    } else {
+        item->name = nullptr;
+    }
+    return true;
+}
+
+ITEM *Item_GetByName(const char *const name)
+{
+    if (name == nullptr) {
+        return nullptr;
+    }
+    // search through all items for matching name
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        if (item->name != nullptr && strcmp(item->name, name) == 0) {
+            return item;
+        }
+    }
     return nullptr;
 }
 
@@ -141,6 +180,7 @@ void Item_Initialise(const int16_t item_num)
     item->data = nullptr;
     item->priv = nullptr;
     item->carried_item = nullptr;
+    item->name = nullptr;
 
     item->active = false;
     item->status = IS_INACTIVE;

--- a/src/libtrx/game/lua/items.c
+++ b/src/libtrx/game/lua/items.c
@@ -44,6 +44,13 @@ static int M_L_ItemIndex(lua_State *const L)
     } else if (strcmp(key, "max_hit_points") == 0) {
         lua_pushinteger(L, item->max_hit_points);
         return 1;
+    } else if (strcmp(key, "name") == 0) {
+        if (item->name != nullptr) {
+            lua_pushstring(L, item->name);
+        } else {
+            lua_pushnil(L);
+        }
+        return 1;
     }
     lua_pushnil(L);
     return 1;
@@ -87,6 +94,12 @@ static int M_L_ItemNewIndex(lua_State *const L)
         item->rot.z = luaL_checkinteger(L, -1);
         lua_pop(L, 1);
         return 0;
+    } else if (strcmp(key, "name") == 0) {
+        const char *const new_name = luaL_checkstring(L, 3);
+        if (!Item_SetName(Item_GetIndex(item), new_name)) {
+            return luaL_error(L, "item name '%s' already in use", new_name);
+        }
+        return 0;
     }
     return luaL_error(L, "Cannot set field '%s' on TRX.Items.ITEM", key);
 }
@@ -114,6 +127,22 @@ static int M_L_ItemsGet(lua_State *const L)
     return 1;
 }
 
+// item = TRX.Items.GetByName(name)
+static int M_L_ItemsGetByName(lua_State *const L)
+{
+    const char *const name = luaL_checkstring(L, 1);
+    ITEM *const item = Item_GetByName(name);
+    if (item == nullptr) {
+        lua_pushnil(L);
+    } else {
+        ITEM **ud = lua_newuserdata(L, sizeof(ITEM *));
+        *ud = item;
+        luaL_getmetatable(L, "TRX.Items.ITEM");
+        lua_setmetatable(L, -2);
+    }
+    return 1;
+}
+
 void LUA_CreateItems(lua_State *const L)
 {
     luaL_newmetatable(L, "TRX.Items.ITEM");
@@ -127,6 +156,8 @@ void LUA_CreateItems(lua_State *const L)
     lua_newtable(L);
     lua_pushcfunction(L, M_L_ItemsGet);
     lua_setfield(L, -2, "Get");
+    lua_pushcfunction(L, M_L_ItemsGetByName);
+    lua_setfield(L, -2, "GetByName");
     lua_pushcfunction(L, M_L_ItemsCount);
     lua_setfield(L, -2, "Count");
     lua_setfield(L, -2, "Items");

--- a/src/libtrx/include/libtrx/game/items/common.h
+++ b/src/libtrx/include/libtrx/game/items/common.h
@@ -31,3 +31,10 @@ void Item_UpdateRoom(int16_t item_num, int16_t room_num);
 int32_t Item_GlobalReplace(
     GAME_OBJECT_ID src_obj_id, GAME_OBJECT_ID dst_obj_id);
 bool Item_IsTriggerActive(ITEM *item);
+
+// Set the name of the item, storing a copy of the provided string.
+// Returns false if the name is already used by another item.
+bool Item_SetName(int16_t item_num, const char *name);
+
+// Retrieve an item by its name, or nullptr if not found
+ITEM *Item_GetByName(const char *name);

--- a/src/libtrx/include/libtrx/game/items/types.h
+++ b/src/libtrx/include/libtrx/game/items/types.h
@@ -41,6 +41,7 @@ typedef struct {
     void *data;
     void *priv;
     CARRIED_ITEM *carried_item;
+    char *name;
 
     XYZ_32 pos;
     XYZ_16 rot;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds the ability to give items names, and find them by their names from LUA.
The names are reset on level load.