### PR TITLE
phase/executor: fix interrupts not skipping fade-outs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 - fixed Cobras not being counted in level kill count
 - fixed stats dialog retaining friendly status for allies that become enemy types in later levels, causing them to get excluded from kill count
 - fixed targeting hostile ex-allies not working if "Enable ally targeting" option is off
+- fixed `/play` and similar commands fading out instead of running instantly on stats/title screens
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/phase/control.h
+++ b/src/trx/game/phase/control.h
@@ -6,6 +6,7 @@ typedef enum {
     PHASE_ACTION_CONTINUE,
     PHASE_ACTION_NO_WAIT,
     PHASE_ACTION_END,
+    PHASE_ACTION_END_FAST,
 } PHASE_ACTION;
 
 // Status returned upon every logical frame by the control routine.

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -127,7 +127,10 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
 
     const GF_COMMAND gf_cmd = M_HandleOverride();
     if (gf_cmd.action != GF_NOOP) {
-        return (PHASE_CONTROL) { .action = PHASE_ACTION_END, .gf_cmd = gf_cmd };
+        return (PHASE_CONTROL) {
+            .action = PHASE_ACTION_END_FAST,
+            .gf_cmd = gf_cmd,
+        };
     }
 
     if (Shell_IsExiting() && !m_Exiting) {
@@ -222,6 +225,8 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
         m_PendingFadeToBlack = false;
     }
 
+    bool skip_fade_out = false;
+
     if (phase->start != nullptr) {
         Clock_SyncTick();
         g_OldInputDB = g_Input;
@@ -231,6 +236,10 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
             goto finish;
         } else if (control.action == PHASE_ACTION_END) {
             gf_cmd = control.gf_cmd;
+            goto finish;
+        } else if (control.action == PHASE_ACTION_END_FAST) {
+            gf_cmd = control.gf_cmd;
+            skip_fade_out = true;
             goto finish;
         }
     }
@@ -244,6 +253,14 @@ GF_COMMAND PhaseExecutor_Run(PHASE *const phase)
                 if (Shell_IsExiting()) {
                     gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
                 } else {
+                    gf_cmd = control.gf_cmd;
+                }
+                goto finish;
+            } else if (control.action == PHASE_ACTION_END_FAST) {
+                if (Shell_IsExiting()) {
+                    gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
+                } else {
+                    skip_fade_out = true;
                     gf_cmd = control.gf_cmd;
                 }
                 goto finish;
@@ -276,7 +293,7 @@ finish:
         phase->end(phase);
     }
 
-    if (phase->request_fade_to_black != nullptr) {
+    if (!skip_fade_out && phase->request_fade_to_black != nullptr) {
         m_PendingFadeToBlack =
             phase->request_fade_to_black(phase, &m_PendingFadeToBlackArgs);
     } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a bug where issuing `/play` and similar commands in cross-fade capable screens (stats, inventory ring) would do a fade-out, instead of getting executed immediately as expected.
