### PR TITLE
inv-ring: add cross-fade support to title screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added a bubble emitter (#4629)
 - added the ability to disable manual camera (Gameplay → Controls → Manual camera)
 - added new Lua event, `trx.events.on_game_start`, which fires when the level finishes loading and the game is about to start
+- added support for cross-fades to the title screen
 - improved inventory ring active item highlight for smoother appearance
 - changed Lua event callback names to be more consistent:
     - `on_level_init` → `before_level_file`

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -30,7 +30,7 @@
 
 #define M_INV_RING_FADE_TIME_FAST                                              \
     (INV_RING_CLOSE_FRAMES / INV_RING_FRAMES / (float)LOGIC_FPS)
-#define M_INV_RING_FADE_TIME_TITLE_FINISH 0.25f
+#define M_INV_RING_FADE_TIME_TO_BLACK 0.25f
 #define M_RING_SWITCH_FRAMES (96 / 2)
 #define M_SELECTING_FRAMES (32 / 2)
 
@@ -344,10 +344,17 @@ static GF_COMMAND M_Control(INV_RING *const ring)
     }
 
     if (ring->motion.status == RNG_FADING_OUT) {
+        if (ring->mode == INV_TITLE_MODE) {
+            const GF_COMMAND gf_cmd = M_Finish(ring, true);
+            ring->is_done = true;
+            ring->motion.status = RNG_DONE;
+            return gf_cmd;
+        }
+
         if (!Fader_IsActive(&ring->back_fader)
             && !Fader_IsActive(&ring->top_fader)) {
             Fader_InitFromCurrentHold(
-                &ring->top_fader, 1.0f, M_INV_RING_FADE_TIME_TITLE_FINISH,
+                &ring->top_fader, 1.0f, M_INV_RING_FADE_TIME_TO_BLACK,
                 1.0f / (float)LOGIC_FPS);
         }
 

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -293,6 +293,9 @@ void InvRing_Draw(INV_RING *const ring)
         Option_Draw(inv_item);
     }
 
-    Output_Overlay_DrawBlackRectangle(
-        Fader_GetCurrentValue(&ring->top_fader), true);
+    float top_opacity = Fader_GetCurrentValue(&ring->top_fader);
+    if (ring->mode == INV_TITLE_MODE && ring->motion.status != RNG_OPENING) {
+        top_opacity = 0.0f;
+    }
+    Output_Overlay_DrawBlackRectangle(top_opacity, true);
 }

--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/debug.h>
+#include <trx/game/fader.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/inventory_ring.h>
 #include <trx/game/music.h>
@@ -12,6 +13,7 @@
 typedef struct {
     INVENTORY_MODE mode;
     INV_RING *ring;
+    bool fade_to_black;
 } M_PRIV;
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
@@ -40,11 +42,33 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
     M_PRIV *const p = phase->priv;
     ASSERT(p->ring != nullptr);
     const GF_COMMAND gf_cmd = InvRing_Control(p->ring);
+    if (p->mode == INV_TITLE_MODE && p->ring->motion.status == RNG_DONE) {
+        p->fade_to_black = true;
+    }
     return (PHASE_CONTROL) {
         .action = p->ring->motion.status == RNG_DONE ? PHASE_ACTION_END
                                                      : PHASE_ACTION_CONTINUE,
         .gf_cmd = gf_cmd,
     };
+}
+
+static bool M_RequestFadeToBlack(PHASE *const phase, FADER_ARGS *const out_args)
+{
+    const M_PRIV *const p = phase->priv;
+    if (p->mode != INV_TITLE_MODE || !p->fade_to_black) {
+        return false;
+    }
+
+    if (out_args != nullptr) {
+        *out_args = (FADER_ARGS) {
+            .from_current = false,
+            .initial = 0.0f,
+            .target = 1.0f,
+            .duration = 0.25f,
+            .debuff = 0.1f,
+        };
+    }
+    return true;
 }
 
 static void M_End(PHASE *const phase)
@@ -71,11 +95,14 @@ PHASE *Phase_Inventory_Create(const INVENTORY_MODE mode)
     PHASE *const phase = Memory_Alloc(sizeof(PHASE));
     M_PRIV *const p = Memory_Alloc(sizeof(M_PRIV));
     p->mode = mode;
+    p->fade_to_black = false;
     phase->priv = p;
     phase->start = M_Start;
     phase->end = M_End;
     phase->control = M_Control;
     phase->draw = M_Draw;
+    phase->request_fade_to_black =
+        mode == INV_TITLE_MODE ? M_RequestFadeToBlack : nullptr;
     return phase;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This lets the game cross-fade directly to a loading screen even from the title screen.

#### Testing

- Loading screens on/off
- Fade effects on/off
- Inventory ring fade effects on/off
- TR2 Assault Course opening lines, which are played with LUA, should continue to play _after_ the game finishes the fade effect, on the first frame. (I know this is super unintuitive why it'd play it before a fade-out, but it'll really do that if we use the wrong Lua event.)