### PR TITLE
items: check previous frame in interpolation tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,8 @@
 - fixed title bar size being too small on HiDPI screens on Windows platform (#2837)
 - fixed statics and items not getting rendered when all portals leading to them are offscreen (#2005)
 - fixed Lara's arms getting stuck in the M16 gun firing animation while she dies (#4130)
+- fixed Lara jittering in the QWOP state
+- fixed doors and trapdoors not interpolating when using the door cheat
 
 **TR1**:
 - added a new easter egg command

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -170,6 +170,7 @@ void Item_Animate(ITEM *const item)
 {
     item->hit_status = false;
     item->touch_bits = 0;
+    item->prev_frame_num = item->frame_num;
     item->frame_num++;
 
     const ANIM *anim = Item_GetAnim(item);

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -26,6 +26,7 @@ typedef struct {
     int16_t required_anim_state;
     int16_t anim_num;
     int16_t frame_num;
+    int16_t prev_frame_num;
     int16_t room_num;
     int16_t next_item;
     int16_t next_active;

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -397,6 +397,10 @@ void Lara_SetControllable(const bool controllable)
 bool Lara_CanInterpolate(
     const ITEM *const item, const int32_t frame_a, const int32_t frame_b)
 {
+    if (item->frame_num == item->prev_frame_num) {
+        return false;
+    }
+
     const LARA_ANIMATION anim_idx = Item_GetRelativeAnim(item);
     if (!M_IsInvalidInterpAnim(LA_U(anim_idx))) {
         return true;
@@ -437,6 +441,7 @@ void Lara_Animate(ITEM *const item)
 {
     const ROOM *const room = Room_Get(item->room_num);
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    item->prev_frame_num = item->frame_num;
     item->frame_num++;
 
     const ANIM *anim = Item_GetAnim(item);

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -255,9 +255,9 @@ int16_t Object_FindReceptacle(const OBJECT_ID object_id)
 bool Object_CanInterpolate(
     const ITEM *const item, const int32_t frame_a, const int32_t frame_b)
 {
-    return item->active && item->status == IS_ACTIVE
-        && item->enable_interpolation
-        && Object_Get(item->object_id)->enable_interpolation;
+    const OBJECT *const obj = Object_Get(item->object_id);
+    return item->enable_interpolation && obj->enable_interpolation
+        && item->prev_frame_num != item->frame_num;
 }
 
 void Object_SetReflective(const OBJECT_ID obj_id, const bool enabled)

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -644,6 +644,8 @@ static bool M_ReadItem(
         M_MUST(M_ReadNum(ctx, "required_anim", &item->required_anim_state));
         M_MUST(M_ReadNum(ctx, "anim_num", &item->anim_num));
         M_MUST(M_ReadNum(ctx, "frame_num", &item->frame_num));
+        // TRX >= 1.0 stores previous frame for interpolation checks
+        M_OPTIONAL(M_ReadNum(ctx, "prev_frame_num", &item->prev_frame_num));
 
         // Prevent issues with pre-injection saves and Lara's enhanced
         // animation set.

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -226,6 +226,7 @@ static void M_WriteItem(
         M_WriteNum(ctx, "required_anim", item->required_anim_state);
         M_WriteNum(ctx, "anim_num", item->anim_num);
         M_WriteNum(ctx, "frame_num", item->frame_num);
+        M_WriteNum(ctx, "prev_frame_num", item->prev_frame_num);
     }
 
     if (obj->save_hitpoints) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This improves the check on whether or not to allow interpolation on an item by storing its previous frame number. This fixes doors not interpolating when using the door cheat, and fixes Lara jittering in the QWOP state.
