### PR TITLE
camera: add support for locked cameras

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the ability to control via Lua which enemies are allies and which are ones that will fight with allies (#3873)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)
 - added catalog object IDs to Lua
+- added support for locked cameras, similar to TR4+ (#2040)
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed ember emitters in TR2 to use the `SFX_LAVA_FOUNTAIN` sample (#4376)
 - changed the following trap types to support being reset (#3993)

--- a/src/meson.build
+++ b/src/meson.build
@@ -106,6 +106,7 @@ common_sources = [
   'trx/game/camera/box_camera.c',
   'trx/game/camera/cinematic.c',
   'trx/game/camera/common.c',
+  'trx/game/camera/environment.c',
   'trx/game/camera/fixed.c',
   'trx/game/camera/photo_mode.c',
   'trx/game/camera/vars.c',

--- a/src/trx/game/camera.h
+++ b/src/trx/game/camera.h
@@ -4,6 +4,7 @@
 #include <trx/game/camera/common.h>
 #include <trx/game/camera/const.h>
 #include <trx/game/camera/enum.h>
+#include <trx/game/camera/environment.h>
 #include <trx/game/camera/fixed.h>
 #include <trx/game/camera/photo_mode.h>
 #include <trx/game/camera/types.h>

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -1,16 +1,10 @@
 #include <trx/game/camera/common.h>
 
 #include <trx/config.h>
-#include <trx/debug.h>
 #include <trx/game/camera.h>
-#include <trx/game/game.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
-#include <trx/game/music.h>
-#include <trx/game/output/vars.h>
 #include <trx/game/rooms.h>
-#include <trx/game/sound.h>
-#include <trx/version.h>
 
 // clang-format off
 #define M_MAX_HEAD_ROTATION (50 * DEG_1) // = 9100
@@ -32,23 +26,6 @@ static const double m_ManualCameraMultiplier[11] = {
 
 static bool m_IsChunky = false;
 static bool m_IsInitialised = false;
-
-static void M_AdjustMusicVolume(const bool is_underwater)
-{
-    if (!Game_IsPlaying()) {
-        return;
-    }
-    const bool is_ambient =
-        Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
-    const bool is_cutscene = GF_GetCurrentLevel()->type == GFL_CUTSCENE;
-    const double base_volume = is_cutscene ? g_Config.audio.cutscene_volume
-        : is_ambient                       ? g_Config.audio.ambient_volume
-                                           : g_Config.audio.music_volume;
-    const double multiplier = !is_underwater || is_cutscene ? 1.0
-        : is_ambient ? g_Config.audio.underwater_ambient_volume
-                     : g_Config.audio.underwater_music_volume;
-    Music_SetVolume(base_volume * multiplier);
-}
 
 static void M_OffsetAdditionalAngle(const int16_t delta)
 {
@@ -139,72 +116,6 @@ void Camera_ClampInterpResult(void)
 
     const CAMERA_STRATEGY *const strategy = M_GetStrategy();
     strategy->clamp_result_func();
-}
-
-void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
-{
-    int16_t target_ok = 2;
-
-    const TRIGGER_CMD *cmd = trigger->command;
-    for (; cmd != nullptr; cmd = cmd->next_cmd) {
-        if (cmd->type == TO_CAMERA) {
-            const TRIGGER_CAMERA_DATA *const cam_data =
-                (TRIGGER_CAMERA_DATA *)cmd->parameter;
-            if (cam_data->camera_num == g_Camera.last) {
-                g_Camera.num = cam_data->camera_num;
-
-                if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
-                    || g_Camera.type == CAM_COMBAT) {
-                    g_Camera.timer = -1;
-                    target_ok = 0;
-                } else {
-                    g_Camera.type = CAM_FIXED;
-                    if (g_Config.visuals.fix_glide_cameras
-                        && cam_data->glide != 0) {
-                        g_Camera.speed = cam_data->glide + 1;
-                    }
-                    target_ok = 1;
-                }
-            } else {
-                target_ok = 0;
-            }
-        } else if (cmd->type == TO_TARGET) {
-            if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
-                g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
-            }
-        }
-    }
-
-    if (g_Camera.item != nullptr
-        && (target_ok == 0
-            || (target_ok == 2 && g_Camera.item->looked_at
-                && g_Camera.item != g_Camera.last_item))) {
-        g_Camera.item = nullptr;
-    }
-
-    if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1 && g_Camera.num == -1
-        && g_Camera.timer > 0) {
-        g_Camera.timer = -1;
-    }
-}
-
-void Camera_EnsureEnvironment(void)
-{
-    if (g_Camera.mic_pos.room_num != NO_ROOM) {
-        const ROOM *const room = Room_Get(g_Camera.mic_pos.room_num);
-        if (room->flags.underwater) {
-            M_AdjustMusicVolume(true);
-            Sound_Effect(SFX_UNDERWATER, nullptr, SPM_ALWAYS);
-        } else {
-            M_AdjustMusicVolume(false);
-            Sound_StopEffect(SFX_UNDERWATER);
-        }
-    }
-
-    if (g_Camera.pos.room_num != NO_ROOM) {
-        const ROOM *const room = Room_Get(g_Camera.pos.room_num);
-        g_Camera.underwater = room->flags.underwater;
-    }
 }
 
 void Camera_Update(void)
@@ -376,32 +287,6 @@ void Camera_Update(void)
     Camera_SetChunky(false);
     if (m_IsInitialised) {
         Camera_EnsureEnvironment();
-    }
-}
-
-void Camera_UpdateMicPosition(void)
-{
-    if (g_Config.audio.enable_lara_mic) {
-        const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-        const ITEM *const lara_item = Lara_GetItem();
-        g_Camera.actual_angle =
-            lara_info->torso_rot.y + lara_info->head_rot.y + lara_item->rot.y;
-        g_Camera.mic_pos.pos = lara_item->pos;
-        g_Camera.mic_pos.room_num = lara_item->room_num;
-    } else {
-        g_Camera.actual_angle = Math_Atan(
-            g_Camera.target.z - g_Camera.pos.z,
-            g_Camera.target.x - g_Camera.pos.x);
-        if (g_TRVersion == 1) {
-            g_Camera.mic_pos = g_Camera.pos;
-        } else {
-            g_Camera.mic_pos.pos.x = g_Camera.pos.x
-                + ((g_PhdPersp * Math_Sin(g_Camera.actual_angle)) >> W2V_SHIFT);
-            g_Camera.mic_pos.pos.z = g_Camera.pos.z
-                + ((g_PhdPersp * Math_Cos(g_Camera.actual_angle)) >> W2V_SHIFT);
-            g_Camera.mic_pos.pos.y = g_Camera.pos.y;
-            g_Camera.mic_pos.room_num = g_Camera.pos.room_num;
-        }
     }
 }
 

--- a/src/trx/game/camera/common.h
+++ b/src/trx/game/camera/common.h
@@ -2,11 +2,8 @@
 
 #include <trx/config/types.h>
 #include <trx/game/camera/types.h>
-#include <trx/game/rooms/types.h>
 
 void Camera_Update(void);
-void Camera_UpdateMicPosition(void);
-void Camera_EnsureEnvironment(void);
 void Camera_MoveManual(void);
 void Camera_Apply(void);
 bool Camera_IsChunky(void);
@@ -15,7 +12,6 @@ void Camera_Initialise(void);
 void Camera_ResetPosition(void);
 void Camera_Reset(void);
 void Camera_ClampInterpResult(void);
-void Camera_RefreshFromTrigger(const TRIGGER *trigger);
 
 void Camera_RegisterStrategy(CAMERA_MODE mode, CAMERA_STRATEGY strategy);
 

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -44,8 +44,10 @@ static inline M_TARGET_STATUS M_HandleCameraTrigger(
 
     g_Camera.num = cam_data->camera_num;
 
-    if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
-        || g_Camera.type == CAM_COMBAT) {
+    const bool is_look_or_combat =
+        g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT;
+    const bool is_locked = Camera_IsLocked(g_Camera.num);
+    if (g_Camera.timer < 0 || (is_look_or_combat && !is_locked)) {
         g_Camera.timer = -1;
         return TARGET_INVALID;
     }
@@ -60,7 +62,10 @@ static inline M_TARGET_STATUS M_HandleCameraTrigger(
 
 static inline void M_HandleTargetTrigger(const TRIGGER_CMD *const cmd)
 {
-    if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
+    const bool is_look_or_combat =
+        g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT;
+    const bool is_locked = Camera_IsLocked(g_Camera.num);
+    if (!is_look_or_combat || is_locked || g_Camera.num == NO_CAMERA) {
         g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
     }
 }

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -10,6 +10,12 @@
 #include <trx/game/sound.h>
 #include <trx/version.h>
 
+typedef enum {
+    TARGET_UNKNOWN,
+    TARGET_INVALID,
+    TARGET_VALID,
+} M_TARGET_STATUS;
+
 static void M_AdjustMusicVolume(const bool is_underwater)
 {
     if (!Game_IsPlaying()) {
@@ -27,46 +33,67 @@ static void M_AdjustMusicVolume(const bool is_underwater)
     Music_SetVolume(base_volume * multiplier);
 }
 
+static inline M_TARGET_STATUS M_HandleCameraTrigger(
+    const TRIGGER_CMD *const cmd)
+{
+    const TRIGGER_CAMERA_DATA *const cam_data =
+        (TRIGGER_CAMERA_DATA *)cmd->parameter;
+    if (cam_data->camera_num != g_Camera.last) {
+        return TARGET_INVALID;
+    }
+
+    g_Camera.num = cam_data->camera_num;
+
+    if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
+        || g_Camera.type == CAM_COMBAT) {
+        g_Camera.timer = -1;
+        return TARGET_INVALID;
+    }
+
+    g_Camera.type = CAM_FIXED;
+    if (g_Config.visuals.fix_glide_cameras && cam_data->glide != 0) {
+        g_Camera.speed = cam_data->glide + 1;
+    }
+
+    return TARGET_VALID;
+}
+
+static inline void M_HandleTargetTrigger(const TRIGGER_CMD *const cmd)
+{
+    if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
+        g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+    }
+}
+
+static inline void M_ValidateTriggerTarget(const M_TARGET_STATUS status)
+{
+    if (g_Camera.item == nullptr) {
+        return;
+    }
+
+    const bool is_new_item = g_Camera.item != g_Camera.last_item;
+    const bool item_was_looked_at = g_Camera.item->looked_at;
+
+    const bool should_clear = (status == TARGET_INVALID)
+        || (status == TARGET_UNKNOWN && item_was_looked_at && is_new_item);
+    if (should_clear) {
+        g_Camera.item = nullptr;
+    }
+}
+
 void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
 {
-    int16_t target_ok = 2;
-
-    const TRIGGER_CMD *cmd = trigger->command;
-    for (; cmd != nullptr; cmd = cmd->next_cmd) {
+    M_TARGET_STATUS status = TARGET_UNKNOWN;
+    for (const TRIGGER_CMD *cmd = trigger->command; cmd != nullptr;
+         cmd = cmd->next_cmd) {
         if (cmd->type == TO_CAMERA) {
-            const TRIGGER_CAMERA_DATA *const cam_data =
-                (TRIGGER_CAMERA_DATA *)cmd->parameter;
-            if (cam_data->camera_num == g_Camera.last) {
-                g_Camera.num = cam_data->camera_num;
-
-                if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
-                    || g_Camera.type == CAM_COMBAT) {
-                    g_Camera.timer = -1;
-                    target_ok = 0;
-                } else {
-                    g_Camera.type = CAM_FIXED;
-                    if (g_Config.visuals.fix_glide_cameras
-                        && cam_data->glide != 0) {
-                        g_Camera.speed = cam_data->glide + 1;
-                    }
-                    target_ok = 1;
-                }
-            } else {
-                target_ok = 0;
-            }
+            status = M_HandleCameraTrigger(cmd);
         } else if (cmd->type == TO_TARGET) {
-            if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
-                g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
-            }
+            M_HandleTargetTrigger(cmd);
         }
     }
 
-    if (g_Camera.item != nullptr
-        && (target_ok == 0
-            || (target_ok == 2 && g_Camera.item->looked_at
-                && g_Camera.item != g_Camera.last_item))) {
-        g_Camera.item = nullptr;
-    }
+    M_ValidateTriggerTarget(status);
 
     if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1 && g_Camera.num == -1
         && g_Camera.timer > 0) {

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -1,0 +1,120 @@
+#include <trx/game/camera/environment.h>
+
+#include <trx/config.h>
+#include <trx/game/camera.h>
+#include <trx/game/game.h>
+#include <trx/game/lara.h>
+#include <trx/game/music.h>
+#include <trx/game/output/vars.h>
+#include <trx/game/rooms.h>
+#include <trx/game/sound.h>
+#include <trx/version.h>
+
+static void M_AdjustMusicVolume(const bool is_underwater)
+{
+    if (!Game_IsPlaying()) {
+        return;
+    }
+    const bool is_ambient =
+        Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
+    const bool is_cutscene = GF_GetCurrentLevel()->type == GFL_CUTSCENE;
+    const double base_volume = is_cutscene ? g_Config.audio.cutscene_volume
+        : is_ambient                       ? g_Config.audio.ambient_volume
+                                           : g_Config.audio.music_volume;
+    const double multiplier = !is_underwater || is_cutscene ? 1.0
+        : is_ambient ? g_Config.audio.underwater_ambient_volume
+                     : g_Config.audio.underwater_music_volume;
+    Music_SetVolume(base_volume * multiplier);
+}
+
+void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
+{
+    int16_t target_ok = 2;
+
+    const TRIGGER_CMD *cmd = trigger->command;
+    for (; cmd != nullptr; cmd = cmd->next_cmd) {
+        if (cmd->type == TO_CAMERA) {
+            const TRIGGER_CAMERA_DATA *const cam_data =
+                (TRIGGER_CAMERA_DATA *)cmd->parameter;
+            if (cam_data->camera_num == g_Camera.last) {
+                g_Camera.num = cam_data->camera_num;
+
+                if (g_Camera.timer < 0 || g_Camera.type == CAM_LOOK
+                    || g_Camera.type == CAM_COMBAT) {
+                    g_Camera.timer = -1;
+                    target_ok = 0;
+                } else {
+                    g_Camera.type = CAM_FIXED;
+                    if (g_Config.visuals.fix_glide_cameras
+                        && cam_data->glide != 0) {
+                        g_Camera.speed = cam_data->glide + 1;
+                    }
+                    target_ok = 1;
+                }
+            } else {
+                target_ok = 0;
+            }
+        } else if (cmd->type == TO_TARGET) {
+            if (g_Camera.type != CAM_LOOK && g_Camera.type != CAM_COMBAT) {
+                g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
+            }
+        }
+    }
+
+    if (g_Camera.item != nullptr
+        && (target_ok == 0
+            || (target_ok == 2 && g_Camera.item->looked_at
+                && g_Camera.item != g_Camera.last_item))) {
+        g_Camera.item = nullptr;
+    }
+
+    if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1 && g_Camera.num == -1
+        && g_Camera.timer > 0) {
+        g_Camera.timer = -1;
+    }
+}
+
+void Camera_EnsureEnvironment(void)
+{
+    if (g_Camera.mic_pos.room_num != NO_ROOM) {
+        const ROOM *const room = Room_Get(g_Camera.mic_pos.room_num);
+        if (room->flags.underwater) {
+            M_AdjustMusicVolume(true);
+            Sound_Effect(SFX_UNDERWATER, nullptr, SPM_ALWAYS);
+        } else {
+            M_AdjustMusicVolume(false);
+            Sound_StopEffect(SFX_UNDERWATER);
+        }
+    }
+
+    if (g_Camera.pos.room_num != NO_ROOM) {
+        const ROOM *const room = Room_Get(g_Camera.pos.room_num);
+        g_Camera.underwater = room->flags.underwater;
+    }
+}
+
+void Camera_UpdateMicPosition(void)
+{
+    if (g_Config.audio.enable_lara_mic) {
+        const LARA_INFO *const lara_info = Lara_GetLaraInfo();
+        const ITEM *const lara_item = Lara_GetItem();
+        g_Camera.actual_angle =
+            lara_info->torso_rot.y + lara_info->head_rot.y + lara_item->rot.y;
+        g_Camera.mic_pos.pos = lara_item->pos;
+        g_Camera.mic_pos.room_num = lara_item->room_num;
+    } else {
+        g_Camera.actual_angle = Math_Atan(
+            g_Camera.target.z - g_Camera.pos.z,
+            g_Camera.target.x - g_Camera.pos.x);
+        if (g_TRVersion == 1) {
+            g_Camera.mic_pos = g_Camera.pos;
+        } else {
+            g_Camera.mic_pos.pos.x = g_Camera.pos.x
+                + ((g_PhdPersp * Math_Sin(g_Camera.actual_angle)) >> W2V_SHIFT);
+            g_Camera.mic_pos.pos.z = g_Camera.pos.z
+                + ((g_PhdPersp * Math_Cos(g_Camera.actual_angle)) >> W2V_SHIFT);
+            g_Camera.mic_pos.pos.y = g_Camera.pos.y;
+            g_Camera.mic_pos.room_num = g_Camera.pos.room_num;
+        }
+    }
+}

--- a/src/trx/game/camera/environment.h
+++ b/src/trx/game/camera/environment.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <trx/game/rooms/types.h>
+
+void Camera_RefreshFromTrigger(const TRIGGER *trigger);
+void Camera_EnsureEnvironment(void);
+void Camera_UpdateMicPosition(void);

--- a/src/trx/game/camera/fixed.c
+++ b/src/trx/game/camera/fixed.c
@@ -1,5 +1,9 @@
+#include <trx/game/camera/fixed.h>
+
+#include <trx/game/camera/const.h>
 #include <trx/game/game_buf.h>
-#include <trx/game/types.h>
+
+#define M_LOCKED_CAMERA 1
 
 static int32_t m_FixedObjectCount = 0;
 static OBJECT_VECTOR *m_FixedObjects = nullptr;
@@ -23,4 +27,14 @@ OBJECT_VECTOR *Camera_GetFixedObject(const int32_t object_idx)
         return nullptr;
     }
     return &m_FixedObjects[object_idx];
+}
+
+bool Camera_IsLocked(const int32_t camera_num)
+{
+    if (camera_num == NO_CAMERA) {
+        return false;
+    }
+
+    const OBJECT_VECTOR *const fixed_camera = Camera_GetFixedObject(camera_num);
+    return (fixed_camera->flags & M_LOCKED_CAMERA) != 0;
 }

--- a/src/trx/game/camera/fixed.h
+++ b/src/trx/game/camera/fixed.h
@@ -5,3 +5,4 @@
 void Camera_InitialiseFixedObjects(int32_t num_objects);
 int32_t Camera_GetFixedObjectCount(void);
 OBJECT_VECTOR *Camera_GetFixedObject(int32_t object_idx);
+bool Camera_IsLocked(int32_t camera_num);

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -1,10 +1,7 @@
 #include <trx/game/camera/photo_mode.h>
 
 #include <trx/config.h>
-#include <trx/game/camera/common.h>
-#include <trx/game/camera/const.h>
-#include <trx/game/camera/enum.h>
-#include <trx/game/camera/vars.h>
+#include <trx/game/camera.h>
 #include <trx/game/input.h>
 #include <trx/game/lara/pose.h>
 #include <trx/game/math.h>

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -513,7 +513,8 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
             g_Camera.num = cam_data->camera_num;
 
-            if (g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT) {
+            if ((g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT)
+                && !Camera_IsLocked(g_Camera.num)) {
                 break;
             }
 


### PR DESCRIPTION
Resolves #2040.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Adds support for TR4 locked cameras and moves some functions to a new camera module to reduce the scope of `common.c`.
