### PR TITLE
misc: implement enemy bleeding after death

### DIFF
--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -7,6 +7,7 @@
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
+#include <trx/version.h>
 
 #define M_SFX_SURF_DISTANCE ((STEP_L * 2) + 1)
 
@@ -204,6 +205,8 @@ void Item_Animate(ITEM *const item)
             }
 
             case AC_DEACTIVATE:
+                const OBJECT *const obj = Object_Get(item->object_id);
+                item->after_death = obj->intelligent ? 1 : 64;
                 item->status = IS_DEACTIVATED;
                 break;
 

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -7,8 +7,10 @@
 #include <trx/game/lara/common.h>
 #include <trx/game/objects.h>
 #include <trx/game/output/const.h>
+#include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sparks.h>
+#include <trx/game/spawn.h>
 #include <trx/memory.h>
 #include <trx/utils.h>
 #include <trx/version.h>
@@ -208,6 +210,7 @@ void Item_Initialise(const int16_t item_num)
     item->timer = 0;
     item->mesh_bits = 0xFFFFFFFF;
     item->touch_bits = 0;
+    item->after_death = 0;
     item->data = nullptr;
     item->priv = nullptr;
     item->carried_item = nullptr;
@@ -279,6 +282,23 @@ void Item_Control(void)
     }
 
     Carrier_AnimateDrops();
+}
+
+void Item_ControlDraw(ITEM *const item)
+{
+    if (g_TRVersion == 3 && item->status != IS_INVISIBLE
+        && item->after_death < 32 && item->after_death > 0) {
+        item->after_death++;
+
+        if (item->after_death == 2 || item->after_death == 5
+            || item->after_death == 11 || item->after_death == 20
+            || item->after_death == 27 || item->after_death == 32
+            || (Random_GetDraw() & 7) == 0) {
+            Spawn_BloodBathD(
+                item->pos.x, item->pos.y - 64, item->pos.z, 0,
+                Random_GetDraw() << 1, item->room_num, 1);
+        }
+    }
 }
 
 void Item_Kill(const int16_t item_num)

--- a/src/trx/game/items/common.h
+++ b/src/trx/game/items/common.h
@@ -21,6 +21,7 @@ int16_t Item_Spawn(const ITEM *item, OBJECT_ID obj_id);
 
 void Item_Initialise(int16_t item_num);
 void Item_Control(void);
+void Item_ControlDraw(ITEM *item);
 void Item_Kill(int16_t item_num);
 void Item_RemoveActive(int16_t item_num);
 void Item_RemoveDrawn(int16_t item_num);

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -20,6 +20,7 @@ typedef struct {
     int32_t floor;
     uint32_t touch_bits;
     uint32_t mesh_bits;
+    int16_t after_death;
     OBJECT_ID object_id;
     int16_t current_anim_state;
     int16_t goal_anim_state;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -17,6 +17,7 @@
 
 static float m_Time = 0.0f;
 static float m_TimeInGame = 0.0f;
+static bool m_ControlFrame = false;
 static int32_t m_AnimatedTexturesOffset = 0;
 
 static int32_t m_FogStart = 0;
@@ -425,4 +426,14 @@ void Output_AdjustDepth(const float factor, const float units)
         m_DepthFactor = factor;
         m_DepthUnits = units;
     }
+}
+
+bool Output_IsControlFrame(void)
+{
+    return m_ControlFrame;
+}
+
+void Output_SetControlFrame(const bool is_control_frame)
+{
+    m_ControlFrame = is_control_frame;
 }

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -17,6 +17,8 @@ void Output_SetTime(float time);
 float Output_GetTime(void);
 float Output_GetTimeInGame(void);
 void Output_SetTimeInGame(float time);
+bool Output_IsControlFrame(void);
+void Output_SetControlFrame(bool is_control_frame);
 
 void Output_SetupBelowWater(bool is_underwater);
 void Output_SetupAboveWater(bool is_underwater);

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -266,7 +266,9 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
 
         Interpolation_SetRate(1.0);
         Output_SetTime(m_CurrentFrame);
+        Output_SetControlFrame(true);
         M_Draw(phase);
+        Output_SetControlFrame(false);
     }
 
 finish:

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -321,13 +321,19 @@ static void M_DrawSkybox(void)
 
 static void M_DrawRoomItem(const int16_t item_num, void *const ud)
 {
-    const ITEM *const item = Item_Get(item_num);
+    ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
     OUTPUT_ITEM_BIND *const bind = Output_Bind_GetItem(item);
-    if (!bind->drawn && item->status != IS_INVISIBLE
-        && obj->draw_func != nullptr) {
-        M_SetupWaterStatus(Room_Get(item->room_num));
-        bind->drawn |= obj->draw_func(item);
+    if (bind->drawn || item->status == IS_INVISIBLE
+        || obj->draw_func == nullptr) {
+        return;
+    }
+
+    M_SetupWaterStatus(Room_Get(item->room_num));
+    bind->drawn |= obj->draw_func(item);
+
+    if (Output_IsControlFrame()) {
+        Item_ControlDraw(item);
     }
 }
 

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -569,7 +569,7 @@ void Sparks_TriggerBlood(
             ((Random_GetControl() & 0x1F) + angle_12 - 16) & 0xFFF;
         spark->vel.x = -(dist * Math_Sin(ang << 4)) >> 7;
         spark->vel.y = -128 - (Random_GetControl() & 0xFF);
-        spark->vel.z = dist * Math_Cos((ang << 4)) >> 7;
+        spark->vel.z = dist * Math_Cos(ang << 4) >> 7;
         spark->friction = 4;
         spark->flags = SPARK_F_BLOOD | SPARK_F_SCALE;
         spark->scalar = 3;
@@ -581,6 +581,60 @@ void Sparks_TriggerBlood(
         spark->src_size.height = 2;
         spark->dst_size.width = 2 - (Random_GetControl() & 1);
         spark->dst_size.height = 2 - (Random_GetControl() & 1);
+    }
+}
+
+void Sparks_TriggerBloodD(
+    const XYZ_32 pos, int32_t angle_12, const int32_t count)
+{
+    const bool censored = false;
+
+    for (int32_t i = 0; i < count; i++) {
+        SPARK *const spark = Sparks_GetFreeSpark();
+        spark->on = true;
+
+        if (censored) {
+            spark->src_color.r = 112;
+            spark->src_color.g = 0;
+            spark->src_color.b = 224;
+            spark->dst_color.r = 96;
+            spark->dst_color.g = 0;
+            spark->dst_color.b = 192;
+        } else {
+            spark->src_color.r = 224;
+            spark->src_color.g = 0;
+            spark->src_color.b = 32;
+            spark->dst_color.r = 192;
+            spark->dst_color.g = 0;
+            spark->dst_color.b = 24;
+        }
+        spark->color = spark->src_color;
+
+        spark->col_fade_speed = 8;
+        spark->fade_to_black = 8;
+        spark->life = 24;
+        spark->s_life = 24;
+        spark->draw_type = 1;
+        spark->dynamic = -1;
+        spark->pos.x = pos.x + (Random_GetDraw() & 0x1F) - 16;
+        spark->pos.y = pos.y + (Random_GetDraw() & 0x1F) - 16;
+        spark->pos.z = pos.z + (Random_GetDraw() & 0x1F) - 16;
+        const int16_t dist = Random_GetDraw() & 0xF;
+        const int32_t ang = ((Random_GetDraw() & 0x1F) + angle_12 - 16) & 0xFFF;
+        spark->vel.x = -(dist * Math_Sin(ang << 4)) >> 7;
+        spark->vel.y = -128 - (Random_GetDraw() & 0xFF);
+        spark->vel.z = dist * Math_Cos(ang << 4) >> 7;
+        spark->friction = 4;
+        spark->flags = SPARK_F_SCALE;
+        spark->scalar = 3;
+        spark->max_y_vel = 0;
+        spark->gravity = (Random_GetDraw() & 0x1F) + 31;
+        spark->size.width = 2;
+        spark->src_size.width = 2;
+        spark->size.height = 2;
+        spark->src_size.height = 2;
+        spark->dst_size.width = 2 - (Random_GetDraw() & 1);
+        spark->dst_size.height = 2 - (Random_GetDraw() & 1);
     }
 }
 

--- a/src/trx/game/sparks/spawners.h
+++ b/src/trx/game/sparks/spawners.h
@@ -42,3 +42,4 @@ void Sparks_TriggerRocketFlame(
     XYZ_32 pos, XYZ_32 vel, int16_t item_num, int16_t room_num);
 
 void Sparks_TriggerBlood(XYZ_32 pos, int32_t angle_12, int32_t count);
+void Sparks_TriggerBloodD(XYZ_32 pos, int32_t angle_12, int32_t count);

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -194,6 +194,23 @@ int16_t Spawn_Blood(
     return effect_num;
 }
 
+int16_t Spawn_BloodD(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num)
+{
+    if (g_TRVersion == 3) {
+        if (Room_Get(room_num)->flags.underwater) {
+            WaterFX_TriggerUnderwaterBloodD(
+                (XYZ_32) { x, y + 64, z }, Random_GetDraw() & 7);
+        } else {
+            Sparks_TriggerBloodD(
+                (XYZ_32) { x, y, z }, y_rot >> 4, (Random_GetDraw() & 7) + 6);
+        }
+        return NO_EFFECT;
+    }
+    return Spawn_Blood(x, y, z, speed, y_rot, room_num);
+}
+
 void Spawn_BloodBath(
     const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
     const int16_t y_rot, const int16_t room_num, const int32_t count)
@@ -212,6 +229,17 @@ void Spawn_BloodBath(
                 z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot,
                 room_num);
         }
+    }
+}
+
+void Spawn_BloodBathD(
+    const int32_t x, const int32_t y, const int32_t z, const int16_t speed,
+    const int16_t y_rot, const int16_t room_num, const int32_t count)
+{
+    for (int32_t i = 0; i < count; i++) {
+        Spawn_BloodD(
+            x - (Random_GetDraw() << 9) / 0x8000 + 256, y,
+            z - (Random_GetDraw() << 9) / 0x8000 + 256, speed, y_rot, room_num);
     }
 }
 

--- a/src/trx/game/spawn.h
+++ b/src/trx/game/spawn.h
@@ -18,7 +18,13 @@ void Spawn_BubbleEx(
 int16_t Spawn_Blood(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num);
+int16_t Spawn_BloodD(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num);
 void Spawn_BloodBath(
+    int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
+    int16_t room_num, int32_t count);
+void Spawn_BloodBathD(
     int32_t x, int32_t y, int32_t z, int16_t speed, int16_t y_rot,
     int16_t room_num, int32_t count);
 int16_t Spawn_GunShot(

--- a/src/trx/game/water_fx.c
+++ b/src/trx/game/water_fx.c
@@ -318,6 +318,29 @@ void WaterFX_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
     ripple->z = pos.z + (Random_GetControl() & 0x3F) - 32;
 }
 
+void WaterFX_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
+{
+    int32_t idx = -1;
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Ripples); i++) {
+        if ((m_Ripples[i].flags & 1U) == 0U) {
+            idx = i;
+            break;
+        }
+    }
+    if (idx < 0) {
+        return;
+    }
+
+    WATER_FX_RIPPLE *const ripple = &m_Ripples[idx];
+    ripple->flags = 0x33U;
+    ripple->init = 1U;
+    ripple->life = (Random_GetDraw() & 7) - 16;
+    ripple->size = size;
+    ripple->x = pos.x + (Random_GetDraw() & 0x3F) - 32;
+    ripple->y = pos.y;
+    ripple->z = pos.z + (Random_GetDraw() & 0x3F) - 32;
+}
+
 static RGBA_8888 M_Gray(int32_t c)
 {
     CLAMP(c, 0, 255);

--- a/src/trx/game/water_fx.h
+++ b/src/trx/game/water_fx.h
@@ -73,3 +73,4 @@ void WaterFX_Splash(const ITEM *item);
 void WaterFX_WadeSplash(const ITEM *item, int32_t water_height, int32_t depth);
 
 void WaterFX_TriggerUnderwaterBlood(XYZ_32 pos, int32_t size);
+void WaterFX_TriggerUnderwaterBloodD(XYZ_32 pos, int32_t size);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This implements the effects where the killed creatures continue to bleed for a few frames after they die.
I haven't added a changelog as this can be included in general blood effects that are already present.

#### Testing

We need to check if this conforms visually to the OG. There are gotchas.

#### Implementation

OG TR3 has a fork of the `DoBloodSplat` function, called `DoBloodSplatD`. This distinction actually applies to other functions, like the blood spills in water, blood baths etc. Both branches do pretty much the same (save for a small y offset difference in blood baths) – except one uses `Random_GetControl`, while the other `Random_GetDraw`. And… yes: the `D` effects actually get spawned… in the draw phase. But this approach is generally speaking a no-go for us, as it makes the logic FPS-dependent, which is something we don't want.

In this PR, I've implemented the `D` variants of the blood functions, but I call them in the control phase, as I iterate through the items so that I don't double-spawn them in 60 FPS.

What I'm not sure of is how close we got to replicating the OG effect with this kind of implementation.