### PR TITLE
creature: fix enemies shooting windows

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed alternate ambient tracks being lost on reload in custom levels (#3997, regression from 1.4)
 - fixed a crash if the game had certain objects (id=17, 18, 41, 43, 50) but was missing their reference objects (id=16, 16, 42, 44, 49, respectively)
 - fixed Lara at times not being able to grab pushblocks despite being in the correct position to do so (#4005, regression from 1.5)
+- fixed enemies being unable to smash windows (#4011, regression from 1.4)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/tr2-1.4.2...tr2-1.5) - 2025-10-04
 Showcase: https://youtu.be/ClkbvsENSvc

--- a/src/tr1/game/objects/effects/twinkle.c
+++ b/src/tr1/game/objects/effects/twinkle.c
@@ -29,7 +29,7 @@ void Twinkle_SparkleItem(ITEM *const item, uint32_t mesh_mask)
     SPHERE slist[34];
     GAME_VECTOR effect_pos;
 
-    int32_t num = Collide_GetSpheres(item, slist, 1);
+    int32_t num = Collide_GetSpheres(item, slist, true);
     effect_pos.room_num = item->room_num;
     for (int i = 0; i < num; i++) {
         if (mesh_mask & (1 << i)) {

--- a/src/tr2/game/creature.c
+++ b/src/tr2/game/creature.c
@@ -13,6 +13,29 @@
 #define M_SHOOT_TARGETING_SPEED 300
 #define M_SHOOT_HIT_CHANCE 0x2000
 
+static void M_CalcShootVectors(
+    const ITEM *const item, const ITEM *const target_item, XYZ_32 *const start,
+    XYZ_32 *const target)
+{
+    start->x = item->pos.x;
+    start->y = item->pos.y - STEP_L * 3;
+    start->z = item->pos.z;
+
+    target->x = target_item->pos.x;
+    target->y = target_item->pos.y - STEP_L * 3;
+    target->z = target_item->pos.z;
+
+    const int16_t angle = XYZ_32_GetYaw((XYZ_32) {
+        .x = target->x - start->x,
+        .y = target->y - start->y,
+        .z = target->z - start->z,
+    });
+
+    const int32_t dist = WALL_L * 2;
+    target->x += (dist * Math_Sin(angle)) >> W2V_SHIFT;
+    target->z += (dist * Math_Cos(angle)) >> W2V_SHIFT;
+}
+
 bool Creature_ShootAtLara(
     ITEM *const item, const AI_INFO *const info, const BITE *const gun,
     const int16_t extra_rotation, const int32_t damage)
@@ -58,21 +81,12 @@ bool Creature_ShootAtLara(
             Item_TakeDamage(target_item, damage / 10, true);
         }
     }
-
     if (effect_num != NO_EFFECT) {
         Effect_Get(effect_num)->rot.y += extra_rotation;
     }
 
-    const XYZ_32 start = {
-        .x = item->pos.x,
-        .y = item->pos.y - STEP_L * 3,
-        .z = item->pos.z,
-    };
-    const XYZ_32 target = {
-        .x = target_item->pos.x,
-        .y = target_item->pos.y - STEP_L * 3,
-        .z = target_item->pos.z,
-    };
+    XYZ_32 start, target;
+    M_CalcShootVectors(item, target_item, &start, &target);
     Gun_SmashItems(start, target, nullptr);
 
     return is_targetable;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4011.

The old **LOS_CheckSmashable** fired an infinite ray from a shooting enemy toward Lara's head to detect smashable objects. The new version was introduced when we needed precise hit locations to spawn ricochets on bells, and it only checks along a finite segment between start and end points.

I could've reinvented the function yet again, but I went for a quick kludge – just extended the segment between the enemy and Lara by two tiles to catch any extra smashables. In practice this feels good enough.