### PR TITLE
build: update ffmpeg

### DIFF
--- a/.github/actions/prepare_macos_tooling/action.yml
+++ b/.github/actions/prepare_macos_tooling/action.yml
@@ -88,8 +88,9 @@ runs:
         # Install to separate staging paths for all architectures in
         # preparation for fusing universal libraries in a follow-up step.
         cd "$RUNNER_TEMP"
-        git clone --depth 1 --branch "n7.1" https://github.com/FFmpeg/FFmpeg ffmpeg-arm64
+        git clone https://github.com/FFmpeg/FFmpeg ffmpeg-arm64
         cd ffmpeg-arm64
+        git checkout 066432ebcf
 
         # Common FFmpeg configure options
         FFMPEG_CONFIG_OPTIONS=" \
@@ -109,8 +110,9 @@ runs:
         sudo make install
 
         cd "$RUNNER_TEMP"
-        git clone --depth 1 --branch "n7.1" https://github.com/FFmpeg/FFmpeg ffmpeg-x86-64
+        git clone https://github.com/FFmpeg/FFmpeg ffmpeg-x86-64
         cd ffmpeg-x86-64
+        git checkout 066432ebcf
         # Configure for x86-64.
         ./configure \
           --arch=x86_64 \
@@ -134,7 +136,6 @@ runs:
           "libavfilter"
           "libavformat"
           "libavutil"
-          "libpostproc"
           "libswresample"
           "libswscale"
         )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed reverb affecting inventory ring sounds (#5056)
 - fixed Pause text color
 - fixed Lara stopping against one-click raised slopes when running instead of beginning to slide (#5038)
+- fixed too low volume in all FMVs (except logo which used a different codec)
 
 
 

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 CWD := `pwd`
 HOST_USER_UID := `id -u`
 HOST_USER_GID := `id -g`
-DOCKER_IMAGE_VERSION := "20260228.rev1"
+DOCKER_IMAGE_VERSION := "20260308.rev1"
 
 default: (trx-build-win "debug")
 

--- a/src/trx/av/video.c
+++ b/src/trx/av/video.c
@@ -1765,7 +1765,9 @@ static int M_ReadThread(void *arg)
     is->ic = ic;
 
     avformat_find_stream_info(ic, nullptr);
+#if LIBAVFORMAT_VERSION_MAJOR < 59
     av_format_inject_global_side_data(ic);
+#endif
 
     if (ic->pb) {
         ic->pb->eof_reached = 0;

--- a/tools/shared/docker/game-linux/Dockerfile
+++ b/tools/shared/docker/game-linux/Dockerfile
@@ -52,9 +52,8 @@ RUN apt-get install -y \
     gcc \
     zlib1g-dev
 RUN git clone \
-    --depth 1 \
-    --branch "n7.1" \
     https://github.com/FFmpeg/FFmpeg
+RUN cd FFmpeg && git checkout 066432ebcf
 COPY ./tools/ffmpeg_flags.txt /tmp/ffmpeg_flags.txt
 RUN cd FFmpeg \
     && ./configure \

--- a/tools/shared/docker/game-win/Dockerfile
+++ b/tools/shared/docker/game-win/Dockerfile
@@ -15,6 +15,7 @@ ENV TZ=Europe/Warsaw
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
+        gcc \
         gcc-mingw-w64-i686 \
         g++-mingw-w64-i686 \
         git \
@@ -55,9 +56,8 @@ FROM mingw AS libav
 RUN apt-get install -y \
     nasm
 RUN git clone \
-    --depth 1 \
-    --branch "n7.1" \
     https://github.com/FFmpeg/FFmpeg
+RUN cd FFmpeg && git checkout 066432ebcf
 COPY --from=zlib /ext/ /usr/i686-w64-mingw32/
 COPY ./tools/ffmpeg_flags.txt /tmp/ffmpeg_flags.txt
 RUN cd FFmpeg \
@@ -68,7 +68,7 @@ RUN cd FFmpeg \
         --prefix=/ext/ \
         --cc=i686-w64-mingw32-gcc \
         --cxx=i686-w64-mingw32-g++ \
-        --host-cc=i686-w64-mingw32-gcc \
+        --host-cc=gcc \
         --strip=i686-w64-mingw32-strip \
         --pkg-config=i686-w64-mingw32-pkg-config \
         --enable-static \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates FFmpeg to support the Acorn Escape FMV audio codec, which results in proper volume attenuation for all TR3 FMVs apart from Core Design / Eidos logo video which uses raw PCM and is already correct.

Resolves #5048.