### PR TITLE
sparks: implement smoke and weather wind

### DIFF
--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -4,8 +4,8 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/pose.h>
 #include <trx/game/matrix.h>
-#include <trx/game/random.h>
 #include <trx/game/rooms.h>
+#include <trx/game/sparks.h>
 #include <trx/utils.h>
 #include <trx/version.h>
 
@@ -20,7 +20,6 @@ static bool m_IsFirstHair;
 static SPHERE m_HairSpheres[M_HAIR_SPHERES];
 static XYZ_32 m_HairVelocity[M_HAIR_SEGMENTS + 1];
 static HAIR_SEGMENT m_HairSegments[M_HAIR_SEGMENTS + 1];
-static int32_t m_HairWind;
 
 static void M_CalculateSpheres(const ANIM_FRAME *const frame)
 {
@@ -277,7 +276,6 @@ void Lara_Hair_Control(const bool in_cutscene)
 
             Matrix_Pop();
         }
-        m_HairWind = 0;
         return;
     }
 
@@ -303,19 +301,8 @@ void Lara_Hair_Control(const bool in_cutscene)
         height = lara_item->floor;
     }
 
-    if (g_Config.visuals.enable_breeze && Room_Get(room_num)->flags.wind) {
-        const int32_t random = Random_GetDraw() & 7;
-        if (random != 0) {
-            m_HairWind += random - 4;
-            if (m_HairWind < 0) {
-                m_HairWind = 0;
-            } else if (m_HairWind >= 8) {
-                m_HairWind--;
-            }
-        }
-    } else {
-        m_HairWind = 0;
-    }
+    const XZ_32 smoke_wind = Sparks_GetSmokeWind();
+    const int32_t hair_wind_z = Sparks_GetHairWindZ();
 
     for (int32_t i = 1; i <= M_HAIR_SEGMENTS; i++) {
         const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
@@ -335,8 +322,13 @@ void Lara_Hair_Control(const bool in_cutscene)
                 s->pos.y = water_height;
             } else if (s->pos.y > height) {
                 s->pos.y = height;
+            } else if (g_TRVersion == 3) {
+                if (Room_Get(room_num)->flags.wind) {
+                    s->pos.x += smoke_wind.x;
+                    s->pos.z += smoke_wind.z;
+                }
             } else {
-                s->pos.z += m_HairWind;
+                s->pos.z += hair_wind_z;
             }
             break;
 

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -1,5 +1,6 @@
 #include <trx/game/sparks.h>
 
+#include <trx/config.h>
 #include <trx/debug.h>
 #include <trx/game/collision.h>
 #include <trx/game/effects.h>
@@ -10,7 +11,9 @@
 #include <trx/game/output/lights.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 #include <trx/utils.h>
+#include <trx/version.h>
 
 #define M_MAX_SPARKS 192
 #define M_MAX_SPARK_DYNAMICS 32
@@ -27,6 +30,10 @@ static SPARK m_Sparks[M_MAX_SPARKS];
 static M_SPARK_DYNAMIC m_Dynamics[M_MAX_SPARK_DYNAMICS];
 static int32_t m_NextSpark = 0;
 static XZ_32 m_SmokeWind = {};
+static int32_t m_HairWindZ = 0;
+static int32_t m_TR3Wind = 0;
+static int32_t m_TR3WindAngle = DEG_180;
+static int32_t m_TR3DWindAngle = DEG_180;
 static SPARKS_CALLBACKS m_Callbacks = {};
 
 static const BITE m_NodeOffsets[16] = {
@@ -165,6 +172,10 @@ void Sparks_Init(void)
     }
     m_NextSpark = 0;
     m_SmokeWind = (XZ_32) {};
+    m_HairWindZ = 0;
+    m_TR3Wind = 0;
+    m_TR3WindAngle = DEG_180;
+    m_TR3DWindAngle = DEG_180;
     m_Callbacks = (SPARKS_CALLBACKS) {};
 }
 
@@ -187,8 +198,80 @@ void Sparks_SetSmokeWind(const XZ_32 wind)
     m_SmokeWind = wind;
 }
 
+int32_t Sparks_GetHairWindZ(void)
+{
+    return m_HairWindZ;
+}
+
+static void M_UpdateWind(void)
+{
+    if (!g_Config.visuals.enable_breeze) {
+        m_SmokeWind = (XZ_32) {};
+        m_HairWindZ = 0;
+        return;
+    }
+
+    if (g_TRVersion != 3) {
+        const ITEM *const lara_item = Lara_GetItem();
+        if (lara_item == nullptr) {
+            m_HairWindZ = 0;
+            return;
+        }
+
+        const ROOM *const room = Room_Get(lara_item->room_num);
+        if (room == nullptr || !room->flags.wind) {
+            m_HairWindZ = 0;
+            return;
+        }
+
+        const int32_t random = Random_GetDraw() & 7;
+        if (random != 0) {
+            m_HairWindZ += random - 4;
+            if (m_HairWindZ < 0) {
+                m_HairWindZ = 0;
+            } else if (m_HairWindZ >= 8) {
+                m_HairWindZ--;
+            }
+        }
+        m_SmokeWind = (XZ_32) {};
+        return;
+    }
+
+    // TR3 wind logic: a small random wind magnitude with a slowly-changing
+    // direction, biased to the [90°, 270°] range.
+    m_TR3Wind += (Random_GetControl() & 7) - 3;
+    if (m_TR3Wind <= -2) {
+        m_TR3Wind++;
+    } else if (m_TR3Wind >= 9) {
+        m_TR3Wind--;
+    }
+
+    // Original TR3 uses a 0..4095 angle space; keep the calculations faithful.
+    m_TR3DWindAngle =
+        (m_TR3DWindAngle + (((Random_GetControl() & 0x3F) - 32) << 1)) & 0x1FFE;
+
+    if (m_TR3DWindAngle < 1024) { // DEG_90
+        m_TR3DWindAngle += (1024 - m_TR3DWindAngle) << 1;
+    } else if (m_TR3DWindAngle > 3072) { // DEG_270
+        m_TR3DWindAngle -= (m_TR3DWindAngle - 3072) << 1;
+    }
+    m_TR3DWindAngle &= 0x1FFE;
+    m_TR3WindAngle =
+        (m_TR3WindAngle + ((m_TR3DWindAngle - m_TR3WindAngle) >> 3)) & 0x1FFE;
+
+    // Promote to DEG_360 for Math_Sin/Cos just at the end.
+    m_SmokeWind = (XZ_32) {
+        .x = (m_TR3Wind * Math_Sin(m_TR3WindAngle << 3)) >> W2V_SHIFT,
+        .z = (m_TR3Wind * Math_Cos(m_TR3WindAngle << 3)) >> W2V_SHIFT,
+    };
+
+    m_HairWindZ = 0;
+}
+
 void Sparks_Control(void)
 {
+    M_UpdateWind();
+
     for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
         SPARK *const sptr = &m_Sparks[i];
         if (!sptr->on) {

--- a/src/trx/game/sparks.h
+++ b/src/trx/game/sparks.h
@@ -92,6 +92,7 @@ typedef struct {
 void Sparks_SetCallbacks(const SPARKS_CALLBACKS *callbacks);
 XZ_32 Sparks_GetSmokeWind(void);
 void Sparks_SetSmokeWind(XZ_32 wind);
+int32_t Sparks_GetHairWindZ(void);
 
 void Sparks_TriggerBubble(
     int32_t x, int32_t y, int32_t z, int32_t size, int32_t size_range,

--- a/src/trx/game/ui/dialogs/setting_helpers/handlers.c
+++ b/src/trx/game/ui/dialogs/setting_helpers/handlers.c
@@ -6,6 +6,7 @@
 #include <trx/game/music.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/sound.h>
+#include <trx/version.h>
 
 bool UI_Settings_EnablePS1Crystals_IsAvailable(
     const UI_SETTINGS_OPTION *const option)
@@ -27,7 +28,7 @@ bool UI_Settings_FogColor_IsAvailable(const UI_SETTINGS_OPTION *const option)
 bool UI_Settings_EnableBreeze_IsAvailable(
     const UI_SETTINGS_OPTION *const option)
 {
-    return g_Config.visuals.enable_braid;
+    return g_Config.visuals.enable_braid || g_TRVersion == 3;
 }
 
 bool UI_Settings_ResponsiveJumping_IsAvailable(const UI_SETTINGS_OPTION *option)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds TR3 wind support to all sparks and weather effects.

#### Testing

- Disabling breeze should disable all wind.
- Check for regression in hair wind movement in windy rooms in TR1-TR2.
- Check for faithfulness of hair wind movement and weather effects movement in windy rooms in TR3.