### PR TITLE
shell: fix -e/--engine not choosing the right mod

### DIFF
--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -48,16 +48,12 @@ static void M_ShowHelp(void)
 SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 {
     SHELL_ARGS *out_args = Memory_Alloc(sizeof(SHELL_ARGS));
-    out_args->mod = M_BASE_MOD;
     out_args->save_to_load = -1;
     out_args->level_to_select = -1;
     out_args->original_args = args;
-    if (args == nullptr) {
-        return out_args;
-    }
 
     // First pass: set the engine version
-    for (int32_t i = 0; i < args->count; i++) {
+    for (int32_t i = 0; args != nullptr && i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);
         const char *const next_arg =
             i + 1 < args->count ? *(char **)Vector_Get(args, i + 1) : nullptr;
@@ -68,7 +64,10 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
     }
 
-    for (int32_t i = 0; i < args->count; i++) {
+    out_args->mod = M_BASE_MOD;
+
+    // Second pass: remaining options
+    for (int32_t i = 0; args != nullptr && i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);
         const char *const next_arg =
             i + 1 < args->count ? *(char **)Vector_Get(args, i + 1) : nullptr;
@@ -136,6 +135,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             out_args->quiet = true;
         }
     }
+
     return out_args;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The NPE fix landed some days ago would cause `-e/--engine` to not load the right mod (eg `-e 1` would try to load `tr2/gameflow.json5`). This PR fixes it.