### PR TITLE
inv-ring: lerp current inventory item shade

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
 - added a bubble emitter (#4629)
+- improved inventory ring active item highlight for smoother appearance
 
 **TR3**:
 - added new blood effects

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -19,6 +19,8 @@
 #include <trx/version.h>
 
 #define M_CAMERA_2_RING 598
+#define M_SHADE_NORMAL SHADE_LOW
+#define M_SHADE_SELECTED SHADE_NEUTRAL
 
 static bool M_IsEnterTransition(const INV_RING *const ring)
 {
@@ -92,12 +94,25 @@ fallback:
 static void M_DrawItem(
     const INV_RING *const ring, const INVENTORY_ITEM *const inv_item)
 {
-    if (ring->motion.status != RNG_FADING_OUT && ring->motion.status != RNG_DONE
-        && inv_item == ring->list[ring->current_object] && !ring->rotating) {
-        Output_SetLightAdder(SHADE_NEUTRAL);
-    } else {
-        Output_SetLightAdder(SHADE_LOW);
+    int32_t shade = M_SHADE_NORMAL;
+    if (ring->motion.status != RNG_FADING_OUT
+        && ring->motion.status != RNG_DONE) {
+        if (ring->rotating) {
+            float t = (ring->rot_count / (float)INV_RING_ROTATE_DURATION);
+            CLAMP(t, 0.0f, 1.0f);
+            if (inv_item == ring->list[ring->rotate_from_object]) {
+                t = 1.0f - t;
+            } else if (inv_item == ring->list[ring->rotate_to_object]) {
+                t = t;
+            } else {
+                t = 1.0f;
+            }
+            shade = LERP((float)M_SHADE_SELECTED, (float)M_SHADE_NORMAL, t);
+        } else if (inv_item == ring->list[ring->current_object]) {
+            shade = M_SHADE_SELECTED;
+        }
     }
+    Output_SetLightAdder(shade);
 
     Matrix_TranslateRel(0, inv_item->y_trans, inv_item->z_trans);
     Matrix_RotY(inv_item->y_rot);

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -117,6 +117,8 @@ void InvRing_InitRing(
     }
 
     ring->rotating = false;
+    ring->rotate_from_object = 0;
+    ring->rotate_to_object = 0;
     ring->rot_count = 0;
     ring->target_object = 0;
     ring->rot_adder = 0;
@@ -310,11 +312,13 @@ void InvRing_DoMotions(INV_RING *const ring)
 void InvRing_RotateLeft(INV_RING *const ring)
 {
     ring->rotating = true;
+    ring->rotate_from_object = ring->current_object;
     if (ring->current_object <= 0) {
         ring->target_object = ring->number_of_objects - 1;
     } else {
         ring->target_object = ring->current_object - 1;
     }
+    ring->rotate_to_object = ring->target_object;
     ring->rot_count = INV_RING_ROTATE_DURATION;
     ring->rot_adder = ring->rot_adder_l;
 }
@@ -322,11 +326,13 @@ void InvRing_RotateLeft(INV_RING *const ring)
 void InvRing_RotateRight(INV_RING *const ring)
 {
     ring->rotating = true;
+    ring->rotate_from_object = ring->current_object;
     if (ring->current_object + 1 >= ring->number_of_objects) {
         ring->target_object = 0;
     } else {
         ring->target_object = ring->current_object + 1;
     }
+    ring->rotate_to_object = ring->target_object;
     ring->rot_count = INV_RING_ROTATE_DURATION;
     ring->rot_adder = ring->rot_adder_r;
 }

--- a/src/trx/game/inventory_ring/types.h
+++ b/src/trx/game/inventory_ring/types.h
@@ -86,6 +86,8 @@ typedef struct {
     int16_t radius;
     int16_t camera_pitch;
     bool rotating;
+    int16_t rotate_from_object;
+    int16_t rotate_to_object;
     int16_t rot_count;
     int16_t current_object;
     int16_t target_object;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the sudden jump in active item brightness when using `/moreguns`.