### PR TITLE
tr3: add initial swamp support

### DIFF
--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -209,6 +209,11 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
 
     room = Room_Get(target->room_num);
     sector = Room_GetWorldSector(room, target->x, target->z);
+    if (room->flags.swamp) {
+        target->y = room->max_ceiling - STEP_L;
+        sector =
+            Room_GetSector(target->x, target->y, target->z, &target->room_num);
+    }
 
     if (target->z < box->left || target->z > box->right || target->x < box->top
         || target->x > box->bottom) {

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -208,6 +208,7 @@ static void M_RoomProperties(
     room->flags.dynamic_lit = (flags & 0x10) != 0;
     room->flags.wind        = (flags & 0x20) != 0;
     room->flags.inside      = (flags & 0x40) != 0;
+    room->flags.swamp       = (flags & 0x80) != 0;
     // clang-format on
 }
 

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -308,15 +308,17 @@ bool Lara_Cheat_ExitFlyMode(void)
     }
 
     const ROOM *const room = Room_Get(lara_item->room_num);
-    const bool room_submerged = room->flags.underwater;
     const int16_t water_height = Room_GetWaterHeight(
         lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
         lara_item->room_num);
 
-    if (room_submerged || (water_height != NO_HEIGHT && water_height > 0)) {
+    if (room->flags.underwater
+        || (water_height != NO_HEIGHT && water_height > 0
+            && !room->flags.swamp)) {
         lara_info->water_status = LWS_UNDERWATER;
     } else {
-        lara_info->water_status = LWS_ABOVE_WATER;
+        lara_info->water_status =
+            room->flags.swamp ? LWS_WADE : LWS_ABOVE_WATER;
         Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
         lara_item->goal_anim_state = LS(LS_STOP);
         lara_item->current_anim_state = LS(LS_STOP);

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -868,11 +868,12 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     const int32_t front_ceiling = coll->side_front.ceiling;
     const bool slope = ABS(left_floor - right_floor) >= SLOPE_DIF;
     const int32_t mid = STEP_L / 2;
+    const ROOM *const room = Room_Get(item->room_num);
 
     if (front_floor >= -STEP_L * 2 - mid && front_floor <= -STEP_L * 2 + mid) {
         if (slope || front_floor - front_ceiling < 0
-            || left_floor - left_ceiling < 0
-            || right_floor - right_ceiling < 0) {
+            || left_floor - left_ceiling < 0 || right_floor - right_ceiling < 0
+            || (room->flags.swamp && lara->water_surface_dist < -768)) {
             return false;
         }
         item->goal_anim_state = LS(LS_STOP);
@@ -883,8 +884,8 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     } else if (
         front_floor >= -STEP_L * 3 - mid && front_floor <= -STEP_L * 3 + mid) {
         if (slope || front_floor - front_ceiling < 0
-            || left_floor - left_ceiling < 0
-            || right_floor - right_ceiling < 0) {
+            || left_floor - left_ceiling < 0 || right_floor - right_ceiling < 0
+            || (room->flags.swamp && lara->water_surface_dist < -768)) {
             return false;
         }
         item->goal_anim_state = LS(LS_STOP);
@@ -895,6 +896,9 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     } else if (
         !slope && front_floor >= -STEP_L * 7 - mid
         && front_floor <= -STEP_L * 4 + mid) {
+        if (room->flags.swamp) {
+            return false;
+        }
         item->goal_anim_state = LS(LS_JUMP_UP);
         item->current_anim_state = LS(LS_STOP);
         Item_SwitchToAnim(item, LA(LA_STAND_STILL), 0);

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -165,6 +165,11 @@ static bool M_TestSlide(ITEM *const item, COLL_INFO *const coll)
         return false;
     }
 
+    const ROOM *const room = Room_Get(item->room_num);
+    if (room->flags.swamp) {
+        return false;
+    }
+
     int16_t angle = 0;
     if (coll->tilt_x > 2) {
         angle = -DEG_90;
@@ -390,7 +395,16 @@ static void M_WalkBack(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
-    if (!M_TestSlide(item, coll)) {
+    if (M_TestSlide(item, coll)) {
+        return;
+    }
+
+    const ROOM *const room = Room_Get(item->room_num);
+    if (coll->side_mid.floor >= 0 && room->flags.swamp) {
+        item->pos.y += 2;
+    } else if (lara->water_status == LWS_WADE && coll->side_mid.floor >= 50) {
+        item->pos.y += 50;
+    } else {
         item->pos.y += coll->side_mid.floor;
     }
 }
@@ -513,7 +527,9 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    if (g_Config.gameplay.fix_step_glitch && coll->side_mid.floor > 100) {
+    const ROOM *const room = Room_Get(item->room_num);
+    if (!room->flags.swamp && g_Config.gameplay.fix_step_glitch
+        && coll->side_mid.floor > 100) {
         item->current_anim_state = LS(LS_JUMP_FORWARD);
         item->goal_anim_state = LS(LS_JUMP_FORWARD);
         Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
@@ -523,7 +539,12 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     }
 
     Lara_Col_Shift(coll);
-    item->pos.y += coll->side_mid.floor;
+    if (room->flags.swamp && coll->side_mid.floor >= 0) {
+        item->pos.y += 2;
+        CLAMPG(item->pos.y, item->floor);
+    } else {
+        item->pos.y += coll->side_mid.floor;
+    }
 }
 
 static void M_FastBack(ITEM *const item, COLL_INFO *const coll)
@@ -563,16 +584,24 @@ static void M_Turn(ITEM *const item, COLL_INFO *const coll)
     item->fall_speed = 0;
     M_Default(item, coll);
 
-    if (coll->side_mid.floor <= 100) {
-        if (!M_TestSlide(item, coll)) {
-            item->pos.y += coll->side_mid.floor;
-        }
-    } else {
+    const ROOM *const room = Room_Get(item->room_num);
+    if (coll->side_mid.floor > 100 && !room->flags.swamp) {
         Item_SwitchToAnim(item, LA(LA_FALL_START), 0);
         item->current_anim_state = LS(LS_JUMP_FORWARD);
         item->goal_anim_state = LS(LS_JUMP_FORWARD);
         item->gravity = true;
         item->fall_speed = 0;
+        return;
+    }
+
+    if (M_TestSlide(item, coll)) {
+        return;
+    }
+
+    if (coll->side_mid.floor < 0 || !room->flags.swamp) {
+        item->pos.y += coll->side_mid.floor;
+    } else {
+        item->pos.y += 2;
     }
 }
 
@@ -729,6 +758,7 @@ static void M_Wade(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
+    const ROOM *const room = Room_Get(item->room_num);
     if (M_DeflectEdge(item, coll)) {
         item->rot.z = 0;
         if (g_Config.gameplay.fix_wade_wall_hit
@@ -736,7 +766,7 @@ static void M_Wade(ITEM *const item, COLL_INFO *const coll)
                 || coll->side_front.type == HT_SPLIT_TRI)
             && coll->side_front.floor < -STEP_L * 5 / 2
             && coll->old_anim_state == LS(LS_WADE)
-            && Item_TestAnimEqual(item, LA(LA_WADE))) {
+            && Item_TestAnimEqual(item, LA(LA_WADE)) && !room->flags.swamp) {
             item->current_anim_state = LS(LS_SPLAT);
             if (Item_TestFrameRange(item, M_LF_WADE_L_START, M_LF_WADE_L_END)) {
                 Item_SwitchToAnim(item, LA(LA_WALL_SMASH_LEFT), 0);
@@ -750,12 +780,12 @@ static void M_Wade(ITEM *const item, COLL_INFO *const coll)
         M_CollideStop(item, coll);
     }
 
-    if (M_Fallen(item, coll)) {
+    if (!room->flags.swamp && M_Fallen(item, coll)) {
         return;
     }
 
     if (coll->side_mid.floor >= -STEPUP_HEIGHT
-        && coll->side_mid.floor < -STEP_L / 2) {
+        && coll->side_mid.floor < -STEP_L / 2 && !room->flags.swamp) {
         if (Item_TestFrameRange(
                 item, M_LF_WADE_STEP_L_START, M_LF_WADE_STEP_L_END)) {
             Item_SwitchToAnim(item, LA(LA_RUN_UP_STEP_LEFT), 0);
@@ -768,7 +798,13 @@ static void M_Wade(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    item->pos.y += MIN(coll->side_mid.floor, 50);
+    if (coll->side_mid.floor >= 50 && !room->flags.swamp) {
+        item->pos.y += 50;
+    } else if (coll->side_mid.floor < 0 || !room->flags.swamp) {
+        item->pos.y += coll->side_mid.floor;
+    } else {
+        item->pos.y += 2;
+    }
 }
 
 static void M_Sprint(ITEM *const item, COLL_INFO *const coll)

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -435,6 +435,7 @@ OBJECT_ID Lara_GetAnimationObject(void)
 
 void Lara_Animate(ITEM *const item)
 {
+    const ROOM *const room = Room_Get(item->room_num);
     LARA_INFO *const lara = Lara_GetLaraInfo();
     item->frame_num++;
 
@@ -504,7 +505,8 @@ void Lara_Animate(ITEM *const item)
             const ANIM_COMMAND_ENVIRONMENT type = data->environment;
             const int32_t height = lara->water_surface_dist;
             if ((type == ACE_WATER && (height >= 0 || height == NO_HEIGHT))
-                || (type == ACE_LAND && height < 0 && height != NO_HEIGHT)) {
+                || (type == ACE_LAND && height < 0 && height != NO_HEIGHT
+                    && !room->flags.swamp)) {
                 break;
             }
 
@@ -517,21 +519,35 @@ void Lara_Animate(ITEM *const item)
         }
     }
 
-    if (item->gravity) {
-        int32_t speed = anim->velocity
-            + anim->acceleration * (item->frame_num - anim->frame_base - 1);
+    const int32_t rel_frame = item->frame_num - anim->frame_base;
+    if (!item->gravity) {
+        int32_t speed = anim->velocity;
+        if (lara->water_status == LWS_WADE && room->flags.swamp) {
+            speed /= 2;
+            speed += (anim->acceleration * rel_frame) / 4;
+        } else {
+            speed += anim->acceleration * rel_frame;
+        }
+        item->speed = (int16_t)(speed >> 16);
+    } else if (room->flags.swamp) {
+        item->speed -= item->speed >> 3;
+        if (ABS(item->speed) < 8) {
+            item->speed = 0;
+            item->gravity = false;
+        }
+        if (item->fall_speed > 128) {
+            item->fall_speed /= 2;
+        }
+        item->fall_speed -= item->fall_speed / 4;
+        CLAMPL(item->fall_speed, 4);
+    } else {
+        int32_t speed = anim->velocity + anim->acceleration * (rel_frame - 1);
         item->speed -= (int16_t)(speed >> 16);
         speed += anim->acceleration;
         item->speed += (int16_t)(speed >> 16);
 
         item->fall_speed += item->fall_speed < FAST_FALL_SPEED ? GRAVITY : 1;
         item->pos.y += item->fall_speed;
-    } else {
-        int32_t speed = anim->velocity;
-        if (anim->acceleration != 0) {
-            speed += anim->acceleration * (item->frame_num - anim->frame_base);
-        }
-        item->speed = (int16_t)(speed >> 16);
     }
 
     item->pos.x += (item->speed * Math_Sin(lara->move_angle)) >> W2V_SHIFT;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -20,12 +20,13 @@
 #define M_COLL_DIST         CREATURE_TARGET_DIST // = 4096
 #define M_MOVE_TIMEOUT      90
 #define M_UW_DAMAGE         5
+#define M_SWAMP_DAMAGE      10
 #define M_DIVE_TILT_MED     (45 * DEG_1)         // = 8190
 #define M_DIVE_TILT_MAX     (85 * DEG_1)         // = 15470
 #define M_DIVE_TILT_MAX_ALT (100 * DEG_1)        // = 18200
 #define M_RADIUS_SURF       LARA_RADIUS          // = 100
 #define M_RADIUS_UW         300
-#define M_WADE_DEPTH        384
+#define M_WADE_DEPTH        (g_TRVersion == 3 ? 256 : 384)
 #define M_SWIM_DEPTH        730
 #define M_LEAN_UNDO_SURF    (LARA_LEAN_UNDO * 2) // = 364
 #define M_LEAN_UNDO_UW      M_LEAN_UNDO_SURF     // = 364
@@ -212,7 +213,6 @@ static void M_UpdateEnvironment(void)
     }
 
     const ROOM *const room = Room_Get(item->room_num);
-    const bool room_submerged = room->flags.underwater;
     const int32_t water_depth = Lara_GetWaterDepth(
         item->pos.x, item->pos.y, item->pos.z, item->room_num);
     const int32_t water_height = Room_GetWaterHeight(
@@ -239,50 +239,59 @@ static void M_UpdateEnvironment(void)
             break;
         }
 
-        if (g_Config.gameplay.enable_wading
-            && water_depth <= M_SWIM_DEPTH - STEP_L) {
-            if (water_height_diff > M_WADE_DEPTH) {
-                lara_info->water_status = LWS_WADE;
-                if (!item->gravity) {
-                    item->goal_anim_state = LS(LS_STOP);
+        if (water_depth > M_SWIM_DEPTH - STEP_L && !room->flags.swamp) {
+            if (room->flags.underwater) {
+                lara_info->air = LARA_MAX_AIR;
+                lara_info->water_status = LWS_UNDERWATER;
+                item->gravity = false;
+                item->pos.y += 100;
+                Lara_UpdateRoomToHeight(0);
+                Sound_StopEffect(SFX_LARA_FALL);
+                if (item->current_anim_state == LS(LS_SWAN_DIVE)) {
+                    item->rot.x = -M_DIVE_TILT_MED;
+                    item->goal_anim_state = LS(LS_DIVE);
+                    Lara_Animate(item);
+                    item->fall_speed *= 2;
+                } else if (item->current_anim_state == LS(LS_FAST_DIVE)) {
+                    item->rot.x = -M_DIVE_TILT_MAX;
+                    item->goal_anim_state = LS(LS_DIVE);
+                    Lara_Animate(item);
+                    item->fall_speed *= 2;
+                } else {
+                    item->rot.x = -M_DIVE_TILT_MED;
+                    Item_SwitchToAnim(item, LA(LA_FREEFALL_TO_UNDERWATER), 0);
+                    item->current_anim_state = LS(LS_DIVE);
+                    item->goal_anim_state = LS(LS_SWIM);
+                    item->fall_speed = (item->fall_speed * 3) / 2;
                 }
+                lara_info->head_rot.x = 0;
+                lara_info->head_rot.y = 0;
+                lara_info->torso_rot.x = 0;
+                lara_info->torso_rot.y = 0;
+                Spawn_Splash(item);
             }
-        } else if (room_submerged) {
-            lara_info->air = LARA_MAX_AIR;
-            lara_info->water_status = LWS_UNDERWATER;
-            item->gravity = false;
-            item->pos.y += 100;
-            Lara_UpdateRoomToHeight(0);
-            Sound_StopEffect(SFX_LARA_FALL);
-            if (item->current_anim_state == LS(LS_SWAN_DIVE)) {
-                item->rot.x = -M_DIVE_TILT_MED;
-                item->goal_anim_state = LS(LS_DIVE);
-                Lara_Animate(item);
-                item->fall_speed *= 2;
-            } else if (item->current_anim_state == LS(LS_FAST_DIVE)) {
-                item->rot.x = -M_DIVE_TILT_MAX;
-                item->goal_anim_state = LS(LS_DIVE);
-                Lara_Animate(item);
-                item->fall_speed *= 2;
-            } else {
-                item->rot.x = -M_DIVE_TILT_MED;
-                Item_SwitchToAnim(item, LA(LA_FREEFALL_TO_UNDERWATER), 0);
-                item->current_anim_state = LS(LS_DIVE);
-                item->goal_anim_state = LS(LS_SWIM);
-                item->fall_speed = (item->fall_speed * 3) / 2;
+        } else if (
+            g_Config.gameplay.enable_wading
+            && water_height_diff > M_WADE_DEPTH) {
+            lara_info->water_status = LWS_WADE;
+            if (!item->gravity) {
+                item->goal_anim_state = LS(LS_STOP);
+            } else if (room->flags.swamp) {
+                if (item->current_anim_state == LS(LS_SWAN_DIVE)
+                    || item->current_anim_state == LS(LS_FAST_DIVE)) {
+                    item->pos.y = water_height + 1000;
+                }
+                Item_SwitchToAnim(item, LA(LA_WADE), 0);
+                item->current_anim_state = LS(LS_WADE);
+                item->goal_anim_state = LS(LS_WADE);
             }
-            lara_info->head_rot.x = 0;
-            lara_info->head_rot.y = 0;
-            lara_info->torso_rot.x = 0;
-            lara_info->torso_rot.y = 0;
-            Spawn_Splash(item);
         }
 
         break;
     }
 
     case LWS_UNDERWATER: {
-        if (room_submerged) {
+        if (room->flags.underwater) {
             break;
         }
 
@@ -324,7 +333,7 @@ static void M_UpdateEnvironment(void)
     }
 
     case LWS_SURFACE: {
-        if (room_submerged) {
+        if (room->flags.underwater) {
             break;
         }
 
@@ -364,7 +373,7 @@ static void M_UpdateEnvironment(void)
             if (item->current_anim_state == LS(LS_WADE)) {
                 item->goal_anim_state = LS(LS_RUN);
             }
-        } else if (water_height_diff > M_SWIM_DEPTH) {
+        } else if (water_height_diff > M_SWIM_DEPTH && !room->flags.swamp) {
             lara_info->water_status = LWS_SURFACE;
             item->pos.y += 1 - water_height_diff;
 
@@ -667,10 +676,22 @@ static void M_HandleEnvironment(void)
 
     switch (lara_info->water_status) {
     case LWS_ABOVE_WATER:
-    case LWS_WADE:
-        lara_info->air = LARA_MAX_AIR;
+    case LWS_WADE: {
+        const ROOM *const room = Room_Get(item->room_num);
+        if (room->flags.swamp && lara_info->water_surface_dist < -775) {
+            if (item->hit_points >= 0) {
+                lara_info->air -= 6;
+                if (lara_info->air < 0) {
+                    lara_info->air = -1;
+                    Lara_TakeDamage(M_SWAMP_DAMAGE, false);
+                }
+            }
+        } else {
+            lara_info->air = LARA_MAX_AIR;
+        }
         M_HandleAboveWater(&coll);
         break;
+    }
 
     case LWS_UNDERWATER:
         if (item->hit_points >= 0) {

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -293,10 +293,10 @@ int32_t Lara_GetWaterDepth(
         room = Room_Get(room_num);
     }
 
-    if (room->flags.underwater) {
+    if (room->flags.underwater || room->flags.swamp) {
         while (sector->portal_room.sky != NO_ROOM) {
             room = Room_Get(sector->portal_room.sky);
-            if (!room->flags.underwater) {
+            if (!room->flags.underwater && !room->flags.swamp) {
                 const int32_t water_height = sector->ceiling.height;
                 sector = Room_GetSector(x, y, z, &room_num);
                 return Room_GetHeight(sector, x, y, z) - water_height;
@@ -308,7 +308,7 @@ int32_t Lara_GetWaterDepth(
 
     while (sector->portal_room.pit != NO_ROOM) {
         room = Room_Get(sector->portal_room.pit);
-        if (room->flags.underwater) {
+        if (room->flags.underwater || room->flags.swamp) {
             const int32_t water_height = sector->floor.height;
             sector = Room_GetSector(x, y, z, &room_num);
             return Room_GetHeight(sector, x, y, z) - water_height;

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -4,6 +4,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 
 // clang-format off
 #define M_LF_ROLL                  2
@@ -178,26 +179,48 @@ static void M_Wade(ITEM *const item, COLL_INFO *const coll)
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     g_Camera.target_elevation = CAM_WADE_ELEVATION;
-    if (g_Input.left) {
-        lara->turn_rate -= LARA_TURN_RATE;
-        CLAMPL(lara->turn_rate, -M_FAST_TURN);
-        item->rot.z -= LARA_LEAN_RATE;
-        CLAMPL(item->rot.z, -LARA_LEAN_MAX);
-    } else if (g_Input.right) {
-        lara->turn_rate += LARA_TURN_RATE;
-        CLAMPG(lara->turn_rate, M_FAST_TURN);
-        item->rot.z += LARA_LEAN_RATE;
-        CLAMPG(item->rot.z, LARA_LEAN_MAX);
-    }
 
-    if (g_Input.forward) {
-        if (lara->water_status != LWS_ABOVE_WATER) {
+    const ROOM *const room = Room_Get(item->room_num);
+    if (room->flags.swamp) {
+        if (g_Input.left) {
+            lara->turn_rate -= LARA_TURN_RATE;
+            CLAMPL(lara->turn_rate, -LARA_SLOW_TURN);
+            item->rot.z -= LARA_LEAN_RATE;
+            CLAMPL(item->rot.z, -LARA_LEAN_MAX / 2);
+        } else if (g_Input.right) {
+            lara->turn_rate += LARA_TURN_RATE;
+            CLAMPG(lara->turn_rate, LARA_SLOW_TURN);
+            item->rot.z += LARA_LEAN_RATE;
+            CLAMPG(item->rot.z, LARA_LEAN_MAX / 2);
+        }
+
+        if (g_Input.forward) {
             item->goal_anim_state = LS(LS_WADE);
         } else {
-            item->goal_anim_state = LS(LS_RUN);
+            item->goal_anim_state = LS(LS_STOP);
         }
     } else {
-        item->goal_anim_state = LS(LS_STOP);
+        if (g_Input.left) {
+            lara->turn_rate -= LARA_TURN_RATE;
+            CLAMPL(lara->turn_rate, -M_FAST_TURN);
+            item->rot.z -= LARA_LEAN_RATE;
+            CLAMPL(item->rot.z, -LARA_LEAN_MAX);
+        } else if (g_Input.right) {
+            lara->turn_rate += LARA_TURN_RATE;
+            CLAMPG(lara->turn_rate, M_FAST_TURN);
+            item->rot.z += LARA_LEAN_RATE;
+            CLAMPG(item->rot.z, LARA_LEAN_MAX);
+        }
+
+        if (g_Input.forward) {
+            if (lara->water_status != LWS_ABOVE_WATER) {
+                item->goal_anim_state = LS(LS_WADE);
+            } else {
+                item->goal_anim_state = LS(LS_RUN);
+            }
+        } else {
+            item->goal_anim_state = LS(LS_STOP);
+        }
     }
 }
 
@@ -260,7 +283,14 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
-    if (g_Input.step_left) {
+    const ROOM *const room = Room_Get(item->room_num);
+    if (room->flags.swamp) {
+        if (g_Input.left) {
+            item->goal_anim_state = LS(LS_TURN_LEFT);
+        } else if (g_Input.right) {
+            item->goal_anim_state = LS(LS_TURN_RIGHT);
+        }
+    } else if (g_Input.step_left) {
         item->goal_anim_state = LS(LS_STEP_LEFT);
     } else if (g_Input.step_right) {
         item->goal_anim_state = LS(LS_STEP_RIGHT);
@@ -271,12 +301,12 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     }
 
     if (lara->water_status == LWS_WADE) {
-        if (g_Input.jump) {
+        if (g_Input.jump && !room->flags.swamp) {
             item->goal_anim_state = LS(LS_COMPRESS);
         }
 
         if (g_Input.forward) {
-            if (g_Input.slow) {
+            if (room->flags.swamp || g_Input.slow) {
                 M_Wade(item, coll);
             } else {
                 M_Walk(item, coll);

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -679,6 +679,7 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         room->flags.dynamic_lit = (flags & 0x10) != 0;
         room->flags.wind        = (flags & 0x20) != 0;
         room->flags.inside      = (flags & 0x40) != 0;
+        room->flags.swamp       = (flags & 0x80) != 0;
         // clang-format on
 
         room->bind.active = false;

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -20,6 +20,12 @@
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const ROOM *const room = Room_Get(item->room_num);
+    if (room->flags.swamp) {
+        Item_Kill(item_num);
+        return;
+    }
+
     if (item->fall_speed) {
         item->rot.x += DEG_1 * 3;
         item->rot.z += DEG_1 * 5;
@@ -34,7 +40,7 @@ static void M_Control(const int16_t item_num)
     item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
     item->pos.x += (item->speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
 
-    if (Room_Get(item->room_num)->flags.underwater) {
+    if (room->flags.underwater) {
         item->fall_speed += (5 - item->fall_speed) / 2;
         item->speed = item->speed + (5 - item->speed) / 2;
     } else {

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -531,11 +531,11 @@ int32_t Room_GetWaterHeight(
         room_num = sector->portal_room.wall;
     } while (room_num != NO_ROOM);
 
-    if (room->flags.underwater) {
+    if (room->flags.underwater || room->flags.swamp) {
         while (sector->portal_room.sky != NO_ROOM
                && !M_IsPortalSolid(sector->ceiling, x, z)) {
             room = Room_Get(sector->portal_room.sky);
-            if (!room->flags.underwater) {
+            if (!room->flags.underwater && !room->flags.swamp) {
                 break;
             }
             sector = Room_GetWorldSector(room, x, z);
@@ -545,7 +545,7 @@ int32_t Room_GetWaterHeight(
         while (sector->portal_room.pit != NO_ROOM
                && !M_IsPortalSolid(sector->floor, x, z)) {
             room = Room_Get(sector->portal_room.pit);
-            if (room->flags.underwater) {
+            if (room->flags.underwater || room->flags.swamp) {
                 return M_GetSurfaceHeight(sector->floor, x, z, true);
             }
             sector = Room_GetWorldSector(room, x, z);

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -164,6 +164,7 @@ typedef struct {
         bool wind;
         bool inside;
         bool dynamic_lit;
+        bool swamp;
     } flags;
 
     struct {

--- a/src/trx/game/ui/elements/bar_lara_air.c
+++ b/src/trx/game/ui/elements/bar_lara_air.c
@@ -16,7 +16,7 @@ bool UI_LaraAirBar(const bool blink_state)
         && lara->air <= LARA_MAX_AIR * UI_BAR_BLINK_THRESHOLD;
     const bool show = g_Config.ui.show_bars
         && (lara->water_status == LWS_UNDERWATER
-            || lara->water_status == LWS_SURFACE);
+            || lara->water_status == LWS_SURFACE || lara->air < LARA_MAX_AIR);
     if (!show) {
         return false;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds swamp support (thanks @rr- for the base commit). The camera is still misbehaving near triangular portals, but I can't figure out what's going on there. Even changing the `NO_BOX` const to 2047 doesn't help (I've left that out of this change as a result). The camera however should behave suitably enough when wading through the mud as it will clamp to a target above Lara's position.

Worth checking going in and out of water as well in all games, including wading.
