### PR TITLE
output: fade patterned inventory backgrounds

### DIFF
--- a/data/common/ship/shaders/2d.glsl
+++ b/data/common/ship/shaders/2d.glsl
@@ -14,6 +14,7 @@
 #define WAVE_FPS_DRIFT 25 / 30
 
 uniform int uEffect;
+uniform float uOpacity;
 
 #ifdef VERTEX
 
@@ -78,6 +79,10 @@ void main(void) {
     }
 
     outColor.rgb *= uBrightnessMultiplier;
+
+    outColor.a *= clamp(uOpacity, 0.0, 1.0);
+    // Output premultiplied alpha so callers can use (ONE, ONE_MINUS_SRC_ALPHA).
+    outColor.rgb *= outColor.a;
 }
 
 #endif

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...develop) - ××××-××-××
+- added a fade-in and fade-out effect to patterned inventory backgrounds
 - added the ability to control whether or not allies are hostile towards Lara via Lua (#3873)
 - added the ability to control via Lua which enemies are allies and which are ones that will fight with allies (#3873)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)

--- a/src/trx/game/fader.c
+++ b/src/trx/game/fader.c
@@ -49,6 +49,14 @@ int32_t Fader_GetCurrentValue(const FADER *const fader)
         }
         return FADER_TRANSPARENT;
     }
+    return Fader_GetRealValue(fader);
+}
+
+int32_t Fader_GetRealValue(const FADER *const fader)
+{
+    if (!g_Config.visuals.enable_fade_effects || fader->args.duration == 0.0) {
+        return fader->args.target;
+    }
     const double elapsed_time = ClockTimer_PeekElapsed(&fader->timer);
     const double target_time = fader->args.duration;
     double ratio = elapsed_time / target_time;

--- a/src/trx/game/fader.h
+++ b/src/trx/game/fader.h
@@ -30,4 +30,5 @@ void Fader_InitEx(FADER *fader, FADER_ARGS args);
 void Fader_Init(FADER *fader, int32_t initial, int32_t target, double duration);
 bool Fader_IsActive(const FADER *fader);
 int32_t Fader_GetCurrentValue(const FADER *fader);
+int32_t Fader_GetRealValue(const FADER *fader);
 void Fader_Draw(FADER *fader);

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -870,6 +870,10 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
 
     INV_RING *const ring = Memory_Alloc(sizeof(INV_RING));
     ring->mode = mode;
+    ring->background_style = mode == INV_TITLE_MODE
+        ? BK_IMAGE
+        : g_Config.ui.inventory_background_style;
+    ring->snapshot_captured = false;
 
     switch (mode) {
     case INV_TITLE_MODE:
@@ -912,14 +916,17 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
         Fader_Init(
             &ring->top_fader, FADER_BLACK, FADER_TRANSPARENT,
             M_INV_RING_FADE_TIME_FAST);
-    } else if (g_Config.ui.inventory_background_style == BK_TRANSPARENT) {
+    } else if (ring->background_style == BK_TRANSPARENT) {
         Output_UnloadBackground();
         Fader_Init(
             &ring->back_fader, FADER_TRANSPARENT, FADER_SEMI_BLACK,
             M_INV_RING_FADE_TIME_FAST);
     } else {
         Output_LoadBackgroundFromObject(
-            g_Config.ui.inventory_background_style == BK_PATTERN_WAVE);
+            ring->background_style == BK_PATTERN_WAVE);
+        Fader_Init(
+            &ring->back_fader, FADER_TRANSPARENT, FADER_BLACK,
+            M_INV_RING_FADE_TIME_FAST);
     }
 
     return ring;
@@ -941,6 +948,7 @@ void InvRing_Close(INV_RING *const ring)
         Sound_StopAll();
     }
     Output_UnloadBackground();
+    Output_Background_EnableSnapshot(false);
 
     if (g_Config.input.enable_buffering_inventory) {
         g_OldInputDB = (INPUT_STATE) {};

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -17,9 +17,36 @@
 #include <trx/game/shell.h>
 #include <trx/game/ui.h>
 #include <trx/game/viewport.h>
+#include <trx/utils.h>
 #include <trx/version.h>
 
 #define M_CAMERA_2_RING 598
+
+static bool M_IsEnterTransition(const INV_RING *const ring)
+{
+    return ring->motion.status == RNG_OPENING;
+}
+
+static bool M_IsExitTransition(const INV_RING *const ring)
+{
+    return ring->motion.status == RNG_EXITING_INVENTORY
+        || ring->motion.status == RNG_FADING_OUT
+        || ring->motion.status == RNG_DONE
+        || (ring->motion.status == RNG_CLOSING
+            && (ring->motion.status_target == RNG_FADING_OUT
+                || ring->motion.status_target == RNG_DONE));
+}
+
+static float M_GetMotionProgress(
+    const int16_t frames_remaining, const int16_t total_frames)
+{
+    if (total_frames == 0) {
+        return 1.0f;
+    }
+    float result = frames_remaining / (float)total_frames;
+    CLAMP(result, 0.0f, 1.0f);
+    return result;
+}
 
 static int32_t M_GetFrames(
     const INV_RING *const ring, const INVENTORY_ITEM *const inv_item,
@@ -157,21 +184,30 @@ void InvRing_Draw(INV_RING *const ring)
 
     if (ring->mode == INV_TITLE_MODE) {
         Interpolation_Interpolate();
-    } else if (g_Config.ui.inventory_background_style == BK_TRANSPARENT) {
-        Matrix_LookAt(
-            g_InvRing_OldCamera.pos.x,
-            g_InvRing_OldCamera.pos.y + g_InvRing_OldCamera.shift,
-            g_InvRing_OldCamera.pos.z, g_InvRing_OldCamera.target.x,
-            g_InvRing_OldCamera.target.y, g_InvRing_OldCamera.target.z, 0);
+    } else {
+        if (!ring->snapshot_captured || M_IsExitTransition(ring)) {
+            Matrix_LookAt(
+                g_InvRing_OldCamera.pos.x,
+                g_InvRing_OldCamera.pos.y + g_InvRing_OldCamera.shift,
+                g_InvRing_OldCamera.pos.z, g_InvRing_OldCamera.target.x,
+                g_InvRing_OldCamera.target.y, g_InvRing_OldCamera.target.z, 0);
 
-        Interpolation_Disable();
-        Game_Draw(false);
-        Interpolation_Enable();
+            Interpolation_Disable();
+            Game_Draw(false);
+            Interpolation_Enable();
+            Output_Background_EnableSnapshot(true);
+            Output_Background_CaptureSnapshotScene();
+            ring->snapshot_captured = true;
+            Output_SwitchViewport(VIEWPORT_GAME);
+            Viewport_Init(-1, -1, -1, -1);
+        } else {
+            Output_Background_EnableSnapshot(true);
+        }
 
-        Fader_Draw(&ring->back_fader);
-        SceneCompositor_Flush();
-
-        Viewport_Init(-1, -1, -1, -1);
+        const float overlay_opacity =
+            Fader_GetRealValue(&ring->back_fader) / 255.0f;
+        Output_Background_SetOverlayOpacity(overlay_opacity);
+        Output_DrawBackground();
     }
 
     const int16_t old_fov = Viewport_GetSystemFOV();

--- a/src/trx/game/inventory_ring/types.h
+++ b/src/trx/game/inventory_ring/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/config/enum.h>
 #include <trx/game/fader.h>
 #include <trx/game/inventory_ring/enum.h>
 #include <trx/game/math.h>
@@ -113,4 +114,7 @@ typedef struct {
     CLOCK_TIMER motion_timer;
     FADER top_fader;
     FADER back_fader;
+
+    BACKGROUND_TYPE background_style;
+    bool snapshot_captured;
 } INV_RING;

--- a/src/trx/game/output/background.c
+++ b/src/trx/game/output/background.c
@@ -198,30 +198,38 @@ void Output_ReloadBackgroundImage(void)
 {
     Output_RefreshBackgroundScaling();
 
-    if (Output_GetBackgroundType() == BK_PATTERN_STATIC
-        || Output_GetBackgroundType() == BK_PATTERN_WAVE) {
+    switch (Output_GetBackgroundType()) {
+    case BK_PATTERN_STATIC:
+    case BK_PATTERN_WAVE:
         Output_LoadBackgroundFromObject(
             Output_GetBackgroundType() == BK_PATTERN_WAVE);
-        return;
-    }
+        break;
 
-    if (m_LastPath == nullptr) {
+    case BK_IMAGE: {
+        if (m_LastPath == nullptr) {
+            Output_UnloadBackground();
+            return;
+        }
+
+        const M_CANDIDATE *const best =
+            M_PickBestCandidate(M_GetScreenAspectRatio());
+        if (best != nullptr) {
+            if (m_LastCandidateName != nullptr
+                && String_Equivalent(best->path, m_LastCandidateName)) {
+                return;
+            }
+            if (M_LoadCandidate(best)) {
+                return;
+            }
+        }
+
         Output_UnloadBackground();
-        return;
+        break;
     }
 
-    const M_CANDIDATE *best = M_PickBestCandidate(M_GetScreenAspectRatio());
-    if (best != nullptr) {
-        if (m_LastCandidateName != nullptr
-            && String_Equivalent(best->path, m_LastCandidateName)) {
-            return;
-        }
-        if (M_LoadCandidate(best)) {
-            return;
-        }
+    default:
+        break;
     }
-
-    Output_UnloadBackground();
 }
 
 void Output_ClearLastBackgroundPath(void)

--- a/src/trx/game/output/background.h
+++ b/src/trx/game/output/background.h
@@ -16,5 +16,11 @@ void Output_UnloadBackground(void);
 
 void Output_DrawBackground(void);
 
+// Scene-only snapshot background composited in SCENE_PASS_BACKGROUND.
+void Output_Background_EnableSnapshot(bool enable);
+bool Output_Background_IsSnapshotEnabled(void);
+void Output_Background_CaptureSnapshotScene(void);
+void Output_Background_SetOverlayOpacity(float opacity);
+
 void Output_RefreshBackgroundScaling(void);
 void Output_ClearLastBackgroundPath(void);

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -184,10 +184,7 @@ void Output_DispatchLevelUnload(void)
     OutputSource_Rooms_ObserveLevelUnload();
     OutputSource_RoomsDebug_ObserveLevelUnload();
     OutputSource_Sprites_ObserveLevelUnload();
-    if (Output_GetBackgroundType() == BK_PATTERN_STATIC
-        || Output_GetBackgroundType() == BK_PATTERN_WAVE) {
-        Output_UnloadBackground();
-    }
+    Output_UnloadBackground();
 }
 
 void Output_DispatchRoomFlip(const ROOM *room)

--- a/src/trx/game/output/sources/background.c
+++ b/src/trx/game/output/sources/background.c
@@ -5,42 +5,174 @@
 #include <trx/game/output/scene_source.h>
 #include <trx/game/output/textures.h>
 #include <trx/gfx/context.h>
+#include <trx/gfx/gl/texture.h>
+#include <trx/gfx/gl/utils.h>
+#include <trx/gfx/renderer.h>
+#include <trx/memory.h>
+#include <trx/utils.h>
 #include <trx/version.h>
 
 #define M_FIT_MODE IMAGE_FIT_SMART
 
 typedef struct {
     SCENE_SOURCE source;
-    GFX_2D_RENDERER *renderer;
+    GFX_2D_RENDERER *snapshot_renderer;
+    GFX_2D_RENDERER *overlay_renderer;
     GFX_2D_SURFACE *surface;
     BACKGROUND_TYPE type;
     bool staged;
+
+    bool snapshot_enabled;
+    GFX_GL_TEXTURE snapshot_texture;
+    int32_t snapshot_width;
+    int32_t snapshot_height;
+    float snapshot_desaturation;
+
+    GFX_GL_TEXTURE solid_black_texture;
+    float overlay_opacity;
+    float dim_opacity;
+
+    uint8_t *readback_geom;
+    uint8_t *readback_ui;
+    uint8_t *readback_final;
+    size_t readback_bytes;
 } M_PRIV;
 
 static M_PRIV m_Priv = {};
 
-static void M_RenderPass(const SCENE_SOURCE *src, SCENE_PASS pass)
+static void M_EnsureReadback(const int32_t w, const int32_t h)
 {
-    if (pass != SCENE_PASS_BACKGROUND || !m_Priv.staged
-        || m_Priv.type == BK_TRANSPARENT) {
+    if (w <= 0 || h <= 0) {
         return;
     }
-    GFX_2D_Renderer_Render(m_Priv.renderer);
+
+    const size_t bytes = (size_t)w * (size_t)h * 4;
+    if (m_Priv.readback_bytes == bytes) {
+        return;
+    }
+
+    m_Priv.readback_geom = Memory_Realloc(m_Priv.readback_geom, bytes);
+    m_Priv.readback_ui = Memory_Realloc(m_Priv.readback_ui, bytes);
+    m_Priv.readback_final = Memory_Realloc(m_Priv.readback_final, bytes);
+    m_Priv.readback_bytes = bytes;
+}
+
+static void M_EnsureSnapshotTexture(void)
+{
+    const int32_t w = Viewport_GetWidth(VIEWPORT_GAME);
+    const int32_t h = Viewport_GetHeight(VIEWPORT_GAME);
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    if (m_Priv.snapshot_texture.initialized && m_Priv.snapshot_width == w
+        && m_Priv.snapshot_height == h) {
+        return;
+    }
+
+    if (!m_Priv.snapshot_texture.initialized) {
+        GFX_GL_Texture_Init(&m_Priv.snapshot_texture, GL_TEXTURE_2D);
+    }
+
+    m_Priv.snapshot_width = w;
+    m_Priv.snapshot_height = h;
+
+    GFX_GL_Texture_Bind(&m_Priv.snapshot_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+        nullptr);
+    GFX_GL_CheckError();
+}
+
+static void M_EnsureSolidBlackTexture(void)
+{
+    if (m_Priv.solid_black_texture.initialized) {
+        return;
+    }
+    GFX_GL_Texture_Init(&m_Priv.solid_black_texture, GL_TEXTURE_2D);
+    const uint8_t pixel[4] = { 0, 0, 0, 255 };
+    GFX_GL_Texture_Bind(&m_Priv.solid_black_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+        &pixel[0]);
+    GFX_GL_CheckError();
+}
+
+static void M_RenderPass(const SCENE_SOURCE *src, SCENE_PASS pass)
+{
+    if (pass != SCENE_PASS_BACKGROUND || !m_Priv.staged) {
+        return;
+    }
+
+    if (m_Priv.snapshot_enabled) {
+        M_EnsureSnapshotTexture();
+        GFX_2D_Renderer_SetExternalTexture(
+            m_Priv.snapshot_renderer, m_Priv.snapshot_texture.id,
+            m_Priv.snapshot_width, m_Priv.snapshot_height, true);
+        GFX_2D_Renderer_SetEffect(m_Priv.snapshot_renderer, GFX_2D_EFFECT_NONE);
+        GFX_2D_Renderer_SetRepeat(m_Priv.snapshot_renderer, 1, 1);
+        GFX_2D_Renderer_SetTextureSize(m_Priv.snapshot_renderer, nullptr);
+        GFX_2D_Renderer_SetOpacity(m_Priv.snapshot_renderer, 1.0f);
+        GFX_2D_Renderer_Render(m_Priv.snapshot_renderer);
+    }
+
+    const bool use_blend =
+        m_Priv.snapshot_enabled || m_Priv.overlay_opacity < 1.0f;
+    if (m_Priv.type != BK_TRANSPARENT) {
+        GFX_2D_Renderer_SetOpacity(
+            m_Priv.overlay_renderer, m_Priv.overlay_opacity);
+        if (use_blend) {
+            GFX_2D_Renderer_RenderWithBlend(m_Priv.overlay_renderer);
+        } else {
+            GFX_2D_Renderer_Render(m_Priv.overlay_renderer);
+        }
+    }
+
+    if (m_Priv.dim_opacity > 0.0f) {
+        M_EnsureSolidBlackTexture();
+        GFX_2D_Renderer_SetExternalTexture(
+            m_Priv.snapshot_renderer, m_Priv.solid_black_texture.id, 1, 1,
+            false);
+        GFX_2D_Renderer_SetEffect(m_Priv.snapshot_renderer, GFX_2D_EFFECT_NONE);
+        GFX_2D_Renderer_SetRepeat(m_Priv.snapshot_renderer, 1, 1);
+        GFX_2D_Renderer_SetTextureSize(m_Priv.snapshot_renderer, nullptr);
+        GFX_2D_Renderer_SetOpacity(
+            m_Priv.snapshot_renderer, m_Priv.dim_opacity);
+        GFX_2D_Renderer_RenderWithBlend(m_Priv.snapshot_renderer);
+    }
+
     m_Priv.staged = false;
 }
 
 static bool M_IsDirty(const SCENE_SOURCE *src, SCENE_PASS pass)
 {
-    return pass == SCENE_PASS_BACKGROUND && m_Priv.staged
-        && m_Priv.type != BK_TRANSPARENT;
+    return pass == SCENE_PASS_BACKGROUND && m_Priv.staged;
 }
 
 void Output_InitBackground(void)
 {
-    m_Priv.renderer = GFX_2D_Renderer_Create();
+    m_Priv.snapshot_renderer = GFX_2D_Renderer_Create();
+    m_Priv.overlay_renderer = GFX_2D_Renderer_Create();
     m_Priv.surface = nullptr;
     m_Priv.type = BK_TRANSPARENT;
     m_Priv.staged = false;
+    m_Priv.snapshot_enabled = false;
+    m_Priv.snapshot_width = 0;
+    m_Priv.snapshot_height = 0;
+    m_Priv.snapshot_desaturation = 0.0f;
+    m_Priv.overlay_opacity = 1.0f;
+    m_Priv.dim_opacity = 0.0f;
+    m_Priv.snapshot_texture = (GFX_GL_TEXTURE) { .initialized = false };
+    m_Priv.solid_black_texture = (GFX_GL_TEXTURE) { .initialized = false };
+    M_EnsureSolidBlackTexture();
 
     m_Priv.source.render_pass = M_RenderPass;
     m_Priv.source.is_dirty = M_IsDirty;
@@ -53,10 +185,26 @@ void Output_ShutdownBackground(void)
         GFX_2D_Surface_Free(m_Priv.surface);
         m_Priv.surface = nullptr;
     }
-    if (m_Priv.renderer != nullptr) {
-        GFX_2D_Renderer_Destroy(m_Priv.renderer);
-        m_Priv.renderer = nullptr;
+    if (m_Priv.snapshot_renderer != nullptr) {
+        GFX_2D_Renderer_Destroy(m_Priv.snapshot_renderer);
+        m_Priv.snapshot_renderer = nullptr;
     }
+    if (m_Priv.overlay_renderer != nullptr) {
+        GFX_2D_Renderer_Destroy(m_Priv.overlay_renderer);
+        m_Priv.overlay_renderer = nullptr;
+    }
+    if (m_Priv.snapshot_texture.initialized) {
+        GFX_GL_Texture_Close(&m_Priv.snapshot_texture);
+        m_Priv.snapshot_texture.initialized = false;
+    }
+    if (m_Priv.solid_black_texture.initialized) {
+        GFX_GL_Texture_Close(&m_Priv.solid_black_texture);
+        m_Priv.solid_black_texture.initialized = false;
+    }
+    Memory_FreePointer(&m_Priv.readback_geom);
+    Memory_FreePointer(&m_Priv.readback_ui);
+    Memory_FreePointer(&m_Priv.readback_final);
+    m_Priv.readback_bytes = 0;
     Output_ClearLastBackgroundPath();
 }
 
@@ -68,7 +216,8 @@ BACKGROUND_TYPE Output_GetBackgroundType(void)
 void Output_RefreshBackgroundScaling(void)
 {
     if (Output_GetBackgroundType() != BK_IMAGE) {
-        GFX_2D_Renderer_SetQuad(m_Priv.renderer, 0.0f, 0.0f, 1.0f, 1.0f);
+        GFX_2D_Renderer_SetQuad(
+            m_Priv.overlay_renderer, 0.0f, 0.0f, 1.0f, 1.0f);
         return;
     }
 
@@ -135,7 +284,7 @@ void Output_RefreshBackgroundScaling(void)
         break;
     }
 
-    GFX_2D_Renderer_SetQuad(m_Priv.renderer, x0, y0, x1, y1);
+    GFX_2D_Renderer_SetQuad(m_Priv.overlay_renderer, x0, y0, x1, y1);
 }
 
 bool Output_LoadBackgroundFromImage(const IMAGE *const image)
@@ -145,11 +294,12 @@ bool Output_LoadBackgroundFromImage(const IMAGE *const image)
     }
     m_Priv.type = BK_IMAGE;
     m_Priv.surface = GFX_2D_Surface_CreateFromImage(image);
-    GFX_2D_Renderer_SetRepeat(m_Priv.renderer, 1, 1);
-    GFX_2D_Renderer_SetTextureSize(m_Priv.renderer, nullptr);
+    m_Priv.overlay_opacity = 1.0f;
+    GFX_2D_Renderer_SetRepeat(m_Priv.overlay_renderer, 1, 1);
+    GFX_2D_Renderer_SetTextureSize(m_Priv.overlay_renderer, nullptr);
     GFX_2D_Renderer_Upload(
-        m_Priv.renderer, &m_Priv.surface->desc, m_Priv.surface->buffer);
-    GFX_2D_Renderer_SetEffect(m_Priv.renderer, GFX_2D_EFFECT_NONE);
+        m_Priv.overlay_renderer, &m_Priv.surface->desc, m_Priv.surface->buffer);
+    GFX_2D_Renderer_SetEffect(m_Priv.overlay_renderer, GFX_2D_EFFECT_NONE);
     Output_RefreshBackgroundScaling();
     return true;
 }
@@ -178,6 +328,7 @@ void Output_LoadBackgroundFromObject(const bool wave)
     const int32_t repeat_x = repeat_y * Viewport_GetWidth(VIEWPORT_GAME)
         / (float)Viewport_GetHeight(VIEWPORT_GAME);
     m_Priv.type = wave ? BK_PATTERN_WAVE : BK_PATTERN_STATIC;
+    m_Priv.overlay_opacity = 1.0f;
 
     const RGBA_8888 *const page = Output_GetTexturePage32(texture->tex_page);
     if (page == nullptr) {
@@ -211,10 +362,10 @@ void Output_LoadBackgroundFromObject(const bool wave)
         .pitch = TEXTURE_PAGE_WIDTH * 2,
     };
     const OUTPUT_TEXTURE_SIZE size = Output_Textures_GetAtlasSize(texture_idx);
-    GFX_2D_Renderer_Upload(m_Priv.renderer, &desc, (uint8_t *)page);
-    GFX_2D_Renderer_SetRepeat(m_Priv.renderer, repeat_x, repeat_y);
+    GFX_2D_Renderer_Upload(m_Priv.overlay_renderer, &desc, (uint8_t *)page);
+    GFX_2D_Renderer_SetRepeat(m_Priv.overlay_renderer, repeat_x, repeat_y);
     GFX_2D_Renderer_SetTextureSize(
-        m_Priv.renderer,
+        m_Priv.overlay_renderer,
         &(GFX_TEXTURE_SIZE) {
             .x0 = size.x0,
             .y0 = size.y0,
@@ -222,7 +373,8 @@ void Output_LoadBackgroundFromObject(const bool wave)
             .y1 = size.y1,
         });
     GFX_2D_Renderer_SetEffect(
-        m_Priv.renderer, wave ? GFX_2D_EFFECT_WAVE : GFX_2D_EFFECT_VIGNETTE);
+        m_Priv.overlay_renderer,
+        wave ? GFX_2D_EFFECT_WAVE : GFX_2D_EFFECT_VIGNETTE);
     Output_RefreshBackgroundScaling();
 }
 
@@ -233,11 +385,57 @@ void Output_UnloadBackground(void)
         m_Priv.surface = nullptr;
     }
     m_Priv.type = BK_TRANSPARENT;
+    m_Priv.overlay_opacity = 1.0f;
+    m_Priv.dim_opacity = 0.0f;
 }
 
 void Output_DrawBackground(void)
 {
-    if (m_Priv.type != BK_TRANSPARENT) {
+    if (m_Priv.type != BK_TRANSPARENT || m_Priv.snapshot_enabled
+        || m_Priv.dim_opacity > 0.0f) {
         m_Priv.staged = true;
     }
+}
+
+void Output_Background_EnableSnapshot(const bool enable)
+{
+    m_Priv.snapshot_enabled = enable;
+}
+
+bool Output_Background_IsSnapshotEnabled(void)
+{
+    return m_Priv.snapshot_enabled;
+}
+
+void Output_Background_CaptureSnapshotScene(void)
+{
+    if (!m_Priv.snapshot_enabled) {
+        return;
+    }
+
+    M_EnsureSnapshotTexture();
+    if (!m_Priv.snapshot_texture.initialized) {
+        return;
+    }
+
+    GFX_Renderer_BindGeometryFbo();
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+
+    GFX_GL_Texture_Bind(&m_Priv.snapshot_texture);
+    glCopyTexSubImage2D(
+        GL_TEXTURE_2D, 0, 0, 0, 0, 0, m_Priv.snapshot_width,
+        m_Priv.snapshot_height);
+    GFX_GL_CheckError();
+}
+
+void Output_Background_SetOverlayOpacity(float opacity)
+{
+    CLAMP(opacity, 0.0f, 1.0f);
+
+    if (m_Priv.type == BK_TRANSPARENT) {
+        m_Priv.dim_opacity = opacity;
+    } else {
+        m_Priv.overlay_opacity = opacity;
+    }
+    m_Priv.staged = true;
 }

--- a/src/trx/gfx/2d/2d_renderer.c
+++ b/src/trx/gfx/2d/2d_renderer.c
@@ -16,6 +16,7 @@ typedef enum {
     M_UNIFORM_TEXTURE_MAIN,
     M_UNIFORM_TEXTURE_SIZE,
     M_UNIFORM_EFFECT,
+    M_UNIFORM_OPACITY,
     M_UNIFORM_NUMBER_OF,
 } M_UNIFORM;
 
@@ -52,6 +53,11 @@ struct GFX_2D_RENDERER {
     } quad;
 
     GFX_2D_EFFECT effect;
+
+    float opacity;
+
+    bool use_external_texture;
+    GLuint external_texture_id;
 
     // shader variable locations
     GLint loc[M_UNIFORM_NUMBER_OF];
@@ -112,6 +118,7 @@ GFX_2D_RENDERER *GFX_2D_Renderer_Create(void)
     const GFX_CONFIG *const config = GFX_Context_GetConfig();
 
     r->effect = GFX_2D_EFFECT_NONE;
+    r->opacity = 1.0f;
     r->repeat.x = 1;
     r->repeat.y = 1;
     r->quad.x0 = 0.0f;
@@ -122,6 +129,8 @@ GFX_2D_RENDERER *GFX_2D_Renderer_Create(void)
     r->vertices = nullptr;
     r->vertex_count = 6;
     r->vertex_format.initialized = false;
+    r->use_external_texture = false;
+    r->external_texture_id = 0;
 
     GFX_GL_Buffer_Init(&r->surface_buffer, GL_ARRAY_BUFFER);
     GFX_GL_Buffer_Bind(&r->surface_buffer);
@@ -155,6 +164,7 @@ GFX_2D_RENDERER *GFX_2D_Renderer_Create(void)
         { M_UNIFORM_TEXTURE_MAIN, "uTexMain" },
         { M_UNIFORM_TEXTURE_SIZE, "uTexSize" },
         { M_UNIFORM_EFFECT, "uEffect" },
+        { M_UNIFORM_OPACITY, "uOpacity" },
         { -1, nullptr },
     };
     for (int32_t i = 0; uniforms[i].name != nullptr; i++) {
@@ -168,6 +178,8 @@ GFX_2D_RENDERER *GFX_2D_Renderer_Create(void)
     GFX_GL_Program_Uniform4f(
         &r->program, r->loc[M_UNIFORM_TEXTURE_SIZE], 0.0f, 0.0f, 1.0f, 1.0f);
     GFX_GL_Program_Uniform1i(&r->program, r->loc[M_UNIFORM_EFFECT], r->effect);
+    GFX_GL_Program_Uniform1f(
+        &r->program, r->loc[M_UNIFORM_OPACITY], r->opacity);
     GFX_GL_CheckError();
 
     return r;
@@ -227,9 +239,52 @@ void GFX_2D_Renderer_Upload(
 
     r->ready = true;
     r->desc = *desc;
+    r->use_external_texture = false;
+    r->external_texture_id = 0;
     if (reupload_vert) {
         M_UploadVertices(r);
     }
+}
+
+void GFX_2D_Renderer_SetExternalTexture(
+    GFX_2D_RENDERER *const r, const GLuint texture_id, const int32_t width,
+    const int32_t height, const bool flip_y)
+{
+    ASSERT(r != nullptr);
+    r->use_external_texture = true;
+    r->external_texture_id = texture_id;
+
+    const float v0 = flip_y ? 1.0f : 0.0f;
+    const float v1 = flip_y ? 0.0f : 1.0f;
+    GFX_2D_SURFACE_DESC desc = {
+        .width = width,
+        .height = height,
+        .bit_count = 32,
+        .tex_format = GL_RGBA,
+        .tex_type = GL_UNSIGNED_INT_8_8_8_8_REV,
+        .uv = {
+            { 0.0f, v0 },
+            { 1.0f, v0 },
+            { 1.0f, v1 },
+            { 0.0f, v1 },
+        },
+        .pitch = width * 4,
+    };
+
+    const bool reupload_vert =
+        memcmp(r->desc.uv, desc.uv, sizeof(desc.uv)) != 0 || !r->ready;
+    r->ready = true;
+    r->desc = desc;
+    if (reupload_vert) {
+        M_UploadVertices(r);
+    }
+}
+
+void GFX_2D_Renderer_ClearExternalTexture(GFX_2D_RENDERER *const r)
+{
+    ASSERT(r != nullptr);
+    r->use_external_texture = false;
+    r->external_texture_id = 0;
 }
 
 void GFX_2D_Renderer_SetTextureSize(
@@ -287,6 +342,18 @@ void GFX_2D_Renderer_SetEffect(GFX_2D_RENDERER *const r, const uint32_t effect)
     }
 }
 
+void GFX_2D_Renderer_SetOpacity(GFX_2D_RENDERER *const r, const float opacity)
+{
+    ASSERT(r != nullptr);
+
+    if (r->opacity != opacity) {
+        GFX_GL_Program_Bind(&r->program);
+        GFX_GL_Program_Uniform1f(
+            &r->program, r->loc[M_UNIFORM_OPACITY], opacity);
+        r->opacity = opacity;
+    }
+}
+
 void GFX_2D_Renderer_Render(GFX_2D_RENDERER *const r)
 {
     ASSERT(r != nullptr);
@@ -298,10 +365,14 @@ void GFX_2D_Renderer_Render(GFX_2D_RENDERER *const r)
     GFX_GL_VertexArray_Bind(&r->vertex_format);
 
     glActiveTexture(GL_TEXTURE0);
-    GFX_GL_Texture_Bind(&r->surface_texture);
+    if (r->use_external_texture) {
+        glBindTexture(GL_TEXTURE_2D, r->external_texture_id);
+    } else {
+        GFX_GL_Texture_Bind(&r->surface_texture);
+    }
 
-    GLboolean blend = glIsEnabled(GL_BLEND);
-    if (blend) {
+    const GLboolean was_blend_enabled = glIsEnabled(GL_BLEND);
+    if (was_blend_enabled) {
         glDisable(GL_BLEND);
     }
 
@@ -309,12 +380,64 @@ void GFX_2D_Renderer_Render(GFX_2D_RENDERER *const r)
     glGetIntegerv(GL_POLYGON_MODE, &bound_polygon_mode[0]);
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
-    GLboolean depth_test = glIsEnabled(GL_DEPTH_TEST);
-    if (depth_test) {
+    const GLboolean was_depth_test_enabled = glIsEnabled(GL_DEPTH_TEST);
+    if (was_depth_test_enabled) {
         glDisable(GL_DEPTH_TEST);
     }
 
     glDrawArrays(GL_TRIANGLES, 0, r->vertex_count);
     glPolygonMode(GL_FRONT_AND_BACK, bound_polygon_mode[0]);
+    if (was_depth_test_enabled) {
+        glEnable(GL_DEPTH_TEST);
+    }
+    if (was_blend_enabled) {
+        glEnable(GL_BLEND);
+    }
+    GFX_GL_CheckError();
+}
+
+void GFX_2D_Renderer_RenderWithBlend(GFX_2D_RENDERER *const r)
+{
+    ASSERT(r != nullptr);
+
+    GFX_GL_Program_Bind(&r->program);
+    GFX_GL_Program_Uniform1i(&r->program, r->loc[M_UNIFORM_EFFECT], r->effect);
+    GFX_GL_Buffer_Bind(&r->surface_buffer);
+    GFX_GL_VertexArray_Bind(&r->vertex_format);
+
+    glActiveTexture(GL_TEXTURE0);
+    if (r->use_external_texture) {
+        glBindTexture(GL_TEXTURE_2D, r->external_texture_id);
+    } else {
+        GFX_GL_Texture_Bind(&r->surface_texture);
+    }
+
+    const GLboolean was_blend_enabled = glIsEnabled(GL_BLEND);
+    GLint prev_blend_src = 0;
+    GLint prev_blend_dst = 0;
+    glGetIntegerv(GL_BLEND_SRC_RGB, &prev_blend_src);
+    glGetIntegerv(GL_BLEND_DST_RGB, &prev_blend_dst);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+    GLint bound_polygon_mode[2];
+    glGetIntegerv(GL_POLYGON_MODE, &bound_polygon_mode[0]);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    const GLboolean was_depth_test_enabled = glIsEnabled(GL_DEPTH_TEST);
+    if (was_depth_test_enabled) {
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    glDrawArrays(GL_TRIANGLES, 0, r->vertex_count);
+
+    glPolygonMode(GL_FRONT_AND_BACK, bound_polygon_mode[0]);
+    if (was_depth_test_enabled) {
+        glEnable(GL_DEPTH_TEST);
+    }
+    glBlendFunc(prev_blend_src, prev_blend_dst);
+    if (!was_blend_enabled) {
+        glDisable(GL_BLEND);
+    }
     GFX_GL_CheckError();
 }

--- a/src/trx/gfx/2d/2d_renderer.h
+++ b/src/trx/gfx/2d/2d_renderer.h
@@ -34,6 +34,13 @@ void GFX_2D_Renderer_Destroy(GFX_2D_RENDERER *renderer);
 void GFX_2D_Renderer_Upload(
     GFX_2D_RENDERER *renderer, GFX_2D_SURFACE_DESC *desc, const uint8_t *data);
 
+// Use an external GL texture instead of the internally managed one.
+// When enabled, the renderer uses a full [0,1] UV mapping by default.
+void GFX_2D_Renderer_SetExternalTexture(
+    GFX_2D_RENDERER *renderer, GLuint texture_id, int32_t width, int32_t height,
+    bool flip_y);
+void GFX_2D_Renderer_ClearExternalTexture(GFX_2D_RENDERER *renderer);
+
 // Set the normalized screen-space quad for rendering.
 // Coordinates are in [0,1] where (0,0) is top-left and (1,1) is bottom-right.
 void GFX_2D_Renderer_SetQuad(
@@ -44,4 +51,7 @@ void GFX_2D_Renderer_SetTextureSize(
     GFX_2D_RENDERER *renderer, const GFX_TEXTURE_SIZE *size);
 void GFX_2D_Renderer_SetEffect(GFX_2D_RENDERER *renderer, uint32_t effect);
 
+void GFX_2D_Renderer_SetOpacity(GFX_2D_RENDERER *renderer, float opacity);
+
 void GFX_2D_Renderer_Render(GFX_2D_RENDERER *renderer);
+void GFX_2D_Renderer_RenderWithBlend(GFX_2D_RENDERER *renderer);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds support for smooth fading of inventory backgrounds for TR2 carpet patterns.

https://github.com/user-attachments/assets/e039a05b-7bbd-49a3-9239-659f99d0444b

Fading of the statistics screen currently remains unsupported.
