### PR TITLE
Fix dome portals

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed "Story So Far..." showing loading screens
 - fixed photo mode camera clipping through overlapping rooms
 - fixed matrix stack overflow crash when moving through overlapping or dome portals (#2685)
+- fixed bogus warnings about resume info in logs when playing cutscenes and in the title level
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -38,6 +38,7 @@
 - changed the unrestricted look mode option to include Lara being able to look freely while shooting an enemy (#4090)
 - changed the `ambient_tracks` property to be only available on the root level
 - changed cutscene data (e.g. `cut1.phd`, as opposed to in-game cinematics) to match TR2 format, where Lara (as `O_LARA`) must be defined as an item in the level file
+- changed the `-q`/`--quiet` argument to no longer silence warnings
 - fixed missing footstep sound effects when Lara climbs off a ladder and when she finishes a handstand (#4030)
 - fixed a crash in custom levels if a flip effect that expects to act on an item is used in a regular trigger (#4085)
 - fixed Lara being able to push blocks through toggle opacity 1 portals (#4129)

--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -51,7 +51,7 @@
 - fixed select level feature slot status not updated on save
 - fixed "Story So Far..." showing loading screens
 - fixed photo mode camera clipping through overlapping rooms
-- fixed matrix stack overflow crash when moving through overlapping or dome portals; TR1 now matches TR2 behavior (stable, with minor underside clipping) (#2685)
+- fixed matrix stack overflow crash when moving through overlapping or dome portals (#2685)
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -67,6 +67,7 @@
 - fixed pistols disappearing from Lara's holsters in the cutscene following The Great Wall (#4145, regression from 0.9)
 - fixed photo mode camera clipping through overlapping rooms
 - fixed Lara's thigh meshes defaulting if entering the fly cheat while holding a flare and she doesn't currently have holstered weapons (#4143, regression from 1.3)
+- fixed weird clipping when moving through overlapping or dome portals (#2685)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -69,6 +69,7 @@
 - fixed photo mode camera clipping through overlapping rooms
 - fixed Lara's thigh meshes defaulting if entering the fly cheat while holding a flare and she doesn't currently have holstered weapons (#4143, regression from 1.3)
 - fixed weird clipping when moving through overlapping or dome portals (#2685)
+- fixed bogus warnings about resume info in logs when playing cutscenes and in the title level
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -44,6 +44,7 @@
 - changed the unrestricted look mode option to include Lara being able to look freely while shooting an enemy (#4090)
 - changed the `ambient_tracks` property to be only available on the root level
 - changed the Pause key to no longer work when Lara's dead (similar to TR1)
+- changed the `-q`/`--quiet` argument to no longer silence warnings
 - removed the following game flow options:
     - `cmd_init`
     - `cmd_title`

--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -169,13 +169,13 @@ GF_COMMAND GF_InterpretSequence(
     default:
         if (level->type == GFL_GYM) {
             Savegame_ResetCurrentInfo(level);
-        } else if (
-            prev_level != nullptr
-            && (level->type == GFL_NORMAL || level->type == GFL_BONUS)) {
-            Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
-        }
-        Savegame_ApplyLogicToCurrentInfo(level);
-        if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+        } else if (level->type == GFL_DEMO) {
+            Savegame_ApplyLogicToCurrentInfo(level);
+        } else if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
+            if (prev_level != nullptr) {
+                Savegame_CarryCurrentInfoToNextLevel(prev_level, level);
+            }
+            Savegame_ApplyLogicToCurrentInfo(level);
             GF_InventoryModifier_Scan(level);
             GF_InventoryModifier_ApplyToResumeInfo(level);
         }

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -506,6 +506,67 @@ void Level_ReadTexturePages(const LEVEL_LOADER *const loader, VFILE *const file)
     Benchmark_End(&benchmark, nullptr);
 }
 
+static XYZ_16 M_ComputePortalNormal(PORTAL *const p)
+{
+    // This fixes a bug in TombEditor where certain portals would get emitted
+    // with wrong normals. TE is guaranteed to emit normals with a good sign in
+    // the Y component, but for sloped ceiling portals, their X and Z
+    // compontents have the wrong sign.
+    //
+    // To fix this, we compute the normal the regular way. We don't know which
+    // way the portal faces, but since the Y component is guaranteed to be
+    // good, we can orient our vector using this information, which should fix
+    // the X/Z components.
+
+    ASSERT(p != nullptr);
+
+    // Geometric normal (ab × ac)
+    const XYZ_32 a = { p->vertex[0].x, p->vertex[0].y, p->vertex[0].z };
+    const XYZ_32 b = { p->vertex[1].x, p->vertex[1].y, p->vertex[1].z };
+    const XYZ_32 c = { p->vertex[2].x, p->vertex[2].y, p->vertex[2].z };
+    const XYZ_32 ab = { b.x - a.x, b.y - a.y, b.z - a.z };
+    const XYZ_32 ac = { c.x - a.x, c.y - a.y, c.z - a.z };
+    XYZ_32 n = {
+        (ab.y * ac.z) - (ab.z * ac.y),
+        (ab.z * ac.x) - (ab.x * ac.z),
+        (ab.x * ac.y) - (ab.y * ac.x),
+    };
+
+    // Degenerate guard
+    if (n.x == 0 && n.y == 0 && n.z == 0) {
+        return (XYZ_16) { .x = 0, .y = 1, .z = 0 };
+    }
+
+    // Integer normalization
+    const int32_t gx = ABS(n.x);
+    const int32_t gy = ABS(n.y);
+    const int32_t gz = ABS(n.z);
+    int32_t g = gx;
+    if (gy != 0) {
+        g = Math_GCD(g, gy);
+    }
+    if (gz != 0) {
+        g = Math_GCD(g, gz);
+    }
+    if (g == 0) {
+        g = 1;
+    }
+    n.x /= g;
+    n.y /= g;
+    n.z /= g;
+
+    // NOTE: we only care about horizontal portals.
+    if (p->normal.y == 0) {
+        return p->normal;
+    }
+    if (p->normal.y != n.y) {
+        n.x *= -1;
+        n.y *= -1;
+        n.z *= -1;
+    }
+    return (XYZ_16) { n.x, n.y, n.z };
+}
+
 void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -519,7 +580,6 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
 
     Room_InitialiseRooms(num_rooms);
     for (int32_t i = 0; i < num_rooms; i++) {
-        LOG_DEBUG("ROOM %d:", i);
         ROOM *const room = Room_Get(i);
 
         room->pos.x = VFile_ReadS32(file);
@@ -547,24 +607,6 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
                 for (int32_t k = 0; k < 4; k++) {
                     M_ReadVertex(&portal->vertex[k], file);
                 }
-                LOG_DEBUG(
-                    "  portal→%d: normal=%d,%d,%d vertices={{%d,%d,%d},{%d,%d,%d},{%d,%d,%d},{%d,%d,%d}}}",
-                    portal->room_num,
-                    portal->normal.x,
-                    portal->normal.y,
-                    portal->normal.z,
-                    portal->vertex[0].x,
-                    portal->vertex[0].y,
-                    portal->vertex[0].z,
-                    portal->vertex[1].x,
-                    portal->vertex[1].y,
-                    portal->vertex[1].z,
-                    portal->vertex[2].x,
-                    portal->vertex[2].y,
-                    portal->vertex[2].z,
-                    portal->vertex[3].x,
-                    portal->vertex[3].y,
-                    portal->vertex[3].z);
             }
         }
 
@@ -640,6 +682,23 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
 
         room->item_num = NO_ITEM;
         room->effect_num = NO_EFFECT;
+    }
+
+    for (int32_t i = 0; i < num_rooms; i++) {
+        ROOM *const room = Room_Get(i);
+        if (room->portals == nullptr) {
+            continue;
+        }
+        for (int32_t j = 0; j < room->portals->count; j++) {
+            PORTAL *const portal = &room->portals->portal[j];
+            const XYZ_16 new_normal = M_ComputePortalNormal(portal);
+            if (new_normal.x != portal->normal.x
+                || new_normal.y != portal->normal.y
+                || new_normal.z != portal->normal.z) {
+                LOG_WARNING("Fixed room %d, portal normal %d", i, j);
+                portal->normal = new_normal;
+            }
+        }
     }
 
     Room_InitialiseFlipStatus();

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -1558,21 +1558,6 @@ bool Level_Initialise(
         Random_SeedControl(0xD371F947);
     }
 
-    RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-    if (resume != nullptr) {
-        resume->stats.timer = 0;
-        resume->stats.secret_flags = 0;
-        resume->stats.secret_count = 0;
-#if TR_VERSION == 1
-        resume->stats.pickup_count = 0;
-#endif
-        resume->stats.kill_count = 0;
-        resume->stats.ammo_hits = 0;
-        resume->stats.ammo_used = 0;
-        resume->stats.medipacks_used = 0;
-        resume->stats.distance_travelled = 0;
-    }
-
     Game_SetIsLevelComplete(false);
     Game_FadeToBlack(-1);
     if (level->type != GFL_TITLE && level->type != GFL_DEMO) {
@@ -1582,6 +1567,24 @@ bool Level_Initialise(
         Game_SetCurrentLevel(level);
     }
     GF_SetCurrentLevel(level);
+
+    if (level->type != GFL_TITLE) {
+        // TODO: move me elsewhere
+        RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
+        if (resume != nullptr) {
+            resume->stats.timer = 0;
+            resume->stats.secret_flags = 0;
+            resume->stats.secret_count = 0;
+#if TR_VERSION == 1
+            resume->stats.pickup_count = 0;
+#endif
+            resume->stats.kill_count = 0;
+            resume->stats.ammo_hits = 0;
+            resume->stats.ammo_used = 0;
+            resume->stats.medipacks_used = 0;
+            resume->stats.distance_travelled = 0;
+        }
+    }
 
     if (level == nullptr) {
         return false;

--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -519,6 +519,7 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
 
     Room_InitialiseRooms(num_rooms);
     for (int32_t i = 0; i < num_rooms; i++) {
+        LOG_DEBUG("ROOM %d:", i);
         ROOM *const room = Room_Get(i);
 
         room->pos.x = VFile_ReadS32(file);
@@ -546,6 +547,24 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
                 for (int32_t k = 0; k < 4; k++) {
                     M_ReadVertex(&portal->vertex[k], file);
                 }
+                LOG_DEBUG(
+                    "  portal→%d: normal=%d,%d,%d vertices={{%d,%d,%d},{%d,%d,%d},{%d,%d,%d},{%d,%d,%d}}}",
+                    portal->room_num,
+                    portal->normal.x,
+                    portal->normal.y,
+                    portal->normal.z,
+                    portal->vertex[0].x,
+                    portal->vertex[0].y,
+                    portal->vertex[0].z,
+                    portal->vertex[1].x,
+                    portal->vertex[1].y,
+                    portal->vertex[1].z,
+                    portal->vertex[2].x,
+                    portal->vertex[2].y,
+                    portal->vertex[2].z,
+                    portal->vertex[3].x,
+                    portal->vertex[3].y,
+                    portal->vertex[3].z);
             }
         }
 
@@ -619,11 +638,6 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         room->flags.inside      = (flags & 0x40) != 0;
         // clang-format on
 
-        room->bound_active = 0;
-        room->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-        room->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
-        room->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
-        room->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
         room->item_num = NO_ITEM;
         room->effect_num = NO_EFFECT;
     }

--- a/src/libtrx/game/math/util.c
+++ b/src/libtrx/game/math/util.c
@@ -99,6 +99,16 @@ int32_t Math_FloorDiv(const int32_t x, const int32_t divisor)
     return (x >= 0) ? x / divisor : -((-x + divisor - 1) / divisor);
 }
 
+int32_t Math_GCD(int32_t a, int32_t b)
+{
+    while (b != 0) {
+        int32_t t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
+
 int16_t XYZ_32_GetYaw(const XYZ_32 pos)
 {
     return Math_Atan(pos.z, pos.x);

--- a/src/libtrx/game/rooms/draw.c
+++ b/src/libtrx/game/rooms/draw.c
@@ -38,16 +38,16 @@ static void M_GetBounds(void)
         const int16_t room_num = m_BoundRooms[m_BoundStart % M_MAX_BOUND_ROOMS];
         m_BoundStart++;
         ROOM *const room = Room_Get(room_num);
-        room->bound_active -= 2;
+        room->bind.active = false;
 
         CLAMPG(room->bound_left, room->test_left);
         CLAMPG(room->bound_top, room->test_top);
         CLAMPL(room->bound_right, room->test_right);
         CLAMPL(room->bound_bottom, room->test_bottom);
 
-        if (!(room->bound_active & 1)) {
+        if (!room->bind.drawn) {
             Room_MarkToBeDrawn(room_num);
-            room->bound_active |= 1;
+            room->bind.drawn = 1;
             if (room->flags.outside) {
                 m_Outside = 1;
             }
@@ -200,7 +200,7 @@ static void M_SetBounds(
         return;
     }
 
-    if (room->bound_active & 2) {
+    if (room->bind.active) {
         CLAMPG(room->test_left, left);
         CLAMPG(room->test_top, top);
         CLAMPL(room->test_right, right);
@@ -208,7 +208,7 @@ static void M_SetBounds(
     } else {
         m_BoundRooms[m_BoundEnd % M_MAX_BOUND_ROOMS] = room_num;
         m_BoundEnd++;
-        room->bound_active |= 2;
+        room->bind.active = true;
         room->test_left = left;
         room->test_top = top;
         room->test_right = right;
@@ -272,7 +272,8 @@ static void M_DrawSingleRoom(const int16_t room_num)
         Output_SetupAboveWater(g_Camera.underwater);
     }
 
-    room->bound_active = 0;
+    room->bind.active = false;
+    room->bind.drawn = false;
 
     Matrix_Push();
     Matrix_TranslateAbs32(room->pos);
@@ -371,7 +372,8 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     room->test_top = Viewport_GetMinY(VIEWPORT_GAME);
     room->test_right = Viewport_GetMaxX(VIEWPORT_GAME);
     room->test_bottom = Viewport_GetMaxY(VIEWPORT_GAME);
-    room->bound_active = 2;
+    room->bind.active = true;
+    room->bind.drawn = false;
 
     g_PhdLeft = room->test_left;
     g_PhdTop = room->test_top;

--- a/src/libtrx/game/rooms/draw.c
+++ b/src/libtrx/game/rooms/draw.c
@@ -25,35 +25,25 @@ static int32_t m_OutsideLeft;
 static int32_t m_OutsideTop;
 static int32_t m_OutsideBottom;
 
-static int32_t m_MidSort = 0;
 static int32_t m_BoundStart;
 static int32_t m_BoundEnd;
 static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
 
 static void M_SetBounds(
-    const int16_t *obj_ptr, int32_t room_num, const ROOM *parent);
+    const PORTAL *const portal, int32_t room_num, const ROOM *parent);
 
 static void M_GetBounds(void)
 {
     while (m_BoundStart != m_BoundEnd) {
-        const int16_t room_num =
-            m_BoundRooms[m_BoundStart++ % M_MAX_BOUND_ROOMS];
+        const int16_t room_num = m_BoundRooms[m_BoundStart % M_MAX_BOUND_ROOMS];
+        m_BoundStart++;
         ROOM *const room = Room_Get(room_num);
-        room->bound_active &= ~2;
-        m_MidSort = (room->bound_active >> 8) + 1;
+        room->bound_active -= 2;
 
-        if (room->test_left < room->bound_left) {
-            room->bound_left = room->test_left;
-        }
-        if (room->test_top < room->bound_top) {
-            room->bound_top = room->test_top;
-        }
-        if (room->test_right > room->bound_right) {
-            room->bound_right = room->test_right;
-        }
-        if (room->test_bottom > room->bound_bottom) {
-            room->bound_bottom = room->test_bottom;
-        }
+        CLAMPG(room->bound_left, room->test_left);
+        CLAMPG(room->bound_top, room->test_top);
+        CLAMPL(room->bound_right, room->test_right);
+        CLAMPL(room->bound_bottom, room->test_bottom);
 
         if (!(room->bound_active & 1)) {
             Room_MarkToBeDrawn(room_num);
@@ -64,18 +54,10 @@ static void M_GetBounds(void)
         }
 
         if (!room->flags.inside || room->flags.outside) {
-            if (room->bound_left < m_OutsideLeft) {
-                m_OutsideLeft = room->bound_left;
-            }
-            if (room->bound_right > m_OutsideRight) {
-                m_OutsideRight = room->bound_right;
-            }
-            if (room->bound_top < m_OutsideTop) {
-                m_OutsideTop = room->bound_top;
-            }
-            if (room->bound_bottom > m_OutsideBottom) {
-                m_OutsideBottom = room->bound_bottom;
-            }
+            CLAMPG(m_OutsideLeft, room->bound_left);
+            CLAMPG(m_OutsideTop, room->bound_top);
+            CLAMPL(m_OutsideRight, room->bound_right);
+            CLAMPL(m_OutsideBottom, room->bound_bottom);
         }
 
         if (room->portals == nullptr) {
@@ -95,32 +77,26 @@ static void M_GetBounds(void)
             };
             // clang-format on
 
-            if (offset.x + offset.y + offset.z >= 0) {
-                continue;
+            if (offset.x + offset.y + offset.z < 0) {
+                M_SetBounds(portal, portal->room_num, room);
             }
-
-            M_SetBounds(&portal->normal.x, portal->room_num, room);
         }
         Matrix_Pop();
     }
 }
 
 static void M_SetBounds(
-    const int16_t *const obj_ptr, const int32_t room_num,
+    const PORTAL *const portal, const int32_t room_num,
     const ROOM *const parent)
 {
     ROOM *const room = Room_Get(room_num);
-    const PORTAL *const portal = (const PORTAL *)(obj_ptr - 1);
 
-    // clang-format off
-    if (room->bound_left <= parent->test_left &&
-        room->bound_right >= parent->test_right &&
-        room->bound_top <= parent->test_top &&
-        room->bound_bottom >= parent->test_bottom
-   ) {
+    if (room->bound_left <= parent->test_left
+        && room->bound_top <= parent->test_top
+        && room->bound_right >= parent->test_right
+        && room->bound_bottom >= parent->test_bottom) {
         return;
     }
-    // clang-format on
 
     const MATRIX *const m = g_MatrixPtr;
     int32_t left = parent->test_right;
@@ -129,7 +105,7 @@ static void M_SetBounds(
     int32_t top = parent->test_bottom;
 
     M_PORTAL_VBUF portal_vbuf[4];
-    int32_t z_behind = 0;
+    int32_t too_near = 0;
 
     for (int32_t i = 0; i < 4; i++) {
         M_PORTAL_VBUF *const dvbuf = &portal_vbuf[i];
@@ -145,14 +121,14 @@ static void M_SetBounds(
         dvbuf->zv = zv;
 
         if (zv <= 0) {
-            z_behind++;
+            too_near++;
             continue;
         }
 
         int32_t xs;
         int32_t ys;
         const int32_t zp = zv / g_PhdPersp;
-        if (zp) {
+        if (zp != 0) {
             xs = Viewport_GetCenterX(VIEWPORT_GAME) + xv / zp;
             ys = Viewport_GetCenterY(VIEWPORT_GAME) + yv / zp;
         } else {
@@ -174,16 +150,16 @@ static void M_SetBounds(
         }
     }
 
-    if (z_behind == 4) {
+    if (too_near == 4) {
         return;
     }
 
-    if (z_behind > 0) {
+    if (too_near > 0) {
         const M_PORTAL_VBUF *dest = &portal_vbuf[0];
         const M_PORTAL_VBUF *last = &portal_vbuf[3];
 
-        for (int32_t i = 0; i < 4; i++, last = dest++) {
-            if ((dest->zv < 0) == (last->zv < 0)) {
+        for (int32_t i = 0; i < 4; i++, last = dest, dest++) {
+            if ((dest->zv <= 0) == (last->zv <= 0)) {
                 continue;
             }
 
@@ -225,25 +201,17 @@ static void M_SetBounds(
     }
 
     if (room->bound_active & 2) {
-        if (left < room->test_left) {
-            room->test_left = left;
-        }
-        if (top < room->test_top) {
-            room->test_top = top;
-        }
-        if (right > room->test_right) {
-            room->test_right = right;
-        }
-        if (bottom > room->test_bottom) {
-            room->test_bottom = bottom;
-        }
+        CLAMPG(room->test_left, left);
+        CLAMPG(room->test_top, top);
+        CLAMPL(room->test_right, right);
+        CLAMPL(room->test_bottom, bottom);
     } else {
-        m_BoundRooms[m_BoundEnd++ % M_MAX_BOUND_ROOMS] = room_num;
+        m_BoundRooms[m_BoundEnd % M_MAX_BOUND_ROOMS] = room_num;
+        m_BoundEnd++;
         room->bound_active |= 2;
-        room->bound_active += (int16_t)(m_MidSort << 8);
         room->test_left = left;
-        room->test_right = right;
         room->test_top = top;
+        room->test_right = right;
         room->test_bottom = bottom;
     }
 }
@@ -255,9 +223,9 @@ static void M_DrawSkybox(void)
     }
 
     g_PhdLeft = m_OutsideLeft;
+    g_PhdTop = m_OutsideTop;
     g_PhdRight = m_OutsideRight;
     g_PhdBottom = m_OutsideBottom;
-    g_PhdTop = m_OutsideTop;
 
     const OBJECT *const skybox = Object_Get(O_SKYBOX);
     if (skybox->loaded) {
@@ -284,8 +252,8 @@ static void M_DrawSingleRoom(const int16_t room_num)
     }
 
     g_PhdLeft = room->bound_left;
-    g_PhdRight = room->bound_right;
     g_PhdTop = room->bound_top;
+    g_PhdRight = room->bound_right;
     g_PhdBottom = room->bound_bottom;
 
     if (g_Config.debug.enable_debug_room_clip) {
@@ -361,9 +329,9 @@ static void M_DrawSingleRoom(const int16_t room_num)
     Matrix_Pop();
 
     room->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-    room->bound_bottom = Viewport_GetMinX(VIEWPORT_GAME);
-    room->bound_right = Viewport_GetMinY(VIEWPORT_GAME);
     room->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
+    room->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
+    room->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
 }
 
 void Room_DrawReset(void)
@@ -439,7 +407,6 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
         M_DrawSingleRoom(Room_DrawGetRoom(i));
     }
 
-    m_MidSort = 0;
     const ITEM *const lara_item = Lara_GetItem();
     if (Object_Get(O_LARA)->loaded) {
         const ROOM *const lara_room = Room_Get(lara_item->room_num);
@@ -449,10 +416,6 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
             Output_SetupAboveWater(g_Camera.underwater);
         }
         Lara_Draw(lara_item);
-        m_MidSort = lara_room->bound_active >> 8;
-        if (m_MidSort) {
-            m_MidSort--;
-        }
     }
 
     Output_SetupAboveWater(false);

--- a/src/libtrx/game/rooms/draw.c
+++ b/src/libtrx/game/rooms/draw.c
@@ -32,6 +32,19 @@ static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
 static void M_SetBounds(
     const PORTAL *const portal, int32_t room_num, const ROOM *parent);
 
+static inline bool M_PortalFacesCamera(
+    const ROOM *const room, const PORTAL *const portal)
+{
+    // clang-format off
+    const XYZ_32 offset = {
+        .x = portal->normal.x * (room->pos.x + portal->vertex[0].x - g_W2VMatrix._03),
+        .y = portal->normal.y * (room->pos.y + portal->vertex[0].y - g_W2VMatrix._13),
+        .z = portal->normal.z * (room->pos.z + portal->vertex[0].z - g_W2VMatrix._23),
+    };
+    // clang-format on
+    return offset.x + offset.y + offset.z < 0;
+}
+
 static void M_GetBounds(void)
 {
     while (m_BoundStart != m_BoundEnd) {
@@ -67,17 +80,8 @@ static void M_GetBounds(void)
         Matrix_Push();
         Matrix_TranslateAbs32(room->pos);
         for (int32_t i = 0; i < room->portals->count; i++) {
-            const PORTAL *const portal = &room->portals->portal[i];
-
-            // clang-format off
-            const XYZ_32 offset = {
-                .x = portal->normal.x * (room->pos.x + portal->vertex[0].x - g_W2VMatrix._03),
-                .y = portal->normal.y * (room->pos.y + portal->vertex[0].y - g_W2VMatrix._13),
-                .z = portal->normal.z * (room->pos.z + portal->vertex[0].z - g_W2VMatrix._23),
-            };
-            // clang-format on
-
-            if (offset.x + offset.y + offset.z < 0) {
+            PORTAL *const portal = &room->portals->portal[i];
+            if (M_PortalFacesCamera(room, portal)) {
                 M_SetBounds(portal, portal->room_num, room);
             }
         }
@@ -242,9 +246,8 @@ static void M_DrawSkybox(void)
     }
 }
 
-static void M_DrawSingleRoom(const int16_t room_num)
+static void M_DrawSingleRoom(ROOM *const room)
 {
-    ROOM *const room = Room_Get(room_num);
     if (room->flags.underwater) {
         Output_SetupBelowWater(g_Camera.underwater);
     } else {
@@ -271,9 +274,6 @@ static void M_DrawSingleRoom(const int16_t room_num)
     } else {
         Output_SetupAboveWater(g_Camera.underwater);
     }
-
-    room->bind.active = false;
-    room->bind.drawn = false;
 
     Matrix_Push();
     Matrix_TranslateAbs32(room->pos);
@@ -406,7 +406,11 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     }
 
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
-        M_DrawSingleRoom(Room_DrawGetRoom(i));
+        const int16_t draw_room_num = Room_DrawGetRoom(i);
+        ROOM *const draw_room = Room_Get(draw_room_num);
+        M_DrawSingleRoom(draw_room);
+        draw_room->bind.active = false;
+        draw_room->bind.drawn = false;
     }
 
     const ITEM *const lara_item = Lara_GetItem();

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -347,6 +347,8 @@ RESUME_INFO *Savegame_GetCurrentInfo(const GF_LEVEL *const level)
         return &m_ResumeInfo[level->num];
     } else if (level->type == GFL_DEMO) {
         return &m_ResumeInfo[GF_GetLevelTable(GFLT_MAIN)->count];
+    } else if (level->type == GFL_CUTSCENE) {
+        return nullptr;
     }
     LOG_WARNING(
         "Warning: unable to get resume info for level %d (type=%s)", level->num,

--- a/src/libtrx/game/shell/main.c
+++ b/src/libtrx/game/shell/main.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
     }
 
     char *log_path = File_GetFullPath(PROJECT_NAME ".log");
-    Log_Init(log_path, args->quiet ? LOG_LEVEL_ERROR : LOG_LEVEL_MAX);
+    Log_Init(log_path, args->quiet ? LOG_LEVEL_WARNING : LOG_LEVEL_MAX);
     Memory_FreePointer(&log_path);
 
     LOG_INFO("Starting %s", g_TRXVersion);

--- a/src/libtrx/include/libtrx/game/math/func.h
+++ b/src/libtrx/include/libtrx/game/math/func.h
@@ -14,6 +14,7 @@ DIRECTION Math_GetDirectionCone(int16_t angle, int16_t cone);
 int16_t Math_DirectionToAngle(DIRECTION dir);
 int32_t Math_AngleMean(int32_t angle1, int32_t angle2, double ratio);
 int32_t Math_FloorDiv(int32_t x, int32_t divisor);
+int32_t Math_GCD(int32_t a, int32_t b);
 
 int16_t XYZ_32_GetYaw(XYZ_32 pos);
 int16_t XYZ_32_GetPitch(XYZ_32 pos);

--- a/src/libtrx/include/libtrx/game/rooms/types.h
+++ b/src/libtrx/include/libtrx/game/rooms/types.h
@@ -152,4 +152,8 @@ typedef struct {
         bool inside;
         bool dynamic_lit;
     } flags;
+    struct {
+        bool active;
+        bool drawn;
+    } bind;
 } ROOM;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2685. The main culprit was the early exit done by the portal normal facing vector check. Removing it fixes the issue and is just 2 lines, but there were still some issues left around how the bounding boxes get computed, so more changes had to follow.

Test level from Lahm: `vis-portal-issues.zip`

This is a pretty fundamental change in how all rooms get scheduled so it might bite us when we least expect. I would appreciate a check if this affects CPU % usage in big levels with lots of rooms (Floater, The Deck). Still, from early testing, it looks good:

<details>
<img width="3840" height="2160" alt="20251026_123646_Test_Level" src="https://github.com/user-attachments/assets/c97df0a0-929e-4249-ac96-2758dd030e15" />
<img width="3840" height="2160" alt="20251026_123732_Test_Level" src="https://github.com/user-attachments/assets/ccc28ddf-e8ef-4f26-8dbc-b1e52ce61867" />
<img width="3840" height="2160" alt="20251026_123751_Test_Level" src="https://github.com/user-attachments/assets/11528fe2-f618-4afa-955f-99d345043eda" />
<img width="3840" height="2160" alt="20251026_123851_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/ec31b0c2-18a0-4e96-8e91-1266d2a1daad" />
<img width="3840" height="2160" alt="20251026_123947_City_of_Vilcabamba" src="https://github.com/user-attachments/assets/16482ae6-ba7a-4bb9-89f1-04c2e0891c26" />
</details>