### PR TITLE
lara: fix sprinting in swamps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 - fixed touching Lava Wedges causing endless Flame effect spawns when the immunity cheat is on
 - fixed touching Lava tiles causing reduced Flame effect when the immunity cheat is on
 - fixed collision issues on bridges, trapdoors, breakable tiles and pushblocks if positioned over a triangle portal (regression from 1.0)
+- fixed Lara being able to sprint through swamps when responsive sprinting is enabled
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -9,6 +9,7 @@
 #include <trx/game/lara/misc.h>
 #include <trx/game/lara/util.h>
 #include <trx/game/objects/general/flare_item.h>
+#include <trx/game/rooms.h>
 #include <trx/game/rooms/geometry.h>
 
 // clang-format off
@@ -37,6 +38,10 @@ static bool M_CanCrouchRoll(const ITEM *const item, const LARA_INFO *const lara)
 
     if (item->current_anim_state == LS(LS_CROUCH_IDLE)
         && lara->gun_status != LGS_ARMLESS) {
+        return false;
+    }
+
+    if (Room_Get(item->room_num)->flags.swamp) {
         return false;
     }
 

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -129,6 +129,7 @@ static void M_Run(ITEM *const item, COLL_INFO *const coll)
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     if (g_Input.sprint && g_Config.gameplay.enable_sprint
+        && lara->water_status != LWS_WADE
         && item->current_anim_state == LS(LS_RUN) && lara->sprint_timer > 0
         && (g_Config.gameplay.enable_responsive_sprint
             || lara->sprint_timer == LARA_MAX_SPRINT)) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara from being able to sprint and crouch roll through swamps that are accessible from gentle slopes. Crouch roll is unreleased so changelog only mentions sprint.