### PR TITLE
Replace item->data with typed item fields

### DIFF
--- a/src/trx/game/carrier.c
+++ b/src/trx/game/carrier.c
@@ -33,12 +33,16 @@ static ITEM *M_GetCarrier(const int16_t item_num)
     // Allow carried items to be allocated to holder objects (pods/statues),
     // but then have those items dropped by the actual creatures within.
     ITEM *item = Item_Get(item_num);
-    if (Object_IsType(item->object_id, g_PlaceholderObjects)) {
-        const int16_t child_item_num = (intptr_t)item->data;
+    const OBJECT *obj = Object_Get(item->object_id);
+    if (obj->carrier_item_num_func != nullptr) {
+        const int16_t child_item_num = obj->carrier_item_num_func(item);
+        if (child_item_num == NO_ITEM) {
+            return nullptr;
+        }
         item = Item_Get(child_item_num);
     }
 
-    const OBJECT *const obj = Object_Get(item->object_id);
+    obj = Object_Get(item->object_id);
     if (!obj->loaded) {
         return nullptr;
     }

--- a/src/trx/game/collision.c
+++ b/src/trx/game/collision.c
@@ -115,7 +115,7 @@ int32_t Collide_GetSpheres(
     spheres[0].r = mesh->radius;
     Matrix_Pop();
 
-    const int16_t *extra_rotation = (int16_t *)item->data;
+    const int16_t *extra_rotation = item->extra_rotations;
     for (int32_t i = 1; i < obj->mesh_count; i++) {
         const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {
@@ -222,7 +222,7 @@ void Collide_GetJointAbsPosition(
         Matrix_Rot16(frame_a->mesh_rots[0]);
     }
 
-    const int16_t *extra_rotation = item->data;
+    const int16_t *extra_rotation = item->extra_rotations;
     const int32_t max_joint = obj->mesh_count > 0 ? obj->mesh_count - 1 : 0;
     const int32_t abs_joint = MIN(max_joint, joint);
     for (int32_t i = 0; i < abs_joint; i++) {

--- a/src/trx/game/creature/behavior.c
+++ b/src/trx/game/creature/behavior.c
@@ -56,7 +56,7 @@ void Creature_Hurt(ITEM *const item, const int32_t damage)
         return;
     }
 
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature != nullptr) {
         creature->hurt_by_lara = true;
     }
@@ -97,7 +97,7 @@ bool Creature_IsHostile(const ITEM *const item)
 
     switch (g_Config.gameplay.ally_hostility_policy) {
     case ALLY_HOSTILITY_POLICY_INDIVIDUAL:
-        const CREATURE *const creature = item->data;
+        const CREATURE *const creature = item->creature_data;
         return creature != nullptr && creature->hurt_by_lara;
     case ALLY_HOSTILITY_POLICY_SHARED:
         return m_AlliesHostile;

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -6,6 +6,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/los.h>
+#include <trx/game/objects/creatures/skidoo_driver.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
@@ -1145,7 +1146,10 @@ void Creature_Die(const int16_t item_num, const bool explode)
             Item_Explode(item_num, -1, 0);
         }
         item->hit_points = DONT_TARGET;
-        const int16_t vehicle_item_num = (int16_t)(intptr_t)item->data;
+        const int16_t vehicle_item_num = SkidooDriver_GetSkidooItemNum(item);
+        if (vehicle_item_num == NO_ITEM) {
+            return;
+        }
         ITEM *const vehicle_item = Item_Get(vehicle_item_num);
         vehicle_item->hit_points = 0;
         vehicle_item->status = IS_INVISIBLE;

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -49,7 +49,7 @@ static void M_GetBaddieTarget(const int16_t item_num, const bool goody)
 {
     ITEM *const lara_item = Lara_GetItem();
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     ITEM *best_item = nullptr;
     int32_t best_distance = INT32_MAX;
@@ -113,7 +113,7 @@ static void M_GetBaddieTarget(const int16_t item_num, const bool goody)
 
 static ITEM *M_ChooseEnemy(const ITEM *const item)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (Creature_IsAlly(item)) {
         M_GetBaddieTarget(creature->item_num, true);
     } else if (Creature_IsAllyTargetingEnemy(item)) {
@@ -256,7 +256,8 @@ void Creature_Initialise(const int16_t item_num)
         item->rot.y += (Random_GetControl() - DEG_90) >> 1;
     }
     item->collidable = true;
-    item->data = nullptr;
+    item->creature_data = nullptr;
+    item->extra_rotations = nullptr;
 }
 
 bool Creature_Activate(const int16_t item_num)
@@ -276,7 +277,7 @@ bool Creature_Activate(const int16_t item_num)
 
 void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -414,7 +415,7 @@ void Creature_Mood(
 void Creature_UpdateMood(
     const ITEM *const item, const AI_INFO *const info, const bool violent)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -521,7 +522,7 @@ void Creature_UpdateMood(
 void Creature_ApplyMood(
     const ITEM *const item, const AI_INFO *const info, const bool violent)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -605,7 +606,7 @@ void Creature_ApplyMood(
 
 int16_t Creature_Turn(ITEM *const item, int16_t max_turn)
 {
-    const CREATURE *const creature = item->data;
+    const CREATURE *const creature = item->creature_data;
     if (creature == nullptr || max_turn == 0) {
         return 0;
     }
@@ -638,7 +639,7 @@ void Creature_Tilt(ITEM *const item, int16_t angle)
 
 void Creature_Head(ITEM *const item, const int16_t required)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -652,7 +653,7 @@ void Creature_Head(ITEM *const item, const int16_t required)
 
 void Creature_Neck(ITEM *const item, const int16_t required)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -667,7 +668,7 @@ void Creature_Neck(ITEM *const item, const int16_t required)
 void Creature_Joint(
     ITEM *const item, const int16_t joint, const int16_t required)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -727,7 +728,7 @@ bool Creature_IsFloating(const ITEM *const item)
 
 bool Creature_CanTargetEnemy(const ITEM *const item, const AI_INFO *const info)
 {
-    const CREATURE *const creature = item->data;
+    const CREATURE *const creature = item->creature_data;
     const ITEM *const enemy =
         creature->enemy != nullptr ? creature->enemy : Lara_GetItem();
     if (!info->ahead || info->distance >= CREATURE_SHOOT_RANGE
@@ -783,7 +784,7 @@ bool Creature_Animate(
     const int16_t item_num, const int16_t angle, const int16_t tilt)
 {
     ITEM *const item = Item_Get(item_num);
-    const CREATURE *const creature = item->data;
+    const CREATURE *const creature = item->creature_data;
     const OBJECT *const obj = Object_Get(item->object_id);
     if (creature == nullptr) {
         return false;

--- a/src/trx/game/creature/shooting.c
+++ b/src/trx/game/creature/shooting.c
@@ -38,7 +38,7 @@ bool Creature_Shoot(
     const int16_t extra_rotation, const int32_t damage)
 {
     const ITEM *const lara_item = Lara_GetItem();
-    const CREATURE *const creature = item->data;
+    const CREATURE *const creature = item->creature_data;
     ITEM *const target_item = creature->enemy;
 
     bool is_targetable;

--- a/src/trx/game/creature/types.h
+++ b/src/trx/game/creature/types.h
@@ -4,11 +4,10 @@
 #include <trx/game/items.h>
 #include <trx/game/pathing/types.h>
 
-typedef struct {
+typedef struct CREATURE {
     union {
-        // NOTE: many draw paths treat item->data as an int16_t rotation array.
-        // For intelligent objects, item->data is a CREATURE*, so joint_rotation
-        // must be the first field to match this expectation.
+        // NOTE: creature extra rotations are provided via this array.
+        // Intelligent objects wire item->extra_rotations to joint_rotation.
         int16_t joint_rotation[4];
         struct {
             // These are old TR1-2 aliases.

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -406,7 +406,8 @@ void Gun_HitTarget(
     }
 
     Item_TakeDamage(item, damage, true);
-    if (item->data != nullptr && Object_Get(item->object_id)->intelligent) {
+    if (item->creature_data != nullptr
+        && Object_Get(item->object_id)->intelligent) {
         Creature_Hurt(item, damage);
     }
 

--- a/src/trx/game/items/common.c
+++ b/src/trx/game/items/common.c
@@ -218,7 +218,8 @@ void Item_Initialise(const int16_t item_num)
     item->ai_bits = 0;
     item->ai_tag = 0;
     item->after_death = 0;
-    item->data = nullptr;
+    item->creature_data = nullptr;
+    item->extra_rotations = nullptr;
     item->priv = nullptr;
     item->carried_item = nullptr;
     item->name = nullptr;

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -16,6 +16,8 @@ typedef struct CARRIED_ITEM {
     struct CARRIED_ITEM *next_item;
 } CARRIED_ITEM;
 
+typedef struct TRAP_DATA TRAP_DATA;
+
 typedef struct {
     int32_t floor;
     uint32_t touch_bits;
@@ -42,7 +44,10 @@ typedef struct {
     int16_t ai_tag;
 
     SHADE shade;
-    void *data;
+    union {
+        void *data; // to be eventually represented as CREATURE*
+        TRAP_DATA *trap_data;
+    };
     void *priv;
     CARRIED_ITEM *carried_item;
     char *name;

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -17,6 +17,7 @@ typedef struct CARRIED_ITEM {
 } CARRIED_ITEM;
 
 typedef struct TRAP_DATA TRAP_DATA;
+typedef struct CREATURE CREATURE;
 
 typedef struct {
     int32_t floor;
@@ -45,9 +46,10 @@ typedef struct {
 
     SHADE shade;
     union {
-        void *data; // to be eventually represented as CREATURE*
+        CREATURE *creature_data;
         TRAP_DATA *trap_data;
     };
+    int16_t *extra_rotations;
     void *priv;
     CARRIED_ITEM *carried_item;
     char *name;

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -68,7 +68,7 @@ int32_t Item_Explode(
     }
 
     // additional meshes
-    const int16_t *extra_rotation = (int16_t *)item->data;
+    const int16_t *extra_rotation = item->extra_rotations;
     for (int32_t i = 1; i < obj->mesh_count; i++) {
         const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         if (bone->matrix_pop) {

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -73,7 +73,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_item->data = lara_info;
+    lara_item->creature_data = (CREATURE *)lara_info; // ?
     lara_item->collidable = false;
 
     m_Controllable = true;

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -73,7 +73,6 @@ void Lara_Initialise(const GF_LEVEL *const level)
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_item->creature_data = (CREATURE *)lara_info; // ?
     lara_item->collidable = false;
 
     m_Controllable = true;

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -427,9 +427,9 @@ void Lara_Flare_Dispose(const bool thrown)
     }
 
     if (Flare_GenerateLight(item->pos, lara_info->flare.age)) {
-        item->data = (void *)(intptr_t)(lara_info->flare.age | 0x8000);
+        FlareItem_SetAge(item, lara_info->flare.age, true);
     } else {
-        item->data = (void *)(intptr_t)(lara_info->flare.age & ~0x8000);
+        FlareItem_SetAge(item, lara_info->flare.age, false);
     }
 
     Item_AddActive(item_num);

--- a/src/trx/game/objects/creatures/ape.c
+++ b/src/trx/game/objects/creatures/ape.c
@@ -45,7 +45,7 @@ static BITE m_ApeBite = { .pos = { 0, -19, 75 }, .mesh_num = 15 };
 static bool M_Vault(int16_t item_num, int16_t angle)
 {
     ITEM *const item = Item_Get(item_num);
-    CREATURE *ape = item->data;
+    CREATURE *const ape = item->creature_data;
     int32_t x = item->pos.x >> WALL_SHIFT;
     int32_t y = item->pos.y;
     int32_t z = item->pos.z >> WALL_SHIFT;
@@ -109,7 +109,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *ape = item->data;
+    CREATURE *const ape = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/baldy.c
+++ b/src/trx/game/objects/creatures/baldy.c
@@ -56,7 +56,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *baldy = item->data;
+    CREATURE *const baldy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/bandit_1.c
+++ b/src/trx/game/objects/creatures/bandit_1.c
@@ -53,7 +53,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/bandit_2.c
+++ b/src/trx/game/objects/creatures/bandit_2.c
@@ -53,7 +53,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/barracuda.c
+++ b/src/trx/game/objects/creatures/barracuda.c
@@ -45,7 +45,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     if (item->hit_points > 0) {
         AI_INFO info;

--- a/src/trx/game/objects/creatures/bartoli.c
+++ b/src/trx/game/objects/creatures/bartoli.c
@@ -2,12 +2,16 @@
 #include <trx/game/camera.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
-#include <trx/game/pathing.h>
+#include <trx/game/objects/creatures/dragon.h>
 #include <trx/game/spawn.h>
 #include <trx/utils.h>
 
-#define BOOM_TIME 130
-#define BARTOLI_RANGE (WALL_L * 5) // = 5120
+#define M_BOOM_TIME 130
+#define M_BARTOLI_RANGE (WALL_L * 5) // = 5120
+
+typedef struct {
+    int16_t dragon_item_num;
+} M_PRIV;
 
 static void M_CreateBoom(const OBJECT_ID obj_id, const ITEM *const origin_item)
 {
@@ -30,21 +34,12 @@ static void M_CreateBoom(const OBJECT_ID obj_id, const ITEM *const origin_item)
 
 static void M_ConvertBartoliToDragon(const int16_t item_num)
 {
-    const ITEM *const item_bartoli = Item_Get(item_num);
-
-    const int16_t item_dragon_back_num = (intptr_t)item_bartoli->data;
-    ITEM *const item_dragon_back = Item_Get(item_dragon_back_num);
-    const int16_t item_dragon_front_num = (intptr_t)item_dragon_back->data;
-    ITEM *const item_dragon_front = Item_Get(item_dragon_front_num);
-
-    item_dragon_back->touch_bits = 0;
-    item_dragon_front->touch_bits = 0;
-
-    LOT_EnableBaddieAI(item_dragon_front_num, true);
-    Item_AddActive(item_dragon_front_num);
-    Item_AddActive(item_dragon_back_num);
-
-    item_dragon_back->status = IS_ACTIVE;
+    const ITEM *const bartoli_item = Item_Get(item_num);
+    const M_PRIV *const p = bartoli_item->priv;
+    const int16_t dragon_item_num = p->dragon_item_num;
+    if (dragon_item_num != NO_ITEM) {
+        Dragon_Activate(dragon_item_num);
+    }
     Item_Kill(item_num);
 }
 
@@ -53,43 +48,15 @@ static bool M_CheckLaraProximity(const ITEM *const origin_item)
     const ITEM *const lara_item = Lara_GetItem();
     const int32_t dx = ABS(lara_item->pos.x - origin_item->pos.x);
     const int32_t dz = ABS(lara_item->pos.z - origin_item->pos.z);
-    return dx < BARTOLI_RANGE && dz < BARTOLI_RANGE;
+    return dx < M_BARTOLI_RANGE && dz < M_BARTOLI_RANGE;
 }
 
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-
-    const int16_t item_dragon_back_num = Item_CreateLevelItem();
-    const int16_t item_dragon_front_num = Item_CreateLevelItem();
-    ASSERT(item_dragon_back_num != NO_ITEM);
-    ASSERT(item_dragon_front_num != NO_ITEM);
-
-    ITEM *const item_dragon_back = Item_Get(item_dragon_back_num);
-    item_dragon_back->object_id = O_DRAGON_BACK;
-    item_dragon_back->pos.x = item->pos.x;
-    item_dragon_back->pos.y = item->pos.y;
-    item_dragon_back->pos.z = item->pos.z;
-    item_dragon_back->rot.y = item->rot.y;
-    item_dragon_back->room_num = item->room_num;
-    item_dragon_back->flags = IF_INVISIBLE;
-    item_dragon_back->shade.value_1 = -1;
-    Item_Initialise(item_dragon_back_num);
-    item_dragon_back->mesh_bits = 0x1FFFFF;
-
-    ITEM *const item_dragon_front = Item_Get(item_dragon_front_num);
-    item_dragon_front->object_id = O_DRAGON_FRONT;
-    item_dragon_front->pos.x = item->pos.x;
-    item_dragon_front->pos.y = item->pos.y;
-    item_dragon_front->pos.z = item->pos.z;
-    item_dragon_front->rot.y = item->rot.y;
-    item_dragon_front->room_num = item->room_num;
-    item_dragon_front->flags = IF_INVISIBLE;
-    item_dragon_front->shade.value_1 = -1;
-    Item_Initialise(item_dragon_front_num);
-    item_dragon_back->data = (void *)(intptr_t)item_dragon_front_num;
-
-    item->data = (void *)(intptr_t)item_dragon_back_num;
+    M_PRIV *const p = item->priv;
+    p->dragon_item_num = Dragon_CreateInactive(item);
+    ASSERT(p->dragon_item_num != NO_ITEM);
 }
 
 static void M_Control(const int16_t item_num)
@@ -111,13 +78,13 @@ static void M_Control(const int16_t item_num)
     Spawn_MysticLight(item_num);
     Item_Animate(item);
 
-    if (item->timer == BOOM_TIME + 0) {
+    if (item->timer == M_BOOM_TIME + 0) {
         M_CreateBoom(O_SPHERE_OF_DOOM_1, item);
-    } else if (item->timer == BOOM_TIME + 10) {
+    } else if (item->timer == M_BOOM_TIME + 10) {
         M_CreateBoom(O_SPHERE_OF_DOOM_2, item);
-    } else if (item->timer == BOOM_TIME + 20) {
+    } else if (item->timer == M_BOOM_TIME + 20) {
         M_CreateBoom(O_SPHERE_OF_DOOM_3, item);
-    } else if (item->timer >= BOOM_TIME + 20) {
+    } else if (item->timer >= M_BOOM_TIME + 20) {
         M_ConvertBartoliToDragon(item_num);
     }
 }
@@ -130,6 +97,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
+    obj->priv_size = sizeof(M_PRIV);
 
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/creatures/bartoli.c
+++ b/src/trx/game/objects/creatures/bartoli.c
@@ -51,6 +51,12 @@ static bool M_CheckLaraProximity(const ITEM *const origin_item)
     return dx < M_BARTOLI_RANGE && dz < M_BARTOLI_RANGE;
 }
 
+static int16_t M_GetCarrierItemNum(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->dragon_item_num;
+}
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -97,6 +103,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
+    obj->carrier_item_num_func = M_GetCarrierItemNum;
     obj->priv_size = sizeof(M_PRIV);
 
     obj->save_flags = true;

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -67,7 +67,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *bat = item->data;
+    CREATURE *const bat = item->creature_data;
     int16_t angle = 0;
     if (item->hit_points <= 0) {
         if (item->pos.y < item->floor) {

--- a/src/trx/game/objects/creatures/bear.c
+++ b/src/trx/game/objects/creatures/bear.c
@@ -55,7 +55,7 @@ static void M_Control(const int16_t item_num)
     OBJECT *const obj = Object_Get(item->object_id);
     obj->pivot_length = g_Config.gameplay.fix_bear_ai ? 0 : 500;
 
-    CREATURE *const bear = (CREATURE *)item->data;
+    CREATURE *const bear = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/big_eel.c
+++ b/src/trx/game/objects/creatures/big_eel.c
@@ -30,6 +30,10 @@ typedef enum {
     BIG_EEL_ANIM_DEATH = 2,
 } BIG_EEL_ANIM;
 
+typedef struct {
+    int32_t pos;
+} M_PRIV;
+
 static const BITE m_BigEelBite = {
     .pos = { .x = 7, .y = 157, .z = 333 },
     .mesh_num = 7,
@@ -39,8 +43,9 @@ static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     const ITEM *const lara_item = Lara_GetItem();
+    M_PRIV *const p = item->priv;
 
-    int32_t pos = (int32_t)(intptr_t)item->data;
+    int32_t pos = p->pos;
     item->pos.z -= (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
     item->pos.x -= ((pos * Math_Sin(item->rot.y)) >> W2V_SHIFT);
 
@@ -84,7 +89,7 @@ static void M_Control(const int16_t item_num)
 
     item->pos.x += (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
     item->pos.z += (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    item->data = (void *)(intptr_t)pos;
+    p->pos = pos;
 
     Item_Animate(item);
 }
@@ -97,6 +102,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->priv_size = sizeof(M_PRIV);
 
     obj->hit_points = BIG_EEL_HITPOINTS;
 

--- a/src/trx/game/objects/creatures/big_spider.c
+++ b/src/trx/game/objects/creatures/big_spider.c
@@ -41,7 +41,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t tilt = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/bird.c
+++ b/src/trx/game/objects/creatures/bird.c
@@ -60,7 +60,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const bird = (CREATURE *)item->data;
+    CREATURE *const bird = item->creature_data;
 
     if (item->hit_points <= 0) {
         switch (item->current_anim_state) {

--- a/src/trx/game/objects/creatures/bird_guardian.c
+++ b/src/trx/game/objects/creatures/bird_guardian.c
@@ -55,7 +55,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/centaur.c
+++ b/src/trx/game/objects/creatures/centaur.c
@@ -42,7 +42,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *centaur = item->data;
+    CREATURE *const centaur = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/centaur_statue.c
+++ b/src/trx/game/objects/creatures/centaur_statue.c
@@ -78,6 +78,12 @@ static void M_Control(const int16_t item_num)
     }
 }
 
+static int16_t M_GetCarrierItemNum(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->centaur_item_num;
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     if (!obj->loaded) {
@@ -86,6 +92,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->carrier_item_num_func = M_GetCarrierItemNum;
     obj->priv_size = sizeof(M_PRIV);
     obj->save_anim = true;
     obj->save_flags = true;

--- a/src/trx/game/objects/creatures/centaur_statue.c
+++ b/src/trx/game/objects/creatures/centaur_statue.c
@@ -9,6 +9,10 @@
 #define CENTAUR_REARING_ANIM 7
 #define CENTAUR_REARING_FRAME 36
 
+typedef struct {
+    int16_t centaur_item_num;
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     OBJECT *const obj = Object_Get(O_CENTAUR);
@@ -17,6 +21,8 @@ static void M_Initialise(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->centaur_item_num = NO_ITEM;
 
     const int16_t centaur_item_num = Item_CreateLevelItem();
     ASSERT(centaur_item_num != NO_ITEM);
@@ -37,7 +43,7 @@ static void M_Initialise(const int16_t item_num)
     centaur->goal_anim_state = centaur->current_anim_state;
     centaur->rot.y = item->rot.y;
 
-    item->data = (void *)(intptr_t)centaur_item_num;
+    p->centaur_item_num = centaur_item_num;
 }
 
 static void M_Control(const int16_t item_num)
@@ -58,12 +64,12 @@ static void M_Control(const int16_t item_num)
         Item_Kill(item_num);
         item->status = IS_DEACTIVATED;
 
-        if (item->data != nullptr) {
-            const int16_t centaur_item_num = (intptr_t)item->data;
-            ITEM *const centaur = Item_Get(centaur_item_num);
+        const M_PRIV *const p = item->priv;
+        if (p->centaur_item_num != NO_ITEM) {
+            ITEM *const centaur = Item_Get(p->centaur_item_num);
             centaur->touch_bits = 0;
-            Item_AddActive(centaur_item_num);
-            LOT_EnableBaddieAI(centaur_item_num, 1);
+            Item_AddActive(p->centaur_item_num);
+            LOT_EnableBaddieAI(p->centaur_item_num, 1);
             centaur->status = IS_ACTIVE;
             Sound_Effect(SFX_EXPLOSION_1, &centaur->pos, SPM_NORMAL);
         } else {
@@ -80,6 +86,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_anim = true;
     obj->save_flags = true;
     obj->enable_interpolation = false;

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -69,7 +69,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     M_PRIV *const p = item->priv;
 
     if (creature == nullptr) {

--- a/src/trx/game/objects/creatures/cowboy.c
+++ b/src/trx/game/objects/creatures/cowboy.c
@@ -52,7 +52,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *cowboy = item->data;
+    CREATURE *const cowboy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -61,7 +61,7 @@ static const HYBRID_INFO m_CrocodileInfo = {
 
 static void M_UpdateCreatureLOT(const ITEM *const item)
 {
-    CREATURE *const creature = (CREATURE *)item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }
@@ -91,7 +91,7 @@ static void M_ControlCrocodile(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *croc = item->data;
+    CREATURE *const croc = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 
@@ -205,7 +205,7 @@ static void M_ControlAlligator(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *gator = item->data;
+    CREATURE *const gator = item->creature_data;
     const SECTOR *sector;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/cultist_1.c
+++ b/src/trx/game/objects/creatures/cultist_1.c
@@ -65,7 +65,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/cultist_2.c
+++ b/src/trx/game/objects/creatures/cultist_2.c
@@ -51,7 +51,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/cultist_3.c
+++ b/src/trx/game/objects/creatures/cultist_3.c
@@ -64,7 +64,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/diver.c
+++ b/src/trx/game/objects/creatures/diver.c
@@ -70,7 +70,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != DIVER_STATE_DEATH) {

--- a/src/trx/game/objects/creatures/dog.c
+++ b/src/trx/game/objects/creatures/dog.c
@@ -58,7 +58,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -105,7 +105,7 @@ static void M_MarkDragonDead(ITEM *const dragon_back_item)
         return;
     }
     const ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
-    CREATURE *const creature = dragon_front_item->data;
+    CREATURE *const creature = dragon_front_item->creature_data;
     creature->flags = -1;
     Stats_AddKill();
 
@@ -257,7 +257,7 @@ static void M_ControlBack(const int16_t item_num)
 
     int16_t angle = 0;
     int16_t head = 0;
-    CREATURE *const creature = dragon_front_item->data;
+    CREATURE *const creature = dragon_front_item->creature_data;
     const OBJECT *const front_obj = Object_Get(O_DRAGON_FRONT);
 
     if (dragon_front_item->hit_points <= 0) {

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -1,3 +1,5 @@
+#include <trx/game/objects/creatures/dragon.h>
+
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/carrier.h>
@@ -60,14 +62,48 @@ typedef enum {
     // clang-format on
 } DRAGON_ANIM;
 
+typedef struct {
+    int16_t dragon_front_item_num;
+} M_PRIV;
+
 static const BITE m_DragonMouth = {
     .pos = { .x = 35, .y = 171, .z = 1168 },
     .mesh_num = 12,
 };
 
+static int16_t M_GetFrontItemNum(const ITEM *const dragon_back_item)
+{
+    const M_PRIV *const p = dragon_back_item->priv;
+    if (p == nullptr) {
+        return NO_ITEM;
+    }
+    return p->dragon_front_item_num;
+}
+
+static bool M_SetFrontItemNum(
+    ITEM *const dragon_back_item, const int16_t dragon_front_item_num)
+{
+    M_PRIV *const p = dragon_back_item->priv;
+    if (p == nullptr) {
+        return false;
+    }
+    p->dragon_front_item_num = dragon_front_item_num;
+    return true;
+}
+
+static void M_InitialiseBack(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->dragon_front_item_num = NO_ITEM;
+}
+
 static void M_MarkDragonDead(ITEM *const dragon_back_item)
 {
-    const int16_t dragon_front_item_num = (intptr_t)dragon_back_item->data;
+    const int16_t dragon_front_item_num = M_GetFrontItemNum(dragon_back_item);
+    if (dragon_front_item_num == NO_ITEM) {
+        return;
+    }
     const ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
     CREATURE *const creature = dragon_front_item->data;
     creature->flags = -1;
@@ -201,15 +237,19 @@ static void M_Collision(
     }
 }
 
-static void M_Control(const int16_t item_num)
+static void M_ControlFront(const int16_t item_num)
+{
+}
+
+static void M_ControlBack(const int16_t item_num)
 {
     const int16_t dragon_back_item_num = item_num;
     ITEM *const dragon_back_item = Item_Get(item_num);
-    if (dragon_back_item->object_id == O_DRAGON_FRONT) {
+
+    const int16_t dragon_front_item_num = M_GetFrontItemNum(dragon_back_item);
+    if (dragon_front_item_num == NO_ITEM) {
         return;
     }
-
-    const int16_t dragon_front_item_num = (intptr_t)dragon_back_item->data;
     ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
     if (!Creature_Activate(dragon_front_item_num)) {
         return;
@@ -419,7 +459,7 @@ static void M_SetupFront(OBJECT *const obj)
     SOFT_ASSERT(
         Object_Get(O_DRAGON_BACK)->loaded, "Dragon back object missing");
     obj->handle_save_func = M_HandleSaveFront;
-    obj->control_func = M_Control;
+    obj->control_func = M_ControlFront;
     obj->collision_func = M_Collision;
 
     obj->hit_points = DRAGON_HITPOINTS;
@@ -441,7 +481,8 @@ static void M_SetupBack(OBJECT *const obj)
         return;
     }
 
-    obj->control_func = M_Control;
+    obj->initialise_func = M_InitialiseBack;
+    obj->control_func = M_ControlBack;
     obj->collision_func = M_Collision;
 
     obj->radius = DRAGON_RADIUS;
@@ -449,6 +490,65 @@ static void M_SetupBack(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    obj->priv_size = sizeof(M_PRIV);
+}
+
+int16_t Dragon_CreateInactive(const ITEM *const item)
+{
+    const int16_t dragon_back_item_num = Item_CreateLevelItem();
+    const int16_t dragon_front_item_num = Item_CreateLevelItem();
+    ASSERT(dragon_back_item_num != NO_ITEM);
+    ASSERT(dragon_front_item_num != NO_ITEM);
+
+    ITEM *const dragon_back_item = Item_Get(dragon_back_item_num);
+    dragon_back_item->object_id = O_DRAGON_BACK;
+    dragon_back_item->pos.x = item->pos.x;
+    dragon_back_item->pos.y = item->pos.y;
+    dragon_back_item->pos.z = item->pos.z;
+    dragon_back_item->rot.y = item->rot.y;
+    dragon_back_item->room_num = item->room_num;
+    dragon_back_item->flags = IF_INVISIBLE;
+    dragon_back_item->shade.value_1 = -1;
+    Item_Initialise(dragon_back_item_num);
+    dragon_back_item->mesh_bits = 0x1FFFFF;
+
+    ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
+    dragon_front_item->object_id = O_DRAGON_FRONT;
+    dragon_front_item->pos.x = item->pos.x;
+    dragon_front_item->pos.y = item->pos.y;
+    dragon_front_item->pos.z = item->pos.z;
+    dragon_front_item->rot.y = item->rot.y;
+    dragon_front_item->room_num = item->room_num;
+    dragon_front_item->flags = IF_INVISIBLE;
+    dragon_front_item->shade.value_1 = -1;
+    Item_Initialise(dragon_front_item_num);
+
+    if (!M_SetFrontItemNum(dragon_back_item, dragon_front_item_num)) {
+        return NO_ITEM;
+    }
+    return dragon_back_item_num;
+}
+
+void Dragon_Activate(const int16_t dragon_back_item_num)
+{
+    if (dragon_back_item_num == NO_ITEM) {
+        return;
+    }
+
+    ITEM *const dragon_back_item = Item_Get(dragon_back_item_num);
+    const int16_t dragon_front_item_num = M_GetFrontItemNum(dragon_back_item);
+    if (dragon_front_item_num == NO_ITEM) {
+        return;
+    }
+
+    ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
+    dragon_back_item->touch_bits = 0;
+    dragon_front_item->touch_bits = 0;
+
+    LOT_EnableBaddieAI(dragon_front_item_num, true);
+    Item_AddActive(dragon_front_item_num);
+    Item_AddActive(dragon_back_item_num);
+    dragon_back_item->status = IS_ACTIVE;
 }
 
 REGISTER_OBJECT(O_DRAGON_FRONT, M_SetupFront)

--- a/src/trx/game/objects/creatures/dragon.h
+++ b/src/trx/game/objects/creatures/dragon.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <trx/game/objects/types.h>
+
+int16_t Dragon_CreateInactive(const ITEM *item);
+void Dragon_Activate(int16_t dragon_item_num);

--- a/src/trx/game/objects/creatures/eel.c
+++ b/src/trx/game/objects/creatures/eel.c
@@ -30,6 +30,10 @@ typedef enum {
     EEL_ANIM_DEATH = 3,
 } EEL_ANIM;
 
+typedef struct {
+    int32_t pos;
+} M_PRIV;
+
 static const BITE m_EelBite = {
     .pos = { .x = 7, .y = 157, .z = 333 },
     .mesh_num = 7,
@@ -38,8 +42,9 @@ static const BITE m_EelBite = {
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
 
-    int32_t pos = (int32_t)(intptr_t)item->data;
+    int32_t pos = p->pos;
     item->pos.x -= (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
     item->pos.z -= (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
 
@@ -90,7 +95,7 @@ static void M_Control(const int16_t item_num)
 
     item->pos.x += (pos * Math_Sin(item->rot.y)) >> W2V_SHIFT;
     item->pos.z += (pos * Math_Cos(item->rot.y)) >> W2V_SHIFT;
-    item->data = (void *)(intptr_t)pos;
+    p->pos = pos;
     Item_Animate(item);
 }
 
@@ -102,6 +107,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->priv_size = sizeof(M_PRIV);
 
     obj->hit_points = EEL_HITPOINTS;
 

--- a/src/trx/game/objects/creatures/jelly.c
+++ b/src/trx/game/objects/creatures/jelly.c
@@ -26,7 +26,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     if (item->hit_points <= 0) {
         if (Item_Explode(item_num, -1, 0)) {

--- a/src/trx/game/objects/creatures/larson.c
+++ b/src/trx/game/objects/creatures/larson.c
@@ -52,7 +52,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *person = item->data;
+    CREATURE *const person = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/lion.c
+++ b/src/trx/game/objects/creatures/lion.c
@@ -50,7 +50,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *lion = item->data;
+    CREATURE *const lion = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/monk.c
+++ b/src/trx/game/objects/creatures/monk.c
@@ -55,7 +55,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -66,7 +66,7 @@ typedef enum {
 
 static void M_Bite(ITEM *const item, ITEM *const enemy, const int32_t dmg)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (enemy == Lara_GetItem()) {
         if (creature->flags == 0 && item->touch_bits & 0x2400) {
             Lara_TakeDamage(dmg, true);
@@ -178,7 +178,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = (CREATURE *)item->data;
+    CREATURE *const creature = item->creature_data;
 
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara = Lara_GetLaraInfo();

--- a/src/trx/game/objects/creatures/mouse.c
+++ b/src/trx/game/objects/creatures/mouse.c
@@ -44,7 +44,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/mutant.c
+++ b/src/trx/game/objects/creatures/mutant.c
@@ -72,7 +72,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *flyer = item->data;
+    CREATURE *const flyer = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -51,7 +51,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *natla = item->data;
+    CREATURE *const natla = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -86,7 +86,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *pierre = item->data;
+    CREATURE *const pierre = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/pod.c
+++ b/src/trx/game/objects/creatures/pod.c
@@ -12,9 +12,15 @@ typedef enum {
     POD_STATE_EXPLODE = 1,
 } POD_STATE;
 
+typedef struct {
+    int16_t bug_item_num;
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->bug_item_num = NO_ITEM;
 
     const int16_t bug_item_num = Item_CreateLevelItem();
     if (bug_item_num != NO_ITEM) {
@@ -29,7 +35,7 @@ static void M_Initialise(const int16_t item_num)
         bug->shade.value_1 = -1;
 
         Item_Initialise(bug_item_num);
-        item->data = (void *)(intptr_t)bug_item_num;
+        p->bug_item_num = bug_item_num;
     }
 
     item->flags = 0;
@@ -74,15 +80,17 @@ static void M_Control(const int16_t item_num)
             item->collidable = false;
             Item_Explode(item_num, 0xFFFE00, 0);
 
-            const int16_t bug_item_num = (intptr_t)item->data;
-            ITEM *const bug = Item_Get(bug_item_num);
-            if (Object_Get(bug->object_id)->loaded) {
-                bug->touch_bits = 0;
-                Item_AddActive(bug_item_num);
-                if (LOT_EnableBaddieAI(bug_item_num, 0)) {
-                    bug->status = IS_ACTIVE;
-                } else {
-                    bug->status = IS_INVISIBLE;
+            const M_PRIV *const p = item->priv;
+            if (p->bug_item_num != NO_ITEM) {
+                ITEM *const bug = Item_Get(p->bug_item_num);
+                if (Object_Get(bug->object_id)->loaded) {
+                    bug->touch_bits = 0;
+                    Item_AddActive(p->bug_item_num);
+                    if (LOT_EnableBaddieAI(p->bug_item_num, 0)) {
+                        bug->status = IS_ACTIVE;
+                    } else {
+                        bug->status = IS_INVISIBLE;
+                    }
                 }
             }
             item->status = IS_DEACTIVATED;
@@ -101,6 +109,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_anim = true;
     obj->save_flags = true;
 }

--- a/src/trx/game/objects/creatures/pod.c
+++ b/src/trx/game/objects/creatures/pod.c
@@ -52,6 +52,12 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
     }
 }
 
+static int16_t M_GetCarrierItemNum(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->bug_item_num;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -109,6 +115,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->carrier_item_num_func = M_GetCarrierItemNum;
     obj->priv_size = sizeof(M_PRIV);
     obj->save_anim = true;
     obj->save_flags = true;

--- a/src/trx/game/objects/creatures/pod.h
+++ b/src/trx/game/objects/creatures/pod.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <trx/game/objects/common.h>
 
 OBJECT_ID Pod_GetBugObjectID(const ITEM *item);

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -45,7 +45,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *raptor = item->data;
+    CREATURE *const raptor = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/rat.c
+++ b/src/trx/game/objects/creatures/rat.c
@@ -70,7 +70,7 @@ static void M_ControlRat(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *rat = item->data;
+    CREATURE *const rat = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/shark.c
+++ b/src/trx/game/objects/creatures/shark.c
@@ -51,7 +51,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     const ITEM *const lara_item = Lara_GetItem();
     const bool lara_was_alive = lara_item->hit_points > 0;

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -188,7 +188,7 @@ static void M_Control(const int16_t item_num)
 
     const ITEM *const lara_item = Lara_GetItem();
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     M_PRIV *const p = item->priv;
 
     const bool lara_alive = lara_item->hit_points > 0;

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -82,7 +82,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *kid = item->data;
+    CREATURE *const kid = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -32,6 +32,10 @@ typedef enum {
     SKIDOO_DRIVER_ANIM_DEATH = 10,
 } SKIDOO_DRIVER_ANIM;
 
+typedef struct {
+    int16_t skidoo_item_num;
+} M_PRIV;
+
 static void M_KillDriver(ITEM *const driver_item)
 {
     const int32_t driver_item_num = Item_GetIndex(driver_item);
@@ -170,6 +174,7 @@ static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const skidoo_driver = Item_Get(item_num);
+    M_PRIV *const p = skidoo_driver->priv;
 
     const int16_t skidoo_item_num = Item_CreateLevelItem();
     ASSERT(skidoo_item_num != NO_ITEM);
@@ -185,7 +190,7 @@ static void M_Initialise(const int16_t item_num)
     skidoo->shade.value_1 = -1;
     Item_Initialise(skidoo_item_num);
 
-    skidoo_driver->data = (void *)(intptr_t)skidoo_item_num;
+    p->skidoo_item_num = skidoo_item_num;
 }
 
 static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
@@ -193,7 +198,8 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->status == IS_DEACTIVATED) {
             item->hit_points = DONT_TARGET;
-            const int16_t skidoo_num = (int16_t)(intptr_t)item->data;
+            const M_PRIV *const p = item->priv;
+            const int16_t skidoo_num = p->skidoo_item_num;
             ITEM *const skidoo = Item_Get(skidoo_num);
             skidoo->object_id = O_SKIDOO_FAST;
             Skidoo_Initialise(skidoo_num);
@@ -204,8 +210,8 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 static void M_Control(const int16_t driver_item_num)
 {
     ITEM *const driver_item = Item_Get(driver_item_num);
-
-    const int16_t skidoo_item_num = (int16_t)(intptr_t)driver_item->data;
+    const M_PRIV *const p = driver_item->priv;
+    const int16_t skidoo_item_num = p->skidoo_item_num;
     ITEM *const skidoo_item = Item_Get(skidoo_item_num);
 
     if (skidoo_item->data == nullptr) {
@@ -267,12 +273,19 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
+    obj->priv_size = sizeof(M_PRIV);
 
     obj->hit_points = 1;
 
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+}
+
+int16_t SkidooDriver_GetSkidooItemNum(const ITEM *const driver_item)
+{
+    const M_PRIV *const p = driver_item->priv;
+    return p->skidoo_item_num;
 }
 
 REGISTER_OBJECT(O_SKIDOO_DRIVER, M_Setup)

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -94,7 +94,7 @@ static void M_ControlDead(ITEM *const driver_item, ITEM *const skidoo_item)
 
 static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
 {
-    CREATURE *const driver_data = skidoo_item->data;
+    CREATURE *const driver_data = skidoo_item->creature_data;
 
     AI_INFO info;
     Creature_AIInfo(skidoo_item, &info);
@@ -214,12 +214,12 @@ static void M_Control(const int16_t driver_item_num)
     const int16_t skidoo_item_num = p->skidoo_item_num;
     ITEM *const skidoo_item = Item_Get(skidoo_item_num);
 
-    if (skidoo_item->data == nullptr) {
+    if (skidoo_item->creature_data == nullptr) {
         LOT_EnableBaddieAI(skidoo_item_num, true);
         skidoo_item->status = IS_ACTIVE;
     }
 
-    CREATURE *const driver_data = skidoo_item->data;
+    CREATURE *const driver_data = skidoo_item->creature_data;
     int16_t angle = 0;
 
     if (skidoo_item->hit_points <= 0) {

--- a/src/trx/game/objects/creatures/skidoo_driver.h
+++ b/src/trx/game/objects/creatures/skidoo_driver.h
@@ -1,3 +1,7 @@
 #pragma once
 
+#include <trx/game/objects/common.h>
+
 #define SKIDOO_DRIVER_HITPOINTS 100
+
+int16_t SkidooDriver_GetSkidooItemNum(const ITEM *driver_item);

--- a/src/trx/game/objects/creatures/spider.c
+++ b/src/trx/game/objects/creatures/spider.c
@@ -65,7 +65,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t angle = 0;
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     if (item->hit_points > 0) {
         AI_INFO info;

--- a/src/trx/game/objects/creatures/tiger.c
+++ b/src/trx/game/objects/creatures/tiger.c
@@ -50,7 +50,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -277,7 +277,7 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    CREATURE *const tony = item->data;
+    CREATURE *const tony = item->creature_data;
     int16_t angle = 0;
     int16_t torso_x = 0;
     int16_t torso_y = 0;

--- a/src/trx/game/objects/creatures/torso.c
+++ b/src/trx/game/objects/creatures/torso.c
@@ -73,7 +73,7 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
-    CREATURE *const torso = item->data;
+    CREATURE *const torso = item->creature_data;
     int16_t head = 0;
     ITEM *const lara_item = Lara_GetItem();
 

--- a/src/trx/game/objects/creatures/trex.c
+++ b/src/trx/game/objects/creatures/trex.c
@@ -66,7 +66,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -26,7 +26,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     if (creature == nullptr) {
         return;
     }

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -76,7 +76,7 @@ static void M_Control(const int16_t item_num)
 
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
     M_PRIV *const p = item->priv;
 
     AI_INFO info;

--- a/src/trx/game/objects/creatures/wolf.c
+++ b/src/trx/game/objects/creatures/wolf.c
@@ -62,7 +62,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const wolf = (CREATURE *)item->data;
+    CREATURE *const wolf = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/worker_1.c
+++ b/src/trx/game/objects/creatures/worker_1.c
@@ -46,7 +46,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/worker_2.c
+++ b/src/trx/game/objects/creatures/worker_2.c
@@ -66,7 +66,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t tilt = 0;

--- a/src/trx/game/objects/creatures/worker_3.c
+++ b/src/trx/game/objects/creatures/worker_3.c
@@ -68,7 +68,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t tilt = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/xian_knight.c
+++ b/src/trx/game/objects/creatures/xian_knight.c
@@ -76,7 +76,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t neck = 0;

--- a/src/trx/game/objects/creatures/xian_spearman.c
+++ b/src/trx/game/objects/creatures/xian_spearman.c
@@ -113,7 +113,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t neck = 0;

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -73,7 +73,7 @@ static void M_Control(const int16_t item_num)
     }
 
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     int16_t head = 0;
     int16_t body = 0;

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -189,7 +189,7 @@ bool Object_DrawAnimatingItemWithSwap(
 
     Output_CalculateObjectLighting(item, bounds);
 
-    const int16_t *extra_rotation = item->data;
+    const int16_t *extra_rotation = item->extra_rotations;
 
     Object_DrawInterpolatedObjectWithSwap(
         obj, item->mesh_bits, extra_rotation, frames[0], frames[1], frac, rate,

--- a/src/trx/game/objects/general/alarm_sound.c
+++ b/src/trx/game/objects/general/alarm_sound.c
@@ -3,6 +3,10 @@
 #include <trx/game/output.h>
 #include <trx/game/sound.h>
 
+typedef struct {
+    int32_t counter;
+} M_PRIV;
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -12,20 +16,20 @@ static void M_Control(const int16_t item_num)
 
     Sound_Effect(SFX_PLATFORM_ALARM, &item->pos, SPM_NORMAL);
 
-    int32_t counter = (int32_t)(intptr_t)item->data;
-    counter++;
-    if (counter > 6) {
+    M_PRIV *const p = item->priv;
+    p->counter++;
+    if (p->counter > 6) {
         Output_AddDynamicLight(item->pos, 12, 11);
-        if (counter > 12) {
-            counter = 0;
+        if (p->counter > 12) {
+            p->counter = 0;
         }
     }
-    item->data = (void *)(intptr_t)counter;
 }
 
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
 }
 

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -62,7 +62,7 @@ static void M_Initialise(const int16_t item_num)
         Item_RemoveActive(item_num);
     }
 
-    if (item->data != nullptr) {
+    if (item->creature_data != nullptr) {
         LOT_DisableBaddieAI(item_num);
     }
 

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -1,6 +1,5 @@
 #include <trx/game/objects/general/door.h>
 
-#include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/pathing.h>
@@ -10,14 +9,14 @@ typedef struct {
     SECTOR *sector;
     SECTOR old_sector;
     int16_t box_num;
-} DOORPOS_DATA;
+} M_DOOR_POS;
 
 typedef struct {
-    DOORPOS_DATA d1;
-    DOORPOS_DATA d1flip;
-    DOORPOS_DATA d2;
-    DOORPOS_DATA d2flip;
-} DOOR_DATA;
+    M_DOOR_POS d1;
+    M_DOOR_POS d1flip;
+    M_DOOR_POS d2;
+    M_DOOR_POS d2flip;
+} M_PRIV;
 
 static const SECTOR m_BlockedSector = {
     .idx = 0,
@@ -70,7 +69,7 @@ static void M_CopySectorProperties(
     target_sector->portal_room.wall = source_sector->portal_room.wall;
 }
 
-static void M_Open(DOORPOS_DATA *const d)
+static void M_Open(M_DOOR_POS *const d)
 {
     if (d->sector == nullptr) {
         return;
@@ -84,7 +83,7 @@ static void M_Open(DOORPOS_DATA *const d)
     }
 }
 
-static void M_Check(DOORPOS_DATA *const d)
+static void M_Check(M_DOOR_POS *const d)
 {
     // Forcefully remove the invisible block if Lara happens to occupy the same
     // tile. This ensures that Lara doesn't void if a timed door happens to
@@ -95,7 +94,7 @@ static void M_Check(DOORPOS_DATA *const d)
     }
 }
 
-static void M_Shut(DOORPOS_DATA *const d)
+static void M_Shut(M_DOOR_POS *const d)
 {
     if (d->sector == nullptr) {
         return;
@@ -111,7 +110,7 @@ static void M_Shut(DOORPOS_DATA *const d)
 
 static void M_InitialisePortal(
     const ROOM *const room, const ITEM *const item, const int32_t sector_dx,
-    const int32_t sector_dz, DOORPOS_DATA *const door_pos)
+    const int32_t sector_dz, M_DOOR_POS *const door_pos)
 {
     door_pos->sector = M_GetRoomRelSector(room, item, sector_dx, sector_dz);
 
@@ -135,8 +134,7 @@ static void M_InitialisePortal(
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    DOOR_DATA *door = GameBuf_Alloc(sizeof(DOOR_DATA), GBUF_ITEM_DATA);
-    item->data = door;
+    M_PRIV *const p = item->priv;
 
     int32_t dx = 0;
     int32_t dz = 0;
@@ -152,34 +150,34 @@ static void M_Initialise(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     const ROOM *room = Room_Get(room_num);
-    M_InitialisePortal(room, item, dx, dz, &door->d1);
+    M_InitialisePortal(room, item, dx, dz, &p->d1);
 
     if (room->flipped_room == NO_ROOM) {
-        door->d1flip.sector = nullptr;
+        p->d1flip.sector = nullptr;
     } else {
         room = Room_Get(room->flipped_room);
-        M_InitialisePortal(room, item, dx, dz, &door->d1flip);
+        M_InitialisePortal(room, item, dx, dz, &p->d1flip);
     }
 
-    room_num = door->d1.sector->portal_room.wall;
-    M_Shut(&door->d1);
-    M_Shut(&door->d1flip);
+    room_num = p->d1.sector->portal_room.wall;
+    M_Shut(&p->d1);
+    M_Shut(&p->d1flip);
 
     if (room_num == NO_ROOM) {
-        door->d2.sector = nullptr;
-        door->d2flip.sector = nullptr;
+        p->d2.sector = nullptr;
+        p->d2flip.sector = nullptr;
     } else {
         room = Room_Get(room_num);
-        M_InitialisePortal(room, item, 0, 0, &door->d2);
+        M_InitialisePortal(room, item, 0, 0, &p->d2);
         if (room->flipped_room == NO_ROOM) {
-            door->d2flip.sector = nullptr;
+            p->d2flip.sector = nullptr;
         } else {
             room = Room_Get(room->flipped_room);
-            M_InitialisePortal(room, item, 0, 0, &door->d2flip);
+            M_InitialisePortal(room, item, 0, 0, &p->d2flip);
         }
 
-        M_Shut(&door->d2);
-        M_Shut(&door->d2flip);
+        M_Shut(&p->d2);
+        M_Shut(&p->d2flip);
 
         const int16_t prev_room = item->room_num;
         Item_UpdateRoom(item_num, room_num);
@@ -190,32 +188,32 @@ static void M_Initialise(const int16_t item_num)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    DOOR_DATA *const door = item->data;
+    M_PRIV *const p = item->priv;
 
     if (Item_IsTriggerActive(item)) {
         if (item->current_anim_state == DOOR_STATE_CLOSED) {
             item->goal_anim_state = DOOR_STATE_OPEN;
         } else {
-            M_Open(&door->d1);
-            M_Open(&door->d2);
-            M_Open(&door->d1flip);
-            M_Open(&door->d2flip);
+            M_Open(&p->d1);
+            M_Open(&p->d2);
+            M_Open(&p->d1flip);
+            M_Open(&p->d2flip);
         }
     } else {
         if (item->current_anim_state == DOOR_STATE_OPEN) {
             item->goal_anim_state = DOOR_STATE_CLOSED;
         } else {
-            M_Shut(&door->d1);
-            M_Shut(&door->d2);
-            M_Shut(&door->d1flip);
-            M_Shut(&door->d2flip);
+            M_Shut(&p->d1);
+            M_Shut(&p->d2);
+            M_Shut(&p->d1flip);
+            M_Shut(&p->d2flip);
         }
     }
 
-    M_Check(&door->d1);
-    M_Check(&door->d2);
-    M_Check(&door->d1flip);
-    M_Check(&door->d2flip);
+    M_Check(&p->d1);
+    M_Check(&p->d2);
+    M_Check(&p->d1flip);
+    M_Check(&p->d2flip);
     Item_Animate(item);
 }
 
@@ -225,6 +223,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Door_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
     obj->save_anim = true;
 }

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -26,6 +26,10 @@
 #define M_FLARE_END_AGE_TR3   (M_MAX_FLARE_AGE_TR3 - 24) // = 876
 // clang-format off
 
+typedef struct {
+    int32_t raw_age;
+} M_PRIV;
+
 static XYZ_32 M_TransformLocalOffset(
     const XYZ_32 pos, const XYZ_16 rot, const XYZ_32 local_offset)
 {
@@ -109,7 +113,8 @@ static void M_Control(const int16_t item_num)
 
     Item_UpdateRoom(item_num, room_num);
 
-    int32_t flare_age = ((int32_t)(intptr_t)item->data) & 0x7FFF;
+    int32_t flare_age = FlareItem_GetAge(item);
+    bool is_active = FlareItem_IsActive(item);
     if (flare_age < Flare_GetMaxAge()) {
         flare_age++;
     } else if (item->fall_speed == 0 && item->speed == 0) {
@@ -118,14 +123,12 @@ static void M_Control(const int16_t item_num)
     }
 
     if (Flare_GenerateLight(item->pos, flare_age)) {
-        flare_age |= 0x8000u;
+        is_active = true;
         Flare_GenerateEffects(&item->pos, item->pos, item->room_num);
     }
 
     if (g_TRVersion >= 3) {
-        const int32_t flare_age_plain = flare_age & 0x7FFF;
-        const bool is_active = (flare_age & 0x8000) != 0;
-        if (flare_age_plain < Flare_GetMaxAge() && is_active) {
+        if (flare_age < Flare_GetMaxAge() && is_active) {
             const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
             const XYZ_32 flare_size = {
                 .x = bounds->max.x - bounds->min.x,
@@ -167,7 +170,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    item->data = (void *)(intptr_t)flare_age;
+    FlareItem_SetAge(item, flare_age, is_active);
 }
 
 static void M_DrawFlash(const CLIP clip)
@@ -206,7 +209,7 @@ static bool M_Draw(const ITEM *const item)
 
     Output_CalculateObjectLighting(item, &frames[0]->bounds);
     Object_DrawMesh(Object_Get(O_FLARE_ITEM)->mesh_idx, clip, false);
-    if ((((int32_t)(intptr_t)item->data) & 0x8000) == 0) {
+    if (!FlareItem_IsActive(item)) {
         goto end;
     }
 
@@ -360,12 +363,35 @@ int32_t Flare_GetMaxAge(void)
     return g_TRVersion >= 3 ? M_MAX_FLARE_AGE_TR3 : M_MAX_FLARE_AGE_TR12;
 }
 
+int32_t FlareItem_GetAge(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->raw_age & 0x7FFF;
+}
+
+bool FlareItem_IsActive(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return (p->raw_age & 0x8000) != 0;
+}
+
+void FlareItem_SetAge(
+    ITEM *const item, const int32_t flare_age, const bool is_active)
+{
+    M_PRIV *const p = item->priv;
+    p->raw_age = flare_age & 0x7FFF;
+    if (is_active) {
+        p->raw_age |= 0x8000;
+    }
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = Pickup_Collision;
     obj->bounds_func = Pickup_Bounds;
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_flags = true;
 

--- a/src/trx/game/objects/general/flare_item.h
+++ b/src/trx/game/objects/general/flare_item.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <trx/game/math.h>
+#include <trx/game/objects/types.h>
 
 void Flare_GenerateEffects(
     const XYZ_32 *sound_pos, XYZ_32 flare_pos, int16_t room_num);
 bool Flare_GenerateLight(XYZ_32 pos, int32_t flare_age);
 int32_t Flare_GetMaxAge(void);
+int32_t FlareItem_GetAge(const ITEM *item);
+bool FlareItem_IsActive(const ITEM *item);
+void FlareItem_SetAge(ITEM *item, int32_t flare_age, bool is_active);

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -68,15 +68,27 @@ static const OBJECT_BOUNDS m_PickUpBoundsUW = {
 static const XYZ_32 m_PickupPosition = { .x = 0, .y = 0, .z = -100 };
 static const XYZ_32 m_PickupPositionUW = { .x = 0, .y = -200, .z = -350 };
 
+typedef struct {
+    int32_t aid_timer;
+    uint32_t secret_mask;
+} M_PRIV;
+
+uint32_t Pickup_GetSecretMask(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->secret_mask;
+}
+
 static void M_Initialise(int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    item->priv = (void *)(intptr_t)(-1);
+    M_PRIV *const p = item->priv;
+    p->aid_timer = -1;
+    p->secret_mask = 0;
 
     if (Object_IsType(item->object_id, g_SecretObjects)) {
         const GF_LEVEL *const level = Game_GetCurrentLevel();
-        item->data =
-            (void *)(intptr_t)Stats_GetSecretMaskForItem(level, item_num);
+        p->secret_mask = Stats_GetSecretMaskForItem(level, item_num);
     }
 
     if (item->status != IS_INVISIBLE) {
@@ -163,7 +175,8 @@ static void M_ControlPickupAids(ITEM *const item)
         return;
     }
 
-    int32_t timer = (int32_t)(intptr_t)item->priv;
+    M_PRIV *const p = item->priv;
+    int32_t timer = p->aid_timer;
     if (timer <= 0
         || (timer < M_AID_WAIT_MIN
             && Random_GetDraw() < M_AID_WAIT_BREAK_CHANCE)) {
@@ -173,7 +186,7 @@ static void M_ControlPickupAids(ITEM *const item)
         timer--;
     }
 
-    item->priv = (void *)(intptr_t)(int32_t)timer;
+    p->aid_timer = timer;
 }
 
 static void M_ControlPickupLights(ITEM *const item)
@@ -502,6 +515,7 @@ static void M_Setup(OBJECT *const obj)
     obj->draw_func = Object_DrawPickupItem;
     obj->initialise_func = M_Initialise;
     obj->handle_save_func = M_HandleSave;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_flags = true;
 }

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -8,6 +8,7 @@
 #include <trx/game/items/anim.h>
 #include <trx/game/lara.h>
 #include <trx/game/lua.h>
+#include <trx/game/objects/general/flare_item.h>
 #include <trx/game/output.h>
 #include <trx/game/overlay.h>
 #include <trx/game/random.h>
@@ -251,7 +252,7 @@ static void M_DoFlarePickup(const int16_t item_num)
     lara->gun_type = LGT_FLARE;
     Gun_InitialiseNewWeapon();
     lara->gun_status = LGS_SPECIAL;
-    lara->flare.age = ((int32_t)(intptr_t)item->data) & 0x7FFF;
+    lara->flare.age = FlareItem_GetAge(item);
     Item_Kill(item_num);
     lara->interact_target.is_moving = false;
 }

--- a/src/trx/game/objects/general/pickup.h
+++ b/src/trx/game/objects/general/pickup.h
@@ -2,6 +2,9 @@
 
 #include <trx/game/objects/types.h>
 
+#include <stdint.h>
+
 bool Pickup_Trigger(int16_t item_num);
 const OBJECT_BOUNDS *Pickup_Bounds(void);
 void Pickup_Collision(int16_t item_num, ITEM *lara_item, COLL_INFO *coll);
+uint32_t Pickup_GetSecretMask(const ITEM *item);

--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -10,6 +10,7 @@
 
 typedef struct {
     bool initialised;
+    bool used_for_save;
     int16_t initial_angle;
 } M_PRIV;
 
@@ -76,10 +77,11 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
         break;
 
     case SAVEGAME_STAGE_BEFORE_SAVE:
-        if (item->data != nullptr) {
+        M_PRIV *const p = item->priv;
+        if (p->used_for_save) {
             // need to reset the crystal status
             item->status = IS_DEACTIVATED;
-            item->data = nullptr;
+            p->used_for_save = false;
             const int16_t item_num = Item_GetIndex(item);
             Item_RemoveDrawn(item_num);
         }
@@ -176,7 +178,8 @@ static void M_CollisionSave(
         return;
     }
 
-    item->data = (void *)1;
+    M_PRIV *const p = item->priv;
+    p->used_for_save = true;
     GF_ShowInventory(INV_SAVE_CRYSTAL_MODE);
 }
 

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -1,4 +1,3 @@
-#include <trx/game/game_buf.h>
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/game/math.h>
@@ -7,6 +6,10 @@
 
 #define ZIPLINE_MAX_SPEED 100
 #define ZIPLINE_ACCELERATION 5
+
+typedef struct {
+    GAME_VECTOR old_pos;
+} M_PRIV;
 
 typedef enum {
     ZIPLINE_STATE_EMPTY = 0,
@@ -39,11 +42,9 @@ static const OBJECT_BOUNDS *M_Bounds(void)
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    GAME_VECTOR *const data =
-        GameBuf_Alloc(sizeof(GAME_VECTOR), GBUF_ITEM_DATA);
-    data->pos = item->pos;
-    data->room_num = item->room_num;
-    item->data = data;
+    M_PRIV *const p = item->priv;
+    p->old_pos.pos = item->pos;
+    p->old_pos.room_num = item->room_num;
 }
 
 static void M_Control(const int16_t item_num)
@@ -54,9 +55,9 @@ static void M_Control(const int16_t item_num)
     }
 
     if (!(item->flags & IF_ONE_SHOT)) {
-        const GAME_VECTOR *const old = item->data;
-        item->pos = old->pos;
-        Item_UpdateRoom(item_num, old->room_num);
+        const M_PRIV *const p = item->priv;
+        item->pos = p->old_pos.pos;
+        Item_UpdateRoom(item_num, p->old_pos.room_num);
         item->status = IS_INACTIVE;
         item->goal_anim_state = ZIPLINE_STATE_GRAB;
         item->current_anim_state = ZIPLINE_STATE_GRAB;
@@ -157,6 +158,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/traps/common.c
+++ b/src/trx/game/objects/traps/common.c
@@ -7,17 +7,16 @@
 void Trap_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    GAME_VECTOR *const data =
-        GameBuf_Alloc(sizeof(GAME_VECTOR), GBUF_ITEM_DATA);
+    TRAP_DATA *const data = GameBuf_Alloc(sizeof(TRAP_DATA), GBUF_ITEM_DATA);
     data->pos = item->pos;
     data->room_num = item->room_num;
-    item->data = data;
+    item->trap_data = data;
 }
 
 void Trap_Reset(ITEM *const item)
 {
+    const TRAP_DATA *const data = item->trap_data;
     const int16_t item_num = Item_GetIndex(item);
-    const GAME_VECTOR *const data = item->data;
 
     item->status = IS_INACTIVE;
     item->pos = data->pos;

--- a/src/trx/game/objects/traps/common.h
+++ b/src/trx/game/objects/traps/common.h
@@ -2,5 +2,10 @@
 
 #include <trx/game/items.h>
 
+typedef struct TRAP_DATA {
+    XYZ_32 pos;
+    int16_t room_num;
+} TRAP_DATA;
+
 void Trap_Initialise(int16_t item_num);
 void Trap_Reset(ITEM *item);

--- a/src/trx/game/objects/traps/dying_monk.c
+++ b/src/trx/game/objects/traps/dying_monk.c
@@ -1,5 +1,4 @@
 #include <trx/game/game.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
@@ -7,14 +6,16 @@
 
 #define MAX_ROOMIES 2
 
+typedef struct {
+    int32_t roomies[MAX_ROOMIES];
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-
-    int32_t *const roomies =
-        GameBuf_Alloc(sizeof(int32_t) * MAX_ROOMIES, GBUF_ITEM_DATA);
+    M_PRIV *const p = item->priv;
     for (int32_t i = 0; i < MAX_ROOMIES; i++) {
-        roomies[i] = NO_ITEM;
+        p->roomies[i] = NO_ITEM;
     }
 
     int32_t roomie_count = 0;
@@ -23,24 +24,22 @@ static void M_Initialise(const int16_t item_num)
         const ITEM *const test_item = Item_Get(test_item_num);
         const OBJECT *const test_obj = Object_Get(test_item->object_id);
         if (test_obj->intelligent) {
-            roomies[roomie_count++] = test_item_num;
+            p->roomies[roomie_count++] = test_item_num;
             if (roomie_count >= MAX_ROOMIES) {
                 break;
             }
         }
         test_item_num = test_item->next_item;
     }
-
-    item->data = roomies;
 }
 
 static void M_Control(const int16_t item_num)
 {
     const ITEM *const item = Item_Get(item_num);
-    const int32_t *const roomies = item->data;
+    const M_PRIV *const p = item->priv;
 
     for (int32_t i = 0; i < MAX_ROOMIES; i++) {
-        int32_t test_item_num = roomies[i];
+        int32_t test_item_num = p->roomies[i];
         if (test_item_num != NO_ITEM) {
             const ITEM *const test_item = Item_Get(test_item_num);
             if (test_item->hit_points > 0) {
@@ -63,6 +62,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
 }
 

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -28,7 +28,6 @@ static void M_CalculateOrigin(ITEM *const item)
 static void M_Initialise(const int16_t item_num)
 {
     Trap_Initialise(item_num);
-
     ITEM *const item = Item_Get(item_num);
     M_CalculateOrigin(item);
 }

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -1,6 +1,5 @@
 #include <trx/game/collision.h>
 #include <trx/game/game.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
 #include <trx/game/output.h>
@@ -24,35 +23,34 @@ typedef struct {
     XYZ_32 main[M_STEPS];
     XYZ_32 wibble[M_STEPS];
     XYZ_32 shoot[M_SHOOTS][M_STEPS];
-} M_LIGHTNING;
+} M_PRIV;
 
 static void M_Initialise(const int16_t item_num)
 {
-    M_LIGHTNING *l = GameBuf_Alloc(sizeof(M_LIGHTNING), GBUF_ITEM_DATA);
     ITEM *const item = Item_Get(item_num);
-    item->data = l;
+    M_PRIV *const p = item->priv;
 
     if (Object_Get(item->object_id)->mesh_count > 1) {
         item->mesh_bits = 1;
-        l->no_target = false;
+        p->no_target = false;
     } else {
-        l->no_target = true;
+        p->no_target = true;
     }
 
-    l->active = false;
-    l->count = 1;
-    l->zapped = false;
+    p->active = false;
+    p->count = 1;
+    p->zapped = false;
 }
 
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    M_LIGHTNING *l = item->data;
+    M_PRIV *const p = item->priv;
 
     if (!Item_IsTriggerActive(item)) {
-        l->count = 1;
-        l->active = false;
-        l->zapped = false;
+        p->count = 1;
+        p->active = false;
+        p->zapped = false;
 
         if (Room_GetFlipStatus()) {
             Room_FlipMap();
@@ -63,66 +61,66 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    l->count--;
-    if (l->count > 0) {
+    p->count--;
+    if (p->count > 0) {
         return;
     }
 
-    if (l->active) {
-        l->active = false;
-        l->count = 35 + (Random_GetControl() * 45) / 0x8000;
-        l->zapped = false;
+    if (p->active) {
+        p->active = false;
+        p->count = 35 + (Random_GetControl() * 45) / 0x8000;
+        p->zapped = false;
         if (Room_GetFlipStatus()) {
             Room_FlipMap();
         }
     } else {
-        l->active = true;
-        l->count = 20;
+        p->active = true;
+        p->count = 20;
 
         for (int32_t i = 0; i < M_STEPS; i++) {
-            l->wibble[i].x = 0;
-            l->wibble[i].y = 0;
-            l->wibble[i].z = 0;
+            p->wibble[i].x = 0;
+            p->wibble[i].y = 0;
+            p->wibble[i].z = 0;
         }
 
-        const int32_t radius = l->no_target ? WALL_L : WALL_L * 5 / 2;
+        const int32_t radius = p->no_target ? WALL_L : WALL_L * 5 / 2;
         if (Lara_IsNearItem(&item->pos, radius)) {
             const ITEM *const lara_item = Lara_GetItem();
-            l->target.x = lara_item->pos.x;
-            l->target.y = lara_item->pos.y;
-            l->target.z = lara_item->pos.z;
+            p->target.x = lara_item->pos.x;
+            p->target.y = lara_item->pos.y;
+            p->target.z = lara_item->pos.z;
 
             Lara_TakeDamage(M_DAMAGE, true);
 
-            l->zapped = true;
-        } else if (l->no_target) {
+            p->zapped = true;
+        } else if (p->no_target) {
             const SECTOR *const sector = Room_GetSector(
                 item->pos.x, item->pos.y, item->pos.z, &item->room_num);
             const int32_t h =
                 Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-            l->target.x = item->pos.x;
-            l->target.y = h;
-            l->target.z = item->pos.z;
-            l->zapped = false;
+            p->target.x = item->pos.x;
+            p->target.y = h;
+            p->target.z = item->pos.z;
+            p->zapped = false;
         } else {
-            l->target.x = 0;
-            l->target.y = 0;
-            l->target.z = 0;
+            p->target.x = 0;
+            p->target.y = 0;
+            p->target.z = 0;
             Collide_GetJointAbsPosition(
-                item, &l->target, 1 + (Random_GetControl() * 5) / 0x7FFF);
-            l->zapped = false;
+                item, &p->target, 1 + (Random_GetControl() * 5) / 0x7FFF);
+            p->zapped = false;
         }
 
         for (int32_t i = 0; i < M_SHOOTS; i++) {
-            l->start[i] = Random_GetControl() * (M_STEPS - 1) / 0x7FFF;
-            l->end[i].x = l->target.x + (Random_GetControl() * WALL_L) / 0x7FFF;
-            l->end[i].y = l->target.y;
-            l->end[i].z = l->target.z + (Random_GetControl() * WALL_L) / 0x7FFF;
+            p->start[i] = Random_GetControl() * (M_STEPS - 1) / 0x7FFF;
+            p->end[i].x = p->target.x + (Random_GetControl() * WALL_L) / 0x7FFF;
+            p->end[i].y = p->target.y;
+            p->end[i].z = p->target.z + (Random_GetControl() * WALL_L) / 0x7FFF;
 
             for (int32_t j = 0; j < M_STEPS; j++) {
-                l->shoot[i][j].x = 0;
-                l->shoot[i][j].y = 0;
-                l->shoot[i][j].z = 0;
+                p->shoot[i][j].x = 0;
+                p->shoot[i][j].y = 0;
+                p->shoot[i][j].z = 0;
             }
         }
 
@@ -137,8 +135,9 @@ static void M_Control(const int16_t item_num)
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
-    const M_LIGHTNING *const l = Item_Get(item_num)->data;
-    if (!l->zapped) {
+    const ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
+    if (!p->zapped) {
         return;
     }
 
@@ -150,14 +149,12 @@ static void M_Collision(
 
 static void M_DrawBolts(const ITEM *const item)
 {
-    const OBJECT *const obj = Object_Get(O_LIGHTNING_EMITTER);
-
     ANIM_FRAME *frmptr[2];
     int32_t rate;
     Item_GetFrames(item, frmptr, &rate);
 
-    M_LIGHTNING *l = item->data;
-    if (!l->active) {
+    M_PRIV *const p = item->priv;
+    if (!p->active) {
         return;
     }
 
@@ -165,16 +162,16 @@ static void M_DrawBolts(const ITEM *const item)
     int32_t y1 = item->interp.result.pos.y + frmptr[0]->offset.y;
     int32_t z1 = item->interp.result.pos.z + frmptr[0]->offset.z;
 
-    int32_t x2 = l->target.x;
-    int32_t y2 = l->target.y;
-    int32_t z2 = l->target.z;
+    int32_t x2 = p->target.x;
+    int32_t y2 = p->target.y;
+    int32_t z2 = p->target.z;
 
     int32_t dx = (x2 - x1) / M_STEPS;
     int32_t dy = (y2 - y1) / M_STEPS;
     int32_t dz = (z2 - z1) / M_STEPS;
 
     for (int32_t i = 0; i < M_STEPS; i++) {
-        XYZ_32 *pos = &l->wibble[i];
+        XYZ_32 *pos = &p->wibble[i];
         if (Game_IsPlaying()) {
             pos->x += (Random_GetDraw() - 0x4000) * M_RND / 0x8000;
             pos->y += (Random_GetDraw() - 0x4000) * M_RND / 0x8000;
@@ -190,7 +187,7 @@ static void M_DrawBolts(const ITEM *const item)
 
         if (i > 0) {
             Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
-                .from = { x1, y1 + l->wibble[i - 1].y, z1 },
+                .from = { x1, y1 + p->wibble[i - 1].y, z1 },
                 .to = { x2, y2, z2 },
                 .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 6 });
         } else {
@@ -204,20 +201,20 @@ static void M_DrawBolts(const ITEM *const item)
         y1 += dy;
         z1 = z2;
 
-        l->main[i].x = x2;
-        l->main[i].y = y2;
-        l->main[i].z = z2;
+        p->main[i].x = x2;
+        p->main[i].y = y2;
+        p->main[i].z = z2;
     }
 
     for (int32_t i = 0; i < M_SHOOTS; i++) {
-        int32_t j = l->start[i];
-        x1 = l->main[j].x;
-        y1 = l->main[j].y;
-        z1 = l->main[j].z;
+        int32_t j = p->start[i];
+        x1 = p->main[j].x;
+        y1 = p->main[j].y;
+        z1 = p->main[j].z;
 
-        x2 = l->end[i].x;
-        y2 = l->end[i].y;
-        z2 = l->end[i].z;
+        x2 = p->end[i].x;
+        y2 = p->end[i].y;
+        z2 = p->end[i].z;
 
         int32_t steps = M_STEPS - j;
         dx = (x2 - x1) / steps;
@@ -225,7 +222,7 @@ static void M_DrawBolts(const ITEM *const item)
         dz = (z2 - z1) / steps;
 
         for (int32_t k = 0; k < steps; k++) {
-            XYZ_32 *pos = &l->shoot[i][k];
+            XYZ_32 *pos = &p->shoot[i][k];
             if (Game_IsPlaying()) {
                 pos->x += (Random_GetDraw() - 0x4000) * M_RND / 0x8000;
                 pos->y += (Random_GetDraw() - 0x4000) * M_RND / 0x8000;
@@ -241,7 +238,7 @@ static void M_DrawBolts(const ITEM *const item)
 
             if (k > 0) {
                 Output_DrawLightningSegment((LIGHTNING_SEGMENT) {
-                    .from = { x1, y1 + l->shoot[i][k - 1].y, z1 },
+                    .from = { x1, y1 + p->shoot[i][k - 1].y, z1 },
                     .to = { x2, y2, z2 },
                     .thickness = Viewport_GetWidth(VIEWPORT_GAME) / 16 });
             } else {
@@ -290,6 +287,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->draw_func = M_Draw;
     obj->collision_func = M_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
 }
 

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -2,7 +2,6 @@
 
 #include <trx/config.h>
 #include <trx/game/camera.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/input.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -25,14 +24,11 @@ typedef enum {
 } MOVABLE_BLOCK_STATE;
 
 typedef struct {
-    int16_t counter_rot[3];
-    int16_t original_rot;
-} M_EXTRA_ROTATIONS;
-
-typedef struct {
     uint16_t gravity_frames;
     bool is_push_pull;
     bool is_forced_moving;
+    int16_t extra_rotations[3];
+    int16_t original_rot;
     GAME_VECTOR initial;
     GAME_VECTOR linked;
 } M_PRIV;
@@ -59,11 +55,11 @@ static void M_GetStack(
 static void M_UpdateRotation(ITEM *const item, const int16_t rot_y)
 {
     item->rot.y = rot_y;
-    M_EXTRA_ROTATIONS *const data = item->data;
+    M_PRIV *const p = item->priv;
     // All 3 indices are potentially used in other parts of the code that can
-    // cast item->data to structs such as XYZ_16. This is similar to things such
-    // as the compass needle that apply extra rotation.
-    data->counter_rot[0] = data->original_rot - rot_y;
+    // cast item->extra_rotations to structs such as XYZ_16. This is similar to
+    // things such as the compass needle that apply extra rotation.
+    p->extra_rotations[0] = p->original_rot - rot_y;
 }
 
 // Indicates if Lara is currently pushing or pulling a block.
@@ -150,11 +146,10 @@ static void M_LoadPriv(ITEM *const item, SG_READ_IO *const io)
         SG_SHOULD(SG_POP(io));
     }
 
-    M_EXTRA_ROTATIONS *const data = item->data;
-    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_0", &data->counter_rot[0]));
-    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_1", &data->counter_rot[1]));
-    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_2", &data->counter_rot[2]));
-    SG_SHOULD(SG_READ_VALUE(io, "original_rot", &data->original_rot));
+    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_0", &p->extra_rotations[0]));
+    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_1", &p->extra_rotations[1]));
+    SG_SHOULD(SG_READ_VALUE(io, "counter_rot_2", &p->extra_rotations[2]));
+    SG_SHOULD(SG_READ_VALUE(io, "original_rot", &p->original_rot));
 }
 
 static void M_SavePriv(const ITEM *const item, SG_WRITE_IO *const io)
@@ -170,11 +165,10 @@ static void M_SavePriv(const ITEM *const item, SG_WRITE_IO *const io)
     SGW_WRITE_VALUE(io, "z", p->linked.pos.z);
     SGW_POP_AND_SET(io, "linked");
 
-    const M_EXTRA_ROTATIONS *const data = item->data;
-    SGW_WRITE_VALUE(io, "counter_rot_0", data->counter_rot[0]);
-    SGW_WRITE_VALUE(io, "counter_rot_1", data->counter_rot[1]);
-    SGW_WRITE_VALUE(io, "counter_rot_2", data->counter_rot[2]);
-    SGW_WRITE_VALUE(io, "original_rot", data->original_rot);
+    SGW_WRITE_VALUE(io, "counter_rot_0", p->extra_rotations[0]);
+    SGW_WRITE_VALUE(io, "counter_rot_1", p->extra_rotations[1]);
+    SGW_WRITE_VALUE(io, "counter_rot_2", p->extra_rotations[2]);
+    SGW_WRITE_VALUE(io, "original_rot", p->original_rot);
 }
 
 static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
@@ -461,14 +455,12 @@ static void M_Initialise(const int16_t item_num)
     // during collision tests and can appear jarring. Additional angles are
     // stored to preserve item appearance in spite of control angle changes.
     ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
 
-    M_EXTRA_ROTATIONS *const data =
-        GameBuf_Alloc(sizeof(XYZ_16), GBUF_ITEM_DATA);
-    item->data = data;
-    data->original_rot =
-        (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
+    item->extra_rotations = p->extra_rotations;
+    p->original_rot = (((item->rot.y + DEG_180) / DEG_90) * DEG_90) - DEG_180;
 
-    M_UpdateRotation(item, data->original_rot);
+    M_UpdateRotation(item, p->original_rot);
     M_SetGravityFrames(item, 0);
     M_SetPushPull(item, false);
     M_SetForcedMoving(item, false);

--- a/src/trx/game/objects/traps/thors_hammer.c
+++ b/src/trx/game/objects/traps/thors_hammer.c
@@ -11,9 +11,14 @@ typedef enum {
     THOR_HAMMER_STATE_DONE = 3,
 } THOR_HAMMER_STATE;
 
+typedef struct {
+    int16_t head_item_num;
+} M_PRIV;
+
 static void M_InitialiseHandle(const int16_t item_num)
 {
     ITEM *const hand_item = Item_Get(item_num);
+    M_PRIV *const p = hand_item->priv;
     const int16_t head_item_num = Item_CreateLevelItem();
     ASSERT(head_item_num != NO_ITEM);
     ITEM *const head_item = Item_Get(head_item_num);
@@ -23,7 +28,7 @@ static void M_InitialiseHandle(const int16_t item_num)
     head_item->rot = hand_item->rot;
     head_item->shade.value_1 = hand_item->shade.value_1;
     Item_Initialise(head_item_num);
-    hand_item->data = head_item;
+    p->head_item_num = head_item_num;
 }
 
 static void M_ControlHandle(const int16_t item_num)
@@ -123,7 +128,8 @@ static void M_ControlHandle(const int16_t item_num)
     }
     Item_Animate(item);
 
-    ITEM *const head_item = item->data;
+    M_PRIV *const p = item->priv;
+    ITEM *const head_item = Item_Get(p->head_item_num);
     const int16_t relative_anim = Item_GetRelativeAnim(item);
     const int16_t relative_frame = Item_GetRelativeFrame(item);
     Item_SwitchToAnim(head_item, relative_anim, relative_frame);
@@ -161,6 +167,7 @@ static void M_SetupHandle(OBJECT *const obj)
     obj->control_func = M_ControlHandle;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = M_CollisionHandle;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
     obj->save_anim = true;
 }

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -75,6 +75,7 @@ typedef struct OBJECT {
     const OBJECT_BOUNDS *(*bounds_func)(void);
     bool (*is_usable_func)(int16_t item_num);
     void (*add_walkable_func)(int16_t item_num);
+    int16_t (*carrier_item_num_func)(const ITEM *item);
     bool (*can_interpolate_func)(
         const ITEM *item, int32_t frame_a, int32_t frame_b);
 

--- a/src/trx/game/objects/vars.c
+++ b/src/trx/game/objects/vars.c
@@ -187,16 +187,6 @@ const OBJECT_ID g_MovableBlockObjects[] = {
     // clang-format on
 };
 
-const OBJECT_ID g_PlaceholderObjects[] = {
-    // clang-format off
-    O_CENTAUR_STATUE,
-    O_PODS,
-    O_BIG_POD,
-    O_BARTOLI,
-    NO_OBJECT,
-    // clang-format on
-};
-
 const OBJECT_ID g_SecretObjects[] = {
     // clang-format off
     O_SECRET_1,

--- a/src/trx/game/objects/vars.h
+++ b/src/trx/game/objects/vars.h
@@ -20,7 +20,6 @@ extern const OBJECT_ID g_NullObjects[];
 extern const OBJECT_ID g_InvObjects[];
 extern const OBJECT_ID g_WaterSpriteObjects[];
 extern const OBJECT_ID g_BossObjects[];
-extern const OBJECT_ID g_PlaceholderObjects[];
 extern const OBJECT_ID g_SecretObjects[];
 extern const OBJECT_ID g_MovableBlockObjects[];
 extern const OBJECT_ID g_GameSpriteObjects[];

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -204,7 +204,7 @@ static void M_Initialise(const int16_t item_num)
         p->extra_rotation = nullptr;
     }
 
-    item->data = p->extra_rotation;
+    item->extra_rotations = p->extra_rotation;
 }
 
 static int32_t M_GetOnQuadBike(

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -277,7 +277,7 @@ bool Box_EscapeBox(
 bool Box_ValidBox(
     const ITEM *item, const int16_t zone_num, const int16_t box_num)
 {
-    const CREATURE *const creature = item->data;
+    const CREATURE *const creature = item->creature_data;
     const int16_t *const zone = Box_GetLotZone(&creature->lot);
     const bool use_fixed_fly_zone =
         g_TRVersion == 3 && creature->lot.setup.fly != 0;

--- a/src/trx/game/pathing/lot.c
+++ b/src/trx/game/pathing/lot.c
@@ -90,8 +90,9 @@ CREATURE *LOT_GetBaddieSlot(const int32_t i)
 void LOT_DisableBaddieAI(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    CREATURE *const creature = (CREATURE *)item->data;
-    item->data = nullptr;
+    CREATURE *const creature = item->creature_data;
+    item->creature_data = nullptr;
+    item->extra_rotations = nullptr;
 
     if (creature != nullptr) {
         creature->item_num = NO_ITEM;
@@ -101,7 +102,7 @@ void LOT_DisableBaddieAI(const int16_t item_num)
 
 bool LOT_EnableBaddieAI(const int16_t item_num, const bool always)
 {
-    if (Item_Get(item_num)->data != nullptr) {
+    if (Item_Get(item_num)->creature_data != nullptr) {
         return true;
     }
 
@@ -152,7 +153,8 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
 {
     CREATURE *const creature = &m_BaddieSlots[slot];
     ITEM *const item = Item_Get(item_num);
-    item->data = creature;
+    item->creature_data = creature;
+    item->extra_rotations = creature->joint_rotation;
 
     creature->item_num = item_num;
     creature->mood = MOOD_BORED;
@@ -182,7 +184,7 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
 
 void LOT_CreateZone(ITEM *const item)
 {
-    CREATURE *const creature = item->data;
+    CREATURE *const creature = item->creature_data;
 
     const int16_t *zone;
     const int16_t *flip;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -11,6 +11,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/general/flare_item.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/output.h>
 #include <trx/game/pathing.h>
@@ -544,7 +545,7 @@ static bool M_ReadFlare(SG_READ_IO *const io)
     M_MUST(SG_READ_VALUE(io, "fall_speed", &item->fall_speed));
     int32_t flare_age;
     M_MUST(SG_READ_VALUE(io, "age", &flare_age));
-    item->data = (void *)(intptr_t)flare_age;
+    FlareItem_SetAge(item, flare_age & 0x7FFF, (flare_age & 0x8000) != 0);
     Item_AddActive(item_num);
     M_FINISH();
 }

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -395,7 +395,7 @@ static bool M_ReadItem(SG_READ_IO *const io, const int16_t item_num)
         M_SHOULD(SG_READ_VALUE(io, "intelligent", &intelligent));
         if (intelligent) {
             LOT_EnableBaddieAI(item_num, true);
-            CREATURE *const creature = item->data;
+            CREATURE *const creature = item->creature_data;
             if (creature != nullptr) {
                 M_MUST(SG_READ_VALUE(io, "head_rot", &creature->head_rotation));
                 M_MUST(SG_READ_VALUE(io, "neck_rot", &creature->neck_rotation));
@@ -429,7 +429,8 @@ static bool M_ReadItem(SG_READ_IO *const io, const int16_t item_num)
                 }
             }
         } else if (obj->intelligent) {
-            item->data = nullptr;
+            item->creature_data = nullptr;
+            item->extra_rotations = nullptr;
             if (item->clear_body && item->hit_points <= 0
                 && (item->flags & IF_KILLED) == 0) {
                 item->next_active = Item_GetPrevActive();

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -92,13 +92,14 @@ static void M_WriteItem(
         SGW_WRITE_VALUE(io, "active", item->active);
         SGW_WRITE_VALUE(io, "gravity", item->gravity);
         SGW_WRITE_VALUE(io, "collidable", item->collidable);
-        const bool intelligent = obj->intelligent && item->data != nullptr;
+        const bool intelligent =
+            obj->intelligent && item->creature_data != nullptr;
         SGW_WRITE_VALUE(io, "intelligent", intelligent);
         SGW_WRITE_VALUE(io, "timer", item->timer);
         SGW_WRITE_VALUE_NZ(io, "ai_bits", item->ai_bits);
         SGW_WRITE_VALUE_NZ(io, "ai_tag", item->ai_tag);
         if (intelligent) {
-            const CREATURE *const creature = item->data;
+            const CREATURE *const creature = item->creature_data;
             SGW_WRITE_VALUE(io, "head_rot", creature->head_rotation);
             SGW_WRITE_VALUE(io, "neck_rot", creature->neck_rotation);
             SGW_WRITE_VALUE(io, "max_turn", creature->maximum_turn);

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -9,6 +9,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/general/flare_item.h>
 #include <trx/game/output.h>
 #include <trx/game/rooms.h>
 #include <trx/game/savegame.h>
@@ -268,7 +269,9 @@ void SG_File_DumpFlares(SG_WRITE_IO *const io)
         SGW_WRITE_VALUE(io, "room_num", item->room_num);
         SGW_WRITE_VALUE(io, "speed", item->speed);
         SGW_WRITE_VALUE(io, "fall_speed", item->fall_speed);
-        SGW_WRITE_VALUE(io, "age", (int32_t)(intptr_t)item->data);
+        const int32_t flare_age = FlareItem_GetAge(item);
+        const int32_t active = FlareItem_IsActive(item) ? 0x8000 : 0;
+        SGW_WRITE_VALUE(io, "age", flare_age | active);
         SGW_POP_AND_APPEND(io);
     }
     SGW_POP_AND_SET(io, "flares");

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -1,6 +1,7 @@
 #include <trx/debug.h>
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
+#include <trx/game/objects/general/pickup.h>
 #include <trx/game/savegame.h>
 #include <trx/game/stats.h>
 #include <trx/log.h>
@@ -85,7 +86,7 @@ void Stats_UpdateSecrets(LEVEL_STATS *const stats)
 void Stats_MarkSecretCollected(const ITEM *const item)
 {
     RESUME_INFO *const resume = Savegame_GetCurrentInfo(Game_GetCurrentLevel());
-    resume->stats.secret_flags |= (uint32_t)(intptr_t)item->data;
+    resume->stats.secret_flags |= Pickup_GetSecretMask(item);
     Stats_UpdateSecrets(&resume->stats);
 }
 

--- a/src/trx/game/stats/scan.c
+++ b/src/trx/game/stats/scan.c
@@ -245,9 +245,9 @@ static void M_CalculateStats(LEVEL_MAX_STATS *const stats)
     }
 
     // Assign secret items their bits so they know which secret to set on
-    // pickup. NOTE: Do not persist to item->data here. This scan runs at game
-    // launch to compute max stats; later, gameplay level loads restore
-    // item->data using cached info in LEVEL_MAX_STATS.
+    // pickup. NOTE: Do not persist runtime pickup state here. This scan runs
+    // at game launch to compute max stats; gameplay level loads restore secret
+    // masks using cached info in LEVEL_MAX_STATS.
     for (int32_t i = 0; i < STATS_MAX_SECRETS; i++) {
         const int32_t item_num = stats->secret_objects[i].item_num;
         if (item_num == NO_ITEM) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR finishes the `item->data` migration by splitting responsibilities into typed item fields: `CREATURE *creature_data`, `TRAP_DATA *trap_data`, and `int16_t *extra_rotations`.
It also migrates all affected gameplay objects away from encoded/punned `item->data` usage into `priv` structs or explicit typed fields, and removes placeholder-carrier indirection in favor of per-object carrier callbacks.

The behavior is intended to stay the same, but the data flow is now much clearer and safer for future TR1/TR2/TR3 work: creature pointers are creature-only, trap reset state is trap-only, and render extra rotations are explicit.

Note: Lara's item for some unknown reason had her `data` set to `lara_info`. I have removed that line and it _should_ work okay, but this assignment was so bizarre that I wanted to highlight it.

#### Testing

- [x] General messing about
  Load a TR1, TR2, and TR3 level with mixed enemies/traps/vehicles, play for 2-3 minutes, save+load once, and confirm no broken AI activation, animation joints, or dropped-item behavior.
- [x] Creature joint rotations
  Play with Shivas and confirm they continue to go out of their way to look directly at Lara.
- [x] `O_DOOR_TYPE_1…8`
  Open/close any door type with normal means, and verify collision/portal blocking updates correctly before and after save+load.
- [x] `O_ZIPLINE_HANDLE`
  Ride once, let it reset, and confirm reset position/room is restored exactly after deactivation and after save+load.
- [x] `O_ALARM_SOUND`
  Trigger alarm and verify periodic dynamic light pulse cadence remains stable over time and after save+load.
- [x] `O_SAVE_CRYSTAL_ITEM`
  Use a crystal to save, confirm the save state was created and crystal disappeared, and that loading the state has the crystal consumed.
- [x] `O_DYING_MONK`
  Kill the baddies in Diving Area and verify monk trigger progression happens only when both goons are dead.
- [x] `O_EEL` / `O_BIG_EEL`
  Engage both eel variants and verify slide/attack/death movement offsets remain correct.
- [x] `O_BARTOLI`
  Start Bartoli sequence and verify delayed dragon conversion still happens at the same timing, and survives save+load.
- [x] `O_DRAGON_BACK` / `O_DRAGON_FRONT`
  After activation, verify front/back linkage, collision, death flow, and post-death handling remain intact, and survives save+load mid-fight and after death.
- [x] `O_SKIDOO_DRIVER`
  Kill driver and verify skidoo transition behavior remains correct, and survives save+load mid-fight and after death.
- [x] `O_THORS_HANDLE`
  Trigger handle/head sequence and verify linked head animation stays frame-synced through the full cycle.
- [x] `O_LIGHTNING_EMITTER`
  Trigger repeatedly and verify active/inactive cadence, zapping behavior, flip-map toggles, and bolt rendering consistency.
- [x] `O_PODS` / `O_BIG_POD` / `O_CENTAUR_STATUE`
  Trigger the pod explosion and verify mutants get spawned, and save+load behaves as expected.
- [x] `O_FLARE_ITEM`
  Drop and pick up a flare and verify age/light-active state persists correctly through save+load.
    - [x] Throw lit flare, leave it active on floor for a while, save+load, and confirm it resumes with expected light/smoke behavior and age doesn't get reset.
    - [x] Pick up world flare and confirm Lara receives the expected flare age (eg it's not possible to renew flare by throwing it away and picking it up again).
    - [x] Confirm that the infinite flare age continues to work as intended
- [x] Pickup objects
    - [x] Pick up standard pickups, confirm they work as expected.
    - [x] Pick up TR2 dragons and verify they do not change randomly colors in the stats – confirm with a few levels. I think Floater was a good candidate?
    - [x] Confirm pickup aids spawn if the setting is on, save+load, confirm they continue to spawn.
- [x] Common traps (falling ceiling, rolling ball, spike wall, ceiling spikes, lava wedge, falling block, icicle, damocles sword)
  Trigger your favorite trap once, verify reset-to-origin behavior, then save+load and verify trap reset state is still correct.
- [x] `O_QUAD_BIKE`
  Go for a ride and confirm the wheels spin.
- [x] `O_MOVABLE_BLOCK_1…4`
  Push/pull blocks and confirm visual orientation/extra rotation behavior is unchanged, and survives save+load. (Needs to be played with the push block rots test level).
- [x] Compass / Stopwatch Inventory Rendering
  Open inventory and verify compass needle updates smoothly and stopwatch hour/minute/second hands track timer correctly.
- [x] Carriers for placeholders
  Validate carried-item drops for holders (pods/statues/Bartoli) still resolve to the correct actual carrier actor. (Needs a test level, IDK if we have one.)

