### PR TITLE
misc: promote height types to int32_t

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - added support for monkey bars
 - changed Lara to be able to grab ealier when performing forward jumps, like TR3
 - fixed a very rare case of raptors using an incorrect death animation
+- fixed Lara unable to run around in random spots at the bottom of The Great Pyramid's starting pit
 
 **TR2**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -147,8 +147,8 @@ static bool M_LOS(
 static inline void M_ClampY(int16_t room_num, XYZ_32 *const pos)
 {
     const SECTOR *const sector = Room_GetSector(*pos, &room_num);
-    const int16_t height = Room_GetHeightEx(sector, *pos, true, NO_ITEM);
-    const int16_t ceiling = Room_GetCeilingEx(sector, *pos, true);
+    const int32_t height = Room_GetHeightEx(sector, *pos, true, NO_ITEM);
+    const int32_t ceiling = Room_GetCeilingEx(sector, *pos, true);
 
     if (ceiling < height && ceiling != NO_HEIGHT && height != NO_HEIGHT) {
         if (ceiling > pos->y - 255 && height < pos->y + 255) {
@@ -177,8 +177,8 @@ static bool M_Collide(
     int16_t room_num = ideal->room_num;
     XYZ_32 sample_pos = { .x = pos.x - shift, .y = pos.y, .z = pos.z };
     const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
-    int16_t height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, sample_pos, true);
+    int32_t height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
+    int32_t ceiling = Room_GetCeilingEx(sector, sample_pos, true);
     if (L_OUT_OF_BOUNDS) {
         pos.x = ROUND_TO_SECTOR(pos.x) + shift;
     }
@@ -298,8 +298,8 @@ static void M_Move(GAME_VECTOR *const ideal, const int32_t speed)
     }
 
     sector = Room_GetSector(pos, &room_num);
-    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
+    int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (pos.y < ceiling || pos.y > height) {
         M_LOS(&g_Camera.target, &g_Camera.pos, 0);
@@ -438,8 +438,8 @@ static void M_Chase(const ITEM *const item)
 
     XYZ_32 pos = g_Camera.target.pos;
     sector = Room_GetSector(pos, &g_Camera.target.room_num);
-    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
+    int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (ceiling + 16 > height - 16 && height != NO_HEIGHT
         && ceiling != NO_HEIGHT) {
@@ -507,8 +507,8 @@ static void M_Combat(const ITEM *const item)
 
     XYZ_32 pos = g_Camera.target.pos;
     sector = Room_GetSector(pos, &g_Camera.target.room_num);
-    int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
-    int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
+    int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
 
     if (ceiling + 64 > height - 64 && height != NO_HEIGHT
         && ceiling != NO_HEIGHT) {
@@ -612,8 +612,8 @@ static void M_Look(const ITEM *const item)
     }
 
     sector = Room_GetSector(pos_1, &room_num);
-    int16_t height = Room_GetHeight(sector, pos_1);
-    int16_t ceiling = Room_GetCeiling(sector, pos_1);
+    int32_t height = Room_GetHeight(sector, pos_1);
+    int32_t ceiling = Room_GetCeiling(sector, pos_1);
 
     if (height == NO_HEIGHT || ceiling == NO_HEIGHT || ceiling >= height
         || pos_1.y > height || pos_1.y < ceiling) {
@@ -787,8 +787,8 @@ static void M_ClampResult(void)
     XYZ_32 pos = g_Camera.interp.result.pos;
     int16_t room_num = g_Camera.interp.room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
-    const int16_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
-    const int16_t ceiling = Room_GetCeilingEx(sector, pos, true);
+    const int32_t height = Room_GetHeightEx(sector, pos, true, NO_ITEM);
+    const int32_t ceiling = Room_GetCeilingEx(sector, pos, true);
     if (height == NO_HEIGHT || ceiling == NO_HEIGHT || height < g_Camera.pos.y
         || ceiling > g_Camera.pos.y) {
         pos = g_Camera.pos.pos;

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1097,7 +1097,7 @@ bool Creature_Animate(
     } else {
         sector = Room_GetSector(item->pos, &room_num);
         if (g_TRVersion == 3) {
-            const int16_t ceiling = Room_GetCeiling(sector, item->pos);
+            const int32_t ceiling = Room_GetCeiling(sector, item->pos);
             int32_t min_y = bounds->min.y;
             switch (item->object_id) {
             case O_TREX:

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -292,7 +292,7 @@ static void M_PlayerControl(const int16_t item_num)
 
     int16_t floor_room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &floor_room_num);
-    const int16_t height = Room_GetHeight(sector, pos);
+    const int32_t height = Room_GetHeight(sector, pos);
     item->floor = height == NO_HEIGHT ? pos.y : height;
 
     Lara_Animate(item);

--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -119,7 +119,7 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
     const SECTOR *const sector = Room_GetSector(
         (XYZ_32) { pickup->pos.x, pickup->pos.y - 10, pickup->pos.z },
         &room_num);
-    const int16_t height = Room_GetHeight(sector, pickup->pos);
+    const int32_t height = Room_GetHeight(sector, pickup->pos);
     const bool in_water = Room_Get(pickup->room_num)->flags.underwater;
 
     if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -237,7 +237,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
             item->goal_anim_state = LS(LS_CRAWL_FORWARD);
         }
     } else if (g_Input.back) {
-        int16_t h = Lara_CeilingFront(item, item->rot.y, -300, LARA_HEIGHT);
+        int32_t h = Lara_CeilingFront(item, item->rot.y, -300, LARA_HEIGHT);
         if (h == NO_HEIGHT || h > 256) {
             return;
         }

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -264,7 +264,7 @@ void Lara_RapidsDrown(void)
     lara_info->gun_type = LGT_UNARMED;
 }
 
-int16_t Lara_FloorFront(
+int32_t Lara_FloorFront(
     const ITEM *const item, const int16_t ang, const int32_t dist)
 {
     XYZ_32 pos = item->pos;
@@ -283,7 +283,7 @@ int16_t Lara_FloorFront(
     return height;
 }
 
-int16_t Lara_CeilingFront(
+int32_t Lara_CeilingFront(
     const ITEM *const item, const int16_t ang, const int32_t dist,
     const int32_t item_height)
 {

--- a/src/trx/game/lara/misc.h
+++ b/src/trx/game/lara/misc.h
@@ -12,8 +12,8 @@ void Lara_TouchLava(void);
 void Lara_TouchDeathSector(GF_DEATH_TILE death_tile);
 void Lara_RapidsDrown(void);
 
-int16_t Lara_FloorFront(const ITEM *item, int16_t ang, int32_t dist);
-int16_t Lara_CeilingFront(
+int32_t Lara_FloorFront(const ITEM *item, int16_t ang, int32_t dist);
+int32_t Lara_CeilingFront(
     const ITEM *item, int16_t ang, int32_t dist, int32_t item_height);
 void Lara_CatchFire(void);
 

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -45,8 +45,8 @@ static bool M_CanCrouchRoll(const ITEM *const item, const LARA_INFO *const lara)
         return false;
     }
 
-    const int16_t height_far = Lara_FloorFront(item, item->rot.y, STEP_L * 2);
-    const int16_t height_near = Lara_FloorFront(item, item->rot.y, STEP_L);
+    const int32_t height_far = Lara_FloorFront(item, item->rot.y, STEP_L * 2);
+    const int32_t height_near = Lara_FloorFront(item, item->rot.y, STEP_L);
     if (height_far >= STEPUP_HEIGHT || height_near < -STEPUP_HEIGHT) {
         return false;
     }
@@ -88,8 +88,8 @@ static bool M_CanJumpDown(const ITEM *const item, const LARA_INFO *const lara)
         return false;
     }
 
-    const int16_t floor_front = Lara_FloorFront(item, item->rot.y, M_JUMP_DIST);
-    const int16_t ceiling_front =
+    const int32_t floor_front = Lara_FloorFront(item, item->rot.y, M_JUMP_DIST);
+    const int32_t ceiling_front =
         Lara_CeilingFront(item, item->rot.y, M_JUMP_DIST, M_JUMP_HEIGHT);
     if (floor_front < M_JUMP_HEIGHT || ceiling_front == NO_HEIGHT
         || ceiling_front > 0) {

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -307,8 +307,8 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         }
     }
 
-    int16_t fheight = NO_HEIGHT;
-    int16_t rheight = NO_HEIGHT;
+    int32_t fheight = NO_HEIGHT;
+    int32_t rheight = NO_HEIGHT;
     if (g_Input.forward) {
         fheight = Lara_FloorFront(item, item->rot.y, M_WALK_DIST);
     } else if (g_Input.back) {
@@ -323,8 +323,8 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
             item->goal_anim_state = LS(LS_TURN_RIGHT);
         }
     } else if (g_Input.step_left) {
-        const int16_t h = Lara_FloorFront(item, item->rot.y - DEG_90, 148);
-        const int16_t c =
+        const int32_t h = Lara_FloorFront(item, item->rot.y - DEG_90, 148);
+        const int32_t c =
             Lara_CeilingFront(item, item->rot.y - DEG_90, 148, LARA_HEIGHT);
         if (g_TRVersion < 3
             || (h < 128 && h > -128 && Room_GetHeightType() != HT_BIG_SLOPE
@@ -332,8 +332,8 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
             item->goal_anim_state = LS(LS_STEP_LEFT);
         }
     } else if (g_Input.step_right) {
-        const int16_t h = Lara_FloorFront(item, item->rot.y + DEG_90, 148);
-        const int16_t c =
+        const int32_t h = Lara_FloorFront(item, item->rot.y + DEG_90, 148);
+        const int32_t c =
             Lara_CeilingFront(item, item->rot.y + DEG_90, 148, LARA_HEIGHT);
         if (g_TRVersion < 3
             || (h < 128 && h > -128 && Room_GetHeightType() != HT_BIG_SLOPE
@@ -363,8 +363,8 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     } else if (g_Input.jump) {
         item->goal_anim_state = LS(LS_COMPRESS);
     } else if (g_Input.forward) {
-        const int16_t h = Lara_FloorFront(item, item->rot.y, M_WALK_DIST);
-        const int16_t c =
+        const int32_t h = Lara_FloorFront(item, item->rot.y, M_WALK_DIST);
+        const int32_t c =
             Lara_CeilingFront(item, item->rot.y, M_WALK_DIST, LARA_HEIGHT);
         const HEIGHT_TYPE height_type = Room_GetHeightType();
 
@@ -372,7 +372,7 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
         if (g_Config.gameplay.wall_glitch_mode != WALL_GLITCH_FIXED) {
             int16_t room_num = item->room_num;
             const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-            const int16_t sector_height =
+            const int32_t sector_height =
                 Room_GetHeightEx(sector, item->pos, true, NO_ITEM);
             inside_wall = sector_height == NO_HEIGHT;
         }

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -31,7 +31,7 @@ static void M_FixEmbeddedPosition(int16_t item_num)
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-    const int16_t ceiling = Room_GetCeiling(sector, item->pos);
+    const int32_t ceiling = Room_GetCeiling(sector, item->pos);
 
     // The bats animation and frame have to be changed to the hanging
     // one to properly measure them. Save it so it can be restored

--- a/src/trx/game/objects/general/bridge_common.c
+++ b/src/trx/game/objects/general/bridge_common.c
@@ -79,7 +79,7 @@ void Bridge_FixEmbeddedPosition(int16_t item_num)
     const SECTOR *const sector = Room_GetSector(
         (XYZ_32) { item->pos.x, item->pos.y - bridge_height, item->pos.z },
         &room_num);
-    const int16_t floor_height = Room_GetHeight(sector, item->pos);
+    const int32_t floor_height = Room_GetHeight(sector, item->pos);
 
     // Only move the bridge up if it's at floor level and there
     // isn't a room portal below.

--- a/src/trx/game/objects/general/cutscene_player.c
+++ b/src/trx/game/objects/general/cutscene_player.c
@@ -33,7 +33,7 @@ static void M_Control(const int16_t item_num)
 
     int16_t floor_room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &floor_room_num);
-    const int16_t height = Room_GetHeight(sector, pos);
+    const int32_t height = Room_GetHeight(sector, pos);
     item->floor = height == NO_HEIGHT ? pos.y : height;
 
     if (item->dynamic_light && item->status != IS_INVISIBLE) {

--- a/src/trx/game/objects/traps/damocles_sword.c
+++ b/src/trx/game/objects/traps/damocles_sword.c
@@ -51,9 +51,7 @@ static void M_Control(const int16_t item_num)
 
         int16_t room_num = item->room_num;
         const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-        const int16_t height = Room_GetHeight(sector, item->pos);
-
-        item->floor = height;
+        item->floor = Room_GetHeight(sector, item->pos);
         Item_UpdateRoom(item_num, room_num);
 
         if (item->pos.y > item->floor) {

--- a/src/trx/game/objects/traps/dart.c
+++ b/src/trx/game/objects/traps/dart.c
@@ -106,15 +106,15 @@ static void M_Control(const int16_t item_num)
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
-    const int32_t height = Room_GetHeight(sector, item->pos);
 
     if (item->object_id == O_DISC) {
         item->rot.x += M_PITCH;
     }
-    item->floor = height;
+    item->floor = Room_GetHeight(sector, item->pos);
+
     const GAME_VECTOR new_pos = { .pos = item->pos,
                                   .room_num = item->room_num };
-    if (item->pos.y >= height) {
+    if (item->pos.y >= item->floor) {
         M_Hit(
             item_num, Spawn_GetRayPos(old_pos, new_pos, STEP_L / 12),
             old_pos.room_num);

--- a/src/trx/game/objects/traps/falling_ceiling.c
+++ b/src/trx/game/objects/traps/falling_ceiling.c
@@ -26,12 +26,13 @@ static void M_Control(const int16_t item_num)
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-    const int16_t height = Room_GetHeight(sector, item->pos);
 
-    item->floor = height;
+    item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
-    if (item->current_anim_state == TRAP_ACTIVATE && item->pos.y >= height) {
-        item->pos.y = height;
+
+    if (item->current_anim_state == TRAP_ACTIVATE
+        && item->pos.y >= item->floor) {
+        item->pos.y = item->floor;
         item->goal_anim_state = TRAP_WORKING;
         item->fall_speed = 0;
         item->gravity = false;

--- a/src/trx/game/objects/traps/gondola.c
+++ b/src/trx/game/objects/traps/gondola.c
@@ -8,40 +8,38 @@
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const gondola = Item_Get(item_num);
+    ITEM *const item = Item_Get(item_num);
 
-    switch (gondola->current_anim_state) {
+    switch (item->current_anim_state) {
     case GONDOLA_STATE_FLOATING:
-        if (gondola->goal_anim_state == GONDOLA_STATE_CRASH) {
-            gondola->mesh_bits = 0xFF;
+        if (item->goal_anim_state == GONDOLA_STATE_CRASH) {
+            item->mesh_bits = 0xFF;
             Item_Explode(item_num, 240, 0);
         }
         break;
 
     case GONDOLA_STATE_SINK: {
-        gondola->pos.y = gondola->pos.y + M_SINK_SPEED;
-        const ANIM_FRAME *const frame = Item_GetBestFrame(gondola);
+        item->pos.y = item->pos.y + M_SINK_SPEED;
+        const ANIM_FRAME *const frame = Item_GetBestFrame(item);
         const int16_t room_shift = frame->bounds.min.y + M_SINK_ROOM_SHIFT;
-        int16_t room_num = gondola->room_num;
+        int16_t room_num = item->room_num;
         const SECTOR *const sector = Room_GetSector(
-            (XYZ_32) { gondola->pos.x, gondola->pos.y + room_shift,
-                       gondola->pos.z },
+            (XYZ_32) { item->pos.x, item->pos.y + room_shift, item->pos.z },
             &room_num);
-        const int32_t height = Room_GetHeight(sector, gondola->pos);
-        gondola->floor = height;
+        item->floor = Room_GetHeight(sector, item->pos);
         Item_UpdateRoom(item_num, room_num);
 
-        if (gondola->pos.y >= height) {
-            gondola->goal_anim_state = GONDOLA_STATE_LAND;
-            gondola->pos.y = height;
+        if (item->pos.y >= item->floor) {
+            item->goal_anim_state = GONDOLA_STATE_LAND;
+            item->pos.y = item->floor;
         }
         break;
     }
     }
 
-    Item_Animate(gondola);
+    Item_Animate(item);
 
-    if (gondola->status == IS_DEACTIVATED) {
+    if (item->status == IS_DEACTIVATED) {
         Item_RemoveActive(item_num);
     }
 }

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -70,7 +70,7 @@ static bool M_TestStop(const ITEM *const item)
     int16_t room_num = item->room_num;
     XYZ_32 sample_pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, dist);
     const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
-    const int16_t height = Room_GetHeight(sector, sample_pos);
+    const int32_t height = Room_GetHeight(sector, sample_pos);
     if (item->object_id != O_ROLLING_BALL_4) {
         // Allow a more lenient height check if regular boulders fall onto
         // slopes with a ceiling in front.
@@ -80,7 +80,7 @@ static bool M_TestStop(const ITEM *const item)
 
     sample_pos.y -= item_height;
     sector = Room_GetSector(sample_pos, &room_num);
-    const int16_t ceiling = Room_GetCeiling(sector, sample_pos);
+    const int32_t ceiling = Room_GetCeiling(sector, sample_pos);
 
     return height < item->pos.y
         || (!item->gravity && ceiling > item->pos.y - item_height);
@@ -123,7 +123,7 @@ static void M_Control(const int16_t item_num)
     if (item->status != IS_ACTIVE) {
         int16_t room_num = item->room_num;
         const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-        const int16_t height = Room_GetHeight(sector, item->pos);
+        const int32_t height = Room_GetHeight(sector, item->pos);
         if (item->floor < height) {
             item->status = IS_ACTIVE;
             item->floor = height;

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -100,7 +100,7 @@ static bool M_DrawShadow_Sprite(
 
             int16_t room_num = item->room_num;
             const SECTOR *const sector = Room_GetSector(anchor_pos, &room_num);
-            const int16_t height = Room_GetHeight(sector, anchor_pos);
+            const int32_t height = Room_GetHeight(sector, anchor_pos);
             if (height != NO_HEIGHT) {
                 anchor_floor = height;
             }

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -106,7 +106,7 @@ static void M_PrepareRoomTriggers(
 
             for (int32_t i = 0; i < vertex_count; i++) {
                 int32_t j = output_indices[i];
-                XYZ_16 vertex_pos = {
+                XYZ_32 vertex_pos = {
                     .x = (x + offsets[j].x) * WALL_L,
                     .z = (z + offsets[j].z) * WALL_L,
                 };
@@ -116,7 +116,7 @@ static void M_PrepareRoomTriggers(
                     .y = room->pos.y,
                 };
 
-                const int16_t height = Room_GetFloorHeightForSector(
+                const int32_t height = Room_GetFloorHeightForSector(
                     sector, world_pos.x, world_pos.z, true);
                 vertex_pos.y = height + (Output_GetWaterEffect() ? -16 : -2);
 

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -347,12 +347,12 @@ int32_t Room_GetOutsideStatus(const XYZ_32 pos, int16_t *const out_room_num)
 
         int16_t rn = candidate_room_num;
         const SECTOR *const sector = Room_GetSector(pos, &rn);
-        const int16_t floor = Room_GetHeight(sector, pos);
+        const int32_t floor = Room_GetHeight(sector, pos);
         if (floor == NO_HEIGHT || pos.y > floor) {
             return -2;
         }
 
-        const int16_t ceiling = Room_GetCeiling(sector, pos);
+        const int32_t ceiling = Room_GetCeiling(sector, pos);
         if (pos.y < ceiling) {
             return -2;
         }
@@ -635,7 +635,7 @@ bool Room_FindValidPos(XYZ_32 *const out_pos, int16_t *const out_room_num)
     }
 
     const SECTOR *sector = Room_GetSector(*out_pos, &room_num);
-    int16_t height = Room_GetHeight(sector, *out_pos);
+    int32_t height = Room_GetHeight(sector, *out_pos);
 
     int32_t x = out_pos->x;
     int32_t y = out_pos->y;

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -15,11 +15,11 @@ static int16_t m_AbyssMinHeight = 0;
 static int32_t m_AbyssMaxHeight = 0;
 static HEIGHT_TYPE m_HeightType = HT_WALL;
 
-static int16_t M_GetUnsplitSurfaceHeight(
+static int32_t M_GetUnsplitSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z,
     const bool fix_tilts)
 {
-    int16_t height = surface.height;
+    int32_t height = surface.height;
     if (surface.tilt == 0 || (height == NO_HEIGHT && fix_tilts)) {
         return height;
     }
@@ -145,7 +145,7 @@ static int16_t M_GetSplitSurfaceHeight(
     return height;
 }
 
-static int16_t M_GetSurfaceHeight(
+static int32_t M_GetSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z,
     const bool fix_tilts)
 {
@@ -411,12 +411,12 @@ int16_t Room_GetTiltType(const SECTOR *sector, const XYZ_32 pos)
                                   : sector->floor.tilt;
 }
 
-int16_t Room_GetHeight(const SECTOR *const sector, const XYZ_32 pos)
+int32_t Room_GetHeight(const SECTOR *const sector, const XYZ_32 pos)
 {
     return Room_GetHeightEx(sector, pos, false, NO_ITEM);
 }
 
-int16_t Room_GetFloorHeightForSector(
+int32_t Room_GetFloorHeightForSector(
     const SECTOR *const sector, const int32_t x, const int32_t z,
     const bool fix_tilts)
 {
@@ -427,7 +427,7 @@ int16_t Room_GetFloorHeightForSector(
     return M_GetSurfaceHeight(sector->floor, x, z, fix_tilts);
 }
 
-int16_t Room_GetHeightEx(
+int32_t Room_GetHeightEx(
     const SECTOR *const sector, const XYZ_32 pos, const bool fix_tilts,
     const int16_t ignore_item_num)
 {
@@ -469,16 +469,16 @@ int16_t Room_GetHeightEx(
     return height;
 }
 
-int16_t Room_GetCeiling(const SECTOR *const sector, const XYZ_32 pos)
+int32_t Room_GetCeiling(const SECTOR *const sector, const XYZ_32 pos)
 {
     return Room_GetCeilingEx(sector, pos, false);
 }
 
-int16_t Room_GetCeilingEx(
+int32_t Room_GetCeilingEx(
     const SECTOR *const sector, const XYZ_32 pos, const bool fix_tilts)
 {
     const SECTOR *const sky_sector = Room_GetSkySector(sector, pos.x, pos.z);
-    int16_t height =
+    int32_t height =
         M_GetSurfaceHeight(sky_sector->ceiling, pos.x, pos.z, fix_tilts);
 
     const SECTOR *const pit_sector = Room_GetPitSector(sector, pos.x, pos.z);
@@ -632,7 +632,7 @@ bool Room_IsOnWalkable(
 {
     sector = Room_GetPitSector(sector, pos.x, pos.z);
 
-    int16_t height = sector->floor.height;
+    int32_t height = sector->floor.height;
     bool object_found = false;
     for (WALKABLE *w = sector->walkable; w != nullptr; w = w->next) {
         // Optionally ignore a walkable.

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -17,12 +17,12 @@ bool Room_IsAbyssHeight(int32_t height);
 HEIGHT_TYPE Room_GetHeightType(void);
 int16_t Room_GetTiltType(const SECTOR *sector, XYZ_32 pos);
 
-int16_t Room_GetHeight(const SECTOR *sector, XYZ_32 pos);
-int16_t Room_GetHeightEx(
+int32_t Room_GetHeight(const SECTOR *sector, XYZ_32 pos);
+int32_t Room_GetHeightEx(
     const SECTOR *sector, XYZ_32 pos, bool fix_tilts, int16_t ignore_item_num);
-int16_t Room_GetCeiling(const SECTOR *sector, XYZ_32 pos);
-int16_t Room_GetCeilingEx(const SECTOR *sector, XYZ_32 pos, bool fix_tilts);
-int16_t Room_GetFloorHeightForSector(
+int32_t Room_GetCeiling(const SECTOR *sector, XYZ_32 pos);
+int32_t Room_GetCeilingEx(const SECTOR *sector, XYZ_32 pos, bool fix_tilts);
+int32_t Room_GetFloorHeightForSector(
     const SECTOR *sector, int32_t x, int32_t z, bool fix_tilts);
 
 int32_t Room_GetWaterHeight(XYZ_32 pos, int16_t room_num);

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -57,7 +57,7 @@ typedef struct {
 
 typedef struct {
     SURFACE_TYPE type;
-    int16_t height;
+    int32_t height;
     bool is_split;
     union {
         int16_t tilt;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara being unable to run forward in random spots at the bottom of The Great Pyramid's pit, by avoiding `int16_t` overflows. 

Thanks to Lahm for establishing the root cause.

I didn't touch `NO_HEIGHT` which remains a hardcoded value.