### PR TITLE
game/cutscene: allow seeking back; fix slow seek forward

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@
 - added an option to control whether or not moving boulders should shake the camera (Gameplay options → General → Enable boulder shake)
 - added an option to make Lara stumble if she hops backwards and there is a slope behind her (Gameplay options → Controls → Backwards slope stumble)
 - added `/trigger` and `/untrigger` console commands, with support for targeting by item ID, item name, or object name
+- added the ability to seek backwards through cutscenes with left button
+- improved the ability to seek through cutscenes to support even faster seeks (Slow = ±1 s, default = ±5 s, new: Draw = ±15 s)
 - improved `/tp` to accept `room`/`item` prefixes and `rN`/`iN` shortcuts
 - improved inventory ring active item highlight for smoother appearance
 - improved savegame file size by reducing it about 20–30%.
@@ -85,6 +87,7 @@
 - fixed one-shot triggers for hidden pickup items making the items permanently invisible (#4784)
 - fixed secret tracks played at low quality when "fix secrets killing music" option is on
 - fixed secret tracks not restored from the savegame when "fix secrets killing music" option is on
+- fixed slow-forward seeking through cutscenes (right+slow) not working (regression from 1.0)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -7,22 +7,123 @@
 #include <trx/game/footprint_fx.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
+#include <trx/game/lua.h>
 #include <trx/game/music.h>
 #include <trx/game/output.h>
 #include <trx/game/shell.h>
 #include <trx/game/water_fx.h>
 #include <trx/game/weather_fx.h>
+#include <trx/utils.h>
 
 static CAMERA_INFO m_LocalCamera = {};
+
+typedef struct {
+    bool is_valid;
+    LARA_SKIN_TYPE skin_type;
+    LARA_GUN_TYPE hand_l_type;
+    LARA_GUN_TYPE hand_r_type;
+    LARA_GUN_TYPE thigh_l_type;
+    LARA_GUN_TYPE thigh_r_type;
+    bool holsters_visible;
+} M_LARA_CUTSCENE_STATE;
+
+static M_LARA_CUTSCENE_STATE m_LaraCutsceneState = {};
+
+static LARA_GUN_TYPE M_GetGunEquipmentType(const LARA_MESH mesh)
+{
+    const LARA_SKIN_EQUIPMENT *const equipment = Lara_Skin_GetEquipment(mesh);
+    if (equipment->type == EQUIPMENT_TYPE_WEAPON) {
+        return (LARA_GUN_TYPE)equipment->data;
+    }
+    return LGT_UNARMED;
+}
+
+static void M_CaptureLaraCutsceneState(void)
+{
+    m_LaraCutsceneState.is_valid = true;
+    m_LaraCutsceneState.skin_type = Lara_Skin_GetType();
+    m_LaraCutsceneState.hand_l_type = M_GetGunEquipmentType(LM_HAND_L);
+    m_LaraCutsceneState.hand_r_type = M_GetGunEquipmentType(LM_HAND_R);
+    m_LaraCutsceneState.thigh_l_type = M_GetGunEquipmentType(LM_THIGH_L);
+    m_LaraCutsceneState.thigh_r_type = M_GetGunEquipmentType(LM_THIGH_R);
+    m_LaraCutsceneState.holsters_visible = Lara_Skin_AreHolstersVisible();
+}
+
+static void M_RestoreLaraCutsceneState(void)
+{
+    if (!m_LaraCutsceneState.is_valid) {
+        return;
+    }
+
+    Lara_Skin_SetType(m_LaraCutsceneState.skin_type);
+    Lara_Skin_SetGunEquipment(LM_HAND_L, m_LaraCutsceneState.hand_l_type);
+    Lara_Skin_SetGunEquipment(LM_HAND_R, m_LaraCutsceneState.hand_r_type);
+    Lara_Skin_SetGunEquipment(LM_THIGH_L, m_LaraCutsceneState.thigh_l_type);
+    Lara_Skin_SetGunEquipment(LM_THIGH_R, m_LaraCutsceneState.thigh_r_type);
+    Lara_Skin_SetHolstersVisible(m_LaraCutsceneState.holsters_visible);
+}
+
+static bool M_IsCutsceneActor(const ITEM *const item)
+{
+    return (item->object_id >= O_PLAYER_1 && item->object_id <= O_PLAYER_10)
+        || item->object_id == O_LARA;
+}
+
+static void M_ResetActorAnimation(ITEM *const item)
+{
+    Item_SwitchToAnim(item, 0, 0);
+    item->prev_frame_num = item->frame_num;
+    item->current_anim_state = Item_GetAnim(item)->current_anim_state;
+    item->goal_anim_state = item->current_anim_state;
+    item->required_anim_state = 0;
+}
+
+static void M_AnimateActors(void)
+{
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        if (!M_IsCutsceneActor(item)) {
+            continue;
+        }
+
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (obj->control_func != nullptr) {
+            obj->control_func(i);
+        }
+    }
+}
+
+static void M_ResetActorsToStart(void)
+{
+    M_RestoreLaraCutsceneState();
+
+    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        if (M_IsCutsceneActor(item)) {
+            M_ResetActorAnimation(item);
+        }
+    }
+}
+
+static void M_ReplayActors(
+    CINE_DATA *const cine_data, const int32_t start_frame,
+    const int32_t end_frame)
+{
+    for (int32_t frame_idx = start_frame; frame_idx < end_frame; frame_idx++) {
+        Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
+        cine_data->frame_idx = frame_idx;
+        Camera_UpdateCutscene();
+        M_AnimateActors();
+        Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
+    }
+}
 
 static void M_PlayerControl(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     CAMERA_INFO *const camera = Cutscene_GetCamera();
     item->rot.y = camera->target_angle;
-    item->pos.x = camera->pos.pos.x;
-    item->pos.y = camera->pos.pos.y;
-    item->pos.z = camera->pos.pos.z;
+    item->pos = camera->pos.pos;
 
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
@@ -70,20 +171,24 @@ static void M_InitialisePlayer(const int16_t item_num)
 static void M_Skip(const int32_t frames)
 {
     CINE_DATA *const cine_data = Camera_GetCineData();
-    cine_data->frame_idx += frames;
-    if (cine_data->frame_idx >= cine_data->frame_count) {
-        cine_data->frame_idx = cine_data->frame_count - 1;
+    const int32_t source_frame = cine_data->frame_idx;
+    int32_t target_frame = source_frame + frames;
+    CLAMP(target_frame, 0, cine_data->frame_count - 1);
+
+    if (target_frame == source_frame) {
+        return;
     }
-    for (int32_t i = 0; i < frames; i++) {
-        for (int32_t j = 0; j < Item_GetTotalCount(); j++) {
-            ITEM *const item = Item_Get(j);
-            if ((item->object_id >= O_PLAYER_1
-                 && item->object_id <= O_PLAYER_10)
-                || item->object_id == O_LARA) {
-                Item_Animate(item);
-            }
-        }
+
+    if (target_frame > source_frame) {
+        M_ReplayActors(cine_data, source_frame, target_frame);
+    } else {
+        Lua_ReloadLevelScript();
+        M_ResetActorsToStart();
+        M_ReplayActors(cine_data, 0, target_frame);
     }
+
+    cine_data->frame_idx = target_frame;
+    Camera_UpdateCutscene();
 }
 
 bool Cutscene_Start(const int32_t level_num)
@@ -92,6 +197,7 @@ bool Cutscene_Start(const int32_t level_num)
     ASSERT(GF_GetCurrentLevel() == level);
 
     M_InitialisePlayer(Item_GetIndex(Lara_GetItem()));
+    M_CaptureLaraCutsceneState();
     Camera_GetCineData()->frame_idx = 0;
 
     if (level->music_track != MX_INACTIVE) {
@@ -125,8 +231,10 @@ GF_COMMAND Cutscene_Control(void)
         if (gf_cmd.action != GF_NOOP) {
             return gf_cmd;
         }
-    } else if (g_InputDB.menu_right) {
-        M_Skip(g_InputDB.slow ? LOGIC_FPS : LOGIC_FPS * 5);
+    } else if (g_InputDB.menu_right || g_InputDB.menu_left) {
+        const int32_t dir = g_InputDB.menu_right ? 1 : -1;
+        const int32_t speed = g_Input.draw ? 15 : (g_Input.slow ? 1 : 5);
+        M_Skip(dir * LOGIC_FPS * speed);
     }
 
     Output_ResetDynamicLights();

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -13,9 +13,13 @@
 #include <trx/game/shell.h>
 #include <trx/game/water_fx.h>
 #include <trx/game/weather_fx.h>
+#include <trx/memory.h>
 #include <trx/utils.h>
 
 static CAMERA_INFO m_LocalCamera = {};
+static OBJECT_MESH **m_CapturedObjectMeshes = nullptr;
+static OBJECT_ID *m_CapturedObjectMeshOwners = nullptr;
+static int32_t m_CapturedObjectMeshCount = 0;
 
 typedef struct {
     bool is_valid;
@@ -49,6 +53,79 @@ static void M_CaptureLaraCutsceneState(void)
     m_LaraCutsceneState.holsters_visible = Lara_Skin_AreHolstersVisible();
 }
 
+static void M_CaptureObjectMeshesState(void)
+{
+    Memory_FreePointer(&m_CapturedObjectMeshes);
+    Memory_FreePointer(&m_CapturedObjectMeshOwners);
+    m_CapturedObjectMeshCount = Object_GetMeshCount();
+    if (m_CapturedObjectMeshCount <= 0) {
+        return;
+    }
+
+    m_CapturedObjectMeshes = Memory_Alloc(
+        m_CapturedObjectMeshCount * sizeof(*m_CapturedObjectMeshes));
+    m_CapturedObjectMeshOwners = Memory_Alloc(
+        m_CapturedObjectMeshCount * sizeof(*m_CapturedObjectMeshOwners));
+    for (int32_t i = 0; i < m_CapturedObjectMeshCount; i++) {
+        m_CapturedObjectMeshes[i] = Object_GetMesh(i);
+        m_CapturedObjectMeshOwners[i] = NO_OBJECT;
+    }
+
+    for (OBJECT_ID obj_id = O_FIRST; obj_id < O_NUMBER_OF; obj_id++) {
+        const OBJECT *const obj = Object_Get(obj_id);
+        if (!obj->loaded || obj->mesh_count <= 0 || obj->mesh_idx < 0) {
+            continue;
+        }
+
+        for (int32_t mesh_idx = 0; mesh_idx < obj->mesh_count; mesh_idx++) {
+            const int32_t abs_idx = obj->mesh_idx + mesh_idx;
+            if (abs_idx >= 0 && abs_idx < m_CapturedObjectMeshCount) {
+                m_CapturedObjectMeshOwners[abs_idx] = obj_id;
+            }
+        }
+    }
+}
+
+static void M_RestoreObjectMeshesState(void)
+{
+    if (m_CapturedObjectMeshes == nullptr || m_CapturedObjectMeshCount <= 0) {
+        return;
+    }
+
+    const int32_t mesh_count = Object_GetMeshCount();
+    if (mesh_count != m_CapturedObjectMeshCount) {
+        return;
+    }
+
+    for (int32_t i = 0; i < mesh_count; i++) {
+        if (Object_GetMesh(i) == m_CapturedObjectMeshes[i]) {
+            continue;
+        }
+
+        int32_t j = -1;
+        for (int32_t k = i + 1; k < mesh_count; k++) {
+            if (Object_GetMesh(k) == m_CapturedObjectMeshes[i]) {
+                j = k;
+                break;
+            }
+        }
+        if (j < 0) {
+            continue;
+        }
+
+        if (m_CapturedObjectMeshOwners[i] == NO_OBJECT
+            || m_CapturedObjectMeshOwners[j] == NO_OBJECT) {
+            continue;
+        }
+
+        const OBJECT *const obj_1 = Object_Get(m_CapturedObjectMeshOwners[i]);
+        const OBJECT *const obj_2 = Object_Get(m_CapturedObjectMeshOwners[j]);
+        Object_SwapMeshEx(
+            m_CapturedObjectMeshOwners[i], m_CapturedObjectMeshOwners[j],
+            i - obj_1->mesh_idx, j - obj_2->mesh_idx);
+    }
+}
+
 static void M_RestoreLaraCutsceneState(void)
 {
     if (!m_LaraCutsceneState.is_valid) {
@@ -78,23 +155,9 @@ static void M_ResetActorAnimation(ITEM *const item)
     item->required_anim_state = 0;
 }
 
-static void M_AnimateActors(void)
-{
-    for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
-        ITEM *const item = Item_Get(i);
-        if (!M_IsCutsceneActor(item)) {
-            continue;
-        }
-
-        const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->control_func != nullptr) {
-            obj->control_func(i);
-        }
-    }
-}
-
 static void M_ResetActorsToStart(void)
 {
+    M_RestoreObjectMeshesState();
     M_RestoreLaraCutsceneState();
 
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
@@ -113,7 +176,8 @@ static void M_ReplayActors(
         Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
         cine_data->frame_idx = frame_idx;
         Camera_UpdateCutscene();
-        M_AnimateActors();
+        Item_Control();
+        Effect_Control();
         Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
     }
 }
@@ -198,6 +262,7 @@ bool Cutscene_Start(const int32_t level_num)
 
     M_InitialisePlayer(Item_GetIndex(Lara_GetItem()));
     M_CaptureLaraCutsceneState();
+    M_CaptureObjectMeshesState();
     Camera_GetCineData()->frame_idx = 0;
 
     if (level->music_track != MX_INACTIVE) {
@@ -209,6 +274,9 @@ bool Cutscene_Start(const int32_t level_num)
 
 void Cutscene_End(void)
 {
+    Memory_FreePointer(&m_CapturedObjectMeshes);
+    Memory_FreePointer(&m_CapturedObjectMeshOwners);
+    m_CapturedObjectMeshCount = 0;
     Music_Stop();
 }
 

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -2,7 +2,9 @@
 
 #include <trx/debug.h>
 #include <trx/filesystem.h>
+#include <trx/game/game_flow/common.h>
 #include <trx/game/lua/embedded_scripts.h>
+#include <trx/game/lua/events.h>
 #include <trx/log.h>
 #include <trx/memory.h>
 #include <trx/strings.h>
@@ -224,6 +226,27 @@ LUA_RESULT Lua_EvalFile(const char *const path)
     const LUA_RESULT result = M_LuaLoadAndRun(p->state, M_LoadFile, real_path);
     Memory_FreePointer(&real_path);
     return result;
+}
+
+void Lua_ReloadLevelScript(void)
+{
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level == nullptr) {
+        return;
+    }
+
+    Lua_ClearLevelListeners();
+    Lua_SetScriptContext(LUA_CONTEXT_LEVEL);
+
+    if (level->script_path != nullptr) {
+        LUA_RESULT res = Lua_EvalFile(level->script_path);
+        if (res.code != LUA_OK) {
+            LOG_ERROR("Lua level script error: %s", res.message);
+        }
+        Lua_FreeResult(&res);
+    }
+
+    Lua_SetScriptContext(LUA_CONTEXT_GLOBAL);
 }
 
 void Lua_FreeResult(LUA_RESULT *const result)

--- a/src/trx/game/lua/common.h
+++ b/src/trx/game/lua/common.h
@@ -29,3 +29,6 @@ void Lua_FreeResult(LUA_RESULT *result);
 
 // Evaluate a Lua script file. Caller must free the result with Lua_FreeResult.
 LUA_RESULT Lua_EvalFile(const char *path);
+
+// Reload current level script and reset level-scoped listeners.
+void Lua_ReloadLevelScript(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds backward seeking to cutscenes and fixes the sluggish fast-forward behavior.

Cutscenes can now seek in both directions. During seeking, actors are replayed frame-by-frame through their control functions with `Camera_UpdateCutscene()`, keeping transforms and camera state perfectly aligned. When rewinding, actors reset to the start of their animation and then play forward up to the target frame.

The slow seek issue came from using debounced input instead of regular input, which made slow-fast-forward basically unusable.

#### Testing

- [x] **Backward seek:** Play a cutscene, move forward, then seek left. Actors should maintain correct orientation and smooth animation while rewinding.
- [x] **Forward seek:** Jump right from various points in the cutscene. Actor and camera states should stay consistent after each seek.
- [x] **Slow seek modifier:** Try seeking with and without the slow key held. The speed should reflect the intended modifier cleanly, with no big jumps. (I recommend using `/debug anim` to see exact frame step values.)