### PR TITLE
rooms/geometry: fix triangular portals

### DIFF
--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -131,6 +131,15 @@ static void M_ReadTriangulation(
     surface->is_split = true;
     surface->split.h1 = (func_data & 0x03E0) >> 5;
     surface->split.h2 = (func_data & 0x7C00) >> 10;
+    if ((surface->split.h1 & 0x10) != 0) {
+        surface->split.h1 |= 0xFFF0;
+    }
+    if ((surface->split.h2 & 0x10) != 0) {
+        surface->split.h2 |= 0xFFF0;
+    }
+    surface->split.h1 <<= 8;
+    surface->split.h2 <<= 8;
+
     for (int32_t i = 0; i < 4; i++) {
         surface->split.tilts[i] = (tilt_data >> (i * 4)) & 0xF;
     }

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -142,6 +142,9 @@ static void M_ReadTriangulation(
 
     for (int32_t i = 0; i < 4; i++) {
         surface->split.tilts[i] = (tilt_data >> (i * 4)) & 0xF;
+        if (surface->type == SURFACE_CEILING) {
+            surface->split.tilts[i] *= -1;
+        }
     }
 }
 

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -64,70 +64,14 @@ static int16_t M_GetUnsplitSurfaceHeight(
     return height;
 }
 
-static int16_t M_GetSplitCeilingHeight(
+static int16_t M_GetSplitSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
+    const bool is_ceiling = surface.type == SURFACE_CEILING;
     if (Camera_IsChunky()) {
         const int16_t ch1 = surface.height + surface.split.h2;
         const int16_t ch2 = surface.height + surface.split.h1;
-        return MAX(ch1, ch2);
-    }
-
-    const int32_t dx = x & M_WALL_MASK;
-    const int32_t dz = z & M_WALL_MASK;
-    const int16_t t0 = -surface.split.tilts[0];
-    const int16_t t1 = -surface.split.tilts[1];
-    const int16_t t2 = -surface.split.tilts[2];
-    const int16_t t3 = -surface.split.tilts[3];
-
-    int16_t height = surface.height;
-    int16_t h1;
-    int16_t h2;
-
-    if (surface.split.type == SPLIT_NWSE_SOLID
-        || surface.split.type == SPLIT_NWSE_PORTAL_SW
-        || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
-        if (dx <= WALL_L - dz) {
-            height += surface.split.h2;
-            h1 = t2 - t1;
-            h2 = t3 - t2;
-        } else {
-            height += surface.split.h1;
-            h1 = t3 - t0;
-            h2 = t0 - t1;
-        }
-    } else if (dx <= dz) {
-        height += surface.split.h2;
-        h1 = t2 - t1;
-        h2 = t0 - t1;
-    } else {
-        height += surface.split.h1;
-        h1 = t3 - t0;
-        h2 = t3 - t2;
-    }
-
-    if (h1 < 0) {
-        height += M_NEG_TILT(h1, z);
-    } else {
-        height -= M_POS_TILT(h1, z);
-    }
-
-    if (h2 < 0) {
-        height += M_POS_TILT(h2, x);
-    } else {
-        height -= M_NEG_TILT(h2, x);
-    }
-
-    return height;
-}
-
-static int16_t M_GetSplitFloorHeight(
-    const SURFACE surface, const int32_t x, const int32_t z)
-{
-    if (Camera_IsChunky()) {
-        const int16_t ch1 = surface.height + surface.split.h2;
-        const int16_t ch2 = surface.height + surface.split.h1;
-        return MIN(ch1, ch2);
+        return is_ceiling ? MAX(ch1, ch2) : MIN(ch1, ch2);
     }
 
     const int32_t dx = x & M_WALL_MASK;
@@ -138,47 +82,64 @@ static int16_t M_GetSplitFloorHeight(
     const int16_t t3 = surface.split.tilts[3];
 
     int16_t height = surface.height;
-    int16_t h1;
-    int16_t h2;
+    int16_t x_off;
+    int16_t z_off;
+    if (!is_ceiling) {
+        m_HeightType = HT_SPLIT_TRI;
+    }
 
     if (surface.split.type == SPLIT_NWSE_SOLID
         || surface.split.type == SPLIT_NWSE_PORTAL_SW
         || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
         if (dx <= WALL_L - dz) {
             height += surface.split.h2;
-            h1 = t2 - t1;
-            h2 = t0 - t1;
+            x_off = t2 - t1;
+            z_off = is_ceiling ? (t3 - t2) : (t0 - t1);
         } else {
             height += surface.split.h1;
-            h1 = t3 - t0;
-            h2 = t3 - t2;
+            x_off = t3 - t0;
+            z_off = is_ceiling ? (t0 - t1) : (t3 - t2);
         }
     } else if (dx <= dz) {
         height += surface.split.h2;
-        h1 = t2 - t1;
-        h2 = t3 - t2;
+        x_off = t2 - t1;
+        z_off = is_ceiling ? (t0 - t1) : (t3 - t2);
     } else {
         height += surface.split.h1;
-        h1 = t3 - t0;
-        h2 = t0 - t1;
+        x_off = t3 - t0;
+        z_off = is_ceiling ? (t3 - t2) : (t0 - t1);
     }
 
-    if (ABS(h1) > 2 || ABS(h2) > 2) {
-        m_HeightType = HT_DIAGONAL;
-    } else if (m_HeightType != HT_SPLIT_TRI) {
-        m_HeightType = HT_SMALL_SLOPE;
-    }
+    if (is_ceiling) {
+        if (x_off < 0) {
+            height += M_NEG_TILT(x_off, z);
+        } else {
+            height -= M_POS_TILT(x_off, z);
+        }
 
-    if (h1 < 0) {
-        height -= M_NEG_TILT(h1, z);
+        if (z_off < 0) {
+            height += M_POS_TILT(z_off, x);
+        } else {
+            height -= M_NEG_TILT(z_off, x);
+        }
     } else {
-        height += M_POS_TILT(h1, z);
-    }
+        if (ABS(x_off) > 2 || ABS(z_off) > 2) {
+            m_HeightType = HT_DIAGONAL;
+        } else if (m_HeightType != HT_SPLIT_TRI) {
+            m_HeightType = HT_SMALL_SLOPE;
+        }
 
-    if (h2 < 0) {
-        height -= M_NEG_TILT(h2, x);
-    } else {
-        height += M_POS_TILT(h2, x);
+        if (x_off < 0) {
+            height -= M_NEG_TILT(x_off, z);
+        } else {
+            height += M_POS_TILT(x_off, z);
+        }
+
+        if (z_off < 0) {
+            height -= M_NEG_TILT(z_off, x);
+        } else {
+            height += M_POS_TILT(z_off, x);
+        }
     }
 
     return height;
@@ -188,13 +149,9 @@ static int16_t M_GetSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z,
     const bool fix_tilts)
 {
-    if (!surface.is_split) {
-        return M_GetUnsplitSurfaceHeight(surface, x, z, fix_tilts);
-    }
-
-    return surface.type == SURFACE_CEILING
-        ? M_GetSplitCeilingHeight(surface, x, z)
-        : M_GetSplitFloorHeight(surface, x, z);
+    return surface.is_split
+        ? M_GetSplitSurfaceHeight(surface, x, z)
+        : M_GetUnsplitSurfaceHeight(surface, x, z, fix_tilts);
 }
 
 static int16_t M_GetSplitTiltType(

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -266,26 +266,26 @@ SECTOR *Room_GetSector(
 
     ASSERT(sector != nullptr);
 
-    if (y >= sector->floor.height) {
-        while (sector->portal_room.pit != NO_ROOM
-               && !M_IsPortalSolid(sector->floor, x, z)) {
+    if (y >= M_GetSurfaceHeight(sector->floor, x, z, true)) {
+        do {
+            if (sector->portal_room.pit == NO_ROOM
+                || M_IsPortalSolid(sector->floor, x, z)) {
+                break;
+            }
             *room_num = sector->portal_room.pit;
             const ROOM *const room = Room_Get(*room_num);
             sector = Room_GetWorldSector(room, x, z);
-            if (y < sector->floor.height) {
+        } while (y >= M_GetSurfaceHeight(sector->floor, x, z, true));
+    } else if (y < M_GetSurfaceHeight(sector->ceiling, x, z, true)) {
+        do {
+            if (sector->portal_room.sky == NO_ROOM
+                || M_IsPortalSolid(sector->ceiling, x, z)) {
                 break;
             }
-        }
-    } else if (y < sector->ceiling.height) {
-        while (sector->portal_room.sky != NO_ROOM
-               && !M_IsPortalSolid(sector->ceiling, x, z)) {
             *room_num = sector->portal_room.sky;
             const ROOM *const room = Room_Get(sector->portal_room.sky);
             sector = Room_GetWorldSector(room, x, z);
-            if (y >= sector->ceiling.height) {
-                break;
-            }
-        }
+        } while (y < M_GetSurfaceHeight(sector->ceiling, x, z, true));
     }
 
     return sector;

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -68,19 +68,8 @@ static int16_t M_GetSplitCeilingHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
     if (Camera_IsChunky()) {
-        int32_t height_adj = surface.split.h2;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-
-        int16_t ch2 = surface.height;
-        int16_t ch1 = ch2 + (height_adj << 8);
-
-        height_adj = surface.split.h1;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        ch2 += height_adj << 8;
+        const int16_t ch1 = surface.height + surface.split.h2;
+        const int16_t ch2 = surface.height + surface.split.h1;
         return MAX(ch1, ch2);
     }
 
@@ -99,36 +88,20 @@ static int16_t M_GetSplitCeilingHeight(
         || surface.split.type == SPLIT_NWSE_PORTAL_SW
         || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
         if (dx <= WALL_L - dz) {
-            int32_t height_adj = surface.split.h2;
-            if ((height_adj & 0x10) != 0) {
-                height_adj |= 0xFFF0;
-            }
-            height += height_adj << 8;
+            height += surface.split.h2;
             h1 = t2 - t1;
             h2 = t3 - t2;
         } else {
-            int32_t height_adj = surface.split.h1;
-            if ((height_adj & 0x10) != 0) {
-                height_adj |= 0xFFF0;
-            }
-            height += height_adj << 8;
+            height += surface.split.h1;
             h1 = t3 - t0;
             h2 = t0 - t1;
         }
     } else if (dx <= dz) {
-        int32_t height_adj = surface.split.h2;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        height += height_adj << 8;
+        height += surface.split.h2;
         h1 = t2 - t1;
         h2 = t0 - t1;
     } else {
-        int32_t height_adj = surface.split.h1;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        height += height_adj << 8;
+        height += surface.split.h1;
         h1 = t3 - t0;
         h2 = t3 - t2;
     }
@@ -152,19 +125,8 @@ static int16_t M_GetSplitFloorHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
     if (Camera_IsChunky()) {
-        int32_t height_adj = surface.split.h2;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-
-        int16_t ch2 = surface.height;
-        int16_t ch1 = ch2 + (height_adj << 8);
-
-        height_adj = surface.split.h1;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        ch2 += height_adj << 8;
+        const int16_t ch1 = surface.height + surface.split.h2;
+        const int16_t ch2 = surface.height + surface.split.h1;
         return MIN(ch1, ch2);
     }
 
@@ -183,36 +145,20 @@ static int16_t M_GetSplitFloorHeight(
         || surface.split.type == SPLIT_NWSE_PORTAL_SW
         || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
         if (dx <= WALL_L - dz) {
-            int32_t height_adj = surface.split.h2;
-            if ((height_adj & 0x10) != 0) {
-                height_adj |= 0xFFF0;
-            }
-            height += height_adj << 8;
+            height += surface.split.h2;
             h1 = t2 - t1;
             h2 = t0 - t1;
         } else {
-            int32_t height_adj = surface.split.h1;
-            if ((height_adj & 0x10) != 0) {
-                height_adj |= 0xFFF0;
-            }
-            height += height_adj << 8;
+            height += surface.split.h1;
             h1 = t3 - t0;
             h2 = t3 - t2;
         }
     } else if (dx <= dz) {
-        int32_t height_adj = surface.split.h2;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        height += height_adj << 8;
+        height += surface.split.h2;
         h1 = t2 - t1;
         h2 = t3 - t2;
     } else {
-        int32_t height_adj = surface.split.h1;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        height += height_adj << 8;
+        height += surface.split.h1;
         h1 = t3 - t0;
         h2 = t0 - t1;
     }

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -64,96 +64,183 @@ static int16_t M_GetUnsplitSurfaceHeight(
     return height;
 }
 
-static int16_t M_GetSplitSurfaceHeight(
+static int16_t M_GetSplitCeilingHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
-    const SPLIT split = surface.split;
-    const bool is_ceiling = surface.type == SURFACE_CEILING;
-    int16_t height = surface.height;
     const int32_t dx = x & M_WALL_MASK;
     const int32_t dz = z & M_WALL_MASK;
-    int32_t x_off, z_off;
+    const int16_t t0 = -surface.split.tilts[0];
+    const int16_t t1 = -surface.split.tilts[1];
+    const int16_t t2 = -surface.split.tilts[2];
+    const int16_t t3 = -surface.split.tilts[3];
 
-    const bool is_nesw =
-        (split.type == SPLIT_NESW_SOLID || split.type == SPLIT_NESW_PORTAL_SE
-         || split.type == SPLIT_NESW_PORTAL_NW);
-    const bool is_first_tri = is_nesw ? (dx <= dz) : (dx <= WALL_L - dz);
-    const int32_t h = is_first_tri ? split.h2 : split.h1;
+    int16_t height = surface.height;
+    int16_t h1;
+    int16_t h2;
 
-    const int32_t height_adj = ((h & 0x10) != 0) ? (h | 0xFFF0) : h;
-    height += height_adj << 8;
-
-    if (is_nesw) {
-        if (is_first_tri) {
-            x_off = split.tilts[is_ceiling ? 1 : 2]
-                - split.tilts[is_ceiling ? 2 : 1];
-            z_off = split.tilts[is_ceiling ? 1 : 3]
-                - split.tilts[is_ceiling ? 0 : 2];
+    if (surface.split.type == SPLIT_NWSE_SOLID
+        || surface.split.type == SPLIT_NWSE_PORTAL_SW
+        || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
+        if (dx <= WALL_L - dz) {
+            int32_t height_adj = surface.split.h2;
+            if ((height_adj & 0x10) != 0) {
+                height_adj |= 0xFFF0;
+            }
+            height += height_adj << 8;
+            h1 = t2 - t1;
+            h2 = t3 - t2;
         } else {
-            x_off = split.tilts[is_ceiling ? 0 : 3]
-                - split.tilts[is_ceiling ? 3 : 0];
-            z_off = split.tilts[is_ceiling ? 2 : 0]
-                - split.tilts[is_ceiling ? 3 : 1];
+            int32_t height_adj = surface.split.h1;
+            if ((height_adj & 0x10) != 0) {
+                height_adj |= 0xFFF0;
+            }
+            height += height_adj << 8;
+            h1 = t3 - t0;
+            h2 = t0 - t1;
         }
+    } else if (dx <= dz) {
+        int32_t height_adj = surface.split.h2;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        height += height_adj << 8;
+        h1 = t2 - t1;
+        h2 = t0 - t1;
     } else {
-        if (is_first_tri) {
-            x_off = split.tilts[is_ceiling ? 1 : 2]
-                - split.tilts[is_ceiling ? 2 : 1];
-            z_off = split.tilts[is_ceiling ? 2 : 0]
-                - split.tilts[is_ceiling ? 3 : 1];
-        } else {
-            x_off = split.tilts[is_ceiling ? 0 : 3]
-                - split.tilts[is_ceiling ? 3 : 0];
-            z_off = split.tilts[is_ceiling ? 1 : 3]
-                - split.tilts[is_ceiling ? 0 : 2];
+        int32_t height_adj = surface.split.h1;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
         }
-    }
-
-    if (!is_ceiling) {
-        m_HeightType = HT_SPLIT_TRI;
+        height += height_adj << 8;
+        h1 = t3 - t0;
+        h2 = t3 - t2;
     }
 
     if (Camera_IsChunky()) {
-        const int32_t h1 = (split.h1 & 0x10) ? (split.h1 | 0xFFF0) : split.h1;
-        const int32_t h2 = (split.h2 & 0x10) ? (split.h2 | 0xFFF0) : split.h2;
-        const int32_t ch1 = surface.height + (h2 << 8);
-        const int32_t ch2 = surface.height + (h1 << 8);
-        if (is_ceiling) {
-            height = (ch1 > ch2) ? ch1 : ch2;
+        int32_t height_adj = surface.split.h2;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+
+        int16_t ch2 = surface.height;
+        int16_t ch1 = ch2 + (height_adj << 8);
+
+        height_adj = surface.split.h1;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        ch2 += height_adj << 8;
+        if (ch1 > ch2) {
+            height = ch1;
         } else {
-            height = (ch1 < ch2) ? ch1 : ch2;
+            height = ch2;
         }
     } else {
-        if (is_ceiling) {
-            if (x_off < 0) {
-                height += M_NEG_TILT(x_off, z);
-            } else {
-                height -= M_POS_TILT(x_off, z);
-            }
-
-            if (z_off < 0) {
-                height += M_POS_TILT(z_off, x);
-            } else {
-                height -= M_NEG_TILT(z_off, x);
-            }
+        if (h1 < 0) {
+            height += M_NEG_TILT(h1, z);
         } else {
-            if (ABS(x_off) > 2 || ABS(z_off) > 2) {
-                m_HeightType = HT_DIAGONAL;
-            } else if (m_HeightType != HT_SPLIT_TRI) {
-                m_HeightType = HT_SMALL_SLOPE;
-            }
+            height -= M_POS_TILT(h1, z);
+        }
 
-            if (x_off < 0) {
-                height -= M_NEG_TILT(x_off, z);
-            } else {
-                height += M_POS_TILT(x_off, z);
-            }
+        if (h2 < 0) {
+            height += M_POS_TILT(h2, x);
+        } else {
+            height -= M_NEG_TILT(h2, x);
+        }
+    }
 
-            if (z_off < 0) {
-                height -= M_NEG_TILT(z_off, x);
-            } else {
-                height += M_POS_TILT(z_off, x);
+    return height;
+}
+
+static int16_t M_GetSplitFloorHeight(
+    const SURFACE surface, const int32_t x, const int32_t z)
+{
+    const int32_t dx = x & M_WALL_MASK;
+    const int32_t dz = z & M_WALL_MASK;
+    const int16_t t0 = surface.split.tilts[0];
+    const int16_t t1 = surface.split.tilts[1];
+    const int16_t t2 = surface.split.tilts[2];
+    const int16_t t3 = surface.split.tilts[3];
+
+    int16_t height = surface.height;
+    int16_t h1;
+    int16_t h2;
+
+    if (surface.split.type == SPLIT_NWSE_SOLID
+        || surface.split.type == SPLIT_NWSE_PORTAL_SW
+        || surface.split.type == SPLIT_NWSE_PORTAL_NE) {
+        if (dx <= WALL_L - dz) {
+            int32_t height_adj = surface.split.h2;
+            if ((height_adj & 0x10) != 0) {
+                height_adj |= 0xFFF0;
             }
+            height += height_adj << 8;
+            h1 = t2 - t1;
+            h2 = t0 - t1;
+        } else {
+            int32_t height_adj = surface.split.h1;
+            if ((height_adj & 0x10) != 0) {
+                height_adj |= 0xFFF0;
+            }
+            height += height_adj << 8;
+            h1 = t3 - t0;
+            h2 = t3 - t2;
+        }
+    } else if (dx <= dz) {
+        int32_t height_adj = surface.split.h2;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        height += height_adj << 8;
+        h1 = t2 - t1;
+        h2 = t3 - t2;
+    } else {
+        int32_t height_adj = surface.split.h1;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        height += height_adj << 8;
+        h1 = t3 - t0;
+        h2 = t0 - t1;
+    }
+
+    if (Camera_IsChunky()) {
+        int32_t height_adj = surface.split.h2;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+
+        int16_t ch2 = surface.height;
+        int16_t ch1 = ch2 + (height_adj << 8);
+
+        height_adj = surface.split.h1;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        ch2 += height_adj << 8;
+
+        if (ch1 < ch2) {
+            height = ch1;
+        } else {
+            height = ch2;
+        }
+    } else {
+        if (ABS(h1) > 2 || ABS(h2) > 2) {
+            m_HeightType = HT_DIAGONAL;
+        } else if (m_HeightType != HT_SPLIT_TRI) {
+            m_HeightType = HT_SMALL_SLOPE;
+        }
+
+        if (h1 < 0) {
+            height -= M_NEG_TILT(h1, z);
+        } else {
+            height += M_POS_TILT(h1, z);
+        }
+
+        if (h2 < 0) {
+            height -= M_NEG_TILT(h2, x);
+        } else {
+            height += M_POS_TILT(h2, x);
         }
     }
 
@@ -164,9 +251,13 @@ static int16_t M_GetSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z,
     const bool fix_tilts)
 {
-    return surface.is_split
-        ? M_GetSplitSurfaceHeight(surface, x, z)
-        : M_GetUnsplitSurfaceHeight(surface, x, z, fix_tilts);
+    if (!surface.is_split) {
+        return M_GetUnsplitSurfaceHeight(surface, x, z, fix_tilts);
+    }
+
+    return surface.type == SURFACE_CEILING
+        ? M_GetSplitCeilingHeight(surface, x, z)
+        : M_GetSplitFloorHeight(surface, x, z);
 }
 
 static int16_t M_GetSplitTiltType(

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -67,6 +67,23 @@ static int16_t M_GetUnsplitSurfaceHeight(
 static int16_t M_GetSplitCeilingHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
+    if (Camera_IsChunky()) {
+        int32_t height_adj = surface.split.h2;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+
+        int16_t ch2 = surface.height;
+        int16_t ch1 = ch2 + (height_adj << 8);
+
+        height_adj = surface.split.h1;
+        if ((height_adj & 0x10) != 0) {
+            height_adj |= 0xFFF0;
+        }
+        ch2 += height_adj << 8;
+        return MAX(ch1, ch2);
+    }
+
     const int32_t dx = x & M_WALL_MASK;
     const int32_t dz = z & M_WALL_MASK;
     const int16_t t0 = -surface.split.tilts[0];
@@ -116,6 +133,24 @@ static int16_t M_GetSplitCeilingHeight(
         h2 = t3 - t2;
     }
 
+    if (h1 < 0) {
+        height += M_NEG_TILT(h1, z);
+    } else {
+        height -= M_POS_TILT(h1, z);
+    }
+
+    if (h2 < 0) {
+        height += M_POS_TILT(h2, x);
+    } else {
+        height -= M_NEG_TILT(h2, x);
+    }
+
+    return height;
+}
+
+static int16_t M_GetSplitFloorHeight(
+    const SURFACE surface, const int32_t x, const int32_t z)
+{
     if (Camera_IsChunky()) {
         int32_t height_adj = surface.split.h2;
         if ((height_adj & 0x10) != 0) {
@@ -130,31 +165,9 @@ static int16_t M_GetSplitCeilingHeight(
             height_adj |= 0xFFF0;
         }
         ch2 += height_adj << 8;
-        if (ch1 > ch2) {
-            height = ch1;
-        } else {
-            height = ch2;
-        }
-    } else {
-        if (h1 < 0) {
-            height += M_NEG_TILT(h1, z);
-        } else {
-            height -= M_POS_TILT(h1, z);
-        }
-
-        if (h2 < 0) {
-            height += M_POS_TILT(h2, x);
-        } else {
-            height -= M_NEG_TILT(h2, x);
-        }
+        return MIN(ch1, ch2);
     }
 
-    return height;
-}
-
-static int16_t M_GetSplitFloorHeight(
-    const SURFACE surface, const int32_t x, const int32_t z)
-{
     const int32_t dx = x & M_WALL_MASK;
     const int32_t dz = z & M_WALL_MASK;
     const int16_t t0 = surface.split.tilts[0];
@@ -204,44 +217,22 @@ static int16_t M_GetSplitFloorHeight(
         h2 = t0 - t1;
     }
 
-    if (Camera_IsChunky()) {
-        int32_t height_adj = surface.split.h2;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
+    if (ABS(h1) > 2 || ABS(h2) > 2) {
+        m_HeightType = HT_DIAGONAL;
+    } else if (m_HeightType != HT_SPLIT_TRI) {
+        m_HeightType = HT_SMALL_SLOPE;
+    }
 
-        int16_t ch2 = surface.height;
-        int16_t ch1 = ch2 + (height_adj << 8);
-
-        height_adj = surface.split.h1;
-        if ((height_adj & 0x10) != 0) {
-            height_adj |= 0xFFF0;
-        }
-        ch2 += height_adj << 8;
-
-        if (ch1 < ch2) {
-            height = ch1;
-        } else {
-            height = ch2;
-        }
+    if (h1 < 0) {
+        height -= M_NEG_TILT(h1, z);
     } else {
-        if (ABS(h1) > 2 || ABS(h2) > 2) {
-            m_HeightType = HT_DIAGONAL;
-        } else if (m_HeightType != HT_SPLIT_TRI) {
-            m_HeightType = HT_SMALL_SLOPE;
-        }
+        height += M_POS_TILT(h1, z);
+    }
 
-        if (h1 < 0) {
-            height -= M_NEG_TILT(h1, z);
-        } else {
-            height += M_POS_TILT(h1, z);
-        }
-
-        if (h2 < 0) {
-            height -= M_NEG_TILT(h2, x);
-        } else {
-            height += M_POS_TILT(h2, x);
-        }
+    if (h2 < 0) {
+        height -= M_NEG_TILT(h2, x);
+    } else {
+        height += M_POS_TILT(h2, x);
     }
 
     return height;

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -50,8 +50,8 @@ typedef struct WALKABLE {
 typedef struct {
     SPLIT_TYPE type;
     int16_t tilts[4];
-    int8_t h1;
-    int8_t h2;
+    int32_t h1;
+    int32_t h2;
 } SPLIT;
 
 typedef struct {

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -49,7 +49,7 @@ typedef struct WALKABLE {
 
 typedef struct {
     SPLIT_TYPE type;
-    uint8_t tilts[4];
+    int16_t tilts[4];
     int8_t h1;
     int8_t h2;
 } SPLIT;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The fix for this turned out to be quite simple, but I ended up going down a few rabbit holes before getting there. The final commit has the fix itself, the rest basically turned into a refactor of the triangle collision functions for better maintainability and slightly better efficiency (e.g. no more repeated manipulation).

The issue was ultimately `Room_GetSector` not testing the correct height and deciding to return the sector above or below when it shouldn't. This is why the camera was so flickery in some areas, and you could even see Lara flicker rapidly between rooms (e.g. first secret in Jungle).

Although it's ultimately a straight-forward fix, I'd appreciate some general checks traversing vertical portals, both with triangles nearby and not.

The camera in TR3 is still not perfect, but it's working pretty well I think given the lack of box data.
