### PR TITLE
audio_reverb: prevent denormals in feedback paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@
 - fixed potential AI behavioural differences in the South Pacific Mercenary (regression from 1.2)
 - fixed smoke from Lara's guns persisting between levels (regression from 1.1)
 - fixed sound effects potentially playing after completing a level and entering into the globe select screen (regression from 1.2)
+- fixed audio lag and framerate drops near the end of an audio track that's playing when no active sound effects are playing (#5167, regression from 1.3)
 
 
 

--- a/src/trx/av/audio_reverb.c
+++ b/src/trx/av/audio_reverb.c
@@ -30,6 +30,7 @@
 #define M_REVERB_MAX_REFLECTIONS_DELAY 300
 #define M_REVERB_MAX_REVERB_DELAY 85
 #define M_REVERB_MIN_DECAY_TIME 0.1f
+#define M_REVERB_DENORMAL_EPSILON 1e-15f
 
 #define M_REVERB_WET_GAIN 1.20f // TRX addition
 #define M_DELAY_MAX_MS 300
@@ -188,7 +189,7 @@ static inline uint32_t M_MsToSamples(
 
 static inline float M_Undenormalize(const float sample_in)
 {
-    return sample_in;
+    return fabsf(sample_in) < M_REVERB_DENORMAL_EPSILON ? 0.0f : sample_in;
 }
 
 static inline void M_DspDelay_Initialize(


### PR DESCRIPTION
Resolves #5167.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This introduces a small threshold when undenormalizing samples to flush near-zero values to zero. It resolves CPU spikes near the end of regular audio tracks when there are no active SFX playing.