### PR TITLE
lua: add lara equipped gun

### DIFF
--- a/data/scripting/catalog.lua
+++ b/data/scripting/catalog.lua
@@ -7,6 +7,7 @@ local catalog = {
   lara_anims = raw.lara_anims,
   music = raw.music,
   samples = raw.samples,
+  weapons = raw.weapons,
 }
 
 trx.catalog = catalog

--- a/data/scripting/lara.lua
+++ b/data/scripting/lara.lua
@@ -14,6 +14,7 @@ local getters = {
   outfit = raw.get_outfit,
   holsters_visible = raw.are_holsters_visible,
   has_pistol_weapon = raw.has_pistol_weapon,
+  equipped_gun = raw.get_equipped_gun,
   extra_anim = raw.get_extra_anim,
   item = function()
     return trx.items[raw.get_item()]

--- a/docs/06-lua/2-reference/13-CATALOG.md
+++ b/docs/06-lua/2-reference/13-CATALOG.md
@@ -23,6 +23,11 @@ A convenience module for accessing TRX catalog IDs.
   Examples:   
   - [lua]`if lara.state == trx.catalog.lara_states.run then ...`
 
+- [lua]`trx.catalog.weapons`   
+  This table contains each TRX Lara gun type ID. Names match the keys from `weapons.json5`, with the `LGT_` prefix stripped and lowercased.   
+  Examples:   
+  - [lua]`if trx.lara.equipped_gun == trx.catalog.weapons.desert_eagle then ...`
+
 - [lua]`trx.catalog.lara_anims`   
   This table contains each TRX Lara animation ID. Names match those defined in `catalog_lara_anims.csv`, with the `LA_` prefix stripped and lowercased.   
   Examples:   

--- a/docs/06-lua/2-reference/3-LARA.md
+++ b/docs/06-lua/2-reference/3-LARA.md
@@ -67,6 +67,10 @@ Module for interacting with the Lara's object.
     relative animation number of the `O_LARA_EXTRA` object.  
     Otherwise, returns -1.
 
+- [lua]`trx.lara.equipped_gun`  
+    Read-only - returns Lara's currently equipped gun ID.
+    Compare values using [lua]`trx.catalog.weapons`.
+
 ## Mesh constants
 
 - `trx.lara.mesh.hips`  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,9 @@
 - added `O_SMASH_OBJECT_3`, which can only be broken with triggers or the Crash Site gun
 - added `O_SMASH_OBJECT_4`, which behaves like `O_SMASH_OBJECT_1` but uses `SFX_SHUTTERS_BREAK`
 - added `O_TREX_ALPHA`, which can target raptors and be distracted by flares
-- added new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
+- added a new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
+- added a new Lua catalog, `trx.catalog.weapons`, for weapon identifiers
+- added a new Lua property, `trx.lara.equipped_gun`, to read Lara's currently equipped gun type
 - added support for using more sound slots than originally possible in custom levels (#3898)
 - changed `O_WINDOW_1` and `O_WINDOW_2` to `O_SMASH_OBJECT_1` and `O_SMASH_OBJECT_2` respectively
 - changed Earthquake to support being reset

--- a/src/trx/game/lua/catalog.c
+++ b/src/trx/game/lua/catalog.c
@@ -1,4 +1,5 @@
 #include <trx/core/memory.h>
+#include <trx/game/lara/enum.h>
 
 #include <ctype.h>
 #include <lauxlib.h>
@@ -66,6 +67,31 @@ static void M_PushLaraStates(lua_State *const L)
     lua_setfield(L, -2, "lara_states");
 }
 
+static void M_PushWeapons(lua_State *const L)
+{
+    lua_newtable(L);
+
+#define X_LUA_WEAPON(enum_value)                                               \
+    M_PushCatalogKey(L, #enum_value, "LGT_", enum_value);
+    X_LUA_WEAPON(LGT_UNARMED);
+    X_LUA_WEAPON(LGT_PISTOLS);
+    X_LUA_WEAPON(LGT_MAGNUMS);
+    X_LUA_WEAPON(LGT_UZIS);
+    X_LUA_WEAPON(LGT_SHOTGUN);
+    X_LUA_WEAPON(LGT_M16);
+    X_LUA_WEAPON(LGT_GRENADE);
+    X_LUA_WEAPON(LGT_HARPOON);
+    X_LUA_WEAPON(LGT_FLARE);
+    X_LUA_WEAPON(LGT_SKIDOO);
+    X_LUA_WEAPON(LGT_AUTOS);
+    X_LUA_WEAPON(LGT_DESERT_EAGLE);
+    X_LUA_WEAPON(LGT_MP5);
+    X_LUA_WEAPON(LGT_ROCKET);
+#undef X_LUA_WEAPON
+
+    lua_setfield(L, -2, "weapons");
+}
+
 static void M_PushLaraAnims(lua_State *const L)
 {
     lua_newtable(L);
@@ -110,6 +136,7 @@ void LUA_CreateCatalog(lua_State *const L)
     M_PushObjects(L);
     M_PushFlipEffects(L);
     M_PushLaraStates(L);
+    M_PushWeapons(L);
     M_PushLaraAnims(L);
     M_PushMusic(L);
     M_PushSamples(L);

--- a/src/trx/game/lua/lara.c
+++ b/src/trx/game/lua/lara.c
@@ -140,6 +140,13 @@ static int M_L_LaraGetExtraAnim(lua_State *const L)
     return 1;
 }
 
+// trxc.lara.get_equipped_gun() → int
+static int M_L_LaraGetEquippedGun(lua_State *const L)
+{
+    lua_pushinteger(L, Lara_GetLaraInfo()->gun_type);
+    return 1;
+}
+
 void LUA_CreateLara(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
@@ -217,6 +224,8 @@ void LUA_CreateLara(lua_State *const L)
     lua_setfield(L, -2, "has_pistol_weapon");
     lua_pushcfunction(L, M_L_LaraGetExtraAnim);
     lua_setfield(L, -2, "get_extra_anim");
+    lua_pushcfunction(L, M_L_LaraGetEquippedGun);
+    lua_setfield(L, -2, "get_equipped_gun");
     lua_setfield(L, -2, "lara");
     lua_pop(L, 1);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This exposes equipped gun property in LUA, as a read-only property, to allow me to test the issues with the turbo speed in the recordings.