### PR TITLE
lara: fix fly cheat not resetting held guns

### DIFF
--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -86,6 +86,14 @@ static void M_ReinitialiseGunMeshes(void)
     Gun_InitialiseNewWeapon();
 }
 
+static void M_ClearHandWeaponMeshes(void)
+{
+    Gun_SetLaraHandRMesh(LGT_UNARMED);
+    if (!Lara_Flare_IsMeshActive()) {
+        Gun_SetLaraHandLMesh(LGT_UNARMED);
+    }
+}
+
 static void M_ResetGunStatus(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
@@ -271,10 +279,7 @@ bool Lara_Cheat_EnterFlyMode(void)
 
     if (lara_info->extra_anim || lara_item->hit_points < 0) {
         M_ResetGunStatus();
-        Lara_Skin_ClearEquipment(LM_HAND_R);
-        if (!Lara_Flare_IsMeshActive()) {
-            Lara_Skin_ClearEquipment(LM_HAND_L);
-        }
+        M_ClearHandWeaponMeshes();
     } else if (Gun_IsRifleType(lara_info->gun_type)) {
         while (lara_info->gun_item_num != NO_ITEM) {
             Gun_Rifle_Undraw(lara_info->gun_type);
@@ -286,6 +291,7 @@ bool Lara_Cheat_EnterFlyMode(void)
             && Lara_Skin_GetEquipment(LM_TORSO)->type
                 == EQUIPMENT_TYPE_WEAPON)) {
         lara_info->gun_status = LGS_ARMLESS;
+        M_ClearHandWeaponMeshes();
     }
 
     lara_info->extra_anim = false;
@@ -362,6 +368,7 @@ bool Lara_Cheat_ExitFlyMode(void)
         lara_info->gun_status = LGS_UNDRAW;
     } else {
         lara_info->gun_status = LGS_ARMLESS;
+        M_ClearHandWeaponMeshes();
         M_ReinitialiseGunMeshes();
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a bug where Lara’s guns could stay visible if fly mode was activated mid-holster with a rifle on her back.

The fly-mode state transition to `LGS_ARMLESS` skipped normal undraw cleanup, leaving hand meshes active.
To fix this, I added a helper in `src/trx/game/lara/cheat.c` to clear hand weapon meshes (keeping active flare intact) and called it during forced `LGS_ARMLESS` in `Lara_Cheat_EnterFlyMode`, and reused the helper in the extra/dead reset path for consistency.

#### Testing

- [x] Equip a rifle (so it is visible on Lara’s back), draw pistols, start holstering, and press fly-cheat input during holster.
  Expected outcome: Lara enters fly mode without guns stuck in her hands.
- [x] Repeat the same holster + fly-cheat timing without a rifle weapon in inventory/on back.
  Expected outcome: behavior remains correct (no hand gun meshes left visible).
- [x] Repeat the same process with a rifle weapon in hands.
  Expected outcome: same as above.
