### PR TITLE
json: fix tiny memory leak

### DIFF
--- a/src/trx/core/json/base.c
+++ b/src/trx/core/json/base.c
@@ -502,7 +502,10 @@ void JSON_ObjectEvictKey(JSON_OBJECT *const obj, const char *const key)
             } else {
                 prev->next = elem->next;
             }
+            M_StringFree(elem->name);
+            JSON_ValueFree(elem->value);
             M_ObjectElementFree(elem);
+            obj->length--;
             return;
         }
         prev = elem;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a tiny memory leak in a rarely used function `JSON_EvictKey`.