### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,6 +34,12 @@ body:
     validations:
       required: true
 
+  - type: markdown
+    attributes:
+      value: |
+        If your report is about TR3, please note that current support is limited to Lara's Home, India, and South Pacific.
+        Reports for other TR3 areas are still out of scope while that work is in progress, so those issues are not being accepted yet.
+
   - type: input
     id: trx_version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report a reproducible problem in TRX
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please open one issue per bug.
+        Before submitting, read the bug reporting guide:
+        https://github.com/LostArtefacts/TRX/blob/develop/BUG_REPORTING.md
+
+  - type: dropdown
+    id: game_type
+    attributes:
+      label: Game type
+      description: What does this affect?
+      options:
+        - Original game
+        - Custom level
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Game
+      options:
+        - All games
+        - TR1
+        - TR2
+        - TR3
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: trx_version
+    attributes:
+      label: TRX version
+      description: Use the exact version. It can be found in the main menu, or .exe properties.
+      placeholder: 1.2.3
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11
+    validations:
+      required: true
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU
+      placeholder: NVIDIA GeForce RTX 4070
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Describe the bug in plain terms, and write the shortest steps that reproduce it.
+      placeholder: |
+        Lara falls through the bridge after loading a save near the switch room.
+        1. Load the attached save.
+        2. Walk onto the bridge.
+        3. Pull the switch.
+        4. Observe Lara falling through the floor.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_result
+    attributes:
+      label: What did you expect instead?
+      placeholder: Lara should stay on the bridge and the switch should work normally.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Attachments
+      description: Attach `TRX.log`, saves, screenshots, videos, and custom level files here if they help reproduce the issue.
+      placeholder: Drag and drop `TRX.log`, save files, screenshots, videos, or custom level files here.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before submitting
+      options:
+        - label: I included enough detail to reproduce this.
+          required: true
+        - label: I attached `TRX.log` and any saves, media, or custom level files needed to reproduce this.
+          required: true
+        - label: This issue covers one bug.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug reporting guidelines
+    url: https://github.com/LostArtefacts/TRX/blob/develop/BUG_REPORTING.md
+    about: Read this before opening a bug report, especially for logs, savegames, and custom levels.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an improvement, enhancement, or new idea
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests can be lightweight.
+        A clear problem statement is more useful than a fully detailed spec.
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like to see?
+      description: Describe the idea in plain terms.
+      placeholder: I'd like photo mode to remember the last-used HUD visibility setting.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Explain the pain point, limitation, or workflow this would improve.
+      placeholder: Re-enabling the same setting every time is repetitive when taking several screenshots in a row.
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Extra context
+      description: Add mockups, examples, references, screenshots, videos, related issues, etc.
+      placeholder: Add any extra context here that helps.
+    validations:
+      required: false

--- a/docs/12-SUPPORT.md
+++ b/docs/12-SUPPORT.md
@@ -2,34 +2,8 @@
 title: Getting support
 ---
 
-# Bug Reporting Guidelines
+# Getting support
 
-To investigate an issue, we need to reproduce it exactly as you see it.
-Reports without enough information can't be looked at – guessing helps no one!
+For bugs, crashes, and feature requests, please use [GitHub issues](https://github.com/LostArtefacts/TRX/issues).
 
-## Minimum Information Required
-
-Please include:
-
-1. **Game setup**
-    - Whether it's an **original game** or a **custom level**.  
-    - If it's custom, please attach the **level files**, **assets**, and **configuration / gameflow**.
-
-2. **System information**
-    - Operating system
-    - GPU model
-    - Exact TRX version (found in the `.exe` properties, logs, or title screen)
-
-3. **Logs**
-    - The full TRX.log from your game folder
-
-4. **Description**
-   - Steps to reproduce (e.g. *"Load Level 3, go to the upper balcony, pull the lever."*)  
-   - Savegames are fine to include if they help reproduce the issue.
-
-## Notes
-
-- Screenshots and videos are welcome, but can't replace the required information.  
-- Some issues are *hardware-specific*, so system info is essential.  
-- Custom levels *without level files* aren't actionable.  
-- Please **don't DM developers on Discord** about bugs – use GitHub issues so we can track them properly.
+Before opening a bug report, read the [bug reporting guide](https://github.com/LostArtefacts/TRX/blob/develop/BUG_REPORTING.md).


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This builds on top of https://github.com/LostArtefacts/TRX/pull/5090 and replaces the freeform issue forms with structured ones, ensuring users include the key details we keep having to request manually.

Example how this works can be found in my fork:

https://github.com/rr-/TRX/issues
https://github.com/rr-/TRX/issues/11

It also updates the website to just redirect to GH instead of repeating the guidelines in yet another place.