### PR TITLE
phase/executor: fix desyncs on exit fade-out

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed Lua `trx.catalog` only exposing `objects` and `flip_effects`; it now also exposes `lara_states`, `lara_anims`, `music`, and `samples`
 - fixed a freeze if firing a grenade very close to room portals (#4938, regression from 1.2)
 - fixed non-deterministic Inventory Ring control (transition speeds depended on v-sync / wall clock timing)
+- fixed game logic speeding up while the game was fading out after quitting
 - fixed Lara being able to shoot smashable objects located in unreachable overlapping rooms (#4949, regression from TR1X 4.14 / TR2X 1.4)
 
 **TR1**:

--- a/src/trx/game/phase/executor.c
+++ b/src/trx/game/phase/executor.c
@@ -145,6 +145,10 @@ static PHASE_CONTROL M_Control(PHASE *const phase)
         };
     }
 
+    if (m_Exiting) {
+        return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
+    }
+
     if (phase != nullptr && phase->control != nullptr) {
         return phase->control(phase);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes quit fade behavior so gameplay/inventory simulation no longer speeds up while the exit fade is active. That removes the visible speed-up/desync effect when quitting during fade-out, while keeping the fade itself intact.

I first tried keeping simulation running during fade-out, but that caused visible speedups/desync and required extra timing workarounds I didn't want to carry. This keeps the fade intact and avoids those side effects with a smaller fix.

#### Testing

- [x] Open inventory, trigger quit (e.g. Alt+F4) while exit fade is active
  Expected outcome: exit fade plays normally, and scene appears frozen (no sped-up ring/game logic).
- [x] Quit from normal gameplay (without inventory)
  Expected outcome: same as above.