### PR TITLE
output/background: add TR2 background support in TR1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,8 @@
     - `flow.play_any_level`
     - `flow.cheat_keys`
 - added the ability for the sound system to use Lara's position instead of camera's position (#1438) (Sound Options → Misc → Microphone near Lara)
+- added an option to use TR2-style inventory ring backgrounds in custom levels (Graphic Options → UI → Inventory background) (#4264)
+- added an option to use TR2-style statistics dialog backgrounds in custom levels (Graphic Options → UI → Stats background) (#4264)
 - improved the positions of some 3D pickup items, such as the scion that Pierre drops
 - improved the quality of the PS1 Uzi SFX (#4024)
 - changed the following game flow options to become hidden settings (available via LUA and the `/set` command):

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -263,9 +263,8 @@ M_GF_HANDLER(M_HandleLevelStats)
         g_TRVersion == 1 && g_Config.ui.stat_detail_mode != SDM_FULL;
 
     PHASE *const phase = Phase_Stats_Create((PHASE_STATS_ARGS) {
-        .background_type = (g_TRVersion == 1 || Game_IsInGym())
-            ? BK_TRANSPARENT
-            : g_Config.ui.stats_background_style,
+        .background_type = Game_IsInGym() ? BK_TRANSPARENT
+                                          : g_Config.ui.stats_background_style,
         .level_num = -1,
         .show_final_stats = false,
         .use_bare_style = use_bare_style,

--- a/src/trx/game/output/sources/background.c
+++ b/src/trx/game/output/sources/background.c
@@ -156,40 +156,35 @@ bool Output_LoadBackgroundFromImage(const IMAGE *const image)
 
 void Output_LoadBackgroundFromObject(const bool wave)
 {
-    if (g_TRVersion == 1) {
-        m_Priv.type = BK_TRANSPARENT;
-    } else {
-        if (m_Priv.surface != nullptr) {
-            GFX_2D_Surface_Free(m_Priv.surface);
-            m_Priv.surface = nullptr;
-        }
+    if (m_Priv.surface != nullptr) {
+        GFX_2D_Surface_Free(m_Priv.surface);
+        m_Priv.surface = nullptr;
+    }
 
-        const OBJECT *const obj = Object_Get(O_INV_BACKGROUND);
-        if (!obj->loaded) {
-            return;
-        }
+    const OBJECT *const obj = Object_Get(O_INV_BACKGROUND);
+    if (!obj->loaded) {
+        return;
+    }
 
-        const OBJECT_MESH *const mesh = Object_GetMesh(obj->mesh_idx);
-        if (mesh->tex_face4s.count < 1) {
-            return;
-        }
+    const OBJECT_MESH *const mesh = Object_GetMesh(obj->mesh_idx);
+    if (mesh->tex_face4s.count < 1) {
+        return;
+    }
 
-        const int32_t texture_idx = mesh->tex_face4s.data[0].texture_idx;
-        const OBJECT_TEXTURE *const texture =
-            Output_GetObjectTexture(texture_idx);
-        ASSERT(texture != nullptr);
-        const int32_t repeat_y = 6;
-        const int32_t repeat_x = repeat_y * Viewport_GetWidth(VIEWPORT_GAME)
-            / (float)Viewport_GetHeight(VIEWPORT_GAME);
-        m_Priv.type = wave ? BK_PATTERN_WAVE : BK_PATTERN_STATIC;
+    const int32_t texture_idx = mesh->tex_face4s.data[0].texture_idx;
+    const OBJECT_TEXTURE *const texture = Output_GetObjectTexture(texture_idx);
+    ASSERT(texture != nullptr);
+    const int32_t repeat_y = 6;
+    const int32_t repeat_x = repeat_y * Viewport_GetWidth(VIEWPORT_GAME)
+        / (float)Viewport_GetHeight(VIEWPORT_GAME);
+    m_Priv.type = wave ? BK_PATTERN_WAVE : BK_PATTERN_STATIC;
 
-        const RGBA_8888 *const page =
-            Output_GetTexturePage32(texture->tex_page);
-        if (page == nullptr) {
-            return;
-        }
+    const RGBA_8888 *const page = Output_GetTexturePage32(texture->tex_page);
+    if (page == nullptr) {
+        return;
+    }
 
-        GFX_2D_SURFACE_DESC desc = {
+    GFX_2D_SURFACE_DESC desc = {
         .width = TEXTURE_PAGE_WIDTH,
         .height = TEXTURE_PAGE_HEIGHT,
         .bit_count = 32,
@@ -215,23 +210,20 @@ void Output_LoadBackgroundFromObject(const bool wave)
         },
         .pitch = TEXTURE_PAGE_WIDTH * 2,
     };
-        const OUTPUT_TEXTURE_SIZE size =
-            Output_Textures_GetAtlasSize(texture_idx);
-        GFX_2D_Renderer_Upload(m_Priv.renderer, &desc, (uint8_t *)page);
-        GFX_2D_Renderer_SetRepeat(m_Priv.renderer, repeat_x, repeat_y);
-        GFX_2D_Renderer_SetTextureSize(
-            m_Priv.renderer,
-            &(GFX_TEXTURE_SIZE) {
-                .x0 = size.x0,
-                .y0 = size.y0,
-                .x1 = size.x1,
-                .y1 = size.y1,
-            });
-        GFX_2D_Renderer_SetEffect(
-            m_Priv.renderer,
-            wave ? GFX_2D_EFFECT_WAVE : GFX_2D_EFFECT_VIGNETTE);
-        Output_RefreshBackgroundScaling();
-    }
+    const OUTPUT_TEXTURE_SIZE size = Output_Textures_GetAtlasSize(texture_idx);
+    GFX_2D_Renderer_Upload(m_Priv.renderer, &desc, (uint8_t *)page);
+    GFX_2D_Renderer_SetRepeat(m_Priv.renderer, repeat_x, repeat_y);
+    GFX_2D_Renderer_SetTextureSize(
+        m_Priv.renderer,
+        &(GFX_TEXTURE_SIZE) {
+            .x0 = size.x0,
+            .y0 = size.y0,
+            .x1 = size.x1,
+            .y1 = size.y1,
+        });
+    GFX_2D_Renderer_SetEffect(
+        m_Priv.renderer, wave ? GFX_2D_EFFECT_WAVE : GFX_2D_EFFECT_VIGNETTE);
+    Output_RefreshBackgroundScaling();
 }
 
 void Output_UnloadBackground(void)


### PR DESCRIPTION
Ref #4264.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows custom levels to use a background object in the inventory and stats screens. The other issues listed in the ticket I feel can be a future enhancement, this just makes the options similar for 1/2 for custom levels as a start.
