### PR TITLE
lara: fix tr1/2 lava spamming flames when immune

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,8 @@
 - fixed non-deterministic Inventory Ring control (transition speeds depended on v-sync / wall clock timing)
 - fixed game logic speeding up while the game was fading out after quitting
 - fixed Lara being able to shoot smashable objects located in unreachable overlapping rooms (#4949, regression from TR1X 4.14 / TR2X 1.4)
-- fixed Lara continuing to side-swim if enhanced sidesteps are enabled, after releasing the direction key but keeping walk pressed
+- fixed touching Lava Wedges causing endless Flame effect spawns when the immunity cheat is on
+- fixed touching Lava tiles causing reduced Flame effect when the immunity cheat is on
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -203,7 +203,15 @@ void Lara_TouchDeathSector(const GF_DEATH_TILE death_tile)
     }
 
     if (g_Config.debug.enable_invulnerability) {
-        Lara_CatchFire();
+        switch (death_tile) {
+        case GF_DEATH_TILE_RAPIDS:
+        case GF_DEATH_TILE_ELECTRIC:
+            Lara_CatchFire();
+            break;
+        case GF_DEATH_TILE_LAVA:
+            Lara_TouchLava();
+            break;
+        }
         return;
     }
 
@@ -225,14 +233,14 @@ void Lara_TouchDeathSector(const GF_DEATH_TILE death_tile)
 
 void Lara_TouchLava(void)
 {
-    ITEM *const lara_item = Lara_GetItem();
-    const LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_info->water_status != LWS_ABOVE_WATER) {
+    if (g_TRVersion == 3) {
+        Lara_CatchFire();
         return;
     }
 
-    if (g_TRVersion == 3) {
-        Lara_CatchFire();
+    ITEM *const lara_item = Lara_GetItem();
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->burn || lara_info->water_status != LWS_ABOVE_WATER) {
         return;
     }
 
@@ -246,6 +254,7 @@ void Lara_TouchLava(void)
             effect->counter = -1 - 24 * Random_GetControl() / 0x7FFF;
         }
     }
+    lara_info->burn = true;
 }
 
 void Lara_RapidsDrown(void)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the Invulnerability cheat and TR1/TR2 Lava and Lava Wedges:
- touching Lava tiles caused unimpressive fires,
- on the other hand, touching Lava Wedges caused infinite flame spam.

In TR3 touching any lava tile causes Lara to burn using regular spark effects.