### PR TITLE
savegame: restore boulder floor on load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added audio fallback for FMV files that lack an audio stream (e.g. remastered `.ogv`), probing alternative extensions for a companion audio track
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
+- fixed boulders that have moved vertically reactivating for a frame after loading a save (regression from 1.2)
 
 **TR2**:
 - fixed flamethrowers and Dragon's breath doing weird animation when hitting floor (#5104, regression from 1.3)

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -54,6 +54,7 @@ void Object_SetupAllObjects(void)
         obj->save_hitpoints = false;
         obj->save_flags = false;
         obj->save_anim = false;
+        obj->load_floor = false;
         obj->intelligent = false;
         obj->smartness = -1;
 

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -245,6 +245,7 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    obj->load_floor = true;
 }
 
 REGISTER_OBJECT(O_ROLLING_BALL_1, M_Setup)

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -115,6 +115,7 @@ typedef struct OBJECT {
     bool save_hitpoints;
     bool save_flags;
     bool save_anim;
+    bool load_floor;
     bool semi_transparent;
 } OBJECT;
 

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -189,7 +189,7 @@ static void M_LoadPostprocess(void)
         ITEM *const item = Item_Get(i);
         const OBJECT *const obj = Object_Get(item->object_id);
 
-        if (obj->save_position && obj->shadow_size) {
+        if (obj->save_position && (obj->shadow_size != 0 || obj->load_floor)) {
             int16_t room_num = item->room_num;
             const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
             item->floor = Room_GetHeight(sector, item->pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures boulder floor values are restored on load to prevent them from re-activating for a frame due to a mismatch with their current position.

An alternative to this would be having `M_PRIV` for boulders that replicates `item->floor` and have that saved/loaded. Or, we could drop the shadow check in the load function, but it'd need heavier testing as there are dozens of objects that save position but don't have a shadow size.
