### PR TITLE
objects/skidoo_common: spawn blood until creature is inactive

### DIFF
--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -145,7 +145,7 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
         }
     } else if (
         obj->intelligent && item->status == IS_ACTIVE
-        && Creature_IsTargetable(item)) {
+        && (Creature_IsTargetable(item) || item->hit_points == 0)) {
         Spawn_BloodBath(
             item->pos.x, skidoo->pos.y - STEP_L, item->pos.z, skidoo->speed,
             skidoo->rot.y, item->room_num, 3);


### PR DESCRIPTION
Resolves #4229.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The targetable creature check will return false once an enemy's HP is 0, but the skidoo is intended to spawn blood until the creature is completely inactive. This adds an additional check in the skidoo control for this scenario.
