### PR TITLE
lara/control: enable baddie push underwater

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed wading splashes spawning when using the fly cheat (#4400, regression from 1.0)
 - fixed grenades not exploding floating water creatures (#4399, regression from TR2X 1.3)
 - fixed water enemies not getting tinted when dead and floating (#4407, regression from 1.0)
+- fixed Lara not colliding with mines/gondolas when underwater (#4424, regression from TR2X 1.3)
 
 **TR1**:
 - fixed Lara standing two clicks below `O_FALLING_BLOCK_3` items rather than directly on top (#4374)

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -643,9 +643,8 @@ void Creature_Collision(
         return;
     }
 
-    if (g_TRVersion >= 2
-        && (lara->water_status == LWS_UNDERWATER
-            || lara->water_status == LWS_SURFACE)) {
+    if (lara->water_status == LWS_UNDERWATER
+        || lara->water_status == LWS_SURFACE) {
         return;
     }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -505,7 +505,7 @@ static void M_HandleUnderwater(COLL_INFO *const coll)
     coll->slopes_are_pits = 0;
     coll->lava_is_pit = 0;
     coll->enable_hit = 0;
-    coll->enable_baddie_push = 0;
+    coll->enable_baddie_push = 1;
 
     Lara_Look_Update();
     Lara_State_Update(item, coll);


### PR DESCRIPTION
Resolves #4424.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR1 originally disabled baddie push when underwater as a whole, so this was mistakenly inherited in TR2 during merging. TR1 now uses the same approach as TR2 in creature collision to detect water status, and so object collision for other types is restored when swimming.
