### PR TITLE
av/fmv: route FMV audio through Audio_Stream

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
     - Black: like the Remasters
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
+- added support for `.ogv` and `.fmv` FMV extensions, with `.ogv` preferred over `.fmv` for remaster compatibility
+- improved FMV audio to play through the game's existing audio mixer instead of opening a separate audio device
+- added audio fallback for FMV files that lack an audio stream (e.g. remastered `.ogv`), probing alternative extensions for a companion audio track
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
 

--- a/src/trx/av/video.c
+++ b/src/trx/av/video.c
@@ -271,6 +271,8 @@ typedef struct {
 
     void (*surface_upload_func)(void *surface, void *user_data);
     void *surface_upload_func_user_data;
+
+    bool audio_enabled;
 } M_STATE;
 
 static int64_t m_AudioCallbackTime;
@@ -1795,7 +1797,7 @@ static int M_ReadThread(void *arg)
         AVRational sar = av_guess_sample_aspect_ratio(ic, st, nullptr);
     }
 
-    if (st_index[AVMEDIA_TYPE_AUDIO] >= 0) {
+    if (is->audio_enabled && st_index[AVMEDIA_TYPE_AUDIO] >= 0) {
         M_StreamComponentOpen(is, st_index[AVMEDIA_TYPE_AUDIO]);
     }
 
@@ -1997,6 +1999,12 @@ void Video_PumpEvents(VIDEO *video)
     video->is_playing = !is->abort_request && !is->playback_finished;
 }
 
+void Video_SetAudioEnabled(VIDEO *const video, const bool enabled)
+{
+    M_STATE *const is = video->priv;
+    is->audio_enabled = enabled;
+}
+
 void Video_SetVolume(VIDEO *const video, const double volume)
 {
     M_STATE *const is = video->priv;
@@ -2137,4 +2145,10 @@ void Video_SetRenderEndFunc(
     M_STATE *const is = video->priv;
     is->render_end_func = func;
     is->render_end_func_user_data = user_data;
+}
+
+void Video_SetExternalAudioClock(VIDEO *const video, const double timestamp)
+{
+    M_STATE *const is = video->priv;
+    M_SetClock(&is->extclk, timestamp, is->extclk.serial);
 }

--- a/src/trx/av/video.h
+++ b/src/trx/av/video.h
@@ -13,6 +13,7 @@ typedef void *(*VIDEO_SURFACE_ALLOCATOR_FUNC)(
     int32_t width, int32_t height, void *user_data);
 
 VIDEO *Video_Open(const char *path);
+void Video_SetAudioEnabled(VIDEO *video, bool enabled);
 void Video_SetVolume(VIDEO *video, double volume);
 void Video_SetSurfaceSize(VIDEO *video, int32_t width, int32_t height);
 void Video_SetSurfacePixelFormat(VIDEO *video, enum AVPixelFormat pixel_format);
@@ -40,6 +41,7 @@ void Video_SetRenderBeginFunc(
 void Video_SetRenderEndFunc(
     VIDEO *video, void (*func)(void *surface, void *user_data),
     void *user_data);
+void Video_SetExternalAudioClock(VIDEO *video, double timestamp);
 void Video_Start(VIDEO *video);
 void Video_Stop(VIDEO *video);
 void Video_PumpEvents(VIDEO *video);

--- a/src/trx/game/fmv.c
+++ b/src/trx/game/fmv.c
@@ -3,6 +3,7 @@
 #include <trx/av/audio.h>
 #include <trx/av/video.h>
 #include <trx/config.h>
+#include <trx/core/filesystem.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
@@ -21,6 +22,10 @@
 #include <string.h>
 
 static bool m_IsPlaying = false;
+
+static const char *const m_FallbackExts[] = {
+    ".mp4", ".mpeg", ".webm", ".avi", ".fmv", ".rpl", nullptr,
+};
 
 typedef struct {
     OUTPUT_QUAD_SURFACE_DESC desc;
@@ -44,6 +49,37 @@ static OUTPUT_QUAD_SURFACE_DESC M_MakeSurfaceDesc(
         },
         .pitch = width * 4,
     };
+}
+
+static int32_t M_OpenAudioStream(const char *const file_name)
+{
+    int32_t audio_id = Audio_Stream_CreateFromFile(file_name);
+    if (audio_id != AUDIO_NO_SOUND) {
+        return audio_id;
+    }
+
+    // The video file may lack an audio stream (e.g. remastered .ogv).
+    // Try other FMV extensions to find a file that contains audio.
+    const char *const dot = strrchr(file_name, '.');
+    if (dot == nullptr) {
+        return AUDIO_NO_SOUND;
+    }
+
+    const size_t base_len = (size_t)(dot - file_name);
+    for (const char *const *ext = m_FallbackExts; *ext != nullptr; ext++) {
+        char *const candidate =
+            String_Format("%.*s%s", (int)base_len, file_name, *ext);
+        if (File_Exists(candidate)) {
+            audio_id = Audio_Stream_CreateFromFile(candidate);
+            Memory_Free(candidate);
+            if (audio_id != AUDIO_NO_SOUND) {
+                return audio_id;
+            }
+        } else {
+            Memory_Free(candidate);
+        }
+    }
+    return AUDIO_NO_SOUND;
 }
 
 static void *M_AllocateSurface(
@@ -129,16 +165,24 @@ static bool M_Play(const char *const file_name)
     Video_SetSurfaceLockFunc(video, M_LockSurface, nullptr);
     Video_SetSurfaceUnlockFunc(video, M_UnlockSurface, nullptr);
     Video_SetSurfaceUploadFunc(video, M_UploadSurface, renderer_2d);
+    Video_SetAudioEnabled(video, false);
+
+    const int32_t audio_id = M_OpenAudioStream(file_name);
 
     g_OldInputDB = g_Input;
     Video_Start(video);
     while (video->is_playing) {
         Shell_ProcessEvents();
-        Video_SetVolume(
-            video,
-            Audio_IsMuted()
-                ? 0.0f
-                : g_Config.audio.master_volume * g_Config.audio.fmv_volume);
+
+        const float volume = Audio_IsMuted()
+            ? 0.0f
+            : g_Config.audio.master_volume * g_Config.audio.fmv_volume;
+        Audio_Stream_SetVolume(audio_id, volume);
+        const double audio_ts = Audio_Stream_GetTimestamp(audio_id);
+        if (audio_ts >= 0.0) {
+            Video_SetExternalAudioClock(video, audio_ts);
+        }
+
         Video_SetSurfaceSize(
             video, Viewport_GetWidth(VIEWPORT_GAME),
             Viewport_GetHeight(VIEWPORT_GAME));
@@ -154,6 +198,8 @@ static bool M_Play(const char *const file_name)
             break;
         }
     }
+
+    Audio_Stream_Close(audio_id);
     Video_Close(video);
 
     Output_Quad_Destroy(renderer_2d);

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -67,7 +67,7 @@ typedef bool (*M_RESOLVE_ATTEMPT_CALLBACK)(
     const char *attempt_path, void *user_data);
 
 static const char *m_FMVExtensions[] = {
-    ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".rpl", nullptr,
+    ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".ogv", ".rpl", ".fmv", nullptr,
 };
 
 static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = {


### PR DESCRIPTION
## Summary

- Stop opening a second SDL audio device inside the ffplay-derived video
  player. Instead, decode FMV audio through the game's existing mixer via
  `Audio_Stream_CreateFromFile` and feed the resulting timestamp back via
  `Video_SetExternalAudioClock` for A/V sync.
- Add `.ogv` and `.fmv` to the FMV extension search list. `.ogv` is
  preferred over `.fmv` so that remastered HD video files are used when
  available (remastered `.ogv` files contain HD video but no audio).
- When the selected video file lacks an audio stream (e.g. a remastered
  `.ogv`), probe alternative extensions (`.mp4`, `.mpeg`, `.webm`,
  `.avi`, `.fmv`, `.rpl`) to locate a companion file that carries the
  original audio track.

## Why

The Tomb Raider remasters ship `.ogv` files with HD video but strip the
audio track. The original `.fmv`/`.rpl` files still contain audio. By
preferring `.ogv` for video and falling back to `.fmv` (or other
formats) for audio, players with remaster assets get HD cutscenes with
working sound.

Routing all FMV audio through the game's existing mixer also avoids
issues on platforms that only support a single audio device (e.g. WebGL
via Emscripten), and ensures FMV volume respects the in-game master and
FMV volume settings.

## Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

## Test plan

- Play an FMV with only `.fmv` files present — audio and video should
  work from the same file
- Play an FMV with both `.ogv` (remaster, no audio) and `.fmv` (original,
  with audio) present — video should come from `.ogv`, audio should fall
  back to `.fmv`
- Verify FMV volume slider and mute toggle still work during playback
- Verify A/V sync is maintained throughout a full cutscene
