### PR TITLE
level/loader: fix TR3 sample property reading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - added high-resolutions 16:9 and 4:3 credit images
     To download the new images ahead of a stable release, please see the [TRX data](https://github.com/LostArtefacts/TRX-data) repository.
 - added support for the serif font (no colors just yet)
+- fixed sample reading to support correct pitch and volume
 
 ## [1.0.3](https://github.com/LostArtefacts/TRX/compare/trx-1.0.2...trx-1.0.3) - 2025-11-27
 - fixed the conveyer belt fuse in Natla's Mines not appearing after using the nearby switch (#4349, regression from 1.0)

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1380,7 +1380,7 @@ void Level_ReadSamples(const LEVEL_LOADER *const loader, VFILE *const file)
         sample_info->number = VFile_ReadS16(file);
 
         if (loader->game_version >= 3) {
-            sample_info->volume = VFile_ReadU8(file) << 8;
+            sample_info->volume = VFile_ReadU8(file) << 7;
             sample_info->range = VFile_ReadU8(file) * WALL_L;
         } else if (loader->game_version == 2) {
             sample_info->volume = VFile_ReadU16(file);
@@ -1392,7 +1392,7 @@ void Level_ReadSamples(const LEVEL_LOADER *const loader, VFILE *const file)
 
         if (loader->game_version >= 3) {
             sample_info->randomness = VFile_ReadU8(file);
-            sample_info->pitch = VFile_ReadU8(file);
+            sample_info->pitch = VFile_ReadS8(file);
         } else {
             sample_info->randomness = VFile_ReadU16(file);
             sample_info->pitch = 0;

--- a/src/trx/game/sound/types.h
+++ b/src/trx/game/sound/types.h
@@ -9,7 +9,7 @@ typedef struct {
     int16_t volume;
     int32_t range;
     int32_t randomness;
-    uint8_t pitch;
+    int8_t pitch;
     union {
         struct {
             uint16_t mode_bits : 2;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR3 samples have signed pitch values and volume is shifted by 7 rather than 8, so this corrects the level loader to match.

Water splash doesn't play (unless in shallow water) because this is no longer an anim command and hardcoded elsewhere, so that's an integration task later. There may be others like this.
