### PR TITLE
output: fix lighting room statics

### DIFF
--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -86,7 +86,7 @@ static void M_AddObjectFace(
             .normal = { .x = normal.x, .y = normal.y, .z = normal.z },
             .flags = flags,
             .uvw_idx = uvw_idx,
-            .shade = SHADE_NEUTRAL,
+            .shade = shade,
             .color = color,
             .trapezoid_ratio = {
                 [0] = face->texture_zw[i].z,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4333. This ended up being a conflict resolution mistake when reverting the 'new lighting switch' commit in c4cffb667e72f.