### PR TITLE
shaders: use radial distance for fog

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -146,10 +146,10 @@ in vec4 gColor;
 in vec2 gTrapezoidRatios;
 out vec4 outColor;
 
-vec4 applyFog(vec4 color, float depth)
+vec4 applyFog(vec4 color, float dist)
 {
     float fogFactor = clamp(
-        (depth - uFogDistance.x) / (uFogDistance.y - uFogDistance.x), 0.0, 1.0);
+        (dist - uFogDistance.x) / (uFogDistance.y - uFogDistance.x), 0.0, 1.0);
     return mix(color, uFogColor, fogFactor);
 }
 
@@ -182,7 +182,7 @@ void main(void) {
 
     // Fog
     if ((gFlags & VERT_NO_LIGHTING) == 0u && uLightingEnabled != 0) {
-        texColor = applyFog(texColor, gEyePos.z);
+        texColor = applyFog(texColor, length(gEyePos.xyz));
     }
 
     texColor.rgb *= uGlobalTint * uBrightnessMultiplier;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - added Animating Item 1-6 control
 - added the option to use TR3 sprite-based shadows (Visuals → Shadows shape)
 - improved a fade-in and fade-out effect on loading screens – they now smoothly transition to the game screen
+- improved fog behavior to be less dependent on camera rotation
 - changed the 2D and 3D statics limit from 256 to unlimited
 - changed the lighting contrast key binding to F9
 - changed underwater statics to be affected by caustics, even if they don't get merged into level geometry (#4430)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Previously, looking straight ahead (especially with short fog distances) felt punishing, since players could see farther by glancing sideways (particularly on 16:9 screens). This PR evens out visibility and reduces that discrepancy.

I attached videos that demonstrate the difference below.

#### OG

https://github.com/user-attachments/assets/f2a7729e-e1ca-4eb9-aedc-8bdf61fbecc6

#### PR

https://github.com/user-attachments/assets/da32dbaf-a8b5-4fe7-8b5f-c81729c77211

