### PR TITLE
savegame: fix final stats death counters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@
 - fixed collision issues on bridges, trapdoors, breakable tiles and pushblocks if positioned over a triangle portal (regression from 1.0)
 - fixed Lara being able to sprint through swamps when responsive sprinting is enabled
 - fixed bar borders scaling poorly (off-by-1px errors, regression from 1.2)
+- fixed death counter not being preserved in saves after changing levels, causing stopwatch and final statistics to sometimes show 0 deaths
 
 **TR1**:
 - added an option to allow Lara to crouch and crawl (Gameplay → Controls → Crawling)

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -967,6 +967,7 @@ void TestReplay_Start(void)
             LOG_WARNING("Unknown line: %s", ln);
         }
     }
+    g_SavedConfig = g_Config;
     Shell_FreeArgs(ctx.args);
 }
 

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -135,8 +135,8 @@ bool SG_File_LoadFromFile(MYFILE *const fp)
     JSON_VALUE *const root = M_ReadRaw(fp, &sg_version);
     JSON_READ_IO *const io = JSON_ReadIO_Create(root, sg_version, nullptr);
 
-    M_MUST(SG_File_LoadMisc(io));
     M_MUST(SG_File_LoadResumeInfoList(io));
+    M_MUST(SG_File_LoadMisc(io));
     M_MUST(SG_File_LoadInventory(io));
     M_MUST(SG_File_LoadFlipmaps(io));
     M_MUST(SG_File_LoadCameras(io));
@@ -262,6 +262,25 @@ bool SG_File_UpdateDeathCounters(
     }
     JSON_ObjectEvictKey(misc_obj, "death_count");
     JSON_ObjectAppendInt(misc_obj, "death_count", death_count);
+
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    int32_t resume_idx = -1;
+    for (int32_t i = 0; i < level_table->count; i++) {
+        if (level_table->levels[i].num == level_num) {
+            resume_idx = i;
+            break;
+        }
+    }
+
+    JSON_ARRAY *const resume_arr = JSON_ObjectGetArray(root_obj, "resume_info");
+    if (resume_arr != nullptr && resume_idx != -1) {
+        JSON_OBJECT *const resume_obj =
+            JSON_ArrayGetObject(resume_arr, resume_idx);
+        if (resume_obj != nullptr) {
+            JSON_ObjectEvictKey(resume_obj, "death_count");
+            JSON_ObjectAppendInt(resume_obj, "death_count", death_count);
+        }
+    }
 
     File_Seek(fp, 0, FILE_SEEK_SET);
     M_SaveRaw(fp, root, level_num, is_quick);

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -713,6 +713,7 @@ static bool M_ReadResumeInfo(JSON_READ_IO *const io, RESUME_INFO *const resume)
     M_MUST(JSON_READ(io, "kills", &resume->stats.kill_count));
     M_MUST(JSON_READ(io, "pickups", &resume->stats.pickup_count));
     M_MUST(JSON_READ(io, "secrets", &resume->stats.secret_flags));
+    M_SHOULD(JSON_READ(io, "death_count", &resume->stats.death_count));
     Stats_UpdateSecrets(&resume->stats);
     M_FINISH();
 }

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -258,6 +258,7 @@ static void M_WriteResumeInfo(
     JSONW_WRITE(io, "ammo_used", resume->stats.ammo_used);
     JSONW_WRITE(io, "distance_travelled", resume->stats.distance_travelled);
     JSONW_WRITE(io, "medipacks_used", resume->stats.medipacks_used);
+    JSONW_WRITE(io, "death_count", resume->stats.death_count);
 }
 
 static int32_t M_GetMusicTrackFlagsCount(void)

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -77,8 +77,8 @@ static void M_ShowWindow(void)
 
 static void M_HandleConfigChange(const EVENT *const event, void *const data)
 {
-    const CONFIG *const old = &g_Config;
-    const CONFIG *const new = &g_SavedConfig;
+    const CONFIG *const old = &g_SavedConfig;
+    const CONFIG *const new = &g_Config;
     Shell_HandleConfigChange(old, new);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR resolves #5018 and fixes a save/load regression where death counts could reset to 0 after moving to another level and reloading, which made stopwatch and final statistics inconsistent.

Death counts are now stored with each level’s resume data and updated in-place when Lara dies in a bound save, so the value remains stable across level transitions and reloads.

#### Testing

- [x] Reproduce issue #5018 flow in TR2: [death-counters.txt](https://github.com/user-attachments/files/25715788/death-counters.txt)
  Expected outcome: death count remains 1 in stopwatch and final stats before and after reloading the later save
- [x] Load an older save that has no per-level death_count field in resume_info
  Expected outcome: save loads normally with no error, and death counter continues updating correctly after a new death
- [x] Check cross-level death tracking: play Vilcabamba, `/save 1`, level skip, `/hp 0`, `/load 1`
  Expected outcome: even though the player died in The Lost Valley, loading the Vilcabamba save should show 1 death.