### PR TITLE
Audit mice

### DIFF
--- a/src/trx/game/objects/creatures/bandit_1.c
+++ b/src/trx/game/objects/creatures/bandit_1.c
@@ -68,7 +68,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/bandit_2.c
+++ b/src/trx/game/objects/creatures/bandit_2.c
@@ -67,7 +67,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/barracuda.c
+++ b/src/trx/game/objects/creatures/barracuda.c
@@ -50,7 +50,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         int16_t head = 0;
         int16_t angle = Creature_Turn(item, creature->maximum_turn);

--- a/src/trx/game/objects/creatures/big_spider.c
+++ b/src/trx/game/objects/creatures/big_spider.c
@@ -49,7 +49,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         angle = Creature_Turn(item, BIG_SPIDER_TURN);
 

--- a/src/trx/game/objects/creatures/bird.c
+++ b/src/trx/game/objects/creatures/bird.c
@@ -93,7 +93,7 @@ static void M_Control(const int16_t item_num)
 
     AI_INFO info;
     Creature_AIInfo(item, &info);
-    Creature_Mood(item, &info, MOOD_BORED);
+    Creature_Mood(item, &info, false);
 
     const int16_t angle = Creature_Turn(item, M_TURN);
 

--- a/src/trx/game/objects/creatures/bird_guardian.c
+++ b/src/trx/game/objects/creatures/bird_guardian.c
@@ -63,7 +63,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         if (info.ahead != 0) {
             head = info.angle;

--- a/src/trx/game/objects/creatures/cultist_1.c
+++ b/src/trx/game/objects/creatures/cultist_1.c
@@ -79,7 +79,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/cultist_2.c
+++ b/src/trx/game/objects/creatures/cultist_2.c
@@ -66,7 +66,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/cultist_3.c
+++ b/src/trx/game/objects/creatures/cultist_3.c
@@ -79,7 +79,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/diver.c
+++ b/src/trx/game/objects/creatures/diver.c
@@ -83,7 +83,7 @@ static void M_Control(const int16_t item_num)
 
     AI_INFO info;
     Creature_AIInfo(item, &info);
-    Creature_Mood(item, &info, MOOD_BORED);
+    Creature_Mood(item, &info, false);
 
     bool shoot;
     const ITEM *const lara_item = Lara_GetItem();

--- a/src/trx/game/objects/creatures/dog.c
+++ b/src/trx/game/objects/creatures/dog.c
@@ -67,7 +67,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         if (info.ahead) {
             head = info.angle;

--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -390,7 +390,7 @@ static void M_ControlBack(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(dragon_front_item, &info);
-        Creature_Mood(dragon_front_item, &info, MOOD_ATTACK);
+        Creature_Mood(dragon_front_item, &info, true);
 
         angle = Creature_Turn(dragon_front_item, M_WALK_TURN);
         const bool is_ahead = info.ahead && info.distance > M_CLOSE_RANGE

--- a/src/trx/game/objects/creatures/jelly.c
+++ b/src/trx/game/objects/creatures/jelly.c
@@ -37,7 +37,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         int16_t angle = Creature_Turn(item, JELLY_TURN);
 

--- a/src/trx/game/objects/creatures/monk.c
+++ b/src/trx/game/objects/creatures/monk.c
@@ -70,7 +70,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         angle = Creature_Turn(item, creature->maximum_turn);
         if (info.ahead != 0) {

--- a/src/trx/game/objects/creatures/mouse.c
+++ b/src/trx/game/objects/creatures/mouse.c
@@ -6,31 +6,29 @@
 #include <trx/game/spawn.h>
 
 // clang-format off
-#define MOUSE_HITPOINTS     4
-#define MOUSE_TOUCH_BITS    0b01111111 // = 0x7F
-#define MOUSE_RADIUS        (WALL_L / 10) // = 102
-#define MOUSE_RUN_TURN      (DEG_1 * 6) // = 1092
-#define MOUSE_ATTACK_RANGE  SQUARE(WALL_L / 3) // = 116281
-#define MOUSE_BITE_DAMAGE   20
-#define MOUSE_WAIT_1_CHANCE 0x500 // = 1280
-#define MOUSE_WAIT_2_CHANCE (MOUSE_WAIT_1_CHANCE + 0x500) // = 2560
+#define M_HITPOINTS     4
+#define M_TOUCH_BITS    0b01111111 // = 0x7F
+#define M_RADIUS        (WALL_L / 10) // = 102
+#define M_RUN_TURN      (DEG_1 * 6) // = 1092
+#define M_ATTACK_RANGE  SQUARE(WALL_L / 3) // = 116281
+#define M_BITE_DAMAGE   20
+#define M_WAIT_1_CHANCE 0x500 // = 1280
+#define M_WAIT_2_CHANCE (M_WAIT_1_CHANCE + 0x500) // = 2560
 // clang-format on
 
 typedef enum {
-    // clang-format off
-    MOUSE_STATE_EMPTY  = 0,
-    MOUSE_STATE_RUN    = 1,
-    MOUSE_STATE_STOP   = 2,
-    MOUSE_STATE_WAIT_1 = 3,
-    MOUSE_STATE_WAIT_2 = 4,
-    MOUSE_STATE_ATTACK = 5,
-    MOUSE_STATE_DEATH  = 6,
-    // clang-format on
-} MOUSE_STATE;
+    M_STATE_NULL,
+    M_STATE_RUN,
+    M_STATE_STOP,
+    M_STATE_WAIT_1,
+    M_STATE_WAIT_2,
+    M_STATE_ATTACK,
+    M_STATE_DEATH,
+} M_STATE;
 
 typedef enum {
-    MOUSE_ANIM_DEATH = 9,
-} MOUSE_ANIM;
+    M_ANIM_DEATH = 9,
+} M_ANIM;
 
 static const BITE m_MouseBite = {
     .pos = { .x = 0, .y = 0, .z = 57 },
@@ -50,74 +48,74 @@ static void M_Control(const int16_t item_num)
     int16_t angle = 0;
 
     if (item->hit_points <= 0) {
-        if (item->current_anim_state != MOUSE_STATE_DEATH) {
-            Item_SwitchToAnim(item, MOUSE_ANIM_DEATH, 0);
-            item->current_anim_state = MOUSE_STATE_DEATH;
+        if (item->current_anim_state != M_STATE_DEATH) {
+            Item_SwitchToAnim(item, M_ANIM_DEATH, 0);
+            item->current_anim_state = M_STATE_DEATH;
         }
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         if (info.ahead) {
             head = info.angle;
         }
-        angle = Creature_Turn(item, MOUSE_RUN_TURN);
+        angle = Creature_Turn(item, M_RUN_TURN);
 
         switch (item->current_anim_state) {
-        case MOUSE_STATE_RUN:
-            creature->maximum_turn = MOUSE_RUN_TURN;
+        case M_STATE_RUN:
+            creature->maximum_turn = M_RUN_TURN;
             if (creature->mood == MOOD_BORED || creature->mood == MOOD_STALK) {
                 const int32_t random = Random_GetControl();
-                if (random < MOUSE_WAIT_1_CHANCE) {
-                    item->required_anim_state = MOUSE_STATE_WAIT_1;
-                    item->goal_anim_state = MOUSE_STATE_STOP;
-                } else if (random < MOUSE_WAIT_2_CHANCE) {
-                    item->goal_anim_state = MOUSE_STATE_STOP;
+                if (random < M_WAIT_1_CHANCE) {
+                    item->required_anim_state = M_STATE_WAIT_1;
+                    item->goal_anim_state = M_STATE_STOP;
+                } else if (random < M_WAIT_2_CHANCE) {
+                    item->goal_anim_state = M_STATE_STOP;
                 }
-            } else if (info.ahead && info.distance < MOUSE_ATTACK_RANGE) {
-                item->goal_anim_state = MOUSE_STATE_STOP;
+            } else if (info.ahead && info.distance < M_ATTACK_RANGE) {
+                item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case MOUSE_STATE_STOP:
+        case M_STATE_STOP:
             creature->maximum_turn = 0;
-            if (item->required_anim_state != MOUSE_STATE_EMPTY) {
+            if (item->required_anim_state != M_STATE_NULL) {
                 item->goal_anim_state = item->required_anim_state;
             }
             break;
 
-        case MOUSE_STATE_WAIT_1:
-            if (Random_GetControl() < MOUSE_WAIT_1_CHANCE) {
-                item->goal_anim_state = MOUSE_STATE_STOP;
+        case M_STATE_WAIT_1:
+            if (Random_GetControl() < M_WAIT_1_CHANCE) {
+                item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case MOUSE_STATE_WAIT_2:
+        case M_STATE_WAIT_2:
             if (creature->mood == MOOD_BORED || creature->mood == MOOD_STALK) {
                 const int32_t random = Random_GetControl();
-                if (random < MOUSE_WAIT_1_CHANCE) {
-                    item->required_anim_state = MOUSE_STATE_WAIT_1;
-                } else if (random > MOUSE_WAIT_2_CHANCE) {
-                    item->required_anim_state = MOUSE_STATE_RUN;
+                if (random < M_WAIT_1_CHANCE) {
+                    item->required_anim_state = M_STATE_WAIT_1;
+                } else if (random > M_WAIT_2_CHANCE) {
+                    item->required_anim_state = M_STATE_RUN;
                 }
-            } else if (info.distance < MOUSE_ATTACK_RANGE) {
-                item->required_anim_state = MOUSE_STATE_ATTACK;
+            } else if (info.distance < M_ATTACK_RANGE) {
+                item->required_anim_state = M_STATE_ATTACK;
             } else {
-                item->required_anim_state = MOUSE_STATE_RUN;
+                item->required_anim_state = M_STATE_RUN;
             }
 
-            if (item->required_anim_state != MOUSE_STATE_EMPTY) {
-                item->goal_anim_state = MOUSE_STATE_STOP;
+            if (item->required_anim_state != M_STATE_NULL) {
+                item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case MOUSE_STATE_ATTACK:
-            if (item->required_anim_state == MOUSE_STATE_EMPTY
-                && (item->touch_bits & MOUSE_TOUCH_BITS) != 0) {
-                Lara_TakeDamage(MOUSE_BITE_DAMAGE, true);
+        case M_STATE_ATTACK:
+            if (item->required_anim_state == M_STATE_NULL
+                && (item->touch_bits & M_TOUCH_BITS) != 0) {
+                Lara_TakeDamage(M_BITE_DAMAGE, true);
                 Creature_Effect(item, &m_MouseBite, Spawn_Blood);
-                item->required_anim_state = MOUSE_STATE_STOP;
+                item->required_anim_state = M_STATE_STOP;
             }
             break;
 
@@ -139,8 +137,8 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
-    obj->hit_points = MOUSE_HITPOINTS;
-    obj->radius = MOUSE_RADIUS;
+    obj->hit_points = M_HITPOINTS;
+    obj->radius = M_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 50;
 

--- a/src/trx/game/objects/creatures/shark.c
+++ b/src/trx/game/objects/creatures/shark.c
@@ -66,7 +66,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         int16_t head = 0;
         int16_t angle = Creature_Turn(item, creature->maximum_turn);

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -98,7 +98,7 @@ static int16_t M_ControlAlive(ITEM *const driver_item, ITEM *const skidoo_item)
 
     AI_INFO info;
     Creature_AIInfo(skidoo_item, &info);
-    Creature_Mood(skidoo_item, &info, MOOD_ATTACK);
+    Creature_Mood(skidoo_item, &info, true);
 
     int16_t angle = Creature_Turn(skidoo_item, SKIDOO_MAX_TURN / 2);
 

--- a/src/trx/game/objects/creatures/spider.c
+++ b/src/trx/game/objects/creatures/spider.c
@@ -70,7 +70,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, SPIDER_TURN);
 

--- a/src/trx/game/objects/creatures/trex.c
+++ b/src/trx/game/objects/creatures/trex.c
@@ -84,7 +84,7 @@ static void M_Control(const int16_t item_num)
     if (info.ahead) {
         head = info.angle;
     }
-    Creature_Mood(item, &info, MOOD_ATTACK);
+    Creature_Mood(item, &info, true);
     angle = Creature_Turn(item, creature->maximum_turn);
 
     if (item->touch_bits != 0) {

--- a/src/trx/game/objects/creatures/winston.c
+++ b/src/trx/game/objects/creatures/winston.c
@@ -58,7 +58,7 @@ static void M_Control(const int16_t item_num)
 
     AI_INFO info;
     Creature_AIInfo(item, &info);
-    Creature_Mood(item, &info, MOOD_ATTACK);
+    Creature_Mood(item, &info, true);
 
     const int16_t angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/winston_army.c
+++ b/src/trx/game/objects/creatures/winston_army.c
@@ -91,7 +91,7 @@ static void M_Control(const int16_t item_num)
 
     AI_INFO info;
     Creature_AIInfo(item, &info);
-    Creature_Mood(item, &info, MOOD_ATTACK);
+    Creature_Mood(item, &info, true);
 
     const int16_t angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/worker_1.c
+++ b/src/trx/game/objects/creatures/worker_1.c
@@ -60,7 +60,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/worker_2.c
+++ b/src/trx/game/objects/creatures/worker_2.c
@@ -80,7 +80,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/worker_3.c
+++ b/src/trx/game/objects/creatures/worker_3.c
@@ -83,7 +83,7 @@ static void M_Control(const int16_t item_num)
     } else {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_BORED);
+        Creature_Mood(item, &info, false);
 
         angle = Creature_Turn(item, creature->maximum_turn);
 

--- a/src/trx/game/objects/creatures/xian_knight.c
+++ b/src/trx/game/objects/creatures/xian_knight.c
@@ -113,7 +113,7 @@ static void M_Control(const int16_t item_num)
         creature->lot.setup.fly = STEP_L / 4;
         Creature_AIInfo(item, &info);
     }
-    Creature_Mood(item, &info, MOOD_ATTACK);
+    Creature_Mood(item, &info, true);
 
     angle = Creature_Turn(item, creature->maximum_turn);
     if (item->current_anim_state != XIAN_KNIGHT_STATE_START) {

--- a/src/trx/game/objects/creatures/xian_spearman.c
+++ b/src/trx/game/objects/creatures/xian_spearman.c
@@ -143,7 +143,7 @@ static void M_Control(const int16_t item_num)
 
     AI_INFO info;
     Creature_AIInfo(item, &info);
-    Creature_Mood(item, &info, MOOD_ATTACK);
+    Creature_Mood(item, &info, true);
 
     angle = Creature_Turn(item, creature->maximum_turn);
     if (item->current_anim_state != XIAN_SPEARMAN_STATE_START) {

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -85,7 +85,7 @@ static void M_Control(const int16_t item_num)
     if (item->hit_points > 0) {
         AI_INFO info;
         Creature_AIInfo(item, &info);
-        Creature_Mood(item, &info, MOOD_ATTACK);
+        Creature_Mood(item, &info, true);
 
         if (info.ahead) {
             head = info.angle;

--- a/tools/tr3/objects_tracker/objects_support.json
+++ b/tools/tr3/objects_tracker/objects_support.json
@@ -15,7 +15,7 @@
   "O_ANIMATING_4":            { "status": "fully implemented" },
   "O_ANIMATING_5":            { "status": "fully implemented" },
   "O_ANIMATING_6":            { "status": "fully implemented" },
-  "O_ASSAULT_TARGET":         { "status": "partially implemented", "todo": "some collision problems" },
+  "O_ASSAULT_TARGET":         { "status": "fully implemented" },
   "O_BEACON_LIGHT":           { "status": "fully implemented" },
   "O_BLADE":                  { "status": "fully implemented" },
   "O_BLUE_LIGHT":             { "status": "fully implemented" },

--- a/tools/tr3/objects_tracker/objects_support.json
+++ b/tools/tr3/objects_tracker/objects_support.json
@@ -70,7 +70,7 @@
   "O_LARGE_MEDIPACK_ITEM":    { "status": "fully implemented" },
   "O_MONKEY":                 { "status": "fully implemented" },
   "O_MOUNTED_GUN":            { "status": "fully implemented" },
-  "O_MOUSE":                  { "status": "partially implemented", "todo": "check 100% parity" },
+  "O_MOUSE":                  { "status": "fully implemented" },
   "O_MOVABLE_BLOCK_1":        { "status": "fully implemented" },
   "O_MOVABLE_BLOCK_2":        { "status": "fully implemented" },
   "O_MP5_AMMO_ITEM":          { "status": "fully implemented" },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the mouse module to use TRX conventions and fixes `Creature_Mood` being given `MOOD` when it takes a `bool`. I can confirm that TR3 mice are the same and have the same parameters as TR2.

No functional changes in this PR.