### PR TITLE
game_flow/inventory: convert reward guns to ammo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@
     - Monochrome (warm): like TR3 PS1 Pause Screen
 - fixed main.sfx resolution being enforced (regression from 1.3)
 
+**TR2**:
+- fixed guns as secret rewards not being converted to the equivalent ammo if Lara already has the gun
+
 **TR3**:
 - added Train control
 - added Patrol Dog control

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -167,8 +167,12 @@ static void M_ModifyInventory_GunOrAmmo(
 
     if (Inv_RequestItem(gun_object_id)) {
         if (type == GF_INV_SECRET) {
-            ammo_info->ammo += ammo_qty * m_SecretInvItems[ammo_object_id];
-            for (int32_t i = 0; i < m_SecretInvItems[ammo_object_id]; i++) {
+            // Convert already collected guns into ammo to maintain stats
+            // accuracy.
+            const int32_t count = m_SecretInvItems[ammo_object_id]
+                + m_SecretInvItems[gun_object_id];
+            ammo_info->ammo += ammo_qty * count;
+            for (int32_t i = 0; i < count; i++) {
                 M_CollectNewPickup(ammo_object_id);
             }
         } else if (type == GF_INV_REGULAR) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This converts secret reward guns to the equivalent ammo if Lara already has the gun. This is in line with TR1/3 secret mode, where if the item were a physical pickup it would be converted by the global replace logic.

- `/play 4`
- use item cheat
- collect all secrets
- Lara should receive 5 clips instead of 4
