### PR TITLE
Fix TR3 hang tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -166,6 +166,7 @@
 - fixed Quad Bike wheels appearing to spin backwards at high speeds
 - fixed the skybox's blue lid for the Thames Wharf and City cutscenes
 - fixed fish schools to no longer swim at supersonic speeds if their triggers do not have timers set, or reuse the same timer
+- fixed Lara letting go of some ledges
 
 ## [1.0.3](https://github.com/LostArtefacts/TRX/compare/trx-1.0.2...trx-1.0.3) - 2025-11-27
 - fixed the conveyer belt fuse in Natla's Mines not appearing after using the nearby switch (#4349, regression from 1.0)

--- a/src/trx/game/collision.c
+++ b/src/trx/game/collision.c
@@ -6,6 +6,7 @@
 #include <trx/game/matrix.h>
 #include <trx/game/rooms.h>
 #include <trx/utils.h>
+#include <trx/version.h>
 
 #define M_HEADROOM 160 // Additional collision space above Lara's head.
 
@@ -321,16 +322,27 @@ void Collide_GetCollisionInfo(
     M_FillSide(
         coll, &coll->side_front, x_pos + x_front, z_pos + z_front, y_pos,
         obj_height, &room_num);
+
+    int16_t room_num2;
+    room_num2 = prev_room_num;
     M_FillSide(
         coll, &coll->side_left, x_pos + x_left, z_pos + z_left, y_pos,
-        obj_height, &room_num);
+        obj_height, &room_num2);
+    room_num2 = prev_room_num;
     M_FillSide(
         coll, &coll->side_right, x_pos + x_right, z_pos + z_right, y_pos,
-        obj_height, &room_num);
-    // TODO: TR3 uses an extra left and right side, purpose to be investigated.
+        obj_height, &room_num2);
 
+    M_FillSide(
+        coll, &coll->side_left2, x_pos + x_left, z_pos + z_left, y_pos,
+        obj_height, &room_num);
+    M_FillSide(
+        coll, &coll->side_right2, x_pos + x_right, z_pos + z_right, y_pos,
+        obj_height, &room_num);
+
+    const int16_t static_room_num = g_TRVersion >= 3 ? prev_room_num : room_num;
     if (Collide_CollideStaticObjects(
-            coll, x_pos, y_pos, z_pos, room_num, obj_height)) {
+            coll, x_pos, y_pos, z_pos, static_room_num, obj_height)) {
         const XYZ_32 test_pos = {
             .x = x_pos + coll->shift.x,
             .y = y_pos,

--- a/src/trx/game/collision.h
+++ b/src/trx/game/collision.h
@@ -26,6 +26,8 @@ typedef struct {
     COLL_SIDE side_front;
     COLL_SIDE side_left;
     COLL_SIDE side_right;
+    COLL_SIDE side_left2;
+    COLL_SIDE side_right2;
     int32_t radius;
     int32_t bad_pos;
     int32_t bad_neg;

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -237,18 +237,19 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     lara->move_angle = item->rot.y;
 
     const DIRECTION dir = Math_GetDirection(item->rot.y);
+    const int32_t hang_test_shift = g_TRVersion >= 3 ? 4 : 2;
     switch (dir) {
     case DIR_NORTH:
-        item->pos.z += 2;
+        item->pos.z += hang_test_shift;
         break;
     case DIR_EAST:
-        item->pos.x += 2;
+        item->pos.x += hang_test_shift;
         break;
     case DIR_SOUTH:
-        item->pos.z -= 2;
+        item->pos.z -= hang_test_shift;
         break;
     case DIR_WEST:
-        item->pos.x -= 2;
+        item->pos.x -= hang_test_shift;
         break;
     default:
         break;
@@ -325,7 +326,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     const int32_t hdif = coll->side_front.floor - bounds->min.y;
 
-    if (ABS(coll->side_left.floor - coll->side_right.floor) >= SLOPE_DIF
+    if (ABS(coll->side_left2.floor - coll->side_right2.floor) >= SLOPE_DIF
         || coll->side_mid.ceiling >= 0 || coll->coll_type != COLL_FRONT || flag
         || coll->hit_static || hdif < -SLOPE_DIF || hdif > SLOPE_DIF) {
         item->pos = coll->old;
@@ -526,8 +527,8 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     if (g_Input.forward) {
         if (coll->side_front.floor > -850 && coll->side_front.floor < -650
             && coll->side_front.floor - coll->side_front.ceiling >= 0
-            && coll->side_left.floor - coll->side_left.ceiling >= 0
-            && coll->side_right.floor - coll->side_right.ceiling >= 0
+            && coll->side_left2.floor - coll->side_left2.ceiling >= 0
+            && coll->side_right2.floor - coll->side_right2.ceiling >= 0
             && !coll->hit_static) {
             item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
             return;
@@ -545,8 +546,8 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     if (g_TRVersion == 3 && (g_Input.forward || g_Input.crouch)
         && coll->side_front.floor > -850 && coll->side_front.floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= -256
-        && coll->side_left.floor - coll->side_left.ceiling >= -256
-        && coll->side_right.floor - coll->side_right.ceiling >= -256
+        && coll->side_left2.floor - coll->side_left2.ceiling >= -256
+        && coll->side_right2.floor - coll->side_right2.ceiling >= -256
         && !coll->hit_static) {
         item->goal_anim_state = LS(LS_CLIMB_TO_CRAWL);
         item->required_anim_state = LS(LS_CROUCH_IDLE);
@@ -870,10 +871,10 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     }
     const int16_t angle = Math_DirectionToAngle(dir);
 
-    const int32_t left_floor = coll->side_left.floor;
-    const int32_t left_ceiling = coll->side_left.ceiling;
-    const int32_t right_floor = coll->side_right.floor;
-    const int32_t right_ceiling = coll->side_right.ceiling;
+    const int32_t left_floor = coll->side_left2.floor;
+    const int32_t left_ceiling = coll->side_left2.ceiling;
+    const int32_t right_floor = coll->side_right2.floor;
+    const int32_t right_ceiling = coll->side_right2.ceiling;
     const int32_t front_floor = coll->side_front.floor;
     const int32_t front_ceiling = coll->side_front.ceiling;
     const bool slope = ABS(left_floor - right_floor) >= SLOPE_DIF;

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -33,7 +33,7 @@ EDGE_CATCH Lara_Col_TestEdgeCatch(
         return EDGE_CATCH_NEG;
     }
 
-    return ABS(coll->side_left.floor - coll->side_right.floor) < SLOPE_DIF
+    return ABS(coll->side_left2.floor - coll->side_right2.floor) < SLOPE_DIF
         ? EDGE_CATCH_POS
         : EDGE_CATCH_NONE;
 }

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -123,36 +123,31 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
-        if (g_TRVersion >= 3) {
-            switch (Math_GetDirection(angle)) {
-            case DIR_NORTH:
-                item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
-                item->pos.x += coll->shift.x;
-                break;
+        switch (Math_GetDirection(angle)) {
+        case DIR_NORTH:
+            item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
+            item->pos.x += coll->shift.x;
+            break;
 
-            case DIR_EAST:
-                item->pos.x = ROUND_TO_SECTOR_END(item->pos.x) - LARA_RADIUS;
-                item->pos.z += coll->shift.z;
-                break;
+        case DIR_EAST:
+            item->pos.x = ROUND_TO_SECTOR_END(item->pos.x) - LARA_RADIUS;
+            item->pos.z += coll->shift.z;
+            break;
 
-            case DIR_SOUTH:
-                item->pos.z = ROUND_TO_SECTOR(item->pos.z) + LARA_RADIUS;
-                item->pos.x += coll->shift.x;
-                break;
+        case DIR_SOUTH:
+            item->pos.z = ROUND_TO_SECTOR(item->pos.z) + LARA_RADIUS;
+            item->pos.x += coll->shift.x;
+            break;
 
-            case DIR_WEST:
-                item->pos.x = ROUND_TO_SECTOR(item->pos.x) + LARA_RADIUS;
-                item->pos.z += coll->shift.z;
-                break;
+        case DIR_WEST:
+            item->pos.x = ROUND_TO_SECTOR(item->pos.x) + LARA_RADIUS;
+            item->pos.z += coll->shift.z;
+            break;
 
-            default:
-                item->pos.x += coll->shift.x;
-                item->pos.z += coll->shift.z;
-                break;
-            }
-        } else {
+        default:
             item->pos.x += coll->shift.x;
             item->pos.z += coll->shift.z;
+            break;
         }
     } else {
         item->pos.y = edge - bounds->min.y;

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -4,6 +4,7 @@
 #include <trx/game/lara/util.h>
 #include <trx/game/rooms.h>
 #include <trx/game/rooms/enum.h>
+#include <trx/game/rooms/utils.h>
 #include <trx/game/sound.h>
 #include <trx/version.h>
 
@@ -122,8 +123,37 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
-        item->pos.x += coll->shift.x;
-        item->pos.z += coll->shift.z;
+        if (g_TRVersion >= 3) {
+            switch (Math_GetDirection(angle)) {
+            case DIR_NORTH:
+                item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
+                item->pos.x += coll->shift.x;
+                break;
+
+            case DIR_EAST:
+                item->pos.x = ROUND_TO_SECTOR_END(item->pos.x) - LARA_RADIUS;
+                item->pos.z += coll->shift.z;
+                break;
+
+            case DIR_SOUTH:
+                item->pos.z = ROUND_TO_SECTOR(item->pos.z) + LARA_RADIUS;
+                item->pos.x += coll->shift.x;
+                break;
+
+            case DIR_WEST:
+                item->pos.x = ROUND_TO_SECTOR(item->pos.x) + LARA_RADIUS;
+                item->pos.z += coll->shift.z;
+                break;
+
+            default:
+                item->pos.x += coll->shift.x;
+                item->pos.z += coll->shift.z;
+                break;
+            }
+        } else {
+            item->pos.x += coll->shift.x;
+            item->pos.z += coll->shift.z;
+        }
     } else {
         item->pos.y = edge - bounds->min.y;
     }
@@ -189,7 +219,7 @@ static bool M_TestHangJumpUp(ITEM *const item, COLL_INFO *const coll)
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
     } else {
-        item->pos.y = edge - bounds->min.y;
+        item->pos.y = edge - bounds->min.y + (g_TRVersion >= 3 ? 4 : 0);
     }
     item->pos.x += coll->shift.x;
     item->pos.z += coll->shift.z;

--- a/src/trx/game/lara/col/monkey.c
+++ b/src/trx/game/lara/col/monkey.c
@@ -156,8 +156,8 @@ static void M_MonkeyIdle(ITEM *const item, COLL_INFO *const coll)
     if (g_Input.forward && coll->side_front.floor > -850
         && coll->side_front.floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= 0
-        && coll->side_left.floor - coll->side_left.ceiling >= 0
-        && coll->side_right.floor - coll->side_right.ceiling >= 0
+        && coll->side_left2.floor - coll->side_left2.ceiling >= 0
+        && coll->side_right2.floor - coll->side_right2.ceiling >= 0
         && !coll->hit_static) {
         item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
         return;
@@ -166,8 +166,8 @@ static void M_MonkeyIdle(ITEM *const item, COLL_INFO *const coll)
     if ((g_Input.forward || g_Input.crouch) && coll->side_front.floor > -850
         && coll->side_front.floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= -256
-        && coll->side_left.floor - coll->side_left.ceiling >= -256
-        && coll->side_right.floor - coll->side_right.ceiling >= -256
+        && coll->side_left2.floor - coll->side_left2.ceiling >= -256
+        && coll->side_right2.floor - coll->side_right2.ceiling >= -256
         && !coll->hit_static) {
         item->goal_anim_state = LS(LS_CLIMB_TO_CRAWL);
         item->required_anim_state = LS(LS_CROUCH_IDLE);

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -42,7 +42,7 @@ static bool M_TestWaterStepOut(ITEM *const item, const COLL_INFO *const coll)
 static bool M_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
 {
     const int32_t coll_hdif =
-        ABS(coll->side_left.floor - coll->side_right.floor);
+        ABS(coll->side_left2.floor - coll->side_right2.floor);
     if (coll->coll_type != COLL_FRONT || !g_Input.action
         || coll_hdif >= SLOPE_DIF) {
         return false;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the hanging issue on triangulated geometry. Turns out the real culprit was `M_TestHangJump` missing the new `switch` statement in one of its branches. 
I also ported an extra offset I found in `M_TestHangJumpUp` and `Lara_Col_HangTest`. The PR even makes use of the extra sides – though that part ended up being a total red herring. I brought the logic over anyway, but honestly, I'm still not sure what it's supposed to fix :sweat_smile: 

#### Testing

We need to test a variety of hanging positions in TR1, TR2, and TR3 across different types of geometry. I don't remember any speedrunning strats that specifically rely on the hanging state, but if there are any, those should be tested as well.