### PR TITLE
misc: fix creature enemy checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,7 @@
 - fixed Lara by default being unable to climb out of water onto steep slopes (change manually in Gameplay → Fixes → Fix water exit)
 - fixed thrown flares falling through trapdoors (regression from 1.1)
 - fixed some level textures appearing slightly misaligned on room geometry
+- fixed potential AI behavioural differences in the South Pacific Mercenary (regression from 1.2)
 
 
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -731,13 +731,14 @@ bool Creature_CanSeeEnemy(const ITEM *const item, const AI_INFO *const info)
     // when there's CanTargetEnemy().
 
     const CREATURE *const creature = item->creature_data;
-    const ITEM *const enemy = creature->enemy;
+    const ITEM *const enemy =
+        creature->enemy != nullptr ? creature->enemy : Lara_GetItem();
 
     if (enemy == nullptr || enemy->hit_points <= 0
         || (enemy != Lara_GetItem() && enemy->creature_data == nullptr)
         || info->angle - creature->joint_rotation[2] <= -DEG_90
         || info->angle - creature->joint_rotation[2] >= DEG_90
-        || info->distance >= CREATURE_SHOOT_RANGE || !info->ahead) {
+        || info->distance >= CREATURE_SHOOT_RANGE) {
         return false;
     }
 

--- a/src/trx/game/objects/creatures/mercenary.c
+++ b/src/trx/game/objects/creatures/mercenary.c
@@ -175,7 +175,7 @@ static void M_Control(const int16_t item_num)
             head = 0;
         } else if (creature->mood == MOOD_ESCAPE) {
             item->goal_anim_state = M_STATE_RUN;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance >= M_SHOOT_RANGE
                 && info.zone_num == info.enemy_zone_num) {
                 item->goal_anim_state = M_STATE_WALK;
@@ -211,7 +211,7 @@ static void M_Control(const int16_t item_num)
             || ((item->ai_bits & AI_FOLLOW) != 0
                 && (creature->reached_goal || enemy_dist > M_RUN_RANGE))) {
             item->goal_anim_state = M_STATE_STOP;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance < M_SHOOT_RANGE
                 || info.zone_num != info.enemy_zone_num) {
                 item->goal_anim_state = M_STATE_STOP;
@@ -241,7 +241,8 @@ static void M_Control(const int16_t item_num)
         } else if (creature->mood == MOOD_ESCAPE) {
             break;
         } else if (
-            Creature_CanSeeEnemy(item, &info) || creature->mood == MOOD_BORED) {
+            Creature_CanTargetEnemy(item, &info)
+            || creature->mood == MOOD_BORED) {
             item->goal_anim_state = M_STATE_WALK;
         } else if (
             creature->mood == MOOD_STALK && (item->ai_bits & AI_FOLLOW) == 0
@@ -260,7 +261,7 @@ static void M_Control(const int16_t item_num)
             if ((Random_GetControl() & 0xFF) == 0) {
                 item->goal_anim_state = M_STATE_STOP;
             }
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             item->goal_anim_state = M_STATE_SHOOT_1;
         } else if (creature->mood != MOOD_BORED || !info.ahead) {
             item->goal_anim_state = M_STATE_STOP;
@@ -273,7 +274,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state == M_STATE_SHOOT_3
             && item->goal_anim_state != M_STATE_STOP
             && (creature->mood == MOOD_ESCAPE || info.distance > M_SHOOT_RANGE
-                || !Creature_CanSeeEnemy(item, &info))) {
+                || !Creature_CanTargetEnemy(item, &info))) {
             item->goal_anim_state = M_STATE_STOP;
         }
 
@@ -300,7 +301,7 @@ static void M_Control(const int16_t item_num)
 
         torso_x = info.x_angle;
         torso_y = info.angle;
-        if (Creature_CanSeeEnemy(item, &info)) {
+        if (Creature_CanTargetEnemy(item, &info)) {
             if (item->current_anim_state == M_STATE_AIM_1) {
                 item->goal_anim_state = M_STATE_SHOOT_1;
             } else if (item->current_anim_state == M_STATE_AIM_2) {

--- a/src/trx/game/objects/creatures/security_guard.c
+++ b/src/trx/game/objects/creatures/security_guard.c
@@ -77,7 +77,7 @@ static void M_FireFinalShot(
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
 
-    if (!Creature_CanSeeEnemy(item, &info) || ABS(info.angle) >= DEG_45) {
+    if (!Creature_CanTargetEnemy(item, &info) || ABS(info.angle) >= DEG_45) {
         return;
     }
 
@@ -203,7 +203,7 @@ static void M_Control(const int16_t item_num)
             item->goal_anim_state = M_STATE_DUCK_START;
         } else if (creature->mood == MOOD_ESCAPE) {
             item->goal_anim_state = M_STATE_RUN;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance > M_WALK_DIST) {
                 item->goal_anim_state = M_STATE_WALK;
             } else {
@@ -243,7 +243,7 @@ static void M_Control(const int16_t item_num)
             item->goal_anim_state = M_STATE_WAIT;
         } else if (creature->mood == MOOD_ESCAPE) {
             item->goal_anim_state = M_STATE_RUN;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance > M_WALK_DIST
                 && info.zone_num == info.enemy_zone_num) {
                 item->goal_anim_state = M_STATE_AIM_4;
@@ -274,7 +274,7 @@ static void M_Control(const int16_t item_num)
             item->required_anim_state = M_STATE_DUCK_START;
             item->goal_anim_state = M_STATE_WAIT;
         } else if (creature->mood != MOOD_ESCAPE) {
-            if (Creature_CanSeeEnemy(item, &info)
+            if (Creature_CanTargetEnemy(item, &info)
                 || ((item->ai_bits & AI_FOLLOW) != 0
                     && (creature->reached_goal || enemy_dist > M_WALK_DIST))) {
                 item->goal_anim_state = M_STATE_WAIT;
@@ -393,7 +393,7 @@ static void M_Control(const int16_t item_num)
         }
         creature->maximum_turn = 0;
 
-        if (Creature_CanSeeEnemy(item, &info)) {
+        if (Creature_CanTargetEnemy(item, &info)) {
             item->goal_anim_state = M_STATE_DUCK_AIM;
         } else if (
             item->hit_status || !near_cover
@@ -410,7 +410,7 @@ static void M_Control(const int16_t item_num)
         }
         creature->maximum_turn = M_DUCK_TURN;
 
-        if (Creature_CanSeeEnemy(item, &info)) {
+        if (Creature_CanTargetEnemy(item, &info)) {
             item->goal_anim_state = M_STATE_DUCK_SHOOT;
         } else {
             item->goal_anim_state = M_STATE_DUCKED;
@@ -438,7 +438,8 @@ static void M_Control(const int16_t item_num)
         }
         creature->maximum_turn = M_WALK_TURN;
 
-        if (Creature_CanSeeEnemy(item, &info) || item->hit_status || !near_cover
+        if (Creature_CanTargetEnemy(item, &info) || item->hit_status
+            || !near_cover
             || (info.ahead && (Random_GetControl() & M_DUCK_END_CHANCE) == 0)) {
             item->goal_anim_state = M_STATE_DUCKED;
         }

--- a/src/trx/game/objects/creatures/swat.c
+++ b/src/trx/game/objects/creatures/swat.c
@@ -86,7 +86,7 @@ static void M_FireFinalShot(
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
 
-    if (!Creature_CanSeeEnemy(item, &info) || ABS(info.angle) >= DEG_45) {
+    if (!Creature_CanTargetEnemy(item, &info) || ABS(info.angle) >= DEG_45) {
         return;
     }
 
@@ -205,7 +205,7 @@ static void M_Control(const int16_t item_num)
             item->goal_anim_state = M_STATE_WALK;
         } else if (creature->mood == MOOD_ESCAPE) {
             item->goal_anim_state = M_STATE_RUN;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance >= M_SHOOT_DIST
                 && info.zone_num == info.enemy_zone_num) {
                 item->goal_anim_state = M_STATE_WALK;
@@ -236,7 +236,7 @@ static void M_Control(const int16_t item_num)
             if ((Random_GetControl() & 0xFF) == 0) {
                 item->goal_anim_state = M_STATE_STOP;
             }
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             item->goal_anim_state = M_STATE_SHOOT_1;
         } else if (creature->mood != MOOD_BORED || !info.ahead) {
             item->goal_anim_state = M_STATE_STOP;
@@ -258,7 +258,7 @@ static void M_Control(const int16_t item_num)
             || ((item->ai_bits & AI_FOLLOW) != 0
                 && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
             item->goal_anim_state = M_STATE_STOP;
-        } else if (Creature_CanSeeEnemy(item, &info)) {
+        } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance < M_SHOOT_DIST
                 || info.zone_num != info.enemy_zone_num) {
                 item->goal_anim_state = M_STATE_STOP;
@@ -286,7 +286,7 @@ static void M_Control(const int16_t item_num)
                 && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
             item->goal_anim_state = M_STATE_WALK;
         } else if (creature->mood != MOOD_ESCAPE) {
-            if (Creature_CanSeeEnemy(item, &info)) {
+            if (Creature_CanTargetEnemy(item, &info)) {
                 item->goal_anim_state = M_STATE_WALK;
             } else if (
                 creature->mood == MOOD_BORED
@@ -306,7 +306,7 @@ static void M_Control(const int16_t item_num)
             torso_y = info.angle;
             torso_x = info.x_angle;
 
-            if (!Creature_CanSeeEnemy(item, &info)) {
+            if (!Creature_CanTargetEnemy(item, &info)) {
                 if (item->current_anim_state == M_STATE_AIM_2) {
                     item->goal_anim_state = M_STATE_WALK;
                 } else {
@@ -328,7 +328,7 @@ static void M_Control(const int16_t item_num)
         if (item->current_anim_state == M_STATE_SHOOT_3
             && item->goal_anim_state != M_STATE_STOP
             && (creature->mood == MOOD_ESCAPE || info.distance > M_SHOOT_DIST
-                || !Creature_CanSeeEnemy(item, &info))) {
+                || !Creature_CanTargetEnemy(item, &info))) {
             item->goal_anim_state = M_STATE_STOP;
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reverts d372fc9 which was implemented in error due to a mix-up with `Creature_CanTargetEnemy`. Usage has been corrected in the South Pacific mercenary, Security Guard and SWAT modules.
