### PR TITLE
objects: backport TR3 lights to TR1/2

### DIFF
--- a/data/common/ship/shaders/lights.glsl
+++ b/data/common/ship/shaders/lights.glsl
@@ -13,6 +13,8 @@ struct Light {
     vec4 color;
     float shade;
     float falloff;
+    float kind;
+    float _pad0;
 };
 
 layout(std140) uniform Lights {
@@ -167,10 +169,13 @@ vec3 lightOwnTR3(float shade)
     return clamp(uTR3Ambient.rgb * (shade8 / 255.0), 0.0, 1.0);
 }
 
-float lightDynamic(float baseLight, vec4 vertexPos)
+float lightDynamicTR12Lum(float baseLight, vec4 vertexPos)
 {
     float lightAdder = baseLight;
     for (int i = 0; i < uNumLights; i++) {
+        if (uLights[i].kind != 0.0) {
+            continue;
+        }
         vec3 dist = uLights[i].pos.xyz - vertexPos.xyz;
         float radius = exp2(uLights[i].falloff);
         float distSq = dot(dist, dist);
@@ -184,6 +189,29 @@ float lightDynamic(float baseLight, vec4 vertexPos)
         lightAdder -= shade;
     }
     return max(lightAdder, 0);
+}
+
+vec3 lightDynamicTR12RGB(vec4 vertexPos)
+{
+    vec3 add = vec3(0.0);
+    for (int i = 0; i < uNumLights; i++) {
+        if (uLights[i].kind == 0.0) {
+            continue;
+        }
+
+        float radius = uLights[i].falloff * 0.5;
+        vec3 dist = uLights[i].pos.xyz - vertexPos.xyz;
+        float distSq = dot(dist, dist);
+        float radiusSq = radius * radius;
+        if (distSq > radiusSq) {
+            continue;
+        }
+
+        float d = sqrt(distSq);
+        float factor = (radius - d) / max(radius, 1.0);
+        add += factor * uLights[i].color.rgb;
+    }
+    return add;
 }
 
 vec3 lightDynamicTR3(vec4 vertexPos)
@@ -216,7 +244,7 @@ float getDynamicLightContrastMul()
     return clamp(2.0 - (uMinShade / float(SHADE_NEUTRAL)), 1.0, 2.0);
 }
 
-float lightTR12(float shade, uint flags, vec3 normal, vec4 pos, float phase)
+float lightLumTR12(float shade, uint flags, vec3 normal, vec4 pos, float phase)
 {
     if ((flags & VERT_USE_OWN_LIGHT) != 0u) {
         shade = uLightAdder + shade;
@@ -224,7 +252,7 @@ float lightTR12(float shade, uint flags, vec3 normal, vec4 pos, float phase)
         shade = lightObjects(normal, pos);
     } else {
         if ((flags & VERT_USE_DYNAMIC_LIGHT) != 0u) {
-            shade = lightDynamic(shade, pos);
+            shade = lightDynamicTR12Lum(shade, pos);
             shade += lightRoom(uRoomLightMode, uTimeInGame, phase);
         }
         shade = clamp(shade, 0, SHADE_MAX);
@@ -282,7 +310,10 @@ LightingResult light(
 
     result.shade = SHADE_NEUTRAL;
 #else
-    result.shade = lightTR12(shade, flags, normal, pos, vertexPhase);
+    result.shade = lightLumTR12(shade, flags, normal, pos, vertexPhase);
+    if ((flags & VERT_USE_DYNAMIC_LIGHT) != 0u) {
+        result.add += lightDynamicTR12RGB(pos) * getDynamicLightContrastMul();
+    }
 #endif
 
     return result;

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -133,6 +133,7 @@ void main(void) {
         gColor.rgb = gammaCurve(gColor.rgb, gamma_exp);
     }
     gColor.rgb *= mul;
+    gColor.rgb = clamp(gColor.rgb + lr.add, 0.0, 1.0);
 #endif
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.1...develop) - ××××-××-××
 - added globe level selection mechanic
 - added Bubble Emitter control (#4629)
+- added dynamic light objects:
+    - added Red Light control
+    - added Green Light control
+    - added Blue Light control
+    - added Amber Light control
+    - added White Light control
+    - added Strobe Light control
+    - added Pulse Light control
+    - added Beacon Light control
+    - added On/Off Light control
 - added the ability to disable manual camera (Gameplay → Controls → Manual camera)
 - added the ability to enable bouncy grenades (Gameplay → General → Enable bouncy grenades)
 - added a new Lua event, `trx.events.on_game_start`, which fires when the level finishes loading and the game is about to start

--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -751,10 +751,6 @@ void Output_AddDynamicLight(
 void Output_AddDynamicLightRGB(
     const XYZ_32 pos, const int32_t falloff, const RGB_888 color)
 {
-    if (g_TRVersion < 3) {
-        return;
-    }
-
     int32_t safe_falloff = falloff;
     CLAMP(safe_falloff, 0, 255);
 
@@ -763,7 +759,7 @@ void Output_AddDynamicLightRGB(
         .shade = {},
         .falloff.value_1 = safe_falloff << M_TR3_DYNAMIC_FALLOFF_SHIFT,
         .color = color,
-        .type = 0,
+        .type = g_TRVersion < 3 ? 1 : 0,
         .dir = {},
     };
     Vector_Add(m_DynamicLights, &light);

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -52,7 +52,8 @@ typedef struct {
     float color[4];
     float shade;
     float falloff;
-    float _pad[2];
+    float kind;
+    float _pad;
 } M_UNIFORM_LIGHT;
 
 typedef struct {
@@ -91,6 +92,7 @@ static void M_FillLight(
     dst_light->color[3] = 0.0f;
     dst_light->shade = src_light->shade.value_1;
     dst_light->falloff = src_light->falloff.value_1;
+    dst_light->kind = src_light->type;
 }
 
 static int16_t M_GetMinShade(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR backports the colored dynamic lights emitted by the following objects:

- `O_STROBE_LIGHT`
- `O_ELECTRICAL_LIGHT`
- `O_ON_OFF_LIGHT`
- `O_PULSE_LIGHT`
- `O_BEACON_LIGHT`
- `O_RED_LIGHT`
- `O_GREEN_LIGHT`
- `O_BLUE_LIGHT`
- `O_AMBER_LIGHT`
- `O_WHITE_LIGHT`

to TR1/2, including the RGB part.

<img width="1847" height="1305" alt="20260125_171859_Test_Level" src="https://github.com/user-attachments/assets/b07bc608-0b42-4614-aec5-74931dc25ce3" />

Note for non-dev readers: this doesn’t add full colored lighting to TR1/2. Only the objects listed above will emit colored light.
Full colored lighting remains a separate topic with no current plans.

