### PR TITLE
output: fix fades glitching in certain setups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed the microphone entering underwater mode too eagerly when `Microphone near Lara` is enabled (#5057, #4888)
 - fixed save counters sometimes drifting after dying and reloading (#5054, regression from TR1X 4.9 / TRX 1.0)
 - fixed flare and gun flash being drawn with a water tint when in shallow water regardless of responsive tint option (#5072, regression from 1.2)
+- fixed fade transitions using the wrong picture size when upscaling or borders are enabled (#5081, regression)
 
 **TR2**:
 - fixed guns as secret rewards not being converted to the equivalent ammo if Lara already has the gun

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -693,8 +693,8 @@ static void M_DrawOp_Pattern(const M_DRAW_OP_PATTERN *const op)
 
 static void M_EnsureSnapshotTexture(M_PRIV *const p)
 {
-    const int32_t w = Viewport_GetWidth(VIEWPORT_GAME);
-    const int32_t h = Viewport_GetHeight(VIEWPORT_GAME);
+    const int32_t w = Viewport_GetWidth(VIEWPORT_TARGET);
+    const int32_t h = Viewport_GetHeight(VIEWPORT_TARGET);
     if (w <= 0 || h <= 0) {
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5081. This fixes fade transitions using the wrong viewport size when integer upscaling is enabled.

#### Testing

- [x] Enable upscaling option
  Expected outcome: the transition uses the same framing and size as the presented image, with no cropped or mismatched viewport
- [x] Enable window borders
  Expected outcome: the transition uses the same framing and size as the presented image, with no cropped or mismatched viewport
- [x] Repeat the same transitions with upscaling set to `1x`
  Expected outcome: fades continue to look unchanged compared to the current non-upscaled behavior
