### PR TITLE
gun: spawn ricochets on assault targets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -144,6 +144,7 @@
 - added an option to fix the MP5 accuracy while running
 - improved run-to-crawl transition
 - improved text colors of the Assault Course statistics and timers
+- improved Assault Course targets to spawn ricochets
 - changed The River Ganges, City and All Hallows to have rain
 - fixed sample reading to support correct pitch and volume
 - fixed pool edges shifting along with the water effect

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -389,7 +389,8 @@ void Gun_HitTarget(
     if (hit_pos != nullptr) {
         const bool make_ricochet = (g_Config.visuals.fix_texture_issues
                                     && item->object_id == O_SCION_ITEM_3)
-            || item->object_id == O_WINSTON_ARMY;
+            || item->object_id == O_WINSTON_ARMY
+            || item->object_id == O_ASSAULT_TARGET;
 
         if (make_ricochet) {
             const GAME_VECTOR pos = {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This implements the suggestion by aredfan for the Assault Course targets to trigger ricochets.