### PR TITLE
objects/effects/twinkle: merge logic

### DIFF
--- a/src/libtrx/game/objects/effects/twinkle.c
+++ b/src/libtrx/game/objects/effects/twinkle.c
@@ -7,7 +7,6 @@
 #include "game/random.h"
 #include "game/spawn.h"
 #include "utils.h"
-#include "version.h"
 
 #define M_DISAPPEAR_RANGE STEP_L
 
@@ -16,10 +15,8 @@ static void M_SpawnTwinkle(const GAME_VECTOR *const pos)
     const int16_t effect_num = Effect_Create(pos->room_num);
     if (effect_num != NO_EFFECT) {
         EFFECT *const effect = Effect_Get(effect_num);
-        effect->pos.x = pos->x;
-        effect->pos.y = pos->y;
-        effect->pos.z = pos->z;
-        effect->counter = 0;
+        effect->pos = pos->pos;
+        effect->counter = Object_Get(O_TWINKLE)->mesh_count;
         effect->object_id = O_TWINKLE;
         effect->frame_num = 0;
     }
@@ -61,35 +58,24 @@ static void M_Control(const int16_t effect_num)
     EFFECT *const effect = Effect_Get(effect_num);
     const OBJECT *const obj = Object_Get(effect->object_id);
 
-    if (g_TRVersion == 1) {
+    effect->frame_num--;
+    if (effect->frame_num <= obj->mesh_count) {
+        effect->frame_num = 0;
+    }
+
+    if (effect->counter < 0) {
         effect->counter++;
-        if (effect->counter == 1) {
-            effect->counter = 0;
-            effect->frame_num--;
-            if (effect->frame_num <= obj->mesh_count) {
-                Effect_Kill(effect_num);
-            }
-        }
-    } else {
-        effect->frame_num--;
-        if (effect->frame_num <= obj->mesh_count) {
-            effect->frame_num = 0;
-        }
-
-        if (effect->counter < 0) {
-            effect->counter++;
-            if (effect->counter == 0) {
-                Effect_Kill(effect_num);
-            }
-            return;
-        }
-
-        const ITEM *const item = Item_Get(effect->counter);
-        const XYZ_32 target_pos = M_GetTargetPos(item);
-        M_NudgeTowardsItem(effect, &target_pos);
-        if (M_ShouldDisappear(effect, &target_pos)) {
+        if (effect->counter == 0) {
             Effect_Kill(effect_num);
         }
+        return;
+    }
+
+    const ITEM *const item = Item_Get(effect->counter);
+    const XYZ_32 target_pos = M_GetTargetPos(item);
+    M_NudgeTowardsItem(effect, &target_pos);
+    if (M_ShouldDisappear(effect, &target_pos)) {
+        Effect_Kill(effect_num);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates TR1 to use the same approach as TR2 for the twinkle effect, so assigning a negative counter like the Xian guard, and incrementing on each frame to reach zero and stop. Positive counters are used for the mystic light effect at the dragon.

Checks:
- using Midas touch
- stepping on Midas touch
- Floater swordman
- dragon
