### PR TITLE
output/sources/rooms: fix caustic cast

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed a crash in custom levels if a flip effect that expects to act on an item is used in a regular trigger (#4085)
 - fixed a crash if trying to kill an enemy by name but there is no naming definition for that object
 - fixed ambient music not playing in demo levels (#4046, regression from 4.13)
+- fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 4.10)
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed ambient music not playing in demo levels (#4046, regression from 1.3)
 - fixed twists not adhering to original game movement (#4078, regression from 1.4)
 - fixed legacy saves in Opera House and Vegas crashing the game (#4103, regression from 1.5)
+- fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 1.4)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/output/sources/rooms.c
+++ b/src/libtrx/game/output/sources/rooms.c
@@ -83,7 +83,7 @@ static int16_t M_ShadeCaustics(
                 [(room->mesh.num_vertices - vtx_idx) % WIBBLE_SIZE];
         source +=
             p->shade_table
-                [((uint8_t)Output_GetTimeInGame() + caustic) % WIBBLE_SIZE];
+                [((int32_t)Output_GetTimeInGame() + caustic) % WIBBLE_SIZE];
         CLAMP(source, 0, SHADE_MAX);
     } else {
         CLAMPG(source, SHADE_MAX);


### PR DESCRIPTION
Resolves #4109.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Tested with Lost Valley example running for more than 25 minutes at 2 x speed.
