### PR TITLE
lara: emit light for electric death

### DIFF
--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -108,7 +108,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     lara_info->current.active = 0;
     lara_info->extra_anim = false;
     lara_info->burn = false;
-    lara_info->electrocuted = false;
+    lara_info->electric = 0;
     lara_info->climb_status = false;
     lara_info->killed_loyal_item = false;
     lara_info->mesh_effects = 0;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -912,8 +912,12 @@ void Lara_Control(void)
         CLAMPG(lara_info->poison_timer, 256);
         Lara_TakeDamage(lara_info->poison_timer >> 4, false);
     }
-    if (lara_info->electrocuted) {
+    if (lara_info->electric != 0) {
+        if (lara_info->electric < 16) {
+            lara_info->electric++;
+        }
         Lara_Electricity_UpdatePoints();
+        Lara_Electricity_EmitLight();
     }
 
     if (lara_info->has_fired && (time4 & 0x7F) == 0) {

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -690,7 +690,7 @@ bool Lara_Draw(const ITEM *const item)
     Matrix_Pop();
 
 finish:
-    if (is_lara && lara->electrocuted) {
+    if (is_lara && lara->electric != 0) {
         Lara_Electricity_Draw(0, lara_item);
         Lara_Electricity_Draw(1, lara_item);
     }

--- a/src/trx/game/lara/electric.c
+++ b/src/trx/game/lara/electric.c
@@ -1,6 +1,8 @@
 #include <trx/game/lara/electric.h>
 
 #include <trx/game/collision.h>
+#include <trx/game/lara.h>
+#include <trx/game/output/lights.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/random.h>
 #include <trx/utils.h>
@@ -91,6 +93,43 @@ void Lara_Electricity_UpdatePoints(void)
         m_ElectricityPoints[i].vel.y = yv;
         m_ElectricityPoints[i].vel.z = zv;
     }
+}
+
+void Lara_Electricity_EmitLight(void)
+{
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->electric == 0) {
+        return;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    const int32_t electric = lara->electric;
+
+    int32_t r = 0;
+    int32_t g = 0;
+    int32_t b = 0;
+    int32_t falloff = 0;
+
+    if (electric < 12) {
+        r = (Random_GetControl() & 7) - electric + 16;
+        g = 32 - electric;
+        b = 255;
+        falloff = (Random_GetControl() & 1) - 2 * electric + 25;
+        r <<= 3;
+        g <<= 3;
+    } else {
+        r = 0;
+        g = (Random_GetControl() & 0x3F) + 64;
+        b = (Random_GetControl() & 0x3F) + 128;
+        falloff = (Random_GetControl() & 3) + 8;
+    }
+
+    CLAMP(r, 0, 255);
+    CLAMP(g, 0, 255);
+    CLAMP(b, 0, 255);
+    CLAMP(falloff, 0, 255);
+
+    Output_AddDynamicLightRGB(lara_item->pos, falloff, (RGB_888) { r, g, b });
 }
 
 void Lara_Electricity_Draw(const int32_t lr, const ITEM *const item)

--- a/src/trx/game/lara/electric.h
+++ b/src/trx/game/lara/electric.h
@@ -3,4 +3,5 @@
 #include <trx/game/items/types.h>
 
 void Lara_Electricity_UpdatePoints(void);
+void Lara_Electricity_EmitLight(void);
 void Lara_Electricity_Draw(int32_t lr, const ITEM *item);

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -216,7 +216,7 @@ void Lara_TouchDeathSector(const GF_DEATH_TILE death_tile)
         Lara_RapidsDrown();
         break;
     case GF_DEATH_TILE_ELECTRIC:
-        lara_info->electrocuted = true;
+        lara_info->electric = 1;
         break;
     case GF_DEATH_TILE_LAVA:
         Lara_TouchLava();
@@ -418,7 +418,7 @@ void Lara_CatchFire(void)
 void Lara_Extinguish(void)
 {
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_info->electrocuted = false;
+    lara_info->electric = 0;
 
     if (!lara_info->burn) {
         return;

--- a/src/trx/game/lara/types.h
+++ b/src/trx/game/lara/types.h
@@ -85,7 +85,7 @@ typedef struct {
 
     bool extra_anim;
     bool burn;
-    bool electrocuted;
+    int16_t electric;
     bool climb_status;
     bool is_crouched;
     bool keep_crouched;

--- a/src/trx/game/objects/traps/electric_fence.c
+++ b/src/trx/game/objects/traps/electric_fence.c
@@ -92,7 +92,7 @@ static void M_TouchFence(const XZ_32 spark_axis, XYZ_32 spark_pos)
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->electrocuted = true;
+    lara->electric = 1;
     lara_item->hit_points = 0;
 }
 
@@ -216,7 +216,7 @@ static void M_Control(const int16_t item_num)
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (lara->electrocuted || p->is_flat
+    if (lara->electric != 0 || p->is_flat
         || lara_item->pos.x < fence_center.x - fence_size.x
         || lara_item->pos.x > fence_center.x + fence_size.x
         || lara_item->pos.z < fence_center.z - fence_size.z

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -146,7 +146,7 @@ static bool M_ReadLara(SG_READ_IO *const io)
     M_SHOULD(SG_READ_VALUE(io, "current_vel_z", &lara->current.vel.z));
     M_MUST(SG_READ_VALUE(io, "burn", &lara->burn));
     // Introduced in TRX 1.2
-    M_SHOULD(SG_READ_VALUE(io, "electrocuted", &lara->electrocuted));
+    M_SHOULD(SG_READ_VALUE(io, "electric", &lara->electric));
 
     M_MUST(SG_READ_VALUE(io, "mesh_effects", &lara->mesh_effects));
     M_MUST(SG_READ_VALUE(io, "extra_anim", &lara->extra_anim));
@@ -579,7 +579,8 @@ static bool M_ReadResumeInfo(SG_READ_IO *const io, RESUME_INFO *const resume)
     M_MUST(SG_READ_VALUE(
         io, "gun_type", &resume->equipped_gun_type)); // LGT_UNARMED
     M_MUST(SG_READ_VALUE(
-        io, "holsters_gun_type", &resume->holsters_gun_type)); // LGT_UNKNOWN
+        io, "holsters_gun_type",
+        &resume->holsters_gun_type)); // LGT_UNKNOWN
 
     // TRX <1.1
     if (g_TRVersion == 2 && SG_ReadIO_GetVersion(io) < SG_VERSION_14) {

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -428,7 +428,7 @@ void SG_File_DumpLara(SG_WRITE_IO *const io)
     SGW_WRITE_VALUE(io, "current_vel_x", lara->current.vel.x);
     SGW_WRITE_VALUE(io, "current_vel_z", lara->current.vel.z);
     SGW_WRITE_VALUE(io, "burn", lara->burn);
-    SGW_WRITE_VALUE(io, "electrocuted", lara->electrocuted);
+    SGW_WRITE_VALUE(io, "electric", lara->electric);
     SGW_WRITE_VALUE(io, "water_surface_dist", lara->water_surface_dist);
 
     SGW_WRITE_VALUE(io, "flare_age", lara->flare.age);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This tweaks the electric death effect to emit light as per the OG, and changes Nevada death tiles to electric (so that touching the fence from above electrocutes Lara rather than burning her).