### PR TITLE
savegame: fix loading rifle data

### DIFF
--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -227,6 +227,8 @@ static bool M_ReadLara(SG_READ_IO *const io)
                 Lara_Skin_SetGunEquipment(i, data);
             } else if (type == EQUIPMENT_TYPE_EXTRA) {
                 Lara_Skin_SetExtraEquipment(i, data);
+            } else {
+                Lara_Skin_ClearEquipment(i);
             }
         }
         M_MUST(SG_POP(io));
@@ -255,6 +257,25 @@ static bool M_ReadLara(SG_READ_IO *const io)
     M_SHOULD(M_ReadAmmo(io, "desert_eagle", &lara->desert_eagle_ammo));
     M_SHOULD(M_ReadAmmo(io, "mp5", &lara->mp5_ammo));
     M_SHOULD(M_ReadAmmo(io, "rocket", &lara->rocket_ammo));
+
+    if (M_OPTIONAL(SG_PUSH(io, "weapon"))) {
+        lara->gun_item_num = Item_Create();
+        ITEM *const weapon_item = Item_Get(lara->gun_item_num);
+        weapon_item->status = IS_ACTIVE;
+        weapon_item->room_num = NO_ROOM;
+        // Introduced in TRX 1.2
+        if (!M_SHOULD(
+                M_ReadObjectID(io, "object_id", &weapon_item->object_id))) {
+            M_MUST(M_ReadObjectID(io, "obj_id", &weapon_item->object_id));
+        }
+        M_MUST(SG_READ_VALUE(io, "anim_num", &weapon_item->anim_num));
+        M_MUST(SG_READ_VALUE(io, "frame_num", &weapon_item->frame_num));
+        M_MUST(SG_READ_VALUE(
+            io, "current_anim_state", &weapon_item->current_anim_state));
+        M_MUST(SG_READ_VALUE(
+            io, "goal_anim_state", &weapon_item->goal_anim_state));
+        M_MUST(SG_POP(io));
+    }
 
     M_MUST(SG_PUSH(io, "interact_target"));
     M_MUST(SG_READ_VALUE(io, "item_num", &lara->interact_target.item_num));

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -495,7 +495,8 @@ void SG_File_DumpLara(SG_WRITE_IO *const io)
     if (lara->gun_item_num != NO_ITEM) {
         SGW_PUSH_OBJECT(io);
         const ITEM *const weapon_item = Item_Get(lara->gun_item_num);
-        SGW_WRITE_VALUE(io, "obj_id", Object_ToGameID(weapon_item->object_id));
+        SGW_WRITE_VALUE(
+            io, "object_id", Object_ToGameID(weapon_item->object_id));
         SGW_WRITE_VALUE(io, "anim_num", weapon_item->anim_num);
         SGW_WRITE_VALUE(io, "frame_num", weapon_item->frame_num);
         SGW_WRITE_VALUE(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a savegame regression introduced in 584f93fe3, where Lara’s `"weapon"` block was not being loaded. This broke rifle weapon state restoration after loading.

`M_ReadLara()` now reads the `"weapon"` object again and reconstructs `gun_item_num` state. As a small compatibility follow-up, loading accepts both `object_id` and legacy `obj_id`, while writing uses `object_id`.

#### Testing

- [x] **Fresh save**
  Start a level, equip rifle, create a save with current build (ideally mid-animation), then reload it
  Expected outcome: rifle state restores correctly (weapon object and animation state are valid)

- [ ] **Existing saves**
  Load a save produced before this change (with `obj_id` key)
  Expected outcome: save loads successfully and rifle data is restored without regressions
