### PR TITLE
sound: handle sound positions similarly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - fixed several OG texture issues in Caves (rooms 0, 1, 2, 6, 24, 30 and 32)
 - fixed Lara automatically being given TR2 weapons in NG+ when playing the OG levels (#4365, regression from 1.0)
 - fixed Lara's pistol holster meshes appearing in NG+ in place of her Uzi holster meshes (#4368, regression from 1.0)
+- fixed Lara's footstep sounds being very quiet when weapons are equipped (#4451, regression from 1.0)
 
 **TR2**:
 - added high-resolution 16:9 and 4:3 loading screens

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -138,15 +138,11 @@ void Camera_UpdateMicPosition(void)
         g_Camera.actual_angle = Math_Atan(
             g_Camera.target.z - g_Camera.pos.z,
             g_Camera.target.x - g_Camera.pos.x);
-        if (g_TRVersion == 1) {
-            g_Camera.mic_pos = g_Camera.pos;
-        } else {
-            g_Camera.mic_pos.pos.x = g_Camera.pos.x
-                + ((g_PhdPersp * Math_Sin(g_Camera.actual_angle)) >> W2V_SHIFT);
-            g_Camera.mic_pos.pos.z = g_Camera.pos.z
-                + ((g_PhdPersp * Math_Cos(g_Camera.actual_angle)) >> W2V_SHIFT);
-            g_Camera.mic_pos.pos.y = g_Camera.pos.y;
-            g_Camera.mic_pos.room_num = g_Camera.pos.room_num;
-        }
+        g_Camera.mic_pos.pos.x = g_Camera.pos.x
+            + ((g_PhdPersp * Math_Sin(g_Camera.actual_angle)) >> W2V_SHIFT);
+        g_Camera.mic_pos.pos.z = g_Camera.pos.z
+            + ((g_PhdPersp * Math_Cos(g_Camera.actual_angle)) >> W2V_SHIFT);
+        g_Camera.mic_pos.pos.y = g_Camera.pos.y;
+        g_Camera.mic_pos.room_num = g_Camera.pos.room_num;
     }
 }

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1381,12 +1381,9 @@ void Level_ReadSamples(const LEVEL_LOADER *const loader, VFILE *const file)
         if (loader->game_version >= 3) {
             sample_info->volume = VFile_ReadU8(file) << 7;
             sample_info->range = VFile_ReadU8(file) * WALL_L;
-        } else if (loader->game_version == 2) {
+        } else {
             sample_info->volume = VFile_ReadU16(file);
             sample_info->range = 10 * WALL_L;
-        } else if (loader->game_version == 1) {
-            sample_info->volume = VFile_ReadU16(file);
-            sample_info->range = 8 * WALL_L;
         }
 
         if (loader->game_version >= 3) {

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -121,21 +121,18 @@ static int32_t M_GetDistance(
 static int32_t M_GetVolume(
     const SAMPLE_INFO *const sample, const int32_t distance, const bool random)
 {
-    if (g_TRVersion == 1) {
-        int32_t volume = sample->volume - distance * 4;
-        if (random && sample->flags.randomize_volume) {
-            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE / 0x8000;
-        }
-        return volume;
-    } else {
-        int32_t volume = sample->volume;
-        if (random && sample->flags.randomize_volume) {
-            volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE / 0x8000;
-        }
-        const int32_t attenuation =
-            SQUARE(distance) / (SQUARE(sample->range) / 0x10000);
-        return (volume * (0x10000 - attenuation)) / 0x10000;
+    int32_t volume = sample->volume;
+    if (random && sample->flags.randomize_volume) {
+        volume -= Random_GetDraw() * M_SOUND_MAX_VOLUME_CHANGE / 0x8000;
     }
+
+    if (g_TRVersion == 1) {
+        return volume - distance * 3.5f;
+    }
+
+    const int32_t attenuation =
+        SQUARE(distance) / (SQUARE(sample->range) / 0x10000);
+    return (volume * (0x10000 - attenuation)) / 0x10000;
 }
 
 static int32_t M_GetPitch(const SAMPLE_INFO *const sample, const uint32_t flags)
@@ -161,18 +158,9 @@ static int32_t M_GetPan(
     }
     const int32_t distance = M_GetDistance(sample, pos);
     if (distance > 0 && !sample->flags.no_pan) {
-        if (g_TRVersion == 1) {
-            const LARA_INFO *const lara = Lara_GetLaraInfo();
-            const ITEM *const lara_item = Lara_GetItem();
-            int16_t angle =
-                Math_Atan(pos->z - lara_item->pos.z, pos->x - lara_item->pos.x);
-            angle -= lara_item->rot.y + lara->torso_rot.y + lara->head_rot.y;
-            return angle;
-        } else {
-            const int32_t dx = pos->x - g_Camera.mic_pos.x;
-            const int32_t dz = pos->z - g_Camera.mic_pos.z;
-            return (int16_t)Math_Atan(dz, dx) - g_Camera.actual_angle;
-        }
+        const int32_t dx = pos->x - g_Camera.mic_pos.x;
+        const int32_t dz = pos->z - g_Camera.mic_pos.z;
+        return (int16_t)Math_Atan(dz, dx) - g_Camera.actual_angle;
     }
     return 0;
 }


### PR DESCRIPTION
Resolves #4451.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This normalizes sound positioning between TR1 and TR2, aside from attenuation which remains fixed for TR1. This is slightly experimental because I'm not sure how I feel about it - I think some sounds are a bit louder, and getting things to balance came only with changing each of the pieces of logic in this PR (mic pos, default sample range, pan, attenuation factor). In the same breath, with SFX volume at 60% (which I normally have it at) I think it sounds acceptable. At 100% I think it's too loud, but that's maybe just me - LMK what you think.

I also tried a full combine with TR2's attenuation, but some TR1 fixed sound sources would cut off very abruptly when going out of range e.g. the switch in room 9 of The Cistern.

The alternative to this if we feel the results are unsuitable would be going back to using the camera target for TR1 rather than position, but with this the "mic at Lara" option almost becomes redundant.
