### PR TITLE
objects/scion3: fix damaging untriggered Scion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,9 @@
 - fixed the photo mode red frame not covering the full screen when using integer upscaling
 - fixed boulders that have moved vertically reactivating for a frame after loading a save (regression from 1.2)
 
+**TR1**:
+- fixed Scion taking damage before activation (regression from 1.0)
+
 **TR2**:
 - fixed thrown flares falling through trapdoors and becoming stuck in the void if thrown underwater near the floor (#3708)
 - fixed flamethrowers and Dragon's breath doing weird animation when hitting floor (#5104, regression from 1.3)

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -14,6 +14,11 @@ static bool M_ShouldSpawnBlood(const ITEM *const item)
     return !g_Config.visuals.fix_texture_issues;
 }
 
+static bool M_CanTakeDamage(const ITEM *const item)
+{
+    return item->status == IS_ACTIVE;
+}
+
 static void M_Control(const int16_t item_num)
 {
     static int32_t counter = 0;
@@ -65,6 +70,7 @@ static void M_Control(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->control_func = M_Control;
+    obj->can_take_damage_func = M_CanTakeDamage;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
     obj->hit_points = 5;
     obj->save_flags = true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the Scion being destructible before it is triggered, as evidenced by the recording from Aredfan:

[record-scion-destruction.txt](https://github.com/user-attachments/files/26002857/record-scion-destruction.txt)

