### PR TITLE
Add WMA audio playback support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Black: like the Remasters
     - Monochrome (cool): like TR3 PS1 Inventory Screen
     - Monochrome (warm): like TR3 PS1 Pause Screen
+- added support for `.wma` music files for broader custom level compatibility
 - added support for `.ogv` and `.fmv` FMV extensions, with `.ogv` preferred over `.fmv` for remaster compatibility
 - added audio fallback for FMV files that lack an audio stream (e.g. remastered `.ogv`), probing alternative extensions for a companion audio track
 - added an option to move Ammo counter location (Graphic Options → UI → Ammo counter location) (#5076)

--- a/src/trx/game/music/backend_files.c
+++ b/src/trx/game/music/backend_files.c
@@ -16,7 +16,7 @@ typedef struct {
 } M_BACKEND_DATA;
 
 static const char *m_ExtensionsToTry[] = {
-    ".flac", ".ogg", ".mp3", ".wav", nullptr,
+    ".flac", ".ogg", ".mp3", ".wav", ".wma", nullptr,
 };
 
 static char *M_GetTrackFileName(const char *base_dir, int32_t track)

--- a/tools/ffmpeg_flags.txt
+++ b/tools/ffmpeg_flags.txt
@@ -6,6 +6,8 @@
 --enable-decoder=mpeg4
 --enable-decoder=mdec
 --enable-decoder=mp3
+--enable-decoder=wmav1
+--enable-decoder=wmav2
 --enable-decoder=h264
 --enable-decoder=h264_qsv
 --enable-decoder=libopenh264
@@ -15,6 +17,7 @@
 --enable-demuxer=h264
 --enable-demuxer=str
 --enable-demuxer=image2
+--enable-demuxer=asf
 --enable-parser=mpegaudio
 --enable-zlib
 --enable-small


### PR DESCRIPTION
Checklist
- [X] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [X]  I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [X]  I have added a readme entry about my new feature or OG bug fix, or it is a different change

Description

## Summary
- Enable WMA audio decoding by adding `wmav1`/`wmav2` decoders and the `asf` demuxer to the FFmpeg build flags
- Add `.wma` to the music backend file extension search list

## Motivation

Many TR2Main custom levels ship their music tracks as `.wma` files. On the desktop build this is not a significant issue, since players typically just use whatever is packaged with the level. However, for the WebGL/web build, WMA support is a major improvement — without WMA decoding these custom levels simply have no music. Adding WMA support dramatically broadens compatibility with the existing custom level ecosystem on the web.

Crucially, this adds essentially nothing to the build. Clean release builds on Linux show:

| | Pre-UPX (stripped) | UPX compressed |
|---|---|---|
| `develop` | 17,641,768 bytes | 8,255,800 bytes |
| `feature/wma-support` | 17,641,768 bytes | 8,255,848 bytes |
| **Difference** | **0 bytes** | **+48 bytes** |

The uncompressed binary size is identical because the WMA decoders are small and fit within existing section alignment. The UPX-compressed binary grows by just 48 bytes. The FFmpeg/libav infrastructure for demuxing and decoding is already linked in; this change simply enables two additional codec paths and one demuxer within it.