### PR TITLE
console: fix moving and deleting Unicode text

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed game crashing when Lara passes through light sources in certain levels
 - fixed waterfall mist not brightening when holding a flare (#4486)
 - fixed resetting camera in the photo mode not clearing the underwater tint
+- fixed developer console text editing (backspace, moving the caret) doing weird things with Unicode characters
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/game/ui/elements/prompt.c
+++ b/src/trx/game/ui/elements/prompt.c
@@ -39,18 +39,49 @@ static void M_Layout(
     caret->ops.layout(caret, x + caret_pos, y, w, h);
 }
 
+static int32_t M_GetPrevCaretPos(
+    const char *const text, const int32_t caret_pos)
+{
+    if (caret_pos <= 0) {
+        return 0;
+    }
+
+    const char *const caret_ptr = text + caret_pos;
+    const char *p = text;
+    const char *prev = text;
+
+    while (p < caret_ptr) {
+        prev = p;
+        p += String_GetCharByteSize(p);
+    }
+
+    return (int32_t)(prev - text);
+}
+
+static int32_t M_GetNextCaretPos(
+    const char *const text, const int32_t caret_pos)
+{
+    const size_t text_len = strlen(text);
+    if ((size_t)caret_pos >= text_len) {
+        return (int32_t)text_len;
+    }
+
+    int32_t next_pos =
+        caret_pos + (int32_t)String_GetCharByteSize(text + caret_pos);
+    if ((size_t)next_pos > text_len) {
+        next_pos = (int32_t)text_len;
+    }
+    return next_pos;
+}
+
 static void M_MoveCaretLeft(UI_PROMPT_STATE *const s)
 {
-    if (s->caret_pos > 0) {
-        s->caret_pos--;
-    }
+    s->caret_pos = M_GetPrevCaretPos(s->current_text, s->caret_pos);
 }
 
 static void M_MoveCaretRight(UI_PROMPT_STATE *const s)
 {
-    if (s->caret_pos < (int32_t)strlen(s->current_text)) {
-        s->caret_pos++;
-    }
+    s->caret_pos = M_GetNextCaretPos(s->current_text, s->caret_pos);
 }
 
 static void M_MoveCaretStart(UI_PROMPT_STATE *const s)
@@ -69,10 +100,16 @@ static void M_DeleteCharBack(UI_PROMPT_STATE *const s)
         return;
     }
 
+    const int32_t delete_start =
+        M_GetPrevCaretPos(s->current_text, s->caret_pos);
+    if (delete_start >= s->caret_pos || delete_start < 0) {
+        return;
+    }
+
     memmove(
-        s->current_text + s->caret_pos - 1, s->current_text + s->caret_pos,
-        strlen(s->current_text) + 1 - s->caret_pos);
-    s->caret_pos--;
+        s->current_text + delete_start, s->current_text + s->caret_pos,
+        strlen(s->current_text) + 1 - (size_t)s->caret_pos);
+    s->caret_pos = delete_start;
 }
 
 static void M_Clear(UI_PROMPT_STATE *const s)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the following bug:

- Open the console
- Type: "1Ω2"
- Press left 2 times
- Type "a"
- Press right 1 time
- Type "b"
- Press backspace 2 times
- Press "c"

Expected: first we edit the text to "1aΩb2" then to "1ac2"
Develop: we end up with "1c2" with some nonsense bytes underneath that end up not getting rendered because of missing glyphs. This is because on develop, we do these operations (move caret left/right, delete the last character) on bytes rather than characters, and most Unicode characters can take up more than a single byte.