### PR TITLE
items/utils: fix exploding Lara using wrong meshes

### DIFF
--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -61,7 +61,7 @@ int32_t Item_Explode(
             effect->counter =
                 is_tr3 ? ((damage << 2) | (Random_GetControl() & 3)) : damage;
             effect->object_id = O_BODY_PART;
-            effect->frame_num = obj->mesh_idx;
+            effect->frame_num = Object_GetItemMeshIndex(item, 0);
             effect->shade = Output_GetLightAdder() - 0x300;
         }
         item->mesh_bits &= ~bit;
@@ -98,7 +98,7 @@ int32_t Item_Explode(
                     ? ((damage << 2) | (Random_GetControl() & 3))
                     : damage;
                 effect->object_id = O_BODY_PART;
-                effect->frame_num = obj->mesh_idx + i;
+                effect->frame_num = Object_GetItemMeshIndex(item, i);
                 effect->shade = Output_GetLightAdder() - 0x300;
             }
             item->mesh_bits &= ~bit;

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -145,3 +145,21 @@ RGB_F Lara_GetMeshTint(const GAME_VECTOR pos)
         return (RGB_F) { 1.0f, 1.0f, 1.0f };
     }
 }
+
+int32_t Lara_GetMeshIndex(const ITEM *const item, const int32_t mesh_idx)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    const int32_t fallback = obj->mesh_idx + mesh_idx;
+
+    const OBJECT_MESH *const mesh = Lara_Mesh_Get(mesh_idx);
+    if (mesh == nullptr) {
+        return fallback;
+    }
+
+    const int32_t resolved = Object_GetMeshIndex(mesh);
+    if (resolved < 0) {
+        return fallback;
+    }
+
+    return resolved;
+}

--- a/src/trx/game/lara/mesh.h
+++ b/src/trx/game/lara/mesh.h
@@ -11,3 +11,4 @@ void Lara_Mesh_SwapAll(OBJECT_ID obj_id);
 void Lara_Mesh_Set(LARA_MESH mesh, OBJECT_MESH *mesh_ptr);
 OBJECT_MESH *Lara_Mesh_Get(LARA_MESH mesh);
 RGB_F Lara_GetMeshTint(GAME_VECTOR pos);
+int32_t Lara_GetMeshIndex(const ITEM *item, int32_t mesh_idx);

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -176,6 +176,23 @@ OBJECT_MESH *Object_GetMesh(const int32_t index)
     return m_MeshPointers[index];
 }
 
+int32_t Object_GetItemMeshIndex(const ITEM *const item, const int32_t mesh_idx)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    const int32_t fallback = obj->mesh_idx + mesh_idx;
+
+    if (obj->get_mesh_index_func == nullptr) {
+        return fallback;
+    }
+
+    const int32_t resolved = obj->get_mesh_index_func(item, mesh_idx);
+    if (resolved < 0) {
+        return fallback;
+    }
+
+    return resolved;
+}
+
 int32_t Object_GetMeshIndex(const OBJECT_MESH *const mesh)
 {
     for (int32_t i = 0; i < m_MeshCount; i++) {

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -55,6 +55,7 @@ int32_t Object_GetMeshOffset(const OBJECT_MESH *mesh);
 void Object_SetMeshOffset(OBJECT_MESH *mesh, int32_t data_offset);
 
 OBJECT_MESH *Object_GetMesh(int32_t index);
+int32_t Object_GetItemMeshIndex(const ITEM *item, int32_t mesh_idx);
 void Object_SwapMesh(
     OBJECT_ID object1_id, OBJECT_ID object2_id, int32_t mesh_num);
 void Object_SwapAllMeshes(OBJECT_ID object1_id, OBJECT_ID object2_id);

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -11,6 +11,7 @@ static void M_SetupLara(void)
     obj->initialise_func = Lara_InitialiseLoad;
     obj->can_interpolate_func = Lara_CanInterpolate;
     obj->draw_func = nullptr;
+    obj->get_mesh_index_func = Lara_GetMeshIndex;
 
     obj->shadow_size = (UNIT_SHADOW * 10) / 16;
     obj->hit_points = g_Config.gameplay.start_lara_hitpoints;
@@ -35,6 +36,7 @@ void Object_SetupAllObjects(void)
         obj->is_usable_func = nullptr;
         obj->can_interpolate_func = Object_CanInterpolate;
         obj->should_spawn_blood_func = nullptr;
+        obj->get_mesh_index_func = nullptr;
         obj->hit_points = DONT_TARGET;
         obj->pivot_length = 0;
         obj->radius = M_DEFAULT_RADIUS;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -78,6 +78,7 @@ typedef struct OBJECT {
     bool (*can_interpolate_func)(
         const ITEM *item, int32_t frame_a, int32_t frame_b);
     bool (*should_spawn_blood_func)(const ITEM *item);
+    int32_t (*get_mesh_index_func)(const ITEM *item, int32_t mesh_idx);
 
     int16_t anim_idx;
     int16_t anim_count;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that if Lara explodes, her correct outfit meshes are used rather than defaulting to `O_LARA`.
