### PR TITLE
inject/utils: remap game object IDs only

### DIFF
--- a/src/libtrx/game/inject/utils.c
+++ b/src/libtrx/game/inject/utils.c
@@ -6,12 +6,14 @@ INJECTION_OBJECT_INFO Inject_ReadObjectPtr(const INJECTION *const injection)
 {
     INJECTION_OBJECT_INFO obj_info = {
         .type = VFile_ReadS32(injection->fp),
-        .id = Object_FromGameID(VFile_ReadS32(injection->fp)),
+        .id = VFile_ReadS32(injection->fp),
     };
 
-    if (obj_info.type == OBJ_TYPE_OBJECT
-        && injection->version < INJ_VERSION_5) {
-        VFile_Skip(injection->fp, 16);
+    if (obj_info.type == OBJ_TYPE_OBJECT) {
+        obj_info.id = Object_FromGameID(obj_info.id);
+        if (injection->version < INJ_VERSION_5) {
+            VFile_Skip(injection->fp, 16);
+        }
     }
 
     return obj_info;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids remapping static 2D/3D objects in injections to game IDs.
