### PR TITLE
More lua

### DIFF
--- a/data/common/ship/scripting/trx/game.lua
+++ b/data/common/ship/scripting/trx/game.lua
@@ -26,6 +26,15 @@ trx.game = setmetatable({
       t = make_levels(trxc.game.LevelTable.DEMOS)
     elseif key == "cutscenes" then
       t = make_levels(trxc.game.LevelTable.CUTSCENES)
+    elseif key == "current_level" then
+      local table_type = trxc.game.get_current_level_table()
+      local i = trxc.game.get_current_level_idx()
+      return {
+        num = trxc.game.get_level_num(table_type, i),
+        name = trxc.game.get_level_name(table_type, i),
+        path = trxc.game.get_level_path(table_type, i),
+        type = trxc.game.get_level_type(table_type, i),
+      }
     elseif key == "version" then
       return trxc.game.get_version()
     elseif key == "trx_version" then

--- a/data/common/ship/scripting/trx/game.lua
+++ b/data/common/ship/scripting/trx/game.lua
@@ -1,48 +1,50 @@
 local raw = trxc.game
 
+local function make_level(table_type, i)
+  return {
+    num = raw.get_level_num(table_type, i),
+    name = raw.get_level_name(table_type, i),
+    path = raw.get_level_path(table_type, i),
+    type = raw.get_level_type(table_type, i),
+  }
+end
+
 local function make_levels(table_type)
+  local count = raw.count_levels(table_type)
   local levels = {}
-  local count = trxc.game.count_levels(table_type)
   for i = 1, count do
-    levels[i] = {
-      num = trxc.game.get_level_num(table_type, i),
-      name = trxc.game.get_level_name(table_type, i),
-      path = trxc.game.get_level_path(table_type, i),
-      type = trxc.game.get_level_type(table_type, i),
-    }
+    levels[i] = make_level(table_type, i)
   end
   return levels
 end
 
+local table_map = {
+  levels = raw.LevelTable.MAIN,
+  demos = raw.LevelTable.DEMOS,
+  cutscenes = raw.LevelTable.CUTSCENES,
+}
+
+local dynamic_getters = {
+  current_level = function()
+    return make_level(raw.get_current_level_table(), raw.get_current_level_idx())
+  end,
+  version = raw.get_version,
+  trx_version = raw.get_trx_version,
+}
+
 trx.game = setmetatable({
-  LevelTable = trxc.game.LevelTable,
-  LevelType = trxc.game.LevelType,
+  LevelTable = raw.LevelTable,
+  LevelType = raw.LevelType,
 }, {
   __index = function(self, key)
-    local t
-    if key == "levels" then
-      t = make_levels(trxc.game.LevelTable.MAIN)
-    elseif key == "demos" then
-      t = make_levels(trxc.game.LevelTable.DEMOS)
-    elseif key == "cutscenes" then
-      t = make_levels(trxc.game.LevelTable.CUTSCENES)
-    elseif key == "current_level" then
-      local table_type = trxc.game.get_current_level_table()
-      local i = trxc.game.get_current_level_idx()
-      return {
-        num = trxc.game.get_level_num(table_type, i),
-        name = trxc.game.get_level_name(table_type, i),
-        path = trxc.game.get_level_path(table_type, i),
-        type = trxc.game.get_level_type(table_type, i),
-      }
-    elseif key == "version" then
-      return trxc.game.get_version()
-    elseif key == "trx_version" then
-      return trxc.game.get_trx_version()
-    else
-      return nil
+    local table_type = table_map[key]
+    if table_type then
+      local t = make_levels(table_type)
+      rawset(self, key, t)
+      return t
     end
-    rawset(self, key, t)
-    return t
+
+    local getter = dynamic_getters[key]
+    return getter and getter() or nil
   end,
 })

--- a/data/common/ship/scripting/trx/game.lua
+++ b/data/common/ship/scripting/trx/game.lua
@@ -1,0 +1,39 @@
+local raw = trxc.game
+
+local function make_levels(table_type)
+  local levels = {}
+  local count = trxc.game.count_levels(table_type)
+  for i = 1, count do
+    levels[i] = {
+      num = trxc.game.get_level_num(table_type, i),
+      name = trxc.game.get_level_name(table_type, i),
+      path = trxc.game.get_level_path(table_type, i),
+      type = trxc.game.get_level_type(table_type, i),
+    }
+  end
+  return levels
+end
+
+trx.game = setmetatable({
+  LevelTable = trxc.game.LevelTable,
+  LevelType = trxc.game.LevelType,
+}, {
+  __index = function(self, key)
+    local t
+    if key == "levels" then
+      t = make_levels(trxc.game.LevelTable.MAIN)
+    elseif key == "demos" then
+      t = make_levels(trxc.game.LevelTable.DEMOS)
+    elseif key == "cutscenes" then
+      t = make_levels(trxc.game.LevelTable.CUTSCENES)
+    elseif key == "version" then
+      return trxc.game.get_version()
+    elseif key == "trx_version" then
+      return trxc.game.get_trx_version()
+    else
+      return nil
+    end
+    rawset(self, key, t)
+    return t
+  end,
+})

--- a/data/common/ship/scripting/trx/items.lua
+++ b/data/common/ship/scripting/trx/items.lua
@@ -4,7 +4,10 @@ local raw = trxc.items
 local getters = {
   pos = raw.get_pos,
   rot = raw.get_rot,
-  room = raw.get_room,
+  room_num = raw.get_room,
+  room = function(idx)
+    return trx.rooms[raw.get_room(idx)]
+  end,
   status = raw.get_status,
   object_id = raw.get_object_id,
   hit_points = raw.get_hit_points,

--- a/data/common/ship/scripting/trx/lara.lua
+++ b/data/common/ship/scripting/trx/lara.lua
@@ -2,8 +2,33 @@ local raw = trxc.lara
 
 local lara = {}
 
+-- Item proxy metatable
+local getters = {
+  exposure_bar = raw.get_exposure_bar,
+}
+
+local setters = {
+  exposure_bar = raw.set_exposure_bar,
+}
+
 function lara.get_item()
   return trx.items[raw.get_item()]
 end
 
+local lara_mt = {
+  __index = function(self, key)
+    local getter = getters[key]
+    return getter and getter() or nil
+  end,
+  __newindex = function(self, key, value)
+    local setter = setters[key]
+    if setter then
+      setter(value)
+      return
+    end
+    error("Cannot set field '" .. key .. "' on trx.lara", 2)
+  end,
+}
+
+setmetatable(lara, lara_mt)
 trx.lara = lara

--- a/data/common/ship/scripting/trx/lara.lua
+++ b/data/common/ship/scripting/trx/lara.lua
@@ -5,15 +5,14 @@ local lara = {}
 -- Item proxy metatable
 local getters = {
   exposure_bar = raw.get_exposure_bar,
+  item = function()
+    return trx.items[raw.get_item()]
+  end,
 }
 
 local setters = {
   exposure_bar = raw.set_exposure_bar,
 }
-
-function lara.get_item()
-  return trx.items[raw.get_item()]
-end
 
 local lara_mt = {
   __index = function(self, key)

--- a/data/common/ship/scripting/trx/rooms.lua
+++ b/data/common/ship/scripting/trx/rooms.lua
@@ -1,0 +1,38 @@
+local raw = trxc.rooms
+
+-- Room proxy metatable
+local getters = {
+  flags = raw.get_flags,
+}
+
+local Room = {}
+
+Room.__index = function(self, key)
+  local getter = getters[key]
+  return getter and getter(self.idx) or nil
+end
+
+-- rooms metatable - functions
+local fn = {}
+
+function fn.get(arg)
+  local idx = raw.get(arg)
+  if not idx then
+    return nil
+  end
+  return setmetatable({ idx = idx }, Room)
+end
+
+trx.rooms = setmetatable({}, {
+  __len = function()
+    return raw.count()
+  end,
+  __index = function(_, key)
+    if key == "fn" then
+      return fn
+    elseif type(key) == "number" or type(key) == "string" then
+      return fn.get(key)
+    end
+    return nil
+  end,
+})

--- a/docs/06-lua/1-examples/README.md
+++ b/docs/06-lua/1-examples/README.md
@@ -28,7 +28,7 @@ This will teleport Lara back to the starting point in TR1 Caves.
 
 ```lua
 trx.events.on_pickup(function(pickup_item)
-  local lara = trx.lara.get_item()
+  local lara = trx.lara.item
   lara.pos = {
     x = 73.5 * 1024,
     y = 3 * 1024,
@@ -57,7 +57,7 @@ to another.
 local last_room = 0
 
 trx.events.on_control(function()
-  local lara = trx.lara.get_item()
+  local lara = trx.lara.item
   if lara.room ~= last_room then
     last_room = lara.room
     if lara.room == 15 then

--- a/docs/06-lua/2-reference/10-ROOMS.md
+++ b/docs/06-lua/2-reference/10-ROOMS.md
@@ -1,0 +1,29 @@
+---
+title: Rooms
+---
+
+## Rooms module
+
+Module for inspecting all rooms in the current level.
+
+### Structures
+
+- [lua]`trx.rooms.Room`
+
+    Represents a room.
+
+    Properties:
+
+    - **`flags`**: Integer bitflags for the room.
+
+### Functions
+
+-- Uses Lua length operator on the rooms table:
+- [lua]`#trx.rooms`  
+  Returns the total number of rooms.
+
+- [lua]`trx.rooms[num]`  
+  Retrieves the [lua]`trx.rooms.Room` at the given 1-based index, or `nil` if out of range.
+
+- [lua]`trx.rooms.fn.get(arg)`  
+  Alias of `trx.rooms[arg]`.

--- a/docs/06-lua/2-reference/11-GAME.md
+++ b/docs/06-lua/2-reference/11-GAME.md
@@ -1,0 +1,38 @@
+---
+title: Game
+---
+
+## Game module
+
+Module for retrieving game version and level tables.
+
+### Structures
+
+- [lua]`trx.game.Level`
+
+    Represents a level entry.
+
+    Properties:
+
+    - **`num`**: Integer ordinal number of the level.
+    - **`name`**: String title of the level.
+    - **`path`**: String file path of the level data.
+    - **`type`**: Integer type identifier of the level.
+
+### Functions
+
+- [lua]`trx.game.version`  
+  Returns the current game version integer. This is guessed from the level data.
+- [lua]`trx.game.trx_version`  
+  Returns the current TRX version string.
+
+- [lua]`#trx.game.levels`  
+  [lua]`#trx.game.demos`  
+  [lua]`#trx.game.cutscenes`  
+  Returns the number of levels of the specific type.
+
+- [lua]`trx.game.levels[num]`  
+  [lua]`trx.game.demos[num]`  
+  [lua]`trx.game.cutscenes[num]`  
+  Retrieves the [lua]`trx.game.Level` of the specific type at the given index,
+  or `nil` if out of range.

--- a/docs/06-lua/2-reference/11-GAME.md
+++ b/docs/06-lua/2-reference/11-GAME.md
@@ -26,6 +26,9 @@ Module for retrieving game version and level tables.
 - [lua]`trx.game.trx_version`  
   Returns the current TRX version string.
 
+- [lua]`trx.game.current_level`  
+  Retrieves the [lua]`trx.game.Level` that's currently loaded or `nil`.
+
 - [lua]`#trx.game.levels`  
   [lua]`#trx.game.demos`  
   [lua]`#trx.game.cutscenes`  

--- a/docs/06-lua/2-reference/3-LARA.md
+++ b/docs/06-lua/2-reference/3-LARA.md
@@ -11,3 +11,8 @@ Module for interacting with the Lara's object.
 - [lua]`trx.lara.get_item()`  
     Returns [lua]`trx.items.Item` associated with Lara, or [lua]`nil` if the
     Lara object is not available.
+
+- [lua]`trx.lara.exposure_timer`  
+    Reads/writes exposure timer (cold water bar). The maximum value is 600.
+    If the cold bar setting is disabled on the game flow level, the health must
+    be managed manually from LUA.

--- a/docs/06-lua/2-reference/3-LARA.md
+++ b/docs/06-lua/2-reference/3-LARA.md
@@ -8,7 +8,7 @@ Module for interacting with the Lara's object.
 
 ### Functions
 
-- [lua]`trx.lara.get_item()`  
+- [lua]`trx.lara.item`  
     Returns [lua]`trx.items.Item` associated with Lara, or [lua]`nil` if the
     Lara object is not available.
 

--- a/docs/06-lua/2-reference/4-ITEMS.md
+++ b/docs/06-lua/2-reference/4-ITEMS.md
@@ -16,7 +16,8 @@ Module for controlling all moveables behavior.
 
     - **`pos`**: A table with fields `x`, `y`, `z` representing position.
     - **`rot`**: A table with fields `x`, `y`, `z` representing rotation.
-    - **`room`**: Integer representing the room number.
+    - **`room_num`**: room number.
+    - **`room`**: [`trx.rooms.Room`] object for the room containing this item.
     - **`status`**: Integer representing the item's status.
     - **`hit_points`**: Integer representing the item's hit points.
     - **`max_hit_points`**: Integer representing the item's hit points.
@@ -24,7 +25,7 @@ Module for controlling all moveables behavior.
     - **`name`**: String name of the item, or `nil` if none.
 
     Writable properties:
-    - `pos` (updating this also updates `room`)
+    - `pos` (updating this also updates `room` and `room_num`)
     - `rot`
     - `hit_points` (updating this also may increase `max_hit_points`)
     - `max_hit_points`

--- a/docs/06-lua/2-reference/4-ITEMS.md
+++ b/docs/06-lua/2-reference/4-ITEMS.md
@@ -32,7 +32,6 @@ Module for controlling all moveables behavior.
 
 ### Functions
 
--- Uses Lua length operator on the items table:
 - [lua]`#trx.items`  
   Returns the total number of allocated items.
 

--- a/src/libtrx/game/console/common.c
+++ b/src/libtrx/game/console/common.c
@@ -60,7 +60,9 @@ bool Console_IsOpened(void)
     return m_IsOpened;
 }
 
-void Console_LogEx(const char *const fmt, ...)
+void Console_LogEx(
+    const LOG_LEVEL level, const char *file, int line, const char *func,
+    const char *const fmt, ...)
 {
     ASSERT(fmt != nullptr);
 
@@ -75,6 +77,8 @@ void Console_LogEx(const char *const fmt, ...)
 
     vsnprintf(text, text_length + 1, fmt, va_copy);
     va_end(va_copy);
+
+    Log_Message(level, file, line, func, "%s", text);
 
     if (m_Verbose) {
         UI_FireEvent((EVENT) {

--- a/src/libtrx/game/game_flow/common.c
+++ b/src/libtrx/game/game_flow/common.c
@@ -119,8 +119,7 @@ GF_LEVEL_TABLE_TYPE GF_GetLevelTableType(const GF_LEVEL_TYPE level_type)
         return GFLT_DEMOS;
 
     case GFL_TITLE:
-        // this needs to be handled separately
-        return GFLT_UNKNOWN;
+        return GFLT_TITLE;
     }
 
     ASSERT_FAIL();
@@ -232,6 +231,9 @@ const GF_LEVEL *GF_GetLastLevel(void)
 const GF_LEVEL *GF_GetLevel(
     const GF_LEVEL_TABLE_TYPE level_table_type, const int32_t num)
 {
+    if (level_table_type == GFLT_TITLE) {
+        return GF_GetTitleLevel();
+    }
     const GF_LEVEL_TABLE *const level_table =
         GF_GetLevelTable(level_table_type);
     ASSERT(level_table != nullptr);

--- a/src/libtrx/game/lua/common.c
+++ b/src/libtrx/game/lua/common.c
@@ -29,6 +29,7 @@ extern void LUA_CreateLog(lua_State *L);
 extern void LUA_CreateMusic(lua_State *L);
 extern void LUA_CreateSound(lua_State *L);
 extern void LUA_CreateConfig(lua_State *L);
+extern void LUA_CreateGame(lua_State *L);
 
 static int M_LoadFile(lua_State *const L, const char *const path)
 {
@@ -163,6 +164,7 @@ void LUA_Init(void)
     M_LoadTRXCModule(L, LUA_CreateMusic);
     M_LoadTRXCModule(L, LUA_CreateSound);
     M_LoadTRXCModule(L, LUA_CreateConfig);
+    M_LoadTRXCModule(L, LUA_CreateGame);
 
     M_PRIV *const p = &m_Priv;
     p->state = L;
@@ -175,6 +177,7 @@ void LUA_Init(void)
     M_LoadTRXModule(L, "log.lua");
     M_LoadTRXModule(L, "sound.lua");
     M_LoadTRXModule(L, "music.lua");
+    M_LoadTRXModule(L, "game.lua");
 }
 
 void LUA_Shutdown(void)

--- a/src/libtrx/game/lua/common.c
+++ b/src/libtrx/game/lua/common.c
@@ -29,6 +29,7 @@ extern void LUA_CreateLog(lua_State *L);
 extern void LUA_CreateMusic(lua_State *L);
 extern void LUA_CreateSound(lua_State *L);
 extern void LUA_CreateConfig(lua_State *L);
+extern void LUA_CreateRooms(lua_State *L);
 extern void LUA_CreateGame(lua_State *L);
 
 static int M_LoadFile(lua_State *const L, const char *const path)
@@ -164,6 +165,7 @@ void LUA_Init(void)
     M_LoadTRXCModule(L, LUA_CreateMusic);
     M_LoadTRXCModule(L, LUA_CreateSound);
     M_LoadTRXCModule(L, LUA_CreateConfig);
+    M_LoadTRXCModule(L, LUA_CreateRooms);
     M_LoadTRXCModule(L, LUA_CreateGame);
 
     M_PRIV *const p = &m_Priv;
@@ -177,6 +179,7 @@ void LUA_Init(void)
     M_LoadTRXModule(L, "log.lua");
     M_LoadTRXModule(L, "sound.lua");
     M_LoadTRXModule(L, "music.lua");
+    M_LoadTRXModule(L, "rooms.lua");
     M_LoadTRXModule(L, "game.lua");
 }
 

--- a/src/libtrx/game/lua/console.c
+++ b/src/libtrx/game/lua/console.c
@@ -24,7 +24,7 @@ static int M_L_ConsoleLog(lua_State *const L)
         lua_call(L, 1, 1);
         const char *arg = lua_tostring(L, -1);
         lua_pop(L, 1);
-        msg = (i > 2) ? String_FormatStatic("%s, %s", msg, arg)
+        msg = (i > 2) ? String_FormatStatic("%s %s", msg, arg)
                       : String_FormatStatic("%s", arg);
     }
 

--- a/src/libtrx/game/lua/console.c
+++ b/src/libtrx/game/lua/console.c
@@ -28,7 +28,6 @@ static int M_L_ConsoleLog(lua_State *const L)
                       : String_FormatStatic("%s", arg);
     }
 
-    Console_LogEx("%s", msg);
     lua_Debug ar;
     const char *src = "?";
     const char *func = "?";
@@ -38,7 +37,7 @@ static int M_L_ConsoleLog(lua_State *const L)
         func = ar.name ? ar.name : "?";
         line = ar.currentline;
     }
-    Log_Message(log_level, src, line, func, "%s", msg);
+    Console_LogEx(log_level, src, line, func, "%s", msg);
     return 0;
 }
 

--- a/src/libtrx/game/lua/game.c
+++ b/src/libtrx/game/lua/game.c
@@ -73,6 +73,21 @@ static int M_L_GameLevelGetType(lua_State *const L)
     return 1;
 }
 
+static int M_L_GameLevelGetCurrentLevelTable(lua_State *const L)
+{
+    const GF_LEVEL *const lvl = GF_GetCurrentLevel();
+    lua_pushinteger(
+        L, lvl != nullptr ? GF_GetLevelTableType(lvl->type) : GFLT_UNKNOWN);
+    return 1;
+}
+
+static int M_L_GameLevelGetCurrentLevelIndex(lua_State *const L)
+{
+    const GF_LEVEL *const lvl = GF_GetCurrentLevel();
+    lua_pushinteger(L, lvl != nullptr ? lvl->num : -1);
+    return 1;
+}
+
 void LUA_CreateGame(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
@@ -92,6 +107,10 @@ void LUA_CreateGame(lua_State *const L)
     lua_setfield(L, -2, "get_level_path");
     lua_pushcfunction(L, M_L_GameLevelGetType);
     lua_setfield(L, -2, "get_level_type");
+    lua_pushcfunction(L, M_L_GameLevelGetCurrentLevelTable);
+    lua_setfield(L, -2, "get_current_level_table");
+    lua_pushcfunction(L, M_L_GameLevelGetCurrentLevelIndex);
+    lua_setfield(L, -2, "get_current_level_idx");
 
     lua_newtable(L);
     lua_pushinteger(L, GFLT_MAIN);

--- a/src/libtrx/game/lua/game.c
+++ b/src/libtrx/game/lua/game.c
@@ -1,0 +1,120 @@
+// Lua binding for game module
+#include "game/game_flow/common.h"
+#include "game/lua/common.h"
+#include "version.h"
+
+#include <lauxlib.h>
+
+// trxc.game.get_version() → int
+static int M_L_GameVersion(lua_State *const L)
+{
+    lua_pushinteger(L, g_TRVersion);
+    return 1;
+}
+
+// trxc.game.get_trx_version() → string
+static int M_L_TRXVersion(lua_State *const L)
+{
+    lua_pushstring(L, g_TRXVersion);
+    return 1;
+}
+
+// trxc.game.count_levels() → int
+static int M_L_GameCountLevels(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    lua_pushinteger(L, GF_GetLevelCount(table_type));
+    return 1;
+}
+
+// Level property getters
+static int M_L_GameLevelGetNum(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    const int32_t idx = luaL_checkinteger(L, 2);
+    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
+    lua_pushinteger(
+        L, lvl != nullptr ? GF_GetLevelOrdinalNumber(table_type, lvl) : 0);
+    return 1;
+}
+
+static int M_L_GameLevelGetName(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    const int32_t idx = luaL_checkinteger(L, 2);
+    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
+    if (lvl != nullptr && lvl->title != nullptr) {
+        lua_pushstring(L, lvl->title);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int M_L_GameLevelGetPath(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    const int32_t idx = luaL_checkinteger(L, 2);
+    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
+    if (lvl != nullptr && lvl->path != nullptr) {
+        lua_pushstring(L, lvl->path);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+static int M_L_GameLevelGetType(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    const int32_t idx = luaL_checkinteger(L, 2);
+    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
+    lua_pushinteger(L, lvl != nullptr ? lvl->type : 0);
+    return 1;
+}
+
+void LUA_CreateGame(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+
+    lua_pushcfunction(L, M_L_GameVersion);
+    lua_setfield(L, -2, "get_version");
+    lua_pushcfunction(L, M_L_TRXVersion);
+    lua_setfield(L, -2, "get_trx_version");
+    lua_pushcfunction(L, M_L_GameCountLevels);
+    lua_setfield(L, -2, "count_levels");
+    lua_pushcfunction(L, M_L_GameLevelGetNum);
+    lua_setfield(L, -2, "get_level_num");
+    lua_pushcfunction(L, M_L_GameLevelGetName);
+    lua_setfield(L, -2, "get_level_name");
+    lua_pushcfunction(L, M_L_GameLevelGetPath);
+    lua_setfield(L, -2, "get_level_path");
+    lua_pushcfunction(L, M_L_GameLevelGetType);
+    lua_setfield(L, -2, "get_level_type");
+
+    lua_newtable(L);
+    lua_pushinteger(L, GFLT_MAIN);
+    lua_setfield(L, -2, "MAIN");
+    lua_pushinteger(L, GFLT_CUTSCENES);
+    lua_setfield(L, -2, "CUTSCENES");
+    lua_pushinteger(L, GFLT_DEMOS);
+    lua_setfield(L, -2, "DEMOS");
+    lua_setfield(L, -2, "LevelTable");
+
+    lua_newtable(L);
+    lua_pushinteger(L, GFL_NORMAL);
+    lua_setfield(L, -2, "NORMAL");
+    lua_pushinteger(L, GFL_CUTSCENE);
+    lua_setfield(L, -2, "CUTSCENE");
+    lua_pushinteger(L, GFL_DEMO);
+    lua_setfield(L, -2, "DEMO");
+    lua_pushinteger(L, GFL_GYM);
+    lua_setfield(L, -2, "GYM");
+    lua_pushinteger(L, GFL_BONUS);
+    lua_setfield(L, -2, "BONUS");
+    lua_setfield(L, -2, "LevelType");
+
+    lua_setfield(L, -2, "game");
+    lua_pop(L, 1);
+}

--- a/src/libtrx/game/lua/items.c
+++ b/src/libtrx/game/lua/items.c
@@ -85,7 +85,7 @@ static int M_L_ItemGetRoom(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    lua_pushinteger(L, item->room_num);
+    lua_pushinteger(L, item->room_num + 1);
     return 1;
 }
 

--- a/src/libtrx/game/lua/lara.c
+++ b/src/libtrx/game/lua/lara.c
@@ -19,12 +19,32 @@ static int M_L_GetLaraItem(lua_State *const L)
     return 1;
 }
 
+// trxc.lara.get_exposure_bar() → int
+static int M_L_LaraGetExposureBar(lua_State *const L)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lua_pushinteger(L, lara->exposure_timer);
+    return 1;
+}
+
+// trxc.lara.set_exposure_bar(timer)
+static int M_L_LaraSetExposureBar(lua_State *const L)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->exposure_timer = luaL_checkinteger(L, 1);
+    return 0;
+}
+
 void LUA_CreateLara(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
     lua_newtable(L);
     lua_pushcfunction(L, M_L_GetLaraItem);
     lua_setfield(L, -2, "get_item");
+    lua_pushcfunction(L, M_L_LaraGetExposureBar);
+    lua_setfield(L, -2, "get_exposure_bar");
+    lua_pushcfunction(L, M_L_LaraSetExposureBar);
+    lua_setfield(L, -2, "set_exposure_bar");
     lua_setfield(L, -2, "lara");
     lua_pop(L, 1);
 }

--- a/src/libtrx/game/lua/rooms.c
+++ b/src/libtrx/game/lua/rooms.c
@@ -1,0 +1,52 @@
+#include "game/lua/common.h"
+#include "game/rooms/common.h"
+
+#include <lauxlib.h>
+
+// trxc.rooms.count() → int
+static int M_L_RoomsCount(lua_State *const L)
+{
+    lua_pushinteger(L, Room_GetCount());
+    return 1;
+}
+
+// trxc.rooms.get(index) → int (1-based) or nil
+static int M_L_RoomsGet(lua_State *const L)
+{
+    const int idx = luaL_checkinteger(L, 1);
+    printf("%d\n", idx);
+    const ROOM *const room = Room_Get(idx - 1);
+    if (room == nullptr) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, idx);
+    }
+    return 1;
+}
+
+// trxc.rooms.get_flags(index) → int or nil
+static int M_L_RoomGetFlags(lua_State *const L)
+{
+    const int idx = luaL_checkinteger(L, 1);
+    const ROOM *const room = Room_Get(idx - 1);
+    if (room == nullptr) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, room->flags);
+    }
+    return 1;
+}
+
+void LUA_CreateRooms(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+    lua_pushcfunction(L, M_L_RoomsCount);
+    lua_setfield(L, -2, "count");
+    lua_pushcfunction(L, M_L_RoomsGet);
+    lua_setfield(L, -2, "get");
+    lua_pushcfunction(L, M_L_RoomGetFlags);
+    lua_setfield(L, -2, "get_flags");
+    lua_setfield(L, -2, "rooms");
+    lua_pop(L, 1);
+}

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -82,6 +82,9 @@ ROOM *Room_Get(const int32_t room_num)
     if (m_Rooms == nullptr) {
         return nullptr;
     }
+    if (room_num < 0 || room_num >= Room_GetCount()) {
+        return nullptr;
+    }
     return &m_Rooms[room_num];
 }
 

--- a/src/libtrx/include/libtrx/game/console/common.h
+++ b/src/libtrx/include/libtrx/game/console/common.h
@@ -5,15 +5,12 @@
 
 #include <stdint.h>
 
-#define Console_Log(...)                                                       \
-    Console_LogEx(__VA_ARGS__);                                                \
-    LOG_INFO(__VA_ARGS__)
+#define Console_LogGeneric(level, ...)                                         \
+    Console_LogEx(level, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define Console_Log(...) Console_LogGeneric(LOG_LEVEL_INFO, __VA_ARGS__)
 #define Console_LogWarning(...)                                                \
-    Console_LogEx(__VA_ARGS__);                                                \
-    LOG_WARNING(__VA_ARGS__)
-#define Console_LogError(...)                                                  \
-    Console_LogEx(__VA_ARGS__);                                                \
-    LOG_ERROR(__VA_ARGS__)
+    Console_LogGeneric(LOG_LEVEL_WARNING, __VA_ARGS__)
+#define Console_LogError(...) Console_LogGeneric(LOG_LEVEL_ERROR, __VA_ARGS__)
 
 void Console_Init(void);
 void Console_Shutdown(void);
@@ -22,7 +19,9 @@ void Console_Open(void);
 void Console_Close(void);
 bool Console_IsOpened(void);
 
-void Console_LogEx(const char *fmt, ...);
+void Console_LogEx(
+    LOG_LEVEL level, const char *file, int line, const char *func,
+    const char *fmt, ...);
 void Console_Clear(void);
 COMMAND_RESULT Console_Eval(const char *cmdline);
 

--- a/src/libtrx/include/libtrx/game/game_flow/enum.h
+++ b/src/libtrx/include/libtrx/game/game_flow/enum.h
@@ -2,6 +2,7 @@
 
 typedef enum {
     GFLT_UNKNOWN = -1,
+    GFLT_TITLE,
     GFLT_MAIN,
     GFLT_CUTSCENES,
     GFLT_DEMOS,

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -232,6 +232,7 @@ sources = [
   'game/lua/lara.c',
   'game/lua/log.c',
   'game/lua/music.c',
+  'game/lua/rooms.c',
   'game/lua/sound.c',
   'game/math/trig.c',
   'game/math/util.c',

--- a/src/libtrx/meson.build
+++ b/src/libtrx/meson.build
@@ -227,6 +227,7 @@ sources = [
   'game/lua/config.c',
   'game/lua/console.c',
   'game/lua/events.c',
+  'game/lua/game.c',
   'game/lua/items.c',
   'game/lua/lara.c',
   'game/lua/log.c',


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Fixes corrupt strings logged by `TRX_ConsoleLog` and the family (double use of the same `__VA_ARGS__` is illegal)
- Adds `trx.lara.exposure_bar`, allowing builders to build manual interactions with the cold bar (resolves #4040) – I'd appreciate some testing of this
- Adds a new `trx.game` API
- Adds a new `trx.rooms` API
- Changes LUA logs to not emit `,` between multiple arguments – just a single space (similar to Python and LUA REPL which chooses `\t` instead – but tabulators are irrelevant for us)
- Simplifies lara item access from `trx.lara.get_item()` to `trx.lara.item`
- Fixes `trx.items.Item.room_num` using 0-indexing
- Internally, adds a new `GFLT_TITLE` table to be able to map `GF_CurrentLevel()` back to the title level (all FFI accessors use level table lookups)
