### PR TITLE
objects/rolling_ball: fix ceiling stop test

### DIFF
--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -46,10 +46,8 @@ static void M_Roll(ITEM *const item)
 static bool M_TestStop(const ITEM *const item)
 {
     int32_t dist;
-    int32_t item_height;
     switch (item->object_id) {
     case O_ROLLING_BALL_1:
-        item_height = STEP_L * 13 / 4;
         if (g_TRVersion == 1) {
             dist = WALL_L / 2;
         } else if (g_TRVersion == 2) {
@@ -59,14 +57,17 @@ static bool M_TestStop(const ITEM *const item)
         }
         break;
     case O_ROLLING_BALL_4:
-        item_height = WALL_L * 33 / 16;
         dist = WALL_L * 17 / 16;
         break;
     default:
-        item_height = WALL_L;
         dist = WALL_L;
         break;
     }
+
+    const ANIM_FRAME *const frame = Item_GetBestFrame(item);
+    const BOUNDS_16 *const bounds = &frame->bounds;
+    const int16_t item_height =
+        ROUND_TO_HALF_CLICK(ABS(bounds->max.y - bounds->min.y));
 
     int16_t room_num = item->room_num;
     const int32_t x =


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes another regression in 589bec40d60bf03b295bb7031fd4e20683d60353 that can cause some boulders to get stuck too early against the ceiling. The second set of snowballs at the start of Tibet is an example. I will share a test level on Discord with lots of different ceiling heights and each boulder type.
