### PR TITLE
savegame: fix remembering back guns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.2.1...develop) - ××××-××-××
 - changed Earthquake to support being reset
+- fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/trx-1.2...trx-1.2.1) - 2026-02-11
 - fixed title ring music inheriting the wrong audio volume (regression from 1.2)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -515,6 +515,13 @@ void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)
     resume->equipped_gun_type = lara->last_gun_type;
     resume->holsters_gun_type = lara->holsters_gun_type;
     resume->back_gun_type = lara->back_gun_type;
+    if (resume->back_gun_type == LGT_UNARMED
+        && Gun_IsRifleType(resume->equipped_gun_type)
+        && Inv_RequestItem(Gun_GetGunObject(resume->equipped_gun_type)) != 0) {
+        // If a rifle is currently drawn, Lara's back mesh is temporarily
+        // unarmed. Preserve the preferred rifle for next-level mesh restore.
+        resume->back_gun_type = resume->equipped_gun_type;
+    }
     if (lara->gun_status == LGS_READY) {
         resume->gun_status = LGS_READY;
     } else {


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes an issue where Lara's back weapon mesh could restore incorrectly between levels.

If Lara ended a level with a rifle equipped (e.g. M16), her back mesh was temporarily unarmed, and that unarmed state was saved. On the next level load, the engine remembered the correct equipped rifle but mismatched the back mesh, defaulting to Shotgun.

The fix ensures that if a rifle is equipped at level end while the back mesh is unarmed, the equipped rifle is saved as the preferred back gun for the next level.

#### Testing

- [x] Enable "Remember guns between levels", equip M16, and finish a level while with the rifle equipped in Lara's hands.
  Expected outcome: in the next level, Lara's back weapon mesh matches the remembered rifle (this bug occurs when there's a cutscene between levels).