### PR TITLE
ui: use sleek bars for reset controls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - changed the fonts to no longer use hardcoded character widths
 - changed the fonts to use dedicated sprites for accented characters instead of composing them at runtime
 - changed the fonts to use dedicated sprites for similar-looking characters instead of using aliases
+- changed the reset keybindings bars appearance to be more visible
 - fixed broken final statistic counters (#4432, regression from 1.0)
 - fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
 - fixed gondolas not being drawn with an underwater tint when they have sunk (#4428)

--- a/src/meson.build
+++ b/src/meson.build
@@ -566,6 +566,7 @@ common_sources = [
   'trx/game/ui/elements/resize.c',
   'trx/game/ui/elements/row_arrows.c',
   'trx/game/ui/elements/scrollable_area.c',
+  'trx/game/ui/elements/sleek_bar.c',
   'trx/game/ui/elements/spacer.c',
   'trx/game/ui/elements/span.c',
   'trx/game/ui/elements/stack.c',

--- a/src/trx/game/ui/elements/progress_button.c
+++ b/src/trx/game/ui/elements/progress_button.c
@@ -1,10 +1,11 @@
 #include <trx/game/ui/elements/progress_button.h>
 
 #include <trx/game/const.h>
-#include <trx/game/ui/elements/bar.h>
+#include <trx/game/ui/elements/hide.h>
 #include <trx/game/ui/elements/label.h>
 #include <trx/game/ui/elements/pad.h>
-#include <trx/game/ui/elements/span.h>
+#include <trx/game/ui/elements/sleek_bar.h>
+#include <trx/game/ui/elements/stack.h>
 #include <trx/memory.h>
 #include <trx/strings.h>
 
@@ -66,21 +67,26 @@ void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
         String_FormatStatic(GS(MISC_HOLD_FMT), key_name);
 
     const float pad[2] = { 6.0f, 3.0f };
+    const float spacing = 2.0f;
+    const float progress =
+        (s->hold_timer - M_HOLD_TIMER_DEBUFF) / (float)M_HOLD_TIMER_MAX;
 
-    UI_BeginPad(0.0f, -pad[1]);
-    UI_BeginSpan();
-    if (s->hold_timer >= M_HOLD_TIMER_DEBUFF) {
-        UI_Bar((UI_BAR_SETTINGS) {
-            .type = UI_BAR_PROGRESS,
-            .value = s->hold_timer - M_HOLD_TIMER_DEBUFF,
-            .max_value = M_HOLD_TIMER_MAX,
-            .w = 0.0, // Span will make it expand anyway!
-            .h = 0.0,
-        });
-    }
     UI_BeginPad(pad[0], pad[1]);
+    UI_BeginStackEx((UI_STACK_SETTINGS) {
+        .orientation = UI_STACK_VERTICAL,
+        .align = {
+            .h = UI_STACK_H_ALIGN_SPAN,
+            .v = UI_STACK_V_ALIGN_TOP,
+        },
+        .spacing = {
+            .h = 0.0f,
+            .v = spacing,
+        },
+    });
     UI_LabelFmt("%s: %s", GameString_Get(s->text), value_label);
-    UI_EndPad();
-    UI_EndSpan();
+    UI_BeginHide(progress < 0.0f);
+    UI_SleekBar(progress);
+    UI_EndHide();
+    UI_EndStack();
     UI_EndPad();
 }

--- a/src/trx/game/ui/elements/sleek_bar.c
+++ b/src/trx/game/ui/elements/sleek_bar.c
@@ -1,0 +1,68 @@
+#include <trx/game/ui/elements/sleek_bar.h>
+
+#include <trx/config.h>
+#include <trx/game/ui/draw.h>
+#include <trx/game/ui/helpers.h>
+#include <trx/utils.h>
+#include <trx/version.h>
+
+typedef struct {
+    float progress;
+} M_DATA;
+
+typedef struct {
+    float x, y, w, h;
+    RGBA_8888 color;
+} M_RECT;
+
+static RGBA_8888 m_BackgroundColor = { 0x06, 0x06, 0x06, 0xFF };
+static RGBA_8888 m_FillColors[TR_VERSION_COUNT] = {
+    { 0xA1, 0x83, 0x3C, 0xFF },
+    { 0x5A, 0xB5, 0x5A, 0xFF },
+    { 0x1C, 0x6A, 0xC4, 0xFF },
+};
+
+static void M_Measure(UI_NODE *const node)
+{
+    node->measure_w = 0.0f;
+    node->measure_h = 4.0f * g_Config.ui.text_scale;
+}
+
+static void M_Draw(const UI_NODE *const node)
+{
+    const M_DATA *const data = node->data;
+    const float border = 1.0f;
+
+    const M_RECT out = {
+        .x = UI_ScaleX(node->x),
+        .y = UI_ScaleY(node->y),
+        .w = UI_ScaleX(node->w),
+        .h = UI_ScaleY(node->h),
+        .color = m_BackgroundColor,
+    };
+    const M_RECT in = {
+        .x = UI_ScaleX(node->x + border),
+        .y = UI_ScaleY(node->y + border),
+        .w = UI_ScaleX(node->w - border * 2.0f) * data->progress,
+        .h = UI_ScaleY(node->h - border * 2.0f),
+        .color = m_FillColors[g_TRVersion - 1],
+    };
+
+    UI_ScheduleDrawScreenFlatQuad(out.x, out.y, 0, out.w, out.h, out.color);
+    UI_ScheduleDrawScreenFlatQuad(in.x, in.y, 0, in.w, in.h, in.color);
+}
+
+void UI_SleekBar(float progress)
+{
+    UI_NODE *const node = UI_AllocNode(
+        &(UI_WIDGET_OPS) {
+            .measure = M_Measure,
+            .layout = UI_LayoutBasic,
+            .draw = M_Draw,
+        },
+        sizeof(M_DATA));
+    M_DATA *const data = node->data;
+    CLAMP(progress, 0.0f, 1.0f);
+    data->progress = progress;
+    UI_AddChild(node);
+}

--- a/src/trx/game/ui/elements/sleek_bar.h
+++ b/src/trx/game/ui/elements/sleek_bar.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+void UI_SleekBar(float progress);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This no longer draws awkward health bar-like widgets behind the reset buttons.
Affects all TR3s, the color varies between games and is hardcoded. The PS1 UI style option has no effect on this.

Before:
![20251224_104116_Level_0_2](https://github.com/user-attachments/assets/bb679777-2fc6-4f8d-9ce4-c5684a4e667d)

After:
![20251224_103349_Level_0](https://github.com/user-attachments/assets/41f2b46a-fbe0-43d0-9ddd-14d4a0691a42)
