### PR TITLE
objects/switch: support one-shot flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
 - added a bubble emitter (#4629)
 - added the ability to disable manual camera (Gameplay → Controls → Manual camera)
+- added support for one-shot flags to all switches
 - improved inventory ring active item highlight for smoother appearance
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 

--- a/src/trx/game/objects/general/switch.c
+++ b/src/trx/game/objects/general/switch.c
@@ -81,7 +81,7 @@ static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     item->flags |= IF_CODE_BITS;
-    if (!Item_IsTriggerActive(item)) {
+    if (!Item_IsTriggerActive(item) && (item->flags & IF_ONE_SHOT) == 0) {
         item->goal_anim_state = SWITCH_STATE_OFF;
         item->timer = 0;
     }
@@ -190,7 +190,7 @@ static void M_CollisionControlled(
 
     if ((g_Input.action && lara->gun_status == LGS_ARMLESS
          && !lara_item->gravity && lara_item->current_anim_state == LS(LS_STOP)
-         && item->status == IS_INACTIVE)
+         && (item->flags & IF_ONE_SHOT) == 0 && item->status == IS_INACTIVE)
         || (lara->interact_target.is_moving
             && lara->interact_target.item_num == item_num)) {
         const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
@@ -247,8 +247,8 @@ static void M_Collision(
     const OBJECT *const obj = Object_Get(item->object_id);
 
     if (!g_Input.action || item->status != IS_INACTIVE
-        || lara->gun_status != LGS_ARMLESS || lara_item->gravity
-        || lara_item->current_anim_state != LS(LS_STOP)
+        || (item->flags & IF_ONE_SHOT) != 0 || lara->gun_status != LGS_ARMLESS
+        || lara_item->gravity || lara_item->current_anim_state != LS(LS_STOP)
         || !Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is one of those "I have no idea  what I'm doing" PRs – when auditing the switch/lever code, I noticed that OG TR3 adds support for one-shot flags.

I'm not sure where it's used, or if it has the opportunity to break TR1 / TR2. I'm happy to test for this in automated way, but I'm not sure how – I suppose I'd need to check for any `TO_OBJECT` trigger that targets a switch, but what other properties would we need to check?