### PR TITLE
sparks: fix ricochets colors on the first frame

### DIFF
--- a/src/trx/game/sparks.c
+++ b/src/trx/game/sparks.c
@@ -1422,6 +1422,7 @@ void Sparks_TriggerRicochet(
     spark->src_color.r = 255;
     spark->src_color.g = (Random_GetControl() & 0x1F) + 32;
     spark->src_color.b = 0;
+    spark->color = spark->src_color;
     spark->dst_color.r = 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 96;
     spark->dst_color.b = 0;
@@ -1457,6 +1458,7 @@ void Sparks_TriggerRicochet(
     spark->src_color.r = c;
     spark->src_color.g = c;
     spark->src_color.b = c;
+    spark->color = spark->src_color;
     c >>= 1;
     spark->dst_color.r = c;
     spark->dst_color.g = c;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the black (or random) color of the ricochet sparks that appears on the first frame.
Great finding by @aredfan.