### PR TITLE
fx: simplify management

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -235,6 +235,7 @@ common_sources = [
   'trx/game/fmv.c',
   'trx/game/fx/explosion_ring.c',
   'trx/game/fx/footprint.c',
+  'trx/game/fx/fx.c',
   'trx/game/fx/gun_flash.c',
   'trx/game/fx/wake.c',
   'trx/game/fx/water.c',

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -8,10 +8,7 @@
 #include <trx/game/collision.h>
 #include <trx/game/const.h>
 #include <trx/game/effects.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/gun_flash.h>
-#include <trx/game/fx/water.h>
-#include <trx/game/fx/weather.h>
+#include <trx/game/fx/fx.h>
 #include <trx/game/gun/misc.h>
 #include <trx/game/gun/smoke.h>
 #include <trx/game/input.h>
@@ -256,10 +253,7 @@ static void M_Control(void)
     Item_Control();
     Effect_Control();
     Sparks_Control();
-    FX_Water_Update();
-    FX_Weather_Update();
-    FX_Footprint_Update();
-    FX_GunFlash_Update();
+    FX_Control();
     Output_AnimateTextures(1);
     Lara_Hair_Control(true);
 }

--- a/src/trx/game/fx/explosion_ring.c
+++ b/src/trx/game/fx/explosion_ring.c
@@ -9,23 +9,22 @@
 #include <trx/game/random.h>
 
 static FX_EXPLOSION_RING m_ExplosionRings[6] = {};
+static bool m_Active = false;
 
 void FX_ExplosionRing_Reset(void)
 {
-    for (int32_t i = 0;
-         i < (int32_t)(sizeof(m_ExplosionRings) / sizeof(m_ExplosionRings[0]));
-         i++) {
+    for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_ExplosionRings); i++) {
         m_ExplosionRings[i] = (FX_EXPLOSION_RING) { 0 };
     }
+    m_Active = false;
 }
 
 FX_EXPLOSION_RING *FX_ExplosionRing_GetRing(const int32_t idx)
 {
-    if (idx < 0
-        || idx >= (int32_t)(sizeof(m_ExplosionRings)
-                            / sizeof(m_ExplosionRings[0]))) {
+    if (idx < 0 || idx >= (int32_t)ARRAY_SIZE(m_ExplosionRings)) {
         return nullptr;
     }
+    m_Active = true;
     return &m_ExplosionRings[idx];
 }
 
@@ -49,6 +48,11 @@ static void M_RotateZX(
 
 void FX_ExplosionRing_Control(void)
 {
+    if (!m_Active) {
+        return;
+    }
+
+    bool any_active = false;
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_ExplosionRings); i++) {
         FX_EXPLOSION_RING *const ring = &m_ExplosionRings[i];
         if (ring->on == 0) {
@@ -62,6 +66,10 @@ void FX_ExplosionRing_Control(void)
         }
 
         ring->radius += ring->speed;
+        any_active = true;
+    }
+    if (!any_active) {
+        m_Active = false;
     }
 }
 

--- a/src/trx/game/fx/footprint.c
+++ b/src/trx/game/fx/footprint.c
@@ -132,7 +132,7 @@ static int32_t M_GetVertexYOffset(
     return dy;
 }
 
-void FX_Footprint_Update(void)
+void FX_Footprint_Control(void)
 {
     if (!g_Config.visuals.enable_footprints) {
         return;

--- a/src/trx/game/fx/footprint.h
+++ b/src/trx/game/fx/footprint.h
@@ -6,5 +6,5 @@ void FX_Footprint_Init(void);
 
 void FX_Footprint_Add(const ITEM *lara_item, bool is_left_foot);
 
-void FX_Footprint_Update(void);
+void FX_Footprint_Control(void);
 void FX_Footprint_Draw(void);

--- a/src/trx/game/fx/fx.c
+++ b/src/trx/game/fx/fx.c
@@ -1,0 +1,27 @@
+#include <trx/game/fx/fx.h>
+
+#include <trx/game/fx/explosion_ring.h>
+#include <trx/game/fx/footprint.h>
+#include <trx/game/fx/gun_flash.h>
+#include <trx/game/fx/wake.h>
+#include <trx/game/fx/water.h>
+#include <trx/game/fx/weather.h>
+
+void FX_Control(void)
+{
+    FX_ExplosionRing_Control();
+    FX_Wake_Control();
+    FX_Water_Control();
+    FX_Weather_Control();
+    FX_Footprint_Control();
+    FX_GunFlash_Control();
+}
+
+void FX_Draw(void)
+{
+    FX_ExplosionRing_Draw();
+    FX_Water_Draw();
+    FX_Weather_Draw();
+    FX_GunFlash_Draw();
+    FX_Footprint_Draw();
+}

--- a/src/trx/game/fx/fx.h
+++ b/src/trx/game/fx/fx.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void FX_Control(void);
+void FX_Draw(void);

--- a/src/trx/game/fx/gun_flash.c
+++ b/src/trx/game/fx/gun_flash.c
@@ -112,7 +112,7 @@ bool FX_GunFlash_Spawn(
     return true;
 }
 
-void FX_GunFlash_Update(void)
+void FX_GunFlash_Control(void)
 {
     for (int32_t i = 0; i < M_MAX_FLASHES; i++) {
         M_GUN_FLASH *const flash = &m_Priv.flashes[i];

--- a/src/trx/game/fx/gun_flash.h
+++ b/src/trx/game/fx/gun_flash.h
@@ -4,5 +4,5 @@
 #include <trx/game/items/types.h>
 
 bool FX_GunFlash_Spawn(const ITEM *owner_item, const CREATURE_GUN *gun);
-void FX_GunFlash_Update(void);
+void FX_GunFlash_Control(void);
 void FX_GunFlash_Draw(void);

--- a/src/trx/game/fx/wake.c
+++ b/src/trx/game/fx/wake.c
@@ -12,6 +12,7 @@ static const XZ_32 m_Offsets[2] = { { .x = -128, 0 }, { .x = 128, .z = 0 } };
 static FX_WAKE_POINT m_Points[M_MAX_POINTS][2] = {};
 static uint8_t m_Shade = 0;
 static uint8_t m_StartIndex = 0;
+static bool m_Active = false;
 
 static RGBA_8888 M_GrayFromWakeLife(const int32_t life, const int32_t shift)
 {
@@ -34,10 +35,16 @@ void FX_Wake_ClearPoints(void)
         m_Points[i][0].life = 0;
         m_Points[i][1].life = 0;
     }
+    m_Active = false;
 }
 
-void FX_Wake_Update(void)
+void FX_Wake_Control(void)
 {
+    if (!m_Active) {
+        return;
+    }
+
+    bool any_active = false;
     for (int32_t i = 0; i < 2; i++) {
         for (int32_t j = 0; j < M_MAX_POINTS; j++) {
             FX_WAKE_POINT *const pt = &m_Points[j][i];
@@ -47,8 +54,14 @@ void FX_Wake_Update(void)
                 pt->pos[0].z += pt->vel[0].z;
                 pt->pos[1].x += pt->vel[1].x;
                 pt->pos[1].z += pt->vel[1].z;
+                if (pt->life > 0) {
+                    any_active = true;
+                }
             }
         }
+    }
+    if (!any_active) {
+        m_Active = false;
     }
 }
 
@@ -75,6 +88,7 @@ uint8_t FX_Wake_GetStartIndex(void)
 void FX_Wake_AdvanceStartIndex(void)
 {
     m_StartIndex = (m_StartIndex + 1) & (M_MAX_POINTS - 1);
+    m_Active = true;
 }
 
 void FX_Wake_Draw(const ITEM *const item)

--- a/src/trx/game/fx/wake.h
+++ b/src/trx/game/fx/wake.h
@@ -9,7 +9,7 @@ typedef struct {
 } FX_WAKE_POINT;
 
 void FX_Wake_ClearPoints(void);
-void FX_Wake_Update(void);
+void FX_Wake_Control(void);
 
 FX_WAKE_POINT *FX_Wake_GetPoint(int32_t wake_idx, int32_t side);
 

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -478,7 +478,7 @@ void FX_Water_Draw(void)
     }
 }
 
-void FX_Water_Update(void)
+void FX_Water_Control(void)
 {
     if (m_SplashCount > 0) {
         m_SplashCount--;

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -63,7 +63,7 @@ typedef struct {
 } FX_WATER_SPLASH_SETUP;
 
 void FX_Water_Init(void);
-void FX_Water_Update(void);
+void FX_Water_Control(void);
 void FX_Water_Draw(void);
 
 FX_WATER_RIPPLE *FX_Water_SetupRipple(

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -387,7 +387,7 @@ void FX_Weather_SetWeather(const WEATHER_TYPE weather_type)
     m_WeatherType = weather_type;
 }
 
-void FX_Weather_Update(void)
+void FX_Weather_Control(void)
 {
     if (!g_Config.visuals.enable_weather) {
         return;

--- a/src/trx/game/fx/weather.h
+++ b/src/trx/game/fx/weather.h
@@ -9,7 +9,7 @@ typedef enum {
 } WEATHER_TYPE;
 
 void FX_Weather_Init(void);
-void FX_Weather_Update(void);
+void FX_Weather_Control(void);
 void FX_Weather_Draw(void);
 WEATHER_TYPE FX_Weather_GetWeather(void);
 void FX_Weather_SetWeather(WEATHER_TYPE weather_type);

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -4,10 +4,7 @@
 #include <trx/game/creature.h>
 #include <trx/game/demo.h>
 #include <trx/game/effects.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/gun_flash.h>
-#include <trx/game/fx/water.h>
-#include <trx/game/fx/weather.h>
+#include <trx/game/fx/fx.h>
 #include <trx/game/game.h>
 #include <trx/game/gym.h>
 #include <trx/game/input.h>
@@ -176,10 +173,7 @@ GF_COMMAND Game_Control(const bool demo_mode)
     Sparks_Control();
 
     Lara_Control();
-    FX_Water_Update();
-    FX_Weather_Update();
-    FX_Footprint_Update();
-    FX_GunFlash_Update();
+    FX_Control();
     Lara_Hair_Control(false);
 
     Camera_Update();

--- a/src/trx/game/objects/creatures/tony_boss.c
+++ b/src/trx/game/objects/creatures/tony_boss.c
@@ -494,10 +494,6 @@ static void M_Control(const int16_t item_num)
     Creature_Joint(item, 1, torso_x);
     Creature_Joint(item, 2, torso_y >> 1);
     Creature_Animate(item_num, angle, 0);
-
-    if (p->explode_count != 0 && item->hit_points <= 0) {
-        FX_ExplosionRing_Control();
-    }
 }
 
 static void M_DrawShield(const ITEM *const item)
@@ -597,9 +593,6 @@ static bool M_Draw(const ITEM *const item)
 
     const bool result = Object_DrawAnimatingItem(item);
     if (p->explode_count != 0) {
-        if (item->hit_points <= 0) {
-            FX_ExplosionRing_Draw();
-        }
         if (p->explode_count != 0 && p->explode_count <= 64) {
             M_DrawShield(item);
         }

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -995,9 +995,7 @@ static bool M_Draw(const ITEM *const item)
     M_PRIV *const p = item->priv;
     Object_DrawAnimatingItem(item);
 
-    if (p->explode_count) {
-        FX_ExplosionRing_Draw();
-    } else {
+    if (p->explode_count == 0) {
         M_TriggerHeadElectricity(item, false, false, true);
         M_TriggerHeadElectricity(item, true, false, true);
     }
@@ -1310,7 +1308,6 @@ static void M_Control(const int16_t item_num)
                 p->dead = 1;
             }
 
-            FX_ExplosionRing_Control();
             return;
         }
 
@@ -1398,10 +1395,6 @@ static void M_Control(const int16_t item_num)
 
     if (old_y_rot == item->rot.y) {
         p->turned = false;
-    }
-
-    if (p->explode_count != 0 && item->hit_points <= 0) {
-        FX_ExplosionRing_Control();
     }
 }
 

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -1268,7 +1268,6 @@ bool Kayak_Control(void)
     }
     FX_Wake_SetShade(wake_shade);
 
-    FX_Wake_Update();
     M_KayakToBaddieCollision(item);
 
     return Lara_Vehicle_GetIndex() != NO_ITEM;

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -3,10 +3,7 @@
 #include <trx/core/vector.h>
 #include <trx/game/camera.h>
 #include <trx/game/effects.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/gun_flash.h>
-#include <trx/game/fx/water.h>
-#include <trx/game/fx/weather.h>
+#include <trx/game/fx/fx.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
 #include <trx/game/output.h>
@@ -507,11 +504,8 @@ void Room_DrawAllRooms(const int16_t current_room, const int16_t target_room)
     }
 
     Output_SetupAboveWater(false);
-    FX_Water_Draw();
-    FX_Weather_Draw();
-    FX_GunFlash_Draw();
+    FX_Draw();
     Sparks_Draw();
-    FX_Footprint_Draw();
 }
 
 void Room_AddDrawnItem(const int16_t room_num, const int16_t item_num)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This simplifies management of the following effects:

- enemy gun flashes in TR3
- kayak wake
- water splashes and ripples
- weather
- footprints
- boss explosion rings

by proxying the calls to individual effect managers behind a common module.
The change can regress, as certain effects were only called from specific objects. This PR changes it so that they're all centrally called with some tiny optimizations not to loop through entire arrays when not needed. The only notable exception to this is the wake effect draw call, which requires an `ITEM*` pointer.

#### Testing

We need to check if there are no regressions around each of the above.