### PR TITLE
shell: support replays without -e in new dir trees

### DIFF
--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -69,6 +69,11 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             i++;
         }
     }
+    if (result->engine_version <= 0 && g_TRVersion > 0) {
+        // Hydrate recordings using old-style directory tree to use
+        // runtime engine version if they miss it.
+        result->engine_version = g_TRVersion;
+    }
 
     result->mod = Shell_GetModByType(MOD_BASE_GAME, result->engine_version);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -189,6 +189,9 @@ static void M_PrepareSystem(void)
     }
 
     if (test_replay_path != nullptr) {
+        // Allow inferring engine version from outer args for replays lacking
+        // embedded info (created with the old directory layout).
+        g_TRVersion = s->args->engine_version;
         SHELL_ARGS *const tmp_args = TestReplay_Open(test_replay_path);
         if (tmp_args != nullptr) {
             tmp_args->headless = s->args->headless;
@@ -201,14 +204,14 @@ static void M_PrepareSystem(void)
     }
 
     g_TRVersion = s->args->engine_version;
+    LOG_INFO("Engine version: %d", g_TRVersion);
+    LOG_INFO("Mod: %s", s->args->mod != nullptr ? s->args->mod->name : nullptr);
     if (s->args->engine_version <= 0 || s->args->mod == nullptr) {
         Shell_ExitSystem(
             "Unknown or ambiguous gameflow file. "
             "Are you missing --engine or --mod?");
     }
 
-    LOG_INFO("Engine version: %d", g_TRVersion);
-    LOG_INFO("Mod: %s", s->args->mod->name);
     Config_ApplyDefaultSettings();
 
     TRXPath_Init(s->args);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This is a minor <ruby>わがまま<rp>（</rp><rt>selfish</rt><rp>）</rp></ruby> tweak to let our bug recordings (which don't include `--engine`) run on my setup, which uses the new combined mods directory. This way, I don't have to manually add `--engine` into the recording files for the game to run, and instead it gets inferred from the outer CLI arguments.