### PR TITLE
lara/misc: fix M16 check on death and undraw M16 on resurrection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - fixed bogus warnings about resume info in logs when playing cutscenes and in the title level
 - fixed title bar size being too small on HiDPI screens on Windows platform (#2837)
 - fixed statics and items not getting rendered when all portals leading to them are offscreen (#2005)
+- fixed Lara's arms getting stuck in the M16 gun firing animation while she dies (#4130)
 
 **TR1**:
 - added a new easter egg command

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -88,7 +88,6 @@ static void M_ResetGunStatus(void)
     lara_info->gun_type = LGT_UNARMED;
     lara_info->request_gun_type = LGT_UNARMED;
     lara_info->gun_item_num = NO_ITEM;
-    lara_info->gun_status = LGS_ARMLESS;
     lara_info->left_arm.frame_num = 0;
     lara_info->left_arm.lock = 0;
     lara_info->right_arm.frame_num = 0;
@@ -253,6 +252,10 @@ bool Lara_Cheat_EnterFlyMode(void)
 
     if (lara_info->extra_anim) {
         M_ResetGunStatus();
+    } else if (Gun_IsRifleType(lara_info->gun_type)) {
+        while (lara_info->gun_item_num != NO_ITEM) {
+            Gun_Rifle_Undraw(lara_info->gun_type);
+        }
     }
 
     if (lara_info->gun_status == LGS_HANDS_BUSY

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -321,7 +321,9 @@ int32_t Lara_GetWaterDepth(
 bool Lara_IsM16Active(void)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (lara->gun_item_num == NO_ITEM || lara->gun_type != LGT_M16) {
+    ITEM *const lara_item = Lara_GetItem();
+    if (lara->gun_item_num == NO_ITEM || lara->gun_type != LGT_M16
+        || lara_item->hit_points <= 0) {
         return false;
     }
 


### PR DESCRIPTION
Resolves #4130.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Adds a `hit_points` check to `Lara_IsM16Active` to prevent her arms getting stuck while firing an M16 when dying. Also undraws the M16 on death to prevent her arms getting stuck while resurrecting with the fly cheat. Thanks to @lahm86 for the code.

Also removes a duplicate `lara_info->gun_status = LGS_ARMLESS;` set in `cheat.c`.