### PR TITLE
savegame: fix counter drift on death

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Monochrome (warm): like TR3 PS1 Pause Screen
 - fixed main.sfx resolution being enforced (regression from 1.3)
 - fixed the microphone entering underwater mode too eagerly when `Microphone near Lara` is enabled (#5057, #4888)
+- fixed save counters sometimes drifting after dying and reloading (#5054, regression from TR1X 4.9 / TRX 1.0)
 
 **TR2**:
 - fixed guns as secret rewards not being converted to the equivalent ammo if Lara already has the gun

--- a/src/trx/game/savegame/file.c
+++ b/src/trx/game/savegame/file.c
@@ -103,6 +103,7 @@ static void M_SaveRaw(
     }
 
     const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, level_num);
+    const JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
     const SAVEGAME_BSON_HEADER header = {
         .magic = M_MAGIC_TRX,
         .initial_version = Savegame_GetInitialVersion(),
@@ -112,7 +113,8 @@ static void M_SaveRaw(
     };
     const SAVEGAME_BSON_EXTENDED_HEADER extra_header = {
         .flags = Game_GetBonusFlag() | (is_quick ? SAVEGAME_EXT_FLAG_QUICK : 0),
-        .counter = Savegame_GetCounter(),
+        .counter =
+            JSON_ObjectGetInt(root_obj, "save_counter", Savegame_GetCounter()),
         .level_num = level->num,
         .title_size = level->title != nullptr ? strlen(level->title) : 0,
     };


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5054.

The issue appears after loading an older save, dying, and returning later to the save list: one slot can inherit a newer save’s number, making slot history look confusing. The bug manifested _only_ after triggering a savegame rescan, which usually happens on the title screen.

#### Testing

[record.txt](https://github.com/user-attachments/files/25822503/record.txt)

- [x] Play the attached recording
  Expected outcome: develop shows duplicate save counters, the PR correctly shows distinct counters.