### PR TITLE
game-flow: fix gym starting with wrong resume info

### DIFF
--- a/src/libtrx/game/game_flow/sequencer.c
+++ b/src/libtrx/game/game_flow/sequencer.c
@@ -169,6 +169,7 @@ GF_COMMAND GF_InterpretSequence(
     default:
         if (level->type == GFL_GYM) {
             Savegame_ResetCurrentInfo(level);
+            Savegame_ApplyLogicToCurrentInfo(level);
         } else if (level->type == GFL_DEMO) {
             Savegame_ApplyLogicToCurrentInfo(level);
         } else if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4182. Regression made in 29151f119c8d.