### PR TITLE
game-flow: add story so far to TR2X

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -5,9 +5,10 @@
 - added loading screens (Gameplay Options → General → Loading screens) (#1620)  
     Tomb Raider II 3×2 upscales done by Arsunt.  
     Tomb Raider II: The Golden Mask images done by Lito Perezito.
-- added restart level option when Lara dies (#1555)
-- added select level option (available under Look button – no UI for this yet, see #545)
-- added game mode selection to the play any level feature
+- added Restart Level option when Lara dies (#1555)
+- added Play Previous Levels feature (available in the New Game screen)
+- added Story So Far… feature (available in the New Game screen)
+- added game mode selection to the Play Any Level feature
 - added a game flow option for cold water in custom levels, similar to TR3 (#4021)
 - added a splash effect when Lara jumps in wading depth water, similar to TR3+ (#3975)
 - added bounding box debugging (`/debug 1` or `/set debug-cuboids 1`)

--- a/src/libtrx/game/game_flow/sequencer_misc.c
+++ b/src/libtrx/game/game_flow/sequencer_misc.c
@@ -7,6 +7,7 @@
 #include "game/inventory_ring/control.h"
 #include "game/objects/vars.h"
 #include "game/phase.h"
+#include "game/savegame.h"
 #include "game/shell/common.h"
 #include "log.h"
 #include "memory.h"
@@ -145,4 +146,87 @@ GF_COMMAND GF_DoCutsceneSequence(const int32_t cutscene_num)
         return (GF_COMMAND) { .action = GF_NOOP };
     }
     return GF_InterpretSequence(level, GFSC_NORMAL, nullptr);
+}
+
+GF_COMMAND GF_PlayAvailableStory(const int32_t slot_num)
+{
+    const int32_t savegame_level = Savegame_GetLevelNumber(slot_num);
+    const bool prev_enable_legal = g_Config.gameplay.enable_legal;
+    g_Config.gameplay.enable_legal = false;
+
+    // Play intro FMVs and cutscenes
+    GF_DoFrontendSequence();
+
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    for (int32_t i = 0; i <= MIN(savegame_level, level_table->count); i++) {
+        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
+        if (level->type == GFL_GYM) {
+            continue;
+        }
+        const GF_COMMAND gf_cmd = GF_InterpretSequence(
+            level, GFSC_STORY, (void *)(intptr_t)savegame_level);
+        if (gf_cmd.action == GF_EXIT_TO_TITLE
+            || gf_cmd.action == GF_EXIT_GAME) {
+            break;
+        }
+    }
+
+    g_Config.gameplay.enable_legal = prev_enable_legal;
+    return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+}
+
+bool GF_HasAvailableStory(const int32_t slot_num)
+{
+    if (Savegame_IsSlotFree(slot_num)) {
+        return false;
+    }
+    const int32_t savegame_level = Savegame_GetLevelNumber(slot_num);
+
+    // Check intro FMVs and cutscenes in frontend sequence (skip legal FMVs)
+    const GF_LEVEL *const title_level = GF_GetTitleLevel();
+    if (title_level != nullptr) {
+        const GF_SEQUENCE *const seq = &title_level->sequence;
+        for (int32_t j = 0; j < seq->length; j++) {
+            const GF_SEQUENCE_EVENT *const ev = &seq->events[j];
+            if (ev->type == GFS_PLAY_CUTSCENE) {
+                return true;
+            }
+            if (ev->type == GFS_PLAY_FMV) {
+                const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
+                const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
+                if (!fmv->is_legal && !fmv->is_credit) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Check for any cutscenes or FMVs up until the save point
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    const int32_t max_level = MIN(savegame_level, level_table->count);
+    for (int32_t i = 0; i <= max_level; i++) {
+        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
+        if (level->type == GFL_GYM) {
+            continue;
+        }
+        const GF_SEQUENCE *const seq = &level->sequence;
+        for (int32_t j = 0; j < seq->length; j++) {
+            const GF_SEQUENCE_EVENT *const ev = &seq->events[j];
+            // Stop checking after the saved level
+            if (ev->type == GFS_LOOP_GAME) {
+                break;
+            }
+            if (ev->type == GFS_PLAY_CUTSCENE) {
+                return true;
+            }
+            if (ev->type == GFS_PLAY_FMV) {
+                const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
+                const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
+                if (!fmv->is_legal && !fmv->is_credit) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }

--- a/src/libtrx/include/libtrx/game/game_flow/sequencer.h
+++ b/src/libtrx/include/libtrx/game/game_flow/sequencer.h
@@ -22,7 +22,7 @@ extern GF_COMMAND GF_InterpretSequence(
 extern GF_COMMAND GF_DoLevelSequence(
     const GF_LEVEL *start_level, GF_SEQUENCE_CONTEXT seq_ctx);
 
-extern GF_COMMAND GF_PlayAvailableStory(int32_t slot_num);
+GF_COMMAND GF_PlayAvailableStory(int32_t slot_num);
 // ----------------------------------------------------------------------------
 // event handler stuff
 // ----------------------------------------------------------------------------

--- a/src/tr1/game/game_flow/sequencer_events.c
+++ b/src/tr1/game/game_flow/sequencer_events.c
@@ -28,7 +28,6 @@ static DECLARE_GF_EVENT_HANDLER((*m_EventHandlers[GFS_NUMBER_OF])) = {
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
-    const GF_LEVEL *const prev_level = GF_GetLevelBefore(level);
 
     if (seq_ctx == GFSC_STORY) {
         const int32_t savegame_level_num = (int32_t)(intptr_t)seq_ctx_arg;
@@ -112,7 +111,9 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayMusic)
 {
-    Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ALWAYS);
+    if (seq_ctx != GFSC_STORY) {
+        Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ALWAYS);
+    }
     return (GF_COMMAND) { .action = GF_NOOP };
 }
 

--- a/src/tr1/game/game_flow/sequencer_misc.c
+++ b/src/tr1/game/game_flow/sequencer_misc.c
@@ -22,94 +22,10 @@ GF_COMMAND GF_RunTitle(void)
     return GF_ShowInventory(INV_TITLE_MODE);
 }
 
-GF_COMMAND GF_PlayAvailableStory(const int32_t slot_num)
-{
-    const int32_t savegame_level = Savegame_GetLevelNumber(slot_num);
-    const bool prev_enable_legal = g_Config.gameplay.enable_legal;
-    g_Config.gameplay.enable_legal = false;
-
-    // Play intro FMVs and cutscenes
-    GF_DoFrontendSequence();
-
-    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
-    for (int32_t i = 0; i <= MIN(savegame_level, level_table->count); i++) {
-        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
-        if (level->type == GFL_GYM) {
-            continue;
-        }
-        const GF_COMMAND gf_cmd = GF_InterpretSequence(
-            level, GFSC_STORY, (void *)(intptr_t)savegame_level);
-        if (gf_cmd.action == GF_EXIT_TO_TITLE
-            || gf_cmd.action == GF_EXIT_GAME) {
-            break;
-        }
-    }
-
-    g_Config.gameplay.enable_legal = prev_enable_legal;
-    return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
-}
-
-bool GF_HasAvailableStory(const int32_t slot_num)
-{
-    if (Savegame_IsSlotFree(slot_num)) {
-        return false;
-    }
-    const int32_t savegame_level = Savegame_GetLevelNumber(slot_num);
-
-    // Check intro FMVs and cutscenes in frontend sequence (skip legal FMVs)
-    const GF_LEVEL *const title_level = GF_GetTitleLevel();
-    if (title_level != nullptr) {
-        const GF_SEQUENCE *const seq = &title_level->sequence;
-        for (int32_t j = 0; j < seq->length; j++) {
-            const GF_SEQUENCE_EVENT *const ev = &seq->events[j];
-            if (ev->type == GFS_PLAY_CUTSCENE) {
-                return true;
-            }
-            if (ev->type == GFS_PLAY_FMV) {
-                const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
-                const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
-                if (!fmv->is_legal && !fmv->is_credit) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    // Check for any cutscenes or FMVs up until the save point
-    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
-    const int32_t max_level = MIN(savegame_level, level_table->count);
-    for (int32_t i = 0; i <= max_level; i++) {
-        const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
-        if (level->type == GFL_GYM) {
-            continue;
-        }
-        const GF_SEQUENCE *const seq = &level->sequence;
-        for (int32_t j = 0; j < seq->length; j++) {
-            const GF_SEQUENCE_EVENT *const ev = &seq->events[j];
-            // Stop checking after the saved level
-            if (ev->type == GFS_LOOP_GAME) {
-                break;
-            }
-            if (ev->type == GFS_PLAY_CUTSCENE) {
-                return true;
-            }
-            if (ev->type == GFS_PLAY_FMV) {
-                const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
-                const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
-                if (!fmv->is_legal && !fmv->is_credit) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 GF_COMMAND GF_DoLevelSequence(
     const GF_LEVEL *const start_level, const GF_SEQUENCE_CONTEXT seq_ctx)
 {
     const GF_LEVEL *current_level = start_level;
-
     const GF_LEVEL_TABLE_TYPE level_table_type =
         GF_GetLevelTableType(current_level->type);
     const int32_t level_count = GF_GetLevelTable(level_table_type)->count;

--- a/src/tr2/game/game_flow/sequencer_events.c
+++ b/src/tr2/game/game_flow/sequencer_events.c
@@ -33,6 +33,15 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
 
+    if (seq_ctx == GFSC_STORY) {
+        const int32_t savegame_level_num = (int32_t)(intptr_t)seq_ctx_arg;
+        if (savegame_level_num == level->num) {
+            return (GF_COMMAND) { .action = GF_EXIT_TO_TITLE };
+        } else {
+            return (GF_COMMAND) { .action = GF_NOOP };
+        }
+    }
+
     if (Lara_GetItem() != nullptr) {
         Lara_Initialise(level);
     }
@@ -99,7 +108,9 @@ static DECLARE_GF_EVENT_HANDLER(M_HandlePlayLevel)
 
 static DECLARE_GF_EVENT_HANDLER(M_HandlePlayMusic)
 {
-    Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ALWAYS);
+    if (seq_ctx != GFSC_STORY) {
+        Music_Play_Direct((int32_t)(intptr_t)event->data, MPM_ALWAYS);
+    }
     return (GF_COMMAND) { .action = GF_NOOP };
 }
 

--- a/src/tr2/game/game_flow/sequencer_misc.c
+++ b/src/tr2/game/game_flow/sequencer_misc.c
@@ -45,14 +45,3 @@ GF_COMMAND GF_DoLevelSequence(
         current_level++;
     }
 }
-
-GF_COMMAND GF_PlayAvailableStory(const int32_t slot_num)
-{
-    Shell_ExitSystem("Not implemented");
-    return (GF_COMMAND) { .action = GF_NOOP };
-}
-
-bool GF_HasAvailableStory(const int32_t slot_num)
-{
-    return false;
-}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is pretty straightforward – we just moved the relevant bits from TR1.
I also fixed the release notes. Also the commands to play music are now ignored in the Story So Far mode, otherwise it would play the level finish music in the inventory if the player has the inventory music disabled.