### PR TITLE
misc: standardize Math_GetDirection usage

### DIFF
--- a/src/libtrx/game/lara/col/climb.c
+++ b/src/libtrx/game/lara/col/climb.c
@@ -235,7 +235,7 @@ static void M_HangTest(ITEM *const item, COLL_INFO *const coll)
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->move_angle = item->rot.y;
 
-    DIRECTION dir = Math_GetDirection(item->rot.y);
+    const DIRECTION dir = Math_GetDirection(item->rot.y);
     switch (dir) {
     case DIR_NORTH:
         item->pos.z += 2;

--- a/src/libtrx/game/math/util.c
+++ b/src/libtrx/game/math/util.c
@@ -39,7 +39,7 @@ int32_t Math_AngleInCone(int32_t angle1, int32_t angle2, int32_t cone)
     return ABS(diff) < cone;
 }
 
-DIRECTION Math_GetDirection(int16_t angle)
+DIRECTION Math_GetDirection(const int16_t angle)
 {
     return (uint16_t)(angle + DEG_45) / DEG_90;
 }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -471,8 +471,7 @@ static void M_Collision(
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    const DIRECTION quadrant =
-        ((uint16_t)(lara_item->rot.y + DEG_45) & 0xC000) / DEG_90;
+    const DIRECTION quadrant = Math_GetDirection(lara_item->rot.y);
     if (lara_item->current_anim_state == LS_STOP) {
         if (g_Input.forward || g_Input.back
             || lara->gun_status != LGS_ARMLESS) {

--- a/src/tr1/game/objects/traps/midas_touch.c
+++ b/src/tr1/game/objects/traps/midas_touch.c
@@ -64,7 +64,7 @@ static void M_Collision(
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
 
-    const DIRECTION quadrant = (uint16_t)(lara_item->rot.y + DEG_45) / DEG_90;
+    const DIRECTION quadrant = Math_GetDirection(lara_item->rot.y);
     switch (quadrant) {
     case DIR_NORTH:
         item->rot.y = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This standardizes the approach of getting quadrants in pushblocks and the Midas touch object, by replacing manual cases of the calculation with `Math_GetDirection` calls. Also fixed a couple of const cases.
