### PR TITLE
misc: fix shadowed variables

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,7 @@ trx_lua_embed = custom_target(
 )
 
 common_build_opts = [
+  '-Wshadow',
   '-Wno-unused',
   '-Wno-unused-parameter',
   '-DMESON_BUILD',

--- a/src/trx/engine/video.c
+++ b/src/trx/engine/video.c
@@ -894,13 +894,12 @@ static void M_InitClock(M_CLOCK *c, int *queue_serial)
     M_SetClock(c, NAN, -1);
 }
 
-static void M_SyncClockToSlave(M_CLOCK *c, M_CLOCK *slave)
+static void M_SyncClockToSlave(M_CLOCK *const c, M_CLOCK *const slave)
 {
-    double M_CLOCK = M_GetClock(c);
+    double clock = M_GetClock(c);
     double slave_clock = M_GetClock(slave);
     if (!isnan(slave_clock)
-        && (isnan(M_CLOCK)
-            || fabs(M_CLOCK - slave_clock) > AV_NOSYNC_THRESHOLD)) {
+        && (isnan(clock) || fabs(clock - slave_clock) > AV_NOSYNC_THRESHOLD)) {
         M_SetClock(c, slave_clock, slave->serial);
     }
 }

--- a/src/trx/game/anims/commands.c
+++ b/src/trx/game/anims/commands.c
@@ -19,29 +19,29 @@ static void M_ParseCommand(ANIM_COMMAND *const command, const int16_t **data)
     }
 
     case AC_JUMP_VELOCITY: {
-        ANIM_COMMAND_VELOCITY_DATA *const data = GameBuf_Alloc(
+        ANIM_COMMAND_VELOCITY_DATA *const cmd_data = GameBuf_Alloc(
             sizeof(ANIM_COMMAND_VELOCITY_DATA), GBUF_ANIM_COMMANDS);
-        data->fall_speed = *data_ptr++;
-        data->speed = *data_ptr++;
-        command->data = (void *)data;
+        cmd_data->fall_speed = *data_ptr++;
+        cmd_data->speed = *data_ptr++;
+        command->data = (void *)cmd_data;
         break;
     }
 
     case AC_SOUND_FX:
     case AC_EFFECT: {
-        ANIM_COMMAND_EFFECT_DATA *const data =
+        ANIM_COMMAND_EFFECT_DATA *const cmd_data =
             GameBuf_Alloc(sizeof(ANIM_COMMAND_EFFECT_DATA), GBUF_ANIM_COMMANDS);
-        data->frame_num = *data_ptr++;
+        cmd_data->frame_num = *data_ptr++;
         const int16_t effect_data = *data_ptr++;
-        data->effect_num = effect_data & 0x3FFF;
-        data->fx_type = 0;
+        cmd_data->effect_num = effect_data & 0x3FFF;
+        cmd_data->fx_type = 0;
         if (command->type == AC_EFFECT && g_TRVersion == 3) {
-            data->fx_type = effect_data & 0xC000;
-            data->environment = ACE_ALL;
+            cmd_data->fx_type = effect_data & 0xC000;
+            cmd_data->environment = ACE_ALL;
         } else {
-            data->environment = (effect_data & 0xC000) >> 14;
+            cmd_data->environment = (effect_data & 0xC000) >> 14;
         }
-        command->data = (void *)data;
+        command->data = (void *)cmd_data;
         break;
     }
 

--- a/src/trx/game/carrier.c
+++ b/src/trx/game/carrier.c
@@ -342,7 +342,6 @@ void Carrier_TestItemDrops(const int16_t item_num)
 
         if (item->room_num != NO_ROOM) {
             // Handle reloading a save with a falling or landed item.
-            ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = item->pos;
             pickup->fall_speed = item->fall_speed;
             Item_UpdateRoom(item->spawn_num, item->room_num);

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -961,14 +961,14 @@ bool Creature_Animate(
         }
 
         if (g_TRVersion >= 3 && hit_item != nullptr) {
-            const int16_t angle = Math_Atan(
-                                      hit_item->pos.z - item->pos.z,
-                                      hit_item->pos.x - item->pos.x)
+            const int16_t item_angle = Math_Atan(
+                                           hit_item->pos.z - item->pos.z,
+                                           hit_item->pos.x - item->pos.x)
                 - item->rot.y;
-            if (angle != 0) {
-                if (ABS(angle) < 2048) {
-                    item->rot.y -= angle;
-                } else if (angle > 0) {
+            if (item_angle != 0) {
+                if (ABS(item_angle) < 2048) {
+                    item->rot.y -= item_angle;
+                } else if (item_angle > 0) {
                     item->rot.y -= 2048;
                 } else {
                     item->rot.y += 2048;
@@ -1030,20 +1030,20 @@ bool Creature_Animate(
         sector = Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
         item->floor = Room_GetHeight(sector, item->pos.x, y, item->pos.z);
 
-        int16_t angle = item->speed != 0 ? Math_Atan(item->speed, -dy) : 0;
+        int16_t item_angle = item->speed != 0 ? Math_Atan(item->speed, -dy) : 0;
         if (g_TRVersion >= 2) {
-            CLAMP(angle, -M_MAX_X_ROT, M_MAX_X_ROT);
+            CLAMP(item_angle, -M_MAX_X_ROT, M_MAX_X_ROT);
         }
 
-        if (angle < item->rot.x - DEG_1) {
+        if (item_angle < item->rot.x - DEG_1) {
             item->rot.x -= DEG_1;
-        } else if (angle > item->rot.x + DEG_1) {
+        } else if (item_angle > item->rot.x + DEG_1) {
             item->rot.x += DEG_1;
         } else {
-            item->rot.x = angle;
+            item->rot.x = item_angle;
         }
     } else {
-        const SECTOR *sector =
+        sector =
             Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
         if (g_TRVersion == 3) {
             const int16_t ceiling =

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -275,12 +275,9 @@ static void M_LoadRoot(const M_CONTEXT *const ctx, JSON_OBJECT *const obj)
     }
     ctx->gf->savegame_fmt_bson = Memory_DupStr(tmp_s);
 
-    {
-        const char *tmp_s =
-            JSON_ObjectGetString(obj, "main_script", JSON_INVALID_STRING);
-        if (tmp_s != JSON_INVALID_STRING) {
-            ctx->gf->main_script_path = Memory_DupStr(tmp_s);
-        }
+    tmp_s = JSON_ObjectGetString(obj, "main_script", JSON_INVALID_STRING);
+    if (tmp_s != JSON_INVALID_STRING) {
+        ctx->gf->main_script_path = Memory_DupStr(tmp_s);
     }
 
     {

--- a/src/trx/game/game_string_table/reader.c
+++ b/src/trx/game/game_string_table/reader.c
@@ -83,8 +83,6 @@ static void M_LoadTableFromJSON(
 
         JSON_OBJECT_ELEMENT *jgs_elem = jgs_obj->start;
         for (size_t i = 0; i < gs_count; i++, jgs_elem = jgs_elem->next) {
-            JSON_OBJECT *const jgs_obj = JSON_ValueAsObject(jgs_elem->value);
-
             const char *const key = jgs_elem->name->string;
             const char *const value =
                 JSON_ValueGetString(jgs_elem->value, JSON_INVALID_STRING);

--- a/src/trx/game/inject/data/anims.c
+++ b/src/trx/game/inject/data/anims.c
@@ -28,9 +28,9 @@ static void M_HandleAnimData(
                 level_info->anims.anim_count, data_count, chunk.injection->fp);
             level_info->anims.anim_count += data_count;
 
-            for (int32_t i = 0; i < data_count; i++) {
+            for (int32_t j = 0; j < data_count; j++) {
                 ANIM *const anim =
-                    Anim_GetAnim(cached_info.anims.anim_count + i);
+                    Anim_GetAnim(cached_info.anims.anim_count + j);
                 anim->jump_anim_num += cached_info.anims.anim_count;
                 anim->frame_ofs += cached_info.anims.frame_count * 2;
                 anim->change_idx += cached_info.anims.change_count;
@@ -52,9 +52,9 @@ static void M_HandleAnimData(
                 chunk.injection->fp);
             level_info->anims.change_count += data_count;
 
-            for (int32_t i = 0; i < data_count; i++) {
+            for (int32_t j = 0; j < data_count; j++) {
                 ANIM_CHANGE *const change =
-                    Anim_GetChange(cached_info.anims.change_count + i);
+                    Anim_GetChange(cached_info.anims.change_count + j);
                 change->range_idx += cached_info.anims.range_count;
             }
             break;
@@ -80,9 +80,9 @@ static void M_HandleAnimData(
                 level_info->anims.range_count, data_count, chunk.injection->fp);
             level_info->anims.range_count += data_count;
 
-            for (int32_t i = 0; i < data_count; i++) {
+            for (int32_t j = 0; j < data_count; j++) {
                 ANIM_RANGE *const range =
-                    Anim_GetRange(cached_info.anims.range_count + i);
+                    Anim_GetRange(cached_info.anims.range_count + j);
                 range->link_anim_num += cached_info.anims.anim_count;
             }
             break;

--- a/src/trx/game/inject/editors/meshes.c
+++ b/src/trx/game/inject/editors/meshes.c
@@ -185,8 +185,8 @@ static void M_MeshEdits(
         edit.vertex_edit_count = VFile_ReadS32(injection->fp);
         edit.vertex_edits =
             Memory_Alloc(sizeof(VERTEX_EDIT) * edit.vertex_edit_count);
-        for (int32_t i = 0; i < edit.vertex_edit_count; i++) {
-            VERTEX_EDIT *vertex_edit = &edit.vertex_edits[i];
+        for (int32_t j = 0; j < edit.vertex_edit_count; j++) {
+            VERTEX_EDIT *vertex_edit = &edit.vertex_edits[j];
             vertex_edit->index = VFile_ReadS16(injection->fp);
             vertex_edit->shift.x = VFile_ReadS16(injection->fp);
             vertex_edit->shift.y = VFile_ReadS16(injection->fp);

--- a/src/trx/game/level/loader.c
+++ b/src/trx/game/level/loader.c
@@ -628,8 +628,8 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         const int32_t sector_count = room->size.x * room->size.z;
         room->sectors =
             GameBuf_Alloc(sizeof(SECTOR) * sector_count, GBUF_ROOM_SECTORS);
-        for (int32_t i = 0; i < sector_count; i++) {
-            SECTOR *const sector = &room->sectors[i];
+        for (int32_t j = 0; j < sector_count; j++) {
+            SECTOR *const sector = &room->sectors[j];
             sector->idx = VFile_ReadU16(file);
             if (loader->game_version == 3) {
                 uint16_t misc_info = VFile_ReadU16(file);
@@ -670,8 +670,8 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
         room->lights = room->num_lights == 0
             ? nullptr
             : GameBuf_Alloc(sizeof(LIGHT) * room->num_lights, GBUF_ROOM_LIGHTS);
-        for (int32_t i = 0; i < room->num_lights; i++) {
-            LIGHT *const light = &room->lights[i];
+        for (int32_t j = 0; j < room->num_lights; j++) {
+            LIGHT *const light = &room->lights[j];
             if (loader->game_version == 3) {
                 // TR3 room lights use the LIGHT_INFO struct layout:
                 // pos (s32*3) + rgb (u8*3) + type (u8) + union (8 bytes).
@@ -721,8 +721,8 @@ void Level_ReadRooms(const LEVEL_LOADER *const loader, VFILE *const file)
             ? nullptr
             : GameBuf_Alloc(
                   sizeof(STATIC_MESH) * static_count, GBUF_ROOM_STATIC_MESHES);
-        for (int32_t i = 0; i < room->num_static_meshes; i++) {
-            STATIC_MESH *const mesh = &room->static_meshes[i];
+        for (int32_t j = 0; j < room->num_static_meshes; j++) {
+            STATIC_MESH *const mesh = &room->static_meshes[j];
             M_ReadPosition(&mesh->pos, file);
             mesh->rot.y = VFile_ReadS16(file);
             M_ReadShade(loader, &mesh->shade, file);

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -6,6 +6,19 @@
 #include <trx/game/sparks/spawners.h>
 #include <trx/version.h>
 
+static void M_SpawnSplash(const GAME_VECTOR pos)
+{
+    const int16_t effect_num = Effect_Create(pos.room_num);
+    if (effect_num != NO_EFFECT) {
+        EFFECT *const effect = Effect_Get(effect_num);
+        effect->pos = pos.pos;
+        effect->rot.y = 0;
+        effect->speed = 0;
+        effect->frame_num = 0;
+        effect->object_id = O_SPLASH_1;
+    }
+}
+
 static void M_Control_TR12(const int16_t effect_num)
 {
     EFFECT *const effect = Effect_Get(effect_num);
@@ -23,17 +36,8 @@ static void M_Control_TR12(const int16_t effect_num)
     const ROOM *const current_room = Room_Get(effect->room_num);
     const ROOM *const next_room = Room_Get(room_num);
     if (!current_room->flags.underwater && next_room->flags.underwater) {
-        const int16_t effect_num = Effect_Create(effect->room_num);
-        if (effect_num != NO_EFFECT) {
-            EFFECT *const splash_fx = Effect_Get(effect_num);
-            splash_fx->pos.x = effect->pos.x;
-            splash_fx->pos.y = effect->pos.y;
-            splash_fx->pos.z = effect->pos.z;
-            splash_fx->rot.y = 0;
-            splash_fx->speed = 0;
-            splash_fx->frame_num = 0;
-            splash_fx->object_id = O_SPLASH_1;
-        }
+        M_SpawnSplash(
+            (GAME_VECTOR) { .pos = effect->pos, .room_num = effect->room_num });
     }
 
     const int32_t ceiling =

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -320,8 +320,8 @@ static void M_Control(const int16_t item_num)
         == PROJECTILE_AREA_DAMAGE_MULTI_SWEEP) {
         Room_GetNearbyRooms(item->pos, radius * 4, radius * 4, item->room_num);
         for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
-            const ROOM *const room = Room_Get(Room_DrawGetRoom(i));
-            for (int16_t target_item_num = room->item_num;
+            const ROOM *const nearby_room = Room_Get(Room_DrawGetRoom(i));
+            for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
                 if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -302,8 +302,8 @@ static void M_Control(const int16_t item_num)
         == PROJECTILE_AREA_DAMAGE_MULTI_SWEEP) {
         Room_GetNearbyRooms(item->pos, radius * 4, radius * 4, item->room_num);
         for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
-            const ROOM *const room = Room_Get(Room_DrawGetRoom(i));
-            for (int16_t target_item_num = room->item_num;
+            const ROOM *const nearby_room = Room_Get(Room_DrawGetRoom(i));
+            for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
                 if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -850,9 +850,8 @@ static void M_Control(const int16_t item_num)
                 + ((360 * Math_Cos(lara_item->rot.y)) >> W2V_SHIFT),
         };
 
-        int16_t room_num = lara_item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+        room_num = lara_item->room_num;
+        sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
         if (Room_GetHeight(sector, pos.x, pos.y, pos.z) >= pos.y - STEP_L) {
             lara_item->pos.x = pos.x;
             lara_item->pos.z = pos.z;

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -852,9 +852,10 @@ bool Skidoo_Control(void)
 
         const int32_t pitch_delta =
             (SKIDOO_MAX_SPEED - skidoo_data->pitch) * 100;
-        const int32_t pitch = (SOUND_DEFAULT_PITCH - pitch_delta) << 8;
 
-        Sound_Effect(SFX_SKIDOO_MOVING, &skidoo->pos, SPM_PITCH | pitch);
+        Sound_Effect(
+            SFX_SKIDOO_MOVING, &skidoo->pos,
+            SPM_PITCH | ((SOUND_DEFAULT_PITCH - pitch_delta) << 8));
     } else {
         skidoo_data->track_mesh = 0;
         if (!drive) {

--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -627,9 +627,8 @@ void Output_CalculateStaticMeshLight(
             continue;
         }
 
-        const int32_t shade = (1 << light->shade.value_1)
+        adder -= (1 << light->shade.value_1)
             - (dist >> (2 * light->falloff.value_1 - light->shade.value_1));
-        adder -= shade;
         if (adder < 0) {
             break;
         }

--- a/src/trx/game/pathing/lot.c
+++ b/src/trx/game/pathing/lot.c
@@ -126,8 +126,7 @@ bool LOT_EnableBaddieAI(const int16_t item_num, const bool always)
 
     int32_t worst_slot = -1;
     for (int32_t slot = 0; slot < LOT_SLOT_COUNT; slot++) {
-        const int32_t item_num = m_BaddieSlots[slot].item_num;
-        const ITEM *const item = Item_Get(item_num);
+        const ITEM *const item = Item_Get(m_BaddieSlots[slot].item_num);
         const int32_t dx = (item->pos.x - g_Camera.pos.pos.x) >> 8;
         const int32_t dy = (item->pos.y - g_Camera.pos.pos.y) >> 8;
         const int32_t dz = (item->pos.z - g_Camera.pos.pos.z) >> 8;

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -775,9 +775,9 @@ static bool M_ReadItem(
                 }
             }
 
-            int16_t game_object_id;
-            M_MUST(M_ReadNum(ctx, "object_id", &game_object_id));
-            carried_item->object_id = Object_FromGameID(game_object_id);
+            int16_t carried_game_object_id;
+            M_MUST(M_ReadNum(ctx, "object_id", &carried_game_object_id));
+            carried_item->object_id = Object_FromGameID(carried_game_object_id);
 
             M_MUST(M_ReadPos(ctx, &carried_item->pos));
             M_MUST(M_ReadNum(ctx, "y_rot", &carried_item->rot.y));

--- a/src/trx/game/savegame/legacy.c
+++ b/src/trx/game/savegame/legacy.c
@@ -702,7 +702,6 @@ static bool M_LoadFromFile(MYFILE *const fp)
 
     // Copy RESUME_INFO of "current position" level to the target level
     if (g_TRVersion == 1) {
-        const GF_LEVEL *const level = Game_GetCurrentLevel();
         const GF_LEVEL *current_position = nullptr;
         const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
         for (int32_t i = 0; i < level_table->count; i++) {
@@ -712,6 +711,7 @@ static bool M_LoadFromFile(MYFILE *const fp)
             }
         }
         if (current_position != nullptr) {
+            const GF_LEVEL *const level = Game_GetCurrentLevel();
             *Savegame_GetCurrentInfo(level) =
                 *Savegame_GetCurrentInfo(current_position);
         }

--- a/src/trx/game/ui/dialogs/settings.c
+++ b/src/trx/game/ui/dialogs/settings.c
@@ -967,7 +967,6 @@ void UI_Settings(UI_SETTINGS_STATE *const s)
     UI_EndModal();
 
     if (s->description.show) {
-        const int32_t sel_row = UI_Scrollable_GetSelectedItem(&s->scroll);
         const UI_SETTINGS_OPTION *const option = M_GetOptionByRow(s, sel_row);
         if (option != nullptr) {
             const char *title = GameString_Get(option->label_id);

--- a/src/trx/game/ui/draw.c
+++ b/src/trx/game/ui/draw.c
@@ -233,9 +233,8 @@ static void M_DrawScreenCentreGradientBox(
 
 static void M_DrawOp_HorizontalLine(const M_DRAW_OP_HORZ_LINE *const op)
 {
-    const float thickness = M_OUTLINE_THICKNESS;
-    const float e = Scaler_Calc(thickness, SCALER_TARGET_TEXT);
     if (g_TRVersion == 1 && op->ui_style == UI_STYLE_PC) {
+        const float e = Scaler_Calc(M_OUTLINE_THICKNESS, SCALER_TARGET_TEXT);
         const RGBA_8888 cd = M_GetMenuColor(C_GENERIC_OUTLINE_DARK);
         const RGBA_8888 cl = M_GetMenuColor(C_GENERIC_OUTLINE_LIGHT);
         M_DrawScreenQuad(
@@ -248,8 +247,7 @@ static void M_DrawOp_HorizontalLine(const M_DRAW_OP_HORZ_LINE *const op)
             op->x0, op->y, op->z, (op->x1 - op->x0) * PHD_ONE / 8, PHD_ONE,
             mesh_idx + 4, (RGBA_F[4]) { M_WHITE, M_WHITE, M_WHITE, M_WHITE });
     } else if (g_TRVersion == 3 && op->ui_style == UI_STYLE_PC) {
-        const float thickness = 1.0f;
-        const float e1 = Scaler_Calc(thickness, SCALER_TARGET_TEXT);
+        const float e1 = Scaler_Calc(1.0f, SCALER_TARGET_TEXT);
         const float e2 = e1 / 3.0f;
         const RGBA_8888 cl = M_GetMenuColor(C_GENERIC_OUTLINE_LIGHT);
         const RGBA_8888 cd = M_GetMenuColor(C_GENERIC_OUTLINE_DARK);
@@ -258,6 +256,7 @@ static void M_DrawOp_HorizontalLine(const M_DRAW_OP_HORZ_LINE *const op)
         M_DrawScreenQuad(
             op->x0, op->y - e2, op->x1, op->y + e2, op->z, cl, cl, cl, cl);
     } else {
+        const float e = Scaler_Calc(M_OUTLINE_THICKNESS, SCALER_TARGET_TEXT);
         M_DrawScreenQuad(
             op->x0, op->y - e, op->x1, op->y + e, op->z,
             M_GetMenuColor(C_BACKGROUND_OUTLINE_BL),

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -384,9 +384,9 @@ static size_t M_WordWrap(
                 // Break word if longer than line
                 if (word_width > max_width) {
                     for (size_t j = i; j < i + word_len; j++) {
-                        const M_GLYPH_INFO *const glyph = glyphs[j];
+                        const M_GLYPH_INFO *const next_glyph = glyphs[j];
                         const float glyph_width =
-                            (glyph->width[current_font] + M_LETTER_SPACING)
+                            (next_glyph->width[current_font] + M_LETTER_SPACING)
                             * scale_f;
                         if (cur_width + glyph_width > max_width) {
                             L_CONCAT_CHAR('\n')
@@ -397,21 +397,21 @@ static size_t M_WordWrap(
                                 cur_width += 2 * space_width;
                             }
                         }
-                        L_CONCAT_STR(glyph->text)
+                        L_CONCAT_STR(next_glyph->text)
                         cur_width += glyph_width;
                     }
                 } else {
                     for (size_t j = i; j < i + word_len; j++) {
-                        const M_GLYPH_INFO *const glyph = glyphs[j];
-                        L_CONCAT_STR(glyph->text)
+                        const M_GLYPH_INFO *const next_glyph = glyphs[j];
+                        L_CONCAT_STR(next_glyph->text)
                     }
                     cur_width = word_width;
                 }
             } else {
                 // Copy word as is
                 for (size_t j = i; j < i + word_len; j++) {
-                    const M_GLYPH_INFO *const glyph = glyphs[j];
-                    L_CONCAT_STR(glyph->text)
+                    const M_GLYPH_INFO *const next_glyph = glyphs[j];
+                    L_CONCAT_STR(next_glyph->text)
                 }
                 cur_width += word_width;
             }

--- a/src/trx/gfx/gl/utils.c
+++ b/src/trx/gfx/gl/utils.c
@@ -25,3 +25,10 @@ const char *GFX_GL_GetErrorString(GLenum err)
         return "UNKNOWN";
     }
 }
+
+void GFX_GL_CheckError(void)
+{
+    for (GLenum err; (err = glGetError()) != GL_NO_ERROR;) {
+        LOG_ERROR("glGetError: (%s)", GFX_GL_GetErrorString(err));
+    }
+}

--- a/src/trx/gfx/gl/utils.h
+++ b/src/trx/gfx/gl/utils.h
@@ -5,11 +5,5 @@
 
 #include <GL/glew.h>
 
-#define GFX_GL_CheckError()                                                    \
-    {                                                                          \
-        for (GLenum err; (err = glGetError()) != GL_NO_ERROR;) {               \
-            LOG_ERROR("glGetError: (%s)", GFX_GL_GetErrorString(err));         \
-        }                                                                      \
-    }
-
+void GFX_GL_CheckError(void);
 const char *GFX_GL_GetErrorString(GLenum err);

--- a/src/trx/utils.h
+++ b/src/trx/utils.h
@@ -38,9 +38,9 @@
 
 #define SWAP(a, b)                                                             \
     do {                                                                       \
-        typeof(a) c = (a);                                                     \
+        typeof(a) SWAP_tmp_ = (a);                                             \
         (a) = (b);                                                             \
-        (b) = c;                                                               \
+        (b) = SWAP_tmp_;                                                       \
     } while (0)
 #define SWAP2(a, b, tmp)                                                       \
     do {                                                                       \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes variable shadowing present in the project throughout, and adds `-Wshadow`.
This helps us catch regressions like the one with gondolas https://github.com/LostArtefacts/TRX/pull/4752 on the compile time level, before they go to QA.

#### Testing

I don't have tips to test – it's a bit all over the place. I can list what I have touched:

- FMV player
- anim commands
- carrier pickup drops
- carrier savegames (dropped vs pre-drop)
- legacy savegames
- settings dialog selected option description
- horizontal line (new game dialog, play previous levels – tr1/2/3)
- tr1/2 + tr3 creature rotations
- level readers
- body parts spawning splashes when landing on water
- multi-sweep grenade/rocket damage
- boat control
- skidoo pitched engine revvs
- tr1/2 + tr3 lights on static meshes
- basic pathfinding

FWIW, I passed my changes through AI, and it did not report any regressions.
I think the risk of regressions is low.