### PR TITLE
rooms/floor-data: fix tr3 antitriggers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,6 +121,7 @@
 - fixed Lara holding onto ledges after dying if the Action key wasn't released
 - fixed being unable to antitrigger Poison Dart Emitters
 - fixed ally Lua API not working with most of the TR3 enemies supported so far
+- fixed one-shot antitriggers / antipads behavior
 - fixed Blades in Coastal Village not respecting antitrigger
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
     - `on_control` → `before_control`
     - `on_control_post` → `after_control`
 - changed turbo cheat to auto‑reset to normal speed if pushed past limit, making it easier for new players to recover from accidental changes
+- changed Blades to support being reset
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
@@ -120,6 +121,7 @@
 - fixed Lara holding onto ledges after dying if the Action key wasn't released
 - fixed being unable to antitrigger Poison Dart Emitters
 - fixed ally Lua API not working with most of the TR3 enemies supported so far
+- fixed Blades in Coastal Village not respecting antitrigger
 
 
 

--- a/src/trx/game/items/enum.h
+++ b/src/trx/game/items/enum.h
@@ -11,11 +11,13 @@ typedef enum {
 
 typedef enum {
     // clang-format off
-    IF_ONE_SHOT  = 0x0100,
-    IF_CODE_BITS = 0x3E00,
-    IF_REVERSE   = 0x4000,
-    IF_INVISIBLE = 0x0100,
-    IF_KILLED    = 0x8000,
+    IF_ONE_SHOT_SWITCH      = 0x0040,
+    IF_ONE_SHOT_ANTITRIGGER = 0x0080,
+    IF_ONE_SHOT             = 0x0100,
+    IF_CODE_BITS            = 0x3E00,
+    IF_REVERSE              = 0x4000,
+    IF_INVISIBLE            = 0x0100,
+    IF_KILLED               = 0x8000,
     // clang-format on
 } ITEM_FLAG;
 

--- a/src/trx/game/objects/traps/blade.c
+++ b/src/trx/game/objects/traps/blade.c
@@ -39,6 +39,9 @@ static void M_Control(const int16_t item_num)
     if (Item_IsTriggerActive(item)
         && item->current_anim_state == BLADE_STATE_STOP) {
         item->goal_anim_state = BLADE_STATE_CUT;
+    } else if (!Item_IsTriggerActive(item) && Item_TestFrameEqual(item, -1)) {
+        item->status = IS_INACTIVE;
+        Item_RemoveActive(item_num);
     } else {
         item->goal_anim_state = BLADE_STATE_STOP;
     }

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -454,7 +454,25 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TO_OBJECT: {
             const int16_t item_num = (int16_t)(intptr_t)cmd->parameter;
             ITEM *const trig_item = Item_Get(item_num);
-            if (trig_item->flags & IF_ONE_SHOT) {
+
+            bool one_shot = false;
+            if (g_TRVersion == 3) {
+                switch (trigger->type) {
+                case TT_SWITCH:
+                    one_shot = trig_item->flags & IF_ONE_SHOT_SWITCH;
+                    break;
+                case TT_ANTIPAD:
+                case TT_ANTITRIGGER:
+                    one_shot = trig_item->flags & IF_ONE_SHOT_ANTITRIGGER;
+                    break;
+                default:
+                    one_shot = trig_item->flags & IF_ONE_SHOT;
+                    break;
+                }
+            } else {
+                one_shot = trig_item->flags & IF_ONE_SHOT;
+            }
+            if (one_shot) {
                 break;
             }
 
@@ -483,6 +501,9 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
             if (trigger->type == TT_SWITCH) {
                 trig_item->flags ^= trigger->mask;
+                if (trigger->one_shot && g_TRVersion == 3) {
+                    trig_item->flags |= IF_ONE_SHOT_SWITCH;
+                }
             } else if (
                 trigger->type == TT_ANTIPAD
                 || trigger->type == TT_ANTITRIGGER) {
@@ -491,7 +512,11 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 }
                 trig_item->flags &= ~trigger->mask;
                 if (trigger->one_shot) {
-                    trig_item->flags |= IF_ONE_SHOT;
+                    if (g_TRVersion == 3) {
+                        trig_item->flags |= IF_ONE_SHOT_ANTITRIGGER;
+                    } else {
+                        trig_item->flags |= IF_ONE_SHOT;
+                    }
                 }
             } else {
                 trig_item->flags |= trigger->mask;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This implements the split one-shot flags for antipads/antitriggers and for switches. @lahm86 can I ask for assessment whether this is something that's safe to land engine-agnostic, or if we should keep the version gate? 

It should fix the problems with antitriggers not working in certain cases, such as the Madhouse door.
The blades in Coastal Village never stop for a different reason, and it's an OG bug: https://www.youtube.com/watch?v=hdrrTGAB39c&t=9135s . To fix that, I implemented Lahm's pattern of resetting other traps.