### PR TITLE
objects: fix random objects bleeding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -185,6 +185,8 @@
 - fixed killing Cobras with a manually-aimed projectile not counting as a kill
 - fixed smoke and spark rotation snapping at 180° instead of rotating smoothly
 - fixed Lara burning instead of getting electrocuted when touching the top of the electric fence
+- fixed driving over Winston with a Quad Bike or shooting him with the Harpoon Gun causing him to bleed
+- fixed driving over Assault Target with a Quad Bike or shooting it with the Harpoon Gun causing it to spawn blood
 
 
 

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -511,7 +511,7 @@ int32_t Gun_FireWeapon(
     Room_GetSector(hit_pos.x, hit_pos.y, hit_pos.z, &hit_pos.room_num);
     Gun_SmashItems(start.pos, hit_pos.pos, nullptr);
     Gun_HitTarget(
-        target, &start, &hit_pos, weapon_type,
+        target, &start, &hit_pos,
         weapon->damage * (Game_IsBonusFlagSet(GBF_JAPANESE) ? 2 : 1));
     return 1;
 }

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -67,7 +67,7 @@ static void M_SmashItem(const int16_t item_num)
         break;
 
     case O_SCION_ITEM_3:
-        Gun_HitTarget(item, nullptr, nullptr, LGT_UNARMED, item->hit_points);
+        Gun_HitTarget(item, nullptr, nullptr, item->hit_points);
         break;
 
     default:
@@ -371,26 +371,11 @@ PROJECTILE_HIT Gun_SmashItems(
 
 void Gun_HitTarget(
     ITEM *const item, const GAME_VECTOR *const start,
-    const GAME_VECTOR *const hit_pos, const LARA_GUN_TYPE weapon_type,
-    int32_t damage)
+    const GAME_VECTOR *const hit_pos, int32_t damage)
 {
-    bool make_ricochet = (g_Config.visuals.fix_texture_issues
-                          && item->object_id == O_SCION_ITEM_3)
-        || item->object_id == O_WINSTON_ARMY
-        || item->object_id == O_ASSAULT_TARGET;
-
-    if (item->object_id == O_SHIVA) {
-        const ITEM *const lara_item = Lara_GetItem();
-        const int32_t dx = item->pos.x - lara_item->pos.x;
-        const int32_t dz = item->pos.z - lara_item->pos.z;
-        const int16_t angle = DEG_180 - item->rot.y + Math_Atan(dz, dx);
-
-        if (item->current_anim_state > 1 && item->current_anim_state < 5
-            && angle > -DEG_90 && angle < DEG_90 && weapon_type != LGT_ROCKET
-            && weapon_type != LGT_GRENADE && weapon_type != LGT_HARPOON) {
-            make_ricochet = true;
-            damage = 0;
-        }
+    const bool make_ricochet = !Item_ShouldSpawnBlood(item);
+    if (item->object_id == O_SHIVA && make_ricochet) {
+        damage = 0;
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();

--- a/src/trx/game/gun/misc.h
+++ b/src/trx/game/gun/misc.h
@@ -22,7 +22,7 @@ void Gun_GetNewTarget(const WEAPON_INFO *weapon);
 void Gun_ChangeTarget(const WEAPON_INFO *weapon);
 void Gun_HitTarget(
     ITEM *item, const GAME_VECTOR *start, const GAME_VECTOR *hit_pos,
-    LARA_GUN_TYPE weapon_type, int32_t damage);
+    int32_t damage);
 
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, CLIP clip, bool interpolated);
 

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -305,6 +305,10 @@ void Item_ControlDraw(ITEM *const item)
         && item->after_death < 32 && item->after_death > 0) {
         item->after_death++;
 
+        if (!Item_ShouldSpawnBlood(item)) {
+            return;
+        }
+
         if (item->after_death == 2 || item->after_death == 5
             || item->after_death == 11 || item->after_death == 20
             || item->after_death == 27 || item->after_death == 32

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -109,3 +109,17 @@ int32_t Item_Explode(
 
     return !(item->mesh_bits & (0x7FFFFFFF >> (31 - obj->mesh_count)));
 }
+
+bool Item_ShouldSpawnBlood(const ITEM *const item)
+{
+    if (item == nullptr) {
+        return true;
+    }
+
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (obj->should_spawn_blood_func != nullptr) {
+        return obj->should_spawn_blood_func(item);
+    }
+
+    return true;
+}

--- a/src/trx/game/items/utils.h
+++ b/src/trx/game/items/utils.h
@@ -21,3 +21,5 @@ void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);
 // * Negative values - deal damage, disable body part explosions.
 // * Zero - don't deal any damage, disable body part explosions.
 int32_t Item_Explode(int16_t item_num, int32_t mesh_bits, int16_t damage);
+
+bool Item_ShouldSpawnBlood(const ITEM *item);

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -45,6 +45,33 @@ typedef struct {
     int32_t effect_mesh;
 } M_PRIV;
 
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    if (item->current_anim_state != M_STATE_WAIT_DEF
+        && item->current_anim_state != M_STATE_WALK_DEF
+        && item->current_anim_state != M_STATE_START) {
+        return true;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    const int32_t dx = item->pos.x - lara_item->pos.x;
+    const int32_t dz = item->pos.z - lara_item->pos.z;
+    const int16_t angle = DEG_180 - item->rot.y + Math_Atan(dz, dx);
+    if (angle <= -DEG_90 || angle >= DEG_90) {
+        return true;
+    }
+
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    // XXX: This uses Lara's currently equipped gun. If she swaps weapons before
+    // a projectile impact resolves, this can differ from the projectile weapon.
+    if (lara->gun_type == LGT_ROCKET || lara->gun_type == LGT_GRENADE
+        || lara->gun_type == LGT_HARPOON) {
+        return true;
+    }
+
+    return false;
+}
+
 static void M_TriggerSmoke(const XYZ_32 pos, const bool uw)
 {
     const ITEM *const lara_item = Lara_GetItem();
@@ -460,6 +487,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->should_spawn_blood_func = M_ShouldSpawnBlood;
     obj->draw_func = M_Draw;
     obj->priv_size = sizeof(M_PRIV);
     obj->priv_load_func = M_LoadPriv;

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -19,6 +19,11 @@ typedef enum {
     // clang-format on
 } M_STATE;
 
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -79,6 +84,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->should_spawn_blood_func = M_ShouldSpawnBlood;
 
     obj->hit_points = DONT_TARGET;
     obj->radius = M_RADIUS;

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -39,6 +39,11 @@ typedef struct {
     bool spawn_checked;
 } M_PRIV;
 
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_LoadPriv(ITEM *const item, SG_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
@@ -243,6 +248,7 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_save_func = M_SavePriv;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->should_spawn_blood_func = M_ShouldSpawnBlood;
 
     obj->hit_points = 20;
     obj->shadow_size = UNIT_SHADOW / 4;

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -22,6 +22,11 @@ typedef struct {
     bool destroyed;
 } M_PRIV;
 
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_LoadPriv(ITEM *const item, SG_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
@@ -207,6 +212,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->should_spawn_blood_func = M_ShouldSpawnBlood;
     obj->priv_size = sizeof(M_PRIV);
     obj->priv_load_func = M_LoadPriv;
     obj->priv_save_func = M_SavePriv;

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -163,9 +163,7 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    Gun_HitTarget(
-        target_item, nullptr, nullptr, LGT_GRENADE,
-        g_Weapons[LGT_GRENADE].damage);
+    Gun_HitTarget(target_item, nullptr, nullptr, g_Weapons[LGT_GRENADE].damage);
     Stats_AddAmmoHits();
 
     if (target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -1,6 +1,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/gun/misc.h>
 #include <trx/game/gun/vars.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/math.h>
 #include <trx/game/objects/vars.h>
@@ -121,11 +122,13 @@ static void M_Control_TR3(const int16_t item_num)
         }
 
         if (target_item->status == IS_ACTIVE) {
-            Spawn_BloodBath(
-                item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num, 3);
+            if (Item_ShouldSpawnBlood(target_item)) {
+                Spawn_BloodBath(
+                    item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,
+                    3);
+            }
             Gun_HitTarget(
-                target_item, nullptr, nullptr, LGT_HARPOON,
-                g_Weapons[LGT_HARPOON].damage);
+                target_item, nullptr, nullptr, g_Weapons[LGT_HARPOON].damage);
             Stats_AddAmmoHits();
         }
 
@@ -273,11 +276,13 @@ static void M_Control_TR12(const int16_t item_num)
         }
 
         if (target_item->status == IS_ACTIVE) {
-            Spawn_BloodBath(
-                item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num, 5);
+            if (Item_ShouldSpawnBlood(target_item)) {
+                Spawn_BloodBath(
+                    item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,
+                    5);
+            }
             Gun_HitTarget(
-                target_item, nullptr, nullptr, LGT_HARPOON,
-                g_Weapons[LGT_HARPOON].damage);
+                target_item, nullptr, nullptr, g_Weapons[LGT_HARPOON].damage);
             Stats_AddAmmoHits();
         }
         hit = true;

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -156,8 +156,7 @@ static bool M_TryExplodeItem(
 
     if (target_item->status == IS_ACTIVE) {
         Gun_HitTarget(
-            target_item, nullptr, nullptr, LGT_ROCKET,
-            g_Weapons[LGT_ROCKET].damage);
+            target_item, nullptr, nullptr, g_Weapons[LGT_ROCKET].damage);
         Stats_AddAmmoHits();
 
         if (target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -1,5 +1,6 @@
 // The Great Pyramid shootable Scion.
 
+#include <trx/config.h>
 #include <trx/game/camera.h>
 #include <trx/game/effects.h>
 #include <trx/game/objects.h>
@@ -7,6 +8,11 @@
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
+
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    return !g_Config.visuals.fix_texture_issues;
+}
 
 static void M_Control(const int16_t item_num)
 {
@@ -59,6 +65,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
+    obj->should_spawn_blood_func = M_ShouldSpawnBlood;
     obj->hit_points = 5;
     obj->save_flags = true;
     obj->save_hitpoints = true;

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -34,6 +34,7 @@ void Object_SetupAllObjects(void)
         obj->add_walkable_func = nullptr;
         obj->is_usable_func = nullptr;
         obj->can_interpolate_func = Object_CanInterpolate;
+        obj->should_spawn_blood_func = nullptr;
         obj->hit_points = DONT_TARGET;
         obj->pivot_length = 0;
         obj->radius = M_DEFAULT_RADIUS;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -77,6 +77,7 @@ typedef struct OBJECT {
     void (*add_walkable_func)(int16_t item_num);
     bool (*can_interpolate_func)(
         const ITEM *item, int32_t frame_a, int32_t frame_b);
+    bool (*should_spawn_blood_func)(const ITEM *item);
 
     int16_t anim_idx;
     int16_t anim_count;

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -6,6 +6,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/gym.h>
 #include <trx/game/input.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
@@ -709,9 +710,11 @@ static void M_SkidooBaddieCollision(ITEM *const quad)
                     Lara_TakeDamage(100, true);
                 }
             } else {
-                Spawn_BloodBath(
-                    item->pos.x, quad->pos.y - 256, item->pos.z, quad->speed,
-                    quad->rot.y, item->room_num, 3);
+                if (Item_ShouldSpawnBlood(item)) {
+                    Spawn_BloodBath(
+                        item->pos.x, quad->pos.y - 256, item->pos.z,
+                        quad->speed, quad->rot.y, item->room_num, 3);
+                }
                 if (item->hit_points > 0) {
                     item->hit_points = 0;
                     Stats_AddKill();

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -146,10 +146,12 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
     } else if (
         obj->intelligent && item->status == IS_ACTIVE
         && (Creature_IsTargetable(item) || item->hit_points == 0)) {
-        Spawn_BloodBath(
-            item->pos.x, skidoo->pos.y - STEP_L, item->pos.z, skidoo->speed,
-            skidoo->rot.y, item->room_num, 3);
-        Gun_HitTarget(item, nullptr, nullptr, LGT_SKIDOO, item->hit_points);
+        if (Item_ShouldSpawnBlood(item)) {
+            Spawn_BloodBath(
+                item->pos.x, skidoo->pos.y - STEP_L, item->pos.z, skidoo->speed,
+                skidoo->rot.y, item->room_num, 3);
+        }
+        Gun_HitTarget(item, nullptr, nullptr, item->hit_points);
     }
     return true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Winston and Assault Targets bleeding when the player runs them over with a Quad Bike or shoots them with the Harpoon Gun.

#### Testing

- [x] **Quad Bike vs Winston**
  Load Lara's Home in TR3. Try to drive both Winston variants with the Quad Bike.
  Expected outcome: no blood VFX; hit behavior still occurs for the Army Winston.

- [x] **Harpoon vs Military Winston**
  Spawn/locate military Winston, fire harpoon bolts at close range.
  Expected outcome: no blood VFX; the bolt continues to despawn on hit.

- [x] **Quad Bike + Harpoon vs Assault Targets**
  In the TR3 assault course, hit targets with Quad Bike and with Harpoon Gun.
  Expected outcome: no blood VFX in either case.

- [x] **Scion Ricochet Policy**
  Shoot the Scion in The Great Pyramid with `fix_texture_issues` enabled and disabled.
  Expected outcome: when the fix is active, it should ricochet, when it's off, it should bleed like in the OG.

- [x] **Shiva Front-Deflect Cases**
  Attack Shiva during defend states with light firearms, and with Rockets/Grenades/Harpoons.
  Expected outcome: normal bullets ricochet off without doing damage or drawing blood; explosives continue to land, Harpoons pierce the armor.