### PR TITLE
Inventory ring: move status transition decisions to control phase

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed heavy triggers with no `TO_TARGET` / `TO_CAMERA` resetting cameras
 - fixed Lua `trx.catalog` only exposing `objects` and `flip_effects`; it now also exposes `lara_states`, `lara_anims`, `music`, and `samples`
 - fixed a freeze if firing a grenade very close to room portals (#4938, regression from 1.2)
+- fixed non-deterministic Inventory Ring control (transition speeds depended on v-sync / wall clock timing)
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -7,6 +7,7 @@
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
 #include <trx/game/rooms.h>
+#include <trx/game/shell.h>
 
 #include <stdint.h>
 
@@ -399,7 +400,7 @@ bool Interpolation_IsEnabled(void)
 
 bool Interpolation_IsActive(void)
 {
-    return m_IsEnabled && M_GetFPS() == 60;
+    return m_IsEnabled && M_GetFPS() == 60 && !Shell_IsExiting();
 }
 
 double Interpolation_GetWorldRate(void)

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -162,7 +162,7 @@ static void M_RingNotActive(
 
     InvRing_ShowExamine(
         inv_item->object_id,
-        ring->motion.status == RNG_OPEN
+        ring->status == RNG_OPEN
             && Option_Examine_CanExamine(inv_item->object_id));
 }
 
@@ -352,42 +352,34 @@ static bool M_CheckDemoTimer(const INV_RING *const ring)
         return false;
     }
 
-    return ring->motion.status == RNG_OPEN
+    return ring->status == RNG_OPEN
         && ClockTimer_CheckElapsed(&m_DemoTimer, g_Config.flow.demo_delay);
 }
 
 static void M_SetupRingSwitchClose(
-    INV_RING *const ring, const RING_STATUS status_target,
-    const int16_t camera_pitch)
+    INV_RING *const ring, const RING_STATUS status_target)
 {
     InvRing_SetStatusTransition(
         ring, RNG_CLOSING, status_target, M_RING_SWITCH_FRAMES / 2);
-    InvRing_MotionCameraPitch(ring, camera_pitch);
-    ring->motion.misc = camera_pitch;
 }
 
 static void M_TransitionToRing(
     INV_RING *const ring, const RING_TYPE source_type,
     const RING_TYPE target_type)
 {
-    InvRing_SetStatusTransition(
-        ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
     g_InvRing_Source[source_type].current = ring->current_object;
     g_InvRing_Source[source_type].count = ring->number_of_objects;
     ring->type = target_type;
     ring->list = g_InvRing_Source[target_type].items;
     ring->number_of_objects = g_InvRing_Source[target_type].count;
     ring->current_object = g_InvRing_Source[target_type].current;
-    InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-    InvRing_MotionRotation(
-        ring, INV_RING_OPEN_ROTATION,
-        -DEG_90 - ring->angle_adder * ring->current_object);
-    ring->ring_pos.rot.y = ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+    InvRing_SetStatusTransition(
+        ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
 }
 
 static GF_COMMAND M_Control(INV_RING *const ring)
 {
-    if (ring->motion.status == RNG_OPENING) {
+    if (ring->status == RNG_OPENING) {
         if (ring->mode == INV_TITLE_MODE
             && (Fader_IsActive(&ring->top_fader)
                 || Fader_IsActive(&ring->back_fader))) {
@@ -401,11 +393,11 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         }
     }
 
-    if (ring->motion.status == RNG_FADING_OUT) {
+    if (ring->status == RNG_FADING_OUT) {
         if (ring->mode == INV_TITLE_MODE) {
             const GF_COMMAND gf_cmd = M_Finish(ring, true);
             ring->is_done = true;
-            ring->motion.status = RNG_DONE;
+            ring->status = RNG_DONE;
             return gf_cmd;
         }
 
@@ -420,10 +412,10 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             || Fader_IsActive(&ring->back_fader)) {
             return (GF_COMMAND) { .action = GF_NOOP };
         }
-        ring->motion.status = RNG_DONE;
+        ring->status = RNG_DONE;
     }
 
-    if (ring->motion.status == RNG_DONE && !ring->is_done) {
+    if (ring->status == RNG_DONE && !ring->is_done) {
         const GF_COMMAND gf_cmd = M_Finish(ring, true);
         ring->is_done = true;
         // Returning to game – resume music
@@ -468,8 +460,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
     }
 
     if (ring->mode != INV_TITLE_MODE && !Fader_IsActive(&ring->back_fader)
-        && !Fader_IsActive(&ring->top_fader)
-        && ring->motion.status != RNG_OPENING) {
+        && !Fader_IsActive(&ring->top_fader) && ring->status != RNG_OPENING) {
         for (int i = 0; i < ring->number_of_objects; i++) {
             INVENTORY_ITEM *const inv_item = ring->list[i];
             if (inv_item->object_id == O_COMPASS_OPTION) {
@@ -482,7 +473,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         return (GF_COMMAND) { .action = GF_NOOP };
     }
 
-    switch (ring->motion.status) {
+    switch (ring->status) {
     case RNG_OPEN:
         if (g_Input.menu_right && ring->number_of_objects > 1) {
             InvRing_RotateLeft(ring);
@@ -594,13 +585,13 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             && ring->mode != INV_GLOBE_SELECT_MODE) {
             if (ring->type == RT_MAIN) {
                 if (g_InvRing_Source[RT_KEYS].count > 0) {
-                    M_SetupRingSwitchClose(ring, RNG_MAIN2KEYS, DEG_45);
+                    M_SetupRingSwitchClose(ring, RNG_MAIN2KEYS);
                 }
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
             } else if (ring->type == RT_OPTION) {
                 if (g_InvRing_Source[RT_MAIN].count > 0) {
-                    M_SetupRingSwitchClose(ring, RNG_OPTION2MAIN, DEG_45);
+                    M_SetupRingSwitchClose(ring, RNG_OPTION2MAIN);
                 }
                 g_InputDB = (INPUT_STATE) {};
             }
@@ -611,12 +602,12 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             if (ring->type == RT_MAIN) {
                 if (g_InvRing_Source[RT_OPTION].count > 0
                     && !InvRing_IsOptionLockedOut()) {
-                    M_SetupRingSwitchClose(ring, RNG_MAIN2OPTION, -DEG_45);
+                    M_SetupRingSwitchClose(ring, RNG_MAIN2OPTION);
                 }
                 g_InputDB = (INPUT_STATE) {};
             } else if (ring->type == RT_KEYS) {
                 if (g_InvRing_Source[RT_MAIN].count > 0) {
-                    M_SetupRingSwitchClose(ring, RNG_KEYS2MAIN, -DEG_45);
+                    M_SetupRingSwitchClose(ring, RNG_KEYS2MAIN);
                 }
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
@@ -719,8 +710,8 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                 }
 
                 InvRing_SetStatusTransition(
-                    ring, ring->motion.status_target,
-                    ring->motion.status_target, M_SELECTING_FRAMES);
+                    ring, ring->status_target, ring->status_target,
+                    M_SELECTING_FRAMES);
                 break;
             }
         }
@@ -728,7 +719,7 @@ static GF_COMMAND M_Control(INV_RING *const ring)
     }
 
     case RNG_EXITING_INVENTORY:
-        if (ring->motion.count == 0) {
+        if (ring->status_frames == 0) {
             if (M_Finish(ring, false).action != GF_NOOP) {
                 // Fade to black. Do it later once reaching RNG_FADING_OUT.
                 InvRing_SetStatusTransition(
@@ -750,11 +741,9 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         break;
     }
 
-    if (ring->motion.status == RNG_OPEN || ring->motion.status == RNG_SELECTING
-        || ring->motion.status == RNG_SELECTED
-        || ring->motion.status == RNG_DESELECTING
-        || ring->motion.status == RNG_DESELECT
-        || ring->motion.status == RNG_CLOSING_ITEM) {
+    if (ring->status == RNG_OPEN || ring->status == RNG_SELECTING
+        || ring->status == RNG_SELECTED || ring->status == RNG_DESELECTING
+        || ring->status == RNG_DESELECT || ring->status == RNG_CLOSING_ITEM) {
         if (!ring->rotating
             && ((!g_Input.menu_left && !g_Input.menu_right)
                 || ring->number_of_objects <= 1)) {
@@ -766,12 +755,11 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         M_RingIsNotOpen(ring);
     }
 
-    if (ring->motion.status == RNG_OPENING || ring->motion.status == RNG_CLOSING
-        || ring->motion.status == RNG_MAIN2OPTION
-        || ring->motion.status == RNG_OPTION2MAIN
-        || ring->motion.status == RNG_EXITING_INVENTORY
-        || ring->motion.status == RNG_FADING_OUT
-        || ring->motion.status == RNG_DONE || ring->rotating) {
+    if (ring->status == RNG_OPENING || ring->status == RNG_CLOSING
+        || ring->status == RNG_MAIN2OPTION || ring->status == RNG_OPTION2MAIN
+        || ring->status == RNG_EXITING_INVENTORY
+        || ring->status == RNG_FADING_OUT || ring->status == RNG_DONE
+        || ring->rotating) {
         M_RingActive();
     }
 

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -360,12 +360,8 @@ static void M_SetupRingSwitchClose(
     INV_RING *const ring, const RING_STATUS status_target,
     const int16_t camera_pitch)
 {
-    InvRing_MotionSetup(
+    InvRing_SetStatusTransition(
         ring, RNG_CLOSING, status_target, M_RING_SWITCH_FRAMES / 2);
-    InvRing_MotionRadius(ring, 0);
-    InvRing_MotionRotation(
-        ring, INV_RING_CLOSE_ROTATION,
-        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
     InvRing_MotionCameraPitch(ring, camera_pitch);
     ring->motion.misc = camera_pitch;
 }
@@ -374,14 +370,10 @@ static void M_TransitionToRing(
     INV_RING *const ring, const RING_TYPE source_type,
     const RING_TYPE target_type)
 {
-    InvRing_MotionSetup(ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
-    ring->camera_pitch = -ring->motion.misc;
-    ring->motion.camera_pitch_rate =
-        ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
-    ring->motion.camera_pitch_target = 0;
+    InvRing_SetStatusTransition(
+        ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
     g_InvRing_Source[source_type].current = ring->current_object;
     g_InvRing_Source[source_type].count = ring->number_of_objects;
-    InvRing_MotionRadius(ring, INV_RING_RADIUS);
     ring->type = target_type;
     ring->list = g_InvRing_Source[target_type].items;
     ring->number_of_objects = g_InvRing_Source[target_type].count;
@@ -517,10 +509,10 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             }
 
             if (M_Finish(ring, false).action != GF_NOOP) {
-                InvRing_MotionSetup(
+                InvRing_SetStatusTransition(
                     ring, RNG_CLOSING, RNG_FADING_OUT, INV_RING_CLOSE_FRAMES);
             } else {
-                InvRing_MotionSetup(
+                InvRing_SetStatusTransition(
                     ring, RNG_CLOSING, RNG_DONE, INV_RING_CLOSE_FRAMES);
                 if (g_Config.visuals.enable_fade_effects
                     && g_Config.ui.inventory_fade_effects) {
@@ -528,11 +520,6 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                         &ring->back_fader, 0.0f, M_INV_RING_FADE_TIME_FAST);
                 }
             }
-            InvRing_MotionRadius(ring, 0);
-            InvRing_MotionCameraPos(ring, INV_RING_CAMERA_START_HEIGHT);
-            InvRing_MotionRotation(
-                ring, INV_RING_CLOSE_ROTATION,
-                ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
 
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
@@ -561,11 +548,8 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                 inv_item->goal_frame = inv_item->open_frame;
                 inv_item->anim_direction = 1;
             }
-            InvRing_MotionSetup(
+            InvRing_SetStatusTransition(
                 ring, RNG_SELECTING, RNG_SELECTED, M_SELECTING_FRAMES);
-            InvRing_MotionRotation(
-                ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
-            InvRing_MotionItemSelect(ring, inv_item);
             g_Input = (INPUT_STATE) {};
             g_InputDB = (INPUT_STATE) {};
 
@@ -674,12 +658,13 @@ static GF_COMMAND M_Control(INV_RING *const ring)
 
         if (!busy) {
             if (g_InputDB.menu_back && ring->mode != INV_GLOBE_SELECT_MODE) {
-                InvRing_MotionSetup(ring, RNG_CLOSING_ITEM, RNG_DESELECT, 0);
+                InvRing_SetStatusTransition(
+                    ring, RNG_CLOSING_ITEM, RNG_DESELECT, 0);
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
                 if (ring->mode == INV_LOAD_MODE || ring->mode == INV_SAVE_MODE
                     || ring->mode == INV_SAVE_CRYSTAL_MODE) {
-                    InvRing_MotionSetup(
+                    InvRing_SetStatusTransition(
                         ring, RNG_CLOSING_ITEM, RNG_EXITING_INVENTORY, 0);
                     g_Input = (INPUT_STATE) {};
                     g_InputDB = (INPUT_STATE) {};
@@ -700,10 +685,10 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                         || inv_item->object_id == O_PDA_OPTION
                         || inv_item->object_id == O_CONTROL_OPTION
                         || inv_item->object_id == O_GLOBE_SELECT_OPTION)) {
-                    InvRing_MotionSetup(
+                    InvRing_SetStatusTransition(
                         ring, RNG_CLOSING_ITEM, RNG_DESELECT, 0);
                 } else {
-                    InvRing_MotionSetup(
+                    InvRing_SetStatusTransition(
                         ring, RNG_CLOSING_ITEM, RNG_EXITING_INVENTORY, 0);
                 }
                 g_Input = (INPUT_STATE) {};
@@ -717,10 +702,8 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
         Option_Close(inv_item);
         Sound_Effect(SFX_MENU_SPINOUT, nullptr, SPM_ALWAYS);
-        InvRing_MotionSetup(
+        InvRing_SetStatusTransition(
             ring, RNG_DESELECTING, RNG_OPEN, M_SELECTING_FRAMES);
-        InvRing_MotionRotation(
-            ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
         g_Input = (INPUT_STATE) {};
         g_InputDB = (INPUT_STATE) {};
         break;
@@ -735,9 +718,9 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                     inv_item->current_frame = 0;
                 }
 
-                ring->motion.count = M_SELECTING_FRAMES;
-                ring->motion.status = ring->motion.status_target;
-                InvRing_MotionItemDeselect(ring, inv_item);
+                InvRing_SetStatusTransition(
+                    ring, ring->motion.status_target,
+                    ring->motion.status_target, M_SELECTING_FRAMES);
                 break;
             }
         }
@@ -748,11 +731,11 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         if (ring->motion.count == 0) {
             if (M_Finish(ring, false).action != GF_NOOP) {
                 // Fade to black. Do it later once reaching RNG_FADING_OUT.
-                InvRing_MotionSetup(
+                InvRing_SetStatusTransition(
                     ring, RNG_CLOSING, RNG_FADING_OUT, INV_RING_CLOSE_FRAMES);
             } else {
                 // Fade to game. Do it as soon as the ring starts to close.
-                InvRing_MotionSetup(
+                InvRing_SetStatusTransition(
                     ring, RNG_CLOSING, RNG_DONE, INV_RING_CLOSE_FRAMES);
                 if (g_Config.visuals.enable_fade_effects
                     && g_Config.ui.inventory_fade_effects) {
@@ -760,11 +743,6 @@ static GF_COMMAND M_Control(INV_RING *const ring)
                         &ring->back_fader, 0.0f, M_INV_RING_FADE_TIME_FAST);
                 }
             }
-            InvRing_MotionRadius(ring, 0);
-            InvRing_MotionCameraPos(ring, INV_RING_CAMERA_START_HEIGHT);
-            InvRing_MotionRotation(
-                ring, INV_RING_CLOSE_ROTATION,
-                ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
         }
         break;
 

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -356,6 +356,43 @@ static bool M_CheckDemoTimer(const INV_RING *const ring)
         && ClockTimer_CheckElapsed(&m_DemoTimer, g_Config.flow.demo_delay);
 }
 
+static void M_SetupRingSwitchClose(
+    INV_RING *const ring, const RING_STATUS status_target,
+    const int16_t camera_pitch)
+{
+    InvRing_MotionSetup(
+        ring, RNG_CLOSING, status_target, M_RING_SWITCH_FRAMES / 2);
+    InvRing_MotionRadius(ring, 0);
+    InvRing_MotionRotation(
+        ring, INV_RING_CLOSE_ROTATION,
+        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
+    InvRing_MotionCameraPitch(ring, camera_pitch);
+    ring->motion.misc = camera_pitch;
+}
+
+static void M_TransitionToRing(
+    INV_RING *const ring, const RING_TYPE source_type,
+    const RING_TYPE target_type)
+{
+    InvRing_MotionSetup(ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
+    ring->camera_pitch = -ring->motion.misc;
+    ring->motion.camera_pitch_rate =
+        ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
+    ring->motion.camera_pitch_target = 0;
+    g_InvRing_Source[source_type].current = ring->current_object;
+    g_InvRing_Source[source_type].count = ring->number_of_objects;
+    InvRing_MotionRadius(ring, INV_RING_RADIUS);
+    ring->type = target_type;
+    ring->list = g_InvRing_Source[target_type].items;
+    ring->number_of_objects = g_InvRing_Source[target_type].count;
+    ring->current_object = g_InvRing_Source[target_type].current;
+    InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
+    InvRing_MotionRotation(
+        ring, INV_RING_OPEN_ROTATION,
+        -DEG_90 - ring->angle_adder * ring->current_object);
+    ring->ring_pos.rot.y = ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+}
+
 static GF_COMMAND M_Control(INV_RING *const ring)
 {
     if (ring->motion.status == RNG_OPENING) {
@@ -573,29 +610,13 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             && ring->mode != INV_GLOBE_SELECT_MODE) {
             if (ring->type == RT_MAIN) {
                 if (g_InvRing_Source[RT_KEYS].count > 0) {
-                    InvRing_MotionSetup(
-                        ring, RNG_CLOSING, RNG_MAIN2KEYS,
-                        M_RING_SWITCH_FRAMES / 2);
-                    InvRing_MotionRadius(ring, 0);
-                    InvRing_MotionRotation(
-                        ring, INV_RING_CLOSE_ROTATION,
-                        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
-                    InvRing_MotionCameraPitch(ring, 0x2000);
-                    ring->motion.misc = 0x2000;
+                    M_SetupRingSwitchClose(ring, RNG_MAIN2KEYS, DEG_45);
                 }
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
             } else if (ring->type == RT_OPTION) {
                 if (g_InvRing_Source[RT_MAIN].count > 0) {
-                    InvRing_MotionSetup(
-                        ring, RNG_CLOSING, RNG_OPTION2MAIN,
-                        M_RING_SWITCH_FRAMES / 2);
-                    InvRing_MotionRadius(ring, 0);
-                    InvRing_MotionRotation(
-                        ring, INV_RING_CLOSE_ROTATION,
-                        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
-                    InvRing_MotionCameraPitch(ring, 0x2000);
-                    ring->motion.misc = 0x2000;
+                    M_SetupRingSwitchClose(ring, RNG_OPTION2MAIN, DEG_45);
                 }
                 g_InputDB = (INPUT_STATE) {};
             }
@@ -606,28 +627,12 @@ static GF_COMMAND M_Control(INV_RING *const ring)
             if (ring->type == RT_MAIN) {
                 if (g_InvRing_Source[RT_OPTION].count > 0
                     && !InvRing_IsOptionLockedOut()) {
-                    InvRing_MotionSetup(
-                        ring, RNG_CLOSING, RNG_MAIN2OPTION,
-                        M_RING_SWITCH_FRAMES / 2);
-                    InvRing_MotionRadius(ring, 0);
-                    InvRing_MotionRotation(
-                        ring, INV_RING_CLOSE_ROTATION,
-                        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
-                    InvRing_MotionCameraPitch(ring, -0x2000);
-                    ring->motion.misc = -0x2000;
+                    M_SetupRingSwitchClose(ring, RNG_MAIN2OPTION, -DEG_45);
                 }
                 g_InputDB = (INPUT_STATE) {};
             } else if (ring->type == RT_KEYS) {
                 if (g_InvRing_Source[RT_MAIN].count > 0) {
-                    InvRing_MotionSetup(
-                        ring, RNG_CLOSING, RNG_KEYS2MAIN,
-                        M_RING_SWITCH_FRAMES / 2);
-                    InvRing_MotionRadius(ring, 0);
-                    InvRing_MotionRotation(
-                        ring, INV_RING_CLOSE_ROTATION,
-                        ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
-                    InvRing_MotionCameraPitch(ring, -0x2000);
-                    ring->motion.misc = -0x2000;
+                    M_SetupRingSwitchClose(ring, RNG_KEYS2MAIN, -DEG_45);
                 }
                 g_Input = (INPUT_STATE) {};
                 g_InputDB = (INPUT_STATE) {};
@@ -636,90 +641,19 @@ static GF_COMMAND M_Control(INV_RING *const ring)
         break;
 
     case RNG_MAIN2OPTION:
-        InvRing_MotionSetup(
-            ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
-        InvRing_MotionRadius(ring, INV_RING_RADIUS);
-        ring->camera_pitch = -ring->motion.misc;
-        ring->motion.camera_pitch_rate =
-            ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
-        ring->motion.camera_pitch_target = 0;
-        g_InvRing_Source[RT_MAIN].current = ring->current_object;
-        g_InvRing_Source[RT_MAIN].count = ring->number_of_objects;
-        ring->type = RT_OPTION;
-        ring->list = g_InvRing_Source[RT_OPTION].items;
-        ring->number_of_objects = g_InvRing_Source[RT_OPTION].count;
-        ring->current_object = g_InvRing_Source[RT_OPTION].current;
-        InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-        InvRing_MotionRotation(
-            ring, INV_RING_OPEN_ROTATION,
-            -DEG_90 - ring->angle_adder * ring->current_object);
-        ring->ring_pos.rot.y =
-            ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+        M_TransitionToRing(ring, RT_MAIN, RT_OPTION);
         break;
 
     case RNG_MAIN2KEYS:
-        InvRing_MotionSetup(
-            ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
-        InvRing_MotionRadius(ring, INV_RING_RADIUS);
-        ring->camera_pitch = -ring->motion.misc;
-        ring->motion.camera_pitch_target = 0;
-        ring->motion.camera_pitch_rate =
-            ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
-        g_InvRing_Source[RT_MAIN].current = ring->current_object;
-        g_InvRing_Source[RT_MAIN].count = ring->number_of_objects;
-        ring->type = RT_KEYS;
-        ring->list = g_InvRing_Source[RT_KEYS].items;
-        ring->number_of_objects = g_InvRing_Source[RT_KEYS].count;
-        ring->current_object = g_InvRing_Source[RT_KEYS].current;
-        InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-        InvRing_MotionRotation(
-            ring, INV_RING_OPEN_ROTATION,
-            -DEG_90 - ring->angle_adder * ring->current_object);
-        ring->ring_pos.rot.y =
-            ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+        M_TransitionToRing(ring, RT_MAIN, RT_KEYS);
         break;
 
     case RNG_KEYS2MAIN:
-        InvRing_MotionSetup(
-            ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
-        InvRing_MotionRadius(ring, INV_RING_RADIUS);
-        ring->camera_pitch = -ring->motion.misc;
-        ring->motion.camera_pitch_target = 0;
-        ring->motion.camera_pitch_rate =
-            ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
-        g_InvRing_Source[RT_KEYS].current = ring->current_object;
-        ring->type = RT_MAIN;
-        ring->list = g_InvRing_Source[RT_MAIN].items;
-        ring->number_of_objects = g_InvRing_Source[RT_MAIN].count;
-        ring->current_object = g_InvRing_Source[RT_MAIN].current;
-        InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-        InvRing_MotionRotation(
-            ring, INV_RING_OPEN_ROTATION,
-            -DEG_90 - ring->angle_adder * ring->current_object);
-        ring->ring_pos.rot.y =
-            ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+        M_TransitionToRing(ring, RT_KEYS, RT_MAIN);
         break;
 
     case RNG_OPTION2MAIN:
-        InvRing_MotionSetup(
-            ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
-        InvRing_MotionRadius(ring, INV_RING_RADIUS);
-        ring->camera_pitch = -ring->motion.misc;
-        ring->motion.camera_pitch_target = 0;
-        ring->motion.camera_pitch_rate =
-            ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
-        g_InvRing_Source[RT_OPTION].count = ring->number_of_objects;
-        g_InvRing_Source[RT_OPTION].current = ring->current_object;
-        ring->type = RT_MAIN;
-        ring->list = g_InvRing_Source[RT_MAIN].items;
-        ring->number_of_objects = g_InvRing_Source[RT_MAIN].count;
-        ring->current_object = g_InvRing_Source[RT_MAIN].current;
-        InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
-        InvRing_MotionRotation(
-            ring, INV_RING_OPEN_ROTATION,
-            -DEG_90 - ring->angle_adder * ring->current_object);
-        ring->ring_pos.rot.y =
-            ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
+        M_TransitionToRing(ring, RT_OPTION, RT_MAIN);
         break;
 
     case RNG_SELECTED: {

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -377,6 +377,32 @@ static void M_TransitionToRing(
         ring, RNG_OPENING, RNG_OPEN, M_RING_SWITCH_FRAMES / 2);
 }
 
+static void M_SnapshotRingState(INV_RING *const ring)
+{
+    ring->prev_radius = ring->radius;
+    ring->prev_camera_y = ring->camera.pos.y;
+    ring->prev_camera_pitch = ring->camera_pitch;
+    ring->prev_ring_rot_y = ring->ring_pos.rot.y;
+}
+
+static void M_SnapshotItemState(INVENTORY_ITEM *const inv_item)
+{
+    inv_item->prev_x_rot_pt = inv_item->x_rot_pt;
+    inv_item->prev_x_rot = inv_item->x_rot;
+    inv_item->prev_y_rot = inv_item->y_rot;
+    inv_item->prev_y_trans = inv_item->y_trans;
+    inv_item->prev_z_trans = inv_item->z_trans;
+    inv_item->prev_manual_rot = inv_item->manual_rot;
+}
+
+static void M_SnapshotFrameState(INV_RING *const ring)
+{
+    M_SnapshotRingState(ring);
+    for (int32_t i = 0; i < ring->number_of_objects; i++) {
+        M_SnapshotItemState(ring->list[i]);
+    }
+}
+
 static GF_COMMAND M_Control(INV_RING *const ring)
 {
     if (ring->status == RNG_OPENING) {
@@ -947,7 +973,40 @@ GF_COMMAND InvRing_Control(INV_RING *const ring)
 {
     InvRing_AdjustMusicVolume(ring);
     m_ActiveRing = ring;
-    const GF_COMMAND gf_cmd = M_Control(ring);
+    INVENTORY_ITEM **const prev_list = ring->list;
+    M_SnapshotFrameState(ring);
+    GF_COMMAND gf_cmd = M_Control(ring);
+
+    if (ring->status != RNG_OPENING && ring->status != RNG_DONE
+        && ring->status != RNG_FADING_OUT) {
+        for (int32_t frame = 0; frame < INV_RING_FRAMES; frame++) {
+            for (int32_t i = 0; i < ring->number_of_objects; i++) {
+                InvRing_UpdateInventoryItem(ring, ring->list[i]);
+            }
+        }
+    }
+
+    if (ring->status != RNG_DONE
+        && (ring->status != RNG_OPENING
+            || (ring->mode != INV_TITLE_MODE
+                || (!Fader_IsActive(&ring->top_fader)
+                    && !Fader_IsActive(&ring->back_fader))))) {
+        for (int32_t frame = 0; frame < INV_RING_FRAMES; frame++) {
+            InvRing_DoMotions(ring);
+        }
+    }
+
+    if (ring->list != prev_list) {
+        M_SnapshotFrameState(ring);
+    }
+
+    // Running motions in control can reach RNG_DONE in this same tick.
+    // Finalize immediately so phase code receives the non-NOOP GF command.
+    if (gf_cmd.action == GF_NOOP && ring->status == RNG_DONE
+        && !ring->is_done) {
+        gf_cmd = M_Control(ring);
+    }
+
     m_ActiveRing = nullptr;
     Overlay_Animate(1);
     return gf_cmd;

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -1,6 +1,7 @@
 #include <trx/game/inventory_ring/draw.h>
 
 #include <trx/config.h>
+#include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/game.h>
 #include <trx/game/input.h>
@@ -28,6 +29,27 @@
 static XYZ_32 M_VectorViewFromWorld(const XYZ_32 v_world)
 {
     return Matrix_MulVec32_M(&g_ViewMatrix, v_world);
+}
+
+static int16_t M_LerpI16(
+    const int16_t prev_value, const int16_t cur_value, const double rate)
+{
+    return (int16_t)round(LERP(prev_value, cur_value, rate));
+}
+
+static int32_t M_LerpI32(
+    const int32_t prev_value, const int32_t cur_value, const double rate)
+{
+    return (int32_t)round(LERP(prev_value, cur_value, rate));
+}
+
+static int16_t M_LerpAngleI16(
+    const int16_t prev_value, const int16_t cur_value, const double rate)
+{
+    const int32_t prev_u16 = (uint16_t)prev_value;
+    const int32_t cur_u16 = (uint16_t)cur_value;
+    const int32_t interp = Math_AngleMean(prev_u16, cur_u16, rate);
+    return (int16_t)(uint16_t)interp;
 }
 
 static float M_GlobeSelectPulse01(const float time)
@@ -115,7 +137,7 @@ static int32_t M_GetFrames(
     *out_frame1 = &obj->frame_base[cur_frame_num];
     *out_frame2 = &obj->frame_base[next_frame_num];
     *out_rate = 10;
-    return (Interpolation_GetWorldRate() - 0.5) * 10.0;
+    return (Interpolation_GetRate() - 0.5) * 10.0;
 
     // OG
 fallback:
@@ -129,6 +151,20 @@ static void M_DrawItem(
     const INV_RING *const ring, const INVENTORY_ITEM *const inv_item,
     const int16_t view_rot_y)
 {
+    const double interp_rate = Interpolation_GetRate();
+    const int16_t draw_x_rot_pt = M_LerpAngleI16(
+        inv_item->prev_x_rot_pt, inv_item->x_rot_pt, interp_rate);
+    const int16_t draw_x_rot =
+        M_LerpAngleI16(inv_item->prev_x_rot, inv_item->x_rot, interp_rate);
+    const int16_t draw_y_rot =
+        M_LerpAngleI16(inv_item->prev_y_rot, inv_item->y_rot, interp_rate);
+    const int32_t draw_y_trans =
+        M_LerpI32(inv_item->prev_y_trans, inv_item->y_trans, interp_rate);
+    const int32_t draw_z_trans =
+        M_LerpI32(inv_item->prev_z_trans, inv_item->z_trans, interp_rate);
+    MATRIX draw_manual_rot = inv_item->prev_manual_rot;
+    Matrix_Slerp3x3_M(&draw_manual_rot, &inv_item->manual_rot, interp_rate);
+
     int32_t shade = M_SHADE_NORMAL;
     if (ring->status != RNG_FADING_OUT && ring->status != RNG_DONE) {
         if (ring->rotating) {
@@ -146,16 +182,16 @@ static void M_DrawItem(
     }
     Output_SetLightAdder(shade);
 
-    Matrix_TranslateRel(0, inv_item->y_trans, inv_item->z_trans);
+    Matrix_TranslateRel(0, draw_y_trans, draw_z_trans);
 
-    Matrix_RotX(-inv_item->x_rot_pt);
+    Matrix_RotX(-draw_x_rot_pt);
     Matrix_RotY(-view_rot_y);
-    Matrix_Mul3x3(&inv_item->manual_rot);
+    Matrix_Mul3x3(&draw_manual_rot);
     Matrix_RotY(view_rot_y);
-    Matrix_RotX(inv_item->x_rot_pt);
+    Matrix_RotX(draw_x_rot_pt);
 
-    Matrix_RotY(inv_item->y_rot);
-    Matrix_RotX(inv_item->x_rot);
+    Matrix_RotY(draw_y_rot);
+    Matrix_RotX(draw_x_rot);
 
     const OBJECT *const obj = Object_Get(inv_item->object_id);
     if (!obj->loaded || obj->mesh_count < 0) {
@@ -244,29 +280,22 @@ const INVENTORY_ITEM *InvRing_GetInvItem(const OBJECT_ID obj_id)
 void InvRing_Draw(INV_RING *const ring)
 {
     InvRing_DrawUI(ring);
+    const double interp_rate = Interpolation_GetRate();
+    const int16_t draw_radius =
+        M_LerpI16(ring->prev_radius, ring->radius, interp_rate);
+    const int16_t draw_camera_y =
+        M_LerpI16(ring->prev_camera_y, ring->camera.pos.y, interp_rate);
+    const int16_t draw_ring_rot_y = M_LerpAngleI16(
+        ring->prev_ring_rot_y, ring->ring_pos.rot.y, interp_rate);
+    const int16_t draw_camera_pitch = M_LerpAngleI16(
+        ring->prev_camera_pitch, ring->camera_pitch, interp_rate);
 
-    const int32_t num_frames = round(
-        ClockTimer_TakeElapsed(&ring->motion_timer) * LOGIC_FPS
-        * INV_RING_FRAMES);
-
-    if (ring->status != RNG_OPENING && ring->status != RNG_DONE
-        && ring->status != RNG_FADING_OUT) {
-        for (int32_t i = 0; i < ring->number_of_objects; i++) {
-            InvRing_UpdateInventoryItem(ring, ring->list[i], num_frames);
-        }
-    }
-
-    if (ring->status != RNG_DONE
-        && (ring->status != RNG_OPENING
-            || (ring->mode != INV_TITLE_MODE
-                || (!Fader_IsActive(&ring->top_fader)
-                    && !Fader_IsActive(&ring->back_fader))))) {
-        for (int32_t i = 0; i < num_frames; i++) {
-            InvRing_DoMotions(ring);
-        }
-    }
-
-    ring->camera.pos.z = ring->radius + M_CAMERA_2_RING;
+    INV_RING draw_ring = *ring;
+    draw_ring.radius = draw_radius;
+    draw_ring.camera.pos.y = draw_camera_y;
+    draw_ring.camera_pitch = draw_camera_pitch;
+    draw_ring.ring_pos.rot.y = draw_ring_rot_y;
+    draw_ring.camera.pos.z = draw_radius + M_CAMERA_2_RING;
 
     if (ring->mode == INV_TITLE_MODE) {
         if (ring->background_path != nullptr) {
@@ -329,28 +358,30 @@ void InvRing_Draw(INV_RING *const ring)
 
     XYZ_32 view_pos;
     XYZ_16 view_rot;
-    InvRing_GetView(ring, &view_pos, &view_rot);
+    InvRing_GetView(&draw_ring, &view_pos, &view_rot);
     Matrix_GenerateW2V(&view_pos, &view_rot);
-    InvRing_Light(ring);
+    InvRing_Light(&draw_ring);
 
     Matrix_Push();
-    Matrix_TranslateAbs32(ring->ring_pos.pos);
-    Matrix_Rot16(ring->ring_pos.rot);
+    Matrix_TranslateAbs32(draw_ring.ring_pos.pos);
+    Matrix_Rot16(draw_ring.ring_pos.rot);
 
     if (!(ring->mode == INV_TITLE_MODE
           && (Fader_IsActive(&ring->top_fader)
               || Fader_IsActive(&ring->back_fader))
           && ring->status == RNG_OPENING)) {
         int16_t angle = 0;
-        for (int32_t i = 0; i < ring->number_of_objects; i++) {
-            INVENTORY_ITEM *const inv_item = ring->list[i];
+        for (int32_t i = 0; i < draw_ring.number_of_objects; i++) {
+            INVENTORY_ITEM *const inv_item = draw_ring.list[i];
             Matrix_Push();
             Matrix_RotY(angle);
-            Matrix_TranslateRel(ring->radius, 0, 0);
+            Matrix_TranslateRel(draw_ring.radius, 0, 0);
             Matrix_RotY(DEG_90);
-            Matrix_RotX(inv_item->x_rot_pt);
-            M_DrawItem(ring, inv_item, view_rot.y);
-            angle += ring->angle_adder;
+            const int16_t draw_x_rot_pt = M_LerpAngleI16(
+                inv_item->prev_x_rot_pt, inv_item->x_rot_pt, interp_rate);
+            Matrix_RotX(draw_x_rot_pt);
+            M_DrawItem(&draw_ring, inv_item, view_rot.y);
+            angle += draw_ring.angle_adder;
             Matrix_Pop();
         }
     }

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -83,32 +83,6 @@ static void M_GlobeSelectApplyLight(
     Output_SetTR3Light(ambient, colors, dirs_view);
 }
 
-static bool M_IsEnterTransition(const INV_RING *const ring)
-{
-    return ring->motion.status == RNG_OPENING;
-}
-
-static bool M_IsExitTransition(const INV_RING *const ring)
-{
-    return ring->motion.status == RNG_EXITING_INVENTORY
-        || ring->motion.status == RNG_FADING_OUT
-        || ring->motion.status == RNG_DONE
-        || (ring->motion.status == RNG_CLOSING
-            && (ring->motion.status_target == RNG_FADING_OUT
-                || ring->motion.status_target == RNG_DONE));
-}
-
-static float M_GetMotionProgress(
-    const int16_t frames_remaining, const int16_t total_frames)
-{
-    if (total_frames == 0) {
-        return 1.0f;
-    }
-    float result = frames_remaining / (float)total_frames;
-    CLAMP(result, 0.0f, 1.0f);
-    return result;
-}
-
 static int32_t M_GetFrames(
     const INV_RING *const ring, const INVENTORY_ITEM *const inv_item,
     ANIM_FRAME **const out_frame1, ANIM_FRAME **const out_frame2,
@@ -118,8 +92,7 @@ static int32_t M_GetFrames(
     const INVENTORY_ITEM *const cur_inv_item = ring->list[ring->current_object];
 
     if (inv_item != cur_inv_item || inv_item->current_frame == 0
-        || (ring->motion.status != RNG_SELECTED
-            && ring->motion.status != RNG_CLOSING_ITEM)) {
+        || (ring->status != RNG_SELECTED && ring->status != RNG_CLOSING_ITEM)) {
         // only apply to animations, eg. the states where Inv_AnimateItem is
         // being actively called
         goto fallback;
@@ -157,8 +130,7 @@ static void M_DrawItem(
     const int16_t view_rot_y)
 {
     int32_t shade = M_SHADE_NORMAL;
-    if (ring->motion.status != RNG_FADING_OUT
-        && ring->motion.status != RNG_DONE) {
+    if (ring->status != RNG_FADING_OUT && ring->status != RNG_DONE) {
         if (ring->rotating) {
             float t = (ring->rot_count / (float)INV_RING_ROTATE_DURATION);
             CLAMP(t, 0.0f, 1.0f);
@@ -277,15 +249,15 @@ void InvRing_Draw(INV_RING *const ring)
         ClockTimer_TakeElapsed(&ring->motion_timer) * LOGIC_FPS
         * INV_RING_FRAMES);
 
-    if (ring->motion.status != RNG_OPENING && ring->motion.status != RNG_DONE
-        && ring->motion.status != RNG_FADING_OUT) {
+    if (ring->status != RNG_OPENING && ring->status != RNG_DONE
+        && ring->status != RNG_FADING_OUT) {
         for (int32_t i = 0; i < ring->number_of_objects; i++) {
             InvRing_UpdateInventoryItem(ring, ring->list[i], num_frames);
         }
     }
 
-    if (ring->motion.status != RNG_DONE
-        && (ring->motion.status != RNG_OPENING
+    if (ring->status != RNG_DONE
+        && (ring->status != RNG_OPENING
             || (ring->mode != INV_TITLE_MODE
                 || (!Fader_IsActive(&ring->top_fader)
                     && !Fader_IsActive(&ring->back_fader))))) {
@@ -368,7 +340,7 @@ void InvRing_Draw(INV_RING *const ring)
     if (!(ring->mode == INV_TITLE_MODE
           && (Fader_IsActive(&ring->top_fader)
               || Fader_IsActive(&ring->back_fader))
-          && ring->motion.status == RNG_OPENING)) {
+          && ring->status == RNG_OPENING)) {
         int16_t angle = 0;
         for (int32_t i = 0; i < ring->number_of_objects; i++) {
             INVENTORY_ITEM *const inv_item = ring->list[i];
@@ -387,7 +359,7 @@ void InvRing_Draw(INV_RING *const ring)
     SceneCompositor_Flush();
     Viewport_AlterFOV(old_fov, old_fov_mode);
 
-    if (ring->motion.status == RNG_SELECTED) {
+    if (ring->status == RNG_SELECTED) {
         INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
         if (inv_item->object_id == O_PASSPORT_CLOSED) {
             inv_item->object_id = O_PASSPORT_OPTION;
@@ -396,7 +368,7 @@ void InvRing_Draw(INV_RING *const ring)
     }
 
     float top_opacity = Fader_GetCurrentValue(&ring->top_fader);
-    if (ring->mode == INV_TITLE_MODE && ring->motion.status != RNG_OPENING) {
+    if (ring->mode == INV_TITLE_MODE && ring->status != RNG_OPENING) {
         top_opacity = 0.0f;
     }
     Output_Overlay_DrawBlackRectangle(top_opacity, true);

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -207,6 +207,7 @@ void InvRing_InitRing(
     ring->type = type;
     ring->list = list;
     ring->radius = 0;
+    ring->prev_radius = 0;
     ring->number_of_objects = qty;
     ring->current_object = current;
     ring->angle_adder = DEG_360 / qty;
@@ -222,6 +223,7 @@ void InvRing_InitRing(
     } else {
         ring->camera_pitch = 0;
     }
+    ring->prev_camera_pitch = ring->camera_pitch;
 
     ring->rotating = false;
     ring->rotate_from_object = 0;
@@ -254,14 +256,14 @@ void InvRing_InitRing(
     ring->ring_pos.pos.z = 0;
     ring->ring_pos.rot.x = 0;
     ring->ring_pos.rot.y = ring->motion.rotate_target - INV_RING_OPEN_ROTATION;
+    ring->prev_ring_rot_y = ring->ring_pos.rot.y;
     ring->ring_pos.rot.z = 0;
 
     ring->light.x = -1536;
     ring->light.y = 256;
     ring->light.z = 1024;
 
-    ring->motion_timer.type = CLOCK_TIMER_SIM;
-    ClockTimer_Sync(&ring->motion_timer);
+    ring->prev_camera_y = ring->camera.pos.y;
 
     m_ShowExamine = false;
     m_ShowUseItemButton = false;
@@ -276,11 +278,17 @@ void InvRing_InitInvItem(INVENTORY_ITEM *const inv_item)
     inv_item->goal_frame = 0;
     inv_item->manual_rot = g_IDMatrix;
     inv_item->x_rot_pt = 0;
+    inv_item->prev_x_rot_pt = inv_item->x_rot_pt;
     inv_item->x_rot = inv_item->x_rot_nosel;
+    inv_item->prev_x_rot = inv_item->x_rot;
     inv_item->y_rot = 0;
+    inv_item->prev_y_rot = inv_item->y_rot;
     inv_item->y_trans = 0;
+    inv_item->prev_y_trans = inv_item->y_trans;
     inv_item->z_trans = 0;
+    inv_item->prev_z_trans = inv_item->z_trans;
     inv_item->action = ACTION_USE;
+    inv_item->prev_manual_rot = inv_item->manual_rot;
     if (inv_item->object_id == O_PASSPORT_OPTION) {
         inv_item->object_id = O_PASSPORT_CLOSED;
     }
@@ -740,25 +748,20 @@ void InvRing_RemoveVersionText(void)
 }
 
 void InvRing_UpdateInventoryItem(
-    const INV_RING *const ring, INVENTORY_ITEM *const inv_item,
-    const int32_t num_frames)
+    const INV_RING *const ring, INVENTORY_ITEM *const inv_item)
 {
 
     if (inv_item != ring->list[ring->current_object]) {
-        for (int32_t i = 0; i < num_frames; i++) {
-            if (inv_item->y_rot < 0) {
-                inv_item->y_rot += 256;
-            } else if (inv_item->y_rot > 0) {
-                inv_item->y_rot -= 256;
-            }
+        if (inv_item->y_rot < 0) {
+            inv_item->y_rot += 256;
+        } else if (inv_item->y_rot > 0) {
+            inv_item->y_rot -= 256;
         }
     } else if (ring->rotating) {
-        for (int32_t i = 0; i < num_frames; i++) {
-            if (inv_item->y_rot > 0) {
-                inv_item->y_rot -= 512;
-            } else if (inv_item->y_rot < 0) {
-                inv_item->y_rot += 512;
-            }
+        if (inv_item->y_rot > 0) {
+            inv_item->y_rot -= 512;
+        } else if (inv_item->y_rot < 0) {
+            inv_item->y_rot += 512;
         }
     } else if (
         ring->status == RNG_SELECTED || ring->status == RNG_DESELECTING
@@ -769,16 +772,12 @@ void InvRing_UpdateInventoryItem(
             return;
         }
 
-        for (int32_t i = 0; i < num_frames; i++) {
-            M_AdjustRot(&inv_item->y_rot, inv_item->y_rot_sel);
-            Matrix_Slerp3x3_M(
-                &inv_item->manual_rot, &g_IDMatrix, M_MANUAL_ROT_RESET_RATE);
-        }
+        M_AdjustRot(&inv_item->y_rot, inv_item->y_rot_sel);
+        Matrix_Slerp3x3_M(
+            &inv_item->manual_rot, &g_IDMatrix, M_MANUAL_ROT_RESET_RATE);
     } else if (
         ring->number_of_objects == 1
         || (!g_Input.menu_right && !g_Input.menu_left)) {
-        for (int32_t i = 0; i < num_frames; i++) {
-            inv_item->y_rot += 256;
-        }
+        inv_item->y_rot += 256;
     }
 }

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -70,15 +70,7 @@ static void M_AdjustRot(int16_t *const rot, const int16_t dest_rot)
 
 static XYZ_32 M_VectorViewFromWorld(const XYZ_32 v_world)
 {
-    const MATRIX *const m = &g_ViewMatrix;
-    return (XYZ_32) {
-        .x = (m->_00 * v_world.x + m->_01 * v_world.y + m->_02 * v_world.z)
-            >> W2V_SHIFT,
-        .y = (m->_10 * v_world.x + m->_11 * v_world.y + m->_12 * v_world.z)
-            >> W2V_SHIFT,
-        .z = (m->_20 * v_world.x + m->_21 * v_world.y + m->_22 * v_world.z)
-            >> W2V_SHIFT,
-    };
+    return Matrix_MulVec32_M(&g_ViewMatrix, v_world);
 }
 
 static void M_HandleRequestedObject(INV_RING *const ring)

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#define M_RING_SWITCH_FRAMES (96 / 2)
 #define M_CAMERA_Y_OFFSET (-96)
 #define M_MANUAL_ROT_RESET_RATE 0.15
 
@@ -91,6 +92,50 @@ static void M_HandleRequestedObject(INV_RING *const ring)
     m_RequestedObjectID = NO_OBJECT;
 }
 
+static void M_MotionCameraPos(INV_RING *const ring, const int16_t target)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->camera_y_target = target;
+    motion->camera_y_rate = (target - ring->camera.pos.y) / motion->count;
+}
+
+static void M_MotionRadius(INV_RING *const ring, const int16_t target)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->radius_target = target;
+    motion->radius_rate = (target - ring->radius) / motion->count;
+}
+
+static void M_MotionItemSelect(
+    INV_RING *const ring, const INVENTORY_ITEM *const inv_item)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->item_pt_x_rot_target = inv_item->x_rot_pt_sel;
+    motion->item_pt_x_rot_rate = inv_item->x_rot_pt_sel / motion->count;
+    motion->item_x_rot_target = inv_item->x_rot_sel;
+    motion->item_x_rot_rate =
+        (inv_item->x_rot_sel - inv_item->x_rot_nosel) / motion->count;
+    motion->item_y_trans_target = inv_item->y_trans_sel;
+    motion->item_y_trans_rate = inv_item->y_trans_sel / motion->count;
+    motion->item_z_trans_target = inv_item->z_trans_sel;
+    motion->item_z_trans_rate = inv_item->z_trans_sel / motion->count;
+}
+
+static void M_MotionItemDeselect(
+    INV_RING *const ring, const INVENTORY_ITEM *const inv_item)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->item_pt_x_rot_target = 0;
+    motion->item_pt_x_rot_rate = -(inv_item->x_rot_pt_sel / motion->count);
+    motion->item_x_rot_target = inv_item->x_rot_nosel;
+    motion->item_x_rot_rate =
+        (inv_item->x_rot_nosel - inv_item->x_rot_sel) / motion->count;
+    motion->item_y_trans_target = 0;
+    motion->item_y_trans_rate = -(inv_item->y_trans_sel / motion->count);
+    motion->item_z_trans_target = 0;
+    motion->item_z_trans_rate = -(inv_item->z_trans_sel / motion->count);
+}
+
 void InvRing_AdjustMusicVolume(const INV_RING *const ring)
 {
     if (ring->mode == INV_TITLE_MODE) {
@@ -155,8 +200,8 @@ void InvRing_InitRing(
     ring->camera.rot.z = 0;
 
     InvRing_MotionInit(ring, RNG_OPENING, RNG_OPEN, INV_RING_OPEN_FRAMES);
-    InvRing_MotionRadius(ring, INV_RING_RADIUS);
-    InvRing_MotionCameraPos(ring, INV_RING_CAMERA_HEIGHT);
+    M_MotionRadius(ring, INV_RING_RADIUS);
+    M_MotionCameraPos(ring, INV_RING_CAMERA_HEIGHT);
     InvRing_MotionRotation(
         ring, INV_RING_OPEN_ROTATION,
         -DEG_90 - ring->current_object * ring->angle_adder);
@@ -406,11 +451,52 @@ void InvRing_MotionSetup(
     motion->camera_y_rate = 0;
 }
 
-void InvRing_MotionRadius(INV_RING *const ring, const int16_t target)
+void InvRing_SetStatusTransition(
+    INV_RING *const ring, const RING_STATUS status,
+    const RING_STATUS status_target, const int16_t frames)
 {
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->radius_target = target;
-    motion->radius_rate = (target - ring->radius) / motion->count;
+    InvRing_MotionSetup(ring, status, status_target, frames);
+
+    const INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
+
+    switch (status) {
+    case RNG_OPENING:
+        M_MotionRadius(ring, INV_RING_RADIUS);
+        ring->camera_pitch = -ring->motion.misc;
+        ring->motion.camera_pitch_rate =
+            ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
+        ring->motion.camera_pitch_target = 0;
+        break;
+
+    case RNG_CLOSING:
+        M_MotionRadius(ring, 0);
+        if (status_target == RNG_DONE || status_target == RNG_FADING_OUT) {
+            M_MotionCameraPos(ring, INV_RING_CAMERA_START_HEIGHT);
+        }
+        InvRing_MotionRotation(
+            ring, INV_RING_CLOSE_ROTATION,
+            ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
+        break;
+
+    case RNG_SELECTING:
+        InvRing_MotionRotation(
+            ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
+        M_MotionItemSelect(ring, inv_item);
+        break;
+
+    case RNG_DESELECT:
+    case RNG_EXITING_INVENTORY:
+        M_MotionItemDeselect(ring, inv_item);
+        break;
+
+    case RNG_DESELECTING:
+        InvRing_MotionRotation(
+            ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
+        break;
+
+    default:
+        break;
+    }
 }
 
 void InvRing_MotionRotation(
@@ -421,48 +507,11 @@ void InvRing_MotionRotation(
     motion->rotate_rate = rotation / motion->count;
 }
 
-void InvRing_MotionCameraPos(INV_RING *const ring, const int16_t target)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->camera_y_target = target;
-    motion->camera_y_rate = (target - ring->camera.pos.y) / motion->count;
-}
-
 void InvRing_MotionCameraPitch(INV_RING *const ring, const int16_t target)
 {
     INV_RING_MOTION *const motion = &ring->motion;
     motion->camera_pitch_target = target;
     motion->camera_pitch_rate = target / motion->count;
-}
-
-void InvRing_MotionItemSelect(
-    INV_RING *const ring, const INVENTORY_ITEM *const inv_item)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->item_pt_x_rot_target = inv_item->x_rot_pt_sel;
-    motion->item_pt_x_rot_rate = inv_item->x_rot_pt_sel / motion->count;
-    motion->item_x_rot_target = inv_item->x_rot_sel;
-    motion->item_x_rot_rate =
-        (inv_item->x_rot_sel - inv_item->x_rot_nosel) / motion->count;
-    motion->item_y_trans_target = inv_item->y_trans_sel;
-    motion->item_y_trans_rate = inv_item->y_trans_sel / motion->count;
-    motion->item_z_trans_target = inv_item->z_trans_sel;
-    motion->item_z_trans_rate = inv_item->z_trans_sel / motion->count;
-}
-
-void InvRing_MotionItemDeselect(
-    INV_RING *const ring, const INVENTORY_ITEM *const inv_item)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->item_pt_x_rot_target = 0;
-    motion->item_pt_x_rot_rate = -(inv_item->x_rot_pt_sel / motion->count);
-    motion->item_x_rot_target = inv_item->x_rot_nosel;
-    motion->item_x_rot_rate =
-        (inv_item->x_rot_nosel - inv_item->x_rot_sel) / motion->count;
-    motion->item_y_trans_target = 0;
-    motion->item_y_trans_rate = -(inv_item->y_trans_sel / motion->count);
-    motion->item_z_trans_target = 0;
-    motion->item_z_trans_rate = -(inv_item->z_trans_sel / motion->count);
 }
 
 void InvRing_SelectMeshes(INVENTORY_ITEM *const inv_item)

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -92,18 +92,57 @@ static void M_HandleRequestedObject(INV_RING *const ring)
     m_RequestedObjectID = NO_OBJECT;
 }
 
+static void M_MotionInit(INV_RING *const ring)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->radius_target = 0;
+    motion->radius_rate = 0;
+    motion->camera_y_target = 0;
+    motion->camera_y_rate = 0;
+    motion->camera_pitch_target = 0;
+    motion->camera_pitch_rate = 0;
+    motion->rotate_target = 0;
+    motion->rotate_rate = 0;
+    motion->item_pt_x_rot_target = 0;
+    motion->item_pt_x_rot_rate = 0;
+    motion->item_x_rot_target = 0;
+    motion->item_x_rot_rate = 0;
+    motion->item_y_trans_target = 0;
+    motion->item_y_trans_rate = 0;
+    motion->item_z_trans_target = 0;
+    motion->item_z_trans_rate = 0;
+
+    motion->misc = 0;
+}
+
 static void M_MotionCameraPos(INV_RING *const ring, const int16_t target)
 {
     INV_RING_MOTION *const motion = &ring->motion;
     motion->camera_y_target = target;
-    motion->camera_y_rate = (target - ring->camera.pos.y) / motion->count;
+    motion->camera_y_rate = (target - ring->camera.pos.y) / ring->status_frames;
+}
+
+static void M_MotionCameraPitch(INV_RING *const ring, const int16_t target)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->camera_pitch_target = target;
+    motion->camera_pitch_rate = target / ring->status_frames;
+    motion->misc = target;
+}
+
+static void M_MotionRotation(
+    INV_RING *const ring, const int16_t rotation, const int16_t target)
+{
+    INV_RING_MOTION *const motion = &ring->motion;
+    motion->rotate_target = target;
+    motion->rotate_rate = rotation / ring->status_frames;
 }
 
 static void M_MotionRadius(INV_RING *const ring, const int16_t target)
 {
     INV_RING_MOTION *const motion = &ring->motion;
     motion->radius_target = target;
-    motion->radius_rate = (target - ring->radius) / motion->count;
+    motion->radius_rate = (target - ring->radius) / ring->status_frames;
 }
 
 static void M_MotionItemSelect(
@@ -111,14 +150,14 @@ static void M_MotionItemSelect(
 {
     INV_RING_MOTION *const motion = &ring->motion;
     motion->item_pt_x_rot_target = inv_item->x_rot_pt_sel;
-    motion->item_pt_x_rot_rate = inv_item->x_rot_pt_sel / motion->count;
+    motion->item_pt_x_rot_rate = inv_item->x_rot_pt_sel / ring->status_frames;
     motion->item_x_rot_target = inv_item->x_rot_sel;
     motion->item_x_rot_rate =
-        (inv_item->x_rot_sel - inv_item->x_rot_nosel) / motion->count;
+        (inv_item->x_rot_sel - inv_item->x_rot_nosel) / ring->status_frames;
     motion->item_y_trans_target = inv_item->y_trans_sel;
-    motion->item_y_trans_rate = inv_item->y_trans_sel / motion->count;
+    motion->item_y_trans_rate = inv_item->y_trans_sel / ring->status_frames;
     motion->item_z_trans_target = inv_item->z_trans_sel;
-    motion->item_z_trans_rate = inv_item->z_trans_sel / motion->count;
+    motion->item_z_trans_rate = inv_item->z_trans_sel / ring->status_frames;
 }
 
 static void M_MotionItemDeselect(
@@ -126,14 +165,15 @@ static void M_MotionItemDeselect(
 {
     INV_RING_MOTION *const motion = &ring->motion;
     motion->item_pt_x_rot_target = 0;
-    motion->item_pt_x_rot_rate = -(inv_item->x_rot_pt_sel / motion->count);
+    motion->item_pt_x_rot_rate =
+        -(inv_item->x_rot_pt_sel / ring->status_frames);
     motion->item_x_rot_target = inv_item->x_rot_nosel;
     motion->item_x_rot_rate =
-        (inv_item->x_rot_nosel - inv_item->x_rot_sel) / motion->count;
+        (inv_item->x_rot_nosel - inv_item->x_rot_sel) / ring->status_frames;
     motion->item_y_trans_target = 0;
-    motion->item_y_trans_rate = -(inv_item->y_trans_sel / motion->count);
+    motion->item_y_trans_rate = -(inv_item->y_trans_sel / ring->status_frames);
     motion->item_z_trans_target = 0;
-    motion->item_z_trans_rate = -(inv_item->z_trans_sel / motion->count);
+    motion->item_z_trans_rate = -(inv_item->z_trans_sel / ring->status_frames);
 }
 
 void InvRing_AdjustMusicVolume(const INV_RING *const ring)
@@ -199,10 +239,13 @@ void InvRing_InitRing(
     ring->camera.rot.y = 0;
     ring->camera.rot.z = 0;
 
-    InvRing_MotionInit(ring, RNG_OPENING, RNG_OPEN, INV_RING_OPEN_FRAMES);
+    ring->status = RNG_OPENING;
+    ring->status_target = RNG_OPEN;
+    ring->status_frames = INV_RING_OPEN_FRAMES;
+
     M_MotionRadius(ring, INV_RING_RADIUS);
     M_MotionCameraPos(ring, INV_RING_CAMERA_HEIGHT);
-    InvRing_MotionRotation(
+    M_MotionRotation(
         ring, INV_RING_OPEN_ROTATION,
         -DEG_90 - ring->current_object * ring->angle_adder);
 
@@ -318,7 +361,7 @@ void InvRing_DoMotions(INV_RING *const ring)
 {
     INV_RING_MOTION *const motion = &ring->motion;
 
-    if (motion->count != 0) {
+    if (ring->status_frames != 0) {
         ring->radius += motion->radius_rate;
         ring->camera.pos.y += motion->camera_y_rate;
         ring->ring_pos.rot.y += motion->rotate_rate;
@@ -330,9 +373,9 @@ void InvRing_DoMotions(INV_RING *const ring)
         inv_item->y_trans += motion->item_y_trans_rate;
         inv_item->z_trans += motion->item_z_trans_rate;
 
-        motion->count--;
-        if (motion->count == 0) {
-            motion->status = motion->status_target;
+        ring->status_frames--;
+        if (ring->status_frames == 0) {
+            ring->status = ring->status_target;
 
             if (motion->radius_rate != 0) {
                 motion->radius_rate = 0;
@@ -410,52 +453,16 @@ void InvRing_RotateRight(INV_RING *const ring)
     ring->rot_adder = ring->rot_adder_r;
 }
 
-void InvRing_MotionInit(
-    INV_RING *const ring, const RING_STATUS status,
-    const RING_STATUS status_target, const int16_t frames)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->count = frames;
-    motion->status = status;
-    motion->status_target = status_target;
-
-    motion->radius_target = 0;
-    motion->radius_rate = 0;
-    motion->camera_y_target = 0;
-    motion->camera_y_rate = 0;
-    motion->camera_pitch_target = 0;
-    motion->camera_pitch_rate = 0;
-    motion->rotate_target = 0;
-    motion->rotate_rate = 0;
-    motion->item_pt_x_rot_target = 0;
-    motion->item_pt_x_rot_rate = 0;
-    motion->item_x_rot_target = 0;
-    motion->item_x_rot_rate = 0;
-    motion->item_y_trans_target = 0;
-    motion->item_y_trans_rate = 0;
-    motion->item_z_trans_target = 0;
-    motion->item_z_trans_rate = 0;
-
-    motion->misc = 0;
-}
-
-void InvRing_MotionSetup(
-    INV_RING *const ring, const RING_STATUS status,
-    const RING_STATUS status_target, const int16_t frames)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->count = frames;
-    motion->status = status;
-    motion->status_target = status_target;
-    motion->radius_rate = 0;
-    motion->camera_y_rate = 0;
-}
-
 void InvRing_SetStatusTransition(
     INV_RING *const ring, const RING_STATUS status,
     const RING_STATUS status_target, const int16_t frames)
 {
-    InvRing_MotionSetup(ring, status, status_target, frames);
+    INV_RING_MOTION *const motion = &ring->motion;
+    ring->status_frames = frames;
+    ring->status = status;
+    ring->status_target = status_target;
+    motion->radius_rate = 0;
+    motion->camera_y_rate = 0;
 
     const INVENTORY_ITEM *const inv_item = ring->list[ring->current_object];
 
@@ -466,20 +473,41 @@ void InvRing_SetStatusTransition(
         ring->motion.camera_pitch_rate =
             ring->motion.misc / (M_RING_SWITCH_FRAMES / 2);
         ring->motion.camera_pitch_target = 0;
+        InvRing_CalcAdders(ring, INV_RING_ROTATE_DURATION);
+        M_MotionRotation(
+            ring, INV_RING_OPEN_ROTATION,
+            -DEG_90 - ring->angle_adder * ring->current_object);
+        ring->ring_pos.rot.y =
+            ring->motion.rotate_target + INV_RING_OPEN_ROTATION;
         break;
 
     case RNG_CLOSING:
         M_MotionRadius(ring, 0);
-        if (status_target == RNG_DONE || status_target == RNG_FADING_OUT) {
+
+        switch (status_target) {
+        case RNG_DONE:
+        case RNG_FADING_OUT:
             M_MotionCameraPos(ring, INV_RING_CAMERA_START_HEIGHT);
+            break;
+        case RNG_MAIN2KEYS:
+        case RNG_OPTION2MAIN:
+            M_MotionCameraPitch(ring, DEG_45);
+            break;
+        case RNG_MAIN2OPTION:
+        case RNG_KEYS2MAIN:
+            M_MotionCameraPitch(ring, -DEG_45);
+            break;
+        default:
+            break;
         }
-        InvRing_MotionRotation(
+
+        M_MotionRotation(
             ring, INV_RING_CLOSE_ROTATION,
             ring->ring_pos.rot.y - INV_RING_CLOSE_ROTATION);
         break;
 
     case RNG_SELECTING:
-        InvRing_MotionRotation(
+        M_MotionRotation(
             ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
         M_MotionItemSelect(ring, inv_item);
         break;
@@ -490,28 +518,13 @@ void InvRing_SetStatusTransition(
         break;
 
     case RNG_DESELECTING:
-        InvRing_MotionRotation(
+        M_MotionRotation(
             ring, 0, -DEG_90 - ring->angle_adder * ring->current_object);
         break;
 
     default:
         break;
     }
-}
-
-void InvRing_MotionRotation(
-    INV_RING *const ring, const int16_t rotation, const int16_t target)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->rotate_target = target;
-    motion->rotate_rate = rotation / motion->count;
-}
-
-void InvRing_MotionCameraPitch(INV_RING *const ring, const int16_t target)
-{
-    INV_RING_MOTION *const motion = &ring->motion;
-    motion->camera_pitch_target = target;
-    motion->camera_pitch_rate = target / motion->count;
 }
 
 void InvRing_SelectMeshes(INVENTORY_ITEM *const inv_item)
@@ -748,11 +761,9 @@ void InvRing_UpdateInventoryItem(
             }
         }
     } else if (
-        ring->motion.status == RNG_SELECTED
-        || ring->motion.status == RNG_DESELECTING
-        || ring->motion.status == RNG_SELECTING
-        || ring->motion.status == RNG_DESELECT
-        || ring->motion.status == RNG_CLOSING_ITEM) {
+        ring->status == RNG_SELECTED || ring->status == RNG_DESELECTING
+        || ring->status == RNG_SELECTING || ring->status == RNG_DESELECT
+        || ring->status == RNG_CLOSING_ITEM) {
 
         if (inv_item->has_manual_rot) {
             return;

--- a/src/trx/game/inventory_ring/priv.h
+++ b/src/trx/game/inventory_ring/priv.h
@@ -51,6 +51,6 @@ void InvRing_RemoveVersionText(void);
 void InvRing_DrawUI(INV_RING *ring);
 
 void InvRing_UpdateInventoryItem(
-    const INV_RING *ring, INVENTORY_ITEM *inv_item, int32_t num_frames);
+    const INV_RING *ring, INVENTORY_ITEM *inv_item);
 
 bool InvRing_IsOptionLockedOut(void);

--- a/src/trx/game/inventory_ring/priv.h
+++ b/src/trx/game/inventory_ring/priv.h
@@ -32,18 +32,18 @@ void InvRing_DoMotions(INV_RING *ring);
 void InvRing_RotateLeft(INV_RING *ring);
 void InvRing_RotateRight(INV_RING *ring);
 
+void InvRing_SetStatusTransition(
+    INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
+    int16_t frames);
+
 void InvRing_MotionInit(
     INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
     int16_t frames);
 void InvRing_MotionSetup(
     INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
     int16_t frames);
-void InvRing_MotionRadius(INV_RING *ring, int16_t target);
 void InvRing_MotionRotation(INV_RING *ring, int16_t rotation, int16_t target);
-void InvRing_MotionCameraPos(INV_RING *ring, int16_t target);
 void InvRing_MotionCameraPitch(INV_RING *ring, int16_t target);
-void InvRing_MotionItemSelect(INV_RING *ring, const INVENTORY_ITEM *inv_item);
-void InvRing_MotionItemDeselect(INV_RING *ring, const INVENTORY_ITEM *inv_item);
 
 void InvRing_ShowItemName(const INVENTORY_ITEM *inv_item);
 void InvRing_ShowItemQuantity(const char *fmt, int32_t qty);

--- a/src/trx/game/inventory_ring/priv.h
+++ b/src/trx/game/inventory_ring/priv.h
@@ -36,15 +36,6 @@ void InvRing_SetStatusTransition(
     INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
     int16_t frames);
 
-void InvRing_MotionInit(
-    INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
-    int16_t frames);
-void InvRing_MotionSetup(
-    INV_RING *ring, RING_STATUS status, RING_STATUS status_target,
-    int16_t frames);
-void InvRing_MotionRotation(INV_RING *ring, int16_t rotation, int16_t target);
-void InvRing_MotionCameraPitch(INV_RING *ring, int16_t target);
-
 void InvRing_ShowItemName(const INVENTORY_ITEM *inv_item);
 void InvRing_ShowItemQuantity(const char *fmt, int32_t qty);
 void InvRing_RemoveItemTexts(void);

--- a/src/trx/game/inventory_ring/types.h
+++ b/src/trx/game/inventory_ring/types.h
@@ -40,11 +40,17 @@ typedef struct {
     int16_t x_rot;
     int16_t y_rot_sel;
     int16_t y_rot;
+    int16_t prev_y_rot;
     int32_t y_trans_sel;
     int32_t y_trans;
+    int32_t prev_y_trans;
     int32_t z_trans_sel;
     int32_t z_trans;
+    int32_t prev_z_trans;
+    int16_t prev_x_rot_pt;
+    int16_t prev_x_rot;
     MATRIX manual_rot;
+    MATRIX prev_manual_rot;
     bool has_manual_rot;
     uint32_t meshes_sel;
     uint32_t meshes_drawn;
@@ -84,7 +90,9 @@ typedef struct {
     INVENTORY_ITEM **list;
     RING_TYPE type;
     int16_t radius;
+    int16_t prev_radius;
     int16_t camera_pitch;
+    int16_t prev_camera_pitch;
     bool rotating;
     int16_t rotate_from_object;
     int16_t rotate_to_object;
@@ -103,10 +111,12 @@ typedef struct {
         XYZ_32 pos;
         XYZ_16 rot;
     } ring_pos;
+    int16_t prev_ring_rot_y;
     struct {
         XYZ_32 pos;
         XYZ_16 rot;
     } camera;
+    int16_t prev_camera_y;
     XYZ_32 light;
     INV_RING_MOTION motion;
 
@@ -116,7 +126,6 @@ typedef struct {
     bool has_spun_out;
     int32_t old_fov;
 
-    CLOCK_TIMER motion_timer;
     FADER top_fader;
     FADER back_fader;
 

--- a/src/trx/game/inventory_ring/types.h
+++ b/src/trx/game/inventory_ring/types.h
@@ -53,9 +53,6 @@ typedef struct {
 } INVENTORY_ITEM;
 
 typedef struct {
-    int16_t count;
-    RING_STATUS status;
-    RING_STATUS status_target;
     int16_t radius_target;
     int16_t radius_rate;
     int16_t camera_y_target;
@@ -95,6 +92,9 @@ typedef struct {
     int16_t current_object;
     int16_t target_object;
     int16_t number_of_objects;
+    RING_STATUS status;
+    RING_STATUS status_target;
+    int16_t status_frames;
     int16_t angle_adder;
     int16_t rot_adder;
     int16_t rot_adder_l;

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -231,7 +231,7 @@ void Lara_Hair_Control(const bool in_cutscene)
     }
 
     Matrix_PushUnit();
-    Matrix_TranslateSet(lara_item->pos.x, lara_item->pos.y, lara_item->pos.z);
+    Matrix_TranslateSet32(lara_item->pos);
     Matrix_Rot16(lara_item->rot);
 
     if (frac == 0 || Lara_Pose_Get() != nullptr) {
@@ -260,7 +260,7 @@ void Lara_Hair_Control(const bool in_cutscene)
             HAIR_SEGMENT *const s = &m_HairSegments[i];
 
             Matrix_PushUnit();
-            Matrix_TranslateSet(ps->pos.x, ps->pos.y, ps->pos.z);
+            Matrix_TranslateSet32(ps->pos);
             Matrix_RotY(ps->rot.y);
             Matrix_RotX(ps->rot.x);
             Matrix_TranslateRel32(bone->pos);
@@ -359,7 +359,7 @@ void Lara_Hair_Control(const bool in_cutscene)
         ps->rot.x = -Math_Atan(distance, s->pos.y - ps->pos.y);
 
         Matrix_PushUnit();
-        Matrix_TranslateSet(ps->pos.x, ps->pos.y, ps->pos.z);
+        Matrix_TranslateSet32(ps->pos);
         Matrix_RotY(ps->rot.y);
         Matrix_RotX(ps->rot.x);
 

--- a/src/trx/game/matrix.c
+++ b/src/trx/game/matrix.c
@@ -620,10 +620,15 @@ void Matrix_TranslateAbs32(const XYZ_32 offset)
     Matrix_TranslateAbs(offset.x, offset.y, offset.z);
 }
 
-void Matrix_TranslateSet(const int32_t x, const int32_t y, const int32_t z)
+void Matrix_TranslateSet32(const XYZ_32 origin)
 {
-    M_TranslateSet(g_MatrixPtr, (XYZ_32) { x, y, z });
-    M_TranslateSet(g_WMatrixPtr, (XYZ_32) { x, y, z });
+    M_TranslateSet(g_MatrixPtr, origin);
+    M_TranslateSet(g_WMatrixPtr, origin);
+}
+
+void Matrix_TranslateSet32_M(MATRIX *const m, const XYZ_32 origin)
+{
+    M_TranslateSet(m, origin);
 }
 
 void Matrix_InitInterpolate(const int32_t frac, const int32_t rate)

--- a/src/trx/game/matrix.h
+++ b/src/trx/game/matrix.h
@@ -55,7 +55,8 @@ void Matrix_TranslateRel32(XYZ_32 offset);
 void Matrix_TranslateAbs(int32_t x, int32_t y, int32_t z);
 void Matrix_TranslateAbs16(XYZ_16 offset);
 void Matrix_TranslateAbs32(XYZ_32 offset);
-void Matrix_TranslateSet(int32_t x, int32_t y, int32_t z);
+void Matrix_TranslateSet32(XYZ_32 origin);
+void Matrix_TranslateSet32_M(MATRIX *out, XYZ_32 origin);
 
 void Matrix_Push_I(void);
 void Matrix_Pop_I(void);

--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -649,7 +649,7 @@ void Output_CalculateObjectLighting(
 
     Matrix_PushUnit();
 
-    Matrix_TranslateSet(0, 0, 0);
+    Matrix_TranslateSet32((XYZ_32) {});
     Matrix_Rot16(item->rot);
     Matrix_TranslateRel32((XYZ_32) {
         .x = (bounds->min.x + bounds->max.x) / 2,

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -170,7 +170,7 @@ static void M_Draw3DPickups(const M_PRIV *const p)
         pickup_view_matrix = g_ViewMatrix;
 
         Matrix_PushUnit();
-        Matrix_TranslateSet(origin.x, origin.y, origin.z);
+        Matrix_TranslateSet32(origin);
         Matrix_RotX(DEG_1 * 15);
         Matrix_RotY(-DEG_180);
         Matrix_RotY(pickup->rot_y);

--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -42,12 +42,12 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
     M_PRIV *const p = phase->priv;
     ASSERT(p->ring != nullptr);
     const GF_COMMAND gf_cmd = InvRing_Control(p->ring);
-    if (p->mode == INV_TITLE_MODE && p->ring->motion.status == RNG_DONE) {
+    if (p->mode == INV_TITLE_MODE && p->ring->status == RNG_DONE) {
         p->fade_to_black = true;
     }
     return (PHASE_CONTROL) {
         .action = (p->mode == INV_GLOBE_SELECT_MODE && gf_cmd.action != GF_NOOP)
-                || p->ring->motion.status == RNG_DONE
+                || p->ring->status == RNG_DONE
             ? PHASE_ACTION_END
             : PHASE_ACTION_CONTINUE,
         .gf_cmd = gf_cmd,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:

- Cloaks motion setups behind a new function, `InvRing_SetStatusTransition`
- Moves `DoMotions` to be called in the control phase
- Moves `UpdateInventoryItem` to be called in the control phase
- To continue looking smooth, it interpolates in-between draw frames with the approach known from `interpolation.c`
    - As a freebie, we now get 60 FPS manual item rotation transforms in the item examine dialog :)

#### What's this even for

This PR fixes one of the main sources of non‑deterministic game behavior, where inventory ring state transitions depended on vsync timing or wall clock variance, causing transitions to complete on random logical frames.

Altering turbo speed in recordings exposes this issue – the game starts behaving inconsistently, and in rare cases (like missed vsync) it can even happen at normal speeds, though not in headless mode.

The following demos illustrate the problem by forcing a bad internal state (a separate bug that this PR nonetheless fixes):
- [test-turbo-sim-speed0.txt](https://github.com/user-attachments/files/25479050/test-turbo-sim-speed0.txt) – good
- [test-turbo-sim-speed4.txt](https://github.com/user-attachments/files/25479054/test-turbo-sim-speed4.txt) – completely broken

#### Testing

- [x] Visuals
  - Traversing inventory rings up/down
  - Opening the ring
  - Closing the ring
  - Item selecting
  - Item deselecting
  - Item usage: meds, guns, key/puzzle items
  - Item examination
  - Manual item rotations
  - Passport open/close
  - Passport page flips
  - Gameplay settings open/close
  - Title and in-game rings camera pitch differences
  Look for interpolation issues and general regressions.
- [x] Behavior
  Expected outcome: Using certain items (sg crystals, keys) interacts with the ring as expected
- [ ] Inventory ring buffering
  Expected outcome: buffering continues to advance the game by 2 logical frames – not more, not less

Here's a recording I used to test for visual regressions in the headless mode:
[test-inv-ring-visuals.txt](https://github.com/user-attachments/files/25479262/test-inv-ring-visuals.txt)
I ran it on develop, renamed all `*wip.jpg` files to `*good.jpg`, then re-ran it on this PR and compared side-by-side.
It looked good enough to me, though the inventory closing seems to happen 1 frame early, hence my request to test buffering.