### PR TITLE
settings: dim bouncy grenades option for TR1

### DIFF
--- a/src/trx/game/ui/dialogs/setting_helpers/handlers.c
+++ b/src/trx/game/ui/dialogs/setting_helpers/handlers.c
@@ -207,6 +207,11 @@ bool UI_Settings_Flare_IsAvailable(const UI_SETTINGS_OPTION *const option)
     return g_Weapons[LGT_FLARE].is_available;
 }
 
+bool UI_Settings_Grenade_IsAvailable(const UI_SETTINGS_OPTION *const option)
+{
+    return g_Weapons[LGT_GRENADE].is_available;
+}
+
 bool UI_Settings_Harpoon_IsAvailable(const UI_SETTINGS_OPTION *const option)
 {
     return g_Weapons[LGT_HARPOON].is_available;

--- a/src/trx/game/ui/dialogs/setting_helpers/handlers.h
+++ b/src/trx/game/ui/dialogs/setting_helpers/handlers.h
@@ -56,5 +56,6 @@ bool UI_Settings_Volume_RequestChange(
     const UI_SETTINGS_OPTION *option, int32_t dir);
 
 bool UI_Settings_Flare_IsAvailable(const UI_SETTINGS_OPTION *option);
+bool UI_Settings_Grenade_IsAvailable(const UI_SETTINGS_OPTION *option);
 bool UI_Settings_Harpoon_IsAvailable(const UI_SETTINGS_OPTION *option);
 bool UI_Settings_M16_IsAvailable(const UI_SETTINGS_OPTION *option);

--- a/src/trx/game/ui/dialogs/setting_tabs/gameplay_general.def
+++ b/src/trx/game/ui/dialogs/setting_tabs/gameplay_general.def
@@ -20,7 +20,7 @@ X_UI_CFG_BOOL(gameplay.enable_deaths_counter,       SETTING_ENABLE_DEATHS_COUNTE
 
 X_UI_CFG_INT32(gameplay.maximum_save_slots,         SETTING_MAXIMUM_SAVE_SLOTS, .min_value = 1, .max_value = 1000, .delta_fast = 10, .delta_slow = 1)
 X_UI_CFG_BOOL(gameplay.enable_enhanced_saves,       SETTING_ENABLE_ENHANCED_SAVES)
-X_UI_CFG_BOOL(gameplay.enable_bouncy_grenades,      SETTING_ENABLE_BOUNCY_GRENADES)
+X_UI_CFG_BOOL(gameplay.enable_bouncy_grenades,      SETTING_ENABLE_BOUNCY_GRENADES, .custom_handler = { .is_available = UI_Settings_Grenade_IsAvailable })
 X_UI_CFG_BOOL(gameplay.remember_gun_status,         SETTING_REMEMBER_GUNS_BETWEEN_LEVELS)
 
 X_UI_CFG_BOOL(gameplay.restore_ps1_enemies,         SETTING_RESTORE_PS1_ENEMIES)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This dims the bouncy grenades option for TR1 as the Grenade Launcher is only obtainable via cheats in this game.