### PR TITLE
stats: support TR1 sector-based secrets in TR2

### DIFF
--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -31,6 +31,7 @@
 - added an option to draw Shotgun flashes (Graphic Options → Visuals → Shotgun flash)
 - added `enable_debug_camera` setting that shows camera position in realtime (reachable via `/debug` and `/set`)
 - added the ability to fast-forward through cutscenes with the right button (+5 s) or with slow+right (+1 s)
+- added support for TR1-like secret triggers (#2047)
 - improved bilinear filtering for smoother edge blending when multiple objects overlap in depth
 - improved ricochets placement
     - fixed disc ricochets being placed inside walls (#4063)

--- a/src/libtrx/game/inventory.c
+++ b/src/libtrx/game/inventory.c
@@ -295,7 +295,7 @@ bool Inv_AddPickup(const ITEM *const item)
     case O_SECRET_2:
     case O_SECRET_3:
         Stats_MarkSecretCollected(item);
-        if (Stats_CheckAllLevelSecretsCollected()) {
+        if (Stats_CheckAllLevelSecretsPickedUp()) {
             GF_InventoryModifier_Apply(Game_GetCurrentLevel(), GF_INV_SECRET);
         }
         return true;

--- a/src/libtrx/game/stats/common.c
+++ b/src/libtrx/game/stats/common.c
@@ -82,18 +82,17 @@ void Stats_MarkSecretCollected(const ITEM *const item)
     Stats_UpdateSecrets(&resume->stats);
 }
 
-bool Stats_CheckAllLevelSecretsCollected(void)
+bool Stats_CheckAllLevelSecretsPickedUp(void)
 {
     const RESUME_INFO *const resume =
         Savegame_GetCurrentInfo(Game_GetCurrentLevel());
     int32_t flags = resume->stats.secret_flags;
-    int32_t count = 0;
+    size_t count = 0;
     while (flags != 0) {
         count += flags & 1;
         flags >>= 1;
     }
-
-    return count >= resume->max_stats.max_secret_count;
+    return count >= resume->max_stats.max_pickup_secret_count;
 }
 
 bool Stats_CheckAllSecretsCollected(GF_LEVEL_TYPE level_type)
@@ -200,6 +199,7 @@ FINAL_STATS Stats_ComputeFinalStats(const GF_LEVEL_TYPE level_type)
         L_ADD(max_stats.max_kill_count);
         L_ADD(max_stats.max_pickup_count);
         L_ADD(max_stats.max_secret_count);
+        L_ADD(max_stats.max_pickup_secret_count);
 #undef L_ADD
     }
 

--- a/src/libtrx/game/stats/scan.c
+++ b/src/libtrx/game/stats/scan.c
@@ -34,32 +34,41 @@ static void M_IncludeKillableItem(
     stats->max_pickup_count += Carrier_GetItemCount(item_num);
 }
 
-static bool M_HasObjectSecrets(void)
+static uint32_t M_ReserveSecretConcreteBit(
+    LEVEL_MAX_STATS *const stats, const OBJECT_ID object_id,
+    const int32_t position)
 {
-    for (int32_t i = 0; g_SecretObjects[i] != NO_OBJECT; i++) {
-        if (Object_Get(g_SecretObjects[i])->loaded) {
-            return true;
+    LOG_TRACE("Reserving bit %d for secret %d", position, object_id);
+    if (position < 0 || position >= STATS_MAX_SECRETS) {
+        LOG_ERROR(
+            "Invalid secret bit %d (max: %d)", position, STATS_MAX_SECRETS);
+        return 0;
+    }
+    const uint32_t secret_bit = 1 << position;
+    if (!(stats->all_secrets_mask & secret_bit)) {
+        stats->all_secrets_mask |= secret_bit;
+        stats->max_secret_count++;
+        if (object_id != NO_OBJECT) {
+            stats->max_pickup_secret_count++;
         }
     }
-    return false;
+    stats->secret_objects[position].assigned_object_id = object_id;
+    stats->secret_objects[position].item_num = NO_ITEM;
+    stats->secret_objects[position].taken = true;
+    return secret_bit;
 }
 
-static uint32_t M_ReserveSecretBit(
+static uint32_t M_ReserveSecretUnusedBit(
     LEVEL_MAX_STATS *const stats, const OBJECT_ID object_id)
 {
-    uint32_t n = stats->all_secrets_mask;
     // Find unused bit
     int32_t position = 0;
+    uint32_t n = stats->all_secrets_mask;
     while ((n & 1) == 1) {
         n >>= 1;
         position++;
     }
-    LOG_TRACE("Reserving bit %d for secret %d", position, object_id);
-    stats->all_secrets_mask |= 1 << position;
-    stats->max_secret_count++;
-    stats->secret_objects[position].assigned_object_id = object_id;
-    stats->secret_objects[position].item_num = NO_ITEM;
-    return 1 << position;
+    return M_ReserveSecretConcreteBit(stats, object_id, position);
 }
 
 static void M_CheckTriggers(
@@ -80,17 +89,8 @@ static void M_CheckTriggers(
     const TRIGGER_CMD *cmd = sector->trigger->command;
     for (; cmd != nullptr; cmd = cmd->next_cmd) {
         if (cmd->type == TO_SECRET) {
-            if (M_HasObjectSecrets()) {
-                // At the moment, we can't mix tile-based and pickup-based
-                // secrets – OG TR2 has both in Bartoli Hideout and a couple of
-                // other levels.
-                continue;
-            }
-            const int16_t secret_num = 1 << (int16_t)(intptr_t)cmd->parameter;
-            if (!(stats->all_secrets_mask & secret_num)) {
-                stats->all_secrets_mask |= secret_num;
-                stats->max_secret_count++;
-            }
+            const uint16_t secret_num = (uint16_t)(intptr_t)cmd->parameter;
+            M_ReserveSecretConcreteBit(stats, NO_OBJECT, secret_num);
         } else if (cmd->type == TO_OBJECT) {
             const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
             if (m_KillableItems[item_num]) {
@@ -152,7 +152,6 @@ static void M_CheckTriggers(
 
 static void M_TraverseFloor(LEVEL_MAX_STATS *const stats)
 {
-    uint32_t secrets = 0;
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         const ROOM *const room = Room_Get(i);
         for (int32_t z_sector = 0; z_sector < room->size.z; z_sector++) {
@@ -169,6 +168,7 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
         stats->secret_objects[i].assigned_object_id = NO_OBJECT;
         stats->secret_objects[i].item_num = NO_ITEM;
+        stats->secret_objects[i].taken = false;
     }
 
     memset(&m_KillableItems, 0, sizeof(m_KillableItems));
@@ -186,7 +186,6 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
     // Check triggers for special pickups / killables
     M_TraverseFloor(stats);
 
-    int32_t secret_count = 0;
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
         ITEM *const item = Item_Get(i);
         if (item->object_id < O_FIRST || item->object_id >= O_NUMBER_OF) {
@@ -199,19 +198,34 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
         }
 
         if (Object_IsType(item->object_id, g_SecretObjects)) {
-            if (secret_count >= STATS_MAX_SECRETS) {
+            int32_t position = -1;
+            for (int32_t j = 0; j < STATS_MAX_SECRETS; j++) {
+                if (!stats->secret_objects[j].taken) {
+                    position = j;
+                    break;
+                }
+            }
+            if (position == -1) {
                 LOG_ERROR("Too many secrets, max %d", STATS_MAX_SECRETS);
                 break;
             }
-            stats->secret_objects[secret_count].assigned_object_id =
+            stats->secret_objects[position].assigned_object_id =
                 item->object_id;
-            stats->secret_objects[secret_count].item_num = i;
-            secret_count++;
+            stats->secret_objects[position].item_num = i;
+            stats->secret_objects[position].taken = true;
+            position++;
         }
     }
 
-    for (int32_t i = 0; i < secret_count; i++) {
-        for (int32_t j = i + 1; j < secret_count; j++) {
+    // Sorts secret objects by their type so that the dragons line up nicely
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        if (stats->secret_objects[i].assigned_object_id == NO_OBJECT) {
+            continue;
+        }
+        for (int32_t j = i + 1; j < STATS_MAX_SECRETS; j++) {
+            if (stats->secret_objects[j].assigned_object_id == NO_OBJECT) {
+                continue;
+            }
             if (stats->secret_objects[i].assigned_object_id
                 > stats->secret_objects[j].assigned_object_id) {
                 SWAP(stats->secret_objects[i], stats->secret_objects[j]);
@@ -219,10 +233,13 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
         }
     }
 
-    for (int32_t k = 0; k < secret_count; k++) {
-        ITEM *const item = Item_Get(stats->secret_objects[k].item_num);
-        item->data = (void *)(intptr_t)M_ReserveSecretBit(
-            stats, stats->secret_objects[k].assigned_object_id);
+    // Assign secret items their bits so they know which secret to set on pickup
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        ITEM *const item = Item_Get(stats->secret_objects[i].item_num);
+        if (item != nullptr) {
+            item->data = (void *)(intptr_t)M_ReserveSecretUnusedBit(
+                stats, stats->secret_objects[i].assigned_object_id);
+        }
     }
 }
 
@@ -241,7 +258,12 @@ void Stats_ScanLevel(void)
     resume->max_stats.max_kill_count -= level->unobtainable.kills;
     resume->max_stats.max_secret_count -= level->unobtainable.secrets;
     LOG_INFO("Scanned level %s:", level->title);
-    LOG_INFO("  Max secrets = %d", resume->max_stats.max_secret_count);
+    LOG_INFO(
+        "  Max secrets = %d (%d pickups, %d sectors)",
+        resume->max_stats.max_secret_count,
+        resume->max_stats.max_pickup_secret_count,
+        resume->max_stats.max_secret_count
+            - resume->max_stats.max_pickup_secret_count);
     LOG_INFO("  Max pickups = %d", resume->max_stats.max_pickup_count);
     LOG_INFO("  Max kills = %d", resume->max_stats.max_kill_count);
     Benchmark_End(&benchmark, nullptr);

--- a/src/libtrx/game/ui/dialogs/stats.c
+++ b/src/libtrx/game/ui/dialogs/stats.c
@@ -1,8 +1,10 @@
 #include "config.h"
 #include "debug.h"
 #include "game/const.h"
+#include "game/game.h"
 #include "game/game_flow.h"
 #include "game/gym.h"
+#include "game/objects.h"
 #include "game/savegame.h"
 #include "game/stats.h"
 #include "game/ui.h"
@@ -38,6 +40,7 @@ typedef struct UI_STATS_DIALOG_STATE {
     UI_STATS_DIALOG_ARGS args;
     UI_REQUESTER_STATE assault_req;
     const M_LOOK *look;
+    bool has_floordata_secrets;
 } UI_STATS_DIALOG_STATE;
 
 static const M_LOOK m_Looks[TR_VERSION_COUNT] = {
@@ -89,7 +92,6 @@ static const char *M_FormatDistance(int32_t distance)
 static void M_FormatIconSecrets(
     char *const out, const LEVEL_STATS *const level_stats)
 {
-    // TODO: implement optional support for TR1-style secrets in TR2, see #2047
     char *ptr = out;
     int32_t num_secrets = 0;
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
@@ -105,10 +107,11 @@ static void M_FormatIconSecrets(
             continue;
         }
         const OBJECT_ID obj_id = Stats_GetSecretObject(i);
-        ASSERT(obj_id != NO_OBJECT);
-        ptr += sprintf(
-            ptr, has_secret ? "\\{secret %d}" : "\\{i}\\{secret %d}\\{/i}",
-            obj_id + 1 - O_SECRET_1);
+        if (obj_id != NO_OBJECT) {
+            ptr += sprintf(
+                ptr, has_secret ? "\\{secret %d}" : "\\{i}\\{secret %d}\\{/i}",
+                obj_id + 1 - O_SECRET_1);
+        }
         if (has_secret) {
             num_secrets++;
         }
@@ -166,6 +169,10 @@ static void M_RowFromRole(
         break;
 
     case M_ROW_ICON_SECRETS: {
+        if (s->has_floordata_secrets) {
+            M_RowFromRole(s, M_ROW_NUM_SECRETS, stats, max_stats);
+            break;
+        }
         char buf[256];
         M_FormatIconSecrets(buf, (LEVEL_STATS *)stats);
         M_Row(s, GS(STATS_SECRETS), buf);
@@ -176,8 +183,8 @@ static void M_RowFromRole(
         M_Row(
             s, GS(STATS_SECRETS),
             String_FormatStatic(
-                g_TRVersion == 1 ? GS(STATS_DETAIL_FMT) : num_fmt,
-                stats->secret_count, max_stats->max_secret_count));
+                GS(STATS_DETAIL_FMT), stats->secret_count,
+                max_stats->max_secret_count));
         break;
 
     case M_ROW_PICKUPS:
@@ -432,6 +439,17 @@ UI_STATS_DIALOG_STATE *UI_StatsDialog_Init(const UI_STATS_DIALOG_ARGS args)
     s->assault_req.reserve_space = true;
     s->args = args;
     s->look = &m_Looks[g_TRVersion - 1];
+
+    s->has_floordata_secrets = false;
+    const GF_LEVEL *const level = Game_GetCurrentLevel();
+    const LEVEL_MAX_STATS *const max_stats = Stats_GetLevelMaxStats(level);
+    for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
+        if (max_stats->secret_objects[i].taken
+            && max_stats->secret_objects[i].assigned_object_id == NO_OBJECT) {
+            s->has_floordata_secrets = true;
+        }
+    }
+
     return s;
 }
 

--- a/src/libtrx/include/libtrx/game/stats/common.h
+++ b/src/libtrx/include/libtrx/game/stats/common.h
@@ -13,7 +13,7 @@ OBJECT_ID Stats_GetSecretObject(int32_t secret_idx);
 void Stats_UpdateSecrets(LEVEL_STATS *stats);
 void Stats_MarkSecretCollected(const ITEM *item);
 bool Stats_CheckAllSecretsCollected(GF_LEVEL_TYPE level_type);
-bool Stats_CheckAllLevelSecretsCollected(void);
+bool Stats_CheckAllLevelSecretsPickedUp(void);
 
 void Stats_UpdateTimer(void);
 void Stats_AddKill(void);

--- a/src/libtrx/include/libtrx/game/stats/types.h
+++ b/src/libtrx/include/libtrx/game/stats/types.h
@@ -5,12 +5,14 @@
 #include <stdint.h>
 
 typedef struct {
-    int32_t max_kill_count;
-    int32_t max_pickup_count;
-    int32_t max_secret_count;
-    int32_t all_secrets_mask;
+    size_t max_pickup_secret_count;
+    size_t max_kill_count;
+    size_t max_pickup_count;
+    size_t max_secret_count;
+    uint32_t all_secrets_mask;
 
     struct {
+        bool taken;
         OBJECT_ID assigned_object_id;
         int32_t item_num;
     } secret_objects[STATS_MAX_SECRETS];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #2047.