### PR TITLE
objects/tony: fix savegame load death frame

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - fixed loading screens showing before playing FMVs in Antarctica
 - fixed end credits referencing non-existing image file
 - fixed Puna to no longer hardcode Lizard locations, and instead use relative offsets
+- fixed Tony briefly appearing for a single frame when loading a save after his death
 - removed the limitation of one Carcass instance per level working with Piranhas
 - removed the limitation of Piranhas only attacking Carcass instances if the level sequence matches Crash Site's
 

--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -586,13 +586,15 @@ static void M_DrawShield(const ITEM *const item)
 static bool M_Draw(const ITEM *const item)
 {
     M_PRIV *const p = item->priv;
-    const bool result = Object_DrawAnimatingItem(item);
+    if ((item->hit_points <= 0 && p->explode_count > 64)) {
+        return false;
+    }
 
+    const bool result = Object_DrawAnimatingItem(item);
     if (p->explode_count != 0) {
         if (item->hit_points <= 0) {
             FX_ExplosionRing_Draw();
         }
-
         if (p->explode_count != 0 && p->explode_count <= 64) {
             M_DrawShield(item);
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Tony appearing for a single frame when the player loads a save with him dead.