### PR TITLE
spawn: merge common spawn functions

### DIFF
--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -74,3 +74,27 @@ int16_t Spawn_Blood(
     }
     return effect_num;
 }
+
+int16_t Spawn_GunShot(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num)
+{
+    const int16_t effect_num = Effect_Create(room_num);
+    if (effect_num == NO_EFFECT) {
+        return effect_num;
+    }
+
+    EFFECT *const effect = Effect_Get(effect_num);
+    effect->pos.x = x;
+    effect->pos.y = y;
+    effect->pos.z = z;
+    effect->room_num = room_num;
+    effect->rot.z = 0;
+    effect->rot.x = 0;
+    effect->rot.y = y_rot;
+    effect->counter = 3;
+    effect->frame_num = 0;
+    effect->object_id = O_GUN_FLASH;
+    effect->shade = SHADE_NEUTRAL;
+    return effect_num;
+}

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -77,6 +77,18 @@ int16_t Spawn_Blood(
     return effect_num;
 }
 
+void Spawn_BloodBath(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num, const int32_t count)
+{
+    for (int32_t i = 0; i < count; i++) {
+        Spawn_Blood(
+            x - (Random_GetDraw() << 9) / 0x8000 + 256,
+            y - (Random_GetDraw() << 9) / 0x8000 + 256,
+            z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot, room_num);
+    }
+}
+
 int16_t Spawn_GunShot(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -42,6 +42,20 @@ void Spawn_Ricochet(const GAME_VECTOR *const pos)
     }
 }
 
+void Spawn_Bubble(const XYZ_32 *const pos, const int16_t room_num)
+{
+    const int16_t effect_num = Effect_Create(room_num);
+    if (effect_num == NO_EFFECT) {
+        return;
+    }
+
+    EFFECT *const effect = Effect_Get(effect_num);
+    effect->pos = *pos;
+    effect->object_id = O_BUBBLE_1;
+    effect->frame_num = -((Random_GetDraw() * 3) / 0x8000);
+    effect->speed = 10 + ((Random_GetDraw() * 6) / 0x8000);
+}
+
 int16_t Spawn_Blood(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -41,3 +41,22 @@ void Spawn_Ricochet(const GAME_VECTOR *const pos)
         Sound_Effect(SFX_LARA_RICOCHET, &effect->pos, SPM_NORMAL);
     }
 }
+
+int16_t Spawn_Blood(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num)
+{
+    const int16_t effect_num = Effect_Create(room_num);
+    if (effect_num != NO_EFFECT) {
+        EFFECT *const effect = Effect_Get(effect_num);
+        effect->pos.x = x;
+        effect->pos.y = y;
+        effect->pos.z = z;
+        effect->rot.y = y_rot;
+        effect->speed = speed;
+        effect->frame_num = 0;
+        effect->object_id = O_BLOOD_1;
+        effect->counter = 0;
+    }
+    return effect_num;
+}

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -3,6 +3,7 @@
 #include "game/effects.h"
 #include "game/random.h"
 #include "game/rooms.h"
+#include "game/sound.h"
 
 void Spawn_Splash(const ITEM *const item)
 {
@@ -25,5 +26,18 @@ void Spawn_Splash(const ITEM *const item)
         effect->rot.y = 2 * Random_GetDraw() + DEG_180;
         effect->speed = Random_GetDraw() / 256;
         effect->frame_num = 0;
+    }
+}
+
+void Spawn_Ricochet(const GAME_VECTOR *const pos)
+{
+    const int16_t effect_num = Effect_Create(pos->room_num);
+    if (effect_num != NO_EFFECT) {
+        EFFECT *const effect = Effect_Get(effect_num);
+        effect->object_id = O_RICOCHET;
+        effect->pos = pos->pos;
+        effect->counter = 4;
+        effect->frame_num = -3 * Random_GetDraw() / 0x8000;
+        Sound_Effect(SFX_LARA_RICOCHET, &effect->pos, SPM_NORMAL);
     }
 }

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -119,3 +119,18 @@ int16_t Spawn_GunHit(
     Sound_Effect(SFX_LARA_BULLETHIT, &lara_item->pos, SPM_NORMAL);
     return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
 }
+
+int16_t Spawn_GunMiss(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    const GAME_VECTOR pos = {
+        .x = lara_item->pos.x + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
+        .y = lara_item->floor,
+        .z = lara_item->pos.z + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
+        .room_num = lara_item->room_num,
+    };
+    Spawn_Ricochet(&pos);
+    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
+}

--- a/src/libtrx/game/spawn.c
+++ b/src/libtrx/game/spawn.c
@@ -1,6 +1,8 @@
 #include "game/spawn.h"
 
+#include "game/collision.h"
 #include "game/effects.h"
+#include "game/lara.h"
 #include "game/random.h"
 #include "game/rooms.h"
 #include "game/sound.h"
@@ -97,4 +99,23 @@ int16_t Spawn_GunShot(
     effect->object_id = O_GUN_FLASH;
     effect->shade = SHADE_NEUTRAL;
     return effect_num;
+}
+
+int16_t Spawn_GunHit(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    XYZ_32 vec = {
+        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
+    };
+    Collide_GetJointAbsPosition(
+        lara_item, &vec, Random_GetControl() * LM_NUMBER_OF / 0x7FFF);
+    Spawn_Blood(
+        vec.x, vec.y, vec.z, lara_item->speed, lara_item->rot.y,
+        lara_item->room_num);
+    Sound_Effect(SFX_LARA_BULLETHIT, &lara_item->pos, SPM_NORMAL);
+    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
 }

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -17,3 +17,6 @@ int16_t Spawn_GunShot(
 int16_t Spawn_GunHit(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
+int16_t Spawn_GunMiss(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -6,6 +6,8 @@
 void Spawn_Splash(const ITEM *item);
 void Spawn_Ricochet(const GAME_VECTOR *pos);
 
+void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
+
 int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -14,3 +14,6 @@ int16_t Spawn_Blood(
 int16_t Spawn_GunShot(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
+int16_t Spawn_GunHit(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -11,6 +11,9 @@ void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
 int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
+void Spawn_BloodBath(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num, int32_t count);
 int16_t Spawn_GunShot(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -11,3 +11,6 @@ void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
 int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
+int16_t Spawn_GunShot(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -6,6 +6,6 @@
 void Spawn_Splash(const ITEM *item);
 void Spawn_Ricochet(const GAME_VECTOR *pos);
 
-extern int16_t Spawn_Blood(
+int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/libtrx/include/libtrx/game/spawn.h
+++ b/src/libtrx/include/libtrx/game/spawn.h
@@ -4,9 +4,8 @@
 #include "./types.h"
 
 void Spawn_Splash(const ITEM *item);
+void Spawn_Ricochet(const GAME_VECTOR *pos);
 
 extern int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
-
-extern void Spawn_Ricochet(const GAME_VECTOR *pos);

--- a/src/tr1/game/creature.c
+++ b/src/tr1/game/creature.c
@@ -25,7 +25,7 @@ bool Creature_ShootAtLara(
     if (is_hit) {
         effect_num = Creature_Effect(item, gun, Spawn_GunHit);
     } else {
-        effect_num = Creature_Effect(item, gun, Spawn_GunShotMiss);
+        effect_num = Creature_Effect(item, gun, Spawn_GunMiss);
     }
 
     if (effect_num != NO_EFFECT) {

--- a/src/tr1/game/creature.c
+++ b/src/tr1/game/creature.c
@@ -23,7 +23,7 @@ bool Creature_ShootAtLara(
 
     int16_t effect_num;
     if (is_hit) {
-        effect_num = Creature_Effect(item, gun, Spawn_GunShotHit);
+        effect_num = Creature_Effect(item, gun, Spawn_GunHit);
     } else {
         effect_num = Creature_Effect(item, gun, Spawn_GunShotMiss);
     }

--- a/src/tr1/game/objects/creatures/bat.c
+++ b/src/tr1/game/objects/creatures/bat.c
@@ -68,7 +68,7 @@ static void M_Control(const int16_t item_num)
     }
 
     CREATURE *bat = item->data;
-    PHD_ANGLE angle = 0;
+    int16_t angle = 0;
     if (item->hit_points <= 0) {
         if (item->pos.y < item->floor) {
             item->gravity = true;

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -29,20 +29,6 @@ static void M_ShootAtLara(EFFECT *const effect)
     effect->rot.y += (Random_GetControl() - 0x4000) / 0x40;
 }
 
-void Spawn_Bubble(const XYZ_32 *const pos, const int16_t room_num)
-{
-    const int16_t effect_num = Effect_Create(room_num);
-    if (effect_num == NO_EFFECT) {
-        return;
-    }
-
-    EFFECT *const effect = Effect_Get(effect_num);
-    effect->pos = *pos;
-    effect->object_id = O_BUBBLE_1;
-    effect->frame_num = -((Random_GetDraw() * 3) / 0x8000);
-    effect->speed = 10 + ((Random_GetDraw() * 6) / 0x8000);
-}
-
 int16_t Spawn_ShardGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
     int16_t room_num)

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -3,12 +3,9 @@
 #include "game/effects.h"
 #include "global/types.h"
 
-#include <libtrx/game/collision.h>
 #include <libtrx/game/lara.h>
 #include <libtrx/game/math.h>
 #include <libtrx/game/random.h>
-#include <libtrx/game/sound.h>
-#include <libtrx/utils.h>
 
 #define SHARD_SPEED 250
 #define ROCKET_SPEED 220

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -165,18 +165,3 @@ int16_t Spawn_GunShotMiss(
     Spawn_Ricochet(&pos);
     return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
 }
-
-void Spawn_Ricochet(const GAME_VECTOR *const pos)
-{
-    const int16_t effect_num = Effect_Create(pos->room_num);
-    if (effect_num != NO_EFFECT) {
-        EFFECT *const effect = Effect_Get(effect_num);
-        effect->pos.x = pos->x;
-        effect->pos.y = pos->y;
-        effect->pos.z = pos->z;
-        effect->counter = 4;
-        effect->object_id = O_RICOCHET;
-        effect->frame_num = -3 * Random_GetDraw() / 0x8000;
-        Sound_Effect(SFX_LARA_RICOCHET, &effect->pos, SPM_NORMAL);
-    }
-}

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -20,14 +20,14 @@ static void M_ShootAtLara(EFFECT *const effect)
         + (bounds->max.y + (bounds->min.y - bounds->max.y) * 3 / 4);
 
     const int32_t dist = Math_Sqrt(SQUARE(x) + SQUARE(z));
-    effect->rot.x = -(PHD_ANGLE)Math_Atan(dist, y);
+    effect->rot.x = -Math_Atan(dist, y);
     effect->rot.y = Math_Atan(z, x);
     effect->rot.x += (Random_GetControl() - 0x4000) / 0x40;
     effect->rot.y += (Random_GetControl() - 0x4000) / 0x40;
 }
 
 int16_t Spawn_ShardGun(
-    int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num)
 {
     int16_t effect_num = Effect_Create(room_num);

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -75,28 +75,6 @@ int16_t Spawn_RocketGun(
     return effect_num;
 }
 
-int16_t Spawn_GunShot(
-    int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
-    int16_t room_num)
-{
-    int16_t effect_num = Effect_Create(room_num);
-    if (effect_num != NO_EFFECT) {
-        EFFECT *effect = Effect_Get(effect_num);
-        effect->pos.x = x;
-        effect->pos.y = y;
-        effect->pos.z = z;
-        effect->room_num = room_num;
-        effect->rot.x = 0;
-        effect->rot.y = y_rot;
-        effect->rot.z = 0;
-        effect->counter = 3;
-        effect->frame_num = 0;
-        effect->object_id = O_GUN_FLASH;
-        effect->shade = SHADE_NEUTRAL;
-    }
-    return effect_num;
-}
-
 int16_t Spawn_GunShotHit(
     int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
     int16_t room_num)

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -74,20 +74,3 @@ int16_t Spawn_RocketGun(
     }
     return effect_num;
 }
-
-int16_t Spawn_GunShotMiss(
-    int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
-    int16_t room_num)
-{
-    const ITEM *const lara_item = Lara_GetItem();
-    const GAME_VECTOR pos = {
-        .x = lara_item->pos.x
-            + ((Random_GetDraw() - 0x4000) * (WALL_L / 2)) / 0x7FFF,
-        .y = lara_item->floor,
-        .z = lara_item->pos.z
-            + ((Random_GetDraw() - 0x4000) * (WALL_L / 2)) / 0x7FFF,
-        .room_num = lara_item->room_num,
-    };
-    Spawn_Ricochet(&pos);
-    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
-}

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -75,25 +75,6 @@ int16_t Spawn_RocketGun(
     return effect_num;
 }
 
-int16_t Spawn_GunShotHit(
-    int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
-    int16_t room_num)
-{
-    const ITEM *const lara_item = Lara_GetItem();
-    XYZ_32 pos = {
-        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-    };
-    Collide_GetJointAbsPosition(
-        lara_item, &pos, (Random_GetControl() * LM_NUMBER_OF) / 0x7FFF);
-    Spawn_Blood(
-        pos.x, pos.y, pos.z, lara_item->speed, lara_item->rot.y,
-        lara_item->room_num);
-    Sound_Effect(SFX_LARA_BULLETHIT, &lara_item->pos, SPM_NORMAL);
-    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
-}
-
 int16_t Spawn_GunShotMiss(
     int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
     int16_t room_num)

--- a/src/tr1/game/spawn.c
+++ b/src/tr1/game/spawn.c
@@ -43,25 +43,6 @@ void Spawn_Bubble(const XYZ_32 *const pos, const int16_t room_num)
     effect->speed = 10 + ((Random_GetDraw() * 6) / 0x8000);
 }
 
-int16_t Spawn_Blood(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t direction,
-    int16_t room_num)
-{
-    int16_t effect_num = Effect_Create(room_num);
-    if (effect_num != NO_EFFECT) {
-        EFFECT *effect = Effect_Get(effect_num);
-        effect->pos.x = x;
-        effect->pos.y = y;
-        effect->pos.z = z;
-        effect->rot.y = direction;
-        effect->object_id = O_BLOOD_1;
-        effect->frame_num = 0;
-        effect->counter = 0;
-        effect->speed = speed;
-    }
-    return effect_num;
-}
-
 int16_t Spawn_ShardGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, PHD_ANGLE y_rot,
     int16_t room_num)

--- a/src/tr1/game/spawn.h
+++ b/src/tr1/game/spawn.h
@@ -4,8 +4,6 @@
 
 #include <libtrx/game/spawn.h>
 
-void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
-
 int16_t Spawn_ShardGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/tr1/game/spawn.h
+++ b/src/tr1/game/spawn.h
@@ -12,10 +12,6 @@ int16_t Spawn_RocketGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
 
-int16_t Spawn_GunShot(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);
-
 int16_t Spawn_GunShotHit(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/tr1/game/spawn.h
+++ b/src/tr1/game/spawn.h
@@ -11,7 +11,3 @@ int16_t Spawn_ShardGun(
 int16_t Spawn_RocketGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
-
-int16_t Spawn_GunShotMiss(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);

--- a/src/tr1/game/spawn.h
+++ b/src/tr1/game/spawn.h
@@ -12,10 +12,6 @@ int16_t Spawn_RocketGun(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
 
-int16_t Spawn_GunShotHit(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);
-
 int16_t Spawn_GunShotMiss(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/tr1/global/types.h
+++ b/src/tr1/global/types.h
@@ -23,8 +23,6 @@
 
 #include <stdint.h>
 
-typedef int16_t PHD_ANGLE;
-
 typedef enum {
     D_TRANS1 = 1,
     D_TRANS2 = 2,

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -75,30 +75,6 @@ void Spawn_MysticLight(const int16_t item_num)
     // clang-format on
 }
 
-int16_t Spawn_GunShot(
-    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
-    const int16_t y_rot, const int16_t room_num)
-{
-    const int16_t effect_num = Effect_Create(room_num);
-    if (effect_num == NO_EFFECT) {
-        return effect_num;
-    }
-
-    EFFECT *const effect = Effect_Get(effect_num);
-    effect->pos.x = x;
-    effect->pos.y = y;
-    effect->pos.z = z;
-    effect->room_num = room_num;
-    effect->rot.z = 0;
-    effect->rot.x = 0;
-    effect->rot.y = y_rot;
-    effect->counter = 3;
-    effect->frame_num = 0;
-    effect->object_id = O_GUN_FLASH;
-    effect->shade = SHADE_NEUTRAL;
-    return effect_num;
-}
-
 int16_t Spawn_GunHit(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -75,20 +75,6 @@ void Spawn_MysticLight(const int16_t item_num)
     // clang-format on
 }
 
-void Spawn_Bubble(const XYZ_32 *const pos, const int16_t room_num)
-{
-    const int16_t effect_num = Effect_Create(room_num);
-    if (effect_num == NO_EFFECT) {
-        return;
-    }
-
-    EFFECT *const effect = Effect_Get(effect_num);
-    effect->pos = *pos;
-    effect->object_id = O_BUBBLE_1;
-    effect->frame_num = -((Random_GetDraw() * 3) / 0x8000);
-    effect->speed = 10 + ((Random_GetDraw() * 6) / 0x8000);
-}
-
 int16_t Spawn_GunShot(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -202,16 +202,3 @@ void Spawn_BloodBath(
             z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot, room_num);
     }
 }
-
-void Spawn_Ricochet(const GAME_VECTOR *const pos)
-{
-    const int16_t effect_num = Effect_Create(pos->room_num);
-    if (effect_num != NO_EFFECT) {
-        EFFECT *const effect = Effect_Get(effect_num);
-        effect->object_id = O_RICOCHET;
-        effect->pos = pos->pos;
-        effect->counter = 4;
-        effect->frame_num = -3 * Random_GetDraw() / 0x8000;
-        Sound_Effect(SFX_LARA_RICOCHET, &effect->pos, SPM_NORMAL);
-    }
-}

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -172,25 +172,6 @@ int16_t Spawn_Knife(
     return effect_num;
 }
 
-int16_t Spawn_Blood(
-    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
-    const int16_t y_rot, const int16_t room_num)
-{
-    const int16_t effect_num = Effect_Create(room_num);
-    if (effect_num != NO_EFFECT) {
-        EFFECT *const effect = Effect_Get(effect_num);
-        effect->pos.x = x;
-        effect->pos.y = y;
-        effect->pos.z = z;
-        effect->rot.y = y_rot;
-        effect->speed = speed;
-        effect->frame_num = 0;
-        effect->object_id = O_BLOOD_1;
-        effect->counter = 0;
-    }
-    return effect_num;
-}
-
 void Spawn_BloodBath(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num, const int32_t count)

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -3,12 +3,9 @@
 #include "game/effects.h"
 #include "game/objects/effects/missile_common.h"
 
-#include <libtrx/game/collision.h>
-#include <libtrx/game/lara.h>
 #include <libtrx/game/math.h>
 #include <libtrx/game/output.h>
 #include <libtrx/game/random.h>
-#include <libtrx/game/sound.h>
 
 #define BARTOLI_LIGHT_RANGE (5 * WALL_L) // = 5120
 

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -75,21 +75,6 @@ void Spawn_MysticLight(const int16_t item_num)
     // clang-format on
 }
 
-int16_t Spawn_GunMiss(
-    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
-    const int16_t y_rot, const int16_t room_num)
-{
-    const ITEM *const lara_item = Lara_GetItem();
-    const GAME_VECTOR pos = {
-        .x = lara_item->pos.x + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
-        .y = lara_item->floor,
-        .z = lara_item->pos.z + ((Random_GetDraw() - 0x4000) << 9) / 0x7FFF,
-        .room_num = lara_item->room_num,
-    };
-    Spawn_Ricochet(&pos);
-    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
-}
-
 int16_t Spawn_Knife(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -99,15 +99,3 @@ int16_t Spawn_Knife(
     Missile_ShootAtLara(effect);
     return effect_num;
 }
-
-void Spawn_BloodBath(
-    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
-    const int16_t y_rot, const int16_t room_num, const int32_t count)
-{
-    for (int32_t i = 0; i < count; i++) {
-        Spawn_Blood(
-            x - (Random_GetDraw() << 9) / 0x8000 + 256,
-            y - (Random_GetDraw() << 9) / 0x8000 + 256,
-            z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot, room_num);
-    }
-}

--- a/src/tr2/game/spawn.c
+++ b/src/tr2/game/spawn.c
@@ -75,25 +75,6 @@ void Spawn_MysticLight(const int16_t item_num)
     // clang-format on
 }
 
-int16_t Spawn_GunHit(
-    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
-    const int16_t y_rot, const int16_t room_num)
-{
-    const ITEM *const lara_item = Lara_GetItem();
-    XYZ_32 vec = {
-        .x = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .y = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-        .z = -((Random_GetDraw() - 0x4000) << 7) / 0x7FFF,
-    };
-    Collide_GetJointAbsPosition(
-        lara_item, &vec, Random_GetControl() * LM_NUMBER_OF / 0x7FFF);
-    Spawn_Blood(
-        vec.x, vec.y, vec.z, lara_item->speed, lara_item->rot.y,
-        lara_item->room_num);
-    Sound_Effect(SFX_LARA_BULLETHIT, &lara_item->pos, SPM_NORMAL);
-    return Spawn_GunShot(x, y, z, speed, y_rot, room_num);
-}
-
 int16_t Spawn_GunMiss(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -10,10 +10,6 @@ int16_t Spawn_FireStream(
 
 void Spawn_MysticLight(int16_t item_num);
 
-int16_t Spawn_GunMiss(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);
-
 int16_t Spawn_Knife(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -10,8 +10,6 @@ int16_t Spawn_FireStream(
 
 void Spawn_MysticLight(int16_t item_num);
 
-void Spawn_Bubble(const XYZ_32 *pos, int16_t room_num);
-
 int16_t Spawn_GunShot(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t yrot,
     int16_t room_num);

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -13,7 +13,3 @@ void Spawn_MysticLight(int16_t item_num);
 int16_t Spawn_Knife(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
-
-void Spawn_BloodBath(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num, int32_t count);

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -10,10 +10,6 @@ int16_t Spawn_FireStream(
 
 void Spawn_MysticLight(int16_t item_num);
 
-int16_t Spawn_GunShot(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t yrot,
-    int16_t room_num);
-
 int16_t Spawn_GunHit(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);

--- a/src/tr2/game/spawn.h
+++ b/src/tr2/game/spawn.h
@@ -10,10 +10,6 @@ int16_t Spawn_FireStream(
 
 void Spawn_MysticLight(int16_t item_num);
 
-int16_t Spawn_GunHit(
-    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
-    int16_t room_num);
-
 int16_t Spawn_GunMiss(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Moves common spawn functions to TRX. The ones left behind are missile specifics mainly - knives, mutant shards etc.

A quick test around the following would be great:
- ricochets
- blood
- bubbles
- gun flash/hits/misses
