### PR TITLE
output: fix stutter

### DIFF
--- a/data/common/ship/shaders/lights.glsl
+++ b/data/common/ship/shaders/lights.glsl
@@ -6,6 +6,7 @@
 #define RLM_SUNSET  3
 
 uniform int uWaterEffect;
+uniform vec3 uWaterEffectParams; // x=choppy amp, y=shimmer amp, z=abs intensity
 
 struct Light {
     vec4 pos;
@@ -36,37 +37,21 @@ float getEffectPhase(vec4 worldPos)
     return phase + rnd;
 }
 
-float effectChoppy(float phase, int waterScheme)
+float effectChoppy(float phase)
 {
-    const float amplitude[22] = float[](
-        16.0,  0.0,   0.0,   0.0,   0.0,
-        16.0,  16.0,  16.0,  16.0,
-        53.0,  53.0,  53.0,  53.0,
-        90.0,  90.0,  90.0,  90.0,
-        127.0, 127.0, 127.0, 127.0,
-        0.0);
     float angle = radians(360.0 * (mod(uTimeInGame / 64.0, 1.0) + phase));
-    return sin(angle) * amplitude[clamp(waterScheme, 0, 21)];
+    return sin(angle) * uWaterEffectParams.x;
 }
 
-float effectShimmer(float phase, int waterScheme)
+float effectShimmer(float phase)
 {
-    const float amplitude[22] = float[](
-        7.875, 4, 8, 12, 15.875,
-        -3.875, -7.875, -11.875, -15.875,
-        -3.875, -7.875, -11.875, -15.875,
-        -3.875, -7.875, -11.875, -15.875,
-        -3.875, -7.875, -11.875, -15.875,
-        0.0);
     float angle = radians(360.0 * (mod(uTimeInGame / 64.0, 1.0) + phase));
-    return sin(angle) * amplitude[clamp(waterScheme, 0, 21)];
+    return sin(angle) * uWaterEffectParams.y;
 }
 
-float effectAbs(float phase, int waterScheme)
+float effectAbs(void)
 {
-    const float intensity[22] = float[](
-        0, -3, 0, 4, 8, 4, 8, 12, 16, 4, 8, 12, 16, 4, 8, 12, 16, 4, 8, 12, 16, 0);
-    return intensity[clamp(waterScheme, 0, 21)];
+    return uWaterEffectParams.z;
 }
 
 int lightFlicker(float t) {
@@ -142,12 +127,11 @@ float lightObjects(vec3 rawNormal, vec4 vertexPos)
 
 vec3 lightObjectsTR3(vec3 rawNormal)
 {
-    vec3 N = safeNormalize(rawNormal.xyz / float(1 << 14));
-    mat3 viewModelT = mat3(transpose(uMatView * uMatModel));
+    vec3 N = safeNormalize(mat3(uMatView * uMatModel) * (rawNormal.xyz / float(1 << 14)));
 
-    vec3 L0 = safeNormalize(viewModelT * uTR3LightDirView[0].xyz);
-    vec3 L1 = safeNormalize(viewModelT * uTR3LightDirView[1].xyz);
-    vec3 L2 = safeNormalize(viewModelT * uTR3LightDirView[2].xyz);
+    vec3 L0 = uTR3LightDirView[0].xyz;
+    vec3 L1 = uTR3LightDirView[1].xyz;
+    vec3 L2 = uTR3LightDirView[2].xyz;
 
     float d0 = max(dot(N, L0), 0.0);
     float d1 = max(dot(N, L1), 0.0);
@@ -171,16 +155,15 @@ float lightDynamic(float baseLight, vec4 vertexPos)
 {
     float lightAdder = baseLight;
     for (int i = 0; i < uNumLights; i++) {
-        Light light = uLights[i];
-        vec3 dist = light.pos.xyz - vertexPos.xyz;
-        float radius = exp2(light.falloff);
+        vec3 dist = uLights[i].pos.xyz - vertexPos.xyz;
+        float radius = exp2(uLights[i].falloff);
         float distSq = dot(dist, dist);
         if (distSq > radius * radius) {
             continue;
         }
 
-        float maxShade = exp2(light.shade);
-        float distTerm = distSq / exp2(2 * light.falloff - light.shade);
+        float maxShade = exp2(uLights[i].shade);
+        float distTerm = distSq / exp2(2 * uLights[i].falloff - uLights[i].shade);
         float shade = maxShade - distTerm;
         lightAdder -= shade;
     }
@@ -191,16 +174,17 @@ vec3 lightDynamicTR3(vec4 vertexPos)
 {
     vec3 add = vec3(0.0);
     for (int i = 0; i < uNumLights; i++) {
-        Light light = uLights[i];
-        float radius = light.falloff * 0.5; // falloff_raw >> 1
-        vec3 dist = light.pos.xyz - vertexPos.xyz;
-        float d = length(dist);
-        if (d > radius) {
+        float radius = uLights[i].falloff * 0.5; // falloff_raw >> 1
+        vec3 dist = uLights[i].pos.xyz - vertexPos.xyz;
+        float distSq = dot(dist, dist);
+        float radiusSq = radius * radius;
+        if (distSq > radiusSq) {
             continue;
         }
 
+        float d = sqrt(distSq);
         float factor = (radius - d) / max(radius, 1.0);
-        add += factor * light.color.rgb;
+        add += factor * uLights[i].color.rgb;
     }
     return add;
 }
@@ -261,7 +245,7 @@ LightingResult light(
         return result;
     }
 
-    if (uTRVersion >= 3) {
+#if defined(TR_VERSION) && TR_VERSION >= 3
         if ((flags & VERT_USE_DYNAMIC_LIGHT) != 0u) {
             result.color.rgb =
                 clamp(
@@ -275,18 +259,18 @@ LightingResult light(
             result.color.rgb *= lightOwnTR3(shade);
         }
         result.shade = SHADE_NEUTRAL;
-    } else {
+#else
         result.shade = light(shade, flags, normal, pos, vertexPhase);
-    }
+#endif
 
     // TR3 caustics
     float add = 0.0;
     if ((flags & VERT_MOVE) != 0u) {
-        add -= effectChoppy(effectPhase, uWaterEffect - 2) / 512.0;
+        add -= effectChoppy(effectPhase) / 512.0;
     }
     if ((flags & VERT_GLOW) != 0u) {
-        add += effectShimmer(effectPhase, uWaterEffect - 2) / 32.0;
-        add += effectAbs(effectPhase, uWaterEffect - 2) / 32.0;
+        add += effectShimmer(effectPhase) / 32.0;
+        add += effectAbs() / 32.0;
     }
     result.color.rgb = clamp(result.color.rgb + add, 0.0, 1.0);
 

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -44,7 +44,8 @@ void main(void) {
     float effectPhase = getEffectPhase(worldPos);
 
     if ((inFlags & VERT_MOVE) != 0u) {
-        worldPos.y += effectChoppy(effectPhase, uWaterEffect - 2);
+        float waterMul = (uWaterEffect != 0) ? 1.0 : 0.0;
+        worldPos.y += effectChoppy(effectPhase) * waterMul;
     }
 
     if ((inFlags & (VERT_ABS_SPRITE | VERT_BILLBOARD)) != 0u) {

--- a/data/common/ship/shaders/meshes_tr12.glsl
+++ b/data/common/ship/shaders/meshes_tr12.glsl
@@ -1,0 +1,2 @@
+#define TR_VERSION 2
+#include "meshes.glsl"

--- a/data/common/ship/shaders/meshes_tr3.glsl
+++ b/data/common/ship/shaders/meshes_tr3.glsl
@@ -1,0 +1,2 @@
+#define TR_VERSION 3
+#include "meshes.glsl"

--- a/src/trx/game/output/shaders/generic.c
+++ b/src/trx/game/output/shaders/generic.c
@@ -155,3 +155,21 @@ GLint Output_Shader_LookupUniform(
     }
     return uniform->location;
 }
+
+bool Output_Shader_TryLookupUniform(
+    const OUTPUT_SHADER *const shader, const char *const name,
+    GLint *const out_location)
+{
+    M_UNIFORM *uniform = nullptr;
+    HASH_FIND_STR(shader->uniform_hash, name, uniform);
+    if (uniform == nullptr) {
+        if (out_location != nullptr) {
+            *out_location = -1;
+        }
+        return false;
+    }
+    if (out_location != nullptr) {
+        *out_location = uniform->location;
+    }
+    return true;
+}

--- a/src/trx/game/output/shaders/generic.h
+++ b/src/trx/game/output/shaders/generic.h
@@ -10,3 +10,6 @@ void Output_Shader_Bind(const OUTPUT_SHADER *shader);
 
 GLint Output_Shader_LookupUniform(
     const OUTPUT_SHADER *shader, const char *name);
+
+bool Output_Shader_TryLookupUniform(
+    const OUTPUT_SHADER *shader, const char *name, GLint *out_location);

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -3,99 +3,183 @@
 #include <trx/game/output/utils.h>
 #include <trx/gfx/gl/utils.h>
 #include <trx/memory.h>
+#include <trx/version.h>
 
 struct OUTPUT_MESH_SHADER {
-    OUTPUT_SHADER *base;
-    int32_t water_effect;
-    bool is_wibble_effect;
-    bool is_alpha_discard_enabled;
-    RGB_F tint;
+    OUTPUT_SHADER *base_tr12;
+    OUTPUT_SHADER *base_tr3;
+
+    int32_t water_effect[2];
+    float water_effect_params[2][3];
+    bool is_wibble_effect[2];
+    bool is_alpha_discard_enabled[2];
+    RGB_F tint[2];
 };
+
+static int32_t M_GetVariantIndex(void)
+{
+    return g_TRVersion >= 3 ? 1 : 0;
+}
+
+static OUTPUT_SHADER *M_GetVariantBase(
+    const OUTPUT_MESH_SHADER *const shader, const int32_t variant_idx)
+{
+    return variant_idx != 0 ? shader->base_tr3 : shader->base_tr12;
+}
 
 OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
 {
     OUTPUT_MESH_SHADER *const shader = Memory_Alloc(sizeof(*shader));
-    shader->water_effect = -1;
-    shader->is_wibble_effect = false;
-    shader->is_alpha_discard_enabled = false;
-    shader->tint = (RGB_F) { 0.0f, 0.0f, 0.0f };
-    shader->base = Output_Shader_Create("shaders/meshes.glsl");
+    shader->water_effect[0] = -1;
+    shader->water_effect[1] = -1;
+    shader->water_effect_params[0][0] = 0.0f;
+    shader->water_effect_params[0][1] = 0.0f;
+    shader->water_effect_params[0][2] = 0.0f;
+    shader->water_effect_params[1][0] = 0.0f;
+    shader->water_effect_params[1][1] = 0.0f;
+    shader->water_effect_params[1][2] = 0.0f;
+    shader->is_wibble_effect[0] = false;
+    shader->is_wibble_effect[1] = false;
+    shader->is_alpha_discard_enabled[0] = false;
+    shader->is_alpha_discard_enabled[1] = false;
+    shader->tint[0] = (RGB_F) { 0.0f, 0.0f, 0.0f };
+    shader->tint[1] = (RGB_F) { 0.0f, 0.0f, 0.0f };
+
+    shader->base_tr12 = Output_Shader_Create("shaders/meshes_tr12.glsl");
+    shader->base_tr3 = Output_Shader_Create("shaders/meshes_tr3.glsl");
+
+    Output_Shader_Bind(shader->base_tr12);
     GFX_TRACK_UNIFORM(
-        glUniform1i, Output_Shader_LookupUniform(shader->base, "uTexAtlas"), 0);
+        glUniform1i,
+        Output_Shader_LookupUniform(shader->base_tr12, "uTexAtlas"), 0);
     GFX_TRACK_UNIFORM(
-        glUniform1i, Output_Shader_LookupUniform(shader->base, "uTexEnvMap"),
-        1);
+        glUniform1i,
+        Output_Shader_LookupUniform(shader->base_tr12, "uTexEnvMap"), 1);
+
+    Output_Shader_Bind(shader->base_tr3);
+    GFX_TRACK_UNIFORM(
+        glUniform1i, Output_Shader_LookupUniform(shader->base_tr3, "uTexAtlas"),
+        0);
+    GFX_TRACK_UNIFORM(
+        glUniform1i,
+        Output_Shader_LookupUniform(shader->base_tr3, "uTexEnvMap"), 1);
     return shader;
 }
 
 void Output_MeshShader_Bind(const OUTPUT_MESH_SHADER *const shader)
 {
-    Output_Shader_Bind(shader->base);
+    const int32_t variant_idx = M_GetVariantIndex();
+    Output_Shader_Bind(M_GetVariantBase(shader, variant_idx));
 }
 
 void Output_MeshShader_Free(OUTPUT_MESH_SHADER *const shader)
 {
-    Output_Shader_Free(shader->base);
+    Output_Shader_Free(shader->base_tr12);
+    Output_Shader_Free(shader->base_tr3);
     Memory_Free(shader);
 }
 
 void Output_MeshShader_UploadModelMatrix(
     const OUTPUT_MESH_SHADER *const shader, const MATRIX *const source)
 {
+    const int32_t variant_idx = M_GetVariantIndex();
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
     GLfloat m[4][4];
     Output_FillMatrix(m, source);
 
     GFX_TRACK_UNIFORM(
-        glUniformMatrix4fv,
-        Output_Shader_LookupUniform(shader->base, "uMatModel"), 1, GL_FALSE,
-        &m[0][0]);
+        glUniformMatrix4fv, Output_Shader_LookupUniform(base, "uMatModel"), 1,
+        GL_FALSE, &m[0][0]);
 }
 
 void Output_MeshShader_UploadAlphaDiscard(
     OUTPUT_MESH_SHADER *const shader, const bool is_enabled)
 {
-    if (is_enabled == shader->is_alpha_discard_enabled) {
+    const int32_t variant_idx = M_GetVariantIndex();
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    if (is_enabled == shader->is_alpha_discard_enabled[variant_idx]) {
         return;
     }
     GFX_TRACK_UNIFORM(
-        glUniform1i, Output_Shader_LookupUniform(shader->base, "uDiscardAlpha"),
+        glUniform1i, Output_Shader_LookupUniform(base, "uDiscardAlpha"),
         is_enabled);
-    shader->is_alpha_discard_enabled = is_enabled;
+    shader->is_alpha_discard_enabled[variant_idx] = is_enabled;
 }
 
 void Output_MeshShader_UploadWaterEffect(
     OUTPUT_MESH_SHADER *const shader, const int32_t water_effect)
 {
-    if (water_effect == shader->water_effect) {
+    const int32_t variant_idx = M_GetVariantIndex();
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    if (water_effect == shader->water_effect[variant_idx]) {
         return;
     }
-    GFX_TRACK_UNIFORM(
-        glUniform1i, Output_Shader_LookupUniform(shader->base, "uWaterEffect"),
-        water_effect);
-    shader->water_effect = water_effect;
+
+    static const float m_ChoppyAmp[22] = {
+        16.0f, 0.0f,   0.0f,   0.0f,   0.0f,   16.0f, 16.0f, 16.0f,
+        16.0f, 53.0f,  53.0f,  53.0f,  53.0f,  90.0f, 90.0f, 90.0f,
+        90.0f, 127.0f, 127.0f, 127.0f, 127.0f, 0.0f,
+    };
+    static const float m_ShimmerAmp[22] = {
+        7.875f,   4.0f,     8.0f,     12.0f,    15.875f,  -3.875f,
+        -7.875f,  -11.875f, -15.875f, -3.875f,  -7.875f,  -11.875f,
+        -15.875f, -3.875f,  -7.875f,  -11.875f, -15.875f, -3.875f,
+        -7.875f,  -11.875f, -15.875f, 0.0f,
+    };
+    static const float m_AbsIntensity[22] = {
+        0.0f,  -3.0f, 0.0f, 4.0f, 8.0f,  4.0f,  8.0f, 12.0f, 16.0f, 4.0f,  8.0f,
+        12.0f, 16.0f, 4.0f, 8.0f, 12.0f, 16.0f, 4.0f, 8.0f,  12.0f, 16.0f, 0.0f,
+    };
+
+    int32_t scheme = water_effect - 2;
+    if (scheme < 0) {
+        scheme = 0;
+    } else if (scheme > 21) {
+        scheme = 21;
+    }
+    const float p0 = m_ChoppyAmp[scheme];
+    const float p1 = m_ShimmerAmp[scheme];
+    const float p2 = m_AbsIntensity[scheme];
+
+    GLint loc = -1;
+    if (Output_Shader_TryLookupUniform(base, "uWaterEffect", &loc)) {
+        GFX_TRACK_UNIFORM(glUniform1i, loc, water_effect);
+    }
+    if (Output_Shader_TryLookupUniform(base, "uWaterEffectParams", &loc)) {
+        GFX_TRACK_UNIFORM(glUniform3f, loc, p0, p1, p2);
+    }
+    shader->water_effect[variant_idx] = water_effect;
+    shader->water_effect_params[variant_idx][0] = p0;
+    shader->water_effect_params[variant_idx][1] = p1;
+    shader->water_effect_params[variant_idx][2] = p2;
 }
 
 void Output_MeshShader_UploadWibbleEffect(
     OUTPUT_MESH_SHADER *const shader, const bool is_enabled)
 {
-    if (is_enabled == shader->is_wibble_effect) {
+    const int32_t variant_idx = M_GetVariantIndex();
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    if (is_enabled == shader->is_wibble_effect[variant_idx]) {
         return;
     }
     GFX_TRACK_UNIFORM(
-        glUniform1i, Output_Shader_LookupUniform(shader->base, "uWibbleEffect"),
+        glUniform1i, Output_Shader_LookupUniform(base, "uWibbleEffect"),
         is_enabled);
-    shader->is_wibble_effect = is_enabled;
+    shader->is_wibble_effect[variant_idx] = is_enabled;
 }
 
 void Output_MeshShader_UploadTint(
     OUTPUT_MESH_SHADER *const shader, const RGB_F tint)
 {
-    if (tint.r == shader->tint.r && tint.g == shader->tint.g
-        && tint.b == shader->tint.b) {
+    const int32_t variant_idx = M_GetVariantIndex();
+    OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    if (tint.r == shader->tint[variant_idx].r
+        && tint.g == shader->tint[variant_idx].g
+        && tint.b == shader->tint[variant_idx].b) {
         return;
     }
     GFX_TRACK_UNIFORM(
-        glUniform3f, Output_Shader_LookupUniform(shader->base, "uGlobalTint"),
-        tint.r, tint.g, tint.b);
-    shader->tint = tint;
+        glUniform3f, Output_Shader_LookupUniform(base, "uGlobalTint"), tint.r,
+        tint.g, tint.b);
+    shader->tint[variant_idx] = tint;
 }

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -13,6 +13,8 @@
 #include <trx/vector.h>
 #include <trx/version.h>
 
+#include <math.h>
+
 #define M_GLOBAL_MEMBERS                                                       \
     X_DECLARE_MEMBER(float, fog_color, [4])                                    \
     X_DECLARE_MEMBER(float, fog_distance, [2])                                 \
@@ -214,9 +216,19 @@ void Output_Uniforms_UploadCPULight(
     ls.tr3_ambient[2] = info->tr3_ambient.b;
     ls.tr3_ambient[3] = 0.0f;
     for (int32_t i = 0; i < 3; i++) {
-        ls.tr3_light_dir_view[i][0] = info->tr3_light_dir_view[i].x;
-        ls.tr3_light_dir_view[i][1] = info->tr3_light_dir_view[i].y;
-        ls.tr3_light_dir_view[i][2] = info->tr3_light_dir_view[i].z;
+        float x = (float)info->tr3_light_dir_view[i].x;
+        float y = (float)info->tr3_light_dir_view[i].y;
+        float z = (float)info->tr3_light_dir_view[i].z;
+        const float len2 = x * x + y * y + z * z;
+        if (len2 > 0.0f) {
+            const float inv_len = 1.0f / sqrtf(len2);
+            x *= inv_len;
+            y *= inv_len;
+            z *= inv_len;
+        }
+        ls.tr3_light_dir_view[i][0] = x;
+        ls.tr3_light_dir_view[i][1] = y;
+        ls.tr3_light_dir_view[i][2] = z;
         ls.tr3_light_dir_view[i][3] = 0.0f;
         ls.tr3_light_color[i][0] = info->tr3_light_color[i].r;
         ls.tr3_light_color[i][1] = info->tr3_light_color[i].g;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes stutter at the TR3 startup that comes from GPU doing some optimization a few seconds into the rendering loop.
Unfortunately optimizing this took splitting `meshes.glsl` into two separate files to help the GPU with the compilation.

Testing:
- TR1 and TR2: sanity tests only: should launch, render fine, and not produce errors in logs.
- TR3: ditto, plus there shouldn't be visible regressions around dynamic lighting (underwater caustics, water surface shimmer and waves, object lighting, smooth light changes on the India slope).