### PR TITLE
strings: fix Hand of Rathmore inconsistent name

### DIFF
--- a/data/tr3/ship/cfg/tr3-la/strings.json5
+++ b/data/tr3/ship/cfg/tr3-la/strings.json5
@@ -70,7 +70,7 @@
                     "name": "Aviary Key",
                 },
                 "puzzle_1": {
-                    "name": "The Hand of Rathmore",
+                    "name": "Hand of Rathmore",
                 }
             }
         },
@@ -78,7 +78,7 @@
             "title": "Reunion",
             "objects": {
                 "puzzle_1": {
-                    "name": "The Hand of Rathmore",
+                    "name": "Hand of Rathmore",
                 }
             }
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fixed surface and underwater effects simulation speed
 - fixed underwater wobble effect amplitude
 - fixed animated textures speed
+- fixed inconsistent Meteor Artifacts names
 
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This drops the `The` prefix from `Hand of Rathmore` in two of the levels making the pickups name consistent across the game.