### PR TITLE
shell/mod: add dynamic mod discovery

### DIFF
--- a/data/tr1/ship/cfg/tr1-demo-pc/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-demo-pc/gameflow.json5
@@ -2,6 +2,9 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 1,
+    "extends": "tr1",
+
     // path to the main menu background image
     "main_menu_picture": "title.webp",
 

--- a/data/tr1/ship/cfg/tr1-level/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-level/gameflow.json5
@@ -1,6 +1,9 @@
 {
     // This file is used to enable the -l argument support.
 
+    "engine": 1,
+    "extends": "tr1",
+
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tmp_%02d.dat",
 

--- a/data/tr1/ship/cfg/tr1-ub/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1-ub/gameflow.json5
@@ -2,6 +2,9 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 1,
+    "extends": "tr1",
+
     "main_menu_picture": "title_ub.webp",
     "savegame_file_fmt": "save_trub_%02d.dat",
 

--- a/data/tr1/ship/cfg/tr1/gameflow.json5
+++ b/data/tr1/ship/cfg/tr1/gameflow.json5
@@ -2,6 +2,8 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 1,
+
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tr1_%02d.dat",
 

--- a/data/tr2/ship/cfg/tr2-gm/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-gm/gameflow.json5
@@ -2,6 +2,9 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 2,
+    "extends": "tr2",
+
     "main_menu_picture": "title_eu_gm.webp",
     "savegame_file_fmt": "save_trgm_%02d.dat",
 

--- a/data/tr2/ship/cfg/tr2-level/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2-level/gameflow.json5
@@ -1,6 +1,9 @@
 {
     // This file is used to enable the -l argument support.
 
+    "engine": 2,
+    "extends": "tr2",
+
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_custom_%02d.dat",
 

--- a/data/tr2/ship/cfg/tr2/gameflow.json5
+++ b/data/tr2/ship/cfg/tr2/gameflow.json5
@@ -2,6 +2,8 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 2,
+
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_%02d.dat",
 

--- a/data/tr3/ship/cfg/tr3-la/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-la/gameflow.json5
@@ -2,6 +2,9 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 3,
+    "extends": "tr3",
+
     "main_menu_picture": "title_eu_gm.webp",
     "savegame_file_fmt": "save_trla_%02d.dat",
 

--- a/data/tr3/ship/cfg/tr3-level/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3-level/gameflow.json5
@@ -1,6 +1,9 @@
 {
     // This file is used to enable the -l argument support.
 
+    "engine": 3,
+    "extends": "tr3",
+
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_custom_%02d.dat",
 

--- a/data/tr3/ship/cfg/tr3/gameflow.json5
+++ b/data/tr3/ship/cfg/tr3/gameflow.json5
@@ -2,6 +2,8 @@
     // NOTE: bad changes to this file may result in crashes.
     // Lines starting with double slashes are comments and are ignored.
 
+    "engine": 3,
+
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_%02d.dat",
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added remembering of the last played mod
 - added a new console command, `/tp enemy`, to cycle Lara through hostile creatures in the current level
 - added a new animation command, `ITEM_ACTION_TURN_90`, which will rotate the affected item 90°
+- added dynamic mod discovery from the games/ directory using new `extends` and `name` fields in gameflow.json5
 - changed `--level` to no longer require `-e/--engine` to work
 
 **TR3**:

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -19,6 +19,19 @@
   },
   "type": "object",
   "properties": {
+    "name": {
+      "type": "string",
+      "description": "Human-readable display name for this mod, shown in the Switch Game menu."
+    },
+    "engine": {
+      "type": "integer",
+      "enum": [1, 2, 3],
+      "description": "Engine version this mod runs on (1 = TR1, 2 = TR2, 3 = TR3)."
+    },
+    "extends": {
+      "type": "string",
+      "description": "Directory name of the base mod this mod extends. Used for asset fallback."
+    },
     "main_menu_picture": {
       "type": "string",
       "description": "Path to the main menu background image."
@@ -138,6 +151,7 @@
     }
   },
   "required": [
+    "engine",
     "main_menu_picture",
     "savegame_file_fmt",
     "levels"

--- a/docs/trx/game_flow/GLOBAL_PROPERTIES.md
+++ b/docs/trx/game_flow/GLOBAL_PROPERTIES.md
@@ -98,6 +98,18 @@ remains distinct for each game.
   </tr>
   <tr valign="top">
     <td>
+      <a name="extends"></a>
+      <code>extends</code>
+    </td>
+    <td>String</td>
+    <td>
+      Directory name of the base mod this mod extends. Used for asset fallback
+      and engine version resolution. Required for custom mods to appear in the
+      Switch Game menu.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td>
       <a name="fog-transparency"></a>
       <code>fog_transparency</code>
     </td>
@@ -233,6 +245,17 @@ remains distinct for each game.
     <td>
       Path to a global Lua script to execute after game initialization, before
       the first level loads.
+    </td>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a name="name"></a>
+      <code>name</code>
+    </td>
+    <td>String</td>
+    <td>
+      Human-readable display name for this mod, shown in the Switch Game menu.
+      If not set, the directory name is used as a fallback.
     </td>
   </tr>
   <tr valign="top">

--- a/src/trx/game/game_flow/common.c
+++ b/src/trx/game/game_flow/common.c
@@ -97,6 +97,8 @@ void GF_Shutdown(void)
     gf->ambient_tracks.count = 0;
     Memory_FreePointer(&gf->settings.sfx_path);
     Memory_FreePointer(&gf->main_script_path);
+    Memory_FreePointer(&gf->meta.name);
+    Memory_FreePointer(&gf->meta.extends);
     Memory_FreePointer(&gf->path);
 }
 

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -306,10 +306,32 @@ static void M_CopyRootSettingsIntoLevel(
     dst->sfx_path = nullptr;
 }
 
+static void M_ReadModMeta(JSON_READ_IO *const io, GF_MOD_META *const meta)
+{
+    meta->name = nullptr;
+    meta->engine = 0;
+    meta->extends = nullptr;
+
+    const char *tmp_s = nullptr;
+    if (JSON_OPTIONAL(JSON_READ(io, "name", &tmp_s)) && tmp_s != nullptr) {
+        meta->name = Memory_DupStr(tmp_s);
+    }
+
+    JSON_OPTIONAL(JSON_READ(io, "engine", &meta->engine));
+
+    tmp_s = nullptr;
+    if (JSON_OPTIONAL(JSON_READ(io, "extends", &tmp_s)) && tmp_s != nullptr) {
+        meta->extends = Memory_DupStr(tmp_s);
+    }
+}
+
 static bool M_LoadRoot(const M_CONTEXT *const ctx)
 {
     JSON_READ_IO *const io = ctx->io;
     const char *tmp_s = nullptr;
+
+    M_ReadModMeta(io, &ctx->gf->meta);
+
     JSON_MUST(JSON_READ(io, "main_menu_picture", &tmp_s));
     ctx->gf->main_menu_background_path =
         Memory_DupStr(TRXPath_TryResolve(TRX_DYNAMIC_PATH_IMAGE_FILE, tmp_s));
@@ -975,5 +997,21 @@ bool GF_ValidateMod(const char *const mod_name, const char *const path)
         return false;
     }
     GF_Shutdown();
+    return true;
+}
+
+bool GF_ReadModMeta(const char *const path, GF_MOD_META *const meta)
+{
+    ASSERT(meta != nullptr);
+
+    JSON_VALUE *const doc = JSONFile_Read(path);
+    if (doc == nullptr) {
+        return false;
+    }
+
+    JSON_READ_IO *const io = JSON_ReadIO_Create(doc, 0, path);
+    M_ReadModMeta(io, meta);
+    JSON_ReadIO_Destroy(io);
+    JSON_ValueFree(doc);
     return true;
 }

--- a/src/trx/game/game_flow/reader.h
+++ b/src/trx/game/game_flow/reader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/game/game_flow/types.h>
+
 // Load the game flow from a file.
 void GF_LoadFromFile(const char *path);
 
@@ -10,3 +12,8 @@ bool GF_TryLoadFromFile(const char *path);
 // Load and validate path-backed gameflow references for a mod.
 // Returns false if parsing fails or any required resolved path is missing.
 bool GF_ValidateMod(const char *mod_name, const char *path);
+
+// Quick-parse a gameflow file to extract only the mod metadata fields
+// ("name", "engine", and "extends"). Returns true on success. Caller must
+// free meta->name and meta->extends with Memory_FreePointer().
+bool GF_ReadModMeta(const char *path, GF_MOD_META *meta);

--- a/src/trx/game/game_flow/types.h
+++ b/src/trx/game/game_flow/types.h
@@ -151,11 +151,23 @@ typedef struct {
 } GF_GLOBE_ENTRY;
 
 // ----------------------------------------------------------------------------
+// Mod metadata
+// ----------------------------------------------------------------------------
+
+typedef struct {
+    char *name;
+    int32_t engine;
+    char *extends;
+} GF_MOD_META;
+
+// ----------------------------------------------------------------------------
 // Game flow structures
 // ----------------------------------------------------------------------------
 
 typedef struct {
     char *path;
+
+    GF_MOD_META meta;
 
     GF_LEVEL *title_level;
     GF_LEVEL_TABLE level_tables[GFLT_NUMBER_OF];

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -1,8 +1,11 @@
 #include <trx/game/shell/mod.h>
 
 #include <trx/core/filesystem.h>
+#include <trx/core/log.h>
+#include <trx/core/memory.h>
 #include <trx/core/strings.h>
 #include <trx/core/utils.h>
+#include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/reader.h>
 #include <trx/game/shell/common.h>
@@ -12,49 +15,174 @@
 
 #include <string.h>
 
-static SHELL_MOD m_KnownMods[] = {
-    { .name = "tr1",
-      .mod_type = MOD_BASE_GAME,
-      .engine_version = 1,
-      .base_mod = nullptr },
-    { .name = "tr1-ub",
-      .mod_type = MOD_EXPANSION_PACK,
-      .engine_version = 1,
-      .base_mod = "tr1" },
-    { .name = "tr1-demo-pc",
-      .mod_type = MOD_MISC,
-      .engine_version = 1,
-      .base_mod = "tr1" },
-    { .name = "tr1-level",
-      .mod_type = MOD_DIRECT_LEVEL,
-      .engine_version = 1,
-      .base_mod = "tr1" },
-    { .name = "tr2",
-      .mod_type = MOD_BASE_GAME,
-      .engine_version = 2,
-      .base_mod = nullptr },
-    { .name = "tr2-gm",
-      .mod_type = MOD_EXPANSION_PACK,
-      .engine_version = 2,
-      .base_mod = "tr2" },
-    { .name = "tr2-level",
-      .mod_type = MOD_DIRECT_LEVEL,
-      .engine_version = 2,
-      .base_mod = "tr2" },
-    { .name = "tr3",
-      .mod_type = MOD_BASE_GAME,
-      .engine_version = 3,
-      .base_mod = nullptr },
-    { .name = "tr3-la",
-      .mod_type = MOD_EXPANSION_PACK,
-      .engine_version = 3,
-      .base_mod = "tr3" },
-    { .name = "tr3-level",
-      .mod_type = MOD_DIRECT_LEVEL,
-      .engine_version = 3,
-      .base_mod = "tr3" },
-    { .name = nullptr }, // sentinel
+typedef struct {
+    GF_MOD_META meta;
+    SHELL_MOD_TYPE mod_type;
+} M_KNOWN_MOD;
+
+static const M_KNOWN_MOD m_KnownModSeeds[] = {
+    { .meta = { .name = "tr1", .engine = 1 }, .mod_type = MOD_BASE_GAME },
+    { .meta = { .name = "tr1-ub", .engine = 1, .extends = "tr1" },
+      .mod_type = MOD_EXPANSION_PACK },
+    { .meta = { .name = "tr1-demo-pc", .engine = 1, .extends = "tr1" },
+      .mod_type = MOD_MISC },
+    { .meta = { .name = "tr1-level", .engine = 1, .extends = "tr1" },
+      .mod_type = MOD_DIRECT_LEVEL },
+    { .meta = { .name = "tr2", .engine = 2 }, .mod_type = MOD_BASE_GAME },
+    { .meta = { .name = "tr2-gm", .engine = 2, .extends = "tr2" },
+      .mod_type = MOD_EXPANSION_PACK },
+    { .meta = { .name = "tr2-level", .engine = 2, .extends = "tr2" },
+      .mod_type = MOD_DIRECT_LEVEL },
+    { .meta = { .name = "tr3", .engine = 3 }, .mod_type = MOD_BASE_GAME },
+    { .meta = { .name = "tr3-la", .engine = 3, .extends = "tr3" },
+      .mod_type = MOD_EXPANSION_PACK },
+    { .meta = { .name = "tr3-level", .engine = 3, .extends = "tr3" },
+      .mod_type = MOD_DIRECT_LEVEL },
 };
+
+static VECTOR *m_Mods = nullptr;
+
+static SHELL_MOD *M_FindMod(const char *const name)
+{
+    if (m_Mods == nullptr || name == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (strcmp(mod->name, name) == 0) {
+            return mod;
+        }
+    }
+    return nullptr;
+}
+
+static void M_AddMod(
+    const char *const name, const char *const title,
+    const SHELL_MOD_TYPE mod_type, const int32_t engine_version,
+    const char *const base_mod)
+{
+    const SHELL_MOD mod = {
+        .name = Memory_DupStr(name),
+        .title = title != nullptr ? Memory_DupStr(title) : nullptr,
+        .mod_type = mod_type,
+        .engine_version = engine_version,
+        .base_mod = base_mod != nullptr ? Memory_DupStr(base_mod) : nullptr,
+        .is_available = false,
+        .is_valid = false,
+    };
+    Vector_Add(m_Mods, &mod);
+}
+
+static void M_SeedKnownMods(void)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(m_KnownModSeeds); i++) {
+        const M_KNOWN_MOD *const seed = &m_KnownModSeeds[i];
+        M_AddMod(
+            seed->meta.name, nullptr, seed->mod_type, seed->meta.engine,
+            seed->meta.extends);
+    }
+}
+
+static void M_ScanForCustomMods(void)
+{
+    const char *const games_dir = TRXPath_Get(TRX_PATH_GAMES_DIR);
+    if (games_dir == nullptr) {
+        return;
+    }
+
+    void *const dir = File_OpenDirectory(games_dir);
+    if (dir == nullptr) {
+        return;
+    }
+
+    const char *entry;
+    while ((entry = File_ReadDirectory(dir)) != nullptr) {
+        if (strcmp(entry, ".") == 0 || strcmp(entry, "..") == 0) {
+            continue;
+        }
+
+        if (M_FindMod(entry) != nullptr) {
+            continue;
+        }
+
+        const char *const gameflow_path =
+            String_FormatStatic("%s/%s/gameflow.json5", games_dir, entry);
+
+        GF_MOD_META meta = {};
+        if (!GF_ReadModMeta(gameflow_path, &meta)) {
+            LOG_WARNING("Failed to read mod metadata from '%s'", gameflow_path);
+            continue;
+        }
+
+        if (meta.engine <= 0) {
+            LOG_WARNING(
+                "Custom mod '%s' has no 'engine' field in gameflow; skipping",
+                entry);
+            Memory_FreePointer(&meta.name);
+            Memory_FreePointer(&meta.extends);
+            continue;
+        }
+
+        M_AddMod(entry, meta.name, MOD_CUSTOM, meta.engine, meta.extends);
+        Memory_FreePointer(&meta.name);
+        Memory_FreePointer(&meta.extends);
+    }
+
+    File_CloseDirectory(dir);
+}
+
+static void M_ReadModMetaForKnownMods(void)
+{
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (!mod->is_available || mod->mod_type == MOD_CUSTOM) {
+            continue;
+        }
+
+        const char *const gameflow_path =
+            TRXPath_Resolve(TRX_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
+        if (gameflow_path == nullptr) {
+            continue;
+        }
+
+        GF_MOD_META meta = {};
+        if (!GF_ReadModMeta(gameflow_path, &meta)) {
+            continue;
+        }
+
+        if (meta.name != nullptr) {
+            Memory_FreePointer(&mod->title);
+            mod->title = meta.name;
+            meta.name = nullptr;
+        }
+
+        if (meta.engine > 0) {
+            mod->engine_version = meta.engine;
+        }
+
+        if (meta.extends != nullptr) {
+            Memory_FreePointer(&mod->base_mod);
+            mod->base_mod = meta.extends;
+            meta.extends = nullptr;
+        }
+
+        Memory_FreePointer(&meta.name);
+        Memory_FreePointer(&meta.extends);
+    }
+}
+
+static void M_ValidateEngineVersions(void)
+{
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (mod->engine_version <= 0 && mod->is_available) {
+            LOG_WARNING(
+                "Mod '%s' has no valid engine version; disabling", mod->name);
+            mod->is_available = false;
+            mod->is_valid = false;
+        }
+    }
+}
 
 static void M_ValidateNoMixedModLayouts(void)
 {
@@ -65,8 +193,11 @@ static void M_ValidateNoMixedModLayouts(void)
         return;
     }
 
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        const SHELL_MOD *const mod = &m_KnownMods[i];
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (mod->mod_type == MOD_CUSTOM) {
+            continue;
+        }
         const char *const legacy_gameflow =
             String_FormatStatic("%s/%s/gameflow.json5", config_dir, mod->name);
         if (File_Exists(legacy_gameflow)) {
@@ -85,24 +216,61 @@ static const char *M_GetModStringsPath(const char *const mod_id)
         TRX_PATH_GAMES_DIR, String_FormatStatic("%s/strings.json5", mod_id));
 }
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    if (m_Mods == nullptr) {
+        return;
+    }
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        Memory_FreePointer(&mod->name);
+        Memory_FreePointer(&mod->title);
+        Memory_FreePointer(&mod->base_mod);
+    }
+    Vector_Free(m_Mods);
+    m_Mods = nullptr;
+}
+
 void Shell_ScanAvailableMods(void)
 {
-    M_ValidateNoMixedModLayouts();
+    if (m_Mods != nullptr) {
+        M_Shutdown();
+    }
+    m_Mods = Vector_Create(sizeof(SHELL_MOD));
 
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        SHELL_MOD *const mod = &m_KnownMods[i];
+    M_SeedKnownMods();
+
+    // Mark availability for all seeded mods.
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
         mod->is_available =
             TRXPath_Exists(TRX_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
         mod->is_valid = mod->is_available;
     }
+
+    M_ValidateNoMixedModLayouts();
+    M_ScanForCustomMods();
+
+    // Mark availability for newly added custom mods.
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
+        if (mod->mod_type == MOD_CUSTOM) {
+            mod->is_available =
+                TRXPath_Exists(TRX_DYNAMIC_PATH_GAMEFLOW_FILE, mod->name);
+            mod->is_valid = mod->is_available;
+        }
+    }
+
+    M_ReadModMetaForKnownMods();
+    M_ValidateEngineVersions();
 }
 
 void Shell_ValidateMods(void)
 {
     const int32_t original_tr_version = g_TRVersion;
 
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        SHELL_MOD *const mod = &m_KnownMods[i];
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        SHELL_MOD *const mod = Vector_Get(m_Mods, i);
         if (!mod->is_available) {
             mod->is_valid = false;
             continue;
@@ -125,7 +293,7 @@ void Shell_ValidateMods(void)
 
 int32_t Shell_GetModCount(void)
 {
-    return ARRAY_SIZE(m_KnownMods) - 1;
+    return m_Mods != nullptr ? m_Mods->count : 0;
 }
 
 const SHELL_MOD *Shell_GetMod(const int32_t index)
@@ -133,15 +301,18 @@ const SHELL_MOD *Shell_GetMod(const int32_t index)
     if (index < 0 || index >= Shell_GetModCount()) {
         return nullptr;
     }
-    return &m_KnownMods[index];
+    return Vector_Get(m_Mods, index);
 }
 
 const SHELL_MOD *Shell_GetModByName(const char *const name)
 {
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        const SHELL_MOD *const mod = &m_KnownMods[i];
+    if (m_Mods == nullptr || name == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
         if (mod->is_available && strcmp(mod->name, name) == 0) {
-            return &m_KnownMods[i];
+            return mod;
         }
     }
     return nullptr;
@@ -155,8 +326,8 @@ static bool M_MatchesEngineVersion(
 
 static const SHELL_MOD *M_GetFirstAvailableMod(const int32_t engine_version)
 {
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        const SHELL_MOD *const mod = &m_KnownMods[i];
+    for (int32_t i = 0; i < m_Mods->count; i++) {
+        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
         if (!Shell_CanSwitchToMod(mod)
             || !M_MatchesEngineVersion(mod, engine_version)) {
             continue;
@@ -185,8 +356,8 @@ const SHELL_MOD *Shell_GetModByType(
 {
     const SHELL_MOD *found = nullptr;
 
-    for (int32_t i = 0; m_KnownMods[i].name != nullptr; i++) {
-        const SHELL_MOD *const mod = &m_KnownMods[i];
+    for (int32_t i = 0; i < Shell_GetModCount(); i++) {
+        const SHELL_MOD *const mod = Vector_Get(m_Mods, i);
         if (!mod->is_available || mod->mod_type != mod_type
             || (engine_version > 0 && mod->engine_version != engine_version)) {
             continue;

--- a/src/trx/game/shell/mod.h
+++ b/src/trx/game/shell/mod.h
@@ -7,13 +7,15 @@ typedef enum {
     MOD_EXPANSION_PACK,
     MOD_MISC,
     MOD_DIRECT_LEVEL,
+    MOD_CUSTOM,
 } SHELL_MOD_TYPE;
 
 typedef struct {
-    const char *name;
+    char *name;
+    char *title;
     SHELL_MOD_TYPE mod_type;
     int32_t engine_version;
-    const char *base_mod;
+    char *base_mod;
     bool is_available;
     bool is_valid;
 } SHELL_MOD;

--- a/src/trx/game/ui/dialogs/switch_mod.c
+++ b/src/trx/game/ui/dialogs/switch_mod.c
@@ -13,6 +13,7 @@
 
 typedef struct {
     const char *name;
+    const char *title;
 } M_ROW;
 
 struct UI_SWITCH_MOD_DIALOG_STATE {
@@ -35,7 +36,8 @@ UI_SWITCH_MOD_DIALOG_STATE *UI_SwitchModDialog_Init(void)
         if (Shell_IsCurrentMod(mod->name)) {
             current_row = s->rows->count;
         }
-        Vector_Add(s->rows, &(M_ROW) { .name = mod->name });
+        Vector_Add(
+            s->rows, &(M_ROW) { .name = mod->name, .title = mod->title });
     }
 
     UI_BasePassportDialog_Init(&s->req, s->rows->count);
@@ -79,10 +81,13 @@ void UI_SwitchModDialog(UI_SWITCH_MOD_DIALOG_STATE *const s)
         const M_ROW *const row = Vector_Get(s->rows, i);
         UI_BeginRequesterRow(&s->req, i);
         UI_BeginAnchor(0.5f, 0.5f);
-        const char *const key =
+        const char *const gs_key =
             String_FormatStatic("dynamic/mods/%s/title", row->name);
-        const char *const title = GS(key);
-        UI_Label(title != nullptr ? title : row->name);
+        const char *const gs_title = GS(gs_key);
+        const char *const display = gs_title != nullptr ? gs_title
+            : row->title != nullptr                     ? row->title
+                                                        : row->name;
+        UI_Label(display);
         UI_EndAnchor();
         UI_EndRequesterRow(&s->req, i);
     }

--- a/tools/update_game_strings
+++ b/tools/update_game_strings
@@ -488,6 +488,7 @@ class RunContext:
             )
         )
         self.used_game_strings += list(get_used_mod_strings(PROJECT_PATHS))
+
         self.object_names_dict = get_objects_map(source_files)
 
     @property


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds dynamic mod discovery so the Switch Game menu is no longer limited to a hardcoded list. Custom mods placed in the `games/` directory are now automatically detected and listed.

Two new optional fields and one mandatory field in `gameflow.json5`:
- **`engine`**: declares the engine version (e.g. `"engine": 2`), used engine version resolution. Required for all mods.
- **`extends`**: declares the base mod (e.g. `"extends": "tr2"`), used for asset fallback.
- **`name`**: human-readable display name shown in the Switch Game menu (e.g. `"name": "The Hidden Dagger"`). Falls back to directory name if absent.

Title priority in the Switch Game menu: translated game string (from `base_strings`) → gameflow `name` → directory name. This preserves translated titles for known mods while supporting custom mod names.

Internally, the static `m_KnownMods[]` array is replaced with a dynamically allocated vector. Known mods are seeded first (preserving their hardcoded metadata as fallback), then the `games/` directory is scanned for additional mods. Engine version for custom mods is resolved by following the `extends` chain.

> **Note**: This PR touches `shell/mod.c` and `shell/mod.h`, which overlap with #5193. It should be merged **after** #5193 to avoid conflicts, or rebased on top of it.

#### Testing

- [x] Start the game with only known mods installed (tr1, tr1-ub, tr2, tr2-gm, etc.)
  Expected: Switch Game menu shows the same entries as before, with translated titles
- [x] Place a custom mod in `games/` with `extends` and `name` in its gameflow
  Expected: the custom mod appears in the Switch Game menu with its name
- [x] Place a custom mod in `games/` with `extends` but no `name`
  Expected: the custom mod appears with the directory name as fallback
- [x] Place a custom mod in `games/` without `extends`
  Expected: the mod is skipped with a log warning
- [x] Switch to a custom mod from the menu
  Expected: the engine restarts with the correct engine version
- [x] Use `--mod custom-mod-name` from CLI
  Expected: the custom mod launches correctly
- [x] Use `-g/--gold` flag
  Expected: still finds the correct expansion pack (no regression)
- [x] Change language in settings, check Switch Game menu
  Expected: known mod titles update to translated versions, custom mod titles stay as-is