### PR TITLE
stats: fix allies not reset

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed running `/title` and similar commands when examining an item causing incorrect item rotation next time the ring opens (old regression)
 - fixed endless sprint cheat setting not retained between game relaunches
 - fixed Cobras not being counted in level kill count
+- fixed stats dialog retaining friendly status for allies that become enemy types in later levels, causing them to get excluded from kill count
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -363,7 +363,7 @@ void Stats_CalculateMaxStats(void)
 
         const LEVEL_LOADER *const loader = Level_GuessLoader(file);
         if (loader != nullptr) {
-            Creature_SetAlliesHostile(false);
+            Creature_Reset();
 
             Lua_ClearLevelListeners();
             Lua_SetScriptContext(LUA_CONTEXT_LEVEL);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes stats dialog retaining friendly status for allies that become enemy types in later levels, causing them to get excluded from kill count.
Required for  https://github.com/LostArtefacts/TRX/pull/4721 to work properly.