### PR TITLE
inv-ring: lazy-init globe

### DIFF
--- a/docs/05-game_flow/2-SEQUENCES.md
+++ b/docs/05-game_flow/2-SEQUENCES.md
@@ -56,6 +56,9 @@ default game flow for examples.
       Ends the current level and opens the globe destination selector.
       Available destinations are configured by the global
       <code><a href="./0-GLOBAL_PROPERTIES.md#globe-select-entries">globe_select_entries</a></code>.
+      You can make the globe selectable at game start. To do this, let the
+      first level contain only the `<code>globe_select</code>` directive, and
+      have its first area link to level 2.
     </td>
   </tr>
   <tr valign="top">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - added a new Lua property, `trx.lara.equipped_gun`, to read Lara's currently equipped gun type
 - added support for using more sound slots than originally possible in custom levels (#3898)
 - added blood effects when enemies shoot any other creature (not just Lara)
+- added support for the globe-style level selection mechanic in the new game for level builders (#4920)
 - changed `O_WINDOW_1` and `O_WINDOW_2` to `O_SMASH_OBJECT_1` and `O_SMASH_OBJECT_2` respectively
 - changed Earthquake to support being reset
 - changed loading screens setting to use modes (`disabled`, `always`, `new-games`). Previously, they were hardcoded to not show for saves (#1290)

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -913,6 +913,12 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
         if (mode == INV_TITLE_MODE && GF_GetGymLevel() != nullptr) {
             Inv_InsertItem(InvRing_GetByObjectID(O_PHOTO_OPTION));
         }
+    } else if (g_InvRing_Source[RT_GLOBE_SELECT].count == 0) {
+        INVENTORY_ITEM *const globe =
+            InvRing_GetByObjectID(O_GLOBE_SELECT_OPTION);
+        if (globe != nullptr) {
+            Inv_InsertItem(globe);
+        }
     }
 
     g_InvRing_Source[RT_KEYS].current = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a globe initialization bug, allowing builders to apply a kludge that makes it usable immediately when starting a new game.

To use it:

1. Change the first zone to point to level 2, not level 1:
    ```diff
    diff --git a/data/tr3/ship/cfg/tr3/gameflow.json5 b/data/tr3/ship/cfg/tr3/gameflow.json5
    index a566614cb..881bd34eb 100644
    --- a/data/tr3/ship/cfg/tr3/gameflow.json5
    +++ b/data/tr3/ship/cfg/tr3/gameflow.json5
    @@ -35,7 +35,7 @@
         ],
     
         "globe_select_entries": [
    -        {"rot": [-1536, -7936, 1536], "start_level_ordinal": 1,  "completion_level_ordinal": 4,  "prereq_zones": [], "mesh_idx": 2},
    +        {"rot": [-1536, -7936, 1536], "start_level_ordinal": 2,  "completion_level_ordinal": 4,  "prereq_zones": [], "mesh_idx": 2},
             {"rot": [1024, -512, -256],   "start_level_ordinal": 5,  "completion_level_ordinal": 8,  "prereq_zones": [0], "mesh_idx": 5},
             {"rot": [2560, 21248, -4096], "start_level_ordinal": 13, "completion_level_ordinal": 15, "prereq_zones": [0], "mesh_idx": 4},
             {"rot": [-3328, 29440, 1024], "start_level_ordinal": -1, "completion_level_ordinal": -1, "prereq_zones": [], "mesh_idx": 3},
    ```

2. Gut out the first level to immediately start with `globe_select`. It still needs to be a valid level file and contain the globe mesh for this to work!
    ```diff
    @@ -64,24 +64,12 @@
             // 1. Jungle
             {
                 "path": "jungle.tr2",
    -            "script": "jungle.lua",
    -            "music_track": 34,
                 "lara_outfit": "tr3_classic",
    -            "weather_type": "rain",
                 "sequence": [
    -                {"type": "loading_screen", "path": "india.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
    -                {"type": "give_item", "object_id": "small_medipack"},
    -                {"type": "give_item", "object_id": "large_medipack"},
    -                {"type": "give_item", "object_id": "flare", "quantity": 2},
    -                {"type": "loop_game"},
    -                {"type": "play_cutscene", "cutscene_id": 0},
    -                {"type": "play_music", "music_track": 14},
    -                {"type": "level_stats"},
    -                {"type": "level_complete"},
    +                {"type": "globe_select", "image": "india.webp"},
                 ],
                 "injections": [
    -                "india_sky.bin",
    -                "lara_guns.bin",
    +                "globe_model.bin",
                 ],
             },
    ```

This is a workaround, but it gets the job done.