### PR TITLE
Add 60 FPS interpolation to shadows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@
 - changed the barefoot SFX option toggle in TR2 to no longer require reloading the level for changes to take effect
 - changed triggers that target pickup items to support antitriggers, switches and bitmasks
 - removed support for legacy (TombATI / TR2 GOG/Steam) and pre-1.0 (TR1X/TR2X) savegame files
+- fixed shadows to support 60 FPS interpolation
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
 - fixed custom levels that contain invalid room static mesh references not being able to load (#4770)

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -46,7 +46,7 @@ static inline bool M_ItemBoundsIntersectsPortal(
         },
     };
 
-    if (Bounds_32_Intersect(&bounds, &portal->bounds)) {
+    if (Bounds32_Intersect(&bounds, &portal->bounds)) {
         return true;
     }
 
@@ -55,7 +55,7 @@ static inline bool M_ItemBoundsIntersectsPortal(
         return false;
     }
     const BOUNDS_32 room_bounds = Room_GetRoomBounds(own_room);
-    return !Bounds_32_Intersect(&bounds, &room_bounds);
+    return !Bounds32_Intersect(&bounds, &room_bounds);
 }
 
 void Item_InitialiseItems(const int32_t num_items)

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -429,8 +429,9 @@ bool Lara_Draw(const ITEM *const item)
         hit_frame == nullptr ? frames[0] : hit_frame;
 
     const OBJECT *const obj = Object_Get(item->object_id);
+    const BOUNDS_16 *const shadow_bounds = Item_GetBoundsAccurate(item);
     if (!Lara_Vehicle_IsMounted()) {
-        Output_DrawShadow(obj->shadow_size, &frame->bounds, item);
+        Output_DrawShadow(obj->shadow_size, shadow_bounds, item);
     }
 
     MATRIX saved_matrix = *g_MatrixPtr;

--- a/src/trx/game/level/rooms.c
+++ b/src/trx/game/level/rooms.c
@@ -25,7 +25,7 @@ static inline bool M_BoundsIntersectsPortal(
             .z = mesh->pos.z + obj->draw_bounds.max.z,
         },
     };
-    return Bounds_32_Intersect(&bounds, &portal->bounds);
+    return Bounds32_Intersect(&bounds, &portal->bounds);
 }
 
 static void M_ComputePortalBounds(void)

--- a/src/trx/game/math/func.h
+++ b/src/trx/game/math/func.h
@@ -37,4 +37,4 @@ float XYZ_F_Length2(XYZ_F pos);
 float XYZ_F_Length(XYZ_F pos);
 XYZ_F XYZ_F_Subtract(XYZ_F a, XYZ_F b);
 
-bool Bounds_32_Intersect(const BOUNDS_32 *a, const BOUNDS_32 *b);
+bool Bounds32_Intersect(const BOUNDS_32 *a, const BOUNDS_32 *b);

--- a/src/trx/game/math/util.c
+++ b/src/trx/game/math/util.c
@@ -263,7 +263,7 @@ XYZ_F XYZ_F_Subtract(const XYZ_F a, const XYZ_F b)
     };
 }
 
-bool Bounds_32_Intersect(const BOUNDS_32 *const a, const BOUNDS_32 *const b)
+bool Bounds32_Intersect(const BOUNDS_32 *const a, const BOUNDS_32 *const b)
 {
     return !(
         a->min.x > b->max.x || a->max.x < b->min.x || a->min.y > b->max.y

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/debug.h>
 #include <trx/game/inventory.h>
+#include <trx/game/items/col.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
@@ -172,7 +173,8 @@ bool Object_DrawAnimatingItemWithSwap(
     }
 
     if (obj->shadow_size != 0) {
-        Output_DrawShadow(obj->shadow_size, &frames[0]->bounds, item);
+        const BOUNDS_16 *const shadow_bounds = Item_GetBoundsAccurate(item);
+        Output_DrawShadow(obj->shadow_size, shadow_bounds, item);
     }
 
     Matrix_Push();

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -163,6 +163,7 @@ bool Object_DrawAnimatingItemWithSwap(
     int32_t rate;
     const int32_t frac = Item_GetFrames(item, frames, &rate);
     const OBJECT *const obj = Object_Get(item->object_id);
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
 
     const OBJECT *swap_obj = mesh_swap;
     if (swap_obj != nullptr && !swap_obj->loaded) {
@@ -173,21 +174,20 @@ bool Object_DrawAnimatingItemWithSwap(
     }
 
     if (obj->shadow_size != 0) {
-        const BOUNDS_16 *const shadow_bounds = Item_GetBoundsAccurate(item);
-        Output_DrawShadow(obj->shadow_size, shadow_bounds, item);
+        Output_DrawShadow(obj->shadow_size, bounds, item);
     }
 
     Matrix_Push();
     Matrix_TranslateAbs32(item->interp.result.pos);
     Matrix_Rot16(item->interp.result.rot);
 
-    const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
+    const CLIP clip = Output_CheckBoundsClip(bounds);
     if (clip == CLIP_NOT_VISIBLE) {
         Matrix_Pop();
         return false;
     }
 
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
+    Output_CalculateObjectLighting(item, bounds);
 
     const int16_t *extra_rotation = item->data;
 
@@ -195,7 +195,7 @@ bool Object_DrawAnimatingItemWithSwap(
         obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate,
         swap_obj);
     if (g_Config.debug.enable_debug_bounding_boxes) {
-        Output_DrawCuboid(&frames[0]->bounds);
+        Output_DrawCuboid(bounds);
     }
     Matrix_Pop();
     return true;

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -117,7 +117,7 @@ static bool M_DrawShadow_Sprite(
         Matrix_TranslateAbs(
             item->interp.result.pos.x, item->interp.result.floor,
             item->interp.result.pos.z);
-        Matrix_RotY(item->rot.y);
+        Matrix_RotY(item->interp.result.rot.y);
         Matrix_TranslateRel(x_mid, 0, z_mid);
         anchor_pos = Matrix_GetOffset(g_WMatrixPtr);
         Matrix_Pop();
@@ -324,7 +324,7 @@ void Output_DrawShadow(
     Matrix_TranslateAbs(
         item->interp.result.pos.x, item->interp.result.floor,
         item->interp.result.pos.z);
-    Matrix_RotY(item->rot.y);
+    Matrix_RotY(item->interp.result.rot.y);
     Matrix_TranslateRel(x_mid, 0, z_mid);
     Matrix_ScaleX((1 << W2V_SHIFT) * x_size / UNIT_SHADOW);
     Matrix_ScaleZ((1 << W2V_SHIFT) * z_size / UNIT_SHADOW);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This make the shadows smoother in 60 FPS by interpolating their animation bounds and rotation.
It also interpolates object lighting (impossible to notice) and bounding boxes (not so impossible, but alas, it's just a debug aid).