### PR TITLE
objects/save-crystal: don't save position

### DIFF
--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -184,7 +184,6 @@ static void M_Setup(OBJECT *const obj)
     if (g_TRVersion == 3) {
         obj->control_func = M_ControlHeal;
         obj->collision_func = nullptr;
-        obj->save_position = true;
         obj->save_flags = true;
     } else if (g_Config.gameplay.enable_save_crystals) {
         obj->control_func = M_ControlSave;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the issue where saving and loading the game repeatedly would nudge the save crystals higher up each time.
