### PR TITLE
level: assign vertex count even to discarded faces

### DIFF
--- a/src/trx/game/inject/editors/rooms.c
+++ b/src/trx/game/inject/editors/rooms.c
@@ -211,11 +211,6 @@ static void M_AddRoomFace(const INJECTION *const injection)
     if (face_type == FT_TEXTURED_QUAD) {
         FACE *const face = &room->mesh.face4s.data[room->mesh.face4s.count];
         face->texture_idx = *source_texture;
-        face->vertex_count = 4;
-        for (int32_t i = 0; i < 4; i++) {
-            face->texture_zw[i].z = 1.0f;
-            face->texture_zw[i].w = 1.0f;
-        }
         face_vertices = face->vertices;
         room->mesh.face4s.count++;
     } else {
@@ -223,10 +218,6 @@ static void M_AddRoomFace(const INJECTION *const injection)
         face->vertex_count = 3;
         face->texture_idx = *source_texture;
         face_vertices = face->vertices;
-        for (int32_t i = 0; i < 3; i++) {
-            face->texture_zw[i].z = 1.0f;
-            face->texture_zw[i].w = 1.0f;
-        }
         room->mesh.face3s.count++;
     }
 

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -296,7 +296,10 @@ static void M_ReadRoomMesh(
         for (int32_t i = 0; i < room->mesh.face4s.count; i++) {
             M_ReadFace(face_ptr++, 4, file);
         }
-        face_ptr += inj_data.num_quads;
+        for (int32_t i = 0; i < inj_data.num_quads; i++) {
+            face_ptr->vertex_count = 4;
+            face_ptr++;
+        }
 
         VFile_Skip(file, 2);
 
@@ -304,7 +307,10 @@ static void M_ReadRoomMesh(
         for (int32_t i = 0; i < room->mesh.face3s.count; i++) {
             M_ReadFace(face_ptr++, 3, file);
         }
-        face_ptr += inj_data.num_quads;
+        for (int32_t i = 0; i < inj_data.num_triangles; i++) {
+            face_ptr->vertex_count = 3;
+            face_ptr++;
+        }
     }
 
     {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes crash when trying to apply Caves injections to irrelevant levels. The injection bumps up the quad and triangle count, but never ends up filling it due to runtime checks, and the mesh builder for the affected rooms was seeing `0` as vertex count.