### PR TITLE
ui/settings: freeze dialog size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.2...develop) - ××××-××-××
+- fixed settings dialog changing size when cycling through non-scrollable tabs
 - fixed Play Previous Level feature not restoring Lara's equipment correctly for pre-1.2 saves (regression from 1.2)
 - fixed Play Previous Level feature causing Lara to instantly die for pre-1.2 saves, when the Persistent Damage option is on (regression from 1.2)
     Note: for those 1.0/1.1 saves, this feature will restore her health to full, as it was not stored correctly. 1.2 will continue to restore the correct HP value.

--- a/src/trx/game/ui/dialogs/settings.c
+++ b/src/trx/game/ui/dialogs/settings.c
@@ -894,6 +894,7 @@ void UI_Settings(UI_SETTINGS_STATE *const s)
         .header_func = M_WindowHeader,
         .footer_func = nullptr,
         .user_data = s,
+        .reserve_scroll_space = true,
     });
 
     if (s->scroll.vis_items == 0) {

--- a/src/trx/game/ui/elements/window.c
+++ b/src/trx/game/ui/elements/window.c
@@ -17,7 +17,8 @@ static bool M_ShouldShowScrollHints(const UI_WINDOW_SETTINGS *const settings)
     if (settings->scrollable == nullptr) {
         return false;
     }
-    return settings->scrollable->vis_items < settings->scrollable->max_items;
+    return settings->reserve_scroll_space
+        || settings->scrollable->vis_items < settings->scrollable->max_items;
 }
 
 static float M_GetOuterPad(void)

--- a/src/trx/game/ui/elements/window.h
+++ b/src/trx/game/ui/elements/window.h
@@ -11,6 +11,7 @@ typedef struct {
     UI_WINDOW_CALLBACK *header_func;
     UI_WINDOW_CALLBACK *footer_func;
     void *user_data;
+    bool reserve_scroll_space;
 } UI_WINDOW_SETTINGS;
 
 void UI_BeginWindow(UI_WINDOW_SETTINGS settings);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a UI sizing glitch in the settings dialog when switching between tabs that are not scrollable.

I added a `reserve_scroll_space` flag to `UI_WINDOW_SETTINGS` and used it in the shared window logic so scroll hint space can be reserved even when a tab does not currently overflow. The settings dialog now enables this flag, which keeps the layout height stable while cycling tabs instead of shifting based on whether scroll hints are visible.

#### Testing

- [x] Open each of the settings dialogs, and switch repeatedly between tabs with and without scrolling
  Expected outcome: dialog width/size stays constant across tab changes
