### PR TITLE
rooms/geometry: reset height type on walkables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,7 @@
 - fixed Lara sometimes getting stuck when crawling backwards off a tilted ledge (#4956)
 - fixed the Tribe Pipeman sometimes not being able to aim darts at Lara correctly (Gameplay → Fixes → Fix Pipeman aim)
 - fixed Lara's footprints sometimes spawning when standing on a bridge, trapdoor or pushblock
+- fixed Lara being unable to walk or sidestep at times when standing on a bridge that sits over a steep slope (regression from 1.1)
 - removed the limitation of one Carcass instance per level working with Piranhas
 - removed the limitation of Piranhas only attacking Carcass instances if the level sequence matches Crash Site's
 - restored the ability for Lara to perform grab cancels, like TR1 and TR2

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -445,6 +445,7 @@ int32_t Room_GetHeightEx(
     // Climb the stack of walkables. In each iteration the test Y pos is moved
     // up to match the current height, so preventing testing below previous
     // walkables.
+    int32_t base_height = height;
     int32_t test_y = pos.y;
     for (const WALKABLE *w = pit_sector->walkable; w != nullptr; w = w->next) {
         if (w->item_num == ignore_item_num) {
@@ -457,6 +458,11 @@ int32_t Room_GetHeightEx(
         }
         height = obj->floor_height_func(item, pos.x, test_y, pos.z, height);
         test_y = MIN(pos.y, height);
+    }
+
+    if (base_height != height) {
+        // A walkable is present, which always override slopes below.
+        m_HeightType = HT_WALL;
     }
 
     return height;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This applies an override on height type if Lara is on a walkable, in line with TR3. It resolves Lara sometimes not being able to walk/sidestep when on a walkable that sits over a steep slope.
