### PR TITLE
inv-ring: clear state on mod switch

### DIFF
--- a/src/trx/game/inventory_ring/vars.c
+++ b/src/trx/game/inventory_ring/vars.c
@@ -30,6 +30,13 @@ void InvRing_LoadVars(const char *const path)
 {
 #define L_READ_INT(key, target) target = JSON_ObjectGetInt(obj, key, target);
 
+    for (int32_t i = 0; i < g_InvRing_Items->count; i++) {
+        INVENTORY_ITEM *const item =
+            *(INVENTORY_ITEM **)Vector_Get(g_InvRing_Items, i);
+        Memory_Free(item);
+    }
+    Vector_Clear(g_InvRing_Items);
+
     JSON_VALUE *const root = JSONFile_ReadEx(path, true);
     JSON_ARRAY *const arr = JSON_ValueAsArray(root);
     if (arr == nullptr) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes inventory ring items setup inheriting wrong configuration when using `/mod` across different game engines.