### PR TITLE
objects/traps: improve collapsible tile and boulder behaviour

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - added `/trigger` and `/untrigger` console commands, with support for targeting by item ID, item name, or object name
 - added the ability to seek backwards through cutscenes with left button
 - added the ability to trigger collapsible tiles from heavy triggers, regardless of Lara's position (#4807)
+- added floor height change detection for boulders when stopped, so they will drop if the floor below them drops (#4808)
 - improved the ability to seek through cutscenes to support even faster seeks (Slow = ±1 s, default = ±5 s, new: Draw = ±15 s)
 - improved `/tp` to accept `room`/`item` prefixes and `rN`/`iN` shortcuts
 - improved inventory ring active item highlight for smoother appearance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - added an option to make Lara stumble if she hops backwards and there is a slope behind her (Gameplay options → Controls → Backwards slope stumble)
 - added `/trigger` and `/untrigger` console commands, with support for targeting by item ID, item name, or object name
 - added the ability to seek backwards through cutscenes with left button
+- added the ability to trigger collapsible tiles from heavy triggers, regardless of Lara's position (#4807)
 - improved the ability to seek through cutscenes to support even faster seeks (Slow = ±1 s, default = ±5 s, new: Draw = ±15 s)
 - improved `/tp` to accept `room`/`item` prefixes and `rN`/`iN` shortcuts
 - improved inventory ring active item highlight for smoother appearance

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -5,9 +5,15 @@
 #include <trx/game/rooms.h>
 #include <trx/vector.h>
 
+typedef struct {
+    bool heavy_triggered;
+    int32_t origin;
+} M_PRIV;
+
 static int32_t M_GetOrigin(const ITEM *const item)
 {
-    return (int32_t)(intptr_t)item->priv;
+    const M_PRIV *const p = item->priv;
+    return p->origin;
 }
 
 static void M_CalculateOrigin(ITEM *const item)
@@ -15,7 +21,8 @@ static void M_CalculateOrigin(ITEM *const item)
     const OBJECT *const obj = Object_Get(item->object_id);
     const ANIM *const anim = Object_GetAnim(obj, 0);
     const ANIM_FRAME *const frame = &anim->frame_ptr[0];
-    item->priv = (void *)(intptr_t)ROUND_TO_CLICK_SIGNED(frame->offset.y);
+    M_PRIV *const p = item->priv;
+    p->origin = ROUND_TO_CLICK_SIGNED(frame->offset.y);
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -69,6 +76,13 @@ static void M_AddWalkable(const int16_t item_num)
     Walkable_Add(item_num, item->pos);
 }
 
+static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
+{
+    M_PRIV *const p = item->priv;
+    p->heavy_triggered = trigger->type == TT_HEAVY;
+    return true;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -77,12 +91,14 @@ static void M_Control(const int16_t item_num)
     switch (item->current_anim_state) {
     case TRAP_SET:
         const ITEM *const lara_item = Lara_GetItem();
-        if (lara_item->pos.y != item->pos.y + origin) {
+        M_PRIV *const p = item->priv;
+        if (!p->heavy_triggered && lara_item->pos.y != item->pos.y + origin) {
             item->status = IS_INACTIVE;
             Item_RemoveActive(item_num);
             return;
         }
         item->goal_anim_state = TRAP_ACTIVATE;
+        p->heavy_triggered = false;
         break;
 
     case TRAP_ACTIVATE:
@@ -130,6 +146,8 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
+    obj->trigger_func = M_Trigger;
+    obj->priv_size = sizeof(M_PRIV);
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;
     obj->add_walkable_func = M_AddWalkable;

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -122,6 +122,15 @@ static void M_Control(const int16_t item_num)
     }
 
     if (item->status != IS_ACTIVE) {
+        int16_t room_num = item->room_num;
+        const SECTOR *const sector = Room_GetSector32(item->pos, &room_num);
+        const int16_t height =
+            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        if (item->pos.y < height) {
+            item->status = IS_ACTIVE;
+            item->floor = height;
+            Item_UpdateRoom(item_num, room_num);
+        }
         return;
     }
 


### PR DESCRIPTION
Resolves #4807.
Resolves #4808.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows collapsible tiles to be heavily triggered regardless of where Lara is, and allows boulders to detect when the floor below them has dropped (after they've come to a stop). For the latter, this doesn't affect untriggered or reset boulders, so they will continue to float if they're positioned as such until they're activated.