### PR TITLE
level: mark statics with bad hitboxes as non-collidable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@
 - fixed secret tracks played at low quality when "fix secrets killing music" option is on
 - fixed secret tracks not restored from the savegame when "fix secrets killing music" option is on
 - fixed slow-forward seeking through cutscenes (right+slow) not working (regression from 1.0)
+- fixed statics marked collidable but with zero‑size hitboxes causing phantom collisions
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/level/rooms.c
+++ b/src/trx/game/level/rooms.c
@@ -63,7 +63,7 @@ static void M_ComputePortalBounds(void)
     }
 }
 
-static void M_FixStatics(void)
+static void M_FixStaticsVisibility(void)
 {
     int32_t total_rooms = Room_GetCount();
     VECTOR **room_stat_vecs =
@@ -143,8 +143,34 @@ static void M_FixStatics(void)
     }
 }
 
+static void M_FixStaticsCollision(void)
+{
+    const int32_t count = Object_GetStaticObjects3DCount();
+    for (int32_t i = 0; i < count; i++) {
+        STATIC_OBJECT_3D *const obj = Object_Get3DStatic(i);
+        if (!obj->loaded || !obj->collidable) {
+            continue;
+        }
+
+        const XYZ_32 hitbox = {
+            .x = obj->collision_bounds.max.x - obj->collision_bounds.min.x,
+            .y = obj->collision_bounds.max.y - obj->collision_bounds.min.y,
+            .z = obj->collision_bounds.max.z - obj->collision_bounds.min.z,
+        };
+
+        if (hitbox.x <= 0 || hitbox.y <= 0 || hitbox.z <= 0) {
+            LOG_WARNING(
+                "Static %d is marked as collidable, but has degenerate "
+                "hitbox (%d x %d x %d)",
+                i, hitbox.x, hitbox.y, hitbox.z);
+            obj->collidable = false;
+        }
+    }
+}
+
 void Level_LoadRooms(void)
 {
     M_ComputePortalBounds();
-    M_FixStatics();
+    M_FixStaticsCollision();
+    M_FixStaticsVisibility();
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR disables collision for static meshes with degenerate hitboxes.

Some levels contain statics that are flagged as collidable, but have nonexistent collision bounds (one or more dimensions <= 0). Those bad bounds still participate in regular collision checks, which result in Lara getting blocked out of the blue in many places.
We now detect these cases during `Level_ReadStaticObjects()` and force such statics to non-collidable, while logging a warning for such statics.

Turns out there are quite a lot of such objects. Examples:
- TR3 City, `/tp 37 -11.75 53` – the beacon light appears to collide with Lara near the tile's dead center.
- TR2 The Great Wall, `/tp door`, `/tp door`, `/fly` + open – the cobwebs appears to collide with Lara near the tile's center.

…but the logs reveal that there are so many more. I'm pretty sure all of them should not be collidable.

#### Testing

- [x] **Degenerate hitboxes**
  Load a level/mod known to include a collidable static with degenerate bounds
  Expected outcome: warning is logged once for that static, and Lara no longer collides with the phantom blocker
- [x] **Normal hitboxes**
  Load a level with ordinary collidable statics (pillars, crates, statues)
  Expected outcome: Lara still collides with all valid statics exactly as before
