### PR TITLE
objects/pickup: prevent pickups during sprint-slide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,7 @@
 - fixed secret tracks not restored from the savegame when "fix secrets killing music" option is on
 - fixed slow-forward seeking through cutscenes (right+slow) not working (regression from 1.0)
 - fixed statics marked collidable but with zero‑size hitboxes causing phantom collisions
+- fixed Lara being displaced during the sprint-slide animation if she tried to pick up an item at the same time (#4843, regression from TR1X 4.14, TR2X 1.4)
 
 **TR1**:
 - added Unfinished Business loading screens (#1310, thanks to rockahub)

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -344,6 +344,21 @@ cleanup:
     item->rot = old_rot;
 }
 
+static inline bool M_HasValidPickupState(const ITEM *const lara_item)
+{
+    // TODO: unify under a pickup style config option, but retain sprint slide
+    // test in TR1/2 mode.
+    const LARA_TRX_ANIMATION anim = LA_U(Item_GetRelativeAnim(lara_item));
+    const LARA_TRX_STATE state = LS_U(lara_item->current_anim_state);
+    if (g_TRVersion < 3) {
+        return state == LS_STOP && anim != LA_SPRINT_SLIDE_STAND_RIGHT
+            && anim != LA_SPRINT_SLIDE_STAND_LEFT;
+    }
+
+    return (state == LS_STOP && anim == LA_STAND_IDLE)
+        || (state == LS_CROUCH_IDLE && anim == LA_CROUCH_IDLE);
+}
+
 static void M_DoAboveWater(const int16_t item_num, ITEM *const lara_item)
 {
     ITEM *const item = Item_Get(item_num);
@@ -408,11 +423,7 @@ static void M_DoAboveWater(const int16_t item_num, ITEM *const lara_item)
 
     if (g_Input.action && !lara_item->gravity && lara->gun_status == LGS_ARMLESS
         && (lara->gun_type != LGT_FLARE || item->object_id != O_FLARE_ITEM)
-        && ((lara_item->current_anim_state == LS(LS_STOP)
-             && (g_TRVersion < 3 || anim == LA_STAND_IDLE))
-            || ((
-                lara_item->current_anim_state == LS(LS_CROUCH_IDLE)
-                && anim == LA_CROUCH_IDLE)))) {
+        && M_HasValidPickupState(lara_item)) {
 
         if (item->object_id == O_FLARE_ITEM) {
             if (lara->is_crouched) {


### PR DESCRIPTION
Resolves #4843.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This guards Lara in TR1 and TR2 from being able to interact with pickups during the sprint slide animations.

Some quick checks around:
- Regular TR1/2 pickups
- Regular TR3 pickups
- Crouch pickups in TR3
