### PR TITLE
objects/movable-block: use new priv data pattern

### DIFF
--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -40,7 +40,7 @@ static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
     for (int32_t i = 0; i < M_LIFT_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
         const JSON_OBJECT *const linked_root =
-            JSON_ObjectGetObject((JSON_OBJECT *)priv_root, key);
+            JSON_ObjectGetObject(priv_root, key);
         if (linked_root != nullptr) {
             p->linked[i].pos.x =
                 JSON_ObjectGetInt(linked_root, "x", p->linked[i].pos.x);

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -9,8 +9,10 @@
 #include <trx/game/objects.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
+#include <trx/game/savegame/legacy_io.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
+#include <trx/strings.h>
 #include <trx/vector.h>
 
 #define LF_PPREADY 19
@@ -20,6 +22,19 @@ typedef enum {
     MOVABLE_BLOCK_STATE_PUSH = 2,
     MOVABLE_BLOCK_STATE_PULL = 3,
 } MOVABLE_BLOCK_STATE;
+
+typedef struct {
+    int16_t counter_rot[3];
+    int16_t original_rot;
+} M_EXTRA_ROTATIONS;
+
+typedef struct {
+    uint16_t gravity_frames;
+    bool is_push_pull;
+    bool is_forced_moving;
+    GAME_VECTOR initial;
+    GAME_VECTOR linked;
+} M_PRIV;
 
 static const OBJECT_BOUNDS m_MovableBlock_Bounds = {
     .shift = {
@@ -43,7 +58,7 @@ static void M_GetStack(
 static void M_UpdateRotation(ITEM *const item, const int16_t rot_y)
 {
     item->rot.y = rot_y;
-    MOVABLE_BLOCK_INFO *const data = item->data;
+    M_EXTRA_ROTATIONS *const data = item->data;
     // All 3 indices are potentially used in other parts of the code that can
     // cast item->data to structs such as XYZ_16. This is similar to things such
     // as the compass needle that apply extra rotation.
@@ -53,28 +68,28 @@ static void M_UpdateRotation(ITEM *const item, const int16_t rot_y)
 // Indicates if Lara is currently pushing or pulling a block.
 static void M_SetPushPull(ITEM *const item, const bool enable)
 {
-    MOVABLE_BLOCK_INFO *const data = item->data;
-    data->is_push_pull = enable;
+    M_PRIV *const p = item->priv;
+    p->is_push_pull = enable;
 }
 
 static bool M_IsPushPull(const ITEM *const item)
 {
-    const MOVABLE_BLOCK_INFO *const data = item->data;
-    return data != nullptr ? data->is_push_pull : false;
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->is_push_pull;
 }
 
 // Indicates if blocks are being forcefully moved by other objects such as
 // lifts.
 static void M_SetForcedMoving(ITEM *const item, const bool enable)
 {
-    MOVABLE_BLOCK_INFO *const data = item->data;
-    data->is_forced_moving = enable;
+    M_PRIV *const p = item->priv;
+    p->is_forced_moving = enable;
 }
 
 static bool M_IsForcedMoving(const ITEM *const item)
 {
-    const MOVABLE_BLOCK_INFO *const data = item->data;
-    return data != nullptr ? data->is_forced_moving : false;
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->is_forced_moving;
 }
 
 // If a stack of multiple blocks need to drop, each subsequently stacked block
@@ -82,42 +97,97 @@ static bool M_IsForcedMoving(const ITEM *const item)
 // blocks and stop moving.
 static void M_SetGravityFrames(ITEM *const item, const uint8_t frames)
 {
-    MOVABLE_BLOCK_INFO *const data = item->data;
-    data->gravity_frames = frames;
+    M_PRIV *const p = item->priv;
+    p->gravity_frames = frames;
 }
 
 static uint16_t M_GetGravityFrames(const ITEM *const item)
 {
-    const MOVABLE_BLOCK_INFO *const data = item->data;
-    return data != nullptr ? data->gravity_frames : 0;
+    const M_PRIV *const p = item->priv;
+    return p != nullptr ? p->gravity_frames : 0;
 }
 
 // Handles the block's initial position and room number for walkables.
 static void M_SetInitial(ITEM *const item)
 {
-    MOVABLE_BLOCK_INFO *const data = item->data;
-    data->initial.pos = item->pos;
-    data->initial.room_num = item->room_num;
+    M_PRIV *const p = item->priv;
+    p->initial.pos = item->pos;
+    p->initial.room_num = item->room_num;
 }
 
 static GAME_VECTOR M_GetInitial(const ITEM *const item)
 {
-    const MOVABLE_BLOCK_INFO *const data = item->data;
-    return data->initial;
+    const M_PRIV *const p = item->priv;
+    return p->initial;
 }
 
 // Handles the block's linked position and room number for walkables.
 static void M_SetLinked(ITEM *const item)
 {
-    MOVABLE_BLOCK_INFO *const data = item->data;
-    data->linked.pos = item->pos;
-    data->linked.room_num = item->room_num;
+    M_PRIV *const p = item->priv;
+    p->linked.pos = item->pos;
+    p->linked.room_num = item->room_num;
 }
 
 static GAME_VECTOR M_GetLinked(const ITEM *const item)
 {
-    const MOVABLE_BLOCK_INFO *const data = item->data;
-    return data->linked;
+    const M_PRIV *const p = item->priv;
+    return p->linked;
+}
+
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    M_PRIV *const p = item->priv;
+    p->gravity_frames = (uint16_t)JSON_ObjectGetInt(
+        priv_root, "gravity_frames", p->gravity_frames);
+    p->is_push_pull =
+        JSON_ObjectGetBool(priv_root, "is_push_pull", p->is_push_pull);
+    p->is_forced_moving =
+        JSON_ObjectGetBool(priv_root, "is_forced_moving", p->is_forced_moving);
+
+    const JSON_OBJECT *const linked_root =
+        JSON_ObjectGetObject(priv_root, "linked");
+    if (linked_root != nullptr) {
+        p->linked.pos.x = JSON_ObjectGetInt(linked_root, "x", p->linked.pos.x);
+        p->linked.pos.y = JSON_ObjectGetInt(linked_root, "y", p->linked.pos.y);
+        p->linked.pos.z = JSON_ObjectGetInt(linked_root, "z", p->linked.pos.z);
+    }
+
+    M_EXTRA_ROTATIONS *const data = item->data;
+    data->counter_rot[0] =
+        JSON_ObjectGetInt(priv_root, "counter_rot_0", data->counter_rot[0]);
+    data->counter_rot[1] =
+        JSON_ObjectGetInt(priv_root, "counter_rot_1", data->counter_rot[1]);
+    data->counter_rot[2] =
+        JSON_ObjectGetInt(priv_root, "counter_rot_2", data->counter_rot[2]);
+    data->original_rot =
+        JSON_ObjectGetInt(priv_root, "original_rot", data->original_rot);
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
+{
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(priv_root, "gravity_frames", p->gravity_frames);
+    JSON_ObjectAppendBool(priv_root, "is_push_pull", p->is_push_pull);
+    JSON_ObjectAppendBool(priv_root, "is_forced_moving", p->is_forced_moving);
+
+    JSON_OBJECT *const linked_root = JSON_ObjectNew();
+    JSON_ObjectAppendInt(linked_root, "x", p->linked.pos.x);
+    JSON_ObjectAppendInt(linked_root, "y", p->linked.pos.y);
+    JSON_ObjectAppendInt(linked_root, "z", p->linked.pos.z);
+    JSON_ObjectAppendObject(priv_root, "linked", linked_root);
+
+    const M_EXTRA_ROTATIONS *const data = item->data;
+    JSON_ObjectAppendInt(priv_root, "counter_rot_0", data->counter_rot[0]);
+    JSON_ObjectAppendInt(priv_root, "counter_rot_1", data->counter_rot[1]);
+    JSON_ObjectAppendInt(priv_root, "counter_rot_2", data->counter_rot[2]);
+    JSON_ObjectAppendInt(priv_root, "original_rot", data->original_rot);
+}
+
+static void M_LoadLegacyPriv(
+    ITEM *const item, const SAVEGAME_LEGACY_IO *const io)
+{
+    M_SetLinked(item);
 }
 
 static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
@@ -404,11 +474,13 @@ static void M_Initialise(const int16_t item_num)
     // during collision tests and can appear jarring. Additional angles are
     // stored to preserve item appearance in spite of control angle changes.
     ITEM *const item = Item_Get(item_num);
-    MOVABLE_BLOCK_INFO *const data =
-        GameBuf_Alloc(sizeof(MOVABLE_BLOCK_INFO), GBUF_ITEM_DATA);
+
+    M_EXTRA_ROTATIONS *const data =
+        GameBuf_Alloc(sizeof(XYZ_16), GBUF_ITEM_DATA);
     item->data = data;
     data->original_rot =
         (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
+
     M_UpdateRotation(item, data->original_rot);
     M_SetGravityFrames(item, 0);
     M_SetPushPull(item, false);
@@ -852,6 +924,10 @@ static void M_Setup(OBJECT *const obj)
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->add_walkable_func = M_AddWalkable;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
+    obj->priv_legacy_load_func = M_LoadLegacyPriv;
     obj->base_rot.y = true;
     obj->save_anim = true;
     obj->save_flags = true;

--- a/src/trx/game/objects/traps/movable_block.h
+++ b/src/trx/game/objects/traps/movable_block.h
@@ -18,13 +18,3 @@ void MovableBlock_ShiftStackY(
 void MovableBlock_SlideStack(
     int32_t stack_height, XYZ_32 old_sector, const ITEM *dest_item,
     bool reposition);
-
-typedef struct {
-    int16_t counter_rot[3];
-    int16_t original_rot;
-    uint16_t gravity_frames;
-    bool is_push_pull;
-    bool is_forced_moving;
-    GAME_VECTOR initial;
-    GAME_VECTOR linked;
-} MOVABLE_BLOCK_INFO;

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -11,7 +11,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/objects/traps/sliding_pillar.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/objects/vehicles/boat.h>
@@ -846,32 +845,6 @@ static bool M_ReadItem(
                 item->data = (void *)(intptr_t)(effect_num + 1);
                 M_MUST(M_Pop(ctx));
             }
-        }
-        break;
-    }
-
-    case O_MOVABLE_BLOCK_1:
-    case O_MOVABLE_BLOCK_2:
-    case O_MOVABLE_BLOCK_3:
-    case O_MOVABLE_BLOCK_4: {
-        if (ctx->sg_version >= VERSION_12) {
-            M_MUST(M_PushObject(ctx, "data"));
-            MOVABLE_BLOCK_INFO *const data = item->data;
-            M_MUST(M_ReadNum(ctx, "counter_rot_0", &data->counter_rot[0]));
-            M_MUST(M_ReadNum(ctx, "counter_rot_1", &data->counter_rot[1]));
-            M_MUST(M_ReadNum(ctx, "counter_rot_2", &data->counter_rot[2]));
-            M_MUST(M_ReadNum(ctx, "original_rot", &data->original_rot));
-            M_MUST(M_ReadNum(ctx, "gravity_frames", &data->gravity_frames));
-            M_MUST(M_ReadBool(ctx, "is_push_pull", &data->is_push_pull));
-            M_MUST(
-                M_ReadBool(ctx, "is_forced_moving", &data->is_forced_moving));
-            M_MUST(M_ReadXYZ32(ctx, "linked", &data->linked.pos));
-            M_MUST(M_Pop(ctx));
-        } else {
-            // For old saves, guess linked sector is at item position.
-            MOVABLE_BLOCK_INFO *const data = item->data;
-            data->linked.pos = item->pos;
-            data->linked.room_num = item->room_num;
         }
         break;
     }

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -9,7 +9,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/objects/traps/sliding_pillar.h>
 #include <trx/game/objects/vehicles/boat.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
@@ -354,25 +353,6 @@ static void M_WriteItem(
             M_WriteNum(ctx, "bl_status", status);
             M_PushObject(ctx);
             M_WriteNum(ctx, "status", status);
-            M_PopAndSet(ctx, "data");
-        }
-        break;
-
-    case O_MOVABLE_BLOCK_1:
-    case O_MOVABLE_BLOCK_2:
-    case O_MOVABLE_BLOCK_3:
-    case O_MOVABLE_BLOCK_4:
-        if (item->data != nullptr) {
-            const MOVABLE_BLOCK_INFO *const data = item->data;
-            M_PushObject(ctx);
-            M_WriteNum(ctx, "counter_rot_0", data->counter_rot[0]);
-            M_WriteNum(ctx, "counter_rot_1", data->counter_rot[1]);
-            M_WriteNum(ctx, "counter_rot_2", data->counter_rot[2]);
-            M_WriteNum(ctx, "original_rot", data->original_rot);
-            M_WriteNum(ctx, "gravity_frames", data->gravity_frames);
-            M_WriteBool(ctx, "is_push_pull", data->is_push_pull);
-            M_WriteBool(ctx, "is_forced_moving", data->is_forced_moving);
-            M_WriteXYZ32(ctx, "linked", data->linked.pos);
             M_PopAndSet(ctx, "data");
         }
         break;

--- a/src/trx/game/savegame/enum.h
+++ b/src/trx/game/savegame/enum.h
@@ -44,7 +44,7 @@ typedef enum {
     // do the shifting on load.
     VERSION_11 = 11,
 
-    // Save and load MOVABLE_BLOCK_INFO in item->data.
+    // Save and load movable block priv data.
     VERSION_12 = 12,
 
     // Added back gun and gun item number properties to Lara.

--- a/src/trx/game/savegame/legacy.c
+++ b/src/trx/game/savegame/legacy.c
@@ -7,11 +7,11 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects/general/pickup.h>
-#include <trx/game/objects/traps/movable_block.h>
 #include <trx/game/objects/traps/sliding_pillar.h>
 #include <trx/game/objects/vehicles/boat.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
 #include <trx/game/pathing.h>
+#include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
 #include <trx/game/savegame/legacy_io.h>
 #include <trx/game/stats.h>
@@ -561,16 +561,6 @@ static void M_ReadItem(M_CONTEXT *const ctx, const int16_t item_num)
     }
 
     switch (item->object_id) {
-    case O_MOVABLE_BLOCK_1:
-    case O_MOVABLE_BLOCK_2:
-    case O_MOVABLE_BLOCK_3:
-    case O_MOVABLE_BLOCK_4: {
-        MOVABLE_BLOCK_INFO *const data = item->data;
-        data->linked.pos = item->pos;
-        data->linked.room_num = item->room_num;
-        break;
-    }
-
     case O_SLIDING_PILLAR: {
         SLIDING_PILLAR_INFO *const data = item->data;
         data->linked.pos = item->pos;

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -251,8 +251,10 @@ SDL_Window *Shell_GetWindow(void)
 
 int32_t Shell_Main(const SHELL_ARGS *args)
 {
-    ASSERT(args != nullptr);
     LOG_INFO("Game directory: %s", File_GetGameDirectory());
+
+    ASSERT(args != nullptr);
+    ASSERT(args->mod != nullptr || args->engine_version != 0);
 
     // Set the g_TRVersion early. Later on it will be overriden by the
     // level loader, but this lets the game load good config defaults.

--- a/src/trx/json.h
+++ b/src/trx/json.h
@@ -11,6 +11,9 @@
 #define json_uintmax_t uintmax_t
 #define json_strtoumax strtoumax
 
+#define JSON_CONST_DISPATCH(arg, ctype, call)                                  \
+    _Generic(0 ? (arg) : (void *)1, const void *: (ctype)call, default: call)
+
 typedef enum {
     JSON_TYPE_STRING,
     JSON_TYPE_NUMBER,
@@ -97,8 +100,16 @@ int64_t JSON_ValueGetInt64(const JSON_VALUE *value, int64_t d);
 double JSON_ValueGetDouble(const JSON_VALUE *value, double d);
 const JSON_NUMBER *JSON_ValueGetNumber(const JSON_VALUE *value);
 const char *JSON_ValueGetString(const JSON_VALUE *value, const char *d);
-JSON_ARRAY *JSON_ValueAsArray(JSON_VALUE *value);
-JSON_OBJECT *JSON_ValueAsObject(JSON_VALUE *value);
+
+JSON_ARRAY *JSON_ValueAsArray_Impl(const JSON_VALUE *value);
+#define JSON_ValueAsArray(value)                                               \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_ARRAY *, JSON_ValueAsArray_Impl(value))
+
+JSON_OBJECT *JSON_ValueAsObject_Impl(const JSON_VALUE *value);
+#define JSON_ValueAsObject(value)                                              \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_OBJECT *, JSON_ValueAsObject_Impl(value))
 
 // arrays
 JSON_ARRAY *JSON_ArrayNew(void);
@@ -112,14 +123,24 @@ void JSON_ArrayAppendString(JSON_ARRAY *arr, const char *string);
 void JSON_ArrayAppendArray(JSON_ARRAY *arr, JSON_ARRAY *arr2);
 void JSON_ArrayAppendObject(JSON_ARRAY *arr, JSON_OBJECT *obj);
 
-JSON_VALUE *JSON_ArrayGetValue(JSON_ARRAY *arr, size_t idx);
+JSON_VALUE *JSON_ArrayGetValue(const JSON_ARRAY *arr, size_t idx);
 int JSON_ArrayGetBool(const JSON_ARRAY *arr, size_t idx, int d);
 int JSON_ArrayGetInt(const JSON_ARRAY *arr, size_t idx, int d);
 double JSON_ArrayGetDouble(const JSON_ARRAY *arr, size_t idx, double d);
 const char *JSON_ArrayGetString(
     const JSON_ARRAY *arr, size_t idx, const char *d);
-JSON_ARRAY *JSON_ArrayGetArray(JSON_ARRAY *arr, size_t idx);
-JSON_OBJECT *JSON_ArrayGetObject(JSON_ARRAY *arr, size_t idx);
+
+JSON_ARRAY *JSON_ArrayGetArray_Impl(const JSON_ARRAY *arr, size_t idx);
+#define JSON_ArrayGetArray(value, ...)                                         \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_ARRAY *,                                             \
+        JSON_ArrayGetArray_Impl(value, __VA_ARGS__))
+
+JSON_OBJECT *JSON_ArrayGetObject_Impl(const JSON_ARRAY *arr, size_t idx);
+#define JSON_ArrayGetObject(value, ...)                                        \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_ARRAY *,                                             \
+        JSON_ArrayGetObject_Impl(value, __VA_ARGS__))
 
 // objects
 JSON_OBJECT *JSON_ObjectNew(void);
@@ -140,15 +161,25 @@ bool JSON_ObjectContainsKey(JSON_OBJECT *obj, const char *key);
 void JSON_ObjectEvictKey(JSON_OBJECT *obj, const char *key);
 void JSON_ObjectMerge(JSON_OBJECT *root, const JSON_OBJECT *obj);
 
-JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *obj, const char *key);
+JSON_VALUE *JSON_ObjectGetValue(const JSON_OBJECT *obj, const char *key);
 int JSON_ObjectGetBool(const JSON_OBJECT *obj, const char *key, int d);
 int JSON_ObjectGetInt(const JSON_OBJECT *obj, const char *key, int d);
 int64_t JSON_ObjectGetInt64(const JSON_OBJECT *obj, const char *key, int64_t d);
 double JSON_ObjectGetDouble(const JSON_OBJECT *obj, const char *key, double d);
 const char *JSON_ObjectGetString(
     const JSON_OBJECT *obj, const char *key, const char *d);
-JSON_ARRAY *JSON_ObjectGetArray(JSON_OBJECT *obj, const char *key);
-JSON_OBJECT *JSON_ObjectGetObject(JSON_OBJECT *obj, const char *key);
+
+JSON_ARRAY *JSON_ObjectGetArray_Impl(const JSON_OBJECT *obj, const char *key);
+#define JSON_ObjectGetArray(value, ...)                                        \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_ARRAY *,                                             \
+        JSON_ObjectGetArray_Impl(value, __VA_ARGS__))
+
+JSON_OBJECT *JSON_ObjectGetObject_Impl(const JSON_OBJECT *obj, const char *key);
+#define JSON_ObjectGetObject(value, ...)                                       \
+    JSON_CONST_DISPATCH(                                                       \
+        value, const JSON_OBJECT *,                                            \
+        JSON_ObjectGetObject_Impl(value, __VA_ARGS__))
 
 typedef enum {
     JSON_PARSE_ERROR_NONE = 0,

--- a/src/trx/json/json_base.c
+++ b/src/trx/json/json_base.c
@@ -92,38 +92,6 @@ static JSON_VALUE *M_ValueFromNumber(JSON_NUMBER *const num)
     return value;
 }
 
-static const JSON_NUMBER *M_ValueAsNumber(const JSON_VALUE *const value)
-{
-    if (value == nullptr || value->type != JSON_TYPE_NUMBER) {
-        return nullptr;
-    }
-    return (const JSON_NUMBER *)value->payload;
-}
-
-static const JSON_STRING *M_ValueAsString(const JSON_VALUE *const value)
-{
-    if (value == nullptr || value->type != JSON_TYPE_STRING) {
-        return nullptr;
-    }
-    return (const JSON_STRING *)value->payload;
-}
-
-static JSON_OBJECT *M_ValueAsObject(JSON_VALUE *const value)
-{
-    if (value == nullptr || value->type != JSON_TYPE_OBJECT) {
-        return nullptr;
-    }
-    return (JSON_OBJECT *)value->payload;
-}
-
-static JSON_ARRAY *M_ValueAsArray(JSON_VALUE *const value)
-{
-    if (value == nullptr || value->type != JSON_TYPE_ARRAY) {
-        return nullptr;
-    }
-    return (JSON_ARRAY *)value->payload;
-}
-
 static void M_ArrayElementFree(JSON_ARRAY_ELEMENT *const element)
 {
     if (element->ref_count == 0) {
@@ -240,12 +208,15 @@ int JSON_ValueGetBool(const JSON_VALUE *const value, const int d)
 
 const JSON_NUMBER *JSON_ValueGetNumber(const JSON_VALUE *const value)
 {
-    return M_ValueAsNumber(value);
+    if (value == nullptr || value->type != JSON_TYPE_NUMBER) {
+        return nullptr;
+    }
+    return (const JSON_NUMBER *)value->payload;
 }
 
 int JSON_ValueGetInt(const JSON_VALUE *const value, const int d)
 {
-    const JSON_NUMBER *const num = M_ValueAsNumber(value);
+    const JSON_NUMBER *const num = JSON_ValueGetNumber(value);
     if (num == nullptr) {
         return d;
     }
@@ -261,31 +232,40 @@ int JSON_ValueGetInt(const JSON_VALUE *const value, const int d)
 
 int64_t JSON_ValueGetInt64(const JSON_VALUE *const value, const int64_t d)
 {
-    const JSON_NUMBER *const num = M_ValueAsNumber(value);
+    const JSON_NUMBER *const num = JSON_ValueGetNumber(value);
     return num != nullptr ? strtoll(num->number, nullptr, 10) : d;
 }
 
 double JSON_ValueGetDouble(const JSON_VALUE *const value, const double d)
 {
-    const JSON_NUMBER *const num = M_ValueAsNumber(value);
+    const JSON_NUMBER *const num = JSON_ValueGetNumber(value);
     return num != nullptr ? atof(num->number) : d;
 }
 
 const char *JSON_ValueGetString(
     const JSON_VALUE *const value, const char *const d)
 {
-    const JSON_STRING *const str = M_ValueAsString(value);
-    return str != nullptr ? str->string : d;
+    if (value == nullptr || value->type != JSON_TYPE_STRING) {
+        return nullptr;
+    }
+    const JSON_STRING *const string = value->payload;
+    return string != nullptr ? string->string : d;
 }
 
-JSON_ARRAY *JSON_ValueAsArray(JSON_VALUE *const value)
+JSON_ARRAY *JSON_ValueAsArray_Impl(const JSON_VALUE *const value)
 {
-    return M_ValueAsArray(value);
+    if (value == nullptr || value->type != JSON_TYPE_ARRAY) {
+        return nullptr;
+    }
+    return (JSON_ARRAY *)value->payload;
 }
 
-JSON_OBJECT *JSON_ValueAsObject(JSON_VALUE *const value)
+JSON_OBJECT *JSON_ValueAsObject_Impl(const JSON_VALUE *const value)
 {
-    return M_ValueAsObject(value);
+    if (value == nullptr || value->type != JSON_TYPE_OBJECT) {
+        return nullptr;
+    }
+    return (JSON_OBJECT *)value->payload;
 }
 
 JSON_ARRAY *JSON_ArrayNew(void)
@@ -327,37 +307,37 @@ void JSON_ArrayAppend(JSON_ARRAY *const arr, JSON_VALUE *const value)
     arr->length++;
 }
 
-void JSON_ArrayAppendBool(JSON_ARRAY *arr, int b)
+void JSON_ArrayAppendBool(JSON_ARRAY *const arr, const int b)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromBool(b));
 }
 
-void JSON_ArrayAppendInt(JSON_ARRAY *arr, int number)
+void JSON_ArrayAppendInt(JSON_ARRAY *const arr, const int number)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromInt(number));
 }
 
-void JSON_ArrayAppendDouble(JSON_ARRAY *arr, double number)
+void JSON_ArrayAppendDouble(JSON_ARRAY *const arr, const double number)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromDouble(number));
 }
 
-void JSON_ArrayAppendString(JSON_ARRAY *arr, const char *string)
+void JSON_ArrayAppendString(JSON_ARRAY *const arr, const char *string)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromString(string));
 }
 
-void JSON_ArrayAppendArray(JSON_ARRAY *arr, JSON_ARRAY *arr2)
+void JSON_ArrayAppendArray(JSON_ARRAY *const arr, JSON_ARRAY *const arr2)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromArray(arr2));
 }
 
-void JSON_ArrayAppendObject(JSON_ARRAY *arr, JSON_OBJECT *obj)
+void JSON_ArrayAppendObject(JSON_ARRAY *const arr, JSON_OBJECT *const obj)
 {
     JSON_ArrayAppend(arr, JSON_ValueFromObject(obj));
 }
 
-JSON_VALUE *JSON_ArrayGetValue(JSON_ARRAY *const arr, const size_t idx)
+JSON_VALUE *JSON_ArrayGetValue(const JSON_ARRAY *const arr, const size_t idx)
 {
     if (arr == nullptr || idx >= arr->length) {
         return nullptr;
@@ -372,37 +352,39 @@ JSON_VALUE *JSON_ArrayGetValue(JSON_ARRAY *const arr, const size_t idx)
 int JSON_ArrayGetBool(
     const JSON_ARRAY *const arr, const size_t idx, const int d)
 {
-    const JSON_VALUE *const value = JSON_ArrayGetValue((JSON_ARRAY *)arr, idx);
+    const JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueGetBool(value, d);
 }
 
 int JSON_ArrayGetInt(const JSON_ARRAY *const arr, const size_t idx, const int d)
 {
-    const JSON_VALUE *const value = JSON_ArrayGetValue((JSON_ARRAY *)arr, idx);
+    const JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueGetInt(value, d);
 }
 
 double JSON_ArrayGetDouble(
     const JSON_ARRAY *const arr, const size_t idx, const double d)
 {
-    const JSON_VALUE *const value = JSON_ArrayGetValue((JSON_ARRAY *)arr, idx);
+    const JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueGetDouble(value, d);
 }
 
 const char *JSON_ArrayGetString(
     const JSON_ARRAY *const arr, const size_t idx, const char *const d)
 {
-    const JSON_VALUE *const value = JSON_ArrayGetValue((JSON_ARRAY *)arr, idx);
+    const JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueGetString(value, d);
 }
 
-JSON_ARRAY *JSON_ArrayGetArray(JSON_ARRAY *arr, const size_t idx)
+JSON_ARRAY *JSON_ArrayGetArray_Impl(
+    const JSON_ARRAY *const arr, const size_t idx)
 {
     JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueAsArray(value);
 }
 
-JSON_OBJECT *JSON_ArrayGetObject(JSON_ARRAY *arr, const size_t idx)
+JSON_OBJECT *JSON_ArrayGetObject_Impl(
+    const JSON_ARRAY *const arr, const size_t idx)
 {
     JSON_VALUE *const value = JSON_ArrayGetValue(arr, idx);
     return JSON_ValueAsObject(value);
@@ -410,13 +392,13 @@ JSON_OBJECT *JSON_ArrayGetObject(JSON_ARRAY *arr, const size_t idx)
 
 JSON_OBJECT *JSON_ObjectNew(void)
 {
-    JSON_OBJECT *obj = Memory_Alloc(sizeof(JSON_OBJECT));
+    JSON_OBJECT *const obj = Memory_Alloc(sizeof(JSON_OBJECT));
     obj->start = nullptr;
     obj->length = 0;
     return obj;
 }
 
-void JSON_ObjectFree(JSON_OBJECT *obj)
+void JSON_ObjectFree(JSON_OBJECT *const obj)
 {
     JSON_OBJECT_ELEMENT *elem = obj->start;
     while (elem) {
@@ -450,39 +432,44 @@ void JSON_ObjectAppend(
     obj->length++;
 }
 
-void JSON_ObjectAppendBool(JSON_OBJECT *obj, const char *key, int b)
+void JSON_ObjectAppendBool(
+    JSON_OBJECT *const obj, const char *const key, const int b)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromBool(b));
 }
 
-void JSON_ObjectAppendInt(JSON_OBJECT *obj, const char *key, int number)
+void JSON_ObjectAppendInt(
+    JSON_OBJECT *const obj, const char *const key, const int number)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromInt(number));
 }
 
-void JSON_ObjectAppendInt64(JSON_OBJECT *obj, const char *key, int64_t number)
+void JSON_ObjectAppendInt64(
+    JSON_OBJECT *const obj, const char *const key, const int64_t number)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromInt64(number));
 }
 
-void JSON_ObjectAppendDouble(JSON_OBJECT *obj, const char *key, double number)
+void JSON_ObjectAppendDouble(
+    JSON_OBJECT *const obj, const char *const key, const double number)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromDouble(number));
 }
 
 void JSON_ObjectAppendString(
-    JSON_OBJECT *obj, const char *key, const char *string)
+    JSON_OBJECT *const obj, const char *const key, const char *string)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromString(string));
 }
 
-void JSON_ObjectAppendArray(JSON_OBJECT *obj, const char *key, JSON_ARRAY *arr)
+void JSON_ObjectAppendArray(
+    JSON_OBJECT *const obj, const char *const key, JSON_ARRAY *const arr)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromArray(arr));
 }
 
 void JSON_ObjectAppendObject(
-    JSON_OBJECT *obj, const char *key, JSON_OBJECT *obj2)
+    JSON_OBJECT *const obj, const char *const key, JSON_OBJECT *const obj2)
 {
     JSON_ObjectAppend(obj, key, JSON_ValueFromObject(obj2));
 }
@@ -533,7 +520,8 @@ void JSON_ObjectMerge(JSON_OBJECT *const root, const JSON_OBJECT *const obj)
     }
 }
 
-JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *const obj, const char *const key)
+JSON_VALUE *JSON_ObjectGetValue(
+    const JSON_OBJECT *const obj, const char *const key)
 {
     if (obj == nullptr) {
         return nullptr;
@@ -551,50 +539,47 @@ JSON_VALUE *JSON_ObjectGetValue(JSON_OBJECT *const obj, const char *const key)
 int JSON_ObjectGetBool(
     const JSON_OBJECT *const obj, const char *const key, const int d)
 {
-    const JSON_VALUE *const value =
-        JSON_ObjectGetValue((JSON_OBJECT *)obj, key);
+    const JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueGetBool(value, d);
 }
 
 int JSON_ObjectGetInt(
     const JSON_OBJECT *const obj, const char *const key, const int d)
 {
-    const JSON_VALUE *const value =
-        JSON_ObjectGetValue((JSON_OBJECT *)obj, key);
+    const JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueGetInt(value, d);
 }
 
 int64_t JSON_ObjectGetInt64(
     const JSON_OBJECT *const obj, const char *const key, const int64_t d)
 {
-    const JSON_VALUE *const value =
-        JSON_ObjectGetValue((JSON_OBJECT *)obj, key);
+    const JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueGetInt64(value, d);
 }
 
 double JSON_ObjectGetDouble(
     const JSON_OBJECT *const obj, const char *const key, const double d)
 {
-    const JSON_VALUE *const value =
-        JSON_ObjectGetValue((JSON_OBJECT *)obj, key);
+    const JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueGetDouble(value, d);
 }
 
 const char *JSON_ObjectGetString(
     const JSON_OBJECT *const obj, const char *const key, const char *const d)
 {
-    const JSON_VALUE *const value =
-        JSON_ObjectGetValue((JSON_OBJECT *)obj, key);
+    const JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueGetString(value, d);
 }
 
-JSON_ARRAY *JSON_ObjectGetArray(JSON_OBJECT *obj, const char *key)
+JSON_ARRAY *JSON_ObjectGetArray_Impl(
+    const JSON_OBJECT *const obj, const char *const key)
 {
     JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueAsArray(value);
 }
 
-JSON_OBJECT *JSON_ObjectGetObject(JSON_OBJECT *obj, const char *key)
+JSON_OBJECT *JSON_ObjectGetObject_Impl(
+    const JSON_OBJECT *const obj, const char *const key)
 {
     JSON_VALUE *const value = JSON_ObjectGetValue(obj, key);
     return JSON_ValueAsObject(value);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR continues the work started in https://github.com/LostArtefacts/TRX/pull/4743 and does the following changes:

- moves the movable block runtime state into `item->priv`
- preserves `counter_rot` in `item->data`
- adds const/mutable `_Generic` overloads for JSON value/object/array accessors
- adds assertions to the shell module to protect game from crashing in case of files being broken symlinks

#### Testing

- Push blocks with OG saves (loading only)
- Push blocks with BSON saves
- Play around with unique-faced push blocks to test the rotation snapping and counter rotations
- Play around with the push block stacking test level (with savegames)