### PR TITLE
cutscene: fix drawing basic shape shadows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,7 @@
 - fixed custom levels that contain invalid room static mesh references not being able to load (#4770)
 - fixed the tip of Lara's braid using an invalid offset position on the first frame of a level (#4821)
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)
+- fixed drawing circle/octagon shadows in TR2/TR3 cutscenes using wrong positions
 - fixed being unable to use the manual camera in TR3 camera mode when Lara is idle (#4670, regression from 1.1)
 - fixed grenades not killing more than a single enemy
 - fixed running `/title` and similar commands leaving the "Examine" button briefly visible in the key items ring (old regression)

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -210,6 +210,12 @@ static void M_PlayerControl(const int16_t item_num)
         Item_UpdateRoom(item_num, room_num);
     }
 
+    int16_t floor_room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(pos.x, pos.y, pos.z, &floor_room_num);
+    const int16_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    item->floor = height == NO_HEIGHT ? pos.y : height;
+
     Lara_Animate(item);
 }
 

--- a/src/trx/game/objects/general/cutscene_player.c
+++ b/src/trx/game/objects/general/cutscene_player.c
@@ -32,6 +32,12 @@ static void M_Control(const int16_t item_num)
         Item_UpdateRoom(item_num, room_num);
     }
 
+    int16_t floor_room_num = item->room_num;
+    const SECTOR *const sector =
+        Room_GetSector(pos.x, pos.y, pos.z, &floor_room_num);
+    const int16_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    item->floor = height == NO_HEIGHT ? pos.y : height;
+
     if (item->dynamic_light && item->status != IS_INVISIBLE) {
         pos.x = 0;
         pos.y = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes misplaced non-sprite shadows in TR2 and TR3 cutscenes appearing in weird places.

<img width="2814" height="1583" alt="image" src="https://github.com/user-attachments/assets/f3f54d1e-7243-4b22-ac4d-395087492e2c" />

The cutscene actor controllers were updating actor position/rotation from the cinematic camera but not keeping floor height in sync with the actor’s actual animated root position. Shadow projection for octagon/circle shadows relies on this floor anchor, so stale or mismatched floor data caused visible displacement.

The fix updates floor every control tick for the main actor. Other actors remain without shadows as before.
In TR1, shadows continue to be not drawn.

#### Testing

- [ ] Set shadow type to Octagon or Circle, then play through TR2 and TR3 cutscenes
  Expected outcome: shadows stay anchored under Lara instead of drifting/offsetting; other actors remain without shadows

- [x] Set shadow type to Octagon or Circle, then play through TR1 cutscenes
  Expected outcome: no shadows get drawn
