### PR TITLE
lara/col/jump: guard swing-in tests

### DIFF
--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -75,7 +75,7 @@ bool Lara_Col_TestHangSwingIn(const ITEM *const item, const int16_t angle)
     const int32_t height_delta = height - pos.y;
     const int32_t ceiling_delta = ceiling - pos.y;
     return has_height && height_delta > 0 && ceiling_delta < -400
-        && pos.y - ceiling - 819 > -110;
+        && (g_TRVersion < 3 || pos.y - ceiling - 819 > -110);
 }
 
 static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
@@ -126,7 +126,8 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     }
     const int16_t angle = Math_DirectionToAngle(dir);
 
-    const bool swing_in = !ladder_hang && Lara_Col_TestHangSwingIn(item, angle);
+    const bool swing_in = (g_TRVersion < 3 || !ladder_hang)
+        && Lara_Col_TestHangSwingIn(item, angle);
     if (swing_in) {
         Item_SwitchToAnim(item, LA(LA_REACH_TO_THIN_LEDGE), 0);
     } else {


### PR DESCRIPTION
Resolves #4937.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This guards the swing-in tests for TR1/2 to allow the original animation to take place on thin ledges. There is also an affected case with TR2 ladders. Recording below, fixed in this PR. Worth double checking the ladder in Temple Ruins room 125 (which looks OK to me).

[ladder.txt](https://github.com/user-attachments/files/25447366/ladder.txt)

I think we can normalise all of this under #3341 by making both animations available in each game, changing the names and adjusting the logic accordingly depending on the edge type. But that can be tackled as a feature separately; it'll touch on monkey-swinging too, so will need to wait for animation counts to align.