### PR TITLE
rooms/floor_data: fix TR3 antitrigger masks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4...develop) - ××××-××-××
 
+**TR3**:
+- fixed door 34 in Thames Wharf closing permanently during the flipmap puzzle (#5170, regression from 1.1)
+
+
+
 ## [1.4](https://github.com/LostArtefacts/TRX/compare/trx-1.3.1...trx-1.4) - 2026-03-21
 Showcase: https://youtu.be/8SavYv2SawI
 - added an option to let Lara stay crouched without holding the button (Gameplay → Controls → Toggle crouch) (#5006)

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -540,7 +540,13 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
                 if (is_shoal_object) {
                     Shoal_TriggerDeactivate(trig_item);
                 }
-                trig_item->flags &= ~trigger->mask;
+
+                // TODO investigate unifying as ~(trigger->mask | IF_REVERSE)
+                if (g_TRVersion >= 3) {
+                    trig_item->flags &= ~(IF_CODE_BITS | IF_REVERSE);
+                } else {
+                    trig_item->flags &= ~trigger->mask;
+                }
                 if (trigger->one_shot) {
                     if (g_TRVersion == 3) {
                         trig_item->flags |= IF_ONE_SHOT_ANTITRIGGER;


### PR DESCRIPTION
Resolves #5170.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates TR3 to allow using an antitrigger for a reverse-activated item, which means it in turn triggers it.
