### PR TITLE
level/loader: duplicate TR1 zone data

### DIFF
--- a/src/libtrx/game/level/loader.c
+++ b/src/libtrx/game/level/loader.c
@@ -1140,6 +1140,14 @@ void Level_ReadPathingData(const LEVEL_LOADER *const loader, VFILE *const file)
             int16_t *const ground_zone =
                 Box_GetGroundZone(flip_status, zone_idx);
             VFile_Read(file, ground_zone, sizeof(int16_t) * num_boxes);
+
+            if (loader->game_version == 1 && zone_idx == 1) {
+                // TODO: remove once TombEditor is updated to generate the same
+                // number of zones as TR2 via injections. This allows enemies of
+                // type g_LOT_Climber to safely be used in TR1 in the meantime.
+                int16_t *const duped_zone = Box_GetGroundZone(flip_status, 3);
+                memcpy(duped_zone, ground_zone, sizeof(int16_t) * num_boxes);
+            }
         }
 
         int16_t *const fly_zone = Box_GetFlyZone(flip_status);

--- a/src/libtrx/game/pathing/box.c
+++ b/src/libtrx/game/pathing/box.c
@@ -39,7 +39,7 @@ void Box_InitialiseBoxes(const int32_t num_boxes)
     }
 
     for (int32_t i = 0; i < 2; i++) {
-        for (int32_t j = 0; j < Box_GetZoneCount(); j++) {
+        for (int32_t j = 0; j < MAX_ZONES; j++) {
             m_GroundZone[j][i] =
                 GameBuf_Alloc(sizeof(int16_t) * num_boxes, GBUF_GROUND_ZONE);
         }


### PR DESCRIPTION
Ref: #4206 

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This duplicates zone 1 data into zone 3 for TR1, hence allowing climber enemies to be loaded. They will not be able to climb until
TombEditor changes are implemented later with injections adding the proper TR2 zoning data, but this avoids a crash in the meantime with acceptable enemy behaviour.
