### PR TITLE
camera/photo-mode: clear underwater flag on reset

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 - fixed ambient music triggers to no longer kill active normal music tracks (#4463)
 - fixed game crashing when Lara passes through light sources in certain levels
 - fixed waterfall mist not brightening when holding a flare (#4486)
+- fixed resetting camera in the photo mode not clearing the underwater tint
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -318,12 +318,14 @@ void Camera_PhotoMode_Update(void)
 {
     M_HandleFOVInputs();
 
+    bool changed = false;
+
     if (g_InputDB.camera_reset) {
         M_ResetCamera(false);
         g_Camera.type = CAM_PHOTO_MODE;
+        changed = true;
     }
 
-    bool changed = false;
     changed |= M_HandleShiftInputs();
     changed |= M_HandleRotationInputs();
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the following bug:

1. Enter photo mode from a dry place
2. Dip the camera underwater
3. Reset camera

Develop: the camera retains underwater tint until moved
PR: fixed