### PR TITLE
ui: fix pause text color

### DIFF
--- a/data/tr3/ship/cfg/tr3/strings-de.json5
+++ b/data/tr3/ship/cfg/tr3/strings-de.json5
@@ -295,6 +295,7 @@
         "INVENTORY_RING_ITEM_COUNT_FMT": "\\{color 3}%s",
         "INVENTORY_RING_OBJECT_NAME_FMT": "\\{color 5}%s",
         "OVERLAY_ITEM_COUNT_FMT": "%s",
+        "PAUSE_PAUSED": "\\{color 5}Pause",
         "STATS_ASSAULT_OTHER_TIMES_FMT": "\\{review}\\{color 2}%s",
         "STATS_GYM_ASSAULT_COURSE": "\\{review}\\{color 5}Angriffskurs",
         "STATS_GYM_RACETRACK_COURSE": "\\{review}\\{color 5}Rennstrecke",

--- a/data/tr3/ship/cfg/tr3/strings-it.json5
+++ b/data/tr3/ship/cfg/tr3/strings-it.json5
@@ -295,6 +295,7 @@
         "INVENTORY_RING_ITEM_COUNT_FMT": "\\{color 3}%s",
         "INVENTORY_RING_OBJECT_NAME_FMT": "\\{color 5}%s",
         "OVERLAY_ITEM_COUNT_FMT": "%s",
+        "PAUSE_PAUSED": "\\{color 5}Pausa",
         "STATS_ASSAULT_OTHER_TIMES_FMT": "\\{color 2}%s",
         "STATS_GYM_ASSAULT_COURSE": "\\{color 5}Corso d'Addestramento",
         "STATS_GYM_RACETRACK_COURSE": "\\{color 5}Corso di Guida",

--- a/data/tr3/ship/cfg/tr3/strings-pl.json5
+++ b/data/tr3/ship/cfg/tr3/strings-pl.json5
@@ -287,6 +287,7 @@
         "INVENTORY_RING_ITEM_COUNT_FMT": "\\{color 3}%s",
         "INVENTORY_RING_OBJECT_NAME_FMT": "\\{color 5}%s",
         "OVERLAY_ITEM_COUNT_FMT": "%s",
+        "PAUSE_PAUSED": "\\{color 5}Pauza",
         "STATS_ASSAULT_OTHER_TIMES_FMT": "\\{color 2}%s",
         "STATS_GYM_ASSAULT_COURSE": "\\{color 5}Tor Przeszkód",
         "STATS_GYM_RACETRACK_COURSE": "\\{color 5}Tor Wyścigowy",

--- a/data/tr3/ship/cfg/tr3/strings.json5
+++ b/data/tr3/ship/cfg/tr3/strings.json5
@@ -295,6 +295,7 @@
         "INVENTORY_RING_ITEM_COUNT_FMT": "\\{color 3}%s",
         "INVENTORY_RING_OBJECT_NAME_FMT": "\\{color 5}%s",
         "OVERLAY_ITEM_COUNT_FMT": "%s",
+        "PAUSE_PAUSED": "\\{color 5}Paused",
         "STATS_ASSAULT_OTHER_TIMES_FMT": "\\{color 2}%s",
         "STATS_GYM_ASSAULT_COURSE": "\\{color 5}Assault Course",
         "STATS_GYM_RACETRACK_COURSE": "\\{color 5}Race Track Course",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.3...develop) - ××××-××-××
 
+**TR3**:
+- fixed Pause text color
+
+
+
 ## [1.3](https://github.com/LostArtefacts/TRX/compare/trx-1.2.2...trx-1.3) - 2026-03-06
 Showcase: https://youtu.be/FgB9JgDM65E
 - added the ability to freely rotate examinable items


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the white Paused text color in the Pause screen to orange to match the OG colors, and improve consistency with the inventory ring colors.