### PR TITLE
camera/environment: fix look at triggers

### DIFF
--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -65,7 +65,7 @@ static inline void M_HandleTargetTrigger(const TRIGGER_CMD *const cmd)
     const bool is_look_or_combat =
         g_Camera.type == CAM_LOOK || g_Camera.type == CAM_COMBAT;
     const bool is_locked = Camera_IsLocked(g_Camera.num);
-    if (!is_look_or_combat || is_locked || g_Camera.num == NO_CAMERA) {
+    if (!is_look_or_combat || is_locked) {
         g_Camera.item = Item_Get((int16_t)(intptr_t)cmd->parameter);
     }
 }


### PR DESCRIPTION
Resolves #4401.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the no camera test in checking trigger targets, which was inherited from the locked camera mode. TR4 forces look at triggers (e.g. `ALEXHUB.TR4` room 68), but this is undesirable in 1-3.
