### PR TITLE
music/backend_cdaudio_wad: clamp track size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed Pause text color
 - fixed Lara stopping against one-click raised slopes when running instead of beginning to slide (#5038)
 - fixed too low volume in all FMVs (except logo which used a different codec)
+- fixed the secret sound not playing in some installations, whereby `cdaudio.wad` contains invalid track sizes (#5049)
 
 
 

--- a/src/trx/game/music/backend_cdaudio_wad.c
+++ b/src/trx/game/music/backend_cdaudio_wad.c
@@ -5,6 +5,7 @@
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 
 #include <stdio.h>
@@ -65,15 +66,28 @@ static bool M_LoadTrackAsWaveFile(
         return false;
     }
 
-    const size_t total_size =
-        M_CDAUDIO_WAD_WAV_HEADER_SIZE + (size_t)track->size;
-    uint8_t *const buf = Memory_Alloc(total_size);
-
     MYFILE *const fp = File_Open(data->path, FILE_OPEN_READ);
     if (fp == nullptr) {
-        Memory_Free(buf);
         return false;
     }
+
+    const size_t file_size = File_Size(fp);
+    if ((size_t)track->offset >= file_size) {
+        LOG_ERROR(
+            "Invalid track offset for %d: offset %lu, file size %zu", track_id,
+            track->offset, file_size);
+        File_Close(fp);
+        return false;
+    }
+
+    // Some installations have invalid track sizes which would result in reading
+    // beyond EOF if left unchecked. The data can still be valid, so clamp such
+    // tracks to the logical remaining file length.
+    const size_t remaining = file_size - (size_t)track->offset;
+    const size_t track_size =
+        M_CDAUDIO_WAD_WAV_HEADER_SIZE + (size_t)track->size;
+    const size_t total_size = MIN(track_size, remaining);
+    uint8_t *const buf = Memory_Alloc(total_size);
 
     File_Seek(fp, (size_t)track->offset, FILE_SEEK_SET);
     const bool ok = File_ReadData(fp, buf, total_size);

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -722,8 +722,6 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             break;
 
         case TO_SECRET: {
-            // TODO: implement support for TR1-style secrets as an option
-            // in TR2, see #2047
             const int16_t secret_num = (int16_t)(intptr_t)cmd->parameter;
             if (Stats_AddSecret(secret_num)) {
                 const MUSIC_PLAY_MODE mode =


### PR DESCRIPTION
Resolves #5049.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes issues in some installations where `cdaudio.wad` defines entries as being longer than the file size itself.
