### PR TITLE
lua/creature: allow controlling hostile flag in Lua

### DIFF
--- a/data/common/ship/scripting/trx/creatures.lua
+++ b/data/common/ship/scripting/trx/creatures.lua
@@ -1,0 +1,29 @@
+local raw = trxc.creatures
+
+local creatures = {}
+
+local getters = {
+  hostile_allies = raw.are_allies_hostile,
+}
+
+local setters = {
+  hostile_allies = raw.set_allies_hostile,
+}
+
+local creatures_mt = {
+  __index = function(self, key)
+    local getter = getters[key]
+    return getter and getter() or nil
+  end,
+  __newindex = function(self, key, value)
+    local setter = setters[key]
+    if setter then
+      setter(value)
+      return
+    end
+    error("Cannot set field '" .. key .. "' on trx.creatures", 2)
+  end,
+}
+
+setmetatable(creatures, creatures_mt)
+trx.creatures = creatures

--- a/docs/06-lua/2-reference/12-CREATURE.md
+++ b/docs/06-lua/2-reference/12-CREATURE.md
@@ -1,0 +1,15 @@
+---
+title: Creatures
+---
+
+## Creatures module
+
+Module for controlling certain creature behavior.
+
+### Functions
+
+- [lua]`trx.creatures.hostile_allies`  
+    Reads/writes the global flag to indicate if allies are hostile towards Lara.  
+    Examples:
+    - [lua]`trx.creatures.hostile_allies = true`  
+      All allies are now hostile

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...develop) - ××××-××-××
+- added the ability to control whether or not allies are hostile towards Lara via Lua (#3873)
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed ember emitters in TR2 to use the `SFX_LAVA_FOUNTAIN` sample (#4376)
 - changed the following trap types to support being reset (#3993)

--- a/src/meson.build
+++ b/src/meson.build
@@ -258,6 +258,7 @@ common_sources = [
   'trx/game/lua/common.c',
   'trx/game/lua/config.c',
   'trx/game/lua/console.c',
+  'trx/game/lua/creatures.c',
   'trx/game/lua/events.c',
   'trx/game/lua/game.c',
   'trx/game/lua/items.c',

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -31,6 +31,7 @@ extern void LUA_CreateSound(lua_State *L);
 extern void LUA_CreateConfig(lua_State *L);
 extern void LUA_CreateRooms(lua_State *L);
 extern void LUA_CreateGame(lua_State *L);
+extern void LUA_CreateCreatures(lua_State *L);
 
 static int M_LoadFile(lua_State *const L, const char *const path)
 {
@@ -171,6 +172,7 @@ void LUA_Init(void)
     M_LoadTRXCModule(L, LUA_CreateConfig);
     M_LoadTRXCModule(L, LUA_CreateRooms);
     M_LoadTRXCModule(L, LUA_CreateGame);
+    M_LoadTRXCModule(L, LUA_CreateCreatures);
 
     M_PRIV *const p = &m_Priv;
     p->state = L;
@@ -185,6 +187,7 @@ void LUA_Init(void)
     M_LoadTRXModule(L, "music.lua");
     M_LoadTRXModule(L, "rooms.lua");
     M_LoadTRXModule(L, "game.lua");
+    M_LoadTRXModule(L, "creatures.lua");
 }
 
 void LUA_Shutdown(void)

--- a/src/trx/game/lua/creatures.c
+++ b/src/trx/game/lua/creatures.c
@@ -1,0 +1,32 @@
+#include <trx/game/creature.h>
+#include <trx/game/lua/common.h>
+
+#include <lauxlib.h>
+
+// trxc.creatures.are_allies_hostile() → bool
+static int M_L_CreaturesAreAlliesHostile(lua_State *const L)
+{
+    const bool hostile = Creature_AreAlliesHostile();
+    lua_pushboolean(L, hostile);
+    return 1;
+}
+
+// trxc.creatures.set_allies_hostile(enable)
+static int M_L_CreaturesSetAlliesHostile(lua_State *const L)
+{
+    const bool hostile = lua_toboolean(L, 1) != 0;
+    Creature_SetAlliesHostile(hostile);
+    return 0;
+}
+
+void LUA_CreateCreatures(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+    lua_pushcfunction(L, M_L_CreaturesAreAlliesHostile);
+    lua_setfield(L, -2, "are_allies_hostile");
+    lua_pushcfunction(L, M_L_CreaturesSetAlliesHostile);
+    lua_setfield(L, -2, "set_allies_hostile");
+    lua_setfield(L, -2, "creatures");
+    lua_pop(L, 1);
+}


### PR DESCRIPTION
Part of #3873.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows controlling whether or not allies are hostile towards Lara via Lua.
