### PR TITLE
lara/look: define TR3 look angles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -160,7 +160,7 @@ Their hard work gave us the perfect base to push TRX further, and made the climb
 - added Asasult Course target control
 - added Asasult Course penalty system
 - added an option to fix the MP5 accuracy while running
-- added TR3 camera control
+- added TR3 camera control and look functionality
 - improved run-to-crawl transition
 - improved text colors of the Assault Course statistics and timers
 - improved Assault Course targets to spawn ricochets

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -13,6 +13,10 @@
 #define M_CHASE_SHIFT       (STEP_L * 3 / 2) // = 384
 #define M_LOOK_SHIFT        (STEP_L * 7 / 8) // = 224
 #define M_CHASE_SPEED       10
+#define M_MAX_LOOK_TILT     (55 * DEG_1) // = 10010
+#define M_MIN_LOOK_TILT     (-75 * DEG_1) // = -13650
+#define M_MAX_LOOK_ROTATION (80 * DEG_1) // = 14560
+#define M_MIN_LOOK_ROTATION -M_MAX_LOOK_ROTATION // = -14560
 // clang-format on
 
 typedef struct {
@@ -570,8 +574,8 @@ static void M_Look(const ITEM *const item)
     lara->head_rot.x <<= 1;
     lara->head_rot.y <<= 1;
 
-    CLAMP(lara->head_rot.x, -13650, 10010);
-    CLAMP(lara->head_rot.y, -14560, 14560);
+    CLAMP(lara->head_rot.x, M_MIN_LOOK_TILT, M_MAX_LOOK_TILT);
+    CLAMP(lara->head_rot.y, M_MIN_LOOK_ROTATION, M_MAX_LOOK_ROTATION);
 
     XYZ_32 pos_1 = M_GetHeadPos(0, 16, 64);
 
@@ -713,7 +717,7 @@ static void M_Look(const ITEM *const item)
     ceiling = Room_GetCeiling(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
 
     if (Room_Get(room_num)->flags.swamp) {
-        g_Camera.pos.y = Room_Get(room_num)->max_ceiling - 256;
+        g_Camera.pos.y = Room_Get(room_num)->max_ceiling - STEP_L;
     } else if (
         ideal_pos.y < ceiling || ideal_pos.y > height || ceiling >= height
         || height == NO_HEIGHT || ceiling == NO_HEIGHT) {

--- a/src/trx/game/lara/look.c
+++ b/src/trx/game/lara/look.c
@@ -8,11 +8,11 @@
 #include <trx/version.h>
 
 // clang-format off
-#define M_MAX_HEAD_ROTATION          ((g_TRVersion == 1 ? 50 : 44) * DEG_1) // = 9100 (TR1), 8008 (TR2)
+#define M_MAX_HEAD_ROTATION          ((g_TRVersion == 1 ? 50 : 44) * DEG_1) // = 9100 (TR1), 8008 (TR2/3)
 #define M_HEAD_TURN                  (2 * DEG_1)             // = 364
-#define M_MIN_HEAD_ROTATION          (-M_MAX_HEAD_ROTATION)  // = -9100 (TR1), -8008 (TR2)
-#define M_MAX_HEAD_TILT              (22 * DEG_1)            // = 4004
-#define M_MIN_HEAD_TILT              (-42 * DEG_1)           // = -7644
+#define M_MIN_HEAD_ROTATION          (-M_MAX_HEAD_ROTATION)  // = -9100 (TR1), -8008 (TR2/3)
+#define M_MAX_HEAD_TILT              ((g_TRVersion < 3 ? 22 : 30) * DEG_1) // = 4004 (TR1/2), 5460 (TR3)
+#define M_MIN_HEAD_TILT              ((g_TRVersion < 3 ? -42 : -35) * DEG_1) // = -7644 (TR1/2), -6370 (TR3)
 #define M_HEAD_TURN_SURF             (3 * DEG_1)             // = 546
 #define M_MAX_HEAD_ROTATION_SURF     (50 * DEG_1)            // = 9100
 #define M_MAX_HEAD_TILT_SURF         (40 * DEG_1)            // = 7280
@@ -108,7 +108,8 @@ void Lara_Look_LeftRight(void)
     LARA_INFO *const lara = Lara_GetLaraInfo();
     g_Camera.type = CAM_LOOK;
 
-    const bool on_surface = lara->water_status == LWS_SURFACE;
+    const bool on_surface =
+        g_TRVersion < 3 && lara->water_status == LWS_SURFACE;
     const int16_t max_head_rot =
         on_surface ? M_MAX_HEAD_ROTATION_SURF : M_MAX_HEAD_ROTATION;
     const int16_t head_turn = on_surface ? M_HEAD_TURN_SURF : M_HEAD_TURN;
@@ -141,7 +142,8 @@ void Lara_Look_UpDown(void)
         SWAP2(g_Input.forward, g_Input.back, temp_forward);
     }
 
-    const bool on_surface = lara->water_status == LWS_SURFACE;
+    const bool on_surface =
+        g_TRVersion < 3 && lara->water_status == LWS_SURFACE;
     const int16_t min_head_tilt =
         on_surface ? M_MIN_HEAD_TILT_SURF : M_MIN_HEAD_TILT;
     const int16_t max_head_tilt =


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This defines the look angle behaviour for Lara in TR3; she has a more lenient tilt and there is no difference between regular look and idling on water surface, unlike TR1/2. I've also tidied up a few magic numbers in the camera look function.

I think it'd be nice to have the angles defined in the camera strategies, so that it's dictated by whichever one is in use rather than the game version. But I can tackle that separately at a later date.
