### PR TITLE
cmd/teleport: add precise coords support

### DIFF
--- a/docs/02-COMMANDS.md
+++ b/docs/02-COMMANDS.md
@@ -24,9 +24,10 @@ whichever key you have bound, and not include it as part of the command itself.
   `/tp {room_number}` (legacy)  
   `/tp item {item_number}`  
   `/tp i{item_number}`  
+  `/tp precise {x} {y} {z}`  
   `/tp {x} {y} {z}`  
   `/tp {object}`  
-  Instant travel! Teleports Lara to a random spot within the specified room, to an item's position by item number, to the specified X,Y,Z coordinates, or to the nearest object of a specific type.
+  Instant travel! Teleports Lara to a random spot within the specified room, to an item's position by item number, to the specified X,Y,Z coordinates (grid units), to precise world-space coordinates (no `1024` scaling), or to the nearest object of a specific type.
 
 - `/hp`  
   `/hp {health}`  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - added blood effects when enemies shoot any other creature (not just Lara)
 - added support for the globe-style level selection mechanic in the new game for level builders (#4920)
 - added an option to control how Lara swings on thin ledges (Gameplay → Controls → Slow ledge swing) (#3341)
+- added `/tp precise {x} {y} {z}` to teleport using raw world-space coordinates (no `/1024` scaling – matches TRView)
 - changed `O_WINDOW_1` and `O_WINDOW_2` to `O_SMASH_OBJECT_1` and `O_SMASH_OBJECT_2` respectively
 - changed Earthquake to support being reset
 - changed loading screens setting to use modes (`disabled`, `always`, `new-games`). Previously, they were hardcoded to not show for saves (#1290)

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -176,19 +176,22 @@ static void M_AlignLaraToItem(const ITEM *const item)
     }
 }
 
-static COMMAND_RESULT M_TeleportToXYZ(float x, const float y, float z)
+static COMMAND_RESULT M_TeleportToXYZ(
+    float x, const float y, float z, const bool precise_coords)
 {
-    if (M_IsFloatRound(x)) {
-        x += 0.5f;
-    }
-    if (M_IsFloatRound(z)) {
-        z += 0.5f;
+    if (!precise_coords) {
+        if (M_IsFloatRound(x)) {
+            x += 0.5f;
+        }
+        if (M_IsFloatRound(z)) {
+            z += 0.5f;
+        }
     }
 
     const XYZ_32 pos = {
-        .x = x * WALL_L,
-        .y = y * WALL_L,
-        .z = z * WALL_L,
+        .x = precise_coords ? x : x * WALL_L,
+        .y = precise_coords ? y : y * WALL_L,
+        .z = precise_coords ? z : z * WALL_L,
     };
     if (!Lara_Cheat_Teleport(pos, NO_ROOM)) {
         Console_LogError(GS(CMD_TELEPORT_POS_FAIL), x, y, z);
@@ -367,8 +370,12 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     }
 
     float x, y, z;
+    if (sscanf(ctx->args, "precise %f %f %f", &x, &y, &z) == 3) {
+        return M_TeleportToXYZ(x, y, z, true);
+    }
+
     if (sscanf(ctx->args, "%f %f %f", &x, &y, &z) == 3) {
-        return M_TeleportToXYZ(x, y, z);
+        return M_TeleportToXYZ(x, y, z, false);
     }
 
     int16_t num = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

When constructing test scenarios, I was annoyed with having to scale TRView raw coords every time, so I extended `/tp` to support raw coords like this:
`/tp precise 73216 3712 62976`