### PR TITLE
creature/common: restore flyer check in TR1/2

### DIFF
--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -992,7 +992,8 @@ bool Creature_Animate(
                 item->pos.x = old.x;
                 item->pos.z = old.z;
             }
-        } else if (Object_IsType(item->object_id, g_WaterObjects)) {
+        } else if (
+            fly_check || Object_IsType(item->object_id, g_WaterObjects)) {
             const int32_t ceiling =
                 Room_GetCeiling(sector, item->pos.x, y, item->pos.z);
             int32_t min_y = bounds->min.y;


### PR DESCRIPTION
Resolves #4738.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores original TR1/2 flyer behaviour which does not expect flyers to ever be over water or swamps, which is in line with the other TR3 fly checks in pathfinding.
