### PR TITLE
objects/movable_block: fix quadrant test

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...develop) - ××××-××-××
 - fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 4.11)
 - fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 4.14)
+- fixed Lara at times not being able to grab pushblocks despite being in the correct position to do so (#4005, regression from 0.9.1)
 
 ## [4.15](https://github.com/LostArtefacts/TRX/compare/tr1-4.14.2...tr1-4.15) - 2025-10-04
 Showcase: https://youtu.be/BwZXWL0WULg

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fixed a crash on game exit if specifying "ambient_tracks" in the game flow root (regression from 1.1)
 - fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 1.4)
 - fixed a crash if the game had certain objects (id=17, 18, 41, 43, 50) but was missing their reference objects (id=16, 16, 42, 44, 49, respectively)
+- fixed Lara at times not being able to grab pushblocks despite being in the correct position to do so (#4005, regression from 1.5)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.2...tr2-1.5) - 2025-10-04
 Showcase: https://youtu.be/ClkbvsENSvc

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -471,7 +471,8 @@ static void M_Collision(
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    const DIRECTION quadrant = ((uint16_t)lara_item->rot.y + DEG_45) / DEG_90;
+    const DIRECTION quadrant =
+        ((uint16_t)(lara_item->rot.y + DEG_45) & 0xC000) / DEG_90;
     if (lara_item->current_anim_state == LS_STOP) {
         if (g_Input.forward || g_Input.back
             || lara->gun_status != LGS_ARMLESS) {


### PR DESCRIPTION
Resolves #4005.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I stopped short of updating `Math_GetDirection` and having pushblocks use that approach, as it would likely cause different behaviour elsewhere.
