### PR TITLE
phase/phase_inventory: stop music before title load

### DIFF
--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -21,6 +21,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     const GF_LEVEL *const level = GF_GetTitleLevel();
     if (p->mode == INV_TITLE_MODE && g_Config.audio.enable_music_in_menu
         && level->music_track >= 0) {
+        Music_Stop();
         Music_Play_Direct(level->music_track, MPM_LOOPED);
     }
 


### PR DESCRIPTION
Resolves #4496.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents the title screen music being queued as an ambient track if it loads while other music is playing.
