### PR TITLE
camera/los_camera: detect manual camera changes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
     - `on_control` → `before_control`
     - `on_control_post` → `after_control`
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
+- fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 
 **TR3**:
 - added new blood effects

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -29,6 +29,8 @@ typedef struct {
         XYZ_16 torso_rot;
     } lara;
     CAMERA_TYPE cam_type;
+    int16_t additional_angle;
+    int16_t additional_elevation;
 } M_STATE;
 
 typedef struct {
@@ -231,13 +233,18 @@ static bool M_UpdateLaraState(void)
         && m_LastState.lara.goal_anim_state == lara_item->goal_anim_state
         && XYZ_16_AreEquivalent(&m_LastState.lara.head_rot, &lara->head_rot)
         && XYZ_32_AreEquivalent(&m_LastState.lara.pos, &lara_item->pos);
+    bool same_camera_state = m_LastState.cam_type == g_Camera.type;
     if (g_Camera.type != CAM_LOOK) {
         same_lara_state &=
             XYZ_16_AreEquivalent(&m_LastState.lara.rot, &lara_item->rot)
             && XYZ_16_AreEquivalent(
                 &m_LastState.lara.torso_rot, &lara->torso_rot);
+        same_camera_state &=
+            m_LastState.additional_angle == g_Camera.additional_angle
+            && m_LastState.additional_elevation
+                == g_Camera.additional_elevation;
     }
-    if (same_lara_state && m_LastState.cam_type == g_Camera.type) {
+    if (same_lara_state && same_camera_state) {
         return false;
     }
 
@@ -248,6 +255,8 @@ static bool M_UpdateLaraState(void)
     if (g_Camera.type != CAM_LOOK) {
         m_LastState.lara.rot = lara_item->rot;
         m_LastState.lara.torso_rot = lara->torso_rot;
+        m_LastState.additional_angle = g_Camera.additional_angle;
+        m_LastState.additional_elevation = g_Camera.additional_elevation;
     }
 
     return true;


### PR DESCRIPTION
Resolves #4670.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the TR3 camera is aware of when the manual camera has been changed, and Lara is idle.
