### PR TITLE
level/loader: enable caustics on visible statics only

### DIFF
--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1061,7 +1061,7 @@ void Level_ReadStaticObjects(
             obj->collidable = true;
         }
 
-        Object_GetMesh(obj->mesh_idx)->enable_caustics = true;
+        Object_GetMesh(obj->mesh_idx)->enable_caustics = obj->visible;
     }
 
     Benchmark_End(&benchmark, nullptr);


### PR DESCRIPTION
Resolves #4458.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids caustics being applied to hidden static meshes, which may be using Lara's default mesh.
