### PR TITLE
camera/environment: improve mic at Lara accuracy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
 - fixed main.sfx resolution being enforced (regression from 1.3)
+- fixed the microphone entering underwater mode too eagerly when `Microphone near Lara` is enabled (#5057)
 
 **TR3**:
 - added Train control

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
 - fixed main.sfx resolution being enforced (regression from 1.3)
-- fixed the microphone entering underwater mode too eagerly when `Microphone near Lara` is enabled (#5057)
+- fixed the microphone entering underwater mode too eagerly when `Microphone near Lara` is enabled (#5057, #4888)
 
 **TR3**:
 - added Train control

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -142,6 +142,9 @@ void Camera_UpdateMicPosition(void)
             lara_info->torso_rot.y + lara_info->head_rot.y + lara_item->rot.y;
         g_Camera.mic_pos.room_num = lara_item->room_num;
         XYZ_32 pos = { 0, 16, 0 };
+        if (lara_info->water_status == LWS_SURFACE) {
+            pos.y = -36;
+        }
         if (lara_info->water_surface_dist != -NO_HEIGHT
             && Lara_GetMeshPos(LM_HEAD, &pos)) {
             g_Camera.mic_pos.pos = pos;

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -140,8 +140,15 @@ void Camera_UpdateMicPosition(void)
         const ITEM *const lara_item = Lara_GetItem();
         g_Camera.actual_angle =
             lara_info->torso_rot.y + lara_info->head_rot.y + lara_item->rot.y;
-        g_Camera.mic_pos.pos = lara_item->pos;
         g_Camera.mic_pos.room_num = lara_item->room_num;
+        XYZ_32 pos = { 0, 16, 0 };
+        if (lara_info->water_surface_dist != -NO_HEIGHT
+            && Lara_GetMeshPos(LM_HEAD, &pos)) {
+            g_Camera.mic_pos.pos = pos;
+            Room_GetSector(pos, &g_Camera.mic_pos.room_num);
+        } else {
+            g_Camera.mic_pos.pos = lara_item->pos;
+        }
     } else {
         g_Camera.actual_angle = Math_Atan(
             g_Camera.target.z - g_Camera.pos.z,


### PR DESCRIPTION
Resolves #5057.
Resolves #4888.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the mic at Lara placement to an offset from her head rather than the floor. It prevents underwater sounds playing too eagerly in shallow water. The water surface guard is in place to avoid sounds not playing when performing glitches such as the flicker.