### PR TITLE
gameflow: enable rain in tr3 cutscene 5

### DIFF
--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -449,6 +449,7 @@
         {
             "path": "cuts/cut2.tr2",
             "music_track": 67,
+            "weather_type": "rain",
             "sequence": [
                 {"type": "loop_game"},
             ],


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the London cutscene missing the rain.
We'll probably have to ensure some rooms have the wind flag enabled, as the rain appears to be missing from some areas where you'd expect it.