### PR TITLE
Improve poly fx z fighting scenarios

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint
 - fixed Lara's flare undraw animation being skippable on specific late draw frames (#1593)
+- fixed footprints rendering with an excessive Y offset
 - fixed water ripples triggering z-fighting with 0-click ground surfaces
 
 **TR3**:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint
 - fixed Lara's flare undraw animation being skippable on specific late draw frames (#1593)
+- fixed water ripples triggering z-fighting with 0-click ground surfaces
 
 **TR3**:
 - added reverb support

--- a/src/trx/game/footprint_fx.c
+++ b/src/trx/game/footprint_fx.c
@@ -17,6 +17,7 @@
 
 #define M_MAX_FOOTPRINTS 32
 #define M_FOOTPRINT_LIFETIME 512
+#define M_FOOTPRINT_Z_DEPTH_ADJUST -0.5f
 
 typedef struct {
     int32_t x;
@@ -105,7 +106,7 @@ static void M_GetWorldPoint(
     const int32_t dx = TRIGMULT2(local.x, c) + TRIGMULT2(local.z, s);
     const int32_t dz = TRIGMULT2(local.z, c) - TRIGMULT2(local.x, s);
     out_world->x = print->x + dx;
-    out_world->y = (print->y - 16) + local.y;
+    out_world->y = print->y + local.y;
     out_world->z = print->z + dz;
 }
 
@@ -186,8 +187,9 @@ void FootprintFX_Draw(void)
         const RGBA_8888 tri_color[3] = { color, color, color };
 
         for (int32_t j = 0; j < 4; j++) {
-            OutputSource_PolyFX_StageSpriteTriWorld(
-                sprite_idx, world, tri_color, DRAW_BLEND_SUB);
+            OutputSource_PolyFX_StageSpriteTriWorldDepth(
+                sprite_idx, world, tri_color, M_FOOTPRINT_Z_DEPTH_ADJUST,
+                DRAW_BLEND_SUB);
         }
     }
 }

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -31,6 +31,7 @@ typedef struct {
     int32_t sprite_idx;
     bool use_custom_uv;
     uint8_t corner_count;
+    float z_depth_adjust;
     XYZ_32 world_pos[4];
     OUTPUT_UVW uvw[4];
     OUTPUT_TEXTURE_SIZE texture_size[4];
@@ -198,7 +199,7 @@ static void M_EmitPrimVertices(M_PRIV *const p, const M_PRIM *const prim)
                     .x = (float)prim->world_pos[corner].x,
                     .y = (float)prim->world_pos[corner].y,
                     .z = (float)prim->world_pos[corner].z,
-                    .w = 0.0f,
+                    .w = prim->z_depth_adjust,
                 },
                 .normal = {
                     .x = prim->disp[corner][0],
@@ -373,12 +374,14 @@ void OutputSource_PolyFX_Shutdown(void)
 static void M_StagePrim(
     const int32_t sprite_idx, const uint8_t corner_count,
     const XYZ_32 *const world_pos, const float (*disp)[2],
-    const RGBA_8888 *const color, const uint16_t flags, VECTOR *const target)
+    const RGBA_8888 *const color, const uint16_t flags,
+    const float z_depth_adjust, VECTOR *const target)
 {
     M_PRIM prim;
     prim.sprite_idx = sprite_idx;
     prim.use_custom_uv = false;
     prim.corner_count = corner_count;
+    prim.z_depth_adjust = z_depth_adjust;
     memset(prim.world_pos, 0, sizeof(prim.world_pos));
     memcpy(prim.world_pos, world_pos, sizeof(prim.world_pos[0]) * corner_count);
     memset(prim.uvw, 0, sizeof(prim.uvw));
@@ -412,22 +415,40 @@ void OutputSource_PolyFX_StageSpriteQuadWorld(
     const int32_t sprite_idx, const XYZ_32 world_pos[4],
     const RGBA_8888 color[4], const DRAW_TYPE draw_type)
 {
+    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+        sprite_idx, world_pos, color, 0.0f, draw_type);
+}
+
+void OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+    const int32_t sprite_idx, const XYZ_32 world_pos[4],
+    const RGBA_8888 color[4], const float z_depth_adjust,
+    const DRAW_TYPE draw_type)
+{
     M_PRIV *const p = &m_Priv;
     VECTOR *const target = M_GetScheduledVectorForDrawType(p, draw_type);
     M_StagePrim(
         sprite_idx, 4, &world_pos[0], nullptr, &color[0],
-        VERT_NO_LIGHTING | VERT_NO_WIBBLE, target);
+        VERT_NO_LIGHTING | VERT_NO_WIBBLE, z_depth_adjust, target);
 }
 
 void OutputSource_PolyFX_StageSpriteTriWorld(
     const int32_t sprite_idx, const XYZ_32 world_pos[3],
     const RGBA_8888 color[3], const DRAW_TYPE draw_type)
 {
+    OutputSource_PolyFX_StageSpriteTriWorldDepth(
+        sprite_idx, world_pos, color, 0.0f, draw_type);
+}
+
+void OutputSource_PolyFX_StageSpriteTriWorldDepth(
+    const int32_t sprite_idx, const XYZ_32 world_pos[3],
+    const RGBA_8888 color[3], const float z_depth_adjust,
+    const DRAW_TYPE draw_type)
+{
     M_PRIV *const p = &m_Priv;
     VECTOR *const target = M_GetScheduledVectorForDrawType(p, draw_type);
     M_StagePrim(
         sprite_idx, 3, &world_pos[0], nullptr, &color[0],
-        VERT_NO_LIGHTING | VERT_NO_WIBBLE, target);
+        VERT_NO_LIGHTING | VERT_NO_WIBBLE, z_depth_adjust, target);
 }
 
 void OutputSource_PolyFX_StageQuadExt(
@@ -436,7 +457,8 @@ void OutputSource_PolyFX_StageQuadExt(
 {
     M_PRIV *const p = &m_Priv;
     VECTOR *const target = M_GetScheduledVectorForDrawType(p, draw_type);
-    M_StagePrim(sprite_idx, 4, &world_pos[0], disp, &color[0], flags, target);
+    M_StagePrim(
+        sprite_idx, 4, &world_pos[0], disp, &color[0], flags, 0.0f, target);
 }
 
 void OutputSource_PolyFX_StageQuadExtUV(
@@ -451,6 +473,7 @@ void OutputSource_PolyFX_StageQuadExtUV(
     prim.sprite_idx = -1;
     prim.use_custom_uv = true;
     prim.corner_count = 4;
+    prim.z_depth_adjust = 0.0f;
     memcpy(prim.world_pos, world_pos, sizeof(prim.world_pos));
     memcpy(prim.uvw, uvw, sizeof(prim.uvw));
     memcpy(prim.texture_size, texture_size, sizeof(prim.texture_size));
@@ -477,6 +500,7 @@ void OutputSource_PolyFX_StageTriExtUV(
     prim.sprite_idx = -1;
     prim.use_custom_uv = true;
     prim.corner_count = 3;
+    prim.z_depth_adjust = 0.0f;
     memset(prim.world_pos, 0, sizeof(prim.world_pos));
     memcpy(prim.world_pos, world_pos, sizeof(world_pos[0]) * 3);
     memset(prim.uvw, 0, sizeof(prim.uvw));
@@ -718,5 +742,6 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
 
     const RGBA_8888 world_color[4] = { color, color, color, color };
     M_StagePrim(
-        sprite_idx, 4, &world_pos[0], disp, &world_color[0], flags, target);
+        sprite_idx, 4, &world_pos[0], disp, &world_color[0], flags, 0.0f,
+        target);
 }

--- a/src/trx/game/output/sources/poly_fx.h
+++ b/src/trx/game/output/sources/poly_fx.h
@@ -16,9 +16,17 @@ void OutputSource_PolyFX_StageSpriteQuadWorld(
     int32_t sprite_idx, const XYZ_32 world_pos[4], const RGBA_8888 color[4],
     DRAW_TYPE draw_type);
 
+void OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+    int32_t sprite_idx, const XYZ_32 world_pos[4], const RGBA_8888 color[4],
+    float z_depth_adjust, DRAW_TYPE draw_type);
+
 void OutputSource_PolyFX_StageSpriteTriWorld(
     int32_t sprite_idx, const XYZ_32 world_pos[3], const RGBA_8888 color[3],
     DRAW_TYPE draw_type);
+
+void OutputSource_PolyFX_StageSpriteTriWorldDepth(
+    int32_t sprite_idx, const XYZ_32 world_pos[3], const RGBA_8888 color[3],
+    float z_depth_adjust, DRAW_TYPE draw_type);
 
 void OutputSource_PolyFX_StageQuadExt(
     int32_t sprite_idx, const XYZ_32 world_pos[4], const float disp[4][2],

--- a/src/trx/game/water_fx.c
+++ b/src/trx/game/water_fx.c
@@ -11,6 +11,9 @@
 
 #include <string.h>
 
+#define M_SPLASH_Z_DEPTH_ADJUST -0.005f
+#define M_RIPPLE_Z_DEPTH_ADJUST -0.005f
+
 static const int16_t m_SplashRings[8][2] = {
     { 0, -24 }, { 17, -17 }, { 24, 0 },  { 17, 17 },
     { 0, 24 },  { -17, 17 }, { -24, 0 }, { -17, -17 },
@@ -388,8 +391,9 @@ static void M_DrawSplash(
                 points[i2],
             };
             const RGBA_8888 quad_color[4] = { c1, c1, c2, c2 };
-            OutputSource_PolyFX_StageSpriteQuadWorld(
-                sprite_idx, quad_pos, quad_color, DRAW_BLEND_ADD);
+            OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+                sprite_idx, quad_pos, quad_color, M_SPLASH_Z_DEPTH_ADJUST,
+                DRAW_BLEND_ADD);
         }
     }
 }
@@ -440,10 +444,12 @@ static void M_DrawRipple(
         },
     };
     const RGBA_8888 quad_color[4] = { color, color, color, color };
-    OutputSource_PolyFX_StageSpriteQuadWorld(
-        sprite_idx, quad_pos[0], quad_color, DRAW_BLEND_ADD);
-    OutputSource_PolyFX_StageSpriteQuadWorld(
-        sprite_idx, quad_pos[1], quad_color, DRAW_BLEND_ADD);
+    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+        sprite_idx, quad_pos[0], quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
+        DRAW_BLEND_ADD);
+    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
+        sprite_idx, quad_pos[1], quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
+        DRAW_BLEND_ADD);
 }
 
 void WaterFX_Draw(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:
- changes footprints to no longer get elevated by 16 (!) world units, and instead adds the z discriminator we use for shape-based shadows among other things.
- changes water ripples to also use the z discriminator, which avoids z-fighting with ground tiles of the same height.

#### Testing

- [x] Run around on various terrain
  Expected outcome: footprints continue to appear visible at slopes of all angles, and behave better in the photo mode.
- [x] `/play crash`, `/tp 23 2 59`, run around
  Expected outcome: water ripples do not trigger z-fighting
- [x] `/play area`, `/tp 16 -4 44`, run around near the tile edge
  Expected outcome: water ripples draw over the ground tiles

I was thinking of whether to discriminate the depth to favor draw over or under the neighboring dirt tiles, but Crash Site looked really weird when we drew under, and in Area 51, it's a bit extreme corner case. We could do subdivisions but I don't think it's worth it.
LMK what you think?