### PR TITLE
phase/cutscene: fix sparks not animating

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -163,6 +163,7 @@
 - changed enemy drops to appear at the tile center, to conform with the OG
 - fixed several texture issues on each of Lara's outfits
 - fixed actors jumping to their start frame at the end of cutscenes
+- fixed Flame in Cutscene 4 and 6 appearing static
 - fixed Swamp Map rotation
 - fixed seaweed disappearing too quickly in certain levels
 - fixed Hand of Rathmore not rotating in Sleeping with the Fishes

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -11,6 +11,7 @@
 #include <trx/game/music.h>
 #include <trx/game/output.h>
 #include <trx/game/shell.h>
+#include <trx/game/sparks.h>
 #include <trx/game/water_fx.h>
 #include <trx/game/weather_fx.h>
 #include <trx/memory.h>
@@ -168,6 +169,20 @@ static void M_ResetActorsToStart(void)
     }
 }
 
+static void M_Control(void)
+{
+    Output_ResetDynamicLights();
+    Camera_UpdateCutscene();
+    Item_Control();
+    Effect_Control();
+    Sparks_Control();
+    WaterFX_Update();
+    WeatherFX_Update();
+    FootprintFX_Update();
+    Output_AnimateTextures(1);
+    Lara_Hair_Control(true);
+}
+
 static void M_ReplayActors(
     CINE_DATA *const cine_data, const int32_t start_frame,
     const int32_t end_frame)
@@ -175,9 +190,7 @@ static void M_ReplayActors(
     for (int32_t frame_idx = start_frame; frame_idx < end_frame; frame_idx++) {
         Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
         cine_data->frame_idx = frame_idx;
-        Camera_UpdateCutscene();
-        Item_Control();
-        Effect_Control();
+        M_Control();
         Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
     }
 }
@@ -305,16 +318,7 @@ GF_COMMAND Cutscene_Control(void)
         M_Skip(dir * LOGIC_FPS * speed);
     }
 
-    Output_ResetDynamicLights();
-
-    Item_Control();
-    Effect_Control();
-    Lara_Hair_Control(true);
-    Camera_UpdateCutscene();
-    WaterFX_Update();
-    WeatherFX_Update();
-    FootprintFX_Update();
-    Output_AnimateTextures(1);
+    M_Control();
 
     CINE_DATA *const cine_data = Camera_GetCineData();
     cine_data->frame_idx++;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes flame effects appearing static during TR3 cutscenes 4 and 6.
The key fix is running `Sparks_Control()` during cutscene updates, so spark-based flame effects keep animating instead of freezing.

#### Testing

- [x] **Cutscene 4 and 6 flame animates**
  Start cutscene 4 and 6 in TR3 and check the flames.
  Expected outcome: flame particles animate and no longer appear static.