### PR TITLE
Fix wade state transitions 2-click to 1-click deep pools

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **TR3**:
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2
+- fixed Lara briefly switching from run back to wade when crossing from 2-click to 1-click water depth
 
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/trx-1.2...trx-1.2.1) - 2026-02-11

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -32,7 +32,7 @@
 #define M_DIVE_TILT_MAX_ALT (100 * DEG_1)        // = 18200
 #define M_RADIUS_SURF       LARA_RADIUS          // = 100
 #define M_RADIUS_UW         300
-#define M_WADE_DEPTH        (g_TRVersion == 3 ? 256 : 384)
+#define M_WADE_DEPTH        256
 #define M_LEAN_UNDO_SURF    (LARA_LEAN_UNDO * 2) // = 364
 #define M_LEAN_UNDO_UW      M_LEAN_UNDO_SURF     // = 364
 #define M_LEAN_MAX_UW       (LARA_LEAN_MAX * 2)  // = 4004

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -517,7 +517,7 @@ static void M_UpdateEnvironment(void)
     case LWS_WADE: {
         g_Camera.target_elevation = CAM_WADE_ELEVATION;
 
-        if (water_height_diff < M_WADE_DEPTH) {
+        if (water_height_diff <= M_WADE_DEPTH) {
             lara_info->water_status = LWS_ABOVE_WATER;
             if (item->current_anim_state == LS(LS_WADE)) {
                 item->goal_anim_state = LS(LS_RUN);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a TR3 water-state edge case where Lara could briefly switch to running when moving from 2-click depth to 1-click depth, then snap back into wading.

#### Implementation details

The bug came from an equality check in `M_UpdateEnvironment()` under `LWS_WADE`: at exactly `M_WADE_DEPTH`, Lara stayed in wade mode even when logic tried to switch out. The fix changes the check to `<= M_WADE_DEPTH`, so shallow water no longer traps her in wade.

Also, originally, TR2 compared `M_WADE_DEPTH = 384` with `water_depth`. TR3 switched to comparing `water_height_diff` and lowered the threshold to 256. TRX was using `water_height_diff` but kept the 384 value for TR2. I changed it to always use 256 for uniform behavior across all games.

#### Testing

- [x] Play Temple Ruins, `/tp 80 0.5 49` near a 2-click to 1-click water transition edge, and move Lara forward/back across the boundary
  Expected outcome: Lara transitions cleanly without briefly running and snapping back to wade
- [x] Repeat movement around different edges and ramps looking for weird behavior (including stopping/turning near the boundary)
  Expected outcome: no sticky wade state at 1-click depth; behavior stays stable
