### PR TITLE
Implement overlay support for music tracks playback

### DIFF
--- a/data/tr2/ship/cfg/tr2-gm/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-gm/gameflow.json5
@@ -221,7 +221,6 @@
         "enable_wading",
         "restore_ps1_enemies",
         "load_music_triggers",
-        "fix_secrets_killing_music",
         "fix_speeches_killing_music",
         "enable_weather",
         "enable_footprints",

--- a/data/tr2/ship/cfg/tr2/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2/gameflow.json5
@@ -744,7 +744,6 @@
         "enable_wading",
         "restore_ps1_enemies",
         "load_music_triggers",
-        "fix_secrets_killing_music",
         "fix_speeches_killing_music",
         "enable_footprints",
     ],

--- a/data/tr3/ship/cfg/tr3-la/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-la/gameflow.json5
@@ -190,7 +190,6 @@
         "enable_wading",
         "restore_ps1_enemies",
         "load_music_triggers",
-        "fix_secrets_killing_music",
         "fix_speeches_killing_music",
     ],
 }

--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -682,7 +682,6 @@
         "enable_wading",
         "restore_ps1_enemies",
         "load_music_triggers",
-        "fix_secrets_killing_music",
         "fix_speeches_killing_music",
     ],
 }

--- a/docs/06-lua/2-reference/6-MUSIC.md
+++ b/docs/06-lua/2-reference/6-MUSIC.md
@@ -32,3 +32,5 @@ title: Music
     Plays the track once but prevents retriggering if it's already playing.
 - `trx.music.PlayMode.DELAY`  
     Schedules the track for later playback without starting it immediately.
+- `trx.music.PlayMode.OVERLAY`  
+    Schedules the track on top of current music track.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - added a new Lua function, `trx.rooms.flip()`, to toggle the flip map (#4704)
 - added a new Lua function, `trx.rooms.flip_effect()`, to set the active flip effect with an optional timer (#4704)
 - added a new Lua catalog, `trx.catalog.flip_effects` for name-based flip effect catalog IDs
+- added a new Lua music play mode, `trx.music.PlayMode.OVERLAY` for playing on top of currently played track
 - added new Lua catalogs for Lara states, Lara anims, music, and samples
 - added a new Lua module, `trx.camera`, with camera getters and `trx.camera.shake()`
 - added `num` to `trx.rooms.Room`
@@ -79,6 +80,8 @@
 - fixed Lara's look head rotation/tilt limits being hardcoded to the engine version rather than camera mode
 - fixed pushblocks being able to fall into rooms below despite no portals being present (#4788, regression from TR1X 4.15/TR2X 1.5)
 - fixed one-shot triggers for hidden pickup items making the items permanently invisible (#4784)
+- fixed secret tracks played at low quality when "fix secrets killing music" option is on
+- fixed secret tracks not restored from the savegame when "fix secrets killing music" option is on
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)
@@ -88,6 +91,8 @@
 - fixed gun injections overwriting Lara's footstep SFX in all levels (#4733, regression from 1.1)
 - fixed pushblocks in Natla's Mines becoming unusable after loading a save made in earlier versions (#4735, regression from 1.1)
 - fixed low-quality texture palette on injected TR2/3 weapons and flares
+- fixed baddie speeches played at low quality when "fix speeches killing music" option is on
+- fixed baddie speeches not restored from the savegame when "fix speeches killing music" option is on
 
 **TR2**:
 - fixed wrong line played when finishing the Assault Course for the first time (#4667, regression from 1.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -95,6 +95,7 @@
 - fixed baddie speeches not restored from the savegame when "fix speeches killing music" option is on
 
 **TR2**:
+- added "Sound Options → Misc → Layered secret music" option
 - fixed wrong line played when finishing the Assault Course for the first time (#4667, regression from 1.1)
 - fixed underwater wobble effect acting twitchy with camera movement
 - fixed several texture issues on each of Lara's outfits
@@ -138,6 +139,7 @@
     - added Beacon Light control
     - added On/Off Light control
 - added Lara's backwards-hop stumble if there is a slope behind her
+- added "Sound Options → Misc → Layered secret music" option
 - improved look camera stability to reduce idle-breathing camera bobbing/roll
 - improved Monkeys to no longer hardcode hostility status based on Tiger presence
 - changed hostile Monkeys to share hostility status, like TR2 Barkhang monks (the original TR3 behavior can be restored in Gameplay → General → Ally hostility policy)

--- a/src/trx/game/lua/music.c
+++ b/src/trx/game/lua/music.c
@@ -62,6 +62,8 @@ void LUA_CreateMusic(lua_State *const L)
     lua_setfield(L, -2, "DELAY");
     lua_pushinteger(L, MPM_NO_REPEAT);
     lua_setfield(L, -2, "NO_REPEAT");
+    lua_pushinteger(L, MPM_OVERLAY);
+    lua_setfield(L, -2, "OVERLAY");
     lua_setfield(L, -2, "PlayMode");
 
     lua_pushcfunction(L, M_L_MusicGetTrack);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -8,7 +8,6 @@
 #include <trx/game/music/backend_cdaudio.h>
 #include <trx/game/music/backend_cdaudio_wad.h>
 #include <trx/game/music/backend_files.h>
-#include <trx/game/sound.h>
 #include <trx/log.h>
 #include <trx/vector.h>
 #include <trx/version.h>
@@ -23,9 +22,22 @@ static MUSIC_ID m_TrackLooped = MX_INACTIVE;
 static MUSIC_ID m_TrackLastPlayed = MX_INACTIVE;
 static MUSIC_ID m_TrackLastLooped = MX_INACTIVE;
 
+typedef struct {
+    int32_t audio_stream_id;
+    MUSIC_ID track_id;
+    MUSIC_PLAY_MODE mode;
+    bool active;
+} M_MUSIC_STREAM;
+
 static float m_MusicVolume = 0.0f;
-static int32_t m_AudioStreamID = -1;
 static const MUSIC_BACKEND *m_Backend = nullptr;
+static M_MUSIC_STREAM m_MainStream = {
+    .audio_stream_id = -1,
+    .track_id = MX_INACTIVE,
+    .mode = MPM_ONCE,
+    .active = false,
+};
+static M_MUSIC_STREAM m_OverlayStreams[MUSIC_MAX_OVERLAY_TRACKS] = {};
 
 static const MUSIC_BACKEND *M_FindBackend(void)
 {
@@ -72,9 +84,18 @@ static const MUSIC_BACKEND *M_FindBackend(void)
     return backend;
 }
 
-static void M_StopActiveStream(void)
+static void M_StreamReset(M_MUSIC_STREAM *const stream)
 {
-    if (m_AudioStreamID < 0) {
+    stream->audio_stream_id = -1;
+    stream->track_id = MX_INACTIVE;
+    stream->mode = MPM_ONCE;
+    stream->active = false;
+}
+
+static void M_StreamClose(M_MUSIC_STREAM *const stream)
+{
+    if (!stream->active || stream->audio_stream_id < 0) {
+        M_StreamReset(stream);
         return;
     }
 
@@ -82,20 +103,51 @@ static void M_StopActiveStream(void)
     // finished by itself. In cases where we end the streams early by hand,
     // we clear the finish callback in order to avoid resuming the BGM playback
     // just after we stop it.
-    Audio_Stream_SetFinishCallback(m_AudioStreamID, nullptr, nullptr);
-    Audio_Stream_Close(m_AudioStreamID);
+    Audio_Stream_SetFinishCallback(stream->audio_stream_id, nullptr, nullptr);
+    Audio_Stream_Close(stream->audio_stream_id);
+    M_StreamReset(stream);
+}
+
+static void M_StopMainStream(void)
+{
+    M_StreamClose(&m_MainStream);
+}
+
+static void M_StopOverlayStreams(void)
+{
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        M_StreamClose(&m_OverlayStreams[i]);
+    }
+}
+
+static void M_ResetStreamState(void)
+{
+    M_StreamReset(&m_MainStream);
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        M_StreamReset(&m_OverlayStreams[i]);
+    }
 }
 
 static void M_StreamFinished(const int32_t stream_id, void *const user_data)
 {
-    // When a stream finishes, play the remembered BGM.
-    if (stream_id == m_AudioStreamID) {
+    M_MUSIC_STREAM *const stream = user_data;
+    if (stream == nullptr) {
+        return;
+    }
+    if (!stream->active || stream->audio_stream_id != stream_id) {
+        return;
+    }
+
+    if (stream == &m_MainStream) {
+        // When the main stream finishes, play the remembered BGM.
         m_TrackCurrent = MX_INACTIVE;
-        m_AudioStreamID = -1;
+        M_StreamReset(stream);
         if (m_TrackLooped >= 0) {
             m_TrackLastLooped = MX_INACTIVE;
             Music_Play_Direct(m_TrackLooped, MPM_LOOP);
         }
+    } else {
+        M_StreamReset(stream);
     }
 }
 
@@ -130,12 +182,87 @@ static bool M_IsAmbientTrack(const MUSIC_ID track_id)
     return false;
 }
 
-static void M_SyncVolume(const int32_t audio_stream_id)
+static void M_SyncVolume(const M_MUSIC_STREAM *const stream)
 {
-    if (audio_stream_id < 0) {
+    if (stream == nullptr || !stream->active || stream->audio_stream_id < 0) {
         return;
     }
-    Audio_Stream_SetVolume(audio_stream_id, m_MusicVolume);
+    Audio_Stream_SetVolume(stream->audio_stream_id, m_MusicVolume);
+}
+
+static void M_SyncVolumes(void)
+{
+    M_SyncVolume(&m_MainStream);
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        M_SyncVolume(&m_OverlayStreams[i]);
+    }
+}
+
+static int32_t M_GetFreeOverlaySlot(void)
+{
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        if (!m_OverlayStreams[i].active) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static bool M_PlayOverlayTrack(const MUSIC_ID track_id)
+{
+    if (m_Backend == nullptr) {
+        LOG_WARNING(
+            "Not playing overlay track %d because no backend is available",
+            track_id);
+        return false;
+    }
+
+    const int32_t slot = M_GetFreeOverlaySlot();
+    if (slot < 0) {
+        LOG_WARNING(
+            "Not playing overlay track %d because all %d overlay slots are in "
+            "use",
+            track_id, MUSIC_MAX_OVERLAY_TRACKS);
+        return false;
+    }
+
+    const int32_t stream_id = m_Backend->play(m_Backend, track_id);
+    if (stream_id < 0) {
+        LOG_ERROR("Failed to create overlay stream for track %d", track_id);
+        return false;
+    }
+
+    m_OverlayStreams[slot].audio_stream_id = stream_id;
+    m_OverlayStreams[slot].track_id = track_id;
+    m_OverlayStreams[slot].mode = MPM_OVERLAY;
+    m_OverlayStreams[slot].active = true;
+    M_SyncVolume(&m_OverlayStreams[slot]);
+    Audio_Stream_SetIsLooped(stream_id, false);
+    Audio_Stream_SetFinishCallback(
+        stream_id, M_StreamFinished, &m_OverlayStreams[slot]);
+    return true;
+}
+
+static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
+{
+    if (!m_MainStream.active || state == nullptr) {
+        return false;
+    }
+
+    state->track_id = MX_INACTIVE;
+    state->mode = MPM_ONCE;
+    state->timestamp = Audio_Stream_GetTimestamp(m_MainStream.audio_stream_id);
+
+    if (m_TrackCurrent != MX_INACTIVE) {
+        state->track_id = m_TrackCurrent;
+        return true;
+    }
+    if (m_TrackLooped != MX_INACTIVE) {
+        state->track_id = m_TrackLooped;
+        state->mode = MPM_LOOP;
+        return true;
+    }
+    return false;
 }
 
 bool Music_Init(void)
@@ -156,13 +283,16 @@ finish:
     m_TrackDelayed = MX_INACTIVE;
     m_TrackLooped = MX_INACTIVE;
     m_TrackLastLooped = MX_INACTIVE;
+    M_ResetStreamState();
     return Audio_Init();
 }
 
 void Music_Shutdown(void)
 {
     m_Initialised = false;
-    M_StopActiveStream();
+    M_StopMainStream();
+    M_StopOverlayStreams();
+    M_ResetStreamState();
     Audio_Shutdown();
 }
 
@@ -174,6 +304,11 @@ bool Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
 
     if (M_IsBrokenTrack(track_id)) {
         return false;
+    }
+
+    if (mode == MPM_OVERLAY) {
+        LOG_INFO("Playing overlay track %d", track_id);
+        return M_PlayOverlayTrack(track_id);
     }
 
     if (track_id == m_TrackCurrent) {
@@ -203,44 +338,7 @@ bool Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
         return true;
     }
 
-    const MUSIC_TRX_ID track = Music_FromGameID(track_id);
-    // TODO: utilise secondary audio stream to allow playing high fidelity
-    // versions of these sounds.
-    if (g_Config.audio.fix_secrets_killing_music && track == MX_SECRET
-        && Sound_IsAvailable(SFX_SECRET)) {
-        return Sound_Effect(SFX_SECRET, nullptr, SPM_ALWAYS);
-    }
-
-    if (g_Config.audio.fix_speeches_killing_music) {
-        SAMPLE_TRX_ID sample_id = SFX_TRX_INVALID;
-        switch (track) {
-        case MX_BALDY_SPEECH:
-            sample_id = SFX_BALDY_SPEECH;
-            break;
-        case MX_COWBOY_SPEECH:
-            sample_id = SFX_COWBOY_SPEECH;
-            break;
-        case MX_LARSON_SPEECH:
-            sample_id = SFX_LARSON_SPEECH;
-            break;
-        case MX_NATLA_SPEECH:
-            sample_id = SFX_NATLA_SPEECH;
-            break;
-        case MX_PIERRE_SPEECH:
-            sample_id = SFX_PIERRE_SPEECH;
-            break;
-        case MX_SKATEKID_SPEECH:
-            sample_id = SFX_SKATEKID_SPEECH;
-            break;
-        default:
-            break;
-        }
-        if (Sound_IsAvailable(sample_id)) {
-            return Sound_Effect(sample_id, nullptr, SPM_ALWAYS);
-        }
-    }
-
-    M_StopActiveStream();
+    M_StopMainStream();
 
     if (m_Backend == nullptr) {
         LOG_WARNING(
@@ -250,15 +348,19 @@ bool Music_Play_Direct(const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode)
 
     LOG_INFO("Playing track %d, mode: %d", track_id, mode);
 
-    m_AudioStreamID = m_Backend->play(m_Backend, track_id);
-    if (m_AudioStreamID < 0) {
+    const int32_t stream_id = m_Backend->play(m_Backend, track_id);
+    if (stream_id < 0) {
         LOG_ERROR("Failed to create music stream for track %d", track_id);
         goto finish;
     }
 
-    M_SyncVolume(m_AudioStreamID);
-    Audio_Stream_SetIsLooped(m_AudioStreamID, is_looped);
-    Audio_Stream_SetFinishCallback(m_AudioStreamID, M_StreamFinished, nullptr);
+    m_MainStream.audio_stream_id = stream_id;
+    m_MainStream.track_id = track_id;
+    m_MainStream.mode = is_looped ? MPM_LOOP : MPM_ONCE;
+    m_MainStream.active = true;
+    M_SyncVolume(&m_MainStream);
+    Audio_Stream_SetIsLooped(stream_id, is_looped);
+    Audio_Stream_SetFinishCallback(stream_id, M_StreamFinished, &m_MainStream);
 
 finish:
     m_TrackDelayed = MX_INACTIVE;
@@ -288,7 +390,9 @@ void Music_Stop(void)
     m_TrackDelayed = MX_INACTIVE;
     m_TrackLooped = MX_INACTIVE;
     m_TrackLastLooped = MX_INACTIVE;
-    M_StopActiveStream();
+    M_StopMainStream();
+    M_StopOverlayStreams();
+    M_ResetStreamState();
 }
 
 void Music_StopTrack_Direct(const MUSIC_ID track)
@@ -297,9 +401,8 @@ void Music_StopTrack_Direct(const MUSIC_ID track)
         return;
     }
 
-    M_StopActiveStream();
+    M_StopMainStream();
     m_TrackCurrent = MX_INACTIVE;
-
     if (m_TrackLooped >= 0) {
         Music_Play_Direct(m_TrackLooped, MPM_LOOP);
     }
@@ -307,42 +410,124 @@ void Music_StopTrack_Direct(const MUSIC_ID track)
 
 void Music_Pause(void)
 {
-    if (m_AudioStreamID < 0) {
-        return;
+    if (m_MainStream.active && m_MainStream.audio_stream_id >= 0) {
+        Audio_Stream_Pause(m_MainStream.audio_stream_id);
     }
-    Audio_Stream_Pause(m_AudioStreamID);
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        if (m_OverlayStreams[i].active
+            && m_OverlayStreams[i].audio_stream_id >= 0) {
+            Audio_Stream_Pause(m_OverlayStreams[i].audio_stream_id);
+        }
+    }
 }
 
 void Music_Unpause(void)
 {
-    if (m_AudioStreamID < 0) {
-        return;
+    if (m_MainStream.active && m_MainStream.audio_stream_id >= 0) {
+        Audio_Stream_Unpause(m_MainStream.audio_stream_id);
     }
-    Audio_Stream_Unpause(m_AudioStreamID);
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        if (m_OverlayStreams[i].active
+            && m_OverlayStreams[i].audio_stream_id >= 0) {
+            Audio_Stream_Unpause(m_OverlayStreams[i].audio_stream_id);
+        }
+    }
 }
 
 double Music_GetTimestamp(void)
 {
-    if (m_AudioStreamID < 0) {
+    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return -1.0;
     }
-    return Audio_Stream_GetTimestamp(m_AudioStreamID);
+    return Audio_Stream_GetTimestamp(m_MainStream.audio_stream_id);
 }
 
 bool Music_SeekTimestamp(const double timestamp)
 {
-    if (m_AudioStreamID < 0) {
+    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SeekTimestamp(m_AudioStreamID, timestamp);
+    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
 bool Music_SyncTimestamp(const double timestamp)
 {
-    if (m_AudioStreamID < 0) {
+    if (!m_MainStream.active || m_MainStream.audio_stream_id < 0) {
         return false;
     }
-    return Audio_Stream_SyncTimestamp(m_AudioStreamID, timestamp);
+    return Audio_Stream_SyncTimestamp(m_MainStream.audio_stream_id, timestamp);
+}
+
+int32_t Music_GetStreamCount(void)
+{
+    int32_t count = 0;
+    if (m_MainStream.active) {
+        count++;
+    }
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        if (m_OverlayStreams[i].active) {
+            count++;
+        }
+    }
+    return count;
+}
+
+bool Music_GetStreamState(
+    const int32_t index, MUSIC_STREAM_STATE *const out_state)
+{
+    if (index < 0 || out_state == nullptr) {
+        return false;
+    }
+
+    int32_t stream_index = 0;
+    if (m_MainStream.active) {
+        if (stream_index == index) {
+            return M_GetMainTrackState(out_state);
+        }
+        stream_index++;
+    }
+
+    for (int32_t i = 0; i < MUSIC_MAX_OVERLAY_TRACKS; i++) {
+        if (!m_OverlayStreams[i].active) {
+            continue;
+        }
+
+        if (stream_index == index) {
+            out_state->track_id = m_OverlayStreams[i].track_id;
+            out_state->mode = m_OverlayStreams[i].mode;
+            out_state->timestamp =
+                Audio_Stream_GetTimestamp(m_OverlayStreams[i].audio_stream_id);
+            return true;
+        }
+        stream_index++;
+    }
+
+    return false;
+}
+
+bool Music_SeekTrackTimestamp(
+    const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode, const double timestamp)
+{
+    if (mode == MPM_OVERLAY) {
+        for (int32_t i = MUSIC_MAX_OVERLAY_TRACKS - 1; i >= 0; i--) {
+            if (!m_OverlayStreams[i].active
+                || m_OverlayStreams[i].track_id != track_id) {
+                continue;
+            }
+            return Audio_Stream_SeekTimestamp(
+                m_OverlayStreams[i].audio_stream_id, timestamp);
+        }
+        return false;
+    }
+
+    MUSIC_STREAM_STATE state = {};
+    if (!M_GetMainTrackState(&state)) {
+        return false;
+    }
+    if (state.track_id != track_id || state.mode != mode) {
+        return false;
+    }
+    return Audio_Stream_SeekTimestamp(m_MainStream.audio_stream_id, timestamp);
 }
 
 MUSIC_ID Music_GetDelayedTrack(void)
@@ -365,7 +550,7 @@ void Music_SetVolume(float volume)
     volume *= g_Config.audio.master_volume;
     if (volume != m_MusicVolume) {
         m_MusicVolume = volume;
-        M_SyncVolume(m_AudioStreamID);
+        M_SyncVolumes();
     }
 }
 

--- a/src/trx/game/music/common.h
+++ b/src/trx/game/music/common.h
@@ -5,6 +5,14 @@
 
 #include <stdint.h>
 
+#define MUSIC_MAX_OVERLAY_TRACKS 3
+
+typedef struct {
+    MUSIC_ID track_id;
+    MUSIC_PLAY_MODE mode;
+    double timestamp;
+} MUSIC_STREAM_STATE;
+
 bool Music_Init(void);
 void Music_Shutdown(void);
 
@@ -20,6 +28,8 @@ void Music_Shutdown(void);
 // MPM_DELAY:
 //   A track does not get played and instead is only marked for later playback.
 //   The track to play is available with Music_GetDelayedTrack().
+// MPM_OVERLAY:
+//   Plays a non-looping track without interrupting active background music.
 bool Music_Play_Direct(MUSIC_ID track, MUSIC_PLAY_MODE mode);
 
 // Stops the provided single track and restarts the looped track if applicable.
@@ -29,7 +39,7 @@ void Music_StopTrack_Direct(MUSIC_ID track);
 // music track slot depending on the game.
 bool Music_Play(MUSIC_TRX_ID track, MUSIC_PLAY_MODE mode);
 
-// Stops any music, whether looped or active speech.
+// Stops all music streams, including looped, active, and overlay tracks.
 void Music_Stop(void);
 
 // Pauses the music.
@@ -46,6 +56,16 @@ bool Music_SeekTimestamp(double timestamp);
 
 // Seeks to the given timestamp if the drift is too big.
 bool Music_SyncTimestamp(double timestamp);
+
+// Returns the number of currently active serializable streams.
+int32_t Music_GetStreamCount(void);
+
+// Returns stream state by active index [0..Music_GetStreamCount()).
+bool Music_GetStreamState(int32_t index, MUSIC_STREAM_STATE *state);
+
+// Seeks timestamp for the active stream that matches track and mode.
+bool Music_SeekTrackTimestamp(
+    MUSIC_ID track, MUSIC_PLAY_MODE mode, double timestamp);
 
 // Returns the delayed track. Ignores looped tracks.
 MUSIC_ID Music_GetDelayedTrack(void);

--- a/src/trx/game/music/enum.h
+++ b/src/trx/game/music/enum.h
@@ -5,4 +5,5 @@ typedef enum {
     MPM_LOOP,
     MPM_DELAY,
     MPM_NO_REPEAT,
+    MPM_OVERLAY,
 } MUSIC_PLAY_MODE;

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -140,7 +140,10 @@ static void M_Control(const int16_t item_num)
                 natla->flags = 0;
                 timer = 0;
                 item->hit_points = M_GetStage2HitPoints(item);
-                Music_Play(MX_NATLA_SPEECH, MPM_NO_REPEAT);
+                const MUSIC_PLAY_MODE mode =
+                    g_Config.audio.fix_speeches_killing_music ? MPM_OVERLAY
+                                                              : MPM_NO_REPEAT;
+                Music_Play(MX_NATLA_SPEECH, mode);
             } else {
                 if (g_Config.gameplay.target_mode == TLM_SEMI
                     || g_Config.gameplay.target_mode == TLM_NONE) {

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/game/creature.h>
 #include <trx/game/music.h>
 #include <trx/game/objects/common.h>
@@ -73,7 +74,10 @@ static void M_Control(const int16_t item_num)
 
         if (item->hit_points < SKATE_KID_SPEECH_HITPOINTS
             && !(item->flags & SKATE_KID_SPEECH_STARTED)) {
-            Music_Play(MX_SKATEKID_SPEECH, MPM_NO_REPEAT);
+            const MUSIC_PLAY_MODE mode =
+                g_Config.audio.fix_speeches_killing_music ? MPM_OVERLAY
+                                                          : MPM_NO_REPEAT;
+            Music_Play(MX_SKATEKID_SPEECH, mode);
             item->flags |= SKATE_KID_SPEECH_STARTED;
         }
 

--- a/src/trx/game/overlay.c
+++ b/src/trx/game/overlay.c
@@ -550,7 +550,9 @@ void Overlay_SetBottomText(const OVERLAY_TEXT text)
 void Overlay_AddDisplayPickup(const OBJECT_ID obj_id)
 {
     if (Object_IsType(obj_id, g_SecretObjects)) {
-        Music_Play(MX_SECRET, MPM_ONCE);
+        const MUSIC_PLAY_MODE mode =
+            g_Config.audio.fix_secrets_killing_music ? MPM_OVERLAY : MPM_ONCE;
+        Music_Play(MX_SECRET, mode);
     }
 
     int32_t grid_x = -1;

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -1,5 +1,6 @@
 #include <trx/game/rooms/floor_data.h>
 
+#include <trx/config.h>
 #include <trx/game/camera.h>
 #include <trx/game/game.h>
 #include <trx/game/game_buf.h>
@@ -29,6 +30,21 @@
 #define M_TRIG_CMD_ARG(t) (t & 0x3FF)
 #define M_TRIG_CAM_GLIDE(t) ((t & 0x3E00) >> 6)
 #define M_LADDER_TYPE(t) ((t & 0x7F00) >> 8)
+
+static bool M_IsSpeechTrack(const MUSIC_ID track_id)
+{
+    switch (Music_FromGameID(track_id)) {
+    case MX_BALDY_SPEECH:
+    case MX_COWBOY_SPEECH:
+    case MX_LARSON_SPEECH:
+    case MX_NATLA_SPEECH:
+    case MX_PIERRE_SPEECH:
+    case MX_SKATEKID_SPEECH:
+        return true;
+    default:
+        return false;
+    }
+}
 
 static const int16_t *M_ReadTrigger(
     const int16_t *data, const int16_t fd_entry, SECTOR *const sector)
@@ -129,6 +145,12 @@ static void M_TriggerMusicTrack(MUSIC_ID track_id, const TRIGGER *const trigger)
     }
 
     uint16_t flags = Music_GetTrackFlags(track_id);
+    MUSIC_PLAY_MODE play_mode = MPM_NO_REPEAT;
+    if (g_Config.audio.fix_speeches_killing_music
+        && M_IsSpeechTrack(track_id)) {
+        play_mode = MPM_OVERLAY;
+    }
+
     // TODO: consolidate
     if (g_TRVersion == 1) {
         if ((flags & IF_ONE_SHOT) != 0) {
@@ -148,7 +170,7 @@ static void M_TriggerMusicTrack(MUSIC_ID track_id, const TRIGGER *const trigger)
             if (trigger->one_shot) {
                 flags |= IF_ONE_SHOT;
             }
-            Music_Play_Direct(track_id, MPM_NO_REPEAT);
+            Music_Play_Direct(track_id, play_mode);
         } else {
             Music_StopTrack_Direct(track_id);
         }
@@ -164,7 +186,7 @@ static void M_TriggerMusicTrack(MUSIC_ID track_id, const TRIGGER *const trigger)
         }
 
         if (trigger->timer == 0) {
-            Music_Play_Direct(track_id, MPM_NO_REPEAT);
+            Music_Play_Direct(track_id, play_mode);
             goto finish;
         }
 
@@ -181,7 +203,7 @@ static void M_TriggerMusicTrack(MUSIC_ID track_id, const TRIGGER *const trigger)
 
         timer--;
         if (timer == 0) {
-            Music_Play_Direct(track_id, MPM_NO_REPEAT);
+            Music_Play_Direct(track_id, play_mode);
         }
         flags = (flags & 0xFF00) | (timer & 0xFF);
     }
@@ -695,7 +717,10 @@ void Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             // in TR2, see #2047
             const int16_t secret_num = (int16_t)(intptr_t)cmd->parameter;
             if (Stats_AddSecret(secret_num)) {
-                Music_Play(MX_SECRET, MPM_ONCE);
+                const MUSIC_PLAY_MODE mode =
+                    g_Config.audio.fix_secrets_killing_music ? MPM_OVERLAY
+                                                             : MPM_ONCE;
+                Music_Play(MX_SECRET, mode);
             }
             break;
         }

--- a/src/trx/game/savegame/enum.h
+++ b/src/trx/game/savegame/enum.h
@@ -19,6 +19,9 @@ typedef enum {
     // Replaced Lara mesh pointers with outfits
     SG_VERSION_15 = 15,
 
+    // Music save format switched to stream list with play modes.
+    SG_VERSION_16 = 16,
+
     SG_MIN_SUPPORTED_VERSION = SG_VERSION_13,
-    SG_CURRENT_VERSION = SG_VERSION_15,
+    SG_CURRENT_VERSION = SG_VERSION_16,
 } SAVEGAME_VERSION;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -386,9 +386,9 @@ static bool M_ReadItem(SG_READ_IO *const io, const int16_t item_num)
             // Introduced in TRX 1.2
             M_OPTIONAL(SG_READ_VALUE(io, "collidable", &item->collidable));
         }
-        // Introduced in TRX 1.2
-        M_SHOULD(SG_READ_VALUE(io, "ai_bits", &item->ai_bits));
-        M_SHOULD(SG_READ_VALUE(io, "ai_tag", &item->ai_tag));
+        // Introduced in TRX 1.2, not written if zero
+        M_OPTIONAL(SG_READ_VALUE(io, "ai_bits", &item->ai_bits));
+        M_OPTIONAL(SG_READ_VALUE(io, "ai_tag", &item->ai_tag));
 
         bool intelligent = obj->intelligent;
         // Introduced in TRX 1.2

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -550,14 +550,19 @@ static bool M_ReadFlare(SG_READ_IO *const io)
     M_FINISH();
 }
 
+static bool M_ShouldLoadMusicTimestamp(
+    const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode,
+    const MUSIC_ID ambient_track)
+{
+    const bool is_ambient = mode == MPM_LOOP && track_id == ambient_track;
+    return !is_ambient
+        || g_Config.audio.music_load_condition == MUSIC_LOAD_ALWAYS;
+}
+
 static bool M_ReadMusicTracks(SG_READ_IO *const io)
 {
-    MUSIC_ID current_track = MX_INACTIVE;
     MUSIC_ID ambient_track = MX_INACTIVE;
-    double timestamp;
-    M_MUST(SG_READ_VALUE(io, "current_track", &current_track));
     M_MUST(SG_READ_VALUE(io, "current_ambient", &ambient_track));
-    M_MUST(SG_READ_VALUE(io, "timestamp", &timestamp));
 
     Music_Stop();
     if (ambient_track != MX_INACTIVE) {
@@ -570,18 +575,59 @@ static bool M_ReadMusicTracks(SG_READ_IO *const io)
         return true;
     }
 
-    const bool is_ambient =
-        current_track != MX_INACTIVE && current_track == ambient_track;
-    if (!is_ambient && current_track != MX_INACTIVE) {
-        Music_Play_Direct(current_track, MPM_ONCE);
-    }
+    if (M_SHOULD(SG_PUSH(io, "streams"))) {
+        // TRX 1.2
+        const int32_t stream_count = SG_ARRAY_LEN(io);
+        for (int32_t i = 0; i < stream_count; i++) {
+            MUSIC_ID track_id = MX_INACTIVE;
+            MUSIC_PLAY_MODE mode = MPM_ONCE;
+            double timestamp = -1.0;
+            M_MUST(SG_PUSH_INDEX(io, i));
+            M_MUST(SG_READ_VALUE(io, "track", &track_id));
+            M_MUST(SG_READ_VALUE(io, "mode", &mode));
+            M_MUST(SG_READ_VALUE(io, "timestamp", &timestamp));
+            M_MUST(SG_POP(io));
 
-    const bool load_timestamp =
-        !is_ambient || g_Config.audio.music_load_condition == MUSIC_LOAD_ALWAYS;
-    if (load_timestamp && !Music_SeekTimestamp(timestamp)) {
-        LOG_WARNING(
-            "Could not load current track %d at timestamp %lf.", current_track,
-            timestamp);
+            if (track_id == MX_INACTIVE) {
+                continue;
+            }
+            if (!Music_Play_Direct(track_id, mode)) {
+                LOG_WARNING("Could not load stream track %d", track_id);
+                continue;
+            }
+
+            if (M_ShouldLoadMusicTimestamp(track_id, mode, ambient_track)
+                && !Music_SeekTrackTimestamp(track_id, mode, timestamp)) {
+                LOG_WARNING(
+                    "Could not load stream track %d at timestamp %lf.",
+                    track_id, timestamp);
+            }
+        }
+        M_MUST(SG_POP(io));
+    } else {
+        MUSIC_ID current_track = MX_INACTIVE;
+        double timestamp = -1.0;
+        M_MUST(SG_READ_VALUE(io, "current_track", &current_track));
+        M_MUST(SG_READ_VALUE(io, "timestamp", &timestamp));
+
+        const bool is_ambient =
+            current_track != MX_INACTIVE && current_track == ambient_track;
+        if (!is_ambient && current_track != MX_INACTIVE
+            && !Music_Play_Direct(current_track, MPM_ONCE)) {
+            LOG_WARNING("Could not load current track %d.", current_track);
+        }
+
+        const MUSIC_ID track_to_seek =
+            is_ambient ? ambient_track : current_track;
+        const MUSIC_PLAY_MODE mode_to_seek = is_ambient ? MPM_LOOP : MPM_ONCE;
+        if (M_ShouldLoadMusicTimestamp(
+                track_to_seek, mode_to_seek, ambient_track)
+            && !Music_SeekTrackTimestamp(
+                track_to_seek, mode_to_seek, timestamp)) {
+            LOG_WARNING(
+                "Could not load current track %d at timestamp %lf.",
+                current_track, timestamp);
+        }
     }
 
     M_FINISH();

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -362,12 +362,24 @@ void SG_File_DumpMusic(SG_WRITE_IO *const io)
     }
     SGW_POP_AND_SET(io, "flags");
 
-    const MUSIC_ID current_track = Music_GetCurrentPlayingTrack();
     const MUSIC_ID current_ambient = Music_GetCurrentLoopedTrack();
     SGW_PUSH_OBJECT(io);
-    SGW_WRITE_VALUE(io, "current_track", current_track);
     SGW_WRITE_VALUE(io, "current_ambient", current_ambient);
-    SGW_WRITE_VALUE(io, "timestamp", Music_GetTimestamp());
+    SGW_PUSH_ARRAY(io);
+    const int32_t stream_count = Music_GetStreamCount();
+    for (int32_t i = 0; i < stream_count; i++) {
+        MUSIC_STREAM_STATE state = {};
+        if (!Music_GetStreamState(i, &state)) {
+            continue;
+        }
+
+        SGW_PUSH_OBJECT(io);
+        SGW_WRITE_VALUE(io, "track", state.track_id);
+        SGW_WRITE_VALUE(io, "mode", state.mode);
+        SGW_WRITE_VALUE(io, "timestamp", state.timestamp);
+        SGW_POP_AND_APPEND(io);
+    }
+    SGW_POP_AND_SET(io, "streams");
     SGW_POP_AND_SET(io, "current");
     SGW_POP_AND_SET(io, "music");
 }


### PR DESCRIPTION
  #### Checklist

  - [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
  - [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
  - [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

  #### Description

  This PR replaces the old "secret/speech kills music" workaround with real overlay music streams.

  - Adds `MPM_OVERLAY` and lets music tracks play in parallel without interrupting BGM.
  - Removes the low-fidelity `Sound_Effect()` substitution kludge for secrets/speeches.
  - Extends savegame music state to support multiple concurrent streams (track + mode + timestamp), while preserving ambient behavior:
      - queued ambient remains ID-only and restarts when resumed,
      - active ambient can resume from timestamp.
  - Keeps backward compatibility with legacy music save data.
  - Exposes `OVERLAY` in Lua music play modes and updates docs/changelog accordingly.

In practice, this means:
- Builders can play high-fidelity overlay tracks with LUA
- Secret chimes and TR1 enemy voice lines can be resumed from a savegame mid-playback
- Secret chimes and TR1 enemy voice lines are now played at high-quality again

Note: overlay tracks will be resumed for Music Load Condition = both Non-Ambient and Always.

#### Testing

We need to test the following scenarios (I tried to be detailed):

- [ ] Secret over BGM (fix on): BGM playing, pick up secret. Expected: BGM keeps playing, while chime plays on top of it.
- [ ] Secret over BGM (fix off): same setup. Expected: BGM stops, chime overrides BGM.
- [ ] Speech over BGM (fix on): trigger any TR1 speech track. Expected: BGM keeps playing, while speech plays on top of it.
- [ ] Speech over BGM (fix off): same setup. Expected: BGM stops, speech overrides BGM.
- [ ] Multiple overlays: BGM playing, issue a LUA command (see below for invocation) to play the track with mode set to override twice. Expected: both overlays play with BGM.
- [ ] Mutliple overlays cap: similar setup as above, except try the command more than 3 times in a row. Expected: an error in the console.
- [ ] Pause/unpause: main + overlay active, pause/unpause game. Expected: all streams pause/resume correctly.
- [ ] Global stop: main + overlays active, go to main menu. Expected: all streams stopped/reset.
- [ ] Save/load, active ambient: save/load mid-ambient. Expected: ambient resumes from saved point (Music Load Condition = Always), OR ambient restarts from scratch (Music Load Condition = Non-Ambient, Never).
- [ ] Save/load, active one-shot: save/load mid one-shot. Expected: one-shot resumes by timestamp (Music Load Condition = Always/Non-Ambient), OR one-shot resumes from scratch (Music Load Condition = Never). Ambient resumes later from start regardless of the setting.
- [ ] Save/load, main + overlay active: save/load during overlap. Expected: both restored with correct mode/timestamp (Music Load Condition = Always).
- [ ] 1.0/1.1 save compatibility: load pre-stream-format save (`current_track`/`current_ambient`/`timestamp`), × BGM/one-shot, × Music Load Condition enum values. Expected: old behavior preserved. Note: overlays were not saved before, now they are.
- [ ] Lua: call `/lua trx.music.play_track(122, {mode = trxc.music.PlayMode.OVERLAY})` while BGM active. Expected: overlay without BGM interruption.
