### PR TITLE
inventory_ring: avoid resuming level SFX in globe menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@
 - fixed some level textures appearing slightly misaligned on room geometry
 - fixed potential AI behavioural differences in the South Pacific Mercenary (regression from 1.2)
 - fixed smoke from Lara's guns persisting between levels (regression from 1.1)
+- fixed sound effects potentially playing after completing a level and entering into the globe select screen (regression from 1.2)
 
 
 

--- a/src/trx/game/inventory_ring/priv.c
+++ b/src/trx/game/inventory_ring/priv.c
@@ -191,8 +191,10 @@ void InvRing_AdjustMusicVolume(const INV_RING *const ring)
         : g_Config.audio.inventory_music_volume;
     Music_SetVolume(base_volume * multiplier);
 
-    Sound_ResetAmbient();
-    Sound_UpdateEffects();
+    if (ring->mode != INV_GLOBE_SELECT_MODE) {
+        Sound_ResetAmbient();
+        Sound_UpdateEffects();
+    }
 }
 
 void InvRing_SetRequestedObjectID(const OBJECT_ID obj_id)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents level sound effects resuming in the globe select menu.