### PR TITLE
overlay: draw supplied 3D pickups if available

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - added an option to use the TR3 camera (Visuals → Camera Mode)
 - improved a fade-in and fade-out effect on loading screens – they now smoothly transition to the game screen
 - improved fog behavior to be less dependent on camera rotation
+- changed the 3D pickups option to try the simplified 3D meshes first, if available, before falling back to inventory items
 - changed the 2D and 3D statics limit from 256 to unlimited
 - changed the lighting contrast key binding to F9
 - changed underwater statics to be affected by caustics, even if they don't get merged into level geometry (#4430)

--- a/src/trx/game/inventory.c
+++ b/src/trx/game/inventory.c
@@ -11,14 +11,6 @@
 
 INVENTORY_MODE g_Inv_Mode = INV_TITLE_MODE;
 
-static OBJECT_ID M_ConvertToPickup(const OBJECT_ID object_id)
-{
-    if (Object_IsType(object_id, g_InvObjects)) {
-        return Object_GetCognateInverse(object_id, g_ItemToInvObjectMap);
-    }
-    return object_id;
-}
-
 static int32_t M_GetFlareQuantity(void)
 {
     return Game_IsBonusFlagSet(GBF_JAPANESE)
@@ -136,6 +128,14 @@ OBJECT_ID Inv_GetItemOption(const OBJECT_ID object_id)
     return Object_GetCognate(object_id, g_ItemToInvObjectMap);
 }
 
+OBJECT_ID Inv_GetItemPickup(const OBJECT_ID object_id)
+{
+    if (Object_IsType(object_id, g_InvObjects)) {
+        return Object_GetCognateInverse(object_id, g_ItemToInvObjectMap);
+    }
+    return object_id;
+}
+
 void Inv_InsertItem(INVENTORY_ITEM *const inv_item)
 {
     Inv_InsertItemEx(inv_item, 1);
@@ -231,7 +231,7 @@ void Inv_RemoveAllItems(void)
 bool Inv_AddItem(const OBJECT_ID object_id)
 {
     const OBJECT_ID inv_object_id = Inv_GetItemOption(object_id);
-    const OBJECT_ID pickup_object_id = M_ConvertToPickup(object_id);
+    const OBJECT_ID pickup_object_id = Inv_GetItemPickup(object_id);
     const OBJECT *const object =
         Object_Get(inv_object_id == NO_OBJECT ? object_id : inv_object_id);
     if (!object->loaded) {

--- a/src/trx/game/inventory.h
+++ b/src/trx/game/inventory.h
@@ -10,6 +10,7 @@ extern INVENTORY_MODE g_Inv_Mode;
 
 bool Inv_AddItemNTimes(OBJECT_ID obj_id, int32_t qty);
 OBJECT_ID Inv_GetItemOption(OBJECT_ID obj_id);
+OBJECT_ID Inv_GetItemPickup(OBJECT_ID obj_id);
 void Inv_InsertItem(INVENTORY_ITEM *inv_item);
 void Inv_InsertItemEx(INVENTORY_ITEM *inv_item, int32_t qty);
 bool Inv_RemoveItem(OBJECT_ID obj_id);

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -318,13 +318,12 @@ bool Object_DrawPickupItem(const ITEM *const item)
     }
 
     // Convert item to menu display item.
-    const OBJECT_ID inv_object_id = Inv_GetItemOption(item->object_id);
-    if (inv_object_id == NO_OBJECT) {
-        return Object_DrawSpriteItem(item);
+    const OBJECT *obj = Object_TryGet(Inv_GetItemPickup(item->object_id));
+    if (obj == nullptr || !obj->loaded || obj->mesh_count < 0) {
+        obj = Object_TryGet(Inv_GetItemOption(item->object_id));
     }
 
-    const OBJECT *const obj = Object_Get(inv_object_id);
-    if (!obj->loaded || obj->mesh_count < 0) {
+    if (obj == nullptr || !obj->loaded || obj->mesh_count < 0) {
         return Object_DrawSpriteItem(item);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This uses the TR3 simplified meshes for the on-the-ground pickups.