### PR TITLE
sound: fix wrongly scaled decibel LUT

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed developer console text editing (backspace, moving the caret) doing weird things with Unicode characters
 - fixed Lara jumping if player holds the swim button when exiting the fly cheat (#4470)
 - fixed game refusing to load savegames made with the JP mode (#4558)
+- fixed quiet sounds being almost inaudible
 
 **TR1**:
 - added the ability to change inventory and statistics background styles (pattern + wave are not implemented in TR1)

--- a/src/trx/engine/audio_sample.c
+++ b/src/trx/engine/audio_sample.c
@@ -50,8 +50,23 @@ typedef struct {
     float volume_r; // sample gain multiplier
 
     float pitch;
-    int32_t volume; // volume specified in hundredths of decibel
-    int32_t pan; // pan specified in hundredths of decibel
+    // `volume`/`pan` come from the game layer (src/trx/game/sound/common.c).
+    // Despite the historic "decibel" naming, these values are not base-10
+    // centi-dB. They are a log2-based gain domain that the OG engine used to
+    // feed directly to DirectSound (-10000..0 style range).
+    //
+    // In TRX we keep the game-side math pristine and simply interpret these as:
+    //   log2(gain) * 1000
+    // i.e. +1000 means "double the amplitude", -1000 means "half the
+    // amplitude". `M_DecibelToMultiplier()` is the corresponding inverse
+    // transform:
+    //   gain = 2^(value/1000)
+    //
+    // This makes combining contributions (volume + pan) an additive operation
+    // in this log2 domain, while still producing a linear multiplier for the
+    // mixer.
+    int32_t volume;
+    int32_t pan;
 
     // pitch shift means the same samples can be reused twice, hence float
     float current_sample;
@@ -72,7 +87,7 @@ static AUDIO_SAMPLE_SOUND m_Samples[AUDIO_MAX_ACTIVE_SAMPLES] = {};
 
 static double M_DecibelToMultiplier(double db_gain)
 {
-    return pow(2.0, db_gain / 600.0);
+    return pow(2.0, db_gain / 1000.0);
 }
 
 static bool M_RecalculateChannelVolumes(int32_t sound_id)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR1/2 volume is computed in a log2 "dB-like" domain:

- `m_DecibelLUT[…]` maps a volume index to a "dB-like" gain value
- `M_DecibelToMultiplier(db_gain)` turns that number back into a linear gain multiplier, with which we can multiply the raw samples that we feed into the SDL mixer

The TR1/TR2 code path was originally ported from the glrage compatibility patch, including its "decibel LUT". That LUT uses log2(), but scales it as if one doubling corresponded to 10 dB, i.e. "+1000 per doubling". That's not how real decibels work: for amplitude, +6.02 dB is one doubling (because dB is defined in base‑10 as gain = 10^(dB/20)).

The audio backend was implemented separately under the "real dB" intuition: if a value behaves like centi‑dB, then the natural base‑2 rewrite is "~600 per doubling" (since 6.02 dB ≈ 602 centi‑dB), leading to gain = 2^(value/600).

Those two assumptions (*1000 in the LUT vs /600 in the backend) are not inverses. The mismatch crushes low volumes and makes quiet samples far quieter than intended.

The backend scaling is adjusted to match the inherited glrage LUT (gain = 2^(value/1000)), restoring internal consistency without redesigning the curve yet.

#### Testing

Volumes of distant objects, quiet objects (bat wings, gun shells); of loud objects (waterfalls, machines).