### PR TITLE
audio_reverb: apply further undenormalization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed Lara being unable to move after grabbing ladders in specific geometry (#5169, regression from 1.1)
 - fixed a missing camera shake effect in room 135 in Aldwych (#5183)
 - fixed a missing sound effect during the flip map in the Egyptian room in Lud's Gate (#5183)
+- fixed potential framerate drops during audio playback when no active sound effects are playing (regression from 1.3)
 
 
 

--- a/src/trx/av/audio_reverb.c
+++ b/src/trx/av/audio_reverb.c
@@ -227,7 +227,7 @@ static inline void M_DspDelay_Write(
     M_DSP_DELAY *const filter, const float sample)
 {
     ASSERT(filter->write_idx < filter->capacity);
-    filter->buffer[filter->write_idx] = sample;
+    filter->buffer[filter->write_idx] = M_Undenormalize(sample);
     filter->write_idx = (filter->write_idx + 1) % filter->capacity;
 }
 
@@ -301,9 +301,11 @@ static inline float M_DspBiQuad_Process(
     M_DSP_BI_QUAD *const filter, const float sample_in)
 {
     const float result = (filter->a0 * sample_in) + filter->delay0;
-    filter->delay0 =
+    const float delay0 =
         (filter->a1 * sample_in) - (filter->b1 * result) + filter->delay1;
-    filter->delay1 = (filter->a2 * sample_in) - (filter->b2 * result);
+    const float delay1 = (filter->a2 * sample_in) - (filter->b2 * result);
+    filter->delay0 = M_Undenormalize(delay0);
+    filter->delay1 = M_Undenormalize(delay1);
 
     return M_Undenormalize((result * filter->c0) + (sample_in * filter->d0));
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This extends the fix applied in 95f502a to avoid further CPU spikes when audio is playing but no SFX.

Recording below - watch the FPS counter. Another good testing place is `/play high` and just stand still while the music plays. For me it was dropping to ~45fps at times.
[record.txt](https://github.com/user-attachments/files/26169349/record.txt)
