### PR TITLE
Refactor rooms API to take XYZ_32 arguments

### DIFF
--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -141,9 +141,10 @@ static const BOX_INFO *M_GetBox(
 static const SECTOR *M_GetSector(
     const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
 {
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int32_t height = Room_GetHeight(sector, x, y, z);
-    const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
+    const XYZ_32 pos = { x, y, z };
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
     if (y > height || y < ceiling) {
         return nullptr;
     }
@@ -158,42 +159,45 @@ static bool M_IsGoodPosition(
 
 static int32_t M_ShiftClamp(GAME_VECTOR *const pos, const int32_t clamp)
 {
-    const int32_t x = pos->x;
-    const int32_t y = pos->y;
-    const int32_t z = pos->z;
+    const SECTOR *const sector = Room_GetSector(pos->pos, &pos->room_num);
+    const BOX_INFO *const box = M_GetBox(sector, pos->x, pos->z, true);
 
-    const SECTOR *const sector = Room_GetSector(x, y, z, &pos->room_num);
-    const BOX_INFO *const box = M_GetBox(sector, x, z, true);
+    const XYZ_32 old_pos = pos->pos;
 
     const int32_t left = box->left + clamp;
     const int32_t right = box->right - clamp;
-    if (z < left && !M_IsGoodPosition(x, y, z - clamp, pos->room_num)) {
+    if (pos->z < left
+        && !M_IsGoodPosition(pos->x, pos->y, pos->z - clamp, pos->room_num)) {
         pos->z = left;
-    } else if (z > right && !M_IsGoodPosition(x, y, z + clamp, pos->room_num)) {
+    } else if (
+        pos->z > right
+        && !M_IsGoodPosition(pos->x, pos->y, pos->z + clamp, pos->room_num)) {
         pos->z = right;
     }
 
     const int32_t top = box->top + clamp;
     const int32_t bottom = box->bottom - clamp;
-    if (x < top && !M_IsGoodPosition(x - clamp, y, z, pos->room_num)) {
+    if (pos->x < top
+        && !M_IsGoodPosition(pos->x - clamp, pos->y, pos->z, pos->room_num)) {
         pos->x = top;
     } else if (
-        x > bottom && !M_IsGoodPosition(x + clamp, y, z, pos->room_num)) {
+        pos->x > bottom
+        && !M_IsGoodPosition(pos->x + clamp, pos->y, pos->z, pos->room_num)) {
         pos->x = bottom;
     }
 
-    int32_t height = Room_GetHeight(sector, x, y, z) - clamp;
-    int32_t ceiling = Room_GetCeiling(sector, x, y, z) + clamp;
+    int32_t height = Room_GetHeight(sector, old_pos) - clamp;
+    int32_t ceiling = Room_GetCeiling(sector, old_pos) + clamp;
 
     if (height < ceiling) {
         ceiling = (height + ceiling) >> 1;
         height = ceiling;
     }
 
-    if (y > height) {
-        return height - y;
-    } else if (y < ceiling) {
-        return ceiling - y;
+    if (old_pos.y > height) {
+        return height - old_pos.y;
+    } else if (old_pos.y < ceiling) {
+        return ceiling - old_pos.y;
     }
 
     return 0;
@@ -213,8 +217,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
     sector = Room_GetWorldSector(room, target->x, target->z);
     if (room->flags.swamp) {
         target->y = room->max_ceiling - STEP_L;
-        sector =
-            Room_GetSector(target->x, target->y, target->z, &target->room_num);
+        sector = Room_GetSector(target->pos, &target->room_num);
     }
 
     if (target->z < box->left || target->z > box->right || target->x < box->top
@@ -398,7 +401,7 @@ static void M_SmartShift(GAME_VECTOR *const target, void (*shift)(M_SHIFT_ARGS))
         target->pos = target_b.pos;
     }
 
-    Room_GetSector(target->x, target->y, target->z, &target->room_num);
+    Room_GetSector(target->pos, &target->room_num);
 }
 
 static void M_Clip(M_SHIFT_ARGS)
@@ -495,37 +498,36 @@ static void M_Move(const GAME_VECTOR *const target, const int32_t speed)
 
     Camera_SetChunky(false);
 
-    const SECTOR *sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-    int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const SECTOR *sector = Room_GetSector(pos.pos, &pos.room_num);
+    int32_t height = Room_GetHeight(sector, pos.pos);
     if (height == NO_HEIGHT) {
         // Attempt to clamp within the previous sector's height bounds. Only if
         // that fails continue to revert fully to the last good Y position.
         pos.room_num = old_pos.room_num;
-        sector = Room_GetSector(old_pos.x, old_pos.y, old_pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, old_pos.x, old_pos.y, old_pos.z);
-        const int32_t old_ceiling =
-            Room_GetCeiling(sector, old_pos.x, old_pos.y, old_pos.z);
+        sector = Room_GetSector(old_pos.pos, &pos.room_num);
+        height = Room_GetHeight(sector, old_pos.pos);
+        const int32_t old_ceiling = Room_GetCeiling(sector, old_pos.pos);
         CLAMP(pos.y, old_ceiling + STEP_L, height - STEP_L);
-        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+        sector = Room_GetSector(pos.pos, &pos.room_num);
+        height = Room_GetHeight(sector, pos.pos);
         if (height == NO_HEIGHT) {
             pos.y = old_pos.y;
             pos.room_num = old_pos.room_num;
-            sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-            height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+            sector = Room_GetSector(pos.pos, &pos.room_num);
+            height = Room_GetHeight(sector, pos.pos);
         }
     }
 
     height -= STEP_L;
     if (pos.y >= height && target->y >= height) {
         LOS_Check(&g_Camera.target, &pos, false);
-        sector = Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
-        height = Room_GetHeight(sector, pos.x, pos.y, pos.z) - STEP_L;
+        sector = Room_GetSector(pos.pos, &pos.room_num);
+        height = Room_GetHeight(sector, pos.pos) - STEP_L;
     }
 
     g_Camera.pos = pos;
 
-    int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z) + STEP_L;
+    int32_t ceiling = Room_GetCeiling(sector, pos.pos) + STEP_L;
     if (height < ceiling) {
         ceiling = (height + ceiling) >> 1;
         height = ceiling;
@@ -741,14 +743,13 @@ static void M_ClampResult(void)
     CLAMP(pos->z, box->left, box->right);
 
 finish:
-    const int32_t floor =
-        Room_GetHeightEx(sector, pos->x, pos->y, pos->z, true, NO_ITEM);
-    const int32_t ceiling =
-        Room_GetCeilingEx(sector, pos->x, pos->y, pos->z, true);
+    const int32_t floor = Room_GetHeightEx(sector, *pos, true, NO_ITEM);
+    const int32_t ceiling = Room_GetCeilingEx(sector, *pos, true);
     if (floor != NO_HEIGHT && ceiling != NO_HEIGHT) {
         CLAMP(pos->y, ceiling - shift, floor - shift);
     }
-    Room_GetSector(pos->x, pos->y + shift, pos->z, &g_Camera.interp.room_num);
+    Room_GetSector(
+        (XYZ_32) { pos->x, pos->y + shift, pos->z }, &g_Camera.interp.room_num);
 }
 
 static void M_Reset(void)
@@ -863,10 +864,9 @@ static void M_Update(
         }
 
         const SECTOR *const sector = Room_GetSector(
-            g_Camera.target.x, target_y, g_Camera.target.z,
+            (XYZ_32) { g_Camera.target.x, target_y, g_Camera.target.z },
             &g_Camera.target.room_num);
-        const int32_t height = Room_GetHeight(
-            sector, g_Camera.target.x, g_Camera.target.y, g_Camera.target.z);
+        const int32_t height = Room_GetHeight(sector, g_Camera.target.pos);
         if (g_Camera.target.y > height) {
             Camera_SetChunky(false);
         }

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -128,9 +128,12 @@ void Camera_ClampInterpResult(void)
 {
     if (g_Camera.type == CAM_PHOTO_MODE) {
         Room_GetSector(
-            g_Camera.interp.result.pos.x,
-            g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
-            g_Camera.interp.result.pos.z, &g_Camera.interp.room_num);
+            (XYZ_32) {
+                g_Camera.interp.result.pos.x,
+                g_Camera.interp.result.pos.y + g_Camera.interp.result.shift,
+                g_Camera.interp.result.pos.z,
+            },
+            &g_Camera.interp.room_num);
         return;
     }
 

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -82,18 +82,15 @@ static bool M_LOS(
     int32_t i = 0;
     for (; i < M_LOS_STEPS; i++) {
         int16_t next_room_num = room_num;
-        const SECTOR *const sector =
-            Room_GetSector(pos.x, pos.y, pos.z, &next_room_num);
+        const SECTOR *const sector = Room_GetSector(pos, &next_room_num);
 
         if (Room_Get(next_room_num)->flags.swamp) {
             clipped = true;
             break;
         }
 
-        const int32_t height =
-            Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-        const int32_t ceiling =
-            Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+        const int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+        const int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
         if (height == NO_HEIGHT || ceiling == NO_HEIGHT || ceiling >= height) {
             if (!valid_space) {
@@ -140,7 +137,7 @@ static bool M_LOS(
         pos.z -= delta.z;
     }
 
-    Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    Room_GetSector(pos, &room_num);
     target->pos = pos;
     target->room_num = room_num;
 
@@ -149,12 +146,9 @@ static bool M_LOS(
 
 static inline void M_ClampY(int16_t room_num, XYZ_32 *const pos)
 {
-    const SECTOR *const sector =
-        Room_GetSector(pos->x, pos->y, pos->z, &room_num);
-    const int16_t height =
-        Room_GetHeightEx(sector, pos->x, pos->y, pos->z, true, NO_ITEM);
-    const int16_t ceiling =
-        Room_GetCeilingEx(sector, pos->x, pos->y, pos->z, true);
+    const SECTOR *const sector = Room_GetSector(*pos, &room_num);
+    const int16_t height = Room_GetHeightEx(sector, *pos, true, NO_ITEM);
+    const int16_t ceiling = Room_GetCeilingEx(sector, *pos, true);
 
     if (ceiling < height && ceiling != NO_HEIGHT && height != NO_HEIGHT) {
         if (ceiling > pos->y - 255 && height < pos->y + 255) {
@@ -181,42 +175,40 @@ static bool M_Collide(
 
     // -X clamp
     int16_t room_num = ideal->room_num;
-    const SECTOR *sector =
-        Room_GetSector(pos.x - shift, pos.y, pos.z, &room_num);
-    int16_t height =
-        Room_GetHeightEx(sector, pos.x - shift, pos.y, pos.z, true, NO_ITEM);
-    int16_t ceiling =
-        Room_GetCeilingEx(sector, pos.x - shift, pos.y, pos.z, true);
+    XYZ_32 sample_pos = { .x = pos.x - shift, .y = pos.y, .z = pos.z };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
+    int16_t height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
+    int16_t ceiling = Room_GetCeilingEx(sector, sample_pos, true);
     if (L_OUT_OF_BOUNDS) {
         pos.x = ROUND_TO_SECTOR(pos.x) + shift;
     }
 
     // -Z clamp
     room_num = ideal->room_num;
-    sector = Room_GetSector(pos.x, pos.y, pos.z - shift, &room_num);
-    height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z - shift, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z - shift, true);
+    sample_pos = (XYZ_32) { .x = pos.x, .y = pos.y, .z = pos.z - shift };
+    sector = Room_GetSector(sample_pos, &room_num);
+    height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, sample_pos, true);
     if (L_OUT_OF_BOUNDS) {
         pos.z = ROUND_TO_SECTOR(pos.z) + shift;
     }
 
     // +X clamp
     room_num = ideal->room_num;
-    sector = Room_GetSector(pos.x + shift, pos.y, pos.z, &room_num);
-    height =
-        Room_GetHeightEx(sector, pos.x + shift, pos.y, pos.z, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x + shift, pos.y, pos.z, true);
+    sample_pos = (XYZ_32) { .x = pos.x + shift, .y = pos.y, .z = pos.z };
+    sector = Room_GetSector(sample_pos, &room_num);
+    height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, sample_pos, true);
     if (L_OUT_OF_BOUNDS) {
         pos.x = ROUND_TO_SECTOR_END(pos.x) - shift;
     }
 
     // +Z clamp
     room_num = ideal->room_num;
-    sector = Room_GetSector(pos.x, pos.y, pos.z + shift, &room_num);
-    height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z + shift, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z + shift, true);
+    sample_pos = (XYZ_32) { .x = pos.x, .y = pos.y, .z = pos.z + shift };
+    sector = Room_GetSector(sample_pos, &room_num);
+    height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, sample_pos, true);
     if (L_OUT_OF_BOUNDS) {
         pos.z = ROUND_TO_SECTOR_END(pos.z) - shift;
     }
@@ -226,16 +218,16 @@ static bool M_Collide(
     }
 
     room_num = ideal->room_num;
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    height = Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &room_num);
+    height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, pos, true);
     if (L_OUT_OF_BOUNDS) {
         return true;
     }
 
 #undef L_OUT_OF_BOUNDS
 
-    Room_GetSector(pos.x, pos.y, pos.z, &ideal->room_num);
+    Room_GetSector(pos, &ideal->room_num);
     ideal->pos = pos;
     return false;
 }
@@ -296,19 +288,18 @@ static void M_Move(GAME_VECTOR *const ideal, const int32_t speed)
 
     XYZ_32 pos = g_Camera.pos.pos;
     int16_t room_num = g_Camera.pos.room_num;
-    const SECTOR *sector =
-        Room_GetSector(pos.x, pos.y + STEP_L, pos.z, &room_num);
+    const XYZ_32 sample_pos = { pos.x, pos.y + STEP_L, pos.z };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
 
     const ROOM *const room = Room_Get(room_num);
     if (room->flags.swamp) {
         pos.y = room->max_ceiling - STEP_L;
-        Room_GetSector(pos.x, pos.y, pos.z, &g_Camera.pos.room_num);
+        Room_GetSector(pos, &g_Camera.pos.room_num);
     }
 
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    int16_t height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &room_num);
+    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (pos.y < ceiling || pos.y > height) {
         M_LOS(&g_Camera.target, &g_Camera.pos, 0);
@@ -335,9 +326,9 @@ static void M_Move(GAME_VECTOR *const ideal, const int32_t speed)
 
     pos = g_Camera.pos.pos;
     room_num = g_Camera.pos.room_num;
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    height = Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &room_num);
+    height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (pos.y - 255 < ceiling && pos.y + 255 > height && ceiling < height
         && ceiling != NO_HEIGHT && height != NO_HEIGHT) {
@@ -355,8 +346,7 @@ static void M_Move(GAME_VECTOR *const ideal, const int32_t speed)
         g_Camera.pos = *ideal;
     }
 
-    Room_GetSector(
-        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
+    Room_GetSector(g_Camera.pos.pos, &g_Camera.pos.room_num);
     m_LastState.cam_type = g_Camera.type;
 
     Camera_UpdateMicPosition();
@@ -434,7 +424,11 @@ static void M_Chase(const ITEM *const item)
 
     int16_t room_num = g_Camera.target.room_num;
     const SECTOR *sector = Room_GetSector(
-        g_Camera.target.x, g_Camera.target.y + STEP_L, g_Camera.target.z,
+        (XYZ_32) {
+            g_Camera.target.x,
+            g_Camera.target.y + STEP_L,
+            g_Camera.target.z,
+        },
         &room_num);
 
     const ROOM *const room = Room_Get(room_num);
@@ -443,10 +437,9 @@ static void M_Chase(const ITEM *const item)
     }
 
     XYZ_32 pos = g_Camera.target.pos;
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &g_Camera.target.room_num);
-    int16_t height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &g_Camera.target.room_num);
+    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (ceiling + 16 > height - 16 && height != NO_HEIGHT
         && ceiling != NO_HEIGHT) {
@@ -460,15 +453,12 @@ static void M_Chase(const ITEM *const item)
         g_Camera.target_elevation = 0;
     }
 
-    sector = Room_GetSector(
-        g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
-        &g_Camera.target.room_num);
+    sector = Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
     pos = g_Camera.target.pos;
     room_num = g_Camera.target.room_num;
-    sector = Room_GetSector(
-        g_Camera.target.x, g_Camera.target.y, g_Camera.target.z, &room_num);
-    height = Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(g_Camera.target.pos, &room_num);
+    height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (pos.y < ceiling || pos.y > height || ceiling >= height
         || height == NO_HEIGHT || ceiling == NO_HEIGHT) {
@@ -503,7 +493,11 @@ static void M_Combat(const ITEM *const item)
 
     int16_t room_num = g_Camera.target.room_num;
     const SECTOR *sector = Room_GetSector(
-        g_Camera.target.x, g_Camera.target.y + STEP_L, g_Camera.target.z,
+        (XYZ_32) {
+            g_Camera.target.x,
+            g_Camera.target.y + STEP_L,
+            g_Camera.target.z,
+        },
         &room_num);
 
     const ROOM *const room = Room_Get(room_num);
@@ -512,10 +506,9 @@ static void M_Combat(const ITEM *const item)
     }
 
     XYZ_32 pos = g_Camera.target.pos;
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &g_Camera.target.room_num);
-    int16_t height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &g_Camera.target.room_num);
+    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (ceiling + 64 > height - 64 && height != NO_HEIGHT
         && ceiling != NO_HEIGHT) {
@@ -530,11 +523,11 @@ static void M_Combat(const ITEM *const item)
     }
 
     pos = g_Camera.target.pos;
-    Room_GetSector(pos.x, pos.y, pos.z, &g_Camera.target.room_num);
+    Room_GetSector(pos, &g_Camera.target.room_num);
     room_num = g_Camera.target.room_num;
-    sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    height = Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    ceiling = Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    sector = Room_GetSector(pos, &room_num);
+    height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (pos.y < ceiling || pos.y > height || ceiling >= height
         || height == NO_HEIGHT || ceiling == NO_HEIGHT) {
@@ -610,32 +603,33 @@ static void M_Look(const ITEM *const item)
     XYZ_32 pos_1 = M_GetHeadPos(0, 16, 64);
 
     int16_t room_num = lara_item->room_num;
-    const SECTOR *sector =
-        Room_GetSector(pos_1.x, pos_1.y + STEP_L, pos_1.z, &room_num);
+    const XYZ_32 sample_pos = { pos_1.x, pos_1.y + STEP_L, pos_1.z };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
 
     const ROOM *room = Room_Get(room_num);
     if (room->flags.swamp) {
         pos_1.y = room->max_ceiling - STEP_L;
     }
 
-    sector = Room_GetSector(pos_1.x, pos_1.y, pos_1.z, &room_num);
-    int16_t height = Room_GetHeight(sector, pos_1.x, pos_1.y, pos_1.z);
-    int16_t ceiling = Room_GetCeiling(sector, pos_1.x, pos_1.y, pos_1.z);
+    sector = Room_GetSector(pos_1, &room_num);
+    int16_t height = Room_GetHeight(sector, pos_1);
+    int16_t ceiling = Room_GetCeiling(sector, pos_1);
 
     if (height == NO_HEIGHT || ceiling == NO_HEIGHT || ceiling >= height
         || pos_1.y > height || pos_1.y < ceiling) {
         pos_1 = M_GetHeadPos(0, 16, 0);
         room_num = lara_item->room_num;
-        sector = Room_GetSector(pos_1.x, pos_1.y + STEP_L, pos_1.z, &room_num);
+        sector = Room_GetSector(
+            (XYZ_32) { pos_1.x, pos_1.y + STEP_L, pos_1.z }, &room_num);
 
         room = Room_Get(room_num);
         if (room->flags.swamp) {
             pos_1.y = room->max_ceiling - STEP_L;
         }
 
-        sector = Room_GetSector(pos_1.x, pos_1.y, pos_1.z, &room_num);
-        height = Room_GetHeight(sector, pos_1.x, pos_1.y, pos_1.z);
-        ceiling = Room_GetCeiling(sector, pos_1.x, pos_1.y, pos_1.z);
+        sector = Room_GetSector(pos_1, &room_num);
+        height = Room_GetHeight(sector, pos_1);
+        ceiling = Room_GetCeiling(sector, pos_1);
 
         if (height == NO_HEIGHT || ceiling == NO_HEIGHT || ceiling >= height
             || pos_1.y > height || pos_1.y < ceiling) {
@@ -673,18 +667,17 @@ static void M_Look(const ITEM *const item)
     for (; i < M_LOS_STEPS; i++) {
         int16_t next_room_num = room_num;
         sector = Room_GetSector(
-            ideal_pos.x, ideal_pos.y + STEP_L, ideal_pos.z, &next_room_num);
+            (XYZ_32) { ideal_pos.x, ideal_pos.y + STEP_L, ideal_pos.z },
+            &next_room_num);
 
         if (Room_Get(next_room_num)->flags.swamp) {
             ideal_pos.y = Room_Get(next_room_num)->max_ceiling - STEP_L;
             break;
         }
 
-        sector = Room_GetSector(
-            ideal_pos.x, ideal_pos.y, ideal_pos.z, &next_room_num);
-        height = Room_GetHeight(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
-        ceiling =
-            Room_GetCeiling(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
+        sector = Room_GetSector(ideal_pos, &next_room_num);
+        height = Room_GetHeight(sector, ideal_pos);
+        ceiling = Room_GetCeiling(sector, ideal_pos);
 
         if (height == NO_HEIGHT || ceiling == NO_HEIGHT || ceiling >= height
             || ideal_pos.y > height || ideal_pos.y < ceiling) {
@@ -735,13 +728,12 @@ static void M_Look(const ITEM *const item)
         Camera_ApplyBounce();
     }
 
-    Room_GetSector(
-        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
+    Room_GetSector(g_Camera.pos.pos, &g_Camera.pos.room_num);
     ideal_pos = g_Camera.pos.pos;
     room_num = g_Camera.pos.room_num;
-    sector = Room_GetSector(ideal_pos.x, ideal_pos.y, ideal_pos.z, &room_num);
-    height = Room_GetHeight(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
-    ceiling = Room_GetCeiling(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
+    sector = Room_GetSector(ideal_pos, &room_num);
+    height = Room_GetHeight(sector, ideal_pos);
+    ceiling = Room_GetCeiling(sector, ideal_pos);
 
     if (ceiling != NO_HEIGHT && height != NO_HEIGHT) {
         if (ceiling > ideal_pos.y - 255 && height < ideal_pos.y + 255
@@ -756,9 +748,9 @@ static void M_Look(const ITEM *const item)
 
     ideal_pos = g_Camera.pos.pos;
     room_num = g_Camera.pos.room_num;
-    sector = Room_GetSector(ideal_pos.x, ideal_pos.y, ideal_pos.z, &room_num);
-    height = Room_GetHeight(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
-    ceiling = Room_GetCeiling(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
+    sector = Room_GetSector(ideal_pos, &room_num);
+    height = Room_GetHeight(sector, ideal_pos);
+    ceiling = Room_GetCeiling(sector, ideal_pos);
 
     if (Room_Get(room_num)->flags.swamp) {
         g_Camera.pos.y = Room_Get(room_num)->max_ceiling - STEP_L;
@@ -770,9 +762,9 @@ static void M_Look(const ITEM *const item)
 
     ideal_pos = g_Camera.pos.pos;
     room_num = g_Camera.pos.room_num;
-    sector = Room_GetSector(ideal_pos.x, ideal_pos.y, ideal_pos.z, &room_num);
-    height = Room_GetHeight(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
-    ceiling = Room_GetCeiling(sector, ideal_pos.x, ideal_pos.y, ideal_pos.z);
+    sector = Room_GetSector(ideal_pos, &room_num);
+    height = Room_GetHeight(sector, ideal_pos);
+    ceiling = Room_GetCeiling(sector, ideal_pos);
 
     if (ideal_pos.y < ceiling || ideal_pos.y > height || ceiling >= height
         || height == NO_HEIGHT || ceiling == NO_HEIGHT
@@ -781,8 +773,7 @@ static void M_Look(const ITEM *const item)
         g_Camera.pos.room_num = lara_item->room_num;
     }
 
-    Room_GetSector(
-        g_Camera.pos.x, g_Camera.pos.y, g_Camera.pos.z, &g_Camera.pos.room_num);
+    Room_GetSector(g_Camera.pos.pos, &g_Camera.pos.room_num);
     m_LastState.cam_type = g_Camera.type;
 
     Camera_UpdateMicPosition();
@@ -795,17 +786,15 @@ static void M_ClampResult(void)
 {
     XYZ_32 pos = g_Camera.interp.result.pos;
     int16_t room_num = g_Camera.interp.room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    const int16_t height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
-    const int16_t ceiling =
-        Room_GetCeilingEx(sector, pos.x, pos.y, pos.z, true);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    const int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
     if (height == NO_HEIGHT || ceiling == NO_HEIGHT || height < g_Camera.pos.y
         || ceiling > g_Camera.pos.y) {
         pos = g_Camera.pos.pos;
         room_num = g_Camera.pos.room_num;
     }
-    Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    Room_GetSector(pos, &room_num);
     g_Camera.interp.result.pos = pos;
     g_Camera.interp.room_num = room_num;
 }
@@ -925,9 +914,7 @@ static void M_Update(
                 + m_LastIdeal.target.z;
         }
 
-        Room_GetSector(
-            g_Camera.target.x, g_Camera.target.y, g_Camera.target.z,
-            &g_Camera.target.room_num);
+        Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
 
         if (g_Camera.type == CAM_CHASE || g_Camera.flags == CF_CHASE_OBJECT) {
             M_Chase(item);

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -158,8 +158,8 @@ static bool M_CameraInsideRoom(const XYZ_32 pos, const int16_t room_num)
 
 static void M_UpdateCameraRooms(void)
 {
-    Room_GetSector32(g_Camera.pos.pos, &g_Camera.pos.room_num);
-    Room_GetSector32(g_Camera.target.pos, &g_Camera.target.room_num);
+    Room_GetSector(g_Camera.pos.pos, &g_Camera.pos.room_num);
+    Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
     if (!M_CameraInsideRoom(g_Camera.pos.pos, g_Camera.pos.room_num)) {
         const int16_t pos_room_num = Room_GetIndexFromPos(g_Camera.pos.pos);
         const int16_t tar_room_num = Room_GetIndexFromPos(g_Camera.target.pos);
@@ -284,7 +284,7 @@ void Camera_PhotoMode_Enter(void)
     g_Camera.target_square = SQUARE(g_Camera.target_distance);
 
     g_Camera.target.room_num = g_Camera.pos.room_num;
-    Room_GetSector32(g_Camera.target.pos, &g_Camera.target.room_num);
+    Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
 
     m_StartingCamera = g_Camera;
 

--- a/src/trx/game/carrier.c
+++ b/src/trx/game/carrier.c
@@ -92,9 +92,9 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
     // to ensure that the initial sector is in the room above, hence we test
     // slightly above the initial y position.
     const SECTOR *const sector = Room_GetSector(
-        pickup->pos.x, pickup->pos.y - 10, pickup->pos.z, &room_num);
-    const int16_t height =
-        Room_GetHeight(sector, pickup->pos.x, pickup->pos.y, pickup->pos.z);
+        (XYZ_32) { pickup->pos.x, pickup->pos.y - 10, pickup->pos.z },
+        &room_num);
+    const int16_t height = Room_GetHeight(sector, pickup->pos);
     const bool in_water = Room_Get(pickup->room_num)->flags.underwater;
 
     if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {
@@ -335,10 +335,10 @@ void Carrier_TestItemDrops(const int16_t item_num)
             int16_t room_num = carrier->room_num;
             pickup->pos.x = ROUND_TO_SECTOR(carrier->pos.x) + WALL_L / 2;
             pickup->pos.z = ROUND_TO_SECTOR(carrier->pos.z) + WALL_L / 2;
-            const SECTOR *const sector = Room_GetSector(
-                pickup->pos.x, carrier->pos.y, pickup->pos.z, &room_num);
+            const SECTOR *const sector = Room_GetSector(pickup->pos, &room_num);
             pickup->pos.y = Room_GetHeight(
-                sector, pickup->pos.x, carrier->pos.y, pickup->pos.z);
+                sector,
+                (XYZ_32) { pickup->pos.x, carrier->pos.y, pickup->pos.z });
         }
 
         item->status = DS_FALLING;

--- a/src/trx/game/collision.c
+++ b/src/trx/game/collision.c
@@ -13,11 +13,10 @@
 #define M_HEADROOM 160 // Additional collision space above Lara's head.
 
 static bool M_IsOnWalkable(
-    const SECTOR *const sector, const int32_t x, const int32_t y,
-    const int32_t z, const int32_t room_height)
+    const SECTOR *const sector, const XYZ_32 pos, const int32_t room_height)
 {
     return g_Config.gameplay.fix_bridge_collision
-        && Room_IsOnWalkable(sector, x, y, z, room_height, NO_ITEM);
+        && Room_IsOnWalkable(sector, pos, room_height, NO_ITEM);
 }
 
 // Probes the front, left, and right of Lara and fills in the collision info for
@@ -25,11 +24,10 @@ static bool M_IsOnWalkable(
 // how big slope and lava pit sectors are treated. For example, in the walk
 // state, Lara won't walk up big slopes or walk down into lava pits.
 static void M_FillSide(
-    const COLL_INFO *const coll, COLL_SIDE *const side, const int32_t x_pos,
-    const int32_t z_pos, const int32_t y_pos, const int32_t obj_height,
-    int16_t *const room_num)
+    const COLL_INFO *const coll, COLL_SIDE *const side, const XYZ_32 pos,
+    const int32_t obj_height, int16_t *const room_num)
 {
-    const int32_t y = y_pos - obj_height;
+    const int32_t y = pos.y - obj_height;
     const int32_t y_top = y - M_HEADROOM;
 
     int16_t local_room_num = *room_num;
@@ -38,16 +36,16 @@ static void M_FillSide(
         ? &local_room_num
         : room_num;
 
-    const SECTOR *const sector =
-        Room_GetSector(x_pos, y_top, z_pos, test_room_num);
-    int32_t height = Room_GetHeight(sector, x_pos, y_top, z_pos);
-    int32_t ceiling = Room_GetCeiling(sector, x_pos, y_top, z_pos);
+    const XYZ_32 sample_pos = { .x = pos.x, .y = y_top, .z = pos.z };
+    const SECTOR *const sector = Room_GetSector(sample_pos, test_room_num);
+    int32_t height = Room_GetHeight(sector, sample_pos);
+    int32_t ceiling = Room_GetCeiling(sector, sample_pos);
     const int32_t room_height = height;
     const int32_t room_ceiling = ceiling;
     const bool sim_wall = room_height == ceiling && room_height != NO_HEIGHT
         && sector->ceiling.tilt == 0 && sector->floor.tilt == 0;
     if (height != NO_HEIGHT) {
-        height -= y_pos;
+        height -= pos.y;
     }
     if (ceiling != NO_HEIGHT) {
         ceiling -= y;
@@ -57,8 +55,7 @@ static void M_FillSide(
     side->ceiling = ceiling;
     side->type = Room_GetHeightType();
 
-    const bool is_on_walkable =
-        M_IsOnWalkable(sector, x_pos, y_top, z_pos, room_height);
+    const bool is_on_walkable = M_IsOnWalkable(sector, sample_pos, room_height);
     if (!is_on_walkable) {
         if (coll->slopes_are_walls
             && (side->type == HT_BIG_SLOPE || side->type == HT_DIAGONAL)
@@ -71,7 +68,7 @@ static void M_FillSide(
             side->floor = STEP_L * 2;
         } else if (
             coll->lava_is_pit && side->floor > 0
-            && Room_GetPitSector(sector, x_pos, z_pos)->is_death_sector) {
+            && Room_GetPitSector(sector, pos.x, pos.z)->is_death_sector) {
             side->floor = STEP_L * 2;
         }
     } else if (sim_wall) {
@@ -297,13 +294,14 @@ void Collide_GetCollisionInfo(
     const int32_t y = y_pos - obj_height;
     const int32_t y_top = y - M_HEADROOM;
 
-    const SECTOR *sector = Room_GetSector(x, y_top, z, &room_num);
-    int32_t height = Room_GetHeight(sector, x, y_top, z);
+    const XYZ_32 sample_pos = { .x = x, .y = y_top, .z = z };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
+    int32_t height = Room_GetHeight(sector, sample_pos);
     int32_t room_height = height;
     if (height != NO_HEIGHT) {
         height -= y_pos;
     }
-    int32_t ceiling = Room_GetCeiling(sector, x, y_top, z);
+    int32_t ceiling = Room_GetCeiling(sector, sample_pos);
     if (ceiling != NO_HEIGHT) {
         ceiling -= y;
     }
@@ -312,13 +310,14 @@ void Collide_GetCollisionInfo(
     coll->side_mid.ceiling = ceiling;
     coll->side_mid.type = Room_GetHeightType();
 
-    bool is_on_walkable = M_IsOnWalkable(sector, x, y_top, z, room_height);
+    bool is_on_walkable = M_IsOnWalkable(sector, sample_pos, room_height);
     if (is_on_walkable) {
         coll->tilt_z = 0;
         coll->tilt_x = 0;
     } else {
         const ITEM *const lara_item = Lara_GetItem();
-        const int16_t tilt = Room_GetTiltType(sector, x, lara_item->pos.y, z);
+        const int16_t tilt =
+            Room_GetTiltType(sector, (XYZ_32) { x, lara_item->pos.y, z });
         coll->tilt_z = tilt >> 8;
         coll->tilt_x = (int8_t)tilt;
     }
@@ -381,24 +380,29 @@ void Collide_GetCollisionInfo(
     }
 
     M_FillSide(
-        coll, &coll->side_front, x_pos + x_front, z_pos + z_front, y_pos,
+        coll, &coll->side_front,
+        (XYZ_32) { .x = x_pos + x_front, .z = z_pos + z_front, .y = y_pos },
         obj_height, &room_num);
 
     int16_t room_num2;
     room_num2 = prev_room_num;
     M_FillSide(
-        coll, &coll->side_left, x_pos + x_left, z_pos + z_left, y_pos,
+        coll, &coll->side_left,
+        (XYZ_32) { .x = x_pos + x_left, .z = z_pos + z_left, .y = y_pos },
         obj_height, &room_num2);
     room_num2 = prev_room_num;
     M_FillSide(
-        coll, &coll->side_right, x_pos + x_right, z_pos + z_right, y_pos,
+        coll, &coll->side_right,
+        (XYZ_32) { .x = x_pos + x_right, .z = z_pos + z_right, .y = y_pos },
         obj_height, &room_num2);
 
     M_FillSide(
-        coll, &coll->side_left2, x_pos + x_left, z_pos + z_left, y_pos,
+        coll, &coll->side_left2,
+        (XYZ_32) { .x = x_pos + x_left, .z = z_pos + z_left, .y = y_pos },
         obj_height, &room_num);
     M_FillSide(
-        coll, &coll->side_right2, x_pos + x_right, z_pos + z_right, y_pos,
+        coll, &coll->side_right2,
+        (XYZ_32) { .x = x_pos + x_right, .z = z_pos + z_right, .y = y_pos },
         obj_height, &room_num);
 
     const int16_t static_room_num = g_TRVersion >= 3 ? prev_room_num : room_num;
@@ -409,11 +413,9 @@ void Collide_GetCollisionInfo(
             .y = y_pos,
             .z = z_pos + coll->shift.z,
         };
-        sector = Room_GetSector(test_pos.x, test_pos.y, test_pos.z, &room_num);
-        if (Room_GetHeight(sector, test_pos.x, test_pos.y, test_pos.z)
-                < test_pos.y - WALL_L / 2
-            || Room_GetCeiling(sector, test_pos.x, test_pos.y, test_pos.z)
-                > y) {
+        sector = Room_GetSector(test_pos, &room_num);
+        if (Room_GetHeight(sector, test_pos) < test_pos.y - WALL_L / 2
+            || Room_GetCeiling(sector, test_pos) > y) {
             coll->shift.x = -coll->shift.x;
             coll->shift.z = -coll->shift.z;
         }
@@ -742,14 +744,13 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
     int32_t yang;
 
     int16_t room_num = item->room_num;
-    const SECTOR *sector =
-        Room_GetSector(old_pos.x, old_pos.y, old_pos.z, &room_num);
-    int32_t oldheight = Room_GetHeight(sector, old_pos.x, old_pos.y, old_pos.z);
+    const SECTOR *sector = Room_GetSector(old_pos, &room_num);
+    int32_t oldheight = Room_GetHeight(sector, old_pos);
     int32_t oldtype = Room_GetHeightType();
 
     room_num = item->room_num;
-    sector = Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    height = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    sector = Room_GetSector(item->pos, &room_num);
+    height = Room_GetHeight(sector, item->pos);
 
     if (item->pos.y >= height) {
         bs = 0;
@@ -758,8 +759,7 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
             && oldheight < height) {
             yang = (uint16_t)item->rot.y;
 
-            const int16_t tilt =
-                Room_GetTiltType(sector, item->pos.x, item->pos.y, item->pos.z);
+            const int16_t tilt = Room_GetTiltType(sector, item->pos);
             const int8_t tiltyoff = tilt >> 8;
             const int8_t tiltxoff = (int8_t)tilt;
             if (tiltyoff < 0) {
@@ -826,8 +826,7 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
         } else {
             item->speed -= item->speed >> 2;
 
-            const int16_t tilt =
-                Room_GetTiltType(sector, item->pos.x, item->pos.y, item->pos.z);
+            const int16_t tilt = Room_GetTiltType(sector, item->pos);
             const int8_t tiltyoff = tilt >> 8;
             const int8_t tiltxoff = (int8_t)tilt;
             if (tiltyoff < 0 && ABS(tiltyoff) - ABS(tiltxoff) >= 2) {
@@ -1083,10 +1082,8 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
         // been reworked in TRX.
 
         room_num = item->room_num;
-        sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        ceiling =
-            Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+        sector = Room_GetSector(item->pos, &room_num);
+        ceiling = Room_GetCeiling(sector, item->pos);
 
         if (item->pos.y < ceiling) {
             const bool x_cross = ROUND_TO_SECTOR(item->pos.x ^ old_pos.x) != 0;
@@ -1112,7 +1109,7 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
     }
 
     room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
 
     if (item->room_num != room_num) {
         Item_UpdateRoom(Item_GetIndex(item), room_num);

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -162,6 +162,8 @@ static void M_AlignLaraToItem(const ITEM *const item)
         dir = L_DIR_SAME;
     } else if (Object_IsType(item->object_id, g_DoorObjects)) {
         dir = L_DIR_OPPOSITE;
+    } else if (item->object_id == O_ZIPLINE_HANDLE) {
+        dir = L_DIR_SAME;
     }
     if (dir != L_DIR_NONE) {
         ITEM *const lara_item = Lara_GetItem();

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -61,10 +61,8 @@ static bool M_CanTargetItem(
     // Out of bounds items
     int16_t room_num = item->room_num;
     if (room_num != NO_ROOM) {
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
-            == NO_HEIGHT) {
+        const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+        if (Room_GetHeight(sector, item->pos) == NO_HEIGHT) {
             return false;
         }
     }

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -188,10 +188,8 @@ static bool M_SwitchToLand(
         item->goal_anim_state = item->current_anim_state;
 
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        item->floor =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+        item->floor = Room_GetHeight(sector, item->pos);
         item->pos.y = item->floor;
         Item_UpdateRoom(item_num, room_num);
     }
@@ -391,8 +389,7 @@ bool Creature_EnsureHabitat(
     // Test the environment for a hybrid creature. Record the water height and
     // return whether or not a type conversion has taken place.
     const ITEM *const item = Item_Get(item_num);
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     if (wh != nullptr) {
         *wh = water_height;
     }
@@ -687,8 +684,7 @@ void Creature_Float(const int16_t item_num)
     item->hit_points = DONT_TARGET;
     item->rot.x = 0;
 
-    const int32_t wh = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t wh = Room_GetWaterHeight(item->pos, item->room_num);
     if (item->pos.y > wh) {
         item->pos.y -= M_FLOAT_SPEED;
     }
@@ -697,16 +693,14 @@ void Creature_Float(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 }
 
 void Creature_Underwater(ITEM *const item, const int32_t depth)
 {
-    const int32_t wh = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t wh = Room_GetWaterHeight(item->pos, item->room_num);
     if (item->pos.y >= wh + depth) {
         return;
     }
@@ -797,7 +791,7 @@ bool Creature_Animate(
 
     if (g_TRVersion >= 2 && !Object_IsType(item->object_id, g_WaterObjects)) {
         int16_t room_num = item->room_num;
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        Room_GetSector(item->pos, &room_num);
         Item_UpdateRoom(item_num, room_num);
     }
 
@@ -811,9 +805,11 @@ bool Creature_Animate(
     int32_t y = item->pos.y + bounds->min.y;
 
     int16_t room_num = item->room_num;
-    Room_GetSector(old.x, y, old.z, &room_num);
-    const SECTOR *sector =
-        Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
+    XYZ_32 sample_pos = { old.x, y, old.z };
+    Room_GetSector(sample_pos, &room_num);
+    sample_pos.x = item->pos.x;
+    sample_pos.z = item->pos.z;
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
     int32_t height = Box_GetBox(sector->box)->height;
     int16_t next_box = lot->node[sector->box].exit_box;
     int32_t next_height =
@@ -845,7 +841,10 @@ bool Creature_Animate(
             item->pos.z = ROUND_TO_SECTOR_END(old.z);
         }
 
-        sector = Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
+        sample_pos.x = item->pos.x;
+        sample_pos.y = y;
+        sample_pos.z = item->pos.z;
+        sector = Room_GetSector(sample_pos, &room_num);
         height = Box_GetBox(sector->box)->height;
         next_box = lot->node[sector->box].exit_box;
         next_height =
@@ -950,7 +949,10 @@ bool Creature_Animate(
     item->pos.z += shift_z;
 
     if (shift_x != 0 || shift_z != 0) {
-        sector = Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
+        sample_pos.x = item->pos.x;
+        sample_pos.y = y;
+        sample_pos.z = item->pos.z;
+        sector = Room_GetSector(sample_pos, &room_num);
         item->rot.y += angle;
         Creature_Tilt(item, tilt * 2);
     }
@@ -984,7 +986,8 @@ bool Creature_Animate(
         int32_t dy = creature->target.y - item->pos.y;
         CLAMP(dy, -lot->setup.fly, lot->setup.fly);
 
-        height = Room_GetHeight(sector, item->pos.x, y, item->pos.z);
+        height =
+            Room_GetHeight(sector, (XYZ_32) { item->pos.x, y, item->pos.z });
         if (item->pos.y + dy > height) {
             if (item->pos.y <= height) {
                 dy = 0;
@@ -996,8 +999,8 @@ bool Creature_Animate(
             }
         } else if (
             fly_check || Object_IsType(item->object_id, g_WaterObjects)) {
-            const int32_t ceiling =
-                Room_GetCeiling(sector, item->pos.x, y, item->pos.z);
+            const int32_t ceiling = Room_GetCeiling(
+                sector, (XYZ_32) { item->pos.x, y, item->pos.z });
             int32_t min_y = bounds->min.y;
             switch (item->object_id) {
             case O_ALLIGATOR:
@@ -1021,7 +1024,8 @@ bool Creature_Animate(
                 }
             }
         } else {
-            Room_GetSector(item->pos.x, y + STEP_L, item->pos.z, &room_num);
+            sample_pos = (XYZ_32) { item->pos.x, y + STEP_L, item->pos.z };
+            Room_GetSector(sample_pos, &room_num);
             const ROOM *const room = Room_Get(room_num);
             if (room->flags.underwater || room->flags.swamp) {
                 dy = -lot->setup.fly;
@@ -1029,8 +1033,9 @@ bool Creature_Animate(
         }
 
         item->pos.y += dy;
-        sector = Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
-        item->floor = Room_GetHeight(sector, item->pos.x, y, item->pos.z);
+        sample_pos = (XYZ_32) { item->pos.x, y, item->pos.z };
+        sector = Room_GetSector(sample_pos, &room_num);
+        item->floor = Room_GetHeight(sector, sample_pos);
 
         int16_t item_angle = item->speed != 0 ? Math_Atan(item->speed, -dy) : 0;
         if (g_TRVersion >= 2) {
@@ -1045,11 +1050,9 @@ bool Creature_Animate(
             item->rot.x = item_angle;
         }
     } else {
-        sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        sector = Room_GetSector(item->pos, &room_num);
         if (g_TRVersion == 3) {
-            const int16_t ceiling =
-                Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+            const int16_t ceiling = Room_GetCeiling(sector, item->pos);
             int32_t min_y = bounds->min.y;
             switch (item->object_id) {
             case O_TREX:
@@ -1064,13 +1067,11 @@ bool Creature_Animate(
 
             if (item->pos.y + min_y < ceiling) {
                 item->pos = old;
-                sector = Room_GetSector(
-                    item->pos.x, item->pos.y, item->pos.z, &room_num);
+                sector = Room_GetSector(item->pos, &room_num);
             }
         }
 
-        item->floor =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        item->floor = Room_GetHeight(sector, item->pos);
 
         if (item->pos.y > item->floor) {
             item->pos.y = item->floor;
@@ -1086,7 +1087,8 @@ bool Creature_Animate(
         // Get the room just above the enemy so that if it is in one-click high
         // water, its effects behave still as though in a dry room.
         Room_GetSector(
-            item->pos.x, item->pos.y - (STEP_L * 2), item->pos.z, &room_num);
+            (XYZ_32) { item->pos.x, item->pos.y - (STEP_L * 2), item->pos.z },
+            &room_num);
         if (g_TRVersion >= 2 && Room_Get(room_num)->flags.underwater) {
             item->hit_points = 0;
         }

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -213,9 +213,8 @@ static void M_PlayerControl(const int16_t item_num)
     }
 
     int16_t floor_room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(pos.x, pos.y, pos.z, &floor_room_num);
-    const int16_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const SECTOR *const sector = Room_GetSector(pos, &floor_room_num);
+    const int16_t height = Room_GetHeight(sector, pos);
     item->floor = height == NO_HEIGHT ? pos.y : height;
 
     Lara_Animate(item);

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -182,10 +182,8 @@ bool Demo_Start(const int32_t level_num)
 
     int16_t room_num = *p->demo_ptr++;
     Item_UpdateRoom(lara->item_num, room_num);
-    const SECTOR *const sector = Room_GetSector(
-        lara_item->pos.x, lara_item->pos.y, lara_item->pos.z, &room_num);
-    lara_item->floor = Room_GetHeight(
-        sector, lara_item->pos.x, lara_item->pos.y, lara_item->pos.z);
+    const SECTOR *const sector = Room_GetSector(lara_item->pos, &room_num);
+    lara_item->floor = Room_GetHeight(sector, lara_item->pos);
 
     if (g_TRVersion >= 2) {
         lara->last_gun_type = *p->demo_ptr++;

--- a/src/trx/game/footprint_fx.c
+++ b/src/trx/game/footprint_fx.c
@@ -68,7 +68,7 @@ void FootprintFX_Add(const ITEM *const lara_item, const bool is_left_foot)
         lara_item, &pos, is_left_foot ? LM_FOOT_L : LM_FOOT_R);
 
     int16_t room_num = lara_item->room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
     if (sector == nullptr) {
         return;
     }
@@ -82,7 +82,7 @@ void FootprintFX_Add(const ITEM *const lara_item, const bool is_left_foot)
         return;
     }
 
-    const int32_t y = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const int32_t y = Room_GetHeight(sector, pos);
     if (y == NO_HEIGHT) {
         return;
     }
@@ -113,14 +113,13 @@ static int32_t M_GetVertexYOffset(
     const M_FOOTPRINT *const print, const XYZ_32 world_pos)
 {
     int16_t room_num = print->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(world_pos.x, print->y, world_pos.z, &room_num);
+    const XYZ_32 pos = { world_pos.x, print->y, world_pos.z };
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
     if (sector == nullptr) {
         return 0;
     }
 
-    const int32_t height =
-        Room_GetHeight(sector, world_pos.x, print->y, world_pos.z);
+    const int32_t height = Room_GetHeight(sector, pos);
     if (height == NO_HEIGHT) {
         return 0;
     }

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -503,11 +503,11 @@ int32_t Gun_FireWeapon(
                 .z = start.z + ((dist * g_MatrixPtr->_22) >> W2V_SHIFT),
                 .room_num = start.room_num,
             };
-        Room_GetSector(hit_pos.x, hit_pos.y, hit_pos.z, &hit_pos.room_num);
+        Room_GetSector(hit_pos.pos, &hit_pos.room_num);
         const bool object_on_los = LOS_Check(&start, &hit_pos, true);
         if (Gun_SmashItems(start.pos, hit_pos.pos, &hit_pos.pos)
             == PROJECTILE_HIT_STOP) {
-            Room_GetSector(hit_pos.x, hit_pos.y, hit_pos.z, &hit_pos.room_num);
+            Room_GetSector(hit_pos.pos, &hit_pos.room_num);
         }
         if (!object_on_los) {
             Spawn_RicochetRay(start, hit_pos);
@@ -522,7 +522,7 @@ int32_t Gun_FireWeapon(
         .z = start.z + ((best_dist * g_MatrixPtr->_22) >> W2V_SHIFT),
         .room_num = src->room_num,
     };
-    Room_GetSector(hit_pos.x, hit_pos.y, hit_pos.z, &hit_pos.room_num);
+    Room_GetSector(hit_pos.pos, &hit_pos.room_num);
     Gun_SmashItems(start.pos, hit_pos.pos, nullptr);
     Gun_HitTarget(
         target, &start, &hit_pos,

--- a/src/trx/game/gun/rifle.c
+++ b/src/trx/game/gun/rifle.c
@@ -305,9 +305,9 @@ static void M_FireGrenade(void)
     projectile_item->interp.prev.pos = projectile_item->pos;
     Item_Initialise(item_num);
 
-    const SECTOR *const sector = Room_GetSector(
-        origin.x, origin.y, origin.z, &projectile_item->room_num);
-    const int32_t height = Room_GetHeight(sector, origin.x, origin.y, origin.z);
+    const SECTOR *const sector =
+        Room_GetSector(origin, &projectile_item->room_num);
+    const int32_t height = Room_GetHeight(sector, origin);
     if (height < origin.y) {
         projectile_item->pos = (XYZ_32) {
             .x = lara_item->pos.x,

--- a/src/trx/game/gun/smoke.c
+++ b/src/trx/game/gun/smoke.c
@@ -48,7 +48,7 @@ void Gun_Smoke_OnFire(const LARA_GUN_TYPE weapon_type, const bool is_right_hand)
 
     GAME_VECTOR pos = { .pos = muzzle_pos,
                         .room_num = Lara_GetItem()->room_num };
-    Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+    Room_GetSector(pos.pos, &pos.room_num);
 
     if (weapon_type == LGT_SHOTGUN && is_right_hand) {
         const XYZ_32 muzzle_tip_pos =
@@ -95,7 +95,7 @@ void Gun_Smoke_Control(void)
             LM_HAND_L, M_GetMuzzleOffset(weapon_type, false));
         GAME_VECTOR pos = { .pos = muzzle_pos,
                             .room_num = Lara_GetItem()->room_num };
-        Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        Room_GetSector(pos.pos, &pos.room_num);
         Sparks_TriggerGunSmoke(
             pos, false, weapon_type, lara->tr3_smoke_count_l);
         lara->tr3_smoke_count_l--;
@@ -106,7 +106,7 @@ void Gun_Smoke_Control(void)
             LM_HAND_R, M_GetMuzzleOffset(weapon_type, true));
         GAME_VECTOR pos = { .pos = muzzle_pos,
                             .room_num = Lara_GetItem()->room_num };
-        Room_GetSector(pos.x, pos.y, pos.z, &pos.room_num);
+        Room_GetSector(pos.pos, &pos.room_num);
         Sparks_TriggerGunSmoke(
             pos, false, weapon_type, lara->tr3_smoke_count_r);
         lara->tr3_smoke_count_r--;

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -30,7 +30,8 @@ static bool M_ShouldPlaySFXAlways(
 
     const int32_t dist =
         item_underwater ? -M_SFX_SURF_DISTANCE : +M_SFX_SURF_DISTANCE;
-    Room_GetSector(item->pos.x, item->pos.y + dist, item->pos.z, &room_num);
+    Room_GetSector(
+        (XYZ_32) { item->pos.x, item->pos.y + dist, item->pos.z }, &room_num);
     const ROOM *const nearby_room = Room_Get(room_num);
     const bool near_underwater = nearby_room->flags.underwater;
     return item_underwater != near_underwater;

--- a/src/trx/game/items/col.c
+++ b/src/trx/game/items/col.c
@@ -10,10 +10,8 @@ static BOUNDS_16 m_InterpolatedBounds = {};
 int16_t Item_GetHeight(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
 
     return height;
 }

--- a/src/trx/game/items/walkable.c
+++ b/src/trx/game/items/walkable.c
@@ -12,7 +12,7 @@
 
 static SECTOR *M_GetItemPitSector(const XYZ_32 pos, int16_t room_num)
 {
-    SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    SECTOR *const sector = Room_GetSector(pos, &room_num);
     return Room_GetPitSector(sector, pos.x, pos.z);
 }
 

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -336,9 +336,8 @@ bool Lara_Cheat_ExitFlyMode(void)
     }
 
     const ROOM *const room = Room_Get(lara_item->room_num);
-    const int16_t water_height = Room_GetWaterHeight(
-        lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
-        lara_item->room_num);
+    const int16_t water_height =
+        Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
 
     if (room->flags.underwater
         || (water_height != NO_HEIGHT && water_height > 0
@@ -383,9 +382,8 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
         return false;
     }
 
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeightEx(sector, pos.x, pos.y, pos.z, true, NO_ITEM);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
     if (height == NO_HEIGHT) {
         return false;
     }
@@ -408,9 +406,8 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
     if (lara_info->extra_anim) {
         const ROOM *const room = Room_Get(lara_item->room_num);
         const bool room_submerged = room->flags.underwater;
-        const int16_t water_height = Room_GetWaterHeight(
-            lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
-            lara_item->room_num);
+        const int16_t water_height =
+            Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
 
         if (room_submerged || (water_height != NO_HEIGHT && water_height > 0)) {
             lara_info->water_status = LWS_UNDERWATER;

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -135,10 +135,8 @@ void Lara_Col_Shift(COLL_INFO *const coll)
 void Lara_Col_MonkeySwingSnap(ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t ceiling =
-        Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t ceiling = Room_GetCeiling(sector, item->pos);
     if (ceiling != NO_HEIGHT) {
         item->pos.y = ceiling + M_MONKEY_CEILING_SNAP;
     }
@@ -179,8 +177,7 @@ void Lara_Col_WadeSplash(ITEM *const item)
 
     const int32_t water_depth = Lara_GetWaterDepth(
         item->pos.x, item->pos.y, item->pos.z, item->room_num);
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
     if (water_height != NO_HEIGHT && water_depth != NO_HEIGHT
         && bounds != nullptr && item->pos.y + bounds->min.y <= water_height

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -78,8 +78,10 @@ static M_CLIMB_RESULT M_TestClimbPos(
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector(x, y - 128, z, &room_num);
-    int32_t height = Room_GetHeight(sector, x, y, z);
+    XYZ_32 sample_pos = { x, y - 128, z };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
+    sample_pos.y = y;
+    int32_t height = Room_GetHeight(sector, sample_pos);
     if (height == NO_HEIGHT) {
         return CLIMB_RESULT_NONE;
     }
@@ -92,7 +94,7 @@ static M_CLIMB_RESULT M_TestClimbPos(
         *shift = height;
     }
 
-    int32_t ceiling = Room_GetCeiling(sector, x, y, z) - y;
+    int32_t ceiling = Room_GetCeiling(sector, sample_pos) - y;
     if (ceiling > M_CLIMB_SHIFT) {
         return CLIMB_RESULT_NONE;
     }
@@ -109,14 +111,17 @@ static M_CLIMB_RESULT M_TestClimbPos(
 
     const int32_t x2 = x + x_front;
     const int32_t z2 = z + z_front;
-    sector = Room_GetSector(x2, y, z2, &room_num);
-    height = Room_GetHeight(sector, x2, y, z2);
+    sample_pos.x = x2;
+    sample_pos.y = y;
+    sample_pos.z = z2;
+    sector = Room_GetSector(sample_pos, &room_num);
+    height = Room_GetHeight(sector, sample_pos);
     if (height != NO_HEIGHT) {
         height -= y;
     }
 
     if (height > M_CLIMB_SHIFT) {
-        ceiling = Room_GetCeiling(sector, x2, y, z2) - y;
+        ceiling = Room_GetCeiling(sector, sample_pos) - y;
         if (ceiling >= M_CLIMB_HEIGHT) {
             return CLIMB_RESULT_POS;
         }
@@ -154,9 +159,12 @@ static M_CLIMB_RESULT M_TestClimbPos(
     }
 
     room_num = item->room_num;
-    sector = Room_GetSector(x, item_height + y, z, &room_num);
-    sector = Room_GetSector(x2, item_height + y, z2, &room_num);
-    ceiling = Room_GetCeiling(sector, x2, item_height + y, z2);
+    sample_pos = (XYZ_32) { x, item_height + y, z };
+    Room_GetSector(sample_pos, &room_num);
+    sample_pos.x = x2;
+    sample_pos.z = z2;
+    sector = Room_GetSector(sample_pos, &room_num);
+    ceiling = Room_GetCeiling(sector, sample_pos);
     if (ceiling == NO_HEIGHT) {
         return CLIMB_RESULT_POS;
     }
@@ -427,8 +435,9 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
     int32_t ceiling;
 
     int16_t room_num = item->room_num;
-    sector = Room_GetSector(x, y, z, &room_num);
-    ceiling = Room_GetCeiling(sector, x, y, z) + STEP_L - y;
+    XYZ_32 sample_pos = { x, y, z };
+    sector = Room_GetSector(sample_pos, &room_num);
+    ceiling = Room_GetCeiling(sector, sample_pos) + STEP_L - y;
     if (ceiling > M_CLIMB_SHIFT) {
         return CLIMB_RESULT_NONE;
     }
@@ -439,8 +448,10 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
 
     const int32_t x2 = x + x_front;
     const int32_t z2 = z + z_front;
-    sector = Room_GetSector(x2, y, z2, &room_num);
-    height = Room_GetHeight(sector, x2, y, z2);
+    sample_pos.x = x2;
+    sample_pos.z = z2;
+    sector = Room_GetSector(sample_pos, &room_num);
+    height = Room_GetHeight(sector, sample_pos);
     if (height == NO_HEIGHT) {
         *ledge = NO_HEIGHT;
         return CLIMB_RESULT_POS;
@@ -449,7 +460,7 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
     height -= y;
     *ledge = height;
     if (height > STEP_L / 2) {
-        ceiling = Room_GetCeiling(sector, x2, y, z2) - y;
+        ceiling = Room_GetCeiling(sector, sample_pos) - y;
         if (ceiling >= M_CLIMB_HEIGHT) {
             return CLIMB_RESULT_POS;
         }
@@ -467,9 +478,12 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
     }
 
     room_num = item->room_num;
-    sector = Room_GetSector(x, y + M_CLIMB_HEIGHT, z, &room_num);
-    sector = Room_GetSector(x2, y + M_CLIMB_HEIGHT, z2, &room_num);
-    ceiling = Room_GetCeiling(sector, x2, y + M_CLIMB_HEIGHT, z2) - y;
+    sample_pos = (XYZ_32) { x, y + M_CLIMB_HEIGHT, z };
+    Room_GetSector(sample_pos, &room_num);
+    sample_pos.x = x2;
+    sample_pos.z = z2;
+    sector = Room_GetSector(sample_pos, &room_num);
+    ceiling = Room_GetCeiling(sector, sample_pos) - y;
     if (ceiling <= height) {
         return CLIMB_RESULT_POS;
     }
@@ -504,9 +518,9 @@ static bool M_TestLedgeJump(const ITEM *const item, const COLL_INFO *const coll)
         .y = item->pos.y,
     };
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    const int32_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
-    const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
     return height == NO_HEIGHT || height < pos.y
         || (ceiling - pos.y) >= -M_LEDGE_JUMP_PUSH_HEIGHT;
 }

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -41,29 +41,27 @@ EDGE_CATCH Lara_Col_TestEdgeCatch(
 
 bool Lara_Col_TestHangSwingIn(const ITEM *const item, const int16_t angle)
 {
-    int32_t x = item->pos.x;
-    int32_t y = item->pos.y;
-    int32_t z = item->pos.z;
+    XYZ_32 pos = item->pos;
     int16_t room_num = item->room_num;
     switch (angle) {
     case 0:
-        z += STEP_L;
+        pos.z += STEP_L;
         break;
     case DEG_90:
-        x += STEP_L;
+        pos.x += STEP_L;
         break;
     case -DEG_180:
-        z -= STEP_L;
+        pos.z -= STEP_L;
         break;
     case -DEG_90:
-        x -= STEP_L;
+        pos.x -= STEP_L;
         break;
     }
 
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    int32_t height = Room_GetHeight(sector, x, y, z);
-    int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-    return height != NO_HEIGHT && height - y > 0 && ceiling - y < -400;
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    int32_t height = Room_GetHeight(sector, pos);
+    int32_t ceiling = Room_GetCeiling(sector, pos);
+    return height != NO_HEIGHT && height - pos.y > 0 && ceiling - pos.y < -400;
 }
 
 static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
@@ -77,8 +75,8 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     if (g_TRVersion >= 3
         && (coll->coll_type == COLL_TOP || coll->coll_type == COLL_TOP_FRONT)) {
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+        const SECTOR *const sector = Room_GetSector(
+            (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
         if ((sector->ladder & LADDER_CEILING) != 0) {
             Item_SwitchToAnim(item, LA(LA_REACH_TO_THIN_LEDGE), 0);
             item->current_anim_state = LS(LS_MONKEY_IDLE);
@@ -171,8 +169,8 @@ static bool M_TestHangJumpUp(ITEM *const item, COLL_INFO *const coll)
 
     if (coll->coll_type == COLL_TOP || coll->coll_type == COLL_TOP_FRONT) {
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+        const SECTOR *const sector = Room_GetSector(
+            (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
         if ((sector->ladder & LADDER_CEILING) != 0) {
             Item_SwitchToAnim(item, LA(LA_MONKEY_GRAB), 0);
             item->current_anim_state = LS(LS_MONKEY_IDLE);
@@ -647,9 +645,9 @@ LANDED_STATE Lara_Col_LandedBad(ITEM *const item)
 {
     const XYZ_32 pos = item->pos;
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
     const int32_t height =
-        Room_GetHeight(sector, pos.x, pos.y - LARA_HEIGHT, pos.z);
+        Room_GetHeight(sector, (XYZ_32) { pos.x, pos.y - LARA_HEIGHT, pos.z });
     item->pos.y = height;
     item->floor = height;
 

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -43,52 +43,51 @@ static bool M_TestWall(
     const ITEM *const item, const int32_t front, const int32_t right,
     const int32_t down)
 {
-    int32_t x = item->pos.x;
-    int32_t y = item->pos.y + down;
-    int32_t z = item->pos.z;
+    XYZ_32 pos = item->pos;
+    pos.y += down;
 
     const DIRECTION dir = Math_GetDirection(item->rot.y);
     switch (dir) {
     case DIR_NORTH:
-        x -= right;
+        pos.x -= right;
         break;
     case DIR_EAST:
-        z -= right;
+        pos.z -= right;
         break;
     case DIR_SOUTH:
-        x += right;
+        pos.x += right;
         break;
     case DIR_WEST:
-        z += right;
+        pos.z += right;
         break;
     default:
         break;
     }
 
     int16_t room_num = item->room_num;
-    Room_GetSector(x, y, z, &room_num);
+    Room_GetSector(pos, &room_num);
 
     switch (dir) {
     case DIR_NORTH:
-        z += front;
+        pos.z += front;
         break;
     case DIR_EAST:
-        x += front;
+        pos.x += front;
         break;
     case DIR_SOUTH:
-        z -= front;
+        pos.z -= front;
         break;
     case DIR_WEST:
-        x -= front;
+        pos.x -= front;
         break;
     default:
         break;
     }
 
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int32_t height = Room_GetHeight(sector, x, y, z);
-    const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-    if (height != NO_HEIGHT && height - y > 0 && ceiling - y < 0) {
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
+    if (height != NO_HEIGHT && height - pos.y > 0 && ceiling - pos.y < 0) {
         return false;
     }
     return true;

--- a/src/trx/game/lara/col/monkey.c
+++ b/src/trx/game/lara/col/monkey.c
@@ -16,8 +16,8 @@
 static bool M_CanMonkeySwing(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
     return (sector->ladder & LADDER_CEILING) != 0;
 }
 

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -121,8 +121,7 @@ static bool M_TestWaterClimbOut(ITEM *const item, const COLL_INFO *const coll)
 static void M_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     const int32_t water_depth =
         Lara_GetWaterDepth(item->pos.x, item->pos.y, item->pos.z, room_num);
 
@@ -146,7 +145,7 @@ static void M_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
     item->fall_speed = 0;
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->water_status = LWS_WADE;
-    item->pos.y = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    item->pos.y = Room_GetHeight(sector, item->pos);
 }
 
 static void M_CommonSurface(ITEM *const item, COLL_INFO *const coll)
@@ -177,8 +176,7 @@ static void M_CommonSurface(ITEM *const item, COLL_INFO *const coll)
         item->pos = coll->old;
     }
 
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     if (water_height - item->pos.y <= -100) {
         item->current_anim_state = LS(LS_DIVE);
         item->goal_anim_state = LS(LS_SWIM);
@@ -309,8 +307,7 @@ static void M_UWDeath(ITEM *const item, COLL_INFO *const coll)
     lara->air = -1;
     lara->gun_status = LGS_HANDS_BUSY;
     item->hit_points = -1;
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     if (water_height != NO_HEIGHT && water_height < item->pos.y - 100) {
         item->pos.y -= 5;
     }

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -801,12 +801,9 @@ void Lara_AlignPosition(const ITEM *const item, const XYZ_32 *const vec)
 
     if (g_Config.gameplay.fix_lara_pickup_embed) {
         int16_t room_num = lara->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(new_pos.x, new_pos.y, new_pos.z, &room_num);
-        const int32_t height =
-            Room_GetHeight(sector, new_pos.x, new_pos.y, new_pos.z);
-        const int32_t ceiling =
-            Room_GetCeiling(sector, new_pos.x, new_pos.y, new_pos.z);
+        const SECTOR *const sector = Room_GetSector(new_pos, &room_num);
+        const int32_t height = Room_GetHeight(sector, new_pos);
+        const int32_t ceiling = Room_GetCeiling(sector, new_pos);
 
         if (ABS(height - lara->pos.y) > STEP_L
             || ABS(ceiling - lara->pos.y) < LARA_HEIGHT) {
@@ -868,10 +865,8 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
 
     if (ref_item->object_id == O_FLARE_ITEM) {
         int16_t room_num = lara_item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(new_pos.x, new_pos.y, new_pos.z, &room_num);
-        const int32_t height =
-            Room_GetHeight(sector, new_pos.x, new_pos.y, new_pos.z);
+        const SECTOR *const sector = Room_GetSector(new_pos, &room_num);
+        const int32_t height = Room_GetHeight(sector, new_pos);
         if (ABS(height - lara_item->pos.y) > STEP_L * 2) {
             return false;
         }

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -48,7 +48,7 @@ static SECTOR *M_GetCurrentSector(void)
     const ITEM *const lara_item = Lara_GetItem();
     int16_t room_num = lara_item->room_num;
     return Room_GetSector(
-        lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z, &room_num);
+        (XYZ_32) { lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z }, &room_num);
 }
 
 static void M_Cheat(void)
@@ -361,8 +361,7 @@ static void M_UpdateEnvironment(void)
     const ROOM *const room = Room_Get(item->room_num);
     const int32_t water_depth = Lara_GetWaterDepth(
         item->pos.x, item->pos.y, item->pos.z, item->room_num);
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     const int32_t water_height_diff =
         water_height == NO_HEIGHT ? NO_HEIGHT : item->pos.y - water_height;
     lara_info->water_surface_dist = -water_height_diff;

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -89,7 +89,7 @@ static void M_InitialiseState(void)
 static void M_DoIgniteEffects(const XYZ_32 flare_pos, int16_t room_num)
 {
     m_IgnitePos = flare_pos;
-    Room_GetSector(m_IgnitePos.x, m_IgnitePos.y, m_IgnitePos.z, &room_num);
+    Room_GetSector(m_IgnitePos, &room_num);
     const ROOM *const room = Room_Get(room_num);
     const SOUND_PLAY_MODE mode =
         room->flags.underwater ? SPM_UNDERWATER : SPM_NORMAL;
@@ -392,9 +392,8 @@ void Lara_Flare_Dispose(const bool thrown)
     };
     Lara_GetJointAbsPosition(&vec, LM_HAND_L);
 
-    const SECTOR *const sector =
-        Room_GetSector(vec.x, vec.y, vec.z, &item->room_num);
-    const int32_t height = Room_GetHeight(sector, vec.x, vec.y, vec.z);
+    const SECTOR *const sector = Room_GetSector(vec, &item->room_num);
+    const int32_t height = Room_GetHeight(sector, vec);
     if (height < vec.y) {
         item->pos.x = lara_item->pos.x;
         item->pos.y = vec.y;

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -280,18 +280,19 @@ void Lara_Hair_Control(const bool in_cutscene)
         water_height = NO_HEIGHT;
     } else {
         water_height = Room_GetWaterHeight(
-            lara_item->pos.x
-                + (frame_1->bounds.min.x + frame_1->bounds.max.x) / 2,
-            lara_item->pos.y
-                + (frame_1->bounds.max.y + frame_1->bounds.min.y) / 2,
-            lara_item->pos.z
-                + (frame_1->bounds.max.z + frame_1->bounds.min.z) / 2,
+            (XYZ_32) {
+                lara_item->pos.x
+                    + (frame_1->bounds.min.x + frame_1->bounds.max.x) / 2,
+                lara_item->pos.y
+                    + (frame_1->bounds.max.y + frame_1->bounds.min.y) / 2,
+                lara_item->pos.z
+                    + (frame_1->bounds.max.z + frame_1->bounds.min.z) / 2,
+            },
             room_num);
     }
 
-    const SECTOR *const sector =
-        Room_GetSector(fs->pos.x, fs->pos.y, fs->pos.z, &room_num);
-    int32_t height = Room_GetHeight(sector, fs->pos.x, fs->pos.y, fs->pos.z);
+    const SECTOR *const sector = Room_GetSector(fs->pos, &room_num);
+    int32_t height = Room_GetHeight(sector, fs->pos);
     if (height < fs->pos.y) {
         height = lara_item->floor;
     }

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -131,9 +131,8 @@ RGB_F Lara_GetMeshTint(const GAME_VECTOR pos)
     }
 
     int16_t room_num = pos.room_num;
-    Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    const int32_t water_height =
-        Room_GetWaterHeight(pos.x, pos.y, pos.z, room_num);
+    Room_GetSector(pos.pos, &room_num);
+    const int32_t water_height = Room_GetWaterHeight(pos.pos, room_num);
 
     if (!Room_Get(room_num)->flags.underwater) {
         return (RGB_F) { 1.0f, 1.0f, 1.0f };

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -195,10 +195,9 @@ void Lara_TouchDeathSector(const GF_DEATH_TILE death_tile)
     }
 
     int16_t room_num = lara_item->room_num;
-    const SECTOR *const sector = Room_GetSector(
-        lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z);
+    const XYZ_32 pos = { lara_item->pos.x, MAX_HEIGHT, lara_item->pos.z };
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
     if (lara_item->floor != height) {
         return;
     }
@@ -268,15 +267,16 @@ void Lara_RapidsDrown(void)
 int16_t Lara_FloorFront(
     const ITEM *const item, const int16_t ang, const int32_t dist)
 {
-    const int32_t x = item->pos.x + ((dist * Math_Sin(ang)) >> W2V_SHIFT);
-    const int32_t y = item->pos.y - LARA_HEIGHT;
-    const int32_t z = item->pos.z + ((dist * Math_Cos(ang)) >> W2V_SHIFT);
+    XYZ_32 pos = item->pos;
+    pos.y -= LARA_HEIGHT;
+    pos = XYZ_32_OffsetYaw(pos, ang, dist);
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    int32_t height = Room_GetHeight(sector, x, y, z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    int32_t height = Room_GetHeight(sector, pos);
     if (height != NO_HEIGHT) {
         height -= item->pos.y;
-        if (height > 0 && Room_GetPitSector(sector, x, z)->is_death_sector) {
+        if (height > 0
+            && Room_GetPitSector(sector, pos.x, pos.z)->is_death_sector) {
             return STEP_L * 2;
         }
     }
@@ -289,9 +289,10 @@ int16_t Lara_CeilingFront(
     const int32_t x = item->pos.x + ((dist * Math_Sin(ang)) >> W2V_SHIFT);
     const int32_t y = item->pos.y - LARA_HEIGHT;
     const int32_t z = item->pos.z + ((dist * Math_Cos(ang)) >> W2V_SHIFT);
+    const XYZ_32 pos = { x, y, z };
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    int32_t height = Room_GetCeiling(sector, x, y, z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    int32_t height = Room_GetCeiling(sector, pos);
     if (height != NO_HEIGHT) {
         height += LARA_HEIGHT - item->pos.y;
     }
@@ -301,13 +302,12 @@ int16_t Lara_CeilingFront(
 void Lara_UpdateRoomToHeight(const int32_t height)
 {
     ITEM *const lara_item = Lara_GetItem();
-    const int32_t x = lara_item->pos.x;
-    const int32_t y = height + lara_item->pos.y;
-    const int32_t z = lara_item->pos.z;
+    XYZ_32 pos = lara_item->pos;
+    pos.y += height;
 
     int16_t room_num = lara_item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    lara_item->floor = Room_GetHeight(sector, x, y, z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    lara_item->floor = Room_GetHeight(sector, pos);
 
     const int16_t item_num = Item_GetIndex(lara_item);
     Item_UpdateRoom(item_num, room_num);
@@ -355,10 +355,10 @@ int32_t Lara_GetWaterDepth(
         while (sector->portal_room.sky != NO_ROOM) {
             room = Room_Get(sector->portal_room.sky);
             if (!room->flags.underwater && !room->flags.swamp) {
-                const int32_t water_height =
-                    Room_GetWaterHeight(x, y, z, room_num);
-                sector = Room_GetSector(x, y, z, &room_num);
-                return Room_GetHeight(sector, x, y, z) - water_height;
+                const XYZ_32 pos = { x, y, z };
+                const int32_t water_height = Room_GetWaterHeight(pos, room_num);
+                sector = Room_GetSector(pos, &room_num);
+                return Room_GetHeight(sector, pos) - water_height;
             }
             sector = Room_GetWorldSector(room, x, z);
         }
@@ -368,9 +368,10 @@ int32_t Lara_GetWaterDepth(
     while (sector->portal_room.pit != NO_ROOM) {
         room = Room_Get(sector->portal_room.pit);
         if (room->flags.underwater || room->flags.swamp) {
-            const int32_t water_height = Room_GetWaterHeight(x, y, z, room_num);
-            sector = Room_GetSector(x, y, z, &room_num);
-            return Room_GetHeight(sector, x, y, z) - water_height;
+            const XYZ_32 pos = { x, y, z };
+            const int32_t water_height = Room_GetWaterHeight(pos, room_num);
+            sector = Room_GetSector(pos, &room_num);
+            return Room_GetHeight(sector, pos) - water_height;
         }
         sector = Room_GetWorldSector(room, x, z);
     }

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -161,8 +161,8 @@ static void M_SharkKill(ITEM *const item, COLL_INFO *const coll)
     lara->hit_direction = -1;
 
     if (Item_TestFrameEqual(item, M_LF_SHARK_DEATH_END)) {
-        const int32_t water_height = Room_GetWaterHeight(
-            item->pos.x, item->pos.y, item->pos.z, item->room_num);
+        const int32_t water_height =
+            Room_GetWaterHeight(item->pos, item->room_num);
         if (water_height != NO_HEIGHT && water_height < item->pos.y - 100) {
             item->pos.y -= 5;
         }
@@ -210,10 +210,8 @@ static void M_RapidsDrown(ITEM *const item, COLL_INFO *const coll)
         LARA_HEIGHT);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    item->pos.y =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z) + 384;
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    item->pos.y = Room_GetHeight(sector, item->pos) + 384;
 
     item->rot.y += 1024;
 

--- a/src/trx/game/lara/state/monkey.c
+++ b/src/trx/game/lara/state/monkey.c
@@ -17,8 +17,8 @@
 static bool M_CanMonkeySwing(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
     return (sector->ladder & LADDER_CEILING) != 0;
 }
 

--- a/src/trx/game/los.c
+++ b/src/trx/game/los.c
@@ -174,19 +174,21 @@ static int32_t M_CheckX(
     m_LOSNumRooms = 1;
 
     if (dx < 0) {
-        int32_t x = ROUND_TO_SECTOR(start->x);
-        int32_t y = start->y + ((dy * (x - start->x)) >> WALL_SHIFT);
-        int32_t z = start->z + ((dz * (x - start->x)) >> WALL_SHIFT);
+        XYZ_32 cur_pos;
+        cur_pos.x = ROUND_TO_SECTOR(start->x);
+        cur_pos.y = start->y + ((dy * (cur_pos.x - start->x)) >> WALL_SHIFT);
+        cur_pos.z = start->z + ((dz * (cur_pos.x - start->x)) >> WALL_SHIFT);
 
-        while (x > target->x) {
+        while (cur_pos.x > target->x) {
+            XYZ_32 sample_pos = cur_pos;
+
             {
-                const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                const SECTOR *const sector =
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = room_num;
                     return -1;
                 }
@@ -197,38 +199,40 @@ static int32_t M_CheckX(
                 m_LOSRooms[m_LOSNumRooms++] = room_num;
             }
 
+            sample_pos.x -= 1;
+
             {
                 const SECTOR *const sector =
-                    Room_GetSector(x - 1, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x - 1, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x - 1, y, z);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = last_room_num;
                     return 0;
                 }
             }
 
-            x -= WALL_L;
-            y -= dy;
-            z -= dz;
+            cur_pos.x -= WALL_L;
+            cur_pos.y -= dy;
+            cur_pos.z -= dz;
         }
     } else {
-        int32_t x = ROUND_TO_SECTOR_END(start->x);
-        int32_t y = start->y + (((x - start->x) * dy) >> WALL_SHIFT);
-        int32_t z = start->z + (((x - start->x) * dz) >> WALL_SHIFT);
+        XYZ_32 cur_pos;
+        cur_pos.x = ROUND_TO_SECTOR_END(start->x);
+        cur_pos.y = start->y + (((cur_pos.x - start->x) * dy) >> WALL_SHIFT);
+        cur_pos.z = start->z + (((cur_pos.x - start->x) * dz) >> WALL_SHIFT);
 
-        while (x < target->x) {
+        while (cur_pos.x < target->x) {
+            XYZ_32 sample_pos = cur_pos;
+
             {
-                const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-                if (y > height || y < ceiling) {
-                    target->z = z;
-                    target->y = y;
-                    target->x = x;
+                const SECTOR *const sector =
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = room_num;
                     return -1;
                 }
@@ -239,23 +243,23 @@ static int32_t M_CheckX(
                 m_LOSRooms[m_LOSNumRooms++] = room_num;
             }
 
+            sample_pos.x += 1;
+
             {
                 const SECTOR *const sector =
-                    Room_GetSector(x + 1, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x + 1, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x + 1, y, z);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = last_room_num;
                     return 0;
                 }
             }
 
-            x += WALL_L;
-            y += dy;
-            z += dz;
+            cur_pos.x += WALL_L;
+            cur_pos.y += dy;
+            cur_pos.z += dz;
         }
     }
 
@@ -281,19 +285,21 @@ static int32_t M_CheckZ(
     m_LOSNumRooms = 1;
 
     if (dz < 0) {
-        int32_t z = ROUND_TO_SECTOR(start->z);
-        int32_t x = start->x + ((dx * (z - start->z)) >> WALL_SHIFT);
-        int32_t y = start->y + ((dy * (z - start->z)) >> WALL_SHIFT);
+        XYZ_32 cur_pos;
+        cur_pos.z = ROUND_TO_SECTOR(start->z);
+        cur_pos.x = start->x + ((dx * (cur_pos.z - start->z)) >> WALL_SHIFT);
+        cur_pos.y = start->y + ((dy * (cur_pos.z - start->z)) >> WALL_SHIFT);
 
-        while (z > target->z) {
+        while (cur_pos.z > target->z) {
+            XYZ_32 sample_pos = cur_pos;
+
             {
-                const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                const SECTOR *const sector =
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = room_num;
                     return -1;
                 }
@@ -304,38 +310,40 @@ static int32_t M_CheckZ(
                 m_LOSRooms[m_LOSNumRooms++] = room_num;
             }
 
+            sample_pos.z -= 1;
+
             {
                 const SECTOR *const sector =
-                    Room_GetSector(x, y, z - 1, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z - 1);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z - 1);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = last_room_num;
                     return 0;
                 }
             }
 
-            z -= WALL_L;
-            x -= dx;
-            y -= dy;
+            cur_pos.z -= WALL_L;
+            cur_pos.x -= dx;
+            cur_pos.y -= dy;
         }
     } else {
-        int32_t z = ROUND_TO_SECTOR_END(start->z);
-        int32_t x = start->x + ((dx * (z - start->z)) >> WALL_SHIFT);
-        int32_t y = start->y + ((dy * (z - start->z)) >> WALL_SHIFT);
+        XYZ_32 cur_pos;
+        cur_pos.z = ROUND_TO_SECTOR_END(start->z);
+        cur_pos.x = start->x + ((dx * (cur_pos.z - start->z)) >> WALL_SHIFT);
+        cur_pos.y = start->y + ((dy * (cur_pos.z - start->z)) >> WALL_SHIFT);
 
-        while (z < target->z) {
+        while (cur_pos.z < target->z) {
+            XYZ_32 sample_pos = cur_pos;
+
             {
-                const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                const SECTOR *const sector =
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = room_num;
                     return -1;
                 }
@@ -346,23 +354,23 @@ static int32_t M_CheckZ(
                 m_LOSRooms[m_LOSNumRooms++] = room_num;
             }
 
+            sample_pos.z += 1;
+
             {
                 const SECTOR *const sector =
-                    Room_GetSector(x, y, z + 1, &room_num);
-                const int32_t height = Room_GetHeight(sector, x, y, z + 1);
-                const int32_t ceiling = Room_GetCeiling(sector, x, y, z + 1);
-                if (y > height || y < ceiling) {
-                    target->x = x;
-                    target->y = y;
-                    target->z = z;
+                    Room_GetSector(sample_pos, &room_num);
+                const int32_t height = Room_GetHeight(sector, sample_pos);
+                const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
+                if (cur_pos.y > height || cur_pos.y < ceiling) {
+                    target->pos = cur_pos;
                     target->room_num = last_room_num;
                     return 0;
                 }
             }
 
-            z += WALL_L;
-            x += dx;
-            y += dy;
+            cur_pos.z += WALL_L;
+            cur_pos.x += dx;
+            cur_pos.y += dy;
         }
     }
 
@@ -373,16 +381,14 @@ static int32_t M_CheckZ(
 static int32_t M_ClipTargetSimple(
     const GAME_VECTOR *const start, GAME_VECTOR *const target)
 {
-    const SECTOR *sector =
-        Room_GetSector(target->x, target->y, target->z, &target->room_num);
+    const SECTOR *sector = Room_GetSector(target->pos, &target->room_num);
 
     // This function exists because of issue #4070.
     int32_t dx = target->x - start->x;
     int32_t dy = target->y - start->y;
     int32_t dz = target->z - start->z;
 
-    const int32_t height =
-        Room_GetHeight(sector, target->x, target->y, target->z);
+    const int32_t height = Room_GetHeight(sector, target->pos);
     if (target->y > height && start->y < height) {
         target->y = height;
         target->x = start->x + dx * (height - start->y) / dy;
@@ -390,8 +396,7 @@ static int32_t M_ClipTargetSimple(
         return false;
     }
 
-    const int32_t ceiling =
-        Room_GetCeiling(sector, target->x, target->y, target->z);
+    const int32_t ceiling = Room_GetCeiling(sector, target->pos);
     if (target->y < ceiling && start->y > ceiling) {
         target->y = ceiling;
         target->x = start->x + dx * (ceiling - start->y) / dy;
@@ -406,60 +411,49 @@ static int32_t M_ClipTargetWithSlopes(
     const GAME_VECTOR *const start, GAME_VECTOR *const target)
 {
     int16_t room_num = target->room_num;
-    const SECTOR *sector =
-        Room_GetSector(target->x, target->y, target->z, &room_num);
+    const SECTOR *sector = Room_GetSector(target->pos, &room_num);
 
-    if (target->y > Room_GetHeight(sector, target->x, target->y, target->z)) {
+    if (target->y > Room_GetHeight(sector, target->pos)) {
         const XYZ_32 origin = {
-            .x =
-                start->x + ((M_CLIP_1 - 1) * (target->x - start->x) / M_CLIP_1),
-            .y =
-                start->y + ((M_CLIP_1 - 1) * (target->y - start->y) / M_CLIP_1),
-            .z =
-                start->z + ((M_CLIP_1 - 1) * (target->z - start->z) / M_CLIP_1),
+            start->x + ((M_CLIP_1 - 1) * (target->x - start->x) / M_CLIP_1),
+            start->y + ((M_CLIP_1 - 1) * (target->y - start->y) / M_CLIP_1),
+            start->z + ((M_CLIP_1 - 1) * (target->z - start->z) / M_CLIP_1),
         };
-        int32_t dx, dy, dz;
+        XYZ_32 delta;
         for (int32_t i = M_CLIP_2 - 1; i > 0; i--) {
-            dx = origin.x + (i * (target->x - origin.x) / M_CLIP_2);
-            dy = origin.y + (i * (target->y - origin.y) / M_CLIP_2);
-            dz = origin.z + (i * (target->z - origin.z) / M_CLIP_2);
-            sector = Room_GetSector(dx, dy, dz, &room_num);
-            if (dy < Room_GetHeight(sector, dx, dy, dz)) {
+            delta.x = origin.x + (i * (target->x - origin.x) / M_CLIP_2);
+            delta.y = origin.y + (i * (target->y - origin.y) / M_CLIP_2);
+            delta.z = origin.z + (i * (target->z - origin.z) / M_CLIP_2);
+            sector = Room_GetSector(delta, &room_num);
+            if (delta.y < Room_GetHeight(sector, delta)) {
                 break;
             }
         }
 
-        target->x = dx;
-        target->y = dy;
-        target->z = dz;
+        target->pos = delta;
         target->room_num = room_num;
         return 0;
     }
 
-    if (target->y < Room_GetCeiling(sector, target->x, target->y, target->z)) {
+    if (target->y < Room_GetCeiling(sector, target->pos)) {
         const XYZ_32 origin = {
-            .x =
-                start->x + ((M_CLIP_1 - 1) * (target->x - start->x) / M_CLIP_1),
-            .y =
-                start->y + ((M_CLIP_1 - 1) * (target->y - start->y) / M_CLIP_1),
-            .z =
-                start->z + ((M_CLIP_1 - 1) * (target->z - start->z) / M_CLIP_1),
+            start->x + ((M_CLIP_1 - 1) * (target->x - start->x) / M_CLIP_1),
+            start->y + ((M_CLIP_1 - 1) * (target->y - start->y) / M_CLIP_1),
+            start->z + ((M_CLIP_1 - 1) * (target->z - start->z) / M_CLIP_1),
         };
-        int32_t dx, dy, dz;
+        XYZ_32 delta;
         for (int32_t i = M_CLIP_2 - 1; i > 0; i--) {
-            dx = origin.x + (i * (target->x - origin.x) / M_CLIP_2);
-            dy = origin.y + (i * (target->y - origin.y) / M_CLIP_2);
-            dz = origin.z + (i * (target->z - origin.z) / M_CLIP_2);
+            delta.x = origin.x + (i * (target->x - origin.x) / M_CLIP_2);
+            delta.y = origin.y + (i * (target->y - origin.y) / M_CLIP_2);
+            delta.z = origin.z + (i * (target->z - origin.z) / M_CLIP_2);
 
-            sector = Room_GetSector(dx, dy, dz, &room_num);
-            if (dy > Room_GetCeiling(sector, dx, dy, dz)) {
+            sector = Room_GetSector(delta, &room_num);
+            if (delta.y > Room_GetCeiling(sector, delta)) {
                 break;
             }
         }
 
-        target->x = dx;
-        target->y = dy;
-        target->z = dz;
+        target->pos = delta;
         target->room_num = room_num;
         return 0;
     }

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -63,30 +63,27 @@ static void M_Control(const int16_t item_num)
     }
 
     if (!p->status) {
-        int32_t x = 2 * m_AnchorX - lara_item->pos.x;
-        int32_t y = lara_item->pos.y;
-        int32_t z = 2 * m_AnchorZ - lara_item->pos.z;
+        const XYZ_32 pos = {
+            .x = 2 * m_AnchorX - lara_item->pos.x,
+            .z = 2 * m_AnchorZ - lara_item->pos.z,
+            .y = lara_item->pos.y,
+        };
 
         int16_t room_num = item->room_num;
-        const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
-        const int32_t h = Room_GetHeight(sector, x, y, z);
+        const SECTOR *sector = Room_GetSector(pos, &room_num);
+        const int32_t h = Room_GetHeight(sector, pos);
         item->floor = h;
 
         room_num = lara_item->room_num;
-        sector = Room_GetSector(
-            lara_item->pos.x, lara_item->pos.y, lara_item->pos.z, &room_num);
-        int32_t lh = Room_GetHeight(
-            sector, lara_item->pos.x, lara_item->pos.y, lara_item->pos.z);
+        sector = Room_GetSector(lara_item->pos, &room_num);
+        int32_t lh = Room_GetHeight(sector, lara_item->pos);
 
         const int16_t relative_anim = Item_GetRelativeAnim(lara_item);
         const int16_t relative_frame = Item_GetRelativeFrame(lara_item);
         Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
-        item->pos.x = x;
-        item->pos.y = y;
-        item->pos.z = z;
-        item->rot.x = lara_item->rot.x;
-        item->rot.y = lara_item->rot.y - DEG_180;
-        item->rot.z = lara_item->rot.z;
+        item->pos = pos;
+        item->rot = lara_item->rot;
+        item->rot.y -= DEG_180;
         Item_UpdateRoom(item_num, lara_item->room_num);
 
         if (h >= lh + WALL_L && !lara_item->gravity) {
@@ -104,13 +101,9 @@ static void M_Control(const int16_t item_num)
     if (p->status) {
         Item_Animate(item);
 
-        int32_t x = item->pos.x;
-        int32_t y = item->pos.y;
-        int32_t z = item->pos.z;
-
         int16_t room_num = item->room_num;
-        const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
-        const int32_t h = Room_GetHeight(sector, x, y, z);
+        const SECTOR *sector = Room_GetSector(item->pos, &room_num);
+        const int32_t h = Room_GetHeight(sector, item->pos);
         item->floor = h;
 
         Room_TestTriggers(item);

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -29,12 +29,9 @@ static void M_FixEmbeddedPosition(int16_t item_num)
         return;
     }
 
-    const int32_t x = item->pos.x;
-    const int32_t y = item->pos.y;
-    const int32_t z = item->pos.z;
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int16_t ceiling = Room_GetCeiling(sector, x, y, z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int16_t ceiling = Room_GetCeiling(sector, item->pos);
 
     // The bats animation and frame have to be changed to the hanging
     // one to properly measure them. Save it so it can be restored

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -236,10 +236,8 @@ static void M_ControlAlligator(const int16_t item_num)
         Item_Animate(item);
 
         room_num = item->room_num;
-        sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        item->floor =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        sector = Room_GetSector(item->pos, &room_num);
+        item->floor = Room_GetHeight(sector, item->pos);
         Item_UpdateRoom(item_num, room_num);
         return;
     }

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -228,8 +228,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    int16_t wh = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    int16_t wh = Room_GetWaterHeight(item->pos, item->room_num);
     if (wh != NO_HEIGHT) {
         item->hit_points = DONT_TARGET;
         LOT_DisableBaddieAI(item_num);

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -271,7 +271,7 @@ static void M_Control(const int16_t item_num)
                     const XYZ_32 offset = XYZ_32_OffsetYaw(
                         item->pos, item->rot.y + DEG_180, WALL_L);
                     const SECTOR *const sector =
-                        Room_GetSector32(offset, &room_num);
+                        Room_GetSector(offset, &room_num);
 
                     if (creature->flags != 0 || sector->box == 0x7FF
                         || Box_GetBox(sector->box)->overlap_index

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -30,8 +30,7 @@ static void M_Control_TR12(const int16_t effect_num)
     effect->fall_speed += GRAVITY;
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
 
     const ROOM *const current_room = Room_Get(effect->room_num);
     const ROOM *const next_room = Room_Get(room_num);
@@ -40,15 +39,13 @@ static void M_Control_TR12(const int16_t effect_num)
             (GAME_VECTOR) { .pos = effect->pos, .room_num = effect->room_num });
     }
 
-    const int32_t ceiling =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
     if (effect->pos.y < ceiling) {
         effect->pos.y = ceiling;
         effect->fall_speed = -effect->fall_speed;
     }
 
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
     if (effect->pos.y >= height) {
         if (effect->counter > 0) {
             effect->speed = 0;
@@ -118,18 +115,15 @@ static void M_Control_TR3(const int16_t effect_num)
     }
 
     int16_t room_num = effect->room_num;
-    SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
-    int32_t c =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
+    int32_t c = Room_GetCeiling(sector, effect->pos);
 
     if (effect->pos.y < c) {
         effect->pos.y = c;
         effect->fall_speed = -effect->fall_speed;
     }
 
-    int32_t h =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    int32_t h = Room_GetHeight(sector, effect->pos);
 
     if (effect->pos.y >= h) {
         if (effect->counter & 3) {

--- a/src/trx/game/objects/effects/bubble.c
+++ b/src/trx/game/objects/effects/bubble.c
@@ -19,13 +19,13 @@ static void M_Control_TR1TR2(const int16_t effect_num)
     };
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
     if (sector == nullptr || !Room_Get(room_num)->flags.underwater) {
         Effect_Kill(effect_num);
         return;
     }
 
-    const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
     if (ceiling == NO_HEIGHT || pos.y <= ceiling) {
         Effect_Kill(effect_num);
         return;
@@ -51,13 +51,13 @@ static void M_Control_TR3(const int16_t effect_num)
     };
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
     if (sector == nullptr) {
         Effect_Kill(effect_num);
         return;
     }
 
-    const int32_t floor = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const int32_t floor = Room_GetHeight(sector, pos);
     if (pos.y > floor) {
         Effect_Kill(effect_num);
         return;
@@ -72,7 +72,7 @@ static void M_Control_TR3(const int16_t effect_num)
         return;
     }
 
-    const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
     if (ceiling == NO_HEIGHT || pos.y <= ceiling) {
         Effect_Kill(effect_num);
         return;

--- a/src/trx/game/objects/effects/ember.c
+++ b/src/trx/game/objects/effects/ember.c
@@ -15,12 +15,9 @@ static void M_Control(const int16_t effect_num)
     effect->pos.y += effect->fall_speed;
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
-    const int32_t ceiling =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
 
     if (effect->pos.y >= height || effect->pos.y < ceiling) {
         Effect_Kill(effect_num);

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -195,8 +195,7 @@ static void M_TR3_ControlSmall(
         Effect_NewRoom(Effect_GetNum(effect), lara_item->room_num);
     }
 
-    const int32_t wh = Room_GetWaterHeight(
-        effect->pos.x, effect->pos.y, effect->pos.z, effect->room_num);
+    const int32_t wh = Room_GetWaterHeight(effect->pos, effect->room_num);
     if (wh == NO_HEIGHT || effect->pos.y <= wh
         || (Room_Get(effect->room_num)->flags.swamp
             && (GF_BadGetLevelNum() == 4 || GF_BadGetLevelNum() == 18
@@ -430,8 +429,8 @@ static void M_TR12_Control(const int16_t effect_num)
             Effect_NewRoom(effect_num, room_num);
         }
 
-        const int32_t water_height = Room_GetWaterHeight(
-            effect->pos.x, effect->pos.y, effect->pos.z, effect->room_num);
+        const int32_t water_height =
+            Room_GetWaterHeight(effect->pos, effect->room_num);
         if ((water_height != NO_HEIGHT && effect->pos.y > water_height)
             || lara_info->water_status == LWS_CHEAT) {
             effect->counter = 0;

--- a/src/trx/game/objects/effects/gun_shell.c
+++ b/src/trx/game/objects/effects/gun_shell.c
@@ -27,8 +27,7 @@ static void M_Control(const int16_t effect_num)
         (effect->speed * Math_Cos(effect->flag1)) >> (W2V_SHIFT + 1);
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
 
     if (effect->room_num != room_num) {
         Effect_NewRoom(effect_num, room_num);
@@ -43,8 +42,7 @@ static void M_Control(const int16_t effect_num)
         return;
     }
 
-    const int32_t ceiling =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
     if (effect->pos.y < ceiling) {
         Sound_Effect(SFX_LARA_SHOTGUN_SHELL, &effect->pos, SPM_NORMAL);
         effect->speed -= 4;
@@ -59,8 +57,7 @@ static void M_Control(const int16_t effect_num)
         effect->pos.y = ceiling;
     }
 
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
     if (effect->pos.y >= height) {
         Sound_Effect(SFX_LARA_SHOTGUN_SHELL, &effect->pos, SPM_NORMAL);
         effect->speed -= 8;

--- a/src/trx/game/objects/effects/hot_liquid.c
+++ b/src/trx/game/objects/effects/hot_liquid.c
@@ -19,10 +19,8 @@ static void M_Control(const int16_t effect_num)
     effect->fall_speed += GRAVITY;
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
 
     if (effect->pos.y >= height) {
         Sound_Effect(SFX_WATERFALL_2, &effect->pos, SPM_NORMAL);

--- a/src/trx/game/objects/effects/missile.c
+++ b/src/trx/game/objects/effects/missile.c
@@ -23,12 +23,9 @@ static void M_Control(const int16_t effect_num)
     effect->pos.x += (speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
-    const int32_t ceiling =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
 
     if (effect->pos.y >= height || effect->pos.y <= ceiling) {
         if (effect->object_id == O_MISSILE_2) {

--- a/src/trx/game/objects/effects/missile_common.c
+++ b/src/trx/game/objects/effects/missile_common.c
@@ -29,13 +29,10 @@ void Missile_Control(const int16_t effect_num)
     effect->pos.x += (speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
 
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
 
-    const int32_t height =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
-    const int32_t ceiling =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    const int32_t height = Room_GetHeight(sector, effect->pos);
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
     if (effect->pos.y >= height || effect->pos.y <= ceiling) {
         if (effect->object_id == O_MISSILE_KNIFE
             || effect->object_id == O_MISSILE_HARPOON) {

--- a/src/trx/game/objects/effects/missile_tony_fire_ball.c
+++ b/src/trx/game/objects/effects/missile_tony_fire_ball.c
@@ -211,12 +211,9 @@ static void M_Control(const int16_t effect_num)
     }
 
     int16_t room_num = effect->room_num;
-    SECTOR *sector =
-        Room_GetSector(effect->pos.x, effect->pos.y, effect->pos.z, &room_num);
-    const int32_t h =
-        Room_GetHeight(sector, effect->pos.x, effect->pos.y, effect->pos.z);
-    const int32_t c =
-        Room_GetCeiling(sector, effect->pos.x, effect->pos.y, effect->pos.z);
+    SECTOR *sector = Room_GetSector(effect->pos, &room_num);
+    const int32_t h = Room_GetHeight(sector, effect->pos);
+    const int32_t c = Room_GetCeiling(sector, effect->pos);
 
     if (effect->pos.y >= h || effect->pos.y < c) {
         if (!effect->flag1 || effect->flag1 == 1 || effect->flag1 == 2
@@ -256,15 +253,10 @@ static void M_Control(const int16_t effect_num)
 
             if (!effect->flag1 || effect->flag1 == 1) {
                 room_num = lara_item->room_num;
-                sector = Room_GetSector(
-                    lara_item->pos.x, lara_item->pos.y, lara_item->pos.z,
-                    &room_num);
+                sector = Room_GetSector(lara_item->pos, &room_num);
                 pos.x = (Random_GetControl() & 0x3FF) + lara_item->pos.x - 512;
-                pos.y = Room_GetCeiling(
-                            sector, lara_item->pos.x, lara_item->pos.y,
-                            lara_item->pos.z)
-                    + 256;
                 pos.z = (Random_GetControl() & 0x3FF) + lara_item->pos.z - 512;
+                pos.y = Room_GetCeiling(sector, lara_item->pos) + 256;
                 Sparks_TriggerExplosionSparks(pos, 3, -2, 0, room_num);
                 TonyBoss_TriggerFireBall(nullptr, 3, &pos, room_num, 0, 0);
             }

--- a/src/trx/game/objects/effects/natla_gun.c
+++ b/src/trx/game/objects/effects/natla_gun.c
@@ -17,25 +17,20 @@ static void M_Control(const int16_t effect_num)
         return;
     }
 
-    int32_t z = effect->pos.z
-        + ((effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT);
-    int32_t x = effect->pos.x
-        + ((effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT);
-    int32_t y = effect->pos.y;
+    const XYZ_32 pos =
+        XYZ_32_OffsetYaw(effect->pos, effect->rot.y, effect->speed);
     int16_t room_num = effect->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
 
-    if (y >= Room_GetHeight(sector, x, y, z)
-        || y <= Room_GetCeiling(sector, x, y, z)) {
+    if (pos.y >= Room_GetHeight(sector, pos)
+        || pos.y <= Room_GetCeiling(sector, pos)) {
         return;
     }
 
     const int16_t new_effect_num = Effect_Create(room_num);
     if (new_effect_num != NO_EFFECT) {
-        EFFECT *new_effect = Effect_Get(new_effect_num);
-        new_effect->pos.x = x;
-        new_effect->pos.y = y;
-        new_effect->pos.z = z;
+        EFFECT *const new_effect = Effect_Get(new_effect_num);
+        new_effect->pos = pos;
         new_effect->rot.y = effect->rot.y;
         new_effect->room_num = room_num;
         new_effect->speed = effect->speed;

--- a/src/trx/game/objects/general/bell.c
+++ b/src/trx/game/objects/general/bell.c
@@ -12,9 +12,8 @@ static void M_Control(const int16_t item_num)
 
     item->goal_anim_state = BELL_STATE_SWING;
 
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &item->room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &item->room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Room_TestTriggers(item);
 
     Item_Animate(item);

--- a/src/trx/game/objects/general/bridge_common.c
+++ b/src/trx/game/objects/general/bridge_common.c
@@ -72,17 +72,14 @@ void Bridge_FixEmbeddedPosition(int16_t item_num)
     // and moves them up.
     ITEM *const item = Item_Get(item_num);
 
-    const int32_t x = item->pos.x;
-    const int32_t y = item->pos.y;
-    const int32_t z = item->pos.z;
-    int16_t room_num = item->room_num;
-
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     const int16_t bridge_height = ABS(bounds->max.y) - ABS(bounds->min.y);
 
-    const SECTOR *const sector =
-        Room_GetSector(x, y - bridge_height, z, &room_num);
-    const int16_t floor_height = Room_GetHeight(sector, x, y, z);
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, item->pos.y - bridge_height, item->pos.z },
+        &room_num);
+    const int16_t floor_height = Room_GetHeight(sector, item->pos);
 
     // Only move the bridge up if it's at floor level and there
     // isn't a room portal below.

--- a/src/trx/game/objects/general/cog.c
+++ b/src/trx/game/objects/general/cog.c
@@ -18,7 +18,7 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 }
 

--- a/src/trx/game/objects/general/copter.c
+++ b/src/trx/game/objects/general/copter.c
@@ -24,7 +24,7 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);

--- a/src/trx/game/objects/general/cutscene_player.c
+++ b/src/trx/game/objects/general/cutscene_player.c
@@ -21,9 +21,7 @@ static void M_Control(const int16_t item_num)
     item->status = IS_ACTIVE;
     CAMERA_INFO *const camera = Cutscene_GetCamera();
     item->rot.y = camera->target_angle;
-    item->pos.x = camera->pos.pos.x;
-    item->pos.y = camera->pos.pos.y;
-    item->pos.z = camera->pos.pos.z;
+    item->pos = camera->pos.pos;
 
     XYZ_32 pos = {};
     Collide_GetJointAbsPosition(item, &pos, 0);
@@ -34,9 +32,8 @@ static void M_Control(const int16_t item_num)
     }
 
     int16_t floor_room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(pos.x, pos.y, pos.z, &floor_room_num);
-    const int16_t height = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const SECTOR *const sector = Room_GetSector(pos, &floor_room_num);
+    const int16_t height = Room_GetHeight(sector, pos);
     item->floor = height == NO_HEIGHT ? pos.y : height;
 
     if (item->dynamic_light && item->status != IS_INVISIBLE) {

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -50,8 +50,7 @@ static bool M_LaraDoorCollision(const SECTOR *const sector)
     }
 
     int16_t room_num = lara->room_num;
-    const SECTOR *const lara_sector =
-        Room_GetSector(lara->pos.x, lara->pos.y, lara->pos.z, &room_num);
+    const SECTOR *const lara_sector = Room_GetSector(lara->pos, &room_num);
     return lara_sector == sector;
 }
 

--- a/src/trx/game/objects/general/drawbridge.c
+++ b/src/trx/game/objects/general/drawbridge.c
@@ -175,7 +175,7 @@ static void M_Control(int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 }
 

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -79,13 +79,13 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+        Room_GetSector(item->pos, &room_num);
 
     const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        Room_GetHeight(sector, item->pos);
     if (item->pos.y < height) {
         const int32_t ceiling =
-            Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+            Room_GetCeiling(sector, item->pos);
         if (item->pos.y < ceiling) {
             item->fall_speed = -item->fall_speed;
             item->pos.y = ceiling;
@@ -338,7 +338,7 @@ static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
 void Flare_GenerateEffects(
     const XYZ_32 *const sound_pos, const XYZ_32 flare_pos, int16_t room_num)
 {
-    Room_GetSector(flare_pos.x, flare_pos.y, flare_pos.z, &room_num);
+    Room_GetSector(flare_pos, &room_num);
     if (Room_Get(room_num)->flags.underwater) {
         Sound_Effect(SFX_LARA_FLARE_BURN, sound_pos, SPM_UNDERWATER);
         if (Random_GetDraw() < 0x4000) {

--- a/src/trx/game/objects/general/general.c
+++ b/src/trx/game/objects/general/general.c
@@ -31,7 +31,7 @@ void General_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
     XYZ_32 pos = { .x = 3000, .y = 720, .z = 0 };

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -260,15 +260,12 @@ static void M_Control(const int16_t item_num)
         item->pos.x += (speed * Math_Sin(item->rot.y)) >> W2V_SHIFT;
 
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        item->floor =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+        item->floor = Room_GetHeight(sector, item->pos);
         Item_UpdateRoom(item_num, room_num);
 
         if (item->pos.y >= item->floor
-            || item->pos.y <= Room_GetCeiling(
-                   sector, item->pos.x, item->pos.y, item->pos.z)) {
+            || item->pos.y <= Room_GetCeiling(sector, item->pos)) {
             radius = M_GetBlastRadius();
             explode = true;
         }

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -58,9 +58,8 @@ static void M_Control_TR3(const int16_t item_num)
     item->pos.z += (item->speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 
     if (Gun_SmashItems(old_pos, item->pos, nullptr) == PROJECTILE_HIT_STOP) {
@@ -136,8 +135,7 @@ static void M_Control_TR3(const int16_t item_num)
         return;
     }
 
-    const int32_t ceiling =
-        Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+    const int32_t ceiling = Room_GetCeiling(sector, item->pos);
     if (item->pos.y >= item->floor || item->pos.y <= ceiling) {
         if (item->hit_points <= 0) {
             item->hit_points = M_TR3_HIT_POINTS;
@@ -216,9 +214,8 @@ static void M_Control_TR12(const int16_t item_num)
     item->pos.y += item->fall_speed;
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 
     bool hit = false;
@@ -290,8 +287,7 @@ static void M_Control_TR12(const int16_t item_num)
     }
 
     if (!hit) {
-        const int32_t ceiling =
-            Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z);
+        const int32_t ceiling = Room_GetCeiling(sector, item->pos);
         if (item->pos.y >= item->floor || item->pos.y <= ceiling) {
             hit = true;
         }

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -344,7 +344,8 @@ static void M_Control(const int16_t item_num)
 
     // Update room number one click up to avoid lift on a room portal.
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y - STEP_L, item->pos.z, &room_num);
+    Room_GetSector(
+        (XYZ_32) { item->pos.x, item->pos.y - STEP_L, item->pos.z }, &room_num);
     Item_UpdateRoom(item_num, room_num);
 }
 

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -14,7 +14,7 @@ void M_TriggerAlertLight(
     const int16_t room_num)
 {
     GAME_VECTOR src = { .pos = pos, .room_num = room_num };
-    Room_GetSector(pos.x, pos.y, pos.z, &src.room_num);
+    Room_GetSector(pos, &src.room_num);
 
     const int32_t dist = 8 * WALL_L;
     GAME_VECTOR dst = {

--- a/src/trx/game/objects/general/mini_copter.c
+++ b/src/trx/game/objects/general/mini_copter.c
@@ -24,7 +24,7 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 }
 

--- a/src/trx/game/objects/general/moving_bar.c
+++ b/src/trx/game/objects/general/moving_bar.c
@@ -18,7 +18,7 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 }
 

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -248,9 +248,8 @@ static void M_Control(const int16_t item_num)
     item->pos.z += (speed * Math_Cos(item->rot.y)) >> W2V_SHIFT;
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 
     if (g_TRVersion == 3) {
@@ -287,8 +286,7 @@ static void M_Control(const int16_t item_num)
     bool explode = false;
     int32_t radius = 0;
     if (item->pos.y >= item->floor
-        || item->pos.y
-            <= Room_GetCeiling(sector, item->pos.x, item->pos.y, item->pos.z)) {
+        || item->pos.y <= Room_GetCeiling(sector, item->pos)) {
         radius = M_BLAST_RADIUS;
         explode = true;
     }

--- a/src/trx/game/objects/general/save_crystal.c
+++ b/src/trx/game/objects/general/save_crystal.c
@@ -171,9 +171,9 @@ static void M_CollisionSave(
 
     int16_t room_num = lara_item->room_num;
     const XYZ_32 pos = lara_item->pos;
-    const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-    const int32_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
-    const int32_t floor = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
+    const int32_t floor = Room_GetHeight(sector, pos);
     if (ceiling >= item->pos.y || floor < item->pos.y) {
         return;
     }

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -76,14 +76,11 @@ static void M_Control(const int16_t item_num)
         item->fall_speed += ZIPLINE_ACCELERATION;
     }
 
-    const int32_t c = Math_Cos(item->rot.y);
-    const int32_t s = Math_Sin(item->rot.y);
-    item->pos.x += (item->fall_speed * s) >> W2V_SHIFT;
-    item->pos.z += (item->fall_speed * c) >> W2V_SHIFT;
     item->pos.y += item->fall_speed >> 2;
+    item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, item->fall_speed);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
     ITEM *const lara_item = Lara_GetItem();
@@ -93,13 +90,13 @@ static void M_Control(const int16_t item_num)
         lara_item->pos = item->pos;
     }
 
-    const int32_t x = item->pos.x + ((s * WALL_L) >> W2V_SHIFT);
-    const int32_t z = item->pos.z + ((c * WALL_L) >> W2V_SHIFT);
-    const int32_t y = item->pos.y + (STEP_L >> 2);
+    XYZ_32 pos = item->pos;
+    pos.y += STEP_L >> 2;
+    pos = XYZ_32_OffsetYaw(pos, item->rot.y, WALL_L);
 
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    if (Room_GetHeight(sector, x, y, z) > y + STEP_L
-        && Room_GetCeiling(sector, x, y, z) < y - STEP_L) {
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    if (Room_GetHeight(sector, pos) > pos.y + STEP_L
+        && Room_GetCeiling(sector, pos) < pos.y - STEP_L) {
         Sound_Effect(SFX_ZIPLINE_GO, &item->pos, SPM_ALWAYS);
         return;
     }

--- a/src/trx/game/objects/traps/damocles_sword.c
+++ b/src/trx/game/objects/traps/damocles_sword.c
@@ -15,9 +15,9 @@ static void M_Reset(ITEM *const item)
     item->fall_speed = 50;
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -50,10 +50,8 @@ static void M_Control(const int16_t item_num)
         item->pos.z += item->goal_anim_state;
 
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-        const int16_t height =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+        const int16_t height = Room_GetHeight(sector, item->pos);
 
         item->floor = height;
         Item_UpdateRoom(item_num, room_num);

--- a/src/trx/game/objects/traps/dart.c
+++ b/src/trx/game/objects/traps/dart.c
@@ -54,7 +54,7 @@ static void M_Hit(
     Sound_Effect(SFX_PROJECTILE_HIT, &item->pos, SPM_NORMAL);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(pos.x, pos.y, pos.z, &room_num);
+    Room_GetSector(pos, &room_num);
 
     const int16_t effect_num = Effect_Create(room_num);
     if (effect_num != NO_EFFECT) {
@@ -104,11 +104,9 @@ static void M_Control(const int16_t item_num)
     M_Animate(item);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const int32_t height = Room_GetHeight(sector, item->pos);
 
     if (item->object_id == O_DISC) {
         item->rot.x += M_PITCH;

--- a/src/trx/game/objects/traps/electric_fence.c
+++ b/src/trx/game/objects/traps/electric_fence.c
@@ -17,7 +17,7 @@ typedef struct {
 static bool M_IsFenceOnDeathSector(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector32(item->pos, &room_num);
+    const SECTOR *sector = Room_GetSector(item->pos, &room_num);
     return sector->is_death_sector;
 }
 

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -126,11 +126,10 @@ static void M_Control(const int16_t item_num)
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    item->floor = Room_GetHeight(sector, item->pos);
 
     if (item->current_anim_state == TRAP_WORKING
         && item->pos.y >= item->floor) {

--- a/src/trx/game/objects/traps/falling_ceiling.c
+++ b/src/trx/game/objects/traps/falling_ceiling.c
@@ -25,10 +25,8 @@ static void M_Control(const int16_t item_num)
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int16_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int16_t height = Room_GetHeight(sector, item->pos);
 
     item->floor = height;
     Item_UpdateRoom(item_num, room_num);

--- a/src/trx/game/objects/traps/gondola.c
+++ b/src/trx/game/objects/traps/gondola.c
@@ -24,10 +24,10 @@ static void M_Control(const int16_t item_num)
         const int16_t room_shift = frame->bounds.min.y + M_SINK_ROOM_SHIFT;
         int16_t room_num = gondola->room_num;
         const SECTOR *const sector = Room_GetSector(
-            gondola->pos.x, gondola->pos.y + room_shift, gondola->pos.z,
+            (XYZ_32) { gondola->pos.x, gondola->pos.y + room_shift,
+                       gondola->pos.z },
             &room_num);
-        const int32_t height = Room_GetHeight(
-            sector, gondola->pos.x, gondola->pos.y, gondola->pos.z);
+        const int32_t height = Room_GetHeight(sector, gondola->pos);
         gondola->floor = height;
         Item_UpdateRoom(item_num, room_num);
 

--- a/src/trx/game/objects/traps/icicle.c
+++ b/src/trx/game/objects/traps/icicle.c
@@ -54,11 +54,10 @@ static void M_Control(const int16_t item_num)
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    item->floor = Room_GetHeight(sector, item->pos);
     if (item->current_anim_state == ICICLE_FALL && item->pos.y >= item->floor) {
         item->pos.y = item->floor;
         item->gravity = false;

--- a/src/trx/game/objects/traps/lava_wedge.c
+++ b/src/trx/game/objects/traps/lava_wedge.c
@@ -17,35 +17,33 @@ static void M_Control(const int16_t item_num)
     }
 
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
     if (item->status != IS_DEACTIVATED) {
-        int32_t x = item->pos.x;
-        int32_t z = item->pos.z;
+        XYZ_32 pos = item->pos;
 
         switch (item->rot.y) {
         case 0:
             item->pos.z += M_SPEED;
-            z += 2 * WALL_L;
+            pos.z += 2 * WALL_L;
             break;
         case -DEG_180:
             item->pos.z -= M_SPEED;
-            z -= 2 * WALL_L;
+            pos.z -= 2 * WALL_L;
             break;
         case DEG_90:
             item->pos.x += M_SPEED;
-            x += 2 * WALL_L;
+            pos.x += 2 * WALL_L;
             break;
         default:
             item->pos.x -= M_SPEED;
-            x -= 2 * WALL_L;
+            pos.x -= 2 * WALL_L;
             break;
         }
 
-        const SECTOR *const sector =
-            Room_GetSector(x, item->pos.y, z, &room_num);
-        if (Room_GetHeight(sector, x, item->pos.y, z) != item->pos.y) {
+        const SECTOR *const sector = Room_GetSector(pos, &room_num);
+        if (Room_GetHeight(sector, pos) != item->pos.y) {
             item->status = IS_DEACTIVATED;
         }
     }

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -94,10 +94,9 @@ static void M_Control(const int16_t item_num)
 
             p->zapped = true;
         } else if (p->no_target) {
-            const SECTOR *const sector = Room_GetSector(
-                item->pos.x, item->pos.y, item->pos.z, &item->room_num);
-            const int32_t h =
-                Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+            const SECTOR *const sector =
+                Room_GetSector(item->pos, &item->room_num);
+            const int32_t h = Room_GetHeight(sector, item->pos);
             p->target.x = item->pos.x;
             p->target.y = h;
             p->target.z = item->pos.z;

--- a/src/trx/game/objects/traps/mine.c
+++ b/src/trx/game/objects/traps/mine.c
@@ -11,7 +11,7 @@ static bool m_DetonateAllMines = false;
 
 static int16_t M_GetBoatItem(const XYZ_32 *const pos, int16_t *const room_num)
 {
-    Room_GetSector(pos->x, pos->y, pos->z, room_num);
+    Room_GetSector(*pos, room_num);
 
     int16_t item_num = Room_Get(*room_num)->item_num;
     while (item_num != NO_ITEM) {

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -174,18 +174,17 @@ static void M_SavePriv(const ITEM *const item, SG_WRITE_IO *const io)
 static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
 
     // Check if there is a hard wall above.
-    if (Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z)
-        == NO_HEIGHT) {
+    if (Room_GetHeight(sector, item->pos) == NO_HEIGHT) {
         return true;
     }
 
     // Make sure there is nothing on top of the block.
     if (Room_GetHeight(
-            sector, item->pos.x, item->pos.y - block_height, item->pos.z)
+            sector,
+            (XYZ_32) { item->pos.x, item->pos.y - block_height, item->pos.z })
         != item->pos.y - block_height) {
         return false;
     }
@@ -199,43 +198,44 @@ static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
         return false;
     }
 
-    int32_t x = item->pos.x;
-    int32_t y = item->pos.y;
-    int32_t z = item->pos.z;
+    XYZ_32 base_pos = item->pos;
     int16_t room_num = item->room_num;
 
     switch (quadrant) {
     case DIR_NORTH:
-        z += WALL_L;
+        base_pos.z += WALL_L;
         break;
     case DIR_EAST:
-        x += WALL_L;
+        base_pos.x += WALL_L;
         break;
     case DIR_SOUTH:
-        z -= WALL_L;
+        base_pos.z -= WALL_L;
         break;
     case DIR_WEST:
-        x -= WALL_L;
+        base_pos.x -= WALL_L;
         break;
     default:
         break;
     }
 
-    const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
+    const SECTOR *sector = Room_GetSector(base_pos, &room_num);
     COLL_INFO coll = {
         .quadrant = quadrant,
         .radius = 500,
     };
-    if (Collide_CollideStaticObjects(&coll, x, y, z, room_num, 1000)) {
+    if (Collide_CollideStaticObjects(
+            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, 1000)) {
         return false;
     }
 
-    if (Room_GetHeight(sector, x, y, z) != y) {
+    if (Room_GetHeight(sector, base_pos) != base_pos.y) {
         return false;
     }
 
-    sector = Room_GetSector(x, y - block_height, z, &room_num);
-    if (Room_GetCeiling(sector, x, y - block_height, z) > y - block_height) {
+    const XYZ_32 sample_pos = { base_pos.x, base_pos.y - block_height,
+                                base_pos.z };
+    sector = Room_GetSector(sample_pos, &room_num);
+    if (Room_GetCeiling(sector, sample_pos) > base_pos.y - block_height) {
         return false;
     }
 
@@ -268,53 +268,58 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
     }
 
     // Test block destination sector.
-    int32_t x = item->pos.x + x_add;
-    int32_t y = item->pos.y;
-    int32_t z = item->pos.z + z_add;
+    XYZ_32 base_pos = {
+        .x = item->pos.x + x_add,
+        .y = item->pos.y,
+        .z = item->pos.z + z_add,
+    };
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
+    const SECTOR *sector = Room_GetSector(base_pos, &room_num);
 
     COLL_INFO coll = {
         .quadrant = quadrant,
         .radius = 500,
     };
-    if (Collide_CollideStaticObjects(&coll, x, y, z, room_num, 1000)) {
+    if (Collide_CollideStaticObjects(
+            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, 1000)) {
         return false;
     }
 
-    if (Room_GetHeight(sector, x, y, z) != y) {
+    if (Room_GetHeight(sector, base_pos) != base_pos.y) {
         return false;
     }
 
-    sector = Room_GetSector(x, y - block_height, z, &room_num);
-    if (Room_GetCeiling(sector, x, y - block_height, z) > y - block_height) {
+    XYZ_32 sample_pos = { base_pos.x, base_pos.y - block_height, base_pos.z };
+    sector = Room_GetSector(sample_pos, &room_num);
+    if (Room_GetCeiling(sector, sample_pos) > base_pos.y - block_height) {
         return false;
     }
 
     // Test Lara destination sector.
-    x += x_add;
-    z += z_add;
+    base_pos.x += x_add;
+    base_pos.z += z_add;
     room_num = item->room_num;
-    sector = Room_GetSector(x, y, z, &room_num);
-
-    if (Room_GetHeight(sector, x, y, z) != y) {
+    sector = Room_GetSector(base_pos, &room_num);
+    if (Room_GetHeight(sector, base_pos) != base_pos.y) {
         return false;
     }
 
-    sector = Room_GetSector(x, y - LARA_HEIGHT, z, &room_num);
-    if (Room_GetCeiling(sector, x, y - LARA_HEIGHT, z) > y - LARA_HEIGHT) {
+    sample_pos = (XYZ_32) { base_pos.x, base_pos.y - LARA_HEIGHT, base_pos.z };
+    sector = Room_GetSector(sample_pos, &room_num);
+    if (Room_GetCeiling(sector, sample_pos) > base_pos.y - LARA_HEIGHT) {
         return false;
     }
 
     ITEM *const lara_item = Lara_GetItem();
-    x = lara_item->pos.x + x_add;
-    y = lara_item->pos.y;
-    z = lara_item->pos.z + z_add;
+    base_pos.x = lara_item->pos.x + x_add;
+    base_pos.y = lara_item->pos.y;
+    base_pos.z = lara_item->pos.z + z_add;
     room_num = lara_item->room_num;
-    sector = Room_GetSector(x, y, z, &room_num);
+    sector = Room_GetSector(base_pos, &room_num);
     coll.radius = LARA_RADIUS;
     coll.quadrant = (quadrant + 2) & 3;
-    if (Collide_CollideStaticObjects(&coll, x, y, z, room_num, LARA_HEIGHT)) {
+    if (Collide_CollideStaticObjects(
+            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, LARA_HEIGHT)) {
         return false;
     }
 
@@ -419,16 +424,14 @@ static void M_KillLara(const ITEM *const item, ITEM *const lara)
 static bool M_IsAgainstFloor(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     return sector->floor.tilt == 0 && sector->floor.height == item->pos.y;
 }
 
 static bool M_IsAgainstCeiling(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     const SECTOR *const sky_sector =
         Room_GetSkySector(sector, item->pos.x, item->pos.z);
     return sky_sector->ceiling.tilt == 0
@@ -564,7 +567,8 @@ static void M_Collision(
 
         int16_t room_num = lara_item->room_num;
         Room_GetSector(
-            item->pos.x, item->pos.y - STEP_L / 2, item->pos.z, &room_num);
+            (XYZ_32) { item->pos.x, item->pos.y - STEP_L / 2, item->pos.z },
+            &room_num);
         if (room_num != item->room_num) {
             return;
         }
@@ -682,10 +686,14 @@ static void M_Control(const int16_t item_num)
     // ROUND_TO_HALF_CLICK because block can fall through floor to undefined
     // sector.
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector(
-        item->pos.x, ROUND_TO_HALF_CLICK(item->pos.y), item->pos.z, &room_num);
-    int32_t under_block_height = Room_GetHeightEx(
-        sector, item->pos.x, item->pos.y, item->pos.z, true, item_num);
+    XYZ_32 sample_pos = {
+        item->pos.x,
+        ROUND_TO_HALF_CLICK(item->pos.y),
+        item->pos.z,
+    };
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
+    int32_t under_block_height =
+        Room_GetHeightEx(sector, item->pos, true, item_num);
 
     bool update_room_num = true;
 
@@ -694,16 +702,21 @@ static void M_Control(const int16_t item_num)
         const int32_t y_prev = item->pos.y - item->fall_speed;
 
         // Query floor at previous y position.
-        const SECTOR *prev_sector =
-            Room_GetSector(item->pos.x, y_prev, item->pos.z, &room_num);
-        int32_t prev_height = Room_GetHeightEx(
-            prev_sector, item->pos.x, y_prev, item->pos.z, true, item_num);
+        sample_pos.y = y_prev;
+        const SECTOR *prev_sector = Room_GetSector(sample_pos, &room_num);
+        int32_t prev_height =
+            Room_GetHeightEx(prev_sector, sample_pos, true, item_num);
 
         // If on a walkable at the previous y position, use the rounded previous
         // y position as the floor.
         if (Room_IsOnWalkable(
-                prev_sector, item->pos.x, ROUND_TO_HALF_CLICK(y_prev),
-                item->pos.z, ROUND_TO_HALF_CLICK(y_prev), item_num)) {
+                prev_sector,
+                (XYZ_32) {
+                    item->pos.x,
+                    ROUND_TO_HALF_CLICK(y_prev),
+                    item->pos.z,
+                },
+                ROUND_TO_HALF_CLICK(y_prev), item_num)) {
             prev_height = ROUND_TO_HALF_CLICK(y_prev);
         }
 
@@ -742,7 +755,8 @@ static void M_Control(const int16_t item_num)
     if (update_room_num) {
         room_num = item->room_num;
         Room_GetSectorOnWalkable(
-            item->pos.x, item->pos.y - WALL_L, item->pos.z, &room_num);
+            (XYZ_32) { item->pos.x, item->pos.y - WALL_L, item->pos.z },
+            &room_num);
         Item_UpdateRoom(item_num, room_num);
     }
 
@@ -865,8 +879,7 @@ static void M_GetStack(
     const int32_t step_y, const int16_t room_num)
 {
     int16_t sector_room_num = room_num;
-    SECTOR *sector =
-        Room_GetSector(stack_pos.x, stack_pos.y, stack_pos.z, &sector_room_num);
+    SECTOR *sector = Room_GetSector(stack_pos, &sector_room_num);
     sector = Room_GetPitSector(sector, stack_pos.x, stack_pos.z);
 
     for (WALKABLE *w = sector->walkable; w != nullptr; w = w->next) {
@@ -911,8 +924,7 @@ void MovableBlock_UpdateBox(const ITEM *const item, const bool blocked)
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     if (sector->floor.height == item->pos.y && sector->box != NO_BOX) {
         BOX_INFO *const box = Box_GetBox(sector->box);
         if (box != nullptr && (box->overlap_index & BOX_BLOCKABLE) != 0) {
@@ -953,7 +965,8 @@ void MovableBlock_ShiftStackY(
         item->pos.y = new_y;
         int16_t sector_room_num = room_num;
         SECTOR *sector = Room_GetSector(
-            item->pos.x, item->pos.y - STEP_L, item->pos.z, &sector_room_num);
+            (XYZ_32) { item->pos.x, item->pos.y - STEP_L, item->pos.z },
+            &sector_room_num);
         Item_UpdateRoom(item_num, sector_room_num);
         if (reposition) {
             const GAME_VECTOR target = {
@@ -986,7 +999,8 @@ void MovableBlock_SlideStack(
         item->pos.z = dest_item->pos.z;
         int16_t sector_room_num = dest_item->room_num;
         Room_GetSector(
-            item->pos.x, item->pos.y - STEP_L, item->pos.z, &sector_room_num);
+            (XYZ_32) { item->pos.x, item->pos.y - STEP_L, item->pos.z },
+            &sector_room_num);
         Item_UpdateRoom(item_num, sector_room_num);
         if (reposition) {
             const GAME_VECTOR target = {

--- a/src/trx/game/objects/traps/pendulum.c
+++ b/src/trx/game/objects/traps/pendulum.c
@@ -61,9 +61,8 @@ static void M_Control(const int16_t item_num)
             lara_item->room_num);
     }
 
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &item->room_num);
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &item->room_num);
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_Animate(item);
 }
 

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -70,12 +70,9 @@ static bool M_TestStop(const ITEM *const item)
         ROUND_TO_HALF_CLICK(ABS(bounds->max.y - bounds->min.y));
 
     int16_t room_num = item->room_num;
-    const int32_t x =
-        item->pos.x + ((dist * Math_Sin(item->rot.y)) >> W2V_SHIFT);
-    const int32_t z =
-        item->pos.z + ((dist * Math_Cos(item->rot.y)) >> W2V_SHIFT);
-    const SECTOR *sector = Room_GetSector(x, item->pos.y, z, &room_num);
-    const int16_t height = Room_GetHeight(sector, x, item->pos.y, z);
+    XYZ_32 sample_pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, dist);
+    const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
+    const int16_t height = Room_GetHeight(sector, sample_pos);
     if (item->object_id != O_ROLLING_BALL_4) {
         // Allow a more lenient height check if regular boulders fall onto
         // slopes with a ceiling in front.
@@ -83,9 +80,9 @@ static bool M_TestStop(const ITEM *const item)
         CLAMPG(item_height, STEP_L * 3 / height_scale);
     }
 
-    sector = Room_GetSector(x, item->pos.y - item_height, z, &room_num);
-    const int16_t ceiling =
-        Room_GetCeiling(sector, x, item->pos.y - item_height, z);
+    sample_pos.y -= item_height;
+    sector = Room_GetSector(sample_pos, &room_num);
+    const int16_t ceiling = Room_GetCeiling(sector, sample_pos);
 
     return height < item->pos.y
         || (!item->gravity && ceiling > item->pos.y - item_height);
@@ -127,9 +124,8 @@ static void M_Control(const int16_t item_num)
 
     if (item->status != IS_ACTIVE) {
         int16_t room_num = item->room_num;
-        const SECTOR *const sector = Room_GetSector32(item->pos, &room_num);
-        const int16_t height =
-            Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+        const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+        const int16_t height = Room_GetHeight(sector, item->pos);
         if (item->floor < height) {
             item->status = IS_ACTIVE;
             item->floor = height;
@@ -155,11 +151,10 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
-    item->floor = Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    item->floor = Room_GetHeight(sector, item->pos);
     Room_TestTriggers(item);
 
     if (item->pos.y >= item->floor - STEP_L) {

--- a/src/trx/game/objects/traps/sliding_pillar.c
+++ b/src/trx/game/objects/traps/sliding_pillar.c
@@ -178,7 +178,7 @@ static void M_Control(const int16_t item_num)
 
     Item_Animate(item);
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
     const GAME_VECTOR linked = M_GetLinked(item);

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -70,15 +70,14 @@ static void M_Move(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     const M_PRIV *const p = item->priv;
     const int32_t step = (p != nullptr && p->step > 0) ? p->step : M_STEP_SLOW;
-    const int32_t y = item->pos.y + step;
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, y, item->pos.z, &room_num);
-    if (Room_GetHeight(sector, item->pos.x, y, item->pos.z) < y + WALL_L) {
+    const XYZ_32 pos = { item->pos.x, item->pos.y + step, item->pos.z };
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    if (Room_GetHeight(sector, pos) < pos.y + WALL_L) {
         item->status = IS_DEACTIVATED;
         Sound_StopEffect(SFX_SPIKE_WALL);
     } else {
-        item->pos.y = y;
+        item->pos.y = pos.y;
         Item_UpdateRoom(item_num, room_num);
         Sound_Effect(SFX_SPIKE_WALL, &item->pos, SPM_NORMAL);
     }

--- a/src/trx/game/objects/traps/spike_wall.c
+++ b/src/trx/game/objects/traps/spike_wall.c
@@ -13,20 +13,16 @@
 static void M_Move(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const int32_t z =
-        item->pos.z + (M_SPEED * Math_Cos(item->rot.y) >> WALL_SHIFT);
-    const int32_t x =
-        item->pos.x + (M_SPEED * Math_Sin(item->rot.y) >> WALL_SHIFT);
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, M_SPEED << 4);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector = Room_GetSector(x, item->pos.y, z, &room_num);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
 
-    if (Room_GetHeight(sector, x, item->pos.y, z) != item->pos.y) {
+    if (Room_GetHeight(sector, pos) != pos.y) {
         item->status = IS_DEACTIVATED;
         Sound_StopEffect(SFX_SPIKE_WALL);
     } else {
-        item->pos.z = z;
-        item->pos.x = x;
+        item->pos = pos;
         Item_UpdateRoom(item_num, room_num);
     }
 

--- a/src/trx/game/objects/traps/spinning_blade.c
+++ b/src/trx/game/objects/traps/spinning_blade.c
@@ -40,15 +40,12 @@ static void M_Control(const int16_t item_num)
 
     if (item->current_anim_state == SPINNING_BLADE_STATE_SPIN) {
         if (item->goal_anim_state != SPINNING_BLADE_STATE_STOP) {
-            const int32_t x = item->pos.x
-                + ((WALL_L * 3 / 2 * Math_Sin(item->rot.y)) >> W2V_SHIFT);
-            const int32_t z = item->pos.z
-                + ((WALL_L * 3 / 2 * Math_Cos(item->rot.y)) >> W2V_SHIFT);
+            const XYZ_32 pos =
+                XYZ_32_OffsetYaw(item->pos, item->rot.y, WALL_L * 3 / 2);
 
             int16_t room_num = item->room_num;
-            const SECTOR *const sector =
-                Room_GetSector(x, item->pos.y, z, &room_num);
-            if (Room_GetHeight(sector, x, item->pos.y, z) == NO_HEIGHT) {
+            const SECTOR *const sector = Room_GetSector(pos, &room_num);
+            if (Room_GetHeight(sector, pos) == NO_HEIGHT) {
                 item->goal_anim_state = SPINNING_BLADE_STATE_STOP;
             }
         }
@@ -76,10 +73,8 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
     item->pos.y = height;
     item->floor = height;
     Item_UpdateRoom(item_num, room_num);

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -172,12 +172,11 @@ static int32_t M_TestWaterHeight(
     pos->z = item->pos.z + ((z_off * c - x_off * s) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
-    Room_GetSector(pos->x, pos->y, pos->z, &room_num);
-    int32_t height = Room_GetWaterHeight(pos->x, pos->y, pos->z, room_num);
+    Room_GetSector(*pos, &room_num);
+    int32_t height = Room_GetWaterHeight(*pos, room_num);
     if (height == NO_HEIGHT) {
-        const SECTOR *const sector =
-            Room_GetSector(pos->x, pos->y, pos->z, &room_num);
-        height = Room_GetHeight(sector, pos->x, pos->y, pos->z);
+        const SECTOR *const sector = Room_GetSector(*pos, &room_num);
+        height = Room_GetHeight(sector, *pos);
         if (height != NO_HEIGHT) {
             return height;
         }
@@ -394,13 +393,10 @@ static int32_t M_Dynamics(const int16_t boat_num)
     }
 
     int16_t room_num = boat_item->room_num;
-    const SECTOR *const sector = Room_GetSector(
-        boat_item->pos.x, boat_item->pos.y, boat_item->pos.z, &room_num);
-    int32_t height = Room_GetWaterHeight(
-        boat_item->pos.x, boat_item->pos.y, boat_item->pos.z, room_num);
+    const SECTOR *const sector = Room_GetSector(boat_item->pos, &room_num);
+    int32_t height = Room_GetWaterHeight(boat_item->pos, room_num);
     if (height == NO_HEIGHT) {
-        height = Room_GetHeight(
-            sector, boat_item->pos.x, boat_item->pos.y, boat_item->pos.z);
+        height = Room_GetHeight(sector, boat_item->pos);
     }
     if (height < boat_item->pos.y - STEP_L / 2) {
         Vehicle_DoShift(boat_item, &boat_item->pos, &old);
@@ -680,15 +676,16 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = boat_item->room_num;
     const SECTOR *sector = Room_GetSector(
-        boat_item->pos.x, boat_item->pos.y + BOAT_SHIFT_Y, boat_item->pos.z,
+        (XYZ_32) {
+            boat_item->pos.x,
+            boat_item->pos.y + BOAT_SHIFT_Y,
+            boat_item->pos.z,
+        },
         &room_num);
-    int32_t height = Room_GetHeight(
-        sector, boat_item->pos.x, boat_item->pos.y, boat_item->pos.z);
-    const int32_t ceiling = Room_GetCeiling(
-        sector, boat_item->pos.x, boat_item->pos.y, boat_item->pos.z);
+    int32_t height = Room_GetHeight(sector, boat_item->pos);
+    const int32_t ceiling = Room_GetCeiling(sector, boat_item->pos);
 
-    const int32_t water_height = Room_GetWaterHeight(
-        boat_item->pos.x, boat_item->pos.y, boat_item->pos.z, room_num);
+    const int32_t water_height = Room_GetWaterHeight(boat_item->pos, room_num);
     p->water = water_height;
 
     if (Lara_Vehicle_GetIndex() == item_num && lara_item->hit_points > 0) {
@@ -761,7 +758,11 @@ static void M_Control(const int16_t item_num)
         Room_TestTriggers(boat_item);
 
         sector = Room_GetSector(
-            lara_item->pos.x, lara_item->pos.y + BOAT_SHIFT_Y, lara_item->pos.z,
+            (XYZ_32) {
+                lara_item->pos.x,
+                lara_item->pos.y + BOAT_SHIFT_Y,
+                lara_item->pos.z,
+            },
             &room_num);
         Item_UpdateRoom(lara->item_num, room_num);
 
@@ -836,8 +837,8 @@ static void M_Control(const int16_t item_num)
         };
 
         room_num = lara_item->room_num;
-        sector = Room_GetSector(pos.x, pos.y, pos.z, &room_num);
-        if (Room_GetHeight(sector, pos.x, pos.y, pos.z) >= pos.y - STEP_L) {
+        sector = Room_GetSector(pos, &room_num);
+        if (Room_GetHeight(sector, pos) >= pos.y - STEP_L) {
             lara_item->pos.x = pos.x;
             lara_item->pos.z = pos.z;
             Item_UpdateRoom(lara->item_num, room_num);

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -57,9 +57,10 @@ int32_t Vehicle_DoShift(
         x = 0;
         z = 0;
 
+        XYZ_32 test_pos = (XYZ_32) { old->x, pos->y, pos->z };
         room_num = vehicle->room_num;
-        sector = Room_GetSector(old->x, pos->y, pos->z, &room_num);
-        height = Room_GetHeight(sector, old->x, pos->y, pos->z);
+        sector = Room_GetSector(test_pos, &room_num);
+        height = Room_GetHeight(sector, test_pos);
         if (height < old->y - STEP_L) {
             if (pos->z > old->z) {
                 z = -shift_z - 1;
@@ -68,9 +69,10 @@ int32_t Vehicle_DoShift(
             }
         }
 
+        test_pos = (XYZ_32) { pos->x, pos->y, old->z };
         room_num = vehicle->room_num;
-        sector = Room_GetSector(pos->x, pos->y, old->z, &room_num);
-        height = Room_GetHeight(sector, pos->x, pos->y, old->z);
+        sector = Room_GetSector(test_pos, &room_num);
+        height = Room_GetHeight(sector, test_pos);
         if (height < old->y - STEP_L) {
             if (pos->x > old->x) {
                 x = -shift_x - 1;

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -230,11 +230,9 @@ static int32_t M_GetOnQuadBike(
     }
 
     int16_t room_num = item->room_num;
-    SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    SECTOR *const sector = Room_GetSector(item->pos, &room_num);
 
-    const int32_t h =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const int32_t h = Room_GetHeight(sector, item->pos);
     if (h < -32000) {
         return 0;
     }
@@ -417,14 +415,14 @@ static int32_t M_TestHeight(
     pos->z = item->pos.z + ((x * c - z * s) >> W2V_SHIFT);
 
     int16_t room_num = item->room_num;
-    SECTOR *const sector = Room_GetSector(pos->x, pos->y, pos->z, &room_num);
-    const int32_t ceiling = Room_GetCeiling(sector, pos->x, pos->y, pos->z);
+    SECTOR *const sector = Room_GetSector(*pos, &room_num);
+    const int32_t ceiling = Room_GetCeiling(sector, *pos);
 
     if (pos->y < ceiling || ceiling == NO_HEIGHT) {
         return NO_HEIGHT;
     }
 
-    return Room_GetHeight(sector, pos->x, pos->y, pos->z);
+    return Room_GetHeight(sector, *pos);
 }
 
 static void M_TriggerExhaustSmoke(
@@ -508,14 +506,12 @@ static bool M_SkidooCanGetOff(const int32_t lr)
     ITEM *const item = Lara_Vehicle_GetItem();
 
     const int16_t angle = item->rot.y + DEG_90 * lr;
-    const int32_t x = item->pos.x + ((512 * Math_Sin(angle)) >> W2V_SHIFT);
-    const int32_t y = item->pos.y;
-    const int32_t z = item->pos.z + ((512 * Math_Cos(angle)) >> W2V_SHIFT);
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, angle, 512);
 
     int16_t room_num = item->room_num;
-    SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int32_t h = Room_GetHeight(sector, x, y, z);
-    const int32_t c = Room_GetCeiling(sector, x, y, z);
+    SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t h = Room_GetHeight(sector, pos);
+    const int32_t c = Room_GetCeiling(sector, pos);
 
     const HEIGHT_TYPE height_type = Room_GetHeightType();
     if (height_type != HT_BIG_SLOPE && height_type != HT_DIAGONAL
@@ -606,11 +602,10 @@ static int32_t M_DoShift(
 
     int32_t x = 0;
     int32_t z = 0;
+    XYZ_32 test_pos = { old_pos->x, new_pos->y, new_pos->z };
     int16_t room_num = item->room_num;
-    SECTOR *sector =
-        Room_GetSector(old_pos->x, new_pos->y, new_pos->z, &room_num);
-    const int32_t h =
-        Room_GetHeight(sector, old_pos->x, new_pos->y, new_pos->z);
+    SECTOR *sector = Room_GetSector(test_pos, &room_num);
+    const int32_t h = Room_GetHeight(sector, test_pos);
 
     if (h < old_pos->y - 256) {
         if (new_pos->z > old_pos->z) {
@@ -620,10 +615,10 @@ static int32_t M_DoShift(
         }
     }
 
+    test_pos = (XYZ_32) { new_pos->x, new_pos->y, old_pos->z };
     room_num = item->room_num;
-    sector = Room_GetSector(new_pos->x, new_pos->y, old_pos->z, &room_num);
-    const int32_t h2 =
-        Room_GetHeight(sector, new_pos->x, new_pos->y, old_pos->z);
+    sector = Room_GetSector(test_pos, &room_num);
+    const int32_t h2 = Room_GetHeight(sector, test_pos);
 
     if (h2 < old_pos->y - 256) {
         if (new_pos->x > old_pos->x) {
@@ -812,10 +807,8 @@ static int32_t M_SkidooDynamics(ITEM *const item)
     }
 
     int16_t room_num = item->room_num;
-    SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
 
     int32_t speed = item->pos.y < height
         ? item->speed
@@ -937,10 +930,8 @@ static int32_t M_SkidooDynamics(ITEM *const item)
     }
 
     room_num = item->room_num;
-    SECTOR *const sector2 =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height2 =
-        Room_GetHeight(sector2, item->pos.x, item->pos.y, item->pos.z);
+    SECTOR *const sector2 = Room_GetSector(item->pos, &room_num);
+    const int32_t height2 = Room_GetHeight(sector2, item->pos);
 
     if (height2 < item->pos.y - 256) {
         M_DoShift(item, &item->pos, &old_pos);
@@ -1328,10 +1319,8 @@ bool QuadBike_Control(void)
         M_TestHeight(item, 550, 260, &front_right_pos);
 
     int16_t room_num = item->room_num;
-    SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
     Room_TestTriggers(lara_item);
 
     if (lara_item->hit_points <= 0) {

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -202,10 +202,8 @@ int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
     }
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
     if (height < -32000) {
         return M_GET_ON_NONE;
     }
@@ -278,9 +276,8 @@ int32_t Skidoo_TestHeight(
     out_pos->y = item->pos.y + ((x_off * sz - z_off * sx) >> W2V_SHIFT);
     out_pos->z = item->pos.z + ((z_off * cy - x_off * sy) >> W2V_SHIFT);
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(out_pos->x, out_pos->y, out_pos->z, &room_num);
-    return Room_GetHeight(sector, out_pos->x, out_pos->y, out_pos->z);
+    const SECTOR *const sector = Room_GetSector(*out_pos, &room_num);
+    return Room_GetHeight(sector, *out_pos);
 }
 
 void Skidoo_DoSnowEffect(const ITEM *const skidoo)
@@ -427,10 +424,8 @@ int32_t Skidoo_Dynamics(ITEM *const skidoo)
     }
 
     int16_t room_num = skidoo->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(skidoo->pos.x, skidoo->pos.y, skidoo->pos.z, &room_num);
-    const int32_t height =
-        Room_GetHeight(sector, skidoo->pos.x, skidoo->pos.y, skidoo->pos.z);
+    const SECTOR *const sector = Room_GetSector(skidoo->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, skidoo->pos);
     if (height < skidoo->pos.y - STEP_L) {
         Vehicle_DoShift(skidoo, &skidoo->pos, &old);
     }
@@ -551,15 +546,11 @@ int32_t Skidoo_CheckGetOffOK(int32_t direction)
         rot = skidoo->rot.y - DEG_90;
     }
 
-    const int32_t c = Math_Cos(rot);
-    const int32_t s = Math_Sin(rot);
-    const int32_t x = skidoo->pos.x - ((M_GET_OFF_DIST * s) >> W2V_SHIFT);
-    const int32_t z = skidoo->pos.z - ((M_GET_OFF_DIST * c) >> W2V_SHIFT);
-    const int32_t y = skidoo->pos.y;
+    const XYZ_32 pos = XYZ_32_OffsetYaw(skidoo->pos, rot, -M_GET_OFF_DIST);
 
     int16_t room_num = skidoo->room_num;
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
-    const int32_t height = Room_GetHeight(sector, x, y, z);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
     const HEIGHT_TYPE height_type = Room_GetHeightType();
 
     if (height_type == HT_BIG_SLOPE || height_type == HT_DIAGONAL
@@ -571,7 +562,7 @@ int32_t Skidoo_CheckGetOffOK(int32_t direction)
         return false;
     }
 
-    const int32_t ceiling = Room_GetCeiling(sector, x, y, z);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
     if (ceiling - skidoo->pos.y > -LARA_HEIGHT) {
         return false;
     }
@@ -809,10 +800,8 @@ bool Skidoo_Control(void)
     const int32_t hfr = Skidoo_TestHeight(skidoo, M_FRONT, M_SIDE, &fr);
 
     int16_t room_num = skidoo->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(skidoo->pos.x, skidoo->pos.y, skidoo->pos.z, &room_num);
-    int32_t height =
-        Room_GetHeight(sector, skidoo->pos.x, skidoo->pos.y, skidoo->pos.z);
+    const SECTOR *const sector = Room_GetSector(skidoo->pos, &room_num);
+    int32_t height = Room_GetHeight(sector, skidoo->pos);
 
     bool dead = false;
     if (lara_item->hit_points <= 0) {

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -100,10 +100,8 @@ static bool M_DrawShadow_Sprite(
             anchor_pos.z += (offset.z * cy - offset.x * sy) >> W2V_SHIFT;
 
             int16_t room_num = item->room_num;
-            const SECTOR *const sector = Room_GetSector(
-                anchor_pos.x, anchor_pos.y, anchor_pos.z, &room_num);
-            const int16_t height = Room_GetHeight(
-                sector, anchor_pos.x, anchor_pos.y, anchor_pos.z);
+            const SECTOR *const sector = Room_GetSector(anchor_pos, &room_num);
+            const int16_t height = Room_GetHeight(sector, anchor_pos);
             if (height != NO_HEIGHT) {
                 anchor_floor = height;
             }
@@ -141,9 +139,9 @@ static bool M_DrawShadow_Sprite(
         const int32_t wz = anchor_pos.z + rz;
 
         int16_t room_num = item->room_num;
-        const SECTOR *const sector =
-            Room_GetSector(wx, anchor_floor, wz, &room_num);
-        int32_t height = Room_GetHeight(sector, wx, anchor_floor, wz);
+        XYZ_32 test_pos = { wx, anchor_floor, wz };
+        const SECTOR *const sector = Room_GetSector(test_pos, &room_num);
+        int32_t height = Room_GetHeight(sector, test_pos);
         if (height == NO_HEIGHT) {
             height = anchor_floor;
         }

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -456,7 +456,8 @@ bool Box_BadFloor(
     const int32_t x, const int32_t y, const int32_t z, const int32_t box_height,
     const int32_t next_height, int16_t room_num, const LOT_INFO *const lot)
 {
-    const SECTOR *const sector = Room_GetSector(x, y, z, &room_num);
+    const SECTOR *const sector =
+        Room_GetSector((XYZ_32) { x, y, z }, &room_num);
     if (sector->box == NO_BOX) {
         return true;
     }

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -78,7 +78,7 @@ static void M_RemoveFlipItems(const ROOM *const room)
 static void M_GetNewRoom(
     const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
 {
-    Room_GetSector(x, y, z, &room_num);
+    Room_GetSector((XYZ_32) { x, y, z }, &room_num);
     Room_MarkToBeDrawn(room_num);
 }
 
@@ -346,13 +346,13 @@ int32_t Room_GetOutsideStatus(const XYZ_32 pos, int16_t *const out_room_num)
         }
 
         int16_t rn = candidate_room_num;
-        const SECTOR *const sector = Room_GetSector(pos.x, pos.y, pos.z, &rn);
-        const int16_t floor = Room_GetHeight(sector, pos.x, pos.y, pos.z);
+        const SECTOR *const sector = Room_GetSector(pos, &rn);
+        const int16_t floor = Room_GetHeight(sector, pos);
         if (floor == NO_HEIGHT || pos.y > floor) {
             return -2;
         }
 
-        const int16_t ceiling = Room_GetCeiling(sector, pos.x, pos.y, pos.z);
+        const int16_t ceiling = Room_GetCeiling(sector, pos);
         if (pos.y < ceiling) {
             return -2;
         }
@@ -525,8 +525,7 @@ bool Room_PointInside(const ROOM *const room, const XYZ_32 point)
     if (point.x >= x1 && point.x < x2 && point.y >= y1 && point.y <= y2
         && point.z >= z1 && point.z < z2) {
         const SECTOR *sector = Room_GetWorldSector(room, point.x, point.z);
-        const int32_t height =
-            Room_GetHeight(sector, point.x, point.y, point.z);
+        const int32_t height = Room_GetHeight(sector, point);
         if (height != NO_HEIGHT) {
             return true;
         }
@@ -635,12 +634,12 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
         }
     }
 
+    const SECTOR *sector = Room_GetSector(*out_pos, &room_num);
+    int16_t height = Room_GetHeight(sector, *out_pos);
+
     int32_t x = out_pos->x;
     int32_t y = out_pos->y;
     int32_t z = out_pos->z;
-    const SECTOR *sector = Room_GetSector(x, y, z, &room_num);
-    int16_t height = Room_GetHeight(sector, x, y, z);
-
     if (height == NO_HEIGHT) {
         // Sample a sphere of points around target x, y, z
         // and teleport to the first available location.
@@ -659,9 +658,8 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
                     .y = y,
                     .z = ROUND_TO_SECTOR(z + dz * unit) + WALL_L / 2,
                 };
-                sector = Room_GetSector(point.x, point.y, point.z, &room_num);
-                height = Room_GetHeightEx(
-                    sector, point.x, point.y, point.z, true, NO_ITEM);
+                sector = Room_GetSector(point, &room_num);
+                height = Room_GetHeightEx(sector, point, true, NO_ITEM);
                 if (height == NO_HEIGHT) {
                     continue;
                 }

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -126,8 +126,8 @@ static bool M_TestLava(const ITEM *const item)
 
     // OG fix: check if floor index has lava
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    const SECTOR *const sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
     return sector->is_death_sector;
 }
 
@@ -361,8 +361,8 @@ void Room_ReadTriangulation(
 void Room_TestTriggers(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    const SECTOR *sector =
-        Room_GetSector(item->pos.x, MAX_HEIGHT, item->pos.z, &room_num);
+    const SECTOR *sector = Room_GetSector(
+        (XYZ_32) { item->pos.x, MAX_HEIGHT, item->pos.z }, &room_num);
 
     Room_TestSectorTrigger(item, sector);
     if (item->object_id != O_TORSO) {
@@ -377,8 +377,12 @@ void Room_TestTriggers(const ITEM *const item)
 
             room_num = item->room_num;
             sector = Room_GetSector(
-                item->pos.x + dx * WALL_L, MAX_HEIGHT,
-                item->pos.z + dz * WALL_L, &room_num);
+                (XYZ_32) {
+                    item->pos.x + dx * WALL_L,
+                    MAX_HEIGHT,
+                    item->pos.z + dz * WALL_L,
+                },
+                &room_num);
             Room_TestSectorTrigger(item, sector);
         }
     }

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -227,15 +227,14 @@ BOUNDS_32 Room_GetRoomBounds(const ROOM *const room)
     };
 }
 
-SECTOR *Room_GetSector(
-    const int32_t x, const int32_t y, const int32_t z, int16_t *const room_num)
+SECTOR *Room_GetSector(const XYZ_32 pos, int16_t *const room_num)
 {
     SECTOR *sector = nullptr;
 
     while (true) {
         const ROOM *room = Room_Get(*room_num);
-        int32_t z_sector = (z - room->pos.z) >> WALL_SHIFT;
-        int32_t x_sector = (x - room->pos.x) >> WALL_SHIFT;
+        int32_t z_sector = (pos.z - room->pos.z) >> WALL_SHIFT;
+        int32_t x_sector = (pos.x - room->pos.x) >> WALL_SHIFT;
 
         if (z_sector <= 0) {
             z_sector = 0;
@@ -266,69 +265,72 @@ SECTOR *Room_GetSector(
 
     ASSERT(sector != nullptr);
 
-    if (y >= M_GetSurfaceHeight(sector->floor, x, z, true)) {
+    if (pos.y >= M_GetSurfaceHeight(sector->floor, pos.x, pos.z, true)) {
         do {
             if (sector->portal_room.pit == NO_ROOM
-                || M_IsPortalSolid(sector->floor, x, z)) {
+                || M_IsPortalSolid(sector->floor, pos.x, pos.z)) {
                 break;
             }
             *room_num = sector->portal_room.pit;
             const ROOM *const room = Room_Get(*room_num);
-            sector = Room_GetWorldSector(room, x, z);
-        } while (y >= M_GetSurfaceHeight(sector->floor, x, z, true));
-    } else if (y < M_GetSurfaceHeight(sector->ceiling, x, z, true)) {
+            sector = Room_GetWorldSector(room, pos.x, pos.z);
+        } while (pos.y
+                 >= M_GetSurfaceHeight(sector->floor, pos.x, pos.z, true));
+    } else if (
+        pos.y < M_GetSurfaceHeight(sector->ceiling, pos.x, pos.z, true)) {
         do {
             if (sector->portal_room.sky == NO_ROOM
-                || M_IsPortalSolid(sector->ceiling, x, z)) {
+                || M_IsPortalSolid(sector->ceiling, pos.x, pos.z)) {
                 break;
             }
             *room_num = sector->portal_room.sky;
             const ROOM *const room = Room_Get(sector->portal_room.sky);
-            sector = Room_GetWorldSector(room, x, z);
-        } while (y < M_GetSurfaceHeight(sector->ceiling, x, z, true));
+            sector = Room_GetWorldSector(room, pos.x, pos.z);
+        } while (pos.y
+                 < M_GetSurfaceHeight(sector->ceiling, pos.x, pos.z, true));
     }
 
     return sector;
 }
 
-SECTOR *Room_GetSector32(const XYZ_32 pos, int16_t *const room_num)
-{
-    return Room_GetSector(pos.x, pos.y, pos.z, room_num);
-}
-
-SECTOR *Room_GetSectorOnWalkable(
-    const int32_t x, const int32_t y, const int32_t z, int16_t *const room_num)
+SECTOR *Room_GetSectorOnWalkable(const XYZ_32 pos, int16_t *const room_num)
 {
     // Resolve wall portals.
     const ROOM *room = Room_Get(*room_num);
-    SECTOR *sector = Room_GetWorldSector(room, x, z);
+    SECTOR *sector = Room_GetWorldSector(room, pos.x, pos.z);
     while (sector->portal_room.wall != NO_ROOM) {
         *room_num = sector->portal_room.wall;
         room = Room_Get(*room_num);
-        sector = Room_GetWorldSector(room, x, z);
+        sector = Room_GetWorldSector(room, pos.x, pos.z);
     }
 
     // Check if on a walkable.
-    const int32_t room_height = Room_GetHeight(sector, x, y, z);
+    const int32_t room_height = Room_GetHeight(sector, pos);
     const bool skip_pit = Room_IsOnWalkable(
-        sector, x, ROUND_TO_HALF_CLICK(y), z, ROUND_TO_HALF_CLICK(y), NO_ITEM);
+        sector,
+        (XYZ_32) {
+            pos.x,
+            ROUND_TO_HALF_CLICK(pos.y),
+            pos.z,
+        },
+        ROUND_TO_HALF_CLICK(pos.y), NO_ITEM);
 
     // Traverse pit sector unless on a walkable.
-    if (!skip_pit && y >= sector->floor.height) {
+    if (!skip_pit && pos.y >= sector->floor.height) {
         while (sector->portal_room.pit != NO_ROOM) {
             *room_num = sector->portal_room.pit;
             room = Room_Get(*room_num);
-            sector = Room_GetWorldSector(room, x, z);
-            if (y < sector->floor.height) {
+            sector = Room_GetWorldSector(room, pos.x, pos.z);
+            if (pos.y < sector->floor.height) {
                 break;
             }
         }
-    } else if (y < sector->ceiling.height) {
+    } else if (pos.y < sector->ceiling.height) {
         while (sector->portal_room.sky != NO_ROOM) {
             *room_num = sector->portal_room.sky;
             room = Room_Get(*room_num);
-            sector = Room_GetWorldSector(room, x, z);
-            if (y >= sector->ceiling.height) {
+            sector = Room_GetWorldSector(room, pos.x, pos.z);
+            if (pos.y >= sector->ceiling.height) {
                 break;
             }
         }
@@ -397,24 +399,21 @@ HEIGHT_TYPE Room_GetHeightType(void)
     return m_HeightType;
 }
 
-int16_t Room_GetTiltType(
-    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z)
+int16_t Room_GetTiltType(const SECTOR *sector, const XYZ_32 pos)
 {
-    sector = Room_GetPitSector(sector, x, z);
+    sector = Room_GetPitSector(sector, pos.x, pos.z);
 
-    if ((y + STEP_L * 2) < sector->floor.height) {
+    if ((pos.y + STEP_L * 2) < sector->floor.height) {
         return 0;
     }
 
-    return sector->floor.is_split ? M_GetSplitTiltType(sector, x, z)
+    return sector->floor.is_split ? M_GetSplitTiltType(sector, pos.x, pos.z)
                                   : sector->floor.tilt;
 }
 
-int16_t Room_GetHeight(
-    const SECTOR *const sector, const int32_t x, const int32_t y,
-    const int32_t z)
+int16_t Room_GetHeight(const SECTOR *const sector, const XYZ_32 pos)
 {
-    return Room_GetHeightEx(sector, x, y, z, false, NO_ITEM);
+    return Room_GetHeightEx(sector, pos, false, NO_ITEM);
 }
 
 int16_t Room_GetFloorHeightForSector(
@@ -429,22 +428,22 @@ int16_t Room_GetFloorHeightForSector(
 }
 
 int16_t Room_GetHeightEx(
-    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
-    const bool fix_tilts, const int16_t ignore_item_num)
+    const SECTOR *const sector, const XYZ_32 pos, const bool fix_tilts,
+    const int16_t ignore_item_num)
 {
     m_HeightType = HT_WALL;
 
-    const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
+    const SECTOR *const pit_sector = Room_GetPitSector(sector, pos.x, pos.z);
     int32_t height = pit_sector->floor.height;
 
     if (Room_IsAbyssHeight(height)) {
         height = m_AbyssMaxHeight;
     } else {
-        height = M_GetSurfaceHeight(pit_sector->floor, x, z, fix_tilts);
+        height = M_GetSurfaceHeight(pit_sector->floor, pos.x, pos.z, fix_tilts);
     }
 
     // Climb the stack of walkables.
-    int32_t test_y = y;
+    int32_t test_y = pos.y;
     for (WALKABLE *w = pit_sector->walkable; w != nullptr; w = w->next) {
         // Optionally ignore a walkable.
         if (w->item_num == ignore_item_num) {
@@ -454,13 +453,13 @@ int16_t Room_GetHeightEx(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
             const int32_t test_height =
-                obj->floor_height_func(item, x, test_y, z, height);
+                obj->floor_height_func(item, pos.x, test_y, pos.z, height);
             // If the floor height changed, try to climb the walkable stack.
             if (test_height != height) {
                 height = test_height;
                 // Only raise the test y value if the test floor height is above
                 // the original y value.
-                if (y > test_height) {
+                if (pos.y > test_height) {
                     test_y = test_height;
                 }
             }
@@ -470,36 +469,37 @@ int16_t Room_GetHeightEx(
     return height;
 }
 
-int16_t Room_GetCeiling(
-    const SECTOR *const sector, const int32_t x, const int32_t y,
-    const int32_t z)
+int16_t Room_GetCeiling(const SECTOR *const sector, const XYZ_32 pos)
 {
-    return Room_GetCeilingEx(sector, x, y, z, false);
+    return Room_GetCeilingEx(sector, pos, false);
 }
 
 int16_t Room_GetCeilingEx(
-    const SECTOR *const sector, const int32_t x, const int32_t y,
-    const int32_t z, const bool fix_tilts)
+    const SECTOR *const sector, const XYZ_32 pos, const bool fix_tilts)
 {
-    const SECTOR *const sky_sector = Room_GetSkySector(sector, x, z);
-    int16_t height = M_GetSurfaceHeight(sky_sector->ceiling, x, z, fix_tilts);
+    const SECTOR *const sky_sector = Room_GetSkySector(sector, pos.x, pos.z);
+    int16_t height =
+        M_GetSurfaceHeight(sky_sector->ceiling, pos.x, pos.z, fix_tilts);
 
-    const SECTOR *const pit_sector = Room_GetPitSector(sector, x, z);
+    const SECTOR *const pit_sector = Room_GetPitSector(sector, pos.x, pos.z);
 
     for (WALKABLE *w = pit_sector->walkable; w != nullptr; w = w->next) {
         const ITEM *const item = Item_Get(w->item_num);
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->ceiling_height_func != nullptr) {
-            height = obj->ceiling_height_func(item, x, y, z, height);
+            height =
+                obj->ceiling_height_func(item, pos.x, pos.y, pos.z, height);
         }
     }
 
     return height;
 }
 
-int32_t Room_GetWaterHeight(
-    const int32_t x, const int32_t y, const int32_t z, int16_t room_num)
+int32_t Room_GetWaterHeight(const XYZ_32 pos, int16_t room_num)
 {
+    const int32_t x = pos.x;
+    const int32_t y = pos.y;
+    const int32_t z = pos.z;
     const SECTOR *sector = nullptr;
     const ROOM *room = nullptr;
 
@@ -627,10 +627,10 @@ int32_t Room_FindGridShift(int32_t src, const int32_t dst)
 }
 
 bool Room_IsOnWalkable(
-    const SECTOR *sector, const int32_t x, const int32_t y, const int32_t z,
-    const int32_t room_height, const int16_t ignore_item_num)
+    const SECTOR *sector, const XYZ_32 pos, const int32_t room_height,
+    const int16_t ignore_item_num)
 {
-    sector = Room_GetPitSector(sector, x, z);
+    sector = Room_GetPitSector(sector, pos.x, pos.z);
 
     int16_t height = sector->floor.height;
     bool object_found = false;
@@ -643,7 +643,7 @@ bool Room_IsOnWalkable(
         const OBJECT *const obj = Object_Get(item->object_id);
         if (obj->floor_height_func != nullptr) {
             const int32_t test_height =
-                obj->floor_height_func(item, x, y, z, height);
+                obj->floor_height_func(item, pos.x, pos.y, pos.z, height);
             // If the floor height changed, try to climb the walkable stack.
             if (test_height != height) {
                 // Check if height changed aka actually on a walkable.

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -3,10 +3,8 @@
 #include <trx/game/rooms/types.h>
 
 BOUNDS_32 Room_GetRoomBounds(const ROOM *room);
-SECTOR *Room_GetSector(int32_t x, int32_t y, int32_t z, int16_t *room_num);
-SECTOR *Room_GetSector32(const XYZ_32 pos, int16_t *room_num);
-SECTOR *Room_GetSectorOnWalkable(
-    int32_t x, int32_t y, int32_t z, int16_t *room_num);
+SECTOR *Room_GetSector(XYZ_32 pos, int16_t *room_num);
+SECTOR *Room_GetSectorOnWalkable(XYZ_32 pos, int16_t *room_num);
 SECTOR *Room_GetWorldSector(const ROOM *room, int32_t x_pos, int32_t z_pos);
 SECTOR *Room_GetUnitSector(
     const ROOM *room, int32_t x_sector, int32_t z_sector);
@@ -17,23 +15,21 @@ void Room_SetAbyssHeight(int16_t height);
 bool Room_IsAbyssHeight(int32_t height);
 
 HEIGHT_TYPE Room_GetHeightType(void);
-int16_t Room_GetTiltType(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
+int16_t Room_GetTiltType(const SECTOR *sector, XYZ_32 pos);
 
-int16_t Room_GetHeight(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
+int16_t Room_GetHeight(const SECTOR *sector, XYZ_32 pos);
 int16_t Room_GetHeightEx(
-    const SECTOR *sector, int32_t x, int32_t y, int32_t z, bool fix_tilts,
-    int16_t ignore_item_num);
+    const SECTOR *sector, XYZ_32 pos, bool fix_tilts, int16_t ignore_item_num);
+int16_t Room_GetCeiling(const SECTOR *sector, XYZ_32 pos);
+int16_t Room_GetCeilingEx(const SECTOR *sector, XYZ_32 pos, bool fix_tilts);
 int16_t Room_GetFloorHeightForSector(
     const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
-int16_t Room_GetCeiling(const SECTOR *sector, int32_t x, int32_t y, int32_t z);
-int16_t Room_GetCeilingEx(
-    const SECTOR *sector, int32_t x, int32_t y, int32_t z, bool fix_tilts);
 
-int32_t Room_GetWaterHeight(int32_t x, int32_t y, int32_t z, int16_t room_num);
+int32_t Room_GetWaterHeight(XYZ_32 pos, int16_t room_num);
 void Room_AlterFloorHeight(const ITEM *item, int32_t height);
 
 int32_t Room_FindGridShift(int32_t src, int32_t dst);
 
 bool Room_IsOnWalkable(
-    const SECTOR *sector, int32_t x, int32_t y, int32_t z, int32_t room_height,
+    const SECTOR *sector, XYZ_32 pos, int32_t room_height,
     int16_t ignore_item_num);

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -126,10 +126,8 @@ static void M_LoadPostprocess(void)
 
         if (obj->save_position && obj->shadow_size) {
             int16_t room_num = item->room_num;
-            const SECTOR *const sector = Room_GetSector(
-                item->pos.x, item->pos.y, item->pos.z, &room_num);
-            item->floor =
-                Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
+            const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+            item->floor = Room_GetHeight(sector, item->pos);
         }
 
         if (obj->save_flags != 0) {

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -651,8 +651,7 @@ void Sparks_TriggerUnderwaterExplosion(const ITEM *item)
         Sparks_TriggerExplosionSparks(item->pos, 2, -1, 1, item->room_num);
     }
 
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     if (water_height == NO_HEIGHT) {
         return;
     }

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -63,10 +63,9 @@ void Spawn_Splash(const ITEM *const item)
         return;
     }
 
-    const int32_t water_height = Room_GetWaterHeight(
-        item->pos.x, item->pos.y, item->pos.z, item->room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
 
     for (int32_t i = 0; i < 10; i++) {
         const int16_t effect_num = Effect_Create(room_num);
@@ -142,7 +141,7 @@ void Spawn_BubbleEx(
     }
 
     int16_t water_room = room_num;
-    Room_GetSector(pos->x, pos->y, pos->z, &water_room);
+    Room_GetSector(*pos, &water_room);
     if (!Room_Get(water_room)->flags.underwater) {
         return;
     }

--- a/src/trx/game/water_fx.c
+++ b/src/trx/game/water_fx.c
@@ -209,13 +209,12 @@ void WaterFX_SetupSplash(const WATER_FX_SPLASH_SETUP *const setup_)
 void WaterFX_Splash(const ITEM *const item)
 {
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     if (!M_IsRoomUnderwater(room_num)) {
         return;
     }
 
-    const int32_t water_height =
-        Room_GetWaterHeight(item->pos.x, item->pos.y, item->pos.z, room_num);
+    const int32_t water_height = Room_GetWaterHeight(item->pos, room_num);
     WATER_FX_SPLASH_SETUP setup = {
         .x = item->pos.x,
         .y = water_height,
@@ -246,7 +245,7 @@ void WaterFX_WadeSplash(
     const ITEM *const item, const int32_t water_height, const int32_t depth)
 {
     int16_t room_num = item->room_num;
-    Room_GetSector(item->pos.x, item->pos.y, item->pos.z, &room_num);
+    Room_GetSector(item->pos, &room_num);
     if (!M_IsRoomUnderwater(room_num)) {
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR does a broad API cleanup for room/sector geometry queries by switching callsites from loose `x, y, z` arguments to `XYZ_32` position structs.

What changed:
- Geometry query APIs now use `XYZ_32`. Affected functions:
    - `Room_GetSector`
    - `Room_GetHeight[Ex]`
    - `Room_GetCeiling[Ex]`
    - `Room_GetWaterHeight`
    - `Room_GetTiltType`
    - `Room_IsOnWalkable`
    - `Room_GetSectorOnWalkable`
- `Room_GetSector32()` was removed, since `Room_GetSector()` now already takes `XYZ_32`.
- Callers across camera, Lara, collision, LOS, creatures, objects, vehicles, FX, save/load, and spawn were updated to the new signatures.

Rationale:
- The main goal is consistency and fewer dumb call mistakes in high-churn gameplay code.
- Passing one position object is easier to read and harder to get wrong.
- Make probe/sample coordinates explicit where Y differs from entity position.

#### Testing

- [x] Quick sanity pass: camera movement, Lara movement, one vehicle, one enemy fight, and one trap-heavy area
  Expected outcome: no obvious collision/room-transition regressions.

I have audited this change with automated tooling. After fixing a few spots, repeated passes did not report further issues.
