### PR TITLE
Small Lua changes

### DIFF
--- a/data/scripting/items.lua
+++ b/data/scripting/items.lua
@@ -87,7 +87,7 @@ end
 local function find_items(query, first_only)
   local matches = first_only and nil or {}
   local count = raw.count()
-  for i = 0, count - 1 do
+  for i = 1, count do
     local item = setmetatable({ idx = i }, Item)
     if is_matching(item, query) then
       if first_only then

--- a/data/scripting/items.lua
+++ b/data/scripting/items.lua
@@ -11,6 +11,8 @@ local getters = {
     return trx.rooms[raw.get_room(idx)]
   end,
   status = raw.get_status,
+  flags = raw.get_flags,
+  timer = raw.get_timer,
   object_id = raw.get_object_id,
   hit_points = raw.get_hit_points,
   max_hit_points = raw.get_max_hit_points,

--- a/docs/06-lua/2-reference/4-ITEMS.md
+++ b/docs/06-lua/2-reference/4-ITEMS.md
@@ -20,6 +20,8 @@ Module for controlling all moveables behavior.
     - **`room_num`**: room number.
     - **`room`**: [`trx.rooms.Room`] object for the room containing this item.
     - **`status`**: Integer representing the item's status.
+    - **`flags`**: Integer representing the item's trigger-related flags.
+    - **`timer`**: Integer representing the item's trigger-related timer value.
     - **`hit_points`**: Integer representing the item's hit points.
     - **`max_hit_points`**: Integer representing the item's hit points.
     - **`object_id`**: Integer ID of the item's object type.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@
 - added a new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
 - added a new Lua catalog, `trx.catalog.weapons`, for weapon identifiers
 - added a new Lua property, `trx.lara.equipped_gun`, to read Lara's currently equipped gun type
+- added a new Lua property, `trx.Item.flags`, to read current item flags (related to triggers)
+- added a new Lua property, `trx.Item.timer`, to read current item timer value (related to triggers)
 - added support for using more sound slots than originally possible in custom levels (#3898)
 - added blood effects when enemies shoot any other creature (not just Lara)
 - added support for the globe-style level selection mechanic in the new game for level builders (#4920)

--- a/src/trx/game/lua/items.c
+++ b/src/trx/game/lua/items.c
@@ -114,6 +114,22 @@ static int M_L_ItemGetStatus(lua_State *const L)
     return 1;
 }
 
+// trxc.items.get_flags(index) → int or nil
+static int M_L_ItemGetFlags(lua_State *const L)
+{
+    M_ITEM_GETTER(L);
+    lua_pushinteger(L, (int)item->flags);
+    return 1;
+}
+
+// trxc.items.get_timer(index) → int or nil
+static int M_L_ItemGetTimer(lua_State *const L)
+{
+    M_ITEM_GETTER(L);
+    lua_pushinteger(L, (int)item->timer);
+    return 1;
+}
+
 // trxc.items.get_object_id(index) → int or nil
 static int M_L_ItemGetObjectId(lua_State *const L)
 {
@@ -280,6 +296,10 @@ void LUA_CreateItems(lua_State *const L)
     lua_setfield(L, -2, "get_room");
     lua_pushcfunction(L, M_L_ItemGetStatus);
     lua_setfield(L, -2, "get_status");
+    lua_pushcfunction(L, M_L_ItemGetFlags);
+    lua_setfield(L, -2, "get_flags");
+    lua_pushcfunction(L, M_L_ItemGetTimer);
+    lua_setfield(L, -2, "get_timer");
     lua_pushcfunction(L, M_L_ItemGetObjectId);
     lua_setfield(L, -2, "get_object_id");
     lua_pushcfunction(L, M_L_ItemGetHitPoints);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes Lua `items.find()` and `items.first()` off-by-one problems, and exposes read-only `Item.flags` and `Item.trigger` properties.