### PR TITLE
objects: use anim/frame helpers

### DIFF
--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -264,9 +264,9 @@ static void M_Control(const int16_t item_num)
             item->current_anim_state = M_STATE_DEATH;
         }
 
-        if (item->frame_num - Anim_GetAnim(item->anim_num)->frame_base > 110) {
+        if (Item_GetRelativeFrame(item) > 110) {
+            Item_SwitchToAnim(item, Item_GetRelativeAnim(item), 110);
             item->mesh_bits = 0;
-            item->frame_num = Anim_GetAnim(item->anim_num)->frame_base + 110;
 
             if (!p->explode_count) {
                 p->ring_count = 0;
@@ -336,8 +336,7 @@ static void M_Control(const int16_t item_num)
             break;
 
         case M_STATE_RISE:
-            if (item->frame_num - Anim_GetAnim(item->anim_num)->frame_base
-                <= 16) {
+            if (Item_GetRelativeFrame(item) <= 16) {
                 tony->maximum_turn = 0;
             } else {
                 tony->maximum_turn = 364;
@@ -378,8 +377,7 @@ static void M_Control(const int16_t item_num)
             torso_y = info.angle;
             torso_x = info.x_angle;
             tony->maximum_turn = 182;
-            if (item->frame_num - Anim_GetAnim(item->anim_num)->frame_base
-                == 28) {
+            if (Item_GetRelativeFrame(item) == 28) {
                 TonyBoss_TriggerFireBall(
                     item, 2, 0, item->room_num, item->rot.y, 0);
             }
@@ -389,8 +387,7 @@ static void M_Control(const int16_t item_num)
             torso_y = info.angle;
             torso_x = info.x_angle;
             tony->maximum_turn = 0;
-            if (item->frame_num - Anim_GetAnim(item->anim_num)->frame_base
-                == 40) {
+            if (Item_GetRelativeFrame(item) == 40) {
                 TonyBoss_TriggerFireBall(item, 0, 0, item->room_num, 0, 0);
                 TonyBoss_TriggerFireBall(item, 1, 0, item->room_num, 0, 0);
             }
@@ -398,8 +395,7 @@ static void M_Control(const int16_t item_num)
 
         case M_STATE_BIG_ROOM:
             tony->maximum_turn = 0;
-            if (item->frame_num - Anim_GetAnim(item->anim_num)->frame_base
-                == 56) {
+            if (Item_GetRelativeFrame(item) == 56) {
                 p->phase = M_PHASE_PHASE2;
                 p->explode_count = 1;
             }
@@ -410,11 +406,9 @@ static void M_Control(const int16_t item_num)
     if (item->current_anim_state == M_STATE_ROCK_ZAPP
         || item->current_anim_state == M_STATE_ZAPP
         || item->current_anim_state == M_STATE_BIG_ROOM) {
-        int32_t f = item->frame_num - Anim_GetAnim(item->anim_num)->frame_base;
-
+        int32_t f = Item_GetRelativeFrame(item);
         if (f > 16) {
             f = Anim_GetAnim(item->anim_num)->frame_end - item->frame_num;
-
             CLAMPG(f, 16);
         }
 

--- a/src/trx/game/objects/traps/spikes.c
+++ b/src/trx/game/objects/traps/spikes.c
@@ -66,7 +66,7 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    if (item->frame_num == Anim_GetAnim(item->anim_num)->frame_base) {
+    if (Item_GetRelativeFrame(item) == 0) {
         if (level_num == 5) {
             Sound_Effect(SFX_SHIVA_SWORD_2, &item->pos, SPM_ALWAYS);
         } else {

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -289,16 +289,15 @@ static void M_Collision(
         - item->rot.y;
 
     if (angle > -0x1FFE && angle < 0x5FFA) {
-        lara_item->anim_num = Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 23;
+        Item_SwitchToObjAnim(lara_item, 23, 0, O_LARA_VEHICLE_ANIM);
         lara_item->current_anim_state = M_STATE_GET_ON_L;
         lara_item->goal_anim_state = M_STATE_GET_ON_L;
     } else {
-        lara_item->anim_num = Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 9;
+        Item_SwitchToObjAnim(lara_item, 9, 0, O_LARA_VEHICLE_ANIM);
         lara_item->current_anim_state = M_STATE_GET_ON_R;
         lara_item->goal_anim_state = M_STATE_GET_ON_R;
     }
 
-    lara_item->frame_num = Anim_GetAnim(lara_item->anim_num)->frame_base;
     item->hit_points = 1;
     lara_item->pos.x = item->pos.x;
     lara_item->pos.y = item->pos.y;
@@ -354,8 +353,7 @@ static bool M_CheckGetOff(void)
 
     if ((lara_item->current_anim_state == M_STATE_GET_OFF_R
          || lara_item->current_anim_state == M_STATE_GET_OFF_L)
-        && lara_item->frame_num
-            == Anim_GetAnim(lara_item->anim_num)->frame_end) {
+        && lara_item->frame_num == Item_GetAnim(lara_item)->frame_end) {
         if (lara_item->current_anim_state == M_STATE_GET_OFF_L) {
             lara_item->rot.y += DEG_90;
         } else {
@@ -371,8 +369,7 @@ static bool M_CheckGetOff(void)
         lara_item->rot.z = 0;
         Lara_Vehicle_SetIndex(NO_ITEM);
         lara->gun_status = LGS_ARMLESS;
-    } else if (
-        lara_item->frame_num == Anim_GetAnim(lara_item->anim_num)->frame_end) {
+    } else if (lara_item->frame_num == Item_GetAnim(lara_item)->frame_end) {
         M_PRIV *const p = item->priv;
         M_QUAD_BIKE_INFO *const quad = &p->quad;
 
@@ -397,7 +394,7 @@ static bool M_CheckGetOff(void)
         }
 
         if (lara_item->current_anim_state == M_STATE_FALL_DEATH) {
-            lara_item->goal_anim_state = 8;
+            lara_item->goal_anim_state = M_STATE_FALL;
             lara_item->fall_speed = 154;
             lara_item->speed = 0;
             quad->flags |= 0x80;
@@ -989,50 +986,43 @@ static void M_AnimateQuadBike(
     if (item->pos.y != item->floor && state != M_STATE_FALL
         && state != M_STATE_LAND && state != M_STATE_FALL_OFF && !killed) {
         if (quad->velocity < 0) {
-            lara_item->anim_num = Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 6;
+            Item_SwitchToObjAnim(lara_item, 6, 0, O_LARA_VEHICLE_ANIM);
         } else {
-            lara_item->anim_num =
-                Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 25;
+            Item_SwitchToObjAnim(lara_item, 25, 0, O_LARA_VEHICLE_ANIM);
         }
 
-        lara_item->frame_num = Anim_GetAnim(lara_item->anim_num)->frame_base;
-        lara_item->current_anim_state = 8;
-        lara_item->goal_anim_state = 8;
+        lara_item->current_anim_state = M_STATE_FALL;
+        lara_item->goal_anim_state = M_STATE_FALL;
     } else if (
         hit_wall != 0 && state != M_STATE_HIT_FRONT && state != M_STATE_HIT_BACK
         && state != M_STATE_HIT_LEFT && state != M_STATE_HIT_RIGHT
         && state != M_STATE_FALL_OFF && quad->velocity > 0x3555 && !killed) {
         switch (hit_wall) {
         case 13:
-            lara_item->anim_num =
-                Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 12;
+            Item_SwitchToObjAnim(lara_item, 12, 0, O_LARA_VEHICLE_ANIM);
             lara_item->current_anim_state = M_STATE_HIT_FRONT;
             lara_item->goal_anim_state = M_STATE_HIT_FRONT;
             break;
 
         case 14:
-            lara_item->anim_num =
-                Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 11;
+            Item_SwitchToObjAnim(lara_item, 11, 0, O_LARA_VEHICLE_ANIM);
             lara_item->current_anim_state = M_STATE_HIT_BACK;
             lara_item->goal_anim_state = M_STATE_HIT_BACK;
             break;
 
         case 11:
-            lara_item->anim_num =
-                Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 14;
+            Item_SwitchToObjAnim(lara_item, 14, 0, O_LARA_VEHICLE_ANIM);
             lara_item->current_anim_state = M_STATE_HIT_LEFT;
             lara_item->goal_anim_state = M_STATE_HIT_LEFT;
             break;
 
         default:
-            lara_item->anim_num =
-                Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 13;
+            Item_SwitchToObjAnim(lara_item, 13, 0, O_LARA_VEHICLE_ANIM);
             lara_item->current_anim_state = M_STATE_HIT_RIGHT;
             lara_item->goal_anim_state = M_STATE_HIT_RIGHT;
             break;
         }
 
-        lara_item->frame_num = Anim_GetAnim(lara_item->anim_num)->frame_base;
         Sound_Effect(SFX_QUAD_FRONT_IMPACT, &item->pos, SPM_NORMAL);
     } else {
         switch (lara_item->current_anim_state) {
@@ -1064,10 +1054,7 @@ static void M_AnimateQuadBike(
             if (!(quad->velocity & 0xFFFFFF00)) {
                 lara_item->goal_anim_state = M_STATE_STOP;
             } else if (g_Input.right) {
-                lara_item->anim_num =
-                    Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 20;
-                lara_item->frame_num =
-                    Anim_GetAnim(lara_item->anim_num)->frame_base;
+                Item_SwitchToObjAnim(lara_item, 20, 0, O_LARA_VEHICLE_ANIM);
                 lara_item->current_anim_state = M_STATE_TURN_R;
                 lara_item->goal_anim_state = M_STATE_TURN_R;
             } else if (!g_Input.left) {
@@ -1124,10 +1111,7 @@ static void M_AnimateQuadBike(
             if (!(quad->velocity & 0xFFFFFF00)) {
                 lara_item->goal_anim_state = M_STATE_STOP;
             } else if (g_Input.left) {
-                lara_item->anim_num =
-                    Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx + 3;
-                lara_item->frame_num =
-                    Anim_GetAnim(lara_item->anim_num)->frame_base;
+                Item_SwitchToObjAnim(lara_item, 3, 0, O_LARA_VEHICLE_ANIM);
                 lara_item->current_anim_state = M_STATE_TURN_L;
                 lara_item->goal_anim_state = M_STATE_TURN_L;
             } else if (!g_Input.right) {
@@ -1453,9 +1437,8 @@ bool QuadBike_Control(void)
         Item_Animate(lara_item);
         item->anim_num = lara_item->anim_num + Object_Get(O_QUAD_BIKE)->anim_idx
             - Object_Get(O_LARA_VEHICLE_ANIM)->anim_idx;
-        item->frame_num = lara_item->frame_num
-            + Anim_GetAnim(item->anim_num)->frame_base
-            - Anim_GetAnim(lara_item->anim_num)->frame_base;
+        item->frame_num = lara_item->frame_num + Item_GetAnim(item)->frame_base
+            - Item_GetAnim(lara_item)->frame_base;
         g_Camera.target_elevation = -5460;
 
         if (quad->flags & 0x40 && item->pos.y == item->floor) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This addresses the Lahm's suggestion to use relative anim helpers we have in the `items/` module.
Affected objects:
- Tony
- Quad Bike
- Spikes