### PR TITLE
gun/rifle: update grenade room number on spawn

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed drawing debug triggers using wrong orientation in some triangular geometry
 - fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
 - fixed Lua `trx.catalog` only exposing `objects` and `flip_effects`; it now also exposes `lara_states`, `lara_anims`, `music`, and `samples`
+- fixed a freeze if firing a grenade very close to room portals (#4938, regression from 1.2)
 
 **TR1**:
 - fixed a very rare case of raptors using an incorrect death animation

--- a/src/trx/game/gun/rifle.c
+++ b/src/trx/game/gun/rifle.c
@@ -292,8 +292,8 @@ static void M_FireGrenade(void)
     projectile_item->interp.prev.pos = projectile_item->pos;
     Item_Initialise(item_num);
 
-    const SECTOR *const sector =
-        Room_GetSector(origin, &projectile_item->room_num);
+    int16_t room_num = projectile_item->room_num;
+    const SECTOR *const sector = Room_GetSector(origin, &room_num);
     const int32_t height = Room_GetHeight(sector, origin);
     if (height < origin.y) {
         projectile_item->pos = (XYZ_32) {
@@ -302,6 +302,9 @@ static void M_FireGrenade(void)
             .z = lara_item->pos.z,
         };
     }
+
+    Room_GetSector(projectile_item->pos, &room_num);
+    Item_UpdateRoom(item_num, room_num);
 
     projectile_item->rot.x = lara->left_arm.rot.x + lara_item->rot.x;
     projectile_item->rot.y = lara->left_arm.rot.y + lara_item->rot.y;


### PR DESCRIPTION
Resolves #4938.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids updating a spawned grenade's room number via a sector check, and instead uses the room update method. This avoids a grenade ending up in two rooms effectively, and hence causing infinite loops when traversing room item linked lists.