### PR TITLE
objects/bandit-2: fix initialising bandit 2b

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...develop) - ××××-××-××
 - fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 1.1)
 - fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 1.4)
+- fixed a crash if the game had object bandit 2B (id=50) but was missing bandit 2 (id=49)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.2...tr2-1.5) - 2025-10-04
 Showcase: https://youtu.be/ClkbvsENSvc

--- a/src/tr2/game/objects/creatures/bandit_2.c
+++ b/src/tr2/game/objects/creatures/bandit_2.c
@@ -253,9 +253,10 @@ static void M_Setup2B(OBJECT *const obj)
     }
 
     const OBJECT *const ref_obj = Object_Get(O_BANDIT_2);
-    ASSERT(ref_obj->loaded);
-    obj->anim_idx = ref_obj->anim_idx;
-    obj->frame_base = ref_obj->frame_base;
+    if (ref_obj->loaded) {
+        obj->anim_idx = ref_obj->anim_idx;
+        obj->frame_base = ref_obj->frame_base;
+    }
 
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves problem with the level not starting if it was missing `O_BANDIT_2` while having `O_BANDIT_2B` reported by Denis on Discord.