### PR TITLE
objects/rolling_ball: clamp regular boulder height

### DIFF
--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -66,8 +66,11 @@ static bool M_TestStop(const ITEM *const item)
 
     const ANIM_FRAME *const frame = Item_GetBestFrame(item);
     const BOUNDS_16 *const bounds = &frame->bounds;
-    const int16_t item_height =
+    int16_t item_height =
         ROUND_TO_HALF_CLICK(ABS(bounds->max.y - bounds->min.y));
+    if (item->object_id != O_ROLLING_BALL_4) {
+        CLAMPG(item_height, STEP_L * 3);
+    }
 
     int16_t room_num = item->room_num;
     const int32_t x =


### PR DESCRIPTION
Resolves #4785.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves boulders getting stuck in corridors with tilts and low ceilings.
