### PR TITLE
level/pipeline: lift enforced main.sfx resolution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Black: like the Remasters
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
+- fixed main.sfx resolution being enforced (regression from 1.3)
 
 
 

--- a/src/trx/av/audio_sample.c
+++ b/src/trx/av/audio_sample.c
@@ -475,6 +475,13 @@ static bool M_ConvertSample(const int32_t sample_id)
     return result;
 }
 
+static bool M_IsOriginalDataDefined(const int32_t sample_id)
+{
+    ASSERT(sample_id >= 0 && sample_id < m_LoadedSamplesCount);
+    const AUDIO_SAMPLE *const sample = &m_LoadedSamples[sample_id];
+    return sample->original_data != nullptr;
+}
+
 void Audio_Sample_Init(void)
 {
     for (int32_t sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_SAMPLES;
@@ -569,6 +576,10 @@ int32_t Audio_Sample_Play(
 
     if (sample_id < 0 || sample_id >= m_LoadedSamplesCount) {
         LOG_DEBUG("Invalid sample id: %d", sample_id);
+        return AUDIO_NO_SOUND;
+    }
+
+    if (!M_IsOriginalDataDefined(sample_id)) {
         return AUDIO_NO_SOUND;
     }
 

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -43,15 +43,19 @@ static void M_InitialiseSamplesFromFile(
     if (file_name == nullptr) {
         file_name = "main.sfx";
     }
+    MYFILE *fp = nullptr;
     const char *const full_path =
-        TRXPath_Resolve(TRX_DYNAMIC_PATH_SFX_FILE, file_name);
-    LOG_DEBUG("Loading samples from %s", full_path);
+        TRXPath_PeekResolve(TRX_DYNAMIC_PATH_SFX_FILE, file_name);
+    if (full_path == nullptr) {
+        goto finish;
+    }
 
-    MYFILE *const fp = File_Open(full_path, FILE_OPEN_READ);
+    fp = File_Open(full_path, FILE_OPEN_READ);
     if (fp == nullptr) {
         LOG_ERROR("Could not open %s samples file", full_path);
         goto finish;
     }
+    LOG_DEBUG("Loading samples from %s", full_path);
 
     const int32_t sample_count = info->samples.offset_count;
     entries = Memory_Alloc(sizeof(M_SAMPLE_ENTRY) * sample_count);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes `main.sfx` being enforced to be present, which is no longer the case for custom levels.
