### PR TITLE
Improve support for mod switching

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4.1...develop) - ××××-××-××
+- added remembering of the last played mod
 
 ## [1.4.1](https://github.com/LostArtefacts/TRX/compare/trx-1.4...trx-1.4.1) - 2026-03-23
 - fixed Lara using the ladder-to-crouch animation in some rare cases despite there being headroom in front of her (regression from 1.2)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4.1...develop) - ××××-××-××
 - added remembering of the last played mod
+- changed `--level` to no longer require `-e/--engine` to work
 
 ## [1.4.1](https://github.com/LostArtefacts/TRX/compare/trx-1.4...trx-1.4.1) - 2026-03-23
 - fixed Lara using the ladder-to-crouch animation in some rare cases despite there being headroom in front of her (regression from 1.2)

--- a/src/meson.build
+++ b/src/meson.build
@@ -671,6 +671,7 @@ common_sources = [
   'trx/game/shell/paths.c',
   'trx/game/shell/platform.c',
   'trx/game/shell/session.c',
+  'trx/game/shell/state.c',
   'trx/game/sound/common.c',
   'trx/game/sound/ids.c',
   'trx/game/sparks/manager.c',

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -53,6 +53,7 @@ static void M_ShowHelp(void)
 SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 {
     SHELL_ARGS *const result = Memory_Alloc(sizeof(SHELL_ARGS));
+    bool wants_gold = false;
     result->save_to_load = -1;
     result->level_to_select = -1;
     result->original_args = args;
@@ -75,8 +76,6 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         result->engine_version = g_TRVersion;
     }
 
-    result->mod = Shell_GetModByType(MOD_BASE_GAME, result->engine_version);
-
     // Second pass: remaining options.
     for (int32_t i = 0; args != nullptr && i < args->count; i++) {
         const char *const arg = *(char **)Vector_Get(args, i);
@@ -94,8 +93,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
         if (!strcmp(arg, "-g") || !strcmp(arg, "--gold")
             || !strcmp(arg, "-gold")) {
-            result->mod =
-                Shell_GetModByType(MOD_EXPANSION_PACK, result->engine_version);
+            wants_gold = true;
         }
 
         if (!strcmp(arg, "--demo-pc") || !strcmp(arg, "-demo_pc")) {
@@ -116,18 +114,11 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                 result->level_to_select = lvnum;
             } else {
                 result->level_to_play = next_arg;
-                if (result->mod == nullptr && result->engine_version == 0) {
-                    Shell_ExitSystem(
-                        "Either --mod or --engine must be provided for "
-                        "--level");
+                if (result->engine_version == 0) {
+                    Shell_ExitSystem("--engine must be provided for --level.");
                 }
-                if (result->mod != nullptr) {
-                    result->mod = Shell_GetModByType(
-                        MOD_DIRECT_LEVEL, result->mod->engine_version);
-                } else {
-                    result->mod = Shell_GetModByType(
-                        MOD_DIRECT_LEVEL, result->engine_version);
-                }
+                result->mod = Shell_GetModByType(
+                    MOD_DIRECT_LEVEL, result->engine_version);
             }
             i++;
         }
@@ -165,8 +156,22 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
     }
 
+    if (result->mod == nullptr) {
+        result->mod = Shell_SelectStartupMod(result->engine_version);
+    }
     if (result->engine_version == 0 && result->mod != nullptr) {
         result->engine_version = result->mod->engine_version;
+    }
+    if (wants_gold) {
+        const int32_t engine_version = result->engine_version != 0
+            ? result->engine_version
+            : (result->mod != nullptr ? result->mod->engine_version : 0);
+        const SHELL_MOD *const gold_mod =
+            Shell_GetModByType(MOD_EXPANSION_PACK, engine_version);
+        if (gold_mod != nullptr) {
+            result->mod = gold_mod;
+            result->engine_version = gold_mod->engine_version;
+        }
     }
 
     return result;

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -1,10 +1,13 @@
 #include <trx/game/shell/args.h>
 
+#include <trx/core/filesystem.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
+#include <trx/core/virtual_file.h>
 #include <trx/debug.h>
+#include <trx/game/level/format/format.h>
 #include <trx/game/shell/common.h>
 #include <trx/version.h>
 
@@ -48,6 +51,23 @@ static void M_ShowHelp(void)
     puts(
         "--debug-render-performance: output diagnostic information after each "
         "frame.");
+}
+
+static int32_t M_GuessEngineVersionFromLevelPath(const char *const path)
+{
+    if (path == nullptr || !File_Exists(path)) {
+        return 0;
+    }
+
+    VFILE *const file = VFile_CreateFromPath(path);
+    if (file == nullptr) {
+        return 0;
+    }
+
+    const LEVEL_FORMAT_LOADER *const loader = Level_Format_GuessLoader(file);
+    const int32_t game_version = loader != nullptr ? loader->game_version : 0;
+    VFile_Close(file);
+    return game_version;
 }
 
 SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
@@ -115,7 +135,13 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             } else {
                 result->level_to_play = next_arg;
                 if (result->engine_version == 0) {
-                    Shell_ExitSystem("--engine must be provided for --level.");
+                    result->engine_version =
+                        M_GuessEngineVersionFromLevelPath(next_arg);
+                }
+                if (result->engine_version == 0) {
+                    Shell_ExitSystem(
+                        "Cannot determine engine version for --level. "
+                        "Please provide --engine.");
                 }
                 result->mod = Shell_GetModByType(
                     MOD_DIRECT_LEVEL, result->engine_version);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -35,6 +35,7 @@
 #include <trx/game/shell.h>
 #include <trx/game/shell/platform.h>
 #include <trx/game/shell/session.h>
+#include <trx/game/shell/state.h>
 #include <trx/game/sound.h>
 #include <trx/game/stats.h>
 #include <trx/game/ui/settings.h>
@@ -248,9 +249,10 @@ static void M_PrepareSystem(void)
     LOG_INFO("Engine version: %d", g_TRVersion);
     LOG_INFO("Mod: %s", s->args->mod != nullptr ? s->args->mod->name : nullptr);
     if (s->args->engine_version <= 0 || s->args->mod == nullptr) {
-        Shell_ExitSystem(
-            "Unknown or ambiguous gameflow file. "
-            "Are you missing --engine or --mod?");
+        Shell_ExitSystem("No playable mods available.");
+    }
+    if (s->args->mod->mod_type != MOD_DIRECT_LEVEL) {
+        ShellState_RememberLastPlayedMod(s->args->mod->name);
     }
 
     Config_ApplyDefaultSettings();

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -33,6 +33,12 @@ int main(int argc, char *argv[])
 
     LOG_INFO("Starting %s", g_TRXVersion);
     Shell_ValidateMods();
+    if (args->mod == nullptr || !args->mod->is_valid) {
+        args->mod = Shell_SelectStartupMod(args->engine_version);
+        if (args->mod != nullptr && args->engine_version == 0) {
+            args->engine_version = args->mod->engine_version;
+        }
+    }
 
     int32_t exit_code;
     bool restart;

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -7,6 +7,7 @@
 #include <trx/game/game_flow/reader.h>
 #include <trx/game/shell/common.h>
 #include <trx/game/shell/paths.h>
+#include <trx/game/shell/state.h>
 #include <trx/version.h>
 
 #include <string.h>
@@ -144,6 +145,39 @@ const SHELL_MOD *Shell_GetModByName(const char *const name)
         }
     }
     return nullptr;
+}
+
+static bool M_MatchesEngineVersion(
+    const SHELL_MOD *const mod, const int32_t engine_version)
+{
+    return engine_version == 0 || mod->engine_version == engine_version;
+}
+
+static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
+{
+    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
+        const SHELL_MOD *const mod = &m_KnownMods[i];
+        if (!Shell_CanSwitchToMod(mod)
+            || !M_MatchesEngineVersion(mod, engine_version)) {
+            continue;
+        }
+        return mod;
+    }
+    return nullptr;
+}
+
+const SHELL_MOD *Shell_SelectStartupMod(const int32_t engine_version)
+{
+    const char *const last_played_mod = ShellState_GetLastPlayedMod();
+    if (last_played_mod != nullptr) {
+        const SHELL_MOD *const mod = Shell_GetModByName(last_played_mod);
+        if (mod != nullptr && Shell_CanSwitchToMod(mod)
+            && M_MatchesEngineVersion(mod, engine_version)) {
+            return mod;
+        }
+    }
+
+    return M_GetFirstAvailableMod(engine_version);
 }
 
 const SHELL_MOD *Shell_GetModByType(

--- a/src/trx/game/shell/mod.h
+++ b/src/trx/game/shell/mod.h
@@ -23,6 +23,7 @@ void Shell_ValidateMods(void);
 int32_t Shell_GetModCount(void);
 const SHELL_MOD *Shell_GetMod(int32_t index);
 const SHELL_MOD *Shell_GetModByName(const char *name);
+const SHELL_MOD *Shell_SelectStartupMod(int32_t engine_version);
 const SHELL_MOD *Shell_GetModByType(
     SHELL_MOD_TYPE mod_type, int32_t engine_version);
 bool Shell_CanSwitchToMod(const SHELL_MOD *mod);

--- a/src/trx/game/shell/state.c
+++ b/src/trx/game/shell/state.c
@@ -1,0 +1,90 @@
+#include <trx/game/shell/state.h>
+
+#include <trx/core/filesystem.h>
+#include <trx/core/json.h>
+#include <trx/core/json/util/file.h>
+#include <trx/core/memory.h>
+#include <trx/core/strings.h>
+#include <trx/game/shell.h>
+
+#include <string.h>
+
+static char *m_LastPlayedMod = nullptr;
+
+#define M_LAST_PLAYED_MOD_KEY "last_played_mod"
+
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    Memory_FreePointer(&m_LastPlayedMod);
+}
+
+static const char *M_GetStatePath(void)
+{
+    return String_FormatStatic("%s/shell.json5", Shell_GetConfigDir());
+}
+
+static void M_LoadState(void)
+{
+    if (m_LastPlayedMod != nullptr) {
+        return;
+    }
+
+    if (!File_Exists(M_GetStatePath())) {
+        return;
+    }
+
+    JSON_VALUE *const root = JSONFile_Read(M_GetStatePath());
+    if (root == nullptr) {
+        return;
+    }
+
+    JSON_OBJECT *const root_obj = JSON_ValueAsObject(root);
+    const char *const mod_name =
+        JSON_ObjectGetString(root_obj, M_LAST_PLAYED_MOD_KEY, nullptr);
+    if (mod_name != nullptr) {
+        m_LastPlayedMod = Memory_DupStr(mod_name);
+    }
+
+    JSON_ValueFree(root);
+}
+
+const char *ShellState_GetLastPlayedMod(void)
+{
+    M_LoadState();
+    return m_LastPlayedMod;
+}
+
+void ShellState_RememberLastPlayedMod(const char *const mod_name)
+{
+    if (mod_name == nullptr) {
+        return;
+    }
+
+    M_LoadState();
+    if (m_LastPlayedMod != nullptr && strcmp(m_LastPlayedMod, mod_name) == 0) {
+        return;
+    }
+
+    Memory_FreePointer(&m_LastPlayedMod);
+    m_LastPlayedMod = Memory_DupStr(mod_name);
+
+    JSON_OBJECT *const root_obj = JSON_ObjectNew();
+    JSON_ObjectAppendString(root_obj, M_LAST_PLAYED_MOD_KEY, m_LastPlayedMod);
+
+    JSON_VALUE *const root = JSON_ValueFromObject(root_obj);
+    const char *const state_path = M_GetStatePath();
+    File_EnsureParentDirectories(state_path);
+    if (File_Exists(state_path)) {
+        JSONFile_Write(state_path, root);
+    } else {
+        size_t out_len = 0;
+        char *out_data = JSON_WritePretty(root, "  ", "\n", &out_len);
+        MYFILE *const fp = File_Open(state_path, FILE_OPEN_WRITE);
+        if (fp != nullptr) {
+            File_WriteData(fp, out_data, out_len - 1); // w/o \0
+            File_Close(fp);
+        }
+        Memory_FreePointer(&out_data);
+    }
+    JSON_ValueFree(root);
+}

--- a/src/trx/game/shell/state.h
+++ b/src/trx/game/shell/state.h
@@ -1,0 +1,4 @@
+#pragma once
+
+const char *ShellState_GetLastPlayedMod(void);
+void ShellState_RememberLastPlayedMod(const char *mod_name);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:

- remembers the last played mod (unless it's `--level`, then it doesn't),
- lifts the requirement to pass either `--mod` or `--engine` under new file hierarchy:
   - if the game remembers the last played mod, it runs that,
   - otherwise it reverts to the first playable mod (TR1 usually),
   - or exits with a fatal error if there are no mods playable
- lifts the requirement to pass `-e` / `--engine` for path-based `-l` / `--level` arguments. For numeric arguments, the game plays the nth level in the last played mod.

#### Testing

- [x] Playing old hierarchy mods
  Expected outcome: no regressions
- [x] Switch Game in the old hierarchy
  Expected outcome: no regressions
- [x] Switch Game in the new hierarchy
  Expected outcome: no regressions
- [x] Remove `cfg/shell.json5`. Start the game.
  Expected outcome: TR1 is launched
- [x] Remove `cfg/shell.json5`. Start with `--gold`.
  Expected outcome: TR1:UB is launched
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart.
  Expected outcome: TR2 is launched
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--gold`.
  Expected outcome: TR2:GM is launched
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--level 2`.
  Expected outcome: the game starts in Venice.
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--level path/to/tr1-level.phd`.
  Expected outcome: the game starts in the specified level with TR1 configuration settings, *not* TR2.
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--level path/to/tr1-level.phd`. Restart again.
  Expected outcome: the game starts in TR2 despite us having played TR1 level inbetween.
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--engine 3`.
  Expected outcome: TR3 is launched
- [x] Remove `cfg/shell.json5`. Start the game. Switch to TR2. Restart with `--engine 3`. Restart again.
  Expected outcome: TR3 continues to be launched
- [x] Edit `shell.json5` to point to `sdapogkfpdov` as the last mod. Start the game.
  Expected outcome: this is ignored as invalid and TR1 is launched.
- [x] Edit `shell.json5` to point to `tr2-level` as the last mod. Start the game.
  Expected outcome: this is ignored as invalid and TR1 is launched.
- [x] More weird scenarios to break this or get it to crash :)
