### PR TITLE
output/debug: fix debug triggers tri orientation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed UI bar scale option not updating the padding and borders (regression from 1.2)
 - fixed Blade stopping in the wrong position when anti-triggered (#4894)
 - fixed very distant Boulders causing camera shake (similar to the Tihocan crocodile targeting bug)
+- fixed drawing debug triggers using wrong orientation in some triangular geometry
 - fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
 
 **TR2**:

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -38,20 +38,28 @@ typedef struct {
 
 static M_PRIV m_Priv = {};
 
-static int32_t M_GetTriggerPortalTriangleIndices(
-    const SECTOR *const sector, int32_t indices[3])
+static int32_t M_GetTriggerTriangleIndices(
+    const SECTOR *const sector, int32_t indices[6])
 {
-    if (sector->portal_room.pit == NO_ROOM) {
-        return 0;
-    }
-    if (!sector->floor.is_split) {
-        return 0;
-    }
-
-    const int32_t clockwise[4] = { 0, 3, 2, 1 };
     int32_t skip = -1;
 
-    switch (sector->floor.split.type) {
+    SPLIT_TYPE split = sector->floor.split.type;
+    if (!sector->floor.is_split) {
+        split = SPLIT_NONE;
+    }
+
+    switch (split) {
+    case SPLIT_NONE:
+    case SPLIT_NESW_SOLID:
+        for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
+            indices[i] = OUTPUT_QUAD_TO_FAN(i);
+        }
+        return OUTPUT_QUAD_VERTICES;
+    case SPLIT_NWSE_SOLID:
+        for (int32_t i = 0; i < OUTPUT_QUAD_VERTICES; i++) {
+            indices[i] = OUTPUT_QUAD_TO_FAN_BACK(i);
+        }
+        return OUTPUT_QUAD_VERTICES;
     case SPLIT_NWSE_PORTAL_SW:
         skip = 0;
         break;
@@ -68,13 +76,13 @@ static int32_t M_GetTriggerPortalTriangleIndices(
         return 0;
     }
 
+    const int32_t clockwise[4] = { 0, 3, 2, 1 };
     int32_t count = 0;
     for (int32_t i = 0; i < 4; i++) {
         if (clockwise[i] != skip) {
             indices[count++] = clockwise[i];
         }
     }
-
     return count;
 }
 
@@ -84,6 +92,8 @@ static void M_PrepareRoomTriggers(
     mesh->triggers.vertex_start = p->vertices->count;
     const RGBA_8888 color = { .r = 255, .g = 0, .b = 255, .a = 128 };
     const XZ_16 offsets[4] = { { 0, 0 }, { 0, 1 }, { 1, 1 }, { 1, 0 } };
+
+    int32_t output_indices[OUTPUT_QUAD_VERTICES];
     for (int32_t z = 0; z < room->size.z; z++) {
         for (int32_t x = 0; x < room->size.x; x++) {
             const SECTOR *sector = Room_GetUnitSector(room, x, z);
@@ -91,15 +101,11 @@ static void M_PrepareRoomTriggers(
                 continue;
             }
 
-            int32_t tri_indices[3];
-            const int32_t tri_count =
-                M_GetTriggerPortalTriangleIndices(sector, tri_indices);
             const int32_t vertex_count =
-                tri_count != 0 ? tri_count : OUTPUT_QUAD_VERTICES;
+                M_GetTriggerTriangleIndices(sector, output_indices);
 
             for (int32_t i = 0; i < vertex_count; i++) {
-                const int32_t j =
-                    tri_count != 0 ? tri_indices[i] : OUTPUT_QUAD_TO_FAN(i);
+                int32_t j = output_indices[i];
                 XYZ_16 vertex_pos = {
                     .x = (x + offsets[j].x) * WALL_L,
                     .z = (z + offsets[j].z) * WALL_L,

--- a/src/trx/game/output/utils.h
+++ b/src/trx/game/output/utils.h
@@ -7,9 +7,13 @@
 #define OUTPUT_QUAD_VERTICES 6
 #define OUTPUT_TRI_VERTICES 3
 
-#define OUTPUT_QUAD_TO_FAN(i) ((int32_t[]) { 0, 2, 1, 0, 3, 2 }[i])
-#define OUTPUT_QUAD_TO_FAN_CW(i) ((int32_t[]) { 0, 1, 2, 0, 2, 3 }[i])
 #define OUTPUT_TRI_TO_FAN(i) ((int32_t[]) { 0, 2, 1 }[i])
+// |＼|
+#define OUTPUT_QUAD_TO_FAN(i) ((int32_t[]) { 0, 2, 1, 0, 3, 2 }[i])
+// |＼| Opposite winding
+#define OUTPUT_QUAD_TO_FAN_CW(i) ((int32_t[]) { 0, 1, 2, 0, 2, 3 }[i])
+// |／|
+#define OUTPUT_QUAD_TO_FAN_BACK(i) ((int32_t[]) { 0, 3, 1, 1, 3, 2 }[i])
 
 #define L_ATI_FIX 1
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes an annoying problem with triggers debug overlay that would use wrong triangle split around many triangular tiles.