### PR TITLE
lara/state: allow Lara to climb ledges with low crawlspaces

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 **TR3**:
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2
 - fixed Lara briefly switching from run back to wade when crossing from 2-click to 1-click water depth
+- fixed Lara unable to climb small ledges with low crawlspaces
 
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/trx-1.2...trx-1.2.1) - 2026-02-11

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -358,9 +358,10 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     } else if (g_Input.forward) {
         const int16_t h = Lara_FloorFront(item, item->rot.y, M_WALK_DIST);
         const int16_t c = Lara_CeilingFront(item, item->rot.y, M_WALK_DIST);
-        if (g_TRVersion == 3 && Room_GetHeightType() == HT_BIG_SLOPE && h < 0) {
+
+        if (Room_GetHeightType() == HT_BIG_SLOPE && h < 0) {
             item->goal_anim_state = LS_STOP;
-        } else if (g_TRVersion == 3 && c > 0) {
+        } else if (c > 0 && !g_Input.action) {
             item->goal_anim_state = LS_STOP;
         } else if (g_Input.slow) {
             M_Walk(item, coll);


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a TR3 movement edge case where Lara would refuse to climb up in front of low crawlspace-style geometry.
It also changes the code to run the stop conditions, previously exclusive to TR3, in TR2 and TR1 as well.

#### Testing

- [x] Play Jungle, `/tp 91 20.5 62`, try to climb up from a run-up, and from standing next to the wall, with forward+action.
  Expected outcome: Lara consistently climbs up no matter the anim.
- [x] Climbing up sanity checks
  Expected outcome: Lara doesn't try to climb 20-sector heights, or 2-click heights.
- [x] Walk and run checks around near-death sectors
  Expected outcome: no unintended changes in Lara's behavior.
- [x] Walk and run into descending and inclining slopes
  Expected outcome: no unintended changes in Lara's behavior.
