### PR TITLE
lara: reset gun smoke count on initialise

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - fixed thrown flares falling through trapdoors (regression from 1.1)
 - fixed some level textures appearing slightly misaligned on room geometry
 - fixed potential AI behavioural differences in the South Pacific Mercenary (regression from 1.2)
+- fixed smoke from Lara's guns persisting between levels (regression from 1.1)
 
 
 

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -129,6 +129,8 @@ void Lara_Initialise(const GF_LEVEL *const level)
     lara_info->interact_target.item_num = NO_ITEM;
     lara_info->interact_target.move_count = 0;
     lara_info->poison_timer = 0;
+    lara_info->tr3_smoke_count_l = 0;
+    lara_info->tr3_smoke_count_r = 0;
 
     LOT_InitialiseLOT(&lara_info->lot);
     lara_info->lot.setup.step = WALL_L * 20;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes gun smoke persisting across levels.
Recording from aredfan: [record.txt](https://github.com/user-attachments/files/26037783/record.txt)