### PR TITLE
objects: add bubble emitter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
+- added a bubble emitter (#4629)
 
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...trx-1.1) - 2026-01-17
 Showcase: https://www.youtube.com/watch?v=veVYyr--H1A

--- a/src/meson.build
+++ b/src/meson.build
@@ -458,6 +458,7 @@ common_sources = [
   'trx/game/objects/names.c',
   'trx/game/objects/setup.c',
   'trx/game/objects/traps/blade.c',
+  'trx/game/objects/traps/bubble_emitter.c',
   'trx/game/objects/traps/common.c',
   'trx/game/objects/traps/damocles_sword.c',
   'trx/game/objects/traps/dart.c',

--- a/src/trx/game/objects/traps/bubble_emitter.c
+++ b/src/trx/game/objects/traps/bubble_emitter.c
@@ -1,0 +1,33 @@
+#include <trx/game/effects.h>
+#include <trx/game/objects.h>
+#include <trx/game/random.h>
+#include <trx/game/sound.h>
+#include <trx/game/spawn.h>
+
+static void M_Control(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    if (!Item_IsTriggerActive(item)) {
+        item->status = IS_INACTIVE;
+        Item_RemoveActive(item_num);
+        return;
+    }
+
+    if (Random_GetControl() % 24) {
+        return;
+    }
+    const int32_t count = 1 + Random_GetControl() % 2;
+    for (int32_t i = 0; i < count; i++) {
+        Spawn_Bubble(&item->pos, item->room_num);
+    }
+}
+
+static void M_Setup(OBJECT *const obj)
+{
+    obj->control_func = M_Control;
+    obj->collision_func = nullptr;
+    obj->draw_func = nullptr;
+    obj->save_flags = true;
+}
+
+REGISTER_OBJECT(O_BUBBLE_EMITTER, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is just a draft – I tied the timer to mean "spawn 1 bubble every X frames (on average)" to let the builder control the strength of the effect. Not sure how canon this is.

I've also checked tomb3, tomb4 and tomb5 for potential OG implementations but haven't found anything.