### PR TITLE
Faster Linux/Windows builds

### DIFF
--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -52,22 +52,21 @@ jobs:
 
       - name: Package asset (${{ inputs.platform }})
         run: |
-          if [ "${{ inputs.zip }}" = "1" ] || [ "${{ inputs.zip }}" = "true" ]; then
-            just tr1-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr1_dir }}"
-            just tr2-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr2_dir }}"
-            if [ "${{ inputs.platform }}" != "win-installer" ]; then
-              just tr3-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr3_dir }}"
+          if [ "${{ inputs.platform }}" = "linux" ] || [ "${{ inputs.platform }}" = "win" ]; then
+            if [ "${{ inputs.zip }}" = "1" ] || [ "${{ inputs.zip }}" = "true" ]; then
+              just trx-package-${{ inputs.platform }} "${{ inputs.target }}" -o "build/artifacts/"
             else
-              echo "Skipping TR3 win-installer build (temporarily disabled)"
+              just trx-package-${{ inputs.platform }} "${{ inputs.target }}" -o "build/artifacts/" --no-zip
             fi
           else
-            just tr1-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr1_dir }}" --no-zip
-            just tr2-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr2_dir }}" --no-zip
-            if [ "${{ inputs.platform }}" != "win-installer" ]; then
-              just tr3-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr3_dir }}" --no-zip
+            if [ "${{ inputs.zip }}" = "1" ] || [ "${{ inputs.zip }}" = "true" ]; then
+              just tr1-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr1_dir }}"
+              just tr2-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr2_dir }}"
             else
-              echo "Skipping TR3 win-installer build (temporarily disabled)"
+              just tr1-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr1_dir }}" --no-zip
+              just tr2-package-${{ inputs.platform }} "${{ inputs.target }}" -o "${{ steps.vars.outputs.tr2_dir }}" --no-zip
             fi
+            echo "Skipping TR3 win-installer build (temporarily disabled)"
           fi
 
       - name: Upload artifacts (tr1)
@@ -75,12 +74,14 @@ jobs:
         with:
           name: ${{ steps.vars.outputs.tr1_asset }}
           path: ${{ steps.vars.outputs.tr1_dir }}
+          compression-level: 0
 
       - name: Upload artifacts (tr2)
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.vars.outputs.tr2_asset }}
           path: ${{ steps.vars.outputs.tr2_dir }}
+          compression-level: 0
 
       - name: Upload artifacts (tr3)
         if: ${{ inputs.platform != 'win-installer' }}
@@ -88,3 +89,4 @@ jobs:
         with:
           name: ${{ steps.vars.outputs.tr3_asset }}
           path: ${{ steps.vars.outputs.tr3_dir }}
+          compression-level: 0

--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -50,9 +50,25 @@ jobs:
           just download-assets 2
           just download-assets 3
 
+      - name: Restore ccache
+        if: ${{ inputs.platform == 'linux' || inputs.platform == 'win' }}
+        uses: actions/cache@v4
+        with:
+          path: .cache/ccache
+          key: ccache-v1-${{ runner.os }}-${{ inputs.platform }}-${{ inputs.target }}-${{ hashFiles('justfile', 'tools/shared/docker/game-linux/Dockerfile', 'tools/shared/docker/game-win/Dockerfile', 'tools/shared/docker/game-win/meson_linux_mingw32.txt') }}
+          restore-keys: |
+            ccache-v1-${{ runner.os }}-${{ inputs.platform }}-${{ inputs.target }}-
+            ccache-v1-${{ runner.os }}-${{ inputs.platform }}-
+
       - name: Package asset (${{ inputs.platform }})
+        env:
+          CCACHE_DIR: /app/.cache/ccache/${{ inputs.platform }}-${{ inputs.target }}
+          CCACHE_BASEDIR: /app
+          CCACHE_COMPILERCHECK: content
+          CCACHE_MAXSIZE: 1G
         run: |
           if [ "${{ inputs.platform }}" = "linux" ] || [ "${{ inputs.platform }}" = "win" ]; then
+            mkdir -p ".cache/ccache/${{ inputs.platform }}-${{ inputs.target }}"
             if [ "${{ inputs.zip }}" = "1" ] || [ "${{ inputs.zip }}" = "true" ]; then
               just trx-package-${{ inputs.platform }} "${{ inputs.target }}" -o "build/artifacts/"
             else

--- a/justfile
+++ b/justfile
@@ -87,3 +87,6 @@ lint: (lint-imports) (lint-format)
 
 trx-build-linux target='debug': (image-linux "0") (_docker_run "rrdash/trx-linux" "build" "--target" target)
 trx-build-win target='debug': (image-win "0") (_docker_run "rrdash/trx-win" "build" "--target" target)
+
+trx-package-linux target='debug' *args: (trx-build-linux target) (_docker_run "rrdash/trx-linux" "package-all" args)
+trx-package-win target='debug' *args: (trx-build-win target) (_docker_run "rrdash/trx-win" "package-all" args)

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 CWD := `pwd`
 HOST_USER_UID := `id -u`
 HOST_USER_GID := `id -g`
-DOCKER_IMAGE_VERSION := "20251017.rev1"
+DOCKER_IMAGE_VERSION := "20260228.rev1"
 
 default: (trx-build-win "debug")
 
@@ -39,6 +39,10 @@ _docker_run tag *args:
         --rm \
         --user \
         {{HOST_USER_UID}}:{{HOST_USER_GID}} \
+        -e CCACHE_DIR \
+        -e CCACHE_BASEDIR \
+        -e CCACHE_COMPILERCHECK \
+        -e CCACHE_MAXSIZE \
         -v {{CWD}}:/app/ \
         $full_tag \
         {{args}}

--- a/tools/shared/docker/game-linux/Dockerfile
+++ b/tools/shared/docker/game-linux/Dockerfile
@@ -157,6 +157,7 @@ ENV PKG_CONFIG_PATH=/ext/lib/pkgconfig/
 RUN apt-get install -y \
         pkg-config \
         git \
+        ccache \
         python3-pip \
     && python3 -m pip install --break-system-packages \
         pyjson5 \
@@ -176,4 +177,9 @@ COPY --from=pcre2 /ext/ /ext/
 COPY --from=glew /ext/ /ext/
 
 ENV PYTHONPATH=/app/tools/
+ENV CCACHE_BASEDIR=/app/
+ENV CCACHE_COMPILERCHECK=content
+ENV CCACHE_DIR=/app/.cache/ccache/linux
+ENV CC="ccache gcc"
+ENV CXX="ccache g++"
 ENTRYPOINT ["/app/tools/shared/docker/game-linux/entrypoint.sh"]

--- a/tools/shared/docker/game-win/Dockerfile
+++ b/tools/shared/docker/game-win/Dockerfile
@@ -180,6 +180,7 @@ RUN apt-get install -y \
         mingw-w64-tools \
         pkg-config \
         upx \
+        ccache \
         python3-pip \
     && python3 -m pip install --break-system-packages \
         pyjson5 \
@@ -198,4 +199,7 @@ ENV PKG_CONFIG_LIBDIR=/ext/lib/
 ENV PKG_CONFIG_PATH=/ext/lib/pkgconfig/
 ENV C_INCLUDE_PATH=/ext/include/
 ENV PYTHONPATH=/app/tools/
+ENV CCACHE_BASEDIR=/app/
+ENV CCACHE_COMPILERCHECK=content
+ENV CCACHE_DIR=/app/.cache/ccache/win
 ENTRYPOINT ["/app/tools/shared/docker/game-win/entrypoint.sh"]

--- a/tools/shared/docker/game-win/meson_linux_mingw32.txt
+++ b/tools/shared/docker/game-win/meson_linux_mingw32.txt
@@ -1,7 +1,7 @@
 [binaries]
-c = '/usr/bin/i686-w64-mingw32-gcc'
-cpp = '/usr/bin/i686-w64-mingw32-g++'
-objc = '/usr/bin/i686-w64-mingw32-gcc'
+c = ['ccache', '/usr/bin/i686-w64-mingw32-gcc']
+cpp = ['ccache', '/usr/bin/i686-w64-mingw32-g++']
+objc = ['ccache', '/usr/bin/i686-w64-mingw32-gcc']
 ar = '/usr/bin/i686-w64-mingw32-ar'
 strip = '/usr/bin/i686-w64-mingw32-strip'
 pkg-config = '/usr/bin/i686-w64-mingw32-pkg-config'

--- a/tools/shared/docker/game_entrypoint.py
+++ b/tools/shared/docker/game_entrypoint.py
@@ -179,36 +179,59 @@ class PackageCommand(BaseCommand):
 
     def run(self, args: argparse.Namespace) -> None:
         options = PackageOptions.from_args(args)
-        if args.output:
-            zip_path = args.output
-            if zip_path.suffix.lower() != ".zip" and not args.no_zip:
-                zip_path /= options.default_stem + ".zip"
-        else:
-            zip_path = Path()
-            if args.no_zip:
-                zip_path /= options.default_stem
-            else:
-                zip_path /= options.default_stem + ".zip"
+        run_package(options=options, output=args.output, no_zip=args.no_zip)
 
-        source_files = [
-            *[
-                (path, str(path.relative_to(ship_dir)))
-                for ship_dir in options.ship_dirs
-                for path in ship_dir.rglob("*")
-                if path.is_file()
-            ],
-            *options.release_zip_files,
-        ]
 
-        if args.no_zip:
-            for src_path, dst_name in source_files:
-                dst_path = zip_path / dst_name
-                dst_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy(src_path, dst_path)
+class PackageAllCommand(BaseCommand):
+    name = "package-all"
+
+    def decorate_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--platform")
+        parser.add_argument("-o", "--output-root", type=Path)
+        parser.add_argument("--no-zip", action="store_true")
+
+    def run(self, args: argparse.Namespace) -> None:
+        for tr_version in [1, 2, 3]:
+            options = PackageOptions(platform=args.platform, tr_version=tr_version)
+            output = None
+            if args.output_root:
+                output = args.output_root / f"tr{tr_version}"
+            run_package(options=options, output=output, no_zip=args.no_zip)
+
+
+def run_package(
+    options: PackageOptions, output: Path | None, no_zip: bool
+) -> None:
+    if output:
+        zip_path = output
+        if zip_path.suffix.lower() != ".zip" and not no_zip:
+            zip_path /= options.default_stem + ".zip"
+    else:
+        zip_path = Path()
+        if no_zip:
+            zip_path /= options.default_stem
         else:
-            zip_path.parent.mkdir(parents=True, exist_ok=True)
-            create_zip(zip_path, source_files)
-        print(f"Created {zip_path}")
+            zip_path /= options.default_stem + ".zip"
+
+    source_files = [
+        *[
+            (path, str(path.relative_to(ship_dir)))
+            for ship_dir in options.ship_dirs
+            for path in ship_dir.rglob("*")
+            if path.is_file()
+        ],
+        *options.release_zip_files,
+    ]
+
+    if no_zip:
+        for src_path, dst_name in source_files:
+            dst_path = zip_path / dst_name
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src_path, dst_path)
+    else:
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        create_zip(zip_path, source_files)
+    print(f"Created {zip_path}")
 
 
 def parse_args(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reduces Windows/Linux build times.

- I introduced ccache (compiler cache) ← this required rebuilding Windows/Linux images
- I added a new tooling to package all 3 games at once instead of doing that individually
- I removed compression from the upload artifacts job.

Mac builds continue to be a miserable slog, meaning stable releases still take forever.

#### Results

Stats without changes between runs:
- Linux: 50 s → 35 s
- Windows: 70 s → 45 s

However this benefit should also propagate to PRs which do contain changes by definition, as the cache is incremental.

#### Testing

We need to grab all 3 games from this PR and compare the version in the bottom right is as expected, and that assorted resources are the same as on any build from yesterday or earlier.