### PR TITLE
lua: add trx.lara.target

### DIFF
--- a/data/scripting/lara.lua
+++ b/data/scripting/lara.lua
@@ -19,6 +19,13 @@ local getters = {
   item = function()
     return trx.items[raw.get_item()]
   end,
+  target = function()
+    local target = raw.get_target()
+    if target == nil then
+      return nil
+    end
+    return trx.items[target]
+  end,
 }
 
 local setters = {

--- a/docs/06-lua/2-reference/3-LARA.md
+++ b/docs/06-lua/2-reference/3-LARA.md
@@ -12,6 +12,10 @@ Module for interacting with the Lara's object.
     Returns [lua]`trx.items.Item` associated with Lara, or [lua]`nil` if the
     Lara object is not available.
 
+- [lua]`trx.lara.target`  
+    Read-only - returns Lara's current gun target as [lua]`trx.items.Item`,
+    or [lua]`nil` if no target is locked.
+
 - [lua]`trx.lara.exposure_bar`  
     Reads/writes exposure timer (cold water bar). The maximum value is 600.
     If the cold bar setting is disabled on the game flow level, the health must

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added a new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
 - added a new Lua catalog, `trx.catalog.weapons`, for weapon identifiers
 - added a new Lua property, `trx.lara.equipped_gun`, to read Lara's currently equipped gun type
+- added a new Lua property, `trx.lara.target`, to read Lara's current locked target item
 - added a new Lua property, `trx.Item.flags`, to read current item flags (related to triggers)
 - added a new Lua property, `trx.Item.timer`, to read current item timer value (related to triggers)
 - added support for using more sound slots than originally possible in custom levels (#3898)

--- a/src/trx/game/lua/lara.c
+++ b/src/trx/game/lua/lara.c
@@ -22,6 +22,18 @@ static int M_L_GetLaraItem(lua_State *const L)
     return 1;
 }
 
+// item_num = trxc.lara.get_target()
+static int M_L_GetLaraTarget(lua_State *const L)
+{
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    if (lara->target == nullptr) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, Item_GetIndex(lara->target) + 1);
+    }
+    return 1;
+}
+
 // trxc.lara.get_exposure_bar() → int
 static int M_L_LaraGetExposureBar(lua_State *const L)
 {
@@ -202,6 +214,8 @@ void LUA_CreateLara(lua_State *const L)
 
     lua_pushcfunction(L, M_L_GetLaraItem);
     lua_setfield(L, -2, "get_item");
+    lua_pushcfunction(L, M_L_GetLaraTarget);
+    lua_setfield(L, -2, "get_target");
     lua_pushcfunction(L, M_L_LaraGetExposureBar);
     lua_setfield(L, -2, "get_exposure_bar");
     lua_pushcfunction(L, M_L_LaraSetExposureBar);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

To make automated tests of the targeting refactor possible, I need to be able to write assertions on Lara's target. This expands the LUA API to allow that.

Usage – point guns at a creature and issue:
```
/lua trx.console.log(trx.lara.target.idx)
```
(`.idx` is an undocumented property.)