### PR TITLE
objects/movable_block: fix room number checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,7 @@
 - fixed Cheats description showing arrows in the indented bullets (#4753, regression from TRX 1.1)
 - fixed game freezing on exit on certain platforms when there are no active sound devices (SDL bug)
 - fixed Lara's look head rotation/tilt limits being hardcoded to the engine version rather than camera mode
+- fixed pushblocks being able to fall into rooms below despite no portals being present (#4788, regression from TR1X 4.15/TR2X 1.5)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -689,15 +689,11 @@ static void M_Control(const int16_t item_num)
     // Check if the block is floating, on a walkable, or on the pit floor.
     // ROUND_TO_HALF_CLICK because block can fall through floor to undefined
     // sector.
-    int16_t room_num = Room_GetIndexFromPos((XYZ_32) {
-        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z });
-    if (room_num == NO_ROOM) {
-        room_num = item->room_num;
-    }
-    const ROOM *const room = Room_Get(room_num);
-    const SECTOR *sector = Room_GetWorldSector(room, item->pos.x, item->pos.z);
+    int16_t room_num = item->room_num;
+    const SECTOR *sector = Room_GetSector(
+        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z, &room_num);
     int32_t under_block_height = Room_GetHeightEx(
-        sector, item->pos.x, item->pos.y, item->pos.z, false, item_num);
+        sector, item->pos.x, item->pos.y, item->pos.z, true, item_num);
 
     bool update_room_num = true;
 
@@ -706,16 +702,10 @@ static void M_Control(const int16_t item_num)
         const int32_t y_prev = item->pos.y - item->fall_speed;
 
         // Query floor at previous y position.
-        room_num = Room_GetIndexFromPos(
-            (XYZ_32) { item->pos.x, ROUND_TO_HALF_CLICK(y_prev), item->pos.z });
-        if (room_num == NO_ROOM) {
-            room_num = item->room_num;
-        }
-        const ROOM *const prev_room = Room_Get(room_num);
         const SECTOR *prev_sector =
-            Room_GetWorldSector(prev_room, item->pos.x, item->pos.z);
+            Room_GetSector(item->pos.x, y_prev, item->pos.z, &room_num);
         int32_t prev_height = Room_GetHeightEx(
-            prev_sector, item->pos.x, y_prev, item->pos.z, false, item_num);
+            prev_sector, item->pos.x, y_prev, item->pos.z, true, item_num);
 
         // If on a walkable at the previous y position, use the rounded previous
         // y position as the floor.


### PR DESCRIPTION
Resolves #4788.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the use of finding a pushblock's room number by position, because doing so does not take portals into consideration. It in turn allowed a block to fall into a room that's physically below, but not connected. Room numbers are restored to the conventional approach of traversing the sector's portals.