### PR TITLE
shell: fix -l/--level

### DIFF
--- a/data/tr1/ship/cfg/tr1-level/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-level/gameflow.json5
@@ -27,7 +27,7 @@
 
     "levels": [
         {
-            "path": "PLACEHOLDER",
+            "path": "%direct_level%",
             "music_track": 0,
             "lara_outfit": "tr1_classic",
             "sequence": [

--- a/data/tr2/ship/cfg/tr2-level/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-level/gameflow.json5
@@ -26,7 +26,7 @@
 
     "levels": [
         {
-            "path": "PLACEHOLDER",
+            "path": "%direct_level%",
             "music_track": -1,
             "lara_outfit": "tr2_classic",
             "sequence": [

--- a/data/tr3/ship/cfg/tr3-level/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-level/gameflow.json5
@@ -20,7 +20,7 @@
 
     "levels": [
         {
-            "path": "PLACEHOLDER",
+            "path": "%direct_level%",
             "music_track": -1,
             "lara_outfit": "tr3_classic",
             "sequence": [

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -108,12 +108,6 @@ GF_COMMAND GF_DoFrontendSequence(void)
 {
     const SHELL_ARGS *const args = Shell_GetArgs();
     if (args != nullptr) {
-        if (args->level_to_play != nullptr) {
-            Memory_Free(g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
-            g_GameFlow.level_tables[GFLT_MAIN].levels[0].path =
-                Memory_DupStr(args->level_to_play);
-        }
-
         if (args->save_to_load >= 0) {
             return (GF_COMMAND) {
                 .action = GF_START_SAVED_GAME,

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -463,9 +463,6 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     }
 
     Game_SetCurrentLevel(nullptr);
-    if (s->args->level_to_play != nullptr) {
-        Memory_FreePointer(&g_GameFlow.level_tables[GFLT_MAIN].levels[0].path);
-    }
 
     if (m_PendingMod != nullptr) {
         if (TestReplay_IsOpened()) {

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -508,6 +508,13 @@ static const char *M_GetBaseModID(void)
     return nullptr;
 }
 
+static const char *M_GetDirectLevelArg(void)
+{
+    return m_Context.args != nullptr && m_Context.args->level_to_play != nullptr
+        ? m_Context.args->level_to_play
+        : "";
+}
+
 static const char *M_GetBaseModDir(void)
 {
     return M_GetModDir(M_GetBaseModID());
@@ -669,6 +676,7 @@ char *TRXPath_ExpandVars(const char *const in)
           M_GetBaseDirForDynamicPath(TRX_DYNAMIC_PATH_SCRIPT_FILE) },
         { "%base_mod%", base_mod_id != nullptr ? base_mod_id : "" },
         { "%base_mod_dir%", M_GetBaseModDir() },
+        { "%direct_level%", M_GetDirectLevelArg() },
         { "%tr_version%", String_FormatStatic("%d", g_TRVersion) },
     };
 
@@ -877,8 +885,14 @@ static bool M_ForEachResolveAttempt(
     ASSERT(path >= 0 && path < TRX_DYNAMIC_PATH_NUMBER_OF);
     ASSERT(callback != nullptr);
 
-    if (rel != nullptr && File_IsAbsolute(rel)) {
-        return callback(rel, user_data);
+    char *expanded_rel = TRXPath_ExpandVars(rel);
+    const char *const effective_rel =
+        expanded_rel != nullptr ? expanded_rel : rel;
+
+    if (effective_rel != nullptr && File_IsAbsolute(effective_rel)) {
+        const bool result = callback(effective_rel, user_data);
+        Memory_FreePointer(&expanded_rel);
+        return result;
     }
 
     const M_DYNAMIC_PATH_POLICY *const policy = &m_PathPolicies[path];
@@ -890,8 +904,8 @@ static bool M_ForEachResolveAttempt(
             break;
         }
 
-        char *candidate =
-            Memory_DupStr(M_ExpandDynamicPattern(path, pattern, rel, nullptr));
+        char *candidate = Memory_DupStr(
+            M_ExpandDynamicPattern(path, pattern, effective_rel, nullptr));
         if (strchr(candidate, '%') != nullptr) {
             Memory_FreePointer(&candidate);
             continue;
@@ -935,6 +949,7 @@ static bool M_ForEachResolveAttempt(
         Memory_FreePointer(&candidate);
     }
 
+    Memory_FreePointer(&expanded_rel);
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`-l`/`--level` got recently broken by adding path resolving at too early stage (parsing of the game flow file).

Instead of adding more hacks, I changed `"path": "PLACEHOLDER"` to `"path": "%direct_level%"` in the gameflow files, removed the manual override, and updated the path resolver to hydrate this variable from shell args. It seems to work okay.