### PR TITLE
build: optimize linter job by using sidecar images

### DIFF
--- a/.github/docker/lint.Dockerfile
+++ b/.github/docker/lint.Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.12-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/bookworm llvm-toolchain-bookworm-21 main' > /etc/apt/sources.list.d/llvm.list
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang-format-21 \
+    && apt-get purge -y --auto-remove gnupg xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/clang-format-21 /usr/local/bin/clang-format
+RUN just_version='1.40.0' && \
+    curl -fsSL "https://github.com/casey/just/releases/download/${just_version}/just-${just_version}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin just && \
+    chmod +x /usr/local/bin/just
+RUN python3 -m pip install --no-cache-dir \
+    prek \
+    pyjson5
+
+ENV PATH="/usr/local/bin:${PATH}"

--- a/.github/workflows/build_lint_image.yml
+++ b/.github/workflows/build_lint_image.yml
@@ -1,0 +1,44 @@
+name: Build lint image
+
+on:
+  push:
+    branches:
+      - main
+      - lint
+    paths:
+      - .github/docker/lint.Dockerfile
+      - .github/workflows/build_lint_image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push lint image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize repository owner
+        id: vars
+        run: echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push lint image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/lint.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.vars.outputs.owner_lc }}/trx-lint:latest
+            ghcr.io/${{ steps.vars.outputs.owner_lc }}/trx-lint:${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,28 +8,38 @@ jobs:
   lint:
     name: Run code linters
     runs-on: ubuntu-latest
+    env:
+      PREK_HOME: ${{ github.workspace }}/.cache/prek
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/lostartefacts/trx-lint:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: 'true'
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install dependencies
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          echo 'deb https://apt.llvm.org/noble llvm-toolchain-noble-21 main' | sudo tee -a /etc/apt/sources.list
-          echo 'deb-src https://apt.llvm.org/noble llvm-toolchain-noble-21 main' | sudo tee -a /etc/apt/sources.list
-          sudo apt update
-          sudo apt-get install -y clang-format-21 python3-pip pipx
-          sudo snap install --edge --classic just
-          sudo ln -s /usr/bin/clang-format-21 /usr/local/bin/clang-format
-          python3 -m pipx install prek
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          sudo python3 -m pip install pyjson5
+      - name: Configure git safe directory
+        working-directory: ${{ github.workspace }}
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Ensure prek cache dir exists
+        run: mkdir -p "${PREK_HOME}"
+
+      - name: Restore prek cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/prek
+          key: prek-v1-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            prek-v1-${{ runner.os }}-
 
       - name: Check formatted code differences
+        working-directory: ${{ github.workspace }}
         run: |
           set +e
           just lint-format
@@ -50,8 +60,9 @@ jobs:
           fi
 
       - name: Check imports
+        working-directory: ${{ github.workspace }}
         run: |
-          git add -A
+          git add -u
           just lint-imports
           git diff --exit-code || (
             include-what-you-use --version


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This makes the linter job faster by around 50% (50 s → 25 s) by introducing a ghcr.io-powered sidecar image that does all the dependency installs. The linter job then only downloads this image instead of `ubuntu-latest` and doing manual dependency installs every time, then runs the linters. It also shaves more time by caching prek environments with GH Action caching.