### PR TITLE
Optimize rendering

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -29,9 +29,7 @@ out vec4 gColor;
 
 vec3 gammaCurve(vec3 rgb, float gamma_exp)
 {
-    vec3 in8 = floor(clamp(rgb, 0.0, 1.0) * 255.0 + 0.5);
-    vec3 out8 = floor(pow(in8 / 256.0, vec3(gamma_exp)) * 256.0);
-    return clamp(out8 / 255.0, 0.0, 1.0);
+    return pow(clamp(rgb, 0.0, 1.0), vec3(gamma_exp));
 }
 
 vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@
 - changed the barefoot SFX option toggle in TR2 to no longer require reloading the level for changes to take effect
 - changed triggers that target pickup items to support antitriggers, switches and bitmasks
 - removed support for legacy (TombATI / TR2 GOG/Steam) and pre-1.0 (TR1X/TR2X) savegame files
+- fixed a small hiccup when launching the game on certain GPUs
 - fixed shadows to support 60 FPS interpolation
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - added the ability to seek backwards through cutscenes with left button
 - added the ability to trigger collapsible tiles from heavy triggers, regardless of Lara's position (#4807)
 - added floor height change detection for boulders when stopped, so they will drop if the floor below them drops (#4808)
+- improved rendering performance
 - improved the ability to seek through cutscenes to support even faster seeks (Slow = ±1 s, default = ±5 s, new: Draw = ±15 s)
 - improved `/tp` to accept `room`/`item` prefixes and `rN`/`iN` shortcuts
 - improved inventory ring active item highlight for smoother appearance

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -30,6 +30,10 @@ typedef struct M_MESH_BUF_BINDING {
     M_MESH_GEOM *geom_data;
     M_MESH_TEXTURE *tex_data;
     M_MESH_SHADE *shade_data;
+    bool needs_room_lights;
+    bool needs_cpu_light;
+    bool needs_object_light;
+    bool needs_own_light;
     int32_t vertex_start;
     int32_t vertex_count;
 
@@ -124,8 +128,13 @@ static void M_FillShade(
     *shade = vertex->shade;
 }
 
-static void M_SyncRoom(MESH_BATCHER *const batcher, const ROOM *const room)
+static void M_SyncRoom(
+    const MESH_BATCHER *const batcher, const M_MESH_BUF_BINDING *const bind,
+    const ROOM *const room)
 {
+    if (!bind->needs_room_lights) {
+        return;
+    }
     Output_Uniforms_UploadRoomLights(Output_GetUniforms(), room);
 }
 
@@ -235,9 +244,12 @@ static void M_DrawOpaqueInstance(
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
     ASSERT(bind != nullptr);
 
-    M_SyncRoom(batcher, inst->room);
-
-    Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
+    M_SyncRoom(batcher, bind, inst->room);
+    if (bind->needs_object_light) {
+        Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
+    } else if (bind->needs_own_light) {
+        Output_Uniforms_UploadOwnLight(Output_GetUniforms(), &inst->light_info);
+    }
     Output_MeshShader_UploadModelMatrix(batcher->shader, &inst->wmatrix);
     Output_MeshShader_UploadTint(batcher->shader, inst->tint);
 
@@ -271,9 +283,12 @@ static void M_DrawBlendAddInstance(
     M_MESH_BUF_BINDING *const bind = M_GetBinding(batcher, inst->mesh);
     ASSERT(bind != nullptr);
 
-    M_SyncRoom(batcher, inst->room);
-
-    Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
+    M_SyncRoom(batcher, bind, inst->room);
+    if (bind->needs_object_light) {
+        Output_Uniforms_UploadCPULight(Output_GetUniforms(), &inst->light_info);
+    } else if (bind->needs_own_light) {
+        Output_Uniforms_UploadOwnLight(Output_GetUniforms(), &inst->light_info);
+    }
     Output_MeshShader_UploadModelMatrix(batcher->shader, &inst->wmatrix);
     Output_MeshShader_UploadTint(batcher->shader, inst->tint);
     Output_MeshShader_UploadWaterEffect(batcher->shader, inst->water_effect);
@@ -364,8 +379,16 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
 
         if (sort_ptr->inst != inst) {
             inst = sort_ptr->inst;
-            Output_Uniforms_UploadCPULight(
-                Output_GetUniforms(), &inst->light_info);
+            const M_MESH_BUF_BINDING *const bind =
+                M_GetBinding(batcher, inst->mesh);
+            ASSERT(bind != nullptr);
+            if (bind->needs_object_light) {
+                Output_Uniforms_UploadCPULight(
+                    Output_GetUniforms(), &inst->light_info);
+            } else if (bind->needs_own_light) {
+                Output_Uniforms_UploadOwnLight(
+                    Output_GetUniforms(), &inst->light_info);
+            }
             Output_MeshShader_UploadModelMatrix(
                 batcher->shader, &inst->wmatrix);
             Output_MeshShader_UploadTint(batcher->shader, inst->tint);
@@ -373,7 +396,7 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
                 batcher->shader, inst->water_effect);
             Output_MeshShader_UploadWibbleEffect(batcher->shader, inst->wibble);
             Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
-            M_SyncRoom(batcher, inst->room);
+            M_SyncRoom(batcher, bind, inst->room);
         }
 
         // indices live in the EBO starting at index_start
@@ -576,6 +599,17 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
         M_FillGeometry(&bind->geom_data[i], &vertices[i]);
         M_FillTexture(&bind->tex_data[i], &vertices[i]);
         M_FillShade(&bind->shade_data[i], &vertices[i]);
+        if ((vertices[i].flags & VERT_USE_DYNAMIC_LIGHT) != 0) {
+            bind->needs_room_lights = true;
+        }
+        if ((vertices[i].flags & VERT_USE_OBJECT_LIGHT) != 0) {
+            bind->needs_object_light = true;
+            bind->needs_cpu_light = true;
+        }
+        if ((vertices[i].flags & VERT_USE_OWN_LIGHT) != 0) {
+            bind->needs_own_light = true;
+            bind->needs_cpu_light = true;
+        }
     }
 
     // 2. Assign Vertex Offsets

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -37,6 +37,11 @@ typedef struct M_MESH_BUF_BINDING {
     int32_t opaque_index_count;
     int32_t blend_add_index_start;
     int32_t blend_add_index_count;
+    int32_t transparent_index_start;
+    int32_t transparent_index_count;
+    int32_t transparent_face_count;
+    int32_t *transparent_face_index_starts;
+    int32_t *transparent_face_index_counts;
 
     UT_hash_handle hh;
 } M_MESH_BUF_BINDING;
@@ -67,7 +72,6 @@ typedef struct MESH_BATCHER {
     } vbo;
 
     VECTOR *transparent_sort; // M_FACE_SORT
-    VECTOR *transparent_indices; // uint32_t
     struct {
         GLuint opaque;
         GLuint transparent;
@@ -76,6 +80,7 @@ typedef struct MESH_BATCHER {
 
     int32_t opaque_total_indices;
     int32_t blend_add_total_indices;
+    int32_t transparent_total_indices;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -303,25 +308,14 @@ static void M_OpaquePass(MESH_BATCHER *const batcher)
 
         // Accumulate transparent polygons and faces.
         for (int32_t j = 0; j < inst->mesh->transparent_faces->count; j++) {
-            const OUTPUT_MESH_FACE *const face =
-                Vector_Get(inst->mesh->transparent_faces, j);
-
-            const int32_t index_start = batcher->transparent_indices->count;
-            for (int32_t k = 0; k < face->vertex_count; k++) {
-                const uint32_t global_idx =
-                    bind->vertex_start + face->vertex_indices[k];
-                Vector_Add(batcher->transparent_indices, &global_idx);
-            }
-            const int32_t index_count =
-                batcher->transparent_indices->count - index_start;
-
             Vector_Add(
                 batcher->transparent_sort,
                 &(M_FACE_SORT) {
                     .inst = inst,
-                    .face = face,
-                    .index_start = index_start,
-                    .index_count = index_count,
+                    .face = Vector_Get(inst->mesh->transparent_faces, j),
+                    .index_start = bind->transparent_index_start
+                        + bind->transparent_face_index_starts[j],
+                    .index_count = bind->transparent_face_index_counts[j],
                 });
         }
     }
@@ -355,16 +349,10 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
         return;
     }
 
-    // Upload indices only
     glBindVertexArray(batcher->vao);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->ebo.transparent);
-    GFX_TRACK_DATA(
-        glBufferData, GL_ELEMENT_ARRAY_BUFFER,
-        batcher->transparent_indices->count * sizeof(uint32_t),
-        Vector_GetData(batcher->transparent_indices), GL_DYNAMIC_DRAW);
 
     const MESH_INSTANCE *inst = nullptr;
-    int32_t last_base_vertex = -1;
 
     for (int32_t i = 0; i < batcher->transparent_sort->count; i++) {
         const M_FACE_SORT *const sort_ptr =
@@ -407,7 +395,6 @@ static void M_RenderBegin(const SCENE_SOURCE *const source)
     for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
         Vector_Clear(batcher->staged[pass]);
     }
-    Vector_Clear(batcher->transparent_indices);
     Vector_Clear(batcher->transparent_sort);
 }
 
@@ -432,7 +419,7 @@ static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
 {
     const MESH_BATCHER *const batcher = source->priv;
     return batcher->staged[pass]->count > 0
-        || (batcher->transparent_indices->count > 0
+        || (batcher->transparent_sort->count > 0
             && pass == SCENE_PASS_TRANSPARENT);
 }
 
@@ -462,7 +449,6 @@ MESH_BATCHER *MeshBatcher_Create(void)
     batcher->source.priv = batcher;
 
     batcher->transparent_sort = Vector_Create(sizeof(M_FACE_SORT));
-    batcher->transparent_indices = Vector_Create(sizeof(uint32_t));
 
     glGenVertexArrays(1, &batcher->vao);
     glGenBuffers(3, &batcher->vbo.geom);
@@ -539,10 +525,6 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
         Vector_Free(batcher->bindings);
         batcher->bindings = nullptr;
     }
-    if (batcher->transparent_indices != nullptr) {
-        Vector_Free(batcher->transparent_indices);
-        batcher->transparent_indices = nullptr;
-    }
     if (batcher->transparent_sort != nullptr) {
         Vector_Free(batcher->transparent_sort);
         batcher->transparent_sort = nullptr;
@@ -567,6 +549,8 @@ void MeshBatcher_RemoveMesh(
     Memory_Free(bind->geom_data);
     Memory_Free(bind->tex_data);
     Memory_Free(bind->shade_data);
+    Memory_Free(bind->transparent_face_index_starts);
+    Memory_Free(bind->transparent_face_index_counts);
     Vector_Remove(batcher->bindings, &bind);
     HASH_DEL(batcher->binding_map, bind);
     if (batcher->bindings->count == 0) {
@@ -607,6 +591,28 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
     bind->blend_add_index_count = mesh->blend_add_vertex_indices->count;
     bind->blend_add_index_start = batcher->blend_add_total_indices;
     batcher->blend_add_total_indices += bind->blend_add_index_count;
+
+    // Transparent
+    bind->transparent_face_count = mesh->transparent_faces->count;
+    bind->transparent_face_index_starts = nullptr;
+    bind->transparent_face_index_counts = nullptr;
+    bind->transparent_index_count = 0;
+    if (bind->transparent_face_count > 0) {
+        bind->transparent_face_index_starts =
+            Memory_Alloc(sizeof(int32_t) * bind->transparent_face_count);
+        bind->transparent_face_index_counts =
+            Memory_Alloc(sizeof(int32_t) * bind->transparent_face_count);
+        for (int32_t i = 0; i < bind->transparent_face_count; i++) {
+            const OUTPUT_MESH_FACE *const face =
+                Vector_Get(mesh->transparent_faces, i);
+            bind->transparent_face_index_starts[i] =
+                bind->transparent_index_count;
+            bind->transparent_face_index_counts[i] = face->vertex_count;
+            bind->transparent_index_count += face->vertex_count;
+        }
+    }
+    bind->transparent_index_start = batcher->transparent_total_indices;
+    batcher->transparent_total_indices += bind->transparent_index_count;
 
     // Prevent double add
     mesh->sealed = 2;
@@ -660,6 +666,8 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
         Memory_Alloc(batcher->opaque_total_indices * sizeof(uint32_t));
     uint32_t *blend_indices =
         Memory_Alloc(batcher->blend_add_total_indices * sizeof(uint32_t));
+    uint32_t *transparent_indices =
+        Memory_Alloc(batcher->transparent_total_indices * sizeof(uint32_t));
 
     // Flatten the data
     for (int32_t i = 0; i < batcher->bindings->count; i++) {
@@ -681,6 +689,20 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
                 Vector_GetData(bind->mesh->blend_add_vertex_indices),
                 bind->blend_add_index_count * sizeof(uint32_t));
         }
+
+        // Copy Transparent Indices
+        if (bind->transparent_index_count > 0) {
+            for (int32_t j = 0; j < bind->transparent_face_count; j++) {
+                const OUTPUT_MESH_FACE *const face =
+                    Vector_Get(bind->mesh->transparent_faces, j);
+                const int32_t dst_start = bind->transparent_index_start
+                    + bind->transparent_face_index_starts[j];
+                for (int32_t k = 0; k < face->vertex_count; k++) {
+                    transparent_indices[dst_start + k] =
+                        bind->vertex_start + face->vertex_indices[k];
+                }
+            }
+        }
     }
 
     // Upload to GPU
@@ -696,8 +718,15 @@ void MeshBatcher_Seal(MESH_BATCHER *const batcher)
         batcher->blend_add_total_indices * sizeof(uint32_t), blend_indices,
         GL_STATIC_DRAW);
 
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->ebo.transparent);
+    GFX_TRACK_DATA(
+        glBufferData, GL_ELEMENT_ARRAY_BUFFER,
+        batcher->transparent_total_indices * sizeof(uint32_t),
+        transparent_indices, GL_STATIC_DRAW);
+
     Memory_FreePointer(&opaque_indices);
     Memory_FreePointer(&blend_indices);
+    Memory_FreePointer(&transparent_indices);
 }
 
 void MeshBatcher_UpdateMeshGeometry(

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -10,7 +10,7 @@
 
 #include <uthash.h>
 
-typedef OUTPUT_SHORT M_MESH_SHADE;
+typedef float M_MESH_SHADE;
 
 typedef struct {
     XYZW_F pos;
@@ -515,8 +515,7 @@ MESH_BATCHER *MeshBatcher_Create(void)
     glBindBuffer(GL_ARRAY_BUFFER, batcher->vbo.shade);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
     glVertexAttribPointer(
-        OUTPUT_MESH_ATTR_SHADE, 1, OUTPUT_SHORT_GL, GL_FALSE,
-        sizeof(M_MESH_SHADE), 0);
+        OUTPUT_MESH_ATTR_SHADE, 1, GL_FLOAT, GL_FALSE, sizeof(M_MESH_SHADE), 0);
 
     glGenBuffers(3, &batcher->ebo.opaque);
 

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -6,10 +6,14 @@
 #include <trx/utils.h>
 #include <trx/version.h>
 
+#include <string.h>
+
 struct OUTPUT_MESH_SHADER {
     OUTPUT_SHADER *base_tr12;
     OUTPUT_SHADER *base_tr3;
 
+    MATRIX model_matrix[2];
+    bool has_model_matrix[2];
     int32_t water_effect[2];
     float water_effect_params[2][3];
     bool is_wibble_effect[2];
@@ -31,6 +35,8 @@ static OUTPUT_SHADER *M_GetVariantBase(
 OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
 {
     OUTPUT_MESH_SHADER *const shader = Memory_Alloc(sizeof(*shader));
+    shader->has_model_matrix[0] = false;
+    shader->has_model_matrix[1] = false;
     shader->water_effect[0] = -1;
     shader->water_effect[1] = -1;
     shader->water_effect_params[0][0] = 0.0f;
@@ -81,10 +87,18 @@ void Output_MeshShader_Free(OUTPUT_MESH_SHADER *const shader)
 }
 
 void Output_MeshShader_UploadModelMatrix(
-    const OUTPUT_MESH_SHADER *const shader, const MATRIX *const source)
+    OUTPUT_MESH_SHADER *const shader, const MATRIX *const source)
 {
     const int32_t variant_idx = M_GetVariantIndex();
     OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
+    if (shader->has_model_matrix[variant_idx]
+        && memcmp(&shader->model_matrix[variant_idx], source, sizeof(*source))
+            == 0) {
+        return;
+    }
+    memcpy(&shader->model_matrix[variant_idx], source, sizeof(*source));
+    shader->has_model_matrix[variant_idx] = true;
+
     GLfloat m[4][4];
     Output_FillMatrix(m, source);
 

--- a/src/trx/game/output/shaders/mesh.h
+++ b/src/trx/game/output/shaders/mesh.h
@@ -41,7 +41,7 @@ void Output_MeshShader_Bind(const OUTPUT_MESH_SHADER *shader);
 
 // TODO: these could could use UBOs
 void Output_MeshShader_UploadModelMatrix(
-    const OUTPUT_MESH_SHADER *shader, const MATRIX *source);
+    OUTPUT_MESH_SHADER *shader, const MATRIX *source);
 void Output_MeshShader_UploadWaterEffect(
     OUTPUT_MESH_SHADER *shader, int32_t water_effect);
 void Output_MeshShader_UploadWibbleEffect(

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -425,7 +425,7 @@ void Output_DisableScissor(void)
 
 void Output_AdjustDepth(const float factor, const float units)
 {
-    if (factor != m_DepthUnits || units != m_DepthUnits) {
+    if (factor != m_DepthFactor || units != m_DepthUnits) {
         glPolygonOffset(factor, units);
         m_DepthFactor = factor;
         m_DepthUnits = units;

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -10,6 +10,7 @@
 #include <trx/gfx/gl/utils.h>
 #include <trx/memory.h>
 #include <trx/utils.h>
+#include <trx/version.h>
 
 #include <string.h>
 
@@ -37,6 +38,7 @@ static struct {
         bool *animated;
         bool *animated_objects;
         bool *animated_sprites;
+        bool *has_transparency_objects;
 
         uint16_t *flags;
         uint16_t *flags_objects;
@@ -274,8 +276,76 @@ static void M_PrepareUVWs(void)
     m_Priv.uvws.flags = Memory_Alloc(m_Priv.uvws.count * sizeof(uint16_t));
     m_Priv.uvws.flags_objects = m_Priv.uvws.flags;
     m_Priv.uvws.flags_sprites = m_Priv.uvws.flags + m_Priv.uvws.count_objects;
+    m_Priv.uvws.has_transparency_objects =
+        Memory_Alloc(m_Priv.uvws.count_objects * sizeof(bool));
     M_FillObjectUVWs();
     M_FillSpriteUVWs();
+}
+
+static bool M_ObjectTextureHasTransparency(const int32_t texture_idx)
+{
+    if (texture_idx < 0 || texture_idx >= Output_GetObjectTextureCount()
+        || m_TexturePages32 == nullptr) {
+        return true;
+    }
+
+    const OBJECT_TEXTURE *const texture = Output_GetObjectTexture(texture_idx);
+    if (texture == nullptr || texture->uv_count <= 0) {
+        return true;
+    }
+    if (texture->tex_page < 0 || texture->tex_page >= m_TexturePageCount) {
+        return true;
+    }
+
+    int32_t min_u = INT32_MAX;
+    int32_t min_v = INT32_MAX;
+    int32_t max_u = INT32_MIN;
+    int32_t max_v = INT32_MIN;
+    for (int32_t i = 0; i < texture->uv_count; i++) {
+        CLAMPG(min_u, texture->uv[i].u);
+        CLAMPG(min_v, texture->uv[i].v);
+        CLAMPL(max_u, texture->uv[i].u);
+        CLAMPL(max_v, texture->uv[i].v);
+    }
+
+    const int32_t x0 = (min_u * (TEXTURE_PAGE_WIDTH - 1)) / 65535;
+    const int32_t y0 = (min_v * (TEXTURE_PAGE_HEIGHT - 1)) / 65535;
+    const int32_t x1 =
+        (max_u * (TEXTURE_PAGE_WIDTH - 1) + 65534) / 65535; // ceil
+    const int32_t y1 =
+        (max_v * (TEXTURE_PAGE_HEIGHT - 1) + 65534) / 65535; // ceil
+
+    int32_t px0 = x0;
+    int32_t py0 = y0;
+    int32_t px1 = x1;
+    int32_t py1 = y1;
+    CLAMP(px0, 0, TEXTURE_PAGE_WIDTH - 1);
+    CLAMP(py0, 0, TEXTURE_PAGE_HEIGHT - 1);
+    CLAMP(px1, 0, TEXTURE_PAGE_WIDTH - 1);
+    CLAMP(py1, 0, TEXTURE_PAGE_HEIGHT - 1);
+
+    const RGBA_8888 *const page = Output_GetTexturePage32(texture->tex_page);
+    if (page == nullptr) {
+        return true;
+    }
+
+    for (int32_t y = py0; y <= py1; y++) {
+        const int32_t row = y * TEXTURE_PAGE_WIDTH;
+        for (int32_t x = px0; x <= px1; x++) {
+            if (page[row + x].a < 255) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static void M_PrepareObjectTransparencyFlags(void)
+{
+    for (int32_t i = 0; i < Output_GetObjectTextureCount(); i++) {
+        m_Priv.uvws.has_transparency_objects[i] =
+            M_ObjectTextureHasTransparency(i);
+    }
 }
 
 static void M_PrepareEnvMap(void)
@@ -382,6 +452,7 @@ static void M_FreeLevelData(void)
     Memory_FreePointer(&m_Priv.uvws.data);
     Memory_FreePointer(&m_Priv.uvws.animated);
     Memory_FreePointer(&m_Priv.uvws.flags);
+    Memory_FreePointer(&m_Priv.uvws.has_transparency_objects);
     Memory_FreePointer(&m_Priv.atlas_sizes.data);
 }
 
@@ -414,6 +485,7 @@ void Output_Textures_ObserveLevelLoad(void)
 {
     M_FreeLevelData();
     M_PrepareUVWs();
+    M_PrepareObjectTransparencyFlags();
     M_PrepareAnimationRanges();
     M_UploadAtlas();
 }
@@ -511,6 +583,10 @@ SCENE_PASS Output_Textures_GetObjectTextureScenePass(const int32_t texture_idx)
     case DRAW_OPAQUE:
         return SCENE_PASS_OPAQUE;
     case DRAW_BLEND:
+        if (!m_Priv.uvws.animated_objects[texture_idx]
+            && !m_Priv.uvws.has_transparency_objects[texture_idx]) {
+            return SCENE_PASS_OPAQUE;
+        }
         return SCENE_PASS_TRANSPARENT;
     case DRAW_BLEND_ADD:
         return SCENE_PASS_BLEND_ADD;

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -75,9 +75,18 @@ typedef struct {
 } M_UNIFORM_LS;
 #pragma pack(pop)
 
+typedef enum {
+    M_LS_MODE_NONE = 0,
+    M_LS_MODE_FULL = 1,
+    M_LS_MODE_OWN = 2,
+} M_LS_MODE;
+
 typedef struct {
     M_UNIFORM_LIGHTS last_lights;
     OUTPUT_LIGHT_INFO last_light_info;
+    M_LS_MODE last_ls_mode;
+    int32_t last_own_light_adder;
+    RGB_F last_own_light_tr3_ambient;
 } M_PRIV;
 
 static void M_FillLight(
@@ -238,11 +247,11 @@ void Output_Uniforms_UploadRoomLights(
     const size_t size = offsetof(M_UNIFORM_LIGHTS, lights)
         + lights.num_lights * sizeof(M_UNIFORM_LIGHT);
 
-    M_PRIV *const priv = uniforms->priv;
-    if (memcmp(&priv->last_lights, &lights, sizeof(lights)) == 0) {
+    M_PRIV *const p = uniforms->priv;
+    if (memcmp(&p->last_lights, &lights, sizeof(lights)) == 0) {
         return;
     }
-    memcpy(&priv->last_lights, &lights, sizeof(lights));
+    memcpy(&p->last_lights, &lights, sizeof(lights));
 
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->lights);
     GFX_TRACK_SUBDATA(glBufferSubData, GL_UNIFORM_BUFFER, 0, size, &lights);
@@ -251,11 +260,15 @@ void Output_Uniforms_UploadRoomLights(
 void Output_Uniforms_UploadCPULight(
     const OUTPUT_UNIFORMS *const uniforms, const OUTPUT_LIGHT_INFO *const info)
 {
-    M_PRIV *const priv = uniforms->priv;
-    if (memcmp(&priv->last_light_info, info, sizeof(*info)) == 0) {
+    M_PRIV *const p = uniforms->priv;
+    if (p->last_ls_mode == M_LS_MODE_FULL
+        && memcmp(&p->last_light_info, info, sizeof(*info)) == 0) {
         return;
     }
-    memcpy(&priv->last_light_info, info, sizeof(*info));
+    memcpy(&p->last_light_info, info, sizeof(*info));
+    p->last_own_light_adder = info->ls_adder;
+    p->last_own_light_tr3_ambient = info->tr3_ambient;
+    p->last_ls_mode = M_LS_MODE_FULL;
 
     M_UNIFORM_LS ls = {};
     ls.adder = info->ls_adder;
@@ -292,6 +305,46 @@ void Output_Uniforms_UploadCPULight(
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->ls);
     GFX_TRACK_SUBDATA(glBufferSubData, GL_UNIFORM_BUFFER, 0, sizeof(ls), &ls);
     GFX_GL_CheckError();
+}
+
+void Output_Uniforms_UploadOwnLight(
+    const OUTPUT_UNIFORMS *const uniforms, const OUTPUT_LIGHT_INFO *const info)
+{
+    M_PRIV *const priv = uniforms->priv;
+
+    if (g_TRVersion >= 3) {
+        if (priv->last_ls_mode == M_LS_MODE_OWN
+            && priv->last_own_light_tr3_ambient.r == info->tr3_ambient.r
+            && priv->last_own_light_tr3_ambient.g == info->tr3_ambient.g
+            && priv->last_own_light_tr3_ambient.b == info->tr3_ambient.b) {
+            return;
+        }
+
+        const float ambient[4] = {
+            info->tr3_ambient.r,
+            info->tr3_ambient.g,
+            info->tr3_ambient.b,
+            0.0f,
+        };
+        glBindBuffer(GL_UNIFORM_BUFFER, uniforms->ls);
+        GFX_TRACK_SUBDATA(
+            glBufferSubData, GL_UNIFORM_BUFFER,
+            offsetof(M_UNIFORM_LS, tr3_ambient), sizeof(ambient), ambient);
+        priv->last_own_light_tr3_ambient = info->tr3_ambient;
+    } else {
+        if (priv->last_ls_mode == M_LS_MODE_OWN
+            && priv->last_own_light_adder == info->ls_adder) {
+            return;
+        }
+
+        const float light_adder = info->ls_adder;
+        glBindBuffer(GL_UNIFORM_BUFFER, uniforms->ls);
+        GFX_TRACK_SUBDATA(
+            glBufferSubData, GL_UNIFORM_BUFFER, offsetof(M_UNIFORM_LS, adder),
+            sizeof(light_adder), &light_adder);
+        priv->last_own_light_adder = info->ls_adder;
+    }
+    priv->last_ls_mode = M_LS_MODE_OWN;
 }
 
 OUTPUT_UNIFORMS *Output_Uniforms_Create(void)

--- a/src/trx/game/output/uniforms.h
+++ b/src/trx/game/output/uniforms.h
@@ -34,6 +34,8 @@ void Output_Uniforms_UploadRoomLights(
     const OUTPUT_UNIFORMS *uniforms, const ROOM *room);
 void Output_Uniforms_UploadCPULight(
     const OUTPUT_UNIFORMS *uniforms, const OUTPUT_LIGHT_INFO *info);
+void Output_Uniforms_UploadOwnLight(
+    const OUTPUT_UNIFORMS *uniforms, const OUTPUT_LIGHT_INFO *info);
 
 void Output_Uniforms_UploadDesaturation(
     const OUTPUT_UNIFORMS *uniforms, float desaturation);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR does a bunch of rendering-focused optimizations aimed to fix lags reported on Discord by DennyCroft.

- Cached model matrices per shader variant so they only upload when something actually changes.
- Precomputed transparent index data when sealing meshes even more, saving a bit on per-frame index list rebuilds and reuploads.
- Made light uploads smarter by checking what each mesh actually needs (room light, object light, or its own) and updating only those uniforms (biggest savings).
- Changed transparent face handling to check if it actually contains any transparent pixels. If not, it gets sent to the opaque buffer only (surprisingly big savings).
- Switched shade vertex attributes from `short` to `float`, which fixes a visible hiccup during the first inventory ring draw (at least on my GPU).
- Simplified the mesh gamma function to a clean `pow(clamp(rgb), gamma_exp)`, dropping silly quantizations.
- Fixed a tiny depth caching bug in `Output_AdjustDepth`.

No API/migration changes expected; this is all internal rendering behavior.

#### Benchmarks

##### DennyCroft's level

<details><pre>
tr2-1.5.1 → trx-1.1-255-gf8385f2c9
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg    │ New avg   │ Change %   ┃
┠──────────────────────┼────────────┼───────────┼────────────┨
┃ Opaque vertices      │ 24536.01   │ 49813.85  │ 🔴 203.02% ┃
┃ Transparent vertices │ 19637.15   │ 22950.59  │ 🟠 116.87% ┃
┃ Transfers            │ 193.96     │ 1328.28   │ 🔴 684.80% ┃
┃ Uniforms             │ 1731.65    │ 2284.97   │ 🔴 131.95% ┃
┃ Throughput           │ 1580.06 KB │ 274.31 KB │ 💚 17.36%  ┃
┃ Time                 │ 2.81 ms    │ 3.82 ms   │ 🔴 136.09% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━┛
tr2-1.5.1 → trx-1.1-262-g45a7f5da1
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg    │ New avg  │ Change %   ┃
┠──────────────────────┼────────────┼──────────┼────────────┨
┃ Opaque vertices      │ 24536.01   │ 49813.85 │ 🔴 203.02% ┃
┃ Transparent vertices │ 19637.15   │ 10599.77 │ 💚 53.98%  ┃
┃ Transfers            │ 193.96     │ 139.08   │ 💚 71.70%  ┃
┃ Uniforms             │ 1731.65    │ 771.12   │ 💚 44.53%  ┃
┃ Throughput           │ 1580.06 KB │ 8.04 KB  │ 💚 0.51%   ┃
┃ Time                 │ 2.81 ms    │ 0.94 ms  │ 💚 33.59%  ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
</pre></details>

##### Midas

<details><pre>
tr1-4.14.2 → tr1-4.15.1
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 7228.83  │ 9715.22  │ 🔴 134.40% ┃
┃ Transparent vertices │ 467.32   │ 909.94   │ 🔴 194.71% ┃
┃ Transfers            │ 38.43    │ 60.70    │ 🔴 157.96% ┃
┃ Uniforms             │ 126.72   │ 222.21   │ 🔴 175.35% ┃
┃ Throughput           │ 56.72 KB │ 96.44 KB │ 🔴 170.03% ┃
┃ Time                 │ 0.27 ms  │ 0.36 ms  │ 🔴 135.50% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
tr1-4.14.2 → trx-1.1
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %  ┃
┠──────────────────────┼──────────┼──────────┼───────────┨
┃ Opaque vertices      │ 7228.83  │ 6964.63  │ ⚪ 96.35% ┃
┃ Transparent vertices │ 467.32   │ 465.51   │ ⚪ 99.61% ┃
┃ Transfers            │ 38.43    │ 17.54    │ 💚 45.64% ┃
┃ Uniforms             │ 126.72   │ 102.88   │ 🟢 81.19% ┃
┃ Throughput           │ 56.72 KB │ 37.78 KB │ 💚 66.61% ┃
┃ Time                 │ 0.27 ms  │ 0.22 ms  │ 🟢 80.22% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┛
tr1-4.14.2 → trx-1.1-255-gf8385f2c9
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %   ┃
┠──────────────────────┼──────────┼──────────┼────────────┨
┃ Opaque vertices      │ 7228.83  │ 6964.75  │ ⚪ 96.35%  ┃
┃ Transparent vertices │ 467.32   │ 465.51   │ ⚪ 99.61%  ┃
┃ Transfers            │ 38.43    │ 17.54    │ 💚 45.64%  ┃
┃ Uniforms             │ 126.72   │ 104.95   │ 🟢 82.82%  ┃
┃ Throughput           │ 56.72 KB │ 36.43 KB │ 💚 64.23%  ┃
┃ Time                 │ 0.27 ms  │ 0.27 ms  │ ⚪ 101.48% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┛
tr1-4.14.2 → trx-1.1-262-g45a7f5da1
┏━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━┓
┃ Subject              │ Old avg  │ New avg  │ Change %  ┃
┠──────────────────────┼──────────┼──────────┼───────────┨
┃ Opaque vertices      │ 7228.83  │ 6964.75  │ ⚪ 96.35% ┃
┃ Transparent vertices │ 467.32   │ 465.51   │ ⚪ 99.61% ┃
┃ Transfers            │ 38.43    │ 11.47    │ 💚 29.86% ┃
┃ Uniforms             │ 126.72   │ 102.01   │ 🟢 80.50% ┃
┃ Throughput           │ 56.72 KB │ 33.58 KB │ 💚 59.21% ┃
┃ Time                 │ 0.27 ms  │ 0.19 ms  │ 💚 69.22% ┃
┗━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━┛
</pre></details>

#### Testing

- [x] **Static render sanity**
  Load one representative level for each game and traverse rooms with opaque, alpha-blended, and additive (TR3-only) effects
  Expected outcome: no visual regressions in mesh lighting, transparency ordering, or depth bias behavior
- [x] **Dynamic lighting regressions**
  Check out dynamic lights: pistols, flames, Ice Palace Talion room, etc.
  Expected outcome: no visual regressions
- [x] **Gamma curve regressions**
  Play with the gamma curve in TR1 or TR2, and in TR3
  Expected outcome: no visual regressions
