### PR TITLE
lara/col/crouch: fix crawl to hang softlocks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,7 @@
 - fixed Puna to no longer hardcode Lizard locations, and instead use relative offsets
 - fixed Puna's summoned Lizards counting towards total level kill count
 - fixed Tony briefly appearing for a single frame when loading a save after his death
+- fixed Lara sometimes getting stuck when crawling backwards off a tilted ledge (#4956)
 - removed the limitation of one Carcass instance per level working with Piranhas
 - removed the limitation of Piranhas only attacking Carcass instances if the level sequence matches Crash Site's
 - restored the ability for Lara to perform grab cancels, like TR1 and TR2

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -20,6 +20,7 @@
 #define M_CRAWL_TO_HANG_XZ_OFFSET  100
 #define M_CRAWL_TO_HANG_FALL_SPEED 512
 #define M_CRAWL_TO_HANG_BAD_CEILING ((STEP_L * 3) / 4) // = 192
+#define M_CRAWL_TO_HANG_FALL_FRAME 9
 // clang-format on
 
 static bool M_DeflectEdgeCrawl(ITEM *const item, COLL_INFO *const coll)
@@ -401,6 +402,16 @@ static void M_CrawlToClimb(ITEM *const item, COLL_INFO *const coll)
     if (edge_catch == EDGE_CATCH_NONE
         || (edge_catch == EDGE_CATCH_NEG
             && !Lara_Col_TestLadderHang(item, coll))) {
+        // LA_CRAWL_TO_HANG_END will loop indefinitely, so in cases where Lara
+        // cannot grab the edge, make her fall and she will then either re-grab
+        // it on a better position, or continue falling if the ledge is a slope.
+        Item_SwitchToAnim(item, LA(LA_JUMP_UP), M_CRAWL_TO_HANG_FALL_FRAME);
+        item->current_anim_state = LS(LS_JUMP_UP);
+        item->goal_anim_state = LS(LS_JUMP_UP);
+        item->gravity = true;
+        item->speed = 2;
+        item->fall_speed = 1;
+        lara->gun_status = LGS_ARMLESS;
         return;
     }
 


### PR DESCRIPTION
Resolves #4956.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes softlocks when Lara crawls backwards off a ledge and fails to grab the ledge. This seems to happen when tilts are involved, and can be reproduced in OG as well. `LA_CRAWL_TO_HANG_END` loops indefinitely and only has a single frame, so her bounds will never change and hence the softlock. The workaround makes her fall and she is then able to re-grab the ledge or continue falling if the tilt is too steep (arguably she perhaps shouldn't try to crawl back off a ledge she couldn't grab but I believe that wasn't changed until TR4/5).

In OG, the softlock can be reproduced by using the steeper slope to Lara's right in the recording in the OP. This workaround obviously isn't present in OG re the additional TRX case; I failed to find any differences though so fell back to this approach.
