### PR TITLE
room/draw: add protruding statics to nearby rooms

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -252,6 +252,7 @@ common_sources = [
   'trx/game/level/reader.c',
   'trx/game/level/reader_tr1.c',
   'trx/game/level/reader_tr2.c',
+  'trx/game/level/rooms.c',
   'trx/game/level/settings.c',
   'trx/game/los.c',
   'trx/game/lua/common.c',

--- a/src/trx/game/carrier.c
+++ b/src/trx/game/carrier.c
@@ -155,6 +155,7 @@ static void M_InitialiseDataDrops(void)
         CARRIED_ITEM *drop = carrier->carried_item;
         for (int32_t j = 0; j < pickups->count; j++) {
             drop->spawn_num = *(const int16_t *)Vector_Get(pickups, j);
+            Item_RemoveDrawn(drop->spawn_num);
             drop->room_num = NO_ROOM;
             drop->fall_speed = 0;
             drop->status = DS_CARRIED;

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -21,6 +21,35 @@ static int16_t m_NextItemActive = NO_ITEM;
 static int16_t m_PrevItemActive = NO_ITEM;
 static int16_t m_NextItemFree = NO_ITEM;
 
+static inline bool M_ItemBoundsIntersectsPortal(
+    const ITEM *item, const ROOM *room, const PORTAL *const portal)
+{
+    // Axis-aligned bound intersection; ignores item rotation.
+    const BOUNDS_16 *const frame_bounds = &Item_GetBestFrame(item)->bounds;
+    if (frame_bounds == nullptr) {
+        return false;
+    }
+    const BOUNDS_32 bounds = {
+        .min = {
+            item->pos.x + frame_bounds->min.x,
+            item->pos.y + frame_bounds->min.y,
+            item->pos.z + frame_bounds->min.z,
+        },
+        .max = {
+            item->pos.x + frame_bounds->max.x,
+            item->pos.y + frame_bounds->max.y,
+            item->pos.z + frame_bounds->max.z,
+        },
+    };
+
+    if (Bounds_32_Intersect(&bounds, &portal->bounds)) {
+        return true;
+    }
+
+    const BOUNDS_32 room_bounds = Room_GetRoomBounds(Room_Get(item->room_num));
+    return !Bounds_32_Intersect(&bounds, &room_bounds);
+}
+
 void Item_InitialiseItems(const int32_t num_items)
 {
     m_Items = GameBuf_Alloc(sizeof(ITEM) * MAX_ITEMS, GBUF_ITEMS);
@@ -229,6 +258,10 @@ void Item_Initialise(const int16_t item_num)
     if (obj->initialise_func != nullptr) {
         obj->initialise_func(item_num);
     }
+
+    if (item->room_num != NO_ROOM) {
+        Room_AddDrawnItem(item->room_num, item_num);
+    }
 }
 
 void Item_Control(void)
@@ -303,6 +336,14 @@ void Item_RemoveDrawn(const int16_t item_num)
     }
 
     ROOM *const room = Room_Get(item->room_num);
+    Room_RemoveDrawnItem(item->room_num, item_num);
+    if (room->portals != nullptr) {
+        for (int32_t i = 0; i < room->portals->count; i++) {
+            const PORTAL *const portal = &room->portals->portal[i];
+            Room_RemoveDrawnItem(portal->room_num, item_num);
+        }
+    }
+
     int16_t link_num = room->item_num;
     if (link_num == item_num) {
         room->item_num = item->next_item;
@@ -352,37 +393,60 @@ void Item_AddActive(const int16_t item_num)
 void Item_UpdateRoom(const int16_t item_num, const int16_t room_num)
 {
     ITEM *const item = &m_Items[item_num];
-    if (item->room_num == room_num) {
-        return;
+    const int16_t old_room_num = item->room_num;
+
+    // Add to new-room draw queues (including portal rooms)
+    // draw queue removal for primary room and portal rooms
+    if (old_room_num != NO_ROOM) {
+        Room_RemoveDrawnItem(old_room_num, item_num);
+        const ROOM *const room = Room_Get(old_room_num);
+        if (room != nullptr && room->portals != nullptr) {
+            for (int32_t i = 0; i < room->portals->count; i++) {
+                Room_RemoveDrawnItem(
+                    room->portals->portal[i].room_num, item_num);
+            }
+        }
     }
-
-    ROOM *room = nullptr;
-
-    if (item->room_num != NO_ROOM) {
-        room = Room_Get(item->room_num);
-
-        int16_t link_num = room->item_num;
-        if (link_num == item_num) {
-            room->item_num = item->next_item;
-        } else {
-            while (link_num != NO_ITEM) {
-                if (m_Items[link_num].next_item == item_num) {
-                    m_Items[link_num].next_item = item->next_item;
-                    break;
+    if (room_num != NO_ROOM) {
+        Room_AddDrawnItem(room_num, item_num);
+        const ROOM *const neighbor_room = Room_Get(room_num);
+        if (neighbor_room != nullptr && neighbor_room->portals != nullptr) {
+            for (int32_t i = 0; i < neighbor_room->portals->count; i++) {
+                const PORTAL *const portal = &neighbor_room->portals->portal[i];
+                if (M_ItemBoundsIntersectsPortal(item, neighbor_room, portal)) {
+                    Room_AddDrawnItem(portal->room_num, item_num);
                 }
-                link_num = m_Items[link_num].next_item;
             }
         }
     }
 
-    if (room_num == NO_ROOM) {
-        Item_RemoveDrawn(item_num);
-        item->room_num = NO_ROOM;
-    } else {
-        room = Room_Get(room_num);
-        item->room_num = room_num;
-        item->next_item = room->item_num;
-        room->item_num = item_num;
+    if (old_room_num != room_num) {
+        ROOM *room = nullptr;
+        if (old_room_num != NO_ROOM) {
+            room = Room_Get(old_room_num);
+            int16_t link_num = room->item_num;
+            if (link_num == item_num) {
+                room->item_num = item->next_item;
+            } else {
+                while (link_num != NO_ITEM) {
+                    if (m_Items[link_num].next_item == item_num) {
+                        m_Items[link_num].next_item = item->next_item;
+                        break;
+                    }
+                    link_num = m_Items[link_num].next_item;
+                }
+            }
+        }
+
+        if (room_num == NO_ROOM) {
+            Item_RemoveDrawn(item_num);
+            item->room_num = NO_ROOM;
+        } else {
+            room = Room_Get(room_num);
+            item->room_num = room_num;
+            item->next_item = room->item_num;
+            room->item_num = item_num;
+        }
     }
 }
 

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -64,4 +64,8 @@ typedef struct {
             XYZ_16 rot;
         } result, prev;
     } interp;
+
+    struct {
+        bool drawn;
+    } bind;
 } ITEM;

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -25,7 +25,7 @@ static void M_DrawBodyPart(
     }
 }
 
-static void M_Draw_I(
+static bool M_Draw_I(
     const ITEM *const item, const ANIM_FRAME *const frame1,
     const ANIM_FRAME *const frame2, const int32_t frac, const int32_t rate)
 {
@@ -47,7 +47,7 @@ static void M_Draw_I(
     const CLIP clip = Output_CheckBoundsClip(&frame1->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     if (g_Config.debug.enable_debug_cuboids) {
@@ -258,14 +258,15 @@ static void M_Draw_I(
 
     Matrix_Pop();
     Matrix_Pop();
+    return true;
 }
 
-void Lara_Draw(const ITEM *const item)
+bool Lara_Draw(const ITEM *const item)
 {
     const bool is_lara = item == Lara_GetItem();
     if (is_lara
         && (item->status == IS_INVISIBLE || (item->flags & IF_ONE_SHOT) != 0)) {
-        return;
+        return false;
     }
 
     const int32_t top = g_PhdTop;
@@ -307,7 +308,7 @@ void Lara_Draw(const ITEM *const item)
     const CLIP clip = Output_CheckBoundsClip(&frame->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     if (g_Config.debug.enable_debug_cuboids) {
@@ -531,4 +532,5 @@ finish:
     g_PhdRight = right;
     g_PhdTop = top;
     g_PhdBottom = bottom;
+    return true;
 }

--- a/src/trx/game/lara/draw.h
+++ b/src/trx/game/lara/draw.h
@@ -2,4 +2,4 @@
 
 #include <trx/game/items/types.h>
 
-void Lara_Draw(const ITEM *item);
+bool Lara_Draw(const ITEM *item);

--- a/src/trx/game/level/loader.h
+++ b/src/trx/game/level/loader.h
@@ -47,6 +47,7 @@ void Level_AppendObjectTextures(
 void Level_AppendSpriteTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 
+void Level_LoadRooms(void);
 void Level_LoadTextures(void);
 void Level_LoadTexturePages(const LEVEL_LOADER *loader);
 void Level_LoadPalettes(void);

--- a/src/trx/game/level/reader.c
+++ b/src/trx/game/level/reader.c
@@ -225,6 +225,7 @@ static void M_CompleteSetup(
     // Configure enemies who carry and drop items
     Carrier_InitialiseLevel(level);
 
+    Level_LoadRooms();
     Level_LoadTextures();
     Level_LoadTexturePages(loader);
     Level_LoadPalettes();

--- a/src/trx/game/level/rooms.c
+++ b/src/trx/game/level/rooms.c
@@ -1,0 +1,143 @@
+#include <trx/game/game_buf.h>
+#include <trx/game/objects.h>
+#include <trx/game/rooms.h>
+#include <trx/log.h>
+#include <trx/memory.h>
+#include <trx/utils.h>
+#include <trx/vector.h>
+
+#include <string.h>
+
+static inline bool M_BoundsIntersectsPortal(
+    const STATIC_MESH *const mesh, const ROOM *const room,
+    const PORTAL *const portal)
+{
+    const STATIC_OBJECT_3D *const obj = Object_Get3DStatic(mesh->static_num);
+    const BOUNDS_32 bounds = {
+        .min = {
+            .x = mesh->pos.x + obj->draw_bounds.min.x,
+            .y = mesh->pos.y + obj->draw_bounds.min.y,
+            .z = mesh->pos.z + obj->draw_bounds.min.z,
+        },
+        .max = {
+            .x = mesh->pos.x + obj->draw_bounds.max.x,
+            .y = mesh->pos.y + obj->draw_bounds.max.y,
+            .z = mesh->pos.z + obj->draw_bounds.max.z,
+        },
+    };
+    return Bounds_32_Intersect(&bounds, &portal->bounds);
+}
+
+static void M_ComputePortalBounds(void)
+{
+    for (int32_t i = 0; i < Room_GetCount(); i++) {
+        ROOM *const room = Room_Get(i);
+        PORTALS *const portals = room->portals;
+        if (portals == nullptr) {
+            continue;
+        }
+        for (uint16_t p = 0; p < portals->count; p++) {
+            PORTAL *const portal = &portals->portal[p];
+            BOUNDS_32 *const bounds = &portal->bounds;
+            bounds->min.x = room->pos.x + portal->vertex[0].x;
+            bounds->min.y = room->pos.y + portal->vertex[0].y;
+            bounds->min.z = room->pos.z + portal->vertex[0].z;
+            bounds->max.x = room->pos.x + portal->vertex[0].x;
+            bounds->max.y = room->pos.y + portal->vertex[0].y;
+            bounds->max.z = room->pos.z + portal->vertex[0].z;
+            for (int32_t k = 1; k < 4; k++) {
+                bounds->min.x =
+                    MIN(bounds->min.x, room->pos.x + portal->vertex[k].x);
+                bounds->min.y =
+                    MIN(bounds->min.y, room->pos.y + portal->vertex[k].y);
+                bounds->min.z =
+                    MIN(bounds->min.z, room->pos.z + portal->vertex[k].z);
+                bounds->max.x =
+                    MAX(bounds->max.x, room->pos.x + portal->vertex[k].x);
+                bounds->max.y =
+                    MAX(bounds->max.y, room->pos.y + portal->vertex[k].y);
+                bounds->max.z =
+                    MAX(bounds->max.z, room->pos.z + portal->vertex[k].z);
+            }
+        }
+    }
+}
+
+static void M_FixStatics(void)
+{
+    int32_t total_rooms = Room_GetCount();
+    VECTOR **room_stat_vecs =
+        Memory_Alloc(sizeof(*room_stat_vecs) * total_rooms);
+
+    for (int32_t i = 0; i < total_rooms; i++) {
+        room_stat_vecs[i] = Vector_Create(sizeof(STATIC_MESH));
+        ROOM *const room = Room_Get(i);
+        for (int32_t m = 0; m < room->num_static_meshes; m++) {
+            Vector_Add(room_stat_vecs[i], &room->static_meshes[m]);
+        }
+    }
+
+    for (int32_t i = 0; i < total_rooms; i++) {
+        ROOM *const room = Room_Get(i);
+        PORTALS *const portals = room->portals;
+        if (portals == nullptr) {
+            continue;
+        }
+        for (uint16_t p = 0; p < portals->count; p++) {
+            const PORTAL *const portal = &portals->portal[p];
+            ROOM *const dest_room = Room_Get(portal->room_num);
+            if (room->flip_status != dest_room->flip_status) {
+                continue;
+            }
+            int32_t orig_count = room_stat_vecs[i]->count;
+            for (int32_t m = 0; m < orig_count; m++) {
+                const STATIC_MESH *const mesh =
+                    Vector_Get(room_stat_vecs[i], m);
+                if (!M_BoundsIntersectsPortal(mesh, room, portal)) {
+                    continue;
+                }
+                if (Vector_Contains(room_stat_vecs[portal->room_num], mesh)) {
+                    continue;
+                }
+                Vector_Add(room_stat_vecs[portal->room_num], mesh);
+                LOG_WARNING(
+                    "Static #%d bleeds into room #%d", mesh->static_num,
+                    portal->room_num);
+            }
+        }
+    }
+
+    int32_t total_needed = 0;
+    for (int32_t i = 0; i < total_rooms; i++) {
+        total_needed += room_stat_vecs[i]->count;
+    }
+    if (total_needed == 0) {
+        for (int32_t i = 0; i < total_rooms; i++) {
+            Vector_Free(room_stat_vecs[i]);
+        }
+        Memory_FreePointer(&room_stat_vecs);
+    } else {
+        STATIC_MESH *all_statics = GameBuf_Alloc(
+            sizeof(STATIC_MESH) * total_needed, GBUF_ROOM_STATIC_MESHES);
+        int32_t offset = 0;
+        for (int32_t i = 0; i < total_rooms; i++) {
+            ROOM *const room = Room_Get(i);
+            room->static_meshes = &all_statics[offset];
+            room->num_static_meshes = 0;
+            VECTOR *vec = room_stat_vecs[i];
+            for (int32_t m = 0; m < vec->count; m++) {
+                room->static_meshes[room->num_static_meshes++] =
+                    *(STATIC_MESH *)Vector_Get(vec, m);
+            }
+            offset += vec->count;
+            Vector_Free(vec);
+        }
+        Memory_FreePointer(&room_stat_vecs);
+    }
+}
+
+void Level_LoadRooms(void)
+{
+    M_ComputePortalBounds();
+    M_FixStatics();
+}

--- a/src/trx/game/lua/rooms.c
+++ b/src/trx/game/lua/rooms.c
@@ -94,7 +94,7 @@ static int M_L_RoomSetWind(lua_State *const L)
 static int M_L_RoomGetBounds(lua_State *const L)
 {
     M_ROOM_GETTER(L);
-    const BOUNDS_32 bounds = Room_GetRoomBounds(idx - 1);
+    const BOUNDS_32 bounds = Room_GetRoomBounds(Room_Get(idx - 1));
     lua_newtable(L);
     lua_pushinteger(L, bounds.min.x);
     lua_setfield(L, -2, "min_x");

--- a/src/trx/game/math/func.h
+++ b/src/trx/game/math/func.h
@@ -26,3 +26,5 @@ float XYZ_F_DotProduct(XYZ_F a, XYZ_F b);
 float XYZ_F_Length2(XYZ_F pos);
 float XYZ_F_Length(XYZ_F pos);
 XYZ_F XYZ_F_Subtract(XYZ_F a, XYZ_F b);
+
+bool Bounds_32_Intersect(const BOUNDS_32 *a, const BOUNDS_32 *b);

--- a/src/trx/game/math/util.c
+++ b/src/trx/game/math/util.c
@@ -175,3 +175,10 @@ XYZ_F XYZ_F_Subtract(const XYZ_F a, const XYZ_F b)
         .z = a.z - b.z,
     };
 }
+
+bool Bounds_32_Intersect(const BOUNDS_32 *const a, const BOUNDS_32 *const b)
+{
+    return !(
+        a->min.x > b->max.x || a->max.x < b->min.x || a->min.y > b->max.y
+        || a->max.y < b->min.y || a->min.z > b->max.z || a->max.z < b->min.z);
+}

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -105,11 +105,10 @@ static void M_Control(const int16_t item_num)
     }
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     if (item->current_anim_state == LS(LS_DEATH)) {
-        Object_DrawAnimatingItem(item);
-        return;
+        return Object_DrawAnimatingItem(item);
     }
 
     OBJECT_MESH *old_mesh_ptrs[LM_NUMBER_OF];
@@ -124,6 +123,7 @@ static void M_Draw(const ITEM *const item)
     for (LARA_MESH mesh = LM_FIRST; mesh < LM_NUMBER_OF; mesh++) {
         Lara_Mesh_Set(mesh, old_mesh_ptrs[mesh]);
     }
+    return true;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -139,11 +139,11 @@ static void M_Control(const int16_t item_num)
     Creature_Animate(item_num, angle, 0);
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
-    Object_DrawAnimatingItem(item);
+    const bool result = Object_DrawAnimatingItem(item);
     if (!Object_Get(O_SKATEBOARD)->loaded) {
-        return;
+        return result;
     }
 
     const int16_t relative_anim = Item_GetRelativeAnim(item);
@@ -154,6 +154,7 @@ static void M_Draw(const ITEM *const item)
 
     ((ITEM *)item)->object_id = O_SKATEKID;
     Item_SwitchToAnim((ITEM *)item, relative_anim, relative_frame);
+    return result;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/xian_common.c
+++ b/src/trx/game/objects/creatures/xian_common.c
@@ -5,7 +5,7 @@
 #include <trx/game/output.h>
 
 // TODO: this duplicates Object_DrawAnimatingItem almost entirely
-void XianWarrior_Draw(const ITEM *item)
+bool XianWarrior_Draw(const ITEM *item)
 {
     ANIM_FRAME *frames[2];
     int32_t rate;
@@ -23,7 +23,7 @@ void XianWarrior_Draw(const ITEM *item)
     const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
@@ -98,4 +98,5 @@ void XianWarrior_Draw(const ITEM *item)
     }
 
     Matrix_Pop();
+    return true;
 }

--- a/src/trx/game/objects/creatures/xian_common.h
+++ b/src/trx/game/objects/creatures/xian_common.h
@@ -2,4 +2,4 @@
 
 #include <trx/game/items/types.h>
 
-void XianWarrior_Draw(const ITEM *item);
+bool XianWarrior_Draw(const ITEM *item);

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -97,7 +97,7 @@ static BOUNDS_16 M_GetBoundingBox(
     return new_bounds;
 }
 
-void Object_DrawUnclippedItem(const ITEM *const item)
+bool Object_DrawUnclippedItem(const ITEM *const item)
 {
     const int32_t left = g_PhdLeft;
     const int32_t top = g_PhdTop;
@@ -115,6 +115,7 @@ void Object_DrawUnclippedItem(const ITEM *const item)
     g_PhdTop = top;
     g_PhdRight = right;
     g_PhdBottom = bottom;
+    return true;
 }
 
 void Object_DrawMesh(
@@ -149,7 +150,7 @@ void Object_DrawStaticObject(
     Matrix_Pop();
 }
 
-void Object_DrawAnimatingItem(const ITEM *item)
+bool Object_DrawAnimatingItem(const ITEM *item)
 {
     ANIM_FRAME *frames[2];
     int32_t rate;
@@ -167,7 +168,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
     const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
@@ -180,6 +181,7 @@ void Object_DrawAnimatingItem(const ITEM *item)
         Output_DrawCuboid(&frames[0]->bounds);
     }
     Matrix_Pop();
+    return true;
 }
 
 void Object_DrawInterpolatedObject(
@@ -282,7 +284,7 @@ void Object_ApplyExtraRotation(
     *extra_rotation = rot_ptr;
 }
 
-void Object_DrawSpriteItem(const ITEM *const item)
+bool Object_DrawSpriteItem(const ITEM *const item)
 {
     const RGB_F tint = Output_GetTint();
     SHADE shade = item->shade;
@@ -301,31 +303,29 @@ void Object_DrawSpriteItem(const ITEM *const item)
         item->interp.result.pos.x, item->interp.result.pos.y,
         item->interp.result.pos.z, obj->mesh_idx - item->frame_num,
         shade.value_1, tint);
+    return true;
 }
 
-void Object_DrawPickupItem(const ITEM *const item)
+bool Object_DrawPickupItem(const ITEM *const item)
 {
     if ((item->flags & IF_INVISIBLE) != 0) {
-        return;
+        return false;
     }
 
     if (!g_Config.visuals.enable_3d_pickups
         && Object_Get(item->object_id)->loaded) {
-        Object_DrawSpriteItem(item);
-        return;
+        return Object_DrawSpriteItem(item);
     }
 
     // Convert item to menu display item.
     const OBJECT_ID inv_object_id = Inv_GetItemOption(item->object_id);
     if (inv_object_id == NO_OBJECT) {
-        Object_DrawSpriteItem(item);
-        return;
+        return Object_DrawSpriteItem(item);
     }
 
     const OBJECT *const obj = Object_Get(inv_object_id);
     if (!obj->loaded || obj->mesh_count < 0) {
-        Object_DrawSpriteItem(item);
-        return;
+        return Object_DrawSpriteItem(item);
     }
 
     // Standardize the bounds and offsets of all pickup items, and handle cases
@@ -380,4 +380,5 @@ void Object_DrawPickupItem(const ITEM *const item)
     }
 
     Matrix_Pop();
+    return true;
 }

--- a/src/trx/game/objects/draw.h
+++ b/src/trx/game/objects/draw.h
@@ -7,13 +7,13 @@
 #include <trx/game/objects/ids.h>
 #include <trx/game/objects/types.h>
 
-void Object_DrawUnclippedItem(const ITEM *item);
+bool Object_DrawUnclippedItem(const ITEM *item);
 void Object_DrawMesh(int32_t mesh_idx, CLIP clip, bool interpolated);
-void Object_DrawSpriteItem(const ITEM *item);
-void Object_DrawPickupItem(const ITEM *item);
+bool Object_DrawSpriteItem(const ITEM *item);
+bool Object_DrawPickupItem(const ITEM *item);
 void Object_DrawStaticObject(const OBJECT *obj, const ANIM_FRAME *frame);
 
-void Object_DrawAnimatingItem(const ITEM *item);
+bool Object_DrawAnimatingItem(const ITEM *item);
 void Object_DrawInterpolatedObject(
     const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,
     const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -94,7 +94,7 @@ static void M_Control(const int16_t item_num)
     item->data = (void *)(intptr_t)flare_age;
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     int32_t rate;
     ANIM_FRAME *frames[2];
@@ -128,6 +128,7 @@ static void M_Draw(const ITEM *const item)
         }
     }
     Matrix_Pop();
+    return true;
 }
 
 void Flare_GenerateEffects(

--- a/src/trx/game/objects/general/sphere_of_doom.c
+++ b/src/trx/game/objects/general/sphere_of_doom.c
@@ -68,7 +68,7 @@ static void M_Control(const int16_t item_num)
     }
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     Matrix_Push();
     Matrix_TranslateAbs32(item->interp.result.pos);
@@ -93,6 +93,7 @@ static void M_Draw(const ITEM *const item)
     }
 
     Matrix_Pop();
+    return true;
 }
 
 static void M_SetupBase(OBJECT *const obj, const bool transparent)

--- a/src/trx/game/objects/general/trapdoor.c
+++ b/src/trx/game/objects/general/trapdoor.c
@@ -186,6 +186,7 @@ static void M_Control(const int16_t item_num)
         }
     }
     Item_Animate(item);
+    Item_UpdateRoom(item_num, item->room_num);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -258,7 +258,7 @@ static void M_DrawBolts(const ITEM *const item)
     }
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     const OBJECT *const obj = Object_Get(O_LIGHTNING_EMITTER);
     ANIM_FRAME *frmptr[2];
@@ -271,7 +271,7 @@ static void M_Draw(const ITEM *const item)
     const CLIP clip = Output_CheckBoundsClip(&frmptr[0]->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     Output_CalculateObjectLighting(item, &frmptr[0]->bounds);
@@ -281,6 +281,7 @@ static void M_Draw(const ITEM *const item)
     Matrix_Pop();
 
     M_DrawBolts(item);
+    return true;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -389,12 +389,12 @@ static const OBJECT_BOUNDS *M_Bounds(void)
     return &m_MovableBlock_Bounds;
 }
 
-static void M_Draw(const ITEM *const item)
+static bool M_Draw(const ITEM *const item)
 {
     if (item->status == IS_ACTIVE) {
-        Object_DrawUnclippedItem(item);
+        return Object_DrawUnclippedItem(item);
     } else {
-        Object_DrawAnimatingItem(item);
+        return Object_DrawAnimatingItem(item);
     }
 }
 

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -58,7 +58,7 @@ typedef struct OBJECT {
     void (*setup_func)(struct OBJECT *obj);
     void (*initialise_func)(int16_t item_num);
     void (*control_func)(int16_t item_num);
-    void (*draw_func)(const ITEM *item);
+    bool (*draw_func)(const ITEM *item);
     void (*collision_func)(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
     int16_t (*floor_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -934,7 +934,7 @@ bool Skidoo_Control(void)
     return Skidoo_CheckGetOff();
 }
 
-void Skidoo_Draw(const ITEM *const item)
+bool Skidoo_Draw(const ITEM *const item)
 {
     int32_t track_mesh_status = 0;
     const SKIDOO_INFO *const skidoo_data = item->data;
@@ -968,7 +968,7 @@ void Skidoo_Draw(const ITEM *const item)
     const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
-        return;
+        return false;
     }
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
@@ -1024,4 +1024,5 @@ void Skidoo_Draw(const ITEM *const item)
     }
 
     Matrix_Pop();
+    return true;
 }

--- a/src/trx/game/objects/vehicles/skidoo_common.h
+++ b/src/trx/game/objects/vehicles/skidoo_common.h
@@ -41,4 +41,4 @@ void Skidoo_Explode(const ITEM *skidoo);
 bool Skidoo_CheckGetOff(void);
 void Skidoo_Guns(void);
 bool Skidoo_Control(void);
-void Skidoo_Draw(const ITEM *item);
+bool Skidoo_Draw(const ITEM *item);

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -142,6 +142,9 @@ void Room_FlipMap(void)
 
         room->item_num = flipped->item_num;
         room->effect_num = flipped->effect_num;
+        memcpy(
+            &room->drawn_items, &flipped->drawn_items,
+            sizeof(room->drawn_items));
 
         M_AddFlipItems(room);
     }
@@ -223,17 +226,16 @@ int32_t Room_GetAdjoiningRooms(
 
 bool Room_PointInside(const ROOM *const room, const XYZ_32 point)
 {
-    const int16_t room_num = Room_GetNumber(room);
-    if (room_num == NO_ROOM) {
+    if (room == nullptr) {
         return false;
     }
-    const BOUNDS_32 bounds = Room_GetRoomBounds(room_num);
-    const int32_t x1 = bounds.min.x + WALL_L;
+    const BOUNDS_32 bounds = Room_GetRoomBounds(room);
+    const int32_t x1 = bounds.min.x;
     const int32_t y1 = bounds.min.y;
-    const int32_t z1 = bounds.min.z + WALL_L;
-    const int32_t x2 = bounds.max.x - WALL_L;
+    const int32_t z1 = bounds.min.z;
+    const int32_t x2 = bounds.max.x;
     const int32_t y2 = bounds.max.y;
-    const int32_t z2 = bounds.max.z - WALL_L;
+    const int32_t z2 = bounds.max.z;
     if (point.x >= x1 && point.x < x2 && point.y >= y1 && point.y <= y2
         && point.z >= z1 && point.z < z2) {
         const SECTOR *sector = Room_GetWorldSector(room, point.x, point.z);
@@ -283,7 +285,7 @@ BOUNDS_32 Room_GetWorldBounds(void)
         .max.y = -MAX_HEIGHT,
     };
     for (int32_t i = 0; i < Room_GetCount(); i++) {
-        const BOUNDS_32 room_bounds = Room_GetRoomBounds(i);
+        const BOUNDS_32 room_bounds = Room_GetRoomBounds(Room_Get(i));
         world_bounds.min.x = MIN(world_bounds.min.x, room_bounds.min.x);
         world_bounds.max.x = MAX(world_bounds.max.x, room_bounds.max.x);
         world_bounds.min.z = MIN(world_bounds.min.z, room_bounds.min.z);
@@ -313,8 +315,8 @@ void Room_GetNearbyRooms(
 
 bool Room_CheckOverlap(const int16_t room_num_0, const int16_t room_num_1)
 {
-    const BOUNDS_32 room_0_bounds = Room_GetRoomBounds(room_num_0);
-    const BOUNDS_32 room_1_bounds = Room_GetRoomBounds(room_num_1);
+    const BOUNDS_32 room_0_bounds = Room_GetRoomBounds(Room_Get(room_num_0));
+    const BOUNDS_32 room_1_bounds = Room_GetRoomBounds(Room_Get(room_num_1));
 
     // clang-format off
     return (

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -8,6 +8,8 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 #define M_MAX_BOUND_ROOMS 128
 
 typedef struct {
@@ -15,6 +17,61 @@ typedef struct {
     int32_t yv;
     int32_t zv;
 } M_PORTAL_VBUF;
+
+static inline void M_DrawSet_Init(ROOM_DRAWSET *const s)
+{
+    s->count = 0;
+    memset(s->bits, 0, sizeof(s->bits));
+}
+
+static inline bool M_DrawSet_Has(
+    const ROOM_DRAWSET *const s, const int16_t item_num)
+{
+    const uint32_t w = item_num >> 6;
+    const uint32_t b = item_num & 63;
+    return (s->bits[w] >> b) & 1ULL;
+}
+
+static inline bool M_DrawSet_Add(ROOM_DRAWSET *const s, const int16_t item_num)
+{
+    const uint32_t w = item_num >> 6;
+    const uint32_t b = item_num & 63;
+    const uint64_t mask = 1ULL << b;
+    if (s->bits[w] & mask) {
+        return false;
+    }
+    s->bits[w] |= mask;
+    s->count++;
+    return true;
+}
+
+static inline bool M_DrawSet_Remove(
+    ROOM_DRAWSET *const s, const int16_t item_num)
+{
+    const uint32_t w = item_num >> 6;
+    const uint32_t b = item_num & 63;
+    const uint64_t mask = 1ULL << b;
+    if (!(s->bits[w] & mask)) {
+        return false;
+    }
+    s->bits[w] &= ~mask;
+    s->count--;
+    return true;
+}
+
+static inline void M_DrawSet_ForEach(
+    const ROOM_DRAWSET *const s, void (*const fn)(int16_t item, void *ud),
+    void *ud)
+{
+    for (uint32_t w = 0; w < ROOM_DRAWSET_WORDS; w++) {
+        uint64_t x = s->bits[w];
+        while (x != 0ULL) {
+            const uint32_t b = __builtin_ctzll(x);
+            fn((int16_t)((w << 6) + b), ud);
+            x &= x - 1; // clear lowest set bit
+        }
+    }
+}
 
 static int32_t m_DrawCount = 0;
 static int16_t m_RoomsToDraw[MAX_ROOMS_TO_DRAW] = {};
@@ -246,6 +303,16 @@ static void M_DrawSkybox(void)
     }
 }
 
+static void M_DrawRoomItem(const int16_t item_num, void *const ud)
+{
+    ITEM *const item = Item_Get(item_num);
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (!item->bind.drawn && item->status != IS_INVISIBLE
+        && obj->draw_func != nullptr) {
+        item->bind.drawn |= obj->draw_func(item);
+    }
+}
+
 static void M_DrawSingleRoom(ROOM *const room)
 {
     if (room->flags.underwater) {
@@ -305,20 +372,12 @@ static void M_DrawSingleRoom(ROOM *const room)
         Matrix_Pop();
     }
 
+    M_DrawSet_ForEach(&room->drawn_items, M_DrawRoomItem, nullptr);
+
     g_PhdLeft = Viewport_GetMinX(VIEWPORT_GAME);
     g_PhdTop = Viewport_GetMinY(VIEWPORT_GAME);
     g_PhdRight = Viewport_GetMaxX(VIEWPORT_GAME);
     g_PhdBottom = Viewport_GetMaxY(VIEWPORT_GAME);
-
-    int16_t item_num = room->item_num;
-    while (item_num != NO_ITEM) {
-        const ITEM *const item = Item_Get(item_num);
-        const OBJECT *const obj = Object_Get(item->object_id);
-        if (item->status != IS_INVISIBLE && obj->draw_func != nullptr) {
-            obj->draw_func(item);
-        }
-        item_num = item->next_item;
-    }
 
     int16_t effect_num = room->effect_num;
     while (effect_num != NO_EFFECT) {
@@ -405,6 +464,10 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
         M_DrawSkybox();
     }
 
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        Item_Get(i)->bind.drawn = false;
+    }
+
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
         const int16_t draw_room_num = Room_DrawGetRoom(i);
         ROOM *const draw_room = Room_Get(draw_room_num);
@@ -425,4 +488,20 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     }
 
     Output_SetupAboveWater(false);
+}
+
+void Room_AddDrawnItem(const int16_t room_num, const int16_t item_num)
+{
+    if (room_num != NO_ROOM) {
+        ROOM *const room = Room_Get(room_num);
+        M_DrawSet_Add(&room->drawn_items, item_num);
+    }
+}
+
+void Room_RemoveDrawnItem(const int16_t room_num, const int16_t item_num)
+{
+    if (room_num != NO_ROOM) {
+        ROOM *const room = Room_Get(room_num);
+        M_DrawSet_Remove(&room->drawn_items, item_num);
+    }
 }

--- a/src/trx/game/rooms/draw.h
+++ b/src/trx/game/rooms/draw.h
@@ -8,3 +8,7 @@ int32_t Room_DrawGetCount(void);
 int16_t Room_DrawGetRoom(int16_t idx);
 
 void Room_DrawAllRooms(int16_t base_room, int16_t target_room);
+
+// Manage per-room draw queue of items
+void Room_AddDrawnItem(int16_t room_num, int16_t item_num);
+void Room_RemoveDrawnItem(int16_t room_num, int16_t item_num);

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -225,20 +225,19 @@ static bool M_IsPortalSolid(
     }
 }
 
-BOUNDS_32 Room_GetRoomBounds(const int16_t room_num)
+BOUNDS_32 Room_GetRoomBounds(const ROOM *const room)
 {
-    const ROOM *const room = Room_Get(room_num);
     ASSERT(room != nullptr);
     return (BOUNDS_32) {
         .min = {
-            .x = room->pos.x,
+            .x = room->pos.x + WALL_L,
             .y = room->max_ceiling,
-            .z = room->pos.z,
+            .z = room->pos.z + WALL_L,
         },
         .max = {
-            .x = room->pos.x + room->size.x * WALL_L,
+            .x = room->pos.x + room->size.x * WALL_L - WALL_L,
             .y = room->min_floor,
-            .z = room->pos.z + room->size.z * WALL_L,
+            .z = room->pos.z + room->size.z * WALL_L - WALL_L,
         },
     };
 }

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -2,7 +2,7 @@
 
 #include <trx/game/rooms/types.h>
 
-BOUNDS_32 Room_GetRoomBounds(int16_t room);
+BOUNDS_32 Room_GetRoomBounds(const ROOM *room);
 SECTOR *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
 SECTOR *Room_GetSectorOnWalkable(
     int32_t x, int32_t y, int32_t z, int16_t *room_num);

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <trx/game/items/const.h>
 #include <trx/game/math.h>
 #include <trx/game/rooms/enum.h>
 #include <trx/game/types.h>
+
+#define ROOM_DRAWSET_WORDS (MAX_ITEMS / 64)
 
 typedef struct TRIGGER_CMD {
     TRIGGER_OBJECT type;
@@ -117,6 +120,11 @@ typedef struct {
 } STATIC_MESH;
 
 typedef struct {
+    uint64_t bits[ROOM_DRAWSET_WORDS];
+    uint16_t count;
+} ROOM_DRAWSET;
+
+typedef struct {
     ROOM_MESH mesh;
     PORTALS *portals;
     SECTOR *sectors;
@@ -153,8 +161,11 @@ typedef struct {
         bool inside;
         bool dynamic_lit;
     } flags;
+
     struct {
         bool active;
         bool drawn;
     } bind;
+
+    ROOM_DRAWSET drawn_items;
 } ROOM;

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -30,6 +30,7 @@ typedef struct {
     int16_t room_num;
     XYZ_16 normal;
     XYZ_16 vertex[4];
+    BOUNDS_32 bounds;
 } PORTAL;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This hopefully fixes the disappearing gazebo problem in Bartoli without introducing regressions.

We'll need a test level with tons of overlapping stuff to verify if this is indeed a workable approach. I just wanted to put the PR out there for Lahm to play with as I'll be AFK during the weekend.

If it is we can consider putting items into all rooms they appear in, especially as they go mid-portal.