### PR TITLE
lara: improve UW per-mesh tint

### DIFF
--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -48,15 +48,24 @@ static void M_DrawLaraMesh(
     const bool interpolated)
 {
     const OBJECT_MESH *const mesh = Lara_GetLaraInfo()->mesh_ptrs[mesh_num];
+    XYZ_32 origin = XYZ_32_From16(mesh->center);
+    switch (mesh_num) {
+    case LM_TORSO:
+    case LM_CALF_L:
+    case LM_CALF_R:
+    case LM_FOOT_L:
+    case LM_FOOT_R:
+        origin.y -= 24;
+        break;
+    case LM_HEAD:
+        origin.y -= 8;
+        break;
+    default:
+        break;
+    }
     const GAME_VECTOR pos = {
         .room_num = item->room_num,
-        .pos = Matrix_MulVec32(
-            g_WMatrixPtr,
-            (XYZ_32) {
-                mesh->center.x,
-                mesh->center.y + (mesh_num == LM_TORSO ? -24 : -8),
-                mesh->center.z,
-            }),
+        .pos = Matrix_MulVec32(g_WMatrixPtr, origin),
     };
     Output_PushTintOverride(Lara_GetMeshTint(pos));
     if (interpolated) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes weird tints with 0-click surfacing animations.