### PR TITLE
sparks: fix rotations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -135,6 +135,7 @@
 - fixed Blades in Coastal Village not respecting antitrigger
 - fixed running down an enemy with a Quad not counting as a kill
 - fixed killing Cobras with a manually-aimed projectile not counting as a kill
+- fixed smoke and spark rotation snapping at 180° instead of rotating smoothly
 
 
 

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -691,7 +691,7 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
     RGBA_8888 color = { spark->color.r, spark->color.g, spark->color.b, 255 };
 
     if ((spark->flags & SPARK_F_ROTATE) != 0U) {
-        const int32_t angle = (int32_t)spark->rot_angle * DEG_180 / 0xFFF.p0;
+        const int32_t angle = (int32_t)spark->rot_angle * DEG_360 / 0xFFF.p0;
         const float s = Math_Sin(angle) / (float)(1 << W2V_SHIFT);
         const float c = Math_Cos(angle) / (float)(1 << W2V_SHIFT);
         for (int32_t i = 0; i < 4; i++) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes various spark rotations snapping back to 0° when crossing 180° instead of going full 360°.

https://github.com/user-attachments/assets/e05d3664-b122-4bce-9c95-5bca45128583

Video by aredfan – note the smoke puff in the lower left corner of the screen near its animation end.