### PR TITLE
photo-mode: fix rotating Lara in cutscenes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -95,6 +95,7 @@
 - fixed game freezing on exit on certain platforms when there are no active sound devices (SDL bug)
 - fixed Lara twitching when trying to step back onto death tiles
 - fixed Lara's look head rotation/tilt limits being hardcoded to the engine version rather than camera mode
+- fixed Lara rotating around an incorrect origin in photo mode during cutscenes
 - fixed pushblocks being able to fall into rooms below despite no portals being present (#4788, regression from TR1X 4.15/TR2X 1.5)
 - fixed one-shot triggers for hidden pickup items making the items permanently invisible (#4784)
 - fixed secret tracks played at low quality when "fix secrets killing music" option is on

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/game/camera.h>
+#include <trx/game/collision.h>
 #include <trx/game/console/common.h>
 #include <trx/game/const.h>
 #include <trx/game/game.h>
@@ -187,9 +188,27 @@ static bool M_HandleItemRotationInputs(ITEM *const item)
     if (delta.x == 0 && delta.y == 0 && delta.z == 0) {
         return false;
     }
+
+    // Keep the item's root joint anchored while rotating, so off-center
+    // animation origins (especially in cutscenes) do not cause huge offsets.
+    // Use live item transforms; interpolation may still contain previous-frame
+    // values and would make both samples identical.
+    const bool was_item_interp_enabled = item->enable_interpolation;
+    item->enable_interpolation = false;
+
+    XYZ_32 old_root_pos = {};
+    Collide_GetJointAbsPosition(item, &old_root_pos, 0);
+
     item->rot.x += delta.x;
     item->rot.y += delta.y;
     item->rot.z += delta.z;
+
+    XYZ_32 new_root_pos = {};
+    Collide_GetJointAbsPosition(item, &new_root_pos, 0);
+    item->enable_interpolation = was_item_interp_enabled;
+    item->pos.x += old_root_pos.x - new_root_pos.x;
+    item->pos.y += old_root_pos.y - new_root_pos.y;
+    item->pos.z += old_root_pos.z - new_root_pos.z;
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes an issue in photo mode where rotating Lara with the arrow keys during cutscenes caused sudden large jumps. The problem was that rotation was applied around an origin that didn't align with the animated root. Rotation now preserves the root joint's world-space anchor, keeping Lara's orientation stable and predictable.

#### Testing

- [x] Enter a cutscene, open photo mode, switch to Lara edit mode, and rotate Lara with arrow keys
  Expected outcome: Lara rotates in place without large positional jumps or orbiting from a bad origin