### PR TITLE
tr2/savegame: fix LIFT_INFO handling

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed a crash if trying to kill an enemy by name but there is no naming definition for that object
 - fixed ambient music not playing in demo levels (#4046, regression from 1.3)
 - fixed twists not adhering to original game movement (#4078, regression from 1.4)
+- fixed legacy saves in Opera House and Vegas crashing the game (#4103, regression from 1.5)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/tr2/game/savegame/savegame_legacy.c
+++ b/src/tr2/game/savegame/savegame_legacy.c
@@ -293,9 +293,12 @@ static void M_ReadItems(void)
             M_Read(item->data, sizeof(SKIDOO_INFO));
             break;
 
-        case O_LIFT:
-            M_Read(item->data, sizeof(LIFT_INFO));
+        case O_LIFT: {
+            LIFT_INFO *data = item->data;
+            data->start_height = M_ReadS32();
+            data->wait_time = M_ReadS32();
             break;
+        }
 
         default:
             break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

In version 1.5, `LIFT_INFO` changed size, but since we weren’t reading its members individually, the shift threw off the entire savegame layout and made the code read invalid data.

Resolves #4103.