### PR TITLE
Optimize mesh builder allocations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added support for `.ogv` and `.fmv` FMV extensions, with `.ogv` preferred over `.fmv` for remaster compatibility
 - added audio fallback for FMV files that lack an audio stream (e.g. remastered `.ogv`), probing alternative extensions for a companion audio track
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)
+- improved level loading times by 5%
 - improved FMV audio to play through the game's existing audio mixer instead of opening a separate audio device
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
 - fixed the photo mode red frame not covering the full screen when using integer upscaling

--- a/src/trx/core/vector.c
+++ b/src/trx/core/vector.c
@@ -102,10 +102,19 @@ void *Vector_GetData(const VECTOR *const vector)
     return P(vector).items;
 }
 
+void *Vector_Expand(VECTOR *const vector, const int32_t count)
+{
+    ASSERT(count >= 0);
+    M_EnsureCapacity(vector, count);
+    char *const items = P(vector).items;
+    void *const result = items + vector->count * vector->item_size;
+    vector->count += count;
+    return result;
+}
+
 void Vector_Add(VECTOR *const vector, const void *const item)
 {
-    M_EnsureCapacity(vector, 1);
-    Vector_Insert(vector, vector->count, item);
+    memcpy(Vector_Expand(vector, 1), item, vector->item_size);
 }
 
 void Vector_Insert(

--- a/src/trx/core/vector.h
+++ b/src/trx/core/vector.h
@@ -24,6 +24,7 @@ bool Vector_Contains(const VECTOR *vector, const void *item);
 
 void *Vector_Get(const VECTOR *vector, int32_t index);
 void *Vector_GetData(const VECTOR *vector);
+void *Vector_Expand(VECTOR *vector, int32_t count);
 void Vector_Add(VECTOR *vector, const void *item);
 void Vector_Insert(VECTOR *vector, int32_t index, const void *item);
 void Vector_Swap(VECTOR *vector, int32_t index1, int32_t index2);

--- a/src/trx/game/output/mesh_batcher/mesh_builder.c
+++ b/src/trx/game/output/mesh_batcher/mesh_builder.c
@@ -7,6 +7,8 @@
 #include <trx/game/output/textures.h>
 #include <trx/game/output/vertex_range.h>
 
+#include <string.h>
+
 struct MESH_BUILDER {
     size_t pending_vertex_count;
     OUTPUT_MESH *mesh;
@@ -18,6 +20,65 @@ static void M_EnsureMesh(MESH_BUILDER *const builder)
     if (builder->mesh == nullptr) {
         builder->mesh = Output_Mesh_Create();
         builder->pending_vertex_count = 0;
+    }
+}
+
+static void M_AddAnimatedVertexRanges(
+    OUTPUT_MESH *const mesh, const OUTPUT_MESH_VERTEX *const vertices,
+    const size_t vertex_count, const size_t vertex_start)
+{
+    size_t range_start = 0;
+    size_t range_count = 0;
+
+    for (size_t i = 0; i < vertex_count; i++) {
+        const bool animated = !(vertices[i].flags & VERT_FLAT_SHADED)
+            && Output_Textures_IsObjectTextureAnimated(vertices[i].uvw_idx / 4);
+        if (!animated) {
+            if (range_count > 0) {
+                Vector_Add(
+                    mesh->animated_vertices,
+                    &(OUTPUT_VERTEX_RANGE) {
+                        .vertex_start = vertex_start + range_start,
+                        .vertex_count = range_count,
+                    });
+                range_count = 0;
+            }
+            continue;
+        }
+
+        if (range_count == 0) {
+            range_start = i;
+        }
+        range_count++;
+    }
+
+    if (range_count > 0) {
+        Vector_Add(
+            mesh->animated_vertices,
+            &(OUTPUT_VERTEX_RANGE) {
+                .vertex_start = vertex_start + range_start,
+                .vertex_count = range_count,
+            });
+    }
+}
+
+static void M_FillFanIndices(
+    VECTOR *const indices, const size_t vertex_count, const bool double_sided)
+{
+    ASSERT(vertex_count >= 3);
+    const size_t tri_count = vertex_count - 2;
+    const size_t index_count = tri_count * 3 * (double_sided ? 2 : 1);
+    int32_t *const out = Vector_Expand(indices, index_count);
+    for (size_t i = 0, j = 0; i < tri_count; i++) {
+        out[j++] = 0;
+        out[j++] = i + 2;
+        out[j++] = i + 1;
+
+        if (double_sided) {
+            out[j++] = i + 1;
+            out[j++] = i + 2;
+            out[j++] = 0;
+        }
     }
 }
 
@@ -46,21 +107,26 @@ void MeshBuilder_Destroy(MESH_BUILDER *const builder)
 void MeshBuilder_AddVertex(
     MESH_BUILDER *const builder, const OUTPUT_MESH_VERTEX *const vertex)
 {
+    MeshBuilder_AddVertices(builder, vertex, 1);
+}
+
+void MeshBuilder_AddVertices(
+    MESH_BUILDER *const builder, const OUTPUT_MESH_VERTEX *const vertices,
+    const size_t vertex_count)
+{
     ASSERT(builder != nullptr);
+    ASSERT(vertex_count > 0);
     M_EnsureMesh(builder);
     ASSERT(builder->mesh != nullptr);
     ASSERT(!builder->mesh->sealed);
-    if (!(vertex->flags & VERT_FLAT_SHADED)
-        && Output_Textures_IsObjectTextureAnimated(vertex->uvw_idx / 4)) {
-        Vector_Add(
-            builder->mesh->animated_vertices,
-            &(OUTPUT_VERTEX_RANGE) {
-                .vertex_start = builder->mesh->vertices->count,
-                .vertex_count = 1,
-            });
-    }
-    Vector_Add(builder->mesh->vertices, vertex);
-    builder->pending_vertex_count++;
+
+    const size_t vertex_start = builder->mesh->vertices->count;
+    memcpy(
+        Vector_Expand(builder->mesh->vertices, vertex_count), vertices,
+        sizeof(OUTPUT_MESH_VERTEX) * vertex_count);
+    M_AddAnimatedVertexRanges(
+        builder->mesh, vertices, vertex_count, vertex_start);
+    builder->pending_vertex_count += vertex_count;
 }
 
 void MeshBuilder_AddFace(
@@ -100,18 +166,12 @@ void MeshBuilder_AddFace(
         }
         Vector_Add(builder->mesh->transparent_faces, &face);
     }
-    if (pass == SCENE_PASS_BLEND_ADD) {
-        for (size_t i = 0; i < idx_count; i++) {
-            Vector_Add(
-                builder->mesh->blend_add_vertex_indices,
-                &(uint32_t) { start + indices[i] });
-        }
-    } else {
-        for (size_t i = 0; i < idx_count; i++) {
-            Vector_Add(
-                builder->mesh->opaque_vertex_indices,
-                &(uint32_t) { start + indices[i] });
-        }
+    VECTOR *const target = pass == SCENE_PASS_BLEND_ADD
+        ? builder->mesh->blend_add_vertex_indices
+        : builder->mesh->opaque_vertex_indices;
+    uint32_t *const out = Vector_Expand(target, idx_count);
+    for (size_t i = 0; i < idx_count; i++) {
+        out[i] = start + indices[i];
     }
     builder->pending_vertex_count = 0;
 }
@@ -123,20 +183,7 @@ void MeshBuilder_AddFan(
     M_EnsureMesh(builder);
     const size_t vtx_count = builder->pending_vertex_count;
     ASSERT(vtx_count >= 3);
-    const size_t tri_count = vtx_count - 2;
-    for (size_t i = 0; i < tri_count; i++) {
-        // front side
-        Vector_Add(builder->indices, &(int32_t) { 0 });
-        Vector_Add(builder->indices, &(int32_t) { i + 2 });
-        Vector_Add(builder->indices, &(int32_t) { i + 1 });
-
-        if (double_sided) {
-            // back side (inverted winding)
-            Vector_Add(builder->indices, &(int32_t) { i + 1 });
-            Vector_Add(builder->indices, &(int32_t) { i + 2 });
-            Vector_Add(builder->indices, &(int32_t) { 0 });
-        }
-    }
+    M_FillFanIndices(builder->indices, vtx_count, double_sided);
     MeshBuilder_AddFace(
         builder, pass, Vector_GetData(builder->indices),
         builder->indices->count);

--- a/src/trx/game/output/mesh_batcher/mesh_builder.h
+++ b/src/trx/game/output/mesh_batcher/mesh_builder.h
@@ -19,6 +19,10 @@ void MeshBuilder_Destroy(MESH_BUILDER *builder);
 void MeshBuilder_AddVertex(
     MESH_BUILDER *builder, const OUTPUT_MESH_VERTEX *vertex);
 
+void MeshBuilder_AddVertices(
+    MESH_BUILDER *builder, const OUTPUT_MESH_VERTEX *vertices,
+    size_t vertex_count);
+
 // Add a face using the recently added vertices.
 void MeshBuilder_AddFace(
     MESH_BUILDER *builder, SCENE_PASS pass, const int32_t *indices,

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -12,7 +12,6 @@
 
 typedef struct {
     OUTPUT_MESH *mesh_batch;
-    int32_t *light_idx_map;
 } M_MESH;
 
 typedef struct {
@@ -99,20 +98,6 @@ static void M_AddObjectFace(
         builder, M_GetScenePass(face, flags), face->double_sided);
 }
 
-static int32_t *M_PrepareLightIndexMap(
-    const OBJECT_MESH *const obj_mesh, const int32_t vertex_count)
-{
-    int32_t v = 0;
-    int32_t *const light_idx_map = Memory_Alloc(sizeof(int32_t) * vertex_count);
-    for (int32_t i = 0; i < obj_mesh->all_faces.count; i++) {
-        const FACE *const face = &obj_mesh->all_faces.data[i];
-        for (int32_t j = 0; j < face->vertex_count; j++) {
-            light_idx_map[v++] = face->vertices[j];
-        }
-    }
-    return light_idx_map;
-}
-
 static void M_PrepareMeshes(M_PRIV *const p)
 {
     p->mesh_count = Object_GetMeshCount();
@@ -146,8 +131,6 @@ static void M_PrepareMeshes(M_PRIV *const p)
         if (mesh != nullptr) {
             MeshBatcher_AddMesh(p->batcher, mesh);
             new_batch->mesh_batch = mesh;
-            new_batch->light_idx_map =
-                M_PrepareLightIndexMap(obj_mesh, mesh->vertices->count);
         }
     }
     MeshBuilder_Destroy(builder);
@@ -161,7 +144,6 @@ static void M_FreeMeshes(M_PRIV *const p)
             if (p->meshes[i].mesh_batch != nullptr) {
                 Output_Mesh_Destroy(p->meshes[i].mesh_batch);
             }
-            Memory_FreePointer(&p->meshes[i].light_idx_map);
         }
         Memory_FreePointer(&p->meshes);
     }

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -15,6 +15,7 @@ typedef struct {
 } M_MESH;
 
 typedef struct {
+    MEMORY_ARENA_ALLOCATOR alloc;
     MESH_BATCHER *batcher;
     int16_t skybox_shade;
     size_t mesh_count;
@@ -46,7 +47,10 @@ static void M_AddObjectFace(
     const FACE *const face, uint16_t flags)
 {
     RGBA_8888 color = (RGBA_8888) { 255, 255, 255, 255 };
+    OUTPUT_MESH_VERTEX vertices[4];
     int32_t uvw_idx = -1;
+
+    ASSERT(face->vertex_count <= 4);
 
     if (flags & VERT_FLAT_SHADED) {
         if (g_TRVersion == 1) {
@@ -80,7 +84,7 @@ static void M_AddObjectFace(
         if ((flags & VERT_FLAT_SHADED) == 0) {
             uvw_idx = Output_Textures_GetObjectUVWIndex(face->texture_idx, i);
         }
-        const OUTPUT_MESH_VERTEX vertex = {
+        vertices[i] = (OUTPUT_MESH_VERTEX) {
             .pos = { .x = pos->x, .y = pos->y, .z = pos->z },
             .normal = { .x = normal.x, .y = normal.y, .z = normal.z },
             .flags = flags,
@@ -92,8 +96,9 @@ static void M_AddObjectFace(
                 [1] = face->texture_zw[i].w,
             },
         };
-        MeshBuilder_AddVertex(builder, &vertex);
     }
+
+    MeshBuilder_AddVertices(builder, vertices, face->vertex_count);
     MeshBuilder_AddFan(
         builder, M_GetScenePass(face, flags), face->double_sided);
 }
@@ -101,7 +106,7 @@ static void M_AddObjectFace(
 static void M_PrepareMeshes(M_PRIV *const p)
 {
     p->mesh_count = Object_GetMeshCount();
-    p->meshes = Memory_Alloc(sizeof(M_MESH) * p->mesh_count);
+    p->meshes = Memory_ArenaAlloc(&p->alloc, sizeof(M_MESH) * p->mesh_count);
 
     MESH_BUILDER *const builder = MeshBuilder_Create();
     for (int32_t i = 0; i < Object_GetMeshCount(); i++) {
@@ -145,8 +150,9 @@ static void M_FreeMeshes(M_PRIV *const p)
                 Output_Mesh_Destroy(p->meshes[i].mesh_batch);
             }
         }
-        Memory_FreePointer(&p->meshes);
+        p->meshes = nullptr;
     }
+    Memory_ArenaReset(&p->alloc);
 }
 
 static void M_UpdateShadesSkybox(
@@ -227,6 +233,7 @@ void OutputSource_Objects_Shutdown(void)
 {
     M_PRIV *const p = &m_Priv;
     M_FreeMeshes(p);
+    Memory_ArenaFree(&p->alloc);
 }
 
 void OutputSource_Objects_ObserveLevelLoad(void)

--- a/src/trx/game/output/sources/rooms.c
+++ b/src/trx/game/output/sources/rooms.c
@@ -3,6 +3,7 @@
 #include <trx/config.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
+#include <trx/debug.h>
 #include <trx/game/output.h>
 #include <trx/game/output/bind.h>
 #include <trx/game/output/mesh_batcher/mesh_builder.h>
@@ -25,6 +26,10 @@ static SCENE_PASS M_GetScenePass(const FACE *const face)
 static void M_AddRoomFace(
     MESH_BUILDER *const builder, const FACE *const face, const ROOM *const room)
 {
+    OUTPUT_MESH_VERTEX vertices[4];
+
+    ASSERT(face->vertex_count <= 4);
+
     for (int32_t i = 0; i < face->vertex_count; i++) {
         const ROOM_VERTEX *const room_vert =
             &room->mesh.vertices[face->vertices[i]];
@@ -46,7 +51,7 @@ static void M_AddRoomFace(
         flags |= VERT_USE_DYNAMIC_LIGHT;
 
         const XYZ_16 *const pos = &room_vert->pos;
-        const OUTPUT_MESH_VERTEX vertex = {
+        vertices[i] = (OUTPUT_MESH_VERTEX) {
             .pos = { .x = pos->x, .y = pos->y, .z = pos->z },
             .flags = flags,
             .uvw_idx = Output_Textures_GetObjectUVWIndex(face->texture_idx, i),
@@ -58,8 +63,8 @@ static void M_AddRoomFace(
                 [1] = face->texture_zw[i].w,
             },
         };
-        MeshBuilder_AddVertex(builder, &vertex);
     }
+    MeshBuilder_AddVertices(builder, vertices, face->vertex_count);
     MeshBuilder_AddFan(builder, M_GetScenePass(face), face->double_sided);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reduces level loading times by 5% on average by doing smarter allocations in the mesh builders.

Results:

| Metric | develop    | branch     | Δ (branch - develop) | Δ % (branch vs develop) |
|--------|------------|------------|----------------------|-------------------------|
| Count  | 100        | 100        | 0                    | 0%                      |
| Mean   | 92.346 ms  | 86.190 ms  | -6.157 ms            | -6.667%                 |
| Median | 95.525 ms  | 82.610 ms  | -12.915 ms           | -13.52%                 |
| Min    | 64.920 ms  | 63.290 ms  | -1.630 ms            | -2.511%                 |
| Max    | 144.030 ms | 142.310 ms | -1.720 ms            | -1.194%                 |
| Pstdev | 20.999 ms  | 21.762 ms  | 0.763 ms             | 3.634%                  |


Methodology:

```
args "-e" "3"

@+0:    cmd { play 9 }
@+1:    quit
```

Played this recording 50 times capturing `Level_Initialise` times on develop and this branch and compared the results.