### PR TITLE
config: change default exposure bar color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - changed the fonts to use dedicated sprites for accented characters instead of composing them at runtime
 - changed the fonts to use dedicated sprites for similar-looking characters instead of using aliases
 - changed the reset keybindings bars appearance to be more visible
+- changed the default exposure bar PC color to blue 2
 - fixed broken final statistic counters (#4432, regression from 1.0)
 - fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
 - fixed gondolas not being drawn with an underwater tint when they have sunk (#4428)

--- a/src/trx/config/map.def
+++ b/src/trx/config/map.def
@@ -136,7 +136,7 @@ X_CFG_ENUM_EX("ui.enemy_healthbar_color",            ui.enemy_health_bar.color, 
 X_CFG_ENUM_EX("ui.enemy_healthbar_color_allies",     ui.enemy_health_bar.color_allies, BC_GREEN, BAR_COLOR)
 X_CFG_ENUM_EX("ui.enemy_healthbar_location",         ui.enemy_health_bar.location, BL_BOTTOM_LEFT, BAR_LOCATION)
 X_CFG_ENUM_EX("ui.enemy_healthbar_show_mode",        ui.enemy_health_bar.show_mode, BSM_ALWAYS, BAR_SHOW_MODE)
-X_CFG_ENUM_EX("ui.exposurebar_color",                ui.lara_exposure_bar.color, BC_PURPLE, BAR_COLOR)
+X_CFG_ENUM_EX("ui.exposurebar_color",                ui.lara_exposure_bar.color, BC_BLUE2, BAR_COLOR)
 X_CFG_ENUM_EX("ui.exposurebar_location",             ui.lara_exposure_bar.location, BL_TOP_RIGHT, BAR_LOCATION)
 X_CFG_ENUM_EX("ui.healthbar_color",                  ui.lara_health_bar.color, BC_RED, BAR_COLOR)
 X_CFG_ENUM_EX("ui.healthbar_location",               ui.lara_health_bar.location, BL_TOP_LEFT, BAR_LOCATION)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is to stay compatible with the OG TR3 PC.