### PR TITLE
config: fix crash with null strings

### DIFF
--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -211,7 +211,11 @@ void ConfigFile_LoadOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
                 (const char *)opt->default_value);
             char **const p = (char **)opt->target;
             Memory_FreePointer(p);
-            *p = Memory_DupStr(val);
+            if (val != nullptr) {
+                *p = Memory_DupStr(val);
+            } else {
+                *p = Memory_DupStr(opt->default_value);
+            }
             break;
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Storing nulls or having certain string values missing in the config file would lead to a game crash when launching. It also could happen when saving the config (eg when touching any option). This PR makes sure to fall back to default string values in such scenarios.