### PR TITLE
bar_lara_air: fix empty air bar showing if Lara dies on land

### DIFF
--- a/src/trx/game/ui/elements/bar_lara_air.c
+++ b/src/trx/game/ui/elements/bar_lara_air.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/lara/const.h>
+#include <trx/game/rooms.h>
 #include <trx/game/ui/elements/bar.h>
 
 bool UI_LaraAirBar(const bool blink_state)
@@ -14,9 +15,11 @@ bool UI_LaraAirBar(const bool blink_state)
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     const bool is_blinking = g_Config.ui.enable_bar_flashing
         && lara->air <= LARA_MAX_AIR * UI_BAR_BLINK_THRESHOLD;
+    const ROOM *const room = Room_Get(lara_item->room_num);
     const bool show = g_Config.ui.show_bars
         && (lara->water_status == LWS_UNDERWATER
-            || lara->water_status == LWS_SURFACE || lara->air < LARA_MAX_AIR);
+            || lara->water_status == LWS_SURFACE
+            || (room->flags.swamp && lara->air < LARA_MAX_AIR));
     if (!show) {
         return false;
     }


### PR DESCRIPTION
Resolves #4309.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Broken in: 0081835

Technically this PR changes OG TR3 behavior slightly. Relevant tomb3 code:
https://github.com/Trxyebeep/tomb3/blob/bfeef1d4d7165b6d8cb9079870c1fc0f083b054c/tomb3/game/health.cpp#L315

In TR3, the game stops drawing the air bar once Lara's HP hits 0 even in a swamp or underwater. I checked OG TR3 and when she dies in the swamp in Jungle and underwater in the gym, the airbar stops drawing as soon as her HP hits 0. This PR makes the game continue to draw the empty air bar if Lara dies underwater or in a swamp and her HP hits 0. I think this is OK and better behavior?

No changelog entry since it's unreleased.