### PR TITLE
lara/col/jump: fix wall glitch mode preventing normal animation

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -80,6 +80,7 @@
 - fixed bogus warnings about resume info in logs when playing cutscenes and in the title level
 - fixed invulnerability cheat not getting disabled during the demos (regression from 1.3)
 - fixed disable targeting allies option not working (#4184, regression from 1.5)
+- fixed Lara losing forward momentum on springboards when the wall glitch mode option is set to `Fixed` (#4187, regression from 1.2)
 
 ## [1.5.1](https://github.com/LostArtefacts/TRX/compare/tr2-1.5...tr2-1.5.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/lara/col/jump.c
+++ b/src/libtrx/game/lara/col/jump.c
@@ -321,7 +321,8 @@ static void M_ForwardJump(ITEM *const item, COLL_INFO *const coll)
     item->fall_speed = 0;
     item->pos.y += coll->side_mid.floor;
     item->speed = 0;
-    if (g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_FIXED) {
+    if (g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_FIXED
+        || coll->side_front.type != COLL_FRONT) {
         Lara_Animate(item);
     }
 }


### PR DESCRIPTION
Resolves #4187.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Wall glitches happen in TR1 and 2 when Lara is in her forward jump animation and she has (effectively) reached the floor at exactly the same time as hitting a wall. The `Lara_Animate` call is the key to her being pushed into the wall. The previous fix for wall glitches blocked this animation call on all occasions, and had the side effect of Lara losing all forward momentum, the case here being when she hit a springboard. The check now maintains momentum when Lara hasn't hit a wall in front of her.

I've checked all the relevant glitches are still working with this.
