### PR TITLE
objects/rolling_ball: fix ceiling stop test

### DIFF
--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -79,7 +79,8 @@ static bool M_TestStop(const ITEM *const item)
     const int16_t ceiling =
         Room_GetCeiling(sector, x, item->pos.y - item_height, z);
 
-    return height < item->pos.y || ceiling > item->pos.y - item_height;
+    return height < item->pos.y
+        || (!item->gravity && ceiling > item->pos.y - item_height);
 }
 
 static void M_Stop(ITEM *const item, const XYZ_32 old_pos)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a regression in 589bec40d60bf03b295bb7031fd4e20683d60353 that causes boulders that spawn above ground with a ceiling in front of them to immediately come to a stop. E.g. Barkhang, `/tp 49 -5 33`.
