### PR TITLE
screenshot: fix invalid free

### DIFF
--- a/src/trx/game/screenshot.c
+++ b/src/trx/game/screenshot.c
@@ -67,7 +67,7 @@ static char *M_GetScreenshotTitle(void)
         if (clean_level_title != nullptr && strlen(clean_level_title) > 0) {
             return clean_level_title;
         }
-        Memory_FreePointer(clean_level_title);
+        Memory_FreePointer(&clean_level_title);
     }
 
     // If title totally invalid, name it based on level number


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes an invalid free call in the screenshot function, causing potential crashes.