### PR TITLE
data/tr3: fix uzi clips qty

### DIFF
--- a/data/tr3/ship/cfg/weapons.json5
+++ b/data/tr3/ship/cfg/weapons.json5
@@ -129,7 +129,7 @@
         "shot_accuracy": 8,
         "gun_height": 650,
         "damage": 1,
-        "pickup_qty": 80,
+        "pickup_qty": 40,
         "target_dist": 8.0,
         "recoil_frame": 3,
         "flash_time": 3,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 **TR3**:
 - added reverb support
 - added a slide-to-sprint animation state change for Lara, similar to TR1 and TR2
+- fixed Uzis having wrong clips capacity (was 80, is now 40 – sorry!)
 - fixed Lara briefly switching from run back to wade when crossing from 2-click to 1-click water depth
 - fixed Lara unable to climb small ledges with low crawlspaces
 - fixed Lara using the thin-ledge swing hang animation instead of the normal hang in some 1-click ledge cases


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Nerfs uzi ammo to 40 as per OG.