### PR TITLE
savegame: crash less in tr3

### DIFF
--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -638,6 +638,12 @@ static bool M_ReadItem(
         M_MUST(M_ReadNum(ctx, "obj_num", &game_object_id));
     }
     const OBJECT_ID object_id = Object_FromGameID(game_object_id);
+    if (object_id == NO_OBJECT) {
+        item->object_id = O_DUMMY;
+        LOG_ERROR("Unsupported object #%d", game_object_id);
+        return true;
+    }
+
     const OBJECT *const obj = Object_Get(object_id);
     item->object_id = object_id;
     if (!M_IsValidItemObject(object_id, item->object_id)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the guaranteed crashes when loading savegames in TR3.
They *should* stay stable now – until you update to a new development snapshot, then you likely will have to toss the old saves away.

Note that I haven't yet tackled saving the private bits from the new objects, so these may very well misbehave when loading the game.