### PR TITLE
lara/state/extra: bypass scion pickup display on level end

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 **TR1**:
 - added the ability to use flames on Pendulums, similar to TR3
 - changed skyboxes in TR1 to be drawn only if the appropriate room flag is set
+- changed the scion pickup in Sanctuary of the Scion to not be displayed on-screen briefly before the level ends (#3682)
 - fixed Scion taking damage before activation (regression from 1.0)
 
 **TR2**:

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -70,16 +70,22 @@ static const M_MIDAS_STEP m_MidasSteps[] = {
 static void M_ScionPedestal(ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (Item_TestFrameEqual(item, M_LF_PICKUP_SCION)
-        && lara->interact_target.item_num != NO_ITEM) {
-        ITEM *const scion = Item_Get(lara->interact_target.item_num);
-        Overlay_AddDisplayPickup(scion->object_id);
-        Inv_AddItem(scion->object_id);
-        scion->status = IS_INVISIBLE;
-        Item_RemoveDrawn(lara->interact_target.item_num);
-        Stats_AddPickup();
-        lara->interact_target.item_num = NO_ITEM;
+    if (!Item_TestFrameEqual(item, M_LF_PICKUP_SCION)
+        || lara->interact_target.item_num == NO_ITEM) {
+        return;
     }
+
+    ITEM *const scion = Item_Get(lara->interact_target.item_num);
+    const ITEM_ACTION action = ItemAction_ToGameID(ITEM_ACTION_FINISH_LEVEL);
+    if (!Anim_HasFXCommand(Item_GetAnim(item), action)) {
+        Overlay_AddDisplayPickup(scion->object_id);
+    }
+
+    Inv_AddItem(scion->object_id);
+    scion->status = IS_INVISIBLE;
+    Item_RemoveDrawn(lara->interact_target.item_num);
+    Stats_AddPickup();
+    lara->interact_target.item_num = NO_ITEM;
 }
 
 static void M_UseMidas(ITEM *const item, COLL_INFO *const coll)


### PR DESCRIPTION
Resolves #3682.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids the scion showing on-screen if Lara's extra animation is just about to end the level, like in Sanctuary of the Scion. It will continue to be shown in Tomb of Qualopec.
