### PR TITLE
carrier: fix saves made mid-enemy death

### DIFF
--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -24,6 +24,15 @@ static const GAME_OBJECT_PAIR m_LegacyMap[] = {
     { NO_OBJECT, NO_OBJECT },
 };
 
+static OBJECT_ID M_ConvertDroppedGun(const OBJECT_ID obj_id)
+{
+    if (g_GameFlow.convert_dropped_guns && Object_IsType(obj_id, g_GunObjects)
+        && Inv_RequestItem(obj_id) && obj_id != O_PISTOL_ITEM) {
+        return Object_GetCognate(obj_id, g_GunAmmoObjectMap);
+    }
+    return obj_id;
+}
+
 static ITEM *M_GetCarrier(const int16_t item_num)
 {
     if (item_num < 0 || item_num >= Item_GetLevelCount()) {
@@ -48,6 +57,28 @@ static ITEM *M_GetCarrier(const int16_t item_num)
     }
 
     return item;
+}
+
+static ITEM *M_EnsureCarriedPickupItem(
+    const ITEM *const carrier, CARRIED_ITEM *const carried_item)
+{
+    if (carried_item->spawn_num == NO_ITEM) {
+        return nullptr;
+    }
+
+    if (carried_item->spawn_num < Item_GetTotalCount()) {
+        return Item_Get(carried_item->spawn_num);
+    }
+
+    // Gameflow drops can reference runtime-spawned pickup indices that do not
+    // exist yet after a fresh level load. Re-spawn and rebind the index.
+    const int16_t spawn_num = Item_Spawn(carrier, carried_item->object_id);
+    if (spawn_num == NO_ITEM) {
+        carried_item->spawn_num = NO_ITEM;
+        return nullptr;
+    }
+    carried_item->spawn_num = spawn_num;
+    return Item_Get(carried_item->spawn_num);
 }
 
 static bool M_IsCarrierType(const OBJECT_ID obj_id)
@@ -277,16 +308,50 @@ bool Carrier_IsItemCarried(const int16_t item_num)
 
 DROP_STATUS Carrier_GetSaveStatus(const CARRIED_ITEM *item)
 {
-    // This allows us to save drops as still being carried to allow accurate
-    // placement again in Carrier_TestItemDrops on load.
     if (item->status == DS_DROPPED) {
         const ITEM *const pickup = Item_Get(item->spawn_num);
-        return pickup->status == IS_INVISIBLE ? DS_COLLECTED : DS_CARRIED;
-    } else if (item->status == DS_FALLING) {
-        return DS_CARRIED;
+        return pickup->status == IS_INVISIBLE ? DS_COLLECTED : DS_DROPPED;
+    }
+    return item->status;
+}
+
+void Carrier_SyncItem(
+    const int16_t carrier_item_num, CARRIED_ITEM *const carried_item)
+{
+    const ITEM *const carrier = Item_Get(carrier_item_num);
+    ITEM *const pickup_item = M_EnsureCarriedPickupItem(carrier, carried_item);
+    if (pickup_item == nullptr) {
+        return;
     }
 
-    return item->status;
+    switch (carried_item->status) {
+    case DS_CARRIED:
+        if (pickup_item->room_num != NO_ROOM) {
+            Item_UpdateRoom(carried_item->spawn_num, NO_ROOM);
+        }
+        break;
+
+    case DS_FALLING:
+    case DS_DROPPED:
+        pickup_item->pos = carried_item->pos;
+        pickup_item->rot.y = carried_item->rot.y;
+        pickup_item->fall_speed = carried_item->fall_speed;
+        if (carried_item->status == DS_DROPPED) {
+            pickup_item->status = IS_INACTIVE;
+        } else {
+            m_AnimatingCount++;
+        }
+        pickup_item->object_id = M_ConvertDroppedGun(pickup_item->object_id);
+        Item_UpdateRoom(carried_item->spawn_num, carried_item->room_num);
+        break;
+
+    case DS_COLLECTED:
+        if (pickup_item->room_num != NO_ROOM) {
+            Item_UpdateRoom(carried_item->spawn_num, NO_ROOM);
+        }
+        pickup_item->status = IS_INVISIBLE;
+        break;
+    }
 }
 
 void Carrier_TestItemDrops(const int16_t item_num)
@@ -305,15 +370,9 @@ void Carrier_TestItemDrops(const int16_t item_num)
             continue;
         }
 
-        OBJECT_ID obj_id = item->object_id;
-        if (g_GameFlow.convert_dropped_guns
-            && Object_IsType(obj_id, g_GunObjects) && Inv_RequestItem(obj_id)
-            && obj_id != O_PISTOL_ITEM) {
-            obj_id = Object_GetCognate(obj_id, g_GunAmmoObjectMap);
-        }
-
         if (item->spawn_num == NO_ITEM) {
             // This is a gameflow-defined drop, so a spawn number is required.
+            const OBJECT_ID obj_id = M_ConvertDroppedGun(item->object_id);
             item->spawn_num = Item_Spawn(carrier, obj_id);
         } else {
             // TR2-style item drops will already have a spawn number.
@@ -346,35 +405,6 @@ void Carrier_TestItemDrops(const int16_t item_num)
         }
 
     } while ((item = item->next_item) != nullptr);
-}
-
-void Carrier_TestLegacyDrops(const int16_t item_num)
-{
-    const ITEM *const carrier = Item_Get(item_num);
-    if (carrier->hit_points > 0) {
-        return;
-    }
-
-    // Handle cases where legacy saves have been loaded. Ensure that
-    // the OG enemy will still spawn items if Lara hasn't yet collected
-    // them by using a test cognate in each case. Ensure also that
-    // collected items do not re-spawn now or in future saves.
-    const OBJECT_ID test_id =
-        Object_GetCognate(carrier->object_id, m_LegacyMap);
-    if (test_id == NO_OBJECT) {
-        return;
-    }
-
-    if (!Inv_RequestItem(test_id)) {
-        Carrier_TestItemDrops(item_num);
-    } else {
-        CARRIED_ITEM *item = carrier->carried_item;
-        while (item != nullptr) {
-            // Simulate Lara having picked up the item.
-            item->status = DS_COLLECTED;
-            item = item->next_item;
-        }
-    }
 }
 
 void Carrier_AnimateDrops(void)

--- a/src/trx/game/items/carrier.h
+++ b/src/trx/game/items/carrier.h
@@ -7,6 +7,8 @@ void Carrier_InitialiseLevel(const GF_LEVEL *level);
 int32_t Carrier_GetItemCount(int16_t item_num);
 bool Carrier_IsItemCarried(int16_t item_num);
 void Carrier_TestItemDrops(int16_t item_num);
-void Carrier_TestLegacyDrops(int16_t item_num);
+
+void Carrier_SyncItem(int16_t item_num, CARRIED_ITEM *carried_item);
 DROP_STATUS Carrier_GetSaveStatus(const CARRIED_ITEM *item);
+
 void Carrier_AnimateDrops(void);

--- a/src/trx/game/savegame/enum.h
+++ b/src/trx/game/savegame/enum.h
@@ -22,6 +22,9 @@ typedef enum {
     // Music save format switched to stream list with play modes.
     SG_VERSION_16 = 16,
 
+    // Carried-item drops are persisted with truthful statuses/positions.
+    SG_VERSION_17 = 17,
+
     SG_MIN_SUPPORTED_VERSION = SG_VERSION_13,
-    SG_CURRENT_VERSION = SG_VERSION_16,
+    SG_CURRENT_VERSION = SG_VERSION_17,
 } SAVEGAME_VERSION;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -430,9 +430,10 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t item_num)
                 } else {
                     item->carried_item = carried_item;
                 }
-                // Introduced in TRX 1.2
-                M_SHOULD(JSON_READ(io, "spawn_num", &carried_item->spawn_num));
             }
+            // Introduced in TRX 1.2. Must be read for both newly allocated and
+            // pre-existing carried entries (e.g. gameflow-defined drops).
+            M_SHOULD(JSON_READ(io, "spawn_num", &carried_item->spawn_num));
 
             M_MUST(M_ReadObjectID(io, "object_id", &carried_item->object_id));
             M_MUST(JSON_READ(io, "pos", &carried_item->pos));
@@ -441,20 +442,16 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t item_num)
             M_MUST(JSON_READ(io, "fall_speed", &carried_item->fall_speed));
             M_MUST(JSON_READ(io, "status", &carried_item->status));
 
-            if (carried_item->status == DS_CARRIED
-                && carried_item->spawn_num != NO_ITEM) {
-                ITEM *const pickup_item = Item_Get(carried_item->spawn_num);
-                if (pickup_item != nullptr
-                    && pickup_item->room_num != NO_ROOM) {
-                    Item_UpdateRoom(carried_item->spawn_num, NO_ROOM);
-                }
-            }
+            Carrier_SyncItem(item_num, carried_item);
 
             prev_item = carried_item;
             carried_item = carried_item->next_item;
             M_MUST(JSON_POP(io));
         }
-        Carrier_TestItemDrops(item_num);
+        // TODO: remove legacy branch in TRX 1.5.
+        if (JSON_ReadIO_GetVersion(io) < SG_VERSION_17) {
+            Carrier_TestItemDrops(item_num);
+        }
         M_MUST(JSON_POP(io));
     }
 

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -126,14 +126,31 @@ static void M_WriteItem(
     JSONW_PUSH_ARRAY(io);
     const CARRIED_ITEM *drop_item = item->carried_item;
     while (drop_item != nullptr) {
+        XYZ_32 drop_pos = drop_item->pos;
+        int16_t drop_rot_y = drop_item->rot.y;
+        int16_t drop_room_num = drop_item->room_num;
+        int16_t drop_fall_speed = drop_item->fall_speed;
+        const DROP_STATUS save_status = Carrier_GetSaveStatus(drop_item);
+
+        if ((save_status == DS_FALLING || save_status == DS_DROPPED)
+            && drop_item->spawn_num != NO_ITEM) {
+            const ITEM *const pickup = Item_Get(drop_item->spawn_num);
+            if (pickup != nullptr) {
+                drop_pos = pickup->pos;
+                drop_rot_y = pickup->rot.y;
+                drop_room_num = pickup->room_num;
+                drop_fall_speed = pickup->fall_speed;
+            }
+        }
+
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "object_id", Object_ToGameID(drop_item->object_id));
-        M_WriteXYZ32(io, "pos", drop_item->pos);
-        JSONW_WRITE(io, "y_rot", drop_item->rot.y);
-        JSONW_WRITE(io, "room_num", drop_item->room_num);
-        JSONW_WRITE(io, "fall_speed", drop_item->fall_speed);
+        M_WriteXYZ32(io, "pos", drop_pos);
+        JSONW_WRITE(io, "y_rot", drop_rot_y);
+        JSONW_WRITE(io, "room_num", drop_room_num);
+        JSONW_WRITE(io, "fall_speed", drop_fall_speed);
         JSONW_WRITE(io, "spawn_num", drop_item->spawn_num);
-        JSONW_WRITE(io, "status", (int32_t)Carrier_GetSaveStatus(drop_item));
+        JSONW_WRITE(io, "status", (int32_t)save_status);
         JSONW_POP_AND_APPEND(io);
         drop_item = drop_item->next_item;
     }

--- a/tools/inspect_save
+++ b/tools/inspect_save
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import sys
 import json
 import struct
 import zlib
@@ -25,10 +26,10 @@ def main() -> None:
         flags, counter, level_num, title_size = struct.unpack("I" * 4, handle.read(16))
         title = handle.read(title_size)
         print(json.dumps(data, indent=4))
-        print("flags:", flags)
-        print("counter:", counter)
-        print("level_num:", level_num)
-        print("title:", title)
+        print("flags:", flags, file=sys.stderr)
+        print("counter:", counter, file=sys.stderr)
+        print("level_num:", level_num, file=sys.stderr)
+        print("title:", title, file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes carried-item very nasty save/load desyncs when saving during or after enemy death, with special focus on TR1 gameflow-style drops (enable_tr2_item_drops=false).

New saves now persist truthful drop state and placement, and load uses the carried-item state as the authority for restoring spawned pickups.
This prevents drops (like Pierre’s Uzi clips) from reappearing at origin/spawn locations after reload in the test-item-drops level.

Legacy save compatibility is preserved: pre-SG_VERSION_17 behavior still goes through the old restore flow so existing saves continue to load correctly.

I don't like this implementation. It's very manual, has edge cases (TR1 pickups), and it duplicates the syncs between `SyncItem`, `TestItemDrops`, and SG writer, but at least it's boring and no longer magic.
I'd love to see alternative that reduces the busywork, though.

#### Implementation details

- Added SG_VERSION_17 to mark the truthful carried-drop persistence format.
- Save path now writes live pickup transform/room/fall-speed for `DS_FALLING` and `DS_DROPPED`, plus truthful status via `Carrier_GetSaveStatus`.
- Load path reads `spawn_num` for both pre-existing and newly allocated carried entries, then syncs each entry through `Carrier_SyncItem`.
- Introduced a shared sync path in carrier code, including re-materializing missing spawned pickup items when a carried entry references a runtime spawn index that does not exist yet after fresh load.
- Kept a legacy load branch for `< SG_VERSION_17` with TODO markers to remove in TRX 1.5.

#### Testing

TR1 recording: [test-tr1-carriers.txt](https://github.com/user-attachments/files/25402769/test-tr1-carriers.txt)
- save 1: before triggering Pierre
- save 2: after triggering Pierre
- save 3: during Pierre's death animation, before drops
- save 4: after Pierre's death animation, after drops
- save 5: after collecting the drops

TR2 recording: [test-tr2-carriers.txt](https://github.com/user-attachments/files/25402771/test-tr2-carriers.txt)
- save 1: before triggering Masked Goon
- save 2: after triggering Masked Goon
- save 3: during Masked Goon's death animation, before drops
- save 4: after Masked Goon's death animation, after drops
- save 5: after collecting the key

Scenarios:

- [x] Run the attached scenario files on this PR
  Expected outcome: killing the enemy in the recording always respawns the right items, except for save 5, where the drops got collected
- [x] Run the attached scenario files on TRX 1.1 and load saves 1-5 (TR1) or 1-4 (TR2) on this PR
  Expected outcome: killing the enemy manually in each save always respawns the right items, except for save 5, where the drops got collected
- [ ] Saving/reloading for falling pickups (underwater pickups) ⚠️ I haven't tested this path at all
  Expected outcome: submersed pickups continue descend after reload, landed pickups are still collectible
- [x] Convert guns gameflow option
  Expected outcome: guns get converted to ammo when Lara has the given weapon, and this persists across reloads
