### PR TITLE
camera: strategize look constants

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - fixed `/play` and similar commands fading out instead of running instantly on stats/title screens
 - fixed Cheats description showing arrows in the indented bullets (#4753, regression from TRX 1.1)
 - fixed game freezing on exit on certain platforms when there are no active sound devices (SDL bug)
+- fixed Lara's look head rotation/tilt limits being hardcoded to the engine version rather than camera mode
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -27,6 +27,8 @@ typedef struct {
     bool test_early_lb_shift;
     bool use_fixed_los_check;
     bool override_chase_speed;
+    CAMERA_LOOK_SETTINGS look_settings;
+    CAMERA_LOOK_SETTINGS look_settings_surf;
 } M_SETTINGS;
 
 static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
@@ -39,7 +41,30 @@ static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
         .test_early_lb_shift = true,
         .use_fixed_los_check = false,
         .override_chase_speed = false,
+        .look_settings = {
+            // clang-format off
+            .max_head_rotation = +50 * DEG_1,
+            .min_head_rotation = -50 * DEG_1,
+            .head_turn         = +2 * DEG_1,
+            .max_head_tilt     = +22 * DEG_1,
+            .min_head_tilt     = -42 * DEG_1,
+            .torso_head_rot_y  = 1.0f,
+            .torso_head_rot_x  = 1.0f,
+            // clang-format on
+        },
+        .look_settings_surf = {
+            // clang-format off
+            .head_turn         = +3 * DEG_1,
+            .max_head_rotation = +50 * DEG_1,
+            .min_head_rotation = -50 * DEG_1,
+            .max_head_tilt     = +40 * DEG_1,
+            .min_head_tilt     = -40 * DEG_1,
+            .torso_head_rot_y  = 0.5f,
+            .torso_head_rot_x  = 0.0f,
+            // clang-format on
+        },
     },
+
     [CAMERA_MODE_TR2] = {
         .chase_speed = 10,
         .min_square = SQUARE(WALL_L / 3),
@@ -49,19 +74,47 @@ static const M_SETTINGS m_CameraSettings[CAMERA_MODE_NUMBER_OF] = {
         .test_early_lb_shift = false,
         .use_fixed_los_check = true,
         .override_chase_speed = true,
+        .look_settings = {
+            // clang-format off
+            .head_turn         = +2 * DEG_1,
+            .max_head_rotation = +44 * DEG_1,
+            .min_head_rotation = -44 * DEG_1,
+            .max_head_tilt     = +22 * DEG_1,
+            .min_head_tilt     = -42 * DEG_1,
+            .torso_head_rot_y  = 1.0f,
+            .torso_head_rot_x  = 1.0f,
+            // clang-format on
+        },
+        .look_settings_surf = {
+            // clang-format off
+            .head_turn         = +3 * DEG_1,
+            .max_head_rotation = +50 * DEG_1,
+            .min_head_rotation = -50 * DEG_1,
+            .max_head_tilt     = +40 * DEG_1,
+            .min_head_tilt     = -40 * DEG_1,
+            .torso_head_rot_y  = 0.5f,
+            .torso_head_rot_x  = 0.0f,
+            // clang-format on
+        },
     },
 };
 
 static BOX_INFO m_FixedBox = {};
 
-static M_SETTINGS M_GetSettings(void)
+static const M_SETTINGS *M_GetSettings(void)
 {
-    return m_CameraSettings[g_Config.visuals.camera_mode];
+    return &m_CameraSettings[g_Config.visuals.camera_mode];
 }
 
 static int16_t M_GetChaseSpeed(void)
 {
-    return M_GetSettings().chase_speed;
+    return M_GetSettings()->chase_speed;
+}
+
+static const CAMERA_LOOK_SETTINGS *M_GetLookSettingsFunc(const bool on_surface)
+{
+    return on_surface ? &M_GetSettings()->look_settings_surf
+                      : &M_GetSettings()->look_settings;
 }
 
 static const BOX_INFO *M_GetBox(
@@ -174,7 +227,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
     int32_t top = box->top;
     int32_t bottom = box->bottom;
 
-    const M_SETTINGS settings = M_GetSettings();
+    const M_SETTINGS *const settings = M_GetSettings();
 
     int32_t test = ROUND_TO_SECTOR_END(target->z - WALL_L);
     const SECTOR *const good_left =
@@ -184,7 +237,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         if (box != nullptr && box->left < left) {
             left = box->left;
         }
-    } else if (settings.test_shift_pair) {
+    } else if (settings->test_shift_pair) {
         left = test;
     }
 
@@ -196,7 +249,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         if (box != nullptr && box->right > right) {
             right = box->right;
         }
-    } else if (settings.test_shift_pair) {
+    } else if (settings->test_shift_pair) {
         right = test;
     }
 
@@ -208,7 +261,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         if (box != nullptr && box->top < top) {
             top = box->top;
         }
-    } else if (settings.test_shift_pair) {
+    } else if (settings->test_shift_pair) {
         top = test;
     }
 
@@ -220,7 +273,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         if (box != nullptr && box->bottom > bottom) {
             bottom = box->bottom;
         }
-    } else if (settings.test_shift_pair) {
+    } else if (settings->test_shift_pair) {
         bottom = test;
     }
 
@@ -244,7 +297,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
     };
 
     bool clip = false;
-    bool prefer_a = !settings.test_shift_pair;
+    bool prefer_a = !settings->test_shift_pair;
 
 #define L_SHIFT(axis1, axis2, l1, l2, r1, r2)                                  \
     shift(                                                                     \
@@ -254,7 +307,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         &target_b.axis1, &target_b.axis2, &target_b.y, g_Camera.target.axis1,  \
         g_Camera.target.axis2, g_Camera.target.y, l1, r2, r1, l2)
 
-    if (!settings.test_shift_pair) {
+    if (!settings->test_shift_pair) {
         if (target->z < left && good_left == nullptr) {
             clip = true;
             if (target->x < g_Camera.target.x) {
@@ -331,7 +384,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         return;
     }
 
-    if (settings.test_shift_pair) {
+    if (settings->test_shift_pair) {
         if (prefer_a) {
             prefer_a = LOS_Check(&g_Camera.target, &target_a, false);
         } else {
@@ -372,8 +425,8 @@ static void M_Clip(M_SHIFT_ARGS)
         *y = top;
     }
 
-    const M_SETTINGS settings = M_GetSettings();
-    if (settings.clip_shift_height) {
+    const M_SETTINGS *const settings = M_GetSettings();
+    if (settings->clip_shift_height) {
         *h = height;
     }
 }
@@ -389,8 +442,9 @@ static void M_Shift(M_SHIFT_ARGS)
     const int32_t tr_square = t_square + r_square;
     const int32_t bl_square = b_square + l_square;
 
-    const M_SETTINGS settings = M_GetSettings();
-    const int32_t scaled_target = g_Camera.target_square * settings.shift_scale;
+    const M_SETTINGS *const settings = M_GetSettings();
+    const int32_t scaled_target =
+        g_Camera.target_square * settings->shift_scale;
 
     int32_t shift;
     if (g_Camera.target_square < tl_square) {
@@ -400,7 +454,7 @@ static void M_Shift(M_SHIFT_ARGS)
             shift = Math_Sqrt(shift);
             *y = target_y + (top >= bottom ? shift : -shift);
         }
-    } else if (tl_square > settings.min_square) {
+    } else if (tl_square > settings->min_square) {
         *x = left;
         *y = top;
     } else if (g_Camera.target_square < bl_square) {
@@ -411,7 +465,7 @@ static void M_Shift(M_SHIFT_ARGS)
             *y = target_y + (top < bottom ? shift : -shift);
         }
     } else if (
-        settings.test_early_lb_shift && bl_square > settings.min_square) {
+        settings->test_early_lb_shift && bl_square > settings->min_square) {
         *x = left;
         *y = bottom;
     } else if (scaled_target < tr_square) {
@@ -421,7 +475,7 @@ static void M_Shift(M_SHIFT_ARGS)
             *x = target_x + (left < right ? shift : -shift);
             *y = top;
         }
-    } else if (settings.test_early_lb_shift || bl_square <= tr_square) {
+    } else if (settings->test_early_lb_shift || bl_square <= tr_square) {
         *x = right;
         *y = top;
     } else {
@@ -518,10 +572,11 @@ static void M_Chase(const ITEM *const item)
         .room_num = g_Camera.pos.room_num,
     };
 
-    const M_SETTINGS settings = M_GetSettings();
-    const int16_t speed = settings.override_chase_speed || g_Camera.fixed_camera
+    const M_SETTINGS *const settings = M_GetSettings();
+    const int16_t speed =
+        settings->override_chase_speed || g_Camera.fixed_camera
         ? g_Camera.speed
-        : settings.chase_speed;
+        : settings->chase_speed;
     M_SmartShift(&target, M_Shift);
     M_Move(&target, speed);
 }
@@ -592,8 +647,8 @@ static void M_Fixed(void)
         .room_num = fixed->data,
     };
 
-    const M_SETTINGS settings = M_GetSettings();
-    if (settings.use_fixed_los_check
+    const M_SETTINGS *const settings = M_GetSettings();
+    if (settings->use_fixed_los_check
         && !LOS_Check(&g_Camera.target, &target, false)) {
         M_ShiftClamp(&target, STEP_L);
     }
@@ -826,6 +881,7 @@ static void M_Update(
 
 static const CAMERA_STRATEGY m_Strategy = {
     .get_chase_speed_func = M_GetChaseSpeed,
+    .get_look_settings_func = M_GetLookSettingsFunc,
     .clamp_result_func = M_ClampResult,
     .reset_func = M_Reset,
     .update_func = M_Update,

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -43,6 +43,11 @@ static const CAMERA_STRATEGY *M_GetStrategy(void)
     return &m_Strategies[g_Config.visuals.camera_mode];
 }
 
+const CAMERA_LOOK_SETTINGS *Camera_GetLookSettings(const bool on_surface)
+{
+    return M_GetStrategy()->get_look_settings_func(on_surface);
+}
+
 void Camera_RegisterStrategy(
     const CAMERA_MODE mode, const CAMERA_STRATEGY strategy)
 {

--- a/src/trx/game/camera/common.h
+++ b/src/trx/game/camera/common.h
@@ -13,6 +13,7 @@ void Camera_ResetPosition(void);
 void Camera_Reset(void);
 void Camera_ApplyBounce(void);
 void Camera_ClampInterpResult(void);
+const CAMERA_LOOK_SETTINGS *Camera_GetLookSettings(bool on_surface);
 
 void Camera_RegisterStrategy(CAMERA_MODE mode, CAMERA_STRATEGY strategy);
 

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -42,9 +42,26 @@ static M_IDEAL m_LastIdeal = {};
 static M_IDEAL m_LastLookIdeal = {};
 static int32_t m_Snaps = 0;
 
+static CAMERA_LOOK_SETTINGS m_LookSettings = {
+    // clang-format off
+    .head_turn         = +2 * DEG_1,
+    .max_head_rotation = +44 * DEG_1,
+    .min_head_rotation = -44 * DEG_1,
+    .max_head_tilt     = +30 * DEG_1,
+    .min_head_tilt     = -35 * DEG_1,
+    .torso_head_rot_y  = 1.0f,
+    .torso_head_rot_x  = 1.0f,
+    // clang-format on
+};
+
 static int16_t M_GetChaseSpeed(void)
 {
     return M_CHASE_SPEED;
+}
+
+static const CAMERA_LOOK_SETTINGS *M_GetLookSettingsFunc(const bool on_surface)
+{
+    return &m_LookSettings;
 }
 
 static bool M_LOS(
@@ -903,6 +920,7 @@ static void M_Update(
 
 static const CAMERA_STRATEGY m_Strategy = {
     .get_chase_speed_func = M_GetChaseSpeed,
+    .get_look_settings_func = M_GetLookSettingsFunc,
     .clamp_result_func = M_ClampResult,
     .reset_func = M_Reset,
     .update_func = M_Update,

--- a/src/trx/game/camera/types.h
+++ b/src/trx/game/camera/types.h
@@ -4,7 +4,18 @@
 #include <trx/game/types.h>
 
 typedef struct {
+    int16_t head_turn;
+    int16_t max_head_rotation;
+    int16_t min_head_rotation;
+    int16_t max_head_tilt;
+    int16_t min_head_tilt;
+    float torso_head_rot_y;
+    float torso_head_rot_x;
+} CAMERA_LOOK_SETTINGS;
+
+typedef struct {
     int16_t (*get_chase_speed_func)(void);
+    const CAMERA_LOOK_SETTINGS *(*get_look_settings_func)(bool on_surface);
     void (*clamp_result_func)(void);
     void (*reset_func)(void);
     void (*update_func)(const ITEM *item, bool fixed_camera, int32_t target_y);

--- a/src/trx/game/lara/look.c
+++ b/src/trx/game/lara/look.c
@@ -5,19 +5,6 @@
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/utils.h>
-#include <trx/version.h>
-
-// clang-format off
-#define M_MAX_HEAD_ROTATION          ((g_TRVersion == 1 ? 50 : 44) * DEG_1) // = 9100 (TR1), 8008 (TR2/3)
-#define M_HEAD_TURN                  (2 * DEG_1)             // = 364
-#define M_MIN_HEAD_ROTATION          (-M_MAX_HEAD_ROTATION)  // = -9100 (TR1), -8008 (TR2/3)
-#define M_MAX_HEAD_TILT              ((g_TRVersion < 3 ? 22 : 30) * DEG_1) // = 4004 (TR1/2), 5460 (TR3)
-#define M_MIN_HEAD_TILT              ((g_TRVersion < 3 ? -42 : -35) * DEG_1) // = -7644 (TR1/2), -6370 (TR3)
-#define M_HEAD_TURN_SURF             (3 * DEG_1)             // = 546
-#define M_MAX_HEAD_ROTATION_SURF     (50 * DEG_1)            // = 9100
-#define M_MAX_HEAD_TILT_SURF         (40 * DEG_1)            // = 7280
-#define M_MIN_HEAD_TILT_SURF         (-M_MAX_HEAD_TILT_SURF) // = -7280
-// clang-format on
 
 static const LARA_TRX_STATE m_StopStates[] = {
     LS_STOP,
@@ -61,13 +48,17 @@ static void M_Reset(void)
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (lara->head_rot.x <= -M_HEAD_TURN || lara->head_rot.x >= M_HEAD_TURN) {
+    const CAMERA_LOOK_SETTINGS *const look = Camera_GetLookSettings(false);
+
+    if (lara->head_rot.x <= -look->head_turn
+        || lara->head_rot.x >= look->head_turn) {
         lara->head_rot.x -= lara->head_rot.x / 8;
     } else {
         lara->head_rot.x = 0;
     }
 
-    if (lara->head_rot.y <= -M_HEAD_TURN || lara->head_rot.y >= M_HEAD_TURN) {
+    if (lara->head_rot.y <= -look->head_turn
+        || lara->head_rot.y >= look->head_turn) {
         lara->head_rot.y += lara->head_rot.y / -8;
     } else {
         lara->head_rot.y = 0;
@@ -105,36 +96,31 @@ static bool M_IsStatePermitted(void)
 
 void Lara_Look_LeftRight(void)
 {
-    LARA_INFO *const lara = Lara_GetLaraInfo();
     g_Camera.type = CAM_LOOK;
 
-    const bool on_surface =
-        g_TRVersion < 3 && lara->water_status == LWS_SURFACE;
-    const int16_t max_head_rot =
-        on_surface ? M_MAX_HEAD_ROTATION_SURF : M_MAX_HEAD_ROTATION;
-    const int16_t head_turn = on_surface ? M_HEAD_TURN_SURF : M_HEAD_TURN;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const CAMERA_LOOK_SETTINGS *const look =
+        Camera_GetLookSettings(lara->water_status == LWS_SURFACE);
 
     if (g_Input.left) {
         g_Input.left = 0;
-        if (lara->head_rot.y > -max_head_rot) {
-            lara->head_rot.y -= head_turn;
+        if (lara->head_rot.y > look->min_head_rotation) {
+            lara->head_rot.y -= look->head_turn;
         }
     } else if (g_Input.right) {
         g_Input.right = 0;
-        if (lara->head_rot.y < max_head_rot) {
-            lara->head_rot.y += head_turn;
+        if (lara->head_rot.y < look->max_head_rotation) {
+            lara->head_rot.y += look->head_turn;
         }
     }
 
     if (lara->gun_status != LGS_HANDS_BUSY && !Lara_Vehicle_IsMounted()) {
-        lara->torso_rot.y =
-            on_surface ? (lara->head_rot.y / 2) : lara->head_rot.y;
+        lara->torso_rot.y = lara->head_rot.y * look->torso_head_rot_y;
     }
 }
 
 void Lara_Look_UpDown(void)
 {
-    LARA_INFO *const lara = Lara_GetLaraInfo();
     g_Camera.type = CAM_LOOK;
 
     if (g_Config.gameplay.enable_inverted_look) {
@@ -142,28 +128,24 @@ void Lara_Look_UpDown(void)
         SWAP2(g_Input.forward, g_Input.back, temp_forward);
     }
 
-    const bool on_surface =
-        g_TRVersion < 3 && lara->water_status == LWS_SURFACE;
-    const int16_t min_head_tilt =
-        on_surface ? M_MIN_HEAD_TILT_SURF : M_MIN_HEAD_TILT;
-    const int16_t max_head_tilt =
-        on_surface ? M_MAX_HEAD_TILT_SURF : M_MAX_HEAD_TILT;
-    const int16_t head_turn = on_surface ? M_HEAD_TURN_SURF : M_HEAD_TURN;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    const CAMERA_LOOK_SETTINGS *const look =
+        Camera_GetLookSettings(lara->water_status == LWS_SURFACE);
 
     if (g_Input.forward) {
         g_Input.forward = 0;
-        if (lara->head_rot.x > min_head_tilt) {
-            lara->head_rot.x -= head_turn;
+        if (lara->head_rot.x > look->min_head_tilt) {
+            lara->head_rot.x -= look->head_turn;
         }
     } else if (g_Input.back) {
         g_Input.back = 0;
-        if (lara->head_rot.x < max_head_tilt) {
-            lara->head_rot.x += head_turn;
+        if (lara->head_rot.x < look->max_head_tilt) {
+            lara->head_rot.x += look->head_turn;
         }
     }
 
     if (lara->gun_status != LGS_HANDS_BUSY) {
-        lara->torso_rot.x = on_surface ? 0 : lara->head_rot.x;
+        lara->torso_rot.x = lara->head_rot.x * look->torso_head_rot_x;
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the engine-hardcoded look camera maximum angles to be tied to the camera mode setting, instead.

For box camera, since `M_Settings` got pretty chunky, I'm returning a pointer instead of copying it on every retrieval.