### PR TITLE
json: fix tiny memory leak

### DIFF
--- a/src/trx/core/json/base.c
+++ b/src/trx/core/json/base.c
@@ -155,7 +155,7 @@ JSON_VALUE *JSON_ValueFromObject(JSON_OBJECT *const obj)
 
 void JSON_ValueFree(JSON_VALUE *const value)
 {
-    if (value == nullptr || value->ref_count != 0) {
+    if (value == nullptr) {
         return;
     }
 
@@ -178,7 +178,9 @@ void JSON_ValueFree(JSON_VALUE *const value)
         break;
     }
 
-    Memory_Free(value);
+    if (value->ref_count == 0) {
+        Memory_Free(value);
+    }
 }
 
 bool JSON_ValueIsNull(const JSON_VALUE *const value)


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes a memory leak in savegame death-counter updates.

The leak happened when `Savegame_UpdateDeathCounters()` modified parsed savegame JSON: the new `death_count` node was heap-allocated, but cleanup could skip traversing parsed nodes due to `ref_count`, so appended nodes were left behind. The fix makes JSON cleanup always traverse payload trees while still only freeing allocations owned by the current node (`ref_count == 0`), so parsed BSON-backed nodes are respected and appended heap nodes are reclaimed correctly.
