### PR TITLE
tr1/2: add a splash effect when jumping into wading depth water

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr1-4.15.1...develop) - ××××-××-××
 - added a game flow option for cold water in custom levels, similar to TR3 (#4021)
+- added a splash effect when Lara jumps in wading depth water, similar to TR3+ (#3975)
 - changed the FOV default increment from 10 to 5 (#4026)
 - changed the bar appearance labels to better align with expectations (#4025)
 - changed exploded meshes to trigger a splash effect when they hit water, similar to TR2

--- a/docs/tr1/IMPROVEMENTS.md
+++ b/docs/tr1/IMPROVEMENTS.md
@@ -199,6 +199,7 @@ Not all options are turned on by default. Refer to the ingame settings for detai
 - added optional dynamic lighting for gun flashes and explosions, similar to TR2+
 - added optional dynamic lighting for flames
 - added an option to toggle between TR1 and TR2 camera modes
+- added a splash effect when Lara jumps in wading depth water, similar to TR3+
 - changed the Scion in The Great Pyramid from spawning blood when hit to a ricochet effect
 - changed waterfall objects to always be drawn when active rather than only when Lara is within a 10 sector range
 - changed exploded meshes to trigger a splash effect when they hit water, similar to TR2

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/tr2-1.5.1...develop) - ××××-××-××
 - added a game flow option for cold water in custom levels, similar to TR3 (#4021)
+- added a splash effect when Lara jumps in wading depth water, similar to TR3+ (#3975)
 - changed the FOV default increment from 10 to 5 (#4026)
 - changed the bar appearance labels to better align with expectations (#4025)
 - fixed missing footstep sound effects when Lara climbs off a ladder and when she finishes a handstand (#4030)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -202,6 +202,7 @@
 - added optional dynamic lighting for flames
 - added the ability to use `.avi`, `.mkv`, `.mp4`, `.mpeg`, and `.webm` files for FMVs
 - added an option to animate the algae in 40 Fathoms, Wreck of the Maria Doria and The Deck
+- added a splash effect when Lara jumps in wading depth water, similar to TR3+
 - changed the hardware renderer to always use 16-bit textures
 - changed the software renderer to use the picture's palette for the background pictures
 - changed fullscreen behavior to use windowed desktop mode

--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -224,6 +224,16 @@ static void M_UpdateEnvironment(void)
         water_height == NO_HEIGHT ? NO_HEIGHT : item->pos.y - water_height;
     lara_info->water_surface_dist = -water_height_diff;
 
+    // Create splash if Lara lands in wading height water. TR3+ feature.
+    if (wading_enabled) {
+        const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
+        if (item->pos.y + bounds->min.y <= water_height
+            && item->pos.y + bounds->max.y >= water_height
+            && item->fall_speed > 0 && water_depth < M_SWIM_DEPTH - STEP_L) {
+            Spawn_Splash(item);
+        }
+    }
+
     switch (lara_info->water_status) {
     case LWS_ABOVE_WATER: {
         if (wading_enabled


### PR DESCRIPTION
Resolves #3975.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Added a splash effect when Lara jumps in wading depth water, similar to TR3+. I tried to port `WadeSplash` as best I could from [tomb3](https://github.com/Trxyebeep/tomb3/blob/bfeef1d4d7165b6d8cb9079870c1fc0f083b054c/tomb3/game/laramisc.cpp#L467). The code could possibly be better placed / optimized, but I wanted to match TR3 first before trying to change things around.

...
