### PR TITLE
objects: simplify mesh swaps routines

### DIFF
--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -4,7 +4,7 @@
 #include <trx/game/items/anim.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/output.h>
+#include <trx/game/objects/draw.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/shell.h>
@@ -524,98 +524,13 @@ static void M_Control(const int16_t item_num)
 
 static bool M_Draw(const ITEM *const item)
 {
-    ANIM_FRAME *frames[2];
-    int32_t rate;
-    const int32_t frac = Item_GetFrames(item, frames, &rate);
-    const OBJECT *const obj = Object_Get(item->object_id);
-
-    if (obj->shadow_size != 0) {
-        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
-    }
-
-    Matrix_Push();
-    Matrix_TranslateAbs32(item->interp.result.pos);
-    Matrix_Rot16(item->interp.result.rot);
-
-    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
-    if (clip == CLIP_NOT_VISIBLE) {
-        Matrix_Pop();
-        return false;
-    }
-
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
-
     const OBJECT *swap;
     if (item->ai_bits == AI_MODIFY) {
         swap = Object_Get(O_MESH_SWAP_3);
     } else {
         swap = Object_Get(O_MESH_SWAP_2);
     }
-
-    const int16_t *extra_rotation = item->data;
-
-    if (frac != 0) {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_InitInterpolate(frac, rate);
-                Matrix_TranslateRel16_ID(frames[0]->offset, frames[1]->offset);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, obj->base_rot, true);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop_I();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push_I();
-                }
-
-                Matrix_TranslateRel32_I(bone->pos);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, true);
-            } else {
-                Object_DrawMesh(swap->mesh_idx + mesh_idx, clip, true);
-            }
-        }
-    } else {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_TranslateRel16(frames[0]->offset);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(
-                    &extra_rotation, obj->base_rot, false);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push();
-                }
-
-                Matrix_TranslateRel32(bone->pos);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, false);
-            } else {
-                Object_DrawMesh(swap->mesh_idx + mesh_idx, clip, false);
-            }
-        }
-    }
-
-    Matrix_Pop();
-    return true;
+    return Object_DrawAnimatingItemWithSwap(item, swap);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -1,9 +1,10 @@
 #include <trx/game/creature.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/output.h>
+#include <trx/game/objects/draw.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 #include <trx/game/shell.h>
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
@@ -430,10 +431,6 @@ static void M_Control(const int16_t item_num)
 
 bool M_Draw(const ITEM *const item)
 {
-    ANIM_FRAME *frames[2];
-    int32_t rate;
-    const int32_t frac = Item_GetFrames(item, frames, &rate);
-    const OBJECT *const obj = Object_Get(item->object_id);
     M_PRIV *const p = item->priv;
 
     if (item->hit_points <= 0 && item->status != IS_ACTIVE
@@ -445,87 +442,8 @@ bool M_Draw(const ITEM *const item)
         M_TriggerSmoke(smoke_pos, true);
     }
 
-    if (obj->shadow_size != 0) {
-        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
-    }
-
-    Matrix_Push();
-    Matrix_TranslateAbs32(item->interp.result.pos);
-    Matrix_Rot16(item->interp.result.rot);
-
-    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
-    if (clip == CLIP_NOT_VISIBLE) {
-        Matrix_Pop();
-        return false;
-    }
-
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
-
     const OBJECT *const swap = Object_Get(O_MESH_SWAP_1);
-    const int16_t *extra_rotation = item->data;
-
-    if (frac != 0) {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_InitInterpolate(frac, rate);
-                Matrix_TranslateRel16_ID(frames[0]->offset, frames[1]->offset);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, obj->base_rot, true);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop_I();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push_I();
-                }
-
-                Matrix_TranslateRel32_I(bone->pos);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, true);
-            } else {
-                Object_DrawMesh(swap->mesh_idx + mesh_idx, clip, true);
-            }
-        }
-    } else {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_TranslateRel16(frames[0]->offset);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(
-                    &extra_rotation, obj->base_rot, false);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push();
-                }
-
-                Matrix_TranslateRel32(bone->pos);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, false);
-            } else {
-                Object_DrawMesh(swap->mesh_idx + mesh_idx, clip, false);
-            }
-        }
-    }
-
-    Matrix_Pop();
-    return true;
+    return Object_DrawAnimatingItemWithSwap(item, swap);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/creatures/xian_common.c
+++ b/src/trx/game/objects/creatures/xian_common.c
@@ -1,102 +1,15 @@
 #include <trx/game/objects/creatures/xian_common.h>
 
-#include <trx/game/matrix.h>
 #include <trx/game/objects/common.h>
-#include <trx/game/output.h>
+#include <trx/game/objects/draw.h>
 
-// TODO: this duplicates Object_DrawAnimatingItem almost entirely
 bool XianWarrior_Draw(const ITEM *item)
 {
-    ANIM_FRAME *frames[2];
-    int32_t rate;
-    const int32_t frac = Item_GetFrames(item, frames, &rate);
-    const OBJECT *const obj = Object_Get(item->object_id);
-
-    if (obj->shadow_size != 0) {
-        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
-    }
-
-    Matrix_Push();
-    Matrix_TranslateAbs32(item->interp.result.pos);
-    Matrix_Rot16(item->interp.result.rot);
-
-    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
-    if (clip == CLIP_NOT_VISIBLE) {
-        Matrix_Pop();
-        return false;
-    }
-
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
-
-    const OBJECT *jade_obj;
+    const OBJECT *swap;
     if (item->object_id == O_XIAN_SPEARMAN) {
-        jade_obj = Object_Get(O_XIAN_SPEARMAN_STATUE);
+        swap = Object_Get(O_XIAN_SPEARMAN_STATUE);
     } else {
-        jade_obj = Object_Get(O_XIAN_KNIGHT_STATUE);
+        swap = Object_Get(O_XIAN_KNIGHT_STATUE);
     }
-
-    const int16_t *extra_rotation = item->data;
-
-    if (frac != 0) {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_InitInterpolate(frac, rate);
-                Matrix_TranslateRel16_ID(frames[0]->offset, frames[1]->offset);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, obj->base_rot, true);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop_I();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push_I();
-                }
-
-                Matrix_TranslateRel32_I(bone->pos);
-                Matrix_Rot16_ID(
-                    frames[0]->mesh_rots[mesh_idx],
-                    frames[1]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, true);
-            } else {
-                Object_DrawMesh(jade_obj->mesh_idx + mesh_idx, clip, true);
-            }
-        }
-    } else {
-        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
-            if (mesh_idx == 0) {
-                Matrix_TranslateRel16(frames[0]->offset);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(
-                    &extra_rotation, obj->base_rot, false);
-            } else {
-                const ANIM_BONE *const bone = Object_GetBone(obj, mesh_idx - 1);
-                if (bone->matrix_pop) {
-                    Matrix_Pop();
-                }
-                if (bone->matrix_push) {
-                    Matrix_Push();
-                }
-
-                Matrix_TranslateRel32(bone->pos);
-                Matrix_Rot16(frames[0]->mesh_rots[mesh_idx]);
-                Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
-            }
-
-            if (item->mesh_bits & (1 << mesh_idx)) {
-                Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, false);
-            } else {
-                Object_DrawMesh(jade_obj->mesh_idx + mesh_idx, clip, false);
-            }
-        }
-    }
-
-    Matrix_Pop();
-    return true;
+    return Object_DrawAnimatingItemWithSwap(item, swap);
 }

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -152,10 +152,24 @@ void Object_DrawStaticObject(
 
 bool Object_DrawAnimatingItem(const ITEM *item)
 {
+    return Object_DrawAnimatingItemWithSwap(item, nullptr);
+}
+
+bool Object_DrawAnimatingItemWithSwap(
+    const ITEM *const item, const OBJECT *const mesh_swap)
+{
     ANIM_FRAME *frames[2];
     int32_t rate;
-    int32_t frac = Item_GetFrames(item, frames, &rate);
+    const int32_t frac = Item_GetFrames(item, frames, &rate);
     const OBJECT *const obj = Object_Get(item->object_id);
+
+    const OBJECT *swap_obj = mesh_swap;
+    if (swap_obj != nullptr && !swap_obj->loaded) {
+        swap_obj = nullptr;
+    }
+    if (swap_obj != nullptr) {
+        ASSERT(swap_obj->mesh_count == obj->mesh_count);
+    }
 
     if (obj->shadow_size != 0) {
         Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
@@ -175,8 +189,9 @@ bool Object_DrawAnimatingItem(const ITEM *item)
 
     const int16_t *extra_rotation = item->data;
 
-    Object_DrawInterpolatedObject(
-        obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate);
+    Object_DrawInterpolatedObjectWithSwap(
+        obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate,
+        swap_obj);
     if (g_Config.debug.enable_debug_cuboids) {
         Output_DrawCuboid(&frames[0]->bounds);
     }
@@ -185,9 +200,19 @@ bool Object_DrawAnimatingItem(const ITEM *item)
 }
 
 void Object_DrawInterpolatedObject(
-    const OBJECT *const obj, const uint32_t meshes,
+    const OBJECT *const obj, const uint32_t mesh_mask,
     const int16_t *extra_rotation, const ANIM_FRAME *const frame1,
     const ANIM_FRAME *const frame2, const int32_t frac, const int32_t rate)
+{
+    Object_DrawInterpolatedObjectWithSwap(
+        obj, mesh_mask, extra_rotation, frame1, frame2, frac, rate, nullptr);
+}
+
+void Object_DrawInterpolatedObjectWithSwap(
+    const OBJECT *const obj, const uint32_t mesh_mask,
+    const int16_t *extra_rotation, const ANIM_FRAME *const frame1,
+    const ANIM_FRAME *const frame2, const int32_t frac, const int32_t rate,
+    const OBJECT *const mesh_swap)
 {
     if (frame1 == nullptr) {
         return;
@@ -224,8 +249,10 @@ void Object_DrawInterpolatedObject(
                 Object_ApplyExtraRotation(&extra_rotation, bone->rot, true);
             }
 
-            if (meshes & (1 << mesh_idx)) {
+            if ((mesh_mask & (1u << mesh_idx)) != 0) {
                 Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, true);
+            } else if (mesh_swap != nullptr) {
+                Object_DrawMesh(mesh_swap->mesh_idx + mesh_idx, clip, true);
             }
         }
     } else {
@@ -249,8 +276,10 @@ void Object_DrawInterpolatedObject(
                 Object_ApplyExtraRotation(&extra_rotation, bone->rot, false);
             }
 
-            if (meshes & (1 << mesh_idx)) {
+            if ((mesh_mask & (1u << mesh_idx)) != 0) {
                 Object_DrawMesh(obj->mesh_idx + mesh_idx, clip, false);
+            } else if (mesh_swap != nullptr) {
+                Object_DrawMesh(mesh_swap->mesh_idx + mesh_idx, clip, false);
             }
         }
     }
@@ -259,7 +288,7 @@ void Object_DrawInterpolatedObject(
 }
 
 void Object_ApplyExtraRotation(
-    const int16_t **extra_rotation, const XYZ_BOOL rot_flags,
+    const int16_t **const extra_rotation, const XYZ_BOOL rot_flags,
     const bool interpolated)
 {
     const int16_t *rot_ptr = *extra_rotation;

--- a/src/trx/game/objects/draw.h
+++ b/src/trx/game/objects/draw.h
@@ -14,10 +14,17 @@ bool Object_DrawPickupItem(const ITEM *item);
 void Object_DrawStaticObject(const OBJECT *obj, const ANIM_FRAME *frame);
 
 bool Object_DrawAnimatingItem(const ITEM *item);
+bool Object_DrawAnimatingItemWithSwap(
+    const ITEM *item, const OBJECT *mesh_swap);
+
 void Object_DrawInterpolatedObject(
-    const OBJECT *obj, uint32_t meshes, const int16_t *extra_rotation,
+    const OBJECT *obj, uint32_t mesh_mask, const int16_t *extra_rotation,
     const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,
     int32_t rate);
+void Object_DrawInterpolatedObjectWithSwap(
+    const OBJECT *obj, uint32_t mesh_mask, const int16_t *extra_rotation,
+    const ANIM_FRAME *frame1, const ANIM_FRAME *frame2, int32_t frac,
+    int32_t rate, const OBJECT *mesh_swap);
 
 void Object_ApplyExtraRotation(
     const int16_t **extra_rotation, const XYZ_BOOL rot_flags,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR simplifies the logic around Monkeys, Shivas and Xian Warrior statues, to deduplicate code related to mesh swaps.
