### PR TITLE
Fix various holster scenarios

### DIFF
--- a/data/common/ship/cfg/outfits.json5
+++ b/data/common/ship/cfg/outfits.json5
@@ -485,6 +485,7 @@
             "LGT_DESERT_EAGLE": {
                 "hand_r": 62,
                 "thigh_r": 9,
+                "thigh_l": 2,
             },
             "LGT_UZIS": {
                 "hand_r": 63,
@@ -548,6 +549,7 @@
             "LGT_DESERT_EAGLE": {
                 "hand_r": 62,
                 "thigh_r": 20,
+                "thigh_l": 13,
             },
             "LGT_UZIS": {
                 "hand_r": 63,
@@ -611,6 +613,7 @@
             "LGT_DESERT_EAGLE": {
                 "hand_r": 62,
                 "thigh_r": 31,
+                "thigh_l": 24,
             },
             "LGT_UZIS": {
                 "hand_r": 63,
@@ -674,6 +677,7 @@
             "LGT_DESERT_EAGLE": {
                 "hand_r": 62,
                 "thigh_r": 42,
+                "thigh_l": 35,
             },
             "LGT_UZIS": {
                 "hand_r": 63,
@@ -737,6 +741,7 @@
             "LGT_DESERT_EAGLE": {
                 "hand_r": 62,
                 "thigh_r": 53,
+                "thigh_l": 46,
             },
             "LGT_UZIS": {
                 "hand_r": 63,

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -58,8 +58,8 @@ static LARA_GUN_TYPE M_DetermineBackGun(void)
 
 static void M_InitialiseCutsceneLevel(void)
 {
-    Gun_SetLaraHolsterLMesh(LGT_PISTOLS);
-    Gun_SetLaraHolsterRMesh(LGT_PISTOLS);
+    Lara_Skin_SetGunEquipment(LM_THIGH_L, LGT_PISTOLS);
+    Lara_Skin_SetGunEquipment(LM_THIGH_R, LGT_PISTOLS);
 }
 
 static void M_InitialiseNormalLevel(const GF_LEVEL *const level)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Found a few mesh gremlins re outfits, so this aims to resolve those.

- If remember guns between levels is used, a cutscene would always reset the guns back to pistols
- If Lara starts a level unarmed, then picks up the Desert Eagle before any other holster gun, her left empty holster would disappear.
- Equally, if she finished a level with the Desert Eagle as the last holster gun, and remember guns is enabled, the left holster would not appear in the next level.

I think we're consistent again with OG here, would appreciate some messing around with giving/picking up weapons to see if I've missed anything else. Thanks!