### PR TITLE
config: hide enable 3d pickups option for TR3

### DIFF
--- a/data/tr3/ship/cfg/tr3-la/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-la/gameflow.json5
@@ -172,6 +172,7 @@
     ],
 
     "hidden_config": [
+        "enable_3d_pickups", // TR3 has no sprite pickups
         "enable_save_crystals",
         "enable_ps1_crystals",
         "enable_reflections",

--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -604,6 +604,7 @@
     ],
 
     "hidden_config": [
+        "enable_3d_pickups", // TR3 has no sprite pickups
         "enable_item_examining",
         "disable_trex_collision",
         "fix_alligator_ai",


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This hides the "enable 3d pickups" option in TR3, as TR3 does not ship with pickup sprites.

I was considering supplying authored sprites, but there are just too many items to cover this.
I didn't add a changelog because I think it's negligible. 