### PR TITLE
objects/movable_block: test pushing through non-portals

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -35,6 +35,7 @@
 - changed the `ambient_tracks` property to be only available on the root level
 - fixed missing footstep sound effects when Lara climbs off a ladder and when she finishes a handstand (#4030)
 - fixed a crash in custom levels if a flip effect that expects to act on an item is used in a regular trigger (#4085)
+- fixed Lara being able to push blocks through toggle opacity 1 portals (#4129)
 - fixed a crash if trying to kill an enemy by name but there is no naming definition for that object
 - fixed ambient music not playing in demo levels (#4046, regression from 4.13)
 - fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 4.10)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed twists not adhering to original game movement (#4078, regression from 1.4)
 - fixed legacy saves in Opera House and Vegas crashing the game (#4103, regression from 1.5)
 - fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 1.4)
+- fixed Lara being able to push blocks through toggle opacity 1 portals (#4129, regression from 1.5)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -503,6 +503,13 @@ static void M_Collision(
             return;
         }
 
+        int16_t room_num = lara_item->room_num;
+        Room_GetSector(
+            item->pos.x, item->pos.y - STEP_L / 2, item->pos.z, &room_num);
+        if (room_num != item->room_num) {
+            return;
+        }
+
         switch (quadrant) {
         case DIR_NORTH:
             lara_item->pos.z = ROUND_TO_SECTOR(lara_item->pos.z);


### PR DESCRIPTION
Resolves #4129.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara being able to push a block that is on the other side of a visibility portal i.e. one that will be included in Lara's `M_ObjectCollision` checks, but not actually interactable.
