### PR TITLE
tr3/sound: update pitch and range management

### DIFF
--- a/src/trx/game/inject/data/sound.c
+++ b/src/trx/game/inject/data/sound.c
@@ -1,4 +1,5 @@
 #include <trx/debug.h>
+#include <trx/game/const.h>
 #include <trx/game/inject.h>
 #include <trx/game/sound.h>
 #include <trx/memory.h>
@@ -17,6 +18,12 @@ static void M_HandleSFXData(const INJECTION_CHUNK chunk)
 
         SAMPLE_INFO *const sample_info = Sound_GetOrCreateSample(sfx_id);
         sample_info->volume = VFile_ReadS16(chunk.injection->fp);
+        sample_info->pitch = 0;
+        if (g_TRVersion >= 2) {
+            sample_info->range = 10 * WALL_L; // TODO: support TR3
+        } else if (g_TRVersion == 1) {
+            sample_info->range = 8 * WALL_L;
+        }
         sample_info->randomness = VFile_ReadS16(chunk.injection->fp);
         sample_info->flags.all = VFile_ReadU16(chunk.injection->fp);
         if (g_TRVersion == 1) {

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1356,16 +1356,21 @@ void Level_ReadSamples(const LEVEL_LOADER *const loader, VFILE *const file)
 
         if (loader->game_version >= 3) {
             sample_info->volume = VFile_ReadU8(file) << 8;
-            VFile_Skip(file, 1);
-        } else {
+            sample_info->range = VFile_ReadU8(file) * WALL_L;
+        } else if (loader->game_version == 2) {
             sample_info->volume = VFile_ReadU16(file);
+            sample_info->range = 10 * WALL_L;
+        } else if (loader->game_version == 1) {
+            sample_info->volume = VFile_ReadU16(file);
+            sample_info->range = 8 * WALL_L;
         }
 
         if (loader->game_version >= 3) {
             sample_info->randomness = VFile_ReadU8(file) << 8;
-            VFile_Skip(file, 1);
+            sample_info->pitch = VFile_ReadU8(file);
         } else {
             sample_info->randomness = VFile_ReadU16(file);
+            sample_info->pitch = 0;
         }
 
         sample_info->flags.all = VFile_ReadU16(file);

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -23,14 +23,12 @@ typedef enum {
 
 #define M_DECIBEL_LUT_SIZE 512
 #define M_SOUND_CLOSE_RANGE (1 * WALL_L)
-#define M_SOUND_FAR_RANGE ((g_TRVersion == 1 ? 8 : 10) * WALL_L)
 
 #define M_MAX_ACTIVE_SOUNDS AUDIO_MAX_ACTIVE_SAMPLES
 #define M_SOUND_RANGE_MULT_CONSTANT 4
-#define M_SOUND_MAX_VOLUME                                                     \
-    ((M_SOUND_FAR_RANGE * M_SOUND_RANGE_MULT_CONSTANT) - 1)
+#define M_SOUND_MAX_VOLUME 0x8000
 #define M_SOUND_MAX_PITCH_CHANGE 6000
-#define M_SOUND_MAX_VOLUME_CHANGE 0x2000
+#define M_SOUND_MAX_VOLUME_CHANGE (g_TRVersion >= 3 ? 0x1000 : 0x2000)
 
 typedef struct {
     SAMPLE_ID sample_id;
@@ -97,7 +95,8 @@ static float M_ConvertPitch(const int32_t pitch)
     return pitch / 0x10000.p0;
 }
 
-static int32_t M_GetDistance(const XYZ_32 *const pos)
+static int32_t M_GetDistance(
+    const SAMPLE_INFO *const sample, const XYZ_32 *const pos)
 {
     if (pos == nullptr) {
         return 0;
@@ -105,38 +104,36 @@ static int32_t M_GetDistance(const XYZ_32 *const pos)
     const int32_t dx = pos->x - g_Camera.mic_pos.x;
     const int32_t dy = pos->y - g_Camera.mic_pos.y;
     const int32_t dz = pos->z - g_Camera.mic_pos.z;
-    if (ABS(dx) > M_SOUND_FAR_RANGE || ABS(dy) > M_SOUND_FAR_RANGE
-        || ABS(dz) > M_SOUND_FAR_RANGE) {
+    if (ABS(dx) > sample->range || ABS(dy) > sample->range
+        || ABS(dz) > sample->range) {
         return INT32_MAX;
     }
-    uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    if (distance > SQUARE(M_SOUND_FAR_RANGE)) {
+    const uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
+    if (distance > SQUARE(sample->range)) {
         return INT32_MAX;
     } else if (distance < SQUARE(M_SOUND_CLOSE_RANGE)) {
-        distance = 0;
+        return 0;
     } else {
-        distance = Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
+        return Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
     }
-    return distance;
 }
 
 static int32_t M_GetVolume(
     const SAMPLE_INFO *const sample, const int32_t distance, const bool random)
 {
     if (g_TRVersion == 1) {
-        int32_t volume =
-            sample->volume - distance * M_SOUND_RANGE_MULT_CONSTANT;
+        int32_t volume = sample->volume - distance * 4;
         if (random && sample->flags.randomize_volume) {
-            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
+            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE / 0x8000;
         }
         return volume;
     } else {
         int32_t volume = sample->volume;
         if (random && sample->flags.randomize_volume) {
-            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE >> 15;
+            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE / 0x8000;
         }
         const int32_t attenuation =
-            SQUARE(distance) / (SQUARE(M_SOUND_FAR_RANGE) / 0x10000);
+            SQUARE(distance) / (SQUARE(sample->range) / 0x10000);
         return (volume * (0x10000 - attenuation)) / 0x10000;
     }
 }
@@ -145,6 +142,7 @@ static int32_t M_GetPitch(const SAMPLE_INFO *const sample, const uint32_t flags)
 {
     int32_t pitch = (flags & SPM_PITCH) != 0 ? (flags >> 8) & 0xFFFFFF
                                              : SOUND_DEFAULT_PITCH;
+    pitch += sample->pitch << 9;
     if (!g_Config.audio.enable_pitched_sounds) {
         return pitch;
     }
@@ -161,7 +159,7 @@ static int32_t M_GetPan(
     if (pos == nullptr) {
         return 0;
     }
-    const int32_t distance = M_GetDistance(pos);
+    const int32_t distance = M_GetDistance(sample, pos);
     if (distance > 0 && !sample->flags.no_pan) {
         if (g_TRVersion == 1) {
             const LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -283,7 +281,7 @@ static void M_SyncActiveSoundHandle(M_ACTIVE_SOUND *const sound)
 
 static void M_UpdateActiveSoundParams(M_ACTIVE_SOUND *const sound)
 {
-    const int32_t distance = M_GetDistance(sound->pos_ptr);
+    const int32_t distance = M_GetDistance(sound->sample, sound->pos_ptr);
     if (distance == INT32_MAX) {
         sound->volume = 0;
         return;
@@ -501,7 +499,7 @@ bool Sound_Effect_Direct(
         return false;
     }
 
-    const int32_t distance = M_GetDistance(pos);
+    const int32_t distance = M_GetDistance(sample, pos);
     if (distance == INT32_MAX) {
         return false;
     }

--- a/src/trx/game/sound/types.h
+++ b/src/trx/game/sound/types.h
@@ -7,7 +7,9 @@
 typedef struct {
     int16_t number;
     int16_t volume;
+    int32_t range;
     int32_t randomness;
+    uint8_t pitch;
     union {
         struct {
             uint16_t mode_bits : 2;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This implements base pitch and range management for TR3.
It has the opportunity to mess with the previous games max relative volume and distance computations so I'd appreciate a check how the game sounds compared to the OG around waterfalls and such.