### PR TITLE
ui: fix photo mode frame with integer upscaling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added audio fallback for FMV files that lack an audio stream (e.g. remastered `.ogv`), probing alternative extensions for a companion audio track
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
+- fixed the photo mode red frame not covering the full screen when using integer upscaling
 - fixed boulders that have moved vertically reactivating for a frame after loading a save (regression from 1.2)
 
 **TR2**:

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -402,7 +402,7 @@ void Output_DrawScreenFrame(
 
 void Output_DrawPhotoModeFrame(const int32_t thickness)
 {
-    const VIEWPORT_RECT rect = Viewport_GetRect(VIEWPORT_GAME);
+    const VIEWPORT_RECT rect = Viewport_GetRect(VIEWPORT_UI);
     const RGBA_8888 color = { 255, 0, 0, 96 };
     OutputSource_UI_StagePhotoModeFrame(rect, color, thickness);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes photo mode red frame only taking a portion of the screen when using integer upscaling:

![20260314_180710_Thames_Wharf](https://github.com/user-attachments/assets/7bfe0e11-2447-4a2c-9774-d661dd84ac00)
