### PR TITLE
camera: fix interrupts from heavy triggers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed UI bar scale option not updating the padding and borders (regression from 1.2)
 - fixed Blade stopping in the wrong position when anti-triggered (#4894)
 - fixed very distant Boulders causing camera shake (similar to the Tihocan crocodile targeting bug)
+- fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
 
 **TR2**:
 - fixed flickering switches and spike ceilings in Temple of Xian and Floating Islands (#4874)

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -100,7 +100,8 @@ void Camera_RefreshFromTrigger(const TRIGGER *const trigger)
 
     M_ValidateTriggerTarget(status);
 
-    if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1 && g_Camera.num == -1
+    if (g_Config.visuals.camera_mode != CAMERA_MODE_TR1
+        && status != TARGET_UNKNOWN && g_Camera.num == -1
         && g_Camera.timer > 0) {
         g_Camera.timer = -1;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes camera getting interrupted by heavy triggers, which can happen in scenarios where the builder uses Boulders to achieve precisely timed triggers.

#### Implementation details

Heavy triggers with no `TO_CAMERA` / `TO_TARGET` were coming through with `status == TARGET_UNKNOWN` and were incorrectly forcing `g_Camera.timer = -1`.
The fix is in `Camera_RefreshFromTrigger` and narrows the timer reset guard so it only applies when the trigger actually produced camera-related status (`status != TARGET_UNKNOWN`). This prevents non-camera heavy refreshes from canceling an active camera timer while preserving existing invalidation behavior for true camera trigger paths.

#### Testing

- [x] Start the test level shared on Discord (same as with the other boulder issue), run `/tp push` three times, press the button a few times.
  Expected outcome: the cameras do not get randomly interrupted and last mostly the same duration.
