### PR TITLE
gun/common: always use pistol animations

### DIFF
--- a/src/trx/game/gun/common.c
+++ b/src/trx/game/gun/common.c
@@ -25,18 +25,15 @@ void Gun_AddDynamicLight(void)
 
 OBJECT_ID Gun_GetLaraAnim(const LARA_GUN_TYPE gun_type)
 {
-    if (g_TRVersion == 1) {
-        switch (gun_type) {
-        case LGT_PISTOLS:
-        case LGT_MAGNUMS:
-        case LGT_AUTOS:
-        case LGT_UZIS:
-            return O_LARA_PISTOLS;
-        default:
-            break;
-        }
+    switch (gun_type) {
+    case LGT_PISTOLS:
+    case LGT_MAGNUMS:
+    case LGT_AUTOS:
+    case LGT_UZIS:
+        return O_LARA_PISTOLS;
+    default:
+        return Gun_GetWeaponAnim(gun_type);
     }
-    return Gun_GetWeaponAnim(gun_type);
 }
 
 OBJECT_ID Gun_GetWeaponAnim(const LARA_GUN_TYPE gun_type)


### PR DESCRIPTION
Resolves #4483.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Setting arm info in the pistols module no longer hardcodes the use of `O_LARA_PISTOLS` in order to support the Desert Eagle. This ensures the pistols object is always used for the other 2-hand guns.
