### PR TITLE
rooms: ignore invalid static 3Ds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,7 @@
 - removed support for legacy (TombATI / TR2 GOG/Steam) and pre-1.0 (TR1X/TR2X) savegame files
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
+- fixed custom levels that contain invalid room static mesh references not being able to load (#4770)
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 - fixed grenades not killing more than a single enemy

--- a/src/trx/game/level/rooms.c
+++ b/src/trx/game/level/rooms.c
@@ -73,7 +73,14 @@ static void M_FixStatics(void)
         room_stat_vecs[i] = Vector_Create(sizeof(STATIC_MESH));
         ROOM *const room = Room_Get(i);
         for (int32_t m = 0; m < room->num_static_meshes; m++) {
-            Vector_Add(room_stat_vecs[i], &room->static_meshes[m]);
+            STATIC_MESH *const static_mesh = &room->static_meshes[m];
+            if (Object_IsValidStatid3D(static_mesh->static_num)) {
+                Vector_Add(room_stat_vecs[i], static_mesh);
+            } else {
+                LOG_WARNING(
+                    "Invalid static 3D (id %d) in room %d",
+                    static_mesh->static_num, i);
+            }
         }
     }
 

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -84,9 +84,12 @@ OBJECT *Object_GetByGameID(const int32_t game_id)
 
 STATIC_OBJECT_3D *Object_Get3DStatic(const int32_t static_id)
 {
-    ASSERT(m_StaticObjects3D != nullptr);
-    ASSERT(static_id >= 0 && static_id < m_StaticObjects3DCount);
     return &m_StaticObjects3D[static_id];
+}
+
+bool Object_IsValidStatid3D(const int32_t static_id)
+{
+    return static_id >= 0 && static_id < m_StaticObjects3DCount;
 }
 
 STATIC_OBJECT_2D *Object_Get2DStatic(const int32_t static_id)

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -34,6 +34,7 @@ void Object_InitialiseStaticObjects2D(int32_t count);
 int32_t Object_GetStaticObjects3DCount(void);
 int32_t Object_GetStaticObjects2DCount(void);
 
+bool Object_IsValidStatid3D(int32_t static_id);
 STATIC_OBJECT_3D *Object_Get3DStatic(int32_t static_id);
 STATIC_OBJECT_2D *Object_Get2DStatic(int32_t static_id);
 


### PR DESCRIPTION
Resolves #4770.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows levels that have invalid references to static meshes to continue to load. A warning is logged and the mesh is removed from the room.
