### PR TITLE
console: fix loading history

### DIFF
--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -122,7 +122,6 @@ static void M_InitModules(void)
     GameStringManager_Init();
     EnumMap_Init();
     UI_Init();
-    Console_Init();
     Overlay_Init();
     GameEvent_Init();
 
@@ -192,6 +191,7 @@ static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
                                             : args->mod->engine_version;
     LOG_INFO("Engine version: %d", g_TRVersion);
     Config_ApplyDefaultSettings();
+    Console_Init();
 
     M_LoadCatalog(CATALOG_OBJECTS, "catalog_objects.csv", false);
     M_LoadCatalog(CATALOG_MUSIC, "catalog_music.csv", false);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The function call I'm updating relies on `g_TRVersion`, but that variable isn't available right at launch – it only becomes set after the mod selection process is complete.