### PR TITLE
inject: fix OG save crash with PS1 enemy restore

### DIFF
--- a/docs/tr1/CHANGELOG.md
+++ b/docs/tr1/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed invulnerability cheat not getting disabled during the demos (regression from 4.13)
 - fixed health bar flicker on medi packs when cycling the inventory ring (#4211, regression from 4.14)
 - fixed title bar size being too small on HiDPI screens on Windows platform (#2837)
+- fixed crash when loading OG saves made in City of Khamoon, while the "Restore PS1 enemies" option is on (#4217, regression from 2.16)
 
 ## [4.15.1](https://github.com/LostArtefacts/TRX/compare/tr1-4.15...tr1-4.15.1) - 2025-10-10
 - changed the examine dialog to be usable with non-puzzle items (#4009)

--- a/src/libtrx/game/inject/common.c
+++ b/src/libtrx/game/inject/common.c
@@ -6,6 +6,7 @@
 #include "game/items.h"
 #include "game/level.h"
 #include "game/rooms.h"
+#include "game/savegame.h"
 #include "memory.h"
 #include "vector.h"
 #include "version.h"
@@ -51,8 +52,17 @@ static bool M_IsRelevant(const INJECTION_FILE_TYPE type)
 #if TR_VERSION == 1
     case IFT_UZI_SFX:
         return g_Config.audio.enable_ps_uzi_sfx;
-    case IFT_PS1_ENEMY:
-        return g_Config.gameplay.restore_ps1_enemies;
+    case IFT_PS1_ENEMY: {
+        if (!g_Config.gameplay.restore_ps1_enemies) {
+            return false;
+        }
+        const SAVEGAME_INFO *const info =
+            Savegame_GetSavegameInfo(Savegame_GetBoundSlot());
+        if (info != nullptr && (info->initial_version == VERSION_LEGACY)) {
+            return false;
+        }
+        return true;
+    }
 #elif TR_VERSION == 2
     case IFT_BAREFOOT_SFX:
         return g_Config.audio.enable_barefoot_sfx;

--- a/src/libtrx/game/savegame/common.c
+++ b/src/libtrx/game/savegame/common.c
@@ -370,7 +370,9 @@ void Savegame_SetCurrentInfo(const int32_t current_slot, const int32_t src_slot)
 
 const SAVEGAME_INFO *Savegame_GetSavegameInfo(const int32_t slot_num)
 {
-    ASSERT(slot_num >= 0);
+    if (slot_num < 0 || slot_num >= m_SaveSlots) {
+        return nullptr;
+    }
     return &m_SavegameInfo[slot_num];
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4217.