### PR TITLE
pickup: fix TR1 and TR2 requiring Lara to stand idle

### DIFF
--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -13,6 +13,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/stats.h>
+#include <trx/version.h>
 
 // clang-format off
 #define M_LF_PICKUP_ERASE        42
@@ -344,7 +345,7 @@ static void M_DoAboveWater(const int16_t item_num, ITEM *const lara_item)
     if (g_Input.action && !lara_item->gravity && lara->gun_status == LGS_ARMLESS
         && (lara->gun_type != LGT_FLARE || item->object_id != O_FLARE_ITEM)
         && ((lara_item->current_anim_state == LS(LS_STOP)
-             && anim == LA_STAND_IDLE)
+             && (g_TRVersion < 3 || anim == LA_STAND_IDLE))
             || ((
                 lara_item->current_anim_state == LS(LS_CROUCH_IDLE)
                 && anim == LA_CROUCH_IDLE)))) {


### PR DESCRIPTION
Resolves #4550.

#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Fix TR1 and TR2 requiring Lara to stand idle to perform a pickup. Added a version check to let TR1/2 ignore the stand idle check.