### PR TITLE
level/rooms: alter degenerate statics check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - changed Earthquake to support being reset
 - changed loading screens setting to use modes (`disabled`, `always`, `new-games`). Previously, they were hardcoded to not show for saves (#1290)
 - changed logs to no longer emit ANSI color characters when the game's output is piped to a file / process
+- changed the degenerate static mesh collision check to only apply when all axes have an empty size
 - improved error reporting for gameflow issues to now display full key paths for faulty nodes
 - fixed Lara teleporting after vaulting 2 or 3 clicks when there is a room below the target position that has no immediately adjoining portal (#4530)
 - fixed Lara attempting to jump up (using action) despite the ceiling above her making it impossible to grab any ledge (#3558)

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -159,7 +159,7 @@ static void M_FixStaticsCollision(void)
             .z = obj->collision_bounds.max.z - obj->collision_bounds.min.z,
         };
 
-        if (hitbox.x <= 0 || hitbox.y <= 0 || hitbox.z <= 0) {
+        if (hitbox.x <= 0 && hitbox.y <= 0 && hitbox.z <= 0) {
             LOG_WARNING(
                 "Static %d is marked as collidable, but has degenerate "
                 "hitbox (%d x %d x %d)",


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This alters the check on static meshes to mark them as non-collidable only if all axis sizes are empty. An example in OG where this was causing an issue is It's a Madhouse room 5 - the monkey here is meant to grab a medi and put it on the little balcony beside the ~~train~~ car, and Lara is not meant to be able to reach it because of the railings in place there. They only have an empty Z size.

The fix should still work for the Jungle slope nudge that was occurring previously.