### PR TITLE
lara/control: fix col update in extra anims

### DIFF
--- a/src/libtrx/game/lara/control.c
+++ b/src/libtrx/game/lara/control.c
@@ -472,7 +472,7 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
     if ((g_TRVersion == 1 || !lara_info->extra_anim)
         && lara_info->water_status != LWS_CHEAT) {
         M_ObjectCollision(coll);
-        if (!Lara_Vehicle_IsMounted()) {
+        if (!Lara_Vehicle_IsMounted() && !lara_info->extra_anim) {
             Lara_Col_Update(item, coll);
         }
     }
@@ -614,7 +614,7 @@ static void M_HandleSurface(COLL_INFO *const coll)
     const SECTOR *const sector = M_GetCurrentSector();
 
     M_ObjectCollision(coll);
-    if (!Lara_Vehicle_IsMounted()) {
+    if (!Lara_Vehicle_IsMounted() && !lara_info->extra_anim) {
         Lara_Col_Update(item, coll);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids Lara's normal collision routines running if object collision has switched her into the extra anim state. This doesn't affect anywhere in OG because the routines with the same state IDs as normal animations are harmless, but as we expand the extra animations there is the risk of running mismatched routines that will further alter Lara and break the extra animations.

An example would be some object switching Lara to extra anim state 9 (which doesn't exist in OG). This matches to normal state `LS_POSE`, which runs the `M_Stop` collision routine, which can switch Lara to `LA_FALL_START` and hence break the extra anim.
