### PR TITLE
input: reset turbo cheat after pushing past max

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `on_level_load` → `after_level_state`
     - `on_control` → `before_control`
     - `on_control_post` → `after_control`
+- changed turbo cheat to auto‑reset to normal speed if pushed past limit, making it easier for new players to recover from accidental changes
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 

--- a/src/trx/game/clock/turbo.c
+++ b/src/trx/game/clock/turbo.c
@@ -11,7 +11,12 @@
 
 void Clock_CycleTurboSpeed(const bool forward)
 {
-    Clock_SetTurboSpeed(Clock_GetTurboSpeed() + (forward ? 1 : -1));
+    int32_t new_speed = Clock_GetTurboSpeed() + (forward ? 1 : -1);
+    if (new_speed < CLOCK_TURBO_SPEED_MIN
+        || new_speed > CLOCK_TURBO_SPEED_MAX) {
+        new_speed = 0;
+    }
+    Clock_SetTurboSpeed(new_speed);
 }
 
 int32_t Clock_GetTurboSpeed(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the turbo cheat input to reset the speed back to normal when the player repeatedly presses the Turbo Cheat key. The intention is to let the players who don't know of the Slow key modifier to more easily recover from accidental speed changes.