### PR TITLE
inject/editors/rooms: set default colour on injected vertices

### DIFF
--- a/src/trx/game/inject/editors/rooms.c
+++ b/src/trx/game/inject/editors/rooms.c
@@ -250,6 +250,7 @@ static void M_AddRoomVertex(const INJECTION *const injection)
     vertex->pos = pos;
     vertex->light_base = shade;
     vertex->light_adder = shade;
+    vertex->color = (RGBA_8888) { 255, 255, 255, 255 };
     room->mesh.num_vertices++;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures injected vertices have a default colour applied rather than defaulting to semi-transparent. Atlantis start area and Rig room 32 are examples of usage.
