### PR TITLE
lara/flare: fix disposal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint
+- fixed Lara's flare undraw animation being skippable on specific late draw frames (#1593)
 
 **TR3**:
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -296,15 +296,20 @@ void Lara_Flare_Undraw(void)
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     int16_t frame_num_1 = lara_info->left_arm.frame_num;
     int16_t frame_num_2 = lara_info->flare.frame_num;
+    const bool is_mounted = Lara_Vehicle_IsMounted();
 
     lara_info->flare.control = true;
 
-    if (lara_item->goal_anim_state == LS(LS_STOP)
-        && !Lara_Vehicle_IsMounted()) {
+    if (lara_item->goal_anim_state == LS(LS_STOP) && !is_mounted) {
         if (Item_TestAnimEqual(lara_item, LA(LA_STAND_IDLE))) {
-            Item_SwitchToAnim(lara_item, LA(LA_FLARE_THROW), frame_num_1);
+            int16_t throw_frame = frame_num_1;
+            if (throw_frame < LF_FL_THROW || throw_frame >= LF_FL_DRAW) {
+                throw_frame = LF_FL_THROW;
+            }
+            Item_SwitchToAnim(lara_item, LA(LA_FLARE_THROW), throw_frame);
             lara_info->flare.frame_num = lara_item->frame_num;
             frame_num_2 = lara_item->frame_num;
+            frame_num_1 = throw_frame;
         }
 
         if (Item_TestAnimEqual(lara_item, LA(LA_FLARE_THROW))) {
@@ -327,9 +332,7 @@ void Lara_Flare_Undraw(void)
             }
             lara_info->flare.frame_num = frame_num_2 + 1;
         }
-    } else if (
-        lara_item->current_anim_state == LS(LS_STOP)
-        && !Lara_Vehicle_IsMounted()) {
+    } else if (lara_item->current_anim_state == LS(LS_STOP) && !is_mounted) {
         Item_SwitchToAnim(lara_item, LA(LA_STAND_STILL), 0);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #1593. This fixes a flare undraw edge case where pressing flare input during specific late flare-draw frames could interrupt the expected throw flow.

#### Testing

- [x] Play the recording from issue #1593
  Expected outcome: Lara throws her flares out instead of drawing phantom flares.
- [x] Try to break it in other ways: hold the flare button during different animations; when the flare's burning out, when she's disposing one, shen she's empty handed.
  Expected outcome: Lara throws and redraws flares normally, with no skipped animations or stuck arm pose
