### PR TITLE
objects/trap/dart: update room for hit position

### DIFF
--- a/src/libtrx/game/objects/traps/dart.c
+++ b/src/libtrx/game/objects/traps/dart.c
@@ -16,7 +16,10 @@ static void M_Hit(const int16_t item_num, const XYZ_32 pos)
     Item_Kill(item_num);
     Sound_Effect(SFX_PROJECTILE_HIT, &item->pos, SPM_NORMAL);
 
-    const int16_t effect_num = Effect_Create(item->room_num);
+    int16_t room_num = item->room_num;
+    Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+
+    const int16_t effect_num = Effect_Create(room_num);
     if (effect_num != NO_EFFECT) {
         EFFECT *const effect = Effect_Get(effect_num);
         effect->object_id = O_RICOCHET;


### PR DESCRIPTION
Resolves #4198.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Spark effects hitting walls may inherit the room number from inside the wall of the finished dart. That may be a portal instance, so this ensures instead that the room number is recalculated based on the hit position, and so ensures underwater status is retained.
