### PR TITLE
shell: do not try to resolve transient levels

### DIFF
--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -672,8 +672,12 @@ static bool M_LoadLevel(
     {
         const char *tmp = nullptr;
         JSON_MUST(JSON_READ(io, "path", &tmp));
-        level->path =
-            Memory_DupStr(TRXPath_TryResolve(TRX_DYNAMIC_PATH_LEVEL_FILE, tmp));
+        if (level->type == GFL_DUMMY || level->type == GFL_CURRENT) {
+            level->path = Memory_DupStr(tmp);
+        } else {
+            level->path = Memory_DupStr(
+                TRXPath_TryResolve(TRX_DYNAMIC_PATH_LEVEL_FILE, tmp));
+        }
     }
     {
         const char *tmp_script = nullptr;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the following warnings on develop:
```
ERR | 2026-02-23 19:42:06.766 [game/shell/paths.c:1059:TRXPath_TryResolve] Failed to resolve path "current.phd". Searched paths:
  - /home/dash/data.local/work/TRX/test/trx/games/tr1/levels/current.phd
  - /home/dash/data.local/work/TRX/test/trx/data/current.phd
  - /home/dash/data.local/work/TRX/test/trx/current.phd
  - /home/dash/data.local/work/TRX/test/trx/cuts/current.phd
  - /home/dash/data.local/work/TRX/test/trx/games/tr1/cuts/current.phd)
```