### PR TITLE
lara: fix overlap-room soft static collisions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - fixed a small hiccup when launching the game on certain GPUs
 - fixed inconsistent music volume in the statistics screens (#4499)
 - fixed shadows to support 60 FPS interpolation
+- fixed soft static mesh collision not working right with statics that appear in overlapping rooms
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
 - fixed custom levels that contain invalid room static mesh references not being able to load (#4770)

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -258,6 +258,32 @@ static void M_WaterCurrent(COLL_INFO *const coll)
     }
 }
 
+static void M_SoftStaticCollision(COLL_INFO *const coll)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    Room_GetNearbyRooms(
+        lara_item->pos, coll->radius + 50, LARA_HEIGHT + 50,
+        lara_item->room_num);
+
+    for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
+        const ROOM *const room = Room_Get(Room_DrawGetRoom(i));
+        for (int32_t j = 0; j < room->num_static_meshes; j++) {
+            const STATIC_MESH *const mesh = &room->static_meshes[j];
+            const STATIC_OBJECT_3D *const obj =
+                Object_Get3DStatic(mesh->static_num);
+            if (!obj->collidable
+                || !XYZ_32_IsNearby(
+                    &lara_item->pos, &mesh->pos, M_STATIC_COLL_DIST)) {
+                continue;
+            }
+
+            if (Item_TestStatic3DBoundsCollide(mesh, lara_item, coll->radius)) {
+                Lara_Col_Static3DPush(mesh, coll);
+            }
+        }
+    }
+}
+
 static void M_ObjectCollision(COLL_INFO *const coll)
 {
     ITEM *const lara_item = Lara_GetItem();
@@ -301,25 +327,10 @@ static void M_ObjectCollision(COLL_INFO *const coll)
         loop_end:
             item_num = next_item_num;
         }
+    }
 
-        if (!g_Config.gameplay.enable_soft_statics) {
-            continue;
-        }
-
-        for (int32_t j = 0; j < room->num_static_meshes; j++) {
-            const STATIC_MESH *const mesh = &room->static_meshes[j];
-            const STATIC_OBJECT_3D *const obj =
-                Object_Get3DStatic(mesh->static_num);
-            if (!obj->collidable
-                || !XYZ_32_IsNearby(
-                    &lara_item->pos, &mesh->pos, M_STATIC_COLL_DIST)) {
-                continue;
-            }
-
-            if (Item_TestStatic3DBoundsCollide(mesh, lara_item, coll->radius)) {
-                Lara_Col_Static3DPush(mesh, coll);
-            }
-        }
+    if (g_Config.gameplay.enable_soft_statics) {
+        M_SoftStaticCollision(coll);
     }
 
     if (lara_info->hit_effect_count != 0 && lara_info->hit_effect != nullptr


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the *Soft Static Collision* option so Lara is no longer blocked by statics from overlapping rooms.

This bug can cause a potential softlock in the OG TR3 when this option is enabled: in High Security Compound, room 96, Lara can’t enter the back of the truck and finish the level, because the truck’s mesh still blocks her even though it’s only visible from the outside.

This change fixes that by making soft static collision use the same nearby-room selection strategy as hard static collision, so static blockers are resolved from the local spatial context instead of piggybacking on the items room traversal. For clarity, item traversal is OK as-is, and does not need to be updated to follow the same strategy:

- Items are in per-room linked lists (`room->item_num`), so they only participate in collision if their rooms match.
- Statics are world geometry blockers, so they now consistently use nearby spatial room resolution.

#### Testing

- [x] **HSC truck soft-lock**  
  Load HSC and go to room 96. Enable Soft Static Collision and move into the back of the truck area.  
  Expected outcome: Lara can enter correctly; no collision from the overlapping room branch blocks movement.
- [ ] **Soft statics regressions**  
  Run into several static meshes with Soft Static Collision enabled and disabled.  
  Expected outcome: soft push behavior still works as before, with no unexpected item collision changes.