### PR TITLE
Drop support for <TRX 1.0 BSON saves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
     - `on_control_post` → `after_control`
 - changed turbo cheat to auto‑reset to normal speed if pushed past limit, making it easier for new players to recover from accidental changes
 - changed Blades to support being reset
+- removed support for < TRX 1.0 savegames
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -154,7 +154,7 @@ M_GF_HANDLER(M_HandlePlayLevel)
 
     default:
         if (level->type == GFL_NORMAL || level->type == GFL_BONUS) {
-            Savegame_SetInitialVersion(SAVEGAME_CURRENT_VERSION);
+            Savegame_SetInitialVersion(SG_CURRENT_VERSION);
             GF_InventoryModifier_Scan(Game_GetCurrentLevel());
             GF_InventoryModifier_Apply(Game_GetCurrentLevel(), GF_INV_REGULAR);
         }

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -82,7 +82,7 @@ static bool M_IsRelevant(
         }
         const SAVEGAME_INFO *const info =
             Savegame_GetSavegameInfo(Savegame_GetBoundSlot());
-        if (info != nullptr && (info->initial_version == VERSION_LEGACY)) {
+        if (info != nullptr && (info->initial_version == SG_VERSION_LEGACY)) {
             return false;
         }
         return true;

--- a/src/trx/game/savegame.h
+++ b/src/trx/game/savegame.h
@@ -1,6 +1,5 @@
 #pragma once
 
 #include <trx/game/savegame/common.h>
-#include <trx/game/savegame/const.h>
 #include <trx/game/savegame/enum.h>
 #include <trx/game/savegame/types.h>

--- a/src/trx/game/savegame/bson.c
+++ b/src/trx/game/savegame/bson.c
@@ -112,7 +112,7 @@ static void M_SaveRaw(
     const SAVEGAME_BSON_HEADER header = {
         .magic = g_TRVersion == 1 ? M_MAGIC_TR1X : M_MAGIC_TR2X,
         .initial_version = Savegame_GetInitialVersion(),
-        .version = SAVEGAME_CURRENT_VERSION,
+        .version = SG_CURRENT_VERSION,
         .compressed_size = compressed_size,
         .uncompressed_size = uncompressed_size,
     };
@@ -187,9 +187,15 @@ static bool M_FillInfo(MYFILE *const fp, SAVEGAME_INFO *const info)
     SAVEGAME_BSON_HEADER header;
     File_Seek(fp, 0, FILE_SEEK_SET);
     File_ReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER));
+    if (header.version < SG_MIN_SUPPORTED_VERSION) {
+        LOG_WARNING(
+            "Too old SG version: %d (min supported: %d)", header.version,
+            SG_MIN_SUPPORTED_VERSION);
+        return false;
+    }
     info->initial_version = header.initial_version;
-    info->features.restart = header.initial_version >= VERSION_LEGACY;
-    info->features.select_level = header.initial_version >= VERSION_1;
+    info->features.restart = header.initial_version >= SG_VERSION_LEGACY;
+    info->features.select_level = header.initial_version >= SG_VERSION_1;
 
     // recover the slot information from the end of the file
     File_Skip(fp, header.compressed_size);

--- a/src/trx/game/savegame/bson_read.c
+++ b/src/trx/game/savegame/bson_read.c
@@ -29,7 +29,7 @@
 
 #define M_MAX_STACK_SIZE 10
 #define M_SHOULD(x) ((x) ? 1 : (LOG_WARNING("%s", ctx->error_msg), 0))
-#define M_OPTIONAL(x) (void)(x);
+#define M_OPTIONAL(x) (x)
 #define M_MUST(x)                                                              \
     if (!(x)) {                                                                \
         goto fail;                                                             \
@@ -187,7 +187,7 @@ static bool M_PushArrayElem(M_CONTEXT *const ctx, const size_t i)
     return true;
 }
 
-static int32_t M_HasKey(M_CONTEXT *const ctx, const char *const key)
+static bool M_HasKey(M_CONTEXT *const ctx, const char *const key)
 {
     JSON_OBJECT *const obj = JSON_ValueAsObject(ctx->current);
     if (obj == nullptr) {
@@ -215,18 +215,8 @@ static bool M_ReadBoolDirect(M_CONTEXT *const ctx, bool *const target)
         *target = false;
         return true;
     } else {
-        // TR1X <4.16, TR2X <1.6
-        const int32_t int_val = JSON_ValueGetInt(ctx->current, -1);
-        if (int_val == 1) {
-            *target = true;
-            return true;
-        } else if (int_val == 0) {
-            *target = false;
-            return true;
-        } else {
-            M_SetError(ctx, "not a bool");
-            return false;
-        }
+        M_SetError(ctx, "not a bool");
+        return false;
     }
 }
 
@@ -345,28 +335,14 @@ static bool M_ReadXYZ16(
 static bool M_ReadPos(M_CONTEXT *const ctx, XYZ_32 *const target)
 {
     ASSERT(target != nullptr);
-    if (M_HasKey(ctx, "x")) {
-        // TR1X <4.16
-        M_MUST(M_ReadNum(ctx, "x", &target->x));
-        M_MUST(M_ReadNum(ctx, "y", &target->y));
-        M_MUST(M_ReadNum(ctx, "z", &target->z));
-    } else {
-        M_MUST(M_ReadXYZ32(ctx, "pos", target));
-    }
+    M_MUST(M_ReadXYZ32(ctx, "pos", target));
     M_FINISH();
 }
 
 static bool M_ReadRot(M_CONTEXT *const ctx, XYZ_16 *const target)
 {
     ASSERT(target != nullptr);
-    if (M_HasKey(ctx, "x_rot")) {
-        // TR1X <v4.16
-        M_MUST(M_ReadNum(ctx, "x_rot", &target->x));
-        M_MUST(M_ReadNum(ctx, "y_rot", &target->y));
-        M_MUST(M_ReadNum(ctx, "z_rot", &target->z));
-    } else {
-        M_MUST(M_ReadXYZ16(ctx, "rot", target));
-    }
+    M_MUST(M_ReadXYZ16(ctx, "rot", target));
     M_FINISH();
 }
 
@@ -376,6 +352,10 @@ static bool M_ReadObjectID(
     int32_t game_id = 0;
     M_MUST(M_ReadNum(ctx, key, &game_id));
     *target = Object_FromGameID(game_id);
+    if (*target == NO_OBJECT) {
+        M_SetError(ctx, "unsupported object #%d", game_id);
+        M_FAIL();
+    }
     M_FINISH();
 }
 
@@ -384,8 +364,7 @@ static bool M_ReadArm(
 {
     ASSERT(arm != nullptr);
     M_MUST(M_PushObject(ctx, key));
-    // TR1X <4.16
-    M_OPTIONAL(M_ReadNum(ctx, "anim_num", &arm->anim_num));
+    M_MUST(M_ReadNum(ctx, "anim_num", &arm->anim_num));
     M_MUST(M_ReadNum(ctx, "frame_num", &arm->frame_num));
     M_MUST(M_ReadNum(ctx, "lock", &arm->lock));
     M_MUST(M_ReadNum(ctx, "flash_gun", &arm->flash_gun));
@@ -409,13 +388,16 @@ static bool M_ReadLara(M_CONTEXT *const ctx)
     LARA_INFO *const lara = Lara_GetLaraInfo();
     ASSERT(lara != nullptr);
 
-    M_MUST(M_ReadNum(ctx, "item_number", &lara->item_num));
+    if (!M_OPTIONAL(M_ReadNum(ctx, "item_number", &lara->item_num))) {
+        // Introduced in TRX 1.2
+        M_MUST(M_ReadNum(ctx, "item_num", &lara->item_num));
+    }
     M_MUST(M_ReadNum(ctx, "gun_status", &lara->gun_status));
     M_MUST(M_ReadNum(ctx, "gun_type", &lara->gun_type));
     M_MUST(M_ReadNum(ctx, "request_gun_type", &lara->request_gun_type));
 
     // TRX <1.1
-    if (g_TRVersion == 2 && ctx->sg_version < VERSION_14) {
+    if (g_TRVersion == 2 && ctx->sg_version < SG_VERSION_14) {
         if (lara->gun_type == LGT_MAGNUMS) {
             lara->gun_type = LGT_AUTOS;
         }
@@ -424,60 +406,49 @@ static bool M_ReadLara(M_CONTEXT *const ctx)
         }
     }
 
-    // TR1X <4.12
-    if (M_HasKey(ctx, "last_gun_type")) {
-        M_MUST(M_ReadNum(ctx, "last_gun_type", &lara->last_gun_type));
-    } else {
-        lara->last_gun_type = lara->request_gun_type;
-    }
-    // Only TR1X >= 4.16, TR2X >=* have new back-gun support
-    M_OPTIONAL(M_ReadObjectID(ctx, "back_gun_obj_id", &lara->back_gun_obj_id));
+    M_MUST(M_ReadNum(ctx, "last_gun_type", &lara->last_gun_type));
+    M_MUST(M_ReadObjectID(ctx, "back_gun_obj_id", &lara->back_gun_obj_id));
     M_MUST(M_ReadNum(ctx, "calc_fall_speed", &lara->calc_fall_speed));
     M_MUST(M_ReadNum(ctx, "water_status", &lara->water_status));
-    // Only TR1X >= 4.15, TR2X >=* has ladder support
-    M_OPTIONAL(M_ReadBool(ctx, "climb_status", &lara->climb_status));
-    M_OPTIONAL(M_ReadBool(ctx, "is_crouched", &lara->is_crouched));
-    M_OPTIONAL(M_ReadBool(ctx, "keep_crouched", &lara->keep_crouched));
+    M_MUST(M_ReadBool(ctx, "climb_status", &lara->climb_status));
+    M_SHOULD(M_ReadBool(ctx, "is_crouched", &lara->is_crouched));
+    M_SHOULD(M_ReadBool(ctx, "keep_crouched", &lara->keep_crouched));
     M_MUST(M_ReadNum(ctx, "pose_count", &lara->pose_count));
     M_MUST(M_ReadNum(ctx, "hit_frame", &lara->hit_frame));
     M_MUST(M_ReadNum(ctx, "hit_direction", &lara->hit_direction));
     M_MUST(M_ReadNum(ctx, "air", &lara->air));
-    // Only TR1X >=4.14, TR2X >=1.4 have sprint function
-    M_OPTIONAL(M_ReadNum(ctx, "sprint_timer", &lara->sprint_timer));
-    // Only TR1X >=4.16, TR2X >=1.6 have exposure bar function
-    M_OPTIONAL(M_ReadNum(ctx, "exposure_timer", &lara->exposure_timer));
-    M_OPTIONAL(M_ReadNum(ctx, "poison_timer", &lara->poison_timer));
+    M_MUST(M_ReadNum(ctx, "sprint_timer", &lara->sprint_timer));
+    M_MUST(M_ReadNum(ctx, "exposure_timer", &lara->exposure_timer));
+    M_SHOULD(M_ReadNum(ctx, "poison_timer", &lara->poison_timer));
     M_MUST(M_ReadNum(ctx, "dive_count", &lara->dive_timer));
     M_MUST(M_ReadNum(ctx, "death_count", &lara->death_timer));
     M_MUST(M_ReadNum(ctx, "current_active", &lara->current.active));
-    M_OPTIONAL(M_ReadNum(ctx, "current_vel_x", &lara->current.vel.x));
-    M_OPTIONAL(M_ReadNum(ctx, "current_vel_z", &lara->current.vel.z));
-    // Only TR1X >=4.12, TR2X >=* have burn flag
-    M_OPTIONAL(M_ReadBool(ctx, "burn", &lara->burn));
+    M_SHOULD(M_ReadNum(ctx, "current_vel_x", &lara->current.vel.x));
+    M_SHOULD(M_ReadNum(ctx, "current_vel_z", &lara->current.vel.z));
+    M_MUST(M_ReadBool(ctx, "burn", &lara->burn));
 
     M_MUST(M_ReadNum(ctx, "mesh_effects", &lara->mesh_effects));
-    M_OPTIONAL(M_ReadBool(ctx, "extra_anim", &lara->extra_anim));
-    M_OPTIONAL(M_ReadNum(ctx, "water_surface_dist", &lara->water_surface_dist));
+    M_MUST(M_ReadBool(ctx, "extra_anim", &lara->extra_anim));
+    M_MUST(M_ReadNum(ctx, "water_surface_dist", &lara->water_surface_dist));
 
-    // Only TR1X >=4.8, TR2X >=* stores hit effect count information
-    M_OPTIONAL(M_ReadNum(ctx, "hit_effect_count", &lara->hit_effect_count));
-    // Only TR1X >=4.8, TR2X >=- stores hit effect information
+    M_MUST(M_ReadNum(ctx, "hit_effect_count", &lara->hit_effect_count));
     int16_t hit_effect = NO_EFFECT;
-    M_OPTIONAL(M_ReadNum(ctx, "hit_effect", &hit_effect));
+    M_MUST(M_ReadNum(ctx, "hit_effect", &hit_effect));
     lara->hit_effect =
         hit_effect != NO_EFFECT && g_Config.gameplay.enable_enhanced_saves
         ? Effect_Get(hit_effect)
         : nullptr;
 
     const int16_t vehicle_idx = Lara_Vehicle_GetIndex();
-    // Only TR1X >=4.16, TR2X >=* stores vehicle information
-    M_OPTIONAL(M_ReadNum(ctx, "vehicle_item_number", &vehicle_idx));
+    if (!M_OPTIONAL(M_ReadNum(ctx, "vehicle_item_number", &vehicle_idx))) {
+        // Introduced in TRX 1.2
+        M_MUST(M_ReadNum(ctx, "vehicle_item_num", &vehicle_idx));
+    }
     Lara_Vehicle_SetIndex(vehicle_idx);
 
-    // Only TR1X >=4.16, TR2X >=* stores flares information
-    M_OPTIONAL(M_ReadNum(ctx, "flare_age", &lara->flare.age));
-    M_OPTIONAL(M_ReadNum(ctx, "flare_frame", &lara->flare.frame_num));
-    M_OPTIONAL(M_ReadBool(ctx, "flare_control_left", &lara->flare.control));
+    M_MUST(M_ReadNum(ctx, "flare_age", &lara->flare.age));
+    M_MUST(M_ReadNum(ctx, "flare_frame", &lara->flare.frame_num));
+    M_MUST(M_ReadBool(ctx, "flare_control_left", &lara->flare.control));
 
     M_MUST(M_PushObject(ctx, "meshes"));
     const int32_t mesh_count = M_GetArrayLength(ctx);
@@ -489,7 +460,7 @@ static bool M_ReadLara(M_CONTEXT *const ctx)
     for (int32_t i = 0; i < mesh_count; i++) {
         M_MUST(M_PushArrayElem(ctx, i));
         int32_t idx = Object_GetMeshOffset(lara->mesh_ptrs[i]);
-        M_OPTIONAL(M_ReadNumDirect(ctx, &idx));
+        M_MUST(M_ReadNumDirect(ctx, &idx));
         OBJECT_MESH *const mesh = Object_FindMesh(idx);
         if (mesh != nullptr) {
             lara->mesh_ptrs[i] = mesh;
@@ -505,29 +476,9 @@ static bool M_ReadLara(M_CONTEXT *const ctx)
     M_MUST(M_ReadNum(ctx, "target_angle2", &lara->target_angles[1]));
     M_MUST(M_ReadNum(ctx, "turn_rate", &lara->turn_rate));
     M_MUST(M_ReadNum(ctx, "move_angle", &lara->move_angle));
-    if (M_HasKey(ctx, "head_rot.y")) {
-        // TR1X <4.16
-        M_MUST(M_ReadNum(ctx, "head_rot.y", &lara->head_rot.y));
-        M_MUST(M_ReadNum(ctx, "head_rot.x", &lara->head_rot.x));
-        M_MUST(M_ReadNum(ctx, "head_rot.z", &lara->head_rot.z));
-        M_MUST(M_ReadNum(ctx, "torso_rot.y", &lara->torso_rot.y));
-        M_MUST(M_ReadNum(ctx, "torso_rot.x", &lara->torso_rot.x));
-        M_MUST(M_ReadNum(ctx, "torso_rot.z", &lara->torso_rot.z));
-    } else {
-        M_MUST(M_ReadXYZ16(ctx, "head_rot", &lara->head_rot));
-        M_MUST(M_ReadXYZ16(ctx, "torso_rot", &lara->torso_rot));
-    }
-
-    if (g_TRVersion == 1) {
-        if (ctx->sg_version >= VERSION_7) {
-            // TR1X > 4.8
-            M_MUST(M_ReadNum(ctx, "last_pos.x", &lara->last_pos.x));
-            M_MUST(M_ReadNum(ctx, "last_pos.y", &lara->last_pos.y));
-            M_MUST(M_ReadNum(ctx, "last_pos.z", &lara->last_pos.z));
-        }
-    } else {
-        M_MUST(M_ReadXYZ32(ctx, "last_pos", &lara->last_pos));
-    }
+    M_MUST(M_ReadXYZ16(ctx, "head_rot", &lara->head_rot));
+    M_MUST(M_ReadXYZ16(ctx, "torso_rot", &lara->torso_rot));
+    M_MUST(M_ReadXYZ32(ctx, "last_pos", &lara->last_pos));
 
     M_MUST(M_ReadArm(ctx, "left_arm", &lara->left_arm));
     M_MUST(M_ReadArm(ctx, "right_arm", &lara->right_arm));
@@ -535,47 +486,19 @@ static bool M_ReadLara(M_CONTEXT *const ctx)
     M_MUST(M_ReadAmmo(ctx, "magnums", &lara->magnum_ammo));
     M_MUST(M_ReadAmmo(ctx, "uzis", &lara->uzi_ammo));
     M_MUST(M_ReadAmmo(ctx, "shotgun", &lara->shotgun_ammo));
-    // TR1X <4.16
-    M_OPTIONAL(M_ReadAmmo(ctx, "harpoon", &lara->harpoon_ammo));
-    M_OPTIONAL(M_ReadAmmo(ctx, "grenade", &lara->grenade_ammo));
-    M_OPTIONAL(M_ReadAmmo(ctx, "m16", &lara->m16_ammo));
+    M_MUST(M_ReadAmmo(ctx, "harpoon", &lara->harpoon_ammo));
+    M_MUST(M_ReadAmmo(ctx, "grenade", &lara->grenade_ammo));
+    M_MUST(M_ReadAmmo(ctx, "m16", &lara->m16_ammo));
+    M_SHOULD(M_ReadAmmo(ctx, "autos", &lara->autos_ammo));
+    M_SHOULD(M_ReadAmmo(ctx, "desert_eagle", &lara->desert_eagle_ammo));
+    M_SHOULD(M_ReadAmmo(ctx, "mp5", &lara->mp5_ammo));
+    M_SHOULD(M_ReadAmmo(ctx, "rocket", &lara->rocket_ammo));
 
-    // TRX <1.1
-    M_OPTIONAL(M_ReadAmmo(ctx, "autos", &lara->autos_ammo));
-    M_OPTIONAL(M_ReadAmmo(ctx, "desert_eagle", &lara->desert_eagle_ammo));
-    M_OPTIONAL(M_ReadAmmo(ctx, "mp5", &lara->mp5_ammo));
-    M_OPTIONAL(M_ReadAmmo(ctx, "rocket", &lara->rocket_ammo));
-
-    if (g_TRVersion == 1 && ctx->sg_version < VERSION_13) {
-        const bool has_rifle = Inv_RequestItem(O_SHOTGUN_ITEM) != 0;
-        Gun_Rifle_LoadLegacy(has_rifle);
-    } else if (M_HasKey(ctx, "weapon")) {
-        M_MUST(M_PushObject(ctx, "weapon"));
-        lara->gun_item_num = Item_Create();
-        ITEM *const weapon_item = Item_Get(lara->gun_item_num);
-        M_MUST(M_ReadObjectID(ctx, "obj_id", &weapon_item->object_id));
-        M_MUST(M_ReadNum(ctx, "anim_num", &weapon_item->anim_num));
-        M_MUST(M_ReadNum(ctx, "frame_num", &weapon_item->frame_num));
-        M_MUST(M_ReadNum(
-            ctx, "current_anim_state", &weapon_item->current_anim_state));
-        M_MUST(
-            M_ReadNum(ctx, "goal_anim_state", &weapon_item->goal_anim_state));
-        weapon_item->status = IS_ACTIVE;
-        weapon_item->room_num = NO_ROOM;
-        M_MUST(M_Pop(ctx));
-    }
-
-    if (M_HasKey(ctx, "interact_target.item_num")) {
-        // TR1X >4.4, TR2X >1.2
-        M_MUST(M_ReadNum(
-            ctx, "interact_target.item_num", &lara->interact_target.item_num));
-        M_MUST(M_ReadNum(
-            ctx, "interact_target.move_count",
-            &lara->interact_target.move_count));
-        M_MUST(M_ReadBool(
-            ctx, "interact_target.is_moving",
-            &lara->interact_target.is_moving));
-    }
+    M_MUST(M_PushObject(ctx, "interact_target"));
+    M_MUST(M_ReadNum(ctx, "item_num", &lara->interact_target.item_num));
+    M_MUST(M_ReadNum(ctx, "move_count", &lara->interact_target.move_count));
+    M_MUST(M_ReadBool(ctx, "is_moving", &lara->interact_target.is_moving));
+    M_MUST(M_Pop(ctx));
 
     M_FINISH();
 }
@@ -628,15 +551,10 @@ static bool M_ReadItem(
 {
     ITEM *const item = Item_Get(item_num);
 
-    int16_t game_object_id = -1;
-    if (!M_ReadNum(ctx, "object_id", &game_object_id)) {
-        // TR1X <4.16, TR2X <1.6
-        M_MUST(M_ReadNum(ctx, "obj_num", &game_object_id));
-    }
-    const OBJECT_ID object_id = Object_FromGameID(game_object_id);
-    if (object_id == NO_OBJECT) {
+    OBJECT_ID object_id = NO_OBJECT;
+    // Not all TR3 objects are implemented as of >= TRX 1.1
+    if (!M_SHOULD(M_ReadObjectID(ctx, "object_id", &object_id))) {
         item->object_id = O_DUMMY;
-        LOG_ERROR("Unsupported object #%d", game_object_id);
         return true;
     }
 
@@ -671,8 +589,7 @@ static bool M_ReadItem(
         M_SHOULD(M_ReadNum(ctx, "required_anim", &item->required_anim_state));
         M_SHOULD(M_ReadNum(ctx, "anim_num", &item->anim_num));
         M_SHOULD(M_ReadNum(ctx, "frame_num", &item->frame_num));
-        // TRX >= 1.0 stores previous frame for interpolation checks
-        M_OPTIONAL(M_ReadNum(ctx, "prev_frame_num", &item->prev_frame_num));
+        M_SHOULD(M_ReadNum(ctx, "prev_frame_num", &item->prev_frame_num));
 
         // Prevent issues with pre-injection saves and Lara's enhanced
         // animation set.
@@ -683,16 +600,15 @@ static bool M_ReadItem(
     }
 
     if (obj->save_hitpoints) {
-        M_SHOULD(M_ReadNum(ctx, "hitpoints", &item->hit_points));
-        // TR1X >= 4.16, TR2X >=1.6 store max hit points information
-        M_OPTIONAL(M_ReadNum(ctx, "max_hitpoints", &item->max_hit_points));
+        M_MUST(M_ReadNum(ctx, "hitpoints", &item->hit_points));
+        M_MUST(M_ReadNum(ctx, "max_hitpoints", &item->max_hit_points));
     }
 
     if (obj->save_flags) {
         M_MUST(M_ReadNum(ctx, "flags", &item->flags));
         M_MUST(M_ReadNum(ctx, "timer", &item->timer));
         ITEM_STATUS saved_status = item->status;
-        M_OPTIONAL(M_ReadNum(ctx, "status", &saved_status));
+        M_MUST(M_ReadNum(ctx, "status", &saved_status));
 
         if ((item->flags & IF_KILLED) != 0) {
             Item_Kill(item_num);
@@ -705,13 +621,16 @@ static bool M_ReadItem(
             }
             item->status = saved_status;
             M_MUST(M_ReadBool(ctx, "gravity", &item->gravity));
+            // Introduced in TRX 1.2
             M_OPTIONAL(M_ReadBool(ctx, "collidable", &item->collidable));
         }
-        M_OPTIONAL(M_ReadNum(ctx, "ai_bits", &item->ai_bits));
-        M_OPTIONAL(M_ReadNum(ctx, "ai_tag", &item->ai_tag));
+        // Introduced in TRX 1.2
+        M_SHOULD(M_ReadNum(ctx, "ai_bits", &item->ai_bits));
+        M_SHOULD(M_ReadNum(ctx, "ai_tag", &item->ai_tag));
 
         bool intelligent = obj->intelligent;
-        M_OPTIONAL(M_ReadBool(ctx, "intelligent", &intelligent));
+        // Introduced in TRX 1.2
+        M_SHOULD(M_ReadBool(ctx, "intelligent", &intelligent));
         if (intelligent) {
             LOT_EnableBaddieAI(item_num, true);
             CREATURE *const creature = item->data;
@@ -722,6 +641,7 @@ static bool M_ReadItem(
                 M_MUST(M_ReadNum(ctx, "creature_flags", &creature->flags));
                 M_MUST(M_ReadNum(ctx, "creature_mood", &creature->mood));
                 if (M_SHOULD(M_PushObject(ctx, "creature"))) {
+                    // Introduced in TRX 1.2
                     M_MUST(M_ReadBool(ctx, "alerted", &creature->alerted));
                     M_MUST(M_ReadBool(ctx, "head_left", &creature->head_left));
                     M_MUST(
@@ -731,12 +651,13 @@ static bool M_ReadItem(
                     M_MUST(M_ReadBool(ctx, "patrol_2", &creature->patrol_2));
                     M_MUST(M_ReadBool(
                         ctx, "hurt_by_lara", &creature->hurt_by_lara));
-                    M_SHOULD(M_ReadNum(
+                    M_MUST(M_ReadNum(
                         ctx, "damage_from_lara", &creature->damage_from_lara));
                     M_MUST(M_PushObject(ctx, "joint_rotations"));
                     for (int32_t i = 0; i < 4; i++) {
                         M_MUST(M_PushArrayElem(ctx, i));
-                        M_OPTIONAL(
+                        // Introduced in TRX 1.2
+                        M_SHOULD(
                             M_ReadNumDirect(ctx, &creature->joint_rotation[i]));
                         M_MUST(M_Pop(ctx));
                     }
@@ -771,24 +692,16 @@ static bool M_ReadItem(
                 } else {
                     item->carried_item = carried_item;
                 }
-                M_OPTIONAL(
-                    M_ReadNum(ctx, "spawn_num", &carried_item->spawn_num));
+                // Introduced in TRX 1.2
+                M_SHOULD(M_ReadNum(ctx, "spawn_num", &carried_item->spawn_num));
             }
 
-            int16_t carried_game_object_id;
-            M_MUST(M_ReadNum(ctx, "object_id", &carried_game_object_id));
-            carried_item->object_id = Object_FromGameID(carried_game_object_id);
-
+            M_MUST(M_ReadObjectID(ctx, "object_id", &carried_item->object_id));
             M_MUST(M_ReadPos(ctx, &carried_item->pos));
             M_MUST(M_ReadNum(ctx, "y_rot", &carried_item->rot.y));
             M_MUST(M_ReadNum(ctx, "room_num", &carried_item->room_num));
             M_MUST(M_ReadNum(ctx, "fall_speed", &carried_item->fall_speed));
             M_MUST(M_ReadNum(ctx, "status", &carried_item->status));
-
-            if (g_TRVersion == 1 && ctx->sg_version < VERSION_10
-                && carried_item->room_num == M_NO_ROOM_LEGACY) {
-                carried_item->room_num = NO_ROOM;
-            }
 
             if (carried_item->status == DS_CARRIED
                 && carried_item->spawn_num != NO_ITEM) {
@@ -805,17 +718,13 @@ static bool M_ReadItem(
         }
         Carrier_TestItemDrops(item_num);
         M_MUST(M_Pop(ctx));
-    } else {
-        if (g_TRVersion == 1 && ctx->sg_version < VERSION_4) {
-            Carrier_TestLegacyDrops(item_num);
-        }
     }
 
     if (obj->priv_size > 0 && obj->priv_load_func != nullptr) {
+        // "priv" introduced in TRX 1.2
         if (M_SHOULD(M_PushObject(ctx, "priv"))
             || M_SHOULD(M_PushObject(ctx, "data"))) {
             JSON_OBJECT *const priv_root = JSON_ValueAsObject(ctx->current);
-            M_MUST(priv_root != nullptr);
             obj->priv_load_func(item, priv_root);
             M_MUST(M_Pop(ctx));
         }
@@ -834,7 +743,11 @@ static bool M_ReadItem(
 static bool M_ReadEffect(M_CONTEXT *const ctx)
 {
     int32_t room_num = NO_ROOM;
-    M_MUST(M_ReadNum(ctx, "room_number", &room_num));
+    if (!M_OPTIONAL(M_ReadNum(ctx, "room_number", &room_num))) {
+        // Introduced in TRX 1.2
+        M_MUST(M_ReadNum(ctx, "room_num", &room_num));
+    }
+
     const int16_t effect_num = Effect_Create(room_num);
     if (effect_num == NO_EFFECT) {
         return true;
@@ -843,10 +756,16 @@ static bool M_ReadEffect(M_CONTEXT *const ctx)
     EFFECT *const effect = Effect_Get(effect_num);
     M_MUST(M_ReadPos(ctx, &effect->pos));
     M_MUST(M_ReadRot(ctx, &effect->rot));
-    M_MUST(M_ReadObjectID(ctx, "object_number", &effect->object_id));
+    if (!M_OPTIONAL(M_ReadObjectID(ctx, "object_number", &effect->object_id))) {
+        // Introduced in TRX 1.2
+        M_MUST(M_ReadObjectID(ctx, "object_id", &effect->object_id));
+    }
     M_MUST(M_ReadNum(ctx, "speed", &effect->speed));
     M_MUST(M_ReadNum(ctx, "fall_speed", &effect->fall_speed));
-    M_MUST(M_ReadNum(ctx, "frame_number", &effect->frame_num));
+    if (!M_OPTIONAL(M_ReadNum(ctx, "frame_number", &effect->frame_num))) {
+        // Introduced in TRX 1.2
+        M_MUST(M_ReadNum(ctx, "frame_num", &effect->frame_num));
+    }
     M_MUST(M_ReadNum(ctx, "counter", &effect->counter));
     M_MUST(M_ReadNum(ctx, "shade", &effect->shade));
     M_FINISH();
@@ -870,41 +789,14 @@ static bool M_ReadFlare(M_CONTEXT *const ctx)
     M_FINISH();
 }
 
-static MUSIC_ID M_ConvertMusicTrack(
-    const MUSIC_ID track_id, uint16_t sg_version)
-{
-    if (g_TRVersion == 1) {
-        return track_id;
-    }
-    // Added in TR2X 1.2 after removing OG music track shifting, so allowing
-    // previous saves to still load. Remove after a suitable period.
-    if (track_id == MX_INACTIVE || sg_version >= VERSION_11) {
-        return track_id;
-    }
-    return Music_ConvertLegacyTrack(track_id);
-}
-
 static bool M_ReadMusicTracks(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 {
     MUSIC_ID current_track = MX_INACTIVE;
     MUSIC_ID ambient_track = MX_INACTIVE;
     double timestamp;
     M_MUST(M_ReadNum(ctx, "current_track", &current_track));
-    M_OPTIONAL(M_ReadNum(ctx, "current_ambient", &ambient_track));
+    M_MUST(M_ReadNum(ctx, "current_ambient", &ambient_track));
     M_MUST(M_ReadNum(ctx, "timestamp", &timestamp));
-
-    // TR1X <=4.11 / TR2X <=1.1 fallback behavior
-    if (g_TRVersion == 1 && ctx->sg_version < VERSION_9) {
-        bool legacy_ambient = false;
-        // TR1X <=4.5 has no is_ambient
-        M_OPTIONAL(M_ReadBool(ctx, "is_ambient", &legacy_ambient));
-        if (legacy_ambient && current_track != MX_INACTIVE) {
-            ambient_track = current_track;
-        }
-    }
-
-    current_track = M_ConvertMusicTrack(current_track, ctx->sg_version);
-    ambient_track = M_ConvertMusicTrack(ambient_track, ctx->sg_version);
 
     Music_Stop();
     if (ambient_track != MX_INACTIVE) {
@@ -963,18 +855,15 @@ static bool M_ReadResumeInfo(
     SAVEGAME_BSON_READ_CONTEXT *const ctx, RESUME_INFO *const resume)
 {
     resume->lara_hitpoints = g_Config.gameplay.start_lara_hitpoints;
-    M_OPTIONAL(M_ReadNum(ctx, "lara_hitpoints", &resume->lara_hitpoints));
-
+    M_MUST(M_ReadNum(ctx, "lara_hitpoints", &resume->lara_hitpoints));
     M_MUST(M_ReadNum(ctx, "gun_status", &resume->gun_status)); // LGS_ARMLESS
     M_MUST(
         M_ReadNum(ctx, "gun_type", &resume->equipped_gun_type)); // LGT_UNARMED
-
-    // TR1X <4.2
-    resume->holsters_gun_type = LGT_UNKNOWN;
-    M_OPTIONAL(M_ReadNum(ctx, "holsters_gun_type", &resume->holsters_gun_type));
+    M_MUST(M_ReadNum(
+        ctx, "holsters_gun_type", &resume->holsters_gun_type)); // LGT_UNKNOWN
 
     // TRX <1.1
-    if (g_TRVersion == 2 && ctx->sg_version < VERSION_14) {
+    if (g_TRVersion == 2 && ctx->sg_version < SG_VERSION_14) {
         if (resume->equipped_gun_type == LGT_MAGNUMS) {
             resume->equipped_gun_type = LGT_AUTOS;
         }
@@ -983,106 +872,67 @@ static bool M_ReadResumeInfo(
         }
     }
 
-    // TR1X <4.2
-    resume->back_gun_type = LGT_UNKNOWN;
-    M_OPTIONAL(M_ReadNum(ctx, "back_gun_type", &resume->back_gun_type));
-
-    // TR2X <1.6
-    M_OPTIONAL(M_ReadBool(ctx, "costume", &resume->flags.costume));
+    M_MUST(
+        M_ReadNum(ctx, "back_gun_type", &resume->back_gun_type)); // LGT_UNKNOWN
+    M_MUST(M_ReadBool(ctx, "costume", &resume->flags.costume));
 
     M_MUST(M_ReadNum(ctx, "pistol_ammo", &resume->pistol_ammo));
     M_MUST(M_ReadNum(ctx, "uzi_ammo", &resume->uzi_ammo));
     M_MUST(M_ReadNum(ctx, "shotgun_ammo", &resume->shotgun_ammo));
+    M_MUST(M_ReadNum(ctx, "magnum_ammo", &resume->magnum_ammo));
+    // Introduced in TRX 1.1
+    M_SHOULD(M_ReadNum(ctx, "autos_ammo", &resume->autos_ammo));
+    M_SHOULD(M_ReadNum(ctx, "desert_eagle_ammo", &resume->desert_eagle_ammo));
 
-    // TRX <1.1
-    if (ctx->sg_version < VERSION_14) {
-        if (g_TRVersion == 1) {
-            M_MUST(M_ReadNum(ctx, "magnum_ammo", &resume->magnum_ammo));
-        } else {
-            M_MUST(M_ReadNum(ctx, "magnum_ammo", &resume->autos_ammo));
-        }
-    } else {
-        M_MUST(M_ReadNum(ctx, "magnum_ammo", &resume->magnum_ammo));
-        M_MUST(M_ReadNum(ctx, "autos_ammo", &resume->autos_ammo));
-        M_OPTIONAL(
-            M_ReadNum(ctx, "desert_eagle_ammo", &resume->desert_eagle_ammo));
-    }
-
-    // TR1X <4.16
-    M_OPTIONAL(M_ReadNum(ctx, "m16_ammo", &resume->m16_ammo));
-    M_OPTIONAL(M_ReadNum(ctx, "grenade_ammo", &resume->grenade_ammo));
-    M_OPTIONAL(M_ReadNum(ctx, "harpoon_ammo", &resume->harpoon_ammo));
+    M_MUST(M_ReadNum(ctx, "m16_ammo", &resume->m16_ammo));
+    M_MUST(M_ReadNum(ctx, "grenade_ammo", &resume->grenade_ammo));
+    M_MUST(M_ReadNum(ctx, "harpoon_ammo", &resume->harpoon_ammo));
     M_MUST(M_ReadNum(ctx, "num_medis", &resume->small_medipacks));
     M_MUST(M_ReadNum(ctx, "num_big_medis", &resume->large_medipacks));
-    // TR1X <4.16
-    M_OPTIONAL(M_ReadNum(ctx, "num_flares", &resume->flares));
-    // TR2X <1.6
-    M_OPTIONAL(M_ReadNum(ctx, "num_scions", &resume->num_scions));
+    M_MUST(M_ReadNum(ctx, "num_flares", &resume->flares));
+    M_MUST(M_ReadNum(ctx, "num_scions", &resume->num_scions));
 
-    // TRX <1.2
-    M_OPTIONAL(M_ReadNum(ctx, "num_quest_item_1", &resume->num_quest_item_1));
-    M_OPTIONAL(M_ReadNum(ctx, "num_quest_item_2", &resume->num_quest_item_2));
-    M_OPTIONAL(M_ReadNum(ctx, "num_quest_item_3", &resume->num_quest_item_3));
-    M_OPTIONAL(M_ReadNum(ctx, "num_quest_item_4", &resume->num_quest_item_4));
+    // Introduced in TRX 1.2
+    M_SHOULD(M_ReadNum(ctx, "num_quest_item_1", &resume->num_quest_item_1));
+    M_SHOULD(M_ReadNum(ctx, "num_quest_item_2", &resume->num_quest_item_2));
+    M_SHOULD(M_ReadNum(ctx, "num_quest_item_3", &resume->num_quest_item_3));
+    M_SHOULD(M_ReadNum(ctx, "num_quest_item_4", &resume->num_quest_item_4));
 
     M_MUST(M_ReadBool(ctx, "available", &resume->flags.available));
 
-    // TRX <1.2
+    // Introduced in TRX 1.2
     resume->level_completed = false;
     resume->prev_level = -1;
     resume->hurt_allies = false;
-    M_OPTIONAL(M_ReadBool(ctx, "level_completed", &resume->level_completed));
-    M_OPTIONAL(M_ReadNum(ctx, "prev_level", &resume->prev_level));
-    M_OPTIONAL(M_ReadBool(ctx, "hurt_allies", &resume->hurt_allies));
+    M_SHOULD(M_ReadBool(ctx, "level_completed", &resume->level_completed));
+    M_SHOULD(M_ReadNum(ctx, "prev_level", &resume->prev_level));
+    M_SHOULD(M_ReadBool(ctx, "hurt_allies", &resume->hurt_allies));
 
-    if (M_HasKey(ctx, "got_pistols")) {
-        // TR1X <4.16
-        M_MUST(M_ReadBool(ctx, "got_pistols", &resume->flags.has_pistols));
-        M_MUST(M_ReadBool(ctx, "got_shotgun", &resume->flags.has_shotgun));
-        if (g_TRVersion == 1) {
-            M_MUST(M_ReadBool(ctx, "got_magnums", &resume->flags.has_magnums));
-        } else {
-            M_MUST(M_ReadBool(ctx, "got_magnums", &resume->flags.has_autos));
-        }
-        M_MUST(M_ReadBool(ctx, "got_uzis", &resume->flags.has_uzis));
-    } else {
-        M_MUST(M_ReadBool(ctx, "has_pistols", &resume->flags.has_pistols));
-        M_MUST(M_ReadBool(ctx, "has_shotgun", &resume->flags.has_shotgun));
-        M_MUST(M_ReadBool(ctx, "has_uzis", &resume->flags.has_uzis));
-    }
-    // TR1X <4.16
-    M_OPTIONAL(M_ReadBool(ctx, "has_m16", &resume->flags.has_m16));
-    M_OPTIONAL(M_ReadBool(ctx, "has_grenade", &resume->flags.has_grenade));
-    M_OPTIONAL(M_ReadBool(ctx, "has_harpoon", &resume->flags.has_harpoon));
+    M_MUST(M_ReadBool(ctx, "has_pistols", &resume->flags.has_pistols));
+    M_MUST(M_ReadBool(ctx, "has_shotgun", &resume->flags.has_shotgun));
+    M_MUST(M_ReadBool(ctx, "has_uzis", &resume->flags.has_uzis));
+    M_MUST(M_ReadBool(ctx, "has_m16", &resume->flags.has_m16));
+    M_MUST(M_ReadBool(ctx, "has_grenade", &resume->flags.has_grenade));
+    M_MUST(M_ReadBool(ctx, "has_harpoon", &resume->flags.has_harpoon));
 
-    // TRX <1.1
-    if (ctx->sg_version < VERSION_14) {
-        if (g_TRVersion == 1) {
-            M_MUST(M_ReadBool(ctx, "has_magnums", &resume->flags.has_magnums));
-        } else {
-            M_MUST(M_ReadBool(ctx, "has_magnums", &resume->flags.has_autos));
-        }
-    } else {
-        M_MUST(M_ReadBool(ctx, "has_magnums", &resume->flags.has_magnums));
-        M_MUST(M_ReadBool(ctx, "has_autos", &resume->flags.has_autos));
-        M_OPTIONAL(M_ReadBool(
-            ctx, "has_desert_eagle", &resume->flags.has_desert_eagle));
-        M_OPTIONAL(M_ReadBool(ctx, "has_mp5", &resume->flags.has_mp5));
-        M_OPTIONAL(M_ReadNum(ctx, "mp5_ammo", &resume->mp5_ammo));
-        M_OPTIONAL(M_ReadBool(ctx, "has_rocket", &resume->flags.has_rocket));
-        M_OPTIONAL(M_ReadNum(ctx, "rocket_ammo", &resume->rocket_ammo));
-    }
+    // Introduced in TRX 1.1
+    M_MUST(M_ReadBool(ctx, "has_magnums", &resume->flags.has_magnums));
+    M_SHOULD(M_ReadBool(ctx, "has_autos", &resume->flags.has_autos));
+    M_SHOULD(
+        M_ReadBool(ctx, "has_desert_eagle", &resume->flags.has_desert_eagle));
+    M_SHOULD(M_ReadBool(ctx, "has_mp5", &resume->flags.has_mp5));
+    M_SHOULD(M_ReadNum(ctx, "mp5_ammo", &resume->mp5_ammo));
+    M_SHOULD(M_ReadBool(ctx, "has_rocket", &resume->flags.has_rocket));
+    M_SHOULD(M_ReadNum(ctx, "rocket_ammo", &resume->rocket_ammo));
 
     M_MUST(M_ReadNum(ctx, "timer", &resume->stats.timer));
-    // TR1X <4.9
-    M_OPTIONAL(M_ReadNum(ctx, "ammo_hits", &resume->stats.ammo_hits));
-    M_OPTIONAL(M_ReadNum(ctx, "ammo_used", &resume->stats.ammo_used));
-    M_OPTIONAL(M_ReadNum(ctx, "medipacks_used", &resume->stats.medipacks_used));
-    M_OPTIONAL(M_ReadNum(
+    M_MUST(M_ReadNum(ctx, "ammo_hits", &resume->stats.ammo_hits));
+    M_MUST(M_ReadNum(ctx, "ammo_used", &resume->stats.ammo_used));
+    M_MUST(M_ReadNum(ctx, "medipacks_used", &resume->stats.medipacks_used));
+    M_MUST(M_ReadNum(
         ctx, "distance_travelled", &resume->stats.distance_travelled));
     M_MUST(M_ReadNum(ctx, "kills", &resume->stats.kill_count));
-    // TR2X <1.6
-    M_OPTIONAL(M_ReadNum(ctx, "pickups", &resume->stats.pickup_count));
+    M_MUST(M_ReadNum(ctx, "pickups", &resume->stats.pickup_count));
     M_MUST(M_ReadNum(ctx, "secrets", &resume->stats.secret_flags));
     Stats_UpdateSecrets(&resume->stats);
     M_FINISH();
@@ -1235,76 +1085,55 @@ bool Savegame_BSON_LoadEffects(SAVEGAME_BSON_READ_CONTEXT *const ctx)
         return true;
     }
 
-    // TR1X <=v2.15.3, TR2X <=v1.1 may not have fx effects
-    if (M_SHOULD(M_PushObject(ctx, "fx"))) {
-        for (int32_t i = 0;; i++) {
-            if (!M_PushArrayElem(ctx, i)) {
-                break;
-            }
-            if (i < MAX_EFFECTS) {
-                M_ReadEffect(ctx);
-            } else {
-                LOG_WARNING(
-                    "Malformed save: expected a max of %d effect, got at least "
-                    "%d. "
-                    "extra effects will be ignored.",
-                    MAX_EFFECTS - 1, i);
-            }
-            M_MUST(M_Pop(ctx));
+    M_MUST(M_PushObject(ctx, "fx"));
+    for (int32_t i = 0;; i++) {
+        if (!M_PushArrayElem(ctx, i)) {
+            break;
+        }
+        if (i < MAX_EFFECTS) {
+            M_ReadEffect(ctx);
+        } else {
+            LOG_WARNING(
+                "Malformed save: expected a max of %d effect, got at least "
+                "%d. Extra effects will be ignored.",
+                MAX_EFFECTS - 1, i);
         }
         M_MUST(M_Pop(ctx));
     }
+    M_MUST(M_Pop(ctx));
     M_FINISH();
 }
 
 bool Savegame_BSON_LoadFlares(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 {
-    if (M_SHOULD(M_PushObject(ctx, "flares"))) {
-        for (int32_t i = 0;; i++) {
-            if (!M_PushArrayElem(ctx, i)) {
-                break;
-            }
-            M_MUST(M_ReadFlare(ctx));
-            M_MUST(M_Pop(ctx));
+    M_MUST(M_PushObject(ctx, "flares"));
+    for (int32_t i = 0;; i++) {
+        if (!M_PushArrayElem(ctx, i)) {
+            break;
         }
+        M_MUST(M_ReadFlare(ctx));
         M_MUST(M_Pop(ctx));
     }
+    M_MUST(M_Pop(ctx));
     M_FINISH();
 }
 
 bool Savegame_BSON_LoadMusic(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 {
-    if (M_HasKey(ctx, "music_track_flags")) {
-        // TR1X <4.16
-        M_MUST(M_PushObject(ctx, "music_track_flags"));
-        M_MUST(M_ReadMusicTrackFlags(ctx));
-        M_MUST(M_Pop(ctx));
-        M_MUST(M_PushObject(ctx, "music"));
-        M_MUST(M_ReadMusicTracks(ctx));
-        M_MUST(M_Pop(ctx));
-    } else {
-        M_MUST(M_PushObject(ctx, "music"));
-        M_MUST(M_PushObject(ctx, "current"));
-        M_MUST(M_ReadMusicTracks(ctx));
-        M_MUST(M_Pop(ctx));
-        M_MUST(M_PushObject(ctx, "flags"));
-        M_MUST(M_ReadMusicTrackFlags(ctx));
-        M_MUST(M_Pop(ctx));
-        M_MUST(M_Pop(ctx));
-    }
-
+    M_MUST(M_PushObject(ctx, "music"));
+    M_MUST(M_PushObject(ctx, "current"));
+    M_MUST(M_ReadMusicTracks(ctx));
+    M_MUST(M_Pop(ctx));
+    M_MUST(M_PushObject(ctx, "flags"));
+    M_MUST(M_ReadMusicTrackFlags(ctx));
+    M_MUST(M_Pop(ctx));
+    M_MUST(M_Pop(ctx));
     M_FINISH();
 }
 
 bool Savegame_BSON_LoadResumeInfoList(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 {
-    if (M_HasKey(ctx, "current_info")) {
-        // TR1X <4.16
-        M_MUST(M_PushObject(ctx, "current_info"));
-    } else {
-        // TR2X <1.6
-        M_MUST(M_PushObject(ctx, "resume_info"));
-    }
+    M_MUST(M_PushObject(ctx, "resume_info"));
     const int32_t length = M_GetArrayLength(ctx);
     const int32_t expected_length = GF_GetLevelTable(GFLT_MAIN)->count;
     if (length != expected_length) {
@@ -1330,19 +1159,19 @@ bool Savegame_BSON_LoadMisc(SAVEGAME_BSON_READ_CONTEXT *const ctx)
 
     {
         int32_t bonus_flag = false;
-        M_OPTIONAL(M_ReadNum(ctx, "bonus_flag", &bonus_flag));
+        M_MUST(M_ReadNum(ctx, "bonus_flag", &bonus_flag));
         Game_SetBonusFlag(bonus_flag);
     }
 
     {
         bool allies_hostile = false;
-        M_OPTIONAL(M_ReadBool(ctx, "are_monks_angry", &allies_hostile));
+        M_MUST(M_ReadBool(ctx, "are_monks_angry", &allies_hostile));
         Creature_SetAlliesHostile(allies_hostile);
     }
 
     {
         int32_t sunset_timer;
-        M_OPTIONAL(M_ReadNum(ctx, "sunset_timer", &sunset_timer));
+        M_MUST(M_ReadNum(ctx, "sunset_timer", &sunset_timer));
         Output_SetTimeInGame(sunset_timer);
     }
 
@@ -1350,11 +1179,11 @@ bool Savegame_BSON_LoadMisc(SAVEGAME_BSON_READ_CONTEXT *const ctx)
         const GF_LEVEL *const current_level = Game_GetCurrentLevel();
         RESUME_INFO *const resume = Savegame_GetCurrentInfo(current_level);
         resume->stats.death_count = -1;
-        M_OPTIONAL(M_ReadNum(ctx, "death_count", &resume->stats.death_count));
+        M_MUST(M_ReadNum(ctx, "death_count", &resume->stats.death_count));
     }
 
     {
-        if (M_HasKey(ctx, "weather_type") != 0) {
+        if (M_HasKey(ctx, "weather_type")) {
             int32_t weather_type = (int32_t)WEATHER_NONE;
             if (M_ReadNum(ctx, "weather_type", &weather_type)) {
                 if (weather_type >= (int32_t)WEATHER_NONE

--- a/src/trx/game/savegame/bson_write.c
+++ b/src/trx/game/savegame/bson_write.c
@@ -235,19 +235,9 @@ static void M_WriteItem(
     const M_FX_ORDER *const fx_order)
 {
     const OBJECT *const obj = Object_Get(item->object_id);
-    // TR1X <4.16, TR2X <1.6
-    M_WriteNum(ctx, "obj_num", Object_ToGameID(item->object_id));
     M_WriteNum(ctx, "object_id", Object_ToGameID(item->object_id));
 
     if (obj->save_position) {
-        // TR1X <4.16
-        M_WriteNum(ctx, "x", item->pos.x);
-        M_WriteNum(ctx, "y", item->pos.y);
-        M_WriteNum(ctx, "z", item->pos.z);
-        M_WriteNum(ctx, "x_rot", item->rot.x);
-        M_WriteNum(ctx, "y_rot", item->rot.y);
-        M_WriteNum(ctx, "z_rot", item->rot.z);
-
         M_WriteXYZ32(ctx, "pos", item->pos);
         M_WriteXYZ16(ctx, "rot", item->rot);
         M_WriteNum(ctx, "room_num", item->room_num);
@@ -315,12 +305,6 @@ static void M_WriteItem(
         M_WriteNum(ctx, "fall_speed", drop_item->fall_speed);
         M_WriteNum(ctx, "spawn_num", drop_item->spawn_num);
         M_WriteNum(ctx, "status", (int32_t)Carrier_GetSaveStatus(drop_item));
-
-        // TR1X <4.16
-        M_WriteNum(ctx, "x", drop_item->pos.x);
-        M_WriteNum(ctx, "y", drop_item->pos.y);
-        M_WriteNum(ctx, "z", drop_item->pos.z);
-
         M_PopAndAppend(ctx);
         drop_item = drop_item->next_item;
     }
@@ -345,9 +329,6 @@ static void M_WriteArm(
     M_WriteNum(ctx, "lock", arm->lock);
     M_WriteNum(ctx, "flash_gun", arm->flash_gun);
     M_WriteXYZ16(ctx, "rot", arm->rot);
-    M_WriteNum(ctx, "x_rot", arm->rot.x);
-    M_WriteNum(ctx, "y_rot", arm->rot.y);
-    M_WriteNum(ctx, "z_rot", arm->rot.z);
     M_PopAndSet(ctx, key);
 }
 
@@ -412,11 +393,6 @@ static void M_WriteResumeInfo(
     M_WriteNum(ctx, "holsters_gun_type", resume->holsters_gun_type);
     M_WriteNum(ctx, "back_gun_type", resume->back_gun_type);
 
-    // TR1X <4.16
-    M_WriteBool(ctx, "got_pistols", resume->flags.has_pistols);
-    M_WriteBool(ctx, "got_shotgun", resume->flags.has_shotgun);
-    M_WriteBool(ctx, "got_magnums", resume->flags.has_magnums);
-    M_WriteBool(ctx, "got_uzis", resume->flags.has_uzis);
     M_WriteBool(ctx, "has_pistols", resume->flags.has_pistols);
     M_WriteBool(ctx, "has_shotgun", resume->flags.has_shotgun);
     M_WriteBool(ctx, "has_magnums", resume->flags.has_magnums);
@@ -496,24 +472,12 @@ void Savegame_BSON_DumpEffects(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
         M_PushObject(ctx);
         M_WriteXYZ32(ctx, "pos", effect->pos);
         M_WriteXYZ16(ctx, "rot", effect->rot);
-        // TR1X <4.16
-        M_WriteNum(ctx, "x", effect->pos.x);
-        M_WriteNum(ctx, "y", effect->pos.y);
-        M_WriteNum(ctx, "z", effect->pos.z);
-        M_WriteNum(ctx, "x_rot", effect->rot.x);
-        M_WriteNum(ctx, "y_rot", effect->rot.y);
-        M_WriteNum(ctx, "z_rot", effect->rot.z);
-
-        // TR1X <4.16, TR2X<1.6
-        M_WriteNum(ctx, "room_number", effect->room_num);
         M_WriteNum(ctx, "room_num", effect->room_num);
-
-        // TR1X <4.16, TR2X<1.6
-        M_WriteNum(ctx, "object_number", Object_ToGameID(effect->object_id));
         M_WriteNum(ctx, "object_id", Object_ToGameID(effect->object_id));
-
         M_WriteNum(ctx, "speed", effect->speed);
         M_WriteNum(ctx, "fall_speed", effect->fall_speed);
+        // Introduced in TRX 1.2
+        M_WriteNum(ctx, "frame_num", effect->frame_num);
         M_WriteNum(ctx, "frame_number", effect->frame_num);
         M_WriteNum(ctx, "counter", effect->counter);
         M_WriteNum(ctx, "shade", effect->shade);
@@ -583,27 +547,12 @@ void Savegame_BSON_DumpMusic(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
 
     const MUSIC_ID current_track = Music_GetCurrentPlayingTrack();
     const MUSIC_ID current_ambient = Music_GetCurrentLoopedTrack();
-    // TR1X >=4.16, TR2X – music/current/…
     M_PushObject(ctx);
     M_WriteNum(ctx, "current_track", current_track);
     M_WriteNum(ctx, "current_ambient", current_ambient);
     M_WriteNum(ctx, "timestamp", Music_GetTimestamp());
     M_PopAndSet(ctx, "current");
-
-    // TR1X <4.16 - music/…
-    M_WriteNum(ctx, "current_track", current_track);
-    M_WriteNum(ctx, "current_ambient", current_ambient);
-    M_WriteNum(ctx, "timestamp", Music_GetTimestamp());
-
     M_PopAndSet(ctx, "music");
-
-    // TR1X <4.16
-    M_PushArray(ctx);
-    for (int32_t i = 0; i < track_flag_count; i++) {
-        M_PushNum(ctx, Music_GetTrackFlags(i));
-        M_PopAndAppend(ctx);
-    }
-    M_PopAndSet(ctx, "music_track_flags");
 }
 
 void Savegame_BSON_DumpItems(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
@@ -629,6 +578,8 @@ void Savegame_BSON_DumpLara(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
 
     M_PushObject(ctx);
 
+    // Introduced in TRX 1.2
+    M_WriteNum(ctx, "item_num", lara->item_num);
     M_WriteNum(ctx, "item_number", lara->item_num);
     M_WriteNum(ctx, "gun_status", lara->gun_status);
     M_WriteNum(ctx, "gun_type", lara->gun_type);
@@ -666,6 +617,8 @@ void Savegame_BSON_DumpLara(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
     M_WriteNum(ctx, "flare_frame", lara->flare.frame_num);
     M_WriteBool(ctx, "flare_control_left", lara->flare.control);
     M_WriteBool(ctx, "extra_anim", lara->extra_anim);
+    // Introduced in TRX 1.2
+    M_WriteNum(ctx, "vehicle_item_num", Lara_Vehicle_GetIndex());
     M_WriteNum(ctx, "vehicle_item_number", Lara_Vehicle_GetIndex());
 
     M_WriteNum(ctx, "mesh_effects", lara->mesh_effects);
@@ -681,21 +634,8 @@ void Savegame_BSON_DumpLara(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
     M_WriteNum(ctx, "turn_rate", lara->turn_rate);
     M_WriteNum(ctx, "move_angle", lara->move_angle);
     M_WriteXYZ16(ctx, "head_rot", lara->head_rot);
-    // TR1X <4.16
-    M_WriteNum(ctx, "head_rot.y", lara->head_rot.y);
-    M_WriteNum(ctx, "head_rot.x", lara->head_rot.x);
-    M_WriteNum(ctx, "head_rot.z", lara->head_rot.z);
     M_WriteXYZ16(ctx, "torso_rot", lara->torso_rot);
-    // TR1X <4.16
-    M_WriteNum(ctx, "torso_rot.y", lara->torso_rot.y);
-    M_WriteNum(ctx, "torso_rot.x", lara->torso_rot.x);
-    M_WriteNum(ctx, "torso_rot.z", lara->torso_rot.z);
     M_WriteXYZ32(ctx, "last_pos", lara->last_pos);
-    // TR1X <4.16
-    M_WriteNum(ctx, "last_pos.x", lara->last_pos.x);
-    M_WriteNum(ctx, "last_pos.y", lara->last_pos.y);
-    M_WriteNum(ctx, "last_pos.z", lara->last_pos.z);
-
     M_WriteArm(ctx, "left_arm", &lara->left_arm);
     M_WriteArm(ctx, "right_arm", &lara->right_arm);
     M_WriteAmmo(ctx, "pistols", &lara->pistol_ammo);
@@ -726,19 +666,6 @@ void Savegame_BSON_DumpLara(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
     M_WriteNum(ctx, "move_count", lara->interact_target.move_count);
     M_WriteBool(ctx, "is_moving", lara->interact_target.is_moving);
     M_PopAndSet(ctx, "interact_target");
-    // TR1X <4.16, TR2X <1.6
-    M_WriteNum(ctx, "interact_target.item_num", lara->interact_target.item_num);
-    M_WriteNum(
-        ctx, "interact_target.move_count", lara->interact_target.move_count);
-    M_WriteBool(
-        ctx, "interact_target.is_moving", lara->interact_target.is_moving);
-
-    if (g_TRVersion == 1) {
-        // TR1X <4.16
-        M_PushObject(ctx);
-        M_WriteLOT(ctx, &lara->lot);
-        M_PopAndSet(ctx, "lot");
-    }
 
     M_PopAndSet(ctx, "lara");
 }
@@ -755,19 +682,6 @@ void Savegame_BSON_DumpResumeInfoList(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)
         M_PopAndAppend(ctx);
     }
     M_PopAndSet(ctx, "resume_info");
-
-    if (g_TRVersion == 1) {
-        // < TR1X <4.16
-        M_PushArray(ctx);
-        for (int32_t i = 0; i < count; i++) {
-            const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
-            const RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-            M_PushObject(ctx);
-            M_WriteResumeInfo(ctx, resume);
-            M_PopAndAppend(ctx);
-        }
-        M_PopAndSet(ctx, "current_info");
-    }
 }
 
 void Savegame_BSON_DumpMisc(SAVEGAME_BSON_WRITE_CONTEXT *const ctx)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -22,7 +22,7 @@
 #define MAX_STRATEGIES 2
 #define SAVES_DIR "saves"
 
-static SAVEGAME_VERSION m_InitialVersion = VERSION_LEGACY;
+static SAVEGAME_VERSION m_InitialVersion = SG_VERSION_LEGACY;
 static SAVEGAME_INFO *m_SavegameInfo = nullptr;
 static RESUME_INFO *m_ResumeInfo = nullptr;
 static int32_t m_SaveSlots = 0;

--- a/src/trx/game/savegame/const.h
+++ b/src/trx/game/savegame/const.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define SAVEGAME_CURRENT_VERSION 14

--- a/src/trx/game/savegame/enum.h
+++ b/src/trx/game/savegame/enum.h
@@ -13,43 +13,15 @@ typedef enum {
 } SAVEGAME_FORMAT;
 
 typedef enum {
-    VERSION_LEGACY = -1,
-    VERSION_0 = 0,
-    VERSION_1 = 1,
-    VERSION_2 = 2,
-    VERSION_3 = 3,
-    VERSION_4 = 4,
-    VERSION_5 = 5,
-    VERSION_6 = 6,
+    SG_VERSION_LEGACY = -1,
+    SG_VERSION_1 = 1,
 
-    // Added extra footer after the compressed BSON structure for quicker
-    // access to essential data, such as the level counter and the level title,
-    // without the need to parse the entire BSON document.
-    // Added TR2+ stats ammo hits/used, health packs used, distance travelled.
-    VERSION_7 = 7,
-
-    // Added the current TRX version string.
-    VERSION_8 = 8,
-
-    // Added the current ambient track to allow triggers to change it at
-    // different stages of the level.
-    // TR2X 1.1 / TR1X 4.11
-    VERSION_9 = 9,
-
-    // Resolved an issue with TR1 game flow carried items and the NO_ROOM change
-    // from 255 to -1.
-    VERSION_10 = 10,
-
-    // Changed TR2 music tracks to no longer shift IDs, legacy saves require to
-    // do the shifting on load.
-    VERSION_11 = 11,
-
-    // Save and load movable block priv data.
-    VERSION_12 = 12,
-
-    // Added back gun and gun item number properties to Lara.
-    VERSION_13 = 13,
+    // Before TRX 1.0
+    SG_VERSION_13 = 13,
 
     // Separated Magnums and Automatic Pistols.
-    VERSION_14 = 14,
+    SG_VERSION_14 = 14,
+
+    SG_MIN_SUPPORTED_VERSION = SG_VERSION_13,
+    SG_CURRENT_VERSION = SG_VERSION_14,
 } SAVEGAME_VERSION;

--- a/src/trx/game/savegame/legacy.c
+++ b/src/trx/game/savegame/legacy.c
@@ -662,7 +662,7 @@ static bool M_FillInfo(MYFILE *const fp, SAVEGAME_INFO *const info)
     }
 
     info->level_num = File_ReadS16(fp);
-    info->initial_version = VERSION_LEGACY;
+    info->initial_version = SG_VERSION_LEGACY;
     info->features.restart = false;
     info->features.select_level = false;
     return true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR tidies up a big batch of old code used for pre‑merge savegames (TR1X/TR2X era), making the savegames module a whole lot easier to maintain. A follow‑up PR will fully retire support for the original save formats (TombATI, TR2 Steam/GOG).

The legacy save formats were vital during early development, but maintaining them now imposes a disproportionate cost on testing and stability. Deprecating this path lets us focus our time on actively improving the engine for everyone.

Nonetheless, players who want to hold onto their older saves can re‑save them with version 1.0 or 1.1 before upgrading, and it should all continue to work – just with an extra step.

#### Testing

1. Create new saves in TR1–3 using versions 1.0 and 1.1 with various gameplay elements. Confirm they still load correctly and don't kick the player out to the main menu.
    Areas of interest:
    - Active enemies
    - Pickups
    - Effects
    - Holster/back/equipped guns

    Note: 1.0 did not support TR3 savegames and it is expected to crash when trying to save the game.
3. Create new saves in the current build for all three games, and confirm they load properly as well.
