### PR TITLE
creature: control allies/ally-targets via Lua

### DIFF
--- a/data/common/ship/scripting/trx/catalog.lua
+++ b/data/common/ship/scripting/trx/catalog.lua
@@ -1,0 +1,7 @@
+local raw = trxc.catalog
+
+local catalog = {
+  objects = raw.objects,
+}
+
+trx.catalog = catalog

--- a/data/common/ship/scripting/trx/creatures.lua
+++ b/data/common/ship/scripting/trx/creatures.lua
@@ -1,6 +1,9 @@
 local raw = trxc.creatures
 
-local creatures = {}
+local creatures = {
+  add_ally = raw.add_ally,
+  add_ally_target = raw.add_ally_target,
+}
 
 local getters = {
   hostile_allies = raw.are_allies_hostile,

--- a/data/tr2/ship/cfg/tr2-gm/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-gm/gameflow.json5
@@ -43,6 +43,7 @@
         // 1. The Cold War
         {
             "path": "data/level1.tr2",
+            "script": "data/scripts/level1.lua",
             "music_track": 29,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/gm_level1.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
@@ -92,6 +93,7 @@
         // 3. Furnace of the Gods
         {
             "path": "data/level3.tr2",
+            "script": "data/scripts/level3.lua",
             "music_track": 55,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/gm_level3.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
@@ -113,6 +115,7 @@
         // 4. Kingdom
         {
             "path": "data/level4.tr2",
+            "script": "data/scripts/level4.lua",
             "music_track": 27,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/gm_level4.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/data/tr2/ship/cfg/tr2/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2/gameflow.json5
@@ -356,6 +356,7 @@
         // 12. Barkhang Monastery
         {
             "path": "data/monastry.tr2",
+            "script": "data/scripts/monastry.lua",
             "music_track": -1,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/tibet.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/data/tr2/ship/data/scripts/level1.lua
+++ b/data/tr2/ship/data/scripts/level1.lua
@@ -1,0 +1,4 @@
+trx.events.on_level_init(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.O_MONK_1)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_2)
+end)

--- a/data/tr2/ship/data/scripts/level3.lua
+++ b/data/tr2/ship/data/scripts/level3.lua
@@ -1,0 +1,5 @@
+trx.events.on_level_init(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.O_MONK_2)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_1)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_2)
+end)

--- a/data/tr2/ship/data/scripts/level4.lua
+++ b/data/tr2/ship/data/scripts/level4.lua
@@ -1,0 +1,4 @@
+trx.events.on_level_init(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.O_MONK_2)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_2)
+end)

--- a/data/tr2/ship/data/scripts/monastry.lua
+++ b/data/tr2/ship/data/scripts/monastry.lua
@@ -1,0 +1,6 @@
+trx.events.on_level_init(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.O_MONK_1)
+  trx.creatures.add_ally(trx.catalog.objects.O_MONK_2)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_1)
+  trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_2)
+end)

--- a/docs/03-MIGRATING.md
+++ b/docs/03-MIGRATING.md
@@ -4,6 +4,15 @@ title: Migrating levels
 
 # Migration guide for level builders
 
+## TRX
+
+### Version 1.0 to 1.1
+
+1. **Ally and ally target behavior moved to Lua**:  
+    Monks being allies and bandits being enemies who will target allies is no
+    longer hardcoded and instead must be defined in Lua. Refer to the game flow
+    and linked script files of the original levels for reference.
+
 ## TR1X
 
 ### Version 4.15 to TRX 1.0

--- a/docs/06-lua/1-examples/README.md
+++ b/docs/06-lua/1-examples/README.md
@@ -10,14 +10,10 @@ This example sets all bats to start with 20 hitpoints, and all wolves to start
 with 30 hitpoints. Simply adjust the lookup table to fit your needs.
 
 ```lua
--- Object IDs for enemies
-local O_WOLF = 7
-local O_BAT = 9
-
 -- Lookup table mapping object IDs to HP
 local hp_lut = {
-  [O_WOLF] = 30,
-  [O_BAT] = 20,
+  [trx.catalog.objects.O_WOLF] = 30,
+  [trx.catalog.objects.O_BAT] = 20,
 }
 
 -- Adjust HP of enemies when the level loads

--- a/docs/06-lua/2-reference/1-LOGGING.md
+++ b/docs/06-lua/2-reference/1-LOGGING.md
@@ -7,7 +7,7 @@ title: Logging
 Lua scripts can log with contextual source info via the global `Log` module.
 Each call records the Lua script filename, function name, and line number. The
 results are logged to the standard output in the console as well as the
-`TR*X.log` file in the installation directory.
+`TRX.log` file in the installation directory.
 
 ### Functions
 

--- a/docs/06-lua/2-reference/12-CREATURE.md
+++ b/docs/06-lua/2-reference/12-CREATURE.md
@@ -13,3 +13,15 @@ Module for controlling certain creature behavior.
     Examples:
     - [lua]`trx.creatures.hostile_allies = true`  
       All allies are now hostile
+
+- [lua]`trx.creatures.add_ally(obj_id)`  
+    Marks the given object as being an ally of Lara.  
+    Examples:
+    - [lua]`trx.creatures.add_ally(trx.catalog.objects.O_MONK_1)`  
+      All items of type `O_MONK_1` are now an ally of Lara
+
+- [lua]`trx.creatures.add_ally_target(obj_id)`  
+    Marks the given object as being one who will fight with any allies of Lara.  
+    Examples:
+    - [lua]`trx.creatures.add_ally_target(trx.catalog.objects.O_BANDIT_1)`  
+      All items of type `O_BANDIT_1` will now target any allies of Lara.

--- a/docs/06-lua/2-reference/13-CATALOG.md
+++ b/docs/06-lua/2-reference/13-CATALOG.md
@@ -1,0 +1,14 @@
+---
+title: Catalog
+---
+
+## Catalog module
+
+A convenience module for accessing TRX catalog IDs.
+
+### Structures
+
+- [lua]`trx.catalog.objects`   
+  This table contains each TRX object ID. Names match those defined in `catalog_objects.csv`   
+  Examples:   
+  - [lua]`if item.object_id == trx.catalog.objects.O_WOLF then ...`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...develop) - ××××-××-××
 - added the ability to control whether or not allies are hostile towards Lara via Lua (#3873)
+- added the ability to control via Lua which enemies are allies and which are ones that will fight with allies (#3873)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)
 - added catalog object IDs to Lua
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...develop) - ××××-××-××
 - added the ability to control whether or not allies are hostile towards Lara via Lua (#3873)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)
+- added catalog object IDs to Lua
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed ember emitters in TR2 to use the `SFX_LAVA_FOUNTAIN` sample (#4376)
 - changed the following trap types to support being reset (#3993)

--- a/src/meson.build
+++ b/src/meson.build
@@ -256,6 +256,7 @@ common_sources = [
   'trx/game/level/rooms.c',
   'trx/game/level/settings.c',
   'trx/game/los.c',
+  'trx/game/lua/catalog.c',
   'trx/game/lua/common.c',
   'trx/game/lua/config.c',
   'trx/game/lua/console.c',

--- a/src/trx/game/creature/behavior.c
+++ b/src/trx/game/creature/behavior.c
@@ -1,11 +1,36 @@
 #include <trx/game/creature.h>
 #include <trx/game/objects/vars.h>
+#include <trx/vector.h>
 
 static bool m_AlliesHostile = false;
+static VECTOR *m_AllyObjects = nullptr;
+static VECTOR *m_AllyTargetingObjects = nullptr;
+
+__attribute__((constructor)) static void M_Init(void)
+{
+    m_AllyObjects = Vector_Create(sizeof(OBJECT_ID));
+    m_AllyTargetingObjects = Vector_Create(sizeof(OBJECT_ID));
+}
+
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+#define L_DELETE_VECTOR(vec)                                                   \
+    if (vec != nullptr) {                                                      \
+        Vector_Free(vec);                                                      \
+        vec = nullptr;                                                         \
+    }
+
+    L_DELETE_VECTOR(m_AllyObjects);
+    L_DELETE_VECTOR(m_AllyTargetingObjects);
+
+#undef L_DELETE_VECTOR
+}
 
 void Creature_Reset(void)
 {
     Creature_SetAlliesHostile(false);
+    Vector_Clear(m_AllyObjects);
+    Vector_Clear(m_AllyTargetingObjects);
 }
 
 bool Creature_AreAlliesHostile(void)
@@ -26,10 +51,20 @@ bool Creature_IsHostile(const ITEM *const item)
 
 bool Creature_IsAlly(const ITEM *const item)
 {
-    return Object_IsType(item->object_id, g_AllyObjects);
+    return Vector_Contains(m_AllyObjects, (void *)&item->object_id);
 }
 
 bool Creature_IsAllyTargetingEnemy(const ITEM *const item)
 {
-    return Object_IsType(item->object_id, g_AllyTargetingEnemies);
+    return Vector_Contains(m_AllyTargetingObjects, (void *)&item->object_id);
+}
+
+void Creature_AddAlly(const OBJECT_ID obj_id)
+{
+    Vector_Add(m_AllyObjects, (void *)&obj_id);
+}
+
+void Creature_AddAllyTargetingEnemy(const OBJECT_ID obj_id)
+{
+    Vector_Add(m_AllyTargetingObjects, (void *)&obj_id);
 }

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -36,6 +36,8 @@ bool Creature_IsAlive(const ITEM *item);
 bool Creature_IsHostile(const ITEM *item);
 bool Creature_IsAlly(const ITEM *item);
 bool Creature_IsAllyTargetingEnemy(const ITEM *item);
+void Creature_AddAlly(OBJECT_ID obj_id);
+void Creature_AddAllyTargetingEnemy(OBJECT_ID obj_id);
 bool Creature_IsTargetable(const ITEM *item);
 
 int16_t Creature_Effect(

--- a/src/trx/game/lua/catalog.c
+++ b/src/trx/game/lua/catalog.c
@@ -1,0 +1,28 @@
+#include <trx/game/objects.h>
+
+#include <lauxlib.h>
+
+static void M_PushObjects(lua_State *const L)
+{
+    lua_newtable(L);
+
+    int32_t id = 0;
+#define X_CATALOG_ID(enum_value)                                               \
+    lua_pushinteger(L, id++);                                                  \
+    lua_setfield(L, -2, #enum_value);
+#include "trx/game/catalog_objects.def"
+#undef X_CATALOG_ID
+
+    lua_setfield(L, -2, "objects");
+}
+
+void LUA_CreateCatalog(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+
+    M_PushObjects(L);
+
+    lua_setfield(L, -2, "catalog");
+    lua_pop(L, 1);
+}

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -21,6 +21,7 @@ static M_PRIV m_Priv = {
 };
 
 // Initialize internal APIs
+extern void LUA_CreateCatalog(lua_State *L);
 extern void LUA_CreateConsole(lua_State *L);
 extern void LUA_CreateEvents(lua_State *L);
 extern void LUA_CreateItems(lua_State *L);
@@ -162,6 +163,7 @@ void LUA_Init(void)
     lua_setglobal(L, "trx");
 
     // Initialize internal modules
+    M_LoadTRXCModule(L, LUA_CreateCatalog);
     M_LoadTRXCModule(L, LUA_CreateConsole);
     M_LoadTRXCModule(L, LUA_CreateEvents);
     M_LoadTRXCModule(L, LUA_CreateItems);
@@ -177,6 +179,7 @@ void LUA_Init(void)
     M_PRIV *const p = &m_Priv;
     p->state = L;
 
+    M_LoadTRXModule(L, "catalog.lua");
     M_LoadTRXModule(L, "items.lua");
     M_LoadTRXModule(L, "config.lua");
     M_LoadTRXModule(L, "console.lua");

--- a/src/trx/game/lua/creatures.c
+++ b/src/trx/game/lua/creatures.c
@@ -1,5 +1,4 @@
 #include <trx/game/creature.h>
-#include <trx/game/lua/common.h>
 
 #include <lauxlib.h>
 
@@ -19,6 +18,22 @@ static int M_L_CreaturesSetAlliesHostile(lua_State *const L)
     return 0;
 }
 
+// trxc.creatures.add_ally(obj_id)
+static int M_L_CreaturesAddAlly(lua_State *const L)
+{
+    const OBJECT_ID obj_id = luaL_checkinteger(L, 1);
+    Creature_AddAlly(obj_id);
+    return 0;
+}
+
+// trxc.creatures.add_ally_target(obj_id)
+static int M_L_CreaturesAddAllyTarget(lua_State *const L)
+{
+    const OBJECT_ID obj_id = luaL_checkinteger(L, 1);
+    Creature_AddAllyTargetingEnemy(obj_id);
+    return 0;
+}
+
 void LUA_CreateCreatures(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
@@ -27,6 +42,10 @@ void LUA_CreateCreatures(lua_State *const L)
     lua_setfield(L, -2, "are_allies_hostile");
     lua_pushcfunction(L, M_L_CreaturesSetAlliesHostile);
     lua_setfield(L, -2, "set_allies_hostile");
+    lua_pushcfunction(L, M_L_CreaturesAddAlly);
+    lua_setfield(L, -2, "add_ally");
+    lua_pushcfunction(L, M_L_CreaturesAddAllyTarget);
+    lua_setfield(L, -2, "add_ally_target");
     lua_setfield(L, -2, "creatures");
     lua_pop(L, 1);
 }

--- a/src/trx/game/lua/items.c
+++ b/src/trx/game/lua/items.c
@@ -118,7 +118,7 @@ static int M_L_ItemGetStatus(lua_State *const L)
 static int M_L_ItemGetObjectId(lua_State *const L)
 {
     M_ITEM_GETTER(L);
-    lua_pushinteger(L, Object_ToGameID(item->object_id));
+    lua_pushinteger(L, item->object_id);
     return 1;
 }
 

--- a/src/trx/game/objects/vars.c
+++ b/src/trx/game/objects/vars.c
@@ -136,27 +136,10 @@ const OBJECT_ID g_WaterObjects[] = {
     // clang-format on
 };
 
-const OBJECT_ID g_AllyObjects[] = {
-    // clang-format off
-    O_MONK_1,
-    O_MONK_2,
-    O_MONK_3,
-    NO_OBJECT,
-    // clang-format on
-};
-
 const OBJECT_ID g_LoyalObjects[] = {
     // clang-format off
     O_LARA,
     O_WINSTON,
-    NO_OBJECT,
-    // clang-format on
-};
-
-const OBJECT_ID g_AllyTargetingEnemies[] = {
-    // clang-format off
-    O_BANDIT_1,
-    O_BANDIT_2,
     NO_OBJECT,
     // clang-format on
 };

--- a/src/trx/game/objects/vars.h
+++ b/src/trx/game/objects/vars.h
@@ -5,9 +5,7 @@
 
 extern const OBJECT_ID g_CreatureObjects[];
 extern const OBJECT_ID g_WaterObjects[];
-extern const OBJECT_ID g_AllyObjects[];
 extern const OBJECT_ID g_LoyalObjects[];
-extern const OBJECT_ID g_AllyTargetingEnemies[];
 extern const OBJECT_ID g_PickupObjects[];
 extern const OBJECT_ID g_ElevatedPickupObjects[];
 extern const OBJECT_ID g_SwitchObjects[];

--- a/src/trx/game/ui/elements/bar_enemy_hp.c
+++ b/src/trx/game/ui/elements/bar_enemy_hp.c
@@ -14,8 +14,7 @@ bool UI_EnemyHealthBar(void)
     if (target == nullptr) {
         return false;
     }
-    const OBJECT *const obj = Object_Get(target->object_id);
-    const bool is_ally = Object_IsType(target->object_id, g_AllyObjects);
+    const bool is_ally = Creature_IsAlly(target);
 
     bool show = g_Config.ui.show_bars;
     switch (g_Config.ui.enemy_health_bar.show_mode) {


### PR DESCRIPTION
Resolves #3873.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces the hard-coded list of allies and ally-targeting creatures with the ability to instead feed this information via Lua. Original TR2 level scripts are provided. In addition, TRX object IDs are now available in Lua, meaning the need to locally define IDs is removed.

I was going to add `remove_ally`/`remove_ally_target` functions but this might be better to reserve until we have a savestate system. WDYT? Also open to any other thoughts on the API.

I think we can follow up once this gets some usage to look into improving such things as the missile behaviour we discussed.
