### PR TITLE
lara/cheat: fix fly cheat flare checks

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -64,6 +64,7 @@
 - fixed Lara being able to push blocks through toggle opacity 1 portals (#4129, regression from 1.5)
 - fixed pistols disappearing from Lara's holsters in the cutscene following The Great Wall (#4145, regression from 0.9)
 - fixed photo mode camera clipping through overlapping rooms
+- fixed Lara's thigh meshes defaulting if entering the fly cheat while holding a flare and she doesn't currently have holstered weapons (#4143, regression from 1.3)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/lara/cheat.c
+++ b/src/libtrx/game/lara/cheat.c
@@ -59,14 +59,12 @@ static void M_GiveAllMedpacksImpl(void)
 
 static void M_ReinitialiseGunMeshes(void)
 {
-#if TR_VERSION >= 2
     const bool has_flare = Lara_Flare_IsMeshActive();
     Lara_Mesh_Initialise(Game_GetCurrentLevel());
     Gun_InitialiseNewWeapon();
     if (has_flare) {
         Lara_Flare_DrawMeshes();
     }
-#endif
 }
 
 static void M_ResetGunStatus(void)
@@ -233,23 +231,18 @@ bool Lara_Cheat_EnterFlyMode(void)
 
     Viewport_AlterFOV(-1);
 
-#if TR_VERSION == 1
-    lara_info->request_gun_type = LGT_UNARMED;
-    if (lara_item->hit_points <= 0) {
-        lara_info->gun_status = LGS_ARMLESS;
-        Lara_Mesh_Initialise(GF_GetCurrentLevel());
-    }
-#else
     if (lara_info->extra_anim) {
         M_ResetGunStatus();
     }
-
+#if TR_VERSION == 1
+    const bool back_gun_test = false;
+#else
+    const bool back_gun_test = lara_info->back_gun_obj_id != O_LARA;
+#endif
     if (lara_info->gun_status == LGS_HANDS_BUSY
-        || (lara_info->gun_status == LGS_UNDRAW
-            && lara_info->back_gun_obj_id != O_LARA)) {
+        || (lara_info->gun_status == LGS_UNDRAW && back_gun_test)) {
         lara_info->gun_status = LGS_ARMLESS;
     }
-#endif
 
     lara_info->extra_anim = false;
     Lara_Vehicle_Dismount();
@@ -318,16 +311,16 @@ bool Lara_Cheat_ExitFlyMode(void)
     }
 
 #if TR_VERSION == 1
-    lara_info->gun_status = LGS_ARMLESS;
-    Lara_Mesh_Initialise(GF_GetCurrentLevel());
+    const bool has_gun = false;
 #else
-    if (lara_info->gun_item_num != NO_ITEM) {
+    const bool has_gun = lara_info->gun_item_num != NO_ITEM;
+#endif
+    if (has_gun) {
         lara_info->gun_status = LGS_UNDRAW;
     } else {
         lara_info->gun_status = LGS_ARMLESS;
         M_ReinitialiseGunMeshes();
     }
-#endif
 
     Console_Log(GS(OSD_FLY_MODE_OFF));
     return true;

--- a/src/libtrx/game/lara/mesh.c
+++ b/src/libtrx/game/lara/mesh.c
@@ -54,7 +54,7 @@ void Lara_Mesh_Initialise(const GF_LEVEL *const level)
     Lara_Mesh_SwapSingle(LM_HEAD, O_LARA);
 
     const LARA_GUN_TYPE holster_gun = M_DetermineHolsterGun();
-    if (holster_gun != LGT_UNARMED) {
+    if (holster_gun != LGT_UNARMED && holster_gun != LGT_FLARE) {
         Gun_SetLaraHolsterLMesh(holster_gun);
         Gun_SetLaraHolsterRMesh(holster_gun);
     }


### PR DESCRIPTION
Resolves #4143.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This should hopefully make the enter/exit fly cheat checks similar in both games aside from the back gun/gun item checks missing for TR1. That should hopefully be addressed soon in itself.
