### PR TITLE
Fix nested indentation rendering as arrows

### DIFF
--- a/data/common/ship/cfg/base_strings-de.json5
+++ b/data/common/ship/cfg/base_strings-de.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "\\{review}Pufferung (Inventar)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "\\{review}Aktiviert die Pufferung des Inventars (2 Frames), um eine präzise Steuerung von Laras Bewegung zu ermöglichen.",
         "SETTING_ENABLE_CHEATS": "Cheats",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Aktiviert verschiedene Cheats:\n\n- L: Beende das Level sofort.\n- I: eine Erhöhung der Anzahl der Munition und Medipacks; und alle plotrelevanten Items des aktuellen Levels.\n- O: Aktiviere Flug-Cheat (in der Luft schwimmen).\n  - GEHEN-Taste: beende Flug-Modus.\n  - WAFFE ZIEHEN-Taste: öffne die nächstgelegene Tür (funktioniert an ein paar Stellen nicht).",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Aktiviert verschiedene Cheats:\n\n- L: Beende das Level sofort.\n- I: eine Erhöhung der Anzahl der Munition und Medipacks; und alle plotrelevanten Items des aktuellen Levels.\n- O: Aktiviere Flug-Cheat (in der Luft schwimmen).\n  - GEHEN-Taste: beende Flug-Modus.\n  - WAFFE ZIEHEN-Taste: öffne die nächstgelegene Tür (funktioniert an ein paar Stellen nicht).",
         "SETTING_ENABLE_COMPASS_STATS": "Levelstatistiken im Kompass",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Aktiviert die Anzeige von Levelstatistiken wenn der Kompass ausgewählt wird.",
         "SETTING_ENABLE_CONSOLE": "Konsole",

--- a/data/common/ship/cfg/base_strings-fr.json5
+++ b/data/common/ship/cfg/base_strings-fr.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "\\{review}Mise en mémoire tampon (inventaire)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "\\{review}Active la mise en mémoire tampon de l'inventaire (2 images) pour un contrôle précis des mouvements de Lara.",
         "SETTING_ENABLE_CHEATS": "Triche",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Active plusieurs fonctions de triche :\n- L: termine immédiatement le niveau.\n- I: donne toutes les armes à Lara, le maximum en munitions et trousses de soin, et tous les éléments utiles au niveau en cours.\n- O: Fait voler Lara (nager dans les airs).\n     - Touche MARCHER : Revenir au sol.\n     - Touche ESPACE : Ouvre les portes fermées (peut ne pas fonctionner sur certaines).",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Active plusieurs fonctions de triche :\n- L: termine immédiatement le niveau.\n- I: donne toutes les armes à Lara, le maximum en munitions et trousses de soin, et tous les éléments utiles au niveau en cours.\n- O: Fait voler Lara (nager dans les airs).\n  - Touche MARCHER : Revenir au sol.\n  - Touche ESPACE : Ouvre les portes fermées (peut ne pas fonctionner sur certaines).",
         "SETTING_ENABLE_COMPASS_STATS": "Statistiques dans la boussole",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Affiche les statistiques du niveau lorsque la boussole est sélectionnée.",
         "SETTING_ENABLE_CONSOLE": "Console",

--- a/data/common/ship/cfg/base_strings-gd.json5
+++ b/data/common/ship/cfg/base_strings-gd.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "Bùthadh (clàr-stòraidh)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "Leigeas leis am putan clàr-stòraidh smachd mionaideach (2-fhraim) a thoirt air gluasad Lara.",
         "SETTING_ENABLE_CHEATS": "Cleasan",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Cuiridh seo diofar chleasan an comas:\n\n- L: crìochnaich an ìre sa bhad.\n- I: bheir do Lara na h-armachd uile, pailteas lòin, pasganan slàinte agus stuthan cuilbheart na h-ìre làithreach.\n- O: cuir snàmh tro èadhar an comas.\n     - Coisich: stad a' snàmh tro èadhar.\n     - Uidheamaich: fosgail an doras as fhaisge (chan obraichidh seo an-còmhnaidh).",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Cuiridh seo diofar chleasan an comas:\n\n- L: crìochnaich an ìre sa bhad.\n- I: bheir do Lara na h-armachd uile, pailteas lòin, pasganan slàinte agus stuthan cuilbheart na h-ìre làithreach.\n- O: cuir snàmh tro èadhar an comas.\n  - Coisich: stad a' snàmh tro èadhar.\n  - Uidheamaich: fosgail an doras as fhaisge (chan obraichidh seo an-còmhnaidh).",
         "SETTING_ENABLE_COMPASS_STATS": "Staitistig ìre anns a' chombaist",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Seallaidh seo staitistig na h-ìre nuair a thaghas tu a' chombaist.",
         "SETTING_ENABLE_CONSOLE": "Co-chomhairle leasachaidh",

--- a/data/common/ship/cfg/base_strings-it.json5
+++ b/data/common/ship/cfg/base_strings-it.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "Buffering (inventario)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "Abilita il buffering dell'inventario (2 fotogrammi) per ottenere un controllo preciso dei movimenti di Lara.",
         "SETTING_ENABLE_CHEATS": "Trucchi",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Abilita vari trucchi:\n\n- L: termina immediatamente il livello.\n- I: dà a Lara tutte le armi; maggior quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n  - tasto CAMMINA: disabilita il trucco DOZY.\n  - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi).",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Abilita vari trucchi:\n\n- L: termina immediatamente il livello.\n- I: dà a Lara tutte le armi; maggior quantità di munizioni e kit medici; tutti gli oggetti necessari per superare il livello.\n- O: abilita il trucco DOZY (nuotare a mezz'aria).\n  - tasto CAMMINA: disabilita il trucco DOZY.\n  - tasto ESTRAI ARMA: apre la porta più vicina (non funziona in certi casi).",
         "SETTING_ENABLE_COMPASS_STATS": "Statistiche livello bussola",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Abilita la visualizzazione delle statistiche del livello quando è selezionata la bussola.",
         "SETTING_ENABLE_CONSOLE": "Console",

--- a/data/common/ship/cfg/base_strings-pl.json5
+++ b/data/common/ship/cfg/base_strings-pl.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "Buforowanie (ekwipunek)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "Włącza buforowanie ekranu ekwipunku, aby uzyskać precyzyjną kontrolę nad ruchem Lary (2 klatki).",
         "SETTING_ENABLE_CHEATS": "Cheaty",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Włącza różne cheaty:\n\n- L: natychmiast kończy poziom.\n- I: daje Larze wszystkie bronie; zwiększa ilość amunicji i apteczek; daje wszystkie przedmioty z bieżącego poziomu.\n- O: włącza latanie.\n  - Klawisz chodzenia: wyjście z trybu latani.\n  - Klawisz broni: otwiera najbliższe drzwi.",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Włącza różne cheaty:\n\n- L: natychmiast kończy poziom.\n- I: daje Larze wszystkie bronie; zwiększa ilość amunicji i apteczek; daje wszystkie przedmioty z bieżącego poziomu.\n- O: włącza latanie.\n  - Klawisz chodzenia: wyjście z trybu latani.\n  - Klawisz broni: otwiera najbliższe drzwi.",
         "SETTING_ENABLE_COMPASS_STATS": "Statystyki w kompasie",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Włącza wyświetlanie statystyk aktualnego poziomu przy wybraniu kompasu.",
         "SETTING_ENABLE_CONSOLE": "Konsola",

--- a/data/common/ship/cfg/base_strings.json5
+++ b/data/common/ship/cfg/base_strings.json5
@@ -427,7 +427,7 @@
         "SETTING_ENABLE_BUFFERING_INVENTORY": "Buffering (inventory)",
         "SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION": "Enables inventory (2-frame) buffering to achieve precise control of Lara's movement.",
         "SETTING_ENABLE_CHEATS": "Cheats",
-        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).",
+        "SETTING_ENABLE_CHEATS_DESCRIPTION": "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).",
         "SETTING_ENABLE_COMPASS_STATS": "Level statistics in compass",
         "SETTING_ENABLE_COMPASS_STATS_DESCRIPTION": "Enables showing level statistics when the compass is selected.",
         "SETTING_ENABLE_CONSOLE": "Console",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed stats dialog retaining friendly status for allies that become enemy types in later levels, causing them to get excluded from kill count
 - fixed targeting hostile ex-allies not working if "Enable ally targeting" option is off
 - fixed `/play` and similar commands fading out instead of running instantly on stats/title screens
+- fixed Cheats description showing arrows in the indented bullets (#4753, regression from TRX 1.1)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - added an option to make Lara stumble if she hops backwards and there is a slope behind her (Gameplay options → Controls → Backwards slope stumble)
 - improved inventory ring active item highlight for smoother appearance
 - improved savegame file size by reducing it about 20–30%.
+- improved indentation for nested bullets in the UIs
 - changed photo mode to no longer show "Entering photo mode" in the console
 - changed photo mode to always display a red frame around the game view when active (not visible in screenshots)
 - changed stats dialog to include allies in kill count if they turn hostile. This applies to all levels that follow, and the final stats screen.

--- a/src/trx/game/game_string.def
+++ b/src/trx/game/game_string.def
@@ -340,7 +340,7 @@ GS_DEFINE(SETTING_ENABLE_BRAID_DESCRIPTION,                   "Enables Lara's br
 GS_DEFINE(SETTING_ENABLE_BREEZE_DESCRIPTION,                  "Enables the breeze effect on Lara's braid in appropriate rooms.")
 GS_DEFINE(SETTING_ENABLE_BUFFERING_FUNC_KEYS_DESCRIPTION,     "Enables F-key (1-frame) buffering to achieve precise control of Lara's movement. This function originally only exists in the TombATI port (TR1).")
 GS_DEFINE(SETTING_ENABLE_BUFFERING_INVENTORY_DESCRIPTION,     "Enables inventory (2-frame) buffering to achieve precise control of Lara's movement.")
-GS_DEFINE(SETTING_ENABLE_CHEATS_DESCRIPTION,                  "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).")
+GS_DEFINE(SETTING_ENABLE_CHEATS_DESCRIPTION,                  "Enables various cheats:\n\n- L: immediately end the level.\n- I: give Lara all weapons; a boost of ammo and medipacks; and all plot items for the current level.\n- O: enable fly cheat (swimming midair).\n  - WALK key: exit fly mode.\n  - GUN key: open the closest door (doesn't work in some places).")
 GS_DEFINE(SETTING_ENABLE_COMPASS_STATS_DESCRIPTION,           "Enables showing level statistics when the compass is selected.")
 GS_DEFINE(SETTING_ENABLE_CONSOLE_DESCRIPTION,                 "Enables the developer console.")
 GS_DEFINE(SETTING_ENABLE_CONTROLLED_DROPS_DESCRIPTION,        "Allows Lara to turn mid-air and grab the ledge she just stepped off, if the action input is held while falling.")

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -541,6 +541,18 @@ static void M_Process(
             glyph_font = M_FONT_DEFAULT;
         }
 
+        float spacing = glyph->width[glyph_font];
+        if (glyph_ptr[1] != nullptr && glyph_ptr[1]->role != GLYPH_NEW_LINE
+            && glyph_ptr[1]->role != GLYPH_NEW_PAGE) {
+            spacing += M_LETTER_SPACING;
+        }
+
+        if (glyph->role == GLYPH_TEXT && glyph->mesh_idx < 0) {
+            // Non-breaking space or other non-rendered text glyphs.
+            x += spacing * scale / UI_TEXT_BASE_SCALE;
+            goto loop_end;
+        }
+
         if (visible && draw_func != nullptr) {
             const OBJECT *object = Object_Get(m_FontObjects[glyph_font]);
             draw_func(
@@ -548,11 +560,6 @@ static void M_Process(
                 m_TextColor[color_idx]);
         }
 
-        float spacing = glyph->width[glyph_font];
-        if (glyph_ptr[1] != nullptr && glyph_ptr[1]->role != GLYPH_NEW_LINE
-            && glyph_ptr[1]->role != GLYPH_NEW_PAGE) {
-            spacing += M_LETTER_SPACING;
-        }
         x += spacing * scale / UI_TEXT_BASE_SCALE;
 
     loop_end:

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -279,13 +279,57 @@ static const M_GLYPH_INFO *M_GetResolvedGlyph(const M_GLYPH_INFO *glyph)
     return entry != nullptr ? entry->glyph : nullptr;
 }
 
+static int32_t M_DetectBulletIndent(
+    const M_GLYPH_INFO **glyphs, const size_t glyph_count, const size_t idx)
+{
+    size_t scan = idx;
+    int32_t leading_spaces = 0;
+    while (scan < glyph_count && glyphs[scan]->role == GLYPH_SPACE) {
+        leading_spaces++;
+        scan++;
+    }
+    if (scan + 1 < glyph_count && glyphs[scan]->role == GLYPH_TEXT
+        && glyphs[scan]->text[0] == '-' && glyphs[scan]->text[1] == '\0'
+        && glyphs[scan + 1]->role == GLYPH_SPACE) {
+        return leading_spaces + 2;
+    }
+    return 0;
+}
+
+static void M_EmitIndent(
+    char *const dst, size_t *const out_len, const int32_t indent,
+    const float space_width, float *const cur_width)
+{
+    for (int32_t s = 0; s < indent; s++) {
+        if (dst != nullptr) {
+            dst[*out_len] = ' ';
+        }
+        (*out_len)++;
+    }
+    *cur_width += indent * space_width;
+}
+
+static void M_EmitNewline(
+    char *const dst, size_t *const out_len, const int32_t indent,
+    const float space_width, float *const cur_width)
+{
+    if (dst != nullptr) {
+        dst[*out_len] = '\n';
+    }
+    (*out_len)++;
+    *cur_width = 0.0f;
+    if (indent > 0) {
+        M_EmitIndent(dst, out_len, indent, space_width, cur_width);
+    }
+}
+
 static size_t M_WordWrap(
     const M_GLYPH_INFO **glyphs, const size_t glyph_count, const float scale_f,
     const float max_width, char *const dst)
 {
     size_t out_len = 0;
     float cur_width = 0.0f;
-    bool in_bullet = false;
+    int32_t bullet_indent = 0;
 
     const float space_width = M_WORD_SPACING * scale_f;
 
@@ -309,31 +353,28 @@ static size_t M_WordWrap(
             continue;
         }
 
+        if (cur_width == 0.0f && bullet_indent == 0) {
+            bullet_indent = M_DetectBulletIndent(glyphs, glyph_count, i);
+        }
+
         if (glyph->role == GLYPH_FONT_MARKER) {
             current_font = glyph->mesh_idx;
         } else if (glyph->role == GLYPH_NEW_LINE) {
             L_CONCAT_CHAR('\n')
             cur_width = 0.0f;
-            in_bullet = false;
+            bullet_indent = 0;
         } else if (glyph->role == GLYPH_NEW_PAGE) {
             L_CONCAT_CHAR('\f')
             cur_width = 0.0f;
-            in_bullet = false;
+            bullet_indent = 0;
         } else if (glyph->role == GLYPH_SPACE) {
-            if (cur_width > 0.0f) {
-                const float w = M_WORD_SPACING * scale_f;
-                if (cur_width + w > max_width) {
-                    L_CONCAT_CHAR('\n')
-                    cur_width = 0.0f;
-                    if (in_bullet) {
-                        L_CONCAT_CHAR(' ')
-                        L_CONCAT_CHAR(' ')
-                        cur_width += 2 * space_width;
-                    }
-                } else {
-                    L_CONCAT_CHAR(' ')
-                    cur_width += w;
-                }
+            const float w = M_WORD_SPACING * scale_f;
+            if (cur_width + w > max_width) {
+                M_EmitNewline(
+                    dst, &out_len, bullet_indent, space_width, &cur_width);
+            } else {
+                L_CONCAT_CHAR(' ')
+                cur_width += w;
             }
         } else if (
             glyph->role == GLYPH_REVIEW_MARKER
@@ -351,13 +392,6 @@ static size_t M_WordWrap(
                 word_len++;
             }
 
-            // Detect bullet start marker ("- " at line start)
-            if (cur_width == 0.0f && word_len == 1 && glyphs[i]->text[0] == '-'
-                && (i + 1 < glyph_count
-                    && glyphs[i + 1]->role == GLYPH_SPACE)) {
-                in_bullet = true;
-            }
-
             // Compute width (sum widths + spacing)
             float word_width = 0.0f;
             for (size_t j = i; j < i + word_len; j++) {
@@ -372,13 +406,8 @@ static size_t M_WordWrap(
             // Wrap line if needed
             if (cur_width + word_width > max_width) {
                 if (cur_width > 0.0f) {
-                    L_CONCAT_CHAR('\n')
-                    cur_width = 0.0f;
-                    if (in_bullet) {
-                        L_CONCAT_CHAR(' ')
-                        L_CONCAT_CHAR(' ')
-                        cur_width += 2 * space_width;
-                    }
+                    M_EmitNewline(
+                        dst, &out_len, bullet_indent, space_width, &cur_width);
                 }
 
                 // Break word if longer than line
@@ -389,13 +418,9 @@ static size_t M_WordWrap(
                             (next_glyph->width[current_font] + M_LETTER_SPACING)
                             * scale_f;
                         if (cur_width + glyph_width > max_width) {
-                            L_CONCAT_CHAR('\n')
-                            cur_width = 0.0f;
-                            if (in_bullet) {
-                                L_CONCAT_CHAR(' ')
-                                L_CONCAT_CHAR(' ')
-                                cur_width += 2 * space_width;
-                            }
+                            M_EmitNewline(
+                                dst, &out_len, bullet_indent, space_width,
+                                &cur_width);
                         }
                         L_CONCAT_STR(next_glyph->text)
                         cur_width += glyph_width;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4753, and improves the auto-indentation of wrapped text in nested bullets to support arbitrary nesting level:

Before:
```
- long long long long
  long line
  - second long long
  bullet
  - third long long
  bullet
- final long long long
  bullet
```

After:
```
- long long long long
  long line
  - second long long
    bullet
  - third long long
    bullet
- final long long long
  bullet
```
