### PR TITLE
objects/harpoon-bolt: fix collision against itself

### DIFF
--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -75,6 +75,10 @@ static void M_Control_TR3(const int16_t item_num)
             continue;
         }
 
+        if (target_item->object_id == O_HARPOON_BOLT) {
+            continue;
+        }
+
         if (!target_item->collidable) {
             continue;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents harpoon bolts from colliding with themselves and thus disappearing early, fixing the issue reported on Discord.

The bolts, and other projectiles, don't have their collision 100% in line with the OG – TR3 hardcodes a lot of objects there, mostly smashable, which we have a different (I like to think that better) handling of.