### PR TITLE
Fix small problems when running /title etc in the key inventory ring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 - fixed grenades not killing more than a single enemy
+- fixed running `/title` and similar while in the key items inventory ring briefly persisting the "Examine" button (old regression)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,8 @@
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 - fixed grenades not killing more than a single enemy
-- fixed running `/title` and similar while in the key items inventory ring briefly persisting the "Examine" button (old regression)
+- fixed running `/title` and similar commands leaving the "Examine" button briefly visible in the key items ring (old regression)
+- fixed running `/title` and similar commands when examining an item causing incorrect item rotation next time the ring opens (old regression)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -874,6 +874,11 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
         Inv_InsertItem(InvRing_GetByObjectID(O_PHOTO_OPTION));
     }
 
+    g_InvRing_Source[RT_KEYS].current = 0;
+    for (int32_t i = 0; i < g_InvRing_Source[RT_KEYS].count; i++) {
+        InvRing_InitInvItem(g_InvRing_Source[RT_KEYS].items[i]);
+    }
+
     g_InvRing_Source[RT_MAIN].current = 0;
     for (int32_t i = 0; i < g_InvRing_Source[RT_MAIN].count; i++) {
         InvRing_InitInvItem(g_InvRing_Source[RT_MAIN].items[i]);

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -153,6 +153,9 @@ void InvRing_InitRing(
 
     ring->motion_timer.type = CLOCK_TIMER_SIM;
     ClockTimer_Sync(&ring->motion_timer);
+
+    m_ShowExamine = false;
+    m_ShowUseItemButton = false;
 }
 
 void InvRing_InitInvItem(INVENTORY_ITEM *const inv_item)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the following:
- running `/title` and similar commands leaving the "Examine" button briefly visible in the key items ring
- running `/title` and similar commands when examining an item causing incorrect item rotation next time the ring opens 