### PR TITLE
objects/rolling_ball: fix interpolation when stopped

### DIFF
--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -118,6 +118,7 @@ static void M_Reset(ITEM *const item)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    item->enable_interpolation = item->status == IS_ACTIVE;
 
     if (item->status == IS_DEACTIVATED && !Item_IsTriggerActive(item)) {
         M_Reset(item);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

As boulders are always animated after being triggered, we need to disable interpolation when they become deactivated.
Regression in a5fbb4e4fc3274f268109398d88d424c7dcf1c2c.
