### PR TITLE
Lua goodies

### DIFF
--- a/data/scripting/catalog.lua
+++ b/data/scripting/catalog.lua
@@ -3,6 +3,10 @@ local raw = trxc.catalog
 local catalog = {
   objects = raw.objects,
   flip_effects = raw.flip_effects,
+  lara_states = raw.lara_states,
+  lara_anims = raw.lara_anims,
+  music = raw.music,
+  samples = raw.samples,
 }
 
 trx.catalog = catalog

--- a/data/scripting/items.lua
+++ b/data/scripting/items.lua
@@ -55,6 +55,64 @@ function fn.get(arg)
   return setmetatable({ idx = idx }, Item)
 end
 
+local find_query_keys = {
+  object_id = true,
+  room_num = true,
+}
+
+local function validate_find_query(query, fn_name)
+  if type(query) ~= "table" then
+    error("trx.items." .. fn_name .. " query must be a table", 2)
+  end
+
+  for key, _ in pairs(query) do
+    if not find_query_keys[key] then
+      trx.log.warn("trx.items." .. fn_name .. ": unknown property '" .. tostring(key) .. "'")
+    end
+  end
+end
+
+local function is_matching(item, query)
+  if query.object_id ~= nil and item.object_id ~= query.object_id then
+    return false
+  end
+  if query.room_num ~= nil and item.room_num ~= query.room_num then
+    return false
+  end
+  return true
+end
+
+local function find_items(query, first_only)
+  local matches = first_only and nil or {}
+  local count = raw.count()
+  for i = 0, count - 1 do
+    local item = setmetatable({ idx = i }, Item)
+    if is_matching(item, query) then
+      if first_only then
+        return item
+      end
+      table.insert(matches, item)
+    end
+  end
+  return first_only and nil or matches
+end
+
+function fn.find(query)
+  if query == nil then
+    return {}
+  end
+  validate_find_query(query, "find")
+  return find_items(query, false)
+end
+
+function fn.first(query)
+  if query == nil then
+    return nil
+  end
+  validate_find_query(query, "first")
+  return find_items(query, true)
+end
+
 -- items metatable - metamethods
 trx.items = setmetatable({}, {
   Item = Item,
@@ -64,6 +122,10 @@ trx.items = setmetatable({}, {
   __index = function(_, key)
     if key == "fn" then
       return fn
+    elseif key == "find" then
+      return fn.find
+    elseif key == "first" then
+      return fn.first
     elseif type(key) == "number" or type(key) == "string" then
       return fn.get(key)
     end

--- a/docs/06-lua/2-reference/4-ITEMS.md
+++ b/docs/06-lua/2-reference/4-ITEMS.md
@@ -58,3 +58,37 @@ Module for controlling all moveables behavior.
   local item_hp = trx.items.fn.get(17).hit_points
   local lara_hp = trx.items.fn.get("lara").hit_points
   ```
+
+- [lua]`trx.items.find(query)`  
+  Finds all items matching the query and returns a list of [lua]`trx.items.Item`.
+
+  Supported query fields:
+  - `object_id`
+  - `room_num`
+
+  Unknown query fields are ignored and logged as warnings.
+
+  Example:
+  ```lua
+  local wolves = trx.items.find({ object_id = trx.catalog.objects.wolf })
+  local wolves_in_room_7 = trx.items.find({
+    object_id = trx.catalog.objects.wolf,
+    room_num = 7,
+  })
+  ```
+
+- [lua]`trx.items.first(query)`  
+  Finds the first item matching the query and returns a [lua]`trx.items.Item`, or `nil` if none match.
+
+  Supported query fields:
+  - `object_id`
+  - `room_num`
+
+  Unknown query fields are ignored and logged as warnings.
+
+  Example:
+  ```lua
+  local first_natla = trx.items.first({
+    object_id = trx.catalog.objects.natla,
+  })
+  ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed very distant Boulders causing camera shake (similar to the Tihocan crocodile targeting bug)
 - fixed drawing debug triggers using wrong orientation in some triangular geometry
 - fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
+- fixed Lua `trx.catalog` only exposing `objects` and `flip_effects`; it now also exposes `lara_states`, `lara_anims`, `music`, and `samples`
 
 **TR2**:
 - fixed flickering switches and spike ceilings in Temple of Xian and Floating Islands (#4874)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added `O_SMASH_OBJECT_3`, which can only be broken with triggers or the Crash Site gun
 - added `O_SMASH_OBJECT_4`, which behaves like `O_SMASH_OBJECT_1` but uses `SFX_SHUTTERS_BREAK`
 - added `O_TREX_ALPHA`, which can target raptors and be distracted by flares
+- added new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
 - added support for using more sound slots than originally possible in custom levels (#3898)
 - changed `O_WINDOW_1` and `O_WINDOW_2` to `O_SMASH_OBJECT_1` and `O_SMASH_OBJECT_2` respectively
 - changed Earthquake to support being reset


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

To support https://github.com/LostArtefacts/TRX/pull/4929 and allow for easier assertions, this PR adds `trx.items.find` and `trx.items.first`:

- `trx.items.find(query)`  
  Finds all items matching the query and returns a list of `trx.items.Item`.
  Example:
  ```lua
  local wolves = trx.items.find({ object_id = trx.catalog.objects.wolf })
  local wolves_in_room_7 = trx.items.find({
    object_id = trx.catalog.objects.wolf,
    room_num = 7,
  })
  ```

- `trx.items.first(query)`  
  Finds the first item matching the query and returns a `trx.items.Item`, or `nil` if none match.
  Example:
  ```lua
  local first_natla = trx.items.first({
    object_id = trx.catalog.objects.natla,
  })
  ```

Supported query fields:
- `object_id`
- `room_num`

Unknown query fields are ignored and logged as warnings.
Also, fixes catalogs that were supposedly added in 1.2 not getting exposed in the outer `trx.catalog` module.