### PR TITLE
Crash hardening

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -50,6 +50,7 @@ trx_lua_embed = custom_target(
   ],
 )
 
+prefix_map = fs.relative_to(meson.current_source_dir() / 'trx', meson.global_build_root())
 common_build_opts = [
   '-Wshadow',
   '-Wno-unused',
@@ -59,9 +60,8 @@ common_build_opts = [
   '-DSDL_MAIN_HANDLED',
   '-fms-extensions',
   '-fno-omit-frame-pointer',
-  '-fmacro-prefix-map=@0@/='.format(
-    fs.relative_to(meson.current_source_dir() / 'trx', meson.global_build_root())
-  ),
+  '-fmacro-prefix-map=@0@/='.format(prefix_map),
+  '-fdebug-prefix-map=@0@/=src/'.format(prefix_map),
   '-DDWST_STATIC',
   '-DPCRE2_STATIC',
   '-DPCRE2_CODE_UNIT_WIDTH=8',

--- a/src/meson.build
+++ b/src/meson.build
@@ -647,6 +647,7 @@ common_sources = [
   'trx/game/shell/mod.c',
   'trx/game/shell/paths.c',
   'trx/game/shell/platform.c',
+  'trx/game/shell/session.c',
   'trx/game/sound/common.c',
   'trx/game/sound/ids.c',
   'trx/game/sparks/manager.c',

--- a/src/trx/av/audio_stream.c
+++ b/src/trx/av/audio_stream.c
@@ -234,8 +234,14 @@ static bool M_DecodeFrame(AUDIO_STREAM_SOUND *stream)
         return M_DecodeFrame(stream);
     }
 
+    if (error_code == AVERROR_EOF) {
+        return false;
+    }
+
     if (error_code < 0) {
-        LOG_ERROR("error while decoding audio stream: %d", error_code);
+        LOG_ERROR(
+            "error while decoding audio stream: %d (%s)", error_code,
+            av_err2str(error_code));
         return false;
     }
 

--- a/src/trx/av/video.c
+++ b/src/trx/av/video.c
@@ -1590,7 +1590,8 @@ static int M_StreamComponentOpen(M_STATE *is, int stream_index)
     const AVDictionaryEntry *t = nullptr;
     int sample_rate;
     int nb_channels;
-    AVChannelLayout ch_layout;
+    AVChannelLayout ch_layout = {};
+    bool has_ch_layout = false;
     int ret = 0;
 
     if (stream_index < 0 || stream_index >= (signed)ic->nb_streams) {
@@ -1631,7 +1632,11 @@ static int M_StreamComponentOpen(M_STATE *is, int stream_index)
     switch (avctx->codec_type) {
     case AVMEDIA_TYPE_AUDIO:
         sample_rate = avctx->sample_rate;
-        ch_layout = avctx->ch_layout;
+        ret = av_channel_layout_copy(&ch_layout, &avctx->ch_layout);
+        if (ret < 0) {
+            goto fail;
+        }
+        has_ch_layout = true;
 
         if ((ret = M_AudioOpen(is, &ch_layout, sample_rate, &is->audio_tgt))
             < 0) {
@@ -1692,7 +1697,9 @@ static int M_StreamComponentOpen(M_STATE *is, int stream_index)
 fail:
     avcodec_free_context(&avctx);
 out:
-    av_channel_layout_uninit(&ch_layout);
+    if (has_ch_layout) {
+        av_channel_layout_uninit(&ch_layout);
+    }
 
     return ret;
 }

--- a/src/trx/core/bson/parse.c
+++ b/src/trx/core/bson/parse.c
@@ -24,6 +24,20 @@ typedef struct {
 static bool M_GetValueSize(M_STATE *state, uint8_t marker);
 static void M_HandleValue(M_STATE *state, JSON_VALUE *value, uint8_t marker);
 
+static int32_t M_ReadI32(const char *const src)
+{
+    int32_t value = 0;
+    memcpy(&value, src, sizeof(value));
+    return value;
+}
+
+static double M_ReadDouble(const char *const src)
+{
+    double value = 0.0;
+    memcpy(&value, src, sizeof(value));
+    return value;
+}
+
 static bool M_GetObjectKeySize(M_STATE *state)
 {
     ASSERT(state != nullptr);
@@ -71,7 +85,7 @@ static bool M_GetInt32ValueSize(M_STATE *state)
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
         return false;
     }
-    int32_t num = *(int32_t *)&state->src[state->offset];
+    int32_t num = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     state->dom_size += sizeof(JSON_NUMBER);
@@ -86,7 +100,7 @@ static bool M_GetDoubleValueSize(M_STATE *state)
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
         return false;
     }
-    double num = *(double *)&state->src[state->offset];
+    double num = M_ReadDouble(&state->src[state->offset]);
     state->offset += sizeof(double);
 
     state->dom_size += sizeof(JSON_NUMBER);
@@ -101,7 +115,7 @@ static bool M_GetStringValueSize(M_STATE *state)
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
         return false;
     }
-    int32_t size = *(int32_t *)&state->src[state->offset];
+    int32_t size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
     if (state->offset + size > state->size) {
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
@@ -147,7 +161,7 @@ static bool M_GetArraySize(M_STATE *state)
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
         return false;
     }
-    const int size = *(int32_t *)&state->src[state->offset];
+    const int size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     while (state->offset < start_offset + size - 1) {
@@ -205,7 +219,7 @@ static bool M_GetObjectSize(M_STATE *state)
         state->error = BSON_PARSE_ERROR_PREMATURE_END_OF_BUFFER;
         return false;
     }
-    const int size = *(int32_t *)&state->src[state->offset];
+    const int size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     while (state->offset < start_offset + size - 1) {
@@ -314,7 +328,7 @@ static void M_HandleInt32Value(M_STATE *state, JSON_VALUE *value)
     ASSERT(value != nullptr);
 
     ASSERT(state->offset + sizeof(int32_t) <= state->size);
-    int32_t num = *(int32_t *)&state->src[state->offset];
+    int32_t num = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     JSON_NUMBER *number = (JSON_NUMBER *)state->dom;
@@ -336,7 +350,7 @@ static void M_HandleDoubleValue(M_STATE *state, JSON_VALUE *value)
     ASSERT(value != nullptr);
 
     ASSERT(state->offset + sizeof(double) <= state->size);
-    double num = *(double *)&state->src[state->offset];
+    double num = M_ReadDouble(&state->src[state->offset]);
     state->offset += sizeof(double);
 
     JSON_NUMBER *number = (JSON_NUMBER *)state->dom;
@@ -367,7 +381,7 @@ static void M_HandleStringValue(M_STATE *state, JSON_VALUE *value)
     ASSERT(value != nullptr);
 
     ASSERT(state->offset + sizeof(int32_t) <= state->size);
-    int32_t size = *(int32_t *)&state->src[state->offset];
+    int32_t size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     JSON_STRING *string = (JSON_STRING *)state->dom;
@@ -417,7 +431,7 @@ static void M_HandleArray(M_STATE *state, JSON_ARRAY *array)
 
     const size_t start_offset = state->offset;
     ASSERT(state->offset + sizeof(int32_t) <= state->size);
-    const int size = *(int32_t *)&state->src[state->offset];
+    const int size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     JSON_ARRAY_ELEMENT *previous = nullptr;
@@ -495,7 +509,7 @@ static void M_HandleObject(M_STATE *state, JSON_OBJECT *object)
 
     const size_t start_offset = state->offset;
     ASSERT(state->offset + sizeof(int32_t) <= state->size);
-    const int size = *(int32_t *)&state->src[state->offset];
+    const int size = M_ReadI32(&state->src[state->offset]);
     state->offset += sizeof(int32_t);
 
     JSON_OBJECT_ELEMENT *previous = nullptr;

--- a/src/trx/core/bson/write.c
+++ b/src/trx/core/bson/write.c
@@ -280,7 +280,7 @@ static char *M_WriteBoolWrapped(char *data, const char *key, bool value)
 static char *M_WriteInt32(char *data, const int32_t value)
 {
     ASSERT(data != nullptr);
-    *(int32_t *)data = value;
+    memcpy(data, &value, sizeof(value));
     data += sizeof(int32_t);
     return data;
 }
@@ -297,7 +297,7 @@ static char *M_WriteInt32Wrapped(
 static char *M_WriteDouble(char *data, const double value)
 {
     ASSERT(data != nullptr);
-    *(double *)data = value;
+    memcpy(data, &value, sizeof(value));
     data += sizeof(double);
     return data;
 }
@@ -350,7 +350,8 @@ static char *M_WriteString(char *data, const JSON_STRING *string)
 {
     ASSERT(data != nullptr);
     ASSERT(string != nullptr);
-    *(uint32_t *)data = string->string_size + 1;
+    const uint32_t bson_string_size = string->string_size + 1;
+    memcpy(data, &bson_string_size, sizeof(bson_string_size));
     data += sizeof(uint32_t);
     memcpy(data, string->string, string->string_size);
     data += string->string_size;
@@ -384,7 +385,8 @@ static char *M_WriteArray(char *data, const JSON_ARRAY *array)
         data = M_WriteValueWrapped(data, key, element->value);
     }
     *data++ = '\0';
-    *(int32_t *)old = data - old;
+    const int32_t object_size = data - old;
+    memcpy(old, &object_size, sizeof(object_size));
     return data;
 }
 
@@ -410,7 +412,8 @@ static char *M_WriteObject(char *data, const JSON_OBJECT *object)
         data = M_WriteValueWrapped(data, element->name->string, element->value);
     }
     *data++ = '\0';
-    *(int32_t *)old = data - old;
+    const int32_t object_size = data - old;
+    memcpy(old, &object_size, sizeof(object_size));
     return data;
 }
 

--- a/src/trx/core/json/util/read_io.c
+++ b/src/trx/core/json/util/read_io.c
@@ -207,7 +207,8 @@ static bool M_ReadBoolCurrent(JSON_READ_IO *const io, bool *const target)
             M_SetError(io, "value out of range: %lld", val);                   \
             return false;                                                      \
         }                                                                      \
-        *(type_ *)target = (type_)val;                                         \
+        const type_ parsed = (type_)val;                                       \
+        memcpy(target, &parsed, sizeof(parsed));                               \
         return true;                                                           \
     }
 L_DEFINE_M_READ_NUM_CURRENT(int8_t, S8, INT8_MIN, INT8_MAX)
@@ -226,7 +227,7 @@ static bool M_ReadNumCurrent_Double(
         return false;
     }
     const double val = JSON_ValueGetDouble(io->current, -1.0);
-    *(double *)target = val;
+    memcpy(target, &val, sizeof(val));
     return true;
 }
 
@@ -237,7 +238,8 @@ static bool M_ReadNumCurrent_Float(JSON_READ_IO *const io, float *const target)
         return false;
     }
     const double val = JSON_ValueGetDouble(io->current, -1.0);
-    *target = (float)val;
+    const float parsed = (float)val;
+    memcpy(target, &parsed, sizeof(parsed));
     return true;
 }
 

--- a/src/trx/core/math/geom.c
+++ b/src/trx/core/math/geom.c
@@ -66,7 +66,10 @@ bool XYZ_32_IsNearby(
 
 int32_t XYZ_32_GetLength(const XYZ_32 pos)
 {
-    return Math_Sqrt(SQUARE(pos.x) + SQUARE(pos.y) + SQUARE(pos.z));
+    return (int32_t)Math_Sqrt64(
+        SQUARE((uint64_t)ABS((int64_t)pos.x))
+        + SQUARE((uint64_t)ABS((int64_t)pos.y))
+        + SQUARE((uint64_t)ABS((int64_t)pos.z)));
 }
 
 int64_t XYZ_32_GetLength2_64(const XYZ_32 pos)

--- a/src/trx/core/math/geom.c
+++ b/src/trx/core/math/geom.c
@@ -72,6 +72,12 @@ int32_t XYZ_32_GetLength(const XYZ_32 pos)
         + SQUARE((uint64_t)ABS((int64_t)pos.z)));
 }
 
+int32_t XYZ_32_GetLength2(const XYZ_32 pos)
+{
+    const int64_t dist_64 = XYZ_32_GetLength2_64(pos);
+    return dist_64 > INT32_MAX ? INT32_MAX : (int32_t)dist_64;
+}
+
 int64_t XYZ_32_GetLength2_64(const XYZ_32 pos)
 {
     return SQUARE((int64_t)pos.x) + SQUARE((int64_t)pos.y)

--- a/src/trx/core/math/geom.c
+++ b/src/trx/core/math/geom.c
@@ -29,11 +29,11 @@ int16_t XYZ_32_GetPitch(XYZ_32 pos)
     return Math_Atan(Math_Sqrt(SQUARE(pos.x) + SQUARE(pos.z)), -pos.y);
 }
 
-int32_t XYZ_32_GetDistance(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
+int32_t XYZ_32_GetDistance(const XYZ_32 pos1, const XYZ_32 pos2)
 {
-    int64_t x = (int64_t)pos1->x - pos2->x;
-    int64_t y = (int64_t)pos1->y - pos2->y;
-    int64_t z = (int64_t)pos1->z - pos2->z;
+    int64_t x = (int64_t)pos1.x - pos2.x;
+    int64_t y = (int64_t)pos1.y - pos2.y;
+    int64_t z = (int64_t)pos1.z - pos2.z;
 
     int32_t scale = 0;
     while ((int32_t)x != x || (int32_t)y != y || (int32_t)z != z) {
@@ -53,12 +53,12 @@ int32_t XYZ_32_GetDistance(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
 }
 
 bool XYZ_32_IsNearby(
-    const XYZ_32 *const pos1, const XYZ_32 *const pos2, const int32_t distance)
+    const XYZ_32 pos1, const XYZ_32 pos2, const int32_t distance)
 {
     const XYZ_32 delta = {
-        .x = pos1->x - pos2->x,
-        .y = pos1->y - pos2->y,
-        .z = pos1->z - pos2->z,
+        .x = pos1.x - pos2.x,
+        .y = pos1.y - pos2.y,
+        .z = pos1.z - pos2.z,
     };
     return delta.x > -distance && delta.x < distance && delta.y > -distance
         && delta.y < distance && delta.z > -distance && delta.z < distance;
@@ -84,14 +84,14 @@ int64_t XYZ_32_GetLength2_64(const XYZ_32 pos)
         + SQUARE((int64_t)pos.z);
 }
 
-bool XYZ_32_AreEquivalent(const XYZ_32 *const pos1, const XYZ_32 *const pos2)
+bool XYZ_32_AreEquivalent(const XYZ_32 pos1, const XYZ_32 pos2)
 {
-    return pos1->x == pos2->x && pos1->y == pos2->y && pos1->z == pos2->z;
+    return pos1.x == pos2.x && pos1.y == pos2.y && pos1.z == pos2.z;
 }
 
-bool XYZ_16_AreEquivalent(const XYZ_16 *const rot1, const XYZ_16 *const rot2)
+bool XYZ_16_AreEquivalent(const XYZ_16 rot1, const XYZ_16 rot2)
 {
-    return rot1->x == rot2->x && rot1->y == rot2->y && rot1->z == rot2->z;
+    return rot1.x == rot2.x && rot1.y == rot2.y && rot1.z == rot2.z;
 }
 
 XYZ_32 XYZ_32_From16(const XYZ_16 src)

--- a/src/trx/core/math/geom.h
+++ b/src/trx/core/math/geom.h
@@ -6,7 +6,7 @@ XYZ_32 XYZ_32_From16(XYZ_16 src);
 int16_t XYZ_32_GetYaw(XYZ_32 pos);
 int16_t XYZ_32_GetYawDiff(XYZ_32 pos1, const XYZ_32 pos2);
 int16_t XYZ_32_GetPitch(XYZ_32 pos);
-int32_t XYZ_32_GetDistance(const XYZ_32 *pos1, const XYZ_32 *pos2);
+int32_t XYZ_32_GetDistance(XYZ_32 pos1, XYZ_32 pos2);
 
 // Take length of a vector
 int32_t XYZ_32_GetLength(XYZ_32 pos);
@@ -17,14 +17,16 @@ int64_t XYZ_32_GetLength2_64(XYZ_32 pos);
 
 int64_t XYZ_32_DotProduct_64(XYZ_32 a, XYZ_32 b);
 
-bool XYZ_32_AreEquivalent(const XYZ_32 *pos1, const XYZ_32 *pos2);
-bool XYZ_32_IsNearby(const XYZ_32 *pos1, const XYZ_32 *pos2, int32_t distance);
+bool XYZ_32_AreEquivalent(XYZ_32 pos1, XYZ_32 pos2);
+bool XYZ_32_IsNearby(XYZ_32 pos1, XYZ_32 pos2, int32_t distance);
+
 XYZ_32 XYZ_32_FromYawPitch(int16_t yaw, int16_t pitch, int32_t distance);
 XYZ_32 XYZ_32_OffsetYaw(XYZ_32 src, int16_t yaw, int32_t distance);
+
 bool XYZ_32_ProjectPointOntoAxis(
     XYZ_32 origin, XYZ_32 axis, int64_t axis_len2, XYZ_32 *pos);
 
-bool XYZ_16_AreEquivalent(const XYZ_16 *rot1, const XYZ_16 *rot2);
+bool XYZ_16_AreEquivalent(XYZ_16 rot1, XYZ_16 rot2);
 
 float XYZ_F_DotProduct(XYZ_F a, XYZ_F b);
 float XYZ_F_Length2(XYZ_F pos);

--- a/src/trx/core/math/geom.h
+++ b/src/trx/core/math/geom.h
@@ -7,9 +7,16 @@ int16_t XYZ_32_GetYaw(XYZ_32 pos);
 int16_t XYZ_32_GetYawDiff(XYZ_32 pos1, const XYZ_32 pos2);
 int16_t XYZ_32_GetPitch(XYZ_32 pos);
 int32_t XYZ_32_GetDistance(const XYZ_32 *pos1, const XYZ_32 *pos2);
+
+// Take length of a vector
 int32_t XYZ_32_GetLength(XYZ_32 pos);
+
+// Take squared length of a vector
+int32_t XYZ_32_GetLength2(XYZ_32 pos);
 int64_t XYZ_32_GetLength2_64(XYZ_32 pos);
+
 int64_t XYZ_32_DotProduct_64(XYZ_32 a, XYZ_32 b);
+
 bool XYZ_32_AreEquivalent(const XYZ_32 *pos1, const XYZ_32 *pos2);
 bool XYZ_32_IsNearby(const XYZ_32 *pos1, const XYZ_32 *pos2, int32_t distance);
 XYZ_32 XYZ_32_FromYawPitch(int16_t yaw, int16_t pitch, int32_t distance);

--- a/src/trx/core/virtual_file.c
+++ b/src/trx/core/virtual_file.c
@@ -82,6 +82,12 @@ void VFile_Read(VFILE *const file, void *const target, const size_t size)
 
 bool VFile_TryRead(VFILE *const file, void *const target, const size_t size)
 {
+    ASSERT(file != nullptr);
+    if (size == 0) {
+        return true;
+    }
+    ASSERT(target != nullptr);
+
     const size_t cur_pos = VFile_GetPos(file);
     if (cur_pos + size > file->size) {
         return false;

--- a/src/trx/game/anims/common.c
+++ b/src/trx/game/anims/common.c
@@ -1,8 +1,12 @@
 #include <trx/game/anims/common.h>
 
+#include <trx/debug.h>
 #include <trx/game/game_buf.h>
 
 static int32_t m_AnimCount = 0;
+static int32_t m_ChangeCount = 0;
+static int32_t m_RangeCount = 0;
+static int32_t m_BoneCount = 0;
 static ANIM *m_Anims = nullptr;
 static ANIM_CHANGE *m_Changes = nullptr;
 static ANIM_RANGE *m_Ranges = nullptr;
@@ -17,17 +21,20 @@ void Anim_InitialiseAnims(const int32_t num_anims)
 
 void Anim_InitialiseChanges(const int32_t num_changes)
 {
+    m_ChangeCount = num_changes;
     m_Changes =
         GameBuf_Alloc(sizeof(ANIM_CHANGE) * num_changes, GBUF_ANIM_CHANGES);
 }
 
 void Anim_InitialiseRanges(const int32_t num_ranges)
 {
+    m_RangeCount = num_ranges;
     m_Ranges = GameBuf_Alloc(sizeof(ANIM_RANGE) * num_ranges, GBUF_ANIM_RANGES);
 }
 
 void Anim_InitialiseBones(const int32_t num_bones)
 {
+    m_BoneCount = num_bones;
     m_Bones = GameBuf_Alloc(sizeof(ANIM_BONE) * num_bones, GBUF_ANIM_BONES);
 }
 
@@ -38,22 +45,37 @@ int32_t Anim_GetTotalCount(void)
 
 ANIM *Anim_GetAnim(const int32_t anim_idx)
 {
-    return anim_idx == NO_ANIM ? &m_NullAnim : &m_Anims[anim_idx];
+    if (anim_idx < 0 || anim_idx >= m_AnimCount) {
+        return &m_NullAnim;
+    }
+    return &m_Anims[anim_idx];
 }
 
 ANIM_CHANGE *Anim_GetChange(const int32_t change_idx)
 {
+    ASSERT(change_idx >= 0 && change_idx < m_ChangeCount);
     return &m_Changes[change_idx];
 }
 
 ANIM_RANGE *Anim_GetRange(const int32_t range_idx)
 {
+    ASSERT(range_idx >= 0 && range_idx < m_RangeCount);
     return &m_Ranges[range_idx];
 }
 
 ANIM_BONE *Anim_GetBone(const int32_t bone_idx)
 {
-    return &m_Bones[bone_idx];
+    ANIM_BONE *const result = Anim_TryGetBone(bone_idx);
+    ASSERT(result != nullptr);
+    return result;
+}
+
+ANIM_BONE *Anim_TryGetBone(const int32_t bone_idx)
+{
+    if (bone_idx >= 0 && bone_idx < m_BoneCount) {
+        return &m_Bones[bone_idx];
+    }
+    return nullptr;
 }
 
 bool Anim_TestAbsFrameEqual(const int16_t abs_frame, const int16_t frame)

--- a/src/trx/game/anims/common.h
+++ b/src/trx/game/anims/common.h
@@ -24,6 +24,7 @@ ANIM *Anim_GetAnim(int32_t anim_idx);
 ANIM_CHANGE *Anim_GetChange(int32_t change_idx);
 ANIM_RANGE *Anim_GetRange(int32_t range_idx);
 ANIM_BONE *Anim_GetBone(int32_t bone_idx);
+ANIM_BONE *Anim_TryGetBone(int32_t bone_idx);
 
 bool Anim_TestAbsFrameEqual(int16_t abs_frame, int16_t frame);
 bool Anim_TestAbsFrameRange(int16_t abs_frame, int16_t start, int16_t end);

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -240,14 +240,14 @@ static bool M_UpdateLaraState(void)
     bool same_lara_state =
         m_LastState.lara.current_anim_state == lara_item->current_anim_state
         && m_LastState.lara.goal_anim_state == lara_item->goal_anim_state
-        && XYZ_16_AreEquivalent(&m_LastState.lara.head_rot, &lara->head_rot)
-        && XYZ_32_AreEquivalent(&m_LastState.lara.pos, &lara_item->pos);
+        && XYZ_16_AreEquivalent(m_LastState.lara.head_rot, lara->head_rot)
+        && XYZ_32_AreEquivalent(m_LastState.lara.pos, lara_item->pos);
     bool same_camera_state = m_LastState.cam_type == g_Camera.type;
     if (g_Camera.type != CAM_LOOK) {
         same_lara_state &=
-            XYZ_16_AreEquivalent(&m_LastState.lara.rot, &lara_item->rot)
+            XYZ_16_AreEquivalent(m_LastState.lara.rot, lara_item->rot)
             && XYZ_16_AreEquivalent(
-                &m_LastState.lara.torso_rot, &lara->torso_rot);
+                m_LastState.lara.torso_rot, lara->torso_rot);
         same_camera_state &=
             m_LastState.additional_angle == g_Camera.additional_angle
             && m_LastState.additional_elevation

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -165,8 +165,8 @@ static int32_t M_CheckX(
         return 1;
     }
 
-    const int32_t dy = ((target->y - start->y) << WALL_SHIFT) / dx;
-    const int32_t dz = ((target->z - start->z) << WALL_SHIFT) / dx;
+    const int32_t dy = ((target->y - start->y) * WALL_L) / dx;
+    const int32_t dz = ((target->z - start->z) * WALL_L) / dx;
 
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;
@@ -276,8 +276,8 @@ static int32_t M_CheckZ(
         return 1;
     }
 
-    const int32_t dx = ((target->x - start->x) << WALL_SHIFT) / dz;
-    const int32_t dy = ((target->y - start->y) << WALL_SHIFT) / dz;
+    const int32_t dx = ((target->x - start->x) * WALL_L) / dz;
+    const int32_t dy = ((target->y - start->y) * WALL_L) / dz;
 
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -144,7 +144,7 @@ int32_t LOS_CheckSmashable(
         }
 
         // Ray segment intersects the object's local AABB
-        const int32_t dist = Item_GetDistance(item, &start);
+        const int32_t dist = Item_GetDistance(item, start);
         if (dist < best_dist) {
             best_dist = dist;
             best_item_num = item_num;

--- a/src/trx/game/console/cmd/kill.c
+++ b/src/trx/game/console/cmd/kill.c
@@ -33,7 +33,7 @@ static bool M_KillSingleEnemyInRange(const int32_t max_dist)
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
         const ITEM *const item = Item_Get(item_num);
         if (Creature_IsHostile(item)) {
-            const int32_t dist = Item_GetDistance(item, &lara_item->pos);
+            const int32_t dist = Item_GetDistance(item, lara_item->pos);
             if (dist <= max_dist) {
                 if (best_item_num == NO_ITEM || dist < best_dist) {
                     best_dist = dist;
@@ -57,7 +57,7 @@ static int32_t M_KillAllEnemiesInRange(const int32_t max_dist)
     for (int16_t item_num = 0; item_num < Item_GetTotalCount(); item_num++) {
         const ITEM *const item = Item_Get(item_num);
         if (Creature_IsHostile(item)) {
-            const int32_t dist = Item_GetDistance(item, &lara_item->pos);
+            const int32_t dist = Item_GetDistance(item, lara_item->pos);
             if (dist <= max_dist) {
                 // Kill this enemy
                 if (Lara_Cheat_KillEnemy(item_num)) {

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -102,7 +102,7 @@ static const ITEM *M_GetItemToTeleporTo(const char *const user_input)
             continue;
         }
 
-        const int32_t distance = Item_GetDistance(item, &lara_item->pos);
+        const int32_t distance = Item_GetDistance(item, lara_item->pos);
         if (distance < closest_distance) {
             closest_distance = distance;
             closest_item_num = item_num;
@@ -126,7 +126,7 @@ static const ITEM *M_GetItemToTeleporTo(const char *const user_input)
                 continue;
             }
 
-            const int32_t distance = Item_GetDistance(item, &lara_item->pos);
+            const int32_t distance = Item_GetDistance(item, lara_item->pos);
             if (distance < near_distance) {
                 continue;
             }

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -628,7 +628,7 @@ int16_t Creature_Turn(ITEM *const item, int16_t max_turn)
 
     int16_t angle = Math_Atan(dz, dx) - item->rot.y;
     if (angle > FRONT_ARC || angle < -FRONT_ARC) {
-        const int32_t range = (item->speed << 14) / max_turn;
+        const int32_t range = (item->speed * (1 << 14)) / max_turn;
         if (SQUARE(dx) + SQUARE(dz) < SQUARE(range)) {
             max_turn /= 2;
         }
@@ -1282,18 +1282,18 @@ int32_t Creature_Vault(
 
         if (old_x_sector >= x_sector) {
             item->rot.y = -DEG_90;
-            item->pos.x = (old_x_sector << WALL_SHIFT) + shift;
+            item->pos.x = (old_x_sector * WALL_L) + shift;
         } else {
             item->rot.y = DEG_90;
-            item->pos.x = (x_sector << WALL_SHIFT) - shift;
+            item->pos.x = (x_sector * WALL_L) - shift;
         }
     } else if (old_x_sector == x_sector) {
         if (old_z_sector >= z_sector) {
             item->rot.y = -DEG_180;
-            item->pos.z = (old_z_sector << WALL_SHIFT) + shift;
+            item->pos.z = (old_z_sector * WALL_L) + shift;
         } else {
             item->rot.y = 0;
-            item->pos.z = (z_sector << WALL_SHIFT) - shift;
+            item->pos.z = (z_sector * WALL_L) - shift;
         }
     }
 

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -110,9 +110,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     FX_WATER_SPLASH_VERT *v = splash->v;
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.inner_xz_off * m_SplashRings[i][0]) << 1;
+        v->wx = (setup.inner_xz_off * m_SplashRings[i][0]) * 2;
         v->wy = 0;
-        v->wz = (setup.inner_xz_off * m_SplashRings[i][1]) << 1;
+        v->wz = (setup.inner_xz_off * m_SplashRings[i][1]) * 2;
         v->xv = (setup.inner_xz_vel * m_SplashRings[i][0]) / 12;
         v->yv = 0;
         v->zv = (setup.inner_xz_vel * m_SplashRings[i][1]) / 12;
@@ -126,11 +126,11 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     for (int32_t i = 0; i < 8; i++) {
         v->wx =
             ((setup.inner_xz_off + setup.inner_xz_size) * m_SplashRings[i][0])
-            << 1;
+            * 2;
         v->wy = setup.inner_y_size;
         v->wz =
             ((setup.inner_xz_off + setup.inner_xz_size) * m_SplashRings[i][1])
-            << 1;
+            * 2;
         v->xv = (setup.inner_xz_vel * m_SplashRings[i][0]) >> 3;
         v->yv = setup.inner_y_vel;
         v->zv = (setup.inner_xz_vel * m_SplashRings[i][1]) >> 3;
@@ -142,9 +142,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.middle_xz_off * m_SplashRings[i][0]) << 1;
+        v->wx = (setup.middle_xz_off * m_SplashRings[i][0]) * 2;
         v->wy = 0;
-        v->wz = (setup.middle_xz_off * m_SplashRings[i][1]) << 1;
+        v->wz = (setup.middle_xz_off * m_SplashRings[i][1]) * 2;
         v->xv = (setup.middle_xz_vel * m_SplashRings[i][0]) / 12;
         v->yv = 0;
         v->zv = (setup.middle_xz_vel * m_SplashRings[i][1]) / 12;
@@ -158,11 +158,11 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     for (int32_t i = 0; i < 8; i++) {
         v->wx =
             ((setup.middle_xz_off + setup.middle_xz_size) * m_SplashRings[i][0])
-            << 1;
+            * 2;
         v->wy = setup.middle_y_size;
         v->wz =
             ((setup.middle_xz_off + setup.middle_xz_size) * m_SplashRings[i][1])
-            << 1;
+            * 2;
         v->xv = (setup.middle_xz_vel * m_SplashRings[i][0]) >> 3;
         v->yv = setup.middle_y_vel;
         v->zv = (setup.middle_xz_vel * m_SplashRings[i][1]) >> 3;
@@ -174,9 +174,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     }
 
     for (int32_t i = 0; i < 8; i++) {
-        v->wx = (setup.outer_xz_off * m_SplashRings[i][0]) << 1;
+        v->wx = (setup.outer_xz_off * m_SplashRings[i][0]) * 2;
         v->wy = 0;
-        v->wz = (setup.outer_xz_off * m_SplashRings[i][1]) << 1;
+        v->wz = (setup.outer_xz_off * m_SplashRings[i][1]) * 2;
         v->xv = (setup.outer_xz_vel * m_SplashRings[i][0]) / 12;
         v->yv = 0;
         v->zv = (setup.outer_xz_vel * m_SplashRings[i][1]) / 12;
@@ -190,11 +190,11 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
     for (int32_t i = 0; i < 8; i++) {
         v->wx =
             ((setup.outer_xz_off + setup.outer_xz_size) * m_SplashRings[i][0])
-            << 1;
+            * 2;
         v->wy = 0;
         v->wz =
             ((setup.outer_xz_off + setup.outer_xz_size) * m_SplashRings[i][1])
-            << 1;
+            * 2;
         v->xv = (setup.outer_xz_vel * m_SplashRings[i][0]) >> 3;
         v->yv = 0;
         v->zv = (setup.outer_xz_vel * m_SplashRings[i][1]) >> 3;

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -79,7 +79,7 @@ static void M_SpawnRainDrop(M_RAINDROP *const drop)
     }
 
     const int32_t dist = Random_GetDraw() & M_RAIN_SPAWN_DIST_MASK;
-    const int32_t angle = (Random_GetDraw() & M_RAIN_SPAWN_ANGLE_MASK) << 3;
+    const int32_t angle = (Random_GetDraw() & M_RAIN_SPAWN_ANGLE_MASK) * 8;
 
     drop->pos = (XYZ_32) {
         .x = lara_item->pos.x + ((dist * Math_Sin(angle)) >> W2V_SHIFT),
@@ -130,7 +130,7 @@ static void M_UpdateRain(void)
         }
 
         drop->pos.x += (int32_t)drop->xv + 4 * wind.x;
-        drop->pos.y += (int32_t)drop->yv << 3;
+        drop->pos.y += (int32_t)drop->yv * 8;
         drop->pos.z += (int32_t)drop->zv + 4 * wind.z;
 
         int32_t rnd = Random_GetDraw();
@@ -172,9 +172,9 @@ static void M_DrawRain(void)
 
         const XYZ_32 to = drop->pos;
         const XYZ_32 from = {
-            drop->pos.x - (wind.x << 2),
-            drop->pos.y - ((int32_t)drop->yv << 3),
-            drop->pos.z - (wind.z << 2),
+            drop->pos.x - (wind.x * 4),
+            drop->pos.y - ((int32_t)drop->yv * 8),
+            drop->pos.z - (wind.z * 4),
         };
 
         const RGBA_8888 from_color = { 0, 0, 0x20, 0x00 };
@@ -192,7 +192,7 @@ static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
     }
 
     const int32_t dist = Random_GetDraw() & M_RAIN_SPAWN_DIST_MASK;
-    const int32_t angle = (Random_GetDraw() & M_RAIN_SPAWN_ANGLE_MASK) << 3;
+    const int32_t angle = (Random_GetDraw() & M_RAIN_SPAWN_ANGLE_MASK) * 8;
 
     snow->pos = (XYZ_32) {
         .x = lara_item->pos.x + ((dist * Math_Sin(angle)) >> W2V_SHIFT),
@@ -210,7 +210,7 @@ static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
     snow->stopped = false;
     snow->xv = (int8_t)((Random_GetDraw() & 7) - 4);
     snow->yv =
-        (uint8_t)(((Random_GetDraw() % M_SNOW_YV_RANGE) + M_SNOW_YV_MIN) << 3);
+        (uint8_t)(((Random_GetDraw() % M_SNOW_YV_RANGE) + M_SNOW_YV_MIN) * 8);
     snow->zv = (int8_t)((Random_GetDraw() & 7) - 4);
     snow->life = (uint8_t)(M_SNOW_LIFE_BASE - ((int32_t)snow->yv << 1));
 }
@@ -273,15 +273,15 @@ static void M_UpdateSnow(void)
 
         const XZ_32 wind = Sparks_GetSmokeWind();
 
-        if (snow->xv < (wind.x << 1)) {
+        if (snow->xv < (wind.x * 2)) {
             snow->xv++;
-        } else if (snow->xv > (wind.x << 1)) {
+        } else if (snow->xv > (wind.x * 2)) {
             snow->xv--;
         }
 
-        if (snow->zv < (wind.z << 1)) {
+        if (snow->zv < (wind.z * 2)) {
             snow->zv++;
-        } else if (snow->zv > (wind.z << 1)) {
+        } else if (snow->zv > (wind.z * 2)) {
             snow->zv--;
         }
 

--- a/src/trx/game/game_buf.c
+++ b/src/trx/game/game_buf.c
@@ -33,6 +33,6 @@ void GameBuf_Shutdown(void)
 
 void *GameBuf_Alloc(const size_t alloc_size, const GAME_BUFFER buffer)
 {
-    const size_t aligned_size = (alloc_size + 3) & ~3;
+    const size_t aligned_size = Memory_Align(alloc_size);
     return Memory_ArenaAlloc(&m_Allocator[buffer], aligned_size);
 }

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -526,7 +526,7 @@ static bool M_LoadSequence(
         JSON_FAIL();
     }
 
-    size_t event_base_size = sizeof(GF_SEQUENCE_EVENT);
+    const size_t event_base_size = sizeof(GF_SEQUENCE_EVENT);
     size_t total_data_size = 0;
     for (int32_t i = 0; i < seq_count; i++) {
         JSON_MUST(JSON_PUSH_INDEX(io, i));
@@ -536,13 +536,16 @@ static bool M_LoadSequence(
         if (event_extra_size < 0) {
             JSON_FAIL();
         }
-        total_data_size += event_base_size;
-        total_data_size += event_extra_size;
         sequence->length++;
+        total_data_size += Memory_Align((size_t)event_extra_size);
     }
 
+    const size_t events_block_size =
+        Memory_Align((size_t)sequence->length * event_base_size);
+    total_data_size += events_block_size;
+
     char *const data = Memory_Alloc(total_data_size);
-    char *extra_data_ptr = data + event_base_size * sequence->length;
+    char *extra_data_ptr = data + events_block_size;
     sequence->events = (GF_SEQUENCE_EVENT *)data;
 
     int32_t j = 0;
@@ -555,7 +558,7 @@ static bool M_LoadSequence(
             // Parsing this event failed - discard it
             continue;
         }
-        extra_data_ptr += event_extra_size;
+        extra_data_ptr += Memory_Align((size_t)event_extra_size);
         j++;
     }
     JSON_FINISH();

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -1,5 +1,6 @@
 #include <trx/config.h>
 #include <trx/core/log.h>
+#include <trx/core/memory.h>
 #include <trx/game/camera.h>
 #include <trx/game/inject.h>
 #include <trx/game/items.h>
@@ -115,10 +116,22 @@ static void M_InsertFloorData(
     const INJECTION *const injection, SECTOR *const sector)
 {
     const int32_t data_length = VFile_ReadS32(injection->fp);
-    int16_t data[data_length];
+    if (data_length < 0) {
+        LOG_WARNING(
+            "Skipping floor data insert with invalid length: %d", data_length);
+        return;
+    }
+
+    if (data_length == 0) {
+        Room_PopulateSectorData(sector, nullptr, NULL_FD_INDEX, NULL_FD_INDEX);
+        return;
+    }
+
+    int16_t *data = Memory_Alloc(sizeof(int16_t) * data_length);
     VFile_Read(injection->fp, data, sizeof(int16_t) * data_length);
 
     if (sector == nullptr) {
+        Memory_FreePointer(&data);
         return;
     }
 
@@ -126,6 +139,7 @@ static void M_InsertFloorData(
     // imported. We pass a dummy null index to allow it to read from the
     // beginning of the array.
     Room_PopulateSectorData(sector, data, 0, NULL_FD_INDEX);
+    Memory_FreePointer(&data);
 }
 
 static void M_RoomShift(

--- a/src/trx/game/inject/testers/items.c
+++ b/src/trx/game/inject/testers/items.c
@@ -21,7 +21,7 @@ static bool M_TestItemMeta(
 
     const ITEM *const item = Item_Get(item_num);
     return item->object_id == obj_info.id
-        && XYZ_32_AreEquivalent(&item->pos, &pos) && item->room_num == room_num
+        && XYZ_32_AreEquivalent(item->pos, pos) && item->room_num == room_num
         && item->rot.y == y_rot;
 }
 

--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -136,7 +136,7 @@ static void M_InitialiseDataDrops(void)
         while (pickup_num != NO_ITEM) {
             ITEM *const pickup = Item_Get(pickup_num);
             if (Object_IsType(pickup->object_id, g_PickupObjects)
-                && XYZ_32_AreEquivalent(&pickup->pos, &carrier->pos)) {
+                && XYZ_32_AreEquivalent(pickup->pos, carrier->pos)) {
                 Vector_Add(pickups, (void *)&pickup_num);
                 Item_RemoveDrawn(pickup_num);
                 pickup->room_num = NO_ROOM;

--- a/src/trx/game/items/col.c
+++ b/src/trx/game/items/col.c
@@ -16,9 +16,9 @@ int16_t Item_GetHeight(const ITEM *const item)
     return height;
 }
 
-int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 *const target)
+int32_t Item_GetDistance(const ITEM *const item, const XYZ_32 target)
 {
-    return XYZ_32_GetDistance(&item->pos, target);
+    return XYZ_32_GetDistance(item->pos, target);
 }
 
 void Item_Translate(
@@ -41,7 +41,7 @@ bool Item_Test3DRange(
 bool Item_IsNearby(
     const ITEM *const item_1, const ITEM *const item_2, const int32_t distance)
 {
-    return XYZ_32_IsNearby(&item_1->pos, &item_2->pos, distance);
+    return XYZ_32_IsNearby(item_1->pos, item_2->pos, distance);
 }
 
 bool Item_TestBoundsCollide(

--- a/src/trx/game/items/col.h
+++ b/src/trx/game/items/col.h
@@ -4,7 +4,7 @@
 #include <trx/game/rooms/types.h>
 
 int16_t Item_GetHeight(const ITEM *item);
-int32_t Item_GetDistance(const ITEM *item, const XYZ_32 *target);
+int32_t Item_GetDistance(const ITEM *item, XYZ_32 target);
 void Item_Translate(ITEM *item, int32_t x, int32_t y, int32_t z);
 bool Item_Test3DRange(int32_t x, int32_t y, int32_t z, int32_t range);
 bool Item_IsNearby(const ITEM *item_1, const ITEM *item_2, int32_t distance);

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -870,7 +870,7 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
         if (ABS(height - lara_item->pos.y) > STEP_L * 2) {
             return false;
         }
-        if (XYZ_32_GetDistance(&new_pos, &lara_item->pos) < STEP_L) {
+        if (XYZ_32_GetDistance(new_pos, lara_item->pos) < STEP_L) {
             return true;
         }
     }

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -275,7 +275,7 @@ static void M_SoftStaticCollision(COLL_INFO *const coll)
                 Object_Get3DStatic(mesh->static_num);
             if (!obj->collidable
                 || !XYZ_32_IsNearby(
-                    &lara_item->pos, &mesh->pos, M_STATIC_COLL_DIST)) {
+                    lara_item->pos, mesh->pos, M_STATIC_COLL_DIST)) {
                 continue;
             }
 

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -164,7 +164,7 @@ void Lara_RefuseInteraction(void)
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     if (!XYZ_32_AreEquivalent(
-            &lara_info->interact_target.initial_pos, &lara_item->pos)) {
+            lara_info->interact_target.initial_pos, lara_item->pos)) {
         lara_info->interact_target.initial_pos = lara_item->pos;
         Sound_Effect(SFX_LARA_NO, &lara_item->pos, SPM_ALWAYS);
     }

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -508,7 +508,7 @@ const ANIM_BONE *Lara_Skin_GetBoneBase(void)
 {
     const LARA_SKIN_OUTFIT *const outfit = M_GetCurrentOutfit();
     const OBJECT *const skin_obj = Object_Get(outfit->obj_id);
-    return Object_GetBone(skin_obj, 0);
+    return Object_TryGetBone(skin_obj, 0);
 }
 
 bool Lara_Skin_IsBraidSupported(void)
@@ -541,7 +541,7 @@ const ANIM_BONE *Lara_Skin_GetBraidBoneBase(void)
     }
 
     const OBJECT *const obj = Object_Get(O_LARA_SKIN_SWAP_EXTRA);
-    return Object_GetBone(obj, offset);
+    return Object_TryGetBone(obj, offset);
 }
 
 bool Lara_Skin_AreHolstersVisible(void)

--- a/src/trx/game/level/sections/objects.c
+++ b/src/trx/game/level/sections/objects.c
@@ -45,12 +45,13 @@ void Level_Section_ReadObjects(LEVEL_CONTEXT *const ctx, VFILE *const file)
     const int32_t num_objects = VFile_ReadS32(file);
     LOG_INFO("objects: %d", num_objects);
     for (int32_t i = 0; i < num_objects; i++) {
+        OBJECT fallback_obj = {};
         const int32_t game_obj_id = VFile_ReadS32(file);
         OBJECT *obj = Object_GetByGameID(game_obj_id);
         if (obj == nullptr) {
             if (loader->game_version == 3) {
                 // TODO: remove this check after we implement the items
-                obj = &(OBJECT) {};
+                obj = &fallback_obj;
             } else {
                 Shell_ExitSystemFmt("Invalid object ID: %d", game_obj_id);
             }

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -358,9 +358,10 @@ static void M_TranslateRel(MATRIX *const m, const XYZ_32 offset)
 
 static void M_TranslateSet(MATRIX *const m, const XYZ_32 pos)
 {
-    m->_03 = pos.x << W2V_SHIFT;
-    m->_13 = pos.y << W2V_SHIFT;
-    m->_23 = pos.z << W2V_SHIFT;
+    const int64_t scale = (int64_t)(1 << W2V_SHIFT);
+    m->_03 = (int64_t)pos.x * scale;
+    m->_13 = (int64_t)pos.y * scale;
+    m->_23 = (int64_t)pos.z * scale;
 }
 
 void Matrix_Mul3x3_M(

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -279,6 +279,11 @@ ANIM_BONE *Object_GetBone(const OBJECT *const obj, const int32_t bone_idx)
     return Anim_GetBone(obj->bone_idx + bone_idx);
 }
 
+ANIM_BONE *Object_TryGetBone(const OBJECT *const obj, const int32_t bone_idx)
+{
+    return Anim_TryGetBone(obj->bone_idx + bone_idx);
+}
+
 OBJECT_ID Object_FindReceptacleKey(const OBJECT_ID receptacle_obj_id)
 {
     return Object_GetCognateInverse(

--- a/src/trx/game/objects/common.h
+++ b/src/trx/game/objects/common.h
@@ -65,6 +65,7 @@ void Object_SwapMeshEx(
 
 ANIM *Object_GetAnim(const OBJECT *obj, int32_t anim_idx);
 ANIM_BONE *Object_GetBone(const OBJECT *obj, int32_t bone_idx);
+ANIM_BONE *Object_TryGetBone(const OBJECT *obj, int32_t bone_idx);
 
 // Given a key or puzzle object, find a matching receptacle item number to
 // establish the interaction target. Takes into account current Lara's

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -1,4 +1,5 @@
 #include <trx/config.h>
+#include <trx/core/math/geom.h>
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
 #include <trx/game/game_buf.h>
@@ -222,7 +223,7 @@ static void M_Control(const int16_t item_num)
             const int32_t dx = lara_item->pos.x - item->pos.x;
             const int32_t dz = lara_item->pos.z - item->pos.z;
             Math_Atan(dz, dx);
-            dist = SQUARE(dx) + SQUARE(dz);
+            dist = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
         }
 
         Creature_UpdateMood(item, &info, true);

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -172,7 +172,7 @@ static void M_ControlPickupAids(ITEM *const item)
         return;
     }
 
-    const int32_t distance = Item_GetDistance(lara, &item->pos);
+    const int32_t distance = Item_GetDistance(lara, item->pos);
     if (distance < M_AID_DIST_MIN || distance > M_AID_DIST_MAX) {
         return;
     }

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -406,7 +406,7 @@ static void M_Control(const int16_t item_num)
             leader->angle_time = (Random_GetControl() & 0xF) + 8;
             int32_t delta = (Random_GetControl() & 0x3F) - 24;
             if ((Random_GetControl() & 3) == 0) {
-                delta <<= 5;
+                delta *= 32;
             }
             leader->angle = (leader->angle + delta) & 0xFFF;
         }

--- a/src/trx/game/objects/general/waterfall.c
+++ b/src/trx/game/objects/general/waterfall.c
@@ -45,10 +45,10 @@ static void M_Control(const int16_t item_num)
         EFFECT *const effect = Effect_Get(effect_num);
         effect->object_id = O_SPLASH_1;
         effect->pos.x =
-            item->pos.x + ((Random_GetDraw() - 0x4000) << WALL_SHIFT) / 0x7FFF;
+            item->pos.x + ((Random_GetDraw() - 0x4000) * WALL_L) / 0x7FFF;
         effect->pos.y = item->pos.y;
         effect->pos.z =
-            item->pos.z + ((Random_GetDraw() - 0x4000) << WALL_SHIFT) / 0x7FFF;
+            item->pos.z + ((Random_GetDraw() - 0x4000) * WALL_L) / 0x7FFF;
         effect->speed = 0;
         effect->frame_num = 0;
         effect->shade = -1;

--- a/src/trx/game/objects/traps/raptor_emitter.c
+++ b/src/trx/game/objects/traps/raptor_emitter.c
@@ -108,7 +108,7 @@ static void M_Control(int16_t item_num)
     }
 
     const ITEM *const lara_item = Lara_GetItem();
-    const int32_t dist = XYZ_32_GetDistance(&lara_item->pos, &item->pos);
+    const int32_t dist = XYZ_32_GetDistance(lara_item->pos, item->pos);
     if (dist < 4 * WALL_L) {
         return;
     }

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -34,7 +34,7 @@ static void M_Roll(ITEM *const item)
     if (g_Config.gameplay.enable_boulder_shake) {
         XYZ_32 mic_pos = g_Camera.mic_pos.pos;
         mic_pos.y = item->pos.y; // Ignore vertical component
-        const int32_t dist = XYZ_32_GetDistance(&mic_pos, &item->pos);
+        const int32_t dist = XYZ_32_GetDistance(mic_pos, item->pos);
         if (dist < M_SHAKE_RANGE) {
             g_Camera.bounce = 40 * (dist - M_SHAKE_RANGE) / M_SHAKE_RANGE;
         }

--- a/src/trx/game/output/func.c
+++ b/src/trx/game/output/func.c
@@ -70,6 +70,10 @@ CLIP Output_CheckBoundsClip(const BOUNDS_16 *const bounds)
         CLAMPL(y_max, yv);
     }
 
+    if (num_z == 0) {
+        return CLIP_NOT_VISIBLE; // out of screen
+    }
+
     const VIEWPORT_RECT vp = Viewport_GetRect(VIEWPORT_GAME);
     x_min += vp.w / 2;
     x_max += vp.w / 2;
@@ -77,8 +81,7 @@ CLIP Output_CheckBoundsClip(const BOUNDS_16 *const bounds)
     y_max += vp.h / 2;
 
     // clang-format off
-    if (num_z == 0
-        || x_min > g_PhdRight
+    if (x_min > g_PhdRight
         || y_min > g_PhdBottom
         || x_max < g_PhdLeft
         || y_max < g_PhdTop) {

--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -111,9 +111,9 @@ static XYZ_32 M_TR3_NormalizeDeltaWorld(const XYZ_32 delta)
     }
 
     return (XYZ_32) {
-        .x = (dx << W2V_SHIFT) / (int32_t)len,
-        .y = (dy << W2V_SHIFT) / (int32_t)len,
-        .z = (dz << W2V_SHIFT) / (int32_t)len,
+        .x = (dx * (1 << W2V_SHIFT)) / (int32_t)len,
+        .y = (dy * (1 << W2V_SHIFT)) / (int32_t)len,
+        .z = (dz * (1 << W2V_SHIFT)) / (int32_t)len,
     };
 }
 

--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -1,6 +1,7 @@
 #include <trx/game/output/lights.h>
 
 #include <trx/core/colors.h>
+#include <trx/core/math/geom.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/game/const.h>
@@ -574,12 +575,12 @@ void Output_CalculateStaticMeshLight(
             if (falloff_half <= 0) {
                 continue;
             }
-            const int32_t dx = pos.x - light->pos.x;
-            const int32_t dy = pos.y - light->pos.y;
-            const int32_t dz = pos.z - light->pos.z;
-
-            const uint32_t distance =
-                Math_Sqrt((uint32_t)(SQUARE(dx) + SQUARE(dy) + SQUARE(dz)));
+            const XYZ_32 delta = {
+                .x = pos.x - light->pos.x,
+                .y = pos.y - light->pos.y,
+                .z = pos.z - light->pos.z,
+            };
+            const uint32_t distance = XYZ_32_GetLength(delta);
             if ((int32_t)distance > falloff_half) {
                 continue;
             }

--- a/src/trx/game/random.c
+++ b/src/trx/game/random.c
@@ -4,8 +4,8 @@
 
 #include <time.h>
 
-static int32_t m_RandControl = 0xD371F947;
-static int32_t m_RandDraw = 0xD371F947;
+static uint32_t m_RandControl = 0xD371F947U;
+static uint32_t m_RandDraw = 0xD371F947U;
 static bool m_IsDrawFrozen = false;
 
 void Random_Seed(void)
@@ -19,19 +19,19 @@ void Random_Seed(void)
 void Random_SeedControl(int32_t seed)
 {
     LOG_DEBUG("%d", seed);
-    m_RandControl = seed;
+    m_RandControl = (uint32_t)seed;
 }
 
 int32_t Random_GetControl(void)
 {
-    m_RandControl = 0x41C64E6D * m_RandControl + 0x3039;
-    return (m_RandControl >> 10) & 0x7FFF;
+    m_RandControl = 0x41C64E6DU * m_RandControl + 0x3039U;
+    return (int32_t)((m_RandControl >> 10) & 0x7FFFU);
 }
 
 void Random_SeedDraw(int32_t seed)
 {
     LOG_DEBUG("%d", seed);
-    m_RandDraw = seed;
+    m_RandDraw = (uint32_t)seed;
 }
 
 int32_t Random_GetDraw(void)
@@ -40,19 +40,19 @@ int32_t Random_GetDraw(void)
     // as caustic initialisation) and normal game play. RNG should remain static
     // when the game output is paused e.g. inventory, pause screen etc.
     if (!m_IsDrawFrozen) {
-        m_RandDraw = 0x41C64E6D * m_RandDraw + 0x3039;
+        m_RandDraw = 0x41C64E6DU * m_RandDraw + 0x3039U;
     }
-    return (m_RandDraw >> 10) & 0x7FFF;
+    return (int32_t)((m_RandDraw >> 10) & 0x7FFFU);
 }
 
 int32_t Random_GetControlSeed(void)
 {
-    return m_RandControl;
+    return (int32_t)m_RandControl;
 }
 
 int32_t Random_GetDrawSeed(void)
 {
-    return m_RandDraw;
+    return (int32_t)m_RandDraw;
 }
 
 void Random_FreezeDraw(bool is_frozen)

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -24,7 +24,7 @@
 #define M_DEBUG 0
 
 typedef struct {
-    VECTOR *raw_args;
+    SHELL_ARGS *args;
 } M_PARSE_CTX;
 
 // Parsed frame events
@@ -342,7 +342,12 @@ static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
         return false;
     }
 
-    ctx->raw_args = Vector_Create(sizeof(const char *));
+    if (ctx->args != nullptr) {
+        Shell_FreeArgs(ctx->args);
+        ctx->args = nullptr;
+    }
+    // Build an owned argv vector for Shell_ParseArgs adoption.
+    VECTOR *raw_args = Vector_Create(sizeof(const char *));
     const char *p = line + 4;
     while (*p != '\0') {
         while (isspace((unsigned char)*p)) {
@@ -362,11 +367,12 @@ static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
         memcpy(tmp, start, len);
         tmp[len] = '\0';
         char *arg = Memory_DupStr(tmp);
-        Vector_Add(ctx->raw_args, &arg);
+        Vector_Add(raw_args, &arg);
         if (*p == '"') {
             p++;
         }
     }
+    ctx->args = Shell_ParseArgs(raw_args);
     return true;
 }
 
@@ -520,7 +526,10 @@ SHELL_ARGS *TestReplay_Open(const char *path)
     }
     Vector_Free(lines);
     LOG_INFO("Loaded %zu frames for playback", p->frames->count);
-    return Shell_ParseArgs(ctx.raw_args);
+    if (ctx.args == nullptr) {
+        ctx.args = Shell_ParseArgs(nullptr);
+    }
+    return ctx.args;
 }
 
 void TestReplay_Start(void)
@@ -540,6 +549,7 @@ void TestReplay_Start(void)
             LOG_WARNING("Unknown line: %s", ln);
         }
     }
+    Shell_FreeArgs(ctx.args);
 }
 
 void TestReplay_Close(void)

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -670,7 +670,7 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
         int32_t best_distance = INT32_MAX;
         for (int32_t i = 0; i < points->count; i++) {
             const XYZ_32 *const point = (const XYZ_32 *)Vector_Get(points, i);
-            const int32_t distance = XYZ_32_GetDistance(point, &initial_pos);
+            const int32_t distance = XYZ_32_GetDistance(*point, initial_pos);
             if (distance < best_distance) {
                 best_distance = distance;
                 x = point->x;

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -173,9 +173,9 @@ void Room_BuildOutsideTable(void)
                 const ROOM *const room = Room_Get(i);
 
                 const int32_t room_x = (room->pos.z >> WALL_SHIFT)
-                    - (m_OutsideOriginCellZ << M_OUTSIDE_TABLE_STEP_SHIFT);
+                    - (m_OutsideOriginCellZ * M_OUTSIDE_TABLE_STEP);
                 const int32_t room_y = (room->pos.x >> WALL_SHIFT)
-                    - (m_OutsideOriginCellX << M_OUTSIDE_TABLE_STEP_SHIFT);
+                    - (m_OutsideOriginCellX * M_OUTSIDE_TABLE_STEP);
 
                 bool cont = false;
                 for (int32_t ry = 0; ry < M_OUTSIDE_TABLE_STEP && !cont; ry++) {

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -241,7 +241,7 @@ void Room_PopulateSectorData(
     sector->trigger = nullptr;
     sector->ladder = LADDER_NONE;
 
-    if (start_index == null_index) {
+    if (start_index == null_index || floor_data == nullptr) {
         return;
     }
 

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -182,7 +182,7 @@ static int16_t M_GetSplitTiltType(
         }
     }
 
-    return (x_off << 8) | (z_off & 0xFF);
+    return ((uint8_t)x_off << 8) | (z_off & 0xFF);
 }
 
 static bool M_IsPortalSolid(

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -345,7 +345,6 @@ void SG_File_DumpFlipmaps(JSON_WRITE_IO *const io)
 void SG_File_DumpCameras(JSON_WRITE_IO *const io)
 {
     JSONW_PUSH_ARRAY(io);
-    JSON_ARRAY *const cameras_arr = JSON_ArrayNew();
     for (int32_t i = 0; i < Camera_GetFixedObjectCount(); i++) {
         const OBJECT_VECTOR *const object = Camera_GetFixedObject(i);
         JSONW_PUSH_VALUE(io, object->flags);

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -3,12 +3,26 @@
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
+#include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/shell/common.h>
 #include <trx/version.h>
 
 #include <stdio.h>
 #include <string.h>
+
+static void M_FreeArgVector(VECTOR *const args)
+{
+    if (args == nullptr) {
+        return;
+    }
+
+    for (int32_t i = 0; i < args->count; i++) {
+        const char *const arg = *(char **)Vector_Get(args, i);
+        Memory_Free((char *)arg);
+    }
+    Vector_Free(args);
+}
 
 static void M_ShowHelp(void)
 {
@@ -38,27 +52,27 @@ static void M_ShowHelp(void)
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 {
-    SHELL_ARGS *out_args = Memory_Alloc(sizeof(SHELL_ARGS));
-    out_args->save_to_load = -1;
-    out_args->level_to_select = -1;
-    out_args->original_args = args;
-    out_args->engine_version = 0;
+    SHELL_ARGS *const result = Memory_Alloc(sizeof(SHELL_ARGS));
+    result->save_to_load = -1;
+    result->level_to_select = -1;
+    result->original_args = args;
+    result->engine_version = 0;
 
-    // First pass: set the engine version
+    // First pass: set the engine version.
     for (int32_t i = 0; args != nullptr && i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);
         const char *const next_arg =
             i + 1 < args->count ? *(char **)Vector_Get(args, i + 1) : nullptr;
         if (!strcmp(arg, "-e") || !strcmp(arg, "--engine")) {
-            String_ParseInteger(next_arg, &out_args->engine_version);
-            CLAMP(out_args->engine_version, 1, 3);
+            String_ParseInteger(next_arg, &result->engine_version);
+            CLAMP(result->engine_version, 1, 3);
             i++;
         }
     }
 
-    out_args->mod = Shell_GetModByType(MOD_BASE_GAME, out_args->engine_version);
+    result->mod = Shell_GetModByType(MOD_BASE_GAME, result->engine_version);
 
-    // Second pass: remaining options
+    // Second pass: remaining options.
     for (int32_t i = 0; args != nullptr && i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);
         const char *const next_arg =
@@ -70,22 +84,22 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 
         if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
             M_ShowHelp();
-            Memory_FreePointer(&out_args);
+            Shell_FreeArgs(result);
             return nullptr;
         }
         if (!strcmp(arg, "-g") || !strcmp(arg, "--gold")
             || !strcmp(arg, "-gold")) {
-            out_args->mod = Shell_GetModByType(
-                MOD_EXPANSION_PACK, out_args->engine_version);
+            result->mod =
+                Shell_GetModByType(MOD_EXPANSION_PACK, result->engine_version);
         }
 
         if (!strcmp(arg, "--demo-pc") || !strcmp(arg, "-demo_pc")) {
-            out_args->mod = Shell_GetModByName("tr1-demo-pc");
+            result->mod = Shell_GetModByName("tr1-demo-pc");
         }
         if (!strcmp(arg, "--mod") && next_arg != nullptr) {
             const SHELL_MOD *const mod = Shell_GetModByName(next_arg);
             if (mod != nullptr) {
-                out_args->mod = mod;
+                result->mod = mod;
             }
             i++;
         }
@@ -94,61 +108,72 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             && next_arg != nullptr) {
             int32_t lvnum = -1;
             if (String_ParseInteger(next_arg, &lvnum)) {
-                out_args->level_to_select = lvnum;
+                result->level_to_select = lvnum;
             } else {
-                out_args->level_to_play = next_arg;
-                if (out_args->mod == nullptr && out_args->engine_version == 0) {
+                result->level_to_play = next_arg;
+                if (result->mod == nullptr && result->engine_version == 0) {
                     Shell_ExitSystem(
                         "Either --mod or --engine must be provided for "
                         "--level");
                 }
-                if (out_args->mod != nullptr) {
-                    out_args->mod = Shell_GetModByType(
-                        MOD_DIRECT_LEVEL, out_args->mod->engine_version);
+                if (result->mod != nullptr) {
+                    result->mod = Shell_GetModByType(
+                        MOD_DIRECT_LEVEL, result->mod->engine_version);
                 } else {
-                    out_args->mod = Shell_GetModByType(
-                        MOD_DIRECT_LEVEL, out_args->engine_version);
+                    result->mod = Shell_GetModByType(
+                        MOD_DIRECT_LEVEL, result->engine_version);
                 }
             }
             i++;
         }
         if ((!strcmp(arg, "-s") || !strcmp(arg, "--save"))
             && next_arg != nullptr) {
-            if (String_ParseInteger(next_arg, &out_args->save_to_load)) {
-                out_args->save_to_load--;
+            if (String_ParseInteger(next_arg, &result->save_to_load)) {
+                result->save_to_load--;
             }
             i++;
         }
         if (!strcmp(arg, "--test-record") && next_arg != nullptr) {
-            out_args->test_record_path = next_arg;
+            result->test_record_path = next_arg;
             i++;
         }
         if ((!strcmp(arg, "--test-play") || !strcmp(arg, "--test-replay"))
             && next_arg != nullptr) {
-            out_args->test_replay_path = next_arg;
+            result->test_replay_path = next_arg;
             i++;
         }
         if (!strcmp(arg, "--headless")) {
-            out_args->headless = true;
+            result->headless = true;
         }
         if (!strcmp(arg, "--headless-fps") && next_arg != nullptr) {
             int32_t fps = 0;
             if (String_ParseInteger(next_arg, &fps) && fps > 0) {
-                out_args->headless_fps = fps;
+                result->headless_fps = fps;
             }
             i++;
         }
         if (!strcmp(arg, "--debug-render-performance")) {
-            out_args->debug_render_performance = true;
+            result->debug_render_performance = true;
         }
         if (!strcmp(arg, "-q") || !strcmp(arg, "--quiet")) {
-            out_args->quiet = true;
+            result->quiet = true;
         }
     }
 
-    if (out_args->engine_version == 0 && out_args->mod != nullptr) {
-        out_args->engine_version = out_args->mod->engine_version;
+    if (result->engine_version == 0 && result->mod != nullptr) {
+        result->engine_version = result->mod->engine_version;
     }
 
-    return out_args;
+    return result;
+}
+
+void Shell_FreeArgs(SHELL_ARGS *const args)
+{
+    if (args == nullptr) {
+        return;
+    }
+
+    M_FreeArgVector(args->original_args);
+    args->original_args = nullptr;
+    Memory_Free(args);
 }

--- a/src/trx/game/shell/args.h
+++ b/src/trx/game/shell/args.h
@@ -4,6 +4,8 @@
 #include <trx/game/shell/mod.h>
 
 typedef struct {
+    // Owned argv snapshot used as backing storage for pointer-valued fields
+    // (e.g. level/replay/test paths). Freed by Shell_FreeArgs.
     VECTOR *original_args;
 
     int32_t engine_version;
@@ -19,4 +21,11 @@ typedef struct {
     bool quiet;
 } SHELL_ARGS;
 
+// Adopts `raw_args`.
+// Requirements:
+// - `raw_args` items must be `char *` allocated on heap (or nullptr).
+// - ownership of vector + strings transfers to returned SHELL_ARGS.
+// - caller must not free or mutate `raw_args` after this call.
 SHELL_ARGS *Shell_ParseArgs(VECTOR *raw_args);
+// Frees SHELL_ARGS and its adopted `original_args` vector + strings.
+void Shell_FreeArgs(SHELL_ARGS *args);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -30,6 +30,7 @@
 #include <trx/game/savegame.h>
 #include <trx/game/shell.h>
 #include <trx/game/shell/platform.h>
+#include <trx/game/shell/session.h>
 #include <trx/game/sound.h>
 #include <trx/game/stats.h>
 #include <trx/game/ui/settings.h>
@@ -39,7 +40,7 @@
 #include <SDL2/SDL.h>
 #include <stdio.h>
 
-static const SHELL_ARGS *m_ShellArgs = nullptr;
+static SHELL_SESSION *m_Session = nullptr;
 static SDL_Window *m_Window = nullptr;
 
 static void M_CreateGameWindow(void)
@@ -117,7 +118,8 @@ static void M_LoadCatalog(
 
 const SHELL_ARGS *Shell_GetArgs(void)
 {
-    return m_ShellArgs;
+    ASSERT(m_Session != nullptr);
+    return m_Session->args;
 }
 
 static void M_InitModules(void)
@@ -175,50 +177,40 @@ static void M_ShutdownModules(void)
     Log_Shutdown();
 }
 
-static SHELL_ARGS *M_CloneArgs(const SHELL_ARGS *const args)
+static void M_PrepareSystem(void)
 {
-    SHELL_ARGS *const copy = Memory_Alloc(sizeof(SHELL_ARGS));
-    *copy = *args;
-    return copy;
-}
+    SHELL_SESSION *const s = m_Session;
+    ASSERT(s != nullptr);
 
-static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
-{
-    const SHELL_ARGS *new_args = args;
-
-    if (args->test_record_path != nullptr
-        && args->test_replay_path != nullptr) {
+    if (s->args->test_record_path != nullptr
+        && s->args->test_replay_path != nullptr) {
         Shell_ExitSystem("Cannot use both --test-record and --test-replay");
     }
 
-    if (args->test_replay_path != nullptr) {
-        SHELL_ARGS *tmp_args = TestReplay_Open(args->test_replay_path);
+    if (s->args->test_replay_path != nullptr) {
+        SHELL_ARGS *const tmp_args = TestReplay_Open(s->args->test_replay_path);
         if (tmp_args != nullptr) {
-            // original args not needed, free immediately.
-            if (tmp_args->original_args != nullptr) {
-                Vector_Free(tmp_args->original_args);
-                tmp_args->original_args = nullptr;
-            }
-            tmp_args->headless = args->headless;
-            tmp_args->debug_render_performance = args->debug_render_performance;
-            new_args = tmp_args;
+            tmp_args->headless = s->args->headless;
+            tmp_args->debug_render_performance =
+                s->args->debug_render_performance;
+            ShellSession_UseArgs(s, tmp_args);
         }
-    } else if (args->headless) {
+    } else if (s->args->headless) {
         Shell_ExitSystem("--headless can only be used with --test-replay");
     }
 
-    g_TRVersion = new_args->engine_version;
-    if (new_args->engine_version <= 0 || new_args->mod == nullptr) {
+    g_TRVersion = s->args->engine_version;
+    if (s->args->engine_version <= 0 || s->args->mod == nullptr) {
         Shell_ExitSystem(
             "Unknown or ambiguous gameflow file. "
             "Are you missing --engine or --mod?");
     }
 
     LOG_INFO("Engine version: %d", g_TRVersion);
-    LOG_INFO("Mod: %s", new_args->mod->name);
+    LOG_INFO("Mod: %s", s->args->mod->name);
     Config_ApplyDefaultSettings();
 
-    TRXPath_Init(new_args);
+    TRXPath_Init(s->args);
 
     Input_Init();
     Console_Init();
@@ -238,7 +230,7 @@ static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
     Lara_Skin_LoadFromFile(
         TRXPath_Resolve(TRX_DYNAMIC_PATH_COMMON_CONFIG, "outfits.json5"));
 
-    if (args->test_replay_path != nullptr) {
+    if (s->args->test_replay_path != nullptr) {
         TestReplay_Start();
     } else {
         char *engine_config_path =
@@ -246,35 +238,28 @@ static const SHELL_ARGS *M_PrepareSystem(const SHELL_ARGS *const args)
         if (engine_config_path == nullptr) {
             Shell_ExitSystem("Failed to resolve engine config path");
         }
-        Config_Read(engine_config_path, Shell_GetGameFlowPath(args->mod));
+        Config_Read(engine_config_path, Shell_GetGameFlowPath(s->args->mod));
         Memory_FreePointer(&engine_config_path);
 
-        if (args->test_record_path != nullptr) {
-            TestRecorder_Open(args->test_record_path, args->original_args);
+        if (s->args->test_record_path != nullptr) {
+            TestRecorder_Open(
+                s->args->test_record_path, s->args->original_args);
         }
     }
     Config_SubscribeChanges(M_HandleConfigChange, nullptr);
 
     Clock_SetSimSpeed(Clock_GetSpeedMultiplier());
-    if (!new_args->headless) {
+    if (!s->args->headless) {
         Sound_Init();
         Music_Init();
         Sound_SetMasterVolume(g_Config.audio.sound_volume);
         Music_SetVolume(g_Config.audio.music_volume);
     } else {
         Clock_DisableWait();
-        const int32_t fps = new_args->headless_fps > 0 ? new_args->headless_fps
-                                                       : Clock_GetCurrentFPS();
+        const int32_t fps = s->args->headless_fps > 0 ? s->args->headless_fps
+                                                      : Clock_GetCurrentFPS();
         Clock_EnableHeadlessFixedFPS(fps);
     }
-
-    Memory_FreePointer(&m_ShellArgs);
-    if (new_args == args) {
-        m_ShellArgs = M_CloneArgs(args);
-    } else {
-        m_ShellArgs = new_args;
-    }
-    return new_args;
 }
 
 SDL_Window *Shell_GetWindow(void)
@@ -282,28 +267,32 @@ SDL_Window *Shell_GetWindow(void)
     return m_Window;
 }
 
-int32_t Shell_Main(const SHELL_ARGS *args)
+int32_t Shell_Main(const SHELL_ARGS *const args)
 {
+    ASSERT(m_Session == nullptr);
+    m_Session = ShellSession_Create();
+
+    SHELL_SESSION *const s = m_Session;
+    ShellSession_UseArgs(s, args);
+
     LOG_INFO("Game directory: %s", TRXPath_Get(TRX_PATH_TRX_DIR));
 
-    ASSERT(args != nullptr);
-
     M_InitModules();
-    args = M_PrepareSystem(args);
-    if (args->mod == nullptr) {
+    M_PrepareSystem();
+    if (s->args->mod == nullptr) {
         Shell_ExitSystem("No --mod specified.");
         return 1;
     }
-    TRXPath_Init(args);
+    TRXPath_Init(s->args);
     M_CreateGameWindow();
     M_CreateGLContext();
     Output_Init();
-    if (!args->headless) {
+    if (!s->args->headless) {
         M_ShowWindow();
     }
 
     GF_Init();
-    GF_LoadFromFile(Shell_GetGameFlowPath(args->mod));
+    GF_LoadFromFile(Shell_GetGameFlowPath(s->args->mod));
 
     GameStringManager_ClearSourceFiles();
     const char *const common_strings_path = Shell_GetCommonStringsPath();
@@ -311,19 +300,19 @@ int32_t Shell_Main(const SHELL_ARGS *args)
         Shell_ExitSystem("Missing common strings file");
     }
     GameStringManager_AddSourceFile(common_strings_path, false);
-    if (args->mod->base_mod != nullptr) {
+    if (s->args->mod->base_mod != nullptr) {
         const char *const base_strings_path =
-            Shell_GetBaseGameStringsPath(args->mod);
+            Shell_GetBaseGameStringsPath(s->args->mod);
         if (base_strings_path == nullptr) {
             Shell_ExitSystemFmt(
-                "Missing base mod strings file for '%s'", args->mod->name);
+                "Missing base mod strings file for '%s'", s->args->mod->name);
         }
         GameStringManager_AddSourceFile(base_strings_path, false);
     }
-    const char *const mod_strings_path = Shell_GetGameStringsPath(args->mod);
+    const char *const mod_strings_path = Shell_GetGameStringsPath(s->args->mod);
     if (mod_strings_path == nullptr) {
         Shell_ExitSystemFmt(
-            "Missing strings file for selected mod '%s'", args->mod->name);
+            "Missing strings file for selected mod '%s'", s->args->mod->name);
     }
     GameStringManager_AddSourceFile(mod_strings_path, true);
     GameStringManager_DiscoverLanguages();
@@ -405,7 +394,7 @@ int32_t Shell_Main(const SHELL_ARGS *args)
             break;
 
         case GF_EXIT_TO_TITLE:
-            if (args->level_to_play != nullptr) {
+            if (s->args->level_to_play != nullptr) {
                 gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
             } else if (g_GameFlow.title_level == nullptr) {
                 Shell_ExitSystem("Missing title level");
@@ -425,7 +414,7 @@ int32_t Shell_Main(const SHELL_ARGS *args)
         }
     }
 
-    if (args->level_to_play != nullptr) {
+    if (s->args->level_to_play != nullptr) {
         Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
     }
     return 0;
@@ -434,5 +423,8 @@ int32_t Shell_Main(const SHELL_ARGS *args)
 void Shell_Shutdown(void)
 {
     M_ShutdownModules();
-    Memory_FreePointer(&m_ShellArgs);
+    if (m_Session != nullptr) {
+        ShellSession_Free(m_Session);
+        m_Session = nullptr;
+    }
 }

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -12,16 +12,17 @@ int main(int argc, char *argv[])
 {
     VECTOR *raw_args = Vector_Create(sizeof(const char *));
     for (int32_t i = 1; i < argc; i++) {
-        Vector_Add(raw_args, &argv[i]);
+        char *const copied_arg = Memory_DupStr(argv[i]);
+        Vector_Add(raw_args, &copied_arg);
     }
 
     TRXPath_Init(nullptr);
     Shell_ScanAvailableMods();
     SHELL_ARGS *args = Shell_ParseArgs(raw_args);
     if (args == nullptr) {
-        Vector_Free(raw_args);
         return 0;
     }
+
     TRXPath_Init(args);
 
     char *log_path = String_Format("%s/TRX.log", TRXPath_Get(TRX_PATH_TRX_DIR));
@@ -29,9 +30,8 @@ int main(int argc, char *argv[])
     Memory_FreePointer(&log_path);
 
     LOG_INFO("Starting %s", g_TRXVersion);
-    int32_t exit_code = Shell_Main(args);
-    Memory_FreePointer(&args);
-    Vector_Free(raw_args);
+    const int32_t exit_code = Shell_Main(args);
+
     Shell_Terminate(exit_code);
     return exit_code;
 }

--- a/src/trx/game/shell/session.c
+++ b/src/trx/game/shell/session.c
@@ -1,0 +1,27 @@
+#include <trx/game/shell/session.h>
+
+#include <trx/core/memory.h>
+
+SHELL_SESSION *ShellSession_Create(void)
+{
+    return Memory_Alloc(sizeof(SHELL_SESSION));
+}
+
+void ShellSession_Free(SHELL_SESSION *const session)
+{
+    if (session != nullptr) {
+        if (session->args != nullptr) {
+            Shell_FreeArgs((SHELL_ARGS *)session->args);
+        }
+        Memory_Free(session);
+    }
+}
+
+void ShellSession_UseArgs(
+    SHELL_SESSION *const session, const SHELL_ARGS *const args)
+{
+    if (session->args != nullptr) {
+        Shell_FreeArgs((SHELL_ARGS *)session->args);
+    }
+    session->args = args;
+}

--- a/src/trx/game/shell/session.h
+++ b/src/trx/game/shell/session.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <trx/game/shell/args.h>
+
+typedef struct {
+    const SHELL_ARGS *args;
+} SHELL_SESSION;
+
+SHELL_SESSION *ShellSession_Create(void);
+// Frees session and currently attached args (if any).
+void ShellSession_Free(SHELL_SESSION *session);
+
+// Replaces session args ownership.
+// The session takes ownership of `args` and frees previously attached args.
+void ShellSession_UseArgs(SHELL_SESSION *session, const SHELL_ARGS *args);

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -139,7 +139,7 @@ static int32_t M_GetPitch(const SAMPLE_INFO *const sample, const uint32_t flags)
 {
     int32_t pitch = (flags & SPM_PITCH) != 0 ? (flags >> 8) & 0xFFFFFF
                                              : SOUND_DEFAULT_PITCH;
-    pitch += sample->pitch << 9;
+    pitch += sample->pitch * (1 << 9);
     if (!g_Config.audio.enable_pitched_sounds) {
         return pitch;
     }

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -230,7 +230,7 @@ static void M_UpdateWind(void)
 
     // Original TR3 uses a 0..4095 angle space; keep the calculations faithful.
     m_TR3DWindAngle =
-        (m_TR3DWindAngle + (((Random_GetControl() & 0x3F) - 32) << 1)) & 0x1FFE;
+        (m_TR3DWindAngle + (((Random_GetControl() & 0x3F) - 32) * 2)) & 0x1FFE;
 
     if (m_TR3DWindAngle < 1024) { // DEG_90
         m_TR3DWindAngle += (1024 - m_TR3DWindAngle) << 1;
@@ -357,7 +357,7 @@ void Sparks_Control(void)
         // Physics
         spark->vel.y += spark->gravity;
         if (spark->max_y_vel != 0) {
-            const int32_t limit = (int32_t)spark->max_y_vel << 5;
+            const int32_t limit = (int32_t)spark->max_y_vel * (1 << 5);
             if ((spark->vel.y < 0 && spark->vel.y < limit)
                 || (spark->vel.y > 0 && spark->vel.y > limit)) {
                 spark->vel.y = limit;

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -178,9 +178,7 @@ void Stats_AddDistanceTravelled(const XYZ_32 pos, const XYZ_32 last_pos)
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     if (level != nullptr) {
         RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.distance_travelled += Math_Sqrt(
-            SQUARE(pos.z - last_pos.z) + SQUARE(pos.y - last_pos.y)
-            + SQUARE(pos.x - last_pos.x));
+        resume->stats.distance_travelled += XYZ_32_GetDistance(&pos, &last_pos);
     }
 }
 

--- a/src/trx/game/stats/common.c
+++ b/src/trx/game/stats/common.c
@@ -178,7 +178,7 @@ void Stats_AddDistanceTravelled(const XYZ_32 pos, const XYZ_32 last_pos)
     const GF_LEVEL *const level = Game_GetCurrentLevel();
     if (level != nullptr) {
         RESUME_INFO *const resume = Savegame_GetCurrentInfo(level);
-        resume->stats.distance_travelled += XYZ_32_GetDistance(&pos, &last_pos);
+        resume->stats.distance_travelled += XYZ_32_GetDistance(pos, last_pos);
     }
 }
 

--- a/tools/shared/docker/game_entrypoint.py
+++ b/tools/shared/docker/game_entrypoint.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import shutil
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from subprocess import check_call, run
 from typing import Any, Self
@@ -82,6 +82,7 @@ class PackageOptions(BaseOptions):
 @dataclass
 class BuildOptions(BaseOptions):
     target: str
+    meson_args: list[str] = field(default_factory=list)
 
     strip_tool = "strip"
     upx_tool = "upx"
@@ -135,6 +136,12 @@ class BuildCommand(BaseCommand):
             choices=["debug", "release", "debugoptim"],
             required=True,
         )
+        parser.add_argument(
+            "--meson-arg",
+            dest="meson_args",
+            action="append",
+            default=[],
+        )
 
     def run(self, args: argparse.Namespace) -> None:
         options = BuildOptions.from_args(args)
@@ -147,13 +154,13 @@ class BuildCommand(BaseCommand):
                 "--buildtype",
                 options.target,
                 *options.build_args,
+                *options.meson_args,
                 options.build_root,
                 options.build_target,
             ]
             if pkg_config_path:
                 command.extend(["--pkg-config-path", pkg_config_path])
             check_call(command)
-
         check_call(["meson", "compile", f"TRX"], cwd=options.build_root)
 
         if options.target == "release":


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR focuses on sanitizer-driven stability fixes. The main goal is to eliminate UB/memory hazards found by ASan/UBSan and Valgrind.

It includes fixes for:
- memory leaks and ownership issues in shell/savegame paths,
- unaligned access in BSON/JSON/game-flow buffers,
- multiple signed-overflow and left-shift UB sites in gameplay/output logic (by no means exhaustive),
- improved AV error handling around channel layout and EOF reporting,
- safety checks for data-driven edge cases (bad anim/bone reads, zero-sized edits, empty virtual reads).