### PR TITLE
lara: add cold breath effect

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,7 @@
 - added sprite-based shadows
 - added footprints
 - added surface-based step sounds
+- added cold breath effects
 - added monochrome inventory backgrounds
 - added high-resolutions 16:9 and 4:3 loading screens
 - added high-resolutions 16:9 and 4:3 title and game end screens

--- a/src/meson.build
+++ b/src/meson.build
@@ -230,6 +230,7 @@ common_sources = [
   'trx/game/items/common.c',
   'trx/game/items/utils.c',
   'trx/game/items/walkable.c',
+  'trx/game/lara/breath.c',
   'trx/game/lara/cheat.c',
   'trx/game/lara/cheat_keys.c',
   'trx/game/lara/col.c',

--- a/src/trx/game/lara/breath.c
+++ b/src/trx/game/lara/breath.c
@@ -1,0 +1,68 @@
+#include <trx/game/lara/breath.h>
+
+#include <trx/game/collision.h>
+#include <trx/game/lara.h>
+#include <trx/game/level/settings.h>
+#include <trx/game/output/state.h>
+#include <trx/game/random.h>
+#include <trx/game/rooms.h>
+#include <trx/game/sparks.h>
+#include <trx/utils.h>
+#include <trx/version.h>
+
+static bool M_CanBreatheVisible(const ITEM *const lara_item)
+{
+    if (lara_item == nullptr) {
+        return false;
+    }
+
+    if (g_TRVersion != 3) {
+        return false;
+    }
+
+    if (!Level_HasColdWater()) {
+        return false;
+    }
+
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->extra_anim) {
+        return false;
+    }
+
+    if (lara->water_status == LWS_CHEAT || lara->water_status == LWS_UNDERWATER
+        || lara_item->hit_points < 0) {
+        return false;
+    }
+
+    if (lara_item->current_anim_state == LS(LS_STOP)) {
+        return Item_GetRelativeFrame(lara_item) >= 30;
+    }
+
+    const int32_t wibble = (int32_t)Output_GetTimeInGame() % 64;
+    return wibble >= 32 && wibble <= 48;
+}
+
+void Lara_Breath_Control(const ITEM *const lara_item)
+{
+    if (!M_CanBreatheVisible(lara_item)) {
+        return;
+    }
+
+    XYZ_32 pos = { .x = 0, .y = -4, .z = 64 };
+    Collide_GetJointAbsPosition(lara_item, &pos, LM_HEAD);
+
+    XYZ_32 end = {
+        .x = (Random_GetControl() & 7) - 4,
+        .y = (Random_GetControl() & 7) - 8,
+        .z = (Random_GetControl() & 0x7F) + 64,
+    };
+    Collide_GetJointAbsPosition(lara_item, &end, LM_HEAD);
+
+    const XYZ_32 vel = {
+        .x = end.x - pos.x,
+        .y = end.y - pos.y,
+        .z = end.z - pos.z,
+    };
+
+    Sparks_TriggerBreath(pos, vel, lara_item->room_num);
+}

--- a/src/trx/game/lara/breath.h
+++ b/src/trx/game/lara/breath.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <trx/game/items.h>
+
+void Lara_Breath_Control(const ITEM *lara_item);

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -7,6 +7,7 @@
 #include <trx/game/gym.h>
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
+#include <trx/game/lara/breath.h>
 #include <trx/game/level/settings.h>
 #include <trx/game/music.h>
 #include <trx/game/pathing.h>
@@ -800,6 +801,7 @@ void Lara_Control(void)
 
     Camera_MoveManual();
     M_HandleEnvironment();
+    Lara_Breath_Control(item);
 
     Stats_AddDistanceTravelled(item->pos, lara_info->last_pos);
     lara_info->last_pos = item->pos;

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -308,9 +308,7 @@ void Sparks_Control(void)
                 (int32_t)sptr->src_color.b, (int32_t)sptr->dst_color.b, fade);
         } else if (
             sptr->life < sptr->fade_to_black && sptr->fade_to_black != 0U) {
-            const float fade =
-                ((int32_t)sptr->life - (int32_t)sptr->fade_to_black)
-                / (float)sptr->fade_to_black;
+            const float fade = sptr->life / (float)sptr->fade_to_black;
             sptr->color.r = sptr->dst_color.r * fade;
             sptr->color.g = sptr->dst_color.g * fade;
             sptr->color.b = sptr->dst_color.b * fade;
@@ -674,4 +672,58 @@ void Sparks_TriggerWaterfallMist(
         sptr->dst_size.height = dst_size;
         sptr->size = sptr->src_size;
     }
+}
+
+void Sparks_TriggerBreath(
+    const XYZ_32 pos, const XYZ_32 vel, const int16_t room_num)
+{
+    const OBJECT *const object = Object_Get(O_EXPLOSION_1);
+    if (object == nullptr || !object->loaded) {
+        return;
+    }
+
+    SPARK *const sptr = Sparks_GetFreeSpark();
+    const int32_t jitter_x = (Random_GetControl() & 0xF) - 8;
+    const int32_t jitter_y = (Random_GetControl() & 0xF) - 8;
+    const int32_t jitter_z = (Random_GetControl() & 0xF) - 8;
+
+    *sptr = (SPARK) {
+        .on = true,
+        .src_color = { 0, 0, 0 },
+        .dst_color = { 32, 32, 32 },
+        .color = { 0, 0, 0 },
+        .col_fade_speed = 4,
+        .fade_to_black = 32,
+        .draw_type = DRAW_BLEND_ADD,
+        .extras = 0,
+        .life = (uint8_t)((Random_GetControl() & 3) + 37),
+        .dynamic = -1,
+        .sprite_idx = object->mesh_idx,
+        .pos = {
+            .x = pos.x + jitter_x,
+            .y = pos.y + jitter_y,
+            .z = pos.z + jitter_z,
+        },
+        .vel = vel,
+        .gravity = 0,
+        .max_y_vel = 0,
+        .friction = 0,
+        .flags = SPARK_F_SPRITE | SPARK_F_ALT_SPRITE | SPARK_F_SCALE,
+        .scalar = 3,
+        .room_num = (uint8_t)room_num,
+    };
+    sptr->s_life = sptr->life;
+
+    const ROOM *const room = Room_Get(room_num);
+    if (room != nullptr && room->flags.wind) {
+        sptr->flags |= SPARK_F_OUTSIDE;
+    }
+
+    const uint8_t dst_size = (uint8_t)((Random_GetControl() & 7) + 32);
+    const uint8_t src_size = (uint8_t)(dst_size >> 3);
+    sptr->src_size.width = src_size;
+    sptr->src_size.height = src_size;
+    sptr->dst_size.width = dst_size;
+    sptr->dst_size.height = dst_size;
+    sptr->size = sptr->src_size;
 }

--- a/src/trx/game/sparks.h
+++ b/src/trx/game/sparks.h
@@ -99,3 +99,5 @@ void Sparks_TriggerBubble(
     int16_t effect_num);
 
 void Sparks_TriggerWaterfallMist(int32_t x, int32_t y, int32_t z, int32_t ang);
+
+void Sparks_TriggerBreath(XYZ_32 pos, XYZ_32 vel, int16_t room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Implements TR3 cold breath effect for Antarctica and other levels that have cold water effect enabled.
I'm not sure how faithful this reimplementation is, as TOMB3 doesn't render Lara's breaths in the cold levels for me at all?

One OG bug I noticed: if you let Lara freeze to her death when she's surfaced, she can trigger a breath effect even after she's transitioned to the drowning animation. I think we should let her finish her breath and then not trigger it anymore, as morbid as this sounds.