### PR TITLE
objects/traps/falling_block: calculate origin dynamically

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed all pendulum types to be able to be antitriggered (#3993)
 - fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
+- fixed Lara standing two clicks below `O_FALLING_BLOCK_3` items in TR1 rather than directly on top (#4374)
 - fixed skybox faces with transparent pixels always rendering in front of all other faces (#4351, regression from 1.0)
 - fixed unbound inputs not being saved between game launches (#4360, regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -3,21 +3,30 @@
 #include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/rooms.h>
 #include <trx/vector.h>
-#include <trx/version.h>
 
-static int32_t M_GetOrigin(const OBJECT_ID obj_id)
+static int32_t M_GetOrigin(const ITEM *const item)
 {
-    if (g_TRVersion == 1) {
-        return -STEP_L * 2;
-    } else {
-        return obj_id == O_FALLING_BLOCK_3 ? -WALL_L : -STEP_L * 2;
-    }
+    return (int32_t)(intptr_t)item->priv;
+}
+
+static void M_CalculateOrigin(ITEM *const item)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    const ANIM *const anim = Object_GetAnim(obj, 0);
+    const ANIM_FRAME *const frame = &anim->frame_ptr[0];
+    item->priv = (void *)(intptr_t)ROUND_TO_CLICK_SIGNED(frame->offset.y);
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_CalculateOrigin(item);
 }
 
 static void M_DropStack(const ITEM *const item)
 {
-    const int32_t origin = M_GetOrigin(item->object_id);
-    XYZ_32 drop_pos = {
+    const int32_t origin = M_GetOrigin(item);
+    const XYZ_32 drop_pos = {
         .x = item->pos.x,
         .y = item->pos.y + origin,
         .z = item->pos.z,
@@ -29,7 +38,7 @@ static int16_t M_GetFloorHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
-    const int32_t origin = M_GetOrigin(item->object_id);
+    const int32_t origin = M_GetOrigin(item);
     if (y <= item->pos.y + origin
         && (item->current_anim_state == TRAP_SET
             || item->current_anim_state == TRAP_ACTIVATE)) {
@@ -42,7 +51,7 @@ static int16_t M_GetCeilingHeight(
     const ITEM *const item, const int32_t x, const int32_t y, const int32_t z,
     const int16_t height)
 {
-    const int32_t origin = M_GetOrigin(item->object_id);
+    const int32_t origin = M_GetOrigin(item);
     if (y > item->pos.y + origin
         && (item->current_anim_state == TRAP_SET
             || item->current_anim_state == TRAP_ACTIVATE)) {
@@ -60,7 +69,7 @@ static void M_AddWalkable(const int16_t item_num)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const int32_t origin = M_GetOrigin(item->object_id);
+    const int32_t origin = M_GetOrigin(item);
 
     switch (item->current_anim_state) {
     case TRAP_SET:
@@ -114,6 +123,7 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;

--- a/src/trx/game/rooms/utils.h
+++ b/src/trx/game/rooms/utils.h
@@ -6,3 +6,5 @@
 #define ROUND_TO_SECTOR(V) ((V) & ~(WALL_L - 1))
 #define ROUND_TO_CLICK_UP(V) (((V) + STEP_L / 2 - 1) & ~(STEP_L / 2 - 1))
 #define ROUND_TO_HALF_CLICK(V) ((V) & ~(STEP_L / 2 - 1))
+#define ROUND_TO_CLICK_SIGNED(V)                                               \
+    (((V) >= 0) ? (((V) + STEP_L - 1) & ~(STEP_L - 1)) : ((V) & ~(STEP_L - 1)))


### PR DESCRIPTION
Resolves #4374.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces game and object type checks for collapsible tile origins with a dynamic frame offset check instead. All three types are as a result available to use freely in all games.
