### PR TITLE
Store new objects data in savegames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed Spike Walls not having sound
 - fixed colored exhaust smokes on Quad Bike for 1 frame
 - fixed Cobras and Rattlesnakes being immune to explosives in their sleeping state
+- fixed Quad Bikes not restoring their state from savegames properly
 - fixed exploding Assault Targets in Lara's Home counting as penalties
 
 

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -1,7 +1,4 @@
-#include <trx/game/objects/creatures/cobra.h>
-
 #include <trx/game/creature.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
@@ -10,6 +7,10 @@
 #include <trx/version.h>
 
 static BITE m_CobraBite = { .pos = { 0, 0, 0 }, .mesh_num = 13 };
+
+typedef struct {
+    int16_t hit_points;
+} M_PRIV;
 
 typedef enum {
     COBRA_STATE_WAKING_UP = 0,
@@ -24,6 +25,18 @@ typedef enum {
     COBRA_ANIM_DEATH = 4,
 } M_COBRA_ANIM;
 
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->hit_points = JSON_ObjectGetInt(priv_root, "hit_points", p->hit_points);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "hit_points", p->hit_points);
+}
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -31,9 +44,8 @@ static void M_Initialise(const int16_t item_num)
     Item_SwitchToAnim(item, COBRA_ANIM_SLEEP, 45);
     item->current_anim_state = COBRA_STATE_SLEEP;
     item->goal_anim_state = COBRA_STATE_SLEEP;
-    COBRA_INFO *const priv = GameBuf_Alloc(sizeof(COBRA_INFO), GBUF_ITEM_DATA);
-    priv->hit_points = item->hit_points;
-    item->priv = priv;
+    M_PRIV *const p = item->priv;
+    p->hit_points = item->hit_points;
     item->hit_points = DONT_TARGET;
 }
 
@@ -56,7 +68,7 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const item = Item_Get(item_num);
     CREATURE *const creature = item->data;
-    COBRA_INFO *const priv = item->priv;
+    M_PRIV *const p = item->priv;
 
     if (creature == nullptr) {
         return;
@@ -92,7 +104,7 @@ static void M_Control(const int16_t item_num)
 
     switch (item->current_anim_state) {
     case COBRA_STATE_WAKING_UP:
-        item->hit_points = priv->hit_points;
+        item->hit_points = p->hit_points;
         break;
 
     case COBRA_STATE_ALERT:
@@ -119,12 +131,12 @@ static void M_Control(const int16_t item_num)
     case COBRA_STATE_SLEEP:
         creature->flags = 0;
         if (item->hit_points != DONT_TARGET) {
-            priv->hit_points = item->hit_points;
+            p->hit_points = item->hit_points;
             item->hit_points = DONT_TARGET;
         }
         if (info.distance < alert_radius && lara_item->hit_points > 0) {
             item->goal_anim_state = COBRA_STATE_WAKING_UP;
-            item->hit_points = priv->hit_points;
+            item->hit_points = p->hit_points;
         }
         break;
     }
@@ -142,6 +154,9 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
 
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = 8;

--- a/src/trx/game/objects/creatures/cobra.h
+++ b/src/trx/game/objects/creatures/cobra.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <stdint.h>
-
-typedef struct {
-    int16_t hit_points;
-} COBRA_INFO;

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -1,5 +1,4 @@
 #include <trx/game/creature.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
@@ -38,10 +37,18 @@ typedef struct {
     bool spawn_checked;
 } M_PRIV;
 
-static void M_Initialise(const int16_t item_num)
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
 {
-    ITEM *const item = Item_Get(item_num);
-    item->priv = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
+    M_PRIV *const p = item->priv;
+    p->knockdown_timer = JSON_ObjectGetInt(priv_root, "knockdown_timer", 0);
+    p->spawn_checked = JSON_ObjectGetBool(priv_root, "spawn_checked", false);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "knockdown_timer", p->knockdown_timer);
+    JSON_ObjectAppendBool(priv_root, "spawn_checked", p->spawn_checked);
 }
 
 static bool M_RemoveNormalWinston(void)
@@ -229,7 +236,9 @@ static void M_Setup(OBJECT *const obj)
         return;
     }
 
-    obj->initialise_func = M_Initialise;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
 
@@ -239,6 +248,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->intelligent = true;
     obj->save_position = true;
+    obj->save_hitpoints = true;
     obj->save_flags = true;
     obj->save_anim = true;
 }

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -1,5 +1,4 @@
 #include <trx/game/const.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/gym.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -20,6 +19,22 @@ typedef struct {
     int32_t bounce_stage;
     bool destroyed;
 } M_PRIV;
+
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->x_rot_speed = JSON_ObjectGetInt(priv_root, "x_rot_speed", 0);
+    p->bounce_stage = JSON_ObjectGetInt(priv_root, "bounce_stage", 0);
+    p->destroyed = JSON_ObjectGetBool(priv_root, "destroyed", false) != 0;
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "x_rot_speed", p->x_rot_speed);
+    JSON_ObjectAppendInt(priv_root, "bounce_stage", p->bounce_stage);
+    JSON_ObjectAppendBool(priv_root, "destroyed", p->destroyed ? 1 : 0);
+}
 
 static void M_ResetItemState(ITEM *const item, const OBJECT *const obj)
 {
@@ -49,9 +64,6 @@ static void M_Initialise(const int16_t item_num)
         LOT_DisableBaddieAI(item_num);
     }
 
-    if (item->priv == nullptr) {
-        item->priv = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
-    }
     M_PRIV *const p = item->priv;
     p->x_rot_speed = 0;
     p->bounce_stage = 0;
@@ -193,6 +205,9 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
     obj->hit_points = 8;
     obj->shadow_size = 128;
     obj->radius = 102;

--- a/src/trx/game/objects/general/electrical_light.c
+++ b/src/trx/game/objects/general/electrical_light.c
@@ -1,5 +1,4 @@
 #include <trx/game/collision.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
@@ -8,12 +7,6 @@
 typedef struct {
     int32_t life;
 } M_PRIV;
-
-static void M_Initialise(const int16_t item_num)
-{
-    ITEM *const item = Item_Get(item_num);
-    item->priv = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
-}
 
 static void M_Control(const int16_t item_num)
 {
@@ -59,9 +52,23 @@ static void M_Control(const int16_t item_num)
     Output_AddDynamicLightRGB(item->pos, 16, (RGB_888) { rg, rg, b });
 }
 
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->life = JSON_ObjectGetInt(priv_root, "life", 0);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "life", p->life);
+}
+
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = M_Initialise;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
     obj->control_func = M_Control;
     obj->draw_func = nullptr;
     obj->save_flags = true;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -7,6 +7,7 @@
 #include <trx/game/rooms/enum.h>
 #include <trx/game/savegame/enum.h>
 #include <trx/game/types.h>
+#include <trx/json.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -66,6 +67,8 @@ typedef struct OBJECT {
     void (*activate_func)(ITEM *item);
     void (*handle_flip_func)(ITEM *item, ROOM_FLIP_STATUS flip_status);
     void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
+    void (*priv_load_func)(ITEM *item, const JSON_OBJECT *root);
+    void (*priv_save_func)(const ITEM *item, JSON_OBJECT *root);
     const OBJECT_BOUNDS *(*bounds_func)(void);
     bool (*is_usable_func)(int16_t item_num);
     void (*add_walkable_func)(int16_t item_num);

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -59,12 +59,67 @@ static bool m_CanHandbrakeStart;
 static uint8_t m_ExhaustSmokeVel;
 
 typedef struct {
-    QUAD_BIKE_INFO quad;
+    int32_t velocity;
+    int16_t front_rot;
+    int16_t rear_rot;
+    int32_t revs;
+    int32_t engine_revs;
+    int16_t track_mesh;
+    int32_t skidoo_turn;
+    int32_t left_fall_speed;
+    int32_t right_fall_speed;
+    int16_t momentum_angle;
+    int16_t extra_rotation;
+    int32_t pitch;
+    uint8_t flags;
+} M_QUAD_BIKE_INFO;
+
+typedef struct {
+    M_QUAD_BIKE_INFO quad;
     int16_t *extra_rotation;
     int32_t extra_rotation_count;
     int32_t rear_rot_x_idx[2];
     int32_t front_rot_x_idx[2];
 } M_PRIV;
+
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->quad.velocity = JSON_ObjectGetInt(priv_root, "velocity", 0);
+    p->quad.front_rot = JSON_ObjectGetInt(priv_root, "front_rot", 0);
+    p->quad.rear_rot = JSON_ObjectGetInt(priv_root, "rear_rot", 0);
+    p->quad.revs = JSON_ObjectGetInt(priv_root, "revs", 0);
+    p->quad.engine_revs = JSON_ObjectGetInt(priv_root, "engine_revs", 0);
+    p->quad.track_mesh = JSON_ObjectGetInt(priv_root, "track_mesh", 0);
+    p->quad.skidoo_turn = JSON_ObjectGetInt(priv_root, "skidoo_turn", 0);
+    p->quad.left_fall_speed =
+        JSON_ObjectGetInt(priv_root, "left_fall_speed", 0);
+    p->quad.right_fall_speed =
+        JSON_ObjectGetInt(priv_root, "right_fall_speed", 0);
+    p->quad.momentum_angle = JSON_ObjectGetInt(priv_root, "momentum_angle", 0);
+    p->quad.extra_rotation = JSON_ObjectGetInt(priv_root, "extra_rotation", 0);
+    p->quad.pitch = JSON_ObjectGetInt(priv_root, "pitch", 0);
+    p->quad.flags = (uint8_t)JSON_ObjectGetInt(priv_root, "flags", 0);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "velocity", p->quad.velocity);
+    JSON_ObjectAppendInt(priv_root, "front_rot", p->quad.front_rot);
+    JSON_ObjectAppendInt(priv_root, "rear_rot", p->quad.rear_rot);
+    JSON_ObjectAppendInt(priv_root, "revs", p->quad.revs);
+    JSON_ObjectAppendInt(priv_root, "engine_revs", p->quad.engine_revs);
+    JSON_ObjectAppendInt(priv_root, "track_mesh", p->quad.track_mesh);
+    JSON_ObjectAppendInt(priv_root, "skidoo_turn", p->quad.skidoo_turn);
+    JSON_ObjectAppendInt(priv_root, "left_fall_speed", p->quad.left_fall_speed);
+    JSON_ObjectAppendInt(
+        priv_root, "right_fall_speed", p->quad.right_fall_speed);
+    JSON_ObjectAppendInt(priv_root, "momentum_angle", p->quad.momentum_angle);
+    JSON_ObjectAppendInt(priv_root, "extra_rotation", p->quad.extra_rotation);
+    JSON_ObjectAppendInt(priv_root, "pitch", p->quad.pitch);
+    JSON_ObjectAppendInt(priv_root, "flags", p->quad.flags);
+}
 
 static int32_t M_CountExtraRotationValues(const XYZ_BOOL flags)
 {
@@ -136,8 +191,8 @@ static void M_CalcExtraRotationLayout(const OBJECT *const obj, M_PRIV *const p)
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
 
-    M_PRIV *const p = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
     p->quad.momentum_angle = item->rot.y;
 
     const OBJECT *const obj = Object_Get(item->object_id);
@@ -149,7 +204,6 @@ static void M_Initialise(const int16_t item_num)
         p->extra_rotation = nullptr;
     }
 
-    item->priv = p;
     item->data = p->extra_rotation;
 }
 
@@ -227,7 +281,7 @@ static void M_Collision(
     lara->gun_status = LGS_HANDS_BUSY;
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    QUAD_BIKE_INFO *const quad = &p->quad;
+    M_QUAD_BIKE_INFO *const quad = &p->quad;
 
     const int16_t angle =
         (int16_t)Math_Atan(
@@ -320,7 +374,7 @@ static bool M_CheckGetOff(void)
     } else if (
         lara_item->frame_num == Anim_GetAnim(lara_item->anim_num)->frame_end) {
         M_PRIV *const p = item->priv;
-        QUAD_BIKE_INFO *const quad = &p->quad;
+        M_QUAD_BIKE_INFO *const quad = &p->quad;
 
         if (lara_item->current_anim_state == M_STATE_FALL_OFF) {
             Item_SwitchToAnim(lara_item, LA(LA_FREEFALL), 0);
@@ -675,7 +729,7 @@ static int32_t M_SkidooDynamics(ITEM *const item)
 {
     m_DontExitQuad = false;
     M_PRIV *const p = item->priv;
-    QUAD_BIKE_INFO *const quad = &p->quad;
+    M_QUAD_BIKE_INFO *const quad = &p->quad;
 
     XYZ_32 old_pos;
     old_pos.x = item->pos.x;
@@ -929,7 +983,7 @@ static void M_AnimateQuadBike(
 
     ITEM *const lara_item = Lara_GetItem();
     M_PRIV *const p = item->priv;
-    QUAD_BIKE_INFO *const quad = &p->quad;
+    M_QUAD_BIKE_INFO *const quad = &p->quad;
     state = lara_item->current_anim_state;
 
     if (item->pos.y != item->floor && state != M_STATE_FALL
@@ -1093,7 +1147,7 @@ static void M_AnimateQuadBike(
 
 static bool M_UserControl(ITEM *item, int32_t height, int32_t *pitch)
 {
-    QUAD_BIKE_INFO *quad;
+    M_QUAD_BIKE_INFO *quad;
 
     M_PRIV *const p = item->priv;
     quad = &p->quad;
@@ -1271,7 +1325,7 @@ bool QuadBike_Control(void)
     ITEM *const item = Lara_Vehicle_GetItem();
     ITEM *const lara_item = Lara_GetItem();
     M_PRIV *const p = item->priv;
-    QUAD_BIKE_INFO *const quad = &p->quad;
+    M_QUAD_BIKE_INFO *const quad = &p->quad;
 
     int32_t hit_wall = M_SkidooDynamics(item);
     bool killed = false;
@@ -1463,6 +1517,9 @@ bool QuadBike_Control(void)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
     obj->collision_func = M_Collision;
     obj->draw_func = Object_DrawAnimatingItem;
     obj->save_position = true;

--- a/src/trx/game/objects/vehicles/quad_bike.h
+++ b/src/trx/game/objects/vehicles/quad_bike.h
@@ -1,21 +1,3 @@
 #pragma once
 
-#include <stdint.h>
-
-typedef struct {
-    int32_t velocity;
-    int16_t front_rot;
-    int16_t rear_rot;
-    int32_t revs;
-    int32_t engine_revs;
-    int16_t track_mesh;
-    int32_t skidoo_turn;
-    int32_t left_fall_speed;
-    int32_t right_fall_speed;
-    int16_t momentum_angle;
-    int16_t extra_rotation;
-    int32_t pitch;
-    uint8_t flags;
-} QUAD_BIKE_INFO;
-
 bool QuadBike_Control(void);

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -10,7 +10,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/creatures/cobra.h>
 #include <trx/game/objects/general/lift.h>
 #include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/objects/traps/sliding_pillar.h>
@@ -869,14 +868,6 @@ static bool M_ReadItem(
         M_MUST(M_ReadNum(ctx, "momentum_angle", &data->momentum_angle));
         M_MUST(M_ReadNum(ctx, "extra_rotation", &data->extra_rotation));
         M_MUST(M_ReadNum(ctx, "pitch", &data->pitch));
-        M_MUST(M_Pop(ctx));
-        break;
-    }
-
-    case O_COBRA: {
-        M_MUST(M_PushObject(ctx, "data"));
-        const COBRA_INFO *const data = item->priv;
-        M_MUST(M_ReadNum(ctx, "hit_points", &data->hit_points));
         M_MUST(M_Pop(ctx));
         break;
     }

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -32,10 +32,7 @@
 #define M_NO_ROOM_LEGACY 255
 
 #define M_MAX_STACK_SIZE 10
-#define M_SHOULD(x)                                                            \
-    if (!(x)) {                                                                \
-        goto success;                                                          \
-    }
+#define M_SHOULD(x) ((x) ? 1 : (LOG_WARNING("%s", ctx->error_msg), 0))
 #define M_OPTIONAL(x) (void)(x);
 #define M_MUST(x)                                                              \
     if (!(x)) {                                                                \
@@ -689,8 +686,8 @@ static bool M_ReadItem(
     }
 
     if (obj->save_hitpoints) {
-        M_MUST(M_ReadNum(ctx, "hitpoints", &item->hit_points));
-        // TR1x >= 4.16, TR2X >=1.6 store max hit points information
+        M_SHOULD(M_ReadNum(ctx, "hitpoints", &item->hit_points));
+        // TR1X >= 4.16, TR2X >=1.6 store max hit points information
         M_OPTIONAL(M_ReadNum(ctx, "max_hitpoints", &item->max_hit_points));
     }
 
@@ -1314,40 +1311,39 @@ bool Savegame_BSON_LoadEffects(SAVEGAME_BSON_READ_CONTEXT *const ctx)
     }
 
     // TR1X <=v2.15.3, TR2X <=v1.1 may not have fx effects
-    M_SHOULD(M_PushObject(ctx, "fx"));
-    for (int32_t i = 0;; i++) {
-        if (!M_PushArrayElem(ctx, i)) {
-            break;
-        }
-        if (i < MAX_EFFECTS) {
-            M_ReadEffect(ctx);
-        } else {
-            LOG_WARNING(
-                "Malformed save: expected a max of %d effect, got at least %d. "
-                "extra effects will be ignored.",
-                MAX_EFFECTS - 1, i);
+    if (M_SHOULD(M_PushObject(ctx, "fx"))) {
+        for (int32_t i = 0;; i++) {
+            if (!M_PushArrayElem(ctx, i)) {
+                break;
+            }
+            if (i < MAX_EFFECTS) {
+                M_ReadEffect(ctx);
+            } else {
+                LOG_WARNING(
+                    "Malformed save: expected a max of %d effect, got at least "
+                    "%d. "
+                    "extra effects will be ignored.",
+                    MAX_EFFECTS - 1, i);
+            }
+            M_MUST(M_Pop(ctx));
         }
         M_MUST(M_Pop(ctx));
     }
-    M_MUST(M_Pop(ctx));
     M_FINISH();
 }
 
 bool Savegame_BSON_LoadFlares(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 {
-    if (g_TRVersion == 1) {
-        M_SHOULD(M_PushObject(ctx, "flares"));
-    } else {
-        M_MUST(M_PushObject(ctx, "flares"));
-    }
-    for (int32_t i = 0;; i++) {
-        if (!M_PushArrayElem(ctx, i)) {
-            break;
+    if (M_SHOULD(M_PushObject(ctx, "flares"))) {
+        for (int32_t i = 0;; i++) {
+            if (!M_PushArrayElem(ctx, i)) {
+                break;
+            }
+            M_MUST(M_ReadFlare(ctx));
+            M_MUST(M_Pop(ctx));
         }
-        M_MUST(M_ReadFlare(ctx));
         M_MUST(M_Pop(ctx));
     }
-    M_MUST(M_Pop(ctx));
     M_FINISH();
 }
 

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -901,6 +901,15 @@ static bool M_ReadItem(
         break;
     }
 
+    if (obj->priv_size > 0 && obj->priv_load_func != nullptr
+        && M_HasKey(ctx, "priv")) {
+        M_MUST(M_PushObject(ctx, "priv"));
+        JSON_OBJECT *const priv_root = JSON_ValueAsObject(ctx->current);
+        M_MUST(priv_root != nullptr);
+        obj->priv_load_func(item, priv_root);
+        M_MUST(M_Pop(ctx));
+    }
+
     if (g_TRVersion >= 2) {
         // TODO: make this call in both engines consistently
         if (obj->handle_save_func != nullptr) {

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -9,7 +9,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/creatures/cobra.h>
 #include <trx/game/objects/general/lift.h>
 #include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/objects/traps/sliding_pillar.h>
@@ -353,16 +352,6 @@ static void M_WriteItem(
             M_WriteNum(ctx, "momentum_angle", data->momentum_angle);
             M_WriteNum(ctx, "extra_rotation", data->extra_rotation);
             M_WriteNum(ctx, "pitch", data->pitch);
-            M_PopAndSet(ctx, "data");
-        }
-        break;
-    }
-
-    case O_COBRA: {
-        if (item->priv != nullptr) {
-            const COBRA_INFO *const data = item->priv;
-            M_PushObject(ctx);
-            M_WriteNum(ctx, "hit_points", data->hit_points);
             M_PopAndSet(ctx, "data");
         }
         break;

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -387,6 +387,14 @@ static void M_WriteItem(
     default:
         break;
     }
+
+    if (obj->priv_size > 0 && obj->priv_save_func != nullptr) {
+        M_PushObject(ctx);
+        JSON_OBJECT *const priv_root = JSON_ValueAsObject(ctx->current);
+        ASSERT(priv_root != nullptr);
+        obj->priv_save_func(item, priv_root);
+        M_PopAndSet(ctx, "priv");
+    }
 }
 
 static void M_WriteArm(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the following objects:

- `O_ELECTRICAL_LIGHT`
- `O_COBRA`
- `O_WINSTON_ARMY`
- `O_QUAD_BIKE`
- `O_ASSAULT_TARGET`

to save and restore its private information to the BSON savegames.

#### Testing

We just play around with these objects and save/reload.
Please note that the assault course active timer will not be persisted and it's out of scope.