### PR TITLE
tools: lint unclosed // clang-format off markers

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ lint-imports:
 
 [group('lint')]
 lint-format:
-    pre-commit run -a
+    prek -a
 
 [group('lint')]
 lint: (lint-imports) (lint-format)

--- a/src/trx/game/objects/creatures/bird.c
+++ b/src/trx/game/objects/creatures/bird.c
@@ -16,7 +16,7 @@
 #define M_CROW_START_ANIM   14
 #define M_CROW_DIE_ANIM     1
 #define M_VULTURE_HITPOINTS 18
-// clang-format off
+// clang-format on
 
 typedef enum {
     M_STATE_EMPTY = 0,

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -24,7 +24,7 @@
 #define M_MAX_FLARE_AGE_TR3   (30 * LOGIC_FPS)         // = 900
 #define M_FLARE_DYING_AGE_TR3 (M_MAX_FLARE_AGE_TR3 - 90) // = 810
 #define M_FLARE_END_AGE_TR3   (M_MAX_FLARE_AGE_TR3 - 24) // = 876
-// clang-format off
+// clang-format on
 
 typedef struct {
     int32_t raw_age;
@@ -78,14 +78,11 @@ static void M_Control(const int16_t item_num)
     item->pos.y += item->fall_speed;
 
     int16_t room_num = item->room_num;
-    const SECTOR *const sector =
-        Room_GetSector(item->pos, &room_num);
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
 
-    const int32_t height =
-        Room_GetHeight(sector, item->pos);
+    const int32_t height = Room_GetHeight(sector, item->pos);
     if (item->pos.y < height) {
-        const int32_t ceiling =
-            Room_GetCeiling(sector, item->pos);
+        const int32_t ceiling = Room_GetCeiling(sector, item->pos);
         if (item->pos.y < ceiling) {
             item->fall_speed = -item->fall_speed;
             item->pos.y = ceiling;
@@ -240,7 +237,7 @@ static bool M_GenerateLight_TR12(const XYZ_32 pos, const int32_t flare_age)
     if (flare_age < M_FLARE_YOUNG_AGE_TR12) {
         const int32_t intensity = M_FLARE_INTENSITY
                 * (flare_age - M_FLARE_YOUNG_AGE_TR12)
-            / (2 * M_FLARE_YOUNG_AGE_TR12)
+                / (2 * M_FLARE_YOUNG_AGE_TR12)
             + M_FLARE_INTENSITY;
         Output_AddDynamicLight(light_pos, intensity, M_FLARE_FALL_OFF);
         return true;
@@ -313,7 +310,7 @@ static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
             b = rnd4 & 0x7F;
             falloff = (Random_GetControl() & 6) + 8;
             Output_AddDynamicLightRGB(
-                    light_pos, falloff, (RGB_888) { r, g, b });
+                light_pos, falloff, (RGB_888) { r, g, b });
             return false;
         }
     } else {
@@ -324,15 +321,12 @@ static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
         g = (rnd3 & 0x3F) + 64;
         b = rnd4 & 0x1F;
         falloff = 16 - ((flare_age - M_FLARE_END_AGE_TR3) >> 1);
-        Output_AddDynamicLightRGB(
-                light_pos, falloff, (RGB_888) { r, g, b });
+        Output_AddDynamicLightRGB(light_pos, falloff, (RGB_888) { r, g, b });
         return (rnd & 1) != 0;
     }
 
-    Output_AddDynamicLightRGB(
-            light_pos, falloff, (RGB_888) { r, g, b });
+    Output_AddDynamicLightRGB(light_pos, falloff, (RGB_888) { r, g, b });
     return true;
-
 }
 
 void Flare_GenerateEffects(

--- a/tools/shared/linting.py
+++ b/tools/shared/linting.py
@@ -114,6 +114,26 @@ def lint_meson_build_sort_order(
                 yield LintWarning(path, "source list is not ordered")
 
 
+def lint_clang_format_markers(
+    context: LintContext, path: Path
+) -> Iterable[LintWarning]:
+    if path.suffix != ".c":
+        return
+    clang_format_off_open = False
+    for i, line in enumerate(path.open("r"), 1):
+        if "// clang-format on" in line:
+            clang_format_off_open = False
+        if "// clang-format off" in line:
+            if clang_format_off_open:
+                yield LintWarning(
+                    path,
+                    "found `// clang-format off` before previous block was closed "
+                    "with `// clang-format on`",
+                    line=i,
+                )
+            clang_format_off_open = True
+
+
 def get_relevant_project(context: LintContext, path: Path) -> str:
     for project, project_path in get_project_paths(context).items():
         if path.absolute().is_relative_to(project_path.absolute()):
@@ -150,6 +170,7 @@ ALL_FILE_LINTERS: list[
     lint_trailing_whitespace,
     lint_const_primitives,
     lint_meson_build_sort_order,
+    lint_clang_format_markers,
 ]
 
 ALL_BULK_LINTERS: list[


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This protects us against
```c
// clang-format off
#define M_DAMAGE            20
#define M_RADIUS            (WALL_L / 5) // = 204
#define M_ATTACK_RANGE      SQUARE(WALL_L / 2) // = 262144
#define M_TURN              (DEG_1 * 3) // = 546
#define M_START_ANIM        5
#define M_DIE_ANIM          8
#define M_EAGLE_HITPOINTS   20
#define M_CROW_HITPOINTS    15
#define M_CROW_START_ANIM   14
#define M_CROW_DIE_ANIM     1
#define M_VULTURE_HITPOINTS 18
// clang-format off ← BAD!!!
```

This is a code formatting-only change.