### PR TITLE
objects/flame-emitter: fix saving tr3 flame emitters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed animated textures speed
 - fixed inconsistent Meteor Artifacts names
 - fixed wrong item selection sound in the inventory ring
+- fixed flame emitters not getting restored when loading from a save
 
 
 

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -785,7 +785,11 @@ static bool M_ReadItem(
         break;
     }
 
-    case O_FLAME_EMITTER: {
+    case O_FLAME_EMITTER:
+    case O_FLAME_EMITTER_BIG:
+    case O_FLAME_EMITTER_SMALL:
+    case O_FLAME_EMITTER_JET:
+    case O_FLAME_EMITTER_SIDE: {
         if ((g_TRVersion >= 2 || ctx->sg_version >= VERSION_3)
             && g_Config.gameplay.enable_enhanced_saves) {
             int32_t effect_num = NO_EFFECT;

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -275,6 +275,10 @@ static void M_WriteItem(
 
     switch (item->object_id) {
     case O_FLAME_EMITTER:
+    case O_FLAME_EMITTER_BIG:
+    case O_FLAME_EMITTER_SMALL:
+    case O_FLAME_EMITTER_JET:
+    case O_FLAME_EMITTER_SIDE:
         if (item->data != nullptr) {
             const int32_t effect_num =
                 fx_order->id_map[(int32_t)(intptr_t)item->data - 1];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the bug that can be observed with the following steps in Lara's Home (thanks aredfan):
1. `/play 0`
2. `/save 1`
3. `/load 1`
4. Exit the bedroom and step on the antitrigger
5. `/tp 55`

Develop: the fireplace doesn't get deactivated
PR: the fireplace remains inactive