### PR TITLE
savegame: fix loading JP savegames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed resetting camera in the photo mode not clearing the underwater tint
 - fixed developer console text editing (backspace, moving the caret) doing weird things with Unicode characters
 - fixed Lara jumping if player holds the swim button when exiting the fly cheat (#4470)
+- fixed game refusing to load savegames made with the JP mode (#4558)
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -1080,7 +1080,8 @@ static bool M_ReadResumeInfo(
     } else {
         M_MUST(M_ReadNum(ctx, "magnum_ammo", &resume->magnum_ammo));
         M_MUST(M_ReadNum(ctx, "autos_ammo", &resume->autos_ammo));
-        M_MUST(M_ReadNum(ctx, "desert_eagle_ammo", &resume->desert_eagle_ammo));
+        M_OPTIONAL(
+            M_ReadNum(ctx, "desert_eagle_ammo", &resume->desert_eagle_ammo));
     }
 
     // TR1X <4.16
@@ -1125,12 +1126,12 @@ static bool M_ReadResumeInfo(
     } else {
         M_MUST(M_ReadBool(ctx, "has_magnums", &resume->flags.has_magnums));
         M_MUST(M_ReadBool(ctx, "has_autos", &resume->flags.has_autos));
-        M_MUST(M_ReadBool(
+        M_OPTIONAL(M_ReadBool(
             ctx, "has_desert_eagle", &resume->flags.has_desert_eagle));
-        M_MUST(M_ReadBool(ctx, "has_mp5", &resume->flags.has_mp5));
-        M_MUST(M_ReadNum(ctx, "mp5_ammo", &resume->mp5_ammo));
-        M_MUST(M_ReadBool(ctx, "has_rocket", &resume->flags.has_rocket));
-        M_MUST(M_ReadNum(ctx, "rocket_ammo", &resume->rocket_ammo));
+        M_OPTIONAL(M_ReadBool(ctx, "has_mp5", &resume->flags.has_mp5));
+        M_OPTIONAL(M_ReadNum(ctx, "mp5_ammo", &resume->mp5_ammo));
+        M_OPTIONAL(M_ReadBool(ctx, "has_rocket", &resume->flags.has_rocket));
+        M_OPTIONAL(M_ReadNum(ctx, "rocket_ammo", &resume->rocket_ammo));
     }
 
     M_MUST(M_ReadNum(ctx, "timer", &resume->stats.timer));
@@ -1387,8 +1388,8 @@ bool Savegame_BSON_LoadMisc(SAVEGAME_BSON_READ_CONTEXT *const ctx)
     M_MUST(M_PushObject(ctx, "misc"));
 
     {
-        bool bonus_flag = false;
-        M_OPTIONAL(M_ReadBool(ctx, "bonus_flag", &bonus_flag));
+        int32_t bonus_flag = false;
+        M_OPTIONAL(M_ReadNum(ctx, "bonus_flag", &bonus_flag));
         Game_SetBonusFlag(bonus_flag);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4558.

The code tried to read a `bool` whereas it's a bitset.
I also made the extended ammo keys optional for the saves made in the develop to continue working without requiring a version bump.