### PR TITLE
photo-mode: fix crash in cutscenes

### DIFF
--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -283,6 +283,9 @@ void Camera_PhotoMode_Enter(void)
     g_Camera.target_distance = CAMERA_DEFAULT_DISTANCE;
     g_Camera.target_square = SQUARE(g_Camera.target_distance);
 
+    g_Camera.target.room_num = g_Camera.pos.room_num;
+    Room_GetSector32(g_Camera.target.pos, &g_Camera.target.room_num);
+
     m_StartingCamera = g_Camera;
 
     m_OriginalFOV = Viewport_GetEffectiveFOV();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes an unreleased regression introduced in https://github.com/LostArtefacts/TRX/pull/4825 that crashes the photo mode when entering the cutscenes, due to uninitialized target camera room number.

#### Testing

- [x] Play TR1, `/play 4`, level skip to the cutscene, enter photo mode.
  Expected outcome: the game no longer should crash and instead enter the photo mode smoothly.
- [x] Repeat the above steps for a few more level-to-cutscenes paths.
- [x] Test photo mode camera behavior when traversing through the void.
  Expected outcome: the camera should lock onto the last viewed room, and shouldn't crash.