### PR TITLE
objects/assault-target: fix twitching after reset

### DIFF
--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -63,11 +63,6 @@ static void M_ResetAssaultTargets(void)
             continue;
         }
 
-        // Ensure we don't run out of LOT slots after repeated restarts.
-        if (item->data != nullptr) {
-            LOT_DisableBaddieAI(item_num);
-        }
-
         if (obj->initialise_func != nullptr) {
             obj->initialise_func(item_num);
         }

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -28,6 +28,7 @@ static void M_ResetItemState(ITEM *const item, const OBJECT *const obj)
     item->current_anim_state = anim->current_anim_state;
     item->goal_anim_state = item->current_anim_state;
     item->required_anim_state = M_STATE_RISE;
+    item->prev_frame_num = item->frame_num;
     item->rot.x = 0;
     item->rot.z = 0;
     item->timer = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes resetting the targets in the Assault Course.
