### PR TITLE
lara/col: fix thin-ledge grab

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2
 - fixed Lara briefly switching from run back to wade when crossing from 2-click to 1-click water depth
 - fixed Lara unable to climb small ledges with low crawlspaces
+- fixed Lara using the thin-ledge swing hang animation instead of the normal hang in some 1-click ledge cases
 
 
 ## [1.2.1](https://github.com/LostArtefacts/TRX/compare/trx-1.2...trx-1.2.1) - 2026-02-11

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -97,9 +97,12 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
 
     int32_t edge;
     const EDGE_CATCH edge_catch = Lara_Col_TestEdgeCatch(item, coll, &edge);
+    bool ladder_hang = false;
+    if (edge_catch == EDGE_CATCH_NEG) {
+        ladder_hang = Lara_Col_TestLadderHang(item, coll);
+    }
     if (edge_catch == EDGE_CATCH_NONE
-        || (edge_catch == EDGE_CATCH_NEG
-            && !Lara_Col_TestLadderHang(item, coll))) {
+        || (edge_catch == EDGE_CATCH_NEG && !ladder_hang)) {
         return false;
     }
 
@@ -109,7 +112,8 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     }
     const int16_t angle = Math_DirectionToAngle(dir);
 
-    if (Lara_Col_TestHangSwingIn(item, angle)) {
+    const bool swing_in = !ladder_hang && Lara_Col_TestHangSwingIn(item, angle);
+    if (swing_in) {
         Item_SwitchToAnim(item, LA(LA_REACH_TO_THIN_LEDGE), 0);
     } else {
         Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), 0);


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a TR3 hang-animation misclassification where Lara could enter the thin-ledge swing hang animation in a 1-click+ hanging setups, that should use the normal hang animation.

#### Testing

- [x] Replay the following TR3 recording:
  ```
  @+0:    cmd "play 1"
  @+1:    cmd "tp 91 19.72 60.8"
  @+2:    ● "right"
  @+26:   ○ "right"
  @+13:   ● "left ctrl"
  @+2:    ● "down"
  @+4:    ○ "down"
  @+120:  ○ "left ctrl"
          quit
  ```
  Expected outcome: Lara doesn't swing on this 1-click ledge.

- [x] Replay the following TR3 recording:
  ```
  @+0:    cmd "play 1"
  @+1:    ● "up"
  @+2:    ● "left alt"
  @+28:   ○ "up"
  @+1:    ○ "left alt"
  @+74:   ● "left alt"
  @+10:   ○ "left alt"
  @+35:   ● "left alt"
  @+16:   ○ "left alt"
  @+27:   ● "left ctrl"
  @+180:  ● "up"
  @+12:   ○ "up"
  @+5:    ○ "left ctrl"
  @+120:  quit
  ```
  Expected outcome: Lara swings on this 0-click ledge.


