### PR TITLE
objects/spike-ceiling: support fast descent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - added examine item feature for certain items
 - added Tony control
 - added Spikes animation in Coastal Village and Madubu Gorge
+- added Aldwych Drill control (Spike Ceiling with timer=1 to descend faster)
 - fixed actors jumping to their start frame at the end of cutscenes
 - fixed Swamp Map rotation
 - fixed seaweed disappearing too quickly in certain levels

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -7,11 +7,67 @@
 
 #define M_DAMAGE 20
 #define M_SPEED 1
+#define M_STEP_SLOW 5
+#define M_STEP_FAST 10
+
+typedef struct {
+    int32_t step;
+    bool animate;
+} M_PRIV;
+
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->step = JSON_ObjectGetInt(priv_root, "step", M_STEP_SLOW);
+    p->animate = JSON_ObjectGetBool(priv_root, "animate", false);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "step", p->step);
+    JSON_ObjectAppendBool(priv_root, "animate", p->animate);
+}
+
+static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
+{
+    M_PRIV *const p = item->priv;
+    if (p == nullptr) {
+        return true;
+    }
+
+    if (trigger->type == TT_ANTITRIGGER || trigger->type == TT_ANTIPAD) {
+        return true;
+    }
+
+    item->timer = 0;
+    if (trigger->timer == 1) {
+        p->step = M_STEP_FAST;
+        p->animate = true;
+    } else {
+        p->step = M_STEP_SLOW;
+        p->animate = false;
+    }
+    return true;
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    Trap_Initialise(item_num);
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    if (p != nullptr) {
+        p->step = M_STEP_SLOW;
+        p->animate = false;
+    }
+}
 
 static void M_Move(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const int32_t y = item->pos.y + 5;
+    const M_PRIV *const p = item->priv;
+    const int32_t step = (p != nullptr && p->step > 0) ? p->step : M_STEP_SLOW;
+    const int32_t y = item->pos.y + step;
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
         Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
@@ -21,8 +77,8 @@ static void M_Move(const int16_t item_num)
     } else {
         item->pos.y = y;
         Item_UpdateRoom(item_num, room_num);
+        Sound_Effect(SFX_SPIKE_WALL, &item->pos, SPM_NORMAL);
     }
-    Sound_Effect(SFX_SPIKE_WALL, &item->pos, SPM_NORMAL);
 }
 
 static void M_HitLara(ITEM *const item)
@@ -51,13 +107,24 @@ static void M_Control(const int16_t item_num)
     if (item->touch_bits) {
         M_HitLara(item);
     }
+
+    if (Item_IsTriggerActive(item) && item->status != IS_DEACTIVATED) {
+        const M_PRIV *const p = item->priv;
+        if (p != nullptr && p->animate) {
+            Item_Animate(item);
+        }
+    }
 }
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = Trap_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->trigger_func = M_Trigger;
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
     obj->save_position = true;
     obj->save_flags = true;
 }

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -4,7 +4,7 @@
 #include <trx/game/collision.h>
 #include <trx/game/items/types.h>
 #include <trx/game/pathing/types.h>
-#include <trx/game/rooms/enum.h>
+#include <trx/game/rooms/types.h>
 #include <trx/game/savegame/enum.h>
 #include <trx/game/types.h>
 #include <trx/json.h>
@@ -65,6 +65,7 @@ typedef struct OBJECT {
     int16_t (*ceiling_height_func)(
         const ITEM *item, int32_t x, int32_t y, int32_t z, int16_t height);
     void (*activate_func)(ITEM *item);
+    bool (*trigger_func)(ITEM *item, const TRIGGER *trigger);
     void (*handle_flip_func)(ITEM *item, ROOM_FLIP_STATUS flip_status);
     void (*handle_save_func)(ITEM *item, SAVEGAME_STAGE stage);
     void (*priv_load_func)(ITEM *item, const JSON_OBJECT *root);

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -458,6 +458,8 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 break;
             }
 
+            const OBJECT *const obj = Object_Get(trig_item->object_id);
+
             const bool is_shoal_object =
                 Object_IsType(trig_item->object_id, g_ShoalObjects);
 
@@ -468,6 +470,14 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 trig_item->timer = trigger->timer;
                 if (trig_item->timer != 1) {
                     trig_item->timer *= LOGIC_FPS;
+                }
+
+                if (obj->trigger_func != nullptr) {
+                    const bool use_default_handling =
+                        obj->trigger_func(trig_item, trigger);
+                    if (!use_default_handling) {
+                        break;
+                    }
                 }
             }
 
@@ -499,7 +509,6 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 break;
             }
 
-            const OBJECT *const obj = Object_Get(trig_item->object_id);
             if (obj->activate_func != nullptr) {
                 obj->activate_func(trig_item);
             } else if (obj->intelligent) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adjusts the Ceiling Spikes behavior to match TR3, making them drop twice as fast when their trigger timer is set to 1. This effect is particularly used to implement the Aldwych Drill.