### PR TITLE
Fix tomb3 regressions in supported objects

### DIFF
--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -200,7 +200,7 @@ static void M_Control(const int16_t item_num)
         creature->maximum_turn = M_STOP_TURN;
 
         if (creature->mood == MOOD_ATTACK) {
-            if (info.angle && info.distance < M_HIT_RANGE * 4) {
+            if (info.ahead && info.distance < M_HIT_RANGE * 4) {
                 if (!p->shared->attack_lara) {
                     item->goal_anim_state = M_STATE_STOP;
                 } else if (Random_GetControl() < DEG_90) {
@@ -251,7 +251,7 @@ static void M_Control(const int16_t item_num)
             } else if (
                 info.distance < M_HIT_RANGE && info.ahead
                 && p->carcass_item_num != NO_ITEM
-                && creature->mood == MOOD_ATTACK) {
+                && creature->mood != MOOD_ATTACK) {
                 creature->flags |= M_HIT_FLAG;
                 Creature_Effect(item, &m_Bite, Spawn_Blood);
             }

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -165,8 +165,8 @@ static void M_Control(const int16_t item_num)
 
     case MOOD_ESCAPE:
     case MOOD_STALK: {
-        creature->target = XYZ_32_OffsetYaw(
-            creature->enemy->pos, bits + info.angle + DEG_180, WALL_L);
+        creature->target =
+            XYZ_32_OffsetYaw(item->pos, bits + info.angle + DEG_180, WALL_L);
         int16_t room_num = item->room_num;
         SECTOR *const sector = Room_GetSector(creature->target, &room_num);
         if (ABS(Box_GetBox(sector->box)->height - item->pos.y) > STEP_L) {

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -222,7 +222,7 @@ static void M_Control(const int16_t item_num)
             const int32_t dx = lara_item->pos.x - item->pos.x;
             const int32_t dz = lara_item->pos.z - item->pos.z;
             Math_Atan(dz, dx);
-            dist = SQUARE(dx) * SQUARE(dz);
+            dist = SQUARE(dx) + SQUARE(dz);
         }
 
         Creature_UpdateMood(item, &info, true);

--- a/src/trx/game/objects/creatures/tribe_pipeman.c
+++ b/src/trx/game/objects/creatures/tribe_pipeman.c
@@ -265,9 +265,8 @@ static void M_Control(const int16_t item_num)
 
             if (Item_GetRelativeFrame(item) == 15) {
                 M_SpawnDart(item);
+                item->goal_anim_state = M_STATE_WAIT_1;
             }
-
-            item->goal_anim_state = M_STATE_WAIT_1;
             break;
 
         case M_STATE_ATTACK_3:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes
- ~~compogna~~… ~~compsagnat~~… little dinos not spawning blood when they nibble on the carcass
- little dinos around the way they attack Lara
- pipeman behavior when he's about to shoot the darts
- monkey distance checks (can't be more specific, the state machine is complex)