### PR TITLE
objects: use runtime game version var

### DIFF
--- a/src/libtrx/game/objects/creatures/bear.c
+++ b/src/libtrx/game/objects/creatures/bear.c
@@ -5,6 +5,7 @@
 #include "game/random.h"
 #include "game/spawn.h"
 #include "utils.h"
+#include "version.h"
 
 // clang-format off
 #define BEAR_CHARGE_DAMAGE 3
@@ -22,11 +23,7 @@
 #define BEAR_RUN_TURN      (5 * DEG_1) // = 910
 #define BEAR_WALK_TURN     (2 * DEG_1) // = 364
 #define BEAR_EAT_RANGE     SQUARE(WALL_L * 3 / 4) // = 589824
-#if TR_VERSION == 1
-#define BEAR_HITPOINTS     20
-#else
-#define BEAR_HITPOINTS     30
-#endif
+#define BEAR_HITPOINTS     (g_TRVersion == 1 ? 20 : 30)
 #define BEAR_RADIUS        (WALL_L / 3) // = 341
 #define BEAR_SMARTNESS     0x4000
 // clang-format on

--- a/src/libtrx/game/objects/creatures/trex.c
+++ b/src/libtrx/game/objects/creatures/trex.c
@@ -165,7 +165,7 @@ static void M_Control(const int16_t item_num)
         case TREX_STATE_ATTACK_2:
             if ((item->touch_bits & TREX_TOUCH_BITS) != 0) {
                 Lara_TakeDamage(TREX_BITE_DAMAGE, true);
-                if (TR_VERSION == 1) {
+                if (g_TRVersion == 1) {
                     item->goal_anim_state = TREX_STATE_KILL;
                     M_KillLara(item);
                 } else {
@@ -190,7 +190,7 @@ static void M_Control(const int16_t item_num)
     }
 
     Creature_Animate(item_num, angle, 0);
-    if (TR_VERSION == 1) {
+    if (g_TRVersion == 1) {
         item->collidable = true;
     }
 }
@@ -201,7 +201,7 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
-    if (TR_VERSION == 1) {
+    if (g_TRVersion == 1) {
         obj->initialise_func = Creature_Initialise;
     }
     obj->control_func = M_Control;
@@ -209,8 +209,8 @@ static void M_Setup(OBJECT *const obj)
 
     obj->hit_points = TREX_HITPOINTS;
     obj->radius = TREX_RADIUS;
-    obj->shadow_size = TR_VERSION == 1 ? UNIT_SHADOW / 4 : UNIT_SHADOW / 2;
-    obj->pivot_length = TR_VERSION == 1 ? 2000 : 1800;
+    obj->shadow_size = g_TRVersion == 1 ? UNIT_SHADOW / 4 : UNIT_SHADOW / 2;
+    obj->pivot_length = g_TRVersion == 1 ? 2000 : 1800;
     obj->smartness = TREX_SMARTNESS;
     obj->lot_setup = g_LOT_Beast;
 

--- a/src/libtrx/game/objects/creatures/wolf.c
+++ b/src/libtrx/game/objects/creatures/wolf.c
@@ -20,11 +20,7 @@
 #define WOLF_SLEEP_CHANCE  32
 #define WOLF_HOWL_CHANCE   384
 #define WOLF_TOUCH         0x774F
-#if TR_VERSION == 1
-#define WOLF_HITPOINTS     6
-#else
-#define WOLF_HITPOINTS     10
-#endif
+#define WOLF_HITPOINTS     (g_TRVersion == 1 ? 6 : 10)
 #define WOLF_RADIUS        (WALL_L / 3) // = 341
 #define WOLF_SMARTNESS     0x2000
 // clang-format on

--- a/src/libtrx/game/objects/effects/blood.c
+++ b/src/libtrx/game/objects/effects/blood.c
@@ -2,6 +2,7 @@
 #include "game/effects.h"
 #include "game/math.h"
 #include "game/objects.h"
+#include "version.h"
 
 static void M_Control(const int16_t effect_num)
 {
@@ -22,7 +23,7 @@ static void M_Control(const int16_t effect_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = TR_VERSION == 2;
+    obj->semi_transparent = g_TRVersion == 2;
 }
 
 REGISTER_OBJECT(O_BLOOD_1, M_Setup)

--- a/src/libtrx/game/objects/effects/body_part.c
+++ b/src/libtrx/game/objects/effects/body_part.c
@@ -2,6 +2,7 @@
 #include "game/lara.h"
 #include "game/rooms.h"
 #include "game/sound.h"
+#include "version.h"
 
 static void M_Control(const int16_t effect_num)
 {
@@ -58,9 +59,9 @@ static void M_Control(const int16_t effect_num)
     }
 
     const int16_t counter_value =
-        (TR_VERSION == 1) ? ABS(effect->counter) : effect->counter;
+        (g_TRVersion == 1) ? ABS(effect->counter) : effect->counter;
     const bool trigger_explosion =
-        (TR_VERSION == 1) ? (effect->counter > 0) : (effect->counter == 0);
+        (g_TRVersion == 1) ? (effect->counter > 0) : (effect->counter == 0);
 
     if (Lara_IsNearItem(&effect->pos, counter_value * 2)) {
         Lara_TakeDamage(counter_value, true);

--- a/src/libtrx/game/objects/effects/dart_effect.c
+++ b/src/libtrx/game/objects/effects/dart_effect.c
@@ -1,5 +1,6 @@
 #include "game/effects.h"
 #include "game/objects.h"
+#include "version.h"
 
 static void M_Control(const int16_t effect_num)
 {
@@ -20,7 +21,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawSpriteItem;
-    obj->semi_transparent = TR_VERSION == 2;
+    obj->semi_transparent = g_TRVersion == 2;
 }
 
 REGISTER_OBJECT(O_DART_EFFECT, M_Setup)

--- a/src/libtrx/game/objects/effects/ember.c
+++ b/src/libtrx/game/objects/effects/ember.c
@@ -1,6 +1,7 @@
 #include "game/effects.h"
 #include "game/lara.h"
 #include "game/rooms.h"
+#include "version.h"
 
 #define M_RANGE 200
 #define M_DAMAGE 10
@@ -34,7 +35,7 @@ static void M_Control(const int16_t effect_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = TR_VERSION == 2;
+    obj->semi_transparent = g_TRVersion == 2;
 }
 
 REGISTER_OBJECT(O_EMBER, M_Setup)

--- a/src/libtrx/game/objects/effects/explosion.c
+++ b/src/libtrx/game/objects/effects/explosion.c
@@ -2,6 +2,7 @@
 #include "game/effects.h"
 #include "game/objects.h"
 #include "game/output.h"
+#include "version.h"
 
 static void M_Control(const int16_t effect_num)
 {
@@ -25,7 +26,7 @@ static void M_Control(const int16_t effect_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = TR_VERSION == 2;
+    obj->semi_transparent = g_TRVersion == 2;
 }
 
 REGISTER_OBJECT(O_EXPLOSION_1, M_Setup)

--- a/src/libtrx/game/objects/effects/flame.c
+++ b/src/libtrx/game/objects/effects/flame.c
@@ -6,19 +6,14 @@
 #include "game/rooms.h"
 #include "game/sound.h"
 #include "utils.h"
+#include "version.h"
 
 #define M_LIGHT_INTENSITY 11
 #define M_LIGHT_FALLOFF 10
 #define M_DAMAGE_PROXIMITY 600
-#if TR_VERSION == 1
-    #define M_IGNITE_PROXIMITY 300
-    #define M_TOO_NEAR_DAMAGE 3
-    #define M_ON_FIRE_DAMAGE 5
-#else
-    #define M_IGNITE_PROXIMITY 450
-    #define M_TOO_NEAR_DAMAGE 5
-    #define M_ON_FIRE_DAMAGE 7
-#endif
+#define M_IGNITE_PROXIMITY (g_TRVersion == 1 ? 300 : 450)
+#define M_TOO_NEAR_DAMAGE (g_TRVersion == 1 ? 3 : 5)
+#define M_ON_FIRE_DAMAGE (g_TRVersion == 1 ? 5 : 7)
 
 static void M_DoEffects(const EFFECT *const effect)
 {

--- a/src/libtrx/game/objects/effects/splash.c
+++ b/src/libtrx/game/objects/effects/splash.c
@@ -1,6 +1,7 @@
 #include "game/const.h"
 #include "game/effects.h"
 #include "game/objects.h"
+#include "version.h"
 
 static void M_Control(const int16_t effect_num)
 {
@@ -20,7 +21,7 @@ static void M_Control(const int16_t effect_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->semi_transparent = TR_VERSION == 2;
+    obj->semi_transparent = g_TRVersion == 2;
 }
 
 REGISTER_OBJECT(O_SPLASH_1, M_Setup)

--- a/src/libtrx/game/objects/effects/twinkle.c
+++ b/src/libtrx/game/objects/effects/twinkle.c
@@ -7,6 +7,7 @@
 #include "game/random.h"
 #include "game/spawn.h"
 #include "utils.h"
+#include "version.h"
 
 #define M_DISAPPEAR_RANGE STEP_L
 
@@ -60,36 +61,36 @@ static void M_Control(const int16_t effect_num)
     EFFECT *const effect = Effect_Get(effect_num);
     const OBJECT *const obj = Object_Get(effect->object_id);
 
-#if TR_VERSION == 1
-    effect->counter++;
-    if (effect->counter == 1) {
-        effect->counter = 0;
+    if (g_TRVersion == 1) {
+        effect->counter++;
+        if (effect->counter == 1) {
+            effect->counter = 0;
+            effect->frame_num--;
+            if (effect->frame_num <= obj->mesh_count) {
+                Effect_Kill(effect_num);
+            }
+        }
+    } else {
         effect->frame_num--;
         if (effect->frame_num <= obj->mesh_count) {
+            effect->frame_num = 0;
+        }
+
+        if (effect->counter < 0) {
+            effect->counter++;
+            if (effect->counter == 0) {
+                Effect_Kill(effect_num);
+            }
+            return;
+        }
+
+        const ITEM *const item = Item_Get(effect->counter);
+        const XYZ_32 target_pos = M_GetTargetPos(item);
+        M_NudgeTowardsItem(effect, &target_pos);
+        if (M_ShouldDisappear(effect, &target_pos)) {
             Effect_Kill(effect_num);
         }
     }
-#else
-    effect->frame_num--;
-    if (effect->frame_num <= obj->mesh_count) {
-        effect->frame_num = 0;
-    }
-
-    if (effect->counter < 0) {
-        effect->counter++;
-        if (effect->counter == 0) {
-            Effect_Kill(effect_num);
-        }
-        return;
-    }
-
-    const ITEM *const item = Item_Get(effect->counter);
-    const XYZ_32 target_pos = M_GetTargetPos(item);
-    M_NudgeTowardsItem(effect, &target_pos);
-    if (M_ShouldDisappear(effect, &target_pos)) {
-        Effect_Kill(effect_num);
-    }
-#endif
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/libtrx/game/objects/general/waterfall.c
+++ b/src/libtrx/game/objects/general/waterfall.c
@@ -3,6 +3,7 @@
 #include "game/output.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "version.h"
 
 #define M_RANGE (WALL_L * 10) // = 10240
 
@@ -15,7 +16,7 @@ static void M_Control(const int16_t item_num)
 
     const ITEM *const lara_item = Lara_GetItem();
     Output_CalculateLight(item->pos, item->room_num);
-    if (TR_VERSION == 2 && Item_IsNearby(item, lara_item, M_RANGE)) {
+    if (g_TRVersion == 2 && Item_IsNearby(item, lara_item, M_RANGE)) {
         Sound_Effect(SFX_WATERFALL_LOOP, &item->pos, SPM_NORMAL);
     }
 

--- a/src/libtrx/game/objects/traps/dart.c
+++ b/src/libtrx/game/objects/traps/dart.c
@@ -5,6 +5,7 @@
 #include "game/rooms.h"
 #include "game/sound.h"
 #include "game/spawn.h"
+#include "version.h"
 
 #define M_DAMAGE 50
 #define M_PITCH (DEG_45 / 2)
@@ -13,9 +14,7 @@ static void M_Hit(const int16_t item_num, const XYZ_32 pos)
 {
     const ITEM *const item = Item_Get(item_num);
     Item_Kill(item_num);
-#if TR_VERSION == 2
     Sound_Effect(SFX_DARTS_HIT, &item->pos, SPM_NORMAL);
-#endif
 
     const int16_t effect_num = Effect_Create(item->room_num);
     if (effect_num != NO_EFFECT) {
@@ -53,12 +52,12 @@ static void M_Control(const int16_t item_num)
     const int32_t height =
         Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
 
-    if (TR_VERSION == 2) {
+    if (g_TRVersion == 2) {
         item->rot.x += M_PITCH;
     }
     item->floor = height;
     if (item->pos.y >= height) {
-        M_Hit(item_num, TR_VERSION == 1 ? old_pos : item->pos);
+        M_Hit(item_num, g_TRVersion == 1 ? old_pos : item->pos);
     }
 }
 

--- a/src/libtrx/game/objects/traps/dart_emitter.c
+++ b/src/libtrx/game/objects/traps/dart_emitter.c
@@ -2,6 +2,7 @@
 #include "game/effects.h"
 #include "game/objects.h"
 #include "game/sound.h"
+#include "version.h"
 
 typedef enum {
     // clang-format off
@@ -48,7 +49,7 @@ static void M_CreateDart(ITEM *const item)
     Item_AddActive(dart_item_num);
     dart_item->status = IS_ACTIVE;
 
-    if (TR_VERSION == 1) {
+    if (g_TRVersion == 1) {
         const int16_t effect_num = Effect_Create(dart_item->room_num);
         if (effect_num != NO_EFFECT) {
             EFFECT *const effect = Effect_Get(effect_num);

--- a/src/libtrx/game/objects/traps/ember_emitter.c
+++ b/src/libtrx/game/objects/traps/ember_emitter.c
@@ -2,6 +2,7 @@
 #include "game/objects.h"
 #include "game/random.h"
 #include "game/sound.h"
+#include "version.h"
 
 static void M_Control(const int16_t item_num)
 {
@@ -18,11 +19,11 @@ static void M_Control(const int16_t item_num)
     effect->fall_speed = Random_GetControl() / -200;
     effect->frame_num = (-4 * Random_GetControl()) / 0x7FFF;
     effect->object_id = O_EMBER;
-#if TR_VERSION == 1
-    Sound_Effect(SFX_LAVA_FOUNTAIN, &item->pos, SPM_NORMAL);
-#else
-    Sound_Effect(SFX_SANDBAG_HIT, &item->pos, SPM_NORMAL);
-#endif
+    if (g_TRVersion == 1) {
+        Sound_Effect(SFX_LAVA_FOUNTAIN, &item->pos, SPM_NORMAL);
+    } else {
+        Sound_Effect(SFX_SANDBAG_HIT, &item->pos, SPM_NORMAL);
+    }
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/libtrx/game/objects/traps/falling_block.c
+++ b/src/libtrx/game/objects/traps/falling_block.c
@@ -3,14 +3,15 @@
 #include "game/objects/traps/movable_block.h"
 #include "game/rooms.h"
 #include "vector.h"
+#include "version.h"
 
 static int32_t M_GetOrigin(const OBJECT_ID obj_id)
 {
-#if TR_VERSION == 1
-    return -STEP_L * 2;
-#else
-    return obj_id == O_FALLING_BLOCK_3 ? -WALL_L : -STEP_L * 2;
-#endif
+    if (g_TRVersion == 1) {
+        return -STEP_L * 2;
+    } else {
+        return obj_id == O_FALLING_BLOCK_3 ? -WALL_L : -STEP_L * 2;
+    }
 }
 
 static void M_DropStack(const ITEM *const item)

--- a/src/libtrx/game/objects/traps/flame_emitter.c
+++ b/src/libtrx/game/objects/traps/flame_emitter.c
@@ -1,6 +1,7 @@
 #include "game/effects.h"
 #include "game/objects.h"
 #include "game/sound.h"
+#include "version.h"
 
 static void M_Control(const int16_t item_num)
 {
@@ -11,7 +12,7 @@ static void M_Control(const int16_t item_num)
             const int32_t flame_num = ((int32_t)(intptr_t)item->data) - 1;
             Effect_Kill(flame_num);
             item->data = nullptr;
-            if (TR_VERSION == 1) {
+            if (g_TRVersion == 1) {
                 Sound_StopEffect(SFX_LOOP_FOR_SMALL_FIRES);
             }
         }

--- a/src/libtrx/game/objects/traps/pendulum.c
+++ b/src/libtrx/game/objects/traps/pendulum.c
@@ -3,16 +3,17 @@
 #include "game/random.h"
 #include "game/rooms.h"
 #include "game/spawn.h"
+#include "version.h"
 
-#define M_DAMAGE (TR_VERSION == 1 ? 100 : 50)
+#define M_DAMAGE (g_TRVersion == 1 ? 100 : 50)
 
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
 
     const bool working =
-        TR_VERSION != 1 || item->current_anim_state == TRAP_WORKING;
-    if (TR_VERSION == 1) {
+        g_TRVersion != 1 || item->current_anim_state == TRAP_WORKING;
+    if (g_TRVersion == 1) {
         if (Item_IsTriggerActive(item)) {
             if (item->current_anim_state == TRAP_SET) {
                 item->goal_anim_state = TRAP_WORKING;
@@ -49,7 +50,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
     obj->collision_func =
-        TR_VERSION == 1 ? Object_Collision_Trap : Object_Collision;
+        g_TRVersion == 1 ? Object_Collision_Trap : Object_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/libtrx/game/objects/traps/rolling_ball.c
+++ b/src/libtrx/game/objects/traps/rolling_ball.c
@@ -7,6 +7,7 @@
 #include "game/rooms.h"
 #include "game/sound.h"
 #include "game/spawn.h"
+#include "version.h"
 
 #define M_DAMAGE_AIR 100
 #define M_SHAKE_RANGE (WALL_L * 10) // = 10240
@@ -26,7 +27,10 @@ static void M_Roll(ITEM *const item)
     item->gravity = false;
     item->fall_speed = 0;
     item->pos.y = item->floor;
-#if TR_VERSION == 2
+
+    if (g_TRVersion != 2) {
+        return;
+    }
     if (item->object_id == O_ROLLING_BALL_2) {
         Sound_Effect(SFX_SNOWBALL_ROLL, &item->pos, SPM_NORMAL);
     } else if (item->object_id == O_ROLLING_BALL_3) {
@@ -35,6 +39,7 @@ static void M_Roll(ITEM *const item)
         Sound_Effect(SFX_ROLLING_BALL, &item->pos, SPM_NORMAL);
     }
 
+#if TR_VERSION == 2
     const int32_t dist = Math_Sqrt(
         (g_Camera.mic_pos.z - item->pos.z) * (g_Camera.mic_pos.z - item->pos.z)
         + (g_Camera.mic_pos.x - item->pos.x)
@@ -48,7 +53,7 @@ static void M_Roll(ITEM *const item)
 static bool M_TestStop(const ITEM *const item)
 {
     int32_t dist;
-    if (TR_VERSION == 1) {
+    if (g_TRVersion == 1) {
         dist = WALL_L / 2;
     } else {
         dist = item->object_id == O_ROLLING_BALL_1 ? STEP_L * 3 / 2 : WALL_L;
@@ -68,15 +73,15 @@ static void M_Stop(ITEM *const item, const XYZ_32 old_pos)
     if (item->object_id == O_ROLLING_BALL_1) {
         item->status = IS_DEACTIVATED;
     }
-#if TR_VERSION == 2
-    if (item->object_id == O_ROLLING_BALL_2) {
-        Sound_Effect(SFX_SNOWBALL_STOP, &item->pos, SPM_NORMAL);
-        item->goal_anim_state = TRAP_WORKING;
-    } else if (item->object_id == O_ROLLING_BALL_3) {
-        Sound_Effect(SFX_ROLLING_2_HIT, &item->pos, SPM_NORMAL);
-        item->goal_anim_state = TRAP_WORKING;
+    if (g_TRVersion == 2) {
+        if (item->object_id == O_ROLLING_BALL_2) {
+            Sound_Effect(SFX_SNOWBALL_STOP, &item->pos, SPM_NORMAL);
+            item->goal_anim_state = TRAP_WORKING;
+        } else if (item->object_id == O_ROLLING_BALL_3) {
+            Sound_Effect(SFX_ROLLING_2_HIT, &item->pos, SPM_NORMAL);
+            item->goal_anim_state = TRAP_WORKING;
+        }
     }
-#endif
 
     item->pos.x = old_pos.x;
     item->pos.y = item->floor;

--- a/src/libtrx/game/objects/traps/spikes.c
+++ b/src/libtrx/game/objects/traps/spikes.c
@@ -2,8 +2,9 @@
 #include "game/lara.h"
 #include "game/random.h"
 #include "game/spawn.h"
+#include "version.h"
 
-#define M_FALL_SPEED_LIMIT (TR_VERSION == 1 ? 0 : GRAVITY)
+#define M_FALL_SPEED_LIMIT (g_TRVersion == 1 ? 0 : GRAVITY)
 #define M_DAMAGE 15
 
 static void M_Collision(

--- a/src/libtrx/game/ui/text.c
+++ b/src/libtrx/game/ui/text.c
@@ -393,7 +393,6 @@ static void M_Process(
 
         const int16_t shade = dimmed ? 0x1600 : SHADE_NEUTRAL;
 
-#if TR_VERSION == 2
         if (glyph->role == GLYPH_SECRET) {
             const int16_t sprite_idx =
                 Object_Get(O_SECRET_1 + glyph->mesh_idx)->mesh_idx;
@@ -414,7 +413,6 @@ static void M_Process(
             x += glyph->width * scale / UI_TEXT_BASE_SCALE;
             goto loop_end;
         }
-#endif
 
         if (glyph->role == GLYPH_COMPOUND && obj->loaded
             && glyph->combine_with.mesh_idx >= 0

--- a/src/libtrx/include/libtrx/version.h
+++ b/src/libtrx/include/libtrx/version.h
@@ -1,4 +1,6 @@
 #pragma once
 
+#include <stdint.h>
+
 extern const char *g_TRXVersion;
 extern int32_t g_TRVersion;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This will retain the shared objects canon behavior even if the level are loaded with the "wrong" engine.
The only exceptions are features that reference not-ported code such as mic position or missing config switches – these stay behind `TR_VERSION`.