### PR TITLE
savegame: fix Play Previous Levels for 1.0 and 1.1 saves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.2...develop) - ××××-××-××
+- fixed Play Previous Level feature not restoring Lara's equipment correctly for pre-1.2 saves (regression from 1.2)
+- fixed Play Previous Level feature causing Lara to instantly die for pre-1.2 saves, when the Persistent Damage option is on (regression from 1.2)
+    Note: for those 1.0/1.1 saves, this feature will restore her health to full, as it was not stored correctly. 1.2 will continue to restore the correct HP value.
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/trx-1.1...trx-1.2) - 2026-02-11
 Showcase: https://www.youtube.com/watch?v=jeq8rQONaic

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -956,8 +956,18 @@ bool SG_File_LoadResumeInfoList(SG_READ_IO *const io)
         const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);
         RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
         M_MUST(SG_PUSH_INDEX(io, i));
+        const bool has_prev_level = SG_ReadIO_HasKey(io, "prev_level");
         M_MUST(M_ReadResumeInfo(io, resume));
         M_MUST(SG_POP(io));
+
+        // TRX 1.0/1.1 did not store prev_level for resume entries. Infer the
+        // canonical predecessor so "Play previous levels" can carry loadout.
+        if (!has_prev_level && resume->prev_level == -1) {
+            const GF_LEVEL *const prev_level = GF_GetLevelBefore(level);
+            if (prev_level != nullptr) {
+                resume->prev_level = prev_level->num;
+            }
+        }
     }
     M_MUST(SG_POP(io));
     M_FINISH();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes `Play previous levels` for TRX saves created in versions 1.0 and 1.1.

Before this change, pre-1.2 saves could lose Lara's carried guns/equipment in the level-select path, and with Persistent Damage enabled Lara could also die instantly on level start (!)
The loader now reconstructs missing resume linkage for those legacy saves so level-select state carry works again. 1.2 saves are unchanged.

#### Implementation details

The issue comes from a format gap introduced when non-linear resume linkage landed in 1.2:
- In 1.2, `resume_info` stores `prev_level`/`level_completed`, and the select-level flow uses that chain to carry state.
- In 1.0/1.1, `prev_level` is not serialized, so the select-level path had no predecessor link to carry from.
- Without that carry, resets in the select-level flow could drop loadout and (with Persistent Damage enabled) leave HP in a dead state.

Implementation in `src/trx/game/savegame/file_read.c`:
- While reading `resume_info[]`, detect whether `prev_level` exists on each entry.
- If missing (legacy 1.0/1.1 shape) and `resume->prev_level == -1`, infer canonical predecessor with `GF_GetLevelBefore(level)` and populate `resume->prev_level`.
- Keying on the field presence rather than save header version is intentional.
- 1.0/1.1 saves may still restore full HP in some cases because those saves did not preserve per-level continuation HP the same way 1.2 does.

#### Testing

Prerequisites: create three TR2 saves, one for each of the 1.0/1.1/1.2 versions. Start the game (do not use `/play` to start the game), level-skip a few levels, play with Lara's `/hp` and give her a few items/guns along the way.

- [x] For 1.0 and 1.1 saves, enable `Persistent damage`, then use **Play previous levels** into a non-first level.
  Expected outcome: Lara does not die instantly on level start and her health is full.
- [x] For the 1.2 save, enable `Persistent damage`, then use **Play previous levels** into a non-first level.
  Expected outcome: Lara starts with the HP she had *at the level start*. So if she ends TGW with 500 HP, playing TGW should restore her to 1000 HP and playing Venice should restore her to 500 HP.
- [x] Disable `Persistent damage`, then use **Play previous levels** into a non-first level.
  Expected outcome: Lara is at her full health for all 3 saves.
- [x] Use **Play previous levels** into a level where prior weapons were collected.
  Expected outcome: Lara's guns/equipment are restored consistently (no fallback to unarmed/default loadout) for all 3 saves.