### PR TITLE
Implement TR3 gun ricochets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@
 - added surface-based step sounds
 - added cold breath effects
 - added gun shells
+- added new ricochets
 - added flare lighting and sparks
 - added monochrome inventory backgrounds
 - added high-resolutions 16:9 and 4:3 loading screens

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -387,8 +387,9 @@ void Gun_HitTarget(
     Item_TakeDamage(item, damage, true);
 
     if (hit_pos != nullptr) {
-        const bool make_ricochet = g_Config.visuals.fix_texture_issues
-            && item->object_id == O_SCION_ITEM_3;
+        const bool make_ricochet = (g_Config.visuals.fix_texture_issues
+                                    && item->object_id == O_SCION_ITEM_3)
+            || item->object_id == O_WINSTON_ARMY;
 
         if (make_ricochet) {
             const GAME_VECTOR pos = {

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -573,9 +573,9 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         flags |= VERT_FLAT_SHADED;
         sprite_idx = -1;
         if (draw_type == DRAW_BLEND_ADD) {
-            draw_type = DRAW_BLEND;
             color.a = 128;
         }
+        draw_type = DRAW_BLEND;
     }
     M_PRIV *const p = &m_Priv;
     VECTOR *const target = M_GetScheduledVectorForDrawType(p, draw_type);

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -1413,3 +1413,77 @@ void Sparks_TriggerFlareSparks(
     smoke_spark->src_size.height = smoke_spark->dst_size.height >> 3;
     smoke_spark->size.height = smoke_spark->dst_size.height >> 3;
 }
+
+void Sparks_TriggerRicochet(
+    const GAME_VECTOR pos, const int32_t angle, const int32_t size)
+{
+    SPARK *spark = Sparks_GetFreeSpark();
+    spark->on = true;
+    spark->src_color.r = 255;
+    spark->src_color.g = (Random_GetControl() & 0x1F) + 32;
+    spark->src_color.b = 0;
+    spark->dst_color.r = 192;
+    spark->dst_color.g = (Random_GetControl() & 0x3F) + 96;
+    spark->dst_color.b = 0;
+    spark->col_fade_speed = 8;
+    spark->fade_to_black = 8;
+    spark->life = 24;
+    spark->s_life = 24;
+    spark->draw_type = DRAW_BLEND_ADD;
+    spark->dynamic = -1;
+    spark->pos.x = pos.x;
+    spark->pos.y = pos.y;
+    spark->pos.z = pos.z;
+    int32_t ang = ((Random_GetControl() & 0x7FF) + angle - 1024) & 0xFFF;
+    spark->vel.x = -Math_Sin(ang << 4) >> 3;
+    spark->vel.y = 2 * (Random_GetControl() & 0x1FF) - 768;
+    spark->vel.z = Math_Cos(ang << 4) >> 3;
+    spark->friction = 1;
+    spark->flags = SPARK_F_SCALE;
+    spark->scalar = 3;
+    spark->gravity =
+        (int16_t)(ABS(spark->vel.y >> 6) + (Random_GetControl() & 0x1F));
+    spark->size.width = (Random_GetControl() & 3) + 4;
+    spark->src_size.width = spark->size.width;
+    spark->dst_size.width = (Random_GetControl() & 1) + 1;
+    spark->size.height = (Random_GetControl() & 3) + 4;
+    spark->src_size.height = spark->size.height;
+    spark->dst_size.height = (Random_GetControl() & 1) + 1;
+    spark->max_y_vel = 0;
+
+    spark = Sparks_GetFreeSpark();
+    spark->on = true;
+    uint8_t c = (uint8_t)((Random_GetControl() & 0x3F) + 128);
+    spark->src_color.r = c;
+    spark->src_color.g = c;
+    spark->src_color.b = c;
+    c >>= 1;
+    spark->dst_color.r = c;
+    spark->dst_color.g = c;
+    spark->dst_color.b = c;
+    spark->draw_type =
+        DRAW_BLEND; // DRAW_BLEND_SUB in the OG, but doesn't that match?
+    spark->col_fade_speed = 8;
+    spark->fade_to_black = 16;
+    spark->life = 28;
+    spark->s_life = 28;
+    spark->dynamic = -1;
+    spark->pos.x = pos.x;
+    spark->pos.y = pos.y;
+    spark->pos.z = pos.z;
+    ang = ((Random_GetControl() & 0x7FF) + angle - 1023) & 0xFFF;
+    spark->vel.x = -Math_Sin(ang << 4) >> 3;
+    spark->vel.y = (Random_GetControl() & 0x1FF) - 384;
+    spark->vel.z = Math_Cos(ang << 4) >> 3;
+    spark->friction = 33;
+    spark->flags = SPARK_F_SCALE;
+    spark->scalar = 3;
+    spark->gravity = (Random_GetControl() & 7) + 4;
+    spark->size.width = (Random_GetControl() & 3) + 4;
+    spark->src_size.width = spark->size.width;
+    spark->dst_size.width = (Random_GetControl() & 1) + 1;
+    spark->size.height = (Random_GetControl() & 3) + 4;
+    spark->src_size.height = spark->size.height;
+    spark->dst_size.height = (Random_GetControl() & 1) + 1;
+    spark->max_y_vel = 0;
+}

--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -1461,8 +1461,7 @@ void Sparks_TriggerRicochet(
     spark->dst_color.r = c;
     spark->dst_color.g = c;
     spark->dst_color.b = c;
-    spark->draw_type =
-        DRAW_BLEND; // DRAW_BLEND_SUB in the OG, but doesn't that match?
+    spark->draw_type = DRAW_BLEND_SUB;
     spark->col_fade_speed = 8;
     spark->fade_to_black = 16;
     spark->life = 28;

--- a/src/trx/game/sparks.h
+++ b/src/trx/game/sparks.h
@@ -114,3 +114,5 @@ void Sparks_TriggerSideFlame(
     XYZ_32 pos, int32_t angle, int32_t speed, bool pilot);
 
 void Sparks_TriggerFlareSparks(XYZ_32 pos, XYZ_32 vel, bool smoke);
+
+void Sparks_TriggerRicochet(GAME_VECTOR pos, int32_t angle, int32_t size);

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -85,6 +85,15 @@ void Spawn_Splash(const ITEM *const item)
 
 void Spawn_Ricochet(const GAME_VECTOR pos)
 {
+    if (g_TRVersion == 3) {
+        const ITEM *const lara_item = Lara_GetItem();
+        const int32_t angle16 = Math_Atan(
+            lara_item->pos.z - pos.pos.z, lara_item->pos.x - pos.pos.x);
+        Sparks_TriggerRicochet(pos, ((uint16_t)angle16 >> 4) & 0x0FFF, 16);
+        Sound_Effect(SFX_LARA_RICOCHET, &pos.pos, SPM_NORMAL);
+        return;
+    }
+
     const int16_t effect_num = Effect_Create(pos.room_num);
     if (effect_num != NO_EFFECT) {
         EFFECT *const effect = Effect_Get(effect_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR implements ricochets.
Army Winston no longer draws blood (which is not yet implemented, but you can now see the ricochets).

---

The last commit was quite tricky to realize why it was needed.
So, ricochets draw two sparks: the orange "firey" bits, and the grey "smokey"/"debrisy" bits. The grey parts get drawn with subtractive blending, meaning they only ever should turn pixels behind them darker. But the OG actually draws them… very light. To show how absurd this is: this happens even in dark rooms, where the grey parts can  show up as very visible, almost white quads, clearly lighter than what’s behind it… which should absolutely not happen with this blending mode.
So what causes this?

For a while I thought the entire pipeline looked right:

The OG declares the grey bits to use `TransType` 3. Reference: TOMB3, `effects2.cpp`, `TriggerRicochetSpark`:

```c
    sptr->TransType = 3;
```

Later, when we draw them, the spark's `3` gets just translated to an internal enum type. Nothing surprising. Reference: TOMB3, `draweffects.cpp`, `S_DrawSparks()`:

```c
    if (sptr->TransType == 3)
    {
        drawType = DT_POLY_COLSUB;
```

This along with a couple of other local stack variables then gets sent to `HWI_InsertAlphaSprite_Sorted`, which upon seeing untextured mode, dispatches it further to `HWI_InsertPoly_GouraudRGB`. Reference: TOMB3, `draweffects.cpp`, `S_DrawSparks()`:

```c
    if (nSprite == -1) {
        HWI_InsertPoly_GouraudRGB(nPoints, zdepth, nDrawtype);
```
This function stashes the emitted vertex information to the global vertex sort buffers. After sorting, the information from the sort buffers gets picked up by `HWR_DrawRoutines()` and friends. These, in turn, check the chosen draw type for each vertex range / bucket, and just blit the vertices with (wrapped) DirectX calls. Reference: TOMB3, `hwrender.cpp`, `HWR_DrawRoutines()`:

```c
    case DT_POLY_COLSUB:
        HWR_EnableZBuffer(0, 1);
        HWR_SetCurrentTexture(TexturePtrs[TPage]);
        HWR_EnableColorSubtraction(1);
        HWR_EnableAlphaBlend(1);
        DrawPrimitive(dpPrimitiveType, vtx, nVtx);
        return;
```

The above just does this, sequentially:
- disables z writes,
- enables z tests,
- sets the texture source,
- enables `D3DRS_ALPHABLENDENABLE`,
- sets the blend func to the very expected `D3DBLEND_ZERO` / `D3DBLEND_INVSRCCOLOR` pair,
- outputs the vertices.

Until now nothing indicates what's wrong. But if you take a closer look at how `HWI_InsertPoly_GouraudRGB` is implemented…

```c
void HWI_InsertPoly_GouraudRGB(int32_t nPoints, float zdepth, int32_t nDrawType)
{
    VERTEX_INFO *vtx;
    TEXTUREBUCKET *bucket;
    D3DTLVERTEX *v;
    int32_t *sort;
    int16_t *info;
    uint32_t maxCol;
    int32_t nBucket;

    maxCol = (nDrawType == DT_POLY_GA || nDrawType == DT_POLY_GTA) ? 0x80FFFFFF
                                                                   : 0xFFFFFFFF;
    vtx = v_buffer;

    if (App.lpDXConfig->bZBuffer && nDrawType != DT_POLY_GA
        && nDrawType != DT_POLY_GTA) {
        nBucket = FindBucket(0);

        if (nBucket == -1) {
            return;
        }

        bucket = &Buckets[nBucket];

        for (int i = 0; i < 3; i++) {
            // …(assign stuff to v)…
        }

        nDrawnPoints++;
        nPoints -= 3;
        vtx--;

        // actually never use nDrawType
    } else {
        if (!SetBufferPtrs(&sort, &info, nDrawType, 0)) {
            return;
        }

        sort[0] = (int32_t)info;
        sort[1] = (int32_t)zdepth;
        info[0] = (int16_t)nDrawType;
        info[1] = 0;
        info[2] = (int16_t)nPoints;
        v = CurrentTLVertex;
        *((D3DTLVERTEX **)(info + 3)) = v;

        for (int i = nPoints; i; i--, v++, vtx++) {
            // …(assign stuff to v)…
        }

        CurrentTLVertex = v;
    }
}
```

Turns out our spark vertices land to the first branch, and since **it never reads `nDrawType` in that branch**, it just defaults to the regular blending. Mystery solved.

Took me five hours to realize this.