### PR TITLE
objects/draw: fix 3D pickups rendering

### DIFF
--- a/data/common/ship/cfg/base_strings-de.json5
+++ b/data/common/ship/cfg/base_strings-de.json5
@@ -620,7 +620,7 @@
         "SETTING_REMEMBER_GUNS_BETWEEN_LEVELS": "Waffen zwischen den Leveln merken",
         "SETTING_REMEMBER_GUNS_BETWEEN_LEVELS_DESCRIPTION": "Bringt Lara dazu, sich zu erinnern, welche Waffe sie als Letztes im vorherigen Level verwendet hat, wenn ein neues Level beginnt. Bei Deaktivierung wird Lara auf geholsterte Pistolen zurückgreifen.",
         "SETTING_RESTORE_PS1_ENEMIES": "PS1 Feinde wiederherstellen",
-	"SETTING_RESTORE_PS1_ENEMIES_DESCRIPTION": "Fügt die Mumie in Raum 25 ein, welche in der Playstation-Version von City of Khamoon erscheint.\nEine Veränderung dieser Option erfordert einen Neustart des Levels.",
+        "SETTING_RESTORE_PS1_ENEMIES_DESCRIPTION": "Fügt die Mumie in Raum 25 ein, welche in der Playstation-Version von City of Khamoon erscheint.\nEine Veränderung dieser Option erfordert einen Neustart des Levels.",
         "SETTING_SCREENSHOT_FORMAT": "Bildschirmfoto-Format",
         "SETTING_SCREENSHOT_FORMAT_DESCRIPTION": "Dateiformat des Bildschirmfotos.",
         "SETTING_SHOW_BARS": "\\{review}Leisten anzeigen",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -157,3 +157,4 @@
 - fixed the M16 accuracy option not taking effect until restarting the game (#4227, regression from 0.3)
 - fixed incorrect keys object orientation in the inventory ring (#4239, regression from 0.3)
 - fixed underwater hum when Microphone near Lara option is on (#2188)
+- fixed 3D pickups not rendering if the associated sprite is not present in the level file (#4275, regression from 0.6)

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -310,7 +310,7 @@ void Object_DrawPickupItem(const ITEM *const item)
     }
 
     if (!g_Config.visuals.enable_3d_pickups
-        || !Object_Get(item->object_id)->loaded) {
+        && Object_Get(item->object_id)->loaded) {
         Object_DrawSpriteItem(item);
         return;
     }


### PR DESCRIPTION
Resolves #4275.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the check that requires a 3D pickup to have its sprite also loaded. This in turn means that if 3D pickups are disabled and a pickup's sprite isn't loaded, it will still render as 3D, otherwise the behaviour is undefined.
