### PR TITLE
Fix warnings of implicit declaration of functions.

### DIFF
--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -9,6 +9,9 @@
 #include <trx/memory.h>
 #include <trx/strings.h>
 
+#include <stdio.h>
+#include <string.h>
+
 // In-memory list of pointers to config options enforced by the game flow.
 static VECTOR *m_EnforcedOptions = nullptr;
 // In-memory list of pointers to config options hidden by the game flow.

--- a/src/trx/config/map.c
+++ b/src/trx/config/map.c
@@ -8,6 +8,8 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 #define X_CFG_BOOL(target_, default_value_)                                    \
     { .name = QUOTE(target_),                                                  \
       .type = COT_BOOL,                                                        \

--- a/src/trx/game/console/cmd/debug.c
+++ b/src/trx/game/console/cmd/debug.c
@@ -6,6 +6,8 @@
 #include <trx/memory.h>
 #include <trx/strings.h>
 
+#include <string.h>
+
 typedef struct {
     bool *target;
     const CONFIG_OPTION *option;

--- a/src/trx/game/console/history.c
+++ b/src/trx/game/console/history.c
@@ -8,6 +8,8 @@
 #include <trx/vector.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 #define MAX_HISTORY_ENTRIES 30
 
 VECTOR *m_History = nullptr;

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -18,6 +18,8 @@
 #include <trx/log.h>
 #include <trx/memory.h>
 
+#include <string.h>
+
 static bool m_IsPlaying = false;
 static const char *m_Extensions[] = {
     ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", nullptr,

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -18,6 +18,8 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <math.h>
+
 #define M_CAMERA_2_RING 598
 
 static bool M_IsEnterTransition(const INV_RING *const ring)

--- a/src/trx/game/level/reader.c
+++ b/src/trx/game/level/reader.c
@@ -23,6 +23,9 @@
 #include <trx/memory.h>
 #include <trx/version.h>
 
+#include <stdlib.h>
+#include <string.h>
+
 #define M_DEFAULT_SFX_PATH "data/main.sfx"
 
 typedef struct {

--- a/src/trx/game/music/backend_cdaudio.c
+++ b/src/trx/game/music/backend_cdaudio.c
@@ -11,6 +11,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 
 typedef struct {
     uint64_t from;

--- a/src/trx/game/music/backend_files.c
+++ b/src/trx/game/music/backend_files.c
@@ -7,6 +7,8 @@
 #include <trx/memory.h>
 #include <trx/strings.h>
 
+#include <stdio.h>
+
 typedef struct {
     const char *dir;
     const char *description;

--- a/src/trx/game/output/func.c
+++ b/src/trx/game/output/func.c
@@ -11,6 +11,8 @@
 #include <trx/log.h>
 #include <trx/utils.h>
 
+#include <math.h>
+
 CLIP Output_CheckBoundsClip(const BOUNDS_16 *const bounds)
 {
     if (g_MatrixPtr->_23 >= Output_GetFarZ()) {

--- a/src/trx/game/output/sources/misc.c
+++ b/src/trx/game/output/sources/misc.c
@@ -9,6 +9,8 @@
 #include <trx/memory.h>
 #include <trx/utils.h>
 
+#include <math.h>
+
 typedef struct {
     XYZW_F pos;
     RGBA_8888 color;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -13,6 +13,8 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <math.h>
+
 static float m_Time = 0.0f;
 static float m_TimeInGame = 0.0f;
 static int32_t m_AnimatedTexturesOffset = 0;

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -11,6 +11,8 @@
 #include <trx/memory.h>
 #include <trx/utils.h>
 
+#include <string.h>
+
 typedef struct {
     OUTPUT_UVW corners[4];
 } M_UVW_PACK;

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -14,6 +14,7 @@
 #include <trx/version.h>
 
 #include <math.h>
+#include <string.h>
 
 #define M_GLOBAL_MEMBERS                                                       \
     X_DECLARE_MEMBER(float, fog_color, [4])                                    \

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -19,6 +19,8 @@
 #include <trx/gfx/context.h>
 #include <trx/gfx/gl/track.h>
 
+#include <stdio.h>
+
 #define M_MAX_PHASES 10
 
 static int32_t m_CurrentFrame = 0;

--- a/src/trx/game/savegame/bson.c
+++ b/src/trx/game/savegame/bson.c
@@ -10,9 +10,9 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <string.h>
 #include <zconf.h>
 #include <zlib.h>
-#include <string.h>
 
 #define M_MAGIC_TR1X MKTAG('T', '1', 'M', 'B')
 #define M_MAGIC_TR2X MKTAG('T', '2', 'X', 'B')

--- a/src/trx/game/savegame/bson.c
+++ b/src/trx/game/savegame/bson.c
@@ -12,6 +12,7 @@
 
 #include <zconf.h>
 #include <zlib.h>
+#include <string.h>
 
 #define M_MAGIC_TR1X MKTAG('T', '1', 'M', 'B')
 #define M_MAGIC_TR2X MKTAG('T', '2', 'X', 'B')

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -27,6 +27,9 @@
 #include <trx/strings.h>
 #include <trx/version.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #define M_NO_ROOM_LEGACY 255
 
 #define M_MAX_STACK_SIZE 10

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -15,6 +15,9 @@
 #include <trx/strings.h>
 #include <trx/version.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #define MAX_STRATEGIES 2
 #define SAVES_DIR "saves"
 

--- a/src/trx/game/stats/scan.c
+++ b/src/trx/game/stats/scan.c
@@ -17,6 +17,8 @@
 #include <trx/memory.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 static bool m_KillableItems[MAX_ITEMS] = {};
 
 static void M_IncludeKillableItem(

--- a/src/trx/game/test_replay.c
+++ b/src/trx/game/test_replay.c
@@ -18,6 +18,7 @@
 #include <trx/vector.h>
 
 #include <ctype.h>
+#include <stdio.h>
 #include <string.h>
 
 #define M_DEBUG 0

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -12,6 +12,9 @@
 #include <trx/strings.h>
 #include <trx/version.h>
 
+#include <stdio.h>
+#include <string.h>
+
 #define M_MIN_ASSAULT_COURSE_ROWS 7
 
 typedef enum {

--- a/src/trx/game/ui/draw.c
+++ b/src/trx/game/ui/draw.c
@@ -9,6 +9,8 @@
 #include <trx/vector.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 #define M_WHITE ((RGBA_F) { 1.0f, 1.0f, 1.0f, 1.0f })
 #define M_OUTLINE_THICKNESS 0.75f
 #define M_SCHEDULE_OP(draw_func, inst)                                         \

--- a/src/trx/game/ui/elements/bar.c
+++ b/src/trx/game/ui/elements/bar.c
@@ -8,6 +8,8 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <math.h>
+
 #define M_COLOR_STEPS 5
 
 typedef struct {

--- a/src/trx/gfx/gl/program.c
+++ b/src/trx/gfx/gl/program.c
@@ -8,6 +8,7 @@
 #include <trx/log.h>
 #include <trx/memory.h>
 
+#include <stdio.h>
 #include <string.h>
 
 static char *M_PreprocessIncludes(const char *src, const char *dir)


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

When compiling TRX, I got several messages like this one:
```
src/trx/gfx/gl/program.c: In function ‘M_PreprocessIncludes’:
src/trx/gfx/gl/program.c:65:9: warning: implicit declaration of function ‘snprintf’ [-Wimplicit-function-declaration]
   65 |         snprintf(full_path, sizeof(full_path), "%s/%s", dir, filename);
      |         ^~~~~~~~
src/trx/gfx/gl/program.c:12:1: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
   11 | #include <string.h>
  +++ |+#include <stdio.h>
   12 |
```
So, I did some fixes to some source files for resolving them.
I just added some system includes, no code changes have been made.
Tested with CYGWIN for UNIX platforms and with MinGW-w64 for Windows platforms.
