### PR TITLE
audio: fix potential deadlock when exiting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fixed targeting hostile ex-allies not working if "Enable ally targeting" option is off
 - fixed `/play` and similar commands fading out instead of running instantly on stats/title screens
 - fixed Cheats description showing arrows in the indented bullets (#4753, regression from TRX 1.1)
+- fixed game freezing on exit on certain platforms when there are no active sound devices (SDL bug)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/engine/audio.c
+++ b/src/trx/engine/audio.c
@@ -15,9 +15,12 @@ static size_t m_MixBufferCapacity = 0;
 static float *m_MixBuffer = nullptr;
 static Uint8 m_Silence = 0;
 static bool m_Muted = false;
+static bool m_CallbackSeen = false;
+static bool m_ShouldSkipSDLQuitAudio = false;
 
 static void M_MixerCallback(void *userdata, Uint8 *stream_data, int32_t len)
 {
+    m_CallbackSeen = true;
     memset(m_MixBuffer, m_Silence, len);
     Audio_Stream_Mix(m_MixBuffer, len);
     Audio_Sample_Mix(m_MixBuffer, len);
@@ -35,6 +38,8 @@ bool Audio_Init(void)
         return true;
     }
 
+    m_CallbackSeen = false;
+    m_ShouldSkipSDLQuitAudio = false;
     int32_t result = SDL_InitSubSystem(SDL_INIT_AUDIO);
     if (result < 0) {
         LOG_ERROR("Error while calling SDL_Init: 0x%lx", result);
@@ -81,7 +86,11 @@ bool Audio_Shutdown(void)
 
     if (g_AudioDeviceID) {
         SDL_PauseAudioDevice(g_AudioDeviceID, 1);
-        SDL_CloseAudioDevice(g_AudioDeviceID);
+        if (!m_CallbackSeen) {
+            m_ShouldSkipSDLQuitAudio = true;
+        } else {
+            SDL_CloseAudioDevice(g_AudioDeviceID);
+        }
         g_AudioDeviceID = 0;
     }
     Memory_FreePointer(&m_MixBuffer);
@@ -89,8 +98,15 @@ bool Audio_Shutdown(void)
     Audio_Sample_Shutdown();
     Audio_Stream_Shutdown();
 
-    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    if (!m_ShouldSkipSDLQuitAudio) {
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
     return true;
+}
+
+bool Audio_ShouldSkipSDLQuitAudio(void)
+{
+    return m_ShouldSkipSDLQuitAudio;
 }
 
 void Audio_Mute(void)
@@ -106,6 +122,22 @@ void Audio_Unmute(void)
 bool Audio_IsMuted(void)
 {
     return m_Muted;
+}
+
+void Audio_LockDevice(void)
+{
+    if (g_AudioDeviceID == 0) {
+        return;
+    }
+    SDL_LockAudioDevice(g_AudioDeviceID);
+}
+
+void Audio_UnlockDevice(void)
+{
+    if (g_AudioDeviceID == 0) {
+        return;
+    }
+    SDL_UnlockAudioDevice(g_AudioDeviceID);
 }
 
 int32_t Audio_GetAVChannelLayout(const int32_t channels)

--- a/src/trx/engine/audio.h
+++ b/src/trx/engine/audio.h
@@ -13,6 +13,7 @@
 
 bool Audio_Init(void);
 bool Audio_Shutdown(void);
+bool Audio_ShouldSkipSDLQuitAudio(void);
 
 void Audio_Mute(void);
 void Audio_Unmute(void);

--- a/src/trx/engine/audio_internal.h
+++ b/src/trx/engine/audio_internal.h
@@ -12,6 +12,9 @@
 
 extern SDL_AudioDeviceID g_AudioDeviceID;
 
+void Audio_LockDevice(void);
+void Audio_UnlockDevice(void);
+
 int32_t Audio_GetAVChannelLayout(int32_t sample_fmt);
 int32_t Audio_GetAVAudioFormat(int32_t sample_fmt);
 int32_t Audio_GetSDLAudioFormat(enum AVSampleFormat sample_fmt);

--- a/src/trx/engine/audio_sample.c
+++ b/src/trx/engine/audio_sample.c
@@ -588,7 +588,7 @@ int32_t Audio_Sample_Play(
 
     int32_t result = AUDIO_NO_SOUND;
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
          sound_id++) {
         AUDIO_SAMPLE_SOUND *sound = &m_Samples[sound_id];
@@ -612,7 +612,7 @@ int32_t Audio_Sample_Play(
         result = sound_id;
         break;
     }
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     if (result == AUDIO_NO_SOUND) {
         LOG_ERROR("All sample buffers are used!");
@@ -638,9 +638,9 @@ bool Audio_Sample_Pause(int32_t sound_id)
     }
 
     if (m_Samples[sound_id].is_playing) {
-        SDL_LockAudioDevice(g_AudioDeviceID);
+        Audio_LockDevice();
         m_Samples[sound_id].is_playing = false;
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
     }
 
     return true;
@@ -669,9 +669,9 @@ bool Audio_Sample_Unpause(int32_t sound_id)
     }
 
     if (!m_Samples[sound_id].is_playing) {
-        SDL_LockAudioDevice(g_AudioDeviceID);
+        Audio_LockDevice();
         m_Samples[sound_id].is_playing = true;
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
     }
 
     return true;
@@ -700,10 +700,10 @@ bool Audio_Sample_Close(int32_t sound_id)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     m_Samples[sound_id].is_used = false;
     m_Samples[sound_id].is_playing = false;
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     return true;
 }
@@ -731,10 +731,10 @@ bool Audio_Sample_SetPan(int32_t sound_id, int32_t pan)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     m_Samples[sound_id].pan = pan;
     M_RecalculateChannelVolumes(sound_id);
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     return true;
 }
@@ -746,10 +746,10 @@ bool Audio_Sample_SetVolume(int32_t sound_id, int32_t volume)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     m_Samples[sound_id].volume = volume;
     M_RecalculateChannelVolumes(sound_id);
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     return true;
 }
@@ -761,10 +761,10 @@ bool Audio_Sample_SetPitch(int32_t sound_id, float pitch)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     m_Samples[sound_id].pitch = pitch;
     M_RecalculateChannelVolumes(sound_id);
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     return true;
 }

--- a/src/trx/engine/audio_stream.c
+++ b/src/trx/engine/audio_stream.c
@@ -263,7 +263,7 @@ static bool M_InitialiseFromFormatContext(
     }
 
     bool ret = false;
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
 
     AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
     int32_t error_code = 0;
@@ -362,7 +362,7 @@ cleanup:
         Audio_Stream_Close(sound_id);
     }
 
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
     return ret;
 }
 
@@ -580,9 +580,9 @@ bool Audio_Stream_Pause(int32_t sound_id)
 
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     if (stream->is_playing) {
-        SDL_LockAudioDevice(g_AudioDeviceID);
+        Audio_LockDevice();
         stream->is_playing = false;
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
     }
 
     return true;
@@ -597,9 +597,9 @@ bool Audio_Stream_Unpause(int32_t sound_id)
 
     AUDIO_STREAM_SOUND *const stream = &m_Streams[sound_id];
     if (!stream->is_playing) {
-        SDL_LockAudioDevice(g_AudioDeviceID);
+        Audio_LockDevice();
         stream->is_playing = true;
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
     }
 
     return true;
@@ -706,7 +706,7 @@ bool Audio_Stream_Close(int32_t sound_id)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
 
     AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
 
@@ -767,7 +767,7 @@ bool Audio_Stream_Close(int32_t sound_id)
 
     M_Clear(stream);
 
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
 
     if (finish_callback) {
         finish_callback(sound_id, finish_callback_user_data);
@@ -889,9 +889,9 @@ double Audio_Stream_GetTimestamp(int32_t sound_id)
     AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
 
     if (stream->duration > 0.0) {
-        SDL_LockAudioDevice(g_AudioDeviceID);
+        Audio_LockDevice();
         timestamp = (double)stream->played_samples / (double)AUDIO_WORKING_RATE;
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
     }
 
     return timestamp;
@@ -904,10 +904,10 @@ double Audio_Stream_GetDuration(int32_t sound_id)
         return -1.0;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     AUDIO_STREAM_SOUND *stream = &m_Streams[sound_id];
     double duration = stream->duration;
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
     return duration;
 }
 
@@ -923,12 +923,12 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
         return false;
     }
 
-    SDL_LockAudioDevice(g_AudioDeviceID);
+    Audio_LockDevice();
     const double time_base_sec = av_q2d(stream->av.stream->time_base);
     if (time_base_sec <= 0.0) {
         LOG_ERROR(
             "Audio_Stream_SeekTimestamp: invalid time_base %f", time_base_sec);
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
         return false;
     }
 
@@ -941,7 +941,7 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
         LOG_ERROR(
             "seek failed for timestamp %f: %s", timestamp,
             av_err2str(error_code));
-        SDL_UnlockAudioDevice(g_AudioDeviceID);
+        Audio_UnlockDevice();
         return false;
     }
 
@@ -954,7 +954,7 @@ bool Audio_Stream_SeekTimestamp(const int32_t sound_id, const double timestamp)
     M_ResetPlaybackState(stream, timestamp);
     stream->is_read_done = false;
 
-    SDL_UnlockAudioDevice(g_AudioDeviceID);
+    Audio_UnlockDevice();
     return true;
 }
 

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -1,5 +1,6 @@
 #include <trx/config.h>
 #include <trx/debug.h>
+#include <trx/engine/audio.h>
 #include <trx/game/output.h>
 #include <trx/game/savegame.h>
 #include <trx/game/shell.h>
@@ -41,7 +42,15 @@ void Shell_Terminate(int32_t exit_code)
     if (window != nullptr) {
         SDL_DestroyWindow(window);
     }
-    SDL_Quit();
+    if (Audio_ShouldSkipSDLQuitAudio()) {
+        const Uint32 inited = SDL_WasInit(0);
+        const Uint32 quit_flags = inited & ~SDL_INIT_AUDIO;
+        if (quit_flags != 0) {
+            SDL_QuitSubSystem(quit_flags);
+        }
+    } else {
+        SDL_Quit();
+    }
     exit(exit_code);
 }
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -81,6 +81,11 @@ static void M_HandleConfigChange(const EVENT *const event, void *const data)
 
 static void M_SetupSDL(void)
 {
+    SDL_version compiled;
+    SDL_VERSION(&compiled);
+    LOG_INFO(
+        "SDL version: %d.%d.%d", compiled.major, compiled.minor,
+        compiled.patch);
     if (SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO) < 0) {
         Shell_ExitSystemFmt("Cannot initialize SDL: %s", SDL_GetError());
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This works around a weird SDL bug with PulseAudio, where the game can enter a deadlock on exit – SDL tries to close a mixer thread that never started, likely caused by a failed connection to an incompatible audio device.