### PR TITLE
option/passport: add restart level feature to tr2

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added LUA scripting engine
     Supports basic events, item interactions, teleporting and much more.
     See [the documentation](../06-lua) for details.
+- added restart level option when Lara dies (#1555)
 - added a game flow option for cold water in custom levels, similar to TR3 (#4021)
 - added a splash effect when Lara jumps in wading depth water, similar to TR3+ (#3975)
 - added bounding box debugging (`/debug 1` or `/set debug-cuboids 1`)

--- a/docs/tr2/IMPROVEMENTS.md
+++ b/docs/tr2/IMPROVEMENTS.md
@@ -30,6 +30,7 @@
 - added options to quiet or mute music while underwater
 - added combined support for The Golden Mask
 - added NG+, Japanese, and Japanese NG+ game mode options to the New Game page in the passport
+- added ability to restart level on death
 - added graphics effects, waterfalls to the savegame so that they now persist on load
 - added a pickup overlay display when Lara pulls the dagger from the dragon
 - added an option to use Lara's neutral jump-twist from early TR1 betas

--- a/src/libtrx/game/option/passport.c
+++ b/src/libtrx/game/option/passport.c
@@ -381,7 +381,11 @@ static void M_ShowSaves(INVENTORY_ITEM *const inv_item)
         UI_SaveSlotDialog_Control(m_Priv.save_slot.state);
     switch (choice.action) {
     case UI_SAVE_SLOT_DIALOG_NO_CHOICE:
-        if (!M_IMMEDIATE) {
+        if (M_IMMEDIATE) {
+            // Make sure it's not possible to confirm empty slots
+            g_Input.menu_confirm = false;
+            g_InputDB.menu_confirm = false;
+        } else {
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
         }

--- a/src/libtrx/game/option/passport.c
+++ b/src/libtrx/game/option/passport.c
@@ -173,7 +173,7 @@ static void M_Close(INVENTORY_ITEM *const inv_item)
 static void M_SoftClose(INVENTORY_ITEM *const inv_item)
 {
     if (g_Inv_Mode == INV_DEATH_MODE) {
-        if (m_Priv.mode != M_MODE_BROWSE) {
+        if (!M_IMMEDIATE && m_Priv.mode != M_MODE_BROWSE) {
             m_Priv.mode = M_MODE_BROWSE;
         }
         g_Input = (INPUT_STATE) {};

--- a/src/libtrx/game/option/passport.c
+++ b/src/libtrx/game/option/passport.c
@@ -214,15 +214,7 @@ static void M_DeterminePages(void)
     case INV_TITLE_MODE:
         m_Priv.mode = M_IMMEDIATE ? M_MODE_PICK_OPTION : M_MODE_BROWSE;
         M_SetPage(PAGE_1, PASSPORT_ROLE_LOAD_GAME, has_saves);
-#if TR_VERSION == 1
         M_SetPage(PAGE_2, PASSPORT_ROLE_NEW_GAME, true);
-#else
-        M_SetPage(
-            PAGE_2,
-            g_GameFlow.play_any_level ? PASSPORT_ROLE_SELECT_LEVEL
-                                      : PASSPORT_ROLE_NEW_GAME,
-            true);
-#endif
         M_SetPage(PAGE_3, PASSPORT_ROLE_EXIT_GAME, true);
         break;
 
@@ -269,19 +261,14 @@ static void M_DeterminePages(void)
         ASSERT_FAIL();
     }
 
-    // Disable saves in gym, restart
+    // Disable saves in gym and save crystals mode.
+    // Offer New Game or Restart instead.
     for (M_PAGE_NUMBER i = PAGE_1; i < PAGE_COUNT; i++) {
         if (m_Priv.pages[i].role != PASSPORT_ROLE_SAVE_GAME) {
             continue;
         }
         if (Game_IsInGym()) {
-#if TR_VERSION == 1
             m_Priv.pages[i].role = PASSPORT_ROLE_NEW_GAME;
-#else
-            m_Priv.pages[i].role = g_GameFlow.play_any_level
-                ? PASSPORT_ROLE_SELECT_LEVEL
-                : PASSPORT_ROLE_NEW_GAME;
-#endif
         } else if (
             g_Config.gameplay.enable_save_crystals
             && g_Inv_Mode != INV_SAVE_CRYSTAL_MODE) {
@@ -292,6 +279,17 @@ static void M_DeterminePages(void)
             }
         }
     }
+
+// If play any level is enabled, replace New Game with Play Any Level.
+#if TR_VERSION == 2
+    if (g_GameFlow.play_any_level) {
+        for (M_PAGE_NUMBER i = PAGE_1; i < PAGE_COUNT; i++) {
+            if (m_Priv.pages[i].role == PASSPORT_ROLE_NEW_GAME) {
+                m_Priv.pages[i].role = PASSPORT_ROLE_SELECT_LEVEL;
+            }
+        }
+    }
+#endif
 
     // Select first available page
     m_Priv.active_page = PAGE_UNDETERMINED;

--- a/src/libtrx/game/option/passport.c
+++ b/src/libtrx/game/option/passport.c
@@ -450,13 +450,13 @@ static void M_SaveGame(INVENTORY_ITEM *const inv_item)
 static void M_NewGame(INVENTORY_ITEM *const inv_item)
 {
     M_ChangePageTextContent(GS(PASSPORT_NEW_GAME));
-    m_Priv.selection = GF_GetFirstLevel()->num;
     if (m_Priv.mode == M_MODE_BROWSE) {
         if (g_InputDB.menu_confirm
             && (g_Config.gameplay.enable_game_modes
                 || g_Config.profile.new_game_plus_unlock)) {
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
+            m_Priv.selection = GF_GetFirstLevel()->num;
             m_Priv.mode = M_MODE_PICK_OPTION;
         }
     } else if (m_Priv.mode == M_MODE_PICK_OPTION) {

--- a/src/libtrx/game/option/passport.c
+++ b/src/libtrx/game/option/passport.c
@@ -199,8 +199,10 @@ static void M_SetPage(
 
 static void M_DeterminePages(void)
 {
-    const bool has_saves =
-        Savegame_GetTotalCount() > 0 && Savegame_GetSlotCount() > 0;
+    const bool can_restart = Savegame_RestartAvailable(Savegame_GetBoundSlot());
+    const bool saving_enabled =
+        Savegame_GetSlotCount() > 0 && !g_GameFlow.load_save_disabled;
+    const bool has_saves = Savegame_GetTotalCount() > 0 && saving_enabled;
 
     m_Priv.selection = -1;
     m_Priv.outer_selection = -1;
@@ -226,46 +228,40 @@ static void M_DeterminePages(void)
 
     case INV_GAME_MODE:
         m_Priv.mode = M_IMMEDIATE ? M_MODE_PICK_OPTION : M_MODE_BROWSE;
-        M_SetPage(PAGE_1, PASSPORT_ROLE_LOAD_GAME, has_saves);
-        M_SetPage(PAGE_2, PASSPORT_ROLE_SAVE_GAME, true);
+        if (!saving_enabled) {
+            M_SetPage(PAGE_2, PASSPORT_ROLE_RESTART, can_restart);
+        } else {
+            M_SetPage(PAGE_1, PASSPORT_ROLE_LOAD_GAME, has_saves);
+            M_SetPage(PAGE_2, PASSPORT_ROLE_SAVE_GAME, true);
+        }
         M_SetPage(PAGE_3, PASSPORT_ROLE_EXIT_TITLE, true);
         break;
 
     case INV_LOAD_MODE:
         m_Priv.mode = M_MODE_PICK_OPTION;
-        if (has_saves) {
-            M_SetPage(
-                PAGE_1,
-                TR_VERSION == 2 || Savegame_GetSlotCount() > 0
-                    ? PASSPORT_ROLE_LOAD_GAME
-                    : PASSPORT_ROLE_RESTART,
-                true);
+        if (!saving_enabled) {
+            M_SetPage(PAGE_2, PASSPORT_ROLE_RESTART, can_restart);
+        } else if (has_saves) {
+            M_SetPage(PAGE_1, PASSPORT_ROLE_LOAD_GAME, true);
         } else {
-            M_SetPage(
-                PAGE_2,
-                TR_VERSION == 2 || Savegame_GetSlotCount() > 0
-                    ? PASSPORT_ROLE_SAVE_GAME
-                    : PASSPORT_ROLE_RESTART,
-                true);
+            M_SetPage(PAGE_2, PASSPORT_ROLE_SAVE_GAME, true);
         }
         break;
 
     case INV_SAVE_MODE:
     case INV_SAVE_CRYSTAL_MODE:
         m_Priv.mode = M_MODE_PICK_OPTION;
-        M_SetPage(PAGE_2, PASSPORT_ROLE_SAVE_GAME, true);
-        if (g_Config.gameplay.enable_save_crystals) {
-            // TODO: remove me after implementing restart level in TR2
-            M_SetPage(PAGE_3, PASSPORT_ROLE_EXIT_TITLE, true);
+        if (!saving_enabled) {
+            M_SetPage(PAGE_2, PASSPORT_ROLE_RESTART, can_restart);
+        } else {
+            M_SetPage(PAGE_2, PASSPORT_ROLE_SAVE_GAME, true);
         }
         break;
 
     case INV_DEATH_MODE:
         m_Priv.mode = M_IMMEDIATE ? M_MODE_PICK_OPTION : M_MODE_BROWSE;
         M_SetPage(PAGE_1, PASSPORT_ROLE_LOAD_GAME, has_saves);
-        if (TR_VERSION == 1) {
-            M_SetPage(PAGE_2, PASSPORT_ROLE_RESTART, true);
-        }
+        M_SetPage(PAGE_2, PASSPORT_ROLE_RESTART, can_restart);
         M_SetPage(PAGE_3, PASSPORT_ROLE_EXIT_TITLE, true);
         break;
 
@@ -273,12 +269,12 @@ static void M_DeterminePages(void)
         ASSERT_FAIL();
     }
 
-    // disable saves in gym, restart
+    // Disable saves in gym, restart
     for (M_PAGE_NUMBER i = PAGE_1; i < PAGE_COUNT; i++) {
         if (m_Priv.pages[i].role != PASSPORT_ROLE_SAVE_GAME) {
             continue;
         }
-        if (Game_IsInGym() || Savegame_GetSlotCount() <= 0) {
+        if (Game_IsInGym()) {
 #if TR_VERSION == 1
             m_Priv.pages[i].role = PASSPORT_ROLE_NEW_GAME;
 #else
@@ -289,7 +285,7 @@ static void M_DeterminePages(void)
         } else if (
             g_Config.gameplay.enable_save_crystals
             && g_Inv_Mode != INV_SAVE_CRYSTAL_MODE) {
-            if (TR_VERSION == 1) {
+            if (can_restart) {
                 m_Priv.pages[i].role = PASSPORT_ROLE_RESTART;
             } else {
                 m_Priv.pages[i].available = false;
@@ -297,17 +293,7 @@ static void M_DeterminePages(void)
         }
     }
 
-    // disable save & load
-    if (g_GameFlow.load_save_disabled) {
-        for (M_PAGE_NUMBER i = PAGE_1; i < PAGE_COUNT; i++) {
-            if (m_Priv.pages[i].role == PASSPORT_ROLE_LOAD_GAME
-                || m_Priv.pages[i].role == PASSPORT_ROLE_SAVE_GAME) {
-                m_Priv.pages[i].available = false;
-            }
-        }
-    }
-
-    // select first available page
+    // Select first available page
     m_Priv.active_page = PAGE_UNDETERMINED;
     for (M_PAGE_NUMBER i = PAGE_1; i < PAGE_COUNT; i++) {
         if (m_Priv.pages[i].available) {
@@ -510,11 +496,6 @@ static void M_NewGame(INVENTORY_ITEM *const inv_item)
 static void M_Restart(INVENTORY_ITEM *const inv_item)
 {
     M_ChangePageTextContent(GS(PASSPORT_RESTART_LEVEL));
-
-    if (!Savegame_RestartAvailable(Savegame_GetBoundSlot())) {
-        inv_item->anim_direction = 1;
-        g_InputDB = (INPUT_STATE) { .menu_right = 1 };
-    }
 }
 
 static void M_ShowPage(INVENTORY_ITEM *const inv_item)

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -55,6 +55,7 @@ static bool M_FillSlot(
     const SAVEGAME_STRATEGY strategy, const int32_t slot_num,
     const char *const path)
 {
+    ASSERT(slot_num >= 0);
     SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
     bool result = false;
     MYFILE *const fp = File_Open(path, FILE_OPEN_READ);
@@ -76,6 +77,7 @@ static bool M_TryFillSlot(
     const SAVEGAME_STRATEGY strategy, const int32_t slot_num,
     const char *const path)
 {
+    ASSERT(slot_num >= 0);
     SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
     if (strategy.format <= savegame_info->format) {
         return true;
@@ -256,11 +258,17 @@ int32_t Savegame_GetBoundSlot(void)
 
 int32_t Savegame_GetLevelNumber(const int32_t slot_num)
 {
+    if (slot_num == -1) {
+        return -1;
+    }
     return m_SavegameInfo[slot_num].level_num;
 }
 
 bool Savegame_IsSlotFree(const int32_t slot_num)
 {
+    if (slot_num < 0) {
+        return -1;
+    }
     return m_SavegameInfo[slot_num].level_num == -1;
 }
 
@@ -277,20 +285,6 @@ int32_t Savegame_GetTotalCount(void)
 int32_t Savegame_GetMostRecentlyCreatedSlot(void)
 {
     return m_MostRecentlyCreatedSlot;
-}
-
-bool Savegame_RestartAvailable(const int32_t slot_num)
-{
-#if TR_VERSION == 1
-    if (slot_num == -1) {
-        return true;
-    }
-
-    const SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
-    return savegame_info->features.restart;
-#else
-    return false;
-#endif
 }
 
 void Savegame_RegisterStrategy(const SAVEGAME_STRATEGY strategy)
@@ -362,6 +356,7 @@ void Savegame_SetCurrentInfo(const int32_t current_slot, const int32_t src_slot)
 
 const SAVEGAME_INFO *Savegame_GetSavegameInfo(const int32_t slot_num)
 {
+    ASSERT(slot_num >= 0);
     return &m_SavegameInfo[slot_num];
 }
 
@@ -730,7 +725,6 @@ bool Savegame_Save(const int32_t slot_idx)
         if (was_slot_empty) {
             m_SavedGames++;
         }
-        Savegame_HighlightNewestSlot();
     } else {
         m_SaveCounter--;
     }
@@ -790,8 +784,9 @@ bool Savegame_UpdateDeathCounters(
     return ret;
 }
 
-bool Savegame_LoadOnlyResumeInfo(int32_t slot_num)
+bool Savegame_LoadOnlyResumeInfo(const int32_t slot_num)
 {
+    ASSERT(slot_num >= 0);
     const SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
     ASSERT(savegame_info->format != SAVEGAME_FORMAT_INVALID);
 
@@ -812,4 +807,13 @@ bool Savegame_LoadOnlyResumeInfo(int32_t slot_num)
 
     Savegame_SetInitialVersion(m_SavegameInfo[slot_num].initial_version);
     return ret;
+}
+
+bool Savegame_RestartAvailable(const int32_t slot_num)
+{
+    if (slot_num == -1) {
+        return true;
+    }
+    const SAVEGAME_INFO *const savegame_info = &m_SavegameInfo[slot_num];
+    return savegame_info->features.restart;
 }

--- a/src/libtrx/include/libtrx/game/savegame/common.h
+++ b/src/libtrx/include/libtrx/game/savegame/common.h
@@ -64,7 +64,6 @@ void Savegame_SetDefaultStats(const GF_LEVEL *level, STATS_COMMON stats);
 STATS_COMMON Savegame_GetDefaultStats(const GF_LEVEL *level);
 
 extern int32_t Savegame_GetSlotCount(void);
-extern void Savegame_HighlightNewestSlot(void);
 
 #define REGISTER_SAVEGAME_STRATEGY(strategy_)                                  \
     __attribute__((__constructor__)) static void M_Register(void)              \

--- a/src/tr1/game/game/game.c
+++ b/src/tr1/game/game/game.c
@@ -47,11 +47,6 @@ void Game_ProcessInput(void)
         Lara_UseItem(O_LARGE_MEDIPACK_OPTION);
     }
 
-    if (g_GameFlow.load_save_disabled) {
-        g_Input.save = 0;
-        g_Input.load = 0;
-    }
-
     if (g_Config.input.enable_buffering && Game_IsPlaying()) {
         if (g_Input.toggle_bilinear_filter) {
             FRAME_BUFFER(toggle_bilinear_filter);
@@ -140,7 +135,8 @@ GF_COMMAND Game_Control(const bool demo_mode)
         if (g_Camera.type == CAM_CINEMATIC) {
             g_OverlayFlag = 0;
         } else if (g_OverlayFlag > 0) {
-            if (g_GameFlow.load_save_disabled) {
+            if (g_GameFlow.lockout_option_ring
+                && g_GameFlow.load_save_disabled) {
                 g_OverlayFlag = 0;
             } else if (g_Input.save) {
                 g_OverlayFlag = -2;

--- a/src/tr1/game/savegame/savegame.c
+++ b/src/tr1/game/savegame/savegame.c
@@ -7,8 +7,3 @@ int32_t Savegame_GetSlotCount(void)
 {
     return g_Config.gameplay.maximum_save_slots;
 }
-
-void Savegame_HighlightNewestSlot(void)
-{
-    g_Passport.select_slot = Savegame_GetMostRecentlyCreatedSlot();
-}

--- a/src/tr1/game/shell/common.c
+++ b/src/tr1/game/shell/common.c
@@ -65,7 +65,6 @@ void Shell_HandleConfigChange(const CONFIG *const old, const CONFIG *const new)
         Savegame_Shutdown();
         Savegame_Init();
         Savegame_ScanSavedGames();
-        Savegame_HighlightNewestSlot();
     }
 #undef L_CHANGED
 }
@@ -101,7 +100,6 @@ int32_t Shell_Main(const SHELL_ARGS *args)
 
     Savegame_Init();
     Savegame_ScanSavedGames();
-    Savegame_HighlightNewestSlot();
 
     // Execute global Lua script if provided
     if (g_GameFlow.main_script_path != nullptr) {

--- a/src/tr2/game/game.c
+++ b/src/tr2/game/game.c
@@ -111,7 +111,8 @@ GF_COMMAND Game_Control(const bool demo_mode)
          || g_OverlayFlag <= 0)
         && lara->death_timer == 0 && !lara->extra_anim) {
         if (g_OverlayFlag > 0) {
-            if (g_GameFlow.load_save_disabled) {
+            if (g_GameFlow.lockout_option_ring
+                && g_GameFlow.load_save_disabled) {
                 g_OverlayFlag = 0;
             } else if (g_Input.save) {
                 g_OverlayFlag = -2;
@@ -180,11 +181,6 @@ void Game_ProcessInput(void)
     }
     if (g_InputDB.use_big_medi && Inv_RequestItem(O_LARGE_MEDIPACK_OPTION)) {
         Lara_UseItem(O_LARGE_MEDIPACK_OPTION);
-    }
-
-    if (g_GameFlow.load_save_disabled) {
-        g_Input.save = 0;
-        g_Input.load = 0;
     }
 
     if (g_InputDB.toggle_ui) {

--- a/src/tr2/game/savegame/common.c
+++ b/src/tr2/game/savegame/common.c
@@ -7,7 +7,3 @@ int32_t Savegame_GetSlotCount(void)
 {
     return MAX_SAVE_SLOTS;
 }
-
-void Savegame_HighlightNewestSlot(void)
-{
-}

--- a/src/tr2/game/savegame/savegame_bson.c
+++ b/src/tr2/game/savegame/savegame_bson.c
@@ -85,7 +85,7 @@ static bool M_FillInfo(MYFILE *const fp, SAVEGAME_INFO *const info)
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER));
     info->initial_version = header.initial_version;
-    info->features.restart = false;
+    info->features.restart = true;
     info->features.select_level = false;
 
     File_Skip(fp, header.compressed_size);

--- a/src/tr2/game/shell/common.c
+++ b/src/tr2/game/shell/common.c
@@ -115,7 +115,6 @@ int32_t Shell_Main(const SHELL_ARGS *args)
     Savegame_Init();
     Savegame_InitCurrentInfo();
     Savegame_ScanSavedGames();
-    Savegame_HighlightNewestSlot();
 
     Level_Init();
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds restart level functionality to TR2.
Resolves #1555.

Affected passport pages:
- death mode, second page, TR2 only
- load mode, second page, TR2 only, when no saves
- quick save mode, second page, TR2 only, with crystals mode enabled