### PR TITLE
lara/hang: fix swing-in on 1-click ledges

### DIFF
--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -41,6 +41,16 @@ EDGE_CATCH Lara_Col_TestEdgeCatch(
 
 bool Lara_Col_TestHangSwingIn(const ITEM *const item, const int16_t angle)
 {
+    // Tests whether a forward hang grab should transition into thin-ledge
+    // swing ("swinging inwards"). The probe samples one click ahead in the
+    // hang direction and requires:
+    // - valid floor at probe point;
+    // - probe floor above Lara;
+    // - enough overhead clearance for swing-in.
+    // The extra clearance guard follows TR3-5 logic: `y - ceiling - 819 > -72`
+    // but uses a relaxed threshold to preserve the animation on certain slope
+    // edge cases.
+
     XYZ_32 pos = item->pos;
     int16_t room_num = item->room_num;
     switch (angle) {
@@ -61,7 +71,11 @@ bool Lara_Col_TestHangSwingIn(const ITEM *const item, const int16_t angle)
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     int32_t height = Room_GetHeight(sector, pos);
     int32_t ceiling = Room_GetCeiling(sector, pos);
-    return height != NO_HEIGHT && height - pos.y > 0 && ceiling - pos.y < -400;
+    const bool has_height = height != NO_HEIGHT;
+    const int32_t height_delta = height - pos.y;
+    const int32_t ceiling_delta = ceiling - pos.y;
+    return has_height && height_delta > 0 && ceiling_delta < -400
+        && pos.y - ceiling - 819 > -110;
 }
 
 static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adjusts the conditions for Lara's swing-in animation further, to prevent the animation from occurring on more invalid cases.

#### Testing

- [x] Check this out: [test-swing-in.txt](https://github.com/user-attachments/files/25413392/test-swing-in.txt)
- [x] Test more edge cases (pun intended)