### PR TITLE
game-flow: enforce water exit fix off in TRUB

### DIFF
--- a/data/tr1/ship/cfg/tr1-ub/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-ub/gameflow.json5
@@ -26,6 +26,7 @@
 
     "enforced_config": {
         "enable_save_crystals": false,
+        "fix_water_exit": false,
     },
 
     "title": {
@@ -154,6 +155,7 @@
         "enable_loading_screens", // UB has no loading screens yet
         "enable_reflections",     // UB has no reflective objects
         "enemy_healthbar_color_allies", // UB has no allies
+        "fix_water_exit",
         "change_pierre_spawn",
         "fix_bear_ai",
         "restore_ps1_enemies",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@
 - fixed crash when loading OG saves made in City of Khamoon, while the "Restore PS1 enemies" option is on (#4217, regression from 2.16)
 - fixed the jump lock mode UI option remaining visible when responsive jumping is disabled (#4027, regression from 4.13)
 - fixed a slight misalignment in the PDA in its open state (#4247)
+- fixed Lara being unable to exit the water in (for example) room 41 of Return to Egypt (#4315, regression from 4.12)
 
 **TR2**:
 - added loading screens (Gameplay Options → General → Loading screens) (#1620)  


### PR DESCRIPTION
Resolves #4315.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Some areas in TRUB require Lara to be able to pull out of water onto slopes, so this ensures the relevant config setting value is applied.
