### PR TITLE
items/actions: use OG move angle for rolls

### DIFF
--- a/src/libtrx/game/items/actions/items.c
+++ b/src/libtrx/game/items/actions/items.c
@@ -8,7 +8,8 @@ static void M_Turn180(ITEM *const item)
 
     item->rot.x = -item->rot.x;
     item->rot.y += DEG_180;
-    if (item == Lara_GetItem()) {
+    if (item == Lara_GetItem()
+        && item->current_anim_state != LS(LS_ROLL_CONT)) {
         LARA_INFO *const lara = Lara_GetLaraInfo();
         lara->move_angle += DEG_180;
     }


### PR DESCRIPTION
Resolves #4094.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Keeps the original (wrong) `move_angle` for the OG roll - the bug should've been fixed before the demo was recorded😄 
