### PR TITLE
Fix smashing objects in overlapping rooms

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed Lua `trx.catalog` only exposing `objects` and `flip_effects`; it now also exposes `lara_states`, `lara_anims`, `music`, and `samples`
 - fixed a freeze if firing a grenade very close to room portals (#4938, regression from 1.2)
 - fixed non-deterministic Inventory Ring control (transition speeds depended on v-sync / wall clock timing)
+- fixed Lara being able to shoot smashable objects located in unreachable overlapping rooms (#4949, regression from TR1X 4.14 / TR2X 1.4)
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)
@@ -51,6 +52,7 @@
 - fixed Airlock door handles not getting drawn from certain angles (#4886, regression from 1.0)
 - fixed loading screens showing before playing FMVs on most levels
 - fixed Lara not being able to move after exiting water, having used an underwater lever with the animated interactions setting enabled (#4912, regression from 1.0)
+- fixed Bell in room 48 being shootable from room 55 (#4949, regression from TR2X 1.4)
 - removed the requirement to use `main.sfx` in custom levels (#3898)
 
 **TR3**:

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -9,9 +9,35 @@
 
 #define M_CLIP_1 8
 #define M_CLIP_2 8
+#define M_MAX_LOS_ROOMS 200
 
-static int32_t m_LOSRooms[200] = {};
+static int32_t m_LOSRooms[M_MAX_LOS_ROOMS] = {};
 static int32_t m_LOSNumRooms = 0;
+
+static inline bool M_TryPushLOSRoom(const int16_t room_num)
+{
+    if (m_LOSNumRooms < M_MAX_LOS_ROOMS) {
+        m_LOSRooms[m_LOSNumRooms++] = room_num;
+        return true;
+    }
+    return false;
+}
+
+static inline bool M_ResetLOSRooms(const int16_t room_num)
+{
+    m_LOSNumRooms = 0;
+    return M_TryPushLOSRoom(room_num);
+}
+
+static inline bool M_RoomInLOSRooms(const int16_t room_num)
+{
+    for (int32_t i = 0; i < m_LOSNumRooms; i++) {
+        if (m_LOSRooms[i] == room_num) {
+            return true;
+        }
+    }
+    return false;
+}
 
 // This routine transforms the world-space LOS segment [start,target] into the
 // object's local coordinates (undoing its translation and Y-rotation), then
@@ -171,8 +197,7 @@ static int32_t M_CheckX(
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;
 
-    m_LOSRooms[0] = room_num;
-    m_LOSNumRooms = 1;
+    M_ResetLOSRooms(room_num);
 
     if (dx < 0) {
         XYZ_32 cur_pos;
@@ -197,7 +222,7 @@ static int32_t M_CheckX(
 
             if (room_num != last_room_num) {
                 last_room_num = room_num;
-                m_LOSRooms[m_LOSNumRooms++] = room_num;
+                M_TryPushLOSRoom(room_num);
             }
 
             sample_pos.x -= 1;
@@ -241,7 +266,7 @@ static int32_t M_CheckX(
 
             if (room_num != last_room_num) {
                 last_room_num = room_num;
-                m_LOSRooms[m_LOSNumRooms++] = room_num;
+                M_TryPushLOSRoom(room_num);
             }
 
             sample_pos.x += 1;
@@ -282,8 +307,7 @@ static int32_t M_CheckZ(
     int16_t room_num = start->room_num;
     int16_t last_room_num = start->room_num;
 
-    m_LOSRooms[0] = room_num;
-    m_LOSNumRooms = 1;
+    M_ResetLOSRooms(room_num);
 
     if (dz < 0) {
         XYZ_32 cur_pos;
@@ -308,7 +332,7 @@ static int32_t M_CheckZ(
 
             if (room_num != last_room_num) {
                 last_room_num = room_num;
-                m_LOSRooms[m_LOSNumRooms++] = room_num;
+                M_TryPushLOSRoom(room_num);
             }
 
             sample_pos.z -= 1;
@@ -352,7 +376,7 @@ static int32_t M_CheckZ(
 
             if (room_num != last_room_num) {
                 last_room_num = room_num;
-                m_LOSRooms[m_LOSNumRooms++] = room_num;
+                M_TryPushLOSRoom(room_num);
             }
 
             sample_pos.z += 1;

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -148,7 +148,8 @@ static bool M_ItemIntersectSegment(
 // @param target World-space ray end
 // @return       First smashable item's index, or NO_ITEM if none hit
 int32_t LOS_CheckSmashable(
-    const XYZ_32 start, const XYZ_32 target, XYZ_32 *const out_hit_pos)
+    const GAME_VECTOR start, const GAME_VECTOR target,
+    XYZ_32 *const out_hit_pos)
 {
     int32_t best_dist = INT32_MAX;
     int16_t best_item_num = NO_ITEM;
@@ -165,12 +166,16 @@ int32_t LOS_CheckSmashable(
         }
 
         XYZ_32 hit_pos;
-        if (!M_ItemIntersectSegment(start, target, item, &hit_pos)) {
+        if (!M_ItemIntersectSegment(start.pos, target.pos, item, &hit_pos)) {
+            continue;
+        }
+
+        if (target.room_num != NO_ROOM && item->room_num != target.room_num) {
             continue;
         }
 
         // Ray segment intersects the object's local AABB
-        const int32_t dist = Item_GetDistance(item, start);
+        const int32_t dist = Item_GetDistance(item, start.pos);
         if (dist < best_dist) {
             best_dist = dist;
             best_item_num = item_num;

--- a/src/trx/game/collision/los.h
+++ b/src/trx/game/collision/los.h
@@ -4,4 +4,5 @@
 
 bool LOS_Check(
     const GAME_VECTOR *start, GAME_VECTOR *target, bool use_detailed_clipping);
-int32_t LOS_CheckSmashable(XYZ_32 start, XYZ_32 target, XYZ_32 *out_hit_pos);
+int32_t LOS_CheckSmashable(
+    GAME_VECTOR start, GAME_VECTOR target, XYZ_32 *out_hit_pos);

--- a/src/trx/game/creature/shooting.c
+++ b/src/trx/game/creature/shooting.c
@@ -112,7 +112,16 @@ bool Creature_Shoot(
 
     XYZ_32 start, target;
     M_CalcShootVectors(item, target_item, &start, &target);
-    Gun_SmashItems(start, target, nullptr, NO_OBJECT);
+    Gun_SmashItems(
+        (GAME_VECTOR) {
+            .pos = start,
+            .room_num = item->room_num,
+        },
+        (GAME_VECTOR) {
+            .pos = target,
+            .room_num = target_item->room_num,
+        },
+        nullptr, NO_OBJECT);
 
     return is_targetable;
 }

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -505,7 +505,7 @@ int32_t Gun_FireWeapon(
             };
         Room_GetSector(hit_pos.pos, &hit_pos.room_num);
         const bool object_on_los = LOS_Check(&start, &hit_pos, true);
-        if (Gun_SmashItems(start.pos, hit_pos.pos, &hit_pos.pos, NO_OBJECT)
+        if (Gun_SmashItems(start, hit_pos, &hit_pos.pos, NO_OBJECT)
             == PROJECTILE_HIT_STOP) {
             Room_GetSector(hit_pos.pos, &hit_pos.room_num);
         }
@@ -520,10 +520,10 @@ int32_t Gun_FireWeapon(
         .x = start.x + ((best_dist * g_MatrixPtr->_20) >> W2V_SHIFT),
         .y = start.y + ((best_dist * g_MatrixPtr->_21) >> W2V_SHIFT),
         .z = start.z + ((best_dist * g_MatrixPtr->_22) >> W2V_SHIFT),
-        .room_num = src->room_num,
+        .room_num = start.room_num,
     };
     Room_GetSector(hit_pos.pos, &hit_pos.room_num);
-    Gun_SmashItems(start.pos, hit_pos.pos, nullptr, NO_OBJECT);
+    Gun_SmashItems(start, hit_pos, nullptr, NO_OBJECT);
     Gun_HitTarget(
         target, &start, &hit_pos,
         weapon->damage * (Game_IsBonusFlagSet(GBF_JAPANESE) ? 2 : 1));

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -374,8 +374,8 @@ void Gun_UpdateLaraMeshes(const OBJECT_ID obj_id)
 }
 
 PROJECTILE_HIT Gun_SmashItems(
-    const XYZ_32 start, const XYZ_32 target, XYZ_32 *const out_hit_pos,
-    const OBJECT_ID missile_obj_id)
+    const GAME_VECTOR start, const GAME_VECTOR target,
+    XYZ_32 *const out_hit_pos, const OBJECT_ID missile_obj_id)
 {
     int32_t hits = 0;
     int16_t last_item_num = NO_ITEM;

--- a/src/trx/game/gun/misc.h
+++ b/src/trx/game/gun/misc.h
@@ -27,4 +27,5 @@ void Gun_HitTarget(
 void Gun_DrawFlash(LARA_GUN_TYPE weapon_type, CLIP clip, bool interpolated);
 
 PROJECTILE_HIT Gun_SmashItems(
-    XYZ_32 start, XYZ_32 target, XYZ_32 *out_hit_pos, OBJECT_ID missile_obj_id);
+    GAME_VECTOR start, GAME_VECTOR target, XYZ_32 *out_hit_pos,
+    OBJECT_ID missile_obj_id);

--- a/src/trx/game/gun/rifle.c
+++ b/src/trx/game/gun/rifle.c
@@ -184,10 +184,13 @@ static void M_FireHarpoon(void)
     }
 
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_HARPOON];
-    const XYZ_32 origin = {
-        .x = lara_item->pos.x,
-        .y = lara_item->pos.y - weapon->gun_height,
-        .z = lara_item->pos.z,
+    const GAME_VECTOR origin = {
+        .pos = {
+            .x = lara_item->pos.x,
+            .y = lara_item->pos.y - weapon->gun_height,
+            .z = lara_item->pos.z,
+        },
+        .room_num = lara_item->room_num,
     };
 
     ITEM *const projectile_item = Item_Get(item_num);
@@ -242,7 +245,12 @@ static void M_FireHarpoon(void)
     projectile_item->status = IS_ACTIVE;
 
     Gun_SmashItems(
-        origin, projectile_item->pos, nullptr, projectile_item->object_id);
+        origin,
+        (GAME_VECTOR) {
+            .pos = projectile_item->pos,
+            .room_num = projectile_item->room_num,
+        },
+        nullptr, projectile_item->object_id);
 
     lara->harpoon_ammo.ammo--;
     Stats_AddAmmoUsed();
@@ -270,10 +278,13 @@ static void M_FireGrenade(void)
         return;
     }
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_GRENADE];
-    const XYZ_32 origin = {
-        .x = lara_item->pos.x,
-        .y = lara_item->pos.y - weapon->gun_height,
-        .z = lara_item->pos.z,
+    const GAME_VECTOR origin = {
+        .pos = {
+            .x = lara_item->pos.x,
+            .y = lara_item->pos.y - weapon->gun_height,
+            .z = lara_item->pos.z,
+        },
+        .room_num = lara_item->room_num,
     };
 
     const int16_t item_num = Item_Create();
@@ -293,12 +304,12 @@ static void M_FireGrenade(void)
     Item_Initialise(item_num);
 
     int16_t room_num = projectile_item->room_num;
-    const SECTOR *const sector = Room_GetSector(origin, &room_num);
-    const int32_t height = Room_GetHeight(sector, origin);
-    if (height < origin.y) {
+    const SECTOR *const sector = Room_GetSector(origin.pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, origin.pos);
+    if (height < origin.pos.y) {
         projectile_item->pos = (XYZ_32) {
             .x = lara_item->pos.x,
-            .y = origin.y,
+            .y = origin.pos.y,
             .z = lara_item->pos.z,
         };
     }
@@ -334,7 +345,12 @@ static void M_FireGrenade(void)
     projectile_item->status = IS_ACTIVE;
 
     Gun_SmashItems(
-        origin, projectile_item->pos, nullptr, projectile_item->object_id);
+        origin,
+        (GAME_VECTOR) {
+            .pos = projectile_item->pos,
+            .room_num = projectile_item->room_num,
+        },
+        nullptr, projectile_item->object_id);
 
     if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
         lara->grenade_ammo.ammo--;
@@ -352,10 +368,13 @@ static void M_FireRocket(void)
         return;
     }
     const WEAPON_INFO *const weapon = &g_Weapons[LGT_ROCKET];
-    const XYZ_32 origin = {
+    const GAME_VECTOR origin = {
+        .pos = {
         .x = lara_item->pos.x,
         .y = lara_item->pos.y - weapon->gun_height,
         .z = lara_item->pos.z,
+        },
+        .room_num = lara_item->room_num,
     };
 
     const int16_t item_num = Item_Create();
@@ -390,7 +409,12 @@ static void M_FireRocket(void)
     projectile_item->status = IS_ACTIVE;
 
     Gun_SmashItems(
-        origin, projectile_item->pos, nullptr, projectile_item->object_id);
+        origin,
+        (GAME_VECTOR) {
+            .pos = projectile_item->pos,
+            .room_num = projectile_item->room_num,
+        },
+        nullptr, projectile_item->object_id);
 
     if (!Game_IsBonusFlagSet(GBF_NGPLUS)) {
         lara->rocket_ammo.ammo--;

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -184,7 +184,10 @@ static bool M_TryExplodeItem(
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const XYZ_32 old_pos = item->pos;
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     const ROOM *const room = Room_Get(item->room_num);
     const bool was_underwater = room != nullptr && room->flags.underwater;
@@ -243,7 +246,7 @@ static void M_Control(const int16_t item_num)
 
         const int16_t y_rot = item->rot.y;
         item->rot.y = item->goal_anim_state;
-        Collide_DoProperDetection(item, old_pos);
+        Collide_DoProperDetection(item, old_pos.pos);
         item->goal_anim_state = item->rot.y;
         item->rot.y = y_rot;
 
@@ -315,7 +318,11 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    if (Gun_SmashItems(old_pos, item->pos, nullptr, item->object_id)
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+    if (Gun_SmashItems(old_pos, new_pos, nullptr, item->object_id)
         == PROJECTILE_HIT_STOP) {
         explode = true;
         radius = M_GetBlastRadius();
@@ -329,7 +336,8 @@ static void M_Control(const int16_t item_num)
             for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
-                if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
+                if (!M_TryExplodeItem(
+                        item, old_pos.pos, target_item_num, radius)) {
                     continue;
                 }
 
@@ -345,14 +353,14 @@ static void M_Control(const int16_t item_num)
         for (int16_t target_item_num = room->item_num;
              target_item_num != NO_ITEM;
              target_item_num = Item_Get(target_item_num)->next_item) {
-            if (M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
+            if (M_TryExplodeItem(item, old_pos.pos, target_item_num, radius)) {
                 explode = true;
             }
         }
     }
 
     if (explode) {
-        M_Explode(item_num, old_pos);
+        M_Explode(item_num, old_pos.pos);
     }
 }
 

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -49,7 +49,10 @@ static void M_Control_TR3(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    const XYZ_32 old_pos = item->pos;
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     M_SetTR3ProjectileShade(item);
 
@@ -62,7 +65,11 @@ static void M_Control_TR3(const int16_t item_num)
     item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 
-    if (Gun_SmashItems(old_pos, item->pos, nullptr, item->object_id)
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+    if (Gun_SmashItems(old_pos, new_pos, nullptr, item->object_id)
         == PROJECTILE_HIT_STOP) {
         Item_Kill(item_num);
         return;
@@ -206,7 +213,10 @@ static void M_Control_TR3(const int16_t item_num)
 static void M_Control_TR12(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const XYZ_32 old_pos = item->pos;
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     if (!Room_Get(item->room_num)->flags.underwater) {
         item->fall_speed += GRAVITY / 2;
@@ -221,8 +231,13 @@ static void M_Control_TR12(const int16_t item_num)
     item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
 
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+
     bool hit = false;
-    if (Gun_SmashItems(old_pos, item->pos, nullptr, item->object_id)
+    if (Gun_SmashItems(old_pos, new_pos, nullptr, item->object_id)
         == PROJECTILE_HIT_STOP) {
         hit = true;
     }

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -178,7 +178,10 @@ static bool M_TryExplodeItem(
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const XYZ_32 old_pos = item->pos;
+    const GAME_VECTOR old_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
 
     const ROOM *const room = Room_Get(item->room_num);
     const bool was_underwater = room != nullptr && room->flags.underwater;
@@ -299,7 +302,11 @@ static void M_Control(const int16_t item_num)
         explode = true;
     }
 
-    if (Gun_SmashItems(old_pos, item->pos, nullptr, item->object_id)
+    const GAME_VECTOR new_pos = {
+        .pos = item->pos,
+        .room_num = item->room_num,
+    };
+    if (Gun_SmashItems(old_pos, new_pos, nullptr, item->object_id)
         == PROJECTILE_HIT_STOP) {
         explode = true;
     }
@@ -312,7 +319,8 @@ static void M_Control(const int16_t item_num)
             for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
-                if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
+                if (!M_TryExplodeItem(
+                        item, old_pos.pos, target_item_num, radius)) {
                     continue;
                 }
 
@@ -328,14 +336,14 @@ static void M_Control(const int16_t item_num)
         for (int16_t target_item_num = room->item_num;
              target_item_num != NO_ITEM;
              target_item_num = Item_Get(target_item_num)->next_item) {
-            if (M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
+            if (M_TryExplodeItem(item, old_pos.pos, target_item_num, radius)) {
                 explode = true;
             }
         }
     }
 
     if (explode) {
-        M_Explode(item_num, old_pos);
+        M_Explode(item_num, old_pos.pos);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #4949.

Reason for the bug: non-Euclidean Tomb geometry
<img width="1239" height="1035" alt="image" src="https://github.com/user-attachments/assets/ad9e7f50-274d-44b2-a4d0-4bd6cbe254d3" />

Modified Aredfan's scenario to include a valid path too:
[test-bell-smash.txt](https://github.com/user-attachments/files/25497523/test-bell-smash.txt)

