### PR TITLE
level: parallelize texture expansion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,7 @@
 - added an option for Lara to wear semi-transparent sunglasses (Graphic Options → Lara's sunglasses)
 - changed the reflections option to be available in all game modes (Graphic Options → Enable reflections)
 - changed the delay in performing a running jump by one frame less, when jump lock mode is set to disabled (Gameplay → Controls → Jump lock mode) (#3841)
-- improved level loading times by 10%
+- improved level loading times by 15%
 - improved FMV audio to play through the game's existing audio mixer instead of opening a separate audio device
 - fixed High lighting contrast not attenuating brightness properly in TR1 and TR2 (regression from 1.1)
 - fixed the photo mode red frame not covering the full screen when using integer upscaling

--- a/src/trx/game/level/sections/textures.c
+++ b/src/trx/game/level/sections/textures.c
@@ -2,12 +2,20 @@
 #include <trx/core/colors.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/thread_pool.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/inject.h>
 #include <trx/game/level/format/format.h>
 #include <trx/game/level/sections/append.h>
 #include <trx/game/level/sections/read.h>
 #include <trx/game/output.h>
+
+typedef struct {
+    const RGB_888 *palette;
+    const uint8_t *input_8_page;
+    const uint16_t *input_16_page;
+    RGBA_8888 *output_32_page;
+} M_TEXTURE_PAGE_DECODE_JOB;
 
 static void M_DecodeTR3ObjectTextureUVs(OBJECT_TEXTURE *const texture)
 {
@@ -30,6 +38,34 @@ static void M_DecodeTR3ObjectTextureUVs(OBJECT_TEXTURE *const texture)
             uv[i] += 256;
         }
         flags >>= 1;
+    }
+}
+
+static void M_Decode8BitTexturePage(void *const userdata)
+{
+    const M_TEXTURE_PAGE_DECODE_JOB *const job = userdata;
+    const uint8_t *input = job->input_8_page;
+    RGBA_8888 *output = job->output_32_page;
+
+    for (int32_t i = 0; i < TEXTURE_PAGE_SIZE; i++) {
+        const uint8_t index = *input++;
+        const RGB_888 pix = job->palette[index];
+        output->r = pix.r;
+        output->g = pix.g;
+        output->b = pix.b;
+        output->a = index == 0 ? 0 : 0xFF;
+        output++;
+    }
+}
+
+static void M_Decode16BitTexturePage(void *const userdata)
+{
+    const M_TEXTURE_PAGE_DECODE_JOB *const job = userdata;
+    const uint16_t *input = job->input_16_page;
+    RGBA_8888 *output = job->output_32_page;
+
+    for (int32_t i = 0; i < TEXTURE_PAGE_SIZE; i++) {
+        *output++ = Color_ARGB1555ToRGBA8888(*input++);
     }
 }
 
@@ -90,30 +126,38 @@ void Level_Section_ReadTexturePages(LEVEL_CONTEXT *const ctx, VFILE *const file)
     VFile_Read(file, info->textures.pages_8, num_pages * TEXTURE_PAGE_SIZE);
 
     info->textures.pages_32 = Memory_Alloc(texture_size_32_bit);
-    RGBA_8888 *output = info->textures.pages_32;
+
+    THREAD_POOL *const pool = ThreadPool_Create(-1);
+    M_TEXTURE_PAGE_DECODE_JOB *const jobs =
+        Memory_Alloc(sizeof(*jobs) * num_pages);
+    uint16_t *input_16 = nullptr;
+    for (int32_t i = 0; i < num_pages; i++) {
+        jobs[i].palette = info->palette.data_24;
+        jobs[i].input_8_page = &info->textures.pages_8[i * TEXTURE_PAGE_SIZE];
+        jobs[i].input_16_page = nullptr;
+        jobs[i].output_32_page =
+            &info->textures.pages_32[i * TEXTURE_PAGE_SIZE];
+    }
 
     if (loader->game_version == 1) {
-        const uint8_t *input = info->textures.pages_8;
-        for (int32_t i = 0; i < num_pages * TEXTURE_PAGE_SIZE; i++) {
-            const uint8_t index = *input++;
-            const RGB_888 pix = info->palette.data_24[index];
-            output->r = pix.r;
-            output->g = pix.g;
-            output->b = pix.b;
-            output->a = index == 0 ? 0 : 0xFF;
-            output++;
+        for (int32_t i = 0; i < num_pages; i++) {
+            ThreadPool_AddJob(pool, M_Decode8BitTexturePage, &jobs[i]);
         }
     } else {
         const int32_t texture_size_16_bit =
             num_pages * TEXTURE_PAGE_SIZE * sizeof(uint16_t);
-        uint16_t *input = Memory_Alloc(texture_size_16_bit);
-        uint16_t *input_ptr = input;
-        VFile_Read(file, input, texture_size_16_bit);
-        for (int32_t i = 0; i < num_pages * TEXTURE_PAGE_SIZE; i++) {
-            *output++ = Color_ARGB1555ToRGBA8888(*input_ptr++);
+        input_16 = Memory_Alloc(texture_size_16_bit);
+        VFile_Read(file, input_16, texture_size_16_bit);
+        for (int32_t i = 0; i < num_pages; i++) {
+            jobs[i].input_16_page = &input_16[i * TEXTURE_PAGE_SIZE];
+            ThreadPool_AddJob(pool, M_Decode16BitTexturePage, &jobs[i]);
         }
-        Memory_FreePointer(&input);
     }
+
+    ThreadPool_Wait(pool);
+    Memory_FreePointer(&input_16);
+    Memory_Free(jobs);
+    ThreadPool_Destroy(pool);
 
     Benchmark_End(&benchmark, nullptr);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the 16-bit texture decoding to happen in a thread pool. It gives us yet another nice performance boost.

I changed the test protocol to start the game in the Title Screen, load Thames Wharf 5 times, and close the game (previously it'd only load Thames Wharf once, which diluted the benchmarks with lots of OS-induced noise).

The results:

##### stable vs branch

| Metric | stable     | branch     | Δ (stable - branch) | Δ % (stable - branch) |
|--------|------------|------------|---------------------|-----------------------|
| Count  | 300        | 300        | 0                   | 0%                    |
| Mean   | 91.122 ms  | 77.090 ms  | -14.033 ms          | -15.4%                |
| P50    | 88.885 ms  | 73.990 ms  | -14.895 ms          | -16.758%              |
| P90    | 113.025 ms | 100.921 ms | -12.104 ms          | -10.709%              |
| P95    | 116.653 ms | 103.574 ms | -13.078 ms          | -11.211%              |
| Min    | 65.500 ms  | 59.640 ms  | -5.860 ms           | -8.947%               |
| Max    | 130.230 ms | 115.080 ms | -15.150 ms          | -11.633%              |
| PSTDEV | 13.770 ms  | 12.242 ms  | -1.527 ms           | -11.091%              |

##### develop vs branch

| Metric | develop    | branch     | Δ (develop - branch) | Δ % (develop - branch) |
|--------|------------|------------|----------------------|------------------------|
| Count  | 300        | 300        | 0                    | 0%                     |
| Mean   | 80.262 ms  | 77.090 ms  | -3.173 ms            | -3.953%                |
| P50    | 76.430 ms  | 73.990 ms  | -2.440 ms            | -3.192%                |
| P90    | 104.026 ms | 100.921 ms | -3.105 ms            | -2.985%                |
| P95    | 106.812 ms | 103.574 ms | -3.238 ms            | -3.031%                |
| Min    | 58.450 ms  | 59.640 ms  | 1.190 ms             | 2.036%                 |
| Max    | 127.160 ms | 115.080 ms | -12.080 ms           | -9.5%                  |
| PSTDEV | 13.607 ms  | 12.242 ms  | -1.364 ms            | -10.027%               |

