### PR TITLE
misc: fix crash when using /mod tr3 → tr1-ub

### DIFF
--- a/src/trx/game/inject/editors/textures.c
+++ b/src/trx/game/inject/editors/textures.c
@@ -55,6 +55,13 @@ static void M_SpriteEdits(
         if (obj == nullptr || !obj->loaded) {
             continue;
         }
+        if (obj->mesh_idx < 0
+            || obj->mesh_idx >= Output_GetSpriteTextureCount()) {
+            LOG_WARNING(
+                "Invalid sprite texture index %d for object %d", obj->mesh_idx,
+                obj_info.id);
+            continue;
+        }
         SPRITE_TEXTURE *const sprite_texture =
             Output_GetSpriteTexture(obj->mesh_idx);
         sprite_texture->x0 = x0;

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -12,6 +12,7 @@
 #include <trx/game/game_flow.h>
 #include <trx/game/inject.h>
 #include <trx/game/items/carrier.h>
+#include <trx/game/level.h>
 #include <trx/game/level/cache.h>
 #include <trx/game/level/format/format.h>
 #include <trx/game/lua.h>
@@ -285,6 +286,7 @@ void Stats_CalculateMaxStats(void)
         const LEVEL_FORMAT_LOADER *const loader =
             Level_Format_GuessLoader(file);
         if (loader != nullptr) {
+            Level_Unload();
             Creature_Reset();
 
             Lua_ClearLevelListeners();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a crash where starting TR3 and issuing `/mod tr1-ub` would result in a hard crash, at least on my machine.

For this to happen, we must not have cached max stats.