### PR TITLE
los: fix checking smashables

### DIFF
--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -170,8 +170,15 @@ int32_t LOS_CheckSmashable(
             continue;
         }
 
-        if (target.room_num != NO_ROOM && item->room_num != target.room_num) {
-            continue;
+        // Confirm item is reachable via visible rooms
+        {
+            GAME_VECTOR start_tmp = start;
+            GAME_VECTOR target_tmp = {
+                .pos = item->pos,
+            };
+            if (!LOS_Check(&start_tmp, &target_tmp, false)) {
+                continue;
+            }
         }
 
         // Ray segment intersects the object's local AABB


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes Smashable Windows in Venice not being shootable.

#### Testing

Try shooting windows etc

Updated e2e scenario that includes previous bells tests:

```
args "-e" "2" "-l" "14"
config gameplay.turbo_speed 50
config gameplay.enable_cheats 1

# setup
@+1:    ● "i"
@+4:    ○ "i"
@+4:    ● "o"
@+3:    ○ "o"
@+7:    cmd "tp 73 3 69"
@+22:   ● "space"
@+3:    ○ "space"
@+31:   ● "left shift"
@+4:    ○ "left shift"
@+3:    ● "end"
@+17:   ○ "end"
@+4:    ● "up"
@+33:   ● "left shift"
@+16:   ○ "up"
@+2:    ○ "left shift"
        cmd "set turbo 0"
@+1:    cmd "save 1"

testcase "m16 non-connected room"
@+0:    cmd "load 1"
@+1:    ● "6"
@+5:    ○ "6"
@+31:   ● "keypad 0"
@+15:   ● "up"
@+6:    ○ "up"
@+9:    ● "left"
@+7:    ○ "left"
@+6:    ● "up"
@+4:    ○ "up"
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed
        expect trx.items[123].flags == 0  # door stays closed
        expect trx.items[124].flags == 0  # door stays closed
@+13:   ● "left ctrl"
@+85:   ○ "left ctrl"
@+19:   ● "space"
@+4:    ○ "space"
@+40:   ○ "keypad 0"
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed
        expect trx.items[123].flags == 0  # door stays closed
        expect trx.items[124].flags == 0  # door stays closed

testcase "grenade non-connected room"
@+0:    cmd "load 1"
@+1:    ● "7"
@+4:    ○ "7"
@+27:   ● "keypad 0"
@+16:   ● "down"
@+2:    ○ "down"
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed
        expect trx.items[123].flags == 0  # door stays closed
        expect trx.items[124].flags == 0  # door stays closed
@+28:   ● "left ctrl"
@+10:   ○ "left ctrl"
@+4:    ● "up"
@+13:   ○ "up"
@+1:    ● "left"
@+7:    ○ "left"
@+40:   ○ "keypad 0"
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed
        expect trx.items[123].flags == 0  # door stays closed
        expect trx.items[124].flags == 0  # door stays closed


testcase "uzi same room"
@+0:    cmd "load 1"
@+1:    ● "4"
@+4:    ○ "4"
@+27:   ● "left alt"
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed
        expect trx.items[123].flags == 0  # door stays closed
        expect trx.items[124].flags == 0  # door stays closed
        ● "left ctrl"
@+30:   ○ "left ctrl"
        ○ "left alt"
@+27:   ● "keypad 0"
@+4:    ● "up"
@+13:   ○ "up"
@+1:    ● "left"
@+7:    ○ "left"
@+40:   ○ "keypad 0"
        expect trx.items[123].flags == 0x3F00  # door got open
        expect trx.items[124].flags == 0x3F00  # door got open
        expect trx.items[121].flags == 0  # door stays closed
        expect trx.items[122].flags == 0  # door stays closed

@+0:    cmd "exit"


testcase "venice window"
@+0:    cmd "play venice"
@+1:    cmd { tp window }
@+10:   ● "end"
@+9:    ○ "end"
        ● "space"
@+3:    ○ "space"
@+26:   ● "right"
@+17:   ○ "right"
@+9:    ● "down"
@+7:    ○ "down"
@+28:   ● "left ctrl"
@+14:   ● "left"
@+3:    ○ "left"
@+29:   ○ "left ctrl"
        expect trx.items[24].flags == 0x3F00  # window got smashed
```
