### PR TITLE
Add math.h for floorf() function

### DIFF
--- a/src/trx/game/ui/elements/gradient_slider.c
+++ b/src/trx/game/ui/elements/gradient_slider.c
@@ -8,6 +8,7 @@
 #include <trx/game/ui/text.h>
 #include <trx/utils.h>
 
+#include <math.h>
 #include <string.h>
 
 #define M_MARKER_BORDER 1.0f


### PR DESCRIPTION
#### Checklist

- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [X] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I updated my sources and I tried to compile them, but I got this message on the console:
```
src/trx/game/ui/elements/gradient_slider.c: In function ‘M_DrawMarker’:
src/trx/game/ui/elements/gradient_slider.c:29:30: warning: implicit declaration of function ‘floorf’ [-Wimplicit-function-declaration]
   29 |     const int32_t inner_x1 = floorf(x - inner_w_s * 0.5f + 0.5f);
      |                              ^~~~~~
src/trx/game/ui/elements/gradient_slider.c:12:1: note: include ‘<math.h>’ or provide a declaration of ‘floorf’
   11 | #include <string.h>
  +++ |+#include <math.h>
   12 |
```
Attached patch fixes the issue, by just adding `math.h` to the included headers.
