### PR TITLE
objects/earthquake: add antitriggers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@
     - `on_control_post` → `after_control`
 - changed turbo cheat to auto‑reset to normal speed if pushed past limit, making it easier for new players to recover from accidental changes
 - changed Blades to support being reset
+- changed Earthquake to support being reset
 - changed the barefoot SFX option toggle in TR2 to no longer require reloading the level for changes to take effect
 - changed triggers that target pickup items to support antitriggers, switches and bitmasks
 - removed support for legacy (TombATI / TR2 GOG/Steam) and pre-1.0 (TR1X/TR2X) savegame files

--- a/src/trx/game/objects/general/earthquake.c
+++ b/src/trx/game/objects/general/earthquake.c
@@ -47,16 +47,29 @@ static void M_FindAndActivateRelatedItems(const ITEM *const item)
     }
 }
 
+static void M_Reset(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->shake_intensity = 0;
+    p->target_intensity = 0;
+    p->target_timer = 0;
+    item->status = IS_INACTIVE;
+    Item_RemoveActive(item_num);
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
 
+    if (!Item_IsTriggerActive(item)) {
+        M_Reset(item_num);
+        return;
+    }
+
     switch (g_TRVersion) {
     case 1:
-        if (!Item_IsTriggerActive(item)) {
-            break;
-        }
         if (Random_GetDraw() < 256) {
             g_Camera.bounce = -150;
             Sound_Effect(SFX_EARTHQUAKE_1, nullptr, SPM_NORMAL);
@@ -74,12 +87,6 @@ static void M_Control(const int16_t item_num)
         break;
 
     case 3: {
-        if (!Item_IsTriggerActive(item)) {
-            p->shake_intensity = 0;
-            p->target_intensity = 100;
-            break;
-        }
-
         if (p->target_intensity == 0) {
             p->target_intensity = 100;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds reset/antitrigger support to the earthquake object so it behaves consistently with the trap reset work introduced in 1.1.

#### Testing

(Requires a test levels for all 3 games)

- [x] Activate the earthquake and deactivate it in all 3 games.
  Expected outcome: shaking/sound stops and the object resets.
- [x] Reactivate the same earthquake after antitrigger reset in all 3 games.
  Expected outcome: earthquake starts cleanly again from its initial runtime state.