### PR TITLE
lara/hair: fix invalid bone lookups

### DIFF
--- a/docs/16-OUTFITS.md
+++ b/docs/16-OUTFITS.md
@@ -248,16 +248,16 @@ behave. The structure of this file is described below.
     <td><code>mesh_offset</code></td>
     <td>Integer</td>
     <td colspan="2">
-      The starting mesh offset in <code>O_LARA_SKIN_SWAP_EXTRA</code> for the
-      braid.
+      The starting offset in <code>O_LARA_SKIN_SWAP_EXTRA</code> for the regular
+      braid meshes and bones.
     </td>
   </tr>
   <tr valign="top">
     <td><code>gold_offset</code></td>
     <td>Integer</td>
     <td colspan="2">
-      The starting mesh offset in <code>O_LARA_SKIN_SWAP_EXTRA</code> for the
-      golden braid.
+      The starting offset in <code>O_LARA_SKIN_SWAP_EXTRA</code> for the golden
+      braid meshes and bones.
     </td>
   </tr>
   <tr valign="top">
@@ -382,3 +382,9 @@ Download the provided TRX WAD to access the data included in the shipped
 injection. Move each of the relevant objects to your WAD. You can then proceed
 to edit the meshes as required. Ensure that you remove the `lara_outfits.bin`
 from your game-flow, otherwise these will override the data in your level.
+
+> I want to customize Lara's braid.
+
+Braid meshes and bones are taken from the `O_LARA_SKIN_SWAP_EXTRA` object, so to
+customize it you will need to follow the same steps as for customizing outfits
+i.e. import the TRX WAD, edit the data and remove the injection.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
 - fixed custom levels that contain invalid room static mesh references not being able to load (#4770)
+- fixed the tip of Lara's braid using an invalid offset position on the first frame of a level (#4821)
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 - fixed grenades not killing more than a single enemy

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -187,12 +187,11 @@ static void M_CalculateSpheres_I(
 
 void Lara_Hair_Initialise(void)
 {
-    const OBJECT *const obj = Object_Get(O_LARA_HAIR);
-    if (!obj->loaded) {
+    const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase();
+    if (bones == nullptr) {
         return;
     }
 
-    const ANIM_BONE *const bones = Object_GetBone(obj, 0);
     m_IsFirstHair = true;
     m_HairSegments[0].rot.x = -DEG_90;
     m_HairSegments[0].rot.y = 0;
@@ -248,8 +247,7 @@ void Lara_Hair_Control(const bool in_cutscene)
     };
     Matrix_Pop();
 
-    const OBJECT *const obj = Object_Get(O_LARA_HAIR);
-    const ANIM_BONE *const bones = Object_GetBone(obj, 0);
+    const ANIM_BONE *const bones = Lara_Skin_GetBraidBoneBase();
 
     HAIR_SEGMENT *const fs = &m_HairSegments[0];
     fs->pos = pos;

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -12,6 +12,8 @@
 
 #define M_HAIR_SEGMENTS 6
 #define M_HAIR_SPHERES 5
+#define M_BONE_IDX(segment)                                                    \
+    (segment == M_HAIR_SEGMENTS ? (segment - 2) : (segment - 1))
 
 static bool m_IsFirstHair;
 static SPHERE m_HairSpheres[M_HAIR_SPHERES];
@@ -190,19 +192,18 @@ void Lara_Hair_Initialise(void)
         return;
     }
 
+    const ANIM_BONE *const bones = Object_GetBone(obj, 0);
     m_IsFirstHair = true;
     m_HairSegments[0].rot.x = -DEG_90;
     m_HairSegments[0].rot.y = 0;
 
-    for (int32_t i = 0; i < M_HAIR_SEGMENTS; i++) {
-        const ANIM_BONE *const bone = Object_GetBone(obj, i);
-        m_HairSegments[i + 1].pos = bone->pos;
-        m_HairSegments[i + 1].rot.x = -DEG_90;
-        m_HairSegments[i + 1].rot.y = 0;
-        m_HairSegments[i + 1].rot.z = 0;
-        m_HairVelocity[i].x = 0;
-        m_HairVelocity[i].y = 0;
-        m_HairVelocity[i].z = 0;
+    for (int32_t i = 1; i <= M_HAIR_SEGMENTS; i++) {
+        const ANIM_BONE *const bone = &bones[M_BONE_IDX(i)];
+        m_HairSegments[i].pos = bone->pos;
+        m_HairSegments[i].rot.x = -DEG_90;
+        m_HairSegments[i].rot.y = 0;
+        m_HairSegments[i].rot.z = 0;
+        m_HairVelocity[i - 1] = (XYZ_32) {};
     }
 }
 
@@ -248,16 +249,15 @@ void Lara_Hair_Control(const bool in_cutscene)
     Matrix_Pop();
 
     const OBJECT *const obj = Object_Get(O_LARA_HAIR);
+    const ANIM_BONE *const bones = Object_GetBone(obj, 0);
 
     HAIR_SEGMENT *const fs = &m_HairSegments[0];
-    fs->pos.x = pos.x;
-    fs->pos.y = pos.y;
-    fs->pos.z = pos.z;
+    fs->pos = pos;
 
     if (m_IsFirstHair) {
         m_IsFirstHair = false;
         for (int32_t i = 1; i <= M_HAIR_SEGMENTS; i++) {
-            const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
+            const ANIM_BONE *const bone = &bones[M_BONE_IDX(i)];
             const HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
             HAIR_SEGMENT *const s = &m_HairSegments[i];
 
@@ -302,7 +302,6 @@ void Lara_Hair_Control(const bool in_cutscene)
     const int32_t hair_wind_z = Sparks_GetHairWindZ();
 
     for (int32_t i = 1; i <= M_HAIR_SEGMENTS; i++) {
-        const ANIM_BONE *const bone = Object_GetBone(obj, i - 1);
         HAIR_SEGMENT *const ps = &m_HairSegments[i - 1];
         HAIR_SEGMENT *const s = &m_HairSegments[i];
 
@@ -365,12 +364,8 @@ void Lara_Hair_Control(const bool in_cutscene)
         Matrix_RotY(ps->rot.y);
         Matrix_RotX(ps->rot.x);
 
-        if (i == M_HAIR_SEGMENTS) {
-            const ANIM_BONE *const last_bone = bone - 1;
-            Matrix_TranslateRel32(last_bone->pos);
-        } else {
-            Matrix_TranslateRel32(bone->pos);
-        }
+        const ANIM_BONE *const bone = &bones[M_BONE_IDX(i)];
+        Matrix_TranslateRel32(bone->pos);
 
         s->pos.x = g_MatrixPtr->_03 >> W2V_SHIFT;
         s->pos.y = g_MatrixPtr->_13 >> W2V_SHIFT;

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -142,6 +142,22 @@ static int32_t M_GetNoHolsterMeshIdx(
     return obj->mesh_idx + offset;
 }
 
+static inline int32_t M_GetRelativeBraidOffset(void)
+{
+    const LARA_SKIN_OUTFIT *const outfit = M_GetCurrentOutfit();
+    if (!outfit->braid.enabled) {
+        return M_NO_MESH;
+    }
+
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    int32_t offset = outfit->braid.mesh_offset;
+    if (outfit->is_reflective || (lara->mesh_effects & (1 << LM_HEAD)) != 0) {
+        offset = outfit->braid.gold_offset;
+    }
+
+    return offset;
+}
+
 static inline int32_t M_GetMeshIdx(
     const LARA_MESH mesh, const LARA_SKIN_OUTFIT *const outfit)
 {
@@ -508,23 +524,24 @@ XYZ_32 Lara_Skin_GetBraidOffset(void)
 
 int32_t Lara_Skin_GetBraidMeshIdx(void)
 {
-    const LARA_SKIN_OUTFIT *const outfit = M_GetCurrentOutfit();
-    if (!outfit->braid.enabled) {
-        return M_NO_MESH;
-    }
-
-    const LARA_INFO *const lara = Lara_GetLaraInfo();
-    int32_t offset = outfit->braid.mesh_offset;
-    if (outfit->is_reflective || (lara->mesh_effects & (1 << LM_HEAD)) != 0) {
-        offset = outfit->braid.gold_offset;
-    }
-
+    const int32_t offset = M_GetRelativeBraidOffset();
     if (offset == M_NO_MESH) {
-        return M_NO_MESH;
+        return offset;
     }
 
     const OBJECT *const obj = Object_Get(O_LARA_SKIN_SWAP_EXTRA);
     return obj->mesh_idx + offset;
+}
+
+const ANIM_BONE *Lara_Skin_GetBraidBoneBase(void)
+{
+    const int32_t offset = M_GetRelativeBraidOffset();
+    if (offset == M_NO_MESH) {
+        return nullptr;
+    }
+
+    const OBJECT *const obj = Object_Get(O_LARA_SKIN_SWAP_EXTRA);
+    return Object_GetBone(obj, offset);
 }
 
 bool Lara_Skin_AreHolstersVisible(void)

--- a/src/trx/game/lara/skin/common.h
+++ b/src/trx/game/lara/skin/common.h
@@ -20,6 +20,7 @@ const ANIM_BONE *Lara_Skin_GetBoneBase(void);
 bool Lara_Skin_IsBraidSupported(void);
 XYZ_32 Lara_Skin_GetBraidOffset(void);
 int32_t Lara_Skin_GetBraidMeshIdx(void);
+const ANIM_BONE *Lara_Skin_GetBraidBoneBase(void);
 
 bool Lara_Skin_AreHolstersVisible(void);
 void Lara_Skin_SetHolstersVisible(bool visible);


### PR DESCRIPTION
Resolves #4821.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes invalid bone lookups for the first frame in Lara's hair setup, and moves the bone offset lookup to reference the outfit object. The latter means builders don't need to specify both the original object for the bone structure and the extra object for the meshes, it's all contained in the new setup.

Before and after debug output re bone offsets for reference:
<details>

```
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] 0 0 50
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] 0 0 54
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] 0 0 54
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] 0 0 48
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] 0 0 36
DBG | 2026-02-08 11:27:15.103 [game/lara/hair.c:200:Lara_Hair_Initialise] -42 20 2

DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 50
DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 54
DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 54
DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 48
DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 36
DBG | 2026-02-08 11:31:31.848 [game/lara/hair.c:204:Lara_Hair_Initialise] 0 0 36
```
</details>