### PR TITLE
output/sources/objects: fix texture index datatype

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,7 @@
 - changed the barefoot SFX option toggle in TR2 to no longer require reloading the level for changes to take effect
 - changed triggers that target pickup items to support antitriggers, switches and bitmasks
 - removed support for legacy (TombATI / TR2 GOG/Steam) and pre-1.0 (TR1X/TR2X) savegame files
+- fixed random face dropouts on levels with more than 32k textures
 - fixed a small hiccup when launching the game on certain GPUs
 - fixed inconsistent music volume in the statistics screens (#4499)
 - fixed shadows to support 60 FPS interpolation

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -47,7 +47,7 @@ static void M_AddObjectFace(
     const FACE *const face, uint16_t flags)
 {
     RGBA_8888 color = (RGBA_8888) { 255, 255, 255, 255 };
-    int16_t uvw_idx = -1;
+    int32_t uvw_idx = -1;
 
     if (flags & VERT_FLAT_SHADED) {
         if (g_TRVersion == 1) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes certain faces never getting rendered when the level ships with more than 32k textures.

Before:

![20260208_104751_Test_Level](https://github.com/user-attachments/assets/756beede-9ca6-40ae-bebb-80a4ea622670)

After:

<img width="3840" height="2160" alt="20260208_120852_Test_Level" src="https://github.com/user-attachments/assets/d10af4dd-ce30-4b24-94e5-788a83a019d8" />
