### PR TITLE
camera/photo-mode: stay more stable near overlaps

### DIFF
--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -158,15 +158,9 @@ static bool M_CameraInsideRoom(const XYZ_32 pos, const int16_t room_num)
 
 static void M_UpdateCameraRooms(void)
 {
-    if (M_CameraInsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)
-        && M_CameraInsideRoom(g_Camera.target.pos, g_Camera.target.room_num)) {
-        Room_GetSector(
-            g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z,
-            &g_Camera.pos.room_num);
-        Room_GetSector(
-            g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
-            &g_Camera.target.room_num);
-    } else {
+    Room_GetSector32(g_Camera.pos.pos, &g_Camera.pos.room_num);
+    Room_GetSector32(g_Camera.target.pos, &g_Camera.target.room_num);
+    if (!M_CameraInsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)) {
         const int16_t pos_room_num = Room_GetIndexFromPos(g_Camera.pos.pos);
         const int16_t tar_room_num = Room_GetIndexFromPos(g_Camera.target.pos);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Applies Lahm's fix for improving photo mode camera near overlapping rooms.
I tried really hard but couldn't think of anything better.