### PR TITLE
lara/state/swim: fix surface swimming input checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - fixed non-deterministic Inventory Ring control (transition speeds depended on v-sync / wall clock timing)
 - fixed game logic speeding up while the game was fading out after quitting
 - fixed Lara being able to shoot smashable objects located in unreachable overlapping rooms (#4949, regression from TR1X 4.14 / TR2X 1.4)
+- fixed Lara continuing to side-swim if enhanced sidesteps are enabled, after releasing the direction key but keeping walk pressed
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/lara/state/swim.c
+++ b/src/trx/game/lara/state/swim.c
@@ -195,12 +195,10 @@ static void M_ForwardSurface(ITEM *const item, COLL_INFO *const coll)
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->dive_timer = 0;
-    if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
-        if (g_Input.left) {
-            item->rot.y -= LARA_SLOW_TURN;
-        } else if (g_Input.right) {
-            item->rot.y += LARA_SLOW_TURN;
-        }
+    if (g_Input.left) {
+        item->rot.y -= LARA_SLOW_TURN;
+    } else if (g_Input.right) {
+        item->rot.y += LARA_SLOW_TURN;
     }
     if (!g_Input.forward || g_Input.jump) {
         item->goal_anim_state = LS(LS_SURF_TREAD);
@@ -221,31 +219,29 @@ static void M_SideBackSurface(ITEM *const item, COLL_INFO *const coll)
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->dive_timer = 0;
 
-    if (!g_Config.input.enable_tr3_sidesteps || !g_Input.slow) {
-        if (g_Input.left) {
-            item->rot.y -= M_TURN_RATE;
-        } else if (g_Input.right) {
-            item->rot.y += M_TURN_RATE;
-        }
+    if (g_Input.left) {
+        item->rot.y -= M_TURN_RATE;
+    } else if (g_Input.right) {
+        item->rot.y += M_TURN_RATE;
+    }
 
-        bool stop = false;
-        switch (LS_U(item->current_anim_state)) {
-        case LS_SURF_BACK:
-            stop = !g_Input.back;
-            break;
-        case LS_SURF_LEFT:
-            stop = !g_Input.step_left;
-            break;
-        case LS_SURF_RIGHT:
-            stop = !g_Input.step_right;
-            break;
-        default:
-            break;
-        }
+    bool stop = false;
+    switch (LS_U(item->current_anim_state)) {
+    case LS_SURF_BACK:
+        stop = !g_Input.back;
+        break;
+    case LS_SURF_LEFT:
+        stop = !g_Input.step_left;
+        break;
+    case LS_SURF_RIGHT:
+        stop = !g_Input.step_right;
+        break;
+    default:
+        break;
+    }
 
-        if (stop) {
-            item->goal_anim_state = LS(LS_SURF_TREAD);
-        }
+    if (stop) {
+        item->goal_anim_state = LS(LS_SURF_TREAD);
     }
 
     item->fall_speed += 8;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This removes the checks on the TR3 sidestepping option in Lara's surface state routines, as the abstraction is already handled when updating the current frame's inputs. This fixes her continuing to side-swim despite the direction key being released, as well as allowing her to turn while swimming forward and walk is held.
