### PR TITLE
loader: don't always make TR3 statics collidable

### DIFF
--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -1126,9 +1126,6 @@ void Level_ReadStaticObjects(
 
         obj->collidable = (tmp_statics[i].flags & 1) == 0;
         obj->visible = (tmp_statics[i].flags & 2) != 0;
-        if (loader->game_version >= 3) {
-            obj->collidable = true;
-        }
 
         Object_GetMesh(obj->mesh_idx)->enable_caustics = obj->visible;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
The Jungle slope collision bug is happening because of the vine static causing collision. Most statics in TR3 levels seem to have the collidable flag set. However, in the India levels, there are a few plants and vines that are set as non-collidable. For example in Jungle, the list of statics looks like this:
```
Level_ReadStaticObjects] static objects: 17
Level_ReadStaticObjects] i: 0; static_id: 0; obj->mesh_idx: 356; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 1; static_id: 1; obj->mesh_idx: 357; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 2; static_id: 2; obj->mesh_idx: 358; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 3; static_id: 3; obj->mesh_idx: 359; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 4; static_id: 4; obj->mesh_idx: 360; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 5; static_id: 5; obj->mesh_idx: 361; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 6; static_id: 6; obj->mesh_idx: 362; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 7; static_id: 7; obj->mesh_idx: 363; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 8; static_id: 8; obj->mesh_idx: 364; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 9; static_id: 9; obj->mesh_idx: 365; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 10; static_id: 10; obj->mesh_idx: 366; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 11; static_id: 11; obj->mesh_idx: 367; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 12; static_id: 12; obj->mesh_idx: 368; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 13; static_id: 30; obj->mesh_idx: 369; flag: 3; flags & 1: 1; collidable: 0
Level_ReadStaticObjects] i: 14; static_id: 31; obj->mesh_idx: 370; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 15; static_id: 32; obj->mesh_idx: 371; flag: 2; flags & 1: 0; collidable: 1
Level_ReadStaticObjects] i: 16; static_id: 33; obj->mesh_idx: 372; flag: 2; flags & 1: 0; collidable: 1
```

I removed the code to always set collidable true for TR3+ done in c8be92f. I don't see anywhere in tomb3/4 that ignores the collidable flag. With this change, Lara no longer bumps into the tiny vine collision box when sliding down the first slope in Jungle.