### PR TITLE
cmd/debug: accept optional option name

### DIFF
--- a/docs/02-COMMANDS.md
+++ b/docs/02-COMMANDS.md
@@ -92,12 +92,15 @@ whichever key you have bound, and not include it as part of the command itself.
 
 - `/debug on`  
   `/debug off`  
+  `/debug {option} on`  
+  `/debug {option} off`  
   Toggles debug mode, turning your screen into a glorious display of dev scribbles.
   - floor triggers - enemy skips incoming!
   - room portals - wait, there are _how_ many rooms?!
   - room clip rectangles – the source of developers nightmares.
   - object mesh spheres - see hitboxes in their natural habitat.
   - Lara's position and animation details - nerdy stats, you've gotta love them.
+  - bounding boxes – to marvel at the collision code.
 
 - `/speed`  
   `/speed {num}`  

--- a/docs/03-MIGRATING.md
+++ b/docs/03-MIGRATING.md
@@ -13,6 +13,7 @@ title: Migrating levels
     became hidden player settings. To change them, put them in the
     `enforced_config` section. List of the affected settings:
     - `demo_delay`
+    - `enable_killer_pushblocks`
 
 ### Version 4.13 to 4.14
 
@@ -93,6 +94,7 @@ title: Migrating levels
     - `play_any_level`
     - `demo_delay`
     - `cheat_keys`
+    - `enable_killer_pushblocks`
 2. **Removed game flow settings**
     The following game flow features were removed and are no longer available:
     - `cmd_init`

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -16,14 +16,15 @@
     - `flow.load_save_disabled`
     - `flow.play_any_level`
     - `flow.cheat_keys`
-- changed the following game flow options to become hidden settings (available via LUA and the `/set` command):
-    - `flow.demo_delay`
-    - `gameplay.enable_killer_pushblocks`
-- changed Select Level and Story So Far features placement to the New Game menu
 - improved bilinear filtering for smoother edge blending when multiple objects overlap in depth
 - improved ricochets placement
     - fixed dart ricochets being placed mid-air (#4063)
     - fixed ricochets not showing on slopes
+- changed the `/debug` command to accept optional option name argument (for example: `/debug pos 1`)
+- changed the following game flow options to become hidden settings (available via LUA and the `/set` command):
+    - `flow.demo_delay`
+    - `gameplay.enable_killer_pushblocks`
+- changed Select Level and Story So Far features placement to the New Game menu
 - changed dart emitters and disc emitters to have separate slots (so with catalogs, both can be used in the same level simultaneously)
 - changed the FOV default increment from 10 to 5 (#4026)
 - changed the bar appearance labels to better align with expectations (#4025)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -22,6 +22,7 @@
 - improved ricochets placement
     - fixed disc ricochets being placed inside walls (#4063)
     - fixed ricochets not showing on slopes
+- changed the `/debug` command to accept optional option name argument (for example: `/debug pos 1`)
 - changed the following game flow options to become hidden settings (available via LUA and the `/set` command):
     - `flow.lockout_option_ring`
     - `flow.load_save_disabled`

--- a/src/libtrx/game/console/cmd/config.c
+++ b/src/libtrx/game/console/cmd/config.c
@@ -87,6 +87,33 @@ static const CONFIG_OPTION *M_GetOptionFromKey(const char *const key)
     return result;
 }
 
+// Builds a source list of all options and returns fuzzy-match results.
+// Caller must free the result vector with Vector_Free().
+static VECTOR *M_GetOptionsFuzzy(const char *const key)
+{
+    VECTOR *source = Vector_Create(sizeof(STRING_FUZZY_SOURCE));
+
+    for (const CONFIG_OPTION *option = Config_GetOptionMap();
+         option->name != nullptr; option++) {
+        STRING_FUZZY_SOURCE source_item = {
+            .key = (const char *)Console_Cmd_Config_NormalizeKey(option->name),
+            .value = (void *)option,
+            .weight = 1,
+        };
+        Vector_Add(source, &source_item);
+    }
+
+    VECTOR *matches = String_FuzzyMatch(key, source);
+
+    for (int32_t i = 0; i < source->count; i++) {
+        const STRING_FUZZY_SOURCE *const source_item = Vector_Get(source, i);
+        Memory_Free((char *)source_item->key);
+    }
+
+    Vector_Free(source);
+    return matches;
+}
+
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
     COMMAND_RESULT result = CR_BAD_INVOCATION;
@@ -232,6 +259,11 @@ COMMAND_RESULT Console_Cmd_Config_Helper(
 cleanup:
     Memory_FreePointer(&normalized_name);
     return result;
+}
+
+VECTOR *Console_Cmd_Config_GetOptionsFromKey(const char *const key)
+{
+    return M_GetOptionsFuzzy(key);
 }
 
 REGISTER_CONSOLE_COMMAND("set", M_Entrypoint, GS_ID(CONSOLE_HELP_SET))

--- a/src/libtrx/game/console/cmd/debug.c
+++ b/src/libtrx/game/console/cmd/debug.c
@@ -6,61 +6,143 @@
 #include "memory.h"
 #include "strings.h"
 
-static bool *const m_AllOptions[] = {
-    &g_Config.debug.enable_debug_portals,
-    &g_Config.debug.enable_debug_room_clip,
-    &g_Config.debug.enable_debug_triggers,
-    &g_Config.debug.enable_debug_spheres,
-    &g_Config.debug.enable_debug_cuboids,
-    &g_Config.debug.enable_debug_pos,
-    nullptr,
+typedef struct {
+    bool *target;
+    const CONFIG_OPTION *option;
+} DEBUG_OPTION_ENTRY;
+
+static DEBUG_OPTION_ENTRY m_AllOptions[] = {
+    { &g_Config.debug.enable_debug_portals, nullptr },
+    { &g_Config.debug.enable_debug_room_clip, nullptr },
+    { &g_Config.debug.enable_debug_triggers, nullptr },
+    { &g_Config.debug.enable_debug_spheres, nullptr },
+    { &g_Config.debug.enable_debug_cuboids, nullptr },
+    { &g_Config.debug.enable_debug_pos, nullptr },
+    { nullptr, nullptr }
 };
 
-static void M_Toggle(const bool enable)
+static void M_InitOptions(void)
 {
-    for (int32_t i = 0; m_AllOptions[i] != nullptr; i++) {
-        void *const target = m_AllOptions[i];
-        const CONFIG_OPTION *const option =
-            Console_Cmd_Config_GetOptionFromTarget(target);
-        char *const name = Console_Cmd_Config_NormalizeKey(option->name);
-        *(bool *)target = enable;
-        const char *const value_str = Config_GetOptionValueAsString(option);
-        ASSERT(value_str != nullptr);
-        Console_Log(GS(OSD_CONFIG_OPTION_SET), name, value_str);
-        Memory_Free(name);
+    for (int32_t i = 0; m_AllOptions[i].target; i++) {
+        m_AllOptions[i].option =
+            Console_Cmd_Config_GetOptionFromTarget(m_AllOptions[i].target);
+    }
+}
+
+static VECTOR *M_BuildMatches(const char *const key)
+{
+    VECTOR *const matches = Console_Cmd_Config_GetOptionsFromKey(key);
+    VECTOR *const filtered = Vector_Create(sizeof(STRING_FUZZY_MATCH));
+
+    for (int32_t i = 0; i < matches->count; i++) {
+        const STRING_FUZZY_MATCH *const match = Vector_Get(matches, i);
+        const CONFIG_OPTION *const option = match->value;
+        for (int32_t j = 0; m_AllOptions[j].target; j++) {
+            if (option == m_AllOptions[j].option) {
+                Vector_Add(filtered, match);
+                break;
+            }
+        }
+    }
+
+    Vector_Free(matches);
+    return filtered;
+}
+
+static void M_LogOption(const CONFIG_OPTION *const option)
+{
+    char *const name = Console_Cmd_Config_NormalizeKey(option->name);
+    Console_Log(
+        GS(OSD_CONFIG_OPTION_SET), name, Config_GetOptionValueAsString(option));
+    Memory_Free(name);
+}
+
+static void M_ShowOption(const CONFIG_OPTION *const option)
+{
+    char *const name = Console_Cmd_Config_NormalizeKey(option->name);
+    Console_Log(
+        GS(OSD_CONFIG_OPTION_GET), name, Config_GetOptionValueAsString(option));
+    Memory_Free(name);
+}
+
+static void M_UpdateOption(const CONFIG_OPTION *const option, const bool enable)
+{
+    *(bool *)option->target = enable;
+    M_LogOption(option);
+}
+
+static void M_UpdateAll(const bool enable)
+{
+    for (int32_t i = 0; m_AllOptions[i].target != nullptr; i++) {
+        M_UpdateOption(m_AllOptions[i].option, enable);
     }
 }
 
 static void M_ShowStatus(void)
 {
-    for (int32_t i = 0; m_AllOptions[i] != nullptr; i++) {
-        void *const target = m_AllOptions[i];
-        const CONFIG_OPTION *const option =
-            Console_Cmd_Config_GetOptionFromTarget(target);
-        char *const name = Console_Cmd_Config_NormalizeKey(option->name);
-        const char *const value_str = Config_GetOptionValueAsString(option);
-        ASSERT(value_str != nullptr);
-        Console_Log(GS(OSD_CONFIG_OPTION_GET), name, value_str);
-        Memory_Free(name);
+    for (int32_t i = 0; m_AllOptions[i].target != nullptr; i++) {
+        M_ShowOption(m_AllOptions[i].option);
     }
 }
 
-static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *ctx)
 {
-    if (String_Match(ctx->args, "^(on|true|1)$")) {
-        M_Toggle(true);
-        Config_Update();
-        return CR_SUCCESS;
-    } else if (String_Match(ctx->args, "^(off|false|0)$")) {
-        M_Toggle(false);
-        Config_Update();
-        return CR_SUCCESS;
-    } else if (String_IsEmpty(ctx->args)) {
+    if (m_AllOptions[0].option == nullptr) {
+        M_InitOptions();
+    }
+
+    if (String_IsEmpty(ctx->args)) {
         M_ShowStatus();
         return CR_SUCCESS;
-    } else {
+    }
+
+    char *args = Memory_DupStr(ctx->args);
+    char *space = strchr(args, ' ');
+    char *key = args;
+    char *val = nullptr;
+
+    if (space) {
+        *space = '\0';
+        val = space + 1;
+    }
+    if (val != nullptr && strchr(val, ' ') != nullptr) {
+        Memory_Free(args);
         return CR_BAD_INVOCATION;
     }
+
+    bool use_set = false;
+    bool explicit_enable = false;
+    if (val == nullptr && String_ParseBool(key, &explicit_enable)) {
+        M_UpdateAll(explicit_enable);
+        Config_Update();
+        Memory_Free(args);
+        return CR_SUCCESS;
+    } else if (val != nullptr && String_ParseBool(val, &explicit_enable)) {
+        use_set = true;
+    } else if (val != nullptr) {
+        Memory_Free(args);
+        return CR_BAD_INVOCATION;
+    }
+
+    VECTOR *const matches = M_BuildMatches(key);
+    if (!matches->count) {
+        Console_LogError(GS(OSD_CONFIG_OPTION_UNKNOWN_OPTION), key);
+        Vector_Free(matches);
+        Memory_Free(args);
+        return CR_FAILURE;
+    }
+
+    for (int32_t i = 0; i < matches->count; i++) {
+        const STRING_FUZZY_MATCH *const match = Vector_Get(matches, i);
+        const CONFIG_OPTION *const option = match->value;
+        M_UpdateOption(
+            option, use_set ? explicit_enable : !*(bool *)option->target);
+    }
+
+    Config_Update();
+    Vector_Free(matches);
+    Memory_Free(args);
+    return CR_SUCCESS;
 }
 
 REGISTER_CONSOLE_COMMAND("debug", M_Entrypoint, GS_ID(CONSOLE_HELP_DEBUG))

--- a/src/libtrx/include/libtrx/game/console/cmd/config.h
+++ b/src/libtrx/include/libtrx/game/console/cmd/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../../config/option.h"
+#include "../../../vector.h"
 #include "../common.h"
 
 #include <stddef.h>
@@ -8,7 +9,13 @@
 char *Console_Cmd_Config_NormalizeKey(const char *key);
 bool Console_Cmd_Config_SetCurrentValue(
     const CONFIG_OPTION *option, const char *new_value);
-const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromKey(const char *key);
+
+// Returns a vector of STRING_FUZZY_MATCH entries for the given key.
+// Caller must free the result with Vector_Free().
+VECTOR *Console_Cmd_Config_GetOptionsFromKey(const char *key);
+
+// Returns a pointer to a CONFIG_OPTION from a pointer into g_Config.
 const CONFIG_OPTION *Console_Cmd_Config_GetOptionFromTarget(const void *target);
+
 COMMAND_RESULT Console_Cmd_Config_Helper(
     const CONFIG_OPTION *option, const char *new_value);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds support for an optional name for the `/debug` command – before, it would turn on *everything* at once, which was a bit much. Now you can target specific options, like `/debug pos 1` or `/debug cuboid 1`, with fuzzy matching. If there's any ambiguity, all matching options will be toggled.

Also, cleans up the change logs and notes.