### PR TITLE
rooms: remove max drawn rooms limit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - added visual previews of bar colors (Graphic Options → Bars)
 - added endless sprint (available previously via the `/restless` command) to the UI settings (Gameplay options → Mods → Endless sprint)
 - added endless flare time cheat (Gameplay options → Mods → Endless flare time)
+- changed rooms-to-draw tracking to no longer stop at the 100-room limit
 - improved inventory ring active item highlight for smoother appearance
 - changed all UI bar colors from hardcoded to configurable via `cfg/ui.json5`, enabling some customization for PS1 bars
 - changed `enable_debug_pos` to split into `enable_debug_pos` and `enable_debug_anim`

--- a/src/trx/game/rooms/const.h
+++ b/src/trx/game/rooms/const.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #define MAX_ROOMS 1024
-#define MAX_ROOMS_TO_DRAW 100
 #define MAX_FLIP_MAPS 10
 
 #define NO_ROOM (-1)

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -11,6 +11,7 @@
 #include <trx/game/water_fx.h>
 #include <trx/game/weather_fx.h>
 #include <trx/utils.h>
+#include <trx/vector.h>
 #include <trx/version.h>
 
 #include <string.h>
@@ -78,8 +79,7 @@ static inline void M_DrawSet_ForEach(
     }
 }
 
-static int32_t m_DrawCount = 0;
-static int16_t m_RoomsToDraw[MAX_ROOMS_TO_DRAW] = {};
+static VECTOR *m_RoomsToDraw = nullptr;
 
 static int32_t m_Outside;
 static int32_t m_OutsideRight;
@@ -90,6 +90,14 @@ static int32_t m_OutsideBottom;
 static int32_t m_BoundStart;
 static int32_t m_BoundEnd;
 static int32_t m_BoundRooms[M_MAX_BOUND_ROOMS] = {};
+
+static void M_EnsureRoomsToDraw(void)
+{
+    if (m_RoomsToDraw != nullptr) {
+        return;
+    }
+    m_RoomsToDraw = Vector_CreateAtCapacity(sizeof(int16_t), 100);
+}
 
 static inline void M_SetupWaterStatus(const ROOM *const room)
 {
@@ -414,32 +422,26 @@ static void M_DrawSingleRoom(const ROOM *const room)
 
 void Room_DrawReset(void)
 {
-    m_DrawCount = 0;
+    M_EnsureRoomsToDraw();
+    Vector_Clear(m_RoomsToDraw);
 }
 
 void Room_MarkToBeDrawn(const int16_t room_num)
 {
-    if (m_DrawCount + 1 == MAX_ROOMS_TO_DRAW) {
+    if (Vector_Contains(m_RoomsToDraw, &room_num)) {
         return;
     }
-
-    for (int32_t i = 0; i < m_DrawCount; i++) {
-        if (m_RoomsToDraw[i] == room_num) {
-            return;
-        }
-    }
-
-    m_RoomsToDraw[m_DrawCount++] = room_num;
+    Vector_Add(m_RoomsToDraw, &room_num);
 }
 
 int32_t Room_DrawGetCount(void)
 {
-    return m_DrawCount;
+    return m_RoomsToDraw->count;
 }
 
 int16_t Room_DrawGetRoom(const int16_t idx)
 {
-    return m_RoomsToDraw[idx];
+    return *(int16_t *)Vector_Get(m_RoomsToDraw, idx);
 }
 
 void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
@@ -524,4 +526,10 @@ void Room_RemoveDrawnItem(const int16_t room_num, const int16_t item_num)
         ROOM *const room = Room_Get(room_num);
         M_DrawSet_Remove(&room->drawn_items, item_num);
     }
+}
+
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    Vector_Free(m_RoomsToDraw);
+    m_RoomsToDraw = nullptr;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

There's still a hidden limit of binding 128 rooms at maximum, but this doesn't seem to be a problem: when I cap this list to just 50 entries, it still renders the big area just fine with no clipping.