### PR TITLE
lara: improve vaulting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - improved error reporting for gameflow issues to now display full key paths for faulty nodes
 - fixed Lara teleporting after vaulting 2 or 3 clicks when there is a room below the target position that has no immediately adjoining portal (#4530)
 - fixed Lara attempting to jump up (using action) despite the ceiling above her making it impossible to grab any ledge (#3558)
+- fixed Lara not being able to grab ledges when under low ceilings (#4093)
 - fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - changed logs to no longer emit ANSI color characters when the game's output is piped to a file / process
 - improved error reporting for gameflow issues to now display full key paths for faulty nodes
 - fixed Lara teleporting after vaulting 2 or 3 clicks when there is a room below the target position that has no immediately adjoining portal (#4530)
+- fixed Lara attempting to jump up (using action) despite the ceiling above her making it impossible to grab any ledge (#3558)
 - fixed NG+ always forcing Lara's default equipped gun at level start even when "remember guns between levels" is enabled (#4711)
 - fixed not restoring Lara's back weapon mesh between levels when "remember guns" is enabled and a rifle-type weapon is equipped at level end
 - fixed a missing footstep sound when Lara starts to sprint

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -12,6 +12,7 @@
 #define M_CLIMB_WIDTH_RIGHT      120
 #define M_CLIMB_HEIGHT           (WALL_L / 2) // = 512
 #define M_VAULT_ANGLE            (30 * DEG_1) // = 5460
+#define M_VAULT_GAP              (-LARA_HEIGHT + STEP_L / 8) // = -730
 #define M_LF_HANG                21
 #define M_LF_STOP_HANG           9
 #define M_LF_CLIMB_L_SHIFT_START 28
@@ -918,6 +919,10 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
         Item_SwitchToAnim(item, LA(LA_CLIMB_3CLICK), 0);
         item->pos.y += front_floor + STEP_L * 3;
         lara->gun_status = LGS_HANDS_BUSY;
+    } else if (
+        !lara->climb_status
+        && front_floor - coll->side_mid.ceiling < M_VAULT_GAP) {
+        return false;
     } else if (
         !slope && front_floor >= -STEP_L * 7 - mid
         && front_floor <= -STEP_L * 4 + mid) {

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -12,6 +12,8 @@
 #define M_LF_START_HANG    12
 #define M_LF_FAST_FALL     1
 #define M_BAD_JUMP_CEILING ((STEP_L * 3) / 4) // = 192
+#define M_HEAD_CLEARANCE   (-STEP_L / 8) // = -32
+#define M_LADDER_CLEARANCE (-STEPUP_HEIGHT) // = -384
 // clang-format on
 
 EDGE_CATCH Lara_Col_TestEdgeCatch(
@@ -205,7 +207,8 @@ static bool M_TestHangJumpUp(ITEM *const item, COLL_INFO *const coll)
     }
 
     if (coll->coll_type != COLL_FRONT
-        || coll->side_mid.ceiling > -STEPUP_HEIGHT) {
+        || coll->side_mid.ceiling
+            > (lara->climb_status ? M_LADDER_CLEARANCE : M_HEAD_CLEARANCE)) {
         return false;
     }
 


### PR DESCRIPTION
Resolves #3558.
Resolves #4093.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara attempting to jump up despite the ceiling above her meaning she could never grab a ledge in the first place, and allows her to jump up and grab ledges when there is a low ceiling above. Updated the `bad-vault` test level, and there are a number of places to test in OG in the linked tickets. A general test around grabbing ladders, pulling up and 2/3 click vaults would be good too.

There are other cases (in the test level) where she can vault through the ceiling or tiny gaps. I didn't tackle these as I don't think it's applicable to OG and it's more of a design decision in custom levels IMO.
