### PR TITLE
output: draw shadows normally

### DIFF
--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -161,18 +161,13 @@ static void M_SortTransparentFaces(const MESH_BATCHER *const batcher)
     M_FACE_SORT *const buf = Vector_GetData(batcher->transparent_sort);
     M_FACE_SORT *bptr = buf;
     for (int32_t i = 0; i < n; i++) {
-        if (bptr->inst->transparent_sort_func != nullptr) {
-            bptr->sort_key =
-                bptr->inst->transparent_sort_func(bptr->inst, bptr->face);
-        } else {
-            // clang-format off
-            bptr->sort_key = (
-                bptr->inst->matrix._20 * (int32_t)bptr->face->mesh_centroid.x +
-                bptr->inst->matrix._21 * (int32_t)bptr->face->mesh_centroid.y +
-                bptr->inst->matrix._22 * (int32_t)bptr->face->mesh_centroid.z +
-                bptr->inst->matrix._23);
-            // clang-format on
-        }
+        // clang-format off
+        bptr->sort_key = (
+            bptr->inst->matrix._20 * (int32_t)bptr->face->mesh_centroid.x +
+            bptr->inst->matrix._21 * (int32_t)bptr->face->mesh_centroid.y +
+            bptr->inst->matrix._22 * (int32_t)bptr->face->mesh_centroid.z +
+            bptr->inst->matrix._23);
+        // clang-format on
         bptr++;
     }
     qsort(buf, n, sizeof(*buf), M_CompareFaceDepth);

--- a/src/trx/game/output/mesh_batcher/batcher.h
+++ b/src/trx/game/output/mesh_batcher/batcher.h
@@ -21,8 +21,6 @@ typedef struct MESH_INSTANCE {
     float depth_adjust;
     VIEWPORT_RECT scissor;
 
-    int32_t (*transparent_sort_func)(
-        const struct MESH_INSTANCE *inst, const OUTPUT_MESH_FACE *face);
     void (*update_light_func)(struct MESH_INSTANCE *inst, void *user_data);
     void *update_light_func_data;
     bool water_effect; // helper for the update_light_func

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -43,12 +43,6 @@ static OUTPUT_MESH *M_GenerateShadow(
     return MeshBuilder_Seal(builder);
 }
 
-static int32_t M_TransparentSort(
-    const MESH_INSTANCE *const inst, const OUTPUT_MESH_FACE *const face)
-{
-    return 0; // Always draw shadows last.
-}
-
 void OutputSource_Shadows_Init(MESH_BATCHER *const batcher)
 {
     M_PRIV *const p = &m_Priv;
@@ -86,7 +80,6 @@ void OutputSource_Shadows_StageShadow(void)
         .mesh = mesh,
         .matrix = *g_MatrixPtr,
         .tint = { 1.0f, 1.0f, 1.0f },
-        .transparent_sort_func = M_TransparentSort,
     };
     // XXX: Mesh batcher currently collects the transparent faces for the
     // transparent pass in the opaque pass, so the shadow, even though


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the rule to always draw shadows last. I don't remember the reason why I added this, but removing it now seems to work fine.

#### Testing

Trying to get the shadows to break the visuals, introduce z conflicts etc. Standing on tilted translucent drawbridges, positioning Lara between panes of glass, etc.