### PR TITLE
savegame: store selected weather

### DIFF
--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -22,6 +22,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/stats.h>
+#include <trx/game/weather_fx.h>
 #include <trx/memory.h>
 #include <trx/strings.h>
 #include <trx/version.h>
@@ -1400,6 +1401,20 @@ bool Savegame_BSON_LoadMisc(SAVEGAME_BSON_READ_CONTEXT *const ctx)
         RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);
         resume->stats.death_count = -1;
         M_OPTIONAL(M_ReadNum(ctx, "death_count", &resume->stats.death_count));
+    }
+
+    {
+        if (M_HasKey(ctx, "weather_type") != 0) {
+            int32_t weather_type = (int32_t)WEATHER_NONE;
+            if (M_ReadNum(ctx, "weather_type", &weather_type)) {
+                if (weather_type >= (int32_t)WEATHER_NONE
+                    && weather_type <= (int32_t)WEATHER_SNOW) {
+                    WeatherFX_SetWeather((WEATHER_TYPE)weather_type);
+                } else {
+                    WeatherFX_SetWeather(WEATHER_NONE);
+                }
+            }
+        }
     }
 
     M_MUST(M_Pop(ctx));

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -19,6 +19,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/savegame/bson.h>
+#include <trx/game/weather_fx.h>
 #include <trx/memory.h>
 #include <trx/strings.h>
 #include <trx/version.h>
@@ -815,6 +816,7 @@ void Savegame_BSON_DumpMisc(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
     M_WriteNum(ctx, "death_count", resume->stats.death_count);
     M_WriteBool(ctx, "are_monks_angry", Creature_AreAlliesHostile());
     M_WriteNum(ctx, "sunset_timer", Output_GetTimeInGame());
+    M_WriteNum(ctx, "weather_type", WeatherFX_GetWeather());
     M_PopAndSet(ctx, "misc");
 
     M_WriteString(ctx, "level_title", level->title);

--- a/src/trx/game/weather_fx.c
+++ b/src/trx/game/weather_fx.c
@@ -535,6 +535,11 @@ void WeatherFX_Init(void)
     M_ClearWeather();
 }
 
+WEATHER_TYPE WeatherFX_GetWeather(void)
+{
+    return m_WeatherType;
+}
+
 void WeatherFX_SetWeather(const WEATHER_TYPE weather_type)
 {
     m_WeatherType = weather_type;

--- a/src/trx/game/weather_fx.h
+++ b/src/trx/game/weather_fx.h
@@ -11,4 +11,5 @@ typedef enum {
 void WeatherFX_Init(void);
 void WeatherFX_Update(void);
 void WeatherFX_Draw(void);
+WEATHER_TYPE WeatherFX_GetWeather(void);
 void WeatherFX_SetWeather(WEATHER_TYPE weather_type);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes `/weather` not getting respected when loading a saved game.