### PR TITLE
misc: assign unused enemies and document HP values

### DIFF
--- a/docs/06-lua/1-examples/README.md
+++ b/docs/06-lua/1-examples/README.md
@@ -7,7 +7,8 @@ title: Examples
 ### Adjusting enemy HP
 
 This example sets all bats to start with 20 hitpoints, and all wolves to start
-with 30 hitpoints. Simply adjust the lookup table to fit your needs.
+with 30 hitpoints. Simply adjust the lookup table to fit your needs. Refer to
+[this section](../../14-ENEMY_DEFAULTS.md) as a reference for original values.
 
 ```lua
 -- Lookup table mapping object IDs to HP

--- a/docs/14-ENEMY_DEFAULTS.md
+++ b/docs/14-ENEMY_DEFAULTS.md
@@ -1,0 +1,80 @@
+---
+title: Enemy defaults
+---
+
+# Enemy defaults
+
+### Tomb Raider 1
+
+| Game ID | TRX ID          | Hit points |
+| ------- | --------------- | ---------- |
+| `7`     | O_WOLF          | `6`        |
+| `8`     | O_BEAR          | `20`       |
+| `9`     | O_BAT           | `1`        |
+| `10`    | O_CROCODILE     | `20`       |
+| `11`    | O_ALLIGATOR     | `20`       |
+| `12`    | O_LION          | `30`       |
+| `13`    | O_LIONESS       | `25`       |
+| `14`    | O_PUMA          | `45`       |
+| `15`    | O_APE           | `22`       |
+| `16`    | O_RAT           | `5`        |
+| `17`    | O_VOLE          | `5`        |
+| `18`    | O_TREX          | `100`      |
+| `19`    | O_RAPTOR        | `20`       |
+| `20`    | O_WARRIOR_1     | `50`       |
+| `21`    | O_WARRIOR_2     | `50`       |
+| `22`    | O_WARRIOR_3     | `50`       |
+| `23`    | O_CENTAUR       | `120`      |
+| `24`    | O_MUMMY         | `18`       |
+| `25`    | O_DINO_WARRIOR  | `100`      |
+| `26`    | O_FISH          | `12`       |
+| `27`    | O_LARSON        | `50`       |
+| `28`    | O_PIERRE        | `70`       |
+| `30`    | O_SKATEKID      | `125`      |
+| `31`    | O_COWBOY        | `150`      |
+| `32`    | O_BALDY         | `200`      |
+| `33`    | O_NATLA         | `400`      |
+| `34`    | O_TORSO         | `500`      |
+| `145`   | O_SCION_ITEM_3  | `5`        |
+
+### Tomb Raider 2
+
+| Game ID | TRX ID          | Hit points |
+| ------- | --------------- | ---------- |
+| `15`    | O_DOG           | `10`       |
+| `16`    | O_CULT_1        | `25`       |
+| `17`    | O_CULT_1A       | `25`       |
+| `18`    | O_CULT_1B       | `25`       |
+| `19`    | O_CULT_2        | `60`       |
+| `20`    | O_CULT_3        | `150`      |
+| `21`    | O_MOUSE         | `4`        |
+| `22`    | O_DRAGON_FRONT  | `300`      |
+| `25`    | O_SHARK         | `30`       |
+| `26`    | O_EEL           | `5`        |
+| `27`    | O_BIG_EEL       | `20`       |
+| `28`    | O_BARRACUDA     | `12`       |
+| `29`    | O_DIVER         | `20`       |
+| `30`    | O_WORKER_1      | `25`       |
+| `31`    | O_WORKER_2      | `20`       |
+| `32`    | O_WORKER_3      | `27`       |
+| `33`    | O_WORKER_4      | `27`       |
+| `34`    | O_WORKER_5      | `20`       |
+| `35`    | O_JELLY         | `10`       |
+| `36`    | O_SPIDER        | `5`        |
+| `37`    | O_BIG_SPIDER    | `40`       |
+| `38`    | O_CROW          | `15`       |
+| `39`    | O_TIGER         | `20`       |
+| `41`    | O_XIAN_SPEARMAN | `100`      |
+| `43`    | O_XIAN_KNIGHT   | `80`       |
+| `45`    | O_YETI          | `30`       |
+| `46`    | O_BIRD_GUARDIAN | `200`      |
+| `47`    | O_EAGLE         | `20`       |
+| `48`    | O_BANDIT_1      | `45`       |
+| `49`    | O_BANDIT_2      | `50`       |
+| `50`    | O_BANDIT_2B     | `50`       |
+| `53`    | O_MONK_1        | `30`       |
+| `54`    | O_MONK_2        | `30`       |
+| `214`   | O_TREX          | `100`      |
+| `265`   | O_BEAR          | `30`       |
+| `266`   | O_WOLF          | `10`       |
+| `267`   | O_MONK_3        | `30`       |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)
 - added catalog object IDs to Lua
 - added support for locked cameras, similar to TR4+ (#2040)
+- added support to use `O_DINO_WARRIOR` and `O_FISH` as aliases for `O_TREX` and `O_BARRACUDA` respectively
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed ember emitters in TR2 to use the `SFX_LAVA_FOUNTAIN` sample (#4376)
 - changed the following trap types to support being reset (#3993)

--- a/src/trx/game/objects/creatures/barracuda.c
+++ b/src/trx/game/objects/creatures/barracuda.c
@@ -150,3 +150,4 @@ static void M_Setup(OBJECT *const obj)
 }
 
 REGISTER_OBJECT(O_BARRACUDA, M_Setup)
+REGISTER_OBJECT(O_FISH, M_Setup)

--- a/src/trx/game/objects/creatures/trex.c
+++ b/src/trx/game/objects/creatures/trex.c
@@ -190,3 +190,4 @@ static void M_Setup(OBJECT *const obj)
 }
 
 REGISTER_OBJECT(O_TREX, M_Setup)
+REGISTER_OBJECT(O_DINO_WARRIOR, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This assigns control to TR1's unused `O_DINO_WARRIOR` and `O_FISH` objects as the t-rex and barracuda respectively. All default enemy HP values have been documented as a guide for Lua adjustments.
