### PR TITLE
lara/common: initialise braid in cutscenes

### DIFF
--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -132,12 +132,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     Lara_Control_Initialise(level->type, m_StartAnimState);
 
     if (level->type == GFL_CUTSCENE) {
-        for (int32_t i = 0; i < LM_NUMBER_OF; i++) {
-            Lara_Mesh_SwapSingle(i, O_LARA);
-        }
-
-        Lara_Mesh_SwapSingle(LM_THIGH_L, O_LARA_PISTOLS);
-        Lara_Mesh_SwapSingle(LM_THIGH_R, O_LARA_PISTOLS);
+        Lara_Mesh_Initialise(level);
         lara_info->gun_status = LGS_ARMLESS;
     } else {
         Lara_InitialiseInventory(level);

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -95,7 +95,14 @@ static OBJECT_ID M_GetTargetMesh(const LARA_MESH mesh_idx)
     return O_LARA;
 }
 
-void Lara_Mesh_Initialise(const GF_LEVEL *const level)
+static void M_InitialiseCutsceneLevel(void)
+{
+    Lara_Mesh_SwapAll(O_LARA);
+    Lara_Mesh_SwapSingle(LM_THIGH_L, O_LARA_PISTOLS);
+    Lara_Mesh_SwapSingle(LM_THIGH_R, O_LARA_PISTOLS);
+}
+
+static void M_InitialiseNormalLevel(const GF_LEVEL *const level)
 {
     const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
 
@@ -116,6 +123,15 @@ void Lara_Mesh_Initialise(const GF_LEVEL *const level)
 
     if (resume != nullptr && resume->equipped_gun_type == LGT_FLARE) {
         Lara_Mesh_SwapSingle(LM_HAND_L, O_LARA_FLARE);
+    }
+}
+
+void Lara_Mesh_Initialise(const GF_LEVEL *const level)
+{
+    if (level->type == GFL_CUTSCENE) {
+        M_InitialiseCutsceneLevel();
+    } else {
+        M_InitialiseNormalLevel(level);
     }
 
     m_BraidStatus = false;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's braid mesh swaps are initialised in cutscenes in TR1.
Unreleased regression in 3ad66b6c4a9cf5698279a640f157d7fc2b5e9dcc
