### PR TITLE
sparks: add TR3 blood effects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 - added a bubble emitter (#4629)
 
 **TR3**:
+- added new blood effects
+- added underwater blood spills
 - added new creature explosions effects
 
 

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -529,6 +529,61 @@ void Sparks_TriggerSideFlame(
     spark->size.height = size >> 1;
 }
 
+void Sparks_TriggerBlood(
+    const XYZ_32 pos, int32_t angle_12, const int32_t count)
+{
+    const bool censored = false;
+
+    for (int32_t i = 0; i < count; i++) {
+        SPARK *const spark = Sparks_GetFreeSpark();
+        spark->on = true;
+
+        if (censored) {
+            spark->src_color.r = 112;
+            spark->src_color.g = 0;
+            spark->src_color.b = 224;
+            spark->dst_color.r = 96;
+            spark->dst_color.g = 0;
+            spark->dst_color.b = 192;
+        } else {
+            spark->src_color.r = 224;
+            spark->src_color.g = 0;
+            spark->src_color.b = 32;
+            spark->dst_color.r = 192;
+            spark->dst_color.g = 0;
+            spark->dst_color.b = 24;
+        }
+        spark->color = spark->src_color;
+
+        spark->col_fade_speed = 8;
+        spark->fade_to_black = 8;
+        spark->life = 24;
+        spark->s_life = 24;
+        spark->draw_type = 1;
+        spark->dynamic = -1;
+        spark->pos.x = pos.x + (Random_GetControl() & 0x1F) - 16;
+        spark->pos.y = pos.y + (Random_GetControl() & 0x1F) - 16;
+        spark->pos.z = pos.z + (Random_GetControl() & 0x1F) - 16;
+        const int16_t dist = Random_GetControl() & 0xF;
+        const int32_t ang =
+            ((Random_GetControl() & 0x1F) + angle_12 - 16) & 0xFFF;
+        spark->vel.x = -(dist * Math_Sin(ang << 4)) >> 7;
+        spark->vel.y = -128 - (Random_GetControl() & 0xFF);
+        spark->vel.z = dist * Math_Cos((ang << 4)) >> 7;
+        spark->friction = 4;
+        spark->flags = SPARK_F_BLOOD | SPARK_F_SCALE;
+        spark->scalar = 3;
+        spark->max_y_vel = 0;
+        spark->gravity = (Random_GetControl() & 0x1F) + 31;
+        spark->size.width = 2;
+        spark->src_size.width = 2;
+        spark->size.height = 2;
+        spark->src_size.height = 2;
+        spark->dst_size.width = 2 - (Random_GetControl() & 1);
+        spark->dst_size.height = 2 - (Random_GetControl() & 1);
+    }
+}
+
 void Sparks_TriggerUnderwaterExplosion(const ITEM *item)
 {
     if (item == nullptr) {

--- a/src/trx/game/sparks/spawners.h
+++ b/src/trx/game/sparks/spawners.h
@@ -40,3 +40,5 @@ void Sparks_TriggerShotgunSparks(XYZ_32 pos, XYZ_32 vel);
 void Sparks_TriggerRocketSmoke(XYZ_32 pos, int32_t c, int16_t room_num);
 void Sparks_TriggerRocketFlame(
     XYZ_32 pos, XYZ_32 vel, int16_t item_num, int16_t room_num);
+
+void Sparks_TriggerBlood(XYZ_32 pos, int32_t angle_12, int32_t count);

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -12,6 +12,7 @@
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
+#include <trx/game/sparks/spawners.h>
 #include <trx/game/water_fx.h>
 #include <trx/version.h>
 
@@ -166,6 +167,18 @@ int16_t Spawn_Blood(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num)
 {
+    if (g_TRVersion == 3) {
+        if (Room_Get(room_num)->flags.underwater) {
+            WaterFX_TriggerUnderwaterBlood(
+                (XYZ_32) { x, y, z }, Random_GetControl() & 7);
+        } else {
+            Sparks_TriggerBlood(
+                (XYZ_32) { x, y, z }, y_rot >> 4,
+                (Random_GetControl() & 7) + 6);
+        }
+        return NO_EFFECT;
+    }
+
     const int16_t effect_num = Effect_Create(room_num);
     if (effect_num != NO_EFFECT) {
         EFFECT *const effect = Effect_Get(effect_num);
@@ -186,10 +199,19 @@ void Spawn_BloodBath(
     const int16_t y_rot, const int16_t room_num, const int32_t count)
 {
     for (int32_t i = 0; i < count; i++) {
-        Spawn_Blood(
-            x - (Random_GetDraw() << 9) / 0x8000 + 256,
-            y - (Random_GetDraw() << 9) / 0x8000 + 256,
-            z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot, room_num);
+        if (g_TRVersion == 3) {
+            Spawn_Blood(
+                x - (Random_GetControl() << 9) / 0x8000 + 256,
+                y - (Random_GetControl() << 9) / 0x8000 + 256,
+                z - (Random_GetControl() << 9) / 0x8000 + 256, speed, y_rot,
+                room_num);
+        } else {
+            Spawn_Blood(
+                x - (Random_GetDraw() << 9) / 0x8000 + 256,
+                y - (Random_GetDraw() << 9) / 0x8000 + 256,
+                z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot,
+                room_num);
+        }
     }
 }
 

--- a/src/trx/game/water_fx.c
+++ b/src/trx/game/water_fx.c
@@ -295,6 +295,29 @@ void WaterFX_WadeSplash(
     }
 }
 
+void WaterFX_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
+{
+    int32_t idx = -1;
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
+        if ((m_Ripples[i].flags & 1U) == 0U) {
+            idx = i;
+            break;
+        }
+    }
+    if (idx < 0) {
+        return;
+    }
+
+    WATER_FX_RIPPLE *const ripple = &m_Ripples[idx];
+    ripple->flags = 0x33U;
+    ripple->init = 1U;
+    ripple->life = (Random_GetControl() & 7) - 16;
+    ripple->size = size;
+    ripple->x = pos.x + (Random_GetControl() & 0x3F) - 32;
+    ripple->y = pos.y;
+    ripple->z = pos.z + (Random_GetControl() & 0x3F) - 32;
+}
+
 static RGBA_8888 M_Gray(int32_t c)
 {
     CLAMP(c, 0, 255);
@@ -356,10 +379,16 @@ static void M_DrawRipple(
     int32_t sprite_idx = base_sprite_idx + 9;
     RGBA_8888 color;
 
+    const bool censored = false;
+
     if ((r->flags & 0x10U) != 0U) {
         if ((r->flags & 0x20U) != 0U) {
             sprite_idx = base_sprite_idx;
-            color = (RGBA_8888) { r->life, 0, 0, 255 };
+            if (censored) {
+                color = (RGBA_8888) { r->life / 2, 0, r->life, 255 };
+            } else {
+                color = (RGBA_8888) { r->life, 0, 0, 255 };
+            }
         } else {
             int32_t c1 = r->init != 0U ? (r->init >> 2) : (r->life >> 2);
             c1 <<= 3;
@@ -373,15 +402,26 @@ static void M_DrawRipple(
         color = M_Gray(c1);
     }
 
-    const XYZ_32 quad_pos[4] = {
-        { r->x - n, r->y, r->z - n },
-        { r->x - n, r->y, r->z + n },
-        { r->x + n, r->y, r->z + n },
-        { r->x + n, r->y, r->z - n },
+    // double-sided
+    const XYZ_32 quad_pos[2][4] = {
+        {
+            { r->x - n, r->y, r->z - n },
+            { r->x + n, r->y, r->z - n },
+            { r->x + n, r->y, r->z + n },
+            { r->x - n, r->y, r->z + n },
+        },
+        {
+            { r->x - n, r->y, r->z - n },
+            { r->x - n, r->y, r->z + n },
+            { r->x + n, r->y, r->z + n },
+            { r->x + n, r->y, r->z - n },
+        },
     };
     const RGBA_8888 quad_color[4] = { color, color, color, color };
     OutputSource_PolyFX_StageSpriteQuadWorld(
-        sprite_idx, quad_pos, quad_color, DRAW_BLEND_ADD);
+        sprite_idx, quad_pos[0], quad_color, DRAW_BLEND_ADD);
+    OutputSource_PolyFX_StageSpriteQuadWorld(
+        sprite_idx, quad_pos[1], quad_color, DRAW_BLEND_ADD);
 }
 
 void WaterFX_Draw(void)

--- a/src/trx/game/water_fx.h
+++ b/src/trx/game/water_fx.h
@@ -71,3 +71,5 @@ WATER_FX_RIPPLE *WaterFX_SetupRipple(
 void WaterFX_SetupSplash(const WATER_FX_SPLASH_SETUP *setup);
 void WaterFX_Splash(const ITEM *item);
 void WaterFX_WadeSplash(const ITEM *item, int32_t water_height, int32_t depth);
+
+void WaterFX_TriggerUnderwaterBlood(XYZ_32 pos, int32_t size);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR implements TR3 blood effects – both on dry land and underwater.

#### Testing

We need to check if nothing that can be targeted in Lara's House bleeds.
A good test to check the "normal blood" effect is to run around through the India spikes.
A good test to check the "lots of blood" effects is to get impaled on the India spikes.
A good test to check the "underwater spill" effects is to play with the piranhas in the Temple Ruins level with the fly cheat (I didn't prevent cheat-Lara from bleeding there – I think that's okay.)