### PR TITLE
tr3/sound: fix randomness factor

### DIFF
--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1366,7 +1366,7 @@ void Level_ReadSamples(const LEVEL_LOADER *const loader, VFILE *const file)
         }
 
         if (loader->game_version >= 3) {
-            sample_info->randomness = VFile_ReadU8(file) << 8;
+            sample_info->randomness = VFile_ReadU8(file);
             sample_info->pitch = VFile_ReadU8(file);
         } else {
             sample_info->randomness = VFile_ReadU16(file);

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -495,8 +495,14 @@ bool Sound_Effect_Direct(
         return false;
     }
 
-    if (sample->randomness && Random_GetDraw() > sample->randomness) {
-        return false;
+    if (sample->randomness) {
+        int32_t r = Random_GetDraw();
+        if (g_TRVersion >= 3) {
+            r &= 0xFF;
+        }
+        if (r > sample->randomness) {
+            return false;
+        }
     }
 
     const int32_t distance = M_GetDistance(sample, pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR tweaks how sounds are randomly skipped, so that it matches the OG TR3.
As an example, Lara will no longer groan with every jump.
