### PR TITLE
math: fix mixed up directions

### DIFF
--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -379,7 +379,7 @@ static void M_CrawlToClimb(ITEM *const item, COLL_INFO *const coll)
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
 
-        switch (Math_GetDirection(item->rot.y)) {
+        switch (dir) {
         case DIR_NORTH:
             item->pos.z =
                 ROUND_TO_SECTOR_END(item->pos.z) - M_CRAWL_TO_HANG_XZ_OFFSET;

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -123,7 +123,7 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
-        switch (Math_GetDirection(angle)) {
+        switch (dir) {
         case DIR_NORTH:
             item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
             item->pos.x += coll->shift.x;

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -82,16 +82,16 @@ static bool M_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
 
     switch (dir) {
     case DIR_NORTH:
-        item->pos.z = (item->pos.z & -WALL_L) + WALL_L + LARA_RADIUS;
-        break;
-    case DIR_WEST:
-        item->pos.x = (item->pos.x & -WALL_L) + WALL_L + LARA_RADIUS;
-        break;
-    case DIR_SOUTH:
-        item->pos.z = (item->pos.z & -WALL_L) - LARA_RADIUS;
+        item->pos.z = ROUND_TO_SECTOR(item->pos.z) + WALL_L + LARA_RADIUS;
         break;
     case DIR_EAST:
-        item->pos.x = (item->pos.x & -WALL_L) - LARA_RADIUS;
+        item->pos.x = ROUND_TO_SECTOR(item->pos.x) + WALL_L + LARA_RADIUS;
+        break;
+    case DIR_SOUTH:
+        item->pos.z = ROUND_TO_SECTOR(item->pos.z) - LARA_RADIUS;
+        break;
+    case DIR_WEST:
+        item->pos.x = ROUND_TO_SECTOR(item->pos.x) - LARA_RADIUS;
         break;
     case DIR_UNKNOWN:
         return false;

--- a/src/trx/game/math/util.c
+++ b/src/trx/game/math/util.c
@@ -49,11 +49,11 @@ DIRECTION Math_GetDirectionCone(const int16_t angle, const int16_t cone)
     if (angle >= -cone && angle <= cone) {
         return DIR_NORTH;
     } else if (angle >= DEG_90 - cone && angle <= DEG_90 + cone) {
-        return DIR_WEST;
+        return DIR_EAST;
     } else if (angle >= DEG_180 - cone || angle <= -DEG_180 + cone) {
         return DIR_SOUTH;
     } else if (angle >= -DEG_90 - cone && angle <= -DEG_90 + cone) {
-        return DIR_EAST;
+        return DIR_WEST;
     }
     return DIR_UNKNOWN;
 }
@@ -63,11 +63,11 @@ int16_t Math_DirectionToAngle(const DIRECTION dir)
     switch (dir) {
     case DIR_NORTH:
         return 0;
-    case DIR_WEST:
+    case DIR_EAST:
         return DEG_90;
     case DIR_SOUTH:
         return -DEG_180;
-    case DIR_EAST:
+    case DIR_WEST:
         return -DEG_90;
     default:
         return 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the cone direction math that mixes up cardinal directions. Both functions do the same mistake, so they cancel themselves out, and the only place where it uses the wrong direction information, it has a third mistake.
This PR sorts it all out.

#### Testing

- Hanging in all 4 directions
- Climbing in all 4 directions
- Crouch-to-hang in all 4 directions
- Hang-to-crouch in all 4 directions
- Climbing out of water in all 4 directions