### PR TITLE
output: tweak alpha discard threshold

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -149,11 +149,11 @@ void main(void) {
         if (texColor.a <= 0.0) {
             discard;
         }
-        if (uDiscardAlpha && texColor.a < 0.9 && (gFlags & VERT_NO_ALPHA_DISCARD) == 0u) {
+        if (uDiscardAlpha && texColor.a < 0.99 && (gFlags & VERT_NO_ALPHA_DISCARD) == 0u) {
             discard;
         }
     } else {
-        if (uDiscardAlpha && texColor.a < 0.9 && (gFlags & VERT_NO_ALPHA_DISCARD) == 0u) {
+        if (uDiscardAlpha && texColor.a < 0.99 && (gFlags & VERT_NO_ALPHA_DISCARD) == 0u) {
             discard;
         }
         texColor.rgb *= texColor.a;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Bumped the cutoff threshold from 0.9 to 0.99 in response to #4083 as I noticed the results were poor in develop.
This shouldn't cause artifacts with anisotropic filtering or on nVidia cards.
