### PR TITLE
objects/pickup: ignore unloaded objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@
 - removed the `scripting/trx` directory – internal TRX LUA scripts now get embedded in the exe
 - fixed broken final statistic counters (#4432, regression from 1.0)
 - fixed undefined behavior (crashes and/or texture glitches) in levels with a lot of textures
+- fixed a crash if a pickup aid spawns against an item whose 3D model isn't present
 - fixed Bacon Lara not always being drawn perfectly in sync with Lara's animation (#4210)
 - fixed gondolas not being drawn with an underwater tint when they have sunk (#4428)
 - fixed the teleport-to-item command not succeeding if used in succession with the same type and an out of bounds item is encountered (#4468)

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -115,6 +115,9 @@ static void M_SpawnPickupAid(const ITEM *const item)
 
     const OBJECT *const obj = Object_Get(obj_id);
     const ANIM_FRAME *const frame = obj->frame_base;
+    if (!obj->loaded || frame == nullptr) {
+        return;
+    }
 
     const GAME_VECTOR pos = {
         .x = item->pos.x + 20 * (Random_GetDraw() - 0x4000) / 0x4000,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Pickup aids rely on the 3D model being present to calculate their positions. This avoids a crash if the model isn't present.
