### PR TITLE
rooms: try draw rooms with protruding items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
     - changed the appearance labels to better align with expectations (#4025)
     - removed the look modes for every bar (except enemy bars that retain the "boss only" setting)
     - fixed health bar flicker on medi packs when cycling the inventory ring (#4211, regression from TR1X 4.14 / TR2X 1.4)
+- improved room scheduler to try and draw objects from rooms to which all portals appear offscreen (#2005)
 - changed the `/debug` command to accept optional option name argument (for example: `/debug pos 1`)
 - changed dart emitters and disc emitters to have separate slots (so with catalogs, both can be used in the same level simultaneously)
 - changed the debug position UI to no longer be hidden in photo mode

--- a/src/meson.build
+++ b/src/meson.build
@@ -252,6 +252,7 @@ common_sources = [
   'trx/game/level/reader.c',
   'trx/game/level/reader_tr1.c',
   'trx/game/level/reader_tr2.c',
+  'trx/game/level/rooms.c',
   'trx/game/level/settings.c',
   'trx/game/los.c',
   'trx/game/lua/common.c',

--- a/src/trx/game/level/loader.h
+++ b/src/trx/game/level/loader.h
@@ -47,6 +47,7 @@ void Level_AppendObjectTextures(
 void Level_AppendSpriteTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 
+void Level_LoadRooms(void);
 void Level_LoadTextures(void);
 void Level_LoadTexturePages(const LEVEL_LOADER *loader);
 void Level_LoadPalettes(void);

--- a/src/trx/game/level/reader.c
+++ b/src/trx/game/level/reader.c
@@ -225,6 +225,7 @@ static void M_CompleteSetup(
     // Configure enemies who carry and drop items
     Carrier_InitialiseLevel(level);
 
+    Level_LoadRooms();
     Level_LoadTextures();
     Level_LoadTexturePages(loader);
     Level_LoadPalettes();

--- a/src/trx/game/level/rooms.c
+++ b/src/trx/game/level/rooms.c
@@ -1,0 +1,102 @@
+#include <trx/game/items.h>
+#include <trx/game/level/loader.h>
+#include <trx/game/objects.h>
+#include <trx/game/rooms.h>
+#include <trx/log.h>
+#include <trx/utils.h>
+
+static bool M_CheckOverlap(
+    const BOUNDS_32 *const room_bounds, const BOUNDS_32 *const other_bounds)
+{
+    int32_t margin = 0;
+    margin = MAX(margin, MAX(0, room_bounds->min.x - other_bounds->min.x));
+    margin = MAX(margin, MAX(0, other_bounds->max.x - room_bounds->max.x));
+    margin = MAX(margin, MAX(0, room_bounds->min.y - other_bounds->min.y));
+    margin = MAX(margin, MAX(0, other_bounds->max.y - room_bounds->max.y));
+    margin = MAX(margin, MAX(0, room_bounds->min.z - other_bounds->min.z));
+    margin = MAX(margin, MAX(0, other_bounds->max.z - room_bounds->max.z));
+    return margin > 32;
+}
+
+static void M_CheckProtrudingItems(void)
+{
+    for (int32_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
+        const ITEM *const item = Item_Get(item_num);
+        if (item->room_num == NO_ROOM) {
+            continue;
+        }
+        if (Object_Get(item->object_id)->intelligent) {
+            continue;
+        }
+
+        ROOM *const room = Room_Get(item->room_num);
+        if (room->flags.protruding_items) {
+            continue;
+        }
+        const BOUNDS_16 *const item_bounds = Item_GetBoundsAccurate(item);
+        const BOUNDS_32 other_bounds = {
+            .min = {
+                .x = item->pos.x + item_bounds->min.x,
+                .y = item->pos.y + item_bounds->min.y,
+                .z = item->pos.z + item_bounds->min.z,
+            },
+            .max = {
+                .x = item->pos.x + item_bounds->max.x,
+                .y = item->pos.y + item_bounds->max.y,
+                .z = item->pos.z + item_bounds->max.z,
+            },
+        };
+        const BOUNDS_32 room_bounds = Room_GetRoomBounds(item->room_num);
+        if (M_CheckOverlap(&room_bounds, &other_bounds)) {
+            room->flags.protruding_items = true;
+            LOG_DEBUG(
+                "Room %d has a protruding item: %d", item->room_num, item_num);
+        }
+    }
+}
+
+static void M_CheckProtrudingStatics(void)
+{
+    for (int32_t room_num = 0; room_num < Room_GetCount(); room_num++) {
+        ROOM *const room = Room_Get(room_num);
+        if (room->flags.protruding_items) {
+            continue;
+        }
+        const BOUNDS_32 room_bounds = Room_GetRoomBounds(room_num);
+        for (int32_t i = 0; i < room->num_static_meshes; i++) {
+            const STATIC_MESH *const mesh = &room->static_meshes[i];
+            const STATIC_OBJECT_3D *const obj =
+                Object_Get3DStatic(mesh->static_num);
+            const BOUNDS_32 other_bounds = {
+                .min = {
+                    .x = mesh->pos.x + obj->draw_bounds.min.x,
+                    .y = mesh->pos.y + obj->draw_bounds.min.y,
+                    .z = mesh->pos.z + obj->draw_bounds.min.z,
+                },
+                .max = {
+                    .x = mesh->pos.x + obj->draw_bounds.max.x,
+                    .y = mesh->pos.y + obj->draw_bounds.max.y,
+                    .z = mesh->pos.z + obj->draw_bounds.max.z,
+                },
+            };
+            if (M_CheckOverlap(&room_bounds, &other_bounds)) {
+                room->flags.protruding_items = true;
+                LOG_DEBUG("Room %d has a protruding static: %d", room_num, i);
+                break;
+            }
+        }
+    }
+}
+
+void Level_LoadRooms(void)
+{
+    // Check all items whether they fit properly within their rooms. If not,
+    // mark the room as having protruding items. Do the same with statics.
+    //
+    // This flag is used by the room traverser to still let a room to be drawn,
+    // even if all portals leading to it are currently offscreen.
+    // This often happens with trapdoors – they're placed directly on portals.
+
+    M_CheckProtrudingItems();
+    M_CheckProtrudingStatics();
+}

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -314,8 +314,8 @@ void Output_EnableScissor(
     VIEWPORT_RECT scissor = {
         .x = window.x + (x * scale_x) - border,
         .y = window.y + (game.h - y) * scale_y - border,
-        .w = w * scale_x + border * 2,
-        .h = h * scale_y + border * 2,
+        .w = MAX(1, w * scale_x + border * 2),
+        .h = MAX(1, h * scale_y + border * 2),
     };
 
     glEnable(GL_SCISSOR_TEST);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -99,7 +99,9 @@ static void M_SetBounds(
         && room->bound_top <= parent->test_top
         && room->bound_right >= parent->test_right
         && room->bound_bottom >= parent->test_bottom) {
-        return;
+        if (!room->flags.protruding_items) {
+            return;
+        }
     }
 
     const MATRIX *const m = g_MatrixPtr;
@@ -155,7 +157,9 @@ static void M_SetBounds(
     }
 
     if (too_near == 4) {
-        return;
+        if (!room->flags.protruding_items) {
+            return;
+        }
     }
 
     if (too_near > 0) {
@@ -201,7 +205,9 @@ static void M_SetBounds(
     }
 
     if (left >= right || top >= bottom) {
-        return;
+        if (!room->flags.protruding_items) {
+            return;
+        }
     }
 
     if (room->bind.active) {

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -151,6 +151,7 @@ typedef struct {
         bool wind;
         bool inside;
         bool dynamic_lit;
+        bool protruding_items;
     } flags;
     struct {
         bool active;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is a caveman fix for #2005 and I'm really looking forward for some alternate solutions :)

It's not a complete fix, so there may still be some cases where the game still fails to draw certain objects/statics. I'd suggest noting what's resolved and what isn't in the original ticket and keeping it open, rather than letting this block the merge.

LMK if the logs can be improved ;-)