### PR TITLE
inventory: use defined quantity on item insert

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed grenades not exploding floating water creatures (#4399, regression from TR2X 1.3)
 - fixed water enemies not getting tinted when dead and floating (#4407, regression from 1.0)
 - fixed Lara not colliding with mines/gondolas when underwater (#4424, regression from TR2X 1.3)
+- fixed flare box pickups containig only one flare if Lara has none in her inventory at that time (#4423, regression from 1.0)
 
 **TR1**:
 - fixed Lara standing two clicks below `O_FALLING_BLOCK_3` items rather than directly on top (#4374)

--- a/src/trx/game/inventory.c
+++ b/src/trx/game/inventory.c
@@ -129,6 +129,11 @@ OBJECT_ID Inv_GetItemOption(const OBJECT_ID object_id)
 
 void Inv_InsertItem(INVENTORY_ITEM *const inv_item)
 {
+    Inv_InsertItemEx(inv_item, 1);
+}
+
+void Inv_InsertItemEx(INVENTORY_ITEM *const inv_item, const int32_t qty)
+{
     ASSERT(inv_item != nullptr);
     INV_RING_SOURCE *const source = &g_InvRing_Source[M_GetRingType(inv_item)];
 
@@ -144,7 +149,7 @@ void Inv_InsertItem(INVENTORY_ITEM *const inv_item)
         source->qtys[i + 1] = source->qtys[i];
     }
     source->items[n] = inv_item;
-    source->qtys[n] = 1;
+    source->qtys[n] = MIN(qty, MAX_QTY);
     source->count++;
 }
 
@@ -238,12 +243,11 @@ bool Inv_AddItem(const OBJECT_ID object_id)
         }
     }
 
+    const int32_t qty = object_id == O_FLAREBOX_ITEM ? M_GetFlareQuantity() : 1;
     for (RING_TYPE ring_type = 0; ring_type < RT_NUMBER_OF; ring_type++) {
         INV_RING_SOURCE *const source = &g_InvRing_Source[ring_type];
         for (int32_t i = 0; i < source->count; i++) {
             if (source->items[i]->object_id == inv_object_id) {
-                const int32_t qty =
-                    object_id == O_FLAREBOX_ITEM ? M_GetFlareQuantity() : 1;
                 source->qtys[i] += qty;
                 CLAMPG(source->qtys[i], MAX_QTY);
                 return true;
@@ -277,7 +281,7 @@ bool Inv_AddItem(const OBJECT_ID object_id)
             *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
         if (inv_item->object_id == object_id
             || inv_item->object_id == inv_object_id) {
-            Inv_InsertItem(inv_item);
+            Inv_InsertItemEx(inv_item, qty);
             return true;
         }
     }

--- a/src/trx/game/inventory.h
+++ b/src/trx/game/inventory.h
@@ -11,6 +11,7 @@ extern INVENTORY_MODE g_Inv_Mode;
 bool Inv_AddItemNTimes(OBJECT_ID obj_id, int32_t qty);
 OBJECT_ID Inv_GetItemOption(OBJECT_ID obj_id);
 void Inv_InsertItem(INVENTORY_ITEM *inv_item);
+void Inv_InsertItemEx(INVENTORY_ITEM *inv_item, int32_t qty);
 bool Inv_RemoveItem(OBJECT_ID obj_id);
 int32_t Inv_RequestItem(OBJECT_ID obj_id);
 void Inv_ClearSelection(void);


### PR DESCRIPTION
Resolves #4423.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows a quantity to be passed when inserting an item in the inventory, so allowing for the correct flare values to be used.
