### PR TITLE
objects/rolling_ball: fix height change check

### DIFF
--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -68,9 +68,6 @@ static bool M_TestStop(const ITEM *const item)
     const BOUNDS_16 *const bounds = &frame->bounds;
     int16_t item_height =
         ROUND_TO_HALF_CLICK(ABS(bounds->max.y - bounds->min.y));
-    if (item->object_id != O_ROLLING_BALL_4) {
-        CLAMPG(item_height, STEP_L * 3);
-    }
 
     int16_t room_num = item->room_num;
     const int32_t x =
@@ -79,6 +76,13 @@ static bool M_TestStop(const ITEM *const item)
         item->pos.z + ((dist * Math_Cos(item->rot.y)) >> W2V_SHIFT);
     const SECTOR *sector = Room_GetSector(x, item->pos.y, z, &room_num);
     const int16_t height = Room_GetHeight(sector, x, item->pos.y, z);
+    if (item->object_id != O_ROLLING_BALL_4) {
+        // Allow a more lenient height check if regular boulders fall onto
+        // slopes with a ceiling in front.
+        const int32_t height_scale = Room_GetHeightType() != HT_WALL ? 2 : 1;
+        CLAMPG(item_height, STEP_L * 3 / height_scale);
+    }
+
     sector = Room_GetSector(x, item->pos.y - item_height, z, &room_num);
     const int16_t ceiling =
         Room_GetCeiling(sector, x, item->pos.y - item_height, z);

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -126,10 +126,9 @@ static void M_Control(const int16_t item_num)
         const SECTOR *const sector = Room_GetSector32(item->pos, &room_num);
         const int16_t height =
             Room_GetHeight(sector, item->pos.x, item->pos.y, item->pos.z);
-        if (item->pos.y < height) {
+        if (item->floor < height) {
             item->status = IS_ACTIVE;
             item->floor = height;
-            Item_UpdateRoom(item_num, room_num);
         }
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids boulders that have stopped on a slope detecting a height change on each frame when they are stopped, hence prevents them from reactivating and Lara being able to die from them. We also leave the room update call until the next frame where it's falling as some boulders (like snowballs) stop partially inside the wall so it could result in flickering.

I've checked the recent test level for falling boulders and all seems good - would appreciate a second glance.
