### PR TITLE
sparks: implement TR3 exploding deaths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
 - added a bubble emitter (#4629)
 
+**TR3**:
+- added new creature explosions effects
+
+
+
 ## [1.1](https://github.com/LostArtefacts/TRX/compare/trx-1.0.3...trx-1.1) - 2026-01-17
 Showcase: https://www.youtube.com/watch?v=veVYyr--H1A
 - added a fade-in and fade-out effect to patterned inventory backgrounds

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -6,6 +6,7 @@
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/utils.h>
+#include <trx/version.h>
 
 void Item_TakeDamage(
     ITEM *const item, const int16_t damage, const bool hit_status)
@@ -41,6 +42,7 @@ int32_t Item_Explode(
     Matrix_Rot16(best_frame->mesh_rots[0]);
 
     const int32_t speed_shift = item->object_id == O_TORSO ? 7 : 8;
+    const bool is_tr3 = g_TRVersion == 3;
 
     // main mesh
     int32_t bit = 1;
@@ -55,7 +57,8 @@ int32_t Item_Explode(
             effect->room_num = item->room_num;
             effect->speed = Random_GetControl() >> speed_shift;
             effect->fall_speed = -Random_GetControl() >> speed_shift;
-            effect->counter = damage;
+            effect->counter =
+                is_tr3 ? ((damage << 2) | (Random_GetControl() & 3)) : damage;
             effect->object_id = O_BODY_PART;
             effect->frame_num = obj->mesh_idx;
             effect->shade = Output_GetLightAdder() - 0x300;
@@ -90,7 +93,9 @@ int32_t Item_Explode(
                 effect->room_num = item->room_num;
                 effect->speed = Random_GetControl() >> speed_shift;
                 effect->fall_speed = -Random_GetControl() >> speed_shift;
-                effect->counter = damage;
+                effect->counter = is_tr3
+                    ? ((damage << 2) | (Random_GetControl() & 3))
+                    : damage;
                 effect->object_id = O_BODY_PART;
                 effect->frame_num = obj->mesh_idx + i;
                 effect->shade = Output_GetLightAdder() - 0x300;

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -1,10 +1,12 @@
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
+#include <trx/game/output.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
+#include <trx/game/sparks/spawners.h>
 #include <trx/version.h>
 
-static void M_Control(const int16_t effect_num)
+static void M_Control_TR12(const int16_t effect_num)
 {
     EFFECT *const effect = Effect_Get(effect_num);
     effect->rot.x += 5 * DEG_1;
@@ -86,9 +88,93 @@ static void M_Control(const int16_t effect_num)
     }
 }
 
+static void M_Control_TR3(const int16_t effect_num)
+{
+    int32_t lp;
+
+    EFFECT *const effect = Effect_Get(effect_num);
+    effect->rot.x += 5 * DEG_1;
+    effect->rot.z += 10 * DEG_1;
+    effect->fall_speed += 3;
+    effect->pos.x +=
+        (effect->speed * Math_Sin(effect->rot.y)) >> (W2V_SHIFT + 2);
+    effect->pos.y += effect->fall_speed;
+    effect->pos.z +=
+        (effect->speed * Math_Cos(effect->rot.y)) >> (W2V_SHIFT + 2);
+
+    const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
+    if (!(time4 & 0xC)) {
+        if (effect->counter & 1) {
+            Sparks_TriggerFireFlame(effect->pos, effect_num, 0);
+        }
+
+        if (effect->counter & 2) {
+            Sparks_TriggerFireSmoke(effect->pos, -1, 0);
+        }
+    }
+
+    int16_t room_num = effect->room_num;
+    SECTOR *const sector =
+        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
+    int32_t c =
+        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+
+    if (effect->pos.y < c) {
+        effect->pos.y = c;
+        effect->fall_speed = -effect->fall_speed;
+    }
+
+    int32_t h =
+        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+
+    if (effect->pos.y >= h) {
+        if (effect->counter & 3) {
+            for (int32_t i = 0; i < 3; i++) {
+                if (effect->counter & 1) {
+                    Sparks_TriggerFireFlame(
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                }
+                if (effect->counter & 2) {
+                    Sparks_TriggerFireSmoke(
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                }
+            }
+            Sound_Effect(SFX_EXPLOSION_1, &effect->pos, SPM_NORMAL);
+        }
+
+        Effect_Kill(effect_num);
+        return;
+    }
+
+    if (Lara_IsNearItem(&effect->pos, effect->counter & ~3)) {
+        Lara_TakeDamage(effect->counter >> 2, true);
+
+        if (effect->counter & 3) {
+            for (int32_t i = 0; i < 3; i++) {
+                if (effect->counter & 1) {
+                    Sparks_TriggerFireFlame(
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                }
+                if (effect->counter & 2) {
+                    Sparks_TriggerFireSmoke(
+                        (XYZ_32) { effect->pos.x, h, effect->pos.z }, -1, 0);
+                }
+            }
+
+            Sound_Effect(SFX_EXPLOSION_1, &effect->pos, SPM_NORMAL);
+        }
+
+        Effect_Kill(effect_num);
+    }
+
+    if (effect->room_num != room_num) {
+        Effect_NewRoom(effect_num, room_num);
+    }
+}
+
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = M_Control;
+    obj->control_func = g_TRVersion == 3 ? M_Control_TR3 : M_Control_TR12;
     obj->loaded = true;
     obj->mesh_count = 0;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR implements the flame effects on exploded body parts.

#### Testing

1. `/natlasucks`
2. Compare the quad explosions with the OG