### PR TITLE
docs: add quick-linkable support instructions

### DIFF
--- a/docs/12-SUPPORT.md
+++ b/docs/12-SUPPORT.md
@@ -1,0 +1,35 @@
+---
+title: Getting support
+---
+
+# Bug Reporting Guidelines
+
+To investigate an issue, we need to reproduce it exactly as you see it.
+Reports without enough information can't be looked at – guessing helps no one!
+
+## Minimum Information Required
+
+Please include:
+
+1. **Game setup**
+    - Whether it's an **original game** or a **custom level**.  
+    - If it's custom, please attach the **level files**, **assets**, and **configuration / gameflow**.
+
+2. **System information**
+    - Operating system
+    - GPU model
+    - Exact TRX version (found in the `.exe` properties, logs, or title screen)
+
+3. **Logs**
+    - The full TR1X.log or TR2X.log from your game folder
+
+4. **Description**
+   - Steps to reproduce (e.g. *"Load Level 3, go to the upper balcony, pull the lever."*)  
+   - Savegames are fine to include if they help reproduce the issue.
+
+## Notes
+
+- Screenshots and videos are welcome, but can't replace the required information.  
+- Some issues are *hardware-specific*, so system info is essential.  
+- Custom levels *without level files* aren't actionable.  
+- Please **don't DM developers on Discord** about bugs – use GitHub issues so we can track them properly.


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds a short support guide outlining the minimum information required to investigate issues.

We've been getting an increasing number of reports (on Discord and elsewhere) without enough detail to reproduce problems. This document makes the expectations clear so issues can be handled more efficiently, and can be easily shared instead of repeating ourselves each time.

I'd appreciate a check on whether the tone feels clear and approachable.