### PR TITLE
output/state: fix simulation speed

### DIFF
--- a/data/common/ship/shaders/lights.glsl
+++ b/data/common/ship/shaders/lights.glsl
@@ -47,7 +47,7 @@ float ogPhaseTurns(vec3 worldPos, int scheme)
     float offTurns = lane / 16.0;  // 0,1/16,...15/16
 
     // time base is uTimeInGame with period 64
-    float tTurns = fract(uTimeInGame * 0.5 / 64.0);
+    float tTurns = fract(uTimeInGame / 64.0);
     return tTurns + offTurns;
 }
 

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -39,7 +39,7 @@ vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
     vec3 ndc = screenPosition.xyz / screenPosition.w;
     vec2 pixelPos = (ndc.xy * 0.5 + 0.5) * uViewportSize;
 #if TR_VERSION == 3
-    float phases = (uTimeInGame * 0.25 + length(worldPosition.xyz)) * (2.0 * PI / WIBBLE_SIZE);
+    float phases = (uTimeInGame * 0.5 + length(worldPosition.xyz)) * (2.0 * PI / WIBBLE_SIZE);
     float scale = length(uViewportSize) / length(vec2(640.0, 480.0));
     float adjustedWibble = scale;
     pixelPos.y += sin(phases) * adjustedWibble;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -374,12 +374,10 @@ void Output_SetTime(const float time)
 
 void Output_AnimateTextures(int32_t num_frames)
 {
-    if (g_TRVersion == 3) {
-        num_frames *= 2;
-    }
+    const int32_t anim_delta = g_TRVersion == 3 ? 2 : 1;
 
     m_TimeInGame += num_frames;
-    m_AnimatedTexturesOffset += num_frames;
+    m_AnimatedTexturesOffset += num_frames * anim_delta;
     bool update = false;
     while (m_AnimatedTexturesOffset > 5) {
         Output_CycleAnimatedTextures();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the regression made in https://github.com/LostArtefacts/TRX/pull/4676 which caused not only the textures in TR3 to operate twice as fast, but many other effects too, as the simulation speed was affected, too.

This is best visible in healing crystals going a bit too hyper in develop.

Unfortunately this means we'll have to re-test the caustics, underwater shading, and texture animation speeds again. Sorry about this.