### PR TITLE
objects/lizard: skip lizard summons in kill stats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,7 @@
 - fixed loading screens showing before playing FMVs in Antarctica
 - fixed end credits referencing non-existing image file
 - fixed Puna to no longer hardcode Lizard locations, and instead use relative offsets
+- fixed Puna's summoned Lizards counting towards total level kill count
 - fixed Tony briefly appearing for a single frame when loading a save after his death
 - removed the limitation of one Carcass instance per level working with Piranhas
 - removed the limitation of Piranhas only attacking Carcass instances if the level sequence matches Crash Site's

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -431,8 +431,7 @@ void Gun_HitTarget(
     LARA_INFO *const lara = Lara_GetLaraInfo();
     if ((item->hit_points == DONT_TARGET && Creature_IsDestructible(item))
         || (item->hit_points > 0 && item->hit_points <= damage)) {
-        const bool skip_stats = item->object_id == O_DRAGON_FRONT;
-        if (!skip_stats) {
+        if (item->include_in_kill_stats) {
             Stats_AddKill();
         }
         if (g_Config.gameplay.target_mode == TLM_SEMI) {

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -230,6 +230,7 @@ void Item_Initialise(const int16_t item_num)
     item->looked_at = false;
     item->enable_interpolation = true;
     item->enable_shadow = true;
+    item->include_in_kill_stats = true;
 
     item->clear_body = false;
     if ((item->flags & IF_KILLED) != 0) {

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -67,6 +67,7 @@ typedef struct {
     bool looked_at;
     bool dynamic_light;
     bool clear_body;
+    bool include_in_kill_stats;
 
     struct {
         struct {

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -96,6 +96,12 @@ static bool M_CanDropItemsBack(const ITEM *const item)
     return item->hit_points <= 0 && item->status == IS_DEACTIVATED;
 }
 
+static void M_InitialiseFront(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    item->include_in_kill_stats = false;
+}
+
 static void M_InitialiseBack(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -463,6 +469,7 @@ static void M_SetupFront(OBJECT *const obj)
 
     SOFT_ASSERT(
         Object_Get(O_DRAGON_BACK)->loaded, "Dragon back object missing");
+    obj->initialise_func = M_InitialiseFront;
     obj->handle_save_func = M_HandleSaveFront;
     obj->control_func = M_ControlFront;
     obj->collision_func = M_Collision;

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -49,10 +49,12 @@ typedef struct {
 typedef struct {
     bool lizard_active;
 } M_SHARED_PRIV;
+
 typedef struct {
     XYZ_32 pos;
     uint16_t y_rot;
 } M_LIZARD_SUMMON_COORDS;
+
 typedef struct {
     uint8_t dead;
     int16_t attack_count;
@@ -306,6 +308,7 @@ static void M_TriggerLizard(M_PRIV *const p)
     item->status = IS_ACTIVE;
     item->collidable = 1;
     item->flags &= ~(IF_KILLED | IF_ONE_SHOT);
+    item->include_in_kill_stats = false;
 
     // Item_Kill removes it from room item chains; reinsert even when room is
     // unchanged.

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -712,7 +712,9 @@ static void M_SkidooBaddieCollision(ITEM *const quad)
                 }
                 if (item->hit_points > 0) {
                     item->hit_points = 0;
-                    Stats_AddKill();
+                    if (item->include_in_kill_stats) {
+                        Stats_AddKill();
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lizards that are summoned by Puna to no longer contribute towards level kill count statistics. This OG bug allowed the player to stack the kills endlessly rendering this metric pointless.