### PR TITLE
data: unhide TRex collision in TGM

### DIFF
--- a/data/tr2/ship/cfg/tr2-gm/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-gm/gameflow.json5
@@ -203,7 +203,6 @@
         "enable_demo",            // TR2G has no demos
         "enable_fmv",             // TR2G has no FMVs
         "enable_item_examining",  // TR2G has no special item descriptions
-        "disable_trex_collision", // TR2G has no T-Rexes
         "fix_alligator_ai",       // TR2G has no alligators
         "fix_animated_sprites",
         "healthbar_poison_color",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed loading screens showing before playing FMVs on most levels
 - fixed Lara not being able to move after exiting water, having used an underwater lever with the animated interactions setting enabled (#4912, regression from 1.0)
 - fixed Bell in room 48 being shootable from room 55 (#4949, regression from TR2X 1.4)
+- fixed "Disable T-Rex Collision" option missing from The Golden Mask (there are T-Rex enemies in Nightmare in Vegas)
 - removed the requirement to use `main.sfx` in custom levels (#3898)
 
 **TR3**:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

From EternalCosmos on Discord:

> tr2-gm gameflow.json5 states that tr2 gold has no t-rexes. and thus hides disable_trex_collision. but there are two in nightmare in vegas 

This PR fixes it.