### PR TITLE
Fix TR3 water effects and animated textures

### DIFF
--- a/data/common/ship/shaders/lights.glsl
+++ b/data/common/ship/shaders/lights.glsl
@@ -47,7 +47,7 @@ float ogPhaseTurns(vec3 worldPos, int scheme)
     float offTurns = lane / 16.0;  // 0,1/16,...15/16
 
     // time base is uTimeInGame with period 64
-    float tTurns = fract(uTimeInGame / 64.0);
+    float tTurns = fract(uTimeInGame * 0.5 / 64.0);
     return tTurns + offTurns;
 }
 

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -38,8 +38,15 @@ vec3 waterWibble(vec4 position)
 {
     vec3 ndc = position.xyz / position.w;
     vec2 pixelPos = (ndc.xy * 0.5 + 0.5) * uViewportSize;
+#if TR_VERSION == 3
+    float phases = (uTimeInGame * 0.25 + pixelPos.x) * (2.0 * PI / WIBBLE_SIZE);
+    float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
+    float adjustedWibble = scale;
+    pixelPos.y += sin(phases) * adjustedWibble;
+#else
     vec2 phases = (uTimeInGame + pixelPos.yx) * (2.0 * PI / WIBBLE_SIZE);
     pixelPos += sin(phases) * MAX_WIBBLE;
+#endif
     // reverse transform
     ndc.xy = (pixelPos / uViewportSize - 0.5) * 2.0;
     return ndc * position.w;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fixed Cobras and Rattlesnakes being immune to explosives in their sleeping state
 - fixed exploding Assault Targets in Lara's Home counting as penalties
 - fixed surface and underwater effects simulation speed
+- fixed underwater wobble effect amplitude
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed colored exhaust smokes on Quad Bike for 1 frame
 - fixed Cobras and Rattlesnakes being immune to explosives in their sleeping state
 - fixed exploding Assault Targets in Lara's Home counting as penalties
+- fixed surface and underwater effects simulation speed
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fixed exploding Assault Targets in Lara's Home counting as penalties
 - fixed surface and underwater effects simulation speed
 - fixed underwater wobble effect amplitude
+- fixed animated textures speed
 
 
 

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -370,8 +370,12 @@ void Output_SetTime(const float time)
     m_Time = time;
 }
 
-void Output_AnimateTextures(const int32_t num_frames)
+void Output_AnimateTextures(int32_t num_frames)
 {
+    if (g_TRVersion == 3) {
+        num_frames *= 2;
+    }
+
     m_TimeInGame += num_frames;
     m_AnimatedTexturesOffset += num_frames;
     bool update = false;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:
- fixes surface and underwater effects simulation speed
- fixes underwater wobble effect amplitude
- fixes animated textures speed

Worth comparing textures animation speed in both TR2 and TR3 to the OG (not necessarily TOMB3) – videos are OK too.