### PR TITLE
objects/upv: fix clipping

### DIFF
--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -258,68 +258,73 @@ static bool M_Draw(const ITEM *const item)
     });
     Matrix_Rot16(item->interp.result.rot);
 
+    bool result = false;
     const CLIP clip = Output_CheckBoundsClip(&frames[0]->bounds);
-    if (clip != CLIP_NOT_VISIBLE) {
-        M_PRIV *const p = item->priv;
-        Output_CalculateObjectLighting(item, &frames[0]->bounds);
-        const ANIM_BONE *const bone = Anim_GetBone(obj->bone_idx);
-
-        if (frac != 0) {
-            Matrix_InitInterpolate(frac, rate);
-            Matrix_TranslateRel16_ID(frames[0]->offset, frames[1]->offset);
-            Matrix_Rot16_ID(frames[0]->mesh_rots[0], frames[1]->mesh_rots[0]);
-            Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx), clip);
-
-            Matrix_Push_I();
-            Matrix_TranslateRel32_I(bone[0].pos);
-            Matrix_Rot16_ID(frames[0]->mesh_rots[1], frames[1]->mesh_rots[1]);
-            Matrix_RotX_I((item->rot.z + (p->rot_x >> 13)));
-            Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 1), clip);
-            Matrix_Pop_I();
-
-            Matrix_Push_I();
-            Matrix_TranslateRel32_I(bone[1].pos);
-            Matrix_Rot16_ID(frames[0]->mesh_rots[2], frames[1]->mesh_rots[2]);
-            Matrix_RotX_I(((p->rot_x >> 13) - item->rot.z));
-            Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 2), clip);
-            Matrix_Pop_I();
-
-            Matrix_Push_I();
-            Matrix_TranslateRel32_I(bone[2].pos);
-            Matrix_Rot16_ID(frames[0]->mesh_rots[3], frames[1]->mesh_rots[3]);
-            Matrix_RotZ_I(p->fan_rot);
-            Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 3), clip);
-            Matrix_Pop_I();
-        } else {
-            Matrix_TranslateRel16(frames[0]->offset);
-            Matrix_Rot16(frames[0]->mesh_rots[0]);
-            Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx), clip);
-
-            Matrix_Push();
-            Matrix_TranslateRel32(bone[0].pos);
-            Matrix_Rot16(frames[0]->mesh_rots[1]);
-            Matrix_RotX((item->rot.z + (p->rot_x >> 13)));
-            Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 1), clip);
-            Matrix_Pop();
-
-            Matrix_Push();
-            Matrix_TranslateRel32(bone[1].pos);
-            Matrix_Rot16(frames[0]->mesh_rots[2]);
-            Matrix_RotX(((p->rot_x >> 13) - item->rot.z));
-            Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 2), clip);
-            Matrix_Pop();
-
-            Matrix_Push();
-            Matrix_TranslateRel32(bone[2].pos);
-            Matrix_Rot16(frames[0]->mesh_rots[3]);
-            Matrix_RotZ(p->fan_rot);
-            Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 3), clip);
-            Matrix_Pop();
-        }
+    if (clip == CLIP_NOT_VISIBLE) {
+        goto finish;
     }
 
+    M_PRIV *const p = item->priv;
+    Output_CalculateObjectLighting(item, &frames[0]->bounds);
+    const ANIM_BONE *const bone = Anim_GetBone(obj->bone_idx);
+
+    if (frac != 0) {
+        Matrix_InitInterpolate(frac, rate);
+        Matrix_TranslateRel16_ID(frames[0]->offset, frames[1]->offset);
+        Matrix_Rot16_ID(frames[0]->mesh_rots[0], frames[1]->mesh_rots[0]);
+        Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx), clip);
+
+        Matrix_Push_I();
+        Matrix_TranslateRel32_I(bone[0].pos);
+        Matrix_Rot16_ID(frames[0]->mesh_rots[1], frames[1]->mesh_rots[1]);
+        Matrix_RotX_I((item->rot.z + (p->rot_x >> 13)));
+        Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 1), clip);
+        Matrix_Pop_I();
+
+        Matrix_Push_I();
+        Matrix_TranslateRel32_I(bone[1].pos);
+        Matrix_Rot16_ID(frames[0]->mesh_rots[2], frames[1]->mesh_rots[2]);
+        Matrix_RotX_I(((p->rot_x >> 13) - item->rot.z));
+        Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 2), clip);
+        Matrix_Pop_I();
+
+        Matrix_Push_I();
+        Matrix_TranslateRel32_I(bone[2].pos);
+        Matrix_Rot16_ID(frames[0]->mesh_rots[3], frames[1]->mesh_rots[3]);
+        Matrix_RotZ_I(p->fan_rot);
+        Output_DrawObjectMesh_I(Object_GetMesh(obj->mesh_idx + 3), clip);
+        Matrix_Pop_I();
+    } else {
+        Matrix_TranslateRel16(frames[0]->offset);
+        Matrix_Rot16(frames[0]->mesh_rots[0]);
+        Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx), clip);
+
+        Matrix_Push();
+        Matrix_TranslateRel32(bone[0].pos);
+        Matrix_Rot16(frames[0]->mesh_rots[1]);
+        Matrix_RotX((item->rot.z + (p->rot_x >> 13)));
+        Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 1), clip);
+        Matrix_Pop();
+
+        Matrix_Push();
+        Matrix_TranslateRel32(bone[1].pos);
+        Matrix_Rot16(frames[0]->mesh_rots[2]);
+        Matrix_RotX(((p->rot_x >> 13) - item->rot.z));
+        Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 2), clip);
+        Matrix_Pop();
+
+        Matrix_Push();
+        Matrix_TranslateRel32(bone[2].pos);
+        Matrix_Rot16(frames[0]->mesh_rots[3]);
+        Matrix_RotZ(p->fan_rot);
+        Output_DrawObjectMesh(Object_GetMesh(obj->mesh_idx + 3), clip);
+        Matrix_Pop();
+    }
+    result = true;
+
+finish:
     Matrix_Pop();
-    return true;
+    return result;
 }
 
 static void M_UserInput(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the bug reported on Discord where UPV would disappear when intersecting with certain portals.