### PR TITLE
camera/los: reduce bobbing in tr3 look cameras

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,6 +114,7 @@
     - added Beacon Light control
     - added On/Off Light control
 - added Lara's backwards-hop stumble if there is a slope behind her
+- improved look camera stability to reduce idle-breathing camera bobbing/roll
 - improved Monkeys to no longer hardcode hostility status based on Tiger presence
 - changed hostile Monkeys to share hostility status, like TR2 Barkhang monks (the original TR3 behavior can be restored in Gameplay → General → Ally hostility policy)
 - changed enemy drops to appear at the tile center, to conform with the OG

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -1,6 +1,7 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/lara.h>
+#include <trx/game/math.h>
 #include <trx/game/rooms.h>
 
 // clang-format off
@@ -585,6 +586,10 @@ static void M_Look(const ITEM *const item)
     CLAMP(lara->head_rot.x, M_MIN_LOOK_TILT, M_MAX_LOOK_TILT);
     CLAMP(lara->head_rot.y, M_MIN_LOOK_ROTATION, M_MAX_LOOK_ROTATION);
 
+    // Get head-relative points in mesh space (faithful), then project the
+    // camera's ray onto the head->forward axis to remove breathing-induced
+    // roll/tilt wobble without moving the ray off Lara's head.
+    const XYZ_32 head_pos = M_GetHeadPos(0, 0, 0);
     XYZ_32 pos_1 = M_GetHeadPos(0, 16, 64);
 
     int16_t room_num = lara_item->room_num;
@@ -623,6 +628,20 @@ static void M_Look(const ITEM *const item)
 
     XYZ_32 pos_2 = M_GetHeadPos(0, 0, -1024);
     XYZ_32 pos_3 = M_GetHeadPos(0, 0, 2048);
+
+    // Constrain the camera ray to pass through Lara's head (OG behavior), but
+    // remove idle-breathing wobble by projecting onto a stable forward axis
+    // derived from yaw + pitch (no roll/tilt from torso animation).
+    const int16_t yaw = lara_item->rot.y + lara->head_rot.y;
+    const int16_t pitch = lara_item->rot.x + lara->head_rot.x;
+    const XYZ_32 axis = XYZ_32_FromYawPitch(yaw, pitch);
+
+    const int64_t axis_len2 = XYZ_32_GetLength2_64(axis);
+    if (axis_len2 != 0) {
+        XYZ_32_ProjectPointOntoAxis(head_pos, axis, axis_len2, &pos_1);
+        XYZ_32_ProjectPointOntoAxis(head_pos, axis, axis_len2, &pos_2);
+        XYZ_32_ProjectPointOntoAxis(head_pos, axis, axis_len2, &pos_3);
+    }
 
     const XYZ_32 delta = {
         .x = (pos_2.x - pos_1.x) >> 3,

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -886,13 +886,13 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
         .y = new_pos.y - lara_item->pos.y,
         .z = new_pos.z - lara_item->pos.z,
     };
-    const int32_t dist = XYZ_32_GetDistance0(&dpos);
-    if (velocity >= dist) {
+    const int32_t length = XYZ_32_GetLength(dpos);
+    if (velocity >= length) {
         lara_item->pos = new_pos;
     } else {
-        lara_item->pos.x += velocity * dpos.x / dist;
-        lara_item->pos.y += velocity * dpos.y / dist;
-        lara_item->pos.z += velocity * dpos.z / dist;
+        lara_item->pos.x += velocity * dpos.x / length;
+        lara_item->pos.y += velocity * dpos.y / length;
+        lara_item->pos.z += velocity * dpos.z / length;
     }
 
     if (walk_to_items && !lara_info->interact_target.is_moving) {

--- a/src/trx/game/math/func.h
+++ b/src/trx/game/math/func.h
@@ -16,15 +16,21 @@ int32_t Math_AngleMean(int32_t angle1, int32_t angle2, double ratio);
 int32_t Math_FloorDiv(int32_t x, int32_t divisor);
 int32_t Math_GCD(int32_t a, int32_t b);
 
+XYZ_32 XYZ_32_From16(XYZ_16 src);
 int16_t XYZ_32_GetYaw(XYZ_32 pos);
 int16_t XYZ_32_GetPitch(XYZ_32 pos);
 int32_t XYZ_32_GetDistance(const XYZ_32 *pos1, const XYZ_32 *pos2);
-int32_t XYZ_32_GetDistance0(const XYZ_32 *pos);
+int32_t XYZ_32_GetLength(XYZ_32 pos);
+int64_t XYZ_32_GetLength2_64(XYZ_32 pos);
+int64_t XYZ_32_DotProduct_64(XYZ_32 a, XYZ_32 b);
 bool XYZ_32_AreEquivalent(const XYZ_32 *pos1, const XYZ_32 *pos2);
-bool XYZ_16_AreEquivalent(const XYZ_16 *rot1, const XYZ_16 *rot2);
-XYZ_32 XYZ_32_From16(XYZ_16 src);
 bool XYZ_32_IsNearby(const XYZ_32 *pos1, const XYZ_32 *pos2, int32_t distance);
-XYZ_32 XYZ_32_DirShift(XYZ_32 src, int16_t angle, int32_t shift);
+XYZ_32 XYZ_32_FromYawPitch(int16_t yaw, int16_t pitch);
+XYZ_32 XYZ_32_OffsetYaw(XYZ_32 src, int16_t yaw, int32_t distance);
+bool XYZ_32_ProjectPointOntoAxis(
+    XYZ_32 origin, XYZ_32 axis, int64_t axis_len2, XYZ_32 *pos);
+
+bool XYZ_16_AreEquivalent(const XYZ_16 *rot1, const XYZ_16 *rot2);
 
 float XYZ_F_DotProduct(XYZ_F a, XYZ_F b);
 float XYZ_F_Length2(XYZ_F pos);

--- a/src/trx/game/math/util.c
+++ b/src/trx/game/math/util.c
@@ -154,9 +154,15 @@ bool XYZ_32_IsNearby(
         && delta.y < distance && delta.z > -distance && delta.z < distance;
 }
 
-int32_t XYZ_32_GetDistance0(const XYZ_32 *const pos)
+int32_t XYZ_32_GetLength(const XYZ_32 pos)
 {
-    return Math_Sqrt(SQUARE(pos->x) + SQUARE(pos->y) + SQUARE(pos->z));
+    return Math_Sqrt(SQUARE(pos.x) + SQUARE(pos.y) + SQUARE(pos.z));
+}
+
+int64_t XYZ_32_GetLength2_64(const XYZ_32 pos)
+{
+    return SQUARE((int64_t)pos.x) + SQUARE((int64_t)pos.y)
+        + SQUARE((int64_t)pos.z);
 }
 
 bool XYZ_32_AreEquivalent(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
@@ -174,13 +180,63 @@ XYZ_32 XYZ_32_From16(const XYZ_16 src)
     return (XYZ_32) { src.x, src.y, src.z };
 }
 
-XYZ_32 XYZ_32_DirShift(XYZ_32 src, int16_t angle, int32_t shift)
+XYZ_32 XYZ_32_OffsetYaw(
+    const XYZ_32 src, const int16_t yaw, const int32_t distance)
 {
     return (XYZ_32) {
-        .x = src.x + ((shift * Math_Sin(angle)) >> W2V_SHIFT),
+        .x = src.x + ((distance * Math_Sin(yaw)) >> W2V_SHIFT),
         .y = src.y,
-        .z = src.z + ((shift * Math_Cos(angle)) >> W2V_SHIFT),
+        .z = src.z + ((distance * Math_Cos(yaw)) >> W2V_SHIFT),
     };
+}
+
+XYZ_32 XYZ_32_FromYawPitch(const int16_t yaw, const int16_t pitch)
+{
+    return (XYZ_32) {
+        .x = (Math_Sin(yaw) * Math_Cos(pitch)) >> W2V_SHIFT,
+        .y = -Math_Sin(pitch),
+        .z = (Math_Cos(yaw) * Math_Cos(pitch)) >> W2V_SHIFT,
+    };
+}
+
+int64_t XYZ_32_DotProduct_64(const XYZ_32 a, const XYZ_32 b)
+{
+    return (int64_t)a.x * b.x + (int64_t)a.y * b.y + (int64_t)a.z * b.z;
+}
+
+bool XYZ_32_ProjectPointOntoAxis(
+    const XYZ_32 origin, const XYZ_32 axis, const int64_t axis_len2,
+    XYZ_32 *const pos)
+{
+    // Finds the value `t` such that the point
+    //   origin + t * axis
+    // is the closest point on the line to the original *pos, and then writes
+    // that point back into *pos.
+    //
+    // Example:
+    // - origin = (0, 0, 0)
+    // - axis   = (1, 0, 0)  // line is the X axis
+    // - *pos   = (5, 2, -3)
+    // The closest point on the X axis is (5, 0, 0), so after the call:
+    // - *pos = (5, 0, 0)
+
+    if (axis_len2 == 0) {
+        return false;
+    }
+
+    const XYZ_32 offset = {
+        .x = pos->x - origin.x,
+        .y = pos->y - origin.y,
+        .z = pos->z - origin.z,
+    };
+
+    const int64_t t_num = XYZ_32_DotProduct_64(offset, axis);
+    *pos = (XYZ_32) {
+        .x = origin.x + (int32_t)((t_num * axis.x) / axis_len2),
+        .y = origin.y + (int32_t)((t_num * axis.y) / axis_len2),
+        .z = origin.z + (int32_t)((t_num * axis.z) / axis_len2),
+    };
+    return true;
 }
 
 float XYZ_F_DotProduct(const XYZ_F a, const XYZ_F b)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -241,7 +241,7 @@ static void M_Control(const int16_t item_num)
 
                 if (creature->mood == MOOD_ESCAPE) {
                     int16_t room_num = item->room_num;
-                    const XYZ_32 offset = XYZ_32_DirShift(
+                    const XYZ_32 offset = XYZ_32_OffsetYaw(
                         item->pos, item->rot.y + DEG_180, WALL_L);
                     const SECTOR *const sector =
                         Room_GetSector32(offset, &room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR stabilizes the look-camera ray by "straightening" the head-derived sample points before they're used.

Right now, we pick three points around Lara's head (`pos_1/2/3`) and use them to build the look ray; those points come from animated head/torso matrices, so when Lara does idle breathing, the head bone gets a tiny roll/tilt wobble and the points wobble, too. The camera then follows that wobble, which feels like bobbing/rolling even when the player is not moving.

The fix keeps the same 3 points, but adjusts them in a controlled way:

1. Take `head_pos` as the anchor point.
2. Compute a stable forward direction axis from just yaw + pitch (`XYZ_32_FromYawPitch(yaw, pitch)`), which ignores the roll/tilt coming from breathing.
3. For each `pos_i`, snap it onto the straight line `head_pos + t*axis` by replacing it with the closest point on that line (`XYZ_32_ProjectPointOntoAxis(…)`).

After this, the ray is still head-locked and faithful to the existing setup, but it no longer inherits breathing roll/tilt noise.

The projection math and small 64-bit helpers were added to `math/` to avoid clouding the camera code.
I also renamed `XYZ_32_DirShift` to `XYZ_32_OffsetYaw` to better match intent.

#### Testing

I'm afraid to test the behavior, we'll either need a test level that has some unique scenarios: cameras next to walls, cameras in very open spaces (think Lara standing on a pillar), pointing at targets down and above Lara…, etc. I only tested this with Jungle room 10 as this is the only look camera I know of :sweat_smile:  but it seemed to work as expected.