### PR TITLE
objects/switch: amend switch states

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed flare box pickups containig only one flare if Lara has none in her inventory at that time (#4423, regression from 1.0)
 - fixed water enemies appearing untinted for a frame after dying and moving to the water surface (#4420, regression from TR2X 0.1)
 - fixed the interactive fly cheat breaking with animated interactions enabled (#4444, regression from TR1X 4.14)
+- fixed switch triggers using an incorrect state check, which could result in fixed camera behavior that deviated from OG (#4456, regression from 1.0)
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/game/objects/general/switch.c
+++ b/src/trx/game/objects/general/switch.c
@@ -82,7 +82,7 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     item->flags |= IF_CODE_BITS;
     if (!Item_IsTriggerActive(item)) {
-        item->goal_anim_state = SWITCH_STATE_ON;
+        item->goal_anim_state = SWITCH_STATE_OFF;
         item->timer = 0;
     }
     Item_Animate(item);
@@ -136,7 +136,7 @@ static bool M_MoveLaraControlled(
     return Lara_MovePosition(item, &move_vector);
 }
 
-static void M_SwitchOn(ITEM *const switch_item, ITEM *const lara_item)
+static void M_TurnSwitchOn(ITEM *const switch_item, ITEM *const lara_item)
 {
     switch (switch_item->object_id) {
     case O_SWITCH_TYPE_SMALL:
@@ -153,10 +153,10 @@ static void M_SwitchOn(ITEM *const switch_item, ITEM *const lara_item)
     }
 
     lara_item->current_anim_state = LS(LS_SWITCH_ON);
-    switch_item->goal_anim_state = SWITCH_STATE_OFF;
+    switch_item->goal_anim_state = SWITCH_STATE_ON;
 }
 
-static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
+static void M_TurnSwitchOff(ITEM *const switch_item, ITEM *const lara_item)
 {
     lara_item->current_anim_state = LS(LS_SWITCH_OFF);
 
@@ -179,7 +179,7 @@ static void M_SwitchOff(ITEM *const switch_item, ITEM *const lara_item)
         break;
     }
 
-    switch_item->goal_anim_state = SWITCH_STATE_ON;
+    switch_item->goal_anim_state = SWITCH_STATE_OFF;
 }
 
 static void M_CollisionControlled(
@@ -203,10 +203,10 @@ static void M_CollisionControlled(
 
         if (Lara_TestPosition(item, &col_bounds)) {
             if (M_MoveLaraControlled(item, bounds)) {
-                if (item->current_anim_state == SWITCH_STATE_ON) {
-                    M_SwitchOn(item, lara_item);
+                if (item->current_anim_state == SWITCH_STATE_OFF) {
+                    M_TurnSwitchOn(item, lara_item);
                 } else {
-                    M_SwitchOff(item, lara_item);
+                    M_TurnSwitchOff(item, lara_item);
                 }
                 lara->head_rot.x = 0;
                 lara->head_rot.y = 0;
@@ -254,16 +254,16 @@ static void M_Collision(
     }
 
     if (item->object_id == O_SWITCH_TYPE_AIRLOCK
-        && item->current_anim_state == SWITCH_STATE_ON) {
+        && item->current_anim_state == SWITCH_STATE_OFF) {
         return;
     }
 
     M_AlignLara(lara_item, item);
 
-    if (item->current_anim_state == SWITCH_STATE_ON) {
-        M_SwitchOn(item, lara_item);
+    if (item->current_anim_state == SWITCH_STATE_OFF) {
+        M_TurnSwitchOn(item, lara_item);
     } else {
-        M_SwitchOff(item, lara_item);
+        M_TurnSwitchOff(item, lara_item);
     }
 
     if (!lara->extra_anim) {
@@ -295,8 +295,8 @@ static void M_CollisionUW(
         return;
     }
 
-    if (item->current_anim_state != SWITCH_STATE_OFF
-        && item->current_anim_state != SWITCH_STATE_ON) {
+    if (item->current_anim_state != SWITCH_STATE_ON
+        && item->current_anim_state != SWITCH_STATE_OFF) {
         return;
     }
 
@@ -309,10 +309,10 @@ static void M_CollisionUW(
     lara_item->goal_anim_state = LS(LS_TREAD);
     lara->gun_status = LGS_HANDS_BUSY;
 
-    if (item->current_anim_state == SWITCH_STATE_ON) {
-        item->goal_anim_state = SWITCH_STATE_OFF;
-    } else {
+    if (item->current_anim_state == SWITCH_STATE_OFF) {
         item->goal_anim_state = SWITCH_STATE_ON;
+    } else {
+        item->goal_anim_state = SWITCH_STATE_OFF;
     }
     item->status = IS_ACTIVE;
     Item_AddActive(item_num);
@@ -358,7 +358,7 @@ bool Switch_Trigger(const int16_t item_num, const int16_t timer)
             return false;
         } else if (
             (item->flags & IF_ONE_SHOT) != 0
-            || item->current_anim_state == SWITCH_STATE_OFF) {
+            || item->current_anim_state == SWITCH_STATE_ON) {
             return false;
         }
 
@@ -370,7 +370,7 @@ bool Switch_Trigger(const int16_t item_num, const int16_t timer)
         return false;
     }
 
-    if (item->current_anim_state == SWITCH_STATE_OFF && timer > 0) {
+    if (item->current_anim_state == SWITCH_STATE_ON && timer > 0) {
         item->timer = timer;
         if (timer != 1) {
             item->timer *= LOGIC_FPS;

--- a/src/trx/game/objects/general/switch.h
+++ b/src/trx/game/objects/general/switch.h
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 typedef enum {
-    SWITCH_STATE_OFF = 0,
-    SWITCH_STATE_ON = 1,
+    SWITCH_STATE_ON = 0,
+    SWITCH_STATE_OFF = 1,
     SWITCH_STATE_LINK = 2,
 } SWITCH_STATE;
 

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -507,7 +507,7 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 (TRIGGER_CAMERA_DATA *)cmd->parameter;
             OBJECT_VECTOR *const camera =
                 Camera_GetFixedObject(cam_data->camera_num);
-            if (camera->flags & IF_ONE_SHOT) {
+            if ((camera->flags & IF_ONE_SHOT) != 0) {
                 break;
             }
 
@@ -522,7 +522,8 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 break;
             }
 
-            if (trigger->type == TT_SWITCH && trigger->timer && switch_off) {
+            if (trigger->type == TT_SWITCH && trigger->timer != 0
+                && switch_off) {
                 break;
             }
 


### PR DESCRIPTION
Resolves  #4456.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Level data defines 0 as switch state on and 1 as off. When testing triggers, the check was originally done against the switch having state `LS_RUN` to mean off, but this was fixed to use the correct switch state name, and in turn inherited the wrong value.  The utility switch state functions have been renamed slightly to reflect what they do more specifically.

It'd be good to double check all switch types (looks OK to me, but would appreciate a second test).

Do we want an FD injection fix to avoid the camera repeating if Lara steps off and back on the tile in Valley? I feel if it always happened it'd be fine, but the fact it's one shot in the flip room feels like an oversight in the unflipped room.
