### PR TITLE
objects/gondola: update room number when sinking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - changed the fonts to use dedicated sprites for accented characters instead of composing them at runtime
 - changed the fonts to use dedicated sprites for similar-looking characters instead of using aliases
 - fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
+- fixed gondolas not being drawn with an underwater tint when they have sunk (#4428)
 - fixed skybox faces with transparent pixels always rendering in front of all other faces (#4351, regression from 1.0)
 - fixed unbound inputs not being saved between game launches (#4360, regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara drawing a flare when the draw weapons input is pressed, and she already has an active flare but no weapons (#4361, regression from TR2X 1.4)

--- a/src/trx/game/objects/traps/gondola.c
+++ b/src/trx/game/objects/traps/gondola.c
@@ -3,7 +3,8 @@
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 
-#define GONDOLA_SINK_SPEED 50
+#define M_SINK_SPEED 50
+#define M_SINK_ROOM_SHIFT (STEP_L * 3 / 2)
 
 static void M_Control(const int16_t item_num)
 {
@@ -18,13 +19,17 @@ static void M_Control(const int16_t item_num)
         break;
 
     case GONDOLA_STATE_SINK: {
-        gondola->pos.y = gondola->pos.y + GONDOLA_SINK_SPEED;
+        gondola->pos.y = gondola->pos.y + M_SINK_SPEED;
+        const ANIM_FRAME *const frame = Item_GetBestFrame(gondola);
+        const int16_t room_shift = frame->bounds.min.y + M_SINK_ROOM_SHIFT;
         int16_t room_num = gondola->room_num;
         const SECTOR *const sector = Room_GetSector(
-            gondola->pos.x, gondola->pos.y, gondola->pos.z, &room_num);
+            gondola->pos.x, gondola->pos.y + room_shift, gondola->pos.z,
+            &room_num);
         const int32_t height = Room_GetHeight(
             sector, gondola->pos.x, gondola->pos.y, gondola->pos.z);
         gondola->floor = height;
+        Item_UpdateRoom(item_num, room_num);
 
         if (gondola->pos.y >= height) {
             gondola->goal_anim_state = GONDOLA_STATE_LAND;


### PR DESCRIPTION
Resolves #4428.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures a gondola's room number is updated when sinking, to ensure it is correctly tinted. Because of its size, a shift is performed on the Y position for a more realistic transition.
