### PR TITLE
stats: respect PS1 enemy setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4...develop) - ××××-××-××
 - fixed Lara using the ladder-to-crouch animation in some rare cases despite there being headroom in front of her (regression from 1.2)
-- fixed toggle-sprint key failing to cancel sprint mid-run (#5174)
-- fixed toggle-duck key failing to keep Lara ducked in run-to-duck and sprint-to-duck paths (#5177)
+- fixed toggle-sprint key failing to cancel sprint mid-run (#5174, regression from 1.4)
+- fixed toggle-duck key failing to keep Lara ducked in run-to-duck and sprint-to-duck paths (#5177, regression from 1.4)
 - fixed flipped state of "Pause music in inventory", changed to "Enable music in inventory" (regression from 1.4)
+- fixed final statistics in City of Khamoon counting the optional PS1 mummy when Restore PS1 enemies is disabled (#5188, regression from 1.1)
 
 **TR3**:
 - fixed door 34 in Thames Wharf closing permanently during the flipmap puzzle (#5170, regression from 1.1)

--- a/src/trx/game/inject/common.c
+++ b/src/trx/game/inject/common.c
@@ -46,8 +46,15 @@ static bool M_IsRelevant(
     const bool stats = (ctx->mode == INJECTION_MODE_STATS);
 
     if (stats) {
-        return type == IFT_GENERAL || type == IFT_FLOOR_DATA
-            || type == IFT_PS1_ENEMY;
+        switch (type) {
+        case IFT_GENERAL:
+        case IFT_FLOOR_DATA:
+        case IFT_PS1_ENEMY:
+            break;
+
+        default:
+            return false;
+        }
     }
 
     switch (type) {

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -1,5 +1,6 @@
 #include <trx/game/stats/init.h>
 
+#include <trx/config.h>
 #include <trx/core/benchmark.h>
 #include <trx/core/hash.h>
 #include <trx/core/json.h>
@@ -42,6 +43,8 @@ static uint64_t M_ComputeInputsChecksum(const GF_LEVEL_TABLE *const level_table)
 {
     uint64_t hash = LevelCache_InitChecksum("max_stats_cache", M_CACHE_VERSION);
     hash = Hash_FNV1a64_UpdateU32(hash, (uint32_t)level_table->count);
+    hash = Hash_FNV1a64_UpdateU32(
+        hash, (uint32_t)g_Config.gameplay.restore_ps1_enemies);
 
     for (int32_t i = 0; i < level_table->count; i++) {
         const GF_LEVEL *const level = GF_GetLevel(GFLT_MAIN, i);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5188.
Changing the restore PS1 enemies option requires the game to be re-launched to update the kill counts.