### PR TITLE
objects: fix ally support in TR3 AI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,7 @@
 - fixed flame emitters not getting restored when loading from a save
 - fixed Lara holding onto ledges after dying if the Action key wasn't released
 - fixed being unable to antitrigger Poison Dart Emitters
+- fixed ally Lua API not working with most of the TR3 enemies supported so far
 
 
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -349,7 +349,7 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
 
     const bool too_far = ABS(z) > M_MAX_DISTANCE || ABS(x) > M_MAX_DISTANCE;
     if (creature->enemy == nullptr || (g_TRVersion == 3 && too_far)) {
-        info->distance = 0x7FFFFFFF;
+        info->distance = INT32_MAX;
     } else if (g_TRVersion < 3 && too_far) {
         info->distance = SQUARE(M_MAX_DISTANCE);
     } else {
@@ -370,6 +370,16 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
         info->x_angle = Math_Atan(x + (z >> 1), y);
     } else {
         info->x_angle = Math_Atan(z + (x >> 1), y);
+    }
+
+    if (g_TRVersion == 3) {
+        if (!creature->hurt_by_lara && creature->enemy == lara_item
+            && !Creature_AreAlliesHostile() && Creature_IsAlly(item)) {
+            creature->enemy = nullptr;
+            info->ahead = false;
+            info->bite = false;
+            info->distance = INT32_MAX;
+        }
     }
 }
 

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -214,11 +214,6 @@ static void M_Control(const int16_t item_num)
         AI_INFO info;
         Creature_AIInfo(item, &info);
 
-        if (!creature->hurt_by_lara && creature->enemy == lara_item
-            && !Creature_AreAlliesHostile() && Creature_IsAlly(item)) {
-            creature->enemy = nullptr;
-        }
-
         int32_t dist;
         if (creature->enemy == lara_item) {
             dist = info.distance;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes TR3 enemies to respect the ally status.

#### Testing

**Green path**

Example test – play Temple Ruins, issue:
```
/lua trx.creatures.add_ally(trx.catalog.objects.cobra)
```
and observe cobras' behavior as Lara approaches them.

**Completeness**
Check what TR1/TR2 creatures do when we try this on them.

**Regressions**
We need to ensure monkeys and monks stay docile and turn aggro when we cross boundaries. Also, that docile monkeys are interested in pickups.