### PR TITLE
inv-ring: fix volume not being reset correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.2...develop) - ××××-××-××
-- fixed settings dialog changing size when cycling through non-scrollable tabs
+- fixed title ring music inheriting the wrong audio volume (regression from 1.2)
+- fixed settings dialog changing size when cycling through non-scrollable tabs (regression from 1.2)
 - fixed Play Previous Level feature not restoring Lara's equipment correctly for pre-1.2 saves (regression from 1.2)
 - fixed Play Previous Level feature causing Lara to instantly die for pre-1.2 saves, when the Persistent Damage option is on (regression from 1.2)
     Note: for those 1.0/1.1 saves, this feature will restore her health to full, as it was not stored correctly. 1.2 will continue to restore the correct HP value.

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -74,6 +74,7 @@ static void M_HandleRequestedObject(INV_RING *const ring)
 void InvRing_AdjustMusicVolume(const INV_RING *const ring)
 {
     if (ring->mode == INV_TITLE_MODE) {
+        Music_SetVolume(g_Config.audio.music_volume);
         return;
     }
     const bool is_ambient =


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a title-menu music regression introduced in 91364c8d9c530acce34a677a059f1aeabf9ca921.

The regression happens because title music can inherit the last runtime-adjusted gameplay volume (for example, inventory ring ambient attenuation) when returning to title.
Since the volume reset was removed from unload flow in that commit and title startup does not always pass through a `play_music` sequence event, the title ring can start with effectively muted music until a settings change forces `Music_SetVolume()`.

This change restores correct behavior by explicitly resetting menu/title music volume to `g_Config.audio.music_volume` when entering title inventory flow, so returning to title no longer depends on previous in-level attenuation state.

#### Testing

Compare the following TR2 recording on develop and on this PR:

```
config gameplay.enable_fmv 0
config gameplay.enable_legal 0

@+0:    noop
@+15:   cmd "set audio.inventory-ambient-volume 0.5"
@+15:   cmd "play 7"
@+2:    ● "escape"
@+2:    ○ "escape"
@+18:   ● "down"
@+6:    ○ "down"
@+20:   ● "left ctrl"
@+11:   ○ "left ctrl"
@+15:   ● "right"
@+6:    ○ "right"
@+7:    ● "right"
@+6:    ○ "right"
@+6:    ● "left ctrl"
@+10:   ○ "left ctrl"
@+80:   quit
```

Expected outcome: develop – the inventory ring gets muted upon return; PR – it gets reset back to 100%.
