### PR TITLE
output: fix fog affecting 3d pickups and inventory ring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
 - fixed the photo mode red frame not covering the full screen when using integer upscaling
 - fixed boulders that have moved vertically reactivating for a frame after loading a save (regression from 1.2)
+- fixed low fog distances affecting 3D pickups and inventory ring view
 
 **TR1**:
 - added the ability to use flames on Pendulums, similar to TR3

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -376,6 +376,11 @@ void InvRing_Draw(INV_RING *const ring)
     XYZ_16 view_rot;
     InvRing_GetView(&draw_ring, &view_pos, &view_rot);
     Matrix_GenerateW2V(&view_pos, &view_rot);
+    const int32_t old_fog_start = Output_GetFogStart();
+    const int32_t old_fog_end = Output_GetFogEnd();
+    Output_SetFogStart(0);
+    Output_SetFogEnd(20 * WALL_L);
+
     InvRing_Light(&draw_ring);
 
     Matrix_Push();
@@ -404,6 +409,8 @@ void InvRing_Draw(INV_RING *const ring)
 
     Matrix_Pop();
     SceneCompositor_Flush();
+    Output_SetFogStart(old_fog_start);
+    Output_SetFogEnd(old_fog_end);
     Viewport_AlterFOV(old_fov, old_fov_mode);
 
     if (ring->status == RNG_SELECTED) {

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -10,6 +10,7 @@
 #include <trx/game/output/sources/objects.h>
 #include <trx/game/output/sources/rooms.h>
 #include <trx/game/output/textures.h>
+#include <trx/game/output/uniforms.h>
 #include <trx/game/viewport.h>
 #include <trx/version.h>
 
@@ -110,11 +111,21 @@ int32_t Output_GetFogEnd(void)
 void Output_SetFogStart(const int32_t dist)
 {
     m_FogStart = dist;
+    const OUTPUT_UNIFORMS *const uniforms = Output_GetUniforms();
+    if (uniforms != nullptr) {
+        Output_Uniforms_UploadFogDistance(
+            uniforms, Output_GetFogStart(), Output_GetFogEnd());
+    }
 }
 
 void Output_SetFogEnd(const int32_t dist)
 {
     m_FogEnd = dist;
+    const OUTPUT_UNIFORMS *const uniforms = Output_GetUniforms();
+    if (uniforms != nullptr) {
+        Output_Uniforms_UploadFogDistance(
+            uniforms, Output_GetFogStart(), Output_GetFogEnd());
+    }
 }
 
 void Output_SetupBelowWater(const bool underwater)

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -184,6 +184,18 @@ void Output_Uniforms_UploadGeneral(const OUTPUT_UNIFORMS *const uniforms)
         glBufferSubData, GL_UNIFORM_BUFFER, 0, sizeof(general), &general);
 }
 
+void Output_Uniforms_UploadFogDistance(
+    const OUTPUT_UNIFORMS *const uniforms, const float start, const float end)
+{
+    ASSERT(uniforms != nullptr);
+    const float fog_distance[2] = { start, end };
+    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
+    TRX_GL_TRACK_SUBDATA(
+        glBufferSubData, GL_UNIFORM_BUFFER,
+        offsetof(M_UNIFORM_GENERAL, fog_distance), sizeof(fog_distance),
+        &fog_distance);
+}
+
 void Output_Uniforms_UploadDesaturation(
     const OUTPUT_UNIFORMS *const uniforms, const float desaturation)
 {

--- a/src/trx/game/output/uniforms.h
+++ b/src/trx/game/output/uniforms.h
@@ -37,6 +37,8 @@ void Output_Uniforms_UploadCPULight(
 void Output_Uniforms_UploadOwnLight(
     const OUTPUT_UNIFORMS *uniforms, const OUTPUT_LIGHT_INFO *info);
 
+void Output_Uniforms_UploadFogDistance(
+    const OUTPUT_UNIFORMS *uniforms, float start, float end);
 void Output_Uniforms_UploadDesaturation(
     const OUTPUT_UNIFORMS *uniforms, float desaturation);
 void Output_Uniforms_UploadGlobalTint(

--- a/src/trx/game/overlay.c
+++ b/src/trx/game/overlay.c
@@ -40,6 +40,7 @@ typedef struct {
 
 static UI_OVERLAY_STATE *m_UI = nullptr;
 static DISPLAY_PICKUP m_Pickups[OUTPUT_UI_MAX_PICKUPS] = {};
+static bool m_PickupsActive;
 
 static const RGBA_F m_WhiteTextColor[4] = {
     { 1.0f, 1.0f, 1.0f, 1.0f },
@@ -418,6 +419,7 @@ static void M_DrawPickups(void)
 
 static void M_AnimatePickups(const int32_t frames)
 {
+    m_PickupsActive = false;
     for (int32_t i = 0; i < OUTPUT_UI_MAX_PICKUPS; i++) {
         DISPLAY_PICKUP *const pickup = &m_Pickups[i];
         pickup->elapsed += frames;
@@ -428,17 +430,21 @@ static void M_AnimatePickups(const int32_t frames)
                 pickup->elapsed = 0;
                 pickup->phase = DPP_DISPLAY;
             }
+            m_PickupsActive = true;
             break;
         case DPP_DISPLAY:
             if (pickup->elapsed >= M_MAX_PICKUP_DURATION_DISPLAY) {
                 pickup->elapsed = 0;
                 pickup->phase = DPP_EASE_OUT;
             }
+            m_PickupsActive = true;
             break;
         case DPP_EASE_OUT:
             if (pickup->elapsed >= M_MAX_PICKUP_DURATION_EASE_OUT) {
                 pickup->elapsed = 0;
                 pickup->phase = DPP_DEAD;
+            } else {
+                m_PickupsActive = true;
             }
             break;
         case DPP_DEAD:
@@ -496,8 +502,16 @@ void Overlay_DrawGameInfo(void)
         return;
     }
 
-    if (g_Config.ui.show_pickups_overlay) {
+    if (g_Config.ui.show_pickups_overlay && m_PickupsActive) {
+        SceneCompositor_Flush();
+        const int32_t old_fog_start = Output_GetFogStart();
+        const int32_t old_fog_end = Output_GetFogEnd();
+        Output_SetFogStart(0);
+        Output_SetFogEnd(20 * WALL_L);
         M_DrawPickups();
+        SceneCompositor_Flush();
+        Output_SetFogStart(old_fog_start);
+        Output_SetFogEnd(old_fog_end);
     }
 
     if (Gym_TrackManager_GetLapTimeDisplayTimer(GYM_TRACK_QUAD) > 0) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes extermely low fog distance values affecting negatively 3D pickups HUD display and the inventory ring view.