### PR TITLE
items: make TR1 body-bag aware

### DIFF
--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -971,12 +971,10 @@ void Creature_Die(const int16_t item_num, const bool explode)
     }
     item->flags |= IF_ONE_SHOT;
 
-#if TR_VERSION >= 2
-    if (item->killed) {
+    if (item->clear_body) {
         item->next_active = Item_GetPrevActive();
         Item_SetPrevActive(item_num);
     }
-#endif
 
     Carrier_TestItemDrops(item_num);
 }

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -192,13 +192,11 @@ void Item_Initialise(const int16_t item_num)
     item->enable_interpolation = true;
     item->enable_shadow = true;
 
-#if TR_VERSION >= 2
-    item->killed = false;
+    item->clear_body = false;
     if ((item->flags & IF_KILLED) != 0) {
-        item->killed = true;
+        item->clear_body = true;
         item->flags &= ~IF_KILLED;
     }
-#endif
 
     if ((item->flags & IF_INVISIBLE) != 0) {
         item->status = IS_INVISIBLE;

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -55,9 +55,7 @@ typedef struct {
     bool collidable;
     bool looked_at;
     bool dynamic_light;
-#if TR_VERSION == 2
-    bool killed;
-#endif
+    bool clear_body;
 
     struct {
         struct {

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -71,9 +71,7 @@ typedef enum {
     TO_CD = 8,
     TO_FLIPEFFECT = 9,
     TO_SECRET = 10,
-#if TR_VERSION == 2
     TO_BODY_BAG = 11,
-#endif
 } TRIGGER_OBJECT;
 
 typedef enum {

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -618,11 +618,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             break;
         }
 
-#if TR_VERSION == 2
         case TO_BODY_BAG:
             Item_ClearKilled();
             break;
-#endif
 
         default:
             break;

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -690,13 +690,11 @@ static bool M_ReadItem(
             }
         } else if (obj->intelligent) {
             item->data = nullptr;
-#if TR_VERSION == 2
-            if (item->killed && item->hit_points <= 0
-                && !(item->flags & IF_KILLED)) {
+            if (item->clear_body && item->hit_points <= 0
+                && (item->flags & IF_KILLED) == 0) {
                 item->next_active = Item_GetPrevActive();
                 Item_SetPrevActive(item_num);
             }
-#endif
         }
     }
 

--- a/src/trx/game/savegame/legacy.c
+++ b/src/trx/game/savegame/legacy.c
@@ -492,13 +492,11 @@ static void M_ReadItem(M_CONTEXT *const ctx, const int16_t item_num)
             }
         } else if (obj->intelligent) {
             item->data = nullptr;
-#if TR_VERSION == 2
-            if (item->killed && item->hit_points <= 0
-                && !(item->flags & IF_KILLED)) {
+            if (item->clear_body && item->hit_points <= 0
+                && (item->flags & IF_KILLED) == 0) {
                 item->next_active = Item_GetPrevActive();
                 Item_SetPrevActive(item_num);
             }
-#endif
         }
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This renames the `killed` flag on TR2 items to better indicate that the purpose is for those items to be targeted by body bag triggers. The functionality is now available in TR1.

The level data uses the high bit to mark enemies that should be targeted for body bags; throughout the OG TR1 levels, this bit is not set on any item. As an aside, TombEditor offers the ability to set the flag, but it does not offer body bag trigger support; it uses type `11` for a TRNG action of some kind.
