### PR TITLE
Fix counting kills from quads and manually aimed projectiles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -129,6 +129,7 @@
 - fixed ally Lua API not working with most of the TR3 enemies supported so far
 - fixed one-shot antitriggers / antipads behavior
 - fixed Blades in Coastal Village not respecting antitrigger
+- fixed running down an enemy with a Quad not counting as a kill
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -130,6 +130,7 @@
 - fixed one-shot antitriggers / antipads behavior
 - fixed Blades in Coastal Village not respecting antitrigger
 - fixed running down an enemy with a Quad not counting as a kill
+- fixed killing Cobras with a manually-aimed projectile not counting as a kill
 
 
 

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -394,7 +394,8 @@ void Gun_HitTarget(
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (item->hit_points > 0 && item->hit_points <= damage) {
+    if ((item->hit_points == DONT_TARGET && Creature_IsDestructible(item))
+        || (item->hit_points > 0 && item->hit_points <= damage)) {
         const bool skip_stats = item->object_id == O_DRAGON_FRONT;
         if (!skip_stats) {
             Stats_AddKill();

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -14,6 +14,7 @@
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
 #include <trx/game/spawn.h>
+#include <trx/game/stats.h>
 #include <trx/version.h>
 
 static const BITE m_QuadBites[6] = {
@@ -706,14 +707,16 @@ static void M_SkidooBaddieCollision(ITEM *const quad)
 
             if (item->object_id == O_ROLLING_BALL_2) {
                 if (item->current_anim_state == 1) {
-                    lara_item->hit_status = true;
-                    lara_item->hit_points -= 100;
+                    Lara_TakeDamage(100, true);
                 }
             } else {
                 Spawn_BloodBath(
                     item->pos.x, quad->pos.y - 256, item->pos.z, quad->speed,
                     quad->rot.y, item->room_num, 3);
-                item->hit_points = 0;
+                if (item->hit_points > 0) {
+                    item->hit_points = 0;
+                    Stats_AddKill();
+                }
             }
 
         loop_end:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes kills from quads and manually aimed projectiles not getting counted in the level stats.

Honestly I don't like `DONT_TARGET`. How do we feel about refactoring it away in favor of introducing `item->targetable`? This way we can get destructible objects to have proper HP (sleeping Cobras now are one-shot as a semi-hardcoded logic, and it's not really possible to change that).
It's a big, big task with tons of objects to go over, though. I think we could tackle it iteratively, however, by declaring `item->targetable` as true by default, getting the targeting logic right, and only going object-by-object to sunset `DONT_TARGET`.

The reason why I'm bringing this up here, is because I find it really upsetting that you can kill Army Winston with the Rocket Launcher, and it's related because we can't use `DONT_TARGET` for him. And instead of complicating the matters further by mixing the existing special HP values with flags, I'd like to tidy things up for good.