### PR TITLE
matrix: increase precision

### DIFF
--- a/src/trx/game/matrix.h
+++ b/src/trx/game/matrix.h
@@ -13,18 +13,7 @@ typedef struct QUATERNION {
 } QUATERNION;
 
 typedef struct {
-    int32_t _00;
-    int32_t _01;
-    int32_t _02;
-    int32_t _03;
-    int32_t _10;
-    int32_t _11;
-    int32_t _12;
-    int32_t _13;
-    int32_t _20;
-    int32_t _21;
-    int32_t _22;
-    int32_t _23;
+    int64_t _00, _01, _02, _03, _10, _11, _12, _13, _20, _21, _22, _23;
 } MATRIX;
 
 extern MATRIX *g_MatrixPtr;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the black screen issue. This is a pretty lame fix, but it gets the job done.

The reason was the view matrix multiplications going well outside `INT32_MAX`, flipping the sign in the translation components.

It bites us only now due to a few subtle reasons that together make the bug.

1. First off OG would store the camera pos verbatim in the late `g_W2VMatrix`, which is complete rubbish. This got recently fixed – we now store the oriented position.
2. Second, this issue only manifests when we try to offset rotated matrices by long distances. But so far, the only rotated matrices were almost always `ITEM`s, and even these almost never attempted to move anything after rotation. For example, each item is drawn roughly like this:
    1. `ROOM`: `Matrix_TranslateAbs` – simple assignment
    2. `ITEM`: `Matrix_TranslateRel` – simple addition
    3. `ITEM`: finally `Matrix_Rot16` – assignments to the rotation components
    Rotation happens last and this means no overflows. But camera was different: first we rotate towards 0,0,0 and _then_ we do a long-distanced offset. And this resulted in overflows.
3. The last reason is that of consistency. The game expects all `MATRIX` translation components to be stored in its fixed-point system (just see the usages of `g_MatrixPtr->_[012]3`: they all shift the results down by `>> W2V_SCALE`). Except `g_W2VMatrix`, due to reasons laid out in point 1. And instead of scaling the translation components down by `>> W2V_SCALE` like the view matrix used to do, to make all matrix translations to behave the same like all other game matrices, I chose to go the easy way, respect `g_MatrixPtr` usages, not touch their call-site `>> W2V_SCALE` shifts, and just promote `g_ViewMatrix` to use this scale as well, diving the translation components by `float(1 << W2V_SCALE)` when uploading to shader as `mat4`.
Together these decisions caused the camera matrix to overflow.

It doesn't mean the module is shit, or the camera multiplications are shit. It doesn't even mean that this fix is shit. It just means that the bug was always there, but the distances were small enough that it never really mattered. I think it's ok to implement it this way. That said, two alternative things can be done.

1) Switch to floating point. I'm absolutely not ready for this, so this is not happening.
2) Do the rots in 64-bit internally, but then scale down by `W2V_SHIFT` when storing the translation components. This requires going after every user of the matrices' translation components (`._03`, `._13`, `._23`), and remove the `>> W2V_SHIFT` scaler. Since there are 350 usages of `W2V_SHIFT` I don't feel like doing this, and just prior to the release, too.