### PR TITLE
output: fix save crystal reflection flip

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -186,7 +186,9 @@ void main(void) {
 
     // Reflections
     if ((gFlags & VERT_REFLECTIVE) != 0u && uReflectionsEnabled != 0) {
-        texColor *= texture(uTexEnvMap, (normalize(gNormal) * 0.5 + 0.5).xy) * 2;
+        vec2 env_uv = (normalize(gNormal) * 0.5 + 0.5).xy;
+        env_uv.y = 1.0 - env_uv.y;
+        texColor *= texture(uTexEnvMap, env_uv) * 2;
     }
 
     // Fog

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)
+- fixed save crystal reflections rendering upside down (regression from 4.14)
 - fixed underwater wobble effect acting twitchy with camera movement
 - fixed gun injections overwriting Lara's footstep SFX in all levels (#4733, regression from 1.1)
 - fixed pushblocks in Natla's Mines becoming unusable after loading a save made in earlier versions (#4735, regression from 1.1)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the regression from 4.14 that caused the reflections to be rendered upside-down.