### PR TITLE
objects/switch: begin merging switch in TRX

### DIFF
--- a/src/libtrx/game/objects/general/switch.c
+++ b/src/libtrx/game/objects/general/switch.c
@@ -1,0 +1,40 @@
+#include "game/objects/general/switch.h"
+
+#include "game/const.h"
+#include "game/items.h"
+
+bool Switch_Trigger(const int16_t item_num, const int16_t timer)
+{
+    ITEM *const item = Item_Get(item_num);
+
+    if (item->object_id == O_SWITCH_TYPE_AIRLOCK) {
+        if (item->status == IS_DEACTIVATED) {
+            Item_RemoveActive(item_num);
+            item->status = IS_INACTIVE;
+            return false;
+        } else if (
+            (item->flags & IF_ONE_SHOT) != 0
+            || item->current_anim_state == SWITCH_STATE_OFF) {
+            return false;
+        }
+
+        item->flags |= IF_ONE_SHOT;
+        return true;
+    }
+
+    if (item->status != IS_DEACTIVATED) {
+        return false;
+    }
+
+    if (item->current_anim_state == SWITCH_STATE_OFF && timer > 0) {
+        item->timer = timer;
+        if (timer != 1) {
+            item->timer *= LOGIC_FPS;
+        }
+        item->status = IS_ACTIVE;
+    } else {
+        Item_RemoveActive(item_num);
+        item->status = IS_INACTIVE;
+    }
+    return true;
+}

--- a/src/libtrx/game/objects/general/switch.c
+++ b/src/libtrx/game/objects/general/switch.c
@@ -1,7 +1,96 @@
 #include "game/objects/general/switch.h"
 
+#include "config.h"
 #include "game/const.h"
 #include "game/items.h"
+#include "game/objects.h"
+
+static const OBJECT_BOUNDS m_SwitchBounds = {
+    .shift = {
+        .min = { .x = -220, .y = +0, .z = +WALL_L / 2 - 220, },
+        .max = { .x = +220, .y = +0, .z = +WALL_L / 2, },
+    },
+    .rot = {
+        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = -10 * DEG_1, },
+        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = +10 * DEG_1, },
+    },
+};
+
+static OBJECT_BOUNDS m_SwitchBoundsControlled = {
+    .shift = {
+        .min = { .x = +0, .y = +0, .z = +0, },
+        .max = { .x = +0, .y = +0, .z = +0, },
+    },
+    .rot = {
+        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = -10 * DEG_1, },
+        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = +10 * DEG_1, },
+    },
+};
+
+static const OBJECT_BOUNDS m_SwitchBoundsUW = {
+    .shift = {
+        .min = { .x = -WALL_L, .y = -WALL_L, .z = -WALL_L, },
+        .max = { .x = +WALL_L, .y = +WALL_L, .z = +WALL_L / 2, },
+    },
+    .rot = {
+        .min = { .x = -80 * DEG_1, .y = -80 * DEG_1, .z = -80 * DEG_1, },
+        .max = { .x = +80 * DEG_1, .y = +80 * DEG_1, .z = +80 * DEG_1, },
+    },
+};
+
+static const OBJECT_BOUNDS *M_Bounds(void)
+{
+#if TR_VERSION == 1
+    if (g_Config.gameplay.enable_walk_to_items) {
+        return &m_SwitchBoundsControlled;
+    }
+#endif
+    return &m_SwitchBounds;
+}
+
+static const OBJECT_BOUNDS *M_BoundsUW(void)
+{
+    return &m_SwitchBoundsUW;
+}
+
+static void M_Control(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    item->flags |= IF_CODE_BITS;
+    if (!Item_IsTriggerActive(item)) {
+        item->goal_anim_state = SWITCH_STATE_ON;
+        item->timer = 0;
+    }
+    Item_Animate(item);
+}
+
+static void M_SetupBase(OBJECT *const obj)
+{
+    obj->control_func = M_Control;
+    obj->save_flags = true;
+    obj->save_anim = true;
+}
+
+static void M_Setup(OBJECT *const obj)
+{
+    M_SetupBase(obj);
+    obj->collision_func = Switch_Collision;
+    obj->bounds_func = M_Bounds;
+}
+
+static void M_SetupPushButton(OBJECT *const obj)
+{
+    M_Setup(obj);
+    obj->enable_interpolation = false;
+    obj->bounds_func = M_Bounds;
+}
+
+static void M_SetupUW(OBJECT *const obj)
+{
+    M_SetupBase(obj);
+    obj->collision_func = Switch_CollisionUW;
+    obj->bounds_func = M_BoundsUW;
+}
 
 bool Switch_Trigger(const int16_t item_num, const int16_t timer)
 {
@@ -38,3 +127,9 @@ bool Switch_Trigger(const int16_t item_num, const int16_t timer)
     }
     return true;
 }
+
+REGISTER_OBJECT(O_SWITCH_TYPE_AIRLOCK, M_Setup)
+REGISTER_OBJECT(O_SWITCH_TYPE_BUTTON, M_SetupPushButton)
+REGISTER_OBJECT(O_SWITCH_TYPE_NORMAL, M_Setup)
+REGISTER_OBJECT(O_SWITCH_TYPE_SMALL, M_Setup)
+REGISTER_OBJECT(O_SWITCH_TYPE_UW, M_SetupUW)

--- a/src/libtrx/include/libtrx/game/objects/general/switch.h
+++ b/src/libtrx/include/libtrx/game/objects/general/switch.h
@@ -8,4 +8,4 @@ typedef enum {
     SWITCH_STATE_LINK = 2,
 } SWITCH_STATE;
 
-extern bool Switch_Trigger(int16_t item_num, int16_t timer);
+bool Switch_Trigger(int16_t item_num, int16_t timer);

--- a/src/libtrx/include/libtrx/game/objects/general/switch.h
+++ b/src/libtrx/include/libtrx/game/objects/general/switch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include "../../collision.h"
 
 typedef enum {
     SWITCH_STATE_OFF = 0,
@@ -9,3 +9,9 @@ typedef enum {
 } SWITCH_STATE;
 
 bool Switch_Trigger(int16_t item_num, int16_t timer);
+
+// TODO: make private
+extern void Switch_Collision(
+    int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
+extern void Switch_CollisionUW(
+    int16_t item_num, ITEM *lara_item, COLL_INFO *coll);

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -349,6 +349,7 @@ sources = [
   'game/objects/general/scion4.c',
   'game/objects/general/scion_holder.c',
   'game/objects/general/sphere_of_doom.c',
+  'game/objects/general/switch.c',
   'game/objects/general/trapdoor.c',
   'game/objects/general/waterfall.c',
   'game/objects/general/window.c',

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -119,7 +119,7 @@ static void M_CollisionControlled(
     }
 }
 
-static void M_Collision(
+void Switch_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     if (g_Config.gameplay.enable_walk_to_items) {
@@ -164,7 +164,7 @@ static void M_Collision(
     }
 }
 
-static void M_CollisionUW(
+void Switch_CollisionUW(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
@@ -209,7 +209,7 @@ static void M_CollisionUW(
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->collision_func = M_Collision;
+    obj->collision_func = Switch_Collision;
     obj->save_anim = true;
     obj->save_flags = true;
     obj->bounds_func = M_Bounds;
@@ -218,7 +218,7 @@ static void M_Setup(OBJECT *const obj)
 static void M_SetupUW(OBJECT *const obj)
 {
     obj->control_func = M_Control;
-    obj->collision_func = M_CollisionUW;
+    obj->collision_func = Switch_CollisionUW;
     obj->save_anim = true;
     obj->save_flags = true;
     obj->bounds_func = M_BoundsUW;

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -5,63 +5,6 @@
 #include <libtrx/game/input.h>
 #include <libtrx/game/objects/general/switch.h>
 
-static const OBJECT_BOUNDS m_Switch_Bounds = {
-    .shift = {
-        .min = { .x = -200, .y = +0, .z = +WALL_L / 2 - 200, },
-        .max = { .x = +200, .y = +0, .z = +WALL_L / 2, },
-    },
-    .rot = {
-        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = -10 * DEG_1, },
-        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = +10 * DEG_1, },
-    },
-};
-
-static OBJECT_BOUNDS m_Switch_BoundsControlled = {
-    .shift = {
-        .min = { .x = +0, .y = +0, .z = +0, },
-        .max = { .x = +0, .y = +0, .z = +0, },
-    },
-    .rot = {
-        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = -10 * DEG_1, },
-        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = +10 * DEG_1, },
-    },
-};
-
-static const OBJECT_BOUNDS m_Switch_BoundsUW = {
-    .shift = {
-        .min = { .x = -WALL_L, .y = -WALL_L, .z = -WALL_L, },
-        .max = { .x = +WALL_L, .y = +WALL_L, .z = +WALL_L / 2, },
-    },
-    .rot = {
-        .min = { .x = -80 * DEG_1, .y = -80 * DEG_1, .z = -80 * DEG_1, },
-        .max = { .x = +80 * DEG_1, .y = +80 * DEG_1, .z = +80 * DEG_1, },
-    },
-};
-
-static const OBJECT_BOUNDS *M_Bounds(void)
-{
-    if (g_Config.gameplay.enable_walk_to_items) {
-        return &m_Switch_BoundsControlled;
-    }
-    return &m_Switch_Bounds;
-}
-
-static const OBJECT_BOUNDS *M_BoundsUW(void)
-{
-    return &m_Switch_BoundsUW;
-}
-
-static void M_Control(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    item->flags |= IF_CODE_BITS;
-    if (!Item_IsTriggerActive(item)) {
-        item->goal_anim_state = SWITCH_STATE_ON;
-        item->timer = 0;
-    }
-    Item_Animate(item);
-}
-
 static void M_CollisionControlled(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -75,14 +18,15 @@ static void M_CollisionControlled(
             && lara->interact_target.item_num == item_num)) {
         const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
 
-        m_Switch_BoundsControlled.shift.min.x = bounds->min.x - 256;
-        m_Switch_BoundsControlled.shift.max.x = bounds->max.x + 256;
-        m_Switch_BoundsControlled.shift.min.z = bounds->min.z - 200;
-        m_Switch_BoundsControlled.shift.max.z = bounds->max.z + 200;
+        OBJECT_BOUNDS col_bounds = *Object_Get(item->object_id)->bounds_func();
+        col_bounds.shift.min.x = bounds->min.x - 256;
+        col_bounds.shift.max.x = bounds->max.x + 256;
+        col_bounds.shift.min.z = bounds->min.z - 200;
+        col_bounds.shift.max.z = bounds->max.z + 200;
 
         XYZ_32 move_vector = { 0, 0, bounds->min.z - 64 };
 
-        if (Lara_TestPosition(item, &m_Switch_BoundsControlled)) {
+        if (Lara_TestPosition(item, &col_bounds)) {
             if (Lara_MovePosition(item, &move_vector)) {
                 if (item->current_anim_state == SWITCH_STATE_ON) {
                     Item_SwitchToAnim(lara_item, LA(LA_WALL_SWITCH_DOWN), 0);
@@ -205,24 +149,3 @@ void Switch_CollisionUW(
         Item_Animate(item);
     }
 }
-
-static void M_Setup(OBJECT *const obj)
-{
-    obj->control_func = M_Control;
-    obj->collision_func = Switch_Collision;
-    obj->save_anim = true;
-    obj->save_flags = true;
-    obj->bounds_func = M_Bounds;
-}
-
-static void M_SetupUW(OBJECT *const obj)
-{
-    obj->control_func = M_Control;
-    obj->collision_func = Switch_CollisionUW;
-    obj->save_anim = true;
-    obj->save_flags = true;
-    obj->bounds_func = M_BoundsUW;
-}
-
-REGISTER_OBJECT(O_SWITCH_TYPE_NORMAL, M_Setup)
-REGISTER_OBJECT(O_SWITCH_TYPE_UW, M_SetupUW)

--- a/src/tr1/game/objects/general/switch.c
+++ b/src/tr1/game/objects/general/switch.c
@@ -224,24 +224,5 @@ static void M_SetupUW(OBJECT *const obj)
     obj->bounds_func = M_BoundsUW;
 }
 
-bool Switch_Trigger(int16_t item_num, int16_t timer)
-{
-    ITEM *const item = Item_Get(item_num);
-    if (item->status != IS_DEACTIVATED) {
-        return false;
-    }
-    if (item->current_anim_state == SWITCH_STATE_OFF && timer > 0) {
-        item->timer = timer;
-        if (timer != 1) {
-            item->timer *= LOGIC_FPS;
-        }
-        item->status = IS_ACTIVE;
-    } else {
-        Item_RemoveActive(item_num);
-        item->status = IS_INACTIVE;
-    }
-    return true;
-}
-
 REGISTER_OBJECT(O_SWITCH_TYPE_NORMAL, M_Setup)
 REGISTER_OBJECT(O_SWITCH_TYPE_UW, M_SetupUW)

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -207,42 +207,6 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 }
 
-bool Switch_Trigger(const int16_t item_num, const int16_t timer)
-{
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->object_id == O_SWITCH_TYPE_AIRLOCK) {
-        if (item->status == IS_DEACTIVATED) {
-            Item_RemoveActive(item_num);
-            item->status = IS_INACTIVE;
-            return false;
-        } else if (
-            (item->flags & IF_ONE_SHOT)
-            || item->current_anim_state == SWITCH_STATE_OFF) {
-            return false;
-        }
-
-        item->flags |= IF_ONE_SHOT;
-        return true;
-    }
-
-    if (item->status != IS_DEACTIVATED) {
-        return false;
-    }
-
-    if (item->current_anim_state == SWITCH_STATE_OFF && timer > 0) {
-        item->timer = timer;
-        if (timer != 1) {
-            item->timer = timer * LOGIC_FPS;
-        }
-        item->status = IS_ACTIVE;
-    } else {
-        Item_RemoveActive(item_num);
-        item->status = IS_INACTIVE;
-    }
-    return true;
-}
-
 static void M_SetupBase(OBJECT *const obj)
 {
     obj->control_func = M_Control;

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -9,38 +9,6 @@ static XYZ_32 g_PushSwitchPosition = { .x = 0, .y = 0, .z = 292 };
 static XYZ_32 m_AirlockPosition = { .x = 0, .y = 0, .z = 212 };
 static XYZ_32 m_SwitchUWPosition = { .x = 0, .y = 0, .z = 108 };
 
-static const OBJECT_BOUNDS m_SwitchBounds = {
-    .shift = {
-        .min = { .x = -220, .y = +0, .z = +WALL_L / 2 - 220, },
-        .max = { .x = +220, .y = +0, .z = +WALL_L / 2, },
-    },
-    .rot = {
-        .min = { .x = -10 * DEG_1, .y = -30 * DEG_1, .z = -10 * DEG_1, },
-        .max = { .x = +10 * DEG_1, .y = +30 * DEG_1, .z = +10 * DEG_1, },
-    },
-};
-
-static const OBJECT_BOUNDS m_SwitchBoundsUW = {
-    .shift = {
-        .min = { .x = -WALL_L, .y = -WALL_L, .z = -WALL_L, },
-        .max = { .x = +WALL_L, .y = +WALL_L, .z = +WALL_L / 2, },
-    },
-    .rot = {
-        .min = { .x = -80 * DEG_1, .y = -80 * DEG_1, .z = -80 * DEG_1, },
-        .max = { .x = +80 * DEG_1, .y = +80 * DEG_1, .z = +80 * DEG_1, },
-    },
-};
-
-static const OBJECT_BOUNDS *M_Bounds(void)
-{
-    return &m_SwitchBounds;
-}
-
-static const OBJECT_BOUNDS *M_BoundsUW(void)
-{
-    return &m_SwitchBoundsUW;
-}
-
 static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
 {
     lara_item->rot.y = switch_item->rot.y;
@@ -195,48 +163,3 @@ void Switch_CollisionUW(
     Item_AddActive(item_num);
     Item_Animate(item);
 }
-
-static void M_Control(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    item->flags |= IF_CODE_BITS;
-    if (!Item_IsTriggerActive(item)) {
-        item->goal_anim_state = SWITCH_STATE_ON;
-        item->timer = 0;
-    }
-    Item_Animate(item);
-}
-
-static void M_SetupBase(OBJECT *const obj)
-{
-    obj->control_func = M_Control;
-    obj->save_flags = true;
-    obj->save_anim = true;
-}
-
-static void M_Setup(OBJECT *const obj)
-{
-    M_SetupBase(obj);
-    obj->collision_func = Switch_Collision;
-    obj->bounds_func = M_Bounds;
-}
-
-static void M_SetupPushButton(OBJECT *const obj)
-{
-    M_Setup(obj);
-    obj->enable_interpolation = false;
-    obj->bounds_func = M_Bounds;
-}
-
-static void M_SetupUW(OBJECT *const obj)
-{
-    M_SetupBase(obj);
-    obj->collision_func = Switch_CollisionUW;
-    obj->bounds_func = M_BoundsUW;
-}
-
-REGISTER_OBJECT(O_SWITCH_TYPE_AIRLOCK, M_Setup)
-REGISTER_OBJECT(O_SWITCH_TYPE_BUTTON, M_SetupPushButton)
-REGISTER_OBJECT(O_SWITCH_TYPE_NORMAL, M_Setup)
-REGISTER_OBJECT(O_SWITCH_TYPE_SMALL, M_Setup)
-REGISTER_OBJECT(O_SWITCH_TYPE_UW, M_SetupUW)

--- a/src/tr2/game/objects/general/switch.c
+++ b/src/tr2/game/objects/general/switch.c
@@ -113,7 +113,7 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
     switch_item->goal_anim_state = SWITCH_STATE_ON;
 }
 
-static void M_Collision(
+void Switch_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
@@ -150,7 +150,7 @@ static void M_Collision(
     Item_Animate(item);
 }
 
-static void M_CollisionUW(
+void Switch_CollisionUW(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
@@ -217,7 +217,7 @@ static void M_SetupBase(OBJECT *const obj)
 static void M_Setup(OBJECT *const obj)
 {
     M_SetupBase(obj);
-    obj->collision_func = M_Collision;
+    obj->collision_func = Switch_Collision;
     obj->bounds_func = M_Bounds;
 }
 
@@ -231,7 +231,7 @@ static void M_SetupPushButton(OBJECT *const obj)
 static void M_SetupUW(OBJECT *const obj)
 {
     M_SetupBase(obj);
-    obj->collision_func = M_CollisionUW;
+    obj->collision_func = Switch_CollisionUW;
     obj->bounds_func = M_BoundsUW;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Similar to pickups, this moves the main setup and control functions to TRX. Collision remains in the separate games for now - I'll tackle `walk-to-items` as a whole next with pickups and switches.
