### PR TITLE
objects/dragon: add independent dragon mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@
 - added `O_SMASH_OBJECT_3`, which can only be broken with triggers or the Crash Site gun
 - added `O_SMASH_OBJECT_4`, which behaves like `O_SMASH_OBJECT_1` but uses `SFX_SHUTTERS_BREAK`
 - added `O_TREX_ALPHA`, which can target raptors and be distracted by flares
+- added the ability to trigger dragons independently of Bartoli in custom levels (#5011)
+  - place an `O_DRAGON_BACK` item in the editor and trigger it normally
+  - the dragon will spawn immediately when triggered and will be one-phase, so no dagger needs to be pulled
 - added a new Lua item query helpers, `trx.items.find(query)` and `trx.items.first(query)`, with support for `object_id` and `room_num` filters
 - added a new Lua catalog, `trx.catalog.weapons`, for weapon identifiers
 - added a new Lua property, `trx.lara.equipped_gun`, to read Lara's currently equipped gun type

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -235,11 +235,6 @@ static void M_PullDagger(ITEM *const item, COLL_INFO *const coll)
         Overlay_AddDisplayPickup(O_PUZZLE_ITEM_2);
     } else if (Item_TestFrameEqual(item, M_LF_DRAGON_DAGGER_ANIM_END)) {
         item->rot.y += DEG_90;
-
-        const ITEM *const dragon_bones = Item_Find(O_DRAGON_BONES_2);
-        if (dragon_bones != nullptr) {
-            Room_TestTriggers(dragon_bones);
-        }
     }
 }
 

--- a/src/trx/game/objects/creatures/bartoli.c
+++ b/src/trx/game/objects/creatures/bartoli.c
@@ -61,8 +61,15 @@ static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    p->dragon_item_num = Dragon_CreateInactive(item);
+    p->dragon_item_num = Item_CreateLevelItem();
     ASSERT(p->dragon_item_num != NO_ITEM);
+
+    ITEM *const dragon_item = Item_Get(p->dragon_item_num);
+    dragon_item->object_id = O_DRAGON_BACK;
+    dragon_item->pos = item->pos;
+    dragon_item->rot.y = item->rot.y;
+    dragon_item->room_num = item->room_num;
+    Item_Initialise(p->dragon_item_num);
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/trx/game/objects/creatures/bartoli.c
+++ b/src/trx/game/objects/creatures/bartoli.c
@@ -3,7 +3,6 @@
 #include <trx/game/camera.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
-#include <trx/game/objects/creatures/dragon.h>
 #include <trx/game/spawn.h>
 
 #define M_BOOM_TIME 130
@@ -38,7 +37,11 @@ static void M_ConvertBartoliToDragon(const int16_t item_num)
     const M_PRIV *const p = bartoli_item->priv;
     const int16_t dragon_item_num = p->dragon_item_num;
     if (dragon_item_num != NO_ITEM) {
-        Dragon_Activate(dragon_item_num);
+        ITEM *const dragon_item = Item_Get(dragon_item_num);
+        const OBJECT *const dragon_obj = Object_Get(dragon_item->object_id);
+        if (dragon_obj->activate_func != nullptr) {
+            dragon_obj->activate_func(dragon_item);
+        }
     }
     Item_Kill(item_num);
 }

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -82,17 +82,6 @@ static int16_t M_GetFrontItemNum(const ITEM *const dragon_back_item)
     return p->dragon_front_item_num;
 }
 
-static bool M_SetFrontItemNum(
-    ITEM *const dragon_back_item, const int16_t dragon_front_item_num)
-{
-    M_PRIV *const p = dragon_back_item->priv;
-    if (p == nullptr) {
-        return false;
-    }
-    p->dragon_front_item_num = dragon_front_item_num;
-    return true;
-}
-
 static bool M_CanDropItemsBack(const ITEM *const item)
 {
     return item->hit_points <= 0 && item->status == IS_DEACTIVATED;
@@ -106,9 +95,24 @@ static void M_InitialiseFront(const int16_t item_num)
 
 static void M_InitialiseBack(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-    p->dragon_front_item_num = NO_ITEM;
+    ITEM *const dragon_back_item = Item_Get(item_num);
+    M_PRIV *const p = dragon_back_item->priv;
+
+    dragon_back_item->status = IS_INVISIBLE;
+    dragon_back_item->shade.value_1 = -1;
+    dragon_back_item->mesh_bits = 0x1FFFFF;
+
+    p->dragon_front_item_num = Item_CreateLevelItem();
+    ASSERT(p->dragon_front_item_num != NO_ITEM);
+
+    ITEM *const dragon_front_item = Item_Get(p->dragon_front_item_num);
+    dragon_front_item->object_id = O_DRAGON_FRONT;
+    dragon_front_item->pos = dragon_back_item->pos;
+    dragon_front_item->rot.y = dragon_back_item->rot.y;
+    dragon_front_item->room_num = dragon_back_item->room_num;
+    dragon_front_item->flags = IF_INVISIBLE;
+    dragon_front_item->shade.value_1 = -1;
+    Item_Initialise(p->dragon_front_item_num);
 }
 
 static void M_MarkDragonDead(ITEM *const dragon_back_item)
@@ -492,38 +496,6 @@ static void M_SetupBack(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     obj->priv_size = sizeof(M_PRIV);
-}
-
-int16_t Dragon_CreateInactive(const ITEM *const item)
-{
-    const int16_t dragon_back_item_num = Item_CreateLevelItem();
-    const int16_t dragon_front_item_num = Item_CreateLevelItem();
-    ASSERT(dragon_back_item_num != NO_ITEM);
-    ASSERT(dragon_front_item_num != NO_ITEM);
-
-    ITEM *const dragon_back_item = Item_Get(dragon_back_item_num);
-    dragon_back_item->object_id = O_DRAGON_BACK;
-    dragon_back_item->pos = item->pos;
-    dragon_back_item->rot.y = item->rot.y;
-    dragon_back_item->room_num = item->room_num;
-    dragon_back_item->flags = IF_INVISIBLE;
-    dragon_back_item->shade.value_1 = -1;
-    Item_Initialise(dragon_back_item_num);
-    dragon_back_item->mesh_bits = 0x1FFFFF;
-
-    ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
-    dragon_front_item->object_id = O_DRAGON_FRONT;
-    dragon_front_item->pos = item->pos;
-    dragon_front_item->rot.y = item->rot.y;
-    dragon_front_item->room_num = item->room_num;
-    dragon_front_item->flags = IF_INVISIBLE;
-    dragon_front_item->shade.value_1 = -1;
-    Item_Initialise(dragon_front_item_num);
-
-    if (!M_SetFrontItemNum(dragon_back_item, dragon_front_item_num)) {
-        return NO_ITEM;
-    }
-    return dragon_back_item_num;
 }
 
 void Dragon_Activate(const int16_t dragon_back_item_num)

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -31,6 +31,10 @@
 #define M_TOUCH_R        0x000000FE
 #define M_ALMOST_LIVE    100
 #define M_LIVE_TIME      330
+#define M_LIGHT_TIME     (-20)
+#define M_BONE_TIME      (-100)
+#define M_DISSOLVE_TIME  (-200)
+#define M_DISSOLVE_SHIFT 10
 #define M_HITPOINTS      300
 #define M_TOUCH_DAMAGE   10
 #define M_SWIPE_DAMAGE   250
@@ -285,26 +289,24 @@ static void M_ControlBack(const int16_t item_num)
                 dragon_front_item->hit_points = front_obj->hit_points / 2;
             }
         } else {
-            if (creature->flags > -20) {
-                // clang-format off
+            if (creature->flags > M_LIGHT_TIME) {
                 Output_AddDynamicLight(
                     dragon_front_item->pos,
                     ((4 * Random_GetDraw()) >> 15) + 12 + creature->flags / 2,
                     ((4 * Random_GetDraw()) >> 15) + 10 + creature->flags / 2);
-                // clang-format on
             }
 
-            if (creature->flags == -100) {
+            if (creature->flags == M_BONE_TIME) {
                 M_Bones(dragon_front_item_num);
-            } else if (creature->flags == -200) {
+            } else if (creature->flags == M_DISSOLVE_TIME) {
                 LOT_DisableBaddieAI(dragon_front_item_num);
                 Item_Kill(dragon_front_item_num);
                 dragon_front_item->status = IS_DEACTIVATED;
                 Item_Kill(dragon_back_item_num);
                 dragon_back_item->status = IS_DEACTIVATED;
-            } else if (creature->flags < -100) {
-                dragon_front_item->pos.y += 10;
-                dragon_back_item->pos.y += 10;
+            } else if (creature->flags < M_BONE_TIME) {
+                dragon_front_item->pos.y += M_DISSOLVE_SHIFT;
+                dragon_back_item->pos.y += M_DISSOLVE_SHIFT;
             }
 
             creature->flags--;

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -1,5 +1,3 @@
-#include <trx/game/objects/creatures/dragon.h>
-
 #include <trx/core/math.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
@@ -113,6 +111,28 @@ static void M_InitialiseBack(const int16_t item_num)
     dragon_front_item->flags = IF_INVISIBLE;
     dragon_front_item->shade.value_1 = -1;
     Item_Initialise(p->dragon_front_item_num);
+}
+
+static void M_ActivateBack(ITEM *const dragon_back_item)
+{
+    if (dragon_back_item->active
+        || dragon_back_item->status == IS_DEACTIVATED) {
+        return;
+    }
+
+    const int16_t dragon_front_item_num = M_GetFrontItemNum(dragon_back_item);
+    if (dragon_front_item_num == NO_ITEM) {
+        return;
+    }
+
+    ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
+    dragon_back_item->touch_bits = 0;
+    dragon_front_item->touch_bits = 0;
+
+    LOT_EnableBaddieAI(dragon_front_item_num, true);
+    Item_AddActive(dragon_front_item_num);
+    Item_AddActive(Item_GetIndex(dragon_back_item));
+    dragon_back_item->status = IS_ACTIVE;
 }
 
 static void M_MarkDragonDead(ITEM *const dragon_back_item)
@@ -486,6 +506,7 @@ static void M_SetupBack(OBJECT *const obj)
     }
 
     obj->initialise_func = M_InitialiseBack;
+    obj->activate_func = M_ActivateBack;
     obj->control_func = M_ControlBack;
     obj->collision_func = M_Collision;
     obj->can_drop_items_func = M_CanDropItemsBack;
@@ -496,28 +517,6 @@ static void M_SetupBack(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     obj->priv_size = sizeof(M_PRIV);
-}
-
-void Dragon_Activate(const int16_t dragon_back_item_num)
-{
-    if (dragon_back_item_num == NO_ITEM) {
-        return;
-    }
-
-    ITEM *const dragon_back_item = Item_Get(dragon_back_item_num);
-    const int16_t dragon_front_item_num = M_GetFrontItemNum(dragon_back_item);
-    if (dragon_front_item_num == NO_ITEM) {
-        return;
-    }
-
-    ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
-    dragon_back_item->touch_bits = 0;
-    dragon_front_item->touch_bits = 0;
-
-    LOT_EnableBaddieAI(dragon_front_item_num, true);
-    Item_AddActive(dragon_front_item_num);
-    Item_AddActive(dragon_back_item_num);
-    dragon_back_item->status = IS_ACTIVE;
 }
 
 REGISTER_OBJECT(O_DRAGON_FRONT, M_SetupFront)

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -1,3 +1,5 @@
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
@@ -29,6 +31,7 @@
 #define M_TOUCH_R        0x000000FE
 #define M_ALMOST_LIVE    100
 #define M_LIVE_TIME      330
+#define M_ONE_PHASE_TIME 178
 #define M_LIGHT_TIME     (-20)
 #define M_BONE_TIME      (-100)
 #define M_DISSOLVE_TIME  (-240)
@@ -62,14 +65,32 @@ typedef enum {
     // clang-format on
 } M_ANIM;
 
+typedef enum {
+    M_MODE_ONE_PHASE,
+    M_MODE_TWO_PHASE,
+} M_MODE;
+
 typedef struct {
     int16_t dragon_front_item_num;
+    M_MODE mode;
 } M_PRIV;
 
 static const BITE m_DragonMouth = {
     .pos = { .x = 35, .y = 171, .z = 1168 },
     .mesh_num = 12,
 };
+
+static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+{
+    M_PRIV *const p = item->priv;
+    JSON_SHOULD(JSON_READ(io, "mode", &p->mode));
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
+{
+    const M_PRIV *const p = item->priv;
+    JSONW_WRITE(io, "mode", p->mode);
+}
 
 static int16_t M_GetFrontItemNum(const ITEM *const dragon_back_item)
 {
@@ -78,6 +99,12 @@ static int16_t M_GetFrontItemNum(const ITEM *const dragon_back_item)
         return NO_ITEM;
     }
     return p->dragon_front_item_num;
+}
+
+static bool M_IsTwoPhaseMode(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p != nullptr && p->mode == M_MODE_TWO_PHASE;
 }
 
 static bool M_CanDropItemsBack(const ITEM *const item)
@@ -95,6 +122,7 @@ static void M_InitialiseBack(const int16_t item_num)
 {
     ITEM *const dragon_back_item = Item_Get(item_num);
     M_PRIV *const p = dragon_back_item->priv;
+    p->mode = M_MODE_TWO_PHASE;
 
     dragon_back_item->status = IS_INVISIBLE;
     dragon_back_item->shade.value_1 = -1;
@@ -111,6 +139,13 @@ static void M_InitialiseBack(const int16_t item_num)
     dragon_front_item->flags = IF_INVISIBLE;
     dragon_front_item->shade.value_1 = -1;
     Item_Initialise(p->dragon_front_item_num);
+}
+
+static bool M_TriggerBack(ITEM *const item, const TRIGGER *const trigger)
+{
+    M_PRIV *const p = item->priv;
+    p->mode = M_MODE_ONE_PHASE;
+    return true;
 }
 
 static void M_ActivateBack(ITEM *const dragon_back_item)
@@ -218,7 +253,7 @@ static void M_Bones(const int16_t item_num)
 static void M_HandleSaveBack(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
-        if (item->status == IS_DEACTIVATED) {
+        if (item->status == IS_DEACTIVATED && M_IsTwoPhaseMode(item)) {
             const int32_t y_pos = item->pos.y;
             int16_t room_num = item->room_num;
             const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
@@ -261,6 +296,7 @@ static void M_Collision(
     const int32_t shift = (cy * dx - sy * dz) >> W2V_SHIFT;
     const int32_t angle = lara_item->rot.y - item->rot.y;
     if (g_Input.action && item->object_id == O_DRAGON_BACK
+        && M_IsTwoPhaseMode(item)
         && (Item_TestAnimEqual(item, M_ANIM_DEAD)
             || (Item_TestAnimEqual(item, M_ANIM_RESURRECT)
                 && Item_TestFrameRange(item, 0, M_ALMOST_LIVE)))
@@ -295,6 +331,7 @@ static void M_ControlBack(const int16_t item_num)
     int16_t head = 0;
     CREATURE *const creature = dragon_front_item->creature_data;
     const OBJECT *const front_obj = Object_Get(O_DRAGON_FRONT);
+    const bool is_two_phase = M_IsTwoPhaseMode(dragon_back_item);
 
     if (dragon_front_item->hit_points <= 0) {
         if (dragon_front_item->current_anim_state != M_STATE_DEATH) {
@@ -303,13 +340,18 @@ static void M_ControlBack(const int16_t item_num)
             dragon_front_item->current_anim_state = M_STATE_DEATH;
             creature->flags = 0;
         } else if (creature->flags >= 0) {
-            Spawn_MysticLight(dragon_front_item_num);
             creature->flags++;
-            if (creature->flags == M_LIVE_TIME) {
-                dragon_front_item->goal_anim_state = M_STATE_STOP;
-            }
-            if (creature->flags > M_LIVE_TIME + M_ALMOST_LIVE) {
-                dragon_front_item->hit_points = front_obj->hit_points / 2;
+            if (is_two_phase) {
+                Spawn_MysticLight(dragon_front_item_num);
+                if (creature->flags == M_LIVE_TIME) {
+                    dragon_front_item->goal_anim_state = M_STATE_STOP;
+                }
+                if (creature->flags > M_LIVE_TIME + M_ALMOST_LIVE) {
+                    dragon_front_item->hit_points = front_obj->hit_points / 2;
+                }
+            } else if (creature->flags == M_ONE_PHASE_TIME) {
+                M_MarkDragonDead(dragon_back_item);
+                creature->flags = M_DISSOLVE_TIME;
             }
         } else {
             if (creature->flags > M_LIGHT_TIME) {
@@ -324,10 +366,19 @@ static void M_ControlBack(const int16_t item_num)
             } else if (creature->flags == M_DISSOLVE_TIME) {
                 Room_TestTriggers(dragon_back_item);
                 LOT_DisableBaddieAI(dragon_front_item_num);
-                Item_Kill(dragon_front_item_num);
                 dragon_front_item->status = IS_DEACTIVATED;
-                Item_Kill(dragon_back_item_num);
                 dragon_back_item->status = IS_DEACTIVATED;
+                if (is_two_phase) {
+                    Item_Kill(dragon_front_item_num);
+                    Item_Kill(dragon_back_item_num);
+                } else {
+                    Item_RemoveActive(dragon_front_item_num);
+                    Item_RemoveActive(dragon_back_item_num);
+                    dragon_front_item->collidable = false;
+                    dragon_back_item->collidable = false;
+                    dragon_front_item->flags |= IF_ONE_SHOT;
+                    dragon_back_item->flags |= IF_ONE_SHOT;
+                }
             } else if (creature->flags < M_BONE_TIME) {
                 dragon_front_item->pos.y += M_DISSOLVE_SHIFT;
                 dragon_back_item->pos.y += M_DISSOLVE_SHIFT;
@@ -510,10 +561,13 @@ static void M_SetupBack(OBJECT *const obj)
 
     obj->initialise_func = M_InitialiseBack;
     obj->handle_save_func = M_HandleSaveBack;
+    obj->trigger_func = M_TriggerBack;
     obj->activate_func = M_ActivateBack;
     obj->control_func = M_ControlBack;
     obj->collision_func = M_Collision;
     obj->can_drop_items_func = M_CanDropItemsBack;
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
 
     obj->radius = M_RADIUS;
 

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -31,7 +31,7 @@
 #define M_LIVE_TIME      330
 #define M_LIGHT_TIME     (-20)
 #define M_BONE_TIME      (-100)
-#define M_DISSOLVE_TIME  (-200)
+#define M_DISSOLVE_TIME  (-240)
 #define M_DISSOLVE_SHIFT 10
 #define M_HITPOINTS      300
 #define M_TOUCH_DAMAGE   10
@@ -215,14 +215,17 @@ static void M_Bones(const int16_t item_num)
     bone_front->mesh_bits = ~0xC00000u;
 }
 
-static void M_HandleSaveFront(ITEM *const item, const SAVEGAME_STAGE stage)
+static void M_HandleSaveBack(ITEM *const item, const SAVEGAME_STAGE stage)
 {
     if (stage == SAVEGAME_STAGE_AFTER_LOAD) {
         if (item->status == IS_DEACTIVATED) {
-            item->pos.y -= 1010;
+            const int32_t y_pos = item->pos.y;
+            int16_t room_num = item->room_num;
+            const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+            item->pos.y = Room_GetHeight(sector, item->pos);
             const int16_t item_num = Item_GetIndex(item);
             M_Bones(item_num);
-            item->pos.y += 1010;
+            item->pos.y = y_pos;
         }
     }
 }
@@ -317,8 +320,9 @@ static void M_ControlBack(const int16_t item_num)
             }
 
             if (creature->flags == M_BONE_TIME) {
-                M_Bones(dragon_front_item_num);
+                M_Bones(dragon_back_item_num);
             } else if (creature->flags == M_DISSOLVE_TIME) {
+                Room_TestTriggers(dragon_back_item);
                 LOT_DisableBaddieAI(dragon_front_item_num);
                 Item_Kill(dragon_front_item_num);
                 dragon_front_item->status = IS_DEACTIVATED;
@@ -482,7 +486,6 @@ static void M_SetupFront(OBJECT *const obj)
     SOFT_ASSERT(
         Object_Get(O_DRAGON_BACK)->loaded, "Dragon back object missing");
     obj->initialise_func = M_InitialiseFront;
-    obj->handle_save_func = M_HandleSaveFront;
     obj->control_func = M_ControlFront;
     obj->collision_func = M_Collision;
 
@@ -506,6 +509,7 @@ static void M_SetupBack(OBJECT *const obj)
     }
 
     obj->initialise_func = M_InitialiseBack;
+    obj->handle_save_func = M_HandleSaveBack;
     obj->activate_func = M_ActivateBack;
     obj->control_func = M_ControlBack;
     obj->collision_func = M_Collision;

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -171,9 +171,7 @@ static void M_Bones(const int16_t item_num)
 
     ITEM *const bone_back = Item_Get(bone_back_item_num);
     bone_back->object_id = O_DRAGON_BONES_3;
-    bone_back->pos.x = dragon_item->pos.x;
-    bone_back->pos.y = dragon_item->pos.y;
-    bone_back->pos.z = dragon_item->pos.z;
+    bone_back->pos = dragon_item->pos;
     bone_back->rot.x = 0;
     bone_back->rot.y = dragon_item->rot.y;
     bone_back->rot.z = 0;
@@ -183,9 +181,7 @@ static void M_Bones(const int16_t item_num)
 
     ITEM *const bone_front = Item_Get(bone_front_item_num);
     bone_front->object_id = O_DRAGON_BONES_2;
-    bone_front->pos.x = dragon_item->pos.x;
-    bone_front->pos.y = dragon_item->pos.y;
-    bone_front->pos.z = dragon_item->pos.z;
+    bone_front->pos = dragon_item->pos;
     bone_front->rot.x = 0;
     bone_front->rot.y = dragon_item->rot.y;
     bone_front->rot.z = 0;
@@ -448,12 +444,8 @@ static void M_ControlBack(const int16_t item_num)
     const int16_t anim_num = Item_GetRelativeAnim(dragon_front_item);
     const int16_t frame_num = Item_GetRelativeFrame(dragon_front_item);
     Item_SwitchToAnim(dragon_back_item, anim_num, frame_num);
-    dragon_back_item->pos.x = dragon_front_item->pos.x;
-    dragon_back_item->pos.y = dragon_front_item->pos.y;
-    dragon_back_item->pos.z = dragon_front_item->pos.z;
-    dragon_back_item->rot.x = dragon_front_item->rot.x;
-    dragon_back_item->rot.y = dragon_front_item->rot.y;
-    dragon_back_item->rot.z = dragon_front_item->rot.z;
+    dragon_back_item->pos = dragon_front_item->pos;
+    dragon_back_item->rot = dragon_front_item->rot;
     Item_UpdateRoom(dragon_back_item_num, dragon_front_item->room_num);
 }
 
@@ -511,9 +503,7 @@ int16_t Dragon_CreateInactive(const ITEM *const item)
 
     ITEM *const dragon_back_item = Item_Get(dragon_back_item_num);
     dragon_back_item->object_id = O_DRAGON_BACK;
-    dragon_back_item->pos.x = item->pos.x;
-    dragon_back_item->pos.y = item->pos.y;
-    dragon_back_item->pos.z = item->pos.z;
+    dragon_back_item->pos = item->pos;
     dragon_back_item->rot.y = item->rot.y;
     dragon_back_item->room_num = item->room_num;
     dragon_back_item->flags = IF_INVISIBLE;
@@ -523,9 +513,7 @@ int16_t Dragon_CreateInactive(const ITEM *const item)
 
     ITEM *const dragon_front_item = Item_Get(dragon_front_item_num);
     dragon_front_item->object_id = O_DRAGON_FRONT;
-    dragon_front_item->pos.x = item->pos.x;
-    dragon_front_item->pos.y = item->pos.y;
-    dragon_front_item->pos.z = item->pos.z;
+    dragon_front_item->pos = item->pos;
     dragon_front_item->rot.y = item->rot.y;
     dragon_front_item->room_num = item->room_num;
     dragon_front_item->flags = IF_INVISIBLE;

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -18,49 +18,47 @@
 #include <trx/game/stats.h>
 
 // clang-format off
-#define DRAGON_CLOSE        900
-#define DRAGON_FAR          2300
-#define DRAGON_MID          ((DRAGON_CLOSE + DRAGON_FAR) / 2) // = 1600
-#define DRAGON_L_COL        -512
-#define DRAGON_R_COL        +512
-#define DRAGON_ALMOST_LIVE  100
-#define DRAGON_CLOSE_RANGE  9437184
-#define DRAGON_STOP_RANGE   37748736
-#define DRAGON_TOUCH_DAMAGE 10
-#define DRAGON_SWIPE_DAMAGE 250
-#define DRAGON_WALK_TURN    (DEG_1 * 2) // = 364
-#define DRAGON_NEED_TURN    (DEG_1) // = 182
-#define DRAGON_TOUCH_L      0x7F000000
-#define DRAGON_TOUCH_R      0x000000FE
-#define DRAGON_LIVE_TIME    330
-#define DRAGON_HITPOINTS    300
-#define DRAGON_RADIUS       (WALL_L / 3) // = 341
+#define M_CLOSE_SHIFT    900
+#define M_FAR_SHIFT      2300
+#define M_MID_SHIFT      ((M_CLOSE_SHIFT + M_FAR_SHIFT) / 2) // = 1600
+#define M_COL_L          (-WALL_L / 2) // = -512
+#define M_COL_R          (+WALL_L / 2) // = +512
+#define M_CLOSE_RANGE    SQUARE(WALL_L * 3) // = 9437184
+#define M_STOP_RANGE     SQUARE(WALL_L * 6) // = 37748736
+#define M_WALK_TURN      (DEG_1 * 2) // = 364
+#define M_NEED_TURN      (DEG_1) // = 182
+#define M_TOUCH_L        0x7F000000
+#define M_TOUCH_R        0x000000FE
+#define M_ALMOST_LIVE    100
+#define M_LIVE_TIME      330
+#define M_HITPOINTS      300
+#define M_TOUCH_DAMAGE   10
+#define M_SWIPE_DAMAGE   250
+#define M_RADIUS         (WALL_L / 3) // = 341
 // clang-format on
 
 typedef enum {
-    // clang-format off
-    DRAGON_STATE_EMPTY       = 0,
-    DRAGON_STATE_WALK        = 1,
-    DRAGON_STATE_LEFT        = 2,
-    DRAGON_STATE_RIGHT       = 3,
-    DRAGON_STATE_AIM         = 4,
-    DRAGON_STATE_FIRE        = 5,
-    DRAGON_STATE_STOP        = 6,
-    DRAGON_STATE_TURN_LEFT   = 7,
-    DRAGON_STATE_TURN_RIGHT  = 8,
-    DRAGON_STATE_SWIPE_LEFT  = 9,
-    DRAGON_STATE_SWIPE_RIGHT = 10,
-    DRAGON_STATE_DEATH       = 11,
-    // clang-format on
-} DRAGON_STATE;
+    M_STATE_EMPTY,
+    M_STATE_WALK,
+    M_STATE_LEFT,
+    M_STATE_RIGHT,
+    M_STATE_AIM,
+    M_STATE_FIRE,
+    M_STATE_STOP,
+    M_STATE_TURN_LEFT,
+    M_STATE_TURN_RIGHT,
+    M_STATE_SWIPE_LEFT,
+    M_STATE_SWIPE_RIGHT,
+    M_STATE_DEATH,
+} M_STATE;
 
 typedef enum {
     // clang-format off
-    DRAGON_ANIM_DIE       = 21,
-    DRAGON_ANIM_DEAD      = 22,
-    DRAGON_ANIM_RESURRECT = 23,
+    M_ANIM_DIE       = 21,
+    M_ANIM_DEAD      = 22,
+    M_ANIM_RESURRECT = 23,
     // clang-format on
-} DRAGON_ANIM;
+} M_ANIM;
 
 typedef struct {
     int16_t dragon_front_item_num;
@@ -133,7 +131,7 @@ static void M_PushLaraAway(
 {
     const int32_t cy = Math_Cos(dragon_item->rot.y);
     const int32_t sy = Math_Sin(dragon_item->rot.y);
-    const int32_t base = shift < DRAGON_MID ? DRAGON_CLOSE : DRAGON_FAR;
+    const int32_t base = shift < M_MID_SHIFT ? M_CLOSE_SHIFT : M_FAR_SHIFT;
     lara_item->pos.x += (cy * (base - shift)) >> W2V_SHIFT;
     lara_item->pos.z -= (sy * (base - shift)) >> W2V_SHIFT;
 }
@@ -217,7 +215,7 @@ static void M_Collision(
         return;
     }
 
-    if (item->current_anim_state != DRAGON_STATE_DEATH) {
+    if (item->current_anim_state != M_STATE_DEATH) {
         Lara_Col_ItemPush(item, coll, true, false);
         return;
     }
@@ -228,7 +226,7 @@ static void M_Collision(
     const int32_t sy = Math_Sin(item->rot.y);
     const int32_t side_shift = (cy * dz + sy * dx) >> W2V_SHIFT;
 
-    if (side_shift <= DRAGON_L_COL || side_shift >= DRAGON_R_COL) {
+    if (side_shift <= M_COL_L || side_shift >= M_COL_R) {
         Lara_Col_ItemPush(item, coll, true, false);
         return;
     }
@@ -236,11 +234,11 @@ static void M_Collision(
     const int32_t shift = (cy * dx - sy * dz) >> W2V_SHIFT;
     const int32_t angle = lara_item->rot.y - item->rot.y;
     if (g_Input.action && item->object_id == O_DRAGON_BACK
-        && (Item_TestAnimEqual(item, DRAGON_ANIM_DEAD)
-            || (Item_TestAnimEqual(item, DRAGON_ANIM_RESURRECT)
-                && Item_TestFrameRange(item, 0, DRAGON_ALMOST_LIVE)))
-        && !lara_item->gravity && shift <= DRAGON_MID
-        && shift > DRAGON_CLOSE - 350 && side_shift > -350 && side_shift < 350
+        && (Item_TestAnimEqual(item, M_ANIM_DEAD)
+            || (Item_TestAnimEqual(item, M_ANIM_RESURRECT)
+                && Item_TestFrameRange(item, 0, M_ALMOST_LIVE)))
+        && !lara_item->gravity && shift <= M_MID_SHIFT
+        && shift > M_CLOSE_SHIFT - 350 && side_shift > -350 && side_shift < 350
         && angle > DEG_90 - 30 * DEG_1 && angle < DEG_90 + 30 * DEG_1) {
         M_PullDagger(lara_item, item);
     } else {
@@ -272,18 +270,18 @@ static void M_ControlBack(const int16_t item_num)
     const OBJECT *const front_obj = Object_Get(O_DRAGON_FRONT);
 
     if (dragon_front_item->hit_points <= 0) {
-        if (dragon_front_item->current_anim_state != DRAGON_STATE_DEATH) {
-            Item_SwitchToAnim(dragon_front_item, DRAGON_ANIM_DIE, 0);
-            dragon_front_item->goal_anim_state = DRAGON_STATE_DEATH;
-            dragon_front_item->current_anim_state = DRAGON_STATE_DEATH;
+        if (dragon_front_item->current_anim_state != M_STATE_DEATH) {
+            Item_SwitchToAnim(dragon_front_item, M_ANIM_DIE, 0);
+            dragon_front_item->goal_anim_state = M_STATE_DEATH;
+            dragon_front_item->current_anim_state = M_STATE_DEATH;
             creature->flags = 0;
         } else if (creature->flags >= 0) {
             Spawn_MysticLight(dragon_front_item_num);
             creature->flags++;
-            if (creature->flags == DRAGON_LIVE_TIME) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_STOP;
+            if (creature->flags == M_LIVE_TIME) {
+                dragon_front_item->goal_anim_state = M_STATE_STOP;
             }
-            if (creature->flags > DRAGON_LIVE_TIME + DRAGON_ALMOST_LIVE) {
+            if (creature->flags > M_LIVE_TIME + M_ALMOST_LIVE) {
                 dragon_front_item->hit_points = front_obj->hit_points / 2;
             }
         } else {
@@ -317,46 +315,46 @@ static void M_ControlBack(const int16_t item_num)
         Creature_AIInfo(dragon_front_item, &info);
         Creature_Mood(dragon_front_item, &info, MOOD_ATTACK);
 
-        angle = Creature_Turn(dragon_front_item, DRAGON_WALK_TURN);
-        const bool is_ahead = info.ahead && info.distance > DRAGON_CLOSE_RANGE
-            && info.distance < DRAGON_STOP_RANGE;
+        angle = Creature_Turn(dragon_front_item, M_WALK_TURN);
+        const bool is_ahead = info.ahead && info.distance > M_CLOSE_RANGE
+            && info.distance < M_STOP_RANGE;
         if (dragon_front_item->touch_bits) {
-            Lara_TakeDamage(DRAGON_TOUCH_DAMAGE, true);
+            Lara_TakeDamage(M_TOUCH_DAMAGE, true);
         }
 
         switch (dragon_front_item->current_anim_state) {
-        case DRAGON_STATE_WALK:
+        case M_STATE_WALK:
             creature->flags = 0;
             if (is_ahead) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_STOP;
-            } else if (angle < -DRAGON_NEED_TURN) {
-                if (info.distance < DRAGON_STOP_RANGE && info.ahead) {
-                    dragon_front_item->goal_anim_state = DRAGON_STATE_STOP;
+                dragon_front_item->goal_anim_state = M_STATE_STOP;
+            } else if (angle < -M_NEED_TURN) {
+                if (info.distance < M_STOP_RANGE && info.ahead) {
+                    dragon_front_item->goal_anim_state = M_STATE_STOP;
                 } else {
-                    dragon_front_item->goal_anim_state = DRAGON_STATE_LEFT;
+                    dragon_front_item->goal_anim_state = M_STATE_LEFT;
                 }
-            } else if (angle > DRAGON_NEED_TURN) {
-                if (info.distance < DRAGON_STOP_RANGE && info.ahead) {
-                    dragon_front_item->goal_anim_state = DRAGON_STATE_STOP;
+            } else if (angle > M_NEED_TURN) {
+                if (info.distance < M_STOP_RANGE && info.ahead) {
+                    dragon_front_item->goal_anim_state = M_STATE_STOP;
                 } else {
-                    dragon_front_item->goal_anim_state = DRAGON_STATE_RIGHT;
+                    dragon_front_item->goal_anim_state = M_STATE_RIGHT;
                 }
             }
             break;
 
-        case DRAGON_STATE_LEFT:
-            if (angle > -DRAGON_NEED_TURN || is_ahead) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_WALK;
+        case M_STATE_LEFT:
+            if (angle > -M_NEED_TURN || is_ahead) {
+                dragon_front_item->goal_anim_state = M_STATE_WALK;
             }
             break;
 
-        case DRAGON_STATE_RIGHT:
-            if (angle < DRAGON_NEED_TURN || is_ahead) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_WALK;
+        case M_STATE_RIGHT:
+            if (angle < M_NEED_TURN || is_ahead) {
+                dragon_front_item->goal_anim_state = M_STATE_WALK;
             }
             break;
 
-        case DRAGON_STATE_AIM:
+        case M_STATE_AIM:
             dragon_front_item->rot.y -= angle;
             if (info.ahead) {
                 head = -info.angle;
@@ -364,14 +362,14 @@ static void M_ControlBack(const int16_t item_num)
 
             if (is_ahead) {
                 creature->flags = 30;
-                dragon_front_item->goal_anim_state = DRAGON_STATE_FIRE;
+                dragon_front_item->goal_anim_state = M_STATE_FIRE;
             } else {
                 creature->flags = 0;
-                dragon_front_item->goal_anim_state = DRAGON_STATE_AIM;
+                dragon_front_item->goal_anim_state = M_STATE_AIM;
             }
             break;
 
-        case DRAGON_STATE_FIRE:
+        case M_STATE_FIRE:
             dragon_front_item->rot.y -= angle;
             if (info.ahead) {
                 head = -info.angle;
@@ -386,56 +384,52 @@ static void M_ControlBack(const int16_t item_num)
                 }
                 creature->flags--;
             } else {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_STOP;
+                dragon_front_item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case DRAGON_STATE_STOP:
+        case M_STATE_STOP:
             dragon_front_item->rot.y -= angle;
             if (is_ahead) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_AIM;
-            } else if (info.distance > DRAGON_STOP_RANGE || !info.ahead) {
-                dragon_front_item->goal_anim_state = DRAGON_STATE_WALK;
-            } else if (
-                info.distance >= DRAGON_CLOSE_RANGE || creature->flags != 0) {
+                dragon_front_item->goal_anim_state = M_STATE_AIM;
+            } else if (info.distance > M_STOP_RANGE || !info.ahead) {
+                dragon_front_item->goal_anim_state = M_STATE_WALK;
+            } else if (info.distance >= M_CLOSE_RANGE || creature->flags != 0) {
                 if (info.angle < 0) {
-                    dragon_front_item->goal_anim_state = DRAGON_STATE_TURN_LEFT;
+                    dragon_front_item->goal_anim_state = M_STATE_TURN_LEFT;
                 } else {
-                    dragon_front_item->goal_anim_state =
-                        DRAGON_STATE_TURN_RIGHT;
+                    dragon_front_item->goal_anim_state = M_STATE_TURN_RIGHT;
                 }
             } else {
                 creature->flags = 1;
                 if (info.angle < 0) {
-                    dragon_front_item->goal_anim_state =
-                        DRAGON_STATE_SWIPE_LEFT;
+                    dragon_front_item->goal_anim_state = M_STATE_SWIPE_LEFT;
                 } else {
-                    dragon_front_item->goal_anim_state =
-                        DRAGON_STATE_SWIPE_RIGHT;
+                    dragon_front_item->goal_anim_state = M_STATE_SWIPE_RIGHT;
                 }
             }
             break;
 
-        case DRAGON_STATE_TURN_LEFT:
+        case M_STATE_TURN_LEFT:
             creature->flags = 0;
             dragon_front_item->rot.y += -DEG_1 - angle;
             break;
 
-        case DRAGON_STATE_TURN_RIGHT:
+        case M_STATE_TURN_RIGHT:
             creature->flags = 0;
             dragon_front_item->rot.y += DEG_1 - angle;
             break;
 
-        case DRAGON_STATE_SWIPE_LEFT:
-            if ((dragon_front_item->touch_bits & DRAGON_TOUCH_L) != 0) {
-                Lara_TakeDamage(DRAGON_SWIPE_DAMAGE, true);
+        case M_STATE_SWIPE_LEFT:
+            if ((dragon_front_item->touch_bits & M_TOUCH_L) != 0) {
+                Lara_TakeDamage(M_SWIPE_DAMAGE, true);
                 creature->flags = 0;
             }
             break;
 
-        case DRAGON_STATE_SWIPE_RIGHT:
-            if ((dragon_front_item->touch_bits & DRAGON_TOUCH_R) != 0) {
-                Lara_TakeDamage(DRAGON_SWIPE_DAMAGE, true);
+        case M_STATE_SWIPE_RIGHT:
+            if ((dragon_front_item->touch_bits & M_TOUCH_R) != 0) {
+                Lara_TakeDamage(M_SWIPE_DAMAGE, true);
                 creature->flags = 0;
             }
             break;
@@ -474,8 +468,8 @@ static void M_SetupFront(OBJECT *const obj)
     obj->control_func = M_ControlFront;
     obj->collision_func = M_Collision;
 
-    obj->hit_points = DRAGON_HITPOINTS;
-    obj->radius = DRAGON_RADIUS;
+    obj->hit_points = M_HITPOINTS;
+    obj->radius = M_RADIUS;
     obj->pivot_length = 300;
 
     obj->intelligent = true;
@@ -498,7 +492,7 @@ static void M_SetupBack(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->can_drop_items_func = M_CanDropItemsBack;
 
-    obj->radius = DRAGON_RADIUS;
+    obj->radius = M_RADIUS;
 
     obj->save_position = true;
     obj->save_flags = true;

--- a/src/trx/game/objects/creatures/dragon.h
+++ b/src/trx/game/objects/creatures/dragon.h
@@ -2,5 +2,4 @@
 
 #include <trx/game/objects/types.h>
 
-int16_t Dragon_CreateInactive(const ITEM *item);
 void Dragon_Activate(int16_t dragon_item_num);

--- a/src/trx/game/objects/creatures/dragon.h
+++ b/src/trx/game/objects/creatures/dragon.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include <trx/game/objects/types.h>
-
-void Dragon_Activate(int16_t dragon_item_num);


### PR DESCRIPTION
Resolves #5011.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows builders to use dragons with no ties to Bartoli by placing a back item and triggering it like any other enemy. It has no dagger concept so has only one phase, and does not turn to bones. It can still activate heavy triggers; for this, the handling is moved out of Lara's extra state and into the dragon, and as a result the dragon will "dissolve" for a few frames more so that the timing matches up. I think the result is fine, and it actually avoids a jump in the skin disappearing (difficult to see any difference anyway with the camera angle in OG).

Most of this is moving some things around and some const refactors; the final commit has the main change.

Will share a test level, but a sanity check of the OG dragon would be good, including save/load while alive and dead.