### PR TITLE
tr1/savegame: fix reading legacy UB saves

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed a crash if trying to kill an enemy by name but there is no naming definition for that object
 - fixed ambient music not playing in demo levels (#4046, regression from 4.13)
 - fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 4.10)
+- fixed legacy UB crashing the game (#4113, regression from 4.12)
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/tr1/game/savegame/savegame_legacy.c
+++ b/src/tr1/game/savegame/savegame_legacy.c
@@ -355,7 +355,7 @@ static void M_ReadResumeInfo(RESUME_INFO *const resume)
 static void M_ReadResumeInfos(MYFILE *const fp)
 {
     const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
-    for (int32_t i = 0; i < 22; i++) {
+    for (int32_t i = 0; i < GF_GetLevelTable(GFLT_MAIN)->count; i++) {
         if (i < level_table->count) {
             const GF_LEVEL *const level = &level_table->levels[i];
             M_ReadResumeInfo(Savegame_GetCurrentInfo(level));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4113.