### PR TITLE
output/rooms: always draw underwater rooms first

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)
 - fixed wading splashes spawning when using the fly cheat (#4400, regression from 1.0)
 - fixed grenades not exploding floating water creatures (#4399, regression from TR2X 1.3)
+- fixed water enemies not getting tinted when dead and floating (#4407, regression from 1.0)
 
 **TR1**:
 - fixed Lara standing two clicks below `O_FALLING_BLOCK_3` items rather than directly on top (#4374)

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -8,6 +8,7 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <stdlib.h>
 #include <string.h>
 
 #define M_MAX_BOUND_ROOMS 128
@@ -85,6 +86,28 @@ static int32_t m_OutsideBottom;
 static int32_t m_BoundStart;
 static int32_t m_BoundEnd;
 static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
+
+static int M_SortRoomsCmp(const void *const a_ptr, const void *const b_ptr)
+{
+    const int16_t a_room_num = *(const int16_t *)a_ptr;
+    const int16_t b_room_num = *(const int16_t *)b_ptr;
+    if (a_room_num == b_room_num) {
+        return 0;
+    }
+
+    const ROOM *const a_room = Room_Get(a_room_num);
+    const ROOM *const b_room = Room_Get(b_room_num);
+    const bool a_underwater = a_room->flags.underwater;
+    const bool b_underwater = b_room->flags.underwater;
+    if (a_underwater != b_underwater) {
+        return a_underwater ? -1 : 1;
+    }
+    if (a_room_num < b_room_num) {
+        return -1;
+    } else {
+        return 1;
+    }
+}
 
 static void M_SetBounds(
     const PORTAL *const portal, int32_t room_num, const ROOM *parent);
@@ -461,6 +484,12 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
 
     if (g_TRVersion == 1 || m_Outside) {
         M_DrawSkybox();
+    }
+
+    if (m_DrawCount > 1) {
+        qsort(
+            m_RoomsToDraw, (size_t)m_DrawCount, sizeof(m_RoomsToDraw[0]),
+            M_SortRoomsCmp);
     }
 
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4407.