### PR TITLE
objects: move common collision/draw routines to TRX

### DIFF
--- a/src/libtrx/game/objects/col.c
+++ b/src/libtrx/game/objects/col.c
@@ -1,0 +1,21 @@
+#include "game/objects/col.h"
+
+#include "game/lara.h"
+
+void Object_Collision(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    ITEM *const item = Item_Get(item_num);
+
+    if (!Lara_TestBoundsCollide(item, coll->radius)) {
+        return;
+    }
+
+    if (!Collide_TestCollision(item, lara_item)) {
+        return;
+    }
+
+    if (coll->enable_baddie_push) {
+        Lara_Push(item, coll, false, true);
+    }
+}

--- a/src/libtrx/game/objects/col.c
+++ b/src/libtrx/game/objects/col.c
@@ -19,3 +19,17 @@ void Object_Collision(
         Lara_Push(item, coll, false, true);
     }
 }
+
+void Object_Collision_Trap(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    ITEM *const item = Item_Get(item_num);
+
+    if (item->status == IS_ACTIVE) {
+        if (Lara_TestBoundsCollide(item, coll->radius)) {
+            Collide_TestCollision(item, lara_item);
+        }
+    } else if (item->status != IS_INVISIBLE) {
+        Object_Collision(item_num, lara_item, coll);
+    }
+}

--- a/src/libtrx/game/objects/draw.c
+++ b/src/libtrx/game/objects/draw.c
@@ -5,6 +5,10 @@
 #include "game/objects/common.h"
 #include "game/output.h"
 
+void Object_DrawDummyItem(const ITEM *const item)
+{
+}
+
 void Object_DrawStaticObject(
     const OBJECT *const obj, const ANIM_FRAME *const frame)
 {

--- a/src/libtrx/game/objects/draw.c
+++ b/src/libtrx/game/objects/draw.c
@@ -6,10 +6,6 @@
 #include "game/output.h"
 #include "game/output/vars.h"
 
-void Object_DrawDummyItem(const ITEM *const item)
-{
-}
-
 void Object_DrawUnclippedItem(const ITEM *const item)
 {
     const int32_t left = g_PhdLeft;

--- a/src/libtrx/game/objects/draw.c
+++ b/src/libtrx/game/objects/draw.c
@@ -62,6 +62,36 @@ void Object_DrawStaticObject(
     Matrix_Pop();
 }
 
+void Object_DrawAnimatingItem(const ITEM *item)
+{
+    ANIM_FRAME *frames[2];
+    int32_t rate;
+    int32_t frac = Item_GetFrames(item, frames, &rate);
+    const OBJECT *const obj = Object_Get(item->object_id);
+
+    if (obj->shadow_size != 0) {
+        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
+    }
+
+    Matrix_Push();
+    Matrix_TranslateAbs32(item->interp.result.pos);
+    Matrix_Rot16(item->interp.result.rot);
+
+    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
+    if (clip == CLIP_NOT_VISIBLE) {
+        Matrix_Pop();
+        return;
+    }
+
+    Output_CalculateObjectLighting(item, &frames[0]->bounds);
+
+    const int16_t *extra_rotation = item->data;
+
+    Object_DrawInterpolatedObject(
+        obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate);
+    Matrix_Pop();
+}
+
 void Object_DrawInterpolatedObject(
     const OBJECT *const obj, const uint32_t meshes,
     const int16_t *extra_rotation, const ANIM_FRAME *const frame1,

--- a/src/libtrx/game/objects/draw.c
+++ b/src/libtrx/game/objects/draw.c
@@ -4,9 +4,30 @@
 #include "game/matrix.h"
 #include "game/objects/common.h"
 #include "game/output.h"
+#include "game/output/vars.h"
 
 void Object_DrawDummyItem(const ITEM *const item)
 {
+}
+
+void Object_DrawUnclippedItem(const ITEM *const item)
+{
+    const int32_t left = g_PhdLeft;
+    const int32_t top = g_PhdTop;
+    const int32_t right = g_PhdRight;
+    const int32_t bottom = g_PhdBottom;
+
+    g_PhdLeft = Viewport_GetMinX(VIEWPORT_GAME);
+    g_PhdTop = Viewport_GetMinY(VIEWPORT_GAME);
+    g_PhdRight = Viewport_GetMaxX(VIEWPORT_GAME);
+    g_PhdBottom = Viewport_GetMaxY(VIEWPORT_GAME);
+
+    Object_DrawAnimatingItem(item);
+
+    g_PhdLeft = left;
+    g_PhdTop = top;
+    g_PhdRight = right;
+    g_PhdBottom = bottom;
 }
 
 void Object_DrawStaticObject(

--- a/src/libtrx/game/objects/draw.c
+++ b/src/libtrx/game/objects/draw.c
@@ -30,6 +30,17 @@ void Object_DrawUnclippedItem(const ITEM *const item)
     g_PhdBottom = bottom;
 }
 
+void Object_DrawMesh(
+    const int32_t mesh_idx, const CLIP clip, const bool interpolated)
+{
+    const OBJECT_MESH *const mesh = Object_GetMesh(mesh_idx);
+    if (interpolated) {
+        Output_DrawObjectMesh_I(mesh, clip);
+    } else {
+        Output_DrawObjectMesh(mesh, clip);
+    }
+}
+
 void Object_DrawStaticObject(
     const OBJECT *const obj, const ANIM_FRAME *const frame)
 {

--- a/src/libtrx/game/objects/general/waterfall.c
+++ b/src/libtrx/game/objects/general/waterfall.c
@@ -37,7 +37,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/libtrx/include/libtrx/game/objects.h
+++ b/src/libtrx/include/libtrx/game/objects.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "objects/col.h"
 #include "objects/common.h"
 #include "objects/draw.h"
 #include "objects/ids.h"

--- a/src/libtrx/include/libtrx/game/objects/col.h
+++ b/src/libtrx/include/libtrx/game/objects/col.h
@@ -1,0 +1,3 @@
+#include "../collision.h"
+
+void Object_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);

--- a/src/libtrx/include/libtrx/game/objects/col.h
+++ b/src/libtrx/include/libtrx/game/objects/col.h
@@ -1,3 +1,4 @@
 #include "../collision.h"
 
 void Object_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
+void Object_Collision_Trap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);

--- a/src/libtrx/include/libtrx/game/objects/common.h
+++ b/src/libtrx/include/libtrx/game/objects/common.h
@@ -75,7 +75,6 @@ int16_t Object_FindReceptacle(GAME_OBJECT_ID obj_id);
 GAME_OBJECT_ID Object_FindReceptacleKey(const GAME_OBJECT_ID receptacle_obj_id);
 
 extern void Object_SetReflective(GAME_OBJECT_ID obj_id, bool enabled);
-extern void Object_DrawAnimatingItem(const ITEM *item);
 
 #define REGISTER_OBJECT(object_id, setup_func_)                                \
     __attribute__((constructor)) static void M_RegisterObject##object_id(void) \

--- a/src/libtrx/include/libtrx/game/objects/draw.h
+++ b/src/libtrx/include/libtrx/game/objects/draw.h
@@ -9,7 +9,7 @@
 
 void Object_DrawDummyItem(const ITEM *item);
 void Object_DrawUnclippedItem(const ITEM *item);
-extern void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
+void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
 
 void Object_DrawStaticObject(const OBJECT *obj, const ANIM_FRAME *frame);
 

--- a/src/libtrx/include/libtrx/game/objects/draw.h
+++ b/src/libtrx/include/libtrx/game/objects/draw.h
@@ -8,7 +8,7 @@
 #include "types.h"
 
 void Object_DrawDummyItem(const ITEM *item);
-extern void Object_DrawUnclippedItem(const ITEM *item);
+void Object_DrawUnclippedItem(const ITEM *item);
 extern void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
 
 void Object_DrawStaticObject(const OBJECT *obj, const ANIM_FRAME *frame);

--- a/src/libtrx/include/libtrx/game/objects/draw.h
+++ b/src/libtrx/include/libtrx/game/objects/draw.h
@@ -7,7 +7,7 @@
 #include "ids.h"
 #include "types.h"
 
-extern void Object_DrawDummyItem(const ITEM *item);
+void Object_DrawDummyItem(const ITEM *item);
 extern void Object_DrawUnclippedItem(const ITEM *item);
 extern void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
 

--- a/src/libtrx/include/libtrx/game/objects/draw.h
+++ b/src/libtrx/include/libtrx/game/objects/draw.h
@@ -7,7 +7,6 @@
 #include "ids.h"
 #include "types.h"
 
-void Object_DrawDummyItem(const ITEM *item);
 void Object_DrawUnclippedItem(const ITEM *item);
 void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
 

--- a/src/libtrx/include/libtrx/game/objects/draw.h
+++ b/src/libtrx/include/libtrx/game/objects/draw.h
@@ -13,6 +13,7 @@ void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
 
 void Object_DrawStaticObject(const OBJECT *obj, const ANIM_FRAME *frame);
 
+void Object_DrawAnimatingItem(const ITEM *item);
 void Object_DrawInterpolatedObject(
     const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,
     const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -232,6 +232,7 @@ sources = [
   'game/music/backend_cdaudio.c',
   'game/music/backend_files.c',
   'game/music/common.c',
+  'game/objects/col.c',
   'game/objects/common.c',
   'game/objects/creatures/bear.c',
   'game/objects/creatures/wolf.c',

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -13,22 +13,6 @@
 #include <libtrx/game/viewport.h>
 #include <libtrx/utils.h>
 
-void Object_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    if (!Lara_TestBoundsCollide(item, coll->radius)) {
-        return;
-    }
-    if (!Collide_TestCollision(item, lara_item)) {
-        return;
-    }
-
-    if (coll->enable_baddie_push) {
-        Lara_Push(item, coll, 0, 1);
-    }
-}
-
 void Object_CollisionTrap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
 {
     ITEM *const item = Item_Get(item_num);

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -13,19 +13,6 @@
 #include <libtrx/game/viewport.h>
 #include <libtrx/utils.h>
 
-void Object_CollisionTrap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_ACTIVE) {
-        if (Lara_TestBoundsCollide(item, coll->radius)) {
-            Collide_TestCollision(item, lara_item);
-        }
-    } else if (item->status != IS_INVISIBLE) {
-        Object_Collision(item_num, lara_item, coll);
-    }
-}
-
 void Object_DrawDummyItem(const ITEM *const item)
 {
 }

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -169,29 +169,6 @@ void Object_DrawPickupItem(const ITEM *const item)
     Matrix_Pop();
 }
 
-void Object_DrawAnimatingItem(const ITEM *const item)
-{
-    ANIM_FRAME *frmptr[2];
-    int32_t rate;
-    int32_t frac = Item_GetFrames(item, frmptr, &rate);
-    const OBJECT *const obj = Object_Get(item->object_id);
-
-    if (obj->shadow_size) {
-        Output_DrawShadow(obj->shadow_size, &frmptr[0]->bounds, item);
-    }
-
-    Matrix_Push();
-    Matrix_TranslateAbs32(item->interp.result.pos);
-    Matrix_Rot16(item->interp.result.rot);
-
-    Output_CalculateObjectLighting(item, &frmptr[0]->bounds);
-    const int16_t *extra_rotation = item->data ? item->data : nullptr;
-
-    Object_DrawInterpolatedObject(
-        obj, item->mesh_bits, extra_rotation, frmptr[0], frmptr[1], frac, rate);
-    Matrix_Pop();
-}
-
 void Object_SetMeshReflective(
     const GAME_OBJECT_ID obj_id, const int32_t mesh_idx, const bool enabled)
 {

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -224,14 +224,3 @@ void Object_SetReflective(const GAME_OBJECT_ID obj_id, const bool enabled)
         Object_SetMeshReflective(obj_id, i, enabled);
     }
 }
-
-void Object_DrawMesh(
-    const int32_t mesh_idx, const CLIP clip, const bool interpolated)
-{
-    const OBJECT_MESH *const mesh = Object_GetMesh(mesh_idx);
-    if (interpolated) {
-        Output_DrawObjectMesh_I(mesh, clip);
-    } else {
-        Output_DrawObjectMesh(mesh, clip);
-    }
-}

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -1,17 +1,11 @@
 #include "game/objects/common.h"
 
 #include "game/inventory.h"
-#include "game/lara.h"
-#include "game/objects/vars.h"
-#include "global/vars.h"
 
 #include <libtrx/config.h>
 #include <libtrx/debug.h>
-#include <libtrx/game/collision.h>
 #include <libtrx/game/matrix.h>
 #include <libtrx/game/output.h>
-#include <libtrx/game/viewport.h>
-#include <libtrx/utils.h>
 
 void Object_DrawSpriteItem(const ITEM *const item)
 {

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -13,10 +13,6 @@
 #include <libtrx/game/viewport.h>
 #include <libtrx/utils.h>
 
-void Object_DrawDummyItem(const ITEM *const item)
-{
-}
-
 void Object_DrawSpriteItem(const ITEM *const item)
 {
     const RGB_F tint = Output_GetTint();

--- a/src/tr1/game/objects/common.c
+++ b/src/tr1/game/objects/common.c
@@ -192,26 +192,6 @@ void Object_DrawAnimatingItem(const ITEM *const item)
     Matrix_Pop();
 }
 
-void Object_DrawUnclippedItem(const ITEM *const item)
-{
-    int32_t left = g_PhdLeft;
-    int32_t top = g_PhdTop;
-    int32_t right = g_PhdRight;
-    int32_t bottom = g_PhdBottom;
-
-    g_PhdLeft = Viewport_GetMinX(VIEWPORT_GAME);
-    g_PhdTop = Viewport_GetMinY(VIEWPORT_GAME);
-    g_PhdRight = Viewport_GetMaxX(VIEWPORT_GAME);
-    g_PhdBottom = Viewport_GetMaxY(VIEWPORT_GAME);
-
-    Object_DrawAnimatingItem(item);
-
-    g_PhdLeft = left;
-    g_PhdTop = top;
-    g_PhdRight = right;
-    g_PhdBottom = bottom;
-}
-
 void Object_SetMeshReflective(
     const GAME_OBJECT_ID obj_id, const int32_t mesh_idx, const bool enabled)
 {

--- a/src/tr1/game/objects/common.h
+++ b/src/tr1/game/objects/common.h
@@ -6,6 +6,5 @@
 
 void Object_DrawSpriteItem(const ITEM *item);
 void Object_DrawPickupItem(const ITEM *item);
-void Object_DrawAnimatingItem(const ITEM *item);
 void Object_SetMeshReflective(
     GAME_OBJECT_ID obj_id, int32_t mesh_idx, bool enabled);

--- a/src/tr1/game/objects/common.h
+++ b/src/tr1/game/objects/common.h
@@ -4,8 +4,6 @@
 
 #include "global/types.h"
 
-void Object_CollisionTrap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-
 void Object_DrawSpriteItem(const ITEM *item);
 void Object_DrawPickupItem(const ITEM *item);
 void Object_DrawAnimatingItem(const ITEM *item);

--- a/src/tr1/game/objects/common.h
+++ b/src/tr1/game/objects/common.h
@@ -4,7 +4,6 @@
 
 #include "global/types.h"
 
-void Object_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 void Object_CollisionTrap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 void Object_DrawSpriteItem(const ITEM *item);

--- a/src/tr1/game/objects/general/cabin.c
+++ b/src/tr1/game/objects/general/cabin.c
@@ -1,4 +1,5 @@
-#include "game/objects/common.h"
+#include <libtrx/game/objects.h>
+#include <libtrx/game/rooms.h>
 
 typedef enum {
     CABIN_STATE_START = 0,

--- a/src/tr1/game/objects/general/camera_target.c
+++ b/src/tr1/game/objects/general/camera_target.c
@@ -2,7 +2,7 @@
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
 }
 
 REGISTER_OBJECT(O_CAMERA_TARGET, M_Setup)

--- a/src/tr1/game/objects/general/earthquake.c
+++ b/src/tr1/game/objects/general/earthquake.c
@@ -21,7 +21,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/general/moving_bar.c
+++ b/src/tr1/game/objects/general/moving_bar.c
@@ -1,4 +1,5 @@
-#include "game/objects/common.h"
+#include <libtrx/game/objects.h>
+#include <libtrx/game/rooms.h>
 
 typedef enum {
     MOVING_BAR_STATE_INACTIVE = 0,

--- a/src/tr1/game/objects/general/scion_holder.c
+++ b/src/tr1/game/objects/general/scion_holder.c
@@ -1,4 +1,4 @@
-#include "game/objects/common.h"
+#include <libtrx/game/objects.h>
 
 static void M_Control(const int16_t item_num)
 {

--- a/src/tr1/game/objects/setup.c
+++ b/src/tr1/game/objects/setup.c
@@ -10,7 +10,7 @@ static void M_SetupLara(void)
 {
     OBJECT *const obj = Object_Get(O_LARA);
     obj->initialise_func = Lara_InitialiseLoad;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->save_position = true;
@@ -36,7 +36,7 @@ static void M_DisableObject(const GAME_OBJECT_ID obj_id)
     obj->initialise_func = nullptr;
     obj->collision_func = nullptr;
     obj->control_func = nullptr;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->floor_height_func = nullptr;
     obj->ceiling_height_func = nullptr;
     obj->add_walkable_func = nullptr;

--- a/src/tr1/game/objects/traps/ember_emitter.c
+++ b/src/tr1/game/objects/traps/ember_emitter.c
@@ -25,7 +25,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->collision_func = Object_Collision;
     obj->save_flags = true;
 }

--- a/src/tr1/game/objects/traps/ember_emitter.c
+++ b/src/tr1/game/objects/traps/ember_emitter.c
@@ -1,6 +1,6 @@
 #include "game/effects.h"
-#include "game/objects/common.h"
 
+#include <libtrx/game/objects.h>
 #include <libtrx/game/random.h>
 #include <libtrx/game/sound.h>
 

--- a/src/tr1/game/objects/traps/falling_ceiling.c
+++ b/src/tr1/game/objects/traps/falling_ceiling.c
@@ -39,7 +39,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->collision_func = Object_CollisionTrap;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_position = true;
     obj->save_anim = true;
     obj->save_flags = true;

--- a/src/tr1/game/objects/traps/flame_emitter.c
+++ b/src/tr1/game/objects/traps/flame_emitter.c
@@ -30,7 +30,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -121,7 +121,7 @@ static void M_Collision(
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->bounds_func = M_Bounds;
     obj->is_usable_func = M_IsUsable;
 }

--- a/src/tr1/game/objects/traps/pendulum.c
+++ b/src/tr1/game/objects/traps/pendulum.c
@@ -42,7 +42,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->collision_func = Object_CollisionTrap;
+    obj->collision_func = Object_Collision_Trap;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/tr1/game/objects/traps/teeth_trap.c
+++ b/src/tr1/game/objects/traps/teeth_trap.c
@@ -49,7 +49,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->collision_func = Object_CollisionTrap;
+    obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
     obj->save_anim = true;
 }

--- a/src/tr1/game/room_draw.c
+++ b/src/tr1/game/room_draw.c
@@ -280,9 +280,10 @@ void Room_DrawSingleRoom(const int16_t room_num)
 
     int16_t item_num = room->item_num;
     while (item_num != NO_ITEM) {
-        ITEM *const item = Item_Get(item_num);
-        if (item->status != IS_INVISIBLE) {
-            Object_Get(item->object_id)->draw_func(item);
+        const ITEM *const item = Item_Get(item_num);
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (item->status != IS_INVISIBLE && obj->draw_func != nullptr) {
+            obj->draw_func(item);
         }
         item_num = item->next_item;
     }

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -81,20 +81,6 @@ void Object_DrawSpriteItem(const ITEM *const item)
         Output_GetLightAdder() + SHADE_NEUTRAL, (RGB_F) { 1.0f, 1.0f, 1.0f });
 }
 
-void Object_Collision_Trap(
-    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_ACTIVE) {
-        if (Item_TestBoundsCollide(item, lara_item, coll->radius)) {
-            Collide_TestCollision(item, lara_item);
-        }
-    } else if (item->status != IS_INVISIBLE) {
-        Object_Collision(item_num, lara_item, coll);
-    }
-}
-
 BOUNDS_16 Object_GetBoundingBox(
     const OBJECT *const obj, const ANIM_FRAME *const frame,
     const uint32_t mesh_bits)

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -81,24 +81,6 @@ void Object_DrawSpriteItem(const ITEM *const item)
         Output_GetLightAdder() + SHADE_NEUTRAL, (RGB_F) { 1.0f, 1.0f, 1.0f });
 }
 
-void Object_Collision(
-    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    if (!Item_TestBoundsCollide(item, lara_item, coll->radius)) {
-        return;
-    }
-
-    if (!Collide_TestCollision(item, lara_item)) {
-        return;
-    }
-
-    if (coll->enable_baddie_push) {
-        Lara_Push(item, coll, false, true);
-    }
-}
-
 void Object_Collision_Trap(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -1,14 +1,8 @@
 #include "game/objects/common.h"
 
-#include "global/vars.h"
-
 #include <libtrx/debug.h>
-#include <libtrx/game/collision.h>
-#include <libtrx/game/lara.h>
 #include <libtrx/game/matrix.h>
 #include <libtrx/game/output.h>
-#include <libtrx/game/viewport.h>
-#include <libtrx/utils.h>
 
 void Object_DrawSpriteItem(const ITEM *const item)
 {

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -40,26 +40,6 @@ void Object_DrawAnimatingItem(const ITEM *item)
     Matrix_Pop();
 }
 
-void Object_DrawUnclippedItem(const ITEM *const item)
-{
-    int32_t left = g_PhdLeft;
-    int32_t top = g_PhdTop;
-    int32_t right = g_PhdRight;
-    int32_t bottom = g_PhdBottom;
-
-    g_PhdLeft = Viewport_GetMinX(VIEWPORT_GAME);
-    g_PhdTop = Viewport_GetMinY(VIEWPORT_GAME);
-    g_PhdRight = Viewport_GetMaxX(VIEWPORT_GAME);
-    g_PhdBottom = Viewport_GetMaxY(VIEWPORT_GAME);
-
-    Object_DrawAnimatingItem(item);
-
-    g_PhdLeft = left;
-    g_PhdTop = top;
-    g_PhdRight = right;
-    g_PhdBottom = bottom;
-}
-
 void Object_DrawSpriteItem(const ITEM *const item)
 {
     SHADE shade = item->shade;

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -145,17 +145,6 @@ BOUNDS_16 Object_GetBoundingBox(
     return new_bounds;
 }
 
-void Object_DrawMesh(
-    const int32_t mesh_idx, const CLIP clip, const bool interpolated)
-{
-    const OBJECT_MESH *const mesh = Object_GetMesh(mesh_idx);
-    if (interpolated) {
-        Output_DrawObjectMesh_I(mesh, clip);
-    } else {
-        Output_DrawObjectMesh(mesh, clip);
-    }
-}
-
 void Object_SetReflective(const GAME_OBJECT_ID obj_id, const bool enabled)
 {
     ASSERT_FAIL();

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -10,10 +10,6 @@
 #include <libtrx/game/viewport.h>
 #include <libtrx/utils.h>
 
-void Object_DrawDummyItem(const ITEM *const item)
-{
-}
-
 void Object_DrawAnimatingItem(const ITEM *item)
 {
     ANIM_FRAME *frames[2];

--- a/src/tr2/game/objects/common.c
+++ b/src/tr2/game/objects/common.c
@@ -10,36 +10,6 @@
 #include <libtrx/game/viewport.h>
 #include <libtrx/utils.h>
 
-void Object_DrawAnimatingItem(const ITEM *item)
-{
-    ANIM_FRAME *frames[2];
-    int32_t rate;
-    int32_t frac = Item_GetFrames(item, frames, &rate);
-    const OBJECT *const obj = Object_Get(item->object_id);
-
-    if (obj->shadow_size != 0) {
-        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
-    }
-
-    Matrix_Push();
-    Matrix_TranslateAbs32(item->interp.result.pos);
-    Matrix_Rot16(item->interp.result.rot);
-
-    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
-    if (clip == CLIP_NOT_VISIBLE) {
-        Matrix_Pop();
-        return;
-    }
-
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
-
-    const int16_t *extra_rotation = item->data;
-
-    Object_DrawInterpolatedObject(
-        obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate);
-    Matrix_Pop();
-}
-
 void Object_DrawSpriteItem(const ITEM *const item)
 {
     SHADE shade = item->shade;

--- a/src/tr2/game/objects/common.h
+++ b/src/tr2/game/objects/common.h
@@ -4,7 +4,6 @@
 
 #include <libtrx/game/objects/common.h>
 
-void Object_DrawAnimatingItem(const ITEM *item);
 void Object_DrawSpriteItem(const ITEM *item);
 
 BOUNDS_16 Object_GetBoundingBox(

--- a/src/tr2/game/objects/common.h
+++ b/src/tr2/game/objects/common.h
@@ -9,5 +9,3 @@ void Object_DrawSpriteItem(const ITEM *item);
 
 BOUNDS_16 Object_GetBoundingBox(
     const OBJECT *obj, const ANIM_FRAME *frame, uint32_t mesh_bits);
-
-void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);

--- a/src/tr2/game/objects/common.h
+++ b/src/tr2/game/objects/common.h
@@ -7,8 +7,6 @@
 void Object_DrawAnimatingItem(const ITEM *item);
 void Object_DrawSpriteItem(const ITEM *item);
 
-void Object_Collision_Trap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-
 BOUNDS_16 Object_GetBoundingBox(
     const OBJECT *obj, const ANIM_FRAME *frame, uint32_t mesh_bits);
 

--- a/src/tr2/game/objects/common.h
+++ b/src/tr2/game/objects/common.h
@@ -7,8 +7,6 @@
 void Object_DrawAnimatingItem(const ITEM *item);
 void Object_DrawSpriteItem(const ITEM *item);
 
-void Object_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
-
 void Object_Collision_Trap(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
 
 BOUNDS_16 Object_GetBoundingBox(

--- a/src/tr2/game/objects/creatures/winston.c
+++ b/src/tr2/game/objects/creatures/winston.c
@@ -1,8 +1,8 @@
 #include "game/creature.h"
-#include "game/objects/common.h"
 #include "game/spawn.h"
 #include "global/vars.h"
 
+#include <libtrx/game/objects.h>
 #include <libtrx/game/random.h>
 #include <libtrx/game/sound.h>
 #include <libtrx/utils.h>

--- a/src/tr2/game/objects/general/bell.c
+++ b/src/tr2/game/objects/general/bell.c
@@ -1,5 +1,7 @@
-#include "game/objects/common.h"
 #include "global/vars.h"
+
+#include <libtrx/game/objects.h>
+#include <libtrx/game/rooms.h>
 
 typedef enum {
     BELL_STATE_STOP = 0,

--- a/src/tr2/game/objects/general/bird_tweeter.c
+++ b/src/tr2/game/objects/general/bird_tweeter.c
@@ -19,7 +19,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
 }
 
 REGISTER_OBJECT(O_BIRD_TWEETER_1, M_Setup)

--- a/src/tr2/game/objects/general/camera_target.c
+++ b/src/tr2/game/objects/general/camera_target.c
@@ -2,7 +2,7 @@
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
 }
 
 REGISTER_OBJECT(O_CAMERA_TARGET, M_Setup)

--- a/src/tr2/game/objects/general/clock_chimes.c
+++ b/src/tr2/game/objects/general/clock_chimes.c
@@ -35,7 +35,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr2/game/objects/general/combat_end.c
+++ b/src/tr2/game/objects/general/combat_end.c
@@ -162,7 +162,7 @@ bool CombatEnd_IsComplete(void)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 
     m_BossTimer = 0;

--- a/src/tr2/game/objects/general/ding_dong.c
+++ b/src/tr2/game/objects/general/ding_dong.c
@@ -14,7 +14,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
 }
 
 REGISTER_OBJECT(O_DING_DONG, M_Setup)

--- a/src/tr2/game/objects/general/earthquake.c
+++ b/src/tr2/game/objects/general/earthquake.c
@@ -48,7 +48,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr2/game/objects/general/general.c
+++ b/src/tr2/game/objects/general/general.c
@@ -1,8 +1,7 @@
 #include "game/objects/general/general.h"
 
-#include "game/objects/common.h"
-
 #include <libtrx/game/collision.h>
+#include <libtrx/game/objects.h>
 #include <libtrx/game/output.h>
 
 typedef enum {

--- a/src/tr2/game/objects/general/lara_alarm.c
+++ b/src/tr2/game/objects/general/lara_alarm.c
@@ -13,7 +13,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr2/game/objects/setup.c
+++ b/src/tr2/game/objects/setup.c
@@ -15,7 +15,7 @@ static void M_SetupLara(void)
 
     obj->shadow_size = (UNIT_SHADOW / 16) * 10;
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
 
     obj->save_position = true;
     obj->save_hitpoints = true;

--- a/src/tr2/game/objects/traps/dying_monk.c
+++ b/src/tr2/game/objects/traps/dying_monk.c
@@ -1,8 +1,8 @@
-#include "game/objects/common.h"
-
 #include <libtrx/game/game.h>
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/lara/common.h>
+#include <libtrx/game/objects.h>
+#include <libtrx/game/rooms.h>
 #include <libtrx/utils.h>
 
 #define MAX_ROOMIES 2

--- a/src/tr2/game/objects/traps/ember_emitter.c
+++ b/src/tr2/game/objects/traps/ember_emitter.c
@@ -27,7 +27,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr2/game/objects/traps/ember_emitter.c
+++ b/src/tr2/game/objects/traps/ember_emitter.c
@@ -1,7 +1,7 @@
 #include "game/effects.h"
-#include "game/objects/common.h"
 #include "global/vars.h"
 
+#include <libtrx/game/objects.h>
 #include <libtrx/game/random.h>
 #include <libtrx/game/sound.h>
 

--- a/src/tr2/game/objects/traps/flame_emitter.c
+++ b/src/tr2/game/objects/traps/flame_emitter.c
@@ -30,7 +30,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->draw_func = Object_DrawDummyItem;
+    obj->draw_func = nullptr;
     obj->save_flags = true;
 }
 

--- a/src/tr2/game/objects/traps/gondola.c
+++ b/src/tr2/game/objects/traps/gondola.c
@@ -1,6 +1,7 @@
 #include "game/objects/traps/gondola.h"
 
-#include "game/objects/common.h"
+#include <libtrx/game/objects.h>
+#include <libtrx/game/rooms.h>
 
 #define GONDOLA_SINK_SPEED 50
 

--- a/src/tr2/game/objects/traps/power_saw.c
+++ b/src/tr2/game/objects/traps/power_saw.c
@@ -1,5 +1,6 @@
-#include "game/objects/common.h"
 #include "game/objects/traps/propeller.h"
+
+#include <libtrx/game/objects.h>
 
 static void M_Setup(OBJECT *const obj)
 {

--- a/src/tr2/game/objects/traps/rolling_ball.c
+++ b/src/tr2/game/objects/traps/rolling_ball.c
@@ -1,4 +1,3 @@
-#include "game/objects/common.h"
 #include "game/spawn.h"
 #include "global/vars.h"
 
@@ -8,7 +7,9 @@
 #include <libtrx/game/game_buf.h>
 #include <libtrx/game/lara/common.h>
 #include <libtrx/game/math.h>
+#include <libtrx/game/objects.h>
 #include <libtrx/game/random.h>
+#include <libtrx/game/rooms.h>
 #include <libtrx/game/sound.h>
 #include <libtrx/utils.h>
 

--- a/src/tr2/game/room_draw.c
+++ b/src/tr2/game/room_draw.c
@@ -308,9 +308,9 @@ void Room_DrawSingleRoomObjects(const int16_t room_num)
 
     int16_t item_num = room->item_num;
     while (item_num != NO_ITEM) {
-        ITEM *const item = Item_Get(item_num);
-        if (item->status != IS_INVISIBLE) {
-            const OBJECT *const obj = Object_Get(item->object_id);
+        const ITEM *const item = Item_Get(item_num);
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (item->status != IS_INVISIBLE && obj->draw_func != nullptr) {
             obj->draw_func(item);
         }
         item_num = item->next_item;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves common object collision and (most) draw routines to TRX. Pickup and sprite drawing remains separate for now as these warrant their own handling later, I feel.

One thought - should we eliminate `Object_DrawDummyItem` and use a null assignment instead?
