### PR TITLE
shell/flow: fix level clear

### DIFF
--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -62,8 +62,6 @@ bool Level_Initialise(
     }
     if (level->type != GFL_TITLE && level->type != GFL_CUTSCENE) {
         Game_SetCurrentLevel(level);
-    } else {
-        Game_SetCurrentLevel(nullptr);
     }
     GF_SetCurrentLevel(level);
 

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -10,6 +10,7 @@
 #include <trx/game/console.h>
 #include <trx/game/events.h>
 #include <trx/game/fmv.h>
+#include <trx/game/game.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_strings/entries.h>
@@ -423,6 +424,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
         }
     }
 
+    Game_SetCurrentLevel(nullptr);
     if (s->args->level_to_play != nullptr) {
         Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes a misguided implementation from 1ca20cde8, which resulted in a crash in the following scenario:

1. Launch tr1
2. `/play 4`
3. Level skip to the cutscene
4. Press action to skip the cutscene (crash)