### PR TITLE
camera: reset roll

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@
 - fixed stats dialog retaining friendly status for allies that become enemy types in later levels, causing them to get excluded from kill count
 - fixed targeting hostile ex-allies not working if "Enable ally targeting" option is off
 - fixed `/play` and similar commands fading out instead of running instantly on stats/title screens
+- fixed `/play` and similar commands sometimes preserving cutscene camera tilt if invoked while a cutscene was paused
 - fixed Cheats description showing arrows in the indented bullets (#4753, regression from TRX 1.1)
 - fixed game freezing on exit on certain platforms when there are no active sound devices (SDL bug)
 - fixed Lara's look head rotation/tilt limits being hardcoded to the engine version rather than camera mode

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -80,6 +80,7 @@ void Camera_ResetPosition(void)
     const CAMERA_STRATEGY *const strategy = M_GetStrategy();
     strategy->reset_func();
 
+    g_Camera.roll = 0;
     g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
     g_Camera.item = nullptr;
     g_Camera.speed = 1;


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a camera state leak where running `/play 7` or similar from an active cutscene could carry over the cutscene roll into the newly started gameplay, resulting in a tilted view.

#### Testing

Compare this TR3 recording on develop and on this PR:

```
config gameplay.enable_legal 0
config ui.enable_photo_mode_ui 0
config visuals.lara_outfit "tr2_vegas"

@+0:    cmd "cut 6"
        ● "space"
@+1:    ● "right"
@+1:    ○ "right"
@+1:    ● "right"
@+1:    ○ "right"
        ○ "space"
        ● "left shift"
@+1:    ● "right"
@+1:    ○ "right"
        ○ "left shift"
@+130:  ● "f1"
@+1:    ○ "f1"
@+30:   cmd "play 7"
@+60:   quit
```

Expected outcome:
On develop, the view remains tilted.
On the PR, the view gets untilted.
