### PR TITLE
rooms: fix flip maps initialisation

### DIFF
--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -382,9 +382,14 @@ void Room_InitialiseFlipStatus(void)
 {
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         ROOM *const room = Room_Get(i);
+        // Some level data links only one side of a flip pair. In that case, a
+        // previous iteration may already have marked this room as flipped.
+        if (room->flip_status == RFS_FLIPPED) {
+            continue;
+        }
         if (room->flipped_room == NO_ROOM) {
             room->flip_status = RFS_NONE;
-        } else if (room->flip_status != RFS_FLIPPED) {
+        } else {
             ROOM *const flipped_room = Room_Get(room->flipped_room);
             room->flip_status = RFS_UNFLIPPED;
             flipped_room->flip_status = RFS_FLIPPED;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a bug where a static mesh that should only exist in flipped-room context can bleed into view from the unflipped side at specific camera angles.

This issue can be observed in the OG TR3 in Aldwych near the Drill.

#### Implementation details

The core issue comes from the flip rooms initialization.

The original games have only the `flipped_room` field, which behaves as expected. `flipped_room` is intentionally asymmetric. For instance, in a flipped pair like 58 ↔ 116: room 58 stores 116 as its `flipped_room`, but 116 stores -1.

TRX long, long ago introduced a `flip_status` enum to each room:

- `RFS_NONE` – it can never be flipped, and is always active
- `RFS_UNFLIPPED` – it can be flipped, but is currently active
- `RFS_FLIPPED` – it can be flipped, but is currently inactive.

This enum helps some places to check if the room is active or not. Again, `RFS_FLIPPED` rooms store their `flipped_room` as `NO_ROOM` just like `RFS_NONE` rooms, so `flipped_room` wouldn't provide this information.

`flip_status` is populated by `Room_InitialiseFlipStatus()`, which iterates through all rooms and assigns their flip state based on `flipped_room`, working bidirectionally. However, in its current implementation, visiting room 58 from the example above will correctly mark room 116 as `RFS_FLIPPED`, but when room 116 is later processed, it will overwrite its own state back to `RFS_NONE`. This effectively erases its flipped status, causing flip-only rooms to be treated as normal ones by the field users. The issue doesn't affect every room pair – it depends on the order in which rooms are processed.

For the flipped room pairs that were processed incorrectly, `M_FixStatics` couldn't consistently filter out flip-only geometry. As a result, large static meshes might appear in the wrong visibility set.

This PR ensures that rooms already marked as `RFS_FLIPPED` keep their status during initialization, preserving correct classification for asymmetric links.
It doesn't alter flipmap behavior – flipmaps remain fully reversible as before – but it fixes TRX's room-state tracking so any systems depending on `flip_status` receive an accurate state.

#### Testing

- [x] **Aldwych Drill**
  In Aldwych, `/tp 51 -0.5 65` and look around, playing with `/flip`.
  Expected outcome: static no longer appears in the unflipped state.

- [x] **Flip/unflip regressions**
  Trigger a flipmap, and then revert it.
  Expected outcome: rooms and statics swap correctly both directions, and collision and interactions across flipped rooms are generally not possible.

Additional areas that I found to be potentially influenced by this change are where the room number is inferred from world position (which is a futile task in itself, because it can never handle overlapping rooms right anyway). Still, here's the list:

- Photo mode when moving across overlapping rooms with different flip statuses (I don't know of any such place in the OGs)
- Cutscenes camera behavior (TR1 cutscene 3 with Natla flipping the rooms on-and-off by turning the lights on)
- LUA `trx.items[5].pos = {x: …, y: …, z: …}` (unused internally, but possible for custom levels)
- `/spawn` and `/teatime` near flipped rooms while currently in an unflipped room
- `/tp x y z` into flip rooms that overlap with unflipped rooms
