### PR TITLE
tr3/data: update All Hallows pickup stats

### DIFF
--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -482,6 +482,7 @@
                 "lara_guns.bin",
                 "stpaul_animating_bounds.bin",
             ],
+            "unobtainable_pickups": 9,
         },
     ],
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This marks-up unobtainable pickups in All Hallows (everything in room 21, beyond the end-level trigger).
