### PR TITLE
lara/cheat: prevent jumping on fly cheat exit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fixed waterfall mist not brightening when holding a flare (#4486)
 - fixed resetting camera in the photo mode not clearing the underwater tint
 - fixed developer console text editing (backspace, moving the caret) doing weird things with Unicode characters
+- fixed Lara jumping if player holds the swim button when exiting the fly cheat (#4470)
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -353,6 +353,14 @@ bool Lara_Cheat_ExitFlyMode(void)
         M_ReinitialiseGunMeshes();
     }
 
+    if (lara_info->water_status == LWS_ABOVE_WATER) {
+        // Prevent Lara from jumping if the player holds the swim button
+        // during the fly cheat exit (#4470)
+        g_Input.any = 0;
+        g_InputDB.any = 0;
+        Lara_Control();
+    }
+
     Console_Log(GS(OSD_FLY_MODE_OFF));
     return true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4470.

It's still possible to jump at the start of a level.