### PR TITLE
shaders: fix high lighting contrast in tr1/tr2

### DIFF
--- a/data/common/ship/shaders/meshes.glsl
+++ b/data/common/ship/shaders/meshes.glsl
@@ -131,7 +131,9 @@ void main(void) {
         gColor.rgb = gammaCurve(gColor.rgb, gamma_exp);
     }
     gColor.rgb *= mul;
-    gColor.rgb = clamp(gColor.rgb + lr.add, 0.0, 1.0);
+    // Preserve the >1.0 lighting range until after texturing so TR1/TR2
+    // high contrast can still brighten textured geometry.
+    gColor.rgb += lr.add;
 #endif
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)
+- fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
 
 **TR3**:
 - added Train control


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes this bug reported on Discord:

<img width="3497" height="990" alt="image" src="https://github.com/user-attachments/assets/54806e54-7302-49a9-8db0-0c1836142575" />