### PR TITLE
Add missing TR3 polish string CFG's

### DIFF
--- a/data/tr3/ship/cfg/tr3-la/strings-pl.json5
+++ b/data/tr3/ship/cfg/tr3-la/strings-pl.json5
@@ -1,0 +1,92 @@
+{
+    // For usage, refer to the documentation here:
+    // https://lostartefacts.dev/trx/docs/stable/game_strings
+    "levels": [
+        {
+            "title": "Dom Lary",
+            "objects": {
+                "key_1": {
+                    "name": "Klucz do toru wyścigowego",
+                }
+            }
+        },
+        {
+            "title": "Wypad na wzgórza",
+            "objects": {
+                "puzzle_1": {
+                    "name": "Łom",
+                },
+                "puzzle_2": {
+                    "name": "Kamień Ostu",
+                }
+            }
+        },
+        {
+            "title": "Kryjówka Willarda",
+            "objects": {
+                "key_1": {
+                    "name": "Klucz do kurhanu",
+                },
+                "puzzle_1": {
+                    "name": "Łom",
+                }
+            }
+        },
+        {
+            "title": "Klif Szekspira",
+            "objects": {
+                "key_1": {
+                    "name": "Karta uruchamiająca wiertło",
+                },
+                "puzzle_1": {
+                    "name": "Dysk dostępu do pompy",
+                }
+            }
+        },
+        {
+            "title": "Na dnie z rybami",
+            "objects": {
+                "puzzle_1": {
+                    "name": "Żarówka układu",
+                },
+                "puzzle_2": {
+                    "name": "Próbka mutanta",
+                },
+                "puzzle_3": {
+                    "name": "Próbka mutanta",
+                },
+                "puzzle_4": {
+                    "name": "Żarówka układu",
+                }
+            }
+        },
+        {
+            "title": "Dom wariatów!",
+            "objects": {
+                "key_1": {
+                    "name": "Klucz do zoo",
+                },
+                "key_4": {
+                    "name": "Klucz do woliery",
+                },
+                "puzzle_1": {
+                    "name": "Dłoń Rathmore'a",
+                }
+            }
+        },
+        {
+            "title": "Spotkanie po latach",
+            "objects": {
+                "puzzle_1": {
+                    "name": "Dłoń Rathmore'a",
+                }
+            }
+        }
+    ],
+    "objects": {
+        "quest_1": {
+            "name": "Dłoń Rathmore'a",
+            "description": "",
+        }
+    }
+}

--- a/data/tr3/ship/cfg/tr3-level/strings-pl.json5
+++ b/data/tr3/ship/cfg/tr3-level/strings-pl.json5
@@ -1,0 +1,9 @@
+{
+    // For usage, refer to the documentation here:
+    // https://lostartefacts.dev/trx/docs/stable/game_strings
+    "levels": [
+        {
+            "title": "Poziom testowy",
+        }
+    ]
+}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description
Adds missing polish translation files for Tomb Raider 3's LA expansion and test folder.
