### PR TITLE
objects/raptor: add TR3 raptor control

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,9 @@
 - fixed drawing debug triggers using wrong orientation in some triangular geometry
 - fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
 
+**TR1**:
+- fixed a very rare case of raptors using an incorrect death animation
+
 **TR2**:
 - fixed flickering switches and spike ceilings in Temple of Xian and Floating Islands (#4874)
 - fixed Airlock door handles not getting drawn from certain angles (#4886, regression from 1.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - added Crocodile control
 - added Carcass control (hanging Raptor)
 - added T-Rex control
+- added Raptor control
 - added Raptor Emitter control
 - added Bat Emitter control with save/load support
 - added Smashable Wall control

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -171,16 +171,8 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {
             item->current_anim_state = M_STATE_DEATH;
-            int32_t death_anim = M_ANIM_DEATH;
-            const int32_t rnd = Random_GetControl();
-            if (!is_tr3) {
-                // TODO: OG bug? Small edge-case of being 2, which gives anim
-                // 11, lunge attack
-                death_anim += rnd / 16200;
-            } else if (rnd <= 0x4000) {
-                death_anim += 1;
-            }
-            Item_SwitchToAnim(item, death_anim, 0);
+            const int32_t offset = Random_GetControl() > 0x4000 ? 0 : 1;
+            Item_SwitchToAnim(item, M_ANIM_DEATH + offset, 0);
         }
         goto finish;
     }

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -5,151 +5,157 @@
 #include <trx/game/random.h>
 #include <trx/game/spawn.h>
 
-#define RAPTOR_ATTACK_RANGE SQUARE(WALL_L * 3 / 2) // = 2359296
-#define RAPTOR_BITE_DAMAGE 100
-#define RAPTOR_CHARGE_DAMAGE 100
-#define RAPTOR_CLOSE_RANGE SQUARE(680) // = 462400
-#define RAPTOR_DIE_ANIM 9
-#define RAPTOR_LUNGE_DAMAGE 100
-#define RAPTOR_LUNGE_RANGE SQUARE(WALL_L * 3 / 2) // = 2359296
-#define RAPTOR_ROAR_CHANCE 256
-#define RAPTOR_RUN_TURN (4 * DEG_1) // = 728
-#define RAPTOR_TOUCH 0xFF7C00
-#define RAPTOR_WALK_TURN (1 * DEG_1) // = 182
-#define RAPTOR_HITPOINTS 20
-#define RAPTOR_RADIUS (WALL_L / 3) // = 341
-#define RAPTOR_SMARTNESS 0x4000
+// clang-format off
+#define M_ATTACK_RANGE  SQUARE(WALL_L * 3 / 2) // = 2359296
+#define M_BITE_DAMAGE   100
+#define M_CHARGE_DAMAGE 100
+#define M_CLOSE_RANGE   SQUARE(680) // = 462400
+#define M_LUNGE_DAMAGE  100
+#define M_LUNGE_RANGE   SQUARE(WALL_L * 3 / 2) // = 2359296
+#define M_ROAR_CHANCE   256
+#define M_RUN_TURN      (4 * DEG_1) // = 728
+#define M_TOUCH         0xFF7C00
+#define M_WALK_TURN     (1 * DEG_1) // = 182
+#define M_HITPOINTS     20
+#define M_RADIUS        (WALL_L / 3) // = 341
+#define M_PIVOT_LENGTH  400
+#define M_SMARTNESS     0x4000
+// clang-format on
 
 typedef enum {
-    RAPTOR_STATE_EMPTY = 0,
-    RAPTOR_STATE_STOP = 1,
-    RAPTOR_STATE_WALK = 2,
-    RAPTOR_STATE_RUN = 3,
-    RAPTOR_STATE_ATTACK_1 = 4,
-    RAPTOR_STATE_DEATH = 5,
-    RAPTOR_STATE_WARNING = 6,
-    RAPTOR_STATE_ATTACK_2 = 7,
-    RAPTOR_STATE_ATTACK_3 = 8,
-} RAPTOR_STATE;
+    M_STATE_EMPTY,
+    M_STATE_STOP,
+    M_STATE_WALK,
+    M_STATE_RUN,
+    M_STATE_ATTACK_1,
+    M_STATE_DEATH,
+    M_STATE_WARNING,
+    M_STATE_ATTACK_2,
+    M_STATE_ATTACK_3,
+} M_STATE;
 
-static BITE m_RaptorBite = { .pos = { 0, 66, 318 }, .mesh_num = 22 };
+typedef enum {
+    M_ANIM_DEATH = 9,
+} M_ANIM;
+
+static BITE m_RaptorBite = {
+    .pos = { 0, 66, 318 },
+    .mesh_num = 22,
+};
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const raptor = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
     int16_t tilt = 0;
 
     if (item->hit_points <= 0) {
-        if (item->current_anim_state != RAPTOR_STATE_DEATH) {
-            item->current_anim_state = RAPTOR_STATE_DEATH;
+        if (item->current_anim_state != M_STATE_DEATH) {
+            item->current_anim_state = M_STATE_DEATH;
             Item_SwitchToAnim(
-                item, RAPTOR_DIE_ANIM + (Random_GetControl() / 16200), 0);
+                item, M_ANIM_DEATH + (Random_GetControl() / 16200), 0);
         }
-    } else {
-        AI_INFO info;
-        Creature_AIInfo(item, &info);
-
-        if (info.ahead) {
-            head = info.angle;
-        }
-
-        Creature_Mood(item, &info, true);
-
-        angle = Creature_Turn(item, raptor->maximum_turn);
-
-        switch (item->current_anim_state) {
-        case RAPTOR_STATE_STOP:
-            if (item->required_anim_state != RAPTOR_STATE_EMPTY) {
-                item->goal_anim_state = item->required_anim_state;
-            } else if (item->touch_bits & RAPTOR_TOUCH) {
-                item->goal_anim_state = RAPTOR_STATE_ATTACK_3;
-            } else if (info.bite && info.distance < RAPTOR_CLOSE_RANGE) {
-                item->goal_anim_state = RAPTOR_STATE_ATTACK_3;
-            } else if (info.bite && info.distance < RAPTOR_LUNGE_RANGE) {
-                item->goal_anim_state = RAPTOR_STATE_ATTACK_1;
-            } else if (raptor->mood == MOOD_BORED) {
-                item->goal_anim_state = RAPTOR_STATE_WALK;
-            } else {
-                item->goal_anim_state = RAPTOR_STATE_RUN;
-            }
-            break;
-
-        case RAPTOR_STATE_WALK:
-            raptor->maximum_turn = RAPTOR_WALK_TURN;
-            if (raptor->mood != MOOD_BORED) {
-                item->goal_anim_state = RAPTOR_STATE_STOP;
-            } else if (info.ahead && Random_GetControl() < RAPTOR_ROAR_CHANCE) {
-                item->required_anim_state = RAPTOR_STATE_WARNING;
-                item->goal_anim_state = RAPTOR_STATE_STOP;
-            }
-            break;
-
-        case RAPTOR_STATE_RUN:
-            tilt = angle;
-            raptor->maximum_turn = RAPTOR_RUN_TURN;
-            if (item->touch_bits & RAPTOR_TOUCH) {
-                item->goal_anim_state = RAPTOR_STATE_STOP;
-            } else if (info.bite && info.distance < RAPTOR_ATTACK_RANGE) {
-                if (item->goal_anim_state == RAPTOR_STATE_RUN) {
-                    if (Random_GetControl() < 0x2000) {
-                        item->goal_anim_state = RAPTOR_STATE_STOP;
-                    } else {
-                        item->goal_anim_state = RAPTOR_STATE_ATTACK_2;
-                    }
-                }
-            } else if (
-                info.ahead && raptor->mood != MOOD_ESCAPE
-                && Random_GetControl() < RAPTOR_ROAR_CHANCE) {
-                item->required_anim_state = RAPTOR_STATE_WARNING;
-                item->goal_anim_state = RAPTOR_STATE_STOP;
-            } else if (raptor->mood == MOOD_BORED) {
-                item->goal_anim_state = RAPTOR_STATE_STOP;
-            }
-            break;
-
-        case RAPTOR_STATE_ATTACK_1:
-            tilt = angle;
-            if (item->required_anim_state == RAPTOR_STATE_EMPTY && info.ahead
-                && (item->touch_bits & RAPTOR_TOUCH)) {
-                Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-                Lara_TakeDamage(RAPTOR_LUNGE_DAMAGE, true);
-                item->required_anim_state = RAPTOR_STATE_STOP;
-            }
-            break;
-
-        case RAPTOR_STATE_ATTACK_2:
-            tilt = angle;
-            if (item->required_anim_state == RAPTOR_STATE_EMPTY && info.ahead
-                && (item->touch_bits & RAPTOR_TOUCH)) {
-                Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-                Lara_TakeDamage(RAPTOR_CHARGE_DAMAGE, true);
-                item->required_anim_state = RAPTOR_STATE_RUN;
-            }
-            break;
-
-        case RAPTOR_STATE_ATTACK_3:
-            tilt = angle;
-            if (item->required_anim_state == RAPTOR_STATE_EMPTY
-                && (item->touch_bits & RAPTOR_TOUCH)) {
-                Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-                Lara_TakeDamage(RAPTOR_BITE_DAMAGE, true);
-                item->required_anim_state = RAPTOR_STATE_STOP;
-            }
-            break;
-        }
+        goto finish;
     }
 
+    AI_INFO info;
+    Creature_AIInfo(item, &info);
+
+    if (info.ahead) {
+        head = info.angle;
+    }
+
+    Creature_Mood(item, &info, true);
+
+    angle = Creature_Turn(item, raptor->maximum_turn);
+
+    switch (item->current_anim_state) {
+    case M_STATE_STOP:
+        if (item->required_anim_state != M_STATE_EMPTY) {
+            item->goal_anim_state = item->required_anim_state;
+        } else if ((item->touch_bits & M_TOUCH) != 0) {
+            item->goal_anim_state = M_STATE_ATTACK_3;
+        } else if (info.bite && info.distance < M_CLOSE_RANGE) {
+            item->goal_anim_state = M_STATE_ATTACK_3;
+        } else if (info.bite && info.distance < M_LUNGE_RANGE) {
+            item->goal_anim_state = M_STATE_ATTACK_1;
+        } else if (raptor->mood == MOOD_BORED) {
+            item->goal_anim_state = M_STATE_WALK;
+        } else {
+            item->goal_anim_state = M_STATE_RUN;
+        }
+        break;
+
+    case M_STATE_WALK:
+        raptor->maximum_turn = M_WALK_TURN;
+        if (raptor->mood != MOOD_BORED) {
+            item->goal_anim_state = M_STATE_STOP;
+        } else if (info.ahead && Random_GetControl() < M_ROAR_CHANCE) {
+            item->required_anim_state = M_STATE_WARNING;
+            item->goal_anim_state = M_STATE_STOP;
+        }
+        break;
+
+    case M_STATE_RUN:
+        tilt = angle;
+        raptor->maximum_turn = M_RUN_TURN;
+        if ((item->touch_bits & M_TOUCH) != 0) {
+            item->goal_anim_state = M_STATE_STOP;
+        } else if (info.bite && info.distance < M_ATTACK_RANGE) {
+            if (item->goal_anim_state == M_STATE_RUN) {
+                if (Random_GetControl() < 0x2000) {
+                    item->goal_anim_state = M_STATE_STOP;
+                } else {
+                    item->goal_anim_state = M_STATE_ATTACK_2;
+                }
+            }
+        } else if (
+            info.ahead && raptor->mood != MOOD_ESCAPE
+            && Random_GetControl() < M_ROAR_CHANCE) {
+            item->required_anim_state = M_STATE_WARNING;
+            item->goal_anim_state = M_STATE_STOP;
+        } else if (raptor->mood == MOOD_BORED) {
+            item->goal_anim_state = M_STATE_STOP;
+        }
+        break;
+
+    case M_STATE_ATTACK_1:
+        tilt = angle;
+        if (item->required_anim_state == M_STATE_EMPTY && info.ahead
+            && (item->touch_bits & M_TOUCH) != 0) {
+            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+            Lara_TakeDamage(M_LUNGE_DAMAGE, true);
+            item->required_anim_state = M_STATE_STOP;
+        }
+        break;
+
+    case M_STATE_ATTACK_2:
+        tilt = angle;
+        if (item->required_anim_state == M_STATE_EMPTY && info.ahead
+            && (item->touch_bits & M_TOUCH) != 0) {
+            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+            Lara_TakeDamage(M_CHARGE_DAMAGE, true);
+            item->required_anim_state = M_STATE_RUN;
+        }
+        break;
+
+    case M_STATE_ATTACK_3:
+        tilt = angle;
+        if (item->required_anim_state == M_STATE_EMPTY
+            && (item->touch_bits & M_TOUCH) != 0) {
+            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+            Lara_TakeDamage(M_BITE_DAMAGE, true);
+            item->required_anim_state = M_STATE_STOP;
+        }
+        break;
+    }
+finish:
     Creature_Tilt(item, tilt);
     Creature_Head(item, head);
     Creature_Animate(item_num, angle, tilt);
@@ -164,10 +170,10 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
-    obj->hit_points = RAPTOR_HITPOINTS;
-    obj->pivot_length = 400;
-    obj->radius = RAPTOR_RADIUS;
-    obj->smartness = RAPTOR_SMARTNESS;
+    obj->hit_points = M_HITPOINTS;
+    obj->pivot_length = M_PIVOT_LENGTH;
+    obj->radius = M_RADIUS;
+    obj->smartness = M_SMARTNESS;
     obj->intelligent = true;
     obj->save_position = true;
     obj->save_hitpoints = true;

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -4,22 +4,25 @@
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/spawn.h>
+#include <trx/version.h>
 
 // clang-format off
-#define M_ATTACK_RANGE  SQUARE(WALL_L * 3 / 2) // = 2359296
-#define M_BITE_DAMAGE   100
-#define M_CHARGE_DAMAGE 100
-#define M_CLOSE_RANGE   SQUARE(680) // = 462400
-#define M_LUNGE_DAMAGE  100
-#define M_LUNGE_RANGE   SQUARE(WALL_L * 3 / 2) // = 2359296
-#define M_ROAR_CHANCE   256
-#define M_RUN_TURN      (4 * DEG_1) // = 728
-#define M_TOUCH         0xFF7C00
-#define M_WALK_TURN     (1 * DEG_1) // = 182
-#define M_HITPOINTS     20
-#define M_RADIUS        (WALL_L / 3) // = 341
-#define M_PIVOT_LENGTH  400
-#define M_SMARTNESS     0x4000
+#define M_ATTACK_RANGE   SQUARE(WALL_L * 3 / 2) // = 2359296
+#define M_BITE_DAMAGE    100
+#define M_CHARGE_DAMAGE  100
+#define M_CLOSE_RANGE    SQUARE(g_TRVersion < 3 ? 680 : 585) // = 462400 / 342225
+#define M_LUNGE_DAMAGE   100
+#define M_LUNGE_RANGE    SQUARE(WALL_L * 3 / 2) // = 2359296
+#define M_ROAR_CHANCE    (g_TRVersion < 3 ? 256 : 128)
+#define M_RUN_TURN       (4 * DEG_1) // = 728
+#define M_TOUCH          0xFF7C00
+#define M_WALK_TURN      (g_TRVersion < 3 ? (1 * DEG_1) : (2 * DEG_1)) // = 182 / 364
+#define M_HITPOINTS      (g_TRVersion == 3 ? 90 : 20)
+#define M_RADIUS         (WALL_L / 3) // = 341
+#define M_PIVOT_LENGTH   (g_TRVersion == 3 ? 600 : 400)
+#define M_SMARTNESS      0x4000
+#define M_INFIGHT_CHANCE 0x400
+#define M_INFIGHT_RANGE  0x400000
 // clang-format on
 
 typedef enum {
@@ -43,6 +46,113 @@ static BITE m_RaptorBite = {
     .mesh_num = 22,
 };
 
+static void M_CalculateTarget(const ITEM *const item)
+{
+    CREATURE *const raptor = item->creature_data;
+    int32_t best_distance = INT32_MAX;
+    const ITEM *best_item = nullptr;
+
+    for (int32_t i = 0; i < LOT_SLOT_COUNT; i++) {
+        const CREATURE *const creature = LOT_GetBaddieSlot(i);
+        if (creature->item_num == NO_ITEM || creature == raptor) {
+            continue;
+        }
+
+        const ITEM *const candidate = Item_Get(creature->item_num);
+        const XYZ_32 delta = {
+            .x = (candidate->pos.x - item->pos.x) >> 6,
+            .y = (candidate->pos.y - item->pos.y) >> 6,
+            .z = (candidate->pos.z - item->pos.z) >> 6,
+        };
+        const int32_t distance = XYZ_32_GetLength2(delta);
+        if (distance < best_distance) {
+            best_item = candidate;
+            best_distance = distance;
+        }
+    }
+
+    if (best_item != nullptr
+        && (best_item->object_id != item->object_id
+            || (Random_GetControl() < M_INFIGHT_CHANCE
+                && best_distance < M_INFIGHT_RANGE))) {
+        raptor->enemy = (ITEM *)best_item;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    const XYZ_32 lara_delta = {
+        .x = (lara_item->pos.x - item->pos.x) >> 6,
+        .y = (lara_item->pos.y - item->pos.y) >> 6,
+        .z = (lara_item->pos.z - item->pos.z) >> 6,
+    };
+    if (XYZ_32_GetLength2(lara_delta) < best_distance) {
+        raptor->enemy = (ITEM *)lara_item;
+    }
+}
+
+static void M_Attack(ITEM *const item, const AI_INFO *const info)
+{
+    int32_t damage = 0;
+    int16_t next_state = M_STATE_EMPTY;
+    switch (item->current_anim_state) {
+    case M_STATE_ATTACK_1:
+        damage = M_LUNGE_DAMAGE;
+        next_state = M_STATE_STOP;
+        break;
+    case M_STATE_ATTACK_2:
+        damage = M_CHARGE_DAMAGE;
+        next_state = M_STATE_RUN;
+        break;
+    case M_STATE_ATTACK_3:
+        damage = M_BITE_DAMAGE;
+        next_state = M_STATE_STOP;
+        break;
+    default:
+        return;
+    }
+
+    if (g_TRVersion < 3) {
+        if (item->required_anim_state == M_STATE_EMPTY && info->ahead
+            && (item->touch_bits & M_TOUCH) != 0) {
+            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+            Lara_TakeDamage(damage, true);
+            item->required_anim_state = next_state;
+        }
+        return;
+    }
+
+    CREATURE *const raptor = item->creature_data;
+    const ITEM *const lara_item = Lara_GetItem();
+    if (raptor->enemy == lara_item) {
+        if ((raptor->flags & 1) != 0 || (item->touch_bits & M_TOUCH) == 0) {
+            return;
+        }
+
+        raptor->flags |= 1;
+        Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+        if (lara_item->hit_points <= 0) {
+            raptor->flags |= 2;
+        }
+
+        Lara_TakeDamage(damage, true);
+        item->required_anim_state = next_state;
+        return;
+    }
+
+    if ((raptor->flags & 1) != 0 || raptor->enemy == nullptr
+        || !XYZ_32_IsNearby(raptor->enemy->pos, item->pos, WALL_L / 2)) {
+        return;
+    }
+
+    raptor->flags |= 1;
+    Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
+
+    raptor->enemy->hit_points -= damage / 4;
+    raptor->enemy->hit_status = true;
+    if (raptor->enemy->hit_points <= 0) {
+        raptor->flags |= 2;
+    }
+}
+
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -52,16 +162,36 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     CREATURE *const raptor = item->creature_data;
     int16_t head = 0;
+    int16_t neck = 0;
     int16_t angle = 0;
     int16_t tilt = 0;
+
+    const bool is_tr3 = g_TRVersion == 3;
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {
             item->current_anim_state = M_STATE_DEATH;
-            Item_SwitchToAnim(
-                item, M_ANIM_DEATH + (Random_GetControl() / 16200), 0);
+            int32_t death_anim = M_ANIM_DEATH;
+            const int32_t rnd = Random_GetControl();
+            if (!is_tr3) {
+                // TODO: OG bug? Small edge-case of being 2, which gives anim
+                // 11, lunge attack
+                death_anim += rnd / 16200;
+            } else if (rnd <= 0x4000) {
+                death_anim += 1;
+            }
+            Item_SwitchToAnim(item, death_anim, 0);
         }
         goto finish;
+    }
+
+    if (is_tr3
+        && (raptor->enemy == nullptr || (Random_GetControl() & 0x7F) == 0)) {
+        M_CalculateTarget(item);
+    }
+
+    if (item->ai_bits != 0) {
+        Creature_GetAITarget(raptor);
     }
 
     AI_INFO info;
@@ -72,19 +202,36 @@ static void M_Control(const int16_t item_num)
     }
 
     Creature_Mood(item, &info, true);
+    if (is_tr3 && raptor->mood == MOOD_BORED) {
+        raptor->maximum_turn /= 2;
+    }
 
     angle = Creature_Turn(item, raptor->maximum_turn);
+    neck = angle * -6;
+
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    const ITEM *const lara_item = Lara_GetItem();
 
     switch (item->current_anim_state) {
     case M_STATE_STOP:
+        raptor->flags &= ~1;
+        raptor->maximum_turn = 0;
+
         if (item->required_anim_state != M_STATE_EMPTY) {
             item->goal_anim_state = item->required_anim_state;
+        } else if (is_tr3 && (raptor->flags & 2) != 0) {
+            raptor->flags &= ~2;
+            item->goal_anim_state = M_STATE_WARNING;
         } else if ((item->touch_bits & M_TOUCH) != 0) {
             item->goal_anim_state = M_STATE_ATTACK_3;
         } else if (info.bite && info.distance < M_CLOSE_RANGE) {
             item->goal_anim_state = M_STATE_ATTACK_3;
         } else if (info.bite && info.distance < M_LUNGE_RANGE) {
             item->goal_anim_state = M_STATE_ATTACK_1;
+        } else if (
+            is_tr3 && raptor->mood == MOOD_ESCAPE && lara->target != item
+            && info.ahead && !item->hit_status) {
+            item->goal_anim_state = M_STATE_STOP;
         } else if (raptor->mood == MOOD_BORED) {
             item->goal_anim_state = M_STATE_WALK;
         } else {
@@ -93,20 +240,29 @@ static void M_Control(const int16_t item_num)
         break;
 
     case M_STATE_WALK:
+        raptor->flags &= ~1;
         raptor->maximum_turn = M_WALK_TURN;
+
         if (raptor->mood != MOOD_BORED) {
             item->goal_anim_state = M_STATE_STOP;
         } else if (info.ahead && Random_GetControl() < M_ROAR_CHANCE) {
             item->required_anim_state = M_STATE_WARNING;
             item->goal_anim_state = M_STATE_STOP;
+            raptor->flags &= ~2;
         }
         break;
 
     case M_STATE_RUN:
         tilt = angle;
+        raptor->flags &= ~1;
         raptor->maximum_turn = M_RUN_TURN;
+
         if ((item->touch_bits & M_TOUCH) != 0) {
             item->goal_anim_state = M_STATE_STOP;
+        } else if (is_tr3 && (raptor->flags & 2) != 0) {
+            item->goal_anim_state = M_STATE_STOP;
+            item->required_anim_state = M_STATE_WARNING;
+            raptor->flags &= ~2;
         } else if (info.bite && info.distance < M_ATTACK_RANGE) {
             if (item->goal_anim_state == M_STATE_RUN) {
                 if (Random_GetControl() < 0x2000) {
@@ -117,47 +273,43 @@ static void M_Control(const int16_t item_num)
             }
         } else if (
             info.ahead && raptor->mood != MOOD_ESCAPE
-            && Random_GetControl() < M_ROAR_CHANCE) {
+            && Random_GetControl() < M_ROAR_CHANCE
+            && (!is_tr3
+                || (raptor->enemy != nullptr
+                    && raptor->enemy->object_id != O_ANIMATING_6))) {
             item->required_anim_state = M_STATE_WARNING;
             item->goal_anim_state = M_STATE_STOP;
         } else if (raptor->mood == MOOD_BORED) {
+            item->goal_anim_state = M_STATE_STOP;
+        } else if (
+            is_tr3 && raptor->mood == MOOD_ESCAPE && lara->target != item
+            && info.ahead) {
             item->goal_anim_state = M_STATE_STOP;
         }
         break;
 
     case M_STATE_ATTACK_1:
-        tilt = angle;
-        if (item->required_anim_state == M_STATE_EMPTY && info.ahead
-            && (item->touch_bits & M_TOUCH) != 0) {
-            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-            Lara_TakeDamage(M_LUNGE_DAMAGE, true);
-            item->required_anim_state = M_STATE_STOP;
-        }
-        break;
-
     case M_STATE_ATTACK_2:
+    case M_STATE_ATTACK_3:
+        raptor->maximum_turn = M_WALK_TURN;
         tilt = angle;
-        if (item->required_anim_state == M_STATE_EMPTY && info.ahead
-            && (item->touch_bits & M_TOUCH) != 0) {
-            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-            Lara_TakeDamage(M_CHARGE_DAMAGE, true);
-            item->required_anim_state = M_STATE_RUN;
-        }
+        M_Attack(item, &info);
         break;
 
-    case M_STATE_ATTACK_3:
-        tilt = angle;
-        if (item->required_anim_state == M_STATE_EMPTY
-            && (item->touch_bits & M_TOUCH) != 0) {
-            Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
-            Lara_TakeDamage(M_BITE_DAMAGE, true);
-            item->required_anim_state = M_STATE_STOP;
-        }
+    default:
         break;
     }
+
 finish:
     Creature_Tilt(item, tilt);
-    Creature_Head(item, head);
+    if (is_tr3) {
+        Creature_Joint(item, 0, head / 2);
+        Creature_Joint(item, 1, head / 2);
+        Creature_Joint(item, 2, neck);
+        Creature_Joint(item, 3, neck);
+    } else {
+        Creature_Head(item, head);
+    }
     Creature_Animate(item_num, angle, tilt);
 }
 
@@ -181,6 +333,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
 
     Object_GetBone(obj, 21)->rot.y = true;
+    if (g_TRVersion >= 3) {
+        Object_GetBone(obj, 20)->rot.y = true;
+        Object_GetBone(obj, 23)->rot.y = true;
+        Object_GetBone(obj, 25)->rot.y = true;
+    }
 }
 
 REGISTER_OBJECT(O_RAPTOR, M_Setup)

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -123,8 +123,7 @@ static void M_CalculateTarget(ITEM *const item)
                 .y = (candidate->pos.y - item->pos.y) >> 6,
                 .z = (candidate->pos.z - item->pos.z) >> 6,
             };
-            const int32_t distance =
-                SQUARE(delta.x) + SQUARE(delta.y) + SQUARE(delta.z);
+            const int32_t distance = XYZ_32_GetLength2(delta);
             if (distance < best_distance) {
                 creature->enemy = (ITEM *)candidate;
                 best_distance = distance;

--- a/tools/tr3/objects_tracker/objects_support.json
+++ b/tools/tr3/objects_tracker/objects_support.json
@@ -97,7 +97,7 @@
   "O_QUEST_ITEM_2":           { "status": "fully implemented" },
   "O_QUEST_ITEM_3":           { "status": "fully implemented" },
   "O_QUEST_ITEM_4":           { "status": "fully implemented" },
-  "O_RAPTOR":                 { "status": "partially implemented", "todo": "check 100% parity" },
+  "O_RAPTOR":                 { "status": "fully implemented" },
   "O_RED_LIGHT":              { "status": "fully implemented" },
   "O_ROCKET_AMMO_ITEM":       { "status": "fully implemented" },
   "O_ROCKET_GUN_ITEM":        { "status": "fully implemented" },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds the TR3 raptor control. They can attack any other creature, including their own kind; they will always favour Lara if she is closest to them. I've kept it in the same module rather than making another object, given the raptor emitters and integration with the T-Rex.
