### PR TITLE
objects/skidoo: use new priv data pattern

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -75,6 +75,7 @@
 - fixed underwater wobble effect acting twitchy with camera movement
 - fixed a deviation in water current behaviour that could result in Lara stopping too early (#4706, regression from TR2X 1.1)
 - fixed gun injections overwriting Lara's footstep SFX in underwater levels (#4733, regression from 1.1)
+- fixed exploding Armed Snowmobile not disappearing the vehicle (#4762)
 
 **TR3**:
 - added a new UI bar appearance, "TR3 PC" (Graphic Options → Bars → Bars appearance)
@@ -251,7 +252,7 @@ Showcase: https://www.youtube.com/watch?v=veVYyr--H1A
 - fixed reading room lights for custom TR2 levels (regression from 1.0)
 - fixed the switch in room 46 of Opera House randomly disappearing
 - fixed game crashing when Lara passes through light sources in levels compiled with dxtre3D
-- fixed Skidoo music not getting resumed (#4519)
+- fixed Snowmobile music not getting resumed (#4519)
 - fixed Stopwatch position in the inventory ring (#2014)
 - fixed static lighting on broken ice/windows (#4506, regression from 1.0)
 

--- a/src/trx/game/creature/behavior.c
+++ b/src/trx/game/creature/behavior.c
@@ -86,7 +86,8 @@ void Creature_Hurt(ITEM *const item, const int32_t damage)
 
 bool Creature_IsHostile(const ITEM *const item)
 {
-    if (!Object_IsType(item->object_id, g_CreatureObjects)) {
+    if (item->object_id != O_SKIDOO_ARMED
+        && !Object_IsType(item->object_id, g_CreatureObjects)) {
         return false;
     }
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1130,6 +1130,16 @@ void Creature_Die(const int16_t item_num, const bool explode)
         item->hit_points = 0;
         return;
 
+    case O_SKIDOO_ARMED:
+        if (explode) {
+            Item_Explode(item_num, -1, 0);
+            ITEM *const vehicle_item = Item_Get(item_num);
+            vehicle_item->hit_points = 0;
+            vehicle_item->status = IS_INVISIBLE;
+            return;
+        }
+        break;
+
     case O_SKIDOO_DRIVER:
         if (explode) {
             Item_Explode(item_num, -1, 0);
@@ -1138,6 +1148,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
         const int16_t vehicle_item_num = (int16_t)(intptr_t)item->data;
         ITEM *const vehicle_item = Item_Get(vehicle_item_num);
         vehicle_item->hit_points = 0;
+        vehicle_item->status = IS_INVISIBLE;
         return;
 
     default:

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -43,6 +43,10 @@ static void M_KillDriver(ITEM *const driver_item)
 
 static void M_MakeMountable(ITEM *const skidoo_item)
 {
+    if (skidoo_item->status == IS_INVISIBLE) {
+        return;
+    }
+
     const int32_t skidoo_item_num = Item_GetIndex(skidoo_item);
     LOT_DisableBaddieAI(skidoo_item_num);
     skidoo_item->object_id = O_SKIDOO_FAST;
@@ -223,7 +227,9 @@ static void M_Control(const int16_t driver_item_num)
         Sound_Effect(SFX_SKIDOO_IDLE, &skidoo_item->pos, SPM_NORMAL);
     } else {
         driver_data->head_rotation = driver_data->head_rotation == 1 ? 2 : 1;
-        Skidoo_DoSnowEffect(skidoo_item);
+        if (skidoo_item->status != IS_INVISIBLE) {
+            Skidoo_DoSnowEffect(skidoo_item);
+        }
 
         const int32_t pitch_delta =
             (SKIDOO_MAX_SPEED - skidoo_item->speed) * 100;

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -49,7 +49,7 @@ static void M_MakeMountable(ITEM *const skidoo_item)
     skidoo_item->status = IS_DEACTIVATED;
     Skidoo_Initialise(skidoo_item_num);
 
-    SKIDOO_INFO *const skidoo_data = skidoo_item->data;
+    SKIDOO_INFO *const skidoo_data = skidoo_item->priv;
     skidoo_data->track_mesh = SKIDOO_GUN_MESH;
 }
 

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -157,9 +157,11 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
 void Skidoo_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    if (item->priv == nullptr) {
+        item->priv = GameBuf_Alloc(sizeof(SKIDOO_INFO), GBUF_ITEM_DATA);
+    }
 
-    SKIDOO_INFO *const skidoo_data =
-        GameBuf_Alloc(sizeof(SKIDOO_INFO), GBUF_ITEM_DATA);
+    SKIDOO_INFO *const skidoo_data = item->priv;
     skidoo_data->skidoo_turn = 0;
     skidoo_data->right_fallspeed = 0;
     skidoo_data->left_fallspeed = 0;
@@ -167,8 +169,6 @@ void Skidoo_Initialise(const int16_t item_num)
     skidoo_data->momentum_angle = item->rot.y;
     skidoo_data->track_mesh = 0;
     skidoo_data->pitch = 0;
-
-    item->data = skidoo_data;
 }
 
 int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
@@ -321,7 +321,7 @@ void Skidoo_DoSnowEffect(const ITEM *const skidoo)
 
 int32_t Skidoo_Dynamics(ITEM *const skidoo)
 {
-    SKIDOO_INFO *const skidoo_data = skidoo->data;
+    SKIDOO_INFO *const skidoo_data = skidoo->priv;
 
     XYZ_32 fl_old;
     XYZ_32 bl_old;
@@ -466,7 +466,7 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
 int32_t Skidoo_UserControl(
     ITEM *const skidoo, const int32_t height, int32_t *const out_pitch)
 {
-    SKIDOO_INFO *const skidoo_data = skidoo->data;
+    SKIDOO_INFO *const skidoo_data = skidoo->priv;
 
     bool drive = false;
 
@@ -583,7 +583,7 @@ int32_t Skidoo_CheckGetOffOK(int32_t direction)
 void Skidoo_Animation(
     ITEM *const skidoo, const int32_t collide, const int32_t dead)
 {
-    const SKIDOO_INFO *const skidoo_data = skidoo->data;
+    const SKIDOO_INFO *const skidoo_data = skidoo->priv;
     ITEM *const lara_item = Lara_GetItem();
 
     if (skidoo->pos.y != skidoo->floor && skidoo->fall_speed > 0
@@ -798,7 +798,7 @@ bool Skidoo_Control(void)
 {
     ITEM *const lara_item = Lara_GetItem();
     ITEM *const skidoo = Lara_Vehicle_GetItem();
-    SKIDOO_INFO *const skidoo_data = skidoo->data;
+    SKIDOO_INFO *const skidoo_data = skidoo->priv;
     int32_t collide = Skidoo_Dynamics(skidoo);
 
     XYZ_32 fl;
@@ -939,7 +939,7 @@ bool Skidoo_Control(void)
 bool Skidoo_Draw(const ITEM *const item)
 {
     int32_t track_mesh_status = 0;
-    const SKIDOO_INFO *const skidoo_data = item->data;
+    const SKIDOO_INFO *const skidoo_data = item->priv;
     if (skidoo_data != nullptr) {
         track_mesh_status = skidoo_data->track_mesh;
     }

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -1,11 +1,57 @@
 #include <trx/game/objects.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
+#include <trx/game/savegame/legacy_io.h>
+
+static void M_PrivLoad(ITEM *const item, const JSON_OBJECT *const root)
+{
+    SKIDOO_INFO *const p = item->priv;
+    p->track_mesh = JSON_ObjectGetInt(root, "track_mesh", p->track_mesh);
+    p->skidoo_turn = JSON_ObjectGetInt(root, "skidoo_turn", p->skidoo_turn);
+    p->left_fallspeed =
+        JSON_ObjectGetInt(root, "left_fallspeed", p->left_fallspeed);
+    p->right_fallspeed =
+        JSON_ObjectGetInt(root, "right_fallspeed", p->right_fallspeed);
+    p->momentum_angle =
+        JSON_ObjectGetInt(root, "momentum_angle", p->momentum_angle);
+    p->extra_rotation =
+        JSON_ObjectGetInt(root, "extra_rotation", p->extra_rotation);
+    p->pitch = JSON_ObjectGetInt(root, "pitch", p->pitch);
+}
+
+static void M_PrivSave(const ITEM *const item, JSON_OBJECT *const root)
+{
+    const SKIDOO_INFO *const p = item->priv;
+    JSON_ObjectAppendInt(root, "track_mesh", p->track_mesh);
+    JSON_ObjectAppendInt(root, "skidoo_turn", p->skidoo_turn);
+    JSON_ObjectAppendInt(root, "left_fallspeed", p->left_fallspeed);
+    JSON_ObjectAppendInt(root, "right_fallspeed", p->right_fallspeed);
+    JSON_ObjectAppendInt(root, "momentum_angle", p->momentum_angle);
+    JSON_ObjectAppendInt(root, "extra_rotation", p->extra_rotation);
+    JSON_ObjectAppendInt(root, "pitch", p->pitch);
+}
+
+static void M_PrivLegacyLoad(
+    ITEM *const item, const SAVEGAME_LEGACY_IO *const io)
+{
+    SKIDOO_INFO *const p = item->priv;
+    p->track_mesh = io->read_s16(io);
+    p->skidoo_turn = io->read_s32(io);
+    p->left_fallspeed = io->read_s32(io);
+    p->right_fallspeed = io->read_s32(io);
+    p->momentum_angle = io->read_s16(io);
+    p->extra_rotation = io->read_s16(io);
+    p->pitch = io->read_s32(io);
+}
 
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = Skidoo_Initialise;
     obj->draw_func = Skidoo_Draw;
     obj->collision_func = Skidoo_Collision;
+    obj->priv_size = sizeof(SKIDOO_INFO);
+    obj->priv_load_func = M_PrivLoad;
+    obj->priv_save_func = M_PrivSave;
+    obj->priv_legacy_load_func = M_PrivLegacyLoad;
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -12,7 +12,6 @@
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/vars.h>
-#include <trx/game/objects/vehicles/skidoo_common.h>
 #include <trx/game/output.h>
 #include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
@@ -810,25 +809,6 @@ static bool M_ReadItem(
         if (g_TRVersion == 1 && ctx->sg_version < VERSION_4) {
             Carrier_TestLegacyDrops(item_num);
         }
-    }
-
-    switch (item->object_id) {
-    case O_SKIDOO_FAST: {
-        M_MUST(M_PushObject(ctx, "data"));
-        SKIDOO_INFO *const data = item->data;
-        M_MUST(M_ReadNum(ctx, "track_mesh", &data->track_mesh));
-        M_MUST(M_ReadNum(ctx, "skidoo_turn", &data->skidoo_turn));
-        M_MUST(M_ReadNum(ctx, "left_fallspeed", &data->left_fallspeed));
-        M_MUST(M_ReadNum(ctx, "right_fallspeed", &data->right_fallspeed));
-        M_MUST(M_ReadNum(ctx, "momentum_angle", &data->momentum_angle));
-        M_MUST(M_ReadNum(ctx, "extra_rotation", &data->extra_rotation));
-        M_MUST(M_ReadNum(ctx, "pitch", &data->pitch));
-        M_MUST(M_Pop(ctx));
-        break;
-    }
-
-    default:
-        break;
     }
 
     if (obj->priv_size > 0 && obj->priv_load_func != nullptr) {

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -9,7 +9,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/vehicles/skidoo_common.h>
 #include <trx/game/output.h>
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
@@ -326,27 +325,6 @@ static void M_WriteItem(
         drop_item = drop_item->next_item;
     }
     M_PopAndSet(ctx, "carried_items");
-
-    switch (item->object_id) {
-    case O_SKIDOO_FAST: {
-        if (item->data != nullptr) {
-            const SKIDOO_INFO *const data = (SKIDOO_INFO *)item->data;
-            M_PushObject(ctx);
-            M_WriteNum(ctx, "track_mesh", data->track_mesh);
-            M_WriteNum(ctx, "skidoo_turn", data->skidoo_turn);
-            M_WriteNum(ctx, "left_fallspeed", data->left_fallspeed);
-            M_WriteNum(ctx, "right_fallspeed", data->right_fallspeed);
-            M_WriteNum(ctx, "momentum_angle", data->momentum_angle);
-            M_WriteNum(ctx, "extra_rotation", data->extra_rotation);
-            M_WriteNum(ctx, "pitch", data->pitch);
-            M_PopAndSet(ctx, "data");
-        }
-        break;
-    }
-
-    default:
-        break;
-    }
 
     if (obj->priv_size > 0 && obj->priv_save_func != nullptr) {
         M_PushObject(ctx);

--- a/src/trx/game/savegame/legacy.c
+++ b/src/trx/game/savegame/legacy.c
@@ -7,7 +7,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects/general/pickup.h>
-#include <trx/game/objects/vehicles/skidoo_common.h>
 #include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
@@ -559,18 +558,6 @@ static void M_ReadItem(M_CONTEXT *const ctx, const int16_t item_num)
     }
 
     switch (item->object_id) {
-    case O_SKIDOO_FAST: {
-        SKIDOO_INFO *const data = item->data;
-        data->track_mesh = M_ReadS16(ctx);
-        data->skidoo_turn = M_ReadS32(ctx);
-        data->left_fallspeed = M_ReadS32(ctx);
-        data->right_fallspeed = M_ReadS32(ctx);
-        data->momentum_angle = M_ReadS16(ctx);
-        data->extra_rotation = M_ReadS16(ctx);
-        data->pitch = M_ReadS32(ctx);
-        break;
-    }
-
     default:
         break;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves (mostly) Skidoo internals to `skidoo_fast.c`. 
Unfortunately because the Skidoo driver shares some of the logic with the mountable Skidoos, I had to leave the data structure public, which remains a code smell, but at least we eliminate the misdirected reliance of SG code on Skidoos.