### PR TITLE
objects/yeti: fix charge attack guard flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - added the ability to use flames on Pendulums, similar to TR3
 - fixed thrown flares falling through trapdoors and becoming stuck in the void if thrown underwater near the floor (#3708)
 - fixed flamethrowers and Dragon's breath doing weird animation when hitting floor (#5104, regression from 1.3)
+- fixed yetis dealing no damage during their charge attack (#5126, regression from TR2X 0.8)
 
 **TR3**:
 - added UPV control

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -7,54 +7,56 @@
 #include <trx/game/spawn.h>
 
 // clang-format off
-#define YETI_HITPOINTS        30
-#define YETI_TOUCH_BITS_R     0b00000111'00000000 // = 0x0700
-#define YETI_TOUCH_BITS_L     0b00111000'00000000 // = 0x3800
-#define YETI_TOUCH_BITS_LR    (YETI_TOUCH_BITS_R | YETI_TOUCH_BITS_L) // = 0x3F00
-#define YETI_RADIUS           (WALL_L / 8) // = 128
-#define YETI_WALK_TURN        (DEG_1 * 4) // = 728
-#define YETI_RUN_TURN         (DEG_1 * 6) // = 1092
-#define YETI_VAULT_SHIFT      300
-#define YETI_ATTACK_1_RANGE   SQUARE(WALL_L / 2) // = 262144
-#define YETI_ATTACK_2_RANGE   SQUARE(WALL_L * 2 / 3) // = 465124
-#define YETI_ATTACK_3_RANGE   SQUARE(WALL_L * 2) // = 4194304
-#define YETI_RUN_RANGE        SQUARE(WALL_L * 2) // = 4194304
-#define YETI_PUNCH_DAMAGE     100
-#define YETI_THUMP_DAMAGE     150
-#define YETI_CHARGE_DAMAGE    200
-#define YETI_ATTACK_1_CHANCE  0x4000
-#define YETI_WAIT_1_CHANCE    0x100
-#define YETI_WAIT_2_CHANCE    (YETI_WAIT_1_CHANCE + 0x100) // = 512
-#define YETI_WALK_CHANCE      (YETI_WAIT_2_CHANCE + 0x100) // = 768
-#define YETI_STOP_ROAR_CHANCE 0x200
+#define M_HITPOINTS        30
+#define M_TOUCH_BITS_R     0b00000111'00000000 // = 0x0700
+#define M_TOUCH_BITS_L     0b00111000'00000000 // = 0x3800
+#define M_TOUCH_BITS_LR    (M_TOUCH_BITS_R | M_TOUCH_BITS_L) // = 0x3F00
+#define M_RADIUS           (WALL_L / 8) // = 128
+#define M_WALK_TURN        (DEG_1 * 4) // = 728
+#define M_RUN_TURN         (DEG_1 * 6) // = 1092
+#define M_VAULT_SHIFT      300
+#define M_ATTACK_1_RANGE   SQUARE(WALL_L / 2) // = 262144
+#define M_ATTACK_2_RANGE   SQUARE(WALL_L * 2 / 3) // = 465124
+#define M_ATTACK_3_RANGE   SQUARE(WALL_L * 2) // = 4194304
+#define M_RUN_RANGE        SQUARE(WALL_L * 2) // = 4194304
+#define M_PUNCH_DAMAGE     100
+#define M_THUMP_DAMAGE     150
+#define M_CHARGE_DAMAGE    200
+#define M_ATTACK_1_CHANCE  0x4000
+#define M_WAIT_1_CHANCE    0x100
+#define M_WAIT_2_CHANCE    (M_WAIT_1_CHANCE + 0x100) // = 512
+#define M_WALK_CHANCE      (M_WAIT_2_CHANCE + 0x100) // = 768
+#define M_STOP_ROAR_CHANCE 0x200
 // clang-format on
 
 typedef enum {
-    YETI_STATE_EMPTY = 0,
-    YETI_STATE_RUN = 1,
-    YETI_STATE_STOP = 2,
-    YETI_STATE_WALK = 3,
-    YETI_STATE_ATTACK_1 = 4,
-    YETI_STATE_ATTACK_2 = 5,
-    YETI_STATE_ATTACK_3 = 6,
-    YETI_STATE_WAIT_1 = 7,
-    YETI_STATE_DEATH = 8,
-    YETI_STATE_WAIT_2 = 9,
-    YETI_STATE_CLIMB_1 = 10,
-    YETI_STATE_CLIMB_2 = 11,
-    YETI_STATE_CLIMB_3 = 12,
-    YETI_STATE_FALL = 13,
-    YETI_STATE_KILL = 14,
-} YETI_STATE;
+    M_STATE_EMPTY,
+    M_STATE_RUN,
+    M_STATE_STOP,
+    M_STATE_WALK,
+    M_STATE_ATTACK_1,
+    M_STATE_ATTACK_2,
+    M_STATE_ATTACK_3,
+    M_STATE_WAIT_1,
+    M_STATE_DEATH,
+    M_STATE_WAIT_2,
+    M_STATE_CLIMB_1,
+    M_STATE_CLIMB_2,
+    M_STATE_CLIMB_3,
+    M_STATE_FALL,
+    M_STATE_KILL,
+} M_STATE;
 
 typedef enum {
-    YETI_ANIM_KILL = 36,
-    YETI_ANIM_FALL = 35,
-    YETI_ANIM_CLIMB_1 = 34,
-    YETI_ANIM_CLIMB_2 = 33,
-    YETI_ANIM_CLIMB_3 = 32,
-    YETI_ANIM_DEATH = 31,
-} YETI_ANIM;
+    // clang-format off
+    M_ANIM_KILL    = 36,
+    M_ANIM_FALL    = 35,
+    M_ANIM_CLIMB_1 = 34,
+    M_ANIM_CLIMB_2 = 33,
+    M_ANIM_CLIMB_3 = 32,
+    M_ANIM_DEATH   = 31,
+    // clang-format on
+} M_ANIM;
 
 static const BITE m_YetiBiteL = {
     .pos = { .x = 12, .y = 101, .z = 19 },
@@ -93,157 +95,157 @@ static void M_Control(const int16_t item_num)
         angle = Creature_Turn(item, creature->maximum_turn);
 
         switch (item->current_anim_state) {
-        case YETI_STATE_STOP:
+        case M_STATE_STOP:
             creature->flags = 0;
             creature->maximum_turn = 0;
             if (creature->mood == MOOD_ESCAPE) {
-                item->goal_anim_state = YETI_STATE_RUN;
-            } else if (item->required_anim_state != YETI_STATE_EMPTY) {
+                item->goal_anim_state = M_STATE_RUN;
+            } else if (item->required_anim_state != M_STATE_EMPTY) {
                 item->goal_anim_state = item->required_anim_state;
             } else if (creature->mood == MOOD_BORED) {
                 const int32_t random = Random_GetControl();
-                if (random < YETI_WAIT_1_CHANCE || !lara_was_alive) {
-                    item->goal_anim_state = YETI_STATE_WAIT_1;
-                } else if (random < YETI_WAIT_2_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_WAIT_2;
-                } else if (random < YETI_WALK_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_WALK;
+                if (random < M_WAIT_1_CHANCE || !lara_was_alive) {
+                    item->goal_anim_state = M_STATE_WAIT_1;
+                } else if (random < M_WAIT_2_CHANCE) {
+                    item->goal_anim_state = M_STATE_WAIT_2;
+                } else if (random < M_WALK_CHANCE) {
+                    item->goal_anim_state = M_STATE_WALK;
                 }
             } else if (
-                info.ahead && info.distance < YETI_ATTACK_1_RANGE
-                && Random_GetControl() < YETI_ATTACK_1_CHANCE) {
-                item->goal_anim_state = YETI_STATE_ATTACK_1;
+                info.ahead && info.distance < M_ATTACK_1_RANGE
+                && Random_GetControl() < M_ATTACK_1_CHANCE) {
+                item->goal_anim_state = M_STATE_ATTACK_1;
                 break;
-            } else if (info.ahead && info.distance < YETI_ATTACK_2_RANGE) {
-                item->goal_anim_state = YETI_STATE_ATTACK_2;
+            } else if (info.ahead && info.distance < M_ATTACK_2_RANGE) {
+                item->goal_anim_state = M_STATE_ATTACK_2;
             } else if (creature->mood == MOOD_STALK) {
-                item->goal_anim_state = YETI_STATE_WALK;
+                item->goal_anim_state = M_STATE_WALK;
             } else {
-                item->goal_anim_state = YETI_STATE_RUN;
+                item->goal_anim_state = M_STATE_RUN;
             }
             break;
 
-        case YETI_STATE_WAIT_1:
+        case M_STATE_WAIT_1:
             if (creature->mood == MOOD_ESCAPE || item->hit_status) {
-                item->goal_anim_state = YETI_STATE_STOP;
+                item->goal_anim_state = M_STATE_STOP;
             } else if (creature->mood == MOOD_BORED) {
                 if (lara_was_alive) {
                     const int32_t random = Random_GetControl();
-                    if (random < YETI_WAIT_1_CHANCE) {
-                        item->goal_anim_state = YETI_STATE_STOP;
-                    } else if (random < YETI_WAIT_2_CHANCE) {
-                        item->goal_anim_state = YETI_STATE_WAIT_2;
-                    } else if (random < YETI_WALK_CHANCE) {
-                        item->goal_anim_state = YETI_STATE_STOP;
-                        item->required_anim_state = YETI_STATE_WALK;
+                    if (random < M_WAIT_1_CHANCE) {
+                        item->goal_anim_state = M_STATE_STOP;
+                    } else if (random < M_WAIT_2_CHANCE) {
+                        item->goal_anim_state = M_STATE_WAIT_2;
+                    } else if (random < M_WALK_CHANCE) {
+                        item->goal_anim_state = M_STATE_STOP;
+                        item->required_anim_state = M_STATE_WALK;
                     }
                 }
-            } else if (Random_GetControl() < YETI_STOP_ROAR_CHANCE) {
-                item->goal_anim_state = YETI_STATE_STOP;
+            } else if (Random_GetControl() < M_STOP_ROAR_CHANCE) {
+                item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case YETI_STATE_WAIT_2:
+        case M_STATE_WAIT_2:
             if (creature->mood == MOOD_ESCAPE || item->hit_status) {
-                item->goal_anim_state = YETI_STATE_STOP;
+                item->goal_anim_state = M_STATE_STOP;
             } else if (creature->mood == MOOD_BORED) {
                 const int32_t random = Random_GetControl();
-                if (random < YETI_WAIT_1_CHANCE || !lara_was_alive) {
-                    item->goal_anim_state = YETI_STATE_WAIT_1;
-                } else if (random < YETI_WAIT_2_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_STOP;
-                } else if (random < YETI_WALK_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_STOP;
-                    item->required_anim_state = YETI_STATE_WALK;
+                if (random < M_WAIT_1_CHANCE || !lara_was_alive) {
+                    item->goal_anim_state = M_STATE_WAIT_1;
+                } else if (random < M_WAIT_2_CHANCE) {
+                    item->goal_anim_state = M_STATE_STOP;
+                } else if (random < M_WALK_CHANCE) {
+                    item->goal_anim_state = M_STATE_STOP;
+                    item->required_anim_state = M_STATE_WALK;
                 }
-            } else if (Random_GetControl() < YETI_STOP_ROAR_CHANCE) {
-                item->goal_anim_state = YETI_STATE_STOP;
+            } else if (Random_GetControl() < M_STOP_ROAR_CHANCE) {
+                item->goal_anim_state = M_STATE_STOP;
             }
             break;
 
-        case YETI_STATE_WALK:
-            creature->maximum_turn = YETI_WALK_TURN;
+        case M_STATE_WALK:
+            creature->maximum_turn = M_WALK_TURN;
             if (creature->mood == MOOD_ESCAPE) {
-                item->goal_anim_state = YETI_STATE_RUN;
+                item->goal_anim_state = M_STATE_RUN;
             } else if (creature->mood == MOOD_BORED) {
                 const int32_t random = Random_GetControl();
-                if (random < YETI_WAIT_1_CHANCE || !lara_was_alive) {
-                    item->goal_anim_state = YETI_STATE_STOP;
-                    item->required_anim_state = YETI_STATE_WAIT_1;
-                } else if (random < YETI_WAIT_2_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_STOP;
-                    item->required_anim_state = YETI_STATE_WAIT_2;
-                } else if (random < YETI_WALK_CHANCE) {
-                    item->goal_anim_state = YETI_STATE_STOP;
+                if (random < M_WAIT_1_CHANCE || !lara_was_alive) {
+                    item->goal_anim_state = M_STATE_STOP;
+                    item->required_anim_state = M_STATE_WAIT_1;
+                } else if (random < M_WAIT_2_CHANCE) {
+                    item->goal_anim_state = M_STATE_STOP;
+                    item->required_anim_state = M_STATE_WAIT_2;
+                } else if (random < M_WALK_CHANCE) {
+                    item->goal_anim_state = M_STATE_STOP;
                 }
             } else if (creature->mood == MOOD_ATTACK) {
-                if (info.ahead && info.distance < YETI_ATTACK_2_RANGE) {
-                    item->goal_anim_state = YETI_STATE_STOP;
-                } else if (info.distance > YETI_RUN_RANGE) {
-                    item->goal_anim_state = YETI_STATE_RUN;
+                if (info.ahead && info.distance < M_ATTACK_2_RANGE) {
+                    item->goal_anim_state = M_STATE_STOP;
+                } else if (info.distance > M_RUN_RANGE) {
+                    item->goal_anim_state = M_STATE_RUN;
                 }
             }
             break;
 
-        case YETI_STATE_RUN:
+        case M_STATE_RUN:
             creature->flags = 0;
-            creature->maximum_turn = YETI_RUN_TURN;
+            creature->maximum_turn = M_RUN_TURN;
             if (creature->mood == MOOD_ESCAPE) {
                 break;
             } else if (creature->mood == MOOD_BORED) {
-                item->goal_anim_state = YETI_STATE_WALK;
-            } else if (info.ahead && info.distance < YETI_ATTACK_2_RANGE) {
-                item->goal_anim_state = YETI_STATE_STOP;
-            } else if (info.ahead && info.distance < YETI_ATTACK_3_RANGE) {
-                item->goal_anim_state = YETI_STATE_ATTACK_3;
+                item->goal_anim_state = M_STATE_WALK;
+            } else if (info.ahead && info.distance < M_ATTACK_2_RANGE) {
+                item->goal_anim_state = M_STATE_STOP;
+            } else if (info.ahead && info.distance < M_ATTACK_3_RANGE) {
+                item->goal_anim_state = M_STATE_ATTACK_3;
             } else if (creature->mood == MOOD_STALK) {
-                item->goal_anim_state = YETI_STATE_WALK;
+                item->goal_anim_state = M_STATE_WALK;
             }
             break;
 
-        case YETI_STATE_ATTACK_1:
+        case M_STATE_ATTACK_1:
             body = head;
             head = 0;
             if (creature->flags == 0
-                && (item->touch_bits & YETI_TOUCH_BITS_R) != 0) {
+                && (item->touch_bits & M_TOUCH_BITS_R) != 0) {
                 Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
-                Lara_TakeDamage(YETI_PUNCH_DAMAGE, true);
+                Lara_TakeDamage(M_PUNCH_DAMAGE, true);
                 creature->flags = 1;
                 break;
             }
             break;
 
-        case YETI_STATE_ATTACK_2:
+        case M_STATE_ATTACK_2:
             body = head;
             head = 0;
 
-            creature->maximum_turn = YETI_WALK_TURN;
+            creature->maximum_turn = M_WALK_TURN;
             if (creature->flags == 0
-                && (item->touch_bits & YETI_TOUCH_BITS_LR) != 0) {
-                if ((item->touch_bits & YETI_TOUCH_BITS_L) != 0) {
+                && (item->touch_bits & M_TOUCH_BITS_LR) != 0) {
+                if ((item->touch_bits & M_TOUCH_BITS_L) != 0) {
                     Creature_Effect(item, &m_YetiBiteL, Spawn_Blood);
                 }
-                if ((item->touch_bits & YETI_TOUCH_BITS_R) != 0) {
+                if ((item->touch_bits & M_TOUCH_BITS_R) != 0) {
                     Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
                 }
-                Lara_TakeDamage(YETI_THUMP_DAMAGE, true);
+                Lara_TakeDamage(M_THUMP_DAMAGE, true);
                 creature->flags = 1;
             }
             break;
 
-        case YETI_STATE_ATTACK_3:
+        case M_STATE_ATTACK_3:
             body = head;
             head = 0;
 
             if (creature->flags != 0
-                && (item->touch_bits & YETI_TOUCH_BITS_LR) != 0) {
-                if ((item->touch_bits & YETI_TOUCH_BITS_L) != 0) {
+                && (item->touch_bits & M_TOUCH_BITS_LR) != 0) {
+                if ((item->touch_bits & M_TOUCH_BITS_L) != 0) {
                     Creature_Effect(item, &m_YetiBiteL, Spawn_Blood);
                 }
-                if ((item->touch_bits & YETI_TOUCH_BITS_R) != 0) {
+                if ((item->touch_bits & M_TOUCH_BITS_R) != 0) {
                     Creature_Effect(item, &m_YetiBiteR, Spawn_Blood);
                 }
-                Lara_TakeDamage(YETI_CHARGE_DAMAGE, true);
+                Lara_TakeDamage(M_CHARGE_DAMAGE, true);
                 creature->flags = 1;
             }
             break;
@@ -251,41 +253,41 @@ static void M_Control(const int16_t item_num)
         default:
             break;
         }
-    } else if (item->current_anim_state != YETI_STATE_DEATH) {
-        Item_SwitchToAnim(item, YETI_ANIM_DEATH, 0);
-        item->current_anim_state = YETI_STATE_DEATH;
+    } else if (item->current_anim_state != M_STATE_DEATH) {
+        Item_SwitchToAnim(item, M_ANIM_DEATH, 0);
+        item->current_anim_state = M_STATE_DEATH;
     }
 
     if (lara_was_alive && lara_item->hit_points <= 0) {
         Creature_SpecialKill(
-            item, YETI_ANIM_KILL, YETI_STATE_KILL, LS_EXTRA_YETI_KILL);
+            item, M_ANIM_KILL, M_STATE_KILL, LS_EXTRA_YETI_KILL);
         return;
     }
 
     Creature_Head(item, body);
     Creature_Neck(item, head);
-    if (item->current_anim_state >= YETI_STATE_CLIMB_1) {
+    if (item->current_anim_state >= M_STATE_CLIMB_1) {
         Creature_Animate(item_num, angle, 0);
     } else {
-        switch (Creature_Vault(item_num, angle, 2, YETI_VAULT_SHIFT)) {
+        switch (Creature_Vault(item_num, angle, 2, M_VAULT_SHIFT)) {
         case -4:
-            Item_SwitchToAnim(item, YETI_ANIM_FALL, 0);
-            item->current_anim_state = YETI_STATE_FALL;
+            Item_SwitchToAnim(item, M_ANIM_FALL, 0);
+            item->current_anim_state = M_STATE_FALL;
             break;
 
         case 2:
-            Item_SwitchToAnim(item, YETI_ANIM_CLIMB_1, 0);
-            item->current_anim_state = YETI_STATE_CLIMB_1;
+            Item_SwitchToAnim(item, M_ANIM_CLIMB_1, 0);
+            item->current_anim_state = M_STATE_CLIMB_1;
             break;
 
         case 3:
-            Item_SwitchToAnim(item, YETI_ANIM_CLIMB_2, 0);
-            item->current_anim_state = YETI_STATE_CLIMB_2;
+            Item_SwitchToAnim(item, M_ANIM_CLIMB_2, 0);
+            item->current_anim_state = M_STATE_CLIMB_2;
             break;
 
         case 4:
-            Item_SwitchToAnim(item, YETI_ANIM_CLIMB_3, 0);
-            item->current_anim_state = YETI_STATE_CLIMB_3;
+            Item_SwitchToAnim(item, M_ANIM_CLIMB_3, 0);
+            item->current_anim_state = M_STATE_CLIMB_3;
             break;
 
         default:
@@ -303,8 +305,8 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Creature_Collision;
 
-    obj->hit_points = YETI_HITPOINTS;
-    obj->radius = YETI_RADIUS;
+    obj->hit_points = M_HITPOINTS;
+    obj->radius = M_RADIUS;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->pivot_length = 100;
     obj->lot_setup = LOT_Setup(LOT_SETUP_CLIMBER);

--- a/src/trx/game/objects/creatures/yeti.c
+++ b/src/trx/game/objects/creatures/yeti.c
@@ -237,7 +237,7 @@ static void M_Control(const int16_t item_num)
             body = head;
             head = 0;
 
-            if (creature->flags != 0
+            if (creature->flags == 0
                 && (item->touch_bits & M_TOUCH_BITS_LR) != 0) {
                 if ((item->touch_bits & M_TOUCH_BITS_L) != 0) {
                     Creature_Effect(item, &m_YetiBiteL, Spawn_Blood);


### PR DESCRIPTION
Resolves #5126.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes yetis dealing no damage during their charge attack. The first commit is a const refactor only; the second contains the fix itself.