### PR TITLE
objects/assault-target: fix reset after exploding

### DIFF
--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -63,7 +63,18 @@ static void M_ResetAssaultTargets(void)
             continue;
         }
 
-        if (obj->initialise_func != nullptr) {
+        if ((item->flags & IF_KILLED) != 0) {
+            // Rockets can kill targets via Creature_Die()+Item_Kill(), which
+            // removes them from room draw + item lists. Use Item_Initialise()
+            // to re-link them back.
+
+            // Clear the flags so that Item_Initialise doesn't mark the item
+            // as active preemptively.
+            item->flags = 0;
+
+            Item_Initialise(item_num);
+        } else if (
+            item->status != IS_INACTIVE && obj->initialise_func != nullptr) {
             obj->initialise_func(item_num);
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Test scenario (warning: loud):

```
args "-l" "0"
config gameplay.enable_cheats 1
config gameplay.enable_legal 0
config gameplay.turbo_speed 2

@+0:    ● "i"
@+1:    ○ "i"
        ● "7"
@+1:    cmd "tp target"
        ○ "7"
        ● "left ctrl"
@+177:  ○ "left ctrl"
@+10:   ● "down"
@+12:   ○ "down"
@+8:    ● "left ctrl"
@+88:   ○ "left ctrl"
@+8:    ● "down"
@+10:   ○ "down"
@+14:   ● "left ctrl"
@+42:   ● "down"
@+6:    ○ "down"
@+35:   ○ "left ctrl"
@+15:   cmd "set turbo 1"
        cmd "tp 15 2 51"
        ● "right"
@+18:   ○ "right"
        ● "up"
@+16:   ○ "up"
@+54:   cmd "tp target"
        ● "left"
@+18:   ○ "left"
        ● "down"
@+22:   ○ "down"
@+10:   ● "left ctrl"
@+20:   ○ "left ctrl"
        ● "down"
@+22:   ○ "down"
@+4:    ● "left ctrl"
@+24:   ○ "left ctrl"
@+60:   quit
```