### PR TITLE
lara/col: fix hanging tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - fixed inconsistent Meteor Artifacts names
 - fixed wrong item selection sound in the inventory ring
 - fixed flame emitters not getting restored when loading from a save
+- fixed Lara holding onto ledges after dying if the Action key wasn't released
 
 
 

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -303,6 +303,11 @@ static void M_NeutralJumpRoll(ITEM *const item, COLL_INFO *const coll)
 
 static void M_UpJump(ITEM *const item, COLL_INFO *const coll)
 {
+    if (g_TRVersion == 3 && item->hit_points <= 0) {
+        item->goal_anim_state = LS(LS_STOP);
+        return;
+    }
+
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->move_angle = item->rot.y;
     coll->bad_pos = NO_BAD_POS;

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -3,6 +3,7 @@
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
+#include <trx/version.h>
 
 // clang-format off
 #define M_CAM_HANG_ANGLE             0
@@ -19,6 +20,11 @@
 
 static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 {
+    if (g_TRVersion == 3 && item->hit_points <= 0) {
+        item->goal_anim_state = LS(LS_STOP);
+        return;
+    }
+
     if (g_Config.gameplay.look_mode != LOOK_MODE_RESTRICTED && g_Input.look) {
         Lara_Look_UpDown();
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara not letting go of the ledges when she dies, as long as the player continues to hold the Action key.
This is especially visible with the Aldwych Drill.