### PR TITLE
lua/lara: expose air timer

### DIFF
--- a/data/scripting/lara.lua
+++ b/data/scripting/lara.lua
@@ -5,6 +5,7 @@ local lara = {}
 -- Item proxy metatable
 local getters = {
   exposure_bar = raw.get_exposure_bar,
+  air_bar = raw.get_air_bar,
   item = function()
     return trx.items[raw.get_item()]
   end,
@@ -12,6 +13,7 @@ local getters = {
 
 local setters = {
   exposure_bar = raw.set_exposure_bar,
+  air_bar = raw.set_air_bar,
 }
 
 local lara_mt = {

--- a/docs/06-lua/2-reference/3-LARA.md
+++ b/docs/06-lua/2-reference/3-LARA.md
@@ -12,7 +12,18 @@ Module for interacting with the Lara's object.
     Returns [lua]`trx.items.Item` associated with Lara, or [lua]`nil` if the
     Lara object is not available.
 
-- [lua]`trx.lara.exposure_timer`  
+- [lua]`trx.lara.exposure_bar`  
     Reads/writes exposure timer (cold water bar). The maximum value is 600.
     If the cold bar setting is disabled on the game flow level, the health must
     be managed manually from LUA.
+
+- [lua]`trx.lara.air_bar`  
+    Reads/writes Lara's air timer. The maximum value is 1800.  
+      
+    Example:
+    ```lua
+    -- Infinite oxygen
+    trx.events.on_control_post(function()
+        trx.lara.air_bar = 1800
+    end)
+    ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added the ability to change pause screen background
 - added the ability to control whether or not allies are hostile towards Lara via Lua (#3873)
 - added the ability to control via Lua which enemies are allies and which are ones that will fight with allies (#3873)
+- added the ability to control Lara's air timer via Lua (#4592)
 - added gamma control (TR3-style) to all games
 - added support for TR3 weather effects to all games (#3881)
 - added support for 3D secret objects, and provided defaults for OG levels in TR2 (#4380)

--- a/src/trx/game/lua/lara.c
+++ b/src/trx/game/lua/lara.c
@@ -35,6 +35,22 @@ static int M_L_LaraSetExposureBar(lua_State *const L)
     return 0;
 }
 
+// trxc.lara.get_air_bar() → int
+static int M_L_LaraGetAirBar(lua_State *const L)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lua_pushinteger(L, lara->air);
+    return 1;
+}
+
+// trxc.lara.set_air_bar(timer)
+static int M_L_LaraSetAirBar(lua_State *const L)
+{
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->air = luaL_checkinteger(L, 1);
+    return 0;
+}
+
 void LUA_CreateLara(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
@@ -45,6 +61,10 @@ void LUA_CreateLara(lua_State *const L)
     lua_setfield(L, -2, "get_exposure_bar");
     lua_pushcfunction(L, M_L_LaraSetExposureBar);
     lua_setfield(L, -2, "set_exposure_bar");
+    lua_pushcfunction(L, M_L_LaraGetAirBar);
+    lua_setfield(L, -2, "get_air_bar");
+    lua_pushcfunction(L, M_L_LaraSetAirBar);
+    lua_setfield(L, -2, "set_air_bar");
     lua_setfield(L, -2, "lara");
     lua_pop(L, 1);
 }


### PR DESCRIPTION
Resolves #4592.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows Lara's air value to be read/written in Lua.
