### PR TITLE
Use priv data pattern for the flame emitters

### DIFF
--- a/src/trx/game/effects.c
+++ b/src/trx/game/effects.c
@@ -84,6 +84,19 @@ int16_t Effect_GetNum(const EFFECT *effect)
     return effect - m_Effects;
 }
 
+int16_t Effect_GetInOrderNum(const int16_t effect_num)
+{
+    int16_t order_num = 0;
+    for (int16_t link_num = Effect_GetActiveNum(); link_num != NO_EFFECT;
+         link_num = Effect_Get(link_num)->next_active) {
+        if (link_num == effect_num) {
+            return order_num;
+        }
+        order_num++;
+    }
+    return NO_EFFECT;
+}
+
 int16_t Effect_GetActiveNum(void)
 {
     return m_NextEffectActive;

--- a/src/trx/game/effects/common.h
+++ b/src/trx/game/effects/common.h
@@ -7,6 +7,7 @@ void Effect_Control(void);
 
 EFFECT *Effect_Get(int16_t effect_num);
 int16_t Effect_GetNum(const EFFECT *effect);
+int16_t Effect_GetInOrderNum(int16_t effect_num);
 int16_t Effect_GetActiveNum(void);
 int16_t Effect_Create(int16_t room_num);
 void Effect_Kill(int16_t effect_num);

--- a/src/trx/game/objects/traps/flame_emitter.c
+++ b/src/trx/game/objects/traps/flame_emitter.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/game/effects.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/effects/flame.h>
@@ -5,25 +6,46 @@
 #include <trx/game/sound.h>
 #include <trx/version.h>
 
+typedef struct {
+    int16_t effect_num;
+} M_PRIV;
+
 typedef void (*FLAME_INIT_FUNC)(EFFECT *const effect, const ITEM *const item);
 
-static void M_KillIfAlive(ITEM *const item)
+static void M_SavePriv(const ITEM *const item, JSON_OBJECT *const priv_root)
 {
-    if (item->data == nullptr) {
+    const M_PRIV *const p = item->priv;
+    JSON_ObjectAppendInt(
+        priv_root, "fx_num", Effect_GetInOrderNum(p->effect_num));
+}
+
+static void M_LoadPriv(ITEM *const item, const JSON_OBJECT *const priv_root)
+{
+    if (!g_Config.gameplay.enable_enhanced_saves) {
+        return;
+    }
+    M_PRIV *const p = item->priv;
+    p->effect_num = JSON_ObjectGetInt(priv_root, "fx_num", p->effect_num);
+}
+
+static void M_KillIfAlive(const ITEM *const item)
+{
+    M_PRIV *const p = item->priv;
+    if (p->effect_num == NO_EFFECT) {
         return;
     }
 
-    const int32_t flame_num = ((int32_t)(intptr_t)item->data) - 1;
-    Effect_Kill(flame_num);
-    item->data = nullptr;
+    Effect_Kill(p->effect_num);
+    p->effect_num = NO_EFFECT;
 
     if (g_TRVersion == 1) {
         Sound_StopEffect(SFX_LOOP_FOR_SMALL_FIRES);
     }
 }
 
-static void M_SpawnIfNeeded(ITEM *const item, const FLAME_INIT_FUNC init_func)
+static int16_t M_Spawn(ITEM *const item, const FLAME_INIT_FUNC init_func)
 {
+    M_PRIV *const p = item->priv;
     const int16_t effect_num = Effect_Create(item->room_num);
     if (effect_num != NO_EFFECT) {
         EFFECT *const effect = Effect_Get(effect_num);
@@ -32,18 +54,25 @@ static void M_SpawnIfNeeded(ITEM *const item, const FLAME_INIT_FUNC init_func)
         effect->counter = 0;
         init_func(effect, item);
     }
-    item->data = (void *)(intptr_t)(effect_num + 1);
+    return effect_num;
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->effect_num = NO_EFFECT;
 }
 
 static void M_ControlCommon(
     const int16_t item_num, const FLAME_INIT_FUNC init_func)
 {
     ITEM *const item = Item_Get(item_num);
-
+    M_PRIV *const p = item->priv;
     if (!Item_IsTriggerActive(item)) {
         M_KillIfAlive(item);
-    } else if (item->data == nullptr) {
-        M_SpawnIfNeeded(item, init_func);
+    } else if (p->effect_num == NO_EFFECT) {
+        p->effect_num = M_Spawn(item, init_func);
     }
 }
 
@@ -103,9 +132,13 @@ static void M_ControlSide(const int16_t item_num)
 
 static void M_SetupCommon(OBJECT *const obj, void (*control_func)(int16_t))
 {
+    obj->initialise_func = M_Initialise;
     obj->control_func = control_func;
     obj->draw_func = nullptr;
     obj->save_flags = true;
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -813,26 +813,6 @@ static bool M_ReadItem(
     }
 
     switch (item->object_id) {
-    case O_FLAME_EMITTER:
-    case O_FLAME_EMITTER_BIG:
-    case O_FLAME_EMITTER_SMALL:
-    case O_FLAME_EMITTER_JET:
-    case O_FLAME_EMITTER_SIDE: {
-        if ((g_TRVersion >= 2 || ctx->sg_version >= VERSION_3)
-            && g_Config.gameplay.enable_enhanced_saves) {
-            int32_t effect_num = NO_EFFECT;
-            // TR1X <4.16, TR2X <1.6
-            if (M_ReadNum(ctx, "fx_num", &effect_num)) {
-                item->data = (void *)(intptr_t)(effect_num + 1);
-            } else if (M_PushObject(ctx, "data")) {
-                M_MUST(M_ReadNum(ctx, "fx_num", &effect_num));
-                item->data = (void *)(intptr_t)(effect_num + 1);
-                M_MUST(M_Pop(ctx));
-            }
-        }
-        break;
-    }
-
     case O_SKIDOO_FAST: {
         M_MUST(M_PushObject(ctx, "data"));
         SKIDOO_INFO *const data = item->data;

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -328,22 +328,6 @@ static void M_WriteItem(
     M_PopAndSet(ctx, "carried_items");
 
     switch (item->object_id) {
-    case O_FLAME_EMITTER:
-    case O_FLAME_EMITTER_BIG:
-    case O_FLAME_EMITTER_SMALL:
-    case O_FLAME_EMITTER_JET:
-    case O_FLAME_EMITTER_SIDE:
-        if (item->data != nullptr) {
-            const int32_t effect_num =
-                fx_order->id_map[(int32_t)(intptr_t)item->data - 1];
-            // TR1X <4.16, TR2X <1.6
-            M_WriteNum(ctx, "fx_num", effect_num);
-            M_PushObject(ctx);
-            M_WriteNum(ctx, "fx_num", effect_num);
-            M_PopAndSet(ctx, "data");
-        }
-        break;
-
     case O_SKIDOO_FAST: {
         if (item->data != nullptr) {
             const SKIDOO_INFO *const data = (SKIDOO_INFO *)item->data;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is a bit weird because I found the save routines' presence, or lack thereof, to have no seeming effect on the game.
I checked this by fiddling with the enhanced save games on/off, and trying to get Lara to catch fire twice by saving/reloading and walking into fire emitters. All good all around.
And TR3 flames still restart, because they're controlled by sparks, which we do not save (yet?).

So…
What I did here was to remove the save/load special handlers for the flame emitters, and replace `item->data` with `item->priv` usage.