### PR TITLE
explosion-ring-fx: fix not stopping when paused

### DIFF
--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -459,6 +459,10 @@ static void M_Control(const int16_t item_num)
     Creature_Joint(item, 1, torso_x);
     Creature_Joint(item, 2, torso_y >> 1);
     Creature_Animate(item_num, angle, 0);
+
+    if (p->explode_count != 0 && item->hit_points <= 0) {
+        ExplosionRingFX_Control();
+    }
 }
 
 static void M_DrawShield(const ITEM *const item)

--- a/src/trx/game/objects/effects/explosion_ring_fx.c
+++ b/src/trx/game/objects/effects/explosion_ring_fx.c
@@ -47,12 +47,8 @@ static void M_RotateZX(
     out->z = (yz * sx + zz * cx) >> W2V_SHIFT;
 }
 
-void ExplosionRingFX_Draw(void)
+void ExplosionRingFX_Control(void)
 {
-    const int32_t time4 = Output_GetTimeInGame() * 4;
-    const int32_t sprite_base = Object_Get(O_EXPLOSION_1)->mesh_idx;
-    const int32_t sprite_idx = sprite_base + 4 + ((time4 >> 4) & 3);
-
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_ExplosionRings); i++) {
         EXPLOSION_RING *const ring = &m_ExplosionRings[i];
         if (ring->on == 0) {
@@ -66,6 +62,20 @@ void ExplosionRingFX_Draw(void)
         }
 
         ring->radius += ring->speed;
+    }
+}
+
+void ExplosionRingFX_Draw(void)
+{
+    const int32_t time4 = Output_GetTimeInGame() * 4;
+    const int32_t sprite_base = Object_Get(O_EXPLOSION_1)->mesh_idx;
+    const int32_t sprite_idx = sprite_base + 4 + ((time4 >> 4) & 3);
+
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_ExplosionRings); i++) {
+        EXPLOSION_RING *const ring = &m_ExplosionRings[i];
+        if (ring->on == 0) {
+            continue;
+        }
 
         int32_t rad = ring->radius;
         for (int32_t band = 0; band < 2; band++) {

--- a/src/trx/game/objects/effects/explosion_ring_fx.h
+++ b/src/trx/game/objects/effects/explosion_ring_fx.h
@@ -21,5 +21,8 @@ typedef struct {
 } EXPLOSION_RING;
 
 void ExplosionRingFX_Reset(void);
-EXPLOSION_RING *ExplosionRingFX_GetRing(int32_t idx);
+
+void ExplosionRingFX_Control(void);
 void ExplosionRingFX_Draw(void);
+
+EXPLOSION_RING *ExplosionRingFX_GetRing(int32_t idx);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the explosion rings special effect after Tony's death not stopping when the player opens the photo mode or the pause screen.