### PR TITLE
tools: fix installer desktop shortcut

### DIFF
--- a/docs/tr1/INSTALLING.md
+++ b/docs/tr1/INSTALLING.md
@@ -352,15 +352,15 @@ If you install everything correctly, your game directory should look more or les
 │   ├── common.glsl
 │   ├── fbo.glsl
 │   └── meshes.glsl
-└── TR1X.exe</code></pre>
+└── TRX.exe</code></pre>
 </details>
 
 *\* Will not be present until the game has been launched.*
 
 ## Playing the game
 
-- To play the game, run `TR1X.exe`.
-- To play the Unfinished Business expansion pack, run `TR1X.exe --gold`.
+- To play the game, run `TRX.exe`.
+- To play the Unfinished Business expansion pack, run `TRX.exe --gold`.
 
 # macOS
 

--- a/docs/tr2/INSTALLING.md
+++ b/docs/tr2/INSTALLING.md
@@ -423,15 +423,15 @@ If you install everything correctly, your game directory should look more or les
 │   ├── common.glsl
 │   ├── fbo.glsl
 │   └── meshes.glsl
-└── TR2X.exe</code></pre>
+└── TRX.exe</code></pre>
 </details>
 
 *\* Will not be present until the game has been launched.*
 
 ## Playing the game
 
-- To play the game, run `TR2X.exe`.
-- To play the Golden Mask expansion pack, run `TR2X.exe --gold`.
+- To play the game, run `TRX.exe`.
+- To play the Golden Mask expansion pack, run `TRX.exe --gold`.
 
 # macOS
 

--- a/tools/installer/TR1X_Installer/Installers/TR1XInstallSource.cs
+++ b/tools/installer/TR1X_Installer/Installers/TR1XInstallSource.cs
@@ -60,6 +60,8 @@ public class TR1XInstallSource : BaseInstallSource
 
     public override bool IsGameFound(string sourceDirectory)
     {
-        return File.Exists(Path.Combine(sourceDirectory, "TR1X.exe")) || File.Exists(Path.Combine(sourceDirectory, "Tomb1Main.exe"));
+        return File.Exists(Path.Combine(sourceDirectory, "TRX.exe"))
+            || File.Exists(Path.Combine(sourceDirectory, "TR1X.exe"))
+            || File.Exists(Path.Combine(sourceDirectory, "Tomb1Main.exe"));
     }
 }

--- a/tools/installer/TR2X_Installer/Installers/TR2XInstallSource.cs
+++ b/tools/installer/TR2X_Installer/Installers/TR2XInstallSource.cs
@@ -58,6 +58,7 @@ public class TR2XInstallSource : GenericInstallSource
 
     public override bool IsGameFound(string sourceDirectory)
     {
-        return File.Exists(Path.Combine(sourceDirectory, "TR2X.exe"));
+        return File.Exists(Path.Combine(sourceDirectory, "TRX.exe"))
+            || File.Exists(Path.Combine(sourceDirectory, "TR2X.exe"));
     }
 }

--- a/tools/installer/TRX_InstallerLib/Models/TRXConstants.cs
+++ b/tools/installer/TRX_InstallerLib/Models/TRXConstants.cs
@@ -16,7 +16,7 @@ public class TRXConstants
     public string? Game { get; set; }
     public string? GoldGame { get; set; }
     public string? GoldFileIdentifier { get; set; }
-    public string Exe => $"{Game}.exe";
+    public string Exe => $"TRX.exe";
     public bool? AllowExpansionTypeSelection { get; set; }
     public string? GoldArgs { get; set; }
     public string? ShortcutTitle { get; set; }

--- a/tools/update_install_trees
+++ b/tools/update_install_trees
@@ -243,7 +243,7 @@ def tr1_ship_files() -> Iterable[Path]:
 
 
 def tr1_files_win() -> Iterable[Path]:
-    yield Path("TR1X.exe")
+    yield Path("TRX.exe")
     yield Path("cfg/TR1X.json5*")
     yield from tr1_og_files()
     yield from tr1_ship_files()
@@ -271,7 +271,7 @@ def tr2_ship_files() -> Iterable[Path]:
 
 
 def tr2_files_win() -> Iterable[Path]:
-    yield Path("TR2X.exe")
+    yield Path("TRX.exe")
     yield Path("cfg/TR2X.json5*")
     yield from tr2_og_files()
     yield from tr2_ship_files()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This should fix the installer desktop shortcuts for TR1, TR2, TR1:GM and TR2:GM.
I haven't tested this.
Also updates outdated documentation on install trees.