### PR TITLE
level: fix reading sprite sequences

### DIFF
--- a/src/libtrx/game/level/common.c
+++ b/src/libtrx/game/level/common.c
@@ -1087,11 +1087,7 @@ void Level_AppendSpriteTextures(
 void Level_ReadSpriteSequences(
     const LEVEL_LOADER *const loader, VFILE *const file)
 {
-    int32_t max_obj_id = -1;
-    const int32_t object_count = M_GetObjectCount(loader);
-    for (OBJECT_ID obj_id = O_FIRST; obj_id <= object_count; obj_id++) {
-        max_obj_id = MAX(max_obj_id, Object_ToGameID(obj_id));
-    }
+    const int32_t max_obj_id = M_GetObjectCount(loader);
 
     BENCHMARK benchmark = Benchmark_Start();
     const int32_t num_sequences = VFile_ReadS32(file);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4171.

Sprite sequences use IDs relative to the maximum object ID supported by the engine.

In the original game, the object count was fixed. Later, as we began supporting cross-engine objects, the ID range expanded. To handle this safely, we introduced APIs that could translate between the original engine's object IDs (used in level files) and the internal representation used by our modernized engine.

Here's how the sprite sequencer determined its range in this early phase of version-agnostic objects:

```c
int32_t max_obj_id = -1;
for (GAME_OBJECT_ID obj_id = O_FIRST; obj_id <= O_ORIGINAL_NUMBER_OF;
     obj_id++) {
    max_obj_id = MAX(max_obj_id, Object_MakeGameID(obj_id));
}
```

`O_ORIGINAL_NUMBER_OF` is the engine's hardcoded number of original objects. At that stage, all new objects were appended linearly after the original list, so every new addition naturally had an ID greater than or equal to `O_ORIGINAL_NUMBER_OF`.

Coincidentally, here's what Object_MakeGameID looked like back then:

```c
int32_t Object_MakeGameID(const GAME_OBJECT_ID game_id)
{
    return game_id - O_FIRST;
}
```

Because of this simple implementation, the loop above always resolved to `O_ORIGINAL_NUMBER_OF`.

Then commit 41939ff changed the game: it merged both the old and new object lists, resulting in an out-of-order ID layout. The improved Object_MakeGameID started returning more meaningful IDs – but now, unknown objects returned -1. This caused an off-by-one situation, with the loop resolving to 190 instead of `O_ORIGINAL_NUMBER_OF` (191).

The obvious fix seemed to be using the true `O_NUMBER_OF` – effectively, "get the maximum game object ID of all known, loaded objects". But that also broke things: the engine had begun injecting additional objects beyond the original dataset, bumping the count to 194.

In reality, sprite sequences and related data still referenced offsets based on the original OG object bounds, not the new expanded ID space. My initial loop-based implementation never made sense to begin with; it assumed the logical maximum should evolve with the engine. In truth, it shouldn't: adding new objects shouldn't retroactively change the offset that the original data expects.

@lahm86 please LMK if all of this makes sense from the injection tool's perspective, too, or if I got it wrong again :sweat_smile: I think it's safe, because `Level_ReadSpriteSequences` only concerns itself with `.phd` and `.tr2`, while the injections rely directly on `Object_Get2DStatic` which is free of the original hardcoded ranges nonsense. But I'd appreciate a confirmation :relieved: 