### PR TITLE
Add support for cdaudio.wad to TR3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed demos not using loading screens
 
 **TR3**:
+- added cdaudio.wad music playback support
 - added monochrome inventory backgrounds
 - added high-resolutions 16:9 and 4:3 loading screens
 - added high-resolutions 16:9 and 4:3 title and game end screens

--- a/src/meson.build
+++ b/src/meson.build
@@ -277,6 +277,7 @@ common_sources = [
   'trx/game/math/util.c',
   'trx/game/matrix.c',
   'trx/game/music/backend_cdaudio.c',
+  'trx/game/music/backend_cdaudio_wad.c',
   'trx/game/music/backend_files.c',
   'trx/game/music/common.c',
   'trx/game/music/ids.c',

--- a/src/trx/engine/audio.c
+++ b/src/trx/engine/audio.c
@@ -35,7 +35,7 @@ bool Audio_Init(void)
         return true;
     }
 
-    int32_t result = SDL_Init(SDL_INIT_AUDIO);
+    int32_t result = SDL_InitSubSystem(SDL_INIT_AUDIO);
     if (result < 0) {
         LOG_ERROR("Error while calling SDL_Init: 0x%lx", result);
         return false;
@@ -84,11 +84,12 @@ bool Audio_Shutdown(void)
         SDL_CloseAudioDevice(g_AudioDeviceID);
         g_AudioDeviceID = 0;
     }
-
     Memory_FreePointer(&m_MixBuffer);
 
     Audio_Sample_Shutdown();
     Audio_Stream_Shutdown();
+
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
     return true;
 }
 

--- a/src/trx/engine/audio.h
+++ b/src/trx/engine/audio.h
@@ -2,6 +2,7 @@
 
 #include <SDL2/SDL_audio.h>
 #include <libavutil/samplefmt.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define AUDIO_MAX_SAMPLES 1000
@@ -20,6 +21,7 @@ bool Audio_IsMuted(void);
 bool Audio_Stream_Pause(int32_t sound_id);
 bool Audio_Stream_Unpause(int32_t sound_id);
 int32_t Audio_Stream_CreateFromFile(const char *path);
+int32_t Audio_Stream_CreateFromMemory(uint8_t *data, size_t size);
 bool Audio_Stream_Close(int32_t sound_id);
 bool Audio_Stream_IsLooped(int32_t sound_id);
 bool Audio_Stream_SetVolume(int32_t sound_id, float volume);

--- a/src/trx/engine/audio_stream.c
+++ b/src/trx/engine/audio_stream.c
@@ -28,6 +28,17 @@
 #define READ_BUFFER_SIZE                                                       \
     (AUDIO_SAMPLES * AUDIO_WORKING_CHANNELS * sizeof(AUDIO_WORKING_FORMAT))
 
+typedef enum {
+    M_STREAM_SRC_NONE,
+    M_STREAM_SRC_MEMORY,
+} M_STREAM_SOURCE_TYPE;
+
+typedef struct {
+    uint8_t *data;
+    size_t size;
+    size_t pos;
+} M_MEM_SOURCE;
+
 typedef struct {
     bool is_used;
     bool is_playing;
@@ -42,6 +53,11 @@ typedef struct {
 
     void (*finish_callback)(int32_t sound_id, void *user_data);
     void *finish_callback_user_data;
+
+    M_STREAM_SOURCE_TYPE src_type;
+    void *src;
+    uint8_t *avio_ctx_buffer;
+    AVIOContext *avio_ctx;
 
     struct {
         AVStream *stream;
@@ -72,6 +88,64 @@ static AUDIO_STREAM_SOUND m_Streams[AUDIO_MAX_ACTIVE_STREAMS] = {};
 static float m_MixBuffer[AUDIO_SAMPLES * AUDIO_WORKING_CHANNELS] = {};
 static size_t m_DecodeBufferCapacity = 0;
 static float *m_DecodeBuffer = nullptr;
+
+static int32_t M_MemoryRead(
+    void *const opaque, uint8_t *const buf, const int32_t buf_size)
+{
+    ASSERT(opaque != nullptr);
+    ASSERT(buf != nullptr);
+
+    if (buf_size <= 0) {
+        return 0;
+    }
+
+    M_MEM_SOURCE *const s = opaque;
+    if (s->pos >= s->size) {
+        return AVERROR_EOF;
+    }
+
+    size_t to_copy = s->size - s->pos;
+    if (to_copy > (size_t)buf_size) {
+        to_copy = (size_t)buf_size;
+    }
+
+    memcpy(buf, s->data + s->pos, to_copy);
+    s->pos += to_copy;
+    return (int32_t)to_copy;
+}
+
+static int64_t M_MemorySeek(
+    void *const opaque, const int64_t offset, const int32_t whence)
+{
+    ASSERT(opaque != nullptr);
+
+    M_MEM_SOURCE *const s = opaque;
+    if ((whence & AVSEEK_SIZE) != 0) {
+        return (int64_t)s->size;
+    }
+
+    const int32_t base_whence = whence & ~AVSEEK_FORCE;
+    int64_t base;
+    if (base_whence == SEEK_SET) {
+        base = 0;
+    } else if (base_whence == SEEK_CUR) {
+        base = (int64_t)s->pos;
+    } else if (base_whence == SEEK_END) {
+        base = (int64_t)s->size;
+    } else {
+        return AVERROR(EINVAL);
+    }
+
+    int64_t new_pos = base + offset;
+    if (new_pos < 0) {
+        new_pos = 0;
+    }
+    if (new_pos > (int64_t)s->size) {
+        new_pos = (int64_t)s->size;
+    }
+    s->pos = (size_t)new_pos;
+    return new_pos;
+}
 
 static void M_SeekToStart(AUDIO_STREAM_SOUND *stream)
 {
@@ -146,6 +220,117 @@ static bool M_DecodeFrame(AUDIO_STREAM_SOUND *stream)
     }
 
     return true;
+}
+
+static bool M_InitialiseFromFormatContext(
+    int32_t sound_id, AVFormatContext *const fmt_ctx)
+{
+    if (!g_AudioDeviceID || sound_id < 0
+        || sound_id >= AUDIO_MAX_ACTIVE_STREAMS) {
+        return false;
+    }
+
+    bool ret = false;
+    SDL_LockAudioDevice(g_AudioDeviceID);
+
+    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+    int32_t error_code = 0;
+
+    stream->av.format_ctx = fmt_ctx;
+
+    error_code = avformat_find_stream_info(stream->av.format_ctx, nullptr);
+    if (error_code < 0) {
+        goto cleanup;
+    }
+
+    stream->av.stream = nullptr;
+    for (uint32_t i = 0; i < stream->av.format_ctx->nb_streams; i++) {
+        AVStream *current_stream = stream->av.format_ctx->streams[i];
+        if (current_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            stream->av.stream = current_stream;
+            break;
+        }
+    }
+    if (!stream->av.stream) {
+        error_code = AVERROR_STREAM_NOT_FOUND;
+        goto cleanup;
+    }
+
+    stream->av.codec =
+        avcodec_find_decoder(stream->av.stream->codecpar->codec_id);
+    if (!stream->av.codec) {
+        error_code = AVERROR_DEMUXER_NOT_FOUND;
+        goto cleanup;
+    }
+
+    stream->av.codec_ctx = avcodec_alloc_context3(stream->av.codec);
+    if (!stream->av.codec_ctx) {
+        error_code = AVERROR(ENOMEM);
+        goto cleanup;
+    }
+
+    error_code = avcodec_parameters_to_context(
+        stream->av.codec_ctx, stream->av.stream->codecpar);
+    if (error_code != 0) {
+        goto cleanup;
+    }
+
+    error_code = avcodec_open2(stream->av.codec_ctx, stream->av.codec, nullptr);
+    if (error_code < 0) {
+        goto cleanup;
+    }
+
+    stream->av.packet = av_packet_alloc();
+    if (!stream->av.packet) {
+        error_code = AVERROR(ENOMEM);
+        goto cleanup;
+    }
+
+    stream->av.frame = av_frame_alloc();
+    if (!stream->av.frame) {
+        error_code = AVERROR(ENOMEM);
+        goto cleanup;
+    }
+
+    M_DecodeFrame(stream);
+
+    const int32_t sdl_channels = stream->av.codec_ctx->ch_layout.nb_channels;
+
+    stream->is_read_done = false;
+    stream->is_used = true;
+    stream->is_playing = true;
+    stream->is_looped = false;
+    stream->volume = 1.0f;
+    stream->timestamp = 0.0;
+    stream->finish_callback = nullptr;
+    stream->finish_callback_user_data = nullptr;
+    stream->duration =
+        (double)stream->av.format_ctx->duration / (double)AV_TIME_BASE;
+    stream->start_at = -1.0; // negative value means unset
+    stream->stop_at = -1.0; // negative value means unset
+
+    stream->sdl.stream = SDL_NewAudioStream(
+        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE,
+        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE);
+    if (!stream->sdl.stream) {
+        LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());
+        goto cleanup;
+    }
+
+    ret = true;
+
+cleanup:
+    if (error_code != 0) {
+        LOG_ERROR(
+            "Error while opening audio stream: %s", av_err2str(error_code));
+    }
+
+    if (!ret) {
+        Audio_Stream_Close(sound_id);
+    }
+
+    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    return ret;
 }
 
 static bool M_EnqueueFrame(AUDIO_STREAM_SOUND *stream)
@@ -264,120 +449,27 @@ static bool M_InitialiseFromPath(int32_t sound_id, const char *file_path)
         return false;
     }
 
-    bool ret = false;
-    SDL_LockAudioDevice(g_AudioDeviceID);
-
-    int32_t error_code;
+    int32_t error_code = 0;
     char *full_path = File_GetFullPath(file_path);
     if (full_path == nullptr) {
         error_code = AVERROR(ENOENT);
-        goto cleanup;
-    }
-
-    AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
-
-    error_code = avformat_open_input(
-        &stream->av.format_ctx, full_path, nullptr, nullptr);
-    if (error_code != 0) {
-        goto cleanup;
-    }
-
-    error_code = avformat_find_stream_info(stream->av.format_ctx, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    stream->av.stream = nullptr;
-    for (uint32_t i = 0; i < stream->av.format_ctx->nb_streams; i++) {
-        AVStream *current_stream = stream->av.format_ctx->streams[i];
-        if (current_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            stream->av.stream = current_stream;
-            break;
-        }
-    }
-    if (!stream->av.stream) {
-        error_code = AVERROR_STREAM_NOT_FOUND;
-        goto cleanup;
-    }
-
-    stream->av.codec =
-        avcodec_find_decoder(stream->av.stream->codecpar->codec_id);
-    if (!stream->av.codec) {
-        error_code = AVERROR_DEMUXER_NOT_FOUND;
-        goto cleanup;
-    }
-
-    stream->av.codec_ctx = avcodec_alloc_context3(stream->av.codec);
-    if (!stream->av.codec_ctx) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    error_code = avcodec_parameters_to_context(
-        stream->av.codec_ctx, stream->av.stream->codecpar);
-    if (error_code) {
-        goto cleanup;
-    }
-
-    error_code = avcodec_open2(stream->av.codec_ctx, stream->av.codec, nullptr);
-    if (error_code < 0) {
-        goto cleanup;
-    }
-
-    stream->av.packet = av_packet_alloc();
-    if (!stream->av.packet) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    stream->av.frame = av_frame_alloc();
-    if (!stream->av.frame) {
-        error_code = AVERROR(ENOMEM);
-        goto cleanup;
-    }
-
-    M_DecodeFrame(stream);
-
-    const int32_t sdl_sample_rate = stream->av.codec_ctx->sample_rate;
-    const int32_t sdl_channels = stream->av.codec_ctx->ch_layout.nb_channels;
-
-    stream->is_read_done = false;
-    stream->is_used = true;
-    stream->is_playing = true;
-    stream->is_looped = false;
-    stream->volume = 1.0f;
-    stream->timestamp = 0.0;
-    stream->finish_callback = nullptr;
-    stream->finish_callback_user_data = nullptr;
-    stream->duration =
-        (double)stream->av.format_ctx->duration / (double)AV_TIME_BASE;
-    stream->start_at = -1.0; // negative value means unset
-    stream->stop_at = -1.0; // negative value means unset
-
-    stream->sdl.stream = SDL_NewAudioStream(
-        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE,
-        AUDIO_WORKING_FORMAT, sdl_channels, AUDIO_WORKING_RATE);
-    if (!stream->sdl.stream) {
-        LOG_ERROR("Failed to create SDL stream: %s", SDL_GetError());
-        goto cleanup;
-    }
-
-    ret = true;
-
-cleanup:
-    if (error_code) {
         LOG_ERROR(
             "Error while opening audio %s: %s", file_path,
             av_err2str(error_code));
+        return false;
     }
 
-    if (!ret) {
-        Audio_Stream_Close(sound_id);
-    }
-
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    AVFormatContext *fmt_ctx = nullptr;
+    error_code = avformat_open_input(&fmt_ctx, full_path, nullptr, nullptr);
     Memory_FreePointer(&full_path);
-    return ret;
+    if (error_code != 0) {
+        LOG_ERROR(
+            "Error while opening audio %s: %s", file_path,
+            av_err2str(error_code));
+        return false;
+    }
+
+    return M_InitialiseFromFormatContext(sound_id, fmt_ctx);
 }
 
 static void M_Clear(AUDIO_STREAM_SOUND *stream)
@@ -394,6 +486,11 @@ static void M_Clear(AUDIO_STREAM_SOUND *stream)
     stream->sdl.stream = nullptr;
     stream->finish_callback = nullptr;
     stream->finish_callback_user_data = nullptr;
+
+    stream->src_type = M_STREAM_SRC_NONE;
+    stream->src = nullptr;
+    stream->avio_ctx_buffer = nullptr;
+    stream->avio_ctx = nullptr;
 }
 
 void Audio_Stream_Init(void)
@@ -499,6 +596,74 @@ int32_t Audio_Stream_CreateFromFile(const char *file_path)
     return AUDIO_NO_SOUND;
 }
 
+int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
+{
+    if (!g_AudioDeviceID) {
+        return AUDIO_NO_SOUND;
+    }
+
+    ASSERT(data != nullptr);
+    ASSERT(size != 0);
+
+    for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS;
+         sound_id++) {
+        AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
+        if (stream->is_used) {
+            continue;
+        }
+
+        M_MEM_SOURCE *const src = Memory_Alloc(sizeof(M_MEM_SOURCE));
+        *src = (M_MEM_SOURCE) {
+            .data = data,
+            .size = size,
+            .pos = 0,
+        };
+
+        stream->src_type = M_STREAM_SRC_MEMORY;
+        stream->src = src;
+
+        stream->avio_ctx_buffer = av_malloc(4096);
+        if (stream->avio_ctx_buffer == nullptr) {
+            Audio_Stream_Close(sound_id);
+            return AUDIO_NO_SOUND;
+        }
+
+        stream->avio_ctx = avio_alloc_context(
+            stream->avio_ctx_buffer, 4096, 0, src, M_MemoryRead, nullptr,
+            M_MemorySeek);
+        if (stream->avio_ctx == nullptr) {
+            Audio_Stream_Close(sound_id);
+            return AUDIO_NO_SOUND;
+        }
+
+        AVFormatContext *fmt_ctx = avformat_alloc_context();
+        if (fmt_ctx == nullptr) {
+            Audio_Stream_Close(sound_id);
+            return AUDIO_NO_SOUND;
+        }
+        fmt_ctx->pb = stream->avio_ctx;
+        fmt_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+        int32_t error_code =
+            avformat_open_input(&fmt_ctx, nullptr, nullptr, nullptr);
+        if (error_code != 0) {
+            LOG_ERROR(
+                "Error while opening audio memory stream: %s",
+                av_err2str(error_code));
+            Audio_Stream_Close(sound_id);
+            return AUDIO_NO_SOUND;
+        }
+
+        if (!M_InitialiseFromFormatContext(sound_id, fmt_ctx)) {
+            return AUDIO_NO_SOUND;
+        }
+
+        return sound_id;
+    }
+
+    return AUDIO_NO_SOUND;
+}
+
 bool Audio_Stream_Close(int32_t sound_id)
 {
     if (!g_AudioDeviceID || sound_id < 0
@@ -523,6 +688,20 @@ bool Audio_Stream_Close(int32_t sound_id)
     if (stream->av.format_ctx) {
         avformat_close_input(&stream->av.format_ctx);
         stream->av.format_ctx = nullptr;
+    }
+
+    if (stream->avio_ctx) {
+        avio_context_free(&stream->avio_ctx);
+        stream->avio_ctx = nullptr;
+    }
+    if (stream->avio_ctx_buffer != nullptr) {
+        av_freep(&stream->avio_ctx_buffer);
+    }
+
+    if (stream->src_type == M_STREAM_SRC_MEMORY && stream->src != nullptr) {
+        M_MEM_SOURCE *const src = stream->src;
+        Memory_FreePointer(&src->data);
+        Memory_FreePointer(&stream->src);
     }
 
     if (stream->swr.ctx) {

--- a/src/trx/engine/audio_stream.c
+++ b/src/trx/engine/audio_stream.c
@@ -194,6 +194,8 @@ static bool M_DecodeFrame(AUDIO_STREAM_SOUND *stream)
         }
     }
 
+    // av_read_frame() overwrites the packet; always unref any previous content.
+    av_packet_unref(stream->av.packet);
     int32_t error_code =
         av_read_frame(stream->av.format_ctx, stream->av.packet);
 
@@ -636,16 +638,16 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
             return AUDIO_NO_SOUND;
         }
 
-        AVFormatContext *fmt_ctx = avformat_alloc_context();
-        if (fmt_ctx == nullptr) {
+        stream->av.format_ctx = avformat_alloc_context();
+        if (stream->av.format_ctx == nullptr) {
             Audio_Stream_Close(sound_id);
             return AUDIO_NO_SOUND;
         }
-        fmt_ctx->pb = stream->avio_ctx;
-        fmt_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+        stream->av.format_ctx->pb = stream->avio_ctx;
+        stream->av.format_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
 
-        int32_t error_code =
-            avformat_open_input(&fmt_ctx, nullptr, nullptr, nullptr);
+        int32_t error_code = avformat_open_input(
+            &stream->av.format_ctx, nullptr, nullptr, nullptr);
         if (error_code != 0) {
             LOG_ERROR(
                 "Error while opening audio memory stream: %s",
@@ -654,7 +656,8 @@ int32_t Audio_Stream_CreateFromMemory(uint8_t *const data, const size_t size)
             return AUDIO_NO_SOUND;
         }
 
-        if (!M_InitialiseFromFormatContext(sound_id, fmt_ctx)) {
+        if (!M_InitialiseFromFormatContext(sound_id, stream->av.format_ctx)) {
+            Audio_Stream_Close(sound_id);
             return AUDIO_NO_SOUND;
         }
 
@@ -690,13 +693,14 @@ bool Audio_Stream_Close(int32_t sound_id)
         stream->av.format_ctx = nullptr;
     }
 
-    if (stream->avio_ctx) {
+    if (stream->avio_ctx != nullptr) {
+        av_freep(&stream->avio_ctx->buffer);
         avio_context_free(&stream->avio_ctx);
         stream->avio_ctx = nullptr;
-    }
-    if (stream->avio_ctx_buffer != nullptr) {
+    } else if (stream->avio_ctx_buffer != nullptr) {
         av_freep(&stream->avio_ctx_buffer);
     }
+    stream->avio_ctx_buffer = nullptr;
 
     if (stream->src_type == M_STREAM_SRC_MEMORY && stream->src != nullptr) {
         M_MEM_SOURCE *const src = stream->src;

--- a/src/trx/filesystem.c
+++ b/src/trx/filesystem.c
@@ -62,6 +62,9 @@ static FILE *M_UTF8Fopen(const char *path, const char *mode)
 #else
 static FILE *M_UTF8Fopen(const char *path, const char *mode)
 {
+    if (path == nullptr || mode == nullptr) {
+        return nullptr;
+    }
     return fopen(path, mode);
 }
 #endif
@@ -81,6 +84,9 @@ static void M_PathAppendPart(char *const path, const char *const part)
 
 static bool M_ExistsRaw(const char *path)
 {
+    if (path == nullptr) {
+        return false;
+    }
     FILE *fp = M_UTF8Fopen(path, "rb");
     if (fp) {
         fclose(fp);

--- a/src/trx/game/music/backend_cdaudio_wad.c
+++ b/src/trx/game/music/backend_cdaudio_wad.c
@@ -1,0 +1,206 @@
+#include <trx/game/music/backend_cdaudio_wad.h>
+
+#include <trx/debug.h>
+#include <trx/engine/audio.h>
+#include <trx/filesystem.h>
+#include <trx/log.h>
+#include <trx/memory.h>
+#include <trx/strings.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define M_CDAUDIO_WAD_TRACK_COUNT 130
+#define M_CDAUDIO_WAD_WFX_OFFSET 20
+#define M_CDAUDIO_WAD_WFX_SIZE 50
+#define M_CDAUDIO_WAD_WAV_HEADER_SIZE 90
+
+typedef struct {
+    char name[260];
+    uint32_t size;
+    uint32_t offset;
+} M_CDAUDIO_WAD_TRACK_DESC;
+
+_Static_assert(
+    sizeof(M_CDAUDIO_WAD_TRACK_DESC) == 268,
+    "Unexpected cdaudio.wad track info size");
+
+typedef struct {
+    uint32_t size;
+    uint32_t offset;
+    bool active;
+} M_CDAUDIO_WAD_TRACK;
+
+typedef struct {
+    const char *path;
+    const char *description;
+    M_CDAUDIO_WAD_TRACK tracks[M_CDAUDIO_WAD_TRACK_COUNT];
+    uint8_t wfx[M_CDAUDIO_WAD_WFX_SIZE];
+    bool has_wfx;
+} M_BACKEND_DATA;
+
+static bool M_LoadTrackAsWaveFile(
+    const MUSIC_BACKEND *const backend, const int32_t track_id,
+    uint8_t **const out_data, size_t *const out_size)
+{
+    ASSERT(backend != nullptr);
+    ASSERT(out_data != nullptr);
+    ASSERT(out_size != nullptr);
+
+    const M_BACKEND_DATA *const data = backend->data;
+    ASSERT(data != nullptr);
+
+    *out_data = nullptr;
+    *out_size = 0;
+
+    const int32_t track_idx = track_id - 1;
+    if (track_idx < 0 || track_idx >= M_CDAUDIO_WAD_TRACK_COUNT) {
+        LOG_ERROR("Invalid track: %d", track_id);
+        return false;
+    }
+
+    const M_CDAUDIO_WAD_TRACK *const track = &data->tracks[track_idx];
+    if (!track->active || track->size == 0) {
+        LOG_ERROR("Invalid track: %d", track_id);
+        return false;
+    }
+
+    const size_t total_size =
+        M_CDAUDIO_WAD_WAV_HEADER_SIZE + (size_t)track->size;
+    uint8_t *const buf = Memory_Alloc(total_size);
+
+    MYFILE *const fp = File_Open(data->path, FILE_OPEN_READ);
+    if (fp == nullptr) {
+        Memory_Free(buf);
+        return false;
+    }
+
+    File_Seek(fp, (size_t)track->offset, FILE_SEEK_SET);
+    const bool ok = File_ReadData(fp, buf, total_size);
+    File_Close(fp);
+    if (!ok) {
+        Memory_Free(buf);
+        return false;
+    }
+
+    *out_data = buf;
+    *out_size = total_size;
+    return true;
+}
+
+static bool M_ReadAllTrackInfos(MYFILE *const fp, M_BACKEND_DATA *const data)
+{
+    ASSERT(fp != nullptr);
+    ASSERT(data != nullptr);
+
+    M_CDAUDIO_WAD_TRACK_DESC track_infos[M_CDAUDIO_WAD_TRACK_COUNT] = {};
+    File_Skip(fp, sizeof(M_CDAUDIO_WAD_TRACK_DESC));
+    if (!File_ReadItems(
+            fp, track_infos, M_CDAUDIO_WAD_TRACK_COUNT,
+            sizeof(M_CDAUDIO_WAD_TRACK_DESC))) {
+        return false;
+    }
+
+    data->has_wfx = false;
+
+    int32_t first_active_idx = -1;
+    for (int32_t i = 0; i < M_CDAUDIO_WAD_TRACK_COUNT; i++) {
+        const bool is_active = track_infos[i].size != 0;
+        data->tracks[i].active = is_active;
+        data->tracks[i].size = track_infos[i].size;
+        data->tracks[i].offset = track_infos[i].offset;
+
+        if (first_active_idx < 0 && is_active) {
+            first_active_idx = i;
+        }
+    }
+
+    if (first_active_idx < 0) {
+        return true;
+    }
+
+    const size_t wfx_pos = (size_t)data->tracks[first_active_idx].offset
+        + M_CDAUDIO_WAD_WFX_OFFSET;
+    File_Seek(fp, wfx_pos, FILE_SEEK_SET);
+    if (!File_ReadData(fp, data->wfx, M_CDAUDIO_WAD_WFX_SIZE)) {
+        return false;
+    }
+    data->has_wfx = true;
+    return true;
+}
+
+static bool M_Init(MUSIC_BACKEND *const backend)
+{
+    ASSERT(backend != nullptr);
+    M_BACKEND_DATA *const data = backend->data;
+    ASSERT(data != nullptr);
+
+    MYFILE *const fp = File_Open(data->path, FILE_OPEN_READ);
+    if (fp == nullptr) {
+        return false;
+    }
+
+    const bool ok = M_ReadAllTrackInfos(fp, data);
+    File_Close(fp);
+    return ok;
+}
+
+static const char *M_Describe(const MUSIC_BACKEND *const backend)
+{
+    ASSERT(backend != nullptr);
+    const M_BACKEND_DATA *const data = backend->data;
+    ASSERT(data != nullptr);
+    return data->description;
+}
+
+static int32_t M_Play(
+    const MUSIC_BACKEND *const backend, const int32_t track_id)
+{
+    ASSERT(backend != nullptr);
+
+    uint8_t *wav_data = nullptr;
+    size_t wav_size = 0;
+    if (!M_LoadTrackAsWaveFile(backend, track_id, &wav_data, &wav_size)) {
+        return AUDIO_NO_SOUND;
+    }
+
+    const int32_t stream_id = Audio_Stream_CreateFromMemory(wav_data, wav_size);
+    if (stream_id < 0) {
+        Memory_Free(wav_data);
+    }
+    return stream_id;
+}
+
+static void M_Shutdown(MUSIC_BACKEND *backend)
+{
+    if (backend == nullptr) {
+        return;
+    }
+
+    if (backend->data != nullptr) {
+        M_BACKEND_DATA *const data = backend->data;
+        Memory_FreePointer(&data->path);
+        Memory_FreePointer(&data->description);
+    }
+    Memory_FreePointer(&backend->data);
+    Memory_FreePointer(&backend);
+}
+
+MUSIC_BACKEND *Music_Backend_CDAudioWad_Factory(const char *const path)
+{
+    ASSERT(path != nullptr);
+
+    M_BACKEND_DATA *const data = Memory_Alloc(sizeof(M_BACKEND_DATA));
+    *data = (M_BACKEND_DATA) {
+        .path = Memory_DupStr(path),
+        .description = String_Format("CDAudio WAD (path: %s)", path),
+    };
+
+    MUSIC_BACKEND *const backend = Memory_Alloc(sizeof(MUSIC_BACKEND));
+    backend->data = data;
+    backend->init = M_Init;
+    backend->describe = M_Describe;
+    backend->play = M_Play;
+    backend->shutdown = M_Shutdown;
+    return backend;
+}

--- a/src/trx/game/music/backend_cdaudio_wad.h
+++ b/src/trx/game/music/backend_cdaudio_wad.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <trx/game/music/types.h>
+
+MUSIC_BACKEND *Music_Backend_CDAudioWad_Factory(const char *path);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -6,6 +6,7 @@
 #include <trx/game/level.h>
 #include <trx/game/music.h>
 #include <trx/game/music/backend_cdaudio.h>
+#include <trx/game/music/backend_cdaudio_wad.h>
 #include <trx/game/music/backend_files.h>
 #include <trx/game/sound.h>
 #include <trx/log.h>
@@ -41,6 +42,12 @@ static const MUSIC_BACKEND *M_FindBackend(void)
             all_backends,
             &(MUSIC_BACKEND *) {
                 Music_Backend_CDAudio_Factory("audio/cdaudio.mp3") });
+    }
+    if (g_TRVersion >= 3) {
+        Vector_Add(
+            all_backends,
+            &(MUSIC_BACKEND *) {
+                Music_Backend_CDAudioWad_Factory("audio/cdaudio.wad") });
     }
 
     const MUSIC_BACKEND *backend = nullptr;

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -541,6 +541,10 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
         Vector_Free(batcher->transparent_indices);
         batcher->transparent_indices = nullptr;
     }
+    if (batcher->transparent_sort != nullptr) {
+        Vector_Free(batcher->transparent_sort);
+        batcher->transparent_sort = nullptr;
+    }
     for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
         if (batcher->staged[pass] != nullptr) {
             Vector_Free(batcher->staged[pass]);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds support for TR3 music playback by parsing the cdaudio.wad file for TR3+ and loading the tracks from memory, reconstructing the RIFF header from .wad. It also fixes a couple of small memory leaks and other Valgrind warnings.