### PR TITLE
Fix GL memory leaks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint
 - fixed Lara's flare undraw animation being skippable on specific late draw frames (#1593)
+- fixed a potential `GL_OUT_OF_MEMORY` error that could occur after reloading levels many times (regression from <1.0)
 
 **TR3**:
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2

--- a/src/trx/game/output/common.c
+++ b/src/trx/game/output/common.c
@@ -64,6 +64,7 @@ void Output_Shutdown(void)
     OutputSource_Shadows_Shutdown();
     OutputSource_Misc_Shutdown();
     OutputSource_Overlay_Shutdown();
+    OutputSource_UI_Shutdown();
 
     if (m_ShaderWorld != nullptr) {
         Output_MeshShader_Free(m_ShaderWorld);

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -85,6 +85,7 @@ typedef struct MESH_BATCHER {
     int32_t opaque_total_indices;
     int32_t blend_add_total_indices;
     int32_t transparent_total_indices;
+    bool layout_dirty;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -446,6 +447,32 @@ static bool M_IsDirty(const SCENE_SOURCE *const source, const SCENE_PASS pass)
             && pass == SCENE_PASS_TRANSPARENT);
 }
 
+static void M_RecalculateLayout(MESH_BATCHER *const batcher)
+{
+    batcher->vertex_count = 0;
+    batcher->opaque_total_indices = 0;
+    batcher->blend_add_total_indices = 0;
+    batcher->transparent_total_indices = 0;
+
+    for (int32_t i = 0; i < batcher->bindings->count; i++) {
+        M_MESH_BUF_BINDING *const bind =
+            *(M_MESH_BUF_BINDING **)Vector_Get(batcher->bindings, i);
+
+        bind->vertex_start = batcher->vertex_count;
+        batcher->vertex_count += bind->vertex_count;
+
+        bind->opaque_index_start = batcher->opaque_total_indices;
+        batcher->opaque_total_indices += bind->opaque_index_count;
+
+        bind->blend_add_index_start = batcher->blend_add_total_indices;
+        batcher->blend_add_total_indices += bind->blend_add_index_count;
+
+        bind->transparent_index_start = batcher->transparent_total_indices;
+        batcher->transparent_total_indices += bind->transparent_index_count;
+    }
+    batcher->layout_dirty = false;
+}
+
 static void M_AnimateTextures(const SCENE_SOURCE *const source)
 {
     MESH_BATCHER *const batcher = source->priv;
@@ -472,6 +499,7 @@ MESH_BATCHER *MeshBatcher_Create(void)
     batcher->source.priv = batcher;
 
     batcher->transparent_sort = Vector_Create(sizeof(M_FACE_SORT));
+    batcher->layout_dirty = true;
 
     glGenVertexArrays(1, &batcher->vao);
     glGenBuffers(3, &batcher->vbo.geom);
@@ -557,7 +585,6 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
             batcher->staged[pass] = nullptr;
         }
     }
-    ASSERT(batcher->vertex_count == 0);
     Memory_Free(batcher);
 }
 
@@ -575,9 +602,7 @@ void MeshBatcher_RemoveMesh(
     Memory_Free(bind->transparent_face_index_counts);
     Vector_Remove(batcher->bindings, &bind);
     HASH_DEL(batcher->binding_map, bind);
-    if (batcher->bindings->count == 0) {
-        batcher->vertex_count = 0;
-    }
+    batcher->layout_dirty = true;
     Memory_Free(bind);
 }
 
@@ -611,19 +636,11 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
         }
     }
 
-    // 2. Assign Vertex Offsets
-    bind->vertex_start = batcher->vertex_count;
-    batcher->vertex_count += bind->vertex_count;
-
-    // 3. Assign Index Offsets
+    // 2. Prepare index counts
     // Opaque
     bind->opaque_index_count = mesh->opaque_vertex_indices->count;
-    bind->opaque_index_start = batcher->opaque_total_indices;
-    batcher->opaque_total_indices += bind->opaque_index_count;
     // Blend/Add
     bind->blend_add_index_count = mesh->blend_add_vertex_indices->count;
-    bind->blend_add_index_start = batcher->blend_add_total_indices;
-    batcher->blend_add_total_indices += bind->blend_add_index_count;
 
     // Transparent
     bind->transparent_face_count = mesh->transparent_faces->count;
@@ -644,18 +661,21 @@ void MeshBatcher_AddMesh(MESH_BATCHER *const batcher, OUTPUT_MESH *const mesh)
             bind->transparent_index_count += face->vertex_count;
         }
     }
-    bind->transparent_index_start = batcher->transparent_total_indices;
-    batcher->transparent_total_indices += bind->transparent_index_count;
 
     // Prevent double add
     mesh->sealed = 2;
 
     Vector_Add(batcher->bindings, &bind);
     HASH_ADD_PTR(batcher->binding_map, mesh, bind);
+    batcher->layout_dirty = true;
 }
 
 void MeshBatcher_Seal(MESH_BATCHER *const batcher)
 {
+    if (batcher->layout_dirty) {
+        M_RecalculateLayout(batcher);
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, batcher->vbo.geom);
     GFX_TRACK_DATA(
         glBufferData, GL_ARRAY_BUFFER,

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -292,8 +292,17 @@ void OutputSource_RoomsDebug_Shutdown(void)
     M_PRIV *const p = &m_Priv;
     if (p->scheduled != nullptr) {
         Vector_Free(p->scheduled);
+        p->scheduled = nullptr;
     }
     M_FreeBuffers(p);
+    if (p->vao != 0) {
+        glDeleteVertexArrays(1, &p->vao);
+        p->vao = 0;
+    }
+    if (p->vbo != 0) {
+        glDeleteBuffers(1, &p->vbo);
+        p->vbo = 0;
+    }
 }
 
 void OutputSource_RoomsDebug_ObserveLevelLoad(void)

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -338,8 +338,22 @@ void OutputSource_UI_Init(void)
 void OutputSource_UI_Shutdown(void)
 {
     M_PRIV *const p = &m_Priv;
-    Vector_Free(p->scheduled_pickups);
-    Vector_Free(p->vertices);
+    if (p->scheduled_pickups != nullptr) {
+        Vector_Free(p->scheduled_pickups);
+        p->scheduled_pickups = nullptr;
+    }
+    if (p->vertices != nullptr) {
+        Vector_Free(p->vertices);
+        p->vertices = nullptr;
+    }
+    if (p->vao != 0) {
+        glDeleteVertexArrays(1, &p->vao);
+        p->vao = 0;
+    }
+    if (p->vbo != 0) {
+        glDeleteBuffers(1, &p->vbo);
+        p->vbo = 0;
+    }
 }
 
 void OutputSource_UI_StagePickup(const OUTPUT_UI_PICKUP pickup)

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -380,5 +380,15 @@ OUTPUT_UNIFORMS *Output_Uniforms_Create(void)
 
 void Output_Uniforms_Free(OUTPUT_UNIFORMS *const uniforms)
 {
+    if (uniforms == nullptr) {
+        return;
+    }
+    if (uniforms->general != 0) {
+        glDeleteBuffers(4, &uniforms->general);
+        uniforms->general = 0;
+        uniforms->matrices = 0;
+        uniforms->lights = 0;
+        uniforms->ls = 0;
+    }
     Memory_Free(uniforms);
 }

--- a/src/trx/gfx/renderer.c
+++ b/src/trx/gfx/renderer.c
@@ -172,6 +172,8 @@ static void M_Shutdown(GFX_RENDERER *renderer)
     GFX_GL_FBO_Close(&p->geometry_fbo);
     GFX_GL_FBO_Close(&p->ui_fbo);
     GFX_GL_Program_Close(&p->program);
+    GFX_GL_Sampler_Close(&p->sampler);
+    GFX_GL_Buffer_Close(&p->buffer);
     GFX_GL_VertexArray_Close(&p->vertex_array);
 
     Memory_FreePointer(&renderer->priv);


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes several OpenGL resource leaks in the output pipeline that could accumulate over repeated level reloads and eventually trigger out-of-memory errors.

As the main fix, it corrects mesh batcher layout lifetime handling: add/remove now only marks layout dirty, and packed vertex/index offsets are rebuilt at `MeshBatcher_Seal()`, so EBO/VBO allocations no longer grow across unload/load cycles when persistent meshes remain bound. It didn't work because the old cleanup code assumed unloading a level would completely clear the mesh batcher, while in reality, some output sources (like cuboids and spheres) only upload once per game launch by design.

Less importantly, it also adds missing cleanup for UI and debug VAO/VBO objects, releases output UBOs in `Output_Uniforms_Free()`, and closes renderer sampler/buffer objects during renderer shutdown. Finally, `OutputSource_UI_Shutdown()` is now called from `Output_Shutdown()` so that cleanup path is actually executed.

No gameplay behavior is changed; this is lifecycle/resource management hardening.

#### Testing

[oom.txt](https://github.com/user-attachments/files/25277581/oom.txt)
This recording repeatedly loads Meteorite Cavern and shows the load attempt number in the console. I chose this level, because surprisingly it has the most vertices overall. For me, on develop, the game ceases to render at around 860 mark.

- [x] Run `oom.txt` on develop
  Expected outcome: the counter gets laggier with time, and eventually the game stops rendering logging a lot of GL errors.
- [x] Run `oom.txt` on this branch
  Expected outcome: the levels load with uniform times, and the recording can complete without glitching.