### PR TITLE
rooms/floor_data: always set sink LOT data

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 **TR2**:
 - fixed wrong line played when finishing the Assault Course for the first time (#4667, regression from 1.1)
 - fixed underwater wobble effect acting twitchy with camera movement
+- fixed a deviation in water current behaviour that could result in Lara stopping too early (#4706, regression from TR2X 1.1)
 
 **TR3**:
 - added a new UI bar appearance, "TR3 PC" (Graphic Options → Bars → Bars appearance)

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -583,7 +583,8 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 const OBJECT_VECTOR *const sink =
                     Camera_GetFixedObject((int16_t)(intptr_t)cmd->parameter);
 
-                if (lara_info->lot.required_box != sink->flags) {
+                if (g_TRVersion == 2
+                    || lara_info->lot.required_box != sink->flags) {
                     lara_info->lot.target = sink->pos;
                     lara_info->lot.required_box = sink->flags;
                 }


### PR DESCRIPTION
Resolves #4706.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves a regression in c3fc8a847 whereby in TR2 originally Lara's sink target was always set if she was on a sink trigger, meaning she wouldn't stop if the sink was in the same box.

We could version guard this, but I've checked TR1 and it's looking correct as well in terms of where the triggers and sinks are. For sanity, a test around Lost Valley, Sanctuary, Natla's Mines and end of The Hive would be good to ensure they're working as expected.
