### PR TITLE
savegame: fix TR1 NG+ weapons and holsters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fixed skybox faces with transparent pixels always rendering in front of all other faces (#4351, regression from 1.0)
 - fixed unbound inputs not being saved between game launches (#4360, regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)
+- fixed Lara automatically being given TR2 weapons in TR1 NG+ when playing the OG levels (#4365, regression from 1.0)
 
 ## [1.0.3](https://github.com/LostArtefacts/TRX/compare/trx-1.0.2...trx-1.0.3) - 2025-11-27
 - fixed the conveyer belt fuse in Natla's Mines not appearing after using the nearby switch (#4349, regression from 1.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed unbound inputs not being saved between game launches (#4360, regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)
 - fixed Lara automatically being given TR2 weapons in TR1 NG+ when playing the OG levels (#4365, regression from 1.0)
+- fixed Lara's pistol holster meshes appearing in TR1 NG+ in place of her Uzi holster meshes (#4368, regression from 1.0)
 
 ## [1.0.3](https://github.com/LostArtefacts/TRX/compare/trx-1.0.2...trx-1.0.3) - 2025-11-27
 - fixed the conveyer belt fuse in Natla's Mines not appearing after using the nearby switch (#4349, regression from 1.0)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -591,11 +591,12 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         if (g_TRVersion == 1) {
             resume->equipped_gun_type = LGT_UZIS;
             resume->back_gun_type = LGT_SHOTGUN;
+            resume->holsters_gun_type = LGT_UZIS;
         } else {
             resume->equipped_gun_type = LGT_GRENADE;
             resume->back_gun_type = LGT_GRENADE;
+            resume->holsters_gun_type = LGT_PISTOLS;
         }
-        resume->holsters_gun_type = LGT_PISTOLS;
     }
 
     resume->stats.secret_flags = 0;

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -5,6 +5,7 @@
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/gun/const.h>
+#include <trx/game/gun/vars.h>
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
@@ -574,18 +575,18 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         resume->flags.has_shotgun = true;
         resume->flags.has_magnums = true;
         resume->flags.has_uzis = true;
-        resume->flags.has_m16 = true;
-        resume->flags.has_grenade = true;
-        resume->flags.has_harpoon = true;
+        resume->flags.has_m16 = g_Weapons[LGT_M16].is_available;
+        resume->flags.has_grenade = g_Weapons[LGT_GRENADE].is_available;
+        resume->flags.has_harpoon = g_Weapons[LGT_HARPOON].is_available;
 
         resume->shotgun_ammo = 10000;
         resume->magnum_ammo = 10000;
         resume->uzi_ammo = 10000;
         resume->flares = g_TRVersion == 1 ? 0 : -1;
 
-        resume->m16_ammo = 10000;
-        resume->grenade_ammo = 10000;
-        resume->harpoon_ammo = 10000;
+        resume->m16_ammo = resume->flags.has_m16 ? 10000 : 0;
+        resume->grenade_ammo = resume->flags.has_grenade ? 10000 : 0;
+        resume->harpoon_ammo = resume->flags.has_harpoon ? 10000 : 0;
 
         if (g_TRVersion == 1) {
             resume->equipped_gun_type = LGT_UZIS;


### PR DESCRIPTION
Resolves #4365.
Resolves #4368.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents the TR2 guns appearing in TR1 NG+, unless they have been made available in the external JSON. It also fixes pistol meshes appearing instead of Uzis.
