### PR TITLE
lara/common: prevent interact flag on underwater switches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed flickering switches and spike ceilings in Temple of Xian and Floating Islands (#4874)
 - fixed Airlock door handles not getting drawn from certain angles (#4886, regression from 1.0)
 - fixed loading screens showing before playing FMVs on most levels
+- fixed Lara not being able to move after exiting water, having used an underwater lever with the animated interactions setting enabled (#4912, regression from 1.0)
 - removed the requirement to use `main.sfx` in custom levels (#3898)
 
 **TR3**:

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -919,7 +919,7 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
             lara_info->gun_status = LGS_HANDS_BUSY;
         }
 
-        lara_info->interact_target.is_moving = true;
+        lara_info->interact_target.is_moving = lara_on_land;
         lara_info->interact_target.move_count = 0;
     }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -956,7 +956,7 @@ void Lara_Control(void)
 
     M_Cheat();
 
-    if (g_TRVersion == 1 && lara_info->interact_target.is_moving
+    if (lara_info->interact_target.is_moving
         && lara_info->interact_target.move_count++ > M_MOVE_TIMEOUT) {
         lara_info->interact_target.is_moving = false;
         lara_info->gun_status = LGS_ARMLESS;


### PR DESCRIPTION
Resolves #4912.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara's item interact flag being set on underwater switches, which do not use controlled collision but share the same move position function as land switches.
