### PR TITLE
objects/mounted_gun: fix Lara rotation on mount

### DIFF
--- a/src/trx/game/objects/vehicles/mounted_gun.c
+++ b/src/trx/game/objects/vehicles/mounted_gun.c
@@ -124,6 +124,7 @@ static void M_Collision(
     const ITEM *const item = Item_Get(item_num);
     lara->gun_status = LGS_HANDS_BUSY;
     lara_item->pos = item->pos;
+    lara_item->rot = item->rot;
     Item_SwitchToObjAnim(lara_item, M_ANIM_MOUNT, 0, O_LARA_VEHICLE_ANIM);
     lara_item->current_anim_state = M_STATE_MOUNT;
     lara_item->goal_anim_state = M_STATE_MOUNT;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's rotation is reset when mounting the Crash Site gun.
