### PR TITLE
Improve weather room indexing

### DIFF
--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -180,10 +180,9 @@ void Room_BuildOutsideTable(void)
                 bool cont = false;
                 for (int32_t ry = 0; ry < M_OUTSIDE_TABLE_STEP && !cont; ry++) {
                     for (int32_t rx = 0; rx < M_OUTSIDE_TABLE_STEP; rx++) {
-                        if (x + rx >= room_x
-                            && x + rx < room_x + room->size.z - 2
+                        if (x + rx >= room_x && x + rx < room_x + room->size.z
                             && y + ry >= room_y
-                            && y + ry < room_y + room->size.x - 2) {
+                            && y + ry < room_y + room->size.x) {
                             cont = true;
                             break;
                         }

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -23,7 +23,9 @@ static int32_t m_FlipEffect = -1;
 static int32_t m_FlipTimer = 0;
 static int32_t m_FlipSlotFlags[MAX_FLIP_MAPS] = {};
 
-#define M_OUTSIDE_TABLE_BLOCK_SHIFT 12 // 4096 (4 * WALL_L)
+#define M_OUTSIDE_TABLE_STEP_SHIFT 2
+#define M_OUTSIDE_TABLE_STEP (1 << M_OUTSIDE_TABLE_STEP_SHIFT)
+#define M_OUTSIDE_TABLE_BLOCK_SHIFT (WALL_SHIFT + M_OUTSIDE_TABLE_STEP_SHIFT)
 #define M_OUTSIDE_TABLE_MAX_ROOMS_PER_CELL 64
 #define M_OUTSIDE_TABLE_SENTINEL NO_ROOM
 #define M_OUTSIDE_OFFSET_EMPTY 0xFFFF
@@ -163,21 +165,21 @@ void Room_BuildOutsideTable(void)
         full_table[i] = M_OUTSIDE_TABLE_SENTINEL;
     }
 
-    const int32_t blocks_x = m_OutsideGridX * 4;
-    const int32_t blocks_z = m_OutsideGridZ * 4;
-    for (int32_t y = 0; y < blocks_x; y += 4) {
-        for (int32_t x = 0; x < blocks_z; x += 4) {
+    const int32_t blocks_x = m_OutsideGridX * M_OUTSIDE_TABLE_STEP;
+    const int32_t blocks_z = m_OutsideGridZ * M_OUTSIDE_TABLE_STEP;
+    for (int32_t y = 0; y < blocks_x; y += M_OUTSIDE_TABLE_STEP) {
+        for (int32_t x = 0; x < blocks_z; x += M_OUTSIDE_TABLE_STEP) {
             for (int32_t i = 0; i < num_rooms; i++) {
                 const ROOM *const room = Room_Get(i);
 
-                const int32_t room_x =
-                    (room->pos.z >> WALL_SHIFT) - (m_OutsideOriginCellZ << 2);
-                const int32_t room_y =
-                    (room->pos.x >> WALL_SHIFT) - (m_OutsideOriginCellX << 2);
+                const int32_t room_x = (room->pos.z >> WALL_SHIFT)
+                    - (m_OutsideOriginCellZ << M_OUTSIDE_TABLE_STEP_SHIFT);
+                const int32_t room_y = (room->pos.x >> WALL_SHIFT)
+                    - (m_OutsideOriginCellX << M_OUTSIDE_TABLE_STEP_SHIFT);
 
                 bool cont = false;
-                for (int32_t ry = 0; ry < 4 && !cont; ry++) {
-                    for (int32_t rx = 0; rx < 4; rx++) {
+                for (int32_t ry = 0; ry < M_OUTSIDE_TABLE_STEP && !cont; ry++) {
+                    for (int32_t rx = 0; rx < M_OUTSIDE_TABLE_STEP; rx++) {
                         if (x + rx >= room_x
                             && x + rx < room_x + room->size.z - 2
                             && y + ry >= room_y
@@ -195,7 +197,9 @@ void Room_BuildOutsideTable(void)
                 int16_t *const cell =
                     &full_table
                         [M_OUTSIDE_TABLE_MAX_ROOMS_PER_CELL
-                         * ((x >> 2) + m_OutsideGridZ * (y >> 2))];
+                         * ((x >> M_OUTSIDE_TABLE_STEP_SHIFT)
+                            + m_OutsideGridZ
+                                * (y >> M_OUTSIDE_TABLE_STEP_SHIFT))];
                 for (int32_t lp = 0; lp < M_OUTSIDE_TABLE_MAX_ROOMS_PER_CELL;
                      lp++) {
                     if (cell[lp] == M_OUTSIDE_TABLE_SENTINEL) {

--- a/src/trx/game/weather_fx.c
+++ b/src/trx/game/weather_fx.c
@@ -254,11 +254,6 @@ static void M_SpawnRainDrop(M_RAINDROP *const drop)
 
 static void M_UpdateRain(void)
 {
-    const ITEM *const lara_item = Lara_GetItem();
-    if (lara_item == nullptr) {
-        return;
-    }
-
     const XZ_32 wind = Sparks_GetSmokeWind();
 
     int32_t num_alive = 0;
@@ -372,11 +367,6 @@ static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
 
 static void M_UpdateSnow(void)
 {
-    const ITEM *const lara_item = Lara_GetItem();
-    if (lara_item == nullptr) {
-        return;
-    }
-
     int32_t num_alive = 0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
         M_SNOWFLAKE *const snow = &m_Snowflakes[i];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Snow doesn't want to spawn on the edges of certain rooms, and this PR fixes it.
Specifically, on develop, it wouldn't spawn on the entire room's edge here:
![20260110_093912_Antarctica](https://github.com/user-attachments/assets/3d51ccd2-c8d1-477b-8ef3-b4b7af9801dd)

#### Testing

We just need to test for regressions against develop, having in mind that the OG snow is wonky too – we just look for _new_ regressions.