### PR TITLE
input: fix checking for input roles

### DIFF
--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -237,8 +237,8 @@ void Input_ExitListenMode(void)
 {
     m_ListenMode = false;
     Input_Update();
-    g_OldInputDB.any = g_Input.any;
-    g_InputDB.any = g_Input.any;
+    InputState_Copy(&g_OldInputDB, g_Input);
+    InputState_Copy(&g_InputDB, g_Input);
 }
 
 bool Input_IsInListenMode(void)
@@ -351,7 +351,9 @@ const char *const *Input_GetLayoutNamePtr(const INPUT_LAYOUT layout)
 INPUT_STATE Input_GetDebounced(const INPUT_STATE input)
 {
     INPUT_STATE result;
-    result.any = input.any & ~g_OldInputDB.any;
+    for (int32_t i = 0; i < INPUT_STATE_ANY_WORDS; i++) {
+        result.any[i] = input.any[i] & ~g_OldInputDB.any[i];
+    }
 
     // Allow holding certain keys
     for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
@@ -436,4 +438,28 @@ bool Input_ParseKeyDesc(
     *scancode = SDL_GetScancodeFromName(keystr);
     *mod = m;
     return *scancode != SDL_SCANCODE_UNKNOWN;
+}
+
+void InputState_Clear(INPUT_STATE *const state)
+{
+    for (int32_t i = 0; i < INPUT_STATE_ANY_WORDS; i++) {
+        state->any[i] = 0;
+    }
+}
+
+void InputState_Copy(INPUT_STATE *const dst, const INPUT_STATE src)
+{
+    for (int32_t i = 0; i < INPUT_STATE_ANY_WORDS; i++) {
+        dst->any[i] = src.any[i];
+    }
+}
+
+bool InputState_IsAnyPressed(const INPUT_STATE state)
+{
+    for (int32_t i = 0; i < INPUT_STATE_ANY_WORDS; i++) {
+        if (state.any[i] != 0) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -12,8 +12,10 @@ typedef enum {
 #undef X_INPUT_ROLE
 } INPUT_ROLE;
 
+#define INPUT_STATE_ANY_WORDS ((INPUT_ROLE_NUMBER_OF + 63) / 64)
+
 typedef union {
-    uint64_t any;
+    uint64_t any[INPUT_STATE_ANY_WORDS];
     struct {
 #define X_INPUT_ROLE(role_name, state_name) uint64_t state_name : 1;
 #include <trx/game/input/roles.def>
@@ -126,3 +128,7 @@ const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod);
 // Returns true if parsing succeeded, false otherwise.
 bool Input_ParseKeyDesc(
     const char *desc, SDL_Scancode *scancode, SDL_Keymod *mod);
+
+void InputState_Clear(INPUT_STATE *state);
+void InputState_Copy(INPUT_STATE *dst, INPUT_STATE src);
+bool InputState_IsAnyPressed(INPUT_STATE state);

--- a/src/trx/game/input/update.c
+++ b/src/trx/game/input/update.c
@@ -19,7 +19,7 @@ static void M_UpdateFromBackend(
 
 void Input_Update(void)
 {
-    g_Input.any = 0;
+    InputState_Clear(&g_Input);
 
     M_UpdateFromBackend(
         &g_Input, &g_Input_Keyboard, g_Config.input.keyboard_layout);
@@ -60,7 +60,7 @@ void Input_Update(void)
     g_InputDB = Input_GetDebounced(g_Input);
 
     if (Input_IsInListenMode()) {
-        g_Input.any = 0;
-        g_InputDB.any = 0;
+        InputState_Clear(&g_Input);
+        InputState_Clear(&g_InputDB);
     }
 }

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -312,8 +312,8 @@ static bool M_CheckDemoTimer(const INV_RING *const ring)
         return false;
     }
 
-    if (ring->mode != INV_TITLE_MODE || g_Input.any || g_InputDB.any
-        || Console_IsOpened()) {
+    if (ring->mode != INV_TITLE_MODE || InputState_IsAnyPressed(g_Input)
+        || InputState_IsAnyPressed(g_InputDB) || Console_IsOpened()) {
         ClockTimer_Sync(&m_DemoTimer);
         return false;
     }

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -356,8 +356,8 @@ bool Lara_Cheat_ExitFlyMode(void)
     if (lara_info->water_status == LWS_ABOVE_WATER) {
         // Prevent Lara from jumping if the player holds the swim button
         // during the fly cheat exit (#4470)
-        g_Input.any = 0;
-        g_InputDB.any = 0;
+        InputState_Clear(&g_Input);
+        InputState_Clear(&g_InputDB);
         Lara_Control();
     }
 

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -87,11 +87,11 @@ static PHASE_CONTROL M_AdvanceFrame(M_PRIV *const p)
         phase->resume(phase);
     }
     if (p->rate >= 1.0) {
-        g_Input.any = 0;
-        g_InputDB.any = 0;
+        InputState_Clear(&g_Input);
+        InputState_Clear(&g_InputDB);
         result = phase->control(phase);
-        g_Input.any = 0;
-        g_InputDB.any = 0;
+        InputState_Clear(&g_Input);
+        InputState_Clear(&g_InputDB);
         p->rate = 0.0;
     }
     p->rate += slow ? M_INTERPOLATION_STEP : 1.0f;

--- a/src/trx/game/ui/dialogs/controls_editor.c
+++ b/src/trx/game/ui/dialogs/controls_editor.c
@@ -335,7 +335,7 @@ static UI_CONTROLS_CHOICE M_NavigateInputsDebounce(
     UI_CONTROLS_EDITOR_STATE *const s)
 {
     Input_Update();
-    if (g_Input.any) {
+    if (InputState_IsAnyPressed(g_Input)) {
         return UI_CONTROLS_CHOICE_NOOP;
     }
     Input_EnterListenMode();
@@ -365,7 +365,7 @@ static UI_CONTROLS_CHOICE M_Listen(UI_CONTROLS_EDITOR_STATE *const s)
 
 static UI_CONTROLS_CHOICE M_ListenDebounce(UI_CONTROLS_EDITOR_STATE *const s)
 {
-    if (!g_Input.any) {
+    if (!InputState_IsAnyPressed(g_Input)) {
         s->phase = M_PHASE_NAVIGATE_INPUTS;
     }
     return UI_CONTROLS_CHOICE_NOOP;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This finally has happened – we've exceeded 64 input roles, meaning `INPUT_STATE.any` has started to break.

Resolves #4504.