### PR TITLE
output: fix TR3 lighting in certain rooms

### DIFF
--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -3,6 +3,7 @@
 #include <trx/game/output/utils.h>
 #include <trx/gfx/gl/utils.h>
 #include <trx/memory.h>
+#include <trx/utils.h>
 #include <trx/version.h>
 
 struct OUTPUT_MESH_SHADER {
@@ -127,16 +128,13 @@ void Output_MeshShader_UploadWaterEffect(
         -7.875f,  -11.875f, -15.875f, 0.0f,
     };
     static const float m_AbsIntensity[22] = {
-        0.0f,  -3.0f, 0.0f, 4.0f, 8.0f,  4.0f,  8.0f, 12.0f, 16.0f, 4.0f,  8.0f,
-        12.0f, 16.0f, 4.0f, 8.0f, 12.0f, 16.0f, 4.0f, 8.0f,  12.0f, 16.0f, 0.0f,
+        0.0f,  253.0f, 0.0f, 4.0f,  8.0f,  4.0f, 8.0f, 12.0f,
+        16.0f, 4.0f,   8.0f, 12.0f, 16.0f, 4.0f, 8.0f, 12.0f,
+        16.0f, 4.0f,   8.0f, 12.0f, 16.0f, 0.0f,
     };
 
     int32_t scheme = water_effect - 2;
-    if (scheme < 0) {
-        scheme = 0;
-    } else if (scheme > 21) {
-        scheme = 21;
-    }
+    CLAMP(scheme, 0, 21);
     const float p0 = m_ChoppyAmp[scheme];
     const float p1 = m_ShimmerAmp[scheme];
     const float p2 = m_AbsIntensity[scheme];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes lighting in room 87 in Jungle.
While TOMB3 declares `abs[1]` as `-3`, its storage is actually `u8` which means in reality it's `253` :sweat_smile: 