### PR TITLE
Fix delayed tracks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed Play Previous Level feature not restoring Lara's equipment correctly for pre-1.2 saves (regression from 1.2)
 - fixed Play Previous Level feature causing Lara to instantly die for pre-1.2 saves, when the Persistent Damage option is on (regression from 1.2)
     Note: for those 1.0/1.1 saves, this feature will restore her health to full, as it was not stored correctly. 1.2 will continue to restore the correct HP value.
+- fixed TR2 delayed music triggers not working (regression from 1.1)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/trx-1.1...trx-1.2) - 2026-02-11
 Showcase: https://www.youtube.com/watch?v=jeq8rQONaic

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed Play Previous Level feature causing Lara to instantly die for pre-1.2 saves, when the Persistent Damage option is on (regression from 1.2)
     Note: for those 1.0/1.1 saves, this feature will restore her health to full, as it was not stored correctly. 1.2 will continue to restore the correct HP value.
 - fixed TR2 delayed music triggers not working (regression from 1.1)
+- fixed TR3 using delayed music triggers (TR2-only feature)
 
 ## [1.2](https://github.com/LostArtefacts/TRX/compare/trx-1.1...trx-1.2) - 2026-02-11
 Showcase: https://www.youtube.com/watch?v=jeq8rQONaic

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -467,6 +467,9 @@ int32_t Gym_TrackManager_GetTargetPenaltyFrames(const GYM_TRACK_TYPE track)
 bool Gym_TrackManager_OnPadContact(
     const GYM_TRACK_TYPE track, const bool on_ground)
 {
+    if (g_TRVersion < 3) {
+        return true;
+    }
     if (track != GYM_TRACK_ASSAULT) {
         return true;
     }

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -185,7 +185,7 @@ static void M_TriggerMusicTrack(MUSIC_ID track_id, const TRIGGER *const trigger)
             }
         }
 
-        if (trigger->timer == 0) {
+        if (trigger->timer == 0 || g_TRVersion != 2) {
             Music_Play_Direct(track_id, play_mode);
             goto finish;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves Lara not saying delayed gym lines in TR2 (`/play 0`, `/tp 18 2 62`, wait for the line to kick in) and equally fixes TR3 attempting to handle delayed triggers - the feature was only part of TR2. In Jungle, `/tp 34 26 75`.
