### PR TITLE
lara/flare: fix flare control on crawl pickup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -130,6 +130,7 @@
 - fixed the Tribe Pipeman sometimes not being able to aim darts at Lara correctly (Gameplay → Fixes → Fix Pipeman aim)
 - fixed Lara's footprints sometimes spawning when standing on a bridge, trapdoor or pushblock
 - fixed Lara being unable to walk or sidestep at times when standing on a bridge that sits over a steep slope (regression from 1.1)
+- fixed Lara's left arm elevating when holding a flare and performing a crouch pickup (regression from 1.1)
 - removed the limitation of one Carcass instance per level working with Piranhas
 - removed the limitation of Piranhas only attacking Carcass instances if the level sequence matches Crash Site's
 - restored the ability for Lara to perform grab cancels, like TR1 and TR2

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -201,15 +201,20 @@ static void M_SetArm(const int32_t flare_frame)
     lara_info->left_arm.frame_base = anim->frame_ptr;
 }
 
-static void M_ControlArmless(void)
+static bool M_CanUseFlareControl(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item->current_anim_state == LS(LS_PICKUP)) {
+        const LARA_TRX_ANIMATION anim = LA_U(Item_GetRelativeAnim(lara_item));
+        return anim != LA_CROUCH_PICKUP && anim != LA_CRAWL_PICKUP;
+    }
+    return Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
+}
+
+static void M_ControlArmless(void)
+{
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-
-    const bool is_mounted_or_armed =
-        Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
-
-    if (is_mounted_or_armed) {
+    if (M_CanUseFlareControl()) {
         if (!lara_info->flare.control) {
             lara_info->left_arm.frame_num = LF_FL_2_HOLD;
             lara_info->flare.control = true;
@@ -231,8 +236,7 @@ static void M_ControlBusyHands(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_info->flare.control =
-        Lara_Vehicle_IsMounted() || Lara_HasState(m_HoldStates);
+    lara_info->flare.control = M_CanUseFlareControl();
     M_ControlInHand();
     M_SetArm(lara_info->left_arm.frame_num);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids Lara positioning her arm into an L shape when holding a flare and performing a pickup while crouched or crawling (latter is unreleased).
