### PR TITLE
cmd/tp: add enemy special target

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4.1...develop) - ××××-××-××
 - added remembering of the last played mod
+- added a new console command, `/tp enemy`, to cycle Lara through hostile creatures in the current level
 - changed `--level` to no longer require `-e/--engine` to work
 
 ## [1.4.1](https://github.com/LostArtefacts/TRX/compare/trx-1.4...trx-1.4.1) - 2026-03-23

--- a/docs/trx/COMMANDS.md
+++ b/docs/trx/COMMANDS.md
@@ -22,13 +22,22 @@ whichever key you have bound, and not include it as part of the command itself.
 - `/tp {room_number}`  
   `/tp room {room_number}`  
   `/tp r{room_number}`  
-  `/tp {room_number}` (legacy)  
   `/tp item {item_number}`  
   `/tp i{item_number}`  
   `/tp precise {x} {y} {z}`  
   `/tp {x} {y} {z}`  
   `/tp {object}`  
-  Instant travel! Teleports Lara to a random spot within the specified room, to an item's position by item number, to the specified X,Y,Z coordinates (grid units), to precise world-space coordinates (no `1024` scaling), or to the nearest object of a specific type.
+  `/tp enemy`  
+  `/tp pickup`  
+  Instant travel! Teleports Lara to:
+  - a random spot within the specified room;
+  - an item's position by item number;
+  - the specified X,Y,Z coordinates in grid units;
+  - the specified world-space coordinates with `precise` (no `1024` scaling);
+  - the next pickup in round-robin order with `pickup`;
+  - the next hostile creature in round-robin order with `enemy`;
+  - the nearest object of a specific type.
+  - legacy: `/tp {room_number}` is still accepted.
 
 - `/hp`  
   `/hp {health}`  

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -3,6 +3,7 @@
 #include <trx/game/console/common.h>
 #include <trx/game/console/registry.h>
 #include <trx/game/const.h>
+#include <trx/game/creature.h>
 #include <trx/game/game.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/items.h>
@@ -11,6 +12,7 @@
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/names.h>
 #include <trx/game/objects/vars.h>
+#include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 
@@ -82,6 +84,18 @@ static bool M_CanTargetItem(
     return true;
 }
 
+static bool M_CanTargetEnemyItem(const ITEM *const item)
+{
+    if (!Creature_IsHostile(item) || item->room_num == NO_ROOM
+        || item->hit_points <= 0 || (item->flags & IF_KILLED) != 0) {
+        return false;
+    }
+
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    return Room_GetHeight(sector, item->pos) != NO_HEIGHT;
+}
+
 static const ITEM *M_GetItemToTeleporTo(const char *const user_input)
 {
     int32_t match_count = 0;
@@ -138,6 +152,31 @@ static const ITEM *M_GetItemToTeleporTo(const char *const user_input)
 
     Memory_FreePointer(&matches);
     return Item_Get(best_item_num);
+}
+
+static const ITEM *M_GetHostileEnemyToTeleportTo(void)
+{
+    const int32_t item_count = Item_GetTotalCount();
+    if (item_count <= 0) {
+        return nullptr;
+    }
+
+    int16_t start_idx = 0;
+    if (m_LastTeleportedItemNum >= 0 && m_LastTeleportedItemNum < item_count) {
+        start_idx = (m_LastTeleportedItemNum + 1) % item_count;
+    }
+
+    for (int32_t i = 0; i < item_count; i++) {
+        const int16_t item_num = (start_idx + i) % item_count;
+        const ITEM *const item = Item_Get(item_num);
+        if (!M_CanTargetEnemyItem(item)) {
+            continue;
+        }
+        m_LastTeleportedItemNum = item_num;
+        return item;
+    }
+
+    return nullptr;
 }
 
 static inline bool M_IsFloatRound(const float num)
@@ -315,6 +354,29 @@ static COMMAND_RESULT M_TeleportToObject(const char *const user_input)
     return CR_SUCCESS;
 }
 
+static COMMAND_RESULT M_TeleportToEnemy(void)
+{
+    ITEM *const enemy_item = (ITEM *)M_GetHostileEnemyToTeleportTo();
+    if (enemy_item == nullptr) {
+        Console_LogError(GS("console/cmd/teleport/object_fail"), "enemy");
+        return CR_FAILURE;
+    }
+
+    const XYZ_32 pos = {
+        .x = enemy_item->pos.x,
+        .y = enemy_item->pos.y - STEP_L / 4,
+        .z = enemy_item->pos.z,
+    };
+    if (!Lara_Cheat_Teleport(pos, enemy_item->room_num)) {
+        Console_LogError(GS("console/cmd/teleport/object_fail"), "enemy");
+        return CR_FAILURE;
+    }
+
+    M_AlignLaraToItem(enemy_item);
+    Console_Log(GS("console/cmd/teleport/object"), "enemy");
+    return CR_SUCCESS;
+}
+
 static bool M_TryParseTagNumber(
     const char *const args, const char tag, int16_t *const out_num)
 {
@@ -396,6 +458,10 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     int16_t room_num = -1;
     if (sscanf(ctx->args, "%hd", &room_num) == 1) { // legacy
         return M_TeleportToRoom(room_num);
+    }
+
+    if (String_Equivalent(ctx->args, "enemy")) {
+        return M_TeleportToEnemy();
     }
 
     return M_TeleportToObject(ctx->args);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds `/tp enemy`.

As an additional convenient enhancement, it changes `/tp` to activate the target item if it's a creature. This is actually a can of worms for the following reasons:

- certain debugging scenarios, like teleporting to Xian statues to check if they take damage in their inactive state, will become harder and require workarounds, as the creatures will immediately activate.
- it is not complete because many of the creatures (Marco Bartoli, for example) will not activate due to special handling.
- it creates inconsistency because traps are not activated.

LMK if you like this or if I should remove this change. I'm leaning towards removing.