### PR TITLE
Some tender love for Valgrind warnings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added a color editor dialog for fog and water colors in Graphic Options → Visuals
 - changed Earthquake to support being reset
 - changed loading screens setting to use modes (`disabled`, `always`, `new-games`). Previously, they were hardcoded to not show for saves (#1290)
+- changed logs to no longer emit ANSI color characters when the game's output is piped to a file / process
 - improved error reporting for gameflow issues to now display full key paths for faulty nodes
 - fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -20,6 +20,17 @@ static VECTOR *m_HiddenOptions = nullptr;
 
 static EVENT_MANAGER *m_EventManager = nullptr;
 
+static void M_FreeStringOptionValues(void)
+{
+    const CONFIG_OPTION *option = Config_GetOptionMap();
+    while (option != nullptr && option->target != nullptr) {
+        if (option->type == COT_STRING || option->type == COT_DYNAMIC_ENUM) {
+            Memory_Free(*(char **)option->target);
+        }
+        option++;
+    }
+}
+
 __attribute__((constructor)) static void M_Init(void)
 {
     m_EventManager = EventManager_Create();
@@ -30,6 +41,7 @@ __attribute__((destructor)) static void M_Shutdown(void)
     EventManager_Free(m_EventManager);
     m_EventManager = nullptr;
 
+    M_FreeStringOptionValues();
     Memory_FreePointer(&g_Config.default_path);
     Memory_FreePointer(&g_Config.enforced_path);
 

--- a/src/trx/engine/audio_sample.c
+++ b/src/trx/engine/audio_sample.c
@@ -492,21 +492,12 @@ void Audio_Sample_Init(void)
 
 void Audio_Sample_Shutdown(void)
 {
-    if (!g_AudioDeviceID) {
-        return;
-    }
-
     Audio_Sample_CloseAll();
     Audio_Sample_UnloadAll();
 }
 
 bool Audio_Sample_Unload(const int32_t sample_id)
 {
-    if (!g_AudioDeviceID) {
-        LOG_ERROR("Unitialized audio device");
-        return false;
-    }
-
     if (sample_id < 0 || sample_id >= AUDIO_MAX_SAMPLES) {
         LOG_ERROR("Maximum allowed samples: %d", AUDIO_MAX_SAMPLES);
         return false;
@@ -526,11 +517,6 @@ bool Audio_Sample_Unload(const int32_t sample_id)
 
 bool Audio_Sample_UnloadAll(void)
 {
-    if (!g_AudioDeviceID) {
-        LOG_ERROR("Unitialized audio device");
-        return false;
-    }
-
     m_LoadedSamplesCount = 0;
     for (int32_t i = 0; i < AUDIO_MAX_SAMPLES; i++) {
         AUDIO_SAMPLE *const sample = &m_LoadedSamples[i];

--- a/src/trx/filesystem.c
+++ b/src/trx/filesystem.c
@@ -29,6 +29,14 @@ struct MYFILE {
 
 const char *m_GameDir = nullptr;
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    if (m_GameDir != nullptr) {
+        SDL_free((void *)m_GameDir);
+        m_GameDir = nullptr;
+    }
+}
+
 #if defined(_WIN32)
     #include <wchar.h>
     #include <stdlib.h>

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -197,6 +197,7 @@ void LUA_Init(void)
 void LUA_Shutdown(void)
 {
     M_PRIV *const p = &m_Priv;
+    Lua_ShutdownEvents();
     lua_close(p->state);
     p->state = nullptr;
 }

--- a/src/trx/game/lua/events.c
+++ b/src/trx/game/lua/events.c
@@ -16,6 +16,35 @@ typedef struct {
 static lua_State *m_L = nullptr;
 static VECTOR *m_Listeners = nullptr;
 
+static void M_ClearAllListeners(const bool unref_from_lua)
+{
+    if (m_Listeners == nullptr) {
+        return;
+    }
+
+    if (unref_from_lua && m_L != nullptr) {
+        for (int32_t i = 0; i < m_Listeners->count; i++) {
+            const M_LISTENER *const lst = Vector_Get(m_Listeners, i);
+            luaL_unref(m_L, LUA_REGISTRYINDEX, lst->ref);
+        }
+    }
+
+    Vector_Free(m_Listeners);
+    m_Listeners = nullptr;
+}
+
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    M_ClearAllListeners(false);
+    m_L = nullptr;
+}
+
+void Lua_ShutdownEvents(void)
+{
+    M_ClearAllListeners(true);
+    m_L = nullptr;
+}
+
 // trxc.events.attach(event_type, callback) → id
 static int32_t M_L_EventsAttach(lua_State *const L)
 {

--- a/src/trx/game/lua/events.h
+++ b/src/trx/game/lua/events.h
@@ -35,6 +35,7 @@ typedef struct {
 
 // Initialize event API in Lua state
 void LUA_CreateEvents(lua_State *L);
+void Lua_ShutdownEvents(void);
 
 // Clear all listeners declared during the current level script
 void Lua_ClearLevelListeners(void);

--- a/src/trx/game/music/common.c
+++ b/src/trx/game/music/common.c
@@ -30,7 +30,7 @@ typedef struct {
 } M_MUSIC_STREAM;
 
 static float m_MusicVolume = 0.0f;
-static const MUSIC_BACKEND *m_Backend = nullptr;
+static MUSIC_BACKEND *m_Backend = nullptr;
 static M_MUSIC_STREAM m_MainStream = {
     .audio_stream_id = -1,
     .track_id = MX_INACTIVE,
@@ -39,7 +39,7 @@ static M_MUSIC_STREAM m_MainStream = {
 };
 static M_MUSIC_STREAM m_OverlayStreams[MUSIC_MAX_OVERLAY_TRACKS] = {};
 
-static const MUSIC_BACKEND *M_FindBackend(void)
+static MUSIC_BACKEND *M_FindBackend(void)
 {
     VECTOR *all_backends = Vector_Create(sizeof(MUSIC_BACKEND *));
     Vector_Add(
@@ -62,7 +62,7 @@ static const MUSIC_BACKEND *M_FindBackend(void)
                 Music_Backend_CDAudioWad_Factory("audio/cdaudio.wad") });
     }
 
-    const MUSIC_BACKEND *backend = nullptr;
+    MUSIC_BACKEND *backend = nullptr;
     for (int32_t i = 0; i < all_backends->count; i++) {
         MUSIC_BACKEND *const tmp_backend =
             *(MUSIC_BACKEND **)Vector_Get(all_backends, i);
@@ -271,6 +271,10 @@ static bool M_GetMainTrackState(MUSIC_STREAM_STATE *const state)
 bool Music_Init(void)
 {
     m_Initialised = true;
+    if (m_Backend != nullptr) {
+        m_Backend->shutdown(m_Backend);
+        m_Backend = nullptr;
+    }
     m_Backend = M_FindBackend();
     if (m_Backend == nullptr) {
         LOG_ERROR("No music backend is available");
@@ -296,6 +300,10 @@ void Music_Shutdown(void)
     M_StopMainStream();
     M_StopOverlayStreams();
     M_ResetStreamState();
+    if (m_Backend != nullptr) {
+        m_Backend->shutdown(m_Backend);
+        m_Backend = nullptr;
+    }
     Audio_Shutdown();
 }
 

--- a/src/trx/game/objects/names.c
+++ b/src/trx/game/objects/names.c
@@ -92,6 +92,11 @@ static void M_ClearAllNames(void)
     }
 }
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    M_ClearAllNames();
+}
+
 void Object_ClearNames(const OBJECT_ID obj_id)
 {
     ASSERT(obj_id >= O_FIRST && obj_id < O_NUMBER_OF);

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -959,4 +959,14 @@ void OutputSource_Overlay_Shutdown(void)
     M_CloseTexture(&p->snapshot.state.texture);
     p->snapshot.state.has_content = false;
     M_CloseTexture(&p->solid_black_texture);
+
+    if (p->ops[0] != nullptr) {
+        Vector_Free(p->ops[0]);
+        p->ops[0] = nullptr;
+    }
+    if (p->ops[1] != nullptr) {
+        Vector_Free(p->ops[1]);
+        p->ops[1] = nullptr;
+    }
+    Memory_ArenaFree(&p->alloc);
 }

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -163,9 +163,16 @@ void SG_File_SaveToFile(MYFILE *const fp, SAVEGAME_INFO *const info)
 
 bool SG_File_FillInfo(MYFILE *const fp, SAVEGAME_INFO *const info)
 {
-    SAVEGAME_BSON_HEADER header;
+    SAVEGAME_BSON_HEADER header = {};
     File_Seek(fp, 0, FILE_SEEK_SET);
-    File_ReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER));
+    if (!File_ReadData(fp, &header, sizeof(SAVEGAME_BSON_HEADER))) {
+        return false;
+    }
+    if (header.magic != M_MAGIC_TR1X && header.magic != M_MAGIC_TR2X
+        && header.magic != M_MAGIC_TRX) {
+        return false;
+    }
+
     if (header.version < SG_MIN_SUPPORTED_VERSION) {
         LOG_WARNING(
             "Too old SG version: %d (min supported: %d)", header.version,

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -179,6 +179,13 @@ static void M_ShutdownModules(void)
     Log_Shutdown();
 }
 
+static SHELL_ARGS *M_CloneArgs(const SHELL_ARGS *const args)
+{
+    SHELL_ARGS *const copy = Memory_Alloc(sizeof(SHELL_ARGS));
+    *copy = *args;
+    return copy;
+}
+
 static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
 {
     const SHELL_ARGS *new_args = args;
@@ -249,7 +256,12 @@ static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
         Clock_EnableHeadlessFixedFPS(fps);
     }
 
-    m_ShellArgs = new_args;
+    Memory_FreePointer(&m_ShellArgs);
+    if (new_args == args) {
+        m_ShellArgs = M_CloneArgs(args);
+    } else {
+        m_ShellArgs = new_args;
+    }
     return new_args;
 }
 
@@ -396,4 +408,5 @@ int32_t Shell_Main(const SHELL_ARGS *args)
 void Shell_Shutdown(void)
 {
     M_ShutdownModules();
+    Memory_FreePointer(&m_ShellArgs);
 }

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
     }
 
     Shell_ScanAvailableMods();
-    SHELL_ARGS *const args = Shell_ParseArgs(raw_args);
+    SHELL_ARGS *args = Shell_ParseArgs(raw_args);
     if (args == nullptr) {
         Vector_Free(raw_args);
         return 0;
@@ -27,6 +27,7 @@ int main(int argc, char *argv[])
 
     LOG_INFO("Starting %s", g_TRXVersion);
     int32_t exit_code = Shell_Main(args);
+    Memory_FreePointer(&args);
     Vector_Free(raw_args);
     Shell_Terminate(exit_code);
     return exit_code;

--- a/src/trx/game/ui/settings.c
+++ b/src/trx/game/ui/settings.c
@@ -552,6 +552,11 @@ void UI_Settings_LoadFromFile(const char *const path)
     JSON_ValueFree(root);
 }
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    M_FreeBarThemes();
+}
+
 static const char *M_GetBarColorName(const UI_BAR_TYPE type)
 {
     if (type < 0 || type >= UI_BAR_NUMBER_OF) {

--- a/src/trx/log.c
+++ b/src/trx/log.c
@@ -15,6 +15,8 @@
 
 static LOG_LEVEL m_LogLevel = LOG_LEVEL_MAX;
 static FILE *m_LogHandle = nullptr;
+static bool m_UseAnsiColors = true;
+
 static const char *const m_LogLevelColors[] = {
     [LOG_LEVEL_INFO] = M_ANSI_COLOR_RESET,
     [LOG_LEVEL_WARNING] = M_ANSI_COLOR_YELLOW,
@@ -31,6 +33,7 @@ static const char *const m_LogLevelStrings[] = {
 void Log_Init(const char *path, const LOG_LEVEL min_level)
 {
     m_LogLevel = min_level;
+    m_UseAnsiColors = Log_ShouldUseAnsiColors();
     if (path != nullptr) {
         m_LogHandle = fopen(path, "w");
     }
@@ -73,10 +76,15 @@ void Log_Message(
 
     // print to stdout
     if (level >= m_LogLevel) {
-        printf("%s", log_color);
+        if (m_UseAnsiColors) {
+            printf("%s", log_color);
+        }
         printf(M_FORMAT, log_str, timestamp_str, file, line, func);
         vprintf(fmt, va);
-        printf("%s", M_ANSI_COLOR_RESET "\n");
+        if (m_UseAnsiColors) {
+            printf("%s", M_ANSI_COLOR_RESET);
+        }
+        printf("\n");
         fflush(stdout);
     }
 

--- a/src/trx/log.h
+++ b/src/trx/log.h
@@ -41,5 +41,6 @@ void Log_Message(
     const char *fmt, ...);
 
 // platform-specific implementations
+bool Log_ShouldUseAnsiColors(void);
 void Log_Init_Extra(const char *path);
 void Log_Shutdown_Extra(void);

--- a/src/trx/log_linux.c
+++ b/src/trx/log_linux.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 static void M_ErrorCallback(void *data, const char *msg, int errnum)
 {
@@ -45,4 +46,9 @@ void Log_Init_Extra(const char *path)
 
 void Log_Shutdown_Extra(void)
 {
+}
+
+bool Log_ShouldUseAnsiColors(void)
+{
+    return isatty(fileno(stdout));
 }

--- a/src/trx/log_unknown.c
+++ b/src/trx/log_unknown.c
@@ -1,5 +1,10 @@
 #include <trx/log.h>
 
+bool Log_ShouldUseAnsiColors(void)
+{
+    return true;
+}
+
 void Log_Init_Extra(const char *path)
 {
 }

--- a/src/trx/log_windows.c
+++ b/src/trx/log_windows.c
@@ -6,6 +6,7 @@
 #include <dbghelp.h>
 #include <tlhelp32.h>
 #include <dwarfstack.h>
+#include <io.h>
 #include <process.h>
 #include <signal.h>
 #include <stdio.h>
@@ -128,4 +129,9 @@ void Log_Init_Extra(const char *log_path)
 void Log_Shutdown_Extra(void)
 {
     Memory_FreePointer(&m_MiniDumpPath);
+}
+
+bool Log_ShouldUseAnsiColors(void)
+{
+    return _isatty(_fileno(stdout));
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds a bunch of missed memory frees when the game shuts down. In practice this doesn't mean anything except for prettier Valgrind standing. The only remaining reported memory leaks on my machine come from drivers and system libraries.

It also no longer litters stdout with ANSI control characters, that normally are used for colored logging, when the game's stdout is piped somewhere: for the first part of this PR, I used `( cd test/tr3 && valgrind --leak-check=full --show-leak-kinds=all ./TRX --test-replay test.txt ) &>log.log`, and that did litter the output a little. Not anymore.

#### Testing

- [ ] Launch the game, exit it right after, and examine the logs
  Expected outcome: no funny stuff