### PR TITLE
monkey: do not hardcode hostility

### DIFF
--- a/data/tr3/ship/cfg/tr3-la/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-la/gameflow.json5
@@ -124,6 +124,7 @@
         // 5. It's a Madhouse!
         {
             "path": "data/zoo.tr2",
+            "script": "data/scripts/zoo.lua",
             "music_track": 34,
             "sequence": [
                 {"type": "loading_screen", "path": "data/images/zoo.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -63,6 +63,7 @@
         // 1. Jungle
         {
             "path": "data/jungle.tr2",
+            "script": "data/scripts/jungle.lua",
             "music_track": 34,
             "weather_type": "rain",
             "sequence": [

--- a/data/tr3/ship/data/scripts/jungle.lua
+++ b/data/tr3/ship/data/scripts/jungle.lua
@@ -1,0 +1,3 @@
+trx.events.before_level_file(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.monkey)
+end)

--- a/data/tr3/ship/data/scripts/zoo.lua
+++ b/data/tr3/ship/data/scripts/zoo.lua
@@ -1,0 +1,3 @@
+trx.events.before_level_file(function(level)
+  trx.creatures.add_ally(trx.catalog.objects.monkey)
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,9 @@
 - added Boulder control
 - added Poison Dart control
 - added Lara's backwards-hop stumble if there is a slope behind her
+- improved Monkeys to no longer hardcode hostility status based on Tiger presence
+- changed hostile Monkeys to share hostility status, like TR2 Barkhang monks
+    This is a deliberate change to simplify the code, that is still in line how most people play the game (either kill all allies, or none at all).
 - changed enemy drops to appear at the tile center, to conform with the OG
 - fixed actors jumping to their start frame at the end of cutscenes
 - fixed Swamp Map rotation

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1417,6 +1417,10 @@ void Creature_GetAITarget(CREATURE *const creature)
             item->ai_bits &= ~AI_FOLLOW;
         }
     } else if (item->object_id == O_MONKEY && item->carried_item == nullptr) {
+        if (Creature_IsHostile(item)) {
+            creature->enemy = lara_item;
+            return;
+        }
         if (item->ai_bits == AI_MODIFY) {
             if (enemy_object_id != O_KEY_ITEM_4) {
                 for (int32_t i = 0; i < Item_GetTotalCount(); i++) {

--- a/src/trx/game/creature/types.h
+++ b/src/trx/game/creature/types.h
@@ -14,6 +14,7 @@ typedef struct {
     bool head_right;
     bool reached_goal;
     bool hurt_by_lara;
+    int32_t damage_from_lara;
     bool patrol_2;
     int16_t item_num;
     MOOD_TYPE mood;

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -443,11 +443,15 @@ void Gun_HitTarget(
     }
 
     if (!Creature_AreAlliesHostile() && Creature_IsAlly(item)) {
-        CREATURE *const creature = item->data;
-        creature->flags += damage;
-        if ((creature->flags & 0xFFF) > M_ALLY_FRIENDLY_FIRE_THRESHOLD
-            || creature->mood == MOOD_BORED) {
+        if (item->hit_points <= 0) {
             Creature_SetAlliesHostile(true);
+        } else if (item->data != nullptr) {
+            CREATURE *const creature = item->data;
+            creature->flags += damage;
+            if ((creature->flags & 0xFFF) > M_ALLY_FRIENDLY_FIRE_THRESHOLD
+                || creature->mood == MOOD_BORED) {
+                Creature_SetAlliesHostile(true);
+            }
         }
     }
 }

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -443,12 +443,12 @@ void Gun_HitTarget(
     }
 
     if (!Creature_AreAlliesHostile() && Creature_IsAlly(item)) {
+        CREATURE *const creature = item->data;
+        creature->damage_from_lara += damage;
         if (item->hit_points <= 0) {
             Creature_SetAlliesHostile(true);
         } else if (item->data != nullptr) {
-            CREATURE *const creature = item->data;
-            creature->flags += damage;
-            if ((creature->flags & 0xFFF) > M_ALLY_FRIENDLY_FIRE_THRESHOLD
+            if (creature->damage_from_lara > M_ALLY_FRIENDLY_FIRE_THRESHOLD
                 || creature->mood == MOOD_BORED) {
                 Creature_SetAlliesHostile(true);
             }

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -215,7 +215,7 @@ static void M_Control(const int16_t item_num)
         Creature_AIInfo(item, &info);
 
         if (!creature->hurt_by_lara && creature->enemy == lara_item
-            && Object_Get(O_TIGER)->loaded) {
+            && !Creature_AreAlliesHostile() && Creature_IsAlly(item)) {
             creature->enemy = nullptr;
         }
 

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -732,9 +732,11 @@ static bool M_ReadItem(
                         M_ReadBool(ctx, "head_right", &creature->head_right));
                     M_MUST(M_ReadBool(
                         ctx, "reached_goal", &creature->reached_goal));
+                    M_MUST(M_ReadBool(ctx, "patrol_2", &creature->patrol_2));
                     M_MUST(M_ReadBool(
                         ctx, "hurt_by_lara", &creature->hurt_by_lara));
-                    M_MUST(M_ReadBool(ctx, "patrol_2", &creature->patrol_2));
+                    M_SHOULD(M_ReadNum(
+                        ctx, "damage_from_lara", &creature->damage_from_lara));
                     M_MUST(M_PushObject(ctx, "joint_rotations"));
                     for (int32_t i = 0; i < 4; i++) {
                         M_MUST(M_PushArrayElem(ctx, i));

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -296,8 +296,9 @@ static void M_WriteItem(
             M_WriteBool(ctx, "head_left", creature->head_left);
             M_WriteBool(ctx, "head_right", creature->head_right);
             M_WriteBool(ctx, "reached_goal", creature->reached_goal);
-            M_WriteBool(ctx, "hurt_by_lara", creature->hurt_by_lara);
             M_WriteBool(ctx, "patrol_2", creature->patrol_2);
+            M_WriteBool(ctx, "hurt_by_lara", creature->hurt_by_lara);
+            M_WriteNum(ctx, "damage_from_lara", creature->damage_from_lara);
             M_PushArray(ctx);
             for (int32_t i = 0; i < 4; i++) {
                 M_PushNum(ctx, creature->joint_rotation[i]);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the Monkey behavior to no longer hardcode hostility based on presence of Tigers in the level.
As a side effect, when you shoot one monkey, you'll now need to shoot them all.

#### Testing

1) Jungle monkeys do not attack Lara, unless she attacks them
2) Attacking a single monkey in Jungle gets others to turn hostile
3) Hostile monkeys prioritize playing with medi packs (seems to be OG behavior…)
4) Jungle monkeys are not included in the level max kill count (you may need to remove `cfg/tr3/max_stats.cache.json`)
5) Temple Ruins monkeys do attack Lara
6) The River Ganges monkeys do attack Lara
7) In both levels they _are_ included in the level kill count