### PR TITLE
lara/state/land: fix clamp glitch

### DIFF
--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -366,10 +366,20 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         const int16_t h = Lara_FloorFront(item, item->rot.y, M_WALK_DIST);
         const int16_t c =
             Lara_CeilingFront(item, item->rot.y, M_WALK_DIST, LARA_HEIGHT);
+        const HEIGHT_TYPE height_type = Room_GetHeightType();
 
-        if (Room_GetHeightType() == HT_BIG_SLOPE && h < 0) {
+        bool inside_wall = false;
+        if (g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_FIXED) {
+            int16_t room_num = item->room_num;
+            const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+            const int16_t sector_height =
+                Room_GetHeightEx(sector, item->pos, true, NO_ITEM);
+            inside_wall = sector_height == NO_HEIGHT;
+        }
+
+        if (height_type == HT_BIG_SLOPE && h < 0 && !inside_wall) {
             item->goal_anim_state = LS_STOP;
-        } else if (c > 0 && !g_Input.action) {
+        } else if (c > 0 && !inside_wall && !g_Input.action) {
             item->goal_anim_state = LS_STOP;
         } else if (g_Input.slow) {
             M_Walk(item, coll);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara being unable to perform certain TR1 and TR2 wall clamp glitches - specifically, she can't turn in no-space (walls with tilts). Regression in 7ace939.

Qualopec recording attached for reference.
[clamp.txt](https://github.com/user-attachments/files/25418198/clamp.txt)