### PR TITLE
demo: show accurate Lara gun meshes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 **TR2**:
 - added the ability to use flames on Pendulums, similar to TR3
+- changed demos to show accurate gun meshes before Lara draws her pre-selected weapon (#3585)
 - fixed Bartoli appearing frozen towards the end of the Opera House cutscene
 - fixed pulling the Dagger of Xian from dragon's corpse not counting as a pickup (regression from 1.0)
 - fixed thrown flares falling through trapdoors and becoming stuck in the void if thrown underwater near the floor (#3708)

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -6,6 +6,7 @@
 #include <trx/game/game.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/game_strings/entries.h>
+#include <trx/game/gun.h>
 #include <trx/game/input.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
@@ -191,6 +192,15 @@ bool Demo_Start(const int32_t level_num)
         Lara_Cheat_GetStuff();
     } else {
         lara->last_gun_type = LGT_PISTOLS;
+    }
+
+    if (Gun_IsRifleType(lara->last_gun_type)) {
+        Gun_SetLaraBackMesh(lara->last_gun_type);
+    } else if (
+        lara->last_gun_type != LGT_UNARMED
+        && lara->last_gun_type != LGT_FLARE) {
+        Gun_SetLaraHolsterLMesh(lara->last_gun_type);
+        Gun_SetLaraHolsterRMesh(lara->last_gun_type);
     }
 
     Camera_Initialise();


### PR DESCRIPTION
Resolves #3585.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates demos to have Lara's meshes updated to accurately show her chosen gun type.
