### PR TITLE
lara/col/land: add missing vault collision

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - changed loading screens setting to use modes (`disabled`, `always`, `new-games`). Previously, they were hardcoded to not show for saves (#1290)
 - changed logs to no longer emit ANSI color characters when the game's output is piped to a file / process
 - improved error reporting for gameflow issues to now display full key paths for faulty nodes
+- fixed Lara teleporting after vaulting 2 or 3 clicks when there is a room below the target position that has no immediately adjoining portal (#4530)
 - fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -294,6 +294,33 @@ static void M_Default(ITEM *const item, COLL_INFO *const coll)
     Lara_Col_GetInfo(item, coll);
 }
 
+static void M_PullUp(ITEM *const item, COLL_INFO *const coll)
+{
+    const int16_t anim = LA_U(Item_GetRelativeAnim(item));
+    if ((anim != LA_CLIMB_2CLICK && anim != LA_CLIMB_3CLICK)
+        || !Item_TestFrameEqual(item, -1)) {
+        M_Default(item, coll);
+        return;
+    }
+
+    Lara_UpdateRoomToHeight(-WALL_L);
+    Lara_Animate(item);
+
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->move_angle = item->rot.y + DEG_180;
+    item->gravity = false;
+    item->fall_speed = 0;
+    coll->bad_pos = STEPUP_HEIGHT;
+    coll->bad_neg = -STEPUP_HEIGHT;
+    coll->slopes_are_pits = 1;
+    coll->slopes_are_walls = 1;
+    coll->bad_ceiling = 0;
+    coll->lava_is_pit = 1;
+
+    Lara_Col_GetInfo(item, coll);
+    Lara_Col_Shift(coll);
+}
+
 static void M_Walk(ITEM *const item, COLL_INFO *const coll)
 {
     item->gravity = false;
@@ -914,7 +941,7 @@ REGISTER_LARA_COL(LS_USE_MIDAS,    M_Default)
 REGISTER_LARA_COL(LS_DIE_MIDAS,    M_Default)
 REGISTER_LARA_COL(LS_GYMNAST,      M_Default)
 REGISTER_LARA_COL(LS_WATER_OUT,    M_Default)
-REGISTER_LARA_COL(LS_PULL_UP,      M_Default)
+REGISTER_LARA_COL(LS_PULL_UP,      M_PullUp)
 REGISTER_LARA_COL(LS_CONTROLLED,   M_Default)
 REGISTER_LARA_COL(LS_FLARE_PICKUP, M_Default)
 REGISTER_LARA_COL(LS_WALK,         M_Walk)


### PR DESCRIPTION
Resolves #4530.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara teleporting after vaulting 2 or 3 clicks when there is a room below the vault-up position but there are no portal connections between. On the final frame of the vault-up animation, Lara is moved into whatever the room above her start position is, which then allows later normal control to move her along into the final room. The added collision checks ensure she is nudged off the edge otherwise her feet remain partially in mid-air.
