### PR TITLE
console/teleport: fix out of bounds test

### DIFF
--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -59,11 +59,13 @@ static bool M_CanTargetItem(
 
     // Out of bounds items
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
-        == NO_HEIGHT) {
-        return false;
+    if (room_num != NO_ROOM) {
+        const SECTOR *const sector =
+            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
+            == NO_HEIGHT) {
+            return false;
+        }
     }
 
     // Non-matches to user input


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids trying to teleport to a gun that Lara is holding in her hands, items of which type do not have a room number. E.g. draw the shotgun, then `/tp shotgun`.

Regression in bcda64ebbfe606163664caee1cb319582f153f21, unreleased.
