### PR TITLE
lara/col/climb: fix ladder woes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4...develop) - ××××-××-××
+- fixed Lara using the ladder-to-crouch animation in some rare cases despite there being headroom in front of her (regression from 1.2)
 
 **TR3**:
 - fixed door 34 in Thames Wharf closing permanently during the flipmap puzzle (#5170, regression from 1.1)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **TR3**:
 - fixed door 34 in Thames Wharf closing permanently during the flipmap puzzle (#5170, regression from 1.1)
+- fixed Lara being unable to move after grabbing ladders in specific geometry (#5169, regression from 1.1)
 
 
 

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -21,6 +21,7 @@
 #define M_LEDGE_JUMP_PUSH_HEIGHT (STEP_L - 16)                    // = 240
 #define M_LEDGE_JUMP_HEIGHT_UP   (LARA_HEIGHT + (STEP_L * 3) / 8) // = 858
 #define M_LEDGE_JUMP_HEIGHT_BACK (LARA_HEIGHT - (STEP_L * 5) / 4) // = 442
+#define M_HANG_SHIFT             (g_TRVersion >= 3 ? 4 : 2)
 // clang-format on
 
 typedef enum {
@@ -46,25 +47,25 @@ static M_CLIMB_RESULT M_TestClimbPos(
     case DIR_NORTH:
         x = item->pos.x + right;
         z = item->pos.z + front;
-        z_front = 2;
+        z_front = M_HANG_SHIFT;
         break;
 
     case DIR_EAST:
         x = item->pos.x + front;
         z = item->pos.z - right;
-        x_front = 2;
+        x_front = M_HANG_SHIFT;
         break;
 
     case DIR_SOUTH:
         x = item->pos.x - right;
         z = item->pos.z - front;
-        z_front = -2;
+        z_front = -M_HANG_SHIFT;
         break;
 
     case DIR_WEST:
         x = item->pos.x - front;
         z = item->pos.z + right;
-        x_front = -2;
+        x_front = -M_HANG_SHIFT;
         break;
 
     default:
@@ -247,19 +248,18 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     lara->move_angle = item->rot.y;
 
     const DIRECTION dir = Math_GetDirection(item->rot.y);
-    const int32_t hang_test_shift = g_TRVersion >= 3 ? 4 : 2;
     switch (dir) {
     case DIR_NORTH:
-        item->pos.z += hang_test_shift;
+        item->pos.z += M_HANG_SHIFT;
         break;
     case DIR_EAST:
-        item->pos.x += hang_test_shift;
+        item->pos.x += M_HANG_SHIFT;
         break;
     case DIR_SOUTH:
-        item->pos.z -= hang_test_shift;
+        item->pos.z -= M_HANG_SHIFT;
         break;
     case DIR_WEST:
-        item->pos.x -= hang_test_shift;
+        item->pos.x -= M_HANG_SHIFT;
         break;
     default:
         break;
@@ -403,25 +403,25 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
     case DIR_NORTH:
         x = item->pos.x + right;
         z = item->pos.z + front;
-        z_front = 2;
+        z_front = M_HANG_SHIFT;
         break;
 
     case DIR_EAST:
         x = item->pos.x + front;
         z = item->pos.z - right;
-        x_front = 2;
+        x_front = M_HANG_SHIFT;
         break;
 
     case DIR_SOUTH:
         x = item->pos.x - right;
         z = item->pos.z - front;
-        z_front = -2;
+        z_front = -M_HANG_SHIFT;
         break;
 
     case DIR_WEST:
         z = item->pos.z + right;
         x = item->pos.x - front;
-        x_front = -2;
+        x_front = -M_HANG_SHIFT;
         break;
 
     default:

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -808,7 +808,7 @@ static void M_UpLadder(ITEM *const item, COLL_INFO *const coll)
         item->goal_anim_state = LS(LS_CLIMB_STANCE);
         Lara_Animate(item);
         if (ABS(ledge_l - ledge_r) <= 120) {
-            if (result_r == CLIMB_RESULT_NEG && result_l == CLIMB_RESULT_NEG) {
+            if (result_r == CLIMB_RESULT_NEG || result_l == CLIMB_RESULT_NEG) {
                 item->goal_anim_state = LS(LS_PULL_UP);
                 item->pos.y += (ledge_r + ledge_l) / 2 - STEP_L;
             } else {


### PR DESCRIPTION
Resolves #5169.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR3 uses a general X/Z shift of 4 for hanging and ladder checks, whereas TR1/2 both use 2. We had this version gate in place in one area but it was missing in two others, which seems to be the cause of the faulty ladder in Thames Wharf.

Also fixed Lara going from ladder to crouch in this area when pulling up, which only became evident with the above fix.
