### PR TITLE
music/common: improve ambient track detection

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -38,6 +38,7 @@
 - changed save crystal collision to make them easier to activate
 - changed the unrestricted look mode option to include Lara being able to look freely while shooting an enemy (#4090)
 - changed the `ambient_tracks` property to be only available on the root level
+- changed music triggers that match the level's default ambient track to automatically be treated as ambient if omitted from `ambient_tracks` (#4181)
 - changed cutscene data (e.g. `cut1.phd`, as opposed to in-game cinematics) to match TR2 format, where Lara (as `O_LARA`) must be defined as an item in the level file
 - changed the `-q`/`--quiet` argument to no longer silence warnings
 - changed the Remove shotguns, Remove Uzis and Remove Magnus into a single "Remove extra guns" option

--- a/docs/tr2/CHANGELOG.md
+++ b/docs/tr2/CHANGELOG.md
@@ -49,6 +49,7 @@
 - changed the debug position UI to no longer be hidden in photo mode
 - changed the unrestricted look mode option to include Lara being able to look freely while shooting an enemy (#4090)
 - changed the `ambient_tracks` property to be only available on the root level
+- changed music triggers that match the level's default ambient track to automatically be treated as ambient if omitted from `ambient_tracks` (#4181)
 - changed the Pause key to no longer work when Lara's dead (similar to TR1)
 - changed the `-q`/`--quiet` argument to no longer silence warnings
 - changed the `Remember Guns between Levels` option to also apply to whether or not Lara starts with those guns equipped

--- a/src/libtrx/game/music/common.c
+++ b/src/libtrx/game/music/common.c
@@ -106,6 +106,11 @@ static bool M_IsBrokenTrack(const MUSIC_ID track_id)
 
 static bool M_IsAmbientTrack(const MUSIC_ID track_id)
 {
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level != nullptr && level->music_track == track_id) {
+        return true;
+    }
+
     const GF_AMBIENT_DATA *const ambient_data = &g_GameFlow.ambient_tracks;
     if (ambient_data == nullptr) {
         return false;


### PR DESCRIPTION
Resolves #4181.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates music handling to allow the level's default ambient track to be included in floor triggers, and optionally (or accidentally) omitted from the game flow ambient track data.

The one shot problems in the issue are related to the trigger setup from TE (i.e. more than one item in a trigger, but only the music marked as one shot will not yield a compiled one shot trigger - all items need the flag).
