### PR TITLE
output: add initial ubo support

### DIFF
--- a/data/common/ship/shaders/2d.glsl
+++ b/data/common/ship/shaders/2d.glsl
@@ -11,9 +11,9 @@
 #define WAVE_ORBIT_RADIUS 0.2
 #define WAVE_FPS_DRIFT 25 / 30
 
-#ifdef VERTEX
-
 uniform int uEffect;
+
+#ifdef VERTEX
 
 layout(location = 0) in vec2 inPosition;
 layout(location = 1) in vec2 inTexCoords;
@@ -51,9 +51,8 @@ void main() {
 
 #elif defined(FRAGMENT)
 
-uniform sampler2D texMain;
+uniform sampler2D uTexMain;
 uniform vec4 uTexSize;
-uniform int uEffect;
 
 in vec2 vertTexCoords;
 in vec2 vertCoords;
@@ -64,7 +63,7 @@ void main(void) {
     vec2 uv = vertTexCoords;
     uv = clampTexAtlas(uv, uTexSize);
 
-    outColor = texture(texMain, uv);
+    outColor = texture(uTexMain, uv);
 
     if ((uEffect & EFFECT_WAVE) != 0) {
         outColor.rgb *= vertLight;

--- a/data/common/ship/shaders/common.glsl
+++ b/data/common/ship/shaders/common.glsl
@@ -28,10 +28,19 @@
 #define MAX_WIBBLE 2
 #define PI 3.1415926538
 
-uniform float uTime;
-uniform float uTimeInGame;
-uniform float uBrightnessMultiplier;
-uniform vec2 uViewportSize;
+layout(std140, binding = 0) uniform Globals {
+    mat4 uMatView;
+    vec4 uFogColor;
+    vec2 uFogDistance; // x = fog start, y = fog end
+    vec2 uViewportSize;
+    float uTime;
+    float uTimeInGame;
+    float uBrightnessMultiplier;
+    int uBillboardLockMode;
+    int uLightingContrast;
+    int uTrapezoidFilterEnabled; // bool
+    int uReflectionsEnabled; // bool
+};
 
 vec2 clampTexAtlas(vec2 uv, vec4 atlasSize)
 {
@@ -39,41 +48,41 @@ vec2 clampTexAtlas(vec2 uv, vec4 atlasSize)
     return clamp(uv, atlasSize.xy + epsilon, atlasSize.zw - epsilon);
 }
 
-vec3 waterWibble(vec4 position, vec2 viewportSize, float time)
+vec3 waterWibble(vec4 position)
 {
     // get screen coordinates
     vec3 ndc = position.xyz / position.w; //perspective divide/normalize
     vec2 viewportCoord = ndc.xy * 0.5 + 0.5; //ndc is -1 to 1 in GL. scale for 0 to 1
-    vec2 viewportPixelCoord = viewportCoord * viewportSize;
+    vec2 viewportPixelCoord = viewportCoord * uViewportSize;
 
-    viewportPixelCoord.x += sin((time + viewportPixelCoord.y) * 2.0 * PI / WIBBLE_SIZE) * MAX_WIBBLE;
-    viewportPixelCoord.y += sin((time + viewportPixelCoord.x) * 2.0 * PI / WIBBLE_SIZE) * MAX_WIBBLE;
+    viewportPixelCoord.x += sin((uTimeInGame + viewportPixelCoord.y) * 2.0 * PI / WIBBLE_SIZE) * MAX_WIBBLE;
+    viewportPixelCoord.y += sin((uTimeInGame + viewportPixelCoord.x) * 2.0 * PI / WIBBLE_SIZE) * MAX_WIBBLE;
 
     // reverse transform
-    viewportCoord = viewportPixelCoord / viewportSize;
+    viewportCoord = viewportPixelCoord / uViewportSize;
     ndc.xy = (viewportCoord - 0.5) * 2.0;
     return ndc * position.w;
 }
 
-vec4 applyFog(vec4 color, float depth, vec2 fogDistance, vec4 fogColor)
+vec4 applyFog(vec4 color, float depth)
 {
-    float fogBegin = fogDistance.x;
-    float fogEnd = fogDistance.y;
+    float fogBegin = uFogDistance.x;
+    float fogEnd = uFogDistance.y;
     if (depth < fogBegin) {
         return color;
     } else if (depth >= fogEnd) {
-        return fogColor;
+        return uFogColor;
     } else {
-        return mix(color, fogColor, (depth - fogBegin) / (fogEnd - fogBegin));
+        return mix(color, uFogColor, (depth - fogBegin) / (fogEnd - fogBegin));
     }
 }
 
-vec3 applyShade(vec3 color, float shade, int lightingContrast)
+vec3 applyShade(vec3 color, float shade)
 {
-    if (lightingContrast == LIGHTING_CONTRAST_MEDIUM) {
+    if (uLightingContrast == LIGHTING_CONTRAST_MEDIUM) {
         shade = max(shade, SHADE_HIGH);
     }
-    if (lightingContrast == LIGHTING_CONTRAST_LOW) {
+    if (uLightingContrast == LIGHTING_CONTRAST_LOW) {
         shade = max(shade, SHADE_NEUTRAL);
     }
 

--- a/data/common/ship/shaders/fbo.glsl
+++ b/data/common/ship/shaders/fbo.glsl
@@ -11,12 +11,12 @@ void main(void) {
 
 #elif defined(FRAGMENT)
 
-uniform sampler2D tex0;
+uniform sampler2D uTex0;
 
 in vec2 vertTexCoords;
 out vec4 outColor;
 
 void main(void) {
-    outColor = texture(tex0, vertTexCoords);
+    outColor = texture(uTex0, vertTexCoords);
 }
 #endif

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -1,6 +1,3 @@
-uniform int uBillboardLockMode;
-uniform int uLightingContrast;
-
 vec4 offsetBillboard(vec3 pos, vec2 displacement, mat4 view, mat4 modelView, mat4 projection, int lockMode)
 {
     if (lockMode == BILLBOARD_LOCK_ROLL) {
@@ -49,9 +46,7 @@ vec4 offsetBillboard(vec3 pos, vec2 displacement, mat4 view, mat4 modelView, mat
 #ifdef VERTEX
 
 uniform mat4 uMatProjection;
-uniform mat4 uMatView;
 uniform mat4 uMatModelView;
-uniform bool uTrapezoidFilterEnabled;
 uniform bool uWibbleEffect;
 
 layout(location = 0) in vec4 inPosition;
@@ -96,7 +91,7 @@ void main(void) {
         && (inFlags & VERT_NO_CAUSTICS) == 0u
         && (inFlags & VERT_BILLBOARD) == 0u)
     ) {
-        gl_Position.xyz = waterWibble(gl_Position, uViewportSize, uTimeInGame);
+        gl_Position.xyz = waterWibble(gl_Position);
     }
 
     gFlags = inFlags;
@@ -104,7 +99,7 @@ void main(void) {
     gTexUV = inUVW.xy;
     gTexLayer = int(inUVW.z);
     gTrapezoidRatios = inTrapezoidRatios;
-    if (uTrapezoidFilterEnabled) {
+    if (uTrapezoidFilterEnabled != 0) {
         gTexUV *= inTrapezoidRatios;
     }
     gShade = inShade;
@@ -115,13 +110,8 @@ void main(void) {
 
 uniform sampler2DArray uTexAtlas;
 uniform sampler2D uTexEnvMap;
-uniform bool uSmoothingEnabled;
-uniform bool uTrapezoidFilterEnabled;
 uniform int uLightingMode;
-uniform bool uReflectionsEnabled;
 uniform vec3 uGlobalTint;
-uniform vec2 uFogDistance; // x = fog start, y = fog end
-uniform vec4 uFogColor;
 uniform bool uDiscardAlpha;
 
 in vec4 gEyePos;
@@ -140,7 +130,7 @@ void main(void) {
 
     if ((gFlags & VERT_FLAT_SHADED) == 0u && gTexLayer >= 0) {
         vec3 texCoords = vec3(gTexUV.x, gTexUV.y, gTexLayer);
-        if (uTrapezoidFilterEnabled) {
+        if (uTrapezoidFilterEnabled != 0) {
             texCoords.xy /= gTrapezoidRatios;
         }
         texCoords.xy = clampTexAtlas(texCoords.xy, gAtlasSize);
@@ -159,18 +149,18 @@ void main(void) {
         texColor.rgb *= texColor.a;
     }
 
-    if ((gFlags & VERT_REFLECTIVE) != 0u && uReflectionsEnabled) {
+    if ((gFlags & VERT_REFLECTIVE) != 0u && uReflectionsEnabled != 0) {
         texColor *= texture(uTexEnvMap, (normalize(gNormal) * 0.5 + 0.5).xy) * 2;
     }
 
     if ((gFlags & VERT_NO_LIGHTING) == 0u && uLightingMode != LIGHTING_MODE_OFF) {
-        texColor.rgb = applyShade(texColor.rgb, gShade, uLightingContrast);
+        texColor.rgb = applyShade(texColor.rgb, gShade);
     }
 
     texColor.rgb *= uGlobalTint;
 
     if ((gFlags & VERT_NO_LIGHTING) == 0u && uLightingMode == LIGHTING_MODE_FULL) {
-        texColor = applyFog(texColor, gEyePos.z, uFogDistance, uFogColor);
+        texColor = applyFog(texColor, gEyePos.z);
     }
 
     texColor.rgb *= uBrightnessMultiplier;

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -39,7 +39,6 @@ static void M_SetupShaderForScene(
     OUTPUT_SHADER *const shader, const GFX_TEXTURE_FILTER filter,
     const bool lighting)
 {
-    Output_Shader_UploadSmoothingEnabled(shader, filter == GFX_TF_BILINEAR);
     Output_Shader_UploadPerspProjectionMatrix(shader);
     Output_Shader_UploadLightingMode(
         shader, lighting ? LIGHTING_MODE_FULL : LIGHTING_MODE_OFF);
@@ -48,7 +47,6 @@ static void M_SetupShaderForScene(
 static void M_SetupShaderForUI(
     OUTPUT_SHADER *const shader, const GFX_TEXTURE_FILTER filter)
 {
-    Output_Shader_UploadSmoothingEnabled(shader, filter == GFX_TF_BILINEAR);
     Output_Shader_UploadOrthoProjectionMatrix(shader);
     Output_Shader_UploadLightingMode(shader, LIGHTING_MODE_ONLY_SHADES);
 }
@@ -112,8 +110,6 @@ static bool M_IsAnySourceDirty(const M_PRIV *const p)
 
 static void M_PrepareScene(const M_PRIV *const p)
 {
-    OUTPUT_SHADER *const shader = Output_GetMeshShader();
-
 #ifndef __APPLE__
     glLineWidth(g_Config.rendering.wireframe_width);
     GFX_GL_CheckError();

--- a/src/trx/game/output/shader.c
+++ b/src/trx/game/output/shader.c
@@ -9,65 +9,75 @@
 #include <trx/memory.h>
 
 typedef enum {
-    M_UNIFORM_TIME,
-    M_UNIFORM_TIME_IN_GAME,
     M_UNIFORM_TEX_ATLAS,
     M_UNIFORM_TEX_ENV_MAP,
-    M_UNIFORM_SMOOTHING_ENABLED,
-    M_UNIFORM_TRAPEZOID_FILTER_ENABLED,
     M_UNIFORM_LIGHTING_MODE,
-    M_UNIFORM_LIGHTING_CONTRAST,
-    M_UNIFORM_REFLECTIONS_ENABLED,
-    M_UNIFORM_BRIGHTNESS_MULTIPLIER,
+    M_UNIFORM_ALPHA_DISCARD,
     M_UNIFORM_GLOBAL_TINT,
-    M_UNIFORM_FOG_COLOR,
-    M_UNIFORM_FOG_DISTANCE,
-    M_UNIFORM_VIEWPORT_SIZE,
     M_UNIFORM_PROJECTION_MATRIX,
-    M_UNIFORM_VIEW_MATRIX,
     M_UNIFORM_VIEW_MODEL_MATRIX,
     M_UNIFORM_WIBBLE_EFFECT,
-    M_UNIFORM_ALPHA_DISCARD,
-    M_UNIFORM_BILLBOARD_LOCK_MODE,
     M_UNIFORM_NUMBER_OF,
 } M_UNIFORM;
+
+#pragma pack(push, 1)
+typedef struct {
+    GLfloat mat_view[4][4];
+    GLfloat fog_color[4];
+    GLfloat fog_distance[2];
+    GLfloat viewport_size[2];
+    GLfloat time;
+    GLfloat time_in_game;
+    GLfloat brightness_multiplier;
+    GLint billboard_lock_mode;
+    GLint lighting_contrast;
+    GLint trapezoid_filter_enabled;
+    GLint reflections_enabled;
+} M_UNIFORM_GLOBALS;
+#pragma pack(pop)
 
 struct OUTPUT_SHADER {
     GFX_GL_PROGRAM program;
     GLint uniforms[M_UNIFORM_NUMBER_OF];
+    GLuint ubo_globals;
 
     bool is_wibble_effect;
     bool is_alpha_discard_enabled;
     RGB_F tint;
 };
 
+static void M_FillMatrix(GLfloat m[4][4], const MATRIX *const source)
+{
+    m[0][0] = source->_00 / (float)(1 << W2V_SHIFT);
+    m[0][1] = source->_10 / (float)(1 << W2V_SHIFT);
+    m[0][2] = source->_20 / (float)(1 << W2V_SHIFT);
+    m[0][3] = 0.0;
+
+    m[1][0] = source->_01 / (float)(1 << W2V_SHIFT);
+    m[1][1] = source->_11 / (float)(1 << W2V_SHIFT);
+    m[1][2] = source->_21 / (float)(1 << W2V_SHIFT);
+    m[1][3] = 0.0;
+
+    m[2][0] = source->_02 / (float)(1 << W2V_SHIFT);
+    m[2][1] = source->_12 / (float)(1 << W2V_SHIFT);
+    m[2][2] = source->_22 / (float)(1 << W2V_SHIFT);
+    m[2][3] = 0.0;
+
+    m[3][0] = source->_03 / (float)(1 << W2V_SHIFT);
+    m[3][1] = source->_13 / (float)(1 << W2V_SHIFT);
+    m[3][2] = source->_23 / (float)(1 << W2V_SHIFT);
+    m[3][3] = 1.0;
+}
+
 static void M_UploadMatrix(
     const OUTPUT_SHADER *const shader, const M_UNIFORM target,
     const MATRIX *const source)
 {
     GLfloat m[4][4];
-    m[0][0] = source->_00 / (float)(1 << W2V_SHIFT);
-    m[0][1] = source->_01 / (float)(1 << W2V_SHIFT);
-    m[0][2] = source->_02 / (float)(1 << W2V_SHIFT);
-    m[0][3] = source->_03 / (float)(1 << W2V_SHIFT);
-
-    m[1][0] = source->_10 / (float)(1 << W2V_SHIFT);
-    m[1][1] = source->_11 / (float)(1 << W2V_SHIFT);
-    m[1][2] = source->_12 / (float)(1 << W2V_SHIFT);
-    m[1][3] = source->_13 / (float)(1 << W2V_SHIFT);
-
-    m[2][0] = source->_20 / (float)(1 << W2V_SHIFT);
-    m[2][1] = source->_21 / (float)(1 << W2V_SHIFT);
-    m[2][2] = source->_22 / (float)(1 << W2V_SHIFT);
-    m[2][3] = source->_23 / (float)(1 << W2V_SHIFT);
-
-    m[3][0] = 0.0;
-    m[3][1] = 0.0;
-    m[3][2] = 0.0;
-    m[3][3] = 1.0;
+    M_FillMatrix(m, source);
 
     GFX_TRACK_UNIFORM(
-        glUniformMatrix4fv, shader->uniforms[target], 1, GL_TRUE, &m[0][0]);
+        glUniformMatrix4fv, shader->uniforms[target], 1, GL_FALSE, &m[0][0]);
 }
 
 OUTPUT_SHADER *Output_Shader_Create(const char *const path)
@@ -80,27 +90,22 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
     GFX_GL_Program_FragmentData(&shader->program, "outColor");
     GFX_GL_Program_Link(&shader->program);
 
+    glGenBuffers(1, &shader->ubo_globals);
+    glBindBuffer(GL_UNIFORM_BUFFER, shader->ubo_globals);
+    glBufferData(
+        GL_UNIFORM_BUFFER, sizeof(M_UNIFORM_GLOBALS), nullptr, GL_DYNAMIC_DRAW);
+    glBindBufferBase(GL_UNIFORM_BUFFER, 0, shader->ubo_globals);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
     const char *const uniform_names[] = {
-        [M_UNIFORM_TIME] = "uTime",
-        [M_UNIFORM_TIME_IN_GAME] = "uTimeInGame",
         [M_UNIFORM_TEX_ATLAS] = "uTexAtlas",
         [M_UNIFORM_TEX_ENV_MAP] = "uTexEnvMap",
-        [M_UNIFORM_SMOOTHING_ENABLED] = "uSmoothingEnabled",
-        [M_UNIFORM_TRAPEZOID_FILTER_ENABLED] = "uTrapezoidFilterEnabled",
         [M_UNIFORM_LIGHTING_MODE] = "uLightingMode",
-        [M_UNIFORM_LIGHTING_CONTRAST] = "uLightingContrast",
-        [M_UNIFORM_REFLECTIONS_ENABLED] = "uReflectionsEnabled",
-        [M_UNIFORM_BRIGHTNESS_MULTIPLIER] = "uBrightnessMultiplier",
         [M_UNIFORM_GLOBAL_TINT] = "uGlobalTint",
-        [M_UNIFORM_FOG_COLOR] = "uFogColor",
-        [M_UNIFORM_FOG_DISTANCE] = "uFogDistance",
-        [M_UNIFORM_VIEWPORT_SIZE] = "uViewportSize",
         [M_UNIFORM_PROJECTION_MATRIX] = "uMatProjection",
-        [M_UNIFORM_VIEW_MATRIX] = "uMatView",
         [M_UNIFORM_VIEW_MODEL_MATRIX] = "uMatModelView",
         [M_UNIFORM_WIBBLE_EFFECT] = "uWibbleEffect",
         [M_UNIFORM_ALPHA_DISCARD] = "uDiscardAlpha",
-        [M_UNIFORM_BILLBOARD_LOCK_MODE] = "uBillboardLockMode",
     };
     for (int32_t i = 0; i < M_UNIFORM_NUMBER_OF; i++) {
         shader->uniforms[i] =
@@ -128,45 +133,32 @@ void Output_Shader_Bind(const OUTPUT_SHADER *const shader)
 
 void Output_Shader_UploadCommonUniforms(const OUTPUT_SHADER *const shader)
 {
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_TRAPEZOID_FILTER_ENABLED],
-        g_Config.rendering.enable_trapezoid_filter);
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_LIGHTING_MODE],
-        g_Config.rendering.enable_lighting);
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_LIGHTING_CONTRAST],
-        g_Config.rendering.lighting_contrast);
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_REFLECTIONS_ENABLED],
-        g_Config.visuals.enable_reflections);
-    GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_BRIGHTNESS_MULTIPLIER],
-        g_Config.visuals.brightness);
-    GFX_TRACK_UNIFORM(
-        glUniform2f, shader->uniforms[M_UNIFORM_VIEWPORT_SIZE],
-        Viewport_GetWidth(VIEWPORT_GAME), Viewport_GetHeight(VIEWPORT_GAME));
-    GFX_TRACK_UNIFORM(
-        glUniform4f, shader->uniforms[M_UNIFORM_FOG_COLOR],
-        Output_GetFogColor().r, Output_GetFogColor().g, Output_GetFogColor().b,
-        Output_GetFogColor().a);
-    GFX_TRACK_UNIFORM(
-        glUniform2f, shader->uniforms[M_UNIFORM_FOG_DISTANCE],
-        Output_GetFogStart(), Output_GetFogEnd());
-    GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_TIME], Output_GetTime());
-    GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_TIME_IN_GAME],
-        Output_GetTimeInGame());
-    GFX_TRACK_UNIFORM(
-        glUniform1i, shader->uniforms[M_UNIFORM_BILLBOARD_LOCK_MODE],
-        g_Config.rendering.sprite_lock_mode);
-    Output_Shader_UploadViewMatrix(shader);
-}
+    M_UNIFORM_GLOBALS globals = {
+        .time = Output_GetTime(),
+        .time_in_game = Output_GetTimeInGame(),
+        .brightness_multiplier = g_Config.visuals.brightness,
+        .viewport_size = {
+            (float)Viewport_GetWidth(VIEWPORT_GAME),
+            (float)Viewport_GetHeight(VIEWPORT_GAME),
+        },
+        .billboard_lock_mode = g_Config.rendering.sprite_lock_mode,
+        .lighting_contrast = g_Config.rendering.lighting_contrast,
+        .trapezoid_filter_enabled = g_Config.rendering.enable_trapezoid_filter,
+        .reflections_enabled = g_Config.visuals.enable_reflections,
+        .fog_distance = {Output_GetFogStart(), Output_GetFogEnd()},
+        .fog_color = {
+            Output_GetFogColor().r,
+            Output_GetFogColor().g,
+            Output_GetFogColor().b,
+            Output_GetFogColor().a,
+        },
+    };
+    M_FillMatrix(globals.mat_view, &g_W2VMatrix);
 
-void Output_Shader_UploadViewMatrix(const OUTPUT_SHADER *const shader)
-{
-    M_UploadMatrix(shader, M_UNIFORM_VIEW_MATRIX, &g_W2VMatrix);
+    glBindBuffer(GL_UNIFORM_BUFFER, shader->ubo_globals);
+    GFX_TRACK_SUBDATA(
+        glBufferSubData, GL_UNIFORM_BUFFER, 0, sizeof(globals), &globals);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void Output_Shader_UploadViewModelMatrix(
@@ -234,11 +226,4 @@ void Output_Shader_UploadLightingMode(
 {
     GFX_TRACK_UNIFORM(
         glUniform1i, shader->uniforms[M_UNIFORM_LIGHTING_MODE], mode);
-}
-
-void Output_Shader_UploadSmoothingEnabled(
-    const OUTPUT_SHADER *const shader, const bool is_enabled)
-{
-    GFX_TRACK_UNIFORM(
-        glUniform1f, shader->uniforms[M_UNIFORM_SMOOTHING_ENABLED], is_enabled);
 }

--- a/src/trx/game/output/shader.c
+++ b/src/trx/game/output/shader.c
@@ -8,6 +8,19 @@
 #include <trx/gfx/gl/utils.h>
 #include <trx/memory.h>
 
+#define M_GLOBAL_MEMBERS                                                       \
+    X_DECLARE_MEMBER(float, mat_view, [4][4])                                  \
+    X_DECLARE_MEMBER(float, fog_color, [4])                                    \
+    X_DECLARE_MEMBER(float, fog_distance, [2])                                 \
+    X_DECLARE_MEMBER(float, viewport_size, [2])                                \
+    X_DECLARE_MEMBER(float, time)                                              \
+    X_DECLARE_MEMBER(float, time_in_game)                                      \
+    X_DECLARE_MEMBER(float, brightness_multiplier)                             \
+    X_DECLARE_MEMBER(int, billboard_lock_mode)                                 \
+    X_DECLARE_MEMBER(int, lighting_contrast)                                   \
+    X_DECLARE_MEMBER(int, trapezoid_filter_enabled)                            \
+    X_DECLARE_MEMBER(int, reflections_enabled)
+
 typedef enum {
     M_UNIFORM_TEX_ATLAS,
     M_UNIFORM_TEX_ENV_MAP,
@@ -22,17 +35,9 @@ typedef enum {
 
 #pragma pack(push, 1)
 typedef struct {
-    GLfloat mat_view[4][4];
-    GLfloat fog_color[4];
-    GLfloat fog_distance[2];
-    GLfloat viewport_size[2];
-    GLfloat time;
-    GLfloat time_in_game;
-    GLfloat brightness_multiplier;
-    GLint billboard_lock_mode;
-    GLint lighting_contrast;
-    GLint trapezoid_filter_enabled;
-    GLint reflections_enabled;
+#define X_DECLARE_MEMBER(a, b, ...) a b __VA_ARGS__;
+    M_GLOBAL_MEMBERS
+#undef X_DECLARE_MEMBER
 } M_UNIFORM_GLOBALS;
 #pragma pack(pop)
 
@@ -45,6 +50,60 @@ struct OUTPUT_SHADER {
     bool is_alpha_discard_enabled;
     RGB_F tint;
 };
+
+static void M_DebugUBO(const GLuint program_id, const GLuint block_idx)
+{
+    // Prints memory layout of the specific UBO in the GPU
+
+    // Get the block name
+    GLint name_len = 0;
+    glGetActiveUniformBlockiv(
+        program_id, block_idx, GL_UNIFORM_BLOCK_NAME_LENGTH, &name_len);
+    char *const block_name = Memory_Alloc(name_len);
+    glGetActiveUniformBlockName(
+        program_id, block_idx, name_len, nullptr, block_name);
+
+    // Get all uniforms within that block
+    GLint uniform_count = 0;
+    glGetActiveUniformBlockiv(
+        program_id, block_idx, GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS,
+        &uniform_count);
+    GLuint *const uniform_indices =
+        Memory_Alloc(sizeof(GLuint) * uniform_count);
+    glGetActiveUniformBlockiv(
+        program_id, block_idx, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES,
+        (GLint *)uniform_indices);
+
+    // Query offsets
+    GLint *const offsets = Memory_Alloc(sizeof(GLint) * uniform_count);
+    glGetActiveUniformsiv(
+        program_id, uniform_count, uniform_indices, GL_UNIFORM_OFFSET, offsets);
+
+    // Print block name and all members
+    LOG_DEBUG("Uniform Block %u: %s", block_idx, block_name);
+    for (GLint i = 0; i < uniform_count; ++i) {
+        char name[256];
+        GLsizei length;
+        glGetActiveUniformName(
+            program_id, uniform_indices[i], sizeof(name), &length, name);
+        LOG_DEBUG("  %s → offset %d", name, offsets[i]);
+    }
+
+    // Cleanup
+    Memory_Free(offsets);
+    Memory_Free(uniform_indices);
+    Memory_Free(block_name);
+}
+
+static void M_DebugGlobals(void)
+{
+    // Prints memory layout of the Globals C struct
+    LOG_DEBUG("C");
+#define X_DECLARE_MEMBER(a, b, ...)                                            \
+    LOG_DEBUG("  %s → offset %d", #b, offsetof(M_UNIFORM_GLOBALS, b));
+    M_GLOBAL_MEMBERS
+#undef X_DECLARE_MEMBER
+}
 
 static void M_FillMatrix(GLfloat m[4][4], const MATRIX *const source)
 {
@@ -96,6 +155,11 @@ OUTPUT_SHADER *Output_Shader_Create(const char *const path)
         GL_UNIFORM_BUFFER, sizeof(M_UNIFORM_GLOBALS), nullptr, GL_DYNAMIC_DRAW);
     glBindBufferBase(GL_UNIFORM_BUFFER, 0, shader->ubo_globals);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+#if 0
+    M_DebugUBO(shader->program.id, 0);
+    M_DebugGlobals();
+#endif
 
     const char *const uniform_names[] = {
         [M_UNIFORM_TEX_ATLAS] = "uTexAtlas",

--- a/src/trx/game/output/shader.h
+++ b/src/trx/game/output/shader.h
@@ -35,12 +35,9 @@ void Output_Shader_Bind(const OUTPUT_SHADER *shader);
 void Output_Shader_UploadCommonUniforms(const OUTPUT_SHADER *shader);
 void Output_Shader_UploadPerspProjectionMatrix(const OUTPUT_SHADER *shader);
 void Output_Shader_UploadOrthoProjectionMatrix(const OUTPUT_SHADER *shader);
-void Output_Shader_UploadViewMatrix(const OUTPUT_SHADER *shader);
 
 void Output_Shader_UploadLightingMode(
     const OUTPUT_SHADER *shader, LIGHTING_MODE mode);
-void Output_Shader_UploadSmoothingEnabled(
-    const OUTPUT_SHADER *shader, bool is_enabled);
 void Output_Shader_UploadAlphaDiscard(OUTPUT_SHADER *shader, bool is_enabled);
 
 // TODO: these could could use UBOs

--- a/src/trx/gfx/gl/program.c
+++ b/src/trx/gfx/gl/program.c
@@ -46,7 +46,9 @@ char *GFX_GL_Program_PreprocessShader(const char *content, GLenum type)
     char *common = nullptr;
     File_Load("shaders/common.glsl", &common, nullptr);
 
-    const char *version_ogl33c = "#version 330 core\n";
+    const char *version_ogl33c =
+        "#version 330 core\n"
+        "#extension GL_ARB_shader_storage_buffer_object : require\n";
     const char *define_vertex = "#define VERTEX\n";
     const char *define_fragment = "#define FRAGMENT\n";
     const char *define_ogl33c = "#define OGL33C\n";
@@ -183,14 +185,6 @@ GLint GFX_GL_Program_UniformLocation(GFX_GL_PROGRAM *program, const char *name)
     return location;
 }
 
-void GFX_GL_Program_Uniform3f(
-    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2)
-{
-    ASSERT(program != nullptr);
-    GFX_TRACK_UNIFORM(glUniform3f, loc, v0, v1, v2);
-    GFX_GL_CheckError();
-}
-
 void GFX_GL_Program_Uniform4f(
     GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
     GLfloat v3)
@@ -219,14 +213,5 @@ void GFX_GL_Program_Uniform2f(
 {
     ASSERT(program != nullptr);
     GFX_TRACK_UNIFORM(glUniform2f, loc, v0, v1);
-    GFX_GL_CheckError();
-}
-
-void GFX_GL_Program_UniformMatrix4fv(
-    GFX_GL_PROGRAM *program, GLint loc, GLsizei count, GLboolean transpose,
-    const GLfloat *value)
-{
-    ASSERT(program != nullptr);
-    GFX_TRACK_UNIFORM(glUniformMatrix4fv, loc, count, transpose, value);
     GFX_GL_CheckError();
 }

--- a/src/trx/gfx/gl/program.h
+++ b/src/trx/gfx/gl/program.h
@@ -20,8 +20,6 @@ void GFX_GL_Program_Link(GFX_GL_PROGRAM *program);
 void GFX_GL_Program_FragmentData(GFX_GL_PROGRAM *program, const char *name);
 GLint GFX_GL_Program_UniformLocation(GFX_GL_PROGRAM *program, const char *name);
 
-void GFX_GL_Program_Uniform3f(
-    GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2);
 void GFX_GL_Program_Uniform4f(
     GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1, GLfloat v2,
     GLfloat v3);
@@ -29,6 +27,3 @@ void GFX_GL_Program_Uniform1i(GFX_GL_PROGRAM *program, GLint loc, GLint v0);
 void GFX_GL_Program_Uniform1f(GFX_GL_PROGRAM *program, GLint loc, GLfloat v0);
 void GFX_GL_Program_Uniform2f(
     GFX_GL_PROGRAM *program, GLint loc, GLfloat v0, GLfloat v1);
-void GFX_GL_Program_UniformMatrix4fv(
-    GFX_GL_PROGRAM *program, GLint loc, GLsizei count, GLboolean transpose,
-    const GLfloat *value);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is a reopen after something weird happened with #4301.

This reduces GPU churn by uploading common uniforms in a single operation into an Uniform Buffer Object – a fixed-sized buffer living on the GPU.
In this particular case, the benefits are negligible and risk breaking compatibility with some _ancient_ hardware that doesn't support UBOs. However, this prepares us later for moving the lights to the GPU, which _will_ require a much bulkier UBO, and _is_ necessary if we want to keep our sanity when adding support for TR3 bulbs.

#### Testing

We need sanity checks around the stuff that got moved into the UBO which is as follows:

- camera view
- fog color
- fog distance
- viewport size (e.g. the upscaling factor)
- time, time in game (e.g. the wibble effect, animated textures)
- brightness multiplier
- sprites lock mode
- lighting contrast mode
- trapezoid filter on/off
- reflections on/off