### PR TITLE
level: fix loading tr3 uvs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - fixed too low volume in all FMVs (except logo which used a different codec)
 - fixed Lara by default being unable to climb out of water onto steep slopes (change manually in Gameplay → Fixes → Fix water exit)
 - fixed thrown flares falling through trapdoors (regression from 1.1)
+- fixed some level textures appearing slightly misaligned on room geometry
 
 
 

--- a/src/trx/game/inject/data/textures.c
+++ b/src/trx/game/inject/data/textures.c
@@ -7,6 +7,7 @@
 #include <trx/game/level/sections/append.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/output/const.h>
+#include <trx/version.h>
 
 static uint16_t M_RemapRGB8(const RGB_888 rgb)
 {
@@ -160,7 +161,7 @@ static void M_HandleTextureInfo(
         case IDT_OBJECT_TEXTURES:
             Level_Section_AppendObjectTextures(
                 level_info->textures.object_count, page_base, data_count,
-                chunk.injection->fp);
+                chunk.injection->fp, g_TRVersion >= 3);
             level_info->textures.object_count += data_count;
             break;
         case IDT_SPRITE_TEXTURES:

--- a/src/trx/game/level/sections/append.h
+++ b/src/trx/game/level/sections/append.h
@@ -19,6 +19,7 @@ void Level_Section_AppendAnimBones(
 void Level_Section_AppendAnimFrames(
     int32_t base_idx, int32_t num_frames, VFILE *file);
 void Level_Section_AppendObjectTextures(
-    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
+    int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file,
+    bool use_tr3_adjustment);
 void Level_Section_AppendSpriteTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);

--- a/src/trx/game/level/sections/textures.c
+++ b/src/trx/game/level/sections/textures.c
@@ -9,6 +9,30 @@
 #include <trx/game/level/sections/read.h>
 #include <trx/game/output.h>
 
+static void M_DecodeTR3ObjectTextureUVs(OBJECT_TEXTURE *const texture)
+{
+    int16_t *const uv = (int16_t *)&texture->uv[0].u;
+    uint8_t flags = 0;
+
+    for (int32_t i = 0; i < 8; i++) {
+        if ((uv[i] & 0x80) != 0) {
+            uv[i] |= 0x00FF;
+            flags |= 1 << i;
+        } else {
+            uv[i] &= 0xFF00;
+        }
+    }
+
+    for (int32_t i = 0; i < 8; i++) {
+        if ((flags & 1) != 0) {
+            uv[i] -= 256;
+        } else {
+            uv[i] += 256;
+        }
+        flags >>= 1;
+    }
+}
+
 void Level_Section_ReadPalettes(LEVEL_CONTEXT *const ctx, VFILE *const file)
 {
     BENCHMARK benchmark = Benchmark_Start();
@@ -104,13 +128,15 @@ void Level_Section_ReadObjectTextures(
     LOG_INFO("object textures: %d", num_textures);
     Output_InitialiseObjectTextures(
         num_textures + Inject_GetDataCount(IDT_OBJECT_TEXTURES));
-    Level_Section_AppendObjectTextures(0, 0, num_textures, file);
+    Level_Section_AppendObjectTextures(
+        0, 0, num_textures, file, ctx->loader->game_version >= 3);
     Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_Section_AppendObjectTextures(
     const int32_t base_idx, const int16_t base_page_idx,
-    const int32_t num_textures, VFILE *const file)
+    const int32_t num_textures, VFILE *const file,
+    const bool use_tr3_adjustment)
 {
     for (int32_t i = 0; i < num_textures; i++) {
         OBJECT_TEXTURE *const texture = Output_GetObjectTexture(base_idx + i);
@@ -120,6 +146,9 @@ void Level_Section_AppendObjectTextures(
         for (int32_t j = 0; j < 4; j++) {
             texture->uv[j].u = VFile_ReadU16(file);
             texture->uv[j].v = VFile_ReadU16(file);
+        }
+        if (use_tr3_adjustment) {
+            M_DecodeTR3ObjectTextureUVs(texture);
         }
     }
 }

--- a/src/trx/game/output/textures.c
+++ b/src/trx/game/output/textures.c
@@ -70,6 +70,11 @@ static OBJECT_TEXTURE *m_ObjectTextures = nullptr;
 static SPRITE_TEXTURE *m_SpriteTextures = nullptr;
 static ANIMATED_TEXTURE_RANGE *m_AnimTextureRanges = nullptr;
 
+static float M_NormalizeObjectUV(const uint16_t uv)
+{
+    return uv / 65535.0f;
+}
+
 static void M_PrepareObjectAnimationRanges(void)
 {
     size_t required_size = 0;
@@ -175,10 +180,10 @@ static void M_FillAtlasObjectSize(const int32_t i)
         size->x1 = MAX(size->x1, texture->uv[j].u);
         size->y1 = MAX(size->y1, texture->uv[j].v);
     }
-    size->x0 /= 65535.0;
-    size->y0 /= 65535.0;
-    size->x1 /= 65535.0;
-    size->y1 /= 65535.0;
+    size->x0 = M_NormalizeObjectUV(size->x0);
+    size->y0 = M_NormalizeObjectUV(size->y0);
+    size->x1 = M_NormalizeObjectUV(size->x1);
+    size->y1 = M_NormalizeObjectUV(size->y1);
 }
 
 static void M_FillAtlasSpriteSize(const int32_t i)
@@ -201,8 +206,8 @@ static void M_FillObjectUVW(const int32_t i)
     const OBJECT_TEXTURE *const texture = Output_GetObjectTexture(i);
     OUTPUT_UVW *const corners = m_Priv.uvws.data_objects[i].corners;
     for (int32_t j = 0; j < 4; j++) {
-        corners[j].u = texture->uv[j].u / 65535.0f;
-        corners[j].v = texture->uv[j].v / 65535.0f;
+        corners[j].u = M_NormalizeObjectUV(texture->uv[j].u);
+        corners[j].v = M_NormalizeObjectUV(texture->uv[j].v);
         corners[j].w = texture->tex_page;
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the coding conventions (https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes TR3 level geometry textures appearing slightly misaligned in some rooms.

The root cause is that the original TR3 discards the lowest seven bits of each UV, snapping them to the nearest full pixel (>=0x80 → 0xFF, <0x80 → 0x00 for the low byte of each UV), whereas TRX uses the UVs verbatim. This PR ports the discard behavior behind a version gate.

Before
![20260314_183845_Nevada_Desert bad](https://github.com/user-attachments/assets/d30442d8-e9b0-4f52-9c80-f273ceaae14e)

After
![20260314_183917_Nevada_Desert good](https://github.com/user-attachments/assets/6e8f3a89-6d2f-4976-bdec-a28e5695a11b)

#### Testing

- [x] Compare a few TR3 rooms and objects against the OG, paying attention to texture borders
  Expected outcome: this PR improves adherence to the original look
- [x] Check for TR1 / TR2 regressions
  Expected outcome: no visual changes in TR1 or TR2