### PR TITLE
Optimize output a bit

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -59,7 +59,7 @@ void main(void) {
 
     gFlags = inFlags;
     gAtlasSize = inTextureSize;
-    gTexLayer = int(inUVW.z);
+    gTexLayer = (gFlags & VERT_FLAT_SHADED) == 0u ? int(inUVW.z) : -1;
     gTrapezoidRatios = inTrapezoidRatios;
     gTexUV = inUVW.xy;
     if (uTrapezoidFilterEnabled != 0) {
@@ -103,7 +103,7 @@ void main(void) {
     vec4 texColor = gColor;
 
     // Texturing and base color
-    if ((gFlags & VERT_FLAT_SHADED) == 0u && gTexLayer >= 0) {
+    if (gTexLayer >= 0) {
         vec3 texCoords = vec3(gTexUV.x, gTexUV.y, gTexLayer);
         if (uTrapezoidFilterEnabled != 0) {
             texCoords.xy /= gTrapezoidRatios;

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -32,9 +32,13 @@ typedef struct M_MESH_BUF_BINDING {
     M_MESH_SHADE *shade_data;
     int32_t vertex_start;
     int32_t vertex_count;
+
+    int32_t opaque_index_start;
+    int32_t opaque_index_count;
+    int32_t blend_add_index_start;
+    int32_t blend_add_index_count;
+
     UT_hash_handle hh;
-    GLuint opaque_ebo;
-    GLuint blend_add_ebo;
 } M_MESH_BUF_BINDING;
 
 typedef struct {
@@ -63,6 +67,11 @@ typedef struct MESH_BATCHER {
     VECTOR *transparent_sort; // M_FACE_SORT
     VECTOR *transparent_indices; // uint32_t
     GLuint transparent_ebo;
+    GLuint opaque_ebo;
+    GLuint blend_add_ebo;
+
+    int32_t opaque_total_indices;
+    int32_t blend_add_total_indices;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -185,25 +194,30 @@ static void M_DrawOpaqueVertices(
     const MESH_BATCHER *const batcher, const MESH_INSTANCE *const inst)
 {
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bind->opaque_ebo);
+    const void *indices_offset =
+        (void *)(intptr_t)(bind->opaque_index_start * sizeof(uint32_t));
     glDrawElementsBaseVertex(
-        GL_TRIANGLES, inst->mesh->opaque_vertex_indices->count, GL_UNSIGNED_INT,
-        nullptr, bind->vertex_start);
+        GL_TRIANGLES, bind->opaque_index_count, GL_UNSIGNED_INT,
+        indices_offset, // Offset in EBO
+        bind->vertex_start // Offset in VBO (baseVertex)
+    );
     GFX_GL_CheckError();
-    g_GFX_Metrics.opaque_vert_count += inst->mesh->opaque_vertex_indices->count;
+    g_GFX_Metrics.opaque_vert_count += bind->opaque_index_count;
 }
 
 static void M_DrawBlendAddVertices(
     const MESH_BATCHER *const batcher, const MESH_INSTANCE *const inst)
 {
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bind->blend_add_ebo);
+    const void *indices_offset =
+        (void *)(intptr_t)(bind->blend_add_index_start * sizeof(uint32_t));
     glDrawElementsBaseVertex(
-        GL_TRIANGLES, inst->mesh->blend_add_vertex_indices->count,
-        GL_UNSIGNED_INT, nullptr, bind->vertex_start);
+        GL_TRIANGLES, bind->blend_add_index_count, GL_UNSIGNED_INT,
+        indices_offset, // Offset in EBO
+        bind->vertex_start // Offset in VBO (baseVertex)
+    );
     GFX_GL_CheckError();
-    g_GFX_Metrics.blend_add_vert_count +=
-        inst->mesh->blend_add_vertex_indices->count;
+    g_GFX_Metrics.blend_add_vert_count += bind->blend_add_index_count;
 }
 
 static void M_DrawOpaqueInstance(
@@ -273,6 +287,7 @@ static void M_OpaquePass(MESH_BATCHER *const batcher, const SCENE_PASS pass)
 
     glBindVertexArray(batcher->partial_vao);
     glBindBuffer(GL_ARRAY_BUFFER, batcher->shade_vbo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->opaque_ebo);
     for (int32_t i = 0; i < staged->count; i++) {
         MESH_INSTANCE *const inst = Vector_Get(staged, i);
         const M_MESH_BUF_BINDING *const bind =
@@ -316,6 +331,7 @@ static void M_BlendAddPass(MESH_BATCHER *const batcher)
     VECTOR *const staged = batcher->staged[SCENE_PASS_BLEND_ADD];
 
     glBindVertexArray(batcher->partial_vao);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->blend_add_ebo);
     for (int32_t i = 0; i < staged->count; i++) {
         const MESH_INSTANCE *const inst = Vector_Get(staged, i);
         const M_MESH_BUF_BINDING *const bind =
@@ -491,6 +507,8 @@ MESH_BATCHER *MeshBatcher_Create(void)
         sizeof(M_MESH_SHADE), 0);
 
     glGenBuffers(1, &batcher->transparent_ebo);
+    glGenBuffers(1, &batcher->opaque_ebo);
+    glGenBuffers(1, &batcher->blend_add_ebo);
 
     return batcher;
 }
@@ -524,6 +542,14 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
         glDeleteBuffers(1, &batcher->transparent_ebo);
         batcher->transparent_ebo = 0;
     }
+    if (batcher->opaque_ebo != 0) {
+        glDeleteBuffers(1, &batcher->opaque_ebo);
+        batcher->opaque_ebo = 0;
+    }
+    if (batcher->blend_add_ebo != 0) {
+        glDeleteBuffers(1, &batcher->blend_add_ebo);
+        batcher->blend_add_ebo = 0;
+    }
     if (batcher->transparent_indices != nullptr) {
         Vector_Free(batcher->transparent_indices);
         batcher->transparent_indices = nullptr;
@@ -545,14 +571,6 @@ void MeshBatcher_RemoveMesh(
     if (bind == nullptr) {
         return;
     }
-    if (bind->opaque_ebo != 0) {
-        glDeleteBuffers(1, &bind->opaque_ebo);
-        bind->opaque_ebo = 0;
-    }
-    if (bind->blend_add_ebo != 0) {
-        glDeleteBuffers(1, &bind->blend_add_ebo);
-        bind->blend_add_ebo = 0;
-    }
     Memory_Free(bind->geom_data);
     Memory_Free(bind->tex_data);
     Memory_Free(bind->shade_data);
@@ -571,10 +589,9 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
     M_MESH_BUF_BINDING *const bind = Memory_Alloc(sizeof(M_MESH_BUF_BINDING));
     bind->mesh = mesh;
     bind->vertex_count = mesh->vertices->count;
-    bind->opaque_ebo = 0;
-    bind->blend_add_ebo = 0;
-    const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
 
+    // 1. Copy Vertex Data
+    const OUTPUT_MESH_VERTEX *const vertices = Vector_GetData(mesh->vertices);
     bind->geom_data = Memory_Alloc(sizeof(M_MESH_GEOM) * bind->vertex_count);
     bind->tex_data = Memory_Alloc(sizeof(M_MESH_TEXTURE) * bind->vertex_count);
     bind->shade_data = Memory_Alloc(sizeof(M_MESH_SHADE) * bind->vertex_count);
@@ -584,10 +601,21 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
         M_FillShade(&bind->shade_data[i], &vertices[i]);
     }
 
+    // 2. Assign Vertex Offsets
     bind->vertex_start = batcher->vertex_count;
     batcher->vertex_count += bind->vertex_count;
 
-    // Prevent the same mesh from being added twice to a mesh batcher
+    // 3. Assign Index Offsets
+    // Opaque
+    bind->opaque_index_count = mesh->opaque_vertex_indices->count;
+    bind->opaque_index_start = batcher->opaque_total_indices;
+    batcher->opaque_total_indices += bind->opaque_index_count;
+    // Blend/Add
+    bind->blend_add_index_count = mesh->blend_add_vertex_indices->count;
+    bind->blend_add_index_start = batcher->blend_add_total_indices;
+    batcher->blend_add_total_indices += bind->blend_add_index_count;
+
+    // Prevent double add
     mesh->sealed = 2;
 
     Vector_Add(batcher->bindings, &bind);
@@ -611,9 +639,9 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
     glBindBuffer(GL_ARRAY_BUFFER, batcher->shade_vbo);
     GFX_TRACK_DATA(
         glBufferData, GL_ARRAY_BUFFER,
-        batcher->vertex_count * sizeof(M_MESH_SHADE), nullptr,
-        GL_DYNAMIC_DRAW); // shades are always dynamic for now
+        batcher->vertex_count * sizeof(M_MESH_SHADE), nullptr, GL_STATIC_DRAW);
 
+    // Upload vertex data
     for (int32_t i = 0; i < batcher->bindings->count; i++) {
         M_MESH_BUF_BINDING *const bind =
             *(M_MESH_BUF_BINDING **)Vector_Get(batcher->bindings, i);
@@ -632,22 +660,51 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
             glBufferSubData, GL_ARRAY_BUFFER,
             bind->vertex_start * sizeof(M_MESH_SHADE),
             bind->vertex_count * sizeof(M_MESH_SHADE), bind->shade_data);
-
-        glGenBuffers(1, &bind->opaque_ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bind->opaque_ebo);
-        GFX_TRACK_DATA(
-            glBufferData, GL_ELEMENT_ARRAY_BUFFER,
-            bind->mesh->opaque_vertex_indices->count * sizeof(uint32_t),
-            Vector_GetData(bind->mesh->opaque_vertex_indices), GL_STATIC_DRAW);
-
-        glGenBuffers(1, &bind->blend_add_ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bind->blend_add_ebo);
-        GFX_TRACK_DATA(
-            glBufferData, GL_ELEMENT_ARRAY_BUFFER,
-            bind->mesh->blend_add_vertex_indices->count * sizeof(uint32_t),
-            Vector_GetData(bind->mesh->blend_add_vertex_indices),
-            GL_STATIC_DRAW);
     }
+
+    // Allocate CPU scratch memory for the combined indices
+    uint32_t *opaque_indices =
+        Memory_Alloc(batcher->opaque_total_indices * sizeof(uint32_t));
+    uint32_t *blend_indices =
+        Memory_Alloc(batcher->blend_add_total_indices * sizeof(uint32_t));
+
+    // Flatten the data
+    for (int32_t i = 0; i < batcher->bindings->count; i++) {
+        M_MESH_BUF_BINDING *const bind =
+            *(M_MESH_BUF_BINDING **)Vector_Get(batcher->bindings, i);
+
+        // Copy Opaque Indices
+        if (bind->opaque_index_count > 0) {
+            memcpy(
+                &opaque_indices[bind->opaque_index_start],
+                Vector_GetData(bind->mesh->opaque_vertex_indices),
+                bind->opaque_index_count * sizeof(uint32_t));
+        }
+
+        // Copy Blend Indices
+        if (bind->blend_add_index_count > 0) {
+            memcpy(
+                &blend_indices[bind->blend_add_index_start],
+                Vector_GetData(bind->mesh->blend_add_vertex_indices),
+                bind->blend_add_index_count * sizeof(uint32_t));
+        }
+    }
+
+    // Upload to GPU
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->opaque_ebo);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ELEMENT_ARRAY_BUFFER,
+        batcher->opaque_total_indices * sizeof(uint32_t), opaque_indices,
+        GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->blend_add_ebo);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ELEMENT_ARRAY_BUFFER,
+        batcher->blend_add_total_indices * sizeof(uint32_t), blend_indices,
+        GL_STATIC_DRAW);
+
+    Memory_FreePointer(&opaque_indices);
+    Memory_FreePointer(&blend_indices);
 }
 
 void MeshBatcher_UpdateMeshGeometry(

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -63,8 +63,6 @@ typedef struct MESH_BATCHER {
     VECTOR *transparent_sort; // M_FACE_SORT
     VECTOR *transparent_indices; // uint32_t
     GLuint transparent_ebo;
-
-    const ROOM *last_room;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -110,7 +108,6 @@ static void M_FillShade(
 
 static void M_SyncRoom(MESH_BATCHER *const batcher, const ROOM *const room)
 {
-    batcher->last_room = room;
     Output_Uniforms_UploadRoomLights(Output_GetUniforms(), room);
 }
 
@@ -215,9 +212,7 @@ static void M_DrawOpaqueInstance(
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
     ASSERT(bind != nullptr);
 
-    if (batcher->last_room != inst->room) {
-        M_SyncRoom(batcher, inst->room);
-    }
+    M_SyncRoom(batcher, inst->room);
 
     Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
     Output_MeshShader_UploadModelMatrix(batcher->shader, &inst->wmatrix);
@@ -253,9 +248,7 @@ static void M_DrawBlendAddInstance(
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
     ASSERT(bind != nullptr);
 
-    if (batcher->last_room != inst->room) {
-        M_SyncRoom(batcher, inst->room);
-    }
+    M_SyncRoom(batcher, inst->room);
 
     Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
     Output_MeshShader_UploadModelMatrix(batcher->shader, &inst->wmatrix);
@@ -276,10 +269,10 @@ static void M_DrawBlendAddInstance(
 
 static void M_OpaquePass(MESH_BATCHER *const batcher, const SCENE_PASS pass)
 {
+    VECTOR *const staged = batcher->staged[pass];
+
     glBindVertexArray(batcher->partial_vao);
     glBindBuffer(GL_ARRAY_BUFFER, batcher->shade_vbo);
-
-    VECTOR *const staged = batcher->staged[pass];
     for (int32_t i = 0; i < staged->count; i++) {
         MESH_INSTANCE *const inst = Vector_Get(staged, i);
         const M_MESH_BUF_BINDING *const bind =
@@ -323,7 +316,6 @@ static void M_BlendAddPass(MESH_BATCHER *const batcher)
     VECTOR *const staged = batcher->staged[SCENE_PASS_BLEND_ADD];
 
     glBindVertexArray(batcher->partial_vao);
-
     for (int32_t i = 0; i < staged->count; i++) {
         const MESH_INSTANCE *const inst = Vector_Get(staged, i);
         const M_MESH_BUF_BINDING *const bind =
@@ -334,6 +326,7 @@ static void M_BlendAddPass(MESH_BATCHER *const batcher)
             M_DrawBlendAddInstance(batcher, inst);
         }
     }
+
     Output_AdjustDepth(0.0f, 0.0f);
 }
 
@@ -373,9 +366,7 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
                 batcher->shader, inst->water_effect);
             Output_MeshShader_UploadWibbleEffect(batcher->shader, inst->wibble);
             Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
-            if (batcher->last_room != inst->room) {
-                M_SyncRoom(batcher, inst->room);
-            }
+            M_SyncRoom(batcher, inst->room);
         }
 
         // indices live in the EBO starting at index_start
@@ -399,7 +390,6 @@ static void M_RenderBegin(const SCENE_SOURCE *const source)
     }
     Vector_Clear(batcher->transparent_indices);
     Vector_Clear(batcher->transparent_sort);
-    batcher->last_room = nullptr;
 }
 
 static void M_RenderPass(

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -166,6 +166,11 @@ static void M_RenderPass(
         return;
     }
 
+    if (!g_Config.debug.enable_debug_triggers
+        && !g_Config.debug.enable_debug_portals) {
+        return;
+    }
+
     glBindVertexArray(p->vao);
     glBindBuffer(GL_ARRAY_BUFFER, p->vbo);
     glVertexAttrib4f(OUTPUT_MESH_ATTR_NORMAL, 0.0f, 0.0f, 0.0f, 0.0f);

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -60,6 +60,11 @@ typedef struct {
 } M_UNIFORM_LS;
 #pragma pack(pop)
 
+typedef struct {
+    M_UNIFORM_LIGHTS last_lights;
+    OUTPUT_LIGHT_INFO last_light_info;
+} M_PRIV;
+
 static void M_FillLight(
     M_UNIFORM_LIGHT *const dst_light, const LIGHT *const src_light)
 {
@@ -161,6 +166,12 @@ void Output_Uniforms_UploadRoomLights(
     const size_t size = offsetof(M_UNIFORM_LIGHTS, lights)
         + lights.num_lights * sizeof(M_UNIFORM_LIGHT);
 
+    M_PRIV *const priv = uniforms->priv;
+    if (memcmp(&priv->last_lights, &lights, sizeof(lights)) == 0) {
+        return;
+    }
+    memcpy(&priv->last_lights, &lights, sizeof(lights));
+
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->lights);
     GFX_TRACK_SUBDATA(glBufferSubData, GL_UNIFORM_BUFFER, 0, size, &lights);
 }
@@ -168,6 +179,12 @@ void Output_Uniforms_UploadRoomLights(
 void Output_Uniforms_UploadCPULight(
     const OUTPUT_UNIFORMS *const uniforms, const OUTPUT_LIGHT_INFO *const info)
 {
+    M_PRIV *const priv = uniforms->priv;
+    if (memcmp(&priv->last_light_info, info, sizeof(*info)) == 0) {
+        return;
+    }
+    memcpy(&priv->last_light_info, info, sizeof(*info));
+
     M_UNIFORM_LS ls = {};
     ls.adder = info->ls_adder;
     ls.divider = info->ls_divider / (float)(1 << (W2V_SHIFT));
@@ -183,7 +200,8 @@ void Output_Uniforms_UploadCPULight(
 
 OUTPUT_UNIFORMS *Output_Uniforms_Create(void)
 {
-    OUTPUT_UNIFORMS *const uniforms = Memory_Alloc(sizeof(OUTPUT_UNIFORMS));
+    OUTPUT_UNIFORMS *const uniforms =
+        Memory_Alloc(sizeof(OUTPUT_UNIFORMS) + sizeof(M_PRIV));
     glGenBuffers(4, &uniforms->general);
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
     glBufferData(
@@ -207,6 +225,7 @@ OUTPUT_UNIFORMS *Output_Uniforms_Create(void)
     glBindBufferBase(GL_UNIFORM_BUFFER, 3, uniforms->ls);
     GFX_GL_CheckError();
 
+    uniforms->priv = (char *)uniforms + sizeof(OUTPUT_UNIFORMS);
     return uniforms;
 }
 

--- a/src/trx/game/output/uniforms.h
+++ b/src/trx/game/output/uniforms.h
@@ -16,6 +16,7 @@ typedef struct {
     GLuint matrices;
     GLuint lights;
     GLuint ls;
+    void *priv;
 } OUTPUT_UNIFORMS;
 
 OUTPUT_UNIFORMS *Output_Uniforms_Create(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

**Before:**

```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ 4.15.1    │ Develop  │ Change %   ┃
┠──────────────────────┼───────────┼──────────┼────────────┨
┃ Opaque vertices      │ 16249.40  │ 19375.34 │ 🟠 119.24% ┃
┃ Transparent vertices │ 1446.63   │ 2009.86  │ 🔴 138.93% ┃
┃ Transfers            │ 118.58    │ 467.86   │ 🔴 394.54% ┃
┃ Uniforms             │ 230.27    │ 284.71   │ 🟠 123.65% ┃
┃ Throughput           │ 157.69 KB │ 26.63 KB │ 💚 16.88%  ┃
┃ Time                 │ 0.57 ms   │ 0.60 ms  │ ⚪ 106.56% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```

Top 5 calls according to qrenderdoc

```
1561 0.85748 288 96  0 57  39  8294400 226 0 0 0 8294400 0
4642 0.67968 6   2   0 2   2   8294400 6   0 0 0 8294400 0
4638 0.47452 6   2   0 2   2   8294400 6   0 0 0 8294400 0
1641 0.16996 576 192 0 123 121 1014998 400 0 0 0 1135500 0
1586 0.11884 228 76  0 66  66  790734  158 0 0 0 802109  0
```

Hundreds of buffers

**After:**

```
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ 4.15.1    │ This PR  │ Change %   ┃
┠──────────────────────┼───────────┼──────────┼────────────┨
┃ Opaque vertices      │ 16249.40  │ 19375.34 │ 🟠 119.24% ┃
┃ Transparent vertices │ 1446.63   │ 2009.86  │ 🔴 138.93% ┃
┃ Transfers            │ 118.58    │ 108.91   │ ⚪ 91.84%  ┃
┃ Uniforms             │ 230.27    │ 284.71   │ 🟠 123.65% ┃
┃ Throughput           │ 157.69 KB │ 17.92 KB │ 💚 11.37%  ┃
┃ Time                 │ 0.57 ms   │ 0.40 ms  │ 💚 71.21%  ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
```

Top 5 calls according to qrenderdoc

```
1561 0.85432 288 96  0 57  39  8294400 226 0 0 0 8294400 0
3231 0.653   6   2   0 2   2   8294400 6   0 0 0 8294400 0
3227 0.46672 6   2   0 2   2   8294400 6   0 0 0 8294400 0
1612 0.16268 576 192 0 123 121 1014998 400 0 0 0 1136340 0
1581 0.1176  228 76  0 66  66  790734  158 0 0 0 802109  0
```

Less than 15 buffers in total

#### Testing

Just general testing around potential glitches in geometry.
The changes were pretty fundamental, so if I happened to mess up something, it should be obvious right away.