### PR TITLE
lara/col: fix TR3 thin ledge swing

### DIFF
--- a/src/trx/game/lara/col.h
+++ b/src/trx/game/lara/col.h
@@ -28,6 +28,7 @@ bool Lara_Col_Fallen(ITEM *item, const COLL_INFO *coll);
 void Lara_Col_DeflectEdgeJump(ITEM *item, COLL_INFO *coll);
 bool Lara_Col_LandedBad(ITEM *item);
 void Lara_Col_MonkeySwingSnap(ITEM *item);
+void Lara_Col_HangTest(ITEM *item, COLL_INFO *coll);
 void Lara_Col_ItemPush(
     const ITEM *item, COLL_INFO *coll, bool hit_on, bool big_push);
 void Lara_Col_Static3DPush(const STATIC_MESH *mesh, COLL_INFO *coll);

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -223,7 +223,7 @@ static bool M_TestClimbStance(ITEM *const item, COLL_INFO *const coll)
     return true;
 }
 
-static void M_HangTest(ITEM *const item, COLL_INFO *const coll)
+void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
 {
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = NO_BAD_NEG;
@@ -512,7 +512,7 @@ static bool M_TestLedgeJump(const ITEM *const item, const COLL_INFO *const coll)
 
 static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 {
-    M_HangTest(item, coll);
+    Lara_Col_HangTest(item, coll);
     if (item->goal_anim_state != LS(LS_HANG)) {
         return;
     }
@@ -566,7 +566,7 @@ static void M_Shimmy(ITEM *const item, COLL_INFO *const coll)
         item->current_anim_state == LS(LS_SHIMMY_LEFT) ? -DEG_90 : DEG_90;
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->move_angle = item->rot.y + angle;
-    M_HangTest(item, coll);
+    Lara_Col_HangTest(item, coll);
     lara->move_angle = item->rot.y + angle;
 }
 

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -115,8 +115,9 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     } else {
         Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), 0);
     }
-    item->current_anim_state = LS(LS_HANG);
-    item->goal_anim_state = LS(LS_HANG);
+    const ANIM *const anim = Item_GetAnim(item);
+    item->current_anim_state = anim->current_anim_state;
+    item->goal_anim_state = anim->current_anim_state;
 
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     if (edge_catch == EDGE_CATCH_POS) {

--- a/src/trx/game/lara/col/monkey.c
+++ b/src/trx/game/lara/col/monkey.c
@@ -113,34 +113,69 @@ cleanup:
 
 static void M_MonkeyIdle(ITEM *const item, COLL_INFO *const coll)
 {
-    if (!g_Input.action || item->hit_points <= 0 || !M_CanMonkeySwing(item)) {
-        M_MonkeySwingFall(item);
+    if (M_CanMonkeySwing(item)) {
+        if (!g_Input.action || item->hit_points <= 0) {
+            M_MonkeySwingFall(item);
+            return;
+        }
+
+        item->gravity = false;
+        item->fall_speed = 0;
+        item->speed = 0;
+
+        M_GetMonkeyCollisionInfo(item, coll, item->rot.y, NO_BAD_NEG, false);
+
+        if (g_Input.forward && coll->coll_type != COLL_FRONT
+            && ABS(coll->side_mid.ceiling - coll->side_front.ceiling)
+                < M_MONKEY_CEILING_SHIFT) {
+            item->goal_anim_state = LS(LS_MONKEY_FORWARD);
+        } else if (
+            g_Input.step_left && M_TestMonkeySide(item, coll, -DEG_90, false)) {
+            item->goal_anim_state = LS(LS_MONKEY_LEFT);
+        } else if (
+            g_Input.step_right && M_TestMonkeySide(item, coll, DEG_90, true)) {
+            item->goal_anim_state = LS(LS_MONKEY_RIGHT);
+        } else if (g_Input.left) {
+            item->goal_anim_state = LS(LS_MONKEY_TURN_LEFT);
+        } else if (g_Input.right) {
+            item->goal_anim_state = LS(LS_MONKEY_TURN_RIGHT);
+        }
+
+        Lara_Col_MonkeySwingSnap(item);
         return;
     }
 
-    item->gravity = false;
-    item->fall_speed = 0;
-    item->speed = 0;
-
-    M_GetMonkeyCollisionInfo(item, coll, item->rot.y, NO_BAD_NEG, false);
-
-    if (g_Input.forward && coll->coll_type != COLL_FRONT
-        && ABS(coll->side_mid.ceiling - coll->side_front.ceiling)
-            < M_MONKEY_CEILING_SHIFT) {
-        item->goal_anim_state = LS(LS_MONKEY_FORWARD);
-    } else if (
-        g_Input.step_left && M_TestMonkeySide(item, coll, -DEG_90, false)) {
-        item->goal_anim_state = LS(LS_MONKEY_LEFT);
-    } else if (
-        g_Input.step_right && M_TestMonkeySide(item, coll, DEG_90, true)) {
-        item->goal_anim_state = LS(LS_MONKEY_RIGHT);
-    } else if (g_Input.left) {
-        item->goal_anim_state = LS(LS_MONKEY_TURN_LEFT);
-    } else if (g_Input.right) {
-        item->goal_anim_state = LS(LS_MONKEY_TURN_RIGHT);
+    // Monkey idle state can be the result of swinging on a thin ledge as well
+    // as actually being on monkeybars. LA_REACH_TO_THIN_LEDGE in TR3 links to
+    // this state.
+    Lara_Col_HangTest(item, coll);
+    if (item->goal_anim_state != LS(LS_MONKEY_IDLE)) {
+        return;
     }
 
-    Lara_Col_MonkeySwingSnap(item);
+    if (g_Input.forward && coll->side_front.floor > -850
+        && coll->side_front.floor < -650
+        && coll->side_front.floor - coll->side_front.ceiling >= 0
+        && coll->side_left.floor - coll->side_left.ceiling >= 0
+        && coll->side_right.floor - coll->side_right.ceiling >= 0
+        && !coll->hit_static) {
+        item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
+        return;
+    }
+
+    if ((g_Input.forward || g_Input.crouch) && coll->side_front.floor > -850
+        && coll->side_front.floor < -650
+        && coll->side_front.floor - coll->side_front.ceiling >= -256
+        && coll->side_left.floor - coll->side_left.ceiling >= -256
+        && coll->side_right.floor - coll->side_right.ceiling >= -256
+        && !coll->hit_static) {
+        item->goal_anim_state = LS(LS_CLIMB_TO_CRAWL);
+        item->required_anim_state = LS(LS_CROUCH_IDLE);
+    } else if (g_Input.left || g_Input.step_left) {
+        item->goal_anim_state = LS(LS_SHIMMY_LEFT);
+    } else if (g_Input.right || g_Input.step_right) {
+        item->goal_anim_state = LS(LS_SHIMMY_RIGHT);
+    }
 }
 
 static void M_MonkeyForward(ITEM *const item, COLL_INFO *const coll)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves Lara falling from a thin ledge in TR3 after the initial grab and swing-in animation completes.

Animation 150 (reach-to-thin-ledge) is different in TR3 compared to 1/2, whereby it links to the monkey idle animation (234) and Lara continues to swing slowly. So we ensure Lara has the correct state based on animation 150's state, and allow her to pull up, do a handstand, or climb into a crawlspace while swinging on a thin ledge.

Will share a test level for TR3, but a sanity check of 1/2 would be good - there, animation 150 should continue to link to 96.
