### PR TITLE
lara: fix swim condition tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,6 +79,7 @@
 - fixed soft static mesh collision not working right with statics that appear in overlapping rooms
 - fixed drawing debug triggers using random tint near water sources
 - fixed drawing debug triggers glitching through triangular portals
+- fixed Lara being force-resurfaced near split-triangle water portals in certain spots
 - fixed custom levels that contain invalid room static mesh references not being able to load (#4770)
 - fixed the tip of Lara's braid using an invalid offset position on the first frame of a level (#4821)
 - fixed drawing shadows twice when item intersects a portal (#4640, regression from 1.0)

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -355,7 +355,8 @@ int32_t Lara_GetWaterDepth(
         while (sector->portal_room.sky != NO_ROOM) {
             room = Room_Get(sector->portal_room.sky);
             if (!room->flags.underwater && !room->flags.swamp) {
-                const int32_t water_height = sector->ceiling.height;
+                const int32_t water_height =
+                    Room_GetWaterHeight(x, y, z, room_num);
                 sector = Room_GetSector(x, y, z, &room_num);
                 return Room_GetHeight(sector, x, y, z) - water_height;
             }
@@ -367,7 +368,7 @@ int32_t Lara_GetWaterDepth(
     while (sector->portal_room.pit != NO_ROOM) {
         room = Room_Get(sector->portal_room.pit);
         if (room->flags.underwater || room->flags.swamp) {
-            const int32_t water_height = sector->floor.height;
+            const int32_t water_height = Room_GetWaterHeight(x, y, z, room_num);
             sector = Room_GetSector(x, y, z, &room_num);
             return Room_GetHeight(sector, x, y, z) - water_height;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara not being able to submerge near certain split-triangle portals, for example in Crash Site, `/tp 66 0.5 28`.

#### Implementation details

In split portal sectors, `Lara_GetWaterDepth()` was mixing two different water-surface models.

- `Room_GetWaterHeight()` is split-aware and returned the actual local waterline (~512 in the Crash Site spot).
- `Lara_GetWaterDepth()` used raw sector portal heights (`sector->ceiling.height` / `sector->floor.height`, ~1280 in the Crash Site spot).

That mismatch caused shallow depth readings near split water boundaries, repeatedly forcing underwater→wade step-outs followed by instant wade→surface corrections. In-game, it looked like Lara kept snapping to the surface with a nasty camera jolt.

The fix now uses `Room_GetWaterHeight()` inside `Lara_GetWaterDepth()` for both sky and pit boundary cases, so depth is measured against the same split-aware surface used everywhere else. Depth classification stays consistent, and the resurfacing loop is gone.

#### Testing

This likely will involve a test level with multiple spots of differing heights (including slopes) with split-triangle water surface portals. For the reported scenario:

- [x] Load Crash Site, `/tp 66 0.5 28`, try to submerge
  Expected outcome: Lara should submerge and freely swim around without collision issues
