### PR TITLE
lua: add object mesh swap ability

### DIFF
--- a/data/common/ship/scripting/trx/objects.lua
+++ b/data/common/ship/scripting/trx/objects.lua
@@ -1,0 +1,7 @@
+local raw = trxc.objects
+
+local objects = {
+  swap_mesh = raw.swap_mesh,
+}
+
+trx.objects = objects

--- a/data/tr2/ship/cfg/tr2/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2/gameflow.json5
@@ -459,6 +459,7 @@
         // 16. Floating Islands
         {
             "path": "data/floating.tr2",
+            "script": "data/scripts/floating.lua",
             "music_track": 55,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/china.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/data/tr2/ship/data/scripts/floating.lua
+++ b/data/tr2/ship/data/scripts/floating.lua
@@ -1,0 +1,3 @@
+trx.events.on_level_start(function(level)
+  trx.objects.swap_mesh(trx.catalog.objects.O_SECRET_2_OPTION, trx.catalog.objects.O_SECRET_3_OPTION, 0, 0)
+end)

--- a/docs/06-lua/2-reference/14-OBJECTS.md
+++ b/docs/06-lua/2-reference/14-OBJECTS.md
@@ -1,0 +1,23 @@
+---
+title: Object
+---
+
+## Object module
+
+Module for controlling game objects.
+
+### Functions
+
+- [lua]`trx.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)`  
+    Swaps the given meshes of the given objects.  
+    Examples:
+    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.O_PIERRE, trx.catalog.objects.O_LARSON, 8, 8)`  
+      Pierre now has Larson's head, and vice-versa
+
+- [lua]`trx.objects.swap_mesh(obj1_id, obj2_id)`  
+    Similar to above, but this will swap out all meshes rather than specific ones. This works best when both objects have the same mesh count; if one object has fewer meshes than the other, the minimum count will be used.  
+    Examples:
+    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.O_PIERRE, trx.catalog.objects.O_LARSON)`  
+      Pierre and Larson's meshes are fully swapped
+    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.O_PIERRE, trx.catalog.objects.O_WARRIOR_1)`  
+      Pierre's 15 meshes are now of mutant type; the mutant's first 15 meshes are Pierre's, the rest are default.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added the ability to control via Lua which enemies are allies and which are ones that will fight with allies (#3873)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)
 - added catalog object IDs to Lua
+- added the ability to swap meshes in Lua
 - added support for locked cameras, similar to TR4+ (#2040)
 - added support to use `O_DINO_WARRIOR` and `O_FISH` as aliases for `O_TREX` and `O_BARRACUDA` respectively
 - changed underwater statics to be affected by caustics, even if they don't get merged into level geometry (#4430)

--- a/src/meson.build
+++ b/src/meson.build
@@ -270,6 +270,7 @@ common_sources = [
   'trx/game/lua/lara.c',
   'trx/game/lua/log.c',
   'trx/game/lua/music.c',
+  'trx/game/lua/objects.c',
   'trx/game/lua/rooms.c',
   'trx/game/lua/sound.c',
   'trx/game/math/trig.c',

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -33,6 +33,7 @@ extern void LUA_CreateConfig(lua_State *L);
 extern void LUA_CreateRooms(lua_State *L);
 extern void LUA_CreateGame(lua_State *L);
 extern void LUA_CreateCreatures(lua_State *L);
+extern void LUA_CreateObjects(lua_State *const L);
 
 static int M_LoadFile(lua_State *const L, const char *const path)
 {
@@ -175,6 +176,7 @@ void LUA_Init(void)
     M_LoadTRXCModule(L, LUA_CreateRooms);
     M_LoadTRXCModule(L, LUA_CreateGame);
     M_LoadTRXCModule(L, LUA_CreateCreatures);
+    M_LoadTRXCModule(L, LUA_CreateObjects);
 
     M_PRIV *const p = &m_Priv;
     p->state = L;
@@ -191,6 +193,7 @@ void LUA_Init(void)
     M_LoadTRXModule(L, "rooms.lua");
     M_LoadTRXModule(L, "game.lua");
     M_LoadTRXModule(L, "creatures.lua");
+    M_LoadTRXModule(L, "objects.lua");
 }
 
 void LUA_Shutdown(void)

--- a/src/trx/game/lua/objects.c
+++ b/src/trx/game/lua/objects.c
@@ -1,0 +1,29 @@
+#include <trx/game/objects.h>
+
+#include <lauxlib.h>
+
+// trxc.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)
+static int M_L_ObjectsSwapMesh(lua_State *const L)
+{
+    const int32_t arg_count = lua_gettop(L);
+    const OBJECT_ID obj1_id = luaL_checkinteger(L, 1);
+    const OBJECT_ID obj2_id = luaL_checkinteger(L, 2);
+    if (arg_count == 2) {
+        Object_SwapAllMeshes(obj1_id, obj2_id);
+    } else {
+        const int32_t mesh1_num = luaL_checkinteger(L, 3);
+        const int32_t mesh2_num = luaL_checkinteger(L, 4);
+        Object_SwapMeshEx(obj1_id, obj2_id, mesh1_num, mesh2_num);
+    }
+    return 0;
+}
+
+void LUA_CreateObjects(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+    lua_pushcfunction(L, M_L_ObjectsSwapMesh);
+    lua_setfield(L, -2, "swap_mesh");
+    lua_setfield(L, -2, "objects");
+    lua_pop(L, 1);
+}

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -185,6 +185,21 @@ void Object_SwapMesh(
     Object_SwapMeshEx(object1_id, object2_id, mesh_num, mesh_num);
 }
 
+void Object_SwapAllMeshes(
+    const OBJECT_ID object1_id, const OBJECT_ID object2_id)
+{
+    const OBJECT *const obj1 = Object_Get(object1_id);
+    const OBJECT *const obj2 = Object_Get(object2_id);
+    if (!obj1->loaded || !obj2->loaded) {
+        return;
+    }
+
+    const int32_t mesh_count = MIN(obj1->mesh_count, obj2->mesh_count);
+    for (int32_t i = 0; i < mesh_count; i++) {
+        Object_SwapMeshEx(object1_id, object2_id, i, i);
+    }
+}
+
 void Object_SwapMeshEx(
     const OBJECT_ID object1_id, const OBJECT_ID object2_id,
     const int32_t mesh_num1, const int32_t mesh_num2)

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -51,6 +51,7 @@ void Object_SetMeshOffset(OBJECT_MESH *mesh, int32_t data_offset);
 OBJECT_MESH *Object_GetMesh(int32_t index);
 void Object_SwapMesh(
     OBJECT_ID object1_id, OBJECT_ID object2_id, int32_t mesh_num);
+void Object_SwapAllMeshes(OBJECT_ID object1_id, OBJECT_ID object2_id);
 void Object_SwapMeshEx(
     OBJECT_ID object1_id, OBJECT_ID object2_id, int32_t mesh_num1,
     int32_t mesh_num2);


### PR DESCRIPTION
Resolves #4437.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds the ability to swap meshes via Lua, and thereby provides a quick way to fix the 3D secrets in Floating Islands. It avoids another injection difference, and having to disable inheritance for this level.
