### PR TITLE
output: fix drawing shadow twice

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
 - added a bubble emitter (#4629)
 - improved inventory ring active item highlight for smoother appearance
+- fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 
 **TR3**:
 - added new blood effects

--- a/src/meson.build
+++ b/src/meson.build
@@ -513,6 +513,7 @@ common_sources = [
   'trx/game/option/passport.c',
   'trx/game/option/sound.c',
   'trx/game/option/stats.c',
+  'trx/game/output/bind.c',
   'trx/game/output/common.c',
   'trx/game/output/draw.c',
   'trx/game/output/func.c',

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -65,8 +65,4 @@ typedef struct {
             XYZ_16 rot;
         } result, prev;
     } interp;
-
-    struct {
-        bool drawn;
-    } bind;
 } ITEM;

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -12,6 +12,7 @@
 #include <trx/game/level/common.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
+#include <trx/game/output/bind.h>
 #include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 #include <trx/game/shell.h>
@@ -739,10 +740,11 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         room->flags.swamp       = (flags & 0x80) != 0;
         // clang-format on
 
-        room->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-        room->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
-        room->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
-        room->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
+        OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+        bind->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
+        bind->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
+        bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
+        bind->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
         room->item_num = NO_ITEM;
         room->effect_num = NO_EFFECT;
 

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -739,7 +739,6 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         room->flags.swamp       = (flags & 0x80) != 0;
         // clang-format on
 
-        room->bind.active = false;
         room->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
         room->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
         room->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);

--- a/src/trx/game/output/bind.c
+++ b/src/trx/game/output/bind.c
@@ -21,7 +21,10 @@ OUTPUT_ITEM_BIND *Output_Bind_GetItem(const ITEM *const item)
 
 void Output_Bind_ResetRooms(void)
 {
-    memset(m_RoomBindings, 0, sizeof(m_RoomBindings));
+    for (int32_t i = 0; i < MAX_ROOMS; i++) {
+        m_RoomBindings[i].active = false;
+        m_RoomBindings[i].drawn = false;
+    }
 }
 
 OUTPUT_ROOM_BIND *Output_Bind_GetRoom(const ROOM *const room)

--- a/src/trx/game/output/bind.c
+++ b/src/trx/game/output/bind.c
@@ -1,10 +1,13 @@
 #include <trx/game/output/bind.h>
 
 #include <trx/game/items.h>
+#include <trx/game/rooms/common.h>
+#include <trx/game/rooms/const.h>
 
 #include <string.h>
 
 static OUTPUT_ITEM_BIND m_ItemBindings[MAX_ITEMS] = {};
+static OUTPUT_ROOM_BIND m_RoomBindings[MAX_ROOMS] = {};
 
 void Output_Bind_ResetItems(void)
 {
@@ -14,4 +17,14 @@ void Output_Bind_ResetItems(void)
 OUTPUT_ITEM_BIND *Output_Bind_GetItem(const ITEM *const item)
 {
     return &m_ItemBindings[Item_GetIndex(item)];
+}
+
+void Output_Bind_ResetRooms(void)
+{
+    memset(m_RoomBindings, 0, sizeof(m_RoomBindings));
+}
+
+OUTPUT_ROOM_BIND *Output_Bind_GetRoom(const ROOM *const room)
+{
+    return &m_RoomBindings[Room_GetNumber(room)];
 }

--- a/src/trx/game/output/bind.c
+++ b/src/trx/game/output/bind.c
@@ -1,0 +1,17 @@
+#include <trx/game/output/bind.h>
+
+#include <trx/game/items.h>
+
+#include <string.h>
+
+static OUTPUT_ITEM_BIND m_ItemBindings[MAX_ITEMS] = {};
+
+void Output_Bind_ResetItems(void)
+{
+    memset(m_ItemBindings, 0, sizeof(m_ItemBindings));
+}
+
+OUTPUT_ITEM_BIND *Output_Bind_GetItem(const ITEM *const item)
+{
+    return &m_ItemBindings[Item_GetIndex(item)];
+}

--- a/src/trx/game/output/bind.h
+++ b/src/trx/game/output/bind.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <trx/game/items/types.h>
+
+typedef struct {
+    bool drawn;
+    bool shadow_drawn;
+} OUTPUT_ITEM_BIND;
+
+void Output_Bind_ResetItems(void);
+OUTPUT_ITEM_BIND *Output_Bind_GetItem(const ITEM *item);

--- a/src/trx/game/output/bind.h
+++ b/src/trx/game/output/bind.h
@@ -11,6 +11,14 @@ typedef struct {
 typedef struct {
     bool active;
     bool drawn;
+    int16_t bound_left;
+    int16_t bound_right;
+    int16_t bound_top;
+    int16_t bound_bottom;
+    int16_t test_left;
+    int16_t test_right;
+    int16_t test_top;
+    int16_t test_bottom;
 } OUTPUT_ROOM_BIND;
 
 void Output_Bind_ResetItems(void);

--- a/src/trx/game/output/bind.h
+++ b/src/trx/game/output/bind.h
@@ -1,11 +1,20 @@
 #pragma once
 
 #include <trx/game/items/types.h>
+#include <trx/game/rooms/types.h>
 
 typedef struct {
     bool drawn;
     bool shadow_drawn;
 } OUTPUT_ITEM_BIND;
 
+typedef struct {
+    bool active;
+    bool drawn;
+} OUTPUT_ROOM_BIND;
+
 void Output_Bind_ResetItems(void);
 OUTPUT_ITEM_BIND *Output_Bind_GetItem(const ITEM *item);
+
+void Output_Bind_ResetRooms(void);
+OUTPUT_ROOM_BIND *Output_Bind_GetRoom(const ROOM *room);

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -5,6 +5,7 @@
 #include <trx/game/lara/common.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
+#include <trx/game/output/bind.h>
 #include <trx/game/output/sources/lightnings.h>
 #include <trx/game/output/sources/misc.h>
 #include <trx/game/output/sources/objects.h>
@@ -299,6 +300,12 @@ void Output_DrawShadow(
     if (!item->enable_shadow) {
         return;
     }
+
+    OUTPUT_ITEM_BIND *const bind = Output_Bind_GetItem(item);
+    if (bind->shadow_drawn) {
+        return;
+    }
+    bind->shadow_drawn = true;
 
     if (g_Config.visuals.shadow_type == SHADOW_TYPE_SPRITE) {
         if (M_DrawShadow_Sprite(size, bounds, item)) {

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/game/output.h>
+#include <trx/game/output/bind.h>
 #include <trx/game/output/mesh_batcher/mesh_builder.h>
 #include <trx/game/random.h>
 #include <trx/memory.h>
@@ -159,6 +160,7 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
 {
     M_PRIV *const p = &m_Priv;
     OUTPUT_MESH *const mesh = p->meshes[Room_GetNumber(room)];
+    const OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
     const MESH_INSTANCE inst = {
         .mesh = mesh,
         .cwmatrix = *g_MatrixPtr,
@@ -168,10 +170,10 @@ void OutputSource_Rooms_StageRoom(const ROOM *const room)
         .water_effect = M_GetWaterEffect(room),
         .enable_scissor = true,
         .scissor = {
-            .x = room->bound_left,
-            .y = room->bound_bottom,
-            .width = room->bound_right - room->bound_left,
-            .height = room->bound_bottom - room->bound_top,
+            .x = bind->bound_left,
+            .y = bind->bound_bottom,
+            .width = bind->bound_right - bind->bound_left,
+            .height = bind->bound_bottom - bind->bound_top,
         },
         .room = Output_GetCurrentRoom(),
     };

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -5,6 +5,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
 #include <trx/game/output.h>
+#include <trx/game/output/bind.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sparks.h>
 #include <trx/game/water_fx.h>
@@ -317,12 +318,13 @@ static void M_DrawSkybox(void)
 
 static void M_DrawRoomItem(const int16_t item_num, void *const ud)
 {
-    ITEM *const item = Item_Get(item_num);
+    const ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
-    if (!item->bind.drawn && item->status != IS_INVISIBLE
+    OUTPUT_ITEM_BIND *const bind = Output_Bind_GetItem(item);
+    if (!bind->drawn && item->status != IS_INVISIBLE
         && obj->draw_func != nullptr) {
         M_SetupWaterStatus(Room_Get(item->room_num));
-        item->bind.drawn |= obj->draw_func(item);
+        bind->drawn |= obj->draw_func(item);
     }
 }
 
@@ -470,9 +472,7 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
         M_DrawSkybox();
     }
 
-    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
-        Item_Get(i)->bind.drawn = false;
-    }
+    Output_Bind_ResetItems();
 
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
         const int16_t draw_room_num = Room_DrawGetRoom(i);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -122,16 +122,17 @@ static void M_GetBounds(void)
         const int16_t room_num = m_BoundRooms[m_BoundStart % M_MAX_BOUND_ROOMS];
         m_BoundStart++;
         ROOM *const room = Room_Get(room_num);
-        room->bind.active = false;
+        OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+        bind->active = false;
 
         CLAMPG(room->bound_left, room->test_left);
         CLAMPG(room->bound_top, room->test_top);
         CLAMPL(room->bound_right, room->test_right);
         CLAMPL(room->bound_bottom, room->test_bottom);
 
-        if (!room->bind.drawn) {
+        if (!bind->drawn) {
             Room_MarkToBeDrawn(room_num);
-            room->bind.drawn = 1;
+            bind->drawn = true;
             if (room->flags.outside) {
                 m_Outside = 1;
             }
@@ -275,7 +276,8 @@ static void M_SetBounds(
         return;
     }
 
-    if (room->bind.active) {
+    OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+    if (bind->active) {
         CLAMPG(room->test_left, left);
         CLAMPG(room->test_top, top);
         CLAMPL(room->test_right, right);
@@ -283,7 +285,7 @@ static void M_SetBounds(
     } else {
         m_BoundRooms[m_BoundEnd % M_MAX_BOUND_ROOMS] = room_num;
         m_BoundEnd++;
-        room->bind.active = true;
+        bind->active = true;
         room->test_left = left;
         room->test_top = top;
         room->test_right = right;
@@ -435,12 +437,14 @@ int16_t Room_DrawGetRoom(const int16_t idx)
 void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
 {
     ROOM *const room = Room_Get(current_room);
+    Output_Bind_ResetRooms();
     room->test_left = Viewport_GetMinX(VIEWPORT_GAME);
     room->test_top = Viewport_GetMinY(VIEWPORT_GAME);
     room->test_right = Viewport_GetMaxX(VIEWPORT_GAME);
     room->test_bottom = Viewport_GetMaxY(VIEWPORT_GAME);
-    room->bind.active = true;
-    room->bind.drawn = false;
+    OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+    bind->active = true;
+    bind->drawn = false;
 
     g_PhdLeft = room->test_left;
     g_PhdTop = room->test_top;
@@ -478,8 +482,9 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
         const int16_t draw_room_num = Room_DrawGetRoom(i);
         ROOM *const draw_room = Room_Get(draw_room_num);
         M_DrawSingleRoom(draw_room);
-        draw_room->bind.active = false;
-        draw_room->bind.drawn = false;
+        OUTPUT_ROOM_BIND *const draw_bind = Output_Bind_GetRoom(draw_room);
+        draw_bind->active = false;
+        draw_bind->drawn = false;
     }
 
     const ITEM *const lara_item = Lara_GetItem();

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -121,14 +121,14 @@ static void M_GetBounds(void)
     while (m_BoundStart != m_BoundEnd) {
         const int16_t room_num = m_BoundRooms[m_BoundStart % M_MAX_BOUND_ROOMS];
         m_BoundStart++;
-        ROOM *const room = Room_Get(room_num);
+        const ROOM *const room = Room_Get(room_num);
         OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
         bind->active = false;
 
-        CLAMPG(room->bound_left, room->test_left);
-        CLAMPG(room->bound_top, room->test_top);
-        CLAMPL(room->bound_right, room->test_right);
-        CLAMPL(room->bound_bottom, room->test_bottom);
+        CLAMPG(bind->bound_left, bind->test_left);
+        CLAMPG(bind->bound_top, bind->test_top);
+        CLAMPL(bind->bound_right, bind->test_right);
+        CLAMPL(bind->bound_bottom, bind->test_bottom);
 
         if (!bind->drawn) {
             Room_MarkToBeDrawn(room_num);
@@ -139,10 +139,10 @@ static void M_GetBounds(void)
         }
 
         if (!room->flags.inside || room->flags.outside) {
-            CLAMPG(m_OutsideLeft, room->bound_left);
-            CLAMPG(m_OutsideTop, room->bound_top);
-            CLAMPL(m_OutsideRight, room->bound_right);
-            CLAMPL(m_OutsideBottom, room->bound_bottom);
+            CLAMPG(m_OutsideLeft, bind->bound_left);
+            CLAMPG(m_OutsideTop, bind->bound_top);
+            CLAMPL(m_OutsideRight, bind->bound_right);
+            CLAMPL(m_OutsideBottom, bind->bound_bottom);
         }
 
         if (room->portals == nullptr) {
@@ -165,20 +165,22 @@ static void M_SetBounds(
     const PORTAL *const portal, const int32_t room_num,
     const ROOM *const parent)
 {
-    ROOM *const room = Room_Get(room_num);
+    const ROOM *const room = Room_Get(room_num);
+    const OUTPUT_ROOM_BIND *const parent_bind = Output_Bind_GetRoom(parent);
+    OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
 
-    if (room->bound_left <= parent->test_left
-        && room->bound_top <= parent->test_top
-        && room->bound_right >= parent->test_right
-        && room->bound_bottom >= parent->test_bottom) {
+    if (bind->bound_left <= parent_bind->test_left
+        && bind->bound_top <= parent_bind->test_top
+        && bind->bound_right >= parent_bind->test_right
+        && bind->bound_bottom >= parent_bind->test_bottom) {
         return;
     }
 
     const MATRIX *const m = g_MatrixPtr;
-    int32_t left = parent->test_right;
-    int32_t right = parent->test_left;
-    int32_t bottom = parent->test_top;
-    int32_t top = parent->test_bottom;
+    int32_t left = parent_bind->test_right;
+    int32_t right = parent_bind->test_left;
+    int32_t bottom = parent_bind->test_top;
+    int32_t top = parent_bind->test_bottom;
 
     M_PORTAL_VBUF portal_vbuf[4];
     int32_t too_near = 0;
@@ -259,37 +261,36 @@ static void M_SetBounds(
         }
     }
 
-    if (left < parent->test_left) {
-        left = parent->test_left;
+    if (left < parent_bind->test_left) {
+        left = parent_bind->test_left;
     }
-    if (right > parent->test_right) {
-        right = parent->test_right;
+    if (right > parent_bind->test_right) {
+        right = parent_bind->test_right;
     }
-    if (top < parent->test_top) {
-        top = parent->test_top;
+    if (top < parent_bind->test_top) {
+        top = parent_bind->test_top;
     }
-    if (bottom > parent->test_bottom) {
-        bottom = parent->test_bottom;
+    if (bottom > parent_bind->test_bottom) {
+        bottom = parent_bind->test_bottom;
     }
 
     if (left >= right || top >= bottom) {
         return;
     }
 
-    OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
     if (bind->active) {
-        CLAMPG(room->test_left, left);
-        CLAMPG(room->test_top, top);
-        CLAMPL(room->test_right, right);
-        CLAMPL(room->test_bottom, bottom);
+        CLAMPG(bind->test_left, left);
+        CLAMPG(bind->test_top, top);
+        CLAMPL(bind->test_right, right);
+        CLAMPL(bind->test_bottom, bottom);
     } else {
         m_BoundRooms[m_BoundEnd % M_MAX_BOUND_ROOMS] = room_num;
         m_BoundEnd++;
         bind->active = true;
-        room->test_left = left;
-        room->test_top = top;
-        room->test_right = right;
-        room->test_bottom = bottom;
+        bind->test_left = left;
+        bind->test_top = top;
+        bind->test_right = right;
+        bind->test_bottom = bottom;
     }
 }
 
@@ -330,15 +331,16 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
     }
 }
 
-static void M_DrawSingleRoom(ROOM *const room)
+static void M_DrawSingleRoom(const ROOM *const room)
 {
     Output_SetCurrentRoom(room);
     M_SetupWaterStatus(room);
 
-    g_PhdLeft = room->bound_left;
-    g_PhdTop = room->bound_top;
-    g_PhdRight = room->bound_right;
-    g_PhdBottom = room->bound_bottom;
+    OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+    g_PhdLeft = bind->bound_left;
+    g_PhdTop = bind->bound_top;
+    g_PhdRight = bind->bound_right;
+    g_PhdBottom = bind->bound_bottom;
 
     if (g_Config.debug.enable_debug_room_clip) {
         Output_DrawScreenFrame(
@@ -354,10 +356,10 @@ static void M_DrawSingleRoom(ROOM *const room)
     Matrix_Push();
     Matrix_TranslateAbs32(room->pos);
 
-    g_PhdLeft = room->bound_left;
-    g_PhdTop = room->bound_top;
-    g_PhdRight = room->bound_right;
-    g_PhdBottom = room->bound_bottom;
+    g_PhdLeft = bind->bound_left;
+    g_PhdTop = bind->bound_top;
+    g_PhdRight = bind->bound_right;
+    g_PhdBottom = bind->bound_bottom;
 
     for (int32_t i = 0; i < room->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &room->static_meshes[i];
@@ -398,10 +400,10 @@ static void M_DrawSingleRoom(ROOM *const room)
 
     Matrix_Pop();
 
-    room->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
-    room->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
-    room->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
-    room->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
+    bind->bound_left = Viewport_GetMaxX(VIEWPORT_GAME);
+    bind->bound_top = Viewport_GetMaxY(VIEWPORT_GAME);
+    bind->bound_right = Viewport_GetMinX(VIEWPORT_GAME);
+    bind->bound_bottom = Viewport_GetMinY(VIEWPORT_GAME);
 }
 
 void Room_DrawReset(void)
@@ -436,20 +438,20 @@ int16_t Room_DrawGetRoom(const int16_t idx)
 
 void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
 {
-    ROOM *const room = Room_Get(current_room);
+    const ROOM *const room = Room_Get(current_room);
     Output_Bind_ResetRooms();
-    room->test_left = Viewport_GetMinX(VIEWPORT_GAME);
-    room->test_top = Viewport_GetMinY(VIEWPORT_GAME);
-    room->test_right = Viewport_GetMaxX(VIEWPORT_GAME);
-    room->test_bottom = Viewport_GetMaxY(VIEWPORT_GAME);
     OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);
+    bind->test_left = Viewport_GetMinX(VIEWPORT_GAME);
+    bind->test_top = Viewport_GetMinY(VIEWPORT_GAME);
+    bind->test_right = Viewport_GetMaxX(VIEWPORT_GAME);
+    bind->test_bottom = Viewport_GetMaxY(VIEWPORT_GAME);
     bind->active = true;
     bind->drawn = false;
 
-    g_PhdLeft = room->test_left;
-    g_PhdTop = room->test_top;
-    g_PhdRight = room->test_right;
-    g_PhdBottom = room->test_bottom;
+    g_PhdLeft = bind->test_left;
+    g_PhdTop = bind->test_top;
+    g_PhdRight = bind->test_right;
+    g_PhdBottom = bind->test_bottom;
 
     m_BoundRooms[0] = current_room;
     m_BoundStart = 0;
@@ -480,7 +482,7 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
 
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
         const int16_t draw_room_num = Room_DrawGetRoom(i);
-        ROOM *const draw_room = Room_Get(draw_room_num);
+        const ROOM *const draw_room = Room_Get(draw_room_num);
         M_DrawSingleRoom(draw_room);
         OUTPUT_ROOM_BIND *const draw_bind = Output_Bind_GetRoom(draw_room);
         draw_bind->active = false;

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -154,15 +154,6 @@ typedef struct {
     ROOM_LIGHT_MODE light_mode;
     int16_t num_lights;
     int16_t num_static_meshes;
-    int16_t bound_left;
-    int16_t bound_right;
-    int16_t bound_top;
-    int16_t bound_bottom;
-    uint16_t bound_active;
-    int16_t test_left;
-    int16_t test_right;
-    int16_t test_top;
-    int16_t test_bottom;
     int16_t item_num;
     int16_t effect_num;
     int16_t flipped_room;

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -176,11 +176,6 @@ typedef struct {
         bool swamp;
     } flags;
 
-    struct {
-        bool active;
-        bool drawn;
-    } bind;
-
     ROOM_DRAWSET drawn_items;
     uint8_t water_scheme;
     uint8_t reverb_info;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This introduces a new module, `output/bind.c`, to avoid requiring everyone who wants to draw items, to pass non-const pointers so that Output_DrawShadow can mutate the binding state.

LMK if we like this, then I'll refactor rooms as a follow-up request to use this pattern too.