### PR TITLE
photo-mode: fix clipping through overlapping rooms

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -48,6 +48,7 @@
 - fixed select level feature to also be available to games started with `/play`
 - fixed select level feature slot status not updated on save
 - fixed "Story So Far..." showing loading screens
+- fixed photo mode camera clipping through overlapping rooms
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed caustics stopping after spending roughly 12 minutes in a level (#4109, regression from 1.4)
 - fixed Lara being able to push blocks through toggle opacity 1 portals (#4129, regression from 1.5)
 - fixed pistols disappearing from Lara's holsters in the cutscene following The Great Wall (#4145, regression from 0.9)
+- fixed photo mode camera clipping through overlapping rooms
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/camera/cinematic.c
+++ b/src/libtrx/game/camera/cinematic.c
@@ -33,8 +33,7 @@ static void M_UpdateCutscene(const XYZ_32 base_pos, const int16_t angle)
 
 #undef SHIFT
 
-    const int16_t room_num =
-        Room_GetIndexFromPos(camera_pos.x, camera_pos.y, camera_pos.z);
+    const int16_t room_num = Room_GetIndexFromPos(camera_pos);
     if (room_num != NO_ROOM) {
         g_Camera.pos.room_num = room_num;
     }

--- a/src/libtrx/game/camera/photo_mode.c
+++ b/src/libtrx/game/camera/photo_mode.c
@@ -164,13 +164,9 @@ static void M_ClampCameraPos(void)
     g_Camera.target.z += (g_Camera.pos.z - prev_cam_pos.z);
 }
 
-static bool M_CameraOutsideRoom(const XYZ_32 pos, const int16_t room_num)
+static bool M_CameraInsideRoom(const XYZ_32 pos, const int16_t room_num)
 {
-    const BOUNDS_32 bounds = Room_GetRoomBounds(room_num);
-    return (
-        pos.x < bounds.min.x + WALL_L || pos.y < bounds.min.y
-        || pos.z < bounds.min.z + WALL_L || pos.x > bounds.max.x - WALL_L
-        || pos.y > bounds.max.y || pos.z > bounds.max.z - WALL_L);
+    return Room_PointInside(Room_Get(room_num), pos);
 }
 
 static void M_UpdateCameraRooms(void)
@@ -181,29 +177,25 @@ static void M_UpdateCameraRooms(void)
         g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
         &g_Camera.target.room_num);
 
-    if (!M_CameraOutsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)
-        && !M_CameraOutsideRoom(
-            g_Camera.target.pos, g_Camera.target.room_num)) {
-        return;
-    }
+    if (!M_CameraInsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)
+        || !M_CameraInsideRoom(g_Camera.target.pos, g_Camera.target.room_num)) {
+        const int16_t pos_room_num = Room_GetIndexFromPos(g_Camera.pos.pos);
+        const int16_t tar_room_num = Room_GetIndexFromPos(g_Camera.target.pos);
 
-    const int16_t pos_room_num =
-        Room_GetIndexFromPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
-    const int16_t tar_room_num = Room_GetIndexFromPos(
-        g_Camera.target.x, g_Camera.target.y, g_Camera.target.z);
-
-    if (pos_room_num != NO_ROOM) {
-        g_Camera.pos.room_num = pos_room_num;
-        if (tar_room_num == NO_ROOM) {
-            g_Camera.target.room_num = pos_room_num;
+        if (pos_room_num != NO_ROOM) {
+            g_Camera.pos.room_num = pos_room_num;
+            if (tar_room_num == NO_ROOM) {
+                g_Camera.target.room_num = pos_room_num;
+            }
+        }
+        if (tar_room_num != NO_ROOM) {
+            g_Camera.target.room_num = tar_room_num;
+            if (pos_room_num == NO_ROOM) {
+                g_Camera.pos.room_num = tar_room_num;
+            }
         }
     }
-    if (tar_room_num != NO_ROOM) {
-        g_Camera.target.room_num = tar_room_num;
-        if (pos_room_num == NO_ROOM) {
-            g_Camera.pos.room_num = tar_room_num;
-        }
-    }
+
     Camera_EnsureEnvironment();
 }
 

--- a/src/libtrx/game/camera/photo_mode.c
+++ b/src/libtrx/game/camera/photo_mode.c
@@ -164,8 +164,29 @@ static void M_ClampCameraPos(void)
     g_Camera.target.z += (g_Camera.pos.z - prev_cam_pos.z);
 }
 
+static bool M_CameraOutsideRoom(const XYZ_32 pos, const int16_t room_num)
+{
+    const BOUNDS_32 bounds = Room_GetRoomBounds(room_num);
+    return (
+        pos.x < bounds.min.x + WALL_L || pos.y < bounds.min.y
+        || pos.z < bounds.min.z + WALL_L || pos.x > bounds.max.x - WALL_L
+        || pos.y > bounds.max.y || pos.z > bounds.max.z - WALL_L);
+}
+
 static void M_UpdateCameraRooms(void)
 {
+    Room_GetSector(
+        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
+    Room_GetSector(
+        g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
+        &g_Camera.target.room_num);
+
+    if (!M_CameraOutsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)
+        && !M_CameraOutsideRoom(
+            g_Camera.target.pos, g_Camera.target.room_num)) {
+        return;
+    }
+
     const int16_t pos_room_num =
         Room_GetIndexFromPos(g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z);
     const int16_t tar_room_num = Room_GetIndexFromPos(

--- a/src/libtrx/game/lara/hair.c
+++ b/src/libtrx/game/lara/hair.c
@@ -25,7 +25,7 @@ static int32_t m_HairWind;
 static int16_t M_GetRoom(const XYZ_32 pos)
 {
     if (g_TRVersion == 1) {
-        const int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+        const int16_t room_num = Room_GetIndexFromPos(pos);
         if (room_num != NO_ROOM) {
             return room_num;
         }

--- a/src/libtrx/game/lua/items.c
+++ b/src/libtrx/game/lua/items.c
@@ -164,8 +164,7 @@ static int M_L_ItemSetPos(lua_State *const L)
     lua_getfield(L, 2, "z");
     item->pos.z = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
-    item->room_num =
-        Room_GetIndexFromPos(item->pos.x, item->pos.y, item->pos.z);
+    item->room_num = Room_GetIndexFromPos(item->pos);
     return 0;
 }
 

--- a/src/libtrx/game/objects/general/cutscene_player.c
+++ b/src/libtrx/game/objects/general/cutscene_player.c
@@ -27,7 +27,7 @@ static void M_Control(const int16_t item_num)
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
 
-    const int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+    const int16_t room_num = Room_GetIndexFromPos(pos);
     if (room_num != NO_ROOM) {
         Item_UpdateRoom(item_num, room_num);
     }

--- a/src/libtrx/game/objects/traps/movable_block.c
+++ b/src/libtrx/game/objects/traps/movable_block.c
@@ -599,8 +599,8 @@ static void M_Control(const int16_t item_num)
     // Check if the block is floating, on a walkable, or on the pit floor.
     // ROUND_TO_HALF_CLICK because block can fall through floor to undefined
     // sector.
-    int16_t room_num = Room_GetIndexFromPos(
-        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z);
+    int16_t room_num = Room_GetIndexFromPos((XYZ_32) {
+        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z });
     if (room_num == NO_ROOM) {
         room_num = item->room_num;
     }
@@ -617,7 +617,7 @@ static void M_Control(const int16_t item_num)
 
         // Query floor at previous y position.
         room_num = Room_GetIndexFromPos(
-            item->pos.x, ROUND_TO_HALF_CLICK(y_prev), item->pos.z);
+            (XYZ_32) { item->pos.x, ROUND_TO_HALF_CLICK(y_prev), item->pos.z });
         if (room_num == NO_ROOM) {
             room_num = item->room_num;
         }

--- a/src/libtrx/game/rooms/common.c
+++ b/src/libtrx/game/rooms/common.c
@@ -220,20 +220,39 @@ int32_t Room_GetAdjoiningRooms(
     return count;
 }
 
-int16_t Room_GetIndexFromPos(const int32_t x, const int32_t y, const int32_t z)
+bool Room_PointInside(const ROOM *const room, const XYZ_32 point)
+{
+    const int16_t room_num = Room_GetNumber(room);
+    if (room_num == NO_ROOM) {
+        return false;
+    }
+    const BOUNDS_32 bounds = Room_GetRoomBounds(room_num);
+    const int32_t x1 = bounds.min.x + WALL_L;
+    const int32_t y1 = bounds.min.y;
+    const int32_t z1 = bounds.min.z + WALL_L;
+    const int32_t x2 = bounds.max.x - WALL_L;
+    const int32_t y2 = bounds.max.y;
+    const int32_t z2 = bounds.max.z - WALL_L;
+    if (point.x >= x1 && point.x < x2 && point.y >= y1 && point.y <= y2
+        && point.z >= z1 && point.z < z2) {
+        const SECTOR *sector = Room_GetWorldSector(room, point.x, point.z);
+        const int32_t height =
+            Room_GetHeight(sector, point.x, point.y, point.z);
+        if (height != NO_HEIGHT) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int16_t Room_GetIndexFromPos(const XYZ_32 point)
 {
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         const ROOM *const room = Room_Get(i);
         if (room->flip_status == RFS_FLIPPED) {
             continue;
         }
-        const int32_t x1 = room->pos.x + WALL_L;
-        const int32_t x2 = room->pos.x + (room->size.x - 1) * WALL_L;
-        const int32_t y1 = room->max_ceiling;
-        const int32_t y2 = room->min_floor;
-        const int32_t z1 = room->pos.z + WALL_L;
-        const int32_t z2 = room->pos.z + (room->size.z - 1) * WALL_L;
-        if (x >= x1 && x < x2 && y >= y1 && y <= y2 && z >= z1 && z < z2) {
+        if (Room_PointInside(room, point)) {
             return i;
         }
     }
@@ -312,12 +331,9 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
     ASSERT(out_pos != nullptr);
     ASSERT(out_room_num != nullptr);
     XYZ_32 initial_pos = *out_pos;
-    int32_t x = out_pos->x;
-    int32_t y = out_pos->y;
-    int32_t z = out_pos->z;
     int16_t room_num = *out_room_num;
     if (room_num == NO_ROOM) {
-        room_num = Room_GetIndexFromPos(x, y, z);
+        room_num = Room_GetIndexFromPos(*out_pos);
     }
     if (room_num == NO_ROOM) {
         return false;
@@ -331,6 +347,9 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
         }
     }
 
+    int32_t x = out_pos->x;
+    int32_t y = out_pos->y;
+    int32_t z = out_pos->z;
     const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
     int16_t height = Room_GetHeight(sector, x, y, z);
 

--- a/src/libtrx/game/rooms/geometry.c
+++ b/src/libtrx/game/rooms/geometry.c
@@ -228,6 +228,7 @@ static bool M_IsPortalSolid(
 BOUNDS_32 Room_GetRoomBounds(const int16_t room_num)
 {
     const ROOM *const room = Room_Get(room_num);
+    ASSERT(room != nullptr);
     return (BOUNDS_32) {
         .min = {
             .x = room->pos.x,

--- a/src/libtrx/include/libtrx/game/rooms/common.h
+++ b/src/libtrx/include/libtrx/game/rooms/common.h
@@ -22,10 +22,11 @@ void Room_SetFlipSlotFlags(int32_t slot_idx, int32_t flags);
 int32_t Room_GetAdjoiningRooms(
     int16_t init_room_num, int16_t out_room_nums[], int32_t max_room_num_count);
 
-int16_t Room_GetIndexFromPos(int32_t x, int32_t y, int32_t z);
+int16_t Room_GetIndexFromPos(XYZ_32 pos);
 int32_t Room_GetFlippedBaseRoom(int32_t room_num);
 BOUNDS_32 Room_GetWorldBounds(void);
 
+bool Room_PointInside(const ROOM *room, XYZ_32 point);
 bool Room_CheckOverlap(int16_t room_num_0, int16_t room_num_1);
 void Room_GetNearbyRooms(
     int32_t x, int32_t y, int32_t z, int32_t r, int32_t h, int16_t room_num);

--- a/src/tr1/game/cutscene.c
+++ b/src/tr1/game/cutscene.c
@@ -29,7 +29,7 @@ static void M_ControlLara(const int16_t item_num)
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
 
-    int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+    int16_t room_num = Room_GetIndexFromPos(pos);
     if (room_num != NO_ROOM) {
         Item_UpdateRoom(item_num, room_num);
         const SECTOR *const sector =

--- a/src/tr2/decomp/decomp.c
+++ b/src/tr2/decomp/decomp.c
@@ -28,7 +28,7 @@ void Lara_Control_Cutscene(const int16_t item_num)
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
 
-    const int16_t room_num = Room_GetIndexFromPos(pos.x, pos.y, pos.z);
+    const int16_t room_num = Room_GetIndexFromPos(pos);
     if (room_num != NO_ROOM) {
         Item_UpdateRoom(item_num, room_num);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the camera so it stays within the current room, unless either the camera source or target goes outside the room's boundaries – then it switches back to the previous behavior.

#### Testing

Some cases I found: (most rooms need to be reached with a combination of `/tp` and the fly cheat, as `/tp` alone doesn't work well with overlapping rooms)

<details>
<img width="3840" height="2160" alt="20251025_211749_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/135fa72c-9231-4704-8dbc-6f5dae188667" />
<img width="3840" height="2160" alt="20251025_211820_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/9ea58c31-5b36-4415-adbb-e621d691456c" />

<hr/>

<img width="3840" height="2160" alt="20251025_213407_Colosseum" src="https://github.com/user-attachments/assets/1c4c2c63-03dc-4b81-ace1-02a42cea6194" />
<img width="3840" height="2160" alt="20251025_213455_Colosseum" src="https://github.com/user-attachments/assets/cf812b3b-4daa-449d-8219-02325bed0020" />

<hr/>
<img width="3840" height="2160" alt="20251025_215052_Palace_Midas" src="https://github.com/user-attachments/assets/1b105cad-e182-4b6f-b61d-dc82dc8d5f6a" />
<img width="3840" height="2160" alt="20251025_215053_Palace_Midas" src="https://github.com/user-attachments/assets/2306c186-956c-417b-9ef1-9b60a4412285" />

<hr/>

<img width="3840" height="2160" alt="20251025_220300_Tomb_of_Tihocan" src="https://github.com/user-attachments/assets/81170b11-fde7-4c03-b97e-5d5276bca0c6" />
<img width="3840" height="2160" alt="20251025_220300_Tomb_of_Tihocan_2" src="https://github.com/user-attachments/assets/ff6b542a-690f-4499-83c5-5b202a4967ad" />

<hr/>

<img width="3840" height="2160" alt="20251025_221915_Diving_Area" src="https://github.com/user-attachments/assets/92a1c7cf-e90b-40c4-bc65-4efc1ed52f59" />
<img width="3840" height="2160" alt="20251025_221917_Diving_Area" src="https://github.com/user-attachments/assets/1f983ffe-06ed-4434-8561-d1b40a2ce8c7" />

<hr/>

<img width="3840" height="2160" alt="20251025_223726_Wreck_of_the_Maria_Doria" src="https://github.com/user-attachments/assets/816434a0-fa29-4931-bc4f-0f8cd53307b7" />
<img width="3840" height="2160" alt="20251025_223727_Wreck_of_the_Maria_Doria" src="https://github.com/user-attachments/assets/a087e6e4-cfd8-4f09-ad2b-d87b3fda2a3e" />

<hr/>

<img width="3840" height="2160" alt="20251025_223934_Wreck_of_the_Maria_Doria" src="https://github.com/user-attachments/assets/8cfee14c-c6d8-46cf-87c7-cbfb01cdaf9b" />
<img width="3840" height="2160" alt="20251025_223936_Wreck_of_the_Maria_Doria" src="https://github.com/user-attachments/assets/ee06de8b-d2b1-4387-a2d0-6f8f6188925b" />

<hr/>

<img width="3840" height="2160" alt="20251025_224744_Barkhang_Monastery" src="https://github.com/user-attachments/assets/1fc58b24-438b-4de4-a5d8-df0b5620ad40" />
<img width="3840" height="2160" alt="20251025_224745_Barkhang_Monastery" src="https://github.com/user-attachments/assets/75490b44-1fc0-487a-92eb-be7b9d23b290" />

<hr/>

<img width="3840" height="2160" alt="20251025_225010_Barkhang_Monastery" src="https://github.com/user-attachments/assets/5aa6fb99-d406-4161-b8a7-998f7bba9d64" />
<img width="3840" height="2160" alt="20251025_225011_Barkhang_Monastery" src="https://github.com/user-attachments/assets/017e2a09-bdf4-4178-a035-63ac60c85bd2" />

<img width="3840" height="2160" alt="20251025_225212_Catacombs_of_the_Talion" src="https://github.com/user-attachments/assets/72edde49-de2e-420d-96d1-947c010dbefe" />
<img width="3840" height="2160" alt="20251025_225214_Catacombs_of_the_Talion" src="https://github.com/user-attachments/assets/22da3b09-75a5-4226-8f9d-8000886cf846" />

This list is by no means exhaustive :)
</details>

The script I used that needs #4156:

```lua
trx.events.on_level_load(function(level)
  for i = 1, #trx.rooms do
    local a = trx.rooms[i].internal_bounds
    for j = i + 1, #trx.rooms do
      local b = trx.rooms[j].internal_bounds

      local overlap =
        a.min_x < b.max_x and a.max_x > b.min_x and
        a.min_y < b.max_y and a.max_y > b.min_y and
        a.min_z < b.max_z and a.max_z > b.min_z

      overlap = overlap and trx.rooms[i].flip_status == trx.rooms[j].flip_status

      if overlap then
        print(
          "Room",
          i - 1,
          "overlaps with Room",
          j - 1,
          trx.rooms[i].flip_status,
          trx.rooms[j].flip_status,
          trx.rooms[i].flipped_room,
          trx.rooms[j].flipped_room)
      end
    end
  end
end)
```