### PR TITLE
camera: introduce strategies

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -103,6 +103,7 @@ common_sources = [
   'trx/game/anims/commands.c',
   'trx/game/anims/common.c',
   'trx/game/anims/frames.c',
+  'trx/game/camera/box_camera.c',
   'trx/game/camera/cinematic.c',
   'trx/game/camera/common.c',
   'trx/game/camera/fixed.c',

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -26,6 +26,8 @@ typedef struct {
     bool test_shift_pair;
     bool clip_shift_height;
     bool test_early_lb_shift;
+    bool use_fixed_los_check;
+    bool override_chase_speed;
 } M_SETTINGS;
 
 static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
@@ -36,6 +38,8 @@ static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
         .test_shift_pair = false,
         .clip_shift_height = false,
         .test_early_lb_shift = true,
+        .use_fixed_los_check = false,
+        .override_chase_speed = false,
     },
     [CAMERA_MODE_TR2] = {
         .chase_speed = 10,
@@ -44,6 +48,8 @@ static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
         .test_shift_pair = true,
         .clip_shift_height = true,
         .test_early_lb_shift = false,
+        .use_fixed_los_check = true,
+        .override_chase_speed = true,
     },
 };
 
@@ -531,7 +537,7 @@ static void M_Chase(const ITEM *const item)
     };
 
     const M_SETTINGS settings = M_GetSettings();
-    const int16_t speed = g_TRVersion >= 2 || g_Camera.fixed_camera
+    const int16_t speed = settings.override_chase_speed || g_Camera.fixed_camera
         ? g_Camera.speed
         : settings.chase_speed;
     M_SmartShift(&target, M_Shift);
@@ -603,7 +609,10 @@ static void M_Fixed(void)
         .z = fixed->z,
         .room_num = fixed->data,
     };
-    if (g_TRVersion >= 2 && !LOS_Check(&g_Camera.target, &target, false)) {
+
+    const M_SETTINGS settings = M_GetSettings();
+    if (settings.use_fixed_los_check
+        && !LOS_Check(&g_Camera.target, &target, false)) {
         M_ShiftClamp(&target, STEP_L);
     }
 

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -1,0 +1,736 @@
+#include <trx/config.h>
+#include <trx/debug.h>
+#include <trx/game/camera.h>
+#include <trx/game/lara.h>
+#include <trx/game/los.h>
+#include <trx/game/pathing.h>
+#include <trx/game/random.h>
+#include <trx/game/rooms.h>
+
+// clang-format off
+#define M_MAX_ELEVATION   (85 * DEG_1) // = 15470
+#define M_COMBAT_DISTANCE (WALL_L * 5 / 2) // = 2560
+#define M_LOOK_DISTANCE   (WALL_L * 3 / 2) // = 1536
+#define M_LOOK_CLAMP      (STEP_L + 50) // = 296
+// clang-format on
+
+#define M_SHIFT_ARGS                                                           \
+    int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,    \
+        int32_t target_h, int32_t left, int32_t top, int32_t right,            \
+        int32_t bottom
+
+typedef struct {
+    int16_t chase_speed;
+    int32_t min_square;
+    int32_t shift_scale;
+    bool test_shift_pair;
+    bool clip_shift_height;
+    bool test_early_lb_shift;
+} M_SETTINGS;
+
+static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
+    [CAMERA_MODE_TR1] = {
+        .chase_speed = 12,
+        .min_square = SQUARE(WALL_L / 4),
+        .shift_scale = 1,
+        .test_shift_pair = false,
+        .clip_shift_height = false,
+        .test_early_lb_shift = true,
+    },
+    [CAMERA_MODE_TR2] = {
+        .chase_speed = 10,
+        .min_square = SQUARE(WALL_L / 3),
+        .shift_scale = 2,
+        .test_shift_pair = true,
+        .clip_shift_height = true,
+        .test_early_lb_shift = false,
+    },
+};
+
+static BOX_INFO m_FixedBox = {};
+
+static M_SETTINGS M_GetSettings(void)
+{
+    return m_CameraSettings[g_Config.visuals.camera_mode];
+}
+
+static int16_t M_GetChaseSpeed(void)
+{
+    return M_GetSettings().chase_speed;
+}
+
+static const BOX_INFO *M_GetBox(
+    const SECTOR *const sector, const int32_t x, const int32_t z,
+    const bool generate_box)
+{
+    if (sector->box != NO_BOX) {
+        return Box_GetBox(sector->box);
+    }
+
+    if (!generate_box) {
+        return nullptr;
+    }
+
+    // A level may have blocked specific sector or room pathfinding, so create a
+    // dummy one-sector box to prevent erratic camera positioning.
+    m_FixedBox.left = z & ~(WALL_L - 1);
+    m_FixedBox.top = x & ~(WALL_L - 1);
+    m_FixedBox.right = m_FixedBox.left + WALL_L - 1;
+    m_FixedBox.bottom = m_FixedBox.top + WALL_L - 1;
+    return &m_FixedBox;
+}
+
+static const SECTOR *M_GetSector(
+    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
+{
+    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
+    const int32_t height = Room_GetHeight(sector, x, y, z);
+    const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
+    if (y > height || y < ceiling) {
+        return nullptr;
+    }
+    return sector;
+}
+
+static bool M_IsGoodPosition(
+    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
+{
+    return M_GetSector(x, y, z, room_num) != nullptr;
+}
+
+static int32_t M_ShiftClamp(GAME_VECTOR *const pos, const int32_t clamp)
+{
+    const int32_t x = pos->x;
+    const int32_t y = pos->y;
+    const int32_t z = pos->z;
+
+    const SECTOR *const sector = Room_GetSector(x, y, z, &pos->room_num);
+    const BOX_INFO *const box = M_GetBox(sector, x, z, true);
+
+    const int32_t left = box->left + clamp;
+    const int32_t right = box->right - clamp;
+    if (z < left && !M_IsGoodPosition(x, y, z - clamp, pos->room_num)) {
+        pos->z = left;
+    } else if (z > right && !M_IsGoodPosition(x, y, z + clamp, pos->room_num)) {
+        pos->z = right;
+    }
+
+    const int32_t top = box->top + clamp;
+    const int32_t bottom = box->bottom - clamp;
+    if (x < top && !M_IsGoodPosition(x - clamp, y, z, pos->room_num)) {
+        pos->x = top;
+    } else if (
+        x > bottom && !M_IsGoodPosition(x + clamp, y, z, pos->room_num)) {
+        pos->x = bottom;
+    }
+
+    int32_t height = Room_GetHeight(sector, x, y, z) - clamp;
+    int32_t ceiling = Room_GetCeiling(sector, x, y, z) + clamp;
+
+    if (height < ceiling) {
+        ceiling = (height + ceiling) >> 1;
+        height = ceiling;
+    }
+
+    if (y > height) {
+        return height - y;
+    } else if (y < ceiling) {
+        return ceiling - y;
+    }
+
+    return 0;
+}
+
+static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
+{
+    LOS_Check(&g_Camera.target, target, false);
+
+    const ROOM *room = Room_Get(g_Camera.target.room_num);
+    const SECTOR *sector =
+        Room_GetWorldSector(room, g_Camera.target.x, g_Camera.target.z);
+    const BOX_INFO *box =
+        M_GetBox(sector, g_Camera.target.x, g_Camera.target.z, true);
+
+    room = Room_Get(target->room_num);
+    sector = Room_GetWorldSector(room, target->x, target->z);
+    if (room->flags.swamp) {
+        target->y = room->max_ceiling - STEP_L;
+        sector =
+            Room_GetSector(target->x, target->y, target->z, &target->room_num);
+    }
+
+    if (target->z < box->left || target->z > box->right || target->x < box->top
+        || target->x > box->bottom) {
+        box = M_GetBox(sector, target->x, target->z, true);
+    }
+
+    int32_t left = box->left;
+    int32_t right = box->right;
+    int32_t top = box->top;
+    int32_t bottom = box->bottom;
+
+    const M_SETTINGS settings = M_GetSettings();
+
+    int32_t test = (target->z - WALL_L) | (WALL_L - 1);
+    const SECTOR *const good_left =
+        M_GetSector(target->x, target->y, test, target->room_num);
+    if (good_left != nullptr) {
+        box = M_GetBox(good_left, target->x, test, false);
+        if (box != nullptr && box->left < left) {
+            left = box->left;
+        }
+    } else if (settings.test_shift_pair) {
+        left = test;
+    }
+
+    test = (target->z + WALL_L) & (~(WALL_L - 1));
+    const SECTOR *const good_right =
+        M_GetSector(target->x, target->y, test, target->room_num);
+    if (good_right != nullptr) {
+        box = M_GetBox(good_right, target->x, test, false);
+        if (box != nullptr && box->right > right) {
+            right = box->right;
+        }
+    } else if (settings.test_shift_pair) {
+        right = test;
+    }
+
+    test = (target->x - WALL_L) | (WALL_L - 1);
+    const SECTOR *const good_top =
+        M_GetSector(test, target->y, target->z, target->room_num);
+    if (good_top != nullptr) {
+        box = M_GetBox(good_top, test, target->z, false);
+        if (box != nullptr && box->top < top) {
+            top = box->top;
+        }
+    } else if (settings.test_shift_pair) {
+        top = test;
+    }
+
+    test = (target->x + WALL_L) & (~(WALL_L - 1));
+    const SECTOR *const good_bottom =
+        M_GetSector(test, target->y, target->z, target->room_num);
+    if (good_bottom != nullptr) {
+        box = M_GetBox(good_bottom, test, target->z, false);
+        if (box != nullptr && box->bottom > bottom) {
+            bottom = box->bottom;
+        }
+    } else if (settings.test_shift_pair) {
+        bottom = test;
+    }
+
+    left += STEP_L;
+    right -= STEP_L;
+    top += STEP_L;
+    bottom -= STEP_L;
+
+    GAME_VECTOR target_a = {
+        .x = target->x,
+        .y = target->y,
+        .z = target->z,
+        .room_num = target->room_num,
+    };
+
+    GAME_VECTOR target_b = {
+        .x = target->x,
+        .y = target->y,
+        .z = target->z,
+        .room_num = target->room_num,
+    };
+
+    bool clip = false;
+    bool prefer_a = !settings.test_shift_pair;
+
+#define L_SHIFT(axis1, axis2, l1, l2, r1, r2)                                  \
+    shift(                                                                     \
+        &target_a.axis1, &target_a.axis2, &target_a.y, g_Camera.target.axis1,  \
+        g_Camera.target.axis2, g_Camera.target.y, l1, l2, r1, r2);             \
+    shift(                                                                     \
+        &target_b.axis1, &target_b.axis2, &target_b.y, g_Camera.target.axis1,  \
+        g_Camera.target.axis2, g_Camera.target.y, l1, r2, r1, l2)
+
+    if (!settings.test_shift_pair) {
+        if (target->z < left && good_left == nullptr) {
+            clip = true;
+            if (target->x < g_Camera.target.x) {
+                L_SHIFT(z, x, left, top, right, bottom);
+            } else {
+                L_SHIFT(z, x, left, bottom, right, top);
+            }
+        } else if (target->z > right && good_right == nullptr) {
+            clip = true;
+            if (target->x < g_Camera.target.x) {
+                L_SHIFT(z, x, right, top, left, bottom);
+            } else {
+                L_SHIFT(z, x, right, bottom, left, top);
+            }
+        } else if (target->x < top && good_top == nullptr) {
+            clip = true;
+            if (target->z < g_Camera.target.z) {
+                L_SHIFT(x, z, top, left, bottom, right);
+            } else {
+                L_SHIFT(x, z, top, right, bottom, left);
+            }
+        } else if (target->x > bottom && good_bottom == nullptr) {
+            clip = true;
+            if (target->z < g_Camera.target.z) {
+                L_SHIFT(x, z, bottom, left, top, right);
+            } else {
+                L_SHIFT(x, z, bottom, right, top, left);
+            }
+        }
+    } else {
+        if (ABS(target->z - g_Camera.target.z)
+            > ABS(target->x - g_Camera.target.x)) {
+            if (target->z < left && good_left == nullptr) {
+                clip = true;
+                prefer_a = g_Camera.pos.x < g_Camera.target.x;
+                L_SHIFT(z, x, left, top, right, bottom);
+            } else if (target->z > right && good_right == nullptr) {
+                clip = true;
+                prefer_a = g_Camera.pos.x < g_Camera.target.x;
+                L_SHIFT(z, x, right, top, left, bottom);
+            } else if (target->x < top && good_top == nullptr) {
+                clip = true;
+                prefer_a = target->z < g_Camera.target.z;
+                L_SHIFT(x, z, top, left, bottom, right);
+            } else if (target->x > bottom && good_bottom == nullptr) {
+                clip = true;
+                prefer_a = target->z < g_Camera.target.z;
+                L_SHIFT(x, z, bottom, left, top, right);
+            }
+        } else {
+            if (target->x < top && good_top == nullptr) {
+                clip = true;
+                prefer_a = g_Camera.pos.z < g_Camera.target.z;
+                L_SHIFT(x, z, top, left, bottom, right);
+            } else if (target->x > bottom && good_bottom == nullptr) {
+                clip = true;
+                prefer_a = g_Camera.pos.z < g_Camera.target.z;
+                L_SHIFT(x, z, bottom, left, top, right);
+            } else if (target->z < left && good_left == nullptr) {
+                clip = true;
+                prefer_a = target->x < g_Camera.target.x;
+                L_SHIFT(z, x, left, top, right, bottom);
+            } else if (target->z > right && good_right == nullptr) {
+                clip = true;
+                prefer_a = target->x < g_Camera.target.x;
+                L_SHIFT(z, x, right, top, left, bottom);
+            }
+        }
+    }
+
+#undef L_SHIFT
+
+    if (!clip) {
+        return;
+    }
+
+    if (settings.test_shift_pair) {
+        if (prefer_a) {
+            prefer_a = LOS_Check(&g_Camera.target, &target_a, false);
+        } else {
+            prefer_a = !LOS_Check(&g_Camera.target, &target_b, false);
+        }
+    }
+
+    if (prefer_a) {
+        target->pos = target_a.pos;
+    } else {
+        target->pos = target_b.pos;
+    }
+
+    Room_GetSector(target->x, target->y, target->z, &target->room_num);
+}
+
+static void M_Clip(M_SHIFT_ARGS)
+{
+    const int32_t x_diff = *x - target_x;
+    const int32_t y_diff = *y - target_y;
+    const int32_t h_diff = *h - target_h;
+    int32_t height = *h;
+
+    if ((right > left) != (target_x < left)) {
+        if (x_diff != 0) {
+            *y = target_y + (left - target_x) * y_diff / x_diff;
+            height = target_h + (left - target_x) * h_diff / x_diff;
+        }
+        *x = left;
+    }
+
+    if ((bottom > top && target_y > top && (*y) < top)
+        || (bottom < top && target_y < top && (*y) > top)) {
+        if (y_diff != 0) {
+            *x = target_x + (top - target_y) * x_diff / y_diff;
+            height = target_h + (top - target_y) * h_diff / y_diff;
+        }
+        *y = top;
+    }
+
+    const M_SETTINGS settings = M_GetSettings();
+    if (settings.clip_shift_height) {
+        *h = height;
+    }
+}
+
+static void M_Shift(M_SHIFT_ARGS)
+{
+    const int32_t l_square = SQUARE(target_x - left);
+    const int32_t r_square = SQUARE(target_x - right);
+    const int32_t t_square = SQUARE(target_y - top);
+    const int32_t b_square = SQUARE(target_y - bottom);
+
+    const int32_t tl_square = t_square + l_square;
+    const int32_t tr_square = t_square + r_square;
+    const int32_t bl_square = b_square + l_square;
+
+    const M_SETTINGS settings = M_GetSettings();
+    const int32_t scaled_target = g_Camera.target_square * settings.shift_scale;
+
+    int32_t shift;
+    if (g_Camera.target_square < tl_square) {
+        *x = left;
+        shift = g_Camera.target_square - l_square;
+        if (shift >= 0) {
+            shift = Math_Sqrt(shift);
+            *y = target_y + (top >= bottom ? shift : -shift);
+        }
+    } else if (tl_square > settings.min_square) {
+        *x = left;
+        *y = top;
+    } else if (g_Camera.target_square < bl_square) {
+        *x = left;
+        shift = g_Camera.target_square - l_square;
+        if (shift >= 0) {
+            shift = Math_Sqrt(shift);
+            *y = target_y + (top < bottom ? shift : -shift);
+        }
+    } else if (
+        settings.test_early_lb_shift && bl_square > settings.min_square) {
+        *x = left;
+        *y = bottom;
+    } else if (scaled_target < tr_square) {
+        shift = scaled_target - t_square;
+        if (shift >= 0) {
+            shift = Math_Sqrt(shift);
+            *x = target_x + (left < right ? shift : -shift);
+            *y = top;
+        }
+    } else if (settings.test_early_lb_shift || bl_square <= tr_square) {
+        *x = right;
+        *y = top;
+    } else {
+        *x = left;
+        *y = bottom;
+    }
+}
+
+static void M_Move(const GAME_VECTOR *const target, const int32_t speed)
+{
+    const GAME_VECTOR old_pos = g_Camera.pos;
+    GAME_VECTOR pos = g_Camera.pos;
+    pos.x += (target->x - pos.x) / speed;
+    pos.z += (target->z - pos.z) / speed;
+    pos.y += (target->y - pos.y) / speed;
+    pos.room_num = target->room_num;
+
+    Camera_SetChunky(false);
+
+    const SECTOR *sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+    int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    if (height == NO_HEIGHT) {
+        // Attempt to clamp within the previous sector's height bounds. Only if
+        // that fails continue to revert fully to the last good Y position.
+        pos.room_num = old_pos.room_num;
+        sector = Room_GetSector(old_pos.x, old_pos.y, old_pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, old_pos.x, old_pos.y, old_pos.z);
+        const int32_t old_ceiling =
+            Room_GetCeiling(sector, old_pos.x, old_pos.y, old_pos.z);
+        CLAMP(pos.y, old_ceiling + STEP_L, height - STEP_L);
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+        if (height == NO_HEIGHT) {
+            pos.y = old_pos.y;
+            pos.room_num = old_pos.room_num;
+            sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+            height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+        }
+    }
+
+    height -= STEP_L;
+    if (pos.y >= height && target->y >= height) {
+        LOS_Check(&g_Camera.target, &pos, false);
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        height = Room_GetHeight(sector, pos.x, pos.y, pos.z) - STEP_L;
+    }
+
+    g_Camera.pos = pos;
+
+    int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z) + STEP_L;
+    if (height < ceiling) {
+        ceiling = (height + ceiling) >> 1;
+        height = ceiling;
+    }
+
+    if (g_Camera.bounce > 0) {
+        g_Camera.pos.y += g_Camera.bounce;
+        g_Camera.target.y += g_Camera.bounce;
+        g_Camera.bounce = 0;
+    } else if (g_Camera.bounce < 0) {
+        const XYZ_32 shake = {
+            .x = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+            .y = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+            .z = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
+        };
+        g_Camera.pos.x += shake.x;
+        g_Camera.pos.y += shake.y;
+        g_Camera.pos.z += shake.z;
+        g_Camera.target.y += shake.x;
+        g_Camera.target.y += shake.y;
+        g_Camera.target.z += shake.z;
+        g_Camera.bounce += 5;
+    }
+
+    if (g_Camera.pos.y > height) {
+        g_Camera.shift = height - g_Camera.pos.y;
+    } else if (g_Camera.pos.y < ceiling) {
+        g_Camera.shift = ceiling - g_Camera.pos.y;
+    } else {
+        g_Camera.shift = 0;
+    }
+
+    Camera_UpdateMicPosition();
+}
+
+static void M_Chase(const ITEM *const item)
+{
+    g_Camera.target_elevation += item->rot.x;
+    g_Camera.target_elevation = MIN(g_Camera.target_elevation, M_MAX_ELEVATION);
+    g_Camera.target_elevation =
+        MAX(g_Camera.target_elevation, -M_MAX_ELEVATION);
+
+    const int32_t distance =
+        (g_Camera.target_distance * Math_Cos(g_Camera.target_elevation))
+        >> W2V_SHIFT;
+    const int16_t angle = g_Camera.target_angle + item->rot.y;
+
+    g_Camera.target_square = SQUARE(distance);
+
+    const XYZ_32 offset = {
+        .y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+            >> W2V_SHIFT,
+        .x = -((distance * Math_Sin(angle)) >> W2V_SHIFT),
+        .z = -((distance * Math_Cos(angle)) >> W2V_SHIFT),
+    };
+
+    GAME_VECTOR target = {
+        .x = g_Camera.target.x + offset.x,
+        .y = g_Camera.target.y + offset.y,
+        .z = g_Camera.target.z + offset.z,
+        .room_num = g_Camera.pos.room_num,
+    };
+
+    const M_SETTINGS settings = M_GetSettings();
+    const int16_t speed = g_TRVersion >= 2 || g_Camera.fixed_camera
+        ? g_Camera.speed
+        : settings.chase_speed;
+    M_SmartShift(&target, M_Shift);
+    M_Move(&target, speed);
+}
+
+static void M_Combat(const ITEM *const item)
+{
+    g_Camera.target.z = item->pos.z;
+    g_Camera.target.x = item->pos.x;
+    g_Camera.target_distance = M_COMBAT_DISTANCE;
+
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->target != nullptr) {
+        g_Camera.target_angle = lara_info->target_angles[0] + item->rot.y;
+        g_Camera.target_elevation = lara_info->target_angles[1] + item->rot.x;
+    } else {
+        g_Camera.target_angle =
+            lara_info->torso_rot.y + lara_info->head_rot.y + item->rot.y;
+        g_Camera.target_elevation =
+            lara_info->torso_rot.x + lara_info->head_rot.x + item->rot.x;
+    }
+
+    const int32_t distance =
+        (M_COMBAT_DISTANCE * Math_Cos(g_Camera.target_elevation)) >> W2V_SHIFT;
+
+    const XYZ_32 offset = {
+        .y =
+            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+              >> W2V_SHIFT),
+        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
+        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
+    };
+
+    GAME_VECTOR target = {
+        .x = g_Camera.target.x + offset.x,
+        .y = g_Camera.target.y + offset.y,
+        .z = g_Camera.target.z + offset.z,
+        .room_num = g_Camera.pos.room_num,
+    };
+
+    if (lara_info->water_status == LWS_UNDERWATER) {
+        const ITEM *const lara_item = Lara_GetItem();
+        const int32_t water_height =
+            lara_info->water_surface_dist + lara_item->pos.y;
+        if (g_Camera.target.y > water_height && water_height > target.y) {
+            target.y = lara_info->water_surface_dist + lara_item->pos.y;
+            target.z = g_Camera.target.z
+                + (water_height - g_Camera.target.y)
+                    * (target.z - g_Camera.target.z)
+                    / (target.y - g_Camera.target.y);
+            target.x = g_Camera.target.x
+                + (water_height - g_Camera.target.y)
+                    * (target.x - g_Camera.target.x)
+                    / (target.y - g_Camera.target.y);
+        }
+    }
+
+    M_SmartShift(&target, M_Shift);
+    M_Move(&target, g_Camera.speed);
+}
+
+static void M_Fixed(void)
+{
+    const OBJECT_VECTOR *const fixed = Camera_GetFixedObject(g_Camera.num);
+    GAME_VECTOR target = {
+        .x = fixed->x,
+        .y = fixed->y,
+        .z = fixed->z,
+        .room_num = fixed->data,
+    };
+    if (g_TRVersion >= 2 && !LOS_Check(&g_Camera.target, &target, false)) {
+        M_ShiftClamp(&target, STEP_L);
+    }
+
+    g_Camera.fixed_camera = true;
+    M_Move(&target, g_Camera.speed);
+
+    if (g_Camera.timer != 0) {
+        g_Camera.timer--;
+        if (g_Camera.timer == 0) {
+            g_Camera.timer = -1;
+        }
+    }
+}
+
+static void M_Look(const ITEM *const item)
+{
+    const XYZ_32 old = {
+        .x = g_Camera.target.x,
+        .y = g_Camera.target.y,
+        .z = g_Camera.target.z,
+    };
+
+    g_Camera.target.z = item->pos.z;
+    g_Camera.target.x = item->pos.x;
+    g_Camera.target_distance = M_LOOK_DISTANCE;
+
+    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    g_Camera.target_angle =
+        item->rot.y + lara_info->torso_rot.y + lara_info->head_rot.y;
+    g_Camera.target_elevation =
+        item->rot.x + lara_info->torso_rot.x + lara_info->head_rot.x;
+
+    const int32_t distance =
+        (M_LOOK_DISTANCE * Math_Cos(g_Camera.target_elevation)) >> W2V_SHIFT;
+
+    g_Camera.shift =
+        (-STEP_L * 2 * Math_Sin(g_Camera.target_elevation)) >> W2V_SHIFT;
+    g_Camera.target.z += (g_Camera.shift * Math_Cos(item->rot.y)) >> W2V_SHIFT;
+    g_Camera.target.x += (g_Camera.shift * Math_Sin(item->rot.y)) >> W2V_SHIFT;
+
+    if (!M_IsGoodPosition(
+            g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
+            g_Camera.target.room_num)) {
+        g_Camera.target.x = item->pos.x;
+        g_Camera.target.z = item->pos.z;
+    }
+
+    g_Camera.target.y += M_ShiftClamp(&g_Camera.target, M_LOOK_CLAMP);
+
+    const XYZ_32 offset = {
+        .y =
+            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
+              >> W2V_SHIFT),
+        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
+        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
+    };
+
+    GAME_VECTOR target = {
+        .x = g_Camera.target.x + offset.x,
+        .y = g_Camera.target.y + offset.y,
+        .z = g_Camera.target.z + offset.z,
+        .room_num = g_Camera.pos.room_num,
+    };
+
+    M_SmartShift(&target, M_Clip);
+    g_Camera.target.z = old.z + (g_Camera.target.z - old.z) / g_Camera.speed;
+    g_Camera.target.x = old.x + (g_Camera.target.x - old.x) / g_Camera.speed;
+    M_Move(&target, g_Camera.speed);
+    g_Camera.debuff = 5;
+}
+
+static void M_ClampResult(void)
+{
+    XYZ_32 *const pos = &g_Camera.interp.result.pos;
+    const int32_t shift = g_Camera.interp.result.shift;
+    const ROOM *const room = Room_Get(g_Camera.interp.room_num);
+    const SECTOR *sector = Room_GetWorldSector(room, pos->x, pos->z);
+    if (sector->box != NO_BOX) {
+        goto finish;
+    }
+
+    sector = Room_GetWorldSector(room, g_Camera.pos.x, g_Camera.pos.z);
+    if (sector->box == NO_BOX) {
+        goto finish;
+    }
+
+    const BOX_INFO *const box = Box_GetBox(sector->box);
+    CLAMP(pos->x, box->top, box->bottom);
+    CLAMP(pos->z, box->left, box->right);
+
+finish:
+    const int32_t floor =
+        Room_GetHeightEx(sector, pos->x, pos->y, pos->z, true, NO_ITEM);
+    const int32_t ceiling =
+        Room_GetCeilingEx(sector, pos->x, pos->y, pos->z, true);
+    if (floor != NO_HEIGHT && ceiling != NO_HEIGHT) {
+        CLAMP(pos->y, ceiling - shift, floor - shift);
+    }
+    Room_GetSector(pos->x, pos->y + shift, pos->z, &g_Camera.interp.room_num);
+}
+
+static void M_Reset(void)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    ASSERT(lara_item != nullptr);
+    g_Camera.shift = lara_item->pos.y - WALL_L;
+
+    g_Camera.target.x = lara_item->pos.x;
+    g_Camera.target.y = g_Camera.shift;
+    g_Camera.target.z = lara_item->pos.z;
+    g_Camera.target.room_num = lara_item->room_num;
+
+    g_Camera.pos.x = g_Camera.target.x;
+    g_Camera.pos.y = g_Camera.target.y;
+    g_Camera.pos.z = g_Camera.target.z - 100;
+    g_Camera.pos.room_num = g_Camera.target.room_num;
+}
+
+static const CAMERA_STRATEGY m_Strategy = {
+    .get_chase_speed_func = M_GetChaseSpeed,
+    .chase_func = M_Chase,
+    .combat_func = M_Combat,
+    .look_func = M_Look,
+    .fixed_func = M_Fixed,
+    .clamp_result_func = M_ClampResult,
+    .reset_func = M_Reset,
+};
+
+REGISTER_CAMERA(CAMERA_MODE_TR1, m_Strategy)
+REGISTER_CAMERA(CAMERA_MODE_TR2, m_Strategy)

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -4,24 +4,15 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/game.h>
-#include <trx/game/input.h>
 #include <trx/game/lara.h>
-#include <trx/game/los.h>
 #include <trx/game/matrix.h>
 #include <trx/game/music.h>
-#include <trx/game/output.h>
-#include <trx/game/pathing.h>
-#include <trx/game/random.h>
+#include <trx/game/output/vars.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
-#include <trx/game/viewport.h>
-#include <trx/utils.h>
+#include <trx/version.h>
 
 // clang-format off
-#define M_MAX_ELEVATION     (85 * DEG_1) // = 15470
-#define M_COMBAT_DISTANCE   (WALL_L * 5 / 2) // = 2560
-#define M_LOOK_DISTANCE     (WALL_L * 3 / 2) // = 1536
-#define M_LOOK_CLAMP        (STEP_L + 50) // = 296
 #define M_MAX_HEAD_ROTATION (50 * DEG_1) // = 9100
 #define M_MIN_HEAD_ROTATION (-M_MAX_HEAD_ROTATION) // = -9100
 #define M_MAX_HEAD_TILT     (85 * DEG_1) // = 15470
@@ -32,52 +23,15 @@
 #define M_LOOK_SPEED        4
 // clang-format on
 
-#define M_SHIFT_ARGS                                                           \
-    int32_t *x, int32_t *y, int32_t *h, int32_t target_x, int32_t target_y,    \
-        int32_t target_h, int32_t left, int32_t top, int32_t right,            \
-        int32_t bottom
-
-typedef struct {
-    int16_t chase_speed;
-    int32_t min_square;
-    int32_t shift_scale;
-    bool test_shift_pair;
-    bool clip_shift_height;
-    bool test_early_lb_shift;
-} M_SETTINGS;
-
-static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
-    [CAMERA_MODE_TR1] = {
-        .chase_speed = 12,
-        .min_square = SQUARE(WALL_L / 4),
-        .shift_scale = 1,
-        .test_shift_pair = false,
-        .clip_shift_height = false,
-        .test_early_lb_shift = true,
-    },
-    [CAMERA_MODE_TR2] = {
-        .chase_speed = 10,
-        .min_square = SQUARE(WALL_L / 3),
-        .shift_scale = 2,
-        .test_shift_pair = true,
-        .clip_shift_height = true,
-        .test_early_lb_shift = false,
-    },
-};
+static CAMERA_STRATEGY m_Strategies[CAMERA_MODE_NUMBER_OF] = {};
 
 // Camera speed option ranges from 1-10, so index 0 is unused.
 static const double m_ManualCameraMultiplier[11] = {
     1.0, .5, .625, .75, .875, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0,
 };
 
-static BOX_INFO m_FixedBox = {};
 static bool m_IsChunky = false;
 static bool m_IsInitialised = false;
-
-static M_SETTINGS M_GetSettings(void)
-{
-    return m_CameraSettings[g_Config.visuals.camera_mode];
-}
 
 static void M_AdjustMusicVolume(const bool is_underwater)
 {
@@ -115,620 +69,15 @@ static void M_OffsetReset(void)
     g_Camera.additional_elevation = 0;
 }
 
-static const BOX_INFO *M_GetBox(
-    const SECTOR *const sector, const int32_t x, const int32_t z,
-    const bool generate_box)
+static const CAMERA_STRATEGY *M_GetStrategy(void)
 {
-    if (sector->box != NO_BOX) {
-        return Box_GetBox(sector->box);
-    }
-
-    if (!generate_box) {
-        return nullptr;
-    }
-
-    // A level may have blocked specific sector or room pathfinding, so create a
-    // dummy one-sector box to prevent erratic camera positioning.
-    m_FixedBox.left = z & ~(WALL_L - 1);
-    m_FixedBox.top = x & ~(WALL_L - 1);
-    m_FixedBox.right = m_FixedBox.left + WALL_L - 1;
-    m_FixedBox.bottom = m_FixedBox.top + WALL_L - 1;
-    return &m_FixedBox;
+    return &m_Strategies[g_Config.visuals.camera_mode];
 }
 
-static const SECTOR *M_GetSector(
-    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
+void Camera_RegisterStrategy(
+    const CAMERA_MODE mode, const CAMERA_STRATEGY strategy)
 {
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int32_t height = Room_GetHeight(sector, x, y, z);
-    const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-    if (y > height || y < ceiling) {
-        return nullptr;
-    }
-    return sector;
-}
-
-static bool M_IsGoodPosition(
-    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
-{
-    return M_GetSector(x, y, z, room_num) != nullptr;
-}
-
-static int32_t M_ShiftClamp(GAME_VECTOR *const pos, const int32_t clamp)
-{
-    const int32_t x = pos->x;
-    const int32_t y = pos->y;
-    const int32_t z = pos->z;
-
-    const SECTOR *const sector = Room_GetSector(x, y, z, &pos->room_num);
-    const BOX_INFO *const box = M_GetBox(sector, x, z, true);
-
-    const int32_t left = box->left + clamp;
-    const int32_t right = box->right - clamp;
-    if (z < left && !M_IsGoodPosition(x, y, z - clamp, pos->room_num)) {
-        pos->z = left;
-    } else if (z > right && !M_IsGoodPosition(x, y, z + clamp, pos->room_num)) {
-        pos->z = right;
-    }
-
-    const int32_t top = box->top + clamp;
-    const int32_t bottom = box->bottom - clamp;
-    if (x < top && !M_IsGoodPosition(x - clamp, y, z, pos->room_num)) {
-        pos->x = top;
-    } else if (
-        x > bottom && !M_IsGoodPosition(x + clamp, y, z, pos->room_num)) {
-        pos->x = bottom;
-    }
-
-    int32_t height = Room_GetHeight(sector, x, y, z) - clamp;
-    int32_t ceiling = Room_GetCeiling(sector, x, y, z) + clamp;
-
-    if (height < ceiling) {
-        ceiling = (height + ceiling) >> 1;
-        height = ceiling;
-    }
-
-    if (y > height) {
-        return height - y;
-    } else if (y < ceiling) {
-        return ceiling - y;
-    }
-
-    return 0;
-}
-
-static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
-{
-    LOS_Check(&g_Camera.target, target, false);
-
-    const ROOM *room = Room_Get(g_Camera.target.room_num);
-    const SECTOR *sector =
-        Room_GetWorldSector(room, g_Camera.target.x, g_Camera.target.z);
-    const BOX_INFO *box =
-        M_GetBox(sector, g_Camera.target.x, g_Camera.target.z, true);
-
-    room = Room_Get(target->room_num);
-    sector = Room_GetWorldSector(room, target->x, target->z);
-    if (room->flags.swamp) {
-        target->y = room->max_ceiling - STEP_L;
-        sector =
-            Room_GetSector(target->x, target->y, target->z, &target->room_num);
-    }
-
-    if (target->z < box->left || target->z > box->right || target->x < box->top
-        || target->x > box->bottom) {
-        box = M_GetBox(sector, target->x, target->z, true);
-    }
-
-    int32_t left = box->left;
-    int32_t right = box->right;
-    int32_t top = box->top;
-    int32_t bottom = box->bottom;
-
-    const M_SETTINGS settings = M_GetSettings();
-
-    int32_t test = (target->z - WALL_L) | (WALL_L - 1);
-    const SECTOR *const good_left =
-        M_GetSector(target->x, target->y, test, target->room_num);
-    if (good_left != nullptr) {
-        box = M_GetBox(good_left, target->x, test, false);
-        if (box != nullptr && box->left < left) {
-            left = box->left;
-        }
-    } else if (settings.test_shift_pair) {
-        left = test;
-    }
-
-    test = (target->z + WALL_L) & (~(WALL_L - 1));
-    const SECTOR *const good_right =
-        M_GetSector(target->x, target->y, test, target->room_num);
-    if (good_right != nullptr) {
-        box = M_GetBox(good_right, target->x, test, false);
-        if (box != nullptr && box->right > right) {
-            right = box->right;
-        }
-    } else if (settings.test_shift_pair) {
-        right = test;
-    }
-
-    test = (target->x - WALL_L) | (WALL_L - 1);
-    const SECTOR *const good_top =
-        M_GetSector(test, target->y, target->z, target->room_num);
-    if (good_top != nullptr) {
-        box = M_GetBox(good_top, test, target->z, false);
-        if (box != nullptr && box->top < top) {
-            top = box->top;
-        }
-    } else if (settings.test_shift_pair) {
-        top = test;
-    }
-
-    test = (target->x + WALL_L) & (~(WALL_L - 1));
-    const SECTOR *const good_bottom =
-        M_GetSector(test, target->y, target->z, target->room_num);
-    if (good_bottom != nullptr) {
-        box = M_GetBox(good_bottom, test, target->z, false);
-        if (box != nullptr && box->bottom > bottom) {
-            bottom = box->bottom;
-        }
-    } else if (settings.test_shift_pair) {
-        bottom = test;
-    }
-
-    left += STEP_L;
-    right -= STEP_L;
-    top += STEP_L;
-    bottom -= STEP_L;
-
-    GAME_VECTOR target_a = {
-        .x = target->x,
-        .y = target->y,
-        .z = target->z,
-        .room_num = target->room_num,
-    };
-
-    GAME_VECTOR target_b = {
-        .x = target->x,
-        .y = target->y,
-        .z = target->z,
-        .room_num = target->room_num,
-    };
-
-    bool clip = false;
-    bool prefer_a = !settings.test_shift_pair;
-
-#define SHIFT(axis1, axis2, l1, l2, r1, r2)                                    \
-    shift(                                                                     \
-        &target_a.axis1, &target_a.axis2, &target_a.y, g_Camera.target.axis1,  \
-        g_Camera.target.axis2, g_Camera.target.y, l1, l2, r1, r2);             \
-    shift(                                                                     \
-        &target_b.axis1, &target_b.axis2, &target_b.y, g_Camera.target.axis1,  \
-        g_Camera.target.axis2, g_Camera.target.y, l1, r2, r1, l2)
-
-    if (!settings.test_shift_pair) {
-        if (target->z < left && good_left == nullptr) {
-            clip = true;
-            if (target->x < g_Camera.target.x) {
-                SHIFT(z, x, left, top, right, bottom);
-            } else {
-                SHIFT(z, x, left, bottom, right, top);
-            }
-        } else if (target->z > right && good_right == nullptr) {
-            clip = true;
-            if (target->x < g_Camera.target.x) {
-                SHIFT(z, x, right, top, left, bottom);
-            } else {
-                SHIFT(z, x, right, bottom, left, top);
-            }
-        } else if (target->x < top && good_top == nullptr) {
-            clip = true;
-            if (target->z < g_Camera.target.z) {
-                SHIFT(x, z, top, left, bottom, right);
-            } else {
-                SHIFT(x, z, top, right, bottom, left);
-            }
-        } else if (target->x > bottom && good_bottom == nullptr) {
-            clip = true;
-            if (target->z < g_Camera.target.z) {
-                SHIFT(x, z, bottom, left, top, right);
-            } else {
-                SHIFT(x, z, bottom, right, top, left);
-            }
-        }
-    } else {
-        if (ABS(target->z - g_Camera.target.z)
-            > ABS(target->x - g_Camera.target.x)) {
-            if (target->z < left && good_left == nullptr) {
-                clip = true;
-                prefer_a = g_Camera.pos.x < g_Camera.target.x;
-                SHIFT(z, x, left, top, right, bottom);
-            } else if (target->z > right && good_right == nullptr) {
-                clip = true;
-                prefer_a = g_Camera.pos.x < g_Camera.target.x;
-                SHIFT(z, x, right, top, left, bottom);
-            } else if (target->x < top && good_top == nullptr) {
-                clip = true;
-                prefer_a = target->z < g_Camera.target.z;
-                SHIFT(x, z, top, left, bottom, right);
-            } else if (target->x > bottom && good_bottom == nullptr) {
-                clip = true;
-                prefer_a = target->z < g_Camera.target.z;
-                SHIFT(x, z, bottom, left, top, right);
-            }
-        } else {
-            if (target->x < top && good_top == nullptr) {
-                clip = true;
-                prefer_a = g_Camera.pos.z < g_Camera.target.z;
-                SHIFT(x, z, top, left, bottom, right);
-            } else if (target->x > bottom && good_bottom == nullptr) {
-                clip = true;
-                prefer_a = g_Camera.pos.z < g_Camera.target.z;
-                SHIFT(x, z, bottom, left, top, right);
-            } else if (target->z < left && good_left == nullptr) {
-                clip = true;
-                prefer_a = target->x < g_Camera.target.x;
-                SHIFT(z, x, left, top, right, bottom);
-            } else if (target->z > right && good_right == nullptr) {
-                clip = true;
-                prefer_a = target->x < g_Camera.target.x;
-                SHIFT(z, x, right, top, left, bottom);
-            }
-        }
-    }
-
-#undef SHIFT
-
-    if (clip == CLIP_NOT_VISIBLE) {
-        return;
-    }
-
-    if (settings.test_shift_pair) {
-        if (prefer_a) {
-            prefer_a = LOS_Check(&g_Camera.target, &target_a, false);
-        } else {
-            prefer_a = !LOS_Check(&g_Camera.target, &target_b, false);
-        }
-    }
-
-    if (prefer_a) {
-        target->pos = target_a.pos;
-    } else {
-        target->pos = target_b.pos;
-    }
-
-    Room_GetSector(target->x, target->y, target->z, &target->room_num);
-}
-
-static void M_Clip(M_SHIFT_ARGS)
-{
-    const int32_t x_diff = *x - target_x;
-    const int32_t y_diff = *y - target_y;
-    const int32_t h_diff = *h - target_h;
-    int32_t height = *h;
-
-    if ((right > left) != (target_x < left)) {
-        if (x_diff != 0) {
-            *y = target_y + (left - target_x) * y_diff / x_diff;
-            height = target_h + (left - target_x) * h_diff / x_diff;
-        }
-        *x = left;
-    }
-
-    if ((bottom > top && target_y > top && (*y) < top)
-        || (bottom < top && target_y < top && (*y) > top)) {
-        if (y_diff != 0) {
-            *x = target_x + (top - target_y) * x_diff / y_diff;
-            height = target_h + (top - target_y) * h_diff / y_diff;
-        }
-        *y = top;
-    }
-
-    const M_SETTINGS settings = M_GetSettings();
-    if (settings.clip_shift_height) {
-        *h = height;
-    }
-}
-
-static void M_Shift(M_SHIFT_ARGS)
-{
-    const int32_t l_square = SQUARE(target_x - left);
-    const int32_t r_square = SQUARE(target_x - right);
-    const int32_t t_square = SQUARE(target_y - top);
-    const int32_t b_square = SQUARE(target_y - bottom);
-
-    const int32_t tl_square = t_square + l_square;
-    const int32_t tr_square = t_square + r_square;
-    const int32_t bl_square = b_square + l_square;
-
-    const M_SETTINGS settings = M_GetSettings();
-    const int32_t scaled_target = g_Camera.target_square * settings.shift_scale;
-
-    int32_t shift;
-    if (g_Camera.target_square < tl_square) {
-        *x = left;
-        shift = g_Camera.target_square - l_square;
-        if (shift >= 0) {
-            shift = Math_Sqrt(shift);
-            *y = target_y + (top >= bottom ? shift : -shift);
-        }
-    } else if (tl_square > settings.min_square) {
-        *x = left;
-        *y = top;
-    } else if (g_Camera.target_square < bl_square) {
-        *x = left;
-        shift = g_Camera.target_square - l_square;
-        if (shift >= 0) {
-            shift = Math_Sqrt(shift);
-            *y = target_y + (top < bottom ? shift : -shift);
-        }
-    } else if (
-        settings.test_early_lb_shift && bl_square > settings.min_square) {
-        *x = left;
-        *y = bottom;
-    } else if (scaled_target < tr_square) {
-        shift = scaled_target - t_square;
-        if (shift >= 0) {
-            shift = Math_Sqrt(shift);
-            *x = target_x + (left < right ? shift : -shift);
-            *y = top;
-        }
-    } else if (settings.test_early_lb_shift || bl_square <= tr_square) {
-        *x = right;
-        *y = top;
-    } else {
-        *x = left;
-        *y = bottom;
-    }
-}
-
-static void M_Move(const GAME_VECTOR *const target, const int32_t speed)
-{
-    const GAME_VECTOR old_pos = g_Camera.pos;
-    GAME_VECTOR pos = g_Camera.pos;
-    pos.x += (target->x - pos.x) / speed;
-    pos.z += (target->z - pos.z) / speed;
-    pos.y += (target->y - pos.y) / speed;
-    pos.room_num = target->room_num;
-
-    Camera_SetChunky(false);
-
-    const SECTOR *sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-    int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
-    if (height == NO_HEIGHT) {
-        // Attempt to clamp within the previous sector's height bounds. Only if
-        // that fails continue to revert fully to the last good Y position.
-        pos.room_num = old_pos.room_num;
-        sector = Room_GetSector(old_pos.x, old_pos.y, old_pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, old_pos.x, old_pos.y, old_pos.z);
-        const int32_t old_ceiling =
-            Room_GetCeiling(sector, old_pos.x, old_pos.y, old_pos.z);
-        CLAMP(pos.y, old_ceiling + STEP_L, height - STEP_L);
-        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
-        if (height == NO_HEIGHT) {
-            pos.y = old_pos.y;
-            pos.room_num = old_pos.room_num;
-            sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-            height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
-        }
-    }
-
-    height -= STEP_L;
-    if (pos.y >= height && target->y >= height) {
-        LOS_Check(&g_Camera.target, &pos, false);
-        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, pos.x, pos.y, pos.z) - STEP_L;
-    }
-
-    g_Camera.pos = pos;
-
-    int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z) + STEP_L;
-    if (height < ceiling) {
-        ceiling = (height + ceiling) >> 1;
-        height = ceiling;
-    }
-
-    if (g_Camera.bounce > 0) {
-        g_Camera.pos.y += g_Camera.bounce;
-        g_Camera.target.y += g_Camera.bounce;
-        g_Camera.bounce = 0;
-    } else if (g_Camera.bounce < 0) {
-        const XYZ_32 shake = {
-            .x = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
-            .y = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
-            .z = g_Camera.bounce * (Random_GetControl() - 0x4000) / 0x7FFF,
-        };
-        g_Camera.pos.x += shake.x;
-        g_Camera.pos.y += shake.y;
-        g_Camera.pos.z += shake.z;
-        g_Camera.target.y += shake.x;
-        g_Camera.target.y += shake.y;
-        g_Camera.target.z += shake.z;
-        g_Camera.bounce += 5;
-    }
-
-    if (g_Camera.pos.y > height) {
-        g_Camera.shift = height - g_Camera.pos.y;
-    } else if (g_Camera.pos.y < ceiling) {
-        g_Camera.shift = ceiling - g_Camera.pos.y;
-    } else {
-        g_Camera.shift = 0;
-    }
-
-    Camera_UpdateMicPosition();
-}
-
-static void M_Chase(const ITEM *const item)
-{
-    g_Camera.target_elevation += item->rot.x;
-    g_Camera.target_elevation = MIN(g_Camera.target_elevation, M_MAX_ELEVATION);
-    g_Camera.target_elevation =
-        MAX(g_Camera.target_elevation, -M_MAX_ELEVATION);
-
-    const int32_t distance =
-        (g_Camera.target_distance * Math_Cos(g_Camera.target_elevation))
-        >> W2V_SHIFT;
-    const int16_t angle = g_Camera.target_angle + item->rot.y;
-
-    g_Camera.target_square = SQUARE(distance);
-
-    const XYZ_32 offset = {
-        .y = (g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-            >> W2V_SHIFT,
-        .x = -((distance * Math_Sin(angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(angle)) >> W2V_SHIFT),
-    };
-
-    GAME_VECTOR target = {
-        .x = g_Camera.target.x + offset.x,
-        .y = g_Camera.target.y + offset.y,
-        .z = g_Camera.target.z + offset.z,
-        .room_num = g_Camera.pos.room_num,
-    };
-
-    const M_SETTINGS settings = M_GetSettings();
-    const int16_t speed = g_TRVersion >= 2 || g_Camera.fixed_camera
-        ? g_Camera.speed
-        : settings.chase_speed;
-    M_SmartShift(&target, M_Shift);
-    M_Move(&target, speed);
-}
-
-static void M_Combat(const ITEM *const item)
-{
-    g_Camera.target.z = item->pos.z;
-    g_Camera.target.x = item->pos.x;
-    g_Camera.target_distance = M_COMBAT_DISTANCE;
-
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_info->target != nullptr) {
-        g_Camera.target_angle = lara_info->target_angles[0] + item->rot.y;
-        g_Camera.target_elevation = lara_info->target_angles[1] + item->rot.x;
-    } else {
-        g_Camera.target_angle =
-            lara_info->torso_rot.y + lara_info->head_rot.y + item->rot.y;
-        g_Camera.target_elevation =
-            lara_info->torso_rot.x + lara_info->head_rot.x + item->rot.x;
-    }
-
-    const int32_t distance =
-        (M_COMBAT_DISTANCE * Math_Cos(g_Camera.target_elevation)) >> W2V_SHIFT;
-
-    const XYZ_32 offset = {
-        .y =
-            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-              >> W2V_SHIFT),
-        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
-    };
-
-    GAME_VECTOR target = {
-        .x = g_Camera.target.x + offset.x,
-        .y = g_Camera.target.y + offset.y,
-        .z = g_Camera.target.z + offset.z,
-        .room_num = g_Camera.pos.room_num,
-    };
-
-    if (lara_info->water_status == LWS_UNDERWATER) {
-        const ITEM *const lara_item = Lara_GetItem();
-        const int32_t water_height =
-            lara_info->water_surface_dist + lara_item->pos.y;
-        if (g_Camera.target.y > water_height && water_height > target.y) {
-            target.y = lara_info->water_surface_dist + lara_item->pos.y;
-            target.z = g_Camera.target.z
-                + (water_height - g_Camera.target.y)
-                    * (target.z - g_Camera.target.z)
-                    / (target.y - g_Camera.target.y);
-            target.x = g_Camera.target.x
-                + (water_height - g_Camera.target.y)
-                    * (target.x - g_Camera.target.x)
-                    / (target.y - g_Camera.target.y);
-        }
-    }
-
-    M_SmartShift(&target, M_Shift);
-    M_Move(&target, g_Camera.speed);
-}
-
-static void M_Fixed(void)
-{
-    const OBJECT_VECTOR *const fixed = Camera_GetFixedObject(g_Camera.num);
-    GAME_VECTOR target = {
-        .x = fixed->x,
-        .y = fixed->y,
-        .z = fixed->z,
-        .room_num = fixed->data,
-    };
-    if (g_TRVersion >= 2 && !LOS_Check(&g_Camera.target, &target, false)) {
-        M_ShiftClamp(&target, STEP_L);
-    }
-
-    g_Camera.fixed_camera = true;
-    M_Move(&target, g_Camera.speed);
-
-    if (g_Camera.timer != 0) {
-        g_Camera.timer--;
-        if (g_Camera.timer == 0) {
-            g_Camera.timer = -1;
-        }
-    }
-}
-
-static void M_Look(const ITEM *const item)
-{
-    const XYZ_32 old = {
-        .x = g_Camera.target.x,
-        .y = g_Camera.target.y,
-        .z = g_Camera.target.z,
-    };
-
-    g_Camera.target.z = item->pos.z;
-    g_Camera.target.x = item->pos.x;
-    g_Camera.target_distance = M_LOOK_DISTANCE;
-
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    g_Camera.target_angle =
-        item->rot.y + lara_info->torso_rot.y + lara_info->head_rot.y;
-    g_Camera.target_elevation =
-        item->rot.x + lara_info->torso_rot.x + lara_info->head_rot.x;
-
-    const int32_t distance =
-        (M_LOOK_DISTANCE * Math_Cos(g_Camera.target_elevation)) >> W2V_SHIFT;
-
-    g_Camera.shift =
-        (-STEP_L * 2 * Math_Sin(g_Camera.target_elevation)) >> W2V_SHIFT;
-    g_Camera.target.z += (g_Camera.shift * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    g_Camera.target.x += (g_Camera.shift * Math_Sin(item->rot.y)) >> W2V_SHIFT;
-
-    if (!M_IsGoodPosition(
-            g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
-            g_Camera.target.room_num)) {
-        g_Camera.target.x = item->pos.x;
-        g_Camera.target.z = item->pos.z;
-    }
-
-    g_Camera.target.y += M_ShiftClamp(&g_Camera.target, M_LOOK_CLAMP);
-
-    const XYZ_32 offset = {
-        .y =
-            +((g_Camera.target_distance * Math_Sin(g_Camera.target_elevation))
-              >> W2V_SHIFT),
-        .x = -((distance * Math_Sin(g_Camera.target_angle)) >> W2V_SHIFT),
-        .z = -((distance * Math_Cos(g_Camera.target_angle)) >> W2V_SHIFT),
-    };
-
-    GAME_VECTOR target = {
-        .x = g_Camera.target.x + offset.x,
-        .y = g_Camera.target.y + offset.y,
-        .z = g_Camera.target.z + offset.z,
-        .room_num = g_Camera.pos.room_num,
-    };
-
-    M_SmartShift(&target, M_Clip);
-    g_Camera.target.z = old.z + (g_Camera.target.z - old.z) / g_Camera.speed;
-    g_Camera.target.x = old.x + (g_Camera.target.x - old.x) / g_Camera.speed;
-    M_Move(&target, g_Camera.speed);
-    g_Camera.debuff = 5;
+    m_Strategies[mode] = strategy;
 }
 
 bool Camera_IsChunky(void)
@@ -754,23 +103,11 @@ void Camera_Initialise(void)
 
 void Camera_ResetPosition(void)
 {
-    const ITEM *const lara_item = Lara_GetItem();
-    ASSERT(lara_item != nullptr);
-    g_Camera.shift = lara_item->pos.y - WALL_L;
-
-    g_Camera.target.x = lara_item->pos.x;
-    g_Camera.target.y = g_Camera.shift;
-    g_Camera.target.z = lara_item->pos.z;
-    g_Camera.target.room_num = lara_item->room_num;
-
-    g_Camera.pos.x = g_Camera.target.x;
-    g_Camera.pos.y = g_Camera.target.y;
-    g_Camera.pos.z = g_Camera.target.z - 100;
-    g_Camera.pos.room_num = g_Camera.target.room_num;
+    const CAMERA_STRATEGY *const strategy = M_GetStrategy();
+    strategy->reset_func();
 
     g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
     g_Camera.item = nullptr;
-
     g_Camera.speed = 1;
     g_Camera.flags = CF_NORMAL;
     g_Camera.bounce = 0;
@@ -800,32 +137,8 @@ void Camera_ClampInterpResult(void)
         return;
     }
 
-    XYZ_32 *const pos = &g_Camera.interp.result.pos;
-    const int32_t shift = g_Camera.interp.result.shift;
-    const ROOM *const room = Room_Get(g_Camera.interp.room_num);
-    const SECTOR *sector = Room_GetWorldSector(room, pos->x, pos->z);
-    if (sector->box != NO_BOX) {
-        goto finish;
-    }
-
-    sector = Room_GetWorldSector(room, g_Camera.pos.x, g_Camera.pos.z);
-    if (sector->box == NO_BOX) {
-        goto finish;
-    }
-
-    const BOX_INFO *const box = Box_GetBox(sector->box);
-    CLAMP(pos->x, box->top, box->bottom);
-    CLAMP(pos->z, box->left, box->right);
-
-finish:
-    const int32_t floor =
-        Room_GetHeightEx(sector, pos->x, pos->y, pos->z, true, NO_ITEM);
-    const int32_t ceiling =
-        Room_GetCeilingEx(sector, pos->x, pos->y, pos->z, true);
-    if (floor != NO_HEIGHT && ceiling != NO_HEIGHT) {
-        CLAMP(pos->y, ceiling - shift, floor - shift);
-    }
-    Room_GetSector(pos->x, pos->y + shift, pos->z, &g_Camera.interp.room_num);
+    const CAMERA_STRATEGY *const strategy = M_GetStrategy();
+    strategy->clamp_result_func();
 }
 
 void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
@@ -969,6 +282,8 @@ void Camera_Update(void)
         }
     }
 
+    const CAMERA_STRATEGY *const strategy = M_GetStrategy();
+
     if (g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT) {
         y -= STEP_L;
         g_Camera.target.room_num = item->room_num;
@@ -982,9 +297,9 @@ void Camera_Update(void)
         }
         g_Camera.fixed_camera = false;
         if (g_Camera.type == CAM_LOOK) {
-            M_Look(item);
+            strategy->look_func(item);
         } else {
-            M_Combat(item);
+            strategy->combat_func(item);
         }
     } else {
         if (fixed_camera) {
@@ -1025,9 +340,9 @@ void Camera_Update(void)
         }
 
         if (g_Camera.type == CAM_CHASE || g_Camera.flags == CF_CHASE_OBJECT) {
-            M_Chase(item);
+            strategy->chase_func(item);
         } else {
-            M_Fixed();
+            strategy->fixed_func();
         }
     }
 
@@ -1057,8 +372,7 @@ void Camera_Update(void)
         g_Camera.target_distance = M_CHASE_ELEVATION;
         g_Camera.flags = CF_NORMAL;
         if (g_TRVersion >= 2) {
-            const M_SETTINGS settings = M_GetSettings();
-            g_Camera.speed = settings.chase_speed;
+            g_Camera.speed = strategy->get_chase_speed_func();
         }
     }
     Camera_SetChunky(false);

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -182,10 +182,8 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
         g_Camera.item = nullptr;
     }
 
-    // TODO: check if this can be removed from TR2 during camera module merge.
-    // It is required not to be present in TR1 otherwise heavy triggers (that
-    // don't have camera data) can cancel active cameras triggered by Lara.
-    if (g_TRVersion >= 2 && g_Camera.num == -1 && g_Camera.timer > 0) {
+    if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1 && g_Camera.num == -1
+        && g_Camera.timer > 0) {
         g_Camera.timer = -1;
     }
 }
@@ -371,7 +369,7 @@ void Camera_Update(void)
         g_Camera.target_elevation = g_Camera.additional_elevation;
         g_Camera.target_distance = M_CHASE_ELEVATION;
         g_Camera.flags = CF_NORMAL;
-        if (g_TRVersion >= 2) {
+        if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1) {
             g_Camera.speed = strategy->get_chase_speed_func();
         }
     }

--- a/src/trx/game/camera/common.h
+++ b/src/trx/game/camera/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/config/types.h>
+#include <trx/game/camera/types.h>
 #include <trx/game/rooms/types.h>
 
 void Camera_Update(void);
@@ -14,3 +16,11 @@ void Camera_ResetPosition(void);
 void Camera_Reset(void);
 void Camera_ClampInterpResult(void);
 void Camera_RefreshFromTrigger(const TRIGGER *trigger);
+
+void Camera_RegisterStrategy(CAMERA_MODE mode, CAMERA_STRATEGY strategy);
+
+#define REGISTER_CAMERA(mode, strategy)                                        \
+    __attribute__((constructor)) static void M_RegisterCamera##mode(void)      \
+    {                                                                          \
+        Camera_RegisterStrategy(mode, strategy);                               \
+    }

--- a/src/trx/game/camera/types.h
+++ b/src/trx/game/camera/types.h
@@ -4,6 +4,16 @@
 #include <trx/game/types.h>
 
 typedef struct {
+    int16_t (*get_chase_speed_func)(void);
+    void (*chase_func)(const ITEM *item);
+    void (*combat_func)(const ITEM *item);
+    void (*look_func)(const ITEM *item);
+    void (*fixed_func)(void);
+    void (*clamp_result_func)(void);
+    void (*reset_func)(void);
+} CAMERA_STRATEGY;
+
+typedef struct {
     GAME_VECTOR pos;
     GAME_VECTOR target;
     CAMERA_TYPE type;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This separates the main camera logic with that of updating the position and target into a strategy-based approach. This will later allow defining the TR3 camera as a separate module.

I've also replaced most game version checks with mode checks instead - for example, removing the LOS check in TR2's fixed camera can be done by choosing TR1 mode. #2074 can be resolved as a result if we feel this is an acceptable approach? I don't want to remove the LOS check entirely as it will impact other areas badly.
