### PR TITLE
inv-ring: fix globe select background

### DIFF
--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -309,7 +309,9 @@ void InvRing_Draw(INV_RING *const ring)
 
         switch (ring->background_style) {
         case BK_NONE:
-            Output_Overlay_DrawGame();
+            if (ring->mode != INV_GLOBE_SELECT_MODE) {
+                Output_Overlay_DrawGame();
+            }
             break;
 
         case BK_TRANSPARENT_MEDIUM:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes the globe select background drawing the last game frame instead of the relevant image. A bug in develop only.

#### Testing

- [x] Test globe select
  Expected outcome: we show pictures, not the game
- [x] Test stats background with background style: none
  Expected outcome: we show the stats dialog showing the last captured game frame