### PR TITLE
savegame: do not write empty music track flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - added endless flare time cheat (Gameplay options → Mods → Endless flare time)
 - changed rooms-to-draw tracking to no longer stop at the 100-room limit
 - improved inventory ring active item highlight for smoother appearance
+- improved savegame file size by reducing it about 20–30%.
 - changed all UI bar colors from hardcoded to configurable via `cfg/ui.json5`, enabling some customization for PS1 bars
 - changed `enable_debug_pos` to split into `enable_debug_pos` and `enable_debug_anim`
 - changed `enable_invulnerability` to only show the marker if the setting `enable_debug_status` is on (off by default) (#4631)

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -185,6 +185,18 @@ static void M_WriteNumNZ_Double(
         float: M_WriteNumNZ_Double,                                            \
         double: M_WriteNumNZ_Double)(ctx, key, value)
 
+static int32_t M_GetMusicTrackFlagsCount(void)
+{
+    int32_t last_index = -1;
+    for (int32_t i = 0; i < MAX_MUSIC_TRACKS; i++) {
+        const uint16_t flags = Music_GetTrackFlags(i);
+        if (flags != 0) {
+            last_index = i;
+        }
+    }
+    return last_index + 1;
+}
+
 // =============================================================================
 // End of internal helpers
 // =============================================================================
@@ -669,9 +681,10 @@ void Savegame_BSON_DumpCameras(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
 
 void Savegame_BSON_DumpMusic(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
 {
+    const int32_t track_flag_count = M_GetMusicTrackFlagsCount();
     M_PushObject(ctx);
     M_PushArray(ctx);
-    for (int32_t i = 0; i < MAX_MUSIC_TRACKS; i++) {
+    for (int32_t i = 0; i < track_flag_count; i++) {
         M_PushNum(ctx, Music_GetTrackFlags(i));
         M_PopAndAppend(ctx);
     }
@@ -695,7 +708,7 @@ void Savegame_BSON_DumpMusic(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
 
     // TR1X <4.16
     M_PushArray(ctx);
-    for (int32_t i = 0; i < MAX_MUSIC_TRACKS; i++) {
+    for (int32_t i = 0; i < track_flag_count; i++) {
         M_PushNum(ctx, Music_GetTrackFlags(i));
         M_PopAndAppend(ctx);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This shrinks the size of the savegame files from 6 KB to around 4 KB.
I did it mostly because it was annoying to use `tools/inspect_save`.