### PR TITLE
Quadbike improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -158,6 +158,7 @@
 - fixed disabling lighting system not working
 - fixed skybox data to show correct top and bottom colors
 - fixed Assault Course timer remaining indefinitely on screen
+- fixed low visibility of Quad Bike exhaust smokes at high speeds
 - fixed the skybox's blue lid for the Thames Wharf and City cutscenes
 - fixed fish schools to no longer swim at supersonic speeds if their triggers do not have timers set, or reuse the same timer
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -158,7 +158,8 @@
 - fixed disabling lighting system not working
 - fixed skybox data to show correct top and bottom colors
 - fixed Assault Course timer remaining indefinitely on screen
-- fixed low visibility of Quad Bike exhaust smokes at high speeds
+- fixed Quad Bike low visibility of exhaust smokes at high speeds
+- fixed Quad Bike wheels appearing to spin backwards at high speeds
 - fixed the skybox's blue lid for the Thames Wharf and City cutscenes
 - fixed fish schools to no longer swim at supersonic speeds if their triggers do not have timers set, or reuse the same timer
 

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1339,9 +1339,17 @@ bool QuadBike_Control(void)
     }
 
     item->floor = height;
-    const int16_t rot = quad->velocity >> 2;
-    quad->front_rot -= rot;
-    quad->rear_rot -= rot + (quad->revs >> 3);
+    // Cap per-frame wheel rotation delta to avoid large int16 angle jumps.
+    // Large jumps can make interpolation pick the "short way" and appear to
+    // spin backwards at high speed.
+    int32_t wheel_delta = quad->velocity >> 2;
+    CLAMP(wheel_delta, -0x1000, 0x1000);
+    quad->front_rot = quad->front_rot - wheel_delta;
+
+    int32_t rear_delta = wheel_delta + (quad->revs >> 3);
+    CLAMP(rear_delta, -0x1000, 0x1000);
+    quad->rear_rot = quad->rear_rot - rear_delta;
+
     if (p->extra_rotation != nullptr) {
         if (p->rear_rot_x_idx[0] >= 0) {
             p->extra_rotation[p->rear_rot_x_idx[0]] = quad->rear_rot;
@@ -1356,6 +1364,7 @@ bool QuadBike_Control(void)
             p->extra_rotation[p->front_rot_x_idx[1]] = quad->front_rot;
         }
     }
+
     quad->left_fall_speed = M_DoDynamics(
         front_left_height, quad->left_fall_speed, &front_left_pos.y);
     quad->right_fall_speed = M_DoDynamics(

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1408,10 +1408,9 @@ bool QuadBike_Control(void)
             const int16_t smoke_rot = item->rot.y + (i == 0 ? 0x9000 : 0x7000);
 
             if (item->speed > 32) {
-                if (item->speed < 64) {
-                    M_TriggerExhaustSmoke(
-                        pos, smoke_rot, 64 - item->speed, true);
-                }
+                int32_t smoke_vel = 96 - item->speed;
+                CLAMP(smoke_vel, 8, 64);
+                M_TriggerExhaustSmoke(pos, smoke_rot, smoke_vel, true);
             } else {
                 int32_t smoke_vel = 0;
                 if (m_ExhaustSmokeVel < 16) {

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -385,9 +385,16 @@ static void M_TriggerExhaustSmoke(
     spark->src_color.b = 0;
 
     if (moving) {
-        spark->dst_color.r = (96 * speed) >> 5;
-        spark->dst_color.g = (96 * speed) >> 5;
-        spark->dst_color.b = (128 * speed) >> 5;
+#if 0
+        // OG
+        spark->dst_color.r = MINMAX((96 * speed) >> 5, 0, 255);
+        spark->dst_color.g = MINMAX((96 * speed) >> 5, 0, 255);
+        spark->dst_color.b = MINMAX((128 * speed) >> 5, 0, 255);
+#else
+        spark->dst_color.r = 96 >> 1;
+        spark->dst_color.g = 96 >> 1;
+        spark->dst_color.b = 128 >> 1;
+#endif
     } else {
         spark->dst_color.r = 96;
         spark->dst_color.g = 96;
@@ -1408,8 +1415,7 @@ bool QuadBike_Control(void)
             const int16_t smoke_rot = item->rot.y + (i == 0 ? 0x9000 : 0x7000);
 
             if (item->speed > 32) {
-                int32_t smoke_vel = 96 - item->speed;
-                CLAMP(smoke_vel, 8, 64);
+                const int32_t smoke_vel = MINMAX(96 - item->speed, 8, 64);
                 M_TriggerExhaustSmoke(pos, smoke_rot, smoke_vel, true);
             } else {
                 int32_t smoke_vel = 0;

--- a/src/trx/utils.h
+++ b/src/trx/utils.h
@@ -33,6 +33,9 @@
         else if ((a) > (c))                                                    \
             (a) = (c);                                                         \
     } while (0)
+
+#define MINMAX(target, low, high) MAX(MIN((target), (low)), (target))
+
 #define SWAP(a, b)                                                             \
     do {                                                                       \
         typeof(a) c = (a);                                                     \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR tweaks the original by making exhaust smoke slightly more visible at high speeds – still subtle, but noticeable enough that players won't mistake it for a bug. (Turns out the smoke was always there, just so faint you could only catch it in photo mode.) It also fixes the wheels so they no longer appear to spin backward at high speeds.
