### PR TITLE
lara/draw: always use Lara's frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...develop) - ××××-××-××
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed all pendulum types to be able to be antitriggered (#3993)
+- fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
 - fixed skybox faces with transparent pixels always rendering in front of all other faces (#4351, regression from 1.0)
 - fixed unbound inputs not being saved between game launches (#4360, regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -269,7 +269,8 @@ static bool M_Draw_I(
 
 bool Lara_Draw(const ITEM *const item)
 {
-    const bool is_lara = item == Lara_GetItem();
+    const ITEM *const lara_item = Lara_GetItem();
+    const bool is_lara = item == lara_item;
     if (is_lara
         && (item->status == IS_INVISIBLE || (item->flags & IF_ONE_SHOT) != 0)) {
         return false;
@@ -289,7 +290,7 @@ bool Lara_Draw(const ITEM *const item)
     ANIM_FRAME *frames[2];
     if (lara->hit_direction < 0) {
         int32_t rate;
-        const int32_t frac = Item_GetFrames(item, frames, &rate);
+        const int32_t frac = Item_GetFrames(lara_item, frames, &rate);
         if (frac != 0 && Lara_Pose_Get() == nullptr) {
             M_Draw_I(item, frames[0], frames[1], frac, rate);
             goto finish;

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -41,7 +41,7 @@ static void M_Control(const int16_t item_num)
         item->hit_points = LARA_MAX_HITPOINTS;
     }
 
-    if (!item->priv) {
+    if (item->priv == nullptr) {
         int32_t x = 2 * m_AnchorX - lara_item->pos.x;
         int32_t y = lara_item->pos.y;
         int32_t z = 2 * m_AnchorZ - lara_item->pos.z;
@@ -80,7 +80,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    if (item->priv) {
+    if (item->priv != nullptr) {
         Item_Animate(item);
 
         int32_t x = item->pos.x;
@@ -107,7 +107,7 @@ static void M_Control(const int16_t item_num)
 
 static bool M_Draw(const ITEM *const item)
 {
-    if (item->current_anim_state == LS(LS_DEATH)) {
+    if (item->priv != nullptr || item->current_anim_state == LS(LS_DEATH)) {
         return Object_DrawAnimatingItem(item);
     }
 


### PR DESCRIPTION
Resolves #4210.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that any object being drawn to match Lara's animation will use Lara's item frames rather than the item's own frames. Bacon Lara will continue to be drawn separately if falling or dead.
