### PR TITLE
savegame: fix crashing when saving in --level

### DIFF
--- a/data/tr3/ship/cfg/tr3-level/strings.json5
+++ b/data/tr3/ship/cfg/tr3-level/strings.json5
@@ -1,0 +1,9 @@
+{
+    // For usage, refer to the documentation here:
+    // https://lostartefacts.dev/trx/docs/stable/game_strings
+    "levels": [
+        {
+            "title": "Test Level",
+        }
+    ]
+}

--- a/src/trx/game/savegame/bson.c
+++ b/src/trx/game/savegame/bson.c
@@ -119,13 +119,14 @@ static void M_SaveRaw(
         .flags = Game_GetBonusFlag(),
         .counter = Savegame_GetCounter(),
         .level_num = level->num,
-        .title_size = strlen(level->title),
+        .title_size = level->title != nullptr ? strlen(level->title) : 0,
     };
 
     File_WriteData(fp, &header, sizeof(header));
     File_WriteData(fp, compressed, compressed_size);
     File_WriteData(fp, &extra_header, sizeof(extra_header));
-    File_WriteData(fp, level->title, strlen(level->title));
+    File_WriteData(
+        fp, level->title, level->title != nullptr ? strlen(level->title) : 0);
 
     Memory_FreePointer(&uncompressed);
     Memory_FreePointer(&compressed);

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -821,7 +821,8 @@ void Savegame_BSON_DumpMisc(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
     M_WriteNum(ctx, "weather_type", WeatherFX_GetWeather());
     M_PopAndSet(ctx, "misc");
 
-    M_WriteString(ctx, "level_title", level->title);
+    M_WriteString(
+        ctx, "level_title", level->title != nullptr ? level->title : "");
     M_WriteNum(ctx, "save_counter", Savegame_GetCounter());
     M_WriteNum(ctx, "level_num", level->num);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

IDK if it happened in TR1/TR2 but it for sure happened in TR3, due to missing title of the test level. It shouldn't happen any longer.

I haven't tested opening the passport with saves created as such.