### PR TITLE
output/objects: apply caustics to uw statics

### DIFF
--- a/data/common/ship/shaders/lights.glsl
+++ b/data/common/ship/shaders/lights.glsl
@@ -114,14 +114,15 @@ float light(float shade, uint flags, vec3 normal, vec4 pos, float phase)
     } else if ((flags & VERT_USE_OBJECT_LIGHT) != 0u) {
         shade = lightObjects(normal, pos);
     } else {
-        if (uWaterEffect) {
-            shade = lightWaterCaustics(shade, pos.xyz);
-        }
         if ((flags & VERT_USE_DYNAMIC_LIGHT) != 0u) {
             shade = lightDynamic(shade, pos);
             shade += lightRoom(uRoomLightMode, uTimeInGame, phase);
         }
         shade = clamp(shade, 0, SHADE_MAX);
+    }
+
+    if (uWaterEffect) {
+        shade = lightWaterCaustics(shade, pos.xyz);
     }
 
     return shade;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added catalog object IDs to Lua
 - added support for locked cameras, similar to TR4+ (#2040)
 - added support to use `O_DINO_WARRIOR` and `O_FISH` as aliases for `O_TREX` and `O_BARRACUDA` respectively
+- changed underwater statics to be affected by caustics, even if they don't get merged into level geometry (#4430)
 - changed the swinging axe to be defined separately from other pendulums (use object `O_SWINGING_AXE` in catalogs)
 - changed the following trap types to support being reset (#3993)
   - collapsible tiles

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -337,6 +337,7 @@ static void M_ReadObjectMesh(OBJECT_MESH *const mesh, VFILE *const file)
     VFile_Skip(file, sizeof(int16_t));
 
     mesh->enable_reflections = false;
+    mesh->enable_caustics = false;
     mesh->depth_adjustment = 0.005;
 
     {
@@ -1060,6 +1061,8 @@ void Level_ReadStaticObjects(
         if (loader->game_version >= 3) {
             obj->collidable = true;
         }
+
+        Object_GetMesh(obj->mesh_idx)->enable_caustics = true;
     }
 
     Benchmark_End(&benchmark, nullptr);

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -35,6 +35,7 @@ typedef struct {
 
     float depth_adjustment;
     bool enable_reflections;
+    bool enable_caustics;
 } OBJECT_MESH;
 
 typedef struct {

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -216,7 +216,7 @@ static void M_Stage(const OBJECT_MESH *const mesh)
         .wmatrix = *g_WMatrixPtr,
         .tint = Output_GetTint(),
         .wibble = false,
-        .water_effect = false,
+        .water_effect = mesh->enable_caustics && Output_GetWaterEffect(),
         .light_info = {
             .ls_adder = Output_GetLightAdder(),
             .ls_divider = Output_GetLightDivider(),

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -481,11 +481,7 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     const ITEM *const lara_item = Lara_GetItem();
     if (Object_Get(O_LARA)->loaded) {
         const ROOM *const lara_room = Room_Get(lara_item->room_num);
-        if (lara_room->flags.underwater) {
-            Output_SetupBelowWater(g_Camera.underwater);
-        } else {
-            Output_SetupAboveWater(g_Camera.underwater);
-        }
+        M_SetupWaterStatus(lara_room);
         Output_SetCurrentRoom(lara_room);
         Lara_Draw(lara_item);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR makes sure that the underwater static objects get always affected by caustics, regardless of whether the editor merged the statics into level geometry or not.

Resolves #4430.

This change affects the following areas in the OGs:

- Sanctuary of the Scion room 5 (huge statues)
- Natla's Mines room 4 and 83 (barrels)
- Venice rooms 11 and 106 (underwater pole)
- Bartoli's Hideout rooms 28, 126, 127, 134, 142, 154, 164 (underwater pole)
- Bartoli's Hideout room 39 (windows)
- Offshore Rig room 85 (barrels)
- Diving Area room 70 (minisub)
- 40 Fathoms rooms 0, 2 (barrels)
- 40 Fathoms room 60 (railing)
- Living Quarters rooms 3, 15, 17 (seaweed)
- Living Quarters room 40 (barrels)
- Temple of Xian rooms 61, 81 (skeleton)
- The River Ganges rooms 5, 166 (fallen blocks)
- Coastal Village room 193 (pulley)
- Madubu Gorge room 62 (bathtub plug)
- Thames Wharf rooms 20, 76 (propeller support)
- Aldwych room 77 (safe)
- High Security Compound room 29 (toilets)
- RX-Tech Mines room 20 (lamp)
- RX-Tech Mines rooms 22, 24, 26, 30 (bathyscaphe)