### PR TITLE
savegame: do not force NG+ guns on every level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.2.1...develop) - ××××-××-××
 - changed Earthquake to support being reset
+- fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/trx-1.2...trx-1.2.1) - 2026-02-11

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -654,19 +654,27 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
         resume->rocket_ammo = resume->flags.has_rocket ? 10000 : 0;
         resume->harpoon_ammo = resume->flags.has_harpoon ? 10000 : 0;
 
-        if (g_TRVersion == 1) {
-            resume->equipped_gun_type = LGT_UZIS;
-            resume->back_gun_type = LGT_SHOTGUN;
-            resume->holsters_gun_type = LGT_UZIS;
-        } else {
-            if (g_TRVersion == 2) {
+        const bool should_force_ngplus_gun_setup =
+            !g_Config.gameplay.remember_gun_status || resume->prev_level == -1;
+        if (should_force_ngplus_gun_setup) {
+            switch (g_TRVersion) {
+            case 1:
+                resume->equipped_gun_type = LGT_UZIS;
+                resume->back_gun_type = LGT_SHOTGUN;
+                resume->holsters_gun_type = LGT_UZIS;
+                break;
+            case 2:
                 resume->equipped_gun_type = LGT_GRENADE;
                 resume->back_gun_type = LGT_GRENADE;
-            } else {
+                resume->holsters_gun_type = LGT_PISTOLS;
+                break;
+            case 3:
+            default:
                 resume->equipped_gun_type = LGT_ROCKET;
                 resume->back_gun_type = LGT_ROCKET;
+                resume->holsters_gun_type = LGT_PISTOLS;
+                break;
             }
-            resume->holsters_gun_type = LGT_PISTOLS;
         }
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes #4711, an issue with NG+ overriding remembered guns at each level start.

`Savegame_ApplyLogicToCurrentInfo` was always forcing NG+ default equipped guns (TR1 Uzis, TR2 Grenade Launcher, TR3 Rocket Launcher), even with Remember guns between levels enabled. This change keeps NG+ inventory/ammo grants as-is, but only applies forced NG+ equipped-gun setup when the option is disabled or it's a new game start.

#### Testing

- [x] In NG+, start a new game in each TR1/2/3.
  Expected outcome: Lara equips stronger firearms instead of just the default Pistols.
- [x] In NG+, start a new game in each TR1/2/3, keep the option Remember guns between levels disabled, and finish the level.
  Expected outcome: same as above.
- [x] In NG+, enable Remember guns between levels, equip a non-default weapon, finish a level.
  Expected outcome: next level keeps the remembered weapon.
- [x] Try to break it with Play Previous Levels feature.