### PR TITLE
lua: split control event into two

### DIFF
--- a/docs/6-lua/2-reference/2-EVENTS.md
+++ b/docs/6-lua/2-reference/2-EVENTS.md
@@ -21,7 +21,9 @@ Lua scripts can listen for game events using the global `Events` API and the
   Fired when a level finishes loading, and after potential savegame data has
   completed loading. Listener receives the level number.
 - [lua]`TRX.EventType.CONTROL`  
-  Fired on every game control loop iteration.
+  Fired before every game control loop iteration.
+- [lua]`TRX.EventType.CONTROL_POST`  
+  Fired after every game control loop iteration.
 - [lua]`TRX.EventType.PICKUP`  
   Fired when the player picks up an item; listener receives the pickup item
   number.

--- a/src/libtrx/game/lua/events.c
+++ b/src/libtrx/game/lua/events.c
@@ -69,8 +69,10 @@ void LUA_CreateEvents(lua_State *const L)
     lua_setfield(L, -2, "LEVEL_LOAD");
     lua_pushinteger(L, LUA_EVENT_PICKUP);
     lua_setfield(L, -2, "PICKUP");
-    lua_pushinteger(L, LUA_EVENT_CONTROL);
+    lua_pushinteger(L, LUA_EVENT_CONTROL_PRE);
     lua_setfield(L, -2, "CONTROL");
+    lua_pushinteger(L, LUA_EVENT_CONTROL_POST);
+    lua_setfield(L, -2, "CONTROL_POST");
     lua_setfield(L, -2, "EventType");
 
     // Events table

--- a/src/libtrx/game/phase/phase_game.c
+++ b/src/libtrx/game/phase/phase_game.c
@@ -43,9 +43,9 @@ static void M_Resume(PHASE *const phase)
 
 static PHASE_CONTROL M_Control(PHASE *const phase)
 {
+    Lua_FireEvent(LUA_EVENT_CONTROL_PRE, 0);
     const GF_COMMAND gf_cmd = Game_Control(false);
-    // Notify Lua control listeners
-    Lua_FireEvent(LUA_EVENT_CONTROL, 0);
+    Lua_FireEvent(LUA_EVENT_CONTROL_POST, 0);
     if (gf_cmd.action != GF_NOOP) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,

--- a/src/libtrx/include/libtrx/game/lua/events.h
+++ b/src/libtrx/include/libtrx/game/lua/events.h
@@ -9,7 +9,8 @@ typedef enum {
     LUA_EVENT_LEVEL_START,
     LUA_EVENT_LEVEL_LOAD,
     LUA_EVENT_PICKUP,
-    LUA_EVENT_CONTROL,
+    LUA_EVENT_CONTROL_PRE,
+    LUA_EVENT_CONTROL_POST,
 } LUA_EVENT_TYPE;
 
 // Initialize event API in Lua state


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

As asked by Saracen in terms of forwards-compatibility with their TRNG work.