### PR TITLE
output/background: fix monochrome tint bleed

### DIFF
--- a/data/common/ship/shaders/common.glsl
+++ b/data/common/ship/shaders/common.glsl
@@ -26,6 +26,7 @@
 #define LIGHTING_CONTRAST_HIGH   2
 
 layout(std140) uniform Globals {
+    vec4 uGlobalTint;
     vec4 uFogColor;
     vec2 uFogDistance; // x = fog start, y = fog end
     vec2 uViewportSize;

--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -139,7 +139,7 @@ void main(void) {
 
 uniform sampler2DArray uTexAtlas;
 uniform sampler2D uTexEnvMap;
-uniform vec3 uGlobalTint;
+uniform vec3 uTint;
 uniform bool uDiscardAlpha;
 
 in vec4 gEyePos;
@@ -195,6 +195,7 @@ void main(void) {
     }
 
     texColor.rgb *= uBrightnessMultiplier;
+    texColor.rgb *= uTint;
 
     // Optional desaturation (0 = original, 1 = monochrome).
     if (uDesaturation > 0.0) {
@@ -203,7 +204,7 @@ void main(void) {
         texColor.rgb = mix(texColor.rgb, vec3(y), clamp(uDesaturation, 0.0, 1.0));
     }
 
-    texColor.rgb *= uGlobalTint;
+    texColor *= uGlobalTint;
 
     outColor = texColor;
 }

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -185,19 +185,13 @@ void Output_MeshShader_UploadTint(OUTPUT_MESH_SHADER *const shader, RGB_F tint)
 {
     const int32_t variant_idx = M_GetVariantIndex();
     OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
-    const RGB_F global_tint = Output_GetGlobalTint();
-    const RGB_F effective_tint = {
-        tint.r * global_tint.r,
-        tint.g * global_tint.g,
-        tint.b * global_tint.b,
-    };
-    if (effective_tint.r == shader->tint[variant_idx].r
-        && effective_tint.g == shader->tint[variant_idx].g
-        && effective_tint.b == shader->tint[variant_idx].b) {
+    if (tint.r == shader->tint[variant_idx].r
+        && tint.g == shader->tint[variant_idx].g
+        && tint.b == shader->tint[variant_idx].b) {
         return;
     }
     TRX_GL_TRACK_UNIFORM(
-        glUniform3f, Output_Shader_LookupUniform(base, "uGlobalTint"),
-        effective_tint.r, effective_tint.g, effective_tint.b);
-    shader->tint[variant_idx] = effective_tint;
+        glUniform3f, Output_Shader_LookupUniform(base, "uTint"), tint.r, tint.g,
+        tint.b);
+    shader->tint[variant_idx] = tint;
 }

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -187,6 +187,10 @@ RGB_F Output_GetGlobalTint(void)
 void Output_SetGlobalTint(const RGB_F tint)
 {
     m_GlobalTint = tint;
+    const OUTPUT_UNIFORMS *const uniforms = Output_GetUniforms();
+    if (uniforms != nullptr) {
+        Output_Uniforms_UploadGlobalTint(uniforms, m_GlobalTint);
+    }
 }
 
 RGB_F Output_GetTint(void)

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #define M_GLOBAL_MEMBERS                                                       \
+    X_DECLARE_MEMBER(float, global_tint, [4])                                  \
     X_DECLARE_MEMBER(float, fog_color, [4])                                    \
     X_DECLARE_MEMBER(float, fog_distance, [2])                                 \
     X_DECLARE_MEMBER(float, viewport_size, [2])                                \
@@ -170,6 +171,12 @@ void Output_Uniforms_UploadGeneral(const OUTPUT_UNIFORMS *const uniforms)
             Output_GetFogColor().b,
             Output_GetFogColor().a,
         },
+        .global_tint = {
+            Output_GetGlobalTint().r,
+            Output_GetGlobalTint().g,
+            Output_GetGlobalTint().b,
+            1.0f,
+        },
     };
 
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
@@ -181,14 +188,22 @@ void Output_Uniforms_UploadDesaturation(
     const OUTPUT_UNIFORMS *const uniforms, const float desaturation)
 {
     ASSERT(uniforms != nullptr);
-
     float clamped = desaturation;
     CLAMP(clamped, 0.0f, 1.0f);
-
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
     TRX_GL_TRACK_SUBDATA(
         glBufferSubData, GL_UNIFORM_BUFFER,
         offsetof(M_UNIFORM_GENERAL, desaturation), sizeof(clamped), &clamped);
+}
+
+void Output_Uniforms_UploadGlobalTint(
+    const OUTPUT_UNIFORMS *const uniforms, const RGB_F tint)
+{
+    ASSERT(uniforms != nullptr);
+    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
+    TRX_GL_TRACK_SUBDATA(
+        glBufferSubData, GL_UNIFORM_BUFFER,
+        offsetof(M_UNIFORM_GENERAL, global_tint), sizeof(tint), &tint);
 }
 
 void Output_Uniforms_UploadGameBrightnessMultiplier(

--- a/src/trx/game/output/uniforms.h
+++ b/src/trx/game/output/uniforms.h
@@ -39,3 +39,5 @@ void Output_Uniforms_UploadOwnLight(
 
 void Output_Uniforms_UploadDesaturation(
     const OUTPUT_UNIFORMS *uniforms, float desaturation);
+void Output_Uniforms_UploadGlobalTint(
+    const OUTPUT_UNIFORMS *uniforms, RGB_F tint);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the monochrome background styles not desaturating water bodies and gun flashes correctly.