### PR TITLE
Implement TR3 flare effects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 - added surface-based step sounds
 - added cold breath effects
 - added gun shells
+- added flare lighting and sparks
 - added monochrome inventory backgrounds
 - added high-resolutions 16:9 and 4:3 loading screens
 - added high-resolutions 16:9 and 4:3 title and game end screens

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -8,6 +8,7 @@
 #include <trx/game/output.h>
 #include <trx/game/output/vars.h>
 #include <trx/game/random.h>
+#include <trx/version.h>
 
 static bool m_CacheMatrices = false;
 
@@ -180,7 +181,8 @@ static bool M_Draw_I(
         M_DrawBodyPart(LM_LARM_L, bone, mesh_rots_1, mesh_rots_2, clip);
         M_DrawBodyPart(LM_HAND_L, bone, mesh_rots_1, mesh_rots_2, clip);
 
-        if (lara->gun_type == LGT_FLARE && lara->left_arm.flash_gun) {
+        if (g_TRVersion < 3 && lara->gun_type == LGT_FLARE
+            && lara->left_arm.flash_gun) {
             Gun_DrawFlash(LGT_FLARE, clip, true);
         }
         Matrix_Pop();
@@ -475,7 +477,8 @@ bool Lara_Draw(const ITEM *const item)
         M_DrawBodyPart(LM_LARM_L, bone, mesh_rots, nullptr, clip);
         M_DrawBodyPart(LM_HAND_L, bone, mesh_rots, nullptr, clip);
 
-        if (lara->gun_type == LGT_FLARE && lara->left_arm.flash_gun) {
+        if (g_TRVersion < 3 && lara->gun_type == LGT_FLARE
+            && lara->left_arm.flash_gun) {
             Gun_DrawFlash(LGT_FLARE, clip, false);
         }
 

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -6,8 +6,11 @@
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/general/flare_item.h>
+#include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
+#include <trx/game/sparks.h>
+#include <trx/version.h>
 
 typedef enum {
     // clang-format off
@@ -20,31 +23,50 @@ typedef enum {
 } M_LARA_FLARE_ANIMATION;
 
 typedef enum {
-    LF_FL_HOLD_FT = 1,
-    LF_FL_THROW_FT = 32,
-    LF_FL_DRAW_FT = 39,
-    LF_FL_IGNITE_FT = 23,
-    LF_FL_2_HOLD_FT = 15,
+    // clang-format off
+    LF_FL_HOLD_FT       = 1,
+    LF_FL_THROW_FT      = 32,
+    LF_FL_DRAW_FT       = 39,
+    LF_FL_IGNITE_FT     = 23,
+    LF_FL_2_HOLD_FT     = 15,
 
-    LF_FL_HOLD = 0,
-    LF_FL_THROW = (LF_FL_HOLD + LF_FL_HOLD_FT), // = 1
+    LF_FL_HOLD          = 0,
+    LF_FL_THROW         = (LF_FL_HOLD + LF_FL_HOLD_FT), // = 1
     LF_FL_THROW_RELEASE = (LF_FL_THROW + 20), // = 21
-    LF_FL_DRAW = (LF_FL_THROW + LF_FL_THROW_FT), // = 33
-    LF_FL_IGNITE = (LF_FL_DRAW + LF_FL_DRAW_FT), // = 72
-    LF_FL_2_HOLD = (LF_FL_IGNITE + LF_FL_IGNITE_FT), // = 95
-    LF_FL_END = (LF_FL_2_HOLD + LF_FL_2_HOLD_FT), // = 110
-    LF_FL_DRAW_GOT_IT = (LF_FL_DRAW + 13), // = 46
+    LF_FL_DRAW          = (LF_FL_THROW + LF_FL_THROW_FT), // = 33
+    LF_FL_IGNITE        = (LF_FL_DRAW + LF_FL_DRAW_FT), // = 72
+    LF_FL_2_HOLD        = (LF_FL_IGNITE + LF_FL_IGNITE_FT), // = 95
+    LF_FL_END           = (LF_FL_2_HOLD + LF_FL_2_HOLD_FT), // = 110
+    LF_FL_DRAW_GOT_IT   = (LF_FL_DRAW + 13), // = 46
+    // clang-format on
 } M_LARA_FLARE_FRAME;
 
 static const LARA_TRX_STATE m_HoldStates[] = {
-    LS_WALK,      LS_STOP,      LS_POSE,       LS_TURN_RIGHT,  LS_TURN_LEFT,
-    LS_WALK_BACK, LS_FAST_TURN, LS_STEP_LEFT,  LS_STEP_RIGHT,  LS_WADE,
-    LS_PICKUP,    LS_SWITCH_ON, LS_SWITCH_OFF, LS_TRX_INVALID, // sentinel
+    // clang-format off
+    LS_WALK,
+    LS_STOP,
+    LS_POSE,
+    LS_TURN_RIGHT,
+    LS_TURN_LEFT,
+    LS_WALK_BACK,
+    LS_FAST_TURN,
+    LS_STEP_LEFT,
+    LS_STEP_RIGHT,
+    LS_WADE,
+    LS_PICKUP,
+    LS_SWITCH_ON,
+    LS_SWITCH_OFF,
+    LS_TRX_INVALID, // sentinel
+    // clang-format on
 };
 
 static const LARA_TRX_STATE m_ThrowStates[] = {
-    LS_FAST_FALL, LS_SWAN_DIVE, LS_FAST_DIVE,
+    // clang-format off
+    LS_FAST_FALL,
+    LS_SWAN_DIVE,
+    LS_FAST_DIVE,
     LS_TRX_INVALID, // sentinel
+    // clang-format on
 };
 
 static XYZ_32 m_IgnitePos = {};
@@ -117,11 +139,38 @@ static void M_ControlInHand(const int32_t flare_age)
 
     lara_info->left_arm.flash_gun = Flare_GenerateLight(vec, flare_age);
 
-    if (lara_info->flare.age < Flare_GetMaxAge()) {
-        lara_info->flare.age++;
-        Flare_GenerateEffects(&lara_item->pos, vec, lara_item->room_num);
-    } else if (M_CanThrowFlare()) {
-        lara_info->gun_status = LGS_UNDRAW;
+    if (lara_info->flare.age >= Flare_GetMaxAge()) {
+        if (M_CanThrowFlare()) {
+            lara_info->gun_status = LGS_UNDRAW;
+        }
+        return;
+    }
+
+    lara_info->flare.age++;
+    Flare_GenerateEffects(&lara_item->pos, vec, lara_item->room_num);
+
+    if (!lara_info->left_arm.flash_gun) {
+        return;
+    }
+
+    if (g_TRVersion < 3) {
+        return;
+    }
+
+    XYZ_32 vec_2 = {
+        .x = 8,
+        .y = 36,
+        .z = WALL_L + (Random_GetDraw() & 0xFF),
+    };
+    Lara_GetJointAbsPosition(&vec_2, LM_HAND_L);
+    const XYZ_32 vel = {
+        .x = vec_2.x - vec.x,
+        .y = vec_2.y - vec.y,
+        .z = vec_2.z - vec.z,
+    };
+    for (int32_t i = 0; i < (Random_GetDraw() & 3) + 4; i++) {
+        const bool smoke = (i >> 2) != 0;
+        Sparks_TriggerFlareSparks(vec, vel, smoke);
     }
 }
 

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -15,9 +15,14 @@
 // clang-format off
 #define M_FLARE_INTENSITY 12
 #define M_FLARE_FALL_OFF  11
-#define M_MAX_FLARE_AGE   (60 * LOGIC_FPS)                  // = 1800
-#define M_FLARE_OLD_AGE   (M_MAX_FLARE_AGE - 2 * LOGIC_FPS) // = 1740
-#define M_FLARE_YOUNG_AGE (LOGIC_FPS)                       // = 30
+
+#define M_MAX_FLARE_AGE_TR12   (60 * LOGIC_FPS)                       // = 1800
+#define M_FLARE_OLD_AGE_TR12   (M_MAX_FLARE_AGE_TR12 - 2 * LOGIC_FPS) // = 1740
+#define M_FLARE_YOUNG_AGE_TR12 (LOGIC_FPS)                            // = 30
+
+#define M_MAX_FLARE_AGE_TR3   (30 * LOGIC_FPS)         // = 900
+#define M_FLARE_DYING_AGE_TR3 (M_MAX_FLARE_AGE_TR3 - 90) // = 810
+#define M_FLARE_END_AGE_TR3   (M_MAX_FLARE_AGE_TR3 - 24) // = 876
 // clang-format off
 
 static XYZ_32 M_TransformLocalOffset(
@@ -196,6 +201,117 @@ end:
     return true;
 }
 
+static bool M_GenerateLight_TR12(const XYZ_32 pos, const int32_t flare_age)
+{
+    if (flare_age >= M_MAX_FLARE_AGE_TR12) {
+        return false;
+    }
+
+    const int32_t random = Random_GetDraw();
+    const XYZ_32 light_pos = {
+        .x = pos.x + (random & 0xA0),
+        .y = pos.y,
+        .z = pos.z,
+    };
+
+    if (flare_age < M_FLARE_YOUNG_AGE_TR12) {
+        const int32_t intensity = M_FLARE_INTENSITY
+                * (flare_age - M_FLARE_YOUNG_AGE_TR12)
+            / (2 * M_FLARE_YOUNG_AGE_TR12)
+            + M_FLARE_INTENSITY;
+        Output_AddDynamicLight(light_pos, intensity, M_FLARE_FALL_OFF);
+        return true;
+    }
+
+    if (flare_age < M_FLARE_OLD_AGE_TR12) {
+        Output_AddDynamicLight(light_pos, M_FLARE_INTENSITY, M_FLARE_FALL_OFF);
+        return true;
+    }
+
+    if (random > 0x2000) {
+        Output_AddDynamicLight(
+            light_pos, M_FLARE_INTENSITY - (random & 3), M_FLARE_FALL_OFF);
+        return true;
+    }
+
+    Output_AddDynamicLight(light_pos, M_FLARE_INTENSITY, M_FLARE_FALL_OFF / 2);
+    return false;
+}
+
+static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
+{
+    if (flare_age >= M_MAX_FLARE_AGE_TR3) {
+        return false;
+    }
+
+    const int32_t rnd = Random_GetControl();
+    const XYZ_32 light_pos = {
+        .x = pos.x + ((rnd & 0xF) << 3),
+        .y = pos.y + ((rnd >> 1) & 0x78),
+        .z = pos.z + ((rnd >> 5) & 0x78),
+    };
+
+    int32_t r = 0;
+    int32_t g = 0;
+    int32_t b = 0;
+    int32_t falloff = 0;
+
+    if (flare_age < 4) {
+        r = (rnd & 0x1F) + (flare_age << 4) + 160;
+        g = ((rnd >> 4) & 0x1F) + (flare_age << 3) + 32;
+        b = ((rnd >> 8) & 0x1F) + (flare_age << 4);
+        falloff = (rnd & 3) + (flare_age << 2) + 4;
+
+        if (falloff > 16) {
+            falloff -= (rnd >> 12) & 3;
+        }
+    } else if (flare_age < 16) {
+        r = (rnd & 0x3F) + (flare_age << 2) + 128;
+        g = ((rnd >> 4) & 0x1F) + (flare_age << 2) + 64;
+        b = ((rnd >> 8) & 0x1F) + (flare_age << 2) + 16;
+        falloff = (rnd & 1) + flare_age + 2;
+    } else if (flare_age < M_FLARE_DYING_AGE_TR3) {
+        r = (rnd & 0x3F) + 192;
+        g = ((rnd >> 4) & 0x1F) + 128;
+        b = ((rnd >> 8) & 0x20) + (((rnd >> 6) & 0x10) << 1);
+        falloff = 16;
+    } else if (flare_age < M_FLARE_END_AGE_TR3) {
+        if (rnd > 0x2000) {
+            r = (rnd & 0x3F) + 192;
+            g = ((rnd >> 4) & 0x1F) + 64;
+            b = ((rnd >> 8) & 0x20) + (((rnd >> 6) & 0x10) << 1);
+            falloff = 16;
+        } else {
+            const int32_t rnd2 = Random_GetControl();
+            const int32_t rnd3 = Random_GetControl();
+            const int32_t rnd4 = Random_GetControl();
+            r = (rnd2 & 0x3F) + 192;
+            g = (rnd3 & 0x3F) + 64;
+            b = rnd4 & 0x7F;
+            falloff = (Random_GetControl() & 6) + 8;
+            Output_AddDynamicLightRGB(
+                    light_pos, falloff, (RGB_888) { r, g, b });
+            return false;
+        }
+    } else {
+        const int32_t rnd2 = Random_GetControl();
+        const int32_t rnd3 = Random_GetControl();
+        const int32_t rnd4 = Random_GetControl();
+        r = (rnd2 & 0x3F) + 192;
+        g = (rnd3 & 0x3F) + 64;
+        b = rnd4 & 0x1F;
+        falloff = 16 - ((flare_age - M_FLARE_END_AGE_TR3) >> 1);
+        Output_AddDynamicLightRGB(
+                light_pos, falloff, (RGB_888) { r, g, b });
+        return (rnd & 1) != 0;
+    }
+
+    Output_AddDynamicLightRGB(
+            light_pos, falloff, (RGB_888) { r, g, b });
+    return true;
+
+}
+
 void Flare_GenerateEffects(
     const XYZ_32 *const sound_pos, const XYZ_32 flare_pos, int16_t room_num)
 {
@@ -212,43 +328,16 @@ void Flare_GenerateEffects(
 
 bool Flare_GenerateLight(const XYZ_32 pos, const int32_t flare_age)
 {
-    if (flare_age >= M_MAX_FLARE_AGE) {
-        return false;
+    if (g_TRVersion >= 3) {
+        return M_GenerateLight_TR3(pos, flare_age);
+    } else {
+        return M_GenerateLight_TR12(pos, flare_age);
     }
-
-    const int32_t random = Random_GetDraw();
-    const XYZ_32 light_pos = {
-        .x = pos.x + (random & 0xA0),
-        .y = pos.y,
-        .z = pos.z,
-    };
-
-    if (flare_age < M_FLARE_YOUNG_AGE) {
-        const int32_t intensity = M_FLARE_INTENSITY
-                * (flare_age - M_FLARE_YOUNG_AGE) / (2 * M_FLARE_YOUNG_AGE)
-            + M_FLARE_INTENSITY;
-        Output_AddDynamicLight(light_pos, intensity, M_FLARE_FALL_OFF);
-        return true;
-    }
-
-    if (flare_age < M_FLARE_OLD_AGE) {
-        Output_AddDynamicLight(light_pos, M_FLARE_INTENSITY, M_FLARE_FALL_OFF);
-        return true;
-    }
-
-    if (random > 0x2000) {
-        Output_AddDynamicLight(
-            light_pos, M_FLARE_INTENSITY - (random & 3), M_FLARE_FALL_OFF);
-        return true;
-    }
-
-    Output_AddDynamicLight(light_pos, M_FLARE_INTENSITY, M_FLARE_FALL_OFF / 2);
-    return false;
 }
 
 int32_t Flare_GetMaxAge(void)
 {
-    return M_MAX_FLARE_AGE;
+    return g_TRVersion >= 3 ? M_MAX_FLARE_AGE_TR3 : M_MAX_FLARE_AGE_TR12;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -7,8 +7,10 @@
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
+#include <trx/game/sparks.h>
 #include <trx/game/spawn.h>
 #include <trx/utils.h>
+#include <trx/version.h>
 
 // clang-format off
 #define M_FLARE_INTENSITY 12
@@ -17,6 +19,22 @@
 #define M_FLARE_OLD_AGE   (M_MAX_FLARE_AGE - 2 * LOGIC_FPS) // = 1740
 #define M_FLARE_YOUNG_AGE (LOGIC_FPS)                       // = 30
 // clang-format off
+
+static XYZ_32 M_TransformLocalOffset(
+    const XYZ_32 pos, const XYZ_16 rot, const XYZ_32 local_offset)
+{
+    Matrix_PushUnit();
+    Matrix_TranslateAbs32(pos);
+    Matrix_Rot16(rot);
+    Matrix_TranslateRel32(local_offset);
+    const XYZ_32 out = {
+        .x = g_WMatrixPtr->_03 >> W2V_SHIFT,
+        .y = g_WMatrixPtr->_13 >> W2V_SHIFT,
+        .z = g_WMatrixPtr->_23 >> W2V_SHIFT,
+    };
+    Matrix_Pop();
+    return out;
+}
 
 static void M_Control(const int16_t item_num)
 {
@@ -131,13 +149,49 @@ static bool M_Draw(const ITEM *const item)
     };
     Matrix_TranslateRel32(flare_offset);
 
-    if (clip != CLIP_NOT_VISIBLE) {
-        Output_CalculateObjectLighting(item, &frames[0]->bounds);
-        Object_DrawMesh(Object_Get(O_FLARE_ITEM)->mesh_idx, clip, false);
-        if (((int32_t)(intptr_t)item->data) & 0x8000) {
-            M_DrawFlash(clip);
-        }
+    if (clip == CLIP_NOT_VISIBLE) {
+        goto end;
     }
+
+    Output_CalculateObjectLighting(item, &frames[0]->bounds);
+    Object_DrawMesh(Object_Get(O_FLARE_ITEM)->mesh_idx, clip, false);
+    if ((((int32_t)(intptr_t)item->data) & 0x8000) == 0) {
+        goto end;
+    }
+
+    if (g_TRVersion < 3) {
+        M_DrawFlash(clip);
+        goto end;
+    }
+
+    const XYZ_32 flare_pos = {
+        .x = item->interp.result.pos.x,
+        .y = item->interp.result.pos.y,
+        .z = item->interp.result.pos.z,
+    };
+    const XYZ_32 tip_local = { .x = -6, .y = 6, .z = 32 };
+    const XYZ_32 tip_pos = M_TransformLocalOffset(
+        flare_pos, item->interp.result.rot, tip_local);
+
+    const XYZ_32 vel_local = {
+        .x = (Random_GetDraw() & 0x7F) - 64,
+        .y = (Random_GetDraw() & 0x7F) - 64,
+        .z = (Random_GetDraw() & 0x1FF) + 512,
+    };
+    const XYZ_32 vel_pos = M_TransformLocalOffset(
+        flare_pos, item->interp.result.rot, vel_local);
+    const XYZ_32 vel = {
+        .x = vel_pos.x - flare_pos.x,
+        .y = vel_pos.y - flare_pos.y,
+        .z = vel_pos.z - flare_pos.z,
+    };
+
+    for (int32_t i = 0; i < (Random_GetDraw() & 3) + 4; i++) {
+        const bool smoke = (i >> 2) != 0;
+        Sparks_TriggerFlareSparks(tip_pos, vel, smoke);
+    }
+
+end:
     Matrix_Pop();
     return true;
 }

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -1,6 +1,7 @@
 #include <trx/game/objects/general/flare_item.h>
 
 #include <trx/game/gun.h>
+#include <trx/game/items/anim.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/general/pickup.h>
@@ -121,6 +122,51 @@ static void M_Control(const int16_t item_num)
         Flare_GenerateEffects(&item->pos, item->pos, item->room_num);
     }
 
+    if (g_TRVersion >= 3) {
+        const int32_t flare_age_plain = flare_age & 0x7FFF;
+        const bool is_active = (flare_age & 0x8000) != 0;
+        if (flare_age_plain < Flare_GetMaxAge() && is_active) {
+            const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
+            const XYZ_32 flare_size = {
+                .x = bounds->max.x - bounds->min.x,
+                .y = bounds->max.y - bounds->min.y,
+                .z = bounds->max.z - bounds->min.z,
+            };
+            const XYZ_32 flare_offset = {
+                .x = -flare_size.x,
+                .y = -flare_size.y,
+                .z = -flare_size.z,
+            };
+
+            const XYZ_32 flare_pos = item->pos;
+            const XYZ_32 tip_local = {
+                .x = flare_offset.x - 6,
+                .y = flare_offset.y + 6,
+                .z = flare_offset.z + 32,
+            };
+            const XYZ_32 tip_pos =
+                M_TransformLocalOffset(flare_pos, item->rot, tip_local);
+
+            const XYZ_32 vel_local = {
+                .x = (Random_GetControl() & 0x7F) - 64,
+                .y = (Random_GetControl() & 0x7F) - 64,
+                .z = (Random_GetControl() & 0x1FF) + 512,
+            };
+            const XYZ_32 vel_pos =
+                M_TransformLocalOffset(flare_pos, item->rot, vel_local);
+            const XYZ_32 vel = {
+                .x = vel_pos.x - flare_pos.x,
+                .y = vel_pos.y - flare_pos.y,
+                .z = vel_pos.z - flare_pos.z,
+            };
+
+            for (int32_t i = 0; i < (Random_GetControl() & 3) + 4; i++) {
+                const bool smoke = (i >> 2) != 0;
+                Sparks_TriggerFlareSparks(tip_pos, vel, smoke);
+            }
+        }
+    }
+
     item->data = (void *)(intptr_t)flare_age;
 }
 
@@ -164,37 +210,11 @@ static bool M_Draw(const ITEM *const item)
         goto end;
     }
 
-    if (g_TRVersion < 3) {
-        M_DrawFlash(clip);
+    if (g_TRVersion >= 3) {
         goto end;
     }
 
-    const XYZ_32 flare_pos = {
-        .x = item->interp.result.pos.x,
-        .y = item->interp.result.pos.y,
-        .z = item->interp.result.pos.z,
-    };
-    const XYZ_32 tip_local = { .x = -6, .y = 6, .z = 32 };
-    const XYZ_32 tip_pos = M_TransformLocalOffset(
-        flare_pos, item->interp.result.rot, tip_local);
-
-    const XYZ_32 vel_local = {
-        .x = (Random_GetDraw() & 0x7F) - 64,
-        .y = (Random_GetDraw() & 0x7F) - 64,
-        .z = (Random_GetDraw() & 0x1FF) + 512,
-    };
-    const XYZ_32 vel_pos = M_TransformLocalOffset(
-        flare_pos, item->interp.result.rot, vel_local);
-    const XYZ_32 vel = {
-        .x = vel_pos.x - flare_pos.x,
-        .y = vel_pos.y - flare_pos.y,
-        .z = vel_pos.z - flare_pos.z,
-    };
-
-    for (int32_t i = 0; i < (Random_GetDraw() & 3) + 4; i++) {
-        const bool smoke = (i >> 2) != 0;
-        Sparks_TriggerFlareSparks(tip_pos, vel, smoke);
-    }
+    M_DrawFlash(clip);
 
 end:
     Matrix_Pop();

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -156,7 +156,7 @@ static void M_RenderScenePasses(const M_PRIV *const p)
         glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_COLOR);
         M_RenderSourcePass(p, SCENE_PASS_BLEND_SUB);
         glBlendEquation(GL_FUNC_ADD);
-        glBlendFunc(GL_ONE, GL_ONE);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
         M_RenderSourcePass(p, SCENE_PASS_BLEND_ADD);
         glDepthMask(GL_TRUE);
         glDisable(GL_CULL_FACE);

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -500,6 +500,7 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         return;
     }
 
+    DRAW_TYPE draw_type = spark->draw_type;
     const XYZ_32 pos = Sparks_GetWorldPos(spark);
     const XYZ_32 world_pos[4] = { pos, pos, pos, pos };
 
@@ -551,9 +552,7 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         { w, -h },
     };
 
-    const RGBA_8888 color = { spark->color.r, spark->color.g, spark->color.b,
-                              255 };
-    const RGBA_8888 world_color[4] = { color, color, color, color };
+    RGBA_8888 color = { spark->color.r, spark->color.g, spark->color.b, 255 };
 
     if ((spark->flags & SPARK_F_ROTATE) != 0U) {
         const int32_t angle = (int32_t)spark->rot_angle * DEG_180 / 0xFFF.p0;
@@ -573,10 +572,15 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
     if ((spark->flags & SPARK_F_SPRITE) == 0U) {
         flags |= VERT_FLAT_SHADED;
         sprite_idx = -1;
+        if (draw_type == DRAW_BLEND_ADD) {
+            draw_type = DRAW_BLEND;
+            color.a = 128;
+        }
     }
     M_PRIV *const p = &m_Priv;
-    VECTOR *const target =
-        M_GetScheduledVectorForDrawType(p, (DRAW_TYPE)spark->draw_type);
+    VECTOR *const target = M_GetScheduledVectorForDrawType(p, draw_type);
+
+    const RGBA_8888 world_color[4] = { color, color, color, color };
     M_StagePrim(
         sprite_idx, 4, &world_pos[0], disp, &world_color[0], flags, target);
 }

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -17,7 +17,7 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
-#define M_MAX_SPARKS 192
+#define M_MAX_SPARKS 400
 #define M_MAX_SPARK_DYNAMICS 32
 
 typedef struct {

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -797,7 +797,7 @@ void Sparks_TriggerFireFlame(
         spark->s_life = spark->life;
     }
 
-    spark->draw_type = 2;
+    spark->draw_type = DRAW_BLEND_ADD;
     spark->extras = 0;
     spark->dynamic = -1;
 
@@ -938,7 +938,7 @@ void Sparks_TriggerFireSmoke(
         spark->s_life = spark->life;
     }
 
-    spark->draw_type = 2;
+    spark->draw_type = DRAW_BLEND_ADD;
     spark->extras = 0;
     spark->dynamic = -1;
     spark->pos.x = pos.x + (Random_GetControl() & 0xF) - 8;
@@ -997,7 +997,7 @@ void Sparks_TriggerStaticFlame(const XYZ_32 pos, const int32_t size)
     spark->fade_to_black = 0;
     spark->life = 2;
     spark->s_life = 2;
-    spark->draw_type = 2;
+    spark->draw_type = DRAW_BLEND_ADD;
     spark->extras = 0;
     spark->dynamic = -1;
     spark->pos.x = pos.x + (Random_GetControl() & 7) - 4;
@@ -1042,7 +1042,7 @@ void Sparks_TriggerSideFlame(
     spark->dst_color.b = 32;
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
-    spark->draw_type = 2;
+    spark->draw_type = DRAW_BLEND_ADD;
     spark->extras = 0;
     spark->life = (Random_GetControl() & 7) + 28;
     spark->s_life = spark->life;
@@ -1311,4 +1311,100 @@ static void M_TriggerExplosionBubbleCallback(
         };
         Spawn_BubbleEx(&bubble_pos, room_num, 6, 15);
     }
+}
+
+void Sparks_TriggerFlareSparks(
+    const XYZ_32 pos, const XYZ_32 vel, const bool smoke)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    const int32_t dx = lara_item->pos.x - pos.x;
+    const int32_t dz = lara_item->pos.z - pos.z;
+    if (dx < -0x4000 || dx > 0x4000 || dz < -0x4000 || dz > 0x4000) {
+        return;
+    }
+
+    SPARK *const spark = Sparks_GetFreeSpark();
+    spark->on = true;
+    spark->src_color.r = 255;
+    spark->src_color.g = 255;
+    spark->src_color.b = 255;
+    spark->dst_color.r = 255;
+    spark->dst_color.g = (Random_GetDraw() & 0x7F) + 64;
+    spark->dst_color.b = 192 - spark->dst_color.g;
+    spark->col_fade_speed = 3;
+    spark->fade_to_black = 5;
+    spark->life = 10;
+    spark->s_life = 10;
+    spark->draw_type = DRAW_BLEND_ADD;
+    spark->dynamic = -1;
+    spark->pos.x = pos.x + (Random_GetDraw() & 7) - 3;
+    spark->pos.y = pos.y + (Random_GetDraw() & 7) - 3;
+    spark->pos.z = pos.z + (Random_GetDraw() & 7) - 3;
+    spark->vel.x = (int16_t)((Random_GetDraw() & 0xFF) + vel.x - 128);
+    spark->vel.y = (int16_t)((Random_GetDraw() & 0xFF) + vel.y - 128);
+    spark->vel.z = (int16_t)((Random_GetDraw() & 0xFF) + vel.z - 128);
+    spark->friction = 34;
+    spark->scalar = 1;
+    spark->size.width = (Random_GetDraw() & 3) + 4;
+    spark->src_size.width = spark->size.width;
+    spark->dst_size.width = (Random_GetDraw() & 1) + 1;
+    spark->size.height = (Random_GetDraw() & 3) + 4;
+    spark->src_size.height = spark->size.height;
+    spark->dst_size.height = (Random_GetDraw() & 1) + 1;
+    spark->max_y_vel = 0;
+    spark->gravity = 0;
+    spark->flags = SPARK_F_SCALE;
+
+    if (!smoke) {
+        return;
+    }
+
+    SPARK *const smoke_spark = Sparks_GetFreeSpark();
+    smoke_spark->on = true;
+    smoke_spark->src_color.r = spark->dst_color.r >> 1;
+    smoke_spark->src_color.g = spark->dst_color.g >> 1;
+    smoke_spark->src_color.b = spark->dst_color.b >> 1;
+    smoke_spark->dst_color.r = 32;
+    smoke_spark->dst_color.g = 32;
+    smoke_spark->dst_color.b = 32;
+    smoke_spark->col_fade_speed = (Random_GetDraw() & 3) + 8;
+    smoke_spark->fade_to_black = 4;
+    smoke_spark->draw_type = DRAW_BLEND_ADD;
+    smoke_spark->life = (Random_GetDraw() & 7) + 13;
+    smoke_spark->s_life = smoke_spark->life;
+    smoke_spark->pos.x = pos.x + (vel.x >> 5);
+    smoke_spark->pos.y = pos.y + (vel.y >> 5);
+    smoke_spark->pos.z = pos.z + (vel.z >> 5);
+    smoke_spark->extras = 0;
+    smoke_spark->dynamic = -1;
+    smoke_spark->vel.x = (int16_t)((Random_GetDraw() & 0x3F) + vel.x - 32);
+    smoke_spark->vel.y = (int16_t)vel.y;
+    smoke_spark->vel.z = (int16_t)((Random_GetDraw() & 0x3F) + vel.z - 32);
+    smoke_spark->friction = 4;
+
+    if (Random_GetDraw() & 1) {
+        smoke_spark->flags = SPARK_F_ALT_SPRITE | SPARK_F_ROTATE
+            | SPARK_F_SPRITE | SPARK_F_SCALE;
+        smoke_spark->rot_angle = Random_GetDraw() & 0xFFF;
+
+        if (Random_GetDraw() & 1) {
+            smoke_spark->rot_add = -16 - (Random_GetDraw() & 0xF);
+        } else {
+            smoke_spark->rot_add = (Random_GetDraw() & 0xF) + 16;
+        }
+    } else {
+        smoke_spark->flags =
+            SPARK_F_ALT_SPRITE | SPARK_F_SPRITE | SPARK_F_SCALE;
+    }
+
+    smoke_spark->sprite_idx = Object_Get(O_EXPLOSION_1)->mesh_idx;
+    smoke_spark->scalar = 2;
+    smoke_spark->gravity = -8 - (Random_GetDraw() & 3);
+    smoke_spark->max_y_vel = -4 - (Random_GetDraw() & 3);
+    smoke_spark->dst_size.width = (Random_GetDraw() & 0xF) + 24;
+    smoke_spark->src_size.width = smoke_spark->dst_size.width >> 3;
+    smoke_spark->size.width = smoke_spark->dst_size.width >> 3;
+    smoke_spark->dst_size.height = smoke_spark->dst_size.width;
+    smoke_spark->src_size.height = smoke_spark->dst_size.height >> 3;
+    smoke_spark->size.height = smoke_spark->dst_size.height >> 3;
 }

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -513,7 +513,12 @@ void Sparks_Control(void)
 void Sparks_Draw(void)
 {
     for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
-        OutputSource_PolyFX_StageSpark(&m_Sparks[i]);
+        SPARK *const spark = &m_Sparks[i];
+        if (!spark->on) {
+            continue;
+        }
+
+        OutputSource_PolyFX_StageSpark(spark);
     }
 }
 

--- a/src/trx/game/sparks.h
+++ b/src/trx/game/sparks.h
@@ -112,3 +112,5 @@ void Sparks_TriggerStaticFlame(XYZ_32 pos, int32_t size);
 void Sparks_TriggerFireSmoke(XYZ_32 pos, int32_t body_part, int32_t type);
 void Sparks_TriggerSideFlame(
     XYZ_32 pos, int32_t angle, int32_t speed, bool pilot);
+
+void Sparks_TriggerFlareSparks(XYZ_32 pos, XYZ_32 vel, bool smoke);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR implements TR3 flare sparks and RGB lighting.
It also fixes the opacity of non-sprite sparks, which OG TR3 caps at 0x80.

#### Testing

Just flare stuff:
- handheld
- thrown
- going out in both variants
- underwater in both variants
- sanity checks in TR1/TR2 for potential regressions