### PR TITLE
Support 60 FPS in TR3 things

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
     - water effects
     - wake effects
     - explosion rings
+    - bat emitters
 - changed Ammo Counter to appear in red when the Menu Style is set to PS1
 - changed Punks to have friendliness assignable through Lua, so removing the hard-coded behaviour in the Lud's Gate level sequence
 - changed Trains to no longer hard-code speed based on the level number and instead take it from their default animation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,8 +43,10 @@
 - added SWAT control
 - added Diver control
 - added Pendulum control
-- changed sparks to use 60 FPS interpolation
-- changed explosion rings to use 60 FPS interpolation
+- added 60 FPS interpolation to:
+    - sparks
+    - wake effects
+    - explosion rings
 - changed Ammo Counter to appear in red when the Menu Style is set to PS1
 - changed Punks to have friendliness assignable through Lua, so removing the hard-coded behaviour in the Lud's Gate level sequence
 - changed Trains to no longer hard-code speed based on the level number and instead take it from their default animation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - added SWAT control
 - added Diver control
 - added Pendulum control
+- changed sparks to use 60 FPS interpolation
 - changed explosion rings to use 60 FPS interpolation
 - changed Ammo Counter to appear in red when the Menu Style is set to PS1
 - changed Punks to have friendliness assignable through Lua, so removing the hard-coded behaviour in the Lud's Gate level sequence

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - added Pendulum control
 - added 60 FPS interpolation to:
     - sparks
+    - water effects
     - wake effects
     - explosion rings
 - changed Ammo Counter to appear in red when the Menu Style is set to PS1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - added SWAT control
 - added Diver control
 - added Pendulum control
+- changed explosion rings to use 60 FPS interpolation
 - changed Ammo Counter to appear in red when the Menu Style is set to PS1
 - changed Punks to have friendliness assignable through Lua, so removing the hard-coded behaviour in the Lud's Gate level sequence
 - changed Trains to no longer hard-code speed based on the level number and instead take it from their default animation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - added Pendulum control
 - added 60 FPS interpolation to:
     - sparks
+    - weather effects
     - water effects
     - wake effects
     - explosion rings

--- a/src/trx/game/fx/explosion_ring.c
+++ b/src/trx/game/fx/explosion_ring.c
@@ -3,6 +3,7 @@
 #include <trx/core/math/func.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/output.h>
 #include <trx/game/output/sources/poly_fx.h>
@@ -31,6 +32,26 @@ static void M_RotateZX(
     out->x = xz;
     out->y = (yz * cx - zz * sx) >> W2V_SHIFT;
     out->z = (yz * sx + zz * cx) >> W2V_SHIFT;
+}
+
+static void M_RememberRing(FX_EXPLOSION_RING *const ring)
+{
+    ring->prev_radius = ring->radius;
+    ring->prev_rot = ring->rot;
+    ring->prev_pos = ring->pos;
+}
+
+static void M_InterpolateRing(
+    const FX_EXPLOSION_RING *const ring, FX_EXPLOSION_RING *const out)
+{
+    *out = *ring;
+    const double ratio = Interpolation_GetWorldRate();
+    out->radius = (int16_t)LERP(ring->prev_radius, ring->radius, ratio);
+    out->rot.x = Math_AngleMean(ring->prev_rot.x, ring->rot.x, ratio);
+    out->rot.z = Math_AngleMean(ring->prev_rot.z, ring->rot.z, ratio);
+    out->pos.x = (int32_t)LERP(ring->prev_pos.x, ring->pos.x, ratio);
+    out->pos.y = (int32_t)LERP(ring->prev_pos.y, ring->pos.y, ratio);
+    out->pos.z = (int32_t)LERP(ring->prev_pos.z, ring->pos.z, ratio);
 }
 
 static void M_BuildRingCircle(
@@ -160,6 +181,7 @@ static void M_ControlExplosionRings(void)
             continue;
         }
 
+        M_RememberRing(ring);
         ring->life--;
         if (ring->life == 0) {
             ring->on = 0;
@@ -183,6 +205,7 @@ static void M_ControlSummonRings(void)
             continue;
         }
 
+        M_RememberRing(ring);
         ring->life--;
         ring->radius -= ring->speed;
         if (ring->life == 0 || ring->radius <= 0) {
@@ -207,6 +230,7 @@ static void M_ControlKnockBackRings(void)
             continue;
         }
 
+        M_RememberRing(ring);
         ring->life--;
         if (ring->life == 0) {
             ring->on = 0;
@@ -229,31 +253,34 @@ static void M_ControlKnockBackRings(void)
 static void M_DrawExplosionRings(const int32_t angle_base)
 {
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_ExplosionRings); i++) {
+        FX_EXPLOSION_RING draw_ring = {};
         FX_EXPLOSION_RING *const ring = &m_ExplosionRings[i];
         if (ring->on == 0) {
             continue;
         }
 
-        int32_t rad = ring->radius;
+        M_InterpolateRing(ring, &draw_ring);
+
+        int32_t rad = draw_ring.radius;
         for (int32_t band = 0; band < 2; band++) {
-            M_BuildRingCircle(ring, rad, band, false, angle_base);
+            M_BuildRingCircle(&draw_ring, rad, band, false, angle_base);
             for (int32_t k = 0; k < 8; k++) {
-                FX_EXPLOSION_VERT *const vtx = &ring->verts[band * 8 + k];
+                FX_EXPLOSION_VERT *const vtx = &draw_ring.verts[band * 8 + k];
 
                 int32_t r = 0;
                 int32_t g = 0;
                 int32_t b = 0;
-                if (ring->on == 2) {
+                if (draw_ring.on == 2) {
                     // Tony
                     r = (Random_GetDraw() & 0x1F) + 224;
                     g = (r >> 2) + (Random_GetDraw() & 0x3F);
                     b = Random_GetDraw() & 0x3F;
-                } else if (ring->on == 3) {
+                } else if (draw_ring.on == 3) {
                     // Sophia
                     r = Random_GetDraw() & 0x3F;
                     g = (Random_GetDraw() & 0x1F) + 224;
                     b = (g >> 2) + (Random_GetDraw() & 0x3F);
-                } else if (ring->on == 4) {
+                } else if (draw_ring.on == 4) {
                     // Puna
                     r = Random_GetDraw() & 0x1F;
                     b = (Random_GetDraw() & 0x3F) + 224;
@@ -274,27 +301,30 @@ static void M_DrawExplosionRings(const int32_t angle_base)
             rad >>= 1;
         }
 
-        M_DrawTexturedRing(ring);
+        M_DrawTexturedRing(&draw_ring);
     }
 }
 
 static void M_DrawSummonRings(const int32_t angle_base)
 {
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_SummonRings); i++) {
+        FX_EXPLOSION_RING draw_ring = {};
         FX_EXPLOSION_RING *const ring = &m_SummonRings[i];
         if (ring->on == 0) {
             continue;
         }
 
+        M_InterpolateRing(ring, &draw_ring);
+
         const int32_t fade = ring->life > 32 ? (64 - ring->life) << 1
             : ring->life < 8                 ? ring->life << 3
                                              : 64;
-        int32_t rad = ring->radius;
+        int32_t rad = draw_ring.radius;
         for (int32_t band = 0; band < 2; band++) {
-            M_BuildRingCircle(ring, rad, band, true, angle_base);
+            M_BuildRingCircle(&draw_ring, rad, band, true, angle_base);
             if (band == 0) {
                 for (int32_t k = 0; k < 8; k++) {
-                    FX_EXPLOSION_VERT *const vtx = &ring->verts[k];
+                    FX_EXPLOSION_VERT *const vtx = &draw_ring.verts[k];
                     const int32_t g = (Random_GetDraw() & 0x1F) + 224;
                     const int32_t b = (g >> 2) + (Random_GetDraw() & 0x3F);
                     const int32_t r = Random_GetDraw() & 0x3F;
@@ -308,26 +338,29 @@ static void M_DrawSummonRings(const int32_t angle_base)
             rad >>= 1;
         }
 
-        M_DrawFlatRing(ring);
+        M_DrawFlatRing(&draw_ring);
     }
 }
 
 static void M_DrawKnockBackRings(const int32_t angle_base)
 {
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_KnockBackRings); i++) {
+        FX_EXPLOSION_RING draw_ring = {};
         FX_EXPLOSION_RING *const ring = &m_KnockBackRings[i];
         if (ring->on == 0) {
             continue;
         }
 
+        M_InterpolateRing(ring, &draw_ring);
+
         int32_t fade = ring->life > 24 ? (32 - ring->life) << 2
             : ring->life < 16          ? ring->life << 1
                                        : 32;
-        int32_t rad = ring->radius;
+        int32_t rad = draw_ring.radius;
         for (int32_t band = 0; band < 2; band++) {
-            M_BuildRingCircle(ring, rad, band, false, angle_base);
+            M_BuildRingCircle(&draw_ring, rad, band, false, angle_base);
             for (int32_t k = 0; k < 8; k++) {
-                FX_EXPLOSION_VERT *const vtx = &ring->verts[band * 8 + k];
+                FX_EXPLOSION_VERT *const vtx = &draw_ring.verts[band * 8 + k];
                 const int32_t g = (Random_GetDraw() & 0x1F) + 224;
                 const int32_t b = (g >> 2) + (Random_GetDraw() & 0x3F);
                 const int32_t r = Random_GetDraw() & 0x3F;
@@ -341,7 +374,7 @@ static void M_DrawKnockBackRings(const int32_t angle_base)
             fade >>= 1;
         }
 
-        M_DrawTexturedRing(ring);
+        M_DrawTexturedRing(&draw_ring);
     }
 }
 
@@ -357,6 +390,14 @@ void FX_ExplosionRing_Reset(void)
     m_ExplosionActive = false;
     m_SummonActive = false;
     m_KnockBackActive = false;
+}
+
+void FX_ExplosionRing_Sync(FX_EXPLOSION_RING *const ring)
+{
+    if (ring == nullptr) {
+        return;
+    }
+    M_RememberRing(ring);
 }
 
 FX_EXPLOSION_RING *FX_ExplosionRing_GetRing(const int32_t idx)
@@ -422,6 +463,7 @@ void FX_ExplosionRing_SpawnKnockBack(const XYZ_32 pos)
         ring->rot.x = 0;
         ring->rot.z = 0;
         ring->radius = ((i == 1) + 2) << 8;
+        FX_ExplosionRing_Sync(ring);
     }
     m_KnockBackActive = true;
 }

--- a/src/trx/game/fx/explosion_ring.h
+++ b/src/trx/game/fx/explosion_ring.h
@@ -15,8 +15,11 @@ typedef struct {
     int16_t life;
     int16_t speed;
     int16_t radius;
+    int16_t prev_radius;
     XZ_16 rot;
+    XZ_16 prev_rot;
     XYZ_32 pos;
+    XYZ_32 prev_pos;
     FX_EXPLOSION_VERT verts[16];
 } FX_EXPLOSION_RING;
 
@@ -27,6 +30,7 @@ void FX_ExplosionRing_Draw(void);
 void FX_ExplosionRing_SpawnKnockBack(XYZ_32 pos);
 void FX_ExplosionRing_BounceKnockBack(void);
 bool FX_ExplosionRing_IsKnockBackActive(void);
+void FX_ExplosionRing_Sync(FX_EXPLOSION_RING *ring);
 
 FX_EXPLOSION_RING *FX_ExplosionRing_GetRing(int32_t idx);
 FX_EXPLOSION_RING *FX_ExplosionRing_GetSummonRing(int32_t idx);

--- a/src/trx/game/fx/wake.c
+++ b/src/trx/game/fx/wake.c
@@ -3,6 +3,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/output/sources/poly_fx.h>
 
 #define M_MAX_POINTS 32
@@ -23,9 +24,9 @@ static RGBA_8888 M_GrayFromWakeLife(const int32_t life, const int32_t shift)
 
 static XYZ_32 M_GetWakeOrigin(const ITEM *const item, const XZ_32 offset)
 {
-    XYZ_32 pos = item->pos;
-    pos = XYZ_32_OffsetYaw(pos, item->rot.y, offset.z);
-    pos = XYZ_32_OffsetYaw(pos, item->rot.y + DEG_90, offset.x);
+    XYZ_32 pos = item->interp.result.pos;
+    pos = XYZ_32_OffsetYaw(pos, item->interp.result.rot.y, offset.z);
+    pos = XYZ_32_OffsetYaw(pos, item->interp.result.rot.y + DEG_90, offset.x);
     return pos;
 }
 
@@ -49,6 +50,8 @@ void FX_Wake_Control(void)
         for (int32_t j = 0; j < M_MAX_POINTS; j++) {
             FX_WAKE_POINT *const pt = &m_Points[j][i];
             if (pt->life > 0) {
+                pt->prev_pos[0] = pt->pos[0];
+                pt->prev_pos[1] = pt->pos[1];
                 pt->life--;
                 pt->pos[0].x += pt->vel[0].x;
                 pt->pos[0].z += pt->vel[0].z;
@@ -95,6 +98,9 @@ void FX_Wake_Draw(const ITEM *const item)
 {
     const int64_t max_origin_dist_sq =
         XYZ_32_GetLength2_64((XYZ_32) { WALL_L / 2, 0, 0 });
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
 
     for (int32_t side = 0; side < 2; side++) {
         const XYZ_32 origin = M_GetWakeOrigin(item, m_Offsets[side]);
@@ -108,15 +114,35 @@ void FX_Wake_Draw(const ITEM *const item)
         int32_t current = (m_StartIndex - 1) & (M_MAX_POINTS - 1);
         const FX_WAKE_POINT *const first_pt = &m_Points[current][side];
         if (first_pt->life != 0) {
+            const XYZ_32 first_pos0 = do_interp
+                ? (XYZ_32) {
+                      .x = (int32_t)LERP(
+                          first_pt->prev_pos[0].x, first_pt->pos[0].x, ratio),
+                      .y = (int32_t)LERP(
+                          first_pt->prev_pos[0].y, first_pt->pos[0].y, ratio),
+                      .z = (int32_t)LERP(
+                          first_pt->prev_pos[0].z, first_pt->pos[0].z, ratio),
+                  }
+                : first_pt->pos[0];
+            const XYZ_32 first_pos1 = do_interp
+                ? (XYZ_32) {
+                      .x = (int32_t)LERP(
+                          first_pt->prev_pos[1].x, first_pt->pos[1].x, ratio),
+                      .y = (int32_t)LERP(
+                          first_pt->prev_pos[1].y, first_pt->pos[1].y, ratio),
+                      .z = (int32_t)LERP(
+                          first_pt->prev_pos[1].z, first_pt->pos[1].z, ratio),
+                  }
+                : first_pt->pos[1];
             const XYZ_32 delta0 = {
-                .x = origin.x - first_pt->pos[0].x,
+                .x = origin.x - first_pos0.x,
                 .y = 0,
-                .z = origin.z - first_pt->pos[0].z,
+                .z = origin.z - first_pos0.z,
             };
             const XYZ_32 delta1 = {
-                .x = origin.x - first_pt->pos[1].x,
+                .x = origin.x - first_pos1.x,
                 .y = 0,
-                .z = origin.z - first_pt->pos[1].z,
+                .z = origin.z - first_pos1.z,
             };
             const int64_t dist0_sq = XYZ_32_GetLength2_64(delta0);
             const int64_t dist1_sq = XYZ_32_GetLength2_64(delta1);
@@ -125,8 +151,8 @@ void FX_Wake_Draw(const ITEM *const item)
                 && dist1_sq > max_origin_dist_sq) {
                 // Prevent a long bridge quad when the hull origin drifts away
                 // from the latest wake segment (e.g. moving over dry slopes).
-                prev[0] = first_pt->pos[1];
-                prev[1] = first_pt->pos[0];
+                prev[0] = first_pos1;
+                prev[1] = first_pos0;
             }
         }
 
@@ -148,7 +174,28 @@ void FX_Wake_Draw(const ITEM *const item)
                 M_GrayFromWakeLife(c34, 2),
             };
 
-            XYZ_32 curr[2] = { pt->pos[0], pt->pos[1] };
+            XYZ_32 curr[2] = {
+                do_interp
+                    ? (XYZ_32) {
+                          .x = (int32_t)LERP(
+                              pt->prev_pos[0].x, pt->pos[0].x, ratio),
+                          .y = (int32_t)LERP(
+                              pt->prev_pos[0].y, pt->pos[0].y, ratio),
+                          .z = (int32_t)LERP(
+                              pt->prev_pos[0].z, pt->pos[0].z, ratio),
+                      }
+                    : pt->pos[0],
+                do_interp
+                    ? (XYZ_32) {
+                          .x = (int32_t)LERP(
+                              pt->prev_pos[1].x, pt->pos[1].x, ratio),
+                          .y = (int32_t)LERP(
+                              pt->prev_pos[1].y, pt->pos[1].y, ratio),
+                          .z = (int32_t)LERP(
+                              pt->prev_pos[1].z, pt->pos[1].z, ratio),
+                      }
+                    : pt->pos[1],
+            };
             const XYZ_32 quad_world[4] = {
                 prev[0],
                 prev[1],

--- a/src/trx/game/fx/wake.h
+++ b/src/trx/game/fx/wake.h
@@ -4,6 +4,7 @@
 
 typedef struct {
     XYZ_32 pos[2];
+    XYZ_32 prev_pos[2];
     XZ_32 vel[2];
     uint8_t life;
 } FX_WAKE_POINT;

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -1,6 +1,7 @@
 #include <trx/game/fx/water.h>
 
 #include <trx/core/utils.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects.h>
@@ -42,6 +43,24 @@ static bool M_IsRoomUnderwater(const int16_t room_num)
     return Room_Get(room_num)->flags.underwater;
 }
 
+static void M_RememberRipple(FX_WATER_RIPPLE *const ripple)
+{
+    ripple->prev_size = ripple->size;
+    ripple->prev_life = ripple->life;
+    ripple->prev_init = ripple->init;
+}
+
+static void M_RememberSplash(FX_WATER_SPLASH *const splash)
+{
+    splash->prev_life = splash->life;
+    for (int32_t i = 0; i < 48; i++) {
+        FX_WATER_SPLASH_VERT *const v = &splash->v[i];
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
+    }
+}
+
 FX_WATER_RIPPLE *FX_Water_SetupRipple(
     const int32_t x, const int32_t y, const int32_t z, int32_t size,
     const bool is_still)
@@ -72,6 +91,7 @@ FX_WATER_RIPPLE *FX_Water_SetupRipple(
     ripple->x = (Random_GetControl() & 0x7F) + x - 64;
     ripple->y = y;
     ripple->z = (Random_GetControl() & 0x7F) + z - 64;
+    M_RememberRipple(ripple);
     return ripple;
 }
 
@@ -120,6 +140,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.inner_friction - 2);
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
 
@@ -138,6 +161,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = (uint8_t)setup.inner_gravity;
         v->friction = (uint8_t)setup.inner_friction;
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
 
@@ -152,6 +178,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.middle_friction - 2);
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
 
@@ -170,6 +199,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = (uint8_t)setup.middle_gravity;
         v->friction = (uint8_t)setup.middle_friction;
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
 
@@ -184,6 +216,9 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)(setup.outer_friction - 2);
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
 
@@ -202,8 +237,12 @@ void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *const setup_)
         v->ozv = v->zv >> 3;
         v->gravity = 0;
         v->friction = (uint8_t)setup.outer_friction;
+        v->prev_wx = v->wx;
+        v->prev_wy = v->wy;
+        v->prev_wz = v->wz;
         v++;
     }
+    splash->prev_life = splash->life;
 
     Sound_Effect(
         SFX_LARA_SPLASH, &(XYZ_32) { setup.x, setup.y, setup.z }, SPM_NORMAL);
@@ -318,6 +357,7 @@ void FX_Water_TriggerUnderwaterBlood(const XYZ_32 pos, const int32_t size)
     ripple->x = pos.x + (Random_GetControl() & 0x3F) - 32;
     ripple->y = pos.y;
     ripple->z = pos.z + (Random_GetControl() & 0x3F) - 32;
+    M_RememberRipple(ripple);
 }
 
 void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
@@ -341,6 +381,7 @@ void FX_Water_TriggerUnderwaterBloodD(const XYZ_32 pos, const int32_t size)
     ripple->x = pos.x + (Random_GetDraw() & 0x3F) - 32;
     ripple->y = pos.y;
     ripple->z = pos.z + (Random_GetDraw() & 0x3F) - 32;
+    M_RememberRipple(ripple);
 }
 
 static RGBA_8888 M_Gray(int32_t c)
@@ -352,13 +393,22 @@ static RGBA_8888 M_Gray(int32_t c)
 static void M_DrawSplash(
     const int32_t base_sprite_idx, const FX_WATER_SPLASH *s)
 {
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
+
     XYZ_32 points[48];
     for (int32_t i = 0; i < 48; i++) {
         const FX_WATER_SPLASH_VERT *const v = &s->v[i];
         points[i] = (XYZ_32) {
-            .x = s->x + (v->wx >> 4),
-            .y = s->y + v->wy,
-            .z = s->z + (v->wz >> 4),
+            .x = s->x
+                + ((do_interp ? (int16_t)LERP(v->prev_wx, v->wx, ratio) : v->wx)
+                   >> 4),
+            .y = s->y
+                + (do_interp ? (int16_t)LERP(v->prev_wy, v->wy, ratio) : v->wy),
+            .z = s->z
+                + ((do_interp ? (int16_t)LERP(v->prev_wz, v->wz, ratio) : v->wz)
+                   >> 4),
         };
     }
 
@@ -369,11 +419,15 @@ static void M_DrawSplash(
             sprite_idx = base_sprite_idx + 4 + ((m_Wibble >> 4) & 3);
         }
 
-        int32_t c = (int32_t)s->life << 1;
+        const int32_t life = do_interp
+            ? (int32_t)LERP(s->prev_life, s->life, ratio)
+            : (int32_t)s->life;
+
+        int32_t c = life << 1;
         CLAMPG(c, 255);
         const RGBA_8888 c1 = M_Gray(c);
 
-        c = ((int32_t)s->life - ((int32_t)s->life >> 2)) << 1;
+        c = (life - (life >> 2)) << 1;
         CLAMPG(c, 255);
         const RGBA_8888 c2 = M_Gray(c);
 
@@ -401,7 +455,16 @@ static void M_DrawSplash(
 static void M_DrawRipple(
     const int32_t base_sprite_idx, const FX_WATER_RIPPLE *r)
 {
-    const int32_t n = (int32_t)r->size << 2;
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
+    const int32_t size = do_interp ? (int32_t)LERP(r->prev_size, r->size, ratio)
+                                   : (int32_t)r->size;
+    const int32_t init = do_interp ? (int32_t)LERP(r->prev_init, r->init, ratio)
+                                   : (int32_t)r->init;
+    const int32_t life = do_interp ? (int32_t)LERP(r->prev_life, r->life, ratio)
+                                   : (int32_t)r->life;
+    const int32_t n = size << 2;
     int32_t sprite_idx = base_sprite_idx + 9;
     RGBA_8888 color;
 
@@ -411,18 +474,18 @@ static void M_DrawRipple(
         if ((r->flags & 0x20U) != 0U) {
             sprite_idx = base_sprite_idx;
             if (censored) {
-                color = (RGBA_8888) { r->life / 2, 0, r->life, 255 };
+                color = (RGBA_8888) { life / 2, 0, life, 255 };
             } else {
-                color = (RGBA_8888) { r->life, 0, 0, 255 };
+                color = (RGBA_8888) { life, 0, 0, 255 };
             }
         } else {
-            int32_t c1 = r->init != 0U ? (r->init >> 2) : (r->life >> 2);
+            int32_t c1 = init != 0 ? (init >> 2) : (life >> 2);
             c1 <<= 3;
             CLAMPG(c1, 255);
             color = M_Gray(c1);
         }
     } else {
-        int32_t c1 = r->init != 0U ? (r->init >> 1) : (r->life >> 1);
+        int32_t c1 = init != 0 ? (init >> 1) : (life >> 1);
         c1 <<= 3;
         CLAMPG(c1, 255);
         color = M_Gray(c1);
@@ -490,6 +553,8 @@ void FX_Water_Control(void)
             continue;
         }
 
+        M_RememberSplash(splash);
+
         bool set = false;
         for (int32_t j = 0; j < 48; j++) {
             FX_WATER_SPLASH_VERT *const v = &splash->v[j];
@@ -536,6 +601,8 @@ void FX_Water_Control(void)
         if ((ripple->flags & 1U) == 0U) {
             continue;
         }
+
+        M_RememberRipple(ripple);
 
         if (ripple->size < 254U) {
             ripple->size += 2U;

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -9,6 +9,9 @@ typedef struct {
     int32_t x;
     int32_t y;
     int32_t z;
+    int32_t prev_size;
+    int32_t prev_life;
+    int32_t prev_init;
     uint8_t flags;
     uint8_t life;
     uint8_t size;
@@ -19,6 +22,9 @@ typedef struct {
     int16_t wx;
     int16_t wy;
     int16_t wz;
+    int16_t prev_wx;
+    int16_t prev_wy;
+    int16_t prev_wz;
     int16_t xv;
     int32_t yv;
     int16_t zv;
@@ -32,6 +38,7 @@ typedef struct {
     int32_t x;
     int32_t y;
     int32_t z;
+    int32_t prev_life;
     uint8_t flags;
     uint8_t life;
     uint8_t pad[2];

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -5,6 +5,7 @@
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
 #include <trx/game/game/state.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/output/shaders/mesh.h>
@@ -35,6 +36,8 @@
 
 typedef struct {
     XYZ_32 pos;
+    XYZ_32 prev_pos;
+    int32_t prev_yv;
     int8_t xv;
     uint8_t yv;
     int8_t zv;
@@ -43,7 +46,10 @@ typedef struct {
 
 typedef struct {
     XYZ_32 pos;
+    XYZ_32 prev_pos;
     bool stopped;
+    int32_t prev_yv;
+    int32_t prev_life;
     int8_t xv;
     uint8_t yv;
     int8_t zv;
@@ -99,6 +105,8 @@ static void M_SpawnRainDrop(M_RAINDROP *const drop)
     drop->xv = (int8_t)((Random_GetDraw() & 7) - 4);
     drop->zv = (int8_t)((Random_GetDraw() & 7) - 4);
     drop->life = (uint8_t)(M_RAIN_LIFE_BASE - ((int32_t)drop->yv << 1));
+    drop->prev_pos = drop->pos;
+    drop->prev_yv = drop->yv;
 }
 
 static void M_UpdateRain(void)
@@ -117,6 +125,9 @@ static void M_UpdateRain(void)
         if (drop->pos.x == 0) {
             continue;
         }
+
+        drop->prev_pos = drop->pos;
+        drop->prev_yv = drop->yv;
 
         int16_t room_num = NO_ROOM;
         const int32_t outside = Room_GetOutsideStatus(drop->pos, &room_num);
@@ -163,6 +174,9 @@ static void M_UpdateRain(void)
 static void M_DrawRain(void)
 {
     const XZ_32 wind = Sparks_GetSmokeWind();
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
 
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
         const M_RAINDROP *const drop = &m_Raindrops[i];
@@ -170,11 +184,20 @@ static void M_DrawRain(void)
             continue;
         }
 
-        const XYZ_32 to = drop->pos;
+        const int32_t yv = do_interp
+            ? (int32_t)LERP(drop->prev_yv, drop->yv, ratio)
+            : (int32_t)drop->yv;
+        const XYZ_32 to = do_interp
+            ? (XYZ_32) {
+                  .x = (int32_t)LERP(drop->prev_pos.x, drop->pos.x, ratio),
+                  .y = (int32_t)LERP(drop->prev_pos.y, drop->pos.y, ratio),
+                  .z = (int32_t)LERP(drop->prev_pos.z, drop->pos.z, ratio),
+              }
+            : drop->pos;
         const XYZ_32 from = {
-            drop->pos.x - (wind.x * 4),
-            drop->pos.y - ((int32_t)drop->yv * 8),
-            drop->pos.z - (wind.z * 4),
+            to.x - (wind.x * 4),
+            to.y - (yv * 8),
+            to.z - (wind.z * 4),
         };
 
         const RGBA_8888 from_color = { 0, 0, 0x20, 0x00 };
@@ -213,6 +236,9 @@ static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
         (uint8_t)(((Random_GetDraw() % M_SNOW_YV_RANGE) + M_SNOW_YV_MIN) * 8);
     snow->zv = (int8_t)((Random_GetDraw() & 7) - 4);
     snow->life = (uint8_t)(M_SNOW_LIFE_BASE - ((int32_t)snow->yv << 1));
+    snow->prev_pos = snow->pos;
+    snow->prev_yv = snow->yv;
+    snow->prev_life = snow->life;
 }
 
 static void M_UpdateSnow(void)
@@ -229,6 +255,10 @@ static void M_UpdateSnow(void)
         if (snow->pos.x == 0) {
             continue;
         }
+
+        snow->prev_pos = snow->pos;
+        snow->prev_yv = snow->yv;
+        snow->prev_life = snow->life;
 
         const XYZ_32 old_pos = snow->pos;
 
@@ -300,13 +330,22 @@ static void M_DrawSnow(void)
     }
 
     const int32_t sprite_idx = obj->mesh_idx;
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
         M_SNOWFLAKE *const snow = &m_Snowflakes[i];
         if (snow->pos.x == 0) {
             continue;
         }
 
-        const XYZ_32 center = snow->pos;
+        const XYZ_32 center = do_interp
+            ? (XYZ_32) {
+                  .x = (int32_t)LERP(snow->prev_pos.x, snow->pos.x, ratio),
+                  .y = (int32_t)LERP(snow->prev_pos.y, snow->pos.y, ratio),
+                  .z = (int32_t)LERP(snow->prev_pos.z, snow->pos.z, ratio),
+              }
+            : snow->pos;
         const int64_t zv = M_GetViewDepth(center);
         const int64_t near_z = Output_GetNearZ();
         const int64_t far_z = Output_GetFarZ();
@@ -324,6 +363,13 @@ static void M_DrawSnow(void)
             continue;
         }
 
+        const int32_t yv = do_interp
+            ? (int32_t)LERP(snow->prev_yv, snow->yv, ratio)
+            : (int32_t)snow->yv;
+        const int32_t life = do_interp
+            ? (int32_t)LERP(snow->prev_life, snow->life, ratio)
+            : (int32_t)snow->life;
+
         const int32_t game_w = Viewport_GetWidth(VIEWPORT_GAME);
         const int32_t game_h = Viewport_GetHeight(VIEWPORT_GAME);
         const int32_t ui_w = Viewport_GetWidth(VIEWPORT_UI);
@@ -339,12 +385,12 @@ static void M_DrawSnow(void)
         };
 
         uint32_t c;
-        if ((snow->yv & 7) < 7) {
-            c = (uint32_t)(snow->yv & 7);
-        } else if (snow->life > 18) {
+        if ((yv & 7) < 7) {
+            c = (uint32_t)(yv & 7);
+        } else if (life > 18) {
             c = 15;
         } else {
-            c = snow->life;
+            c = (uint32_t)life;
         }
         c <<= 3;
         CLAMPG(c, 255);

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -77,7 +77,6 @@ static void M_TriggerGas(
     spark->dst_color.r = 0;
     spark->dst_color.g = (Random_GetControl() & 0xF) + 32;
     spark->dst_color.b = 0;
-    spark->color = spark->src_color;
 
     if (vel.x != 0 || vel.y != 0 || vel.z != 0) {
         spark->col_fade_speed = 6;
@@ -152,6 +151,7 @@ static void M_TriggerGas(
         spark->src_size.height = spark->size.height;
         spark->dst_size.height = spark->dst_size.width;
     }
+    Sparks_FinishSetup(spark);
 }
 
 static int16_t M_TriggerGasThrower(

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -133,7 +133,6 @@ static void M_TriggerFireSparks(const ITEM *const item)
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
 
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
@@ -181,6 +180,7 @@ static void M_TriggerFireSparks(const ITEM *const item)
     size >>= 2;
     spark->dst_size.width = size;
     spark->dst_size.height = size;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_TriggerFireLight(const ITEM *const item)

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -100,7 +100,6 @@ static void M_TriggerSmoke(const XYZ_32 pos, const bool uw)
         spark->dst_color.g = 64;
         spark->dst_color.b = 64;
     }
-    spark->color = spark->src_color;
 
     spark->col_fade_speed = 8;
     spark->fade_to_black = 64;
@@ -159,6 +158,7 @@ static void M_TriggerSmoke(const XYZ_32 pos, const bool uw)
         spark->dst_size.width + (Random_GetControl() & 0x1F) + 32;
     spark->size.height = spark->dst_size.height >> 3;
     spark->src_size.height = spark->size.height;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Damage(

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -114,6 +114,7 @@ static void M_ExplodeLondonBoss(const ITEM *const item)
         if (ring != nullptr) {
             ring->pos = pos;
             ring->on = 3;
+            FX_ExplosionRing_Sync(ring);
             p->ring_count++;
         }
 
@@ -389,6 +390,7 @@ static void M_Control(const int16_t item_num)
                     ring->speed = 128 + (i << 5);
                     ring->rot.x = ((Random_GetControl() & 0x1FF) - 256) << 4;
                     ring->rot.z = ((Random_GetControl() & 0x1FF) - 256) << 4;
+                    FX_ExplosionRing_Sync(ring);
                 }
 
                 if (!p->dropped_item) {
@@ -647,6 +649,7 @@ static void M_Control(const int16_t item_num)
                         ring->rot.z =
                             16 * ((Random_GetControl() & 0x1FF) - 256);
                         ring->radius = 2048 - ABS(r - 512);
+                        FX_ExplosionRing_Sync(ring);
                         break;
                     }
                 }

--- a/src/trx/game/objects/creatures/sophia_plasma_ball.c
+++ b/src/trx/game/objects/creatures/sophia_plasma_ball.c
@@ -30,7 +30,6 @@ static void M_TriggerPlasmaBallFlame(const int16_t effect_num, const XYZ_32 vel)
     spark->dst_color.r = 32;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.b = (Random_GetControl() & 0x3F) + 128;
-    spark->color = spark->src_color;
 
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
@@ -73,6 +72,7 @@ static void M_TriggerPlasmaBallFlame(const int16_t effect_num, const XYZ_32 vel)
     spark->src_size.height = spark->size.height;
     spark->dst_size.width = spark->size.width >> 2;
     spark->dst_size.height = spark->size.height >> 2;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Control(const int16_t effect_num)

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -164,6 +164,7 @@ static void M_Explode(ITEM *const item)
         if (ring != nullptr) {
             ring->pos = pos;
             ring->on = 2;
+            FX_ExplosionRing_Sync(ring);
             p->ring_count++;
         }
 
@@ -317,6 +318,7 @@ static void M_Control(const int16_t item_num)
                     ring->speed = 128 + (i << 5);
                     ring->rot.x = ((Random_GetControl() & 0x1FF) - 256) & 0xFFF;
                     ring->rot.z = ((Random_GetControl() & 0x1FF) - 256) & 0xFFF;
+                    FX_ExplosionRing_Sync(ring);
                 }
 
                 if (!p->dropped_item) {

--- a/src/trx/game/objects/creatures/tony.c
+++ b/src/trx/game/objects/creatures/tony.c
@@ -101,7 +101,7 @@ static void M_TriggerFlame(int16_t item_num, int32_t node)
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
+
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
     spark->draw_type = 2;
@@ -144,6 +144,7 @@ static void M_TriggerFlame(int16_t item_num, int32_t node)
     spark->size.height = spark->size.width;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = spark->size.height >> 2;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Explode(ITEM *const item)

--- a/src/trx/game/objects/creatures/tony_fire_ball.c
+++ b/src/trx/game/objects/creatures/tony_fire_ball.c
@@ -31,7 +31,7 @@ static void M_TriggerFireBallFlame(
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
+
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
     spark->draw_type = 2;
@@ -90,6 +90,7 @@ static void M_TriggerFireBallFlame(
         spark->gravity = 0;
         spark->scalar = 2;
     }
+    Sparks_FinishSetup(spark);
 }
 
 void TonyBoss_TriggerFireBall(

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -264,6 +264,7 @@ static void M_TriggerSummonSmoke(const XYZ_32 pos)
         spark->dst_size.width + (Random_GetControl() & 0x1F) + 32;
     spark->src_size.height = spark->dst_size.height >> 1;
     spark->size.height = spark->dst_size.height >> 1;
+    Sparks_FinishSetup(spark);
 }
 
 static bool M_CanDropItems(const ITEM *const item)
@@ -351,7 +352,6 @@ static void M_TriggerElectricSparks(
     spark->src_color.r = 255;
     spark->src_color.g = 255;
     spark->src_color.b = 255;
-    spark->color = spark->src_color;
 
     if (shield) {
         spark->dst_color.r = 255;
@@ -399,6 +399,7 @@ static void M_TriggerElectricSparks(
     spark->dst_size.height = (Random_GetControl() & 3) + 4;
     spark->gravity = 15;
     spark->max_y_vel = 0;
+    Sparks_FinishSetup(spark);
 }
 
 static bool M_LaraOnLOS(

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -148,6 +148,7 @@ static void M_Explode(ITEM *const item)
         if (ring != nullptr) {
             ring->pos = pos;
             ring->on = 4;
+            FX_ExplosionRing_Sync(ring);
         }
         p->ring_count++;
         Sparks_TriggerExplosionSparks(pos, 3, -2, 2, 0);
@@ -1288,6 +1289,7 @@ static void M_Control(const int16_t item_num)
                     ring->speed = (i << 5) + 128;
                     ring->rot.x = ((Random_GetControl() & 0x1FF) - 256) & 0xFFF;
                     ring->rot.z = ((Random_GetControl() & 0x1FF) - 256) & 0xFFF;
+                    FX_ExplosionRing_Sync(ring);
                 }
 
                 if (!p->dropped_item) {

--- a/src/trx/game/objects/general/bat_emitter.c
+++ b/src/trx/game/objects/general/bat_emitter.c
@@ -3,6 +3,7 @@
 #include <trx/core/math.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
@@ -16,9 +17,12 @@
 
 typedef struct {
     XYZ_32 pos;
+    XYZ_32 prev_pos;
     int16_t angle;
+    int16_t prev_angle;
     int16_t speed;
     uint8_t wing_y_off;
+    uint8_t prev_wing_y_off;
     bool active;
     uint8_t life;
 } M_BAT;
@@ -63,6 +67,34 @@ static int32_t M_GetWingYOffset(const int32_t corner, const uint8_t wing_y_off)
 
     const int16_t angle = wing_y_off << 10;
     return (Math_Sin(angle) >> 6) - 512;
+}
+
+static void M_RememberBat(M_BAT *const bat)
+{
+    bat->prev_pos = bat->pos;
+    bat->prev_angle = bat->angle;
+    bat->prev_wing_y_off = bat->wing_y_off;
+}
+
+static uint8_t M_GetInterpolatedWingYOffset(
+    const M_BAT *const bat, const double ratio)
+{
+    int32_t wing_diff =
+        (int32_t)bat->wing_y_off - (int32_t)bat->prev_wing_y_off;
+    if (wing_diff > 32) {
+        wing_diff -= 64;
+    } else if (wing_diff < -32) {
+        wing_diff += 64;
+    }
+
+    int32_t wing_interp = LERP(
+        (int32_t)bat->prev_wing_y_off,
+        (int32_t)bat->prev_wing_y_off + wing_diff, ratio);
+    wing_interp %= 64;
+    if (wing_interp < 0) {
+        wing_interp += 64;
+    }
+    return (uint8_t)wing_interp;
 }
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -173,6 +205,9 @@ static bool M_Draw(const ITEM *const item)
 
     const RGBA_8888 color = { 0x60, 0xA0, 0xF8, 0xFF };
     const RGBA_8888 tri_color[3] = { color, color, color };
+    const double ratio = Interpolation_GetWorldRate();
+    const bool do_interp =
+        Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
 
     for (int32_t i = 0; i < M_MAX_BATS; i++) {
         const M_BAT *const bat = &p->bats[i];
@@ -180,14 +215,29 @@ static bool M_Draw(const ITEM *const item)
             continue;
         }
 
+        const XYZ_32 draw_pos = do_interp
+            ? (XYZ_32) {
+                  .x = (int32_t)LERP(bat->prev_pos.x, bat->pos.x, ratio),
+                  .y = (int32_t)LERP(bat->prev_pos.y, bat->pos.y, ratio),
+                  .z = (int32_t)LERP(bat->prev_pos.z, bat->pos.z, ratio),
+              }
+            : bat->pos;
+        const int16_t draw_angle = do_interp
+            ? (Math_AngleMean(bat->prev_angle << 4, bat->angle << 4, ratio)
+               >> 4)
+            : bat->angle;
+        const uint8_t draw_wing_y_off = do_interp
+            ? M_GetInterpolatedWingYOffset(bat, ratio)
+            : bat->wing_y_off;
+
         XYZ_32 world[5] = {};
         Matrix_Push();
-        Matrix_TranslateAbs32(bat->pos);
-        Matrix_RotY(bat->angle << 4);
+        Matrix_TranslateAbs32(draw_pos);
+        Matrix_RotY(draw_angle << 4);
         for (int32_t j = 0; j < 5; j++) {
             const XYZ_32 local = {
                 .x = m_BatMesh[j].x,
-                .y = m_BatMesh[j].y + M_GetWingYOffset(j, bat->wing_y_off),
+                .y = m_BatMesh[j].y + M_GetWingYOffset(j, draw_wing_y_off),
                 .z = m_BatMesh[j].z,
             };
             world[j] = Matrix_MulVec32_M(g_WMatrixPtr, local);
@@ -220,6 +270,8 @@ static void M_Update(M_PRIV *const p)
         if (!bat->active) {
             continue;
         }
+
+        M_RememberBat(bat);
 
         if ((i & 3) == 0 && (Random_GetControl() & 7) == 0) {
             Sound_Effect(SFX_BATS_1, &bat->pos, SPM_NORMAL);
@@ -276,6 +328,7 @@ static void M_TriggerBats(M_PRIV *const p, const XYZ_32 pos, int16_t ang)
         bat->wing_y_off = Random_GetControl() & 0x3F;
         bat->life = (Random_GetControl() & 7) + 144;
         bat->active = true;
+        M_RememberBat(bat);
     }
 
     p->bats_alive = true;

--- a/src/trx/game/objects/general/gas_emitter.c
+++ b/src/trx/game/objects/general/gas_emitter.c
@@ -30,7 +30,7 @@ static void M_Control(const int16_t item_num)
     spark->dst_color.r = 12;
     spark->dst_color.g = 32;
     spark->dst_color.b = 0;
-    spark->color = spark->src_color;
+
     spark->fade_to_black = 32;
     spark->col_fade_speed = (Random_GetControl() & 7) + 24;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -69,6 +69,7 @@ static void M_Control(const int16_t item_num)
     spark->size.height = (size + (Random_GetControl() & 0x1F) + 32) >> 1;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = spark->size.height;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/general/smoke_emitter.c
+++ b/src/trx/game/objects/general/smoke_emitter.c
@@ -35,6 +35,7 @@ static void M_Control(const int16_t item_num)
     spark->dst_color.r = 32;
     spark->dst_color.g = 32;
     spark->dst_color.b = 32;
+
     spark->fade_to_black = 64;
     spark->col_fade_speed = (Random_GetControl() & 7) + 16;
     spark->life = (Random_GetControl() & 0xF) + 96;
@@ -91,6 +92,7 @@ static void M_Control(const int16_t item_num)
         spark->dst_color.g = 24;
         spark->dst_color.b = 24;
     }
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Setup(OBJECT *const obj)

--- a/src/trx/game/objects/traps/cleaner.c
+++ b/src/trx/game/objects/traps/cleaner.c
@@ -83,6 +83,7 @@ static void M_TriggerSparks(
     spark->dst_color.r = spark->src_color.b >> 2;
     spark->dst_color.g = spark->src_color.b >> 1;
     spark->dst_color.b = (Random_GetControl() & 0x3F) + 192;
+
     spark->col_fade_speed = 8;
     spark->fade_to_black = 8;
     spark->draw_type = 2;
@@ -108,6 +109,7 @@ static void M_TriggerSparks(
     spark->dst_size.height = spark->size.height >> 1;
     spark->max_y_vel = 0;
     spark->gravity = (Random_GetControl() & 3) + 4;
+    Sparks_FinishSetup(spark);
 }
 
 static XZ_32 M_GetDirection(const int16_t yaw)

--- a/src/trx/game/objects/traps/electric_fence.c
+++ b/src/trx/game/objects/traps/electric_fence.c
@@ -31,7 +31,6 @@ static void M_TriggerFenceSparks(const XYZ_32 pos, const bool kill)
     spark->dst_color.b = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.r = spark->dst_color.b >> 2;
     spark->dst_color.g = spark->dst_color.b >> 1; // OG: 1
-    spark->color = spark->src_color;
 
     spark->col_fade_speed = 8;
     spark->fade_to_black = 16;
@@ -58,6 +57,7 @@ static void M_TriggerFenceSparks(const XYZ_32 pos, const bool kill)
     spark->size.height = spark->size.width * 2;
     spark->src_size.height = spark->src_size.width * 2;
     spark->dst_size.height = spark->dst_size.width * 2;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_TouchFence(const XZ_32 spark_axis, XYZ_32 spark_pos)

--- a/src/trx/game/objects/traps/pendulum.c
+++ b/src/trx/game/objects/traps/pendulum.c
@@ -87,7 +87,7 @@ static void M_TriggerFireSparks(const ITEM *const item)
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
+
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
     spark->fade_to_black = 8;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -123,6 +123,7 @@ static void M_TriggerFireSparks(const ITEM *const item)
     spark->size.height = spark->size.width;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = spark->size.height >> 2;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_TriggerFireLight(const ITEM *const item)

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -1031,7 +1031,7 @@ static void M_TriggerRapidsMist(const XYZ_32 pos)
     spark->dst_color.r = 192;
     spark->dst_color.g = 192;
     spark->dst_color.b = 192;
-    spark->color = spark->src_color;
+
     spark->col_fade_speed = 2;
     spark->fade_to_black = 4;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -1071,6 +1071,7 @@ static void M_TriggerRapidsMist(const XYZ_32 pos)
     spark->src_size.height = spark->src_size.width;
     spark->size.height = spark->src_size.width;
     spark->dst_size.height = spark->dst_size.width;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_KayakToBaddieCollision(const ITEM *const p)

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -1011,6 +1011,7 @@ static void M_DoWake(
         pt->pos[i].x = pos.x;
         pt->pos[i].y = item->pos.y + 32;
         pt->pos[i].z = pos.z;
+        pt->prev_pos[i] = pt->pos[i];
         pt->vel[i].x = vel[i].x;
         pt->vel[i].z = vel[i].z;
     }

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -449,7 +449,6 @@ static void M_TriggerExhaustSmoke(
         spark->dst_color.g = 96;
         spark->dst_color.b = 128;
     }
-    spark->color = spark->src_color;
 
     spark->col_fade_speed = 4;
     spark->fade_to_black = 4;
@@ -498,6 +497,7 @@ static void M_TriggerExhaustSmoke(
     spark->dst_size.height = spark->dst_size.width;
     spark->src_size.height = spark->dst_size.height >> 1;
     spark->size.height = spark->dst_size.height >> 1;
+    Sparks_FinishSetup(spark);
 }
 
 static bool M_SkidooCanGetOff(const int32_t lr)

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -756,7 +756,6 @@ static void M_TriggerMist(
     spark->dst_color.r = 64;
     spark->dst_color.g = 64;
     spark->dst_color.b = 64;
-    spark->color = spark->src_color;
 
     spark->fade_to_black = 12;
     spark->col_fade_speed = (Random_GetControl() & 3) + 4;
@@ -801,6 +800,7 @@ static void M_TriggerMist(
     spark->src_size.height = spark->src_size.width;
     spark->size.width = spark->src_size.width;
     spark->size.height = spark->src_size.height;
+    Sparks_FinishSetup(spark);
 }
 
 static void M_Control(int16_t item_num)

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -4,6 +4,9 @@
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/camera.h>
+#include <trx/game/effects.h>
+#include <trx/game/interpolation.h>
+#include <trx/game/items.h>
 #include <trx/game/output.h>
 #include <trx/game/output/scene_compositor.h>
 #include <trx/game/output/shaders/mesh.h>
@@ -79,6 +82,56 @@ static int32_t M_GetViewDepth(const XYZ_32 pos)
         g_ViewMatrix._22 * pos.z +
         g_ViewMatrix._23;
     // clang-format on
+}
+
+static XYZ_32 M_GetSparkRenderPos(const SPARK *const spark, const float ratio)
+{
+    const bool use_current_state =
+        (int32_t)spark->s_life - (int32_t)spark->life <= 1;
+    if (use_current_state) {
+        return Sparks_GetWorldPos(spark);
+    }
+
+    if ((spark->flags & SPARK_F_ATTACHED_NODE) != 0U) {
+        const XYZ_32 current_pos = Sparks_GetWorldPos(spark);
+        return (XYZ_32) {
+            .x = (int32_t)LERP(spark->prev_world_pos.x, current_pos.x, ratio),
+            .y = (int32_t)LERP(spark->prev_world_pos.y, current_pos.y, ratio),
+            .z = (int32_t)LERP(spark->prev_world_pos.z, current_pos.z, ratio),
+        };
+    }
+
+    const XYZ_32 local_pos = {
+        .x = (int32_t)LERP(spark->prev_pos.x, spark->pos.x, ratio),
+        .y = (int32_t)LERP(spark->prev_pos.y, spark->pos.y, ratio),
+        .z = (int32_t)LERP(spark->prev_pos.z, spark->pos.z, ratio),
+    };
+
+    if ((spark->flags & SPARK_F_FX) != 0U) {
+        const EFFECT *const effect = Effect_Get(spark->effect_num);
+        if ((spark->flags & SPARK_F_ATTACHED_POS) != 0U) {
+            return effect->interp.result.pos;
+        }
+        return (XYZ_32) {
+            .x = effect->interp.result.pos.x + local_pos.x,
+            .y = effect->interp.result.pos.y + local_pos.y,
+            .z = effect->interp.result.pos.z + local_pos.z,
+        };
+    }
+
+    if ((spark->flags & SPARK_F_ITEM) != 0U) {
+        const ITEM *const item = Item_Get(spark->item_num);
+        if ((spark->flags & SPARK_F_ATTACHED_POS) != 0U) {
+            return item->interp.result.pos;
+        }
+        return (XYZ_32) {
+            .x = item->interp.result.pos.x + local_pos.x,
+            .y = item->interp.result.pos.y + local_pos.y,
+            .z = item->interp.result.pos.z + local_pos.z,
+        };
+    }
+
+    return local_pos;
 }
 
 static void M_ApplyTintToColors(RGBA_8888 color[4], const uint8_t corner_count)
@@ -662,7 +715,10 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
     }
 
     DRAW_TYPE draw_type = spark->draw_type;
-    const XYZ_32 pos = Sparks_GetWorldPos(spark);
+    const float ratio = Interpolation_GetWorldRate();
+    const bool use_current_state =
+        (int32_t)spark->s_life - (int32_t)spark->life <= 1;
+    const XYZ_32 pos = M_GetSparkRenderPos(spark, ratio);
     const XYZ_32 world_pos[4] = { pos, pos, pos, pos };
 
     const int64_t zv = M_GetViewDepth(pos);
@@ -677,8 +733,29 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         vpos_z = 1;
     }
 
-    int32_t sw = (int32_t)spark->size.width;
-    int32_t sh = (int32_t)spark->size.height;
+    const RGB_888 render_color = use_current_state
+        ? spark->color
+        : (RGB_888) {
+              .r = (uint8_t)LERP(
+                  (int32_t)spark->prev_color.r, (int32_t)spark->color.r, ratio),
+              .g = (uint8_t)LERP(
+                  (int32_t)spark->prev_color.g, (int32_t)spark->color.g, ratio),
+              .b = (uint8_t)LERP(
+                  (int32_t)spark->prev_color.b, (int32_t)spark->color.b, ratio),
+          };
+
+    const int32_t render_width = use_current_state
+        ? (int32_t)spark->size.width
+        : (int32_t)LERP(
+              (int32_t)spark->prev_size.width, (int32_t)spark->size.width,
+              ratio);
+    const int32_t render_height = use_current_state
+        ? (int32_t)spark->size.height
+        : (int32_t)LERP(
+              (int32_t)spark->prev_size.height, (int32_t)spark->size.height,
+              ratio);
+    int32_t sw = render_width;
+    int32_t sh = render_height;
 
     const bool use_sprite = (spark->flags & SPARK_F_SPRITE) != 0U;
     if ((spark->flags & SPARK_F_SCALE) != 0U) {
@@ -687,8 +764,8 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         sh = (int32_t)(((((int64_t)sh * g_PhdPersp) << scalar) / vpos_z));
 
         if (use_sprite) {
-            const int32_t max_w = (int32_t)spark->size.width << scalar;
-            const int32_t max_h = (int32_t)spark->size.height << scalar;
+            const int32_t max_w = render_width << scalar;
+            const int32_t max_h = render_height << scalar;
             int32_t min_wh = 4;
             if ((spark->flags & SPARK_F_ATTACHED_NODE) != 0U
                 && spark->node_num == 0U) {
@@ -697,8 +774,8 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
             CLAMP(sw, min_wh, max_w);
             CLAMP(sh, min_wh, max_h);
         } else {
-            const int32_t max_w = (int32_t)spark->size.width << 2;
-            const int32_t max_h = (int32_t)spark->size.height << 2;
+            const int32_t max_w = render_width << 2;
+            const int32_t max_h = render_height << 2;
             CLAMP(sw, 1, max_w);
             CLAMP(sh, 1, max_h);
         }
@@ -713,10 +790,15 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         { w, -h },
     };
 
-    RGBA_8888 color = { spark->color.r, spark->color.g, spark->color.b, 255 };
+    RGBA_8888 color = { render_color.r, render_color.g, render_color.b, 255 };
 
     if ((spark->flags & SPARK_F_ROTATE) != 0U) {
-        const int32_t angle = (int32_t)spark->rot_angle * DEG_360 / 0xFFF.p0;
+        const int32_t rot_angle = use_current_state
+            ? (int32_t)spark->rot_angle
+            : Math_AngleMean(
+                  (int32_t)spark->prev_rot_angle, (int32_t)spark->rot_angle,
+                  ratio);
+        const int32_t angle = rot_angle * DEG_360 / 0xFFF.p0;
         const float s = Math_Sin(angle) / (float)(1 << W2V_SHIFT);
         const float c = Math_Cos(angle) / (float)(1 << W2V_SHIFT);
         for (int32_t i = 0; i < 4; i++) {

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -131,6 +131,30 @@ SPARK *Sparks_GetSpark(const int32_t idx)
     return &m_Sparks[idx];
 }
 
+void Sparks_Sync(SPARK *const spark)
+{
+    if (spark == nullptr) {
+        return;
+    }
+
+    const XYZ_32 world_pos = Sparks_GetWorldPos(spark);
+    spark->prev_pos = spark->pos;
+    spark->prev_world_pos = world_pos;
+    spark->prev_color = spark->color;
+    spark->prev_size = spark->size;
+    spark->prev_rot_angle = spark->rot_angle;
+}
+
+void Sparks_FinishSetup(SPARK *const spark)
+{
+    if (spark == nullptr) {
+        return;
+    }
+
+    spark->color = spark->src_color;
+    Sparks_Sync(spark);
+}
+
 int8_t Sparks_AllocDynamic(const uint8_t flags)
 {
     for (int32_t i = 0; i < M_MAX_SPARK_DYNAMICS; i++) {
@@ -411,6 +435,7 @@ void Sparks_Control(void)
             if (lived > b) {
                 spark->pos = Sparks_GetWorldPos(spark);
                 spark->flags &= ~(SPARK_F_ATTACHED_NODE | SPARK_F_ITEM);
+                Sparks_Sync(spark);
             }
         }
     }

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -278,6 +278,12 @@ void Sparks_Control(void)
 
         const int32_t lived = (int32_t)spark->s_life - (int32_t)spark->life;
 
+        spark->prev_pos = spark->pos;
+        spark->prev_world_pos = Sparks_GetWorldPos(spark);
+        spark->prev_color = spark->color;
+        spark->prev_size = spark->size;
+        spark->prev_rot_angle = spark->rot_angle;
+
         // Color fade: src -> dst, then fade-to-black.
         if (lived < (int32_t)spark->col_fade_speed
             && spark->col_fade_speed != 0U) {

--- a/src/trx/game/sparks/manager.h
+++ b/src/trx/game/sparks/manager.h
@@ -13,6 +13,8 @@ XYZ_32 Sparks_GetWorldPos(const SPARK *spark);
 
 SPARK *Sparks_GetFreeSpark(void);
 SPARK *Sparks_GetSpark(int32_t idx);
+void Sparks_Sync(SPARK *spark);
+void Sparks_FinishSetup(SPARK *spark);
 
 int8_t Sparks_AllocDynamic(uint8_t flags);
 void Sparks_FreeDynamic(int8_t idx);

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -27,7 +27,6 @@ void Sparks_TriggerBubble(
     SPARK *const spark = Sparks_GetFreeSpark();
     *spark = (SPARK) {
         .on = true,
-        .color = { 0, 0, 0 },
         .src_color = { 0, 0, 0 },
         .dst_color = { 144, 144, 144 },
         .fade_to_black = 2,
@@ -59,6 +58,7 @@ void Sparks_TriggerBubble(
     spark->dst_size.width = dst;
     spark->dst_size.height = dst;
     spark->size = spark->src_size;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerWaterfallMist(
@@ -80,7 +80,6 @@ void Sparks_TriggerWaterfallMist(
 
         *spark = (SPARK) {
             .on = true,
-            .color = { 128, 128, 128 },
             .src_color = { 128, 128, 128 },
             .dst_color = { 192, 192, 192 },
             .col_fade_speed = 2,
@@ -125,6 +124,7 @@ void Sparks_TriggerWaterfallMist(
         spark->dst_size.width = dst_size;
         spark->dst_size.height = dst_size;
         spark->size = spark->src_size;
+        Sparks_FinishSetup(spark);
     }
 }
 
@@ -143,7 +143,6 @@ void Sparks_TriggerBreath(
 
     *spark = (SPARK) {
         .on = true,
-        .color = { 0, 0, 0 },
         .src_color = { 0, 0, 0 },
         .dst_color = { 32, 32, 32 },
         .col_fade_speed = 4,
@@ -180,6 +179,7 @@ void Sparks_TriggerBreath(
     spark->dst_size.width = dst_size;
     spark->dst_size.height = dst_size;
     spark->size = spark->src_size;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerFireFlame(
@@ -212,7 +212,6 @@ void Sparks_TriggerFireFlame(
         spark->src_color.g = (Random_GetControl() & 0x1F) + 48;
         spark->src_color.b = 48;
     }
-    spark->color = spark->src_color;
 
     if (type != 254) {
         spark->dst_color.r = (Random_GetControl() & 0x3F) - 64;
@@ -339,6 +338,7 @@ void Sparks_TriggerFireFlame(
         spark->dst_size.width = size >> 4;
         spark->dst_size.height = size >> 4;
     }
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerFireSmoke(
@@ -360,7 +360,6 @@ void Sparks_TriggerFireSmoke(
     spark->dst_color.r = 32;
     spark->dst_color.g = 32;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
 
     if (body_part == -1) {
         if (type == 255) {
@@ -416,6 +415,7 @@ void Sparks_TriggerFireSmoke(
     spark->src_size.height = spark->src_size.width;
     spark->size.height = spark->src_size.width;
     spark->dst_size.height = spark->dst_size.width;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerStaticFlame(const XYZ_32 pos, const int32_t size)
@@ -436,7 +436,6 @@ void Sparks_TriggerStaticFlame(const XYZ_32 pos, const int32_t size)
     spark->dst_color.r = spark->src_color.r;
     spark->dst_color.g = spark->src_color.g;
     spark->dst_color.b = 64;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 1;
     spark->fade_to_black = 0;
     spark->life = 2;
@@ -462,6 +461,7 @@ void Sparks_TriggerStaticFlame(const XYZ_32 pos, const int32_t size)
     spark->src_size.width = size;
     spark->size.height = size;
     spark->size.width = size;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerSideFlame(
@@ -484,7 +484,6 @@ void Sparks_TriggerSideFlame(
     spark->dst_color.r = (Random_GetControl() & 0x3F) - 64;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 0x80;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -527,6 +526,7 @@ void Sparks_TriggerSideFlame(
     spark->src_size.height = size >> 1;
     spark->size.width = size >> 1;
     spark->size.height = size >> 1;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerBlood(
@@ -553,7 +553,6 @@ void Sparks_TriggerBlood(
             spark->dst_color.g = 0;
             spark->dst_color.b = 24;
         }
-        spark->color = spark->src_color;
 
         spark->col_fade_speed = 8;
         spark->fade_to_black = 8;
@@ -581,6 +580,7 @@ void Sparks_TriggerBlood(
         spark->src_size.height = 2;
         spark->dst_size.width = 2 - (Random_GetControl() & 1);
         spark->dst_size.height = 2 - (Random_GetControl() & 1);
+        Sparks_FinishSetup(spark);
     }
 }
 
@@ -608,7 +608,6 @@ void Sparks_TriggerBloodD(
             spark->dst_color.g = 0;
             spark->dst_color.b = 24;
         }
-        spark->color = spark->src_color;
 
         spark->col_fade_speed = 8;
         spark->fade_to_black = 8;
@@ -635,6 +634,7 @@ void Sparks_TriggerBloodD(
         spark->src_size.height = 2;
         spark->dst_size.width = 2 - (Random_GetDraw() & 1);
         spark->dst_size.height = 2 - (Random_GetDraw() & 1);
+        Sparks_FinishSetup(spark);
     }
 }
 
@@ -713,7 +713,6 @@ void Sparks_TriggerExplosionSparks(
     SPARK *const spark = Sparks_GetFreeSpark();
     *spark = (SPARK) {
         .on = true,
-        .color = { 255, 0, 0 },
         .src_color = { 255, 0, 0 },
         .dst_color = { 0, 0, 0 },
         .draw_type = DRAW_BLEND_ADD,
@@ -758,7 +757,6 @@ void Sparks_TriggerExplosionSparks(
         spark->fade_to_black = 16;
         spark->life = (uint8_t)((Random_GetControl() & 7) + 24);
     }
-    spark->color = spark->src_color;
     spark->s_life = spark->life;
 
     if (dynamic == -2) {
@@ -803,6 +801,7 @@ void Sparks_TriggerExplosionSparks(
     } else {
         Sparks_TriggerExplosionSmokeEnd(pos, uw, room_num);
     }
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerExplosionBubble(const XYZ_32 pos, const int16_t room_num)
@@ -823,7 +822,6 @@ void Sparks_TriggerExplosionBubble(const XYZ_32 pos, const int16_t room_num)
     SPARK *const spark = Sparks_GetFreeSpark();
     *spark = (SPARK) {
         .on = true,
-        .color = { 128, 64, 0 },
         .src_color = { 128, 64, 0 },
         .dst_color = { 128, 128, 128 },
         .col_fade_speed = 8,
@@ -850,6 +848,7 @@ void Sparks_TriggerExplosionBubble(const XYZ_32 pos, const int16_t room_num)
     spark->dst_size.width = (uint8_t)(size << 1);
     spark->dst_size.height = spark->dst_size.width;
     spark->size = spark->src_size;
+    Sparks_FinishSetup(spark);
 
     for (int32_t i = 0; i < 7; i++) {
         const XYZ_32 bubble_pos = {
@@ -880,7 +879,6 @@ void Sparks_TriggerExplosionSmoke(
     spark->dst_color.r = 64;
     spark->dst_color.g = 64;
     spark->dst_color.b = 64;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 2;
     spark->fade_to_black = 8;
     spark->draw_type = DRAW_BLEND_SUB;
@@ -916,6 +914,7 @@ void Sparks_TriggerExplosionSmoke(
         spark->dst_size.width + (Random_GetControl() & 0x1F) + 32;
     spark->size.height = spark->dst_size.height >> 3;
     spark->src_size.height = spark->size.height;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerExplosionSmokeEnd(
@@ -947,7 +946,6 @@ void Sparks_TriggerExplosionSmokeEnd(
         spark->dst_color.g = 64;
         spark->dst_color.b = 64;
     }
-    spark->color = spark->src_color;
 
     spark->col_fade_speed = 8;
     spark->fade_to_black = 64;
@@ -1001,6 +999,7 @@ void Sparks_TriggerExplosionSmokeEnd(
     spark->size.height = (uint8_t)(spark->dst_size.height >> 3);
     spark->src_size.height = spark->size.height;
     spark->room_num = (uint8_t)room_num;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerDartSmoke(const XYZ_32 pos, const XZ_32 vel, const bool hit)
@@ -1021,7 +1020,6 @@ void Sparks_TriggerDartSmoke(const XYZ_32 pos, const XZ_32 vel, const bool hit)
     spark->dst_color.r = 64;
     spark->dst_color.g = 48;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 8;
     spark->fade_to_black = 4;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -1092,6 +1090,7 @@ void Sparks_TriggerDartSmoke(const XYZ_32 pos, const XZ_32 vel, const bool hit)
         spark->gravity = -4 - (Random_GetControl() & 3);
         spark->max_y_vel = -4 - (Random_GetControl() & 3);
     }
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerFlareSparks(
@@ -1113,7 +1112,6 @@ void Sparks_TriggerFlareSparks(
     spark->dst_color.r = 255;
     spark->dst_color.g = (Random_GetDraw() & 0x7F) + 64;
     spark->dst_color.b = 192 - spark->dst_color.g;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 3;
     spark->fade_to_black = 5;
     spark->life = 10;
@@ -1137,6 +1135,7 @@ void Sparks_TriggerFlareSparks(
     spark->max_y_vel = 0;
     spark->gravity = 0;
     spark->flags = SPARK_F_SCALE;
+    Sparks_FinishSetup(spark);
 
     if (!smoke) {
         return;
@@ -1150,7 +1149,6 @@ void Sparks_TriggerFlareSparks(
     smoke_spark->dst_color.r = 32;
     smoke_spark->dst_color.g = 32;
     smoke_spark->dst_color.b = 32;
-    spark->color = spark->src_color;
     smoke_spark->col_fade_speed = (Random_GetDraw() & 3) + 8;
     smoke_spark->fade_to_black = 4;
     smoke_spark->draw_type = DRAW_BLEND_ADD;
@@ -1191,6 +1189,7 @@ void Sparks_TriggerFlareSparks(
     smoke_spark->dst_size.height = smoke_spark->dst_size.width;
     smoke_spark->src_size.height = smoke_spark->dst_size.height >> 3;
     smoke_spark->size.height = smoke_spark->dst_size.height >> 3;
+    Sparks_FinishSetup(smoke_spark);
 }
 
 void Sparks_TriggerRicochet(
@@ -1201,11 +1200,9 @@ void Sparks_TriggerRicochet(
     spark->src_color.r = 255;
     spark->src_color.g = (Random_GetControl() & 0x1F) + 32;
     spark->src_color.b = 0;
-    spark->color = spark->src_color;
     spark->dst_color.r = 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 96;
     spark->dst_color.b = 0;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 8;
     spark->fade_to_black = 8;
     spark->life = 24;
@@ -1231,6 +1228,7 @@ void Sparks_TriggerRicochet(
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = (Random_GetControl() & 1) + 1;
     spark->max_y_vel = 0;
+    Sparks_FinishSetup(spark);
 
     spark = Sparks_GetFreeSpark();
     spark->on = true;
@@ -1238,7 +1236,6 @@ void Sparks_TriggerRicochet(
     spark->src_color.r = c;
     spark->src_color.g = c;
     spark->src_color.b = c;
-    spark->color = spark->src_color;
     c >>= 1;
     spark->dst_color.r = c;
     spark->dst_color.g = c;
@@ -1267,6 +1264,7 @@ void Sparks_TriggerRicochet(
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = (Random_GetControl() & 1) + 1;
     spark->max_y_vel = 0;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerGunSmoke(
@@ -1288,7 +1286,6 @@ void Sparks_TriggerGunSmokeDirected(
     spark->dst_color.r = shade << 2;
     spark->dst_color.g = shade << 2;
     spark->dst_color.b = shade << 2;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 4;
     spark->fade_to_black = 32 - (initial << 4);
     spark->life = (Random_GetControl() & 3) + 40;
@@ -1370,6 +1367,7 @@ void Sparks_TriggerGunSmokeDirected(
         spark->src_size.height = spark->size.width;
         spark->dst_size.height = size;
     }
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerShotgunSparks(const XYZ_32 pos, const XYZ_32 vel)
@@ -1382,7 +1380,6 @@ void Sparks_TriggerShotgunSparks(const XYZ_32 pos, const XYZ_32 vel)
     spark->dst_color.r = 255;
     spark->dst_color.g = (Random_GetControl() & 0x7F) + 64;
     spark->dst_color.b = 0;
-    spark->color = spark->src_color;
     spark->col_fade_speed = 3;
     spark->fade_to_black = 5;
     spark->life = 10;
@@ -1406,6 +1403,7 @@ void Sparks_TriggerShotgunSparks(const XYZ_32 pos, const XYZ_32 vel)
     spark->size.height = (Random_GetControl() & 3) + 4;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = 1;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerRocketSmoke(
@@ -1420,7 +1418,6 @@ void Sparks_TriggerRocketSmoke(
     spark->dst_color.r = c + 64;
     spark->dst_color.g = c + 64;
     spark->dst_color.b = c + 64;
-    spark->color = spark->src_color;
     spark->fade_to_black = 12;
     spark->col_fade_speed = (Random_GetControl() & 3) + 4;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -1461,6 +1458,7 @@ void Sparks_TriggerRocketSmoke(
     spark->src_size.height = size >> 2;
     spark->size.height = size >> 2;
     spark->dst_size.height = size;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerRocketFlame(
@@ -1475,7 +1473,6 @@ void Sparks_TriggerRocketFlame(
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
     spark->fade_to_black = 12;
     spark->col_fade_speed = (Random_GetControl() & 3) + 12;
     spark->draw_type = DRAW_BLEND_ADD;
@@ -1517,6 +1514,7 @@ void Sparks_TriggerRocketFlame(
     spark->size.height = spark->size.width;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = 2;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerFlamethrowerHitFlame(const XYZ_32 pos)
@@ -1537,7 +1535,6 @@ void Sparks_TriggerFlamethrowerHitFlame(const XYZ_32 pos)
     spark->dst_color.r = (Random_GetControl() & 0x3F) + 192;
     spark->dst_color.g = (Random_GetControl() & 0x3F) + 128;
     spark->dst_color.b = 32;
-    spark->color = spark->src_color;
 
     spark->fade_to_black = 8;
     spark->col_fade_speed = (Random_GetControl() & 3) + 8;
@@ -1580,6 +1577,7 @@ void Sparks_TriggerFlamethrowerHitFlame(const XYZ_32 pos)
     spark->size.height = spark->size.width;
     spark->src_size.height = spark->size.height;
     spark->dst_size.height = spark->size.height >> 4;
+    Sparks_FinishSetup(spark);
 }
 
 void Sparks_TriggerFlamethrowerSmoke(const XYZ_32 pos, const bool uw)
@@ -1610,7 +1608,6 @@ void Sparks_TriggerFlamethrowerSmoke(const XYZ_32 pos, const bool uw)
         spark->dst_color.g = 64;
         spark->dst_color.b = 64;
     }
-    spark->color = spark->src_color;
 
     spark->col_fade_speed = 8;
     spark->fade_to_black = 23;
@@ -1669,4 +1666,5 @@ void Sparks_TriggerFlamethrowerSmoke(const XYZ_32 pos, const bool uw)
         spark->dst_size.width + (Random_GetControl() & 0x1F) + 32;
     spark->size.height = spark->dst_size.height >> 3;
     spark->src_size.height = spark->size.height;
+    Sparks_FinishSetup(spark);
 }

--- a/src/trx/game/sparks/types.h
+++ b/src/trx/game/sparks/types.h
@@ -16,15 +16,18 @@ typedef struct SPARK {
     // NOTE: `pos` is either absolute world position, or a relative offset when
     // attached to an FX/ITEM and not using `SPARK_F_ATTACHED_POS`.
     XYZ_32 pos;
+    XYZ_32 prev_pos;
+    XYZ_32 prev_world_pos;
     XYZ_32 vel;
     struct {
         uint8_t width;
         uint8_t height;
-    } src_size, dst_size, size;
+    } src_size, dst_size, size, prev_size;
 
     RGB_888 src_color;
     RGB_888 dst_color;
     RGB_888 color;
+    RGB_888 prev_color;
 
     uint8_t scalar;
     uint8_t col_fade_speed;
@@ -46,6 +49,7 @@ typedef struct SPARK {
     int8_t dynamic;
 
     uint16_t rot_angle; // 0..0xFFF
+    uint16_t prev_rot_angle; // 0..0xFFF
     int8_t rot_add;
 
     int32_t sprite_idx;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds 60 FPS interpolation to:
    - sparks
    - weather effects
    - water effects
    - wake effects
    - explosion rings
    - bat emitters

#### Testing

- [x] Sparks
- [x] Snow
- [x] Rain
- [x] Ripples
- [x] Splashes
- [x] Kayak wake
- [x] Explosion rings
- [x] Bat emitters in Madubu

Expected outcome: stuff animates more smoothly
Watch out for:
- in visually heavy scenes, things teleporting across the screen for split-frame (which would suggest the game tries to interpolate state resets)
- jerky animation (which would suggest things fall back to 30 FPS)

This does not fix the bosses' explosion blast.