### PR TITLE
savegame: fix quicksave slots

### DIFF
--- a/src/trx/core/memory.h
+++ b/src/trx/core/memory.h
@@ -72,3 +72,5 @@ void Memory_ArenaReset(MEMORY_ARENA_ALLOCATOR *allocator);
 // Frees the entire buffer owned by the arena allocator. allocator must not be
 // nullptr.
 void Memory_ArenaFree(MEMORY_ARENA_ALLOCATOR *allocator);
+
+#define AUTO_FREE __attribute__((cleanup(Memory_FreePointer)))

--- a/src/trx/core/strings/common.c
+++ b/src/trx/core/strings/common.c
@@ -21,20 +21,12 @@ typedef struct {
 
 static M_STATIC_BUFFER m_StaticBufferRing[M_MAX_STATIC_BUFFERS] = {};
 static int m_StaticBufNext = 0;
-static bool m_ExitRegistered = false;
 
-static void M_Shutdown(void)
+__attribute__((destructor)) static void M_Shutdown(void)
 {
     for (int32_t i = 0; i < M_MAX_STATIC_BUFFERS; i++) {
-        Memory_Free(m_StaticBufferRing[i].buf);
-    }
-}
-
-static void M_EnsureShutdown(void)
-{
-    if (!m_ExitRegistered) {
-        atexit(M_Shutdown);
-        m_ExitRegistered = true;
+        Memory_FreePointer(&m_StaticBufferRing[i].buf);
+        m_StaticBufferRing[i].capacity = 0;
     }
 }
 
@@ -322,7 +314,6 @@ const char *String_FormatStatic(const char *const fmt, ...)
 
 const char *String_FormatStaticV(const char *const fmt, va_list args)
 {
-    M_EnsureShutdown();
     M_STATIC_BUFFER *const buffer = M_CycleStaticBuffer();
     String_FormatIntoV(&buffer->buf, &buffer->capacity, fmt, args);
     return buffer->buf;

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -944,7 +944,14 @@ void Savegame_ScanSavedGames(void)
     M_ScanSavedGamesDir(".");
     M_ScanSavedGamesDir(TRXPath_Get(TRX_PATH_LEGACY_SAVES_DIR));
     M_ScanSavedGamesDir(TRXPath_Get(TRX_PATH_SAVES_DIR));
-    M_ScanSavedGamesDir(M_GetSaveWriteDir());
+
+    {
+        // M_GetSaveWriteDir may use static formatting storage, so copy it
+        // before scanning because nested formatting calls during scan can
+        // overwrite it.
+        AUTO_FREE char *write_dir = Memory_DupStr(M_GetSaveWriteDir());
+        M_ScanSavedGamesDir(write_dir);
+    }
 
     for (SAVEGAME_SLOT_POOL pool = 0; pool < SAVEGAME_SLOT_POOL_NUMBER_OF;
          pool++) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes quicksave slots being capped at 7 slots when launching the game / exiting to title.
The reason was a nested usage of the static string buffers ring, which is capped at handling max 8 strings at a time. Using it like this results in overwrites.

This class of bug is not new with this particular API. Though it's comfortable in use, it's also easy to misuse, so maybe it's best to sunset it in favor of short-lived allocations. Or use a frame-bound arena similar to the UI. IDK. I tried to think of a way to intentionally crash on unintended overwrites, but didn't find a way that wouldn't require the user to do extra actions, which is unreliable.

Anyway, I fixed the quicksave slots bug by eliminating this one problematic use in favor of a short-lived local allocation.

To sweeten things up I have added `AUTO_FREE` macro that uses gcc/clang `cleanup` extension (confirmed to be compatible on Macs). It should make it more comfortable to use normal `String_Format` over `String_FormatStatic`.