### PR TITLE
objects/save-crystal: fix freeze in TR1

### DIFF
--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -56,8 +56,12 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    if (!g_Config.gameplay.enable_save_crystals && g_TRVersion != 3) {
-        item->status = IS_INVISIBLE;
+    if (g_TRVersion != 3) {
+        if (g_Config.gameplay.enable_save_crystals) {
+            Item_AddActive(item_num);
+        } else {
+            Item_Get(item_num)->status = IS_INVISIBLE;
+        }
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the regression introduced by the heal crystals implementation, that caused the TR1 crystals to no longer animate.