### PR TITLE
item+creature: refactor targeting apis

### DIFF
--- a/src/trx/game/const.h
+++ b/src/trx/game/const.h
@@ -4,8 +4,6 @@
 
 #define LOGIC_FPS 30
 
-#define DONT_TARGET (-16384)
-
 #define STEP_L 256
 #define WALL_L 1024 // = 1 << WALL_SHIFT
 #define WALL_SHIFT 10

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -693,7 +693,7 @@ void Creature_Float(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
 
-    item->hit_points = DONT_TARGET;
+    item->hit_points = 0;
     item->rot.x = 0;
 
     const int32_t wh = Room_GetWaterHeight(item->pos, item->room_num);
@@ -723,13 +723,6 @@ void Creature_Underwater(ITEM *const item, const int32_t depth)
     } else {
         CLAMPG(item->rot.x, 0);
     }
-}
-
-bool Creature_IsFloating(const ITEM *const item)
-{
-    return Object_IsType(item->object_id, g_WaterObjects)
-        && Object_Get(item->object_id)->intelligent
-        && item->hit_points == DONT_TARGET;
 }
 
 bool Creature_CanSeeEnemy(const ITEM *const item, const AI_INFO *const info)
@@ -1205,7 +1198,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
         if (explode) {
             Item_Explode(item_num, -1, 0);
         }
-        item->hit_points = DONT_TARGET;
+        item->hit_points = 0;
         const int16_t vehicle_item_num = SkidooDriver_GetSkidooItemNum(item);
         if (vehicle_item_num == NO_ITEM) {
             return;
@@ -1220,7 +1213,7 @@ void Creature_Die(const int16_t item_num, const bool explode)
     }
 
     item->collidable = false;
-    item->hit_points = DONT_TARGET;
+    item->hit_points = 0;
     if (explode) {
         Item_Explode(item_num, -1, 0);
         Item_Kill(item_num);
@@ -1301,31 +1294,6 @@ int32_t Creature_Vault(
 
     Item_UpdateRoom(item_num, room_num);
     return vault;
-}
-
-bool Creature_IsAlive(const ITEM *const item)
-{
-    const OBJECT *const obj = Object_Get(item->object_id);
-    if (obj->intelligent && Object_IsType(item->object_id, g_WaterObjects)) {
-        return item->hit_points > 0;
-    }
-
-    return (item->hit_points > 0)
-        || (item->hit_points == DONT_TARGET && item->active);
-}
-
-bool Creature_IsTargetable(const ITEM *const item)
-{
-    return item->hit_points != DONT_TARGET && item->hit_points > 0
-        && (!Object_Get(item->object_id)->intelligent
-            || item->status == IS_ACTIVE)
-        && (g_Config.gameplay.enable_ally_targeting
-            || Creature_IsHostile(item));
-}
-
-bool Creature_IsDestructible(const ITEM *const item)
-{
-    return Object_IsType(item->object_id, g_DestructibleCreatureObjects);
 }
 
 int16_t Creature_Effect(

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -20,7 +20,6 @@ void Creature_Joint(ITEM *item, int16_t joint, int16_t required);
 
 void Creature_Float(int16_t item_num);
 void Creature_Underwater(ITEM *item, int32_t depth);
-bool Creature_IsFloating(const ITEM *item);
 
 bool Creature_CanSeeEnemy(const ITEM *item, const AI_INFO *info);
 bool Creature_CanTargetEnemy(const ITEM *item, const AI_INFO *info);
@@ -37,16 +36,11 @@ void Creature_Reset(void);
 bool Creature_AreAlliesHostile(void);
 void Creature_SetAlliesHostile(bool enable);
 void Creature_Hurt(ITEM *item, int32_t damage);
-bool Creature_IsAlive(const ITEM *item);
 bool Creature_IsHostile(const ITEM *item);
 bool Creature_IsAlly(const ITEM *item);
 bool Creature_IsAllyTargetingEnemy(const ITEM *item);
 void Creature_AddAlly(OBJECT_ID obj_id);
 void Creature_AddAllyTargetingEnemy(OBJECT_ID obj_id);
-bool Creature_IsTargetable(const ITEM *item);
-
-// Returns true if the target object can be destroyed with a missile.
-bool Creature_IsDestructible(const ITEM *item);
 
 int16_t Creature_Effect(
     const ITEM *item, const BITE *bite,

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -517,9 +517,8 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
 
     const int32_t max_dist = weapon->target_dist;
 
-    for (int16_t item_num = Item_GetNextActive(); item_num != NO_ITEM;) {
+    for (int32_t item_num = 0; item_num < Item_GetLevelCount(); item_num++) {
         ITEM *const item = Item_Get(item_num);
-        item_num = item->next_active;
 
         if (item == lara_item || !Item_IsTargetable(item)) {
             continue;

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -521,7 +521,7 @@ void Gun_HitTarget(
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    const bool was_alive = Item_IsAlive(item);
+    const bool was_alive = item->hit_points > 0;
     const bool clears_target = was_alive && damage >= item->hit_points;
     if (clears_target) {
         if (item->include_in_kill_stats) {

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -544,7 +544,11 @@ void Gun_HitTarget(
                 .pos = hit_pos->pos,
                 .room_num = item->room_num,
             };
-            Spawn_RicochetRay(*start, pos);
+            if (start != nullptr) {
+                Spawn_RicochetRay(*start, pos);
+            } else {
+                Spawn_Ricochet(pos);
+            }
         } else {
             Spawn_Blood(
                 hit_pos->x, hit_pos->y, hit_pos->z, item->speed, item->rot.y,

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -3,7 +3,6 @@
 #include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/game/collision/los.h>
-#include <trx/game/const.h>
 #include <trx/game/creature.h>
 #include <trx/game/gun/common.h>
 #include <trx/game/gun/pistols.h>
@@ -429,8 +428,9 @@ void Gun_HitTarget(
     }
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if ((item->hit_points == DONT_TARGET && Creature_IsDestructible(item))
-        || (item->hit_points > 0 && item->hit_points <= damage)) {
+    const bool was_alive = Item_IsAlive(item);
+    const bool clears_target = was_alive && damage >= item->hit_points;
+    if (clears_target) {
         if (item->include_in_kill_stats) {
             Stats_AddKill();
         }
@@ -517,14 +517,11 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
 
     const int32_t max_dist = weapon->target_dist;
 
-    for (int32_t i = 0; i < LOT_SLOT_COUNT; i++) {
-        const CREATURE *const creature = LOT_GetBaddieSlot(i);
-        if (creature->item_num == NO_ITEM) {
-            continue;
-        }
+    for (int16_t item_num = Item_GetNextActive(); item_num != NO_ITEM;) {
+        ITEM *const item = Item_Get(item_num);
+        item_num = item->next_active;
 
-        ITEM *const item = Item_Get(creature->item_num);
-        if (!Creature_IsTargetable(item)) {
+        if (item == lara_item || !Item_IsTargetable(item)) {
             continue;
         }
 
@@ -556,8 +553,10 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
             && angles[0] <= weapon->lock_angles[1]
             && angles[1] >= weapon->lock_angles[2]
             && angles[1] <= weapon->lock_angles[3]) {
-            m_TargetList[num_targets] = item;
-            num_targets++;
+            if (num_targets < LOT_SLOT_COUNT) {
+                m_TargetList[num_targets] = item;
+                num_targets++;
+            }
             const int16_t y_rot = ABS(angles[0]);
             if (g_TRVersion == 1) {
                 if (y_rot < best_y_rot) {

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -31,9 +31,102 @@ typedef enum {
 
 static ITEM *m_TargetList[LOT_SLOT_COUNT] = {};
 static ITEM *m_LastTargetList[LOT_SLOT_COUNT] = {};
+static int16_t m_TargetCount = 0;
 
 // TODO: meh
 extern void Smashable_Smash(int16_t item_num);
+
+static bool M_TargetListContains(const ITEM *const item, const int16_t count)
+{
+    for (int16_t i = 0; i < count; i++) {
+        if (m_TargetList[i] == item) {
+            return true;
+        }
+    }
+    return false;
+}
+
+typedef struct {
+    const WEAPON_INFO *weapon;
+    const GAME_VECTOR *start;
+    const ITEM *lara_item;
+    const LARA_INFO *lara;
+    const ITEM *old_target;
+    int32_t max_dist;
+    ITEM *best_target;
+    int16_t best_y_rot;
+    int32_t best_dist;
+    int16_t num_targets;
+    int32_t old_target_dist;
+    int16_t old_target_y_rot;
+    bool old_target_in_list;
+} M_TARGET_CONTEXT;
+
+static void M_ConsiderTarget(M_TARGET_CONTEXT *const ctx, ITEM *const item)
+{
+    if (item == ctx->lara_item || !Item_IsTargetable(item)) {
+        return;
+    }
+
+    const int32_t dx = item->pos.x - ctx->start->x;
+    const int32_t dy = item->pos.y - ctx->start->y;
+    const int32_t dz = item->pos.z - ctx->start->z;
+    if (ABS(dx) > ctx->max_dist || ABS(dy) > ctx->max_dist
+        || ABS(dz) > ctx->max_dist) {
+        return;
+    }
+
+    const int32_t dist = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
+    if (dist >= SQUARE(ctx->max_dist)) {
+        return;
+    }
+
+    GAME_VECTOR target;
+    Gun_FindTargetPoint(item, &target);
+    if (!LOS_Check(ctx->start, &target, true)) {
+        return;
+    }
+
+    int16_t angles[2];
+    Math_GetVectorAngles(
+        target.x - ctx->start->x, target.y - ctx->start->y,
+        target.z - ctx->start->z, angles);
+    angles[0] -= ctx->lara->torso_rot.y + ctx->lara_item->rot.y;
+    angles[1] -= ctx->lara->torso_rot.x + ctx->lara_item->rot.x;
+
+    if (angles[0] < ctx->weapon->lock_angles[0]
+        || angles[0] > ctx->weapon->lock_angles[1]
+        || angles[1] < ctx->weapon->lock_angles[2]
+        || angles[1] > ctx->weapon->lock_angles[3]) {
+        return;
+    }
+
+    if (ctx->num_targets < LOT_SLOT_COUNT) {
+        m_TargetList[ctx->num_targets] = item;
+        ctx->num_targets++;
+    }
+
+    const int16_t y_rot = ABS(angles[0]);
+    if (item == ctx->old_target) {
+        ctx->old_target_dist = dist;
+        ctx->old_target_y_rot = y_rot;
+        ctx->old_target_in_list = true;
+    }
+
+    if (g_TRVersion == 1) {
+        if (y_rot < ctx->best_y_rot) {
+            ctx->best_dist = dist;
+            ctx->best_y_rot = y_rot;
+            ctx->best_target = item;
+        }
+    } else {
+        if (y_rot < ctx->best_y_rot + M_NEAR_ANGLE && dist < ctx->best_dist) {
+            ctx->best_dist = dist;
+            ctx->best_y_rot = y_rot;
+            ctx->best_target = item;
+        }
+    }
+}
 
 static void M_DrawGunGlow(const XYZ_32 offset, const RGB_F color)
 {
@@ -496,6 +589,7 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
 {
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara = Lara_GetLaraInfo();
+    const ITEM *const old_target = lara->target;
 
     // Preserve OG targeting behavior.
     if (g_Config.gameplay.target_mode == TLM_FULL
@@ -510,69 +604,42 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
         .room_num = lara_item->room_num,
     };
 
-    ITEM *best_target = nullptr;
-    int16_t best_y_rot = INT16_MAX;
-    int16_t num_targets = 0;
-    int32_t best_dist = INT32_MAX;
+    M_TARGET_CONTEXT ctx = {
+        .weapon = weapon,
+        .start = &start,
+        .lara_item = lara_item,
+        .lara = lara,
+        .old_target = old_target,
+        .max_dist = weapon->target_dist,
+        .best_target = nullptr,
+        .best_y_rot = INT16_MAX,
+        .best_dist = INT32_MAX,
+        .num_targets = 0,
+        .old_target_dist = INT32_MAX,
+        .old_target_y_rot = INT16_MAX,
+        .old_target_in_list = false,
+    };
 
-    const int32_t max_dist = weapon->target_dist;
+    // First pass: active creatures
+    for (int32_t i = 0; i < LOT_SLOT_COUNT; i++) {
+        const CREATURE *const creature = LOT_GetBaddieSlot(i);
+        if (creature->item_num == NO_ITEM) {
+            continue;
+        }
+        M_ConsiderTarget(&ctx, Item_Get(creature->item_num));
+    }
 
+    // Second pass: other objects, including skidoo driver, whose targetable
+    // ITEM is NOT in the active item list
     for (int32_t item_num = 0; item_num < Item_GetLevelCount(); item_num++) {
         ITEM *const item = Item_Get(item_num);
-
-        if (item == lara_item || !Item_IsTargetable(item)) {
+        if (M_TargetListContains(item, ctx.num_targets)) {
             continue;
         }
-
-        const int32_t dx = item->pos.x - start.x;
-        const int32_t dy = item->pos.y - start.y;
-        const int32_t dz = item->pos.z - start.z;
-        if (ABS(dx) > max_dist || ABS(dy) > max_dist || ABS(dz) > max_dist) {
-            continue;
-        }
-
-        const int32_t dist = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-        if (dist >= SQUARE(max_dist)) {
-            continue;
-        }
-
-        GAME_VECTOR target;
-        Gun_FindTargetPoint(item, &target);
-        if (!LOS_Check(&start, &target, true)) {
-            continue;
-        }
-
-        int16_t angles[2];
-        Math_GetVectorAngles(
-            target.x - start.x, target.y - start.y, target.z - start.z, angles);
-        angles[0] -= lara->torso_rot.y + lara_item->rot.y;
-        angles[1] -= lara->torso_rot.x + lara_item->rot.x;
-
-        if (angles[0] >= weapon->lock_angles[0]
-            && angles[0] <= weapon->lock_angles[1]
-            && angles[1] >= weapon->lock_angles[2]
-            && angles[1] <= weapon->lock_angles[3]) {
-            if (num_targets < LOT_SLOT_COUNT) {
-                m_TargetList[num_targets] = item;
-                num_targets++;
-            }
-            const int16_t y_rot = ABS(angles[0]);
-            if (g_TRVersion == 1) {
-                if (y_rot < best_y_rot) {
-                    best_dist = dist;
-                    best_y_rot = y_rot;
-                    best_target = item;
-                }
-            } else {
-                if (y_rot < best_y_rot + M_NEAR_ANGLE && dist < best_dist) {
-                    best_dist = dist;
-                    best_y_rot = y_rot;
-                    best_target = item;
-                }
-            }
-        }
+        M_ConsiderTarget(&ctx, item);
     }
-    m_TargetList[num_targets] = nullptr;
+
+    m_TargetCount = ctx.num_targets;
 
     if ((g_Config.gameplay.target_mode == TLM_FULL
          || g_Config.gameplay.target_mode == TLM_SEMI)
@@ -581,18 +648,17 @@ void Gun_GetNewTarget(const WEAPON_INFO *const weapon)
         return;
     }
 
-    if (num_targets > 0) {
-        for (int32_t slot = 0; slot < LOT_SLOT_COUNT; slot++) {
-            if (m_TargetList[slot] == nullptr) {
-                lara->target = nullptr;
-            }
+    if (ctx.num_targets > 0) {
+        bool found_current_target = false;
+        for (int16_t slot = 0; slot < ctx.num_targets; slot++) {
             if (m_TargetList[slot] == lara->target) {
+                found_current_target = true;
                 break;
             }
         }
 
-        if (lara->target == nullptr) {
-            lara->target = best_target;
+        if (!found_current_target) {
+            lara->target = ctx.best_target;
             m_LastTargetList[0] = nullptr;
         }
     } else {
@@ -615,11 +681,7 @@ void Gun_ChangeTarget(const WEAPON_INFO *const weapon)
     lara->target = nullptr;
     bool found_new_target = false;
 
-    for (int32_t new_target = 0; new_target < LOT_SLOT_COUNT; new_target++) {
-        if (!m_TargetList[new_target]) {
-            break;
-        }
-
+    for (int16_t new_target = 0; new_target < m_TargetCount; new_target++) {
         for (int32_t last_target = 0; last_target < LOT_SLOT_COUNT;
              last_target++) {
             if (!m_LastTargetList[last_target]) {

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -21,38 +21,11 @@ static bool M_UseTR3ExplodingEffects(const ITEM *const item)
         && !Object_IsType(item->object_id, g_HeavyShatterableObjects);
 }
 
-/*
-bool Creature_IsFloating(const ITEM *const item)
+static bool M_IsFloating(const ITEM *const item)
 {
     return Object_IsType(item->object_id, g_WaterObjects)
-        && Object_Get(item->object_id)->intelligent
-        && item->hit_points == DONT_TARGET;
+        && Object_Get(item->object_id)->intelligent && item->hit_points <= 0;
 }
-
-bool Creature_IsAlive(const ITEM *const item)
-{
-    const OBJECT *const obj = Object_Get(item->object_id);
-    if (obj->intelligent && Object_IsType(item->object_id, g_WaterObjects)) {
-        return item->hit_points > 0;
-    }
-    return (item->hit_points > 0)
-        || (item->hit_points == DONT_TARGET && item->active);
-}
-
-bool Creature_IsTargetable(const ITEM *const item)
-{
-    return item->hit_points != DONT_TARGET && item->hit_points > 0
-        && (!Object_Get(item->object_id)->intelligent
-            || item->status == IS_ACTIVE)
-        && (g_Config.gameplay.enable_ally_targeting
-            || Creature_IsHostile(item));
-}
-
-bool Creature_IsDestructible(const ITEM *const item)
-{
-    return Object_IsType(item->object_id, g_DestructibleCreatureObjects);
-}
-*/
 
 bool Item_IsAlive(const ITEM *const item)
 {
@@ -92,7 +65,7 @@ bool Item_CanTakeDamage(const ITEM *const item)
         return obj->can_take_damage_func(item);
     }
 
-    return Item_IsAlive(item);
+    return Item_IsAlive(item) || M_IsFloating(item);
 }
 
 bool Item_CanBeProjectileTarget(const ITEM *const item)
@@ -104,6 +77,10 @@ bool Item_CanBeProjectileTarget(const ITEM *const item)
     const OBJECT *const obj = Object_Get(item->object_id);
     if (obj->can_be_projectile_target_func != nullptr) {
         return obj->can_be_projectile_target_func(item);
+    }
+
+    if (M_IsFloating(item)) {
+        return true;
     }
 
     if (!item->collidable || item->status == IS_INVISIBLE

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -51,9 +51,7 @@ bool Item_IsTargetable(const ITEM *const item)
         return obj->is_targetable_func(item);
     }
 
-    return item->hit_points > 0
-        && (!Object_Get(item->object_id)->intelligent
-            || item->status == IS_ACTIVE)
+    return item->hit_points > 0 && item->status == IS_ACTIVE
         && (g_Config.gameplay.enable_ally_targeting
             || Creature_IsHostile(item));
 }

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -1,10 +1,12 @@
 #include <trx/game/items/utils.h>
 
+#include <trx/config.h>
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
 #include <trx/game/effects.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/vars.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/version.h>
@@ -19,10 +21,103 @@ static bool M_UseTR3ExplodingEffects(const ITEM *const item)
         && !Object_IsType(item->object_id, g_HeavyShatterableObjects);
 }
 
+/*
+bool Creature_IsFloating(const ITEM *const item)
+{
+    return Object_IsType(item->object_id, g_WaterObjects)
+        && Object_Get(item->object_id)->intelligent
+        && item->hit_points == DONT_TARGET;
+}
+
+bool Creature_IsAlive(const ITEM *const item)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (obj->intelligent && Object_IsType(item->object_id, g_WaterObjects)) {
+        return item->hit_points > 0;
+    }
+    return (item->hit_points > 0)
+        || (item->hit_points == DONT_TARGET && item->active);
+}
+
+bool Creature_IsTargetable(const ITEM *const item)
+{
+    return item->hit_points != DONT_TARGET && item->hit_points > 0
+        && (!Object_Get(item->object_id)->intelligent
+            || item->status == IS_ACTIVE)
+        && (g_Config.gameplay.enable_ally_targeting
+            || Creature_IsHostile(item));
+}
+
+bool Creature_IsDestructible(const ITEM *const item)
+{
+    return Object_IsType(item->object_id, g_DestructibleCreatureObjects);
+}
+*/
+
+bool Item_IsAlive(const ITEM *const item)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (obj->is_alive_func != nullptr) {
+        return obj->is_alive_func(item);
+    }
+
+    if (obj->intelligent && Object_IsType(item->object_id, g_WaterObjects)) {
+        return item->hit_points > 0;
+    }
+    return (item->hit_points > 0) || (item->active);
+}
+
+bool Item_IsTargetable(const ITEM *const item)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (Object_IsType(item->object_id, g_ProjectileObjects)) {
+        return false;
+    }
+
+    if (obj->is_targetable_func != nullptr) {
+        return obj->is_targetable_func(item);
+    }
+
+    return item->hit_points > 0
+        && (!Object_Get(item->object_id)->intelligent
+            || item->status == IS_ACTIVE)
+        && (g_Config.gameplay.enable_ally_targeting
+            || Creature_IsHostile(item));
+}
+
+bool Item_CanTakeDamage(const ITEM *const item)
+{
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (obj->can_take_damage_func != nullptr) {
+        return obj->can_take_damage_func(item);
+    }
+
+    return Item_IsAlive(item);
+}
+
+bool Item_CanBeProjectileTarget(const ITEM *const item)
+{
+    if (Object_IsType(item->object_id, g_ProjectileObjects)) {
+        return false;
+    }
+
+    const OBJECT *const obj = Object_Get(item->object_id);
+    if (obj->can_be_projectile_target_func != nullptr) {
+        return obj->can_be_projectile_target_func(item);
+    }
+
+    if (!item->collidable || item->status == IS_INVISIBLE
+        || obj->collision_func == nullptr) {
+        return false;
+    }
+
+    return Item_IsTargetable(item);
+}
+
 void Item_TakeDamage(
     ITEM *const item, const int16_t damage, const bool hit_status)
 {
-    if (item->hit_points == DONT_TARGET && !Creature_IsDestructible(item)) {
+    if (!Item_CanTakeDamage(item)) {
         return;
     }
 

--- a/src/trx/game/items/utils.h
+++ b/src/trx/game/items/utils.h
@@ -15,6 +15,11 @@
 
 bool Item_IsTriggerActive(ITEM *item);
 
+bool Item_IsAlive(const ITEM *item);
+bool Item_IsTargetable(const ITEM *item);
+bool Item_CanTakeDamage(const ITEM *item);
+bool Item_CanBeProjectileTarget(const ITEM *item);
+
 void Item_TakeDamage(ITEM *item, int16_t damage, bool hit_status);
 
 bool Item_IsMeshVisible(const ITEM *item, int32_t mesh_num);

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -9,6 +9,7 @@
 #include <trx/game/input.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/inventory.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
@@ -195,11 +196,7 @@ bool Lara_Cheat_KillEnemy(const int16_t item_num)
     if ((item->flags & IF_KILLED) != 0) {
         return false;
     }
-    if (item->hit_points == DONT_TARGET) {
-        if (item->status != IS_ACTIVE) {
-            return false;
-        }
-    } else if (item->hit_points <= 0) {
+    if (!Item_IsAlive(item) && item->status != IS_ACTIVE) {
         return false;
     }
 

--- a/src/trx/game/objects/creatures/big_eel.c
+++ b/src/trx/game/objects/creatures/big_eel.c
@@ -39,6 +39,11 @@ static const BITE m_BigEelBite = {
     .mesh_num = 7,
 };
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -102,6 +107,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->is_targetable_func = M_IsTargetable;
     obj->priv_size = sizeof(M_PRIV);
 
     obj->hit_points = BIG_EEL_HITPOINTS;

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -1,5 +1,3 @@
-#include <trx/core/json/util/read_io.h>
-#include <trx/core/json/util/write_io.h>
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
 #include <trx/game/game_flow.h>
@@ -9,10 +7,6 @@
 #include <trx/version.h>
 
 static BITE m_CobraBite = { .pos = { 0, 0, 0 }, .mesh_num = 13 };
-
-typedef struct {
-    int16_t hit_points;
-} M_PRIV;
 
 typedef enum {
     COBRA_STATE_WAKING_UP = 0,
@@ -27,18 +21,6 @@ typedef enum {
     COBRA_ANIM_DEATH = 4,
 } M_COBRA_ANIM;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
-{
-    M_PRIV *const p = item->priv;
-    JSON_SHOULD(JSON_READ(io, "hit_points", &p->hit_points));
-}
-
-static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
-{
-    const M_PRIV *const p = item->priv;
-    JSONW_WRITE(io, "hit_points", p->hit_points);
-}
-
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -46,9 +28,22 @@ static void M_Initialise(const int16_t item_num)
     Item_SwitchToAnim(item, COBRA_ANIM_SLEEP, 45);
     item->current_anim_state = COBRA_STATE_SLEEP;
     item->goal_anim_state = COBRA_STATE_SLEEP;
-    M_PRIV *const p = item->priv;
-    p->hit_points = item->hit_points;
-    item->hit_points = DONT_TARGET;
+}
+
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return item->hit_points > 0 && item->status == IS_ACTIVE
+        && item->current_anim_state != COBRA_STATE_SLEEP;
+}
+
+static bool M_CanTakeDamage(const ITEM *const item)
+{
+    return item->hit_points > 0;
+}
+
+static bool M_CanBeProjectileTarget(const ITEM *const item)
+{
+    return item->hit_points > 0 && item->collidable;
 }
 
 static void M_Control(const int16_t item_num)
@@ -70,14 +65,13 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const item = Item_Get(item_num);
     CREATURE *const creature = item->creature_data;
-    M_PRIV *const p = item->priv;
 
     if (creature == nullptr) {
         return;
     }
 
     int16_t angle = 0;
-    if (item->hit_points <= 0 && item->hit_points != DONT_TARGET) {
+    if (item->hit_points <= 0) {
         if (item->current_anim_state != COBRA_STATE_DEATH) {
             Item_SwitchToAnim(item, COBRA_ANIM_DEATH, 0);
             item->current_anim_state = COBRA_ANIM_DEATH;
@@ -106,7 +100,6 @@ static void M_Control(const int16_t item_num)
 
     switch (item->current_anim_state) {
     case COBRA_STATE_WAKING_UP:
-        item->hit_points = p->hit_points;
         break;
 
     case COBRA_STATE_ALERT:
@@ -132,13 +125,8 @@ static void M_Control(const int16_t item_num)
 
     case COBRA_STATE_SLEEP:
         creature->flags = 0;
-        if (item->hit_points != DONT_TARGET) {
-            p->hit_points = item->hit_points;
-            item->hit_points = DONT_TARGET;
-        }
         if (info.distance < alert_radius && lara_item->hit_points > 0) {
             item->goal_anim_state = COBRA_STATE_WAKING_UP;
-            item->hit_points = p->hit_points;
         }
         break;
     }
@@ -156,9 +144,9 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
-    obj->priv_size = sizeof(M_PRIV);
-    obj->priv_load_func = M_LoadPriv;
-    obj->priv_save_func = M_SavePriv;
+    obj->is_targetable_func = M_IsTargetable;
+    obj->can_take_damage_func = M_CanTakeDamage;
+    obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
 
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = 8;

--- a/src/trx/game/objects/creatures/crocodile.c
+++ b/src/trx/game/objects/creatures/crocodile.c
@@ -218,7 +218,7 @@ static void M_ControlAlligator(const int16_t item_num)
         if (item->current_anim_state != M_ALLIGATOR_STATE_DEATH) {
             item->current_anim_state = M_ALLIGATOR_STATE_DEATH;
             Item_SwitchToAnim(item, M_ALLIGATOR_DIE_ANIM, 0);
-            item->hit_points = DONT_TARGET;
+            item->hit_points = 0;
             Carrier_TestItemDrops(item_num);
         }
 

--- a/src/trx/game/objects/creatures/eel.c
+++ b/src/trx/game/objects/creatures/eel.c
@@ -39,6 +39,11 @@ static const BITE m_EelBite = {
     .mesh_num = 7,
 };
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -107,6 +112,7 @@ static void M_Setup(OBJECT *const obj)
 
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
+    obj->is_targetable_func = M_IsTargetable;
     obj->priv_size = sizeof(M_PRIV);
 
     obj->hit_points = EEL_HITPOINTS;

--- a/src/trx/game/objects/creatures/mummy.c
+++ b/src/trx/game/objects/creatures/mummy.c
@@ -64,10 +64,8 @@ static void M_Control(const int16_t item_num)
             Stats_AddKill();
         }
         Item_RemoveActive(item_num);
-        if (item->hit_points != DONT_TARGET) {
-            Carrier_TestItemDrops(item_num);
-        }
-        item->hit_points = DONT_TARGET;
+        Carrier_TestItemDrops(item_num);
+        item->hit_points = 0;
     }
 }
 

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -42,18 +42,6 @@ static int32_t M_GetStage2HitPoints(const ITEM *const item)
 
 static bool M_IsTargetable(const ITEM *const item)
 {
-    return item->hit_points > 0
-        && item->current_anim_state != NATLA_STATE_SEMIDEATH;
-}
-
-static bool M_CanTakeDamage(const ITEM *const item)
-{
-    return item->hit_points > 0
-        && item->current_anim_state != NATLA_STATE_SEMIDEATH;
-}
-
-static bool M_CanBeProjectileTarget(const ITEM *const item)
-{
     return item->hit_points > 0 && item->status == IS_ACTIVE
         && item->current_anim_state != NATLA_STATE_SEMIDEATH;
 }
@@ -334,8 +322,6 @@ static void M_Setup(OBJECT *const obj)
     obj->smartness = NATLA_SMARTNESS;
     obj->intelligent = true;
     obj->is_targetable_func = M_IsTargetable;
-    obj->can_take_damage_func = M_CanTakeDamage;
-    obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -40,6 +40,19 @@ static int32_t M_GetStage2HitPoints(const ITEM *const item)
     return item->max_hit_points / 2;
 }
 
+static bool M_GunHit(
+    ITEM *const item, const GAME_VECTOR *const start,
+    const GAME_VECTOR *const hit_pos, int32_t *const damage)
+{
+    if (item->current_anim_state == NATLA_STATE_SEMIDEATH) {
+        if (damage != nullptr) {
+            *damage = 0;
+        }
+        return false;
+    }
+    return true;
+}
+
 static bool M_IsTargetable(const ITEM *const item)
 {
     return item->hit_points > 0 && item->status == IS_ACTIVE
@@ -65,7 +78,8 @@ static void M_Control(const int16_t item_num)
     int16_t timer = natla->flags & NATLA_TIMER;
     int16_t facing = (int16_t)(intptr_t)item->priv;
 
-    if (item->hit_points <= 0) {
+    if (item->hit_points <= 0
+        && item->current_anim_state != NATLA_STATE_SEMIDEATH) {
         item->goal_anim_state = NATLA_STATE_DEATH;
     } else if (item->hit_points <= M_GetStage2HitPoints(item)) {
         natla->lot.setup.step = STEP_L;
@@ -156,7 +170,7 @@ static void M_Control(const int16_t item_num)
                     LARA_INFO *const lara = Lara_GetLaraInfo();
                     lara->target = nullptr;
                 }
-                item->hit_points = 1;
+                item->hit_points = 0;
             }
             break;
 
@@ -316,12 +330,15 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->initialise_func = Creature_Initialise;
     obj->control_func = M_Control;
+    obj->gun_hit_func = M_GunHit;
+    obj->is_targetable_func = M_IsTargetable;
+
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->hit_points = NATLA_HITPOINTS;
     obj->radius = NATLA_RADIUS;
     obj->smartness = NATLA_SMARTNESS;
+
     obj->intelligent = true;
-    obj->is_targetable_func = M_IsTargetable;
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -40,6 +40,24 @@ static int32_t M_GetStage2HitPoints(const ITEM *const item)
     return item->max_hit_points / 2;
 }
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return item->hit_points > 0
+        && item->current_anim_state != NATLA_STATE_SEMIDEATH;
+}
+
+static bool M_CanTakeDamage(const ITEM *const item)
+{
+    return item->hit_points > 0
+        && item->current_anim_state != NATLA_STATE_SEMIDEATH;
+}
+
+static bool M_CanBeProjectileTarget(const ITEM *const item)
+{
+    return item->hit_points > 0 && item->status == IS_ACTIVE
+        && item->current_anim_state != NATLA_STATE_SEMIDEATH;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -59,7 +77,7 @@ static void M_Control(const int16_t item_num)
     int16_t timer = natla->flags & NATLA_TIMER;
     int16_t facing = (int16_t)(intptr_t)item->priv;
 
-    if (item->hit_points <= 0 && item->hit_points > DONT_TARGET) {
+    if (item->hit_points <= 0) {
         item->goal_anim_state = NATLA_STATE_DEATH;
     } else if (item->hit_points <= M_GetStage2HitPoints(item)) {
         natla->lot.setup.step = STEP_L;
@@ -150,7 +168,7 @@ static void M_Control(const int16_t item_num)
                     LARA_INFO *const lara = Lara_GetLaraInfo();
                     lara->target = nullptr;
                 }
-                item->hit_points = DONT_TARGET;
+                item->hit_points = 1;
             }
             break;
 
@@ -315,6 +333,9 @@ static void M_Setup(OBJECT *const obj)
     obj->radius = NATLA_RADIUS;
     obj->smartness = NATLA_SMARTNESS;
     obj->intelligent = true;
+    obj->is_targetable_func = M_IsTargetable;
+    obj->can_take_damage_func = M_CanTakeDamage;
+    obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
     obj->save_position = true;
     obj->save_hitpoints = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -226,7 +226,7 @@ static void M_Control(const int16_t item_num)
         if (LOS_Check(&start, &target, true)) {
             pierre->flags = 1;
         } else if (pierre->flags > PIERRE_DISAPPEAR) {
-            item->hit_points = DONT_TARGET;
+            item->hit_points = 0;
             LOT_DisableBaddieAI(item_num);
             Item_Kill(item_num);
             m_PierreItemNum = NO_ITEM;
@@ -235,7 +235,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t wh = Room_GetWaterHeight(item->pos, item->room_num);
     if (wh != NO_HEIGHT) {
-        item->hit_points = DONT_TARGET;
+        item->hit_points = 0;
         LOT_DisableBaddieAI(item_num);
         Item_Kill(item_num);
         m_PierreItemNum = NO_ITEM;

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -42,7 +42,7 @@ static void M_KillDriver(ITEM *const driver_item)
     Item_RemoveActive(driver_item_num);
     driver_item->collidable = 0;
     driver_item->flags |= IF_ONE_SHOT;
-    driver_item->hit_points = DONT_TARGET;
+    driver_item->hit_points = 0;
 }
 
 static void M_MakeMountable(ITEM *const skidoo_item)
@@ -197,7 +197,7 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->status == IS_DEACTIVATED) {
-            item->hit_points = DONT_TARGET;
+            item->hit_points = 0;
             const M_PRIV *const p = item->priv;
             const int16_t skidoo_num = p->skidoo_item_num;
             ITEM *const skidoo = Item_Get(skidoo_num);

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -264,6 +264,11 @@ static void M_Control(const int16_t driver_item_num)
     }
 }
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     if (!obj->loaded) {
@@ -274,6 +279,7 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->control_func = M_Control;
     obj->priv_size = sizeof(M_PRIV);
+    obj->is_targetable_func = M_IsTargetable;
 
     obj->hit_points = 1;
 

--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -239,6 +239,11 @@ static bool M_CanDropItems(const ITEM *const item)
         && Item_GetRelativeFrame(item) >= 110;
 }
 
+static bool M_CanBeExploded(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Die(int16_t item_num)
 {
     ITEM *item;
@@ -616,6 +621,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
     obj->draw_func = M_Draw;
     obj->can_drop_items_func = M_CanDropItems;
+    obj->can_be_exploded_func = M_CanBeExploded;
 
     obj->shadow_size = 0;
     obj->hit_points = 100;

--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -244,7 +244,7 @@ static void M_Die(int16_t item_num)
     ITEM *item;
 
     item = Item_Get(item_num);
-    item->hit_points = DONT_TARGET;
+    item->hit_points = 0;
     item->collidable = 0;
     Item_Kill(item_num);
     LOT_DisableBaddieAI(item_num);

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -201,7 +201,7 @@ static void M_Die(int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     item->collidable = 0;
-    item->hit_points = DONT_TARGET;
+    item->hit_points = 0;
     Item_Kill(item_num);
     LOT_DisableBaddieAI(item_num);
     item->flags |= IF_INVISIBLE;

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -207,6 +207,11 @@ static void M_Die(int16_t item_num)
     item->flags |= IF_INVISIBLE;
 }
 
+static bool M_CanBeExploded(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_TriggerSummonSmoke(const XYZ_32 pos)
 {
     SPARK *const spark = Sparks_GetFreeSpark();
@@ -1416,6 +1421,7 @@ static void M_Setup(OBJECT *const obj)
     obj->gun_hit_func = M_GunHit;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
     obj->can_drop_items_func = M_CanDropItems;
+    obj->can_be_exploded_func = M_CanBeExploded;
 
     obj->shadow_size = 0;
     obj->hit_points = 200;

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -24,6 +24,26 @@ static bool M_ShouldSpawnBlood(const ITEM *const item)
     return false;
 }
 
+static bool M_IsAlive(const ITEM *const item)
+{
+    return item->hit_points > 0;
+}
+
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return item->object_id == O_LARA && false;
+}
+
+static bool M_CanTakeDamage(const ITEM *const item)
+{
+    return item->object_id == O_LARA && false;
+}
+
+static bool M_CanBeProjectileTarget(const ITEM *const item)
+{
+    return item->object_id == O_LARA && false;
+}
+
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -85,8 +105,12 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
+    obj->is_alive_func = M_IsAlive;
+    obj->is_targetable_func = M_IsTargetable;
+    obj->can_take_damage_func = M_CanTakeDamage;
+    obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
 
-    obj->hit_points = DONT_TARGET;
+    obj->hit_points = 1;
     obj->radius = M_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 4;
     obj->smartness = -1;

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -19,11 +19,6 @@ typedef enum {
     // clang-format on
 } M_STATE;
 
-static bool M_ShouldSpawnBlood(const ITEM *const item)
-{
-    return false;
-}
-
 static bool M_IsAlive(const ITEM *const item)
 {
     return item->hit_points > 0;
@@ -31,17 +26,22 @@ static bool M_IsAlive(const ITEM *const item)
 
 static bool M_IsTargetable(const ITEM *const item)
 {
-    return item->object_id == O_LARA && false;
+    return false;
 }
 
 static bool M_CanTakeDamage(const ITEM *const item)
 {
-    return item->object_id == O_LARA && false;
+    return false;
 }
 
 static bool M_CanBeProjectileTarget(const ITEM *const item)
 {
-    return item->object_id == O_LARA && false;
+    return false;
+}
+
+static bool M_ShouldSpawnBlood(const ITEM *const item)
+{
+    return false;
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -44,6 +44,11 @@ static bool M_ShouldSpawnBlood(const ITEM *const item)
     return false;
 }
 
+static bool M_CanBeExploded(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
@@ -249,6 +254,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
+    obj->can_be_exploded_func = M_CanBeExploded;
 
     obj->hit_points = 20;
     obj->shadow_size = UNIT_SHADOW / 4;

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -1,6 +1,5 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
-#include <trx/game/const.h>
 #include <trx/game/gym.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -20,6 +19,7 @@ typedef struct {
     int32_t x_rot_speed;
     int32_t bounce_stage;
     bool destroyed;
+    bool targetable;
 } M_PRIV;
 
 static bool M_ShouldSpawnBlood(const ITEM *const item)
@@ -33,6 +33,8 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
     JSON_SHOULD(JSON_READ(io, "x_rot_speed", &p->x_rot_speed));
     JSON_SHOULD(JSON_READ(io, "bounce_stage", &p->bounce_stage));
     JSON_SHOULD(JSON_READ(io, "destroyed", &p->destroyed));
+    p->targetable = !p->destroyed;
+    JSON_OPTIONAL(JSON_READ(io, "targetable", &p->targetable));
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
@@ -41,6 +43,7 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "x_rot_speed", p->x_rot_speed);
     JSONW_WRITE(io, "bounce_stage", p->bounce_stage);
     JSONW_WRITE(io, "destroyed", p->destroyed);
+    JSONW_WRITE(io, "targetable", p->targetable);
 }
 
 static void M_ResetItemState(ITEM *const item, const OBJECT *const obj)
@@ -75,6 +78,7 @@ static void M_Initialise(const int16_t item_num)
     p->x_rot_speed = 0;
     p->bounce_stage = 0;
     p->destroyed = false;
+    p->targetable = true;
 
     item->active = false;
     item->status = IS_INACTIVE;
@@ -100,7 +104,7 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    if (item->hit_points != DONT_TARGET) {
+    if (p->targetable) {
         if (item->hit_status) {
             Sound_Effect(SFX_TARGET_HITS, &item->pos, SPM_NORMAL);
         }
@@ -132,12 +136,12 @@ static void M_Control(const int16_t item_num)
             break;
 
         case M_STATE_HIT_3:
-            if (item->hit_points <= 0 && item->hit_points != DONT_TARGET) {
+            if (item->hit_points <= 0) {
                 LARA_INFO *const lara = Lara_GetLaraInfo();
                 if (lara->target == item) {
                     lara->target = nullptr;
                 }
-                item->hit_points = DONT_TARGET;
+                p->targetable = false;
                 p->x_rot_speed = DEG_1 * 10;
                 p->bounce_stage = 0;
                 p->destroyed = true;
@@ -152,7 +156,7 @@ static void M_Control(const int16_t item_num)
             if (lara->target == item) {
                 lara->target = nullptr;
             }
-            item->hit_points = DONT_TARGET;
+            p->targetable = false;
             p->x_rot_speed = DEG_1;
             p->bounce_stage = 0;
             p->destroyed = false;
@@ -207,19 +211,42 @@ static void M_Control(const int16_t item_num)
     Item_Animate(item);
 }
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->targetable && item->status == IS_ACTIVE
+        && item->hit_points > 0;
+}
+
+static bool M_CanTakeDamage(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->targetable && item->hit_points > 0;
+}
+
+static bool M_CanBeProjectileTarget(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->targetable && item->status == IS_ACTIVE
+        && item->collidable && item->hit_points > 0;
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
+    obj->is_targetable_func = M_IsTargetable;
+    obj->can_take_damage_func = M_CanTakeDamage;
+    obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
     obj->priv_size = sizeof(M_PRIV);
     obj->priv_load_func = M_LoadPriv;
     obj->priv_save_func = M_SavePriv;
     obj->hit_points = 8;
     obj->shadow_size = 128;
     obj->radius = 102;
-    obj->intelligent = true;
+    obj->intelligent = false;
 }
 
 REGISTER_OBJECT(O_ASSAULT_TARGET, M_Setup)

--- a/src/trx/game/objects/general/combat_end.c
+++ b/src/trx/game/objects/general/combat_end.c
@@ -4,6 +4,7 @@
 #include <trx/game/creature.h>
 #include <trx/game/game.h>
 #include <trx/game/gun.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/vehicle.h>
 #include <trx/game/objects/common.h>
@@ -21,7 +22,7 @@ static int32_t M_CountAliveEnemies(void)
     int32_t count = 0;
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         const ITEM *const item = Item_Get(i);
-        if (item->object_id != M_BOSS_TYPE && Creature_IsAlive(item)
+        if (item->object_id != M_BOSS_TYPE && Item_IsAlive(item)
             && Creature_IsHostile(item)) {
             count++;
         }
@@ -33,7 +34,7 @@ static bool M_IsBossDead(void)
 {
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         const ITEM *const item = Item_Get(i);
-        if (item->object_id == M_BOSS_TYPE && !Creature_IsAlive(item)) {
+        if (item->object_id == M_BOSS_TYPE && !Item_IsAlive(item)) {
             return true;
         }
     }

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -91,14 +91,14 @@ static void M_Explode(int16_t grenade_item_num, const XYZ_32 pos)
 
 static bool M_CanExplodeTarget(const ITEM *const item)
 {
-    if (item->object_id == O_TRIBE_BOSS || item->object_id == O_TONY) {
-        return false;
+    const OBJECT *const object = Object_Get(item->object_id);
+    if (object->can_be_exploded_func != nullptr) {
+        return object->can_be_exploded_func(item);
     }
 
     // TODO: as some creatures have more than one death animation, have a
     // way to expose those specific ones for checking, or delegate
     // responsibility directly to the objects.
-    const OBJECT *const object = Object_Get(item->object_id);
     const ITEM_ACTION action = ItemAction_ToGameID(ITEM_ACTION_FINISH_LEVEL);
     for (int32_t i = 0; i < object->anim_count; i++) {
         const ANIM *const anim = Object_GetAnim(object, i);

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -6,6 +6,7 @@
 #include <trx/game/fx/water.h>
 #include <trx/game/gun/misc.h>
 #include <trx/game/gun/vars.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/general/smashable.h>
 #include <trx/game/rooms.h>
@@ -128,9 +129,7 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    if (!Creature_IsTargetable(target_item)
-        && !Creature_IsDestructible(target_item)
-        && !Creature_IsFloating(target_item)) {
+    if (!Item_CanBeProjectileTarget(target_item)) {
         return false;
     }
 
@@ -163,7 +162,7 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    if (target_item->status != IS_ACTIVE) {
+    if (!Item_CanTakeDamage(target_item)) {
         return false;
     }
 

--- a/src/trx/game/objects/general/grenade.c
+++ b/src/trx/game/objects/general/grenade.c
@@ -111,7 +111,7 @@ static bool M_CanExplodeTarget(const ITEM *const item)
 }
 
 static bool M_TryExplodeItem(
-    const ITEM *const projectile_item, const XYZ_32 old_pos,
+    const ITEM *const projectile_item, const GAME_VECTOR old_pos,
     const int16_t target_item_num, const int32_t radius)
 {
     ITEM *const target_item = Item_Get(target_item_num);
@@ -171,7 +171,7 @@ static bool M_TryExplodeItem(
         .room_num = projectile_item->room_num,
     };
     Gun_HitTarget(
-        target_item, nullptr, &hit_pos, g_Weapons[LGT_GRENADE].damage);
+        target_item, &old_pos, &hit_pos, g_Weapons[LGT_GRENADE].damage);
     Stats_AddAmmoHits();
 
     if (target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {
@@ -335,8 +335,7 @@ static void M_Control(const int16_t item_num)
             for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
-                if (!M_TryExplodeItem(
-                        item, old_pos.pos, target_item_num, radius)) {
+                if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
                     continue;
                 }
 
@@ -352,7 +351,7 @@ static void M_Control(const int16_t item_num)
         for (int16_t target_item_num = room->item_num;
              target_item_num != NO_ITEM;
              target_item_num = Item_Get(target_item_num)->next_item) {
-            if (M_TryExplodeItem(item, old_pos.pos, target_item_num, radius)) {
+            if (M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
                 explode = true;
             }
         }

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -132,7 +132,7 @@ static void M_Control_TR3(const int16_t item_num)
             const GAME_VECTOR hit_pos = { .pos = item->pos,
                                           .room_num = item->room_num };
             Gun_HitTarget(
-                target_item, nullptr, &hit_pos, g_Weapons[LGT_HARPOON].damage);
+                target_item, &old_pos, &hit_pos, g_Weapons[LGT_HARPOON].damage);
             Stats_AddAmmoHits();
         }
 
@@ -297,7 +297,7 @@ static void M_Control_TR12(const int16_t item_num)
                 .room_num = item->room_num,
             };
             Gun_HitTarget(
-                target_item, nullptr, &hit_pos, g_Weapons[LGT_HARPOON].damage);
+                target_item, &old_pos, &hit_pos, g_Weapons[LGT_HARPOON].damage);
             Stats_AddAmmoHits();
         }
         hit = true;

--- a/src/trx/game/objects/general/harpoon_bolt.c
+++ b/src/trx/game/objects/general/harpoon_bolt.c
@@ -83,16 +83,11 @@ static void M_Control_TR3(const int16_t item_num)
             continue;
         }
 
-        if (target_item->object_id == O_HARPOON_BOLT) {
-            continue;
-        }
-
         if (!target_item->collidable) {
             continue;
         }
 
-        if (!Creature_IsTargetable(target_item)
-            && !Creature_IsDestructible(target_item)) {
+        if (!Item_CanBeProjectileTarget(target_item)) {
             continue;
         }
 
@@ -128,7 +123,7 @@ static void M_Control_TR3(const int16_t item_num)
             continue;
         }
 
-        if (target_item->status == IS_ACTIVE) {
+        if (Item_CanTakeDamage(target_item)) {
             if (Item_ShouldSpawnBlood(target_item)) {
                 Spawn_BloodBath(
                     item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,
@@ -255,7 +250,7 @@ static void M_Control_TR12(const int16_t item_num)
             continue;
         }
 
-        if (!Creature_IsTargetable(target_item)) {
+        if (!Item_CanBeProjectileTarget(target_item)) {
             continue;
         }
 
@@ -291,7 +286,7 @@ static void M_Control_TR12(const int16_t item_num)
             continue;
         }
 
-        if (target_item->status == IS_ACTIVE) {
+        if (Item_CanTakeDamage(target_item)) {
             if (Item_ShouldSpawnBlood(target_item)) {
                 Spawn_BloodBath(
                     item->pos.x, item->pos.y, item->pos.z, 0, 0, item->room_num,

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -107,7 +107,7 @@ static bool M_CanExplodeTarget(const ITEM *const item)
 }
 
 static bool M_TryExplodeItem(
-    const ITEM *const projectile_item, const XYZ_32 old_pos,
+    const ITEM *const projectile_item, const GAME_VECTOR old_pos,
     const int16_t target_item_num, const int32_t radius)
 {
     ITEM *const target_item = Item_Get(target_item_num);
@@ -163,7 +163,7 @@ static bool M_TryExplodeItem(
             .room_num = projectile_item->room_num,
         };
         Gun_HitTarget(
-            target_item, nullptr, &hit_pos, g_Weapons[LGT_ROCKET].damage);
+            target_item, &old_pos, &hit_pos, g_Weapons[LGT_ROCKET].damage);
         Stats_AddAmmoHits();
 
         if (target_item->hit_points <= 0 && M_CanExplodeTarget(target_item)) {
@@ -318,8 +318,7 @@ static void M_Control(const int16_t item_num)
             for (int16_t target_item_num = nearby_room->item_num;
                  target_item_num != NO_ITEM;
                  target_item_num = Item_Get(target_item_num)->next_item) {
-                if (!M_TryExplodeItem(
-                        item, old_pos.pos, target_item_num, radius)) {
+                if (!M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
                     continue;
                 }
 
@@ -335,7 +334,7 @@ static void M_Control(const int16_t item_num)
         for (int16_t target_item_num = room->item_num;
              target_item_num != NO_ITEM;
              target_item_num = Item_Get(target_item_num)->next_item) {
-            if (M_TryExplodeItem(item, old_pos.pos, target_item_num, radius)) {
+            if (M_TryExplodeItem(item, old_pos, target_item_num, radius)) {
                 explode = true;
             }
         }

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -90,11 +90,11 @@ static void M_Explode(const int16_t rocket_item_num, const XYZ_32 pos)
 
 static bool M_CanExplodeTarget(const ITEM *const item)
 {
-    if (item->object_id == O_TRIBE_BOSS || item->object_id == O_TONY) {
-        return false;
+    const OBJECT *const object = Object_Get(item->object_id);
+    if (object->can_be_exploded_func != nullptr) {
+        return object->can_be_exploded_func(item);
     }
 
-    const OBJECT *const object = Object_Get(item->object_id);
     const ITEM_ACTION action = ItemAction_ToGameID(ITEM_ACTION_FINISH_LEVEL);
     for (int32_t i = 0; i < object->anim_count; i++) {
         const ANIM *const anim = Object_GetAnim(object, i);

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -6,6 +6,7 @@
 #include <trx/game/fx/water.h>
 #include <trx/game/gun/misc.h>
 #include <trx/game/gun/vars.h>
+#include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/output/lights.h>
 #include <trx/game/output/state.h>
@@ -123,9 +124,7 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    if (!Creature_IsTargetable(target_item)
-        && !Creature_IsDestructible(target_item)
-        && !Creature_IsFloating(target_item)) {
+    if (!Item_CanBeProjectileTarget(target_item)) {
         return false;
     }
 
@@ -158,7 +157,7 @@ static bool M_TryExplodeItem(
         return false;
     }
 
-    if (target_item->status == IS_ACTIVE) {
+    if (Item_CanTakeDamage(target_item)) {
         const GAME_VECTOR hit_pos = {
             .pos = projectile_item->pos,
             .room_num = projectile_item->room_num,

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -34,7 +34,7 @@ static void M_Control(const int16_t item_num)
 
     if (counter == 0) {
         item->status = IS_INVISIBLE;
-        item->hit_points = DONT_TARGET;
+        item->hit_points = 0;
         Room_TestTriggers(item);
         Item_RemoveDrawn(item_num);
     }

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -248,6 +248,11 @@ static void M_FindCarcass(const ITEM *const shoal_item)
     p->carcass_item_num = Item_FindTypeInRoom(shoal_item->room_num, O_CARCASS);
 }
 
+static bool M_IsTargetable(const ITEM *const item)
+{
+    return false;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -727,6 +732,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
+    obj->is_targetable_func = M_IsTargetable;
     obj->draw_func = M_Draw;
     obj->hit_points = NO_ITEM;
     obj->save_position = true;

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -37,8 +37,12 @@ void Object_SetupAllObjects(void)
         obj->can_drop_items_func = nullptr;
         obj->can_interpolate_func = Object_CanInterpolate;
         obj->should_spawn_blood_func = nullptr;
+        obj->is_alive_func = nullptr;
+        obj->is_targetable_func = nullptr;
+        obj->can_take_damage_func = nullptr;
+        obj->can_be_projectile_target_func = nullptr;
         obj->get_mesh_index_func = nullptr;
-        obj->hit_points = DONT_TARGET;
+        obj->hit_points = 0;
         obj->pivot_length = 0;
         obj->radius = M_DEFAULT_RADIUS;
         obj->shadow_size = 0;

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -41,6 +41,7 @@ void Object_SetupAllObjects(void)
         obj->is_targetable_func = nullptr;
         obj->can_take_damage_func = nullptr;
         obj->can_be_projectile_target_func = nullptr;
+        obj->can_be_exploded_func = nullptr;
         obj->get_mesh_index_func = nullptr;
         obj->hit_points = 0;
         obj->pivot_length = 0;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -83,6 +83,10 @@ typedef struct OBJECT {
     bool (*can_interpolate_func)(
         const ITEM *item, int32_t frame_a, int32_t frame_b);
     bool (*should_spawn_blood_func)(const ITEM *item);
+    bool (*is_alive_func)(const ITEM *item);
+    bool (*is_targetable_func)(const ITEM *item);
+    bool (*can_take_damage_func)(const ITEM *item);
+    bool (*can_be_projectile_target_func)(const ITEM *item);
     int32_t (*get_mesh_index_func)(const ITEM *item, int32_t mesh_idx);
 
     int16_t anim_idx;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -87,6 +87,7 @@ typedef struct OBJECT {
     bool (*is_targetable_func)(const ITEM *item);
     bool (*can_take_damage_func)(const ITEM *item);
     bool (*can_be_projectile_target_func)(const ITEM *item);
+    bool (*can_be_exploded_func)(const ITEM *item);
     int32_t (*get_mesh_index_func)(const ITEM *item, int32_t mesh_idx);
 
     int16_t anim_idx;

--- a/src/trx/game/objects/vars.c
+++ b/src/trx/game/objects/vars.c
@@ -131,9 +131,11 @@ const OBJECT_ID g_CreatureObjects[] = {
     // clang-format on
 };
 
-const OBJECT_ID g_DestructibleCreatureObjects[] = {
+const OBJECT_ID g_ProjectileObjects[] = {
     // clang-format off
-    O_COBRA,
+    O_HARPOON_BOLT,
+    O_GRENADE,
+    O_ROCKET,
     NO_OBJECT,
     // clang-format on
 };

--- a/src/trx/game/objects/vars.h
+++ b/src/trx/game/objects/vars.h
@@ -4,7 +4,7 @@
 #include <trx/game/objects/ids.h>
 
 extern const OBJECT_ID g_CreatureObjects[];
-extern const OBJECT_ID g_DestructibleCreatureObjects[];
+extern const OBJECT_ID g_ProjectileObjects[];
 extern const OBJECT_ID g_WaterObjects[];
 extern const OBJECT_ID g_LoyalObjects[];
 extern const OBJECT_ID g_PickupObjects[];

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -297,7 +297,6 @@ static void M_Collision(
         lara_item->goal_anim_state = M_STATE_GET_ON_R;
     }
 
-    item->hit_points = 1;
     lara_item->pos.x = item->pos.x;
     lara_item->pos.y = item->pos.y;
     lara_item->pos.z = item->pos.z;

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -145,7 +145,7 @@ static bool M_CheckBaddieCollision(ITEM *const item, ITEM *const skidoo)
         }
     } else if (
         obj->intelligent && item->status == IS_ACTIVE
-        && (Creature_IsTargetable(item) || item->hit_points == 0)) {
+        && (Item_IsTargetable(item) || item->hit_points == 0)) {
         if (Item_ShouldSpawnBlood(item)) {
             Spawn_BloodBath(
                 item->pos.x, skidoo->pos.y - STEP_L, item->pos.z, skidoo->speed,


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR refactors targeting/damage checks and removes the special `DONT_TARGET` hitpoints value in favor of dedicated helper functions.

This has actual player-facing consequences:
- Assault Targets no longer have to become intelligent to be targetable. This makes them no longer collide after Lara shoots them, making TRX adhere to the OG.
- Hitting sleeping Cobras with Harpoons requires now two hits instead of one. This steers away from the OG, but IMO is very reasonable, as it consults real Cobras HP values and not a made-up one-shot special death condition.

#### Implementation details

The goal is to make lock-on, projectile hit filtering, and damageability decisions consistent across enemies, bosses, special targets, and non-creature objects. Instead of using a special health value `DONT_TARGET` and status checks in many call sites, the logic now goes through `Item_IsAlive`, `Item_IsTargetable`, `Item_CanTakeDamage`, and `Item_CanBeProjectileTarget`.

`OBJECT` now supports opt-in callback hooks (`is_alive_func`, `is_targetable_func`, `can_take_damage_func`, `can_be_projectile_target_func`) so special cases stay local to each object (for example cobra sleeping/waking behavior, Natla semideath handling etc). Projectile objects are explicitly grouped and excluded from projectile-target logic, and gun target acquisition now iterates active items with bounds-safe target list writes.

#### Testing

- [x] In a level with mixed hostiles and non-hostiles, equip a lock-on weapon and cycle targets
- [x] Validate normal combat
- [x] Validate special cases
    Creatures requiring special attention:

    - [x] Natla (semideath)
    - [x] Skidoo Driver
    - [x] Shiva (shield vs no shield)
    - [x] Tony (shield vs no shield)
    - [x] Tribe Boss (shield vs no shield)
    - [x] Floating creatures
    - [x] Cobra (sleeping vs not sleeping)
    - [x] Crocodile (item drops…)
    - [x] Mummy (item drops…)
    - [x] Pierre (runaway vs final encounter)
    - [x] Winston
    - [x] Army Winston (shield and death state)
    - [x] Assault Target (collision after shooting)
    - [x] TR2 HSH ending condition
    - [x] Floating creatures (dead)
    - [x] Pod / Big Pod
    - [x] Centaur Statue
    - [x] Bacon Lara

    All creatures require testing with:
    - Normal guns, and separately: harpoons, grenades, and rockets
    - × Dead state and normal state
- [x] Game behavior (especially targeting and projectile damager) from non-creature objects that have HP:
    - [x] Raptor emitter
    - [x] Quad bike
    - [x] Fishies
    - [x] Scion
