### PR TITLE
misc: fix London AI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed a missing camera shake effect in room 135 in Aldwych (#5183)
 - fixed a missing sound effect during the flip map in the Egyptian room in Lud's Gate (#5183)
 - fixed potential framerate drops during audio playback when no active sound effects are playing (regression from 1.3)
+- fixed some enemies automatically being hostile when triggered if other enemies have been killed (#5203, regression from 1.1)
 
 
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1440,7 +1440,7 @@ void Creature_GetAITarget(CREATURE *const creature)
                     creature->enemy = lara_item;
                     item->ai_bits &= ~(AI_AMBUSH | AI_MODIFY);
                     item->ai_bits |= AI_GUARD;
-                    creature->alerted = 0;
+                    creature->alerted = false;
                 }
             }
         } else {
@@ -1449,7 +1449,7 @@ void Creature_GetAITarget(CREATURE *const creature)
     } else if (ai_bits & AI_FOLLOW) {
         if (creature->hurt_by_lara) {
             creature->enemy = lara_item;
-            creature->alerted = 1;
+            creature->alerted = true;
             item->ai_bits &= ~AI_FOLLOW;
         } else if (item->hit_status) {
             item->ai_bits &= ~AI_FOLLOW;

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -286,16 +286,15 @@ static void M_Control(const int16_t item_num)
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
 
-    int32_t enemy_dist;
-    int32_t enemy_angle;
+    AI_INFO lara_info = {};
     if (creature->enemy == lara_item) {
-        enemy_dist = info.distance;
-        enemy_angle = info.angle;
+        lara_info.distance = info.distance;
+        lara_info.angle = info.angle;
     } else {
         const int32_t dx = lara_item->pos.x - item->pos.x;
         const int32_t dz = lara_item->pos.z - item->pos.z;
-        enemy_angle = Math_Atan(dz, dx) - item->rot.y;
-        enemy_dist = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
+        lara_info.angle = Math_Atan(dz, dx) - item->rot.y;
+        lara_info.distance = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
     }
 
     if (!creature->alerted && creature->enemy == lara_item) {
@@ -308,7 +307,8 @@ static void M_Control(const int16_t item_num)
     ITEM *const enemy = creature->enemy;
     creature->enemy = lara_item;
     if (item->hit_status
-        || ((enemy_dist < M_ALERT_DIST || Creature_CanSeeEnemy(item, &info))
+        || ((lara_info.distance < M_ALERT_DIST
+             || Creature_CanSeeEnemy(item, &lara_info))
             && ABS(lara_item->pos.y - item->pos.y) < M_ALERT_HEIGHT
             && Creature_IsHostile(item) && (item->ai_bits & AI_FOLLOW) == 0)) {
         if (!creature->alerted) {
@@ -329,7 +329,7 @@ static void M_Control(const int16_t item_num)
 
         creature->flags = 0;
         creature->maximum_turn = 0;
-        head = enemy_angle;
+        head = lara_info.angle;
 
         if ((item->ai_bits & AI_GUARD) != 0) {
             head = Creature_AIGuard(creature);
@@ -351,7 +351,8 @@ static void M_Control(const int16_t item_num)
         } else if (
             creature->mood == MOOD_BORED
             || ((item->ai_bits & AI_FOLLOW) != 0
-                && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
+                && (creature->reached_goal
+                    || lara_info.distance > M_RUN_DIST))) {
             if (item->required_anim_state != M_STATE_NULL) {
                 item->goal_anim_state = item->required_anim_state;
             } else if (info.ahead) {
@@ -372,7 +373,7 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_WALK:
         creature->maximum_turn = M_WALK_TURN;
-        head = enemy_angle;
+        head = lara_info.angle;
 
         if ((item->ai_bits & AI_PATROL_1) != 0) {
             item->goal_anim_state = M_STATE_WALK;
@@ -409,7 +410,7 @@ static void M_Control(const int16_t item_num)
             }
         } else if (
             (item->ai_bits & AI_FOLLOW) != 0
-            && (creature->reached_goal || enemy_dist > M_RUN_DIST)) {
+            && (creature->reached_goal || lara_info.distance > M_RUN_DIST)) {
             item->goal_anim_state = M_STATE_STOP;
         } else if (creature->mood == MOOD_BORED) {
             item->goal_anim_state = M_STATE_WALK;

--- a/src/trx/game/objects/creatures/security_guard.c
+++ b/src/trx/game/objects/creatures/security_guard.c
@@ -87,17 +87,16 @@ static void M_FireFinalShot(
     Sound_Effect(SFX_SECURITY_GUARD_FIRE, &item->pos, SPM_NORMAL);
 }
 
-static bool M_IsNearCover(
-    const ITEM *const item, const int32_t enemy_angle, const int32_t enemy_dist)
+static bool M_IsNearCover(const ITEM *const item, const AI_INFO *const info)
 {
     const XYZ_32 pos =
-        XYZ_32_OffsetYaw(item->pos, item->rot.y + enemy_angle, WALL_L);
+        XYZ_32_OffsetYaw(item->pos, item->rot.y + info->angle, WALL_L);
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     const int32_t height = Room_GetHeight(sector, pos);
     return item->pos.y > height + STEPUP_HEIGHT
         && item->pos.y < height + STEPUP_HEIGHT * 3
-        && enemy_dist > M_ALERT_DIST;
+        && info->distance > M_ALERT_DIST;
 }
 
 static bool M_ShouldDuck(const ITEM *const item, const bool near_cover)
@@ -144,26 +143,26 @@ static void M_Control(const int16_t item_num)
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
 
-    int32_t enemy_dist;
-    int32_t enemy_angle;
+    AI_INFO lara_info = {};
     if (creature->enemy == lara_item) {
-        enemy_dist = info.distance;
-        enemy_angle = info.angle;
+        lara_info.distance = info.distance;
+        lara_info.angle = info.angle;
     } else {
         const int32_t dx = lara_item->pos.x - item->pos.x;
         const int32_t dz = lara_item->pos.z - item->pos.z;
-        enemy_angle = Math_Atan(dz, dx) - item->rot.y;
-        enemy_dist = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
+        lara_info.angle = Math_Atan(dz, dx) - item->rot.y;
+        lara_info.distance = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
     }
 
     Creature_Mood(item, &info, creature->enemy != lara_item);
     angle = Creature_Turn(item, creature->maximum_turn);
-    const bool near_cover = M_IsNearCover(item, enemy_angle, enemy_dist);
+    const bool near_cover = M_IsNearCover(item, &lara_info);
 
     ITEM *const enemy = creature->enemy;
     creature->enemy = lara_item;
     if (item->hit_status
-        || ((enemy_dist < M_ALERT_DIST || Creature_CanSeeEnemy(item, &info))
+        || ((lara_info.distance < M_ALERT_DIST
+             || Creature_CanSeeEnemy(item, &lara_info))
             && ABS(lara_item->pos.y - item->pos.y) < M_ALERT_HEIGHT)) {
         if (!creature->alerted) {
             Sound_Effect(SFX_ENGLISH_HOY, &item->pos, SPM_NORMAL);
@@ -177,7 +176,7 @@ static void M_Control(const int16_t item_num)
 
     switch (item->current_anim_state) {
     case M_STATE_WAIT:
-        head = enemy_angle;
+        head = lara_info.angle;
         creature->maximum_turn = 0;
 
         if (anim_idx == M_ANIM_WALK_STOP || anim_idx == M_ANIM_RUN_STOP_1
@@ -219,7 +218,8 @@ static void M_Control(const int16_t item_num)
         } else if (
             creature->mood == MOOD_BORED
             || ((item->ai_bits & AI_FOLLOW) != 0
-                && (creature->reached_goal || enemy_dist > M_WALK_DIST))) {
+                && (creature->reached_goal
+                    || lara_info.distance > M_WALK_DIST))) {
             if (info.ahead) {
                 item->goal_anim_state = M_STATE_WAIT;
             } else {
@@ -232,7 +232,7 @@ static void M_Control(const int16_t item_num)
         break;
 
     case M_STATE_WALK:
-        head = enemy_angle;
+        head = lara_info.angle;
         creature->maximum_turn = M_WALK_TURN;
 
         if ((item->ai_bits & AI_PATROL_1) != 0) {
@@ -276,7 +276,8 @@ static void M_Control(const int16_t item_num)
         } else if (creature->mood != MOOD_ESCAPE) {
             if (Creature_CanTargetEnemy(item, &info)
                 || ((item->ai_bits & AI_FOLLOW) != 0
-                    && (creature->reached_goal || enemy_dist > M_WALK_DIST))) {
+                    && (creature->reached_goal
+                        || lara_info.distance > M_WALK_DIST))) {
                 item->goal_anim_state = M_STATE_WAIT;
             } else if (creature->mood == MOOD_BORED) {
                 item->goal_anim_state = M_STATE_WALK;

--- a/src/trx/game/objects/creatures/swat.c
+++ b/src/trx/game/objects/creatures/swat.c
@@ -149,16 +149,15 @@ static void M_Control(const int16_t item_num)
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
 
-    int32_t enemy_dist;
-    int32_t enemy_angle;
+    AI_INFO lara_info = {};
     if (creature->enemy == lara_item) {
-        enemy_dist = info.distance;
-        enemy_angle = info.angle;
+        lara_info.distance = info.distance;
+        lara_info.angle = info.angle;
     } else {
         const int32_t dx = lara_item->pos.x - item->pos.x;
         const int32_t dz = lara_item->pos.z - item->pos.z;
-        enemy_angle = Math_Atan(dz, dx) - item->rot.y;
-        enemy_dist = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
+        lara_info.angle = Math_Atan(dz, dx) - item->rot.y;
+        lara_info.distance = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
     }
 
     Creature_Mood(item, &info, creature->enemy != lara_item);
@@ -167,7 +166,8 @@ static void M_Control(const int16_t item_num)
     ITEM *const enemy = creature->enemy;
     creature->enemy = lara_item;
     if (item->hit_status
-        || ((enemy_dist < M_ALERT_DIST || Creature_CanSeeEnemy(item, &info))
+        || ((lara_info.distance < M_ALERT_DIST
+             || Creature_CanSeeEnemy(item, &lara_info))
             && ABS(lara_item->pos.y - item->pos.y) < M_ALERT_HEIGHT)) {
         if (!creature->alerted) {
             const SAMPLE_TRX_ID alert_sfx = item->object_id == O_SWAT_3
@@ -181,7 +181,7 @@ static void M_Control(const int16_t item_num)
 
     switch (item->current_anim_state) {
     case M_STATE_STOP:
-        head = enemy_angle;
+        head = lara_info.angle;
         creature->flags = 0;
         creature->maximum_turn = 0;
 
@@ -217,7 +217,8 @@ static void M_Control(const int16_t item_num)
         } else if (
             creature->mood == MOOD_BORED
             || ((item->ai_bits & AI_FOLLOW) != 0
-                && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
+                && (creature->reached_goal
+                    || lara_info.distance > M_RUN_DIST))) {
             item->goal_anim_state = M_STATE_STOP;
         } else if (info.distance > M_RUN_DIST) {
             item->goal_anim_state = M_STATE_RUN;
@@ -227,7 +228,7 @@ static void M_Control(const int16_t item_num)
         break;
 
     case M_STATE_WAIT:
-        head = enemy_angle;
+        head = lara_info.angle;
         creature->flags = 0;
         creature->maximum_turn = 0;
 
@@ -244,7 +245,7 @@ static void M_Control(const int16_t item_num)
         break;
 
     case M_STATE_WALK:
-        head = enemy_angle;
+        head = lara_info.angle;
         creature->flags = 0;
         creature->maximum_turn = M_WALK_TURN;
 
@@ -256,7 +257,8 @@ static void M_Control(const int16_t item_num)
         } else if (
             (item->ai_bits & AI_GUARD) != 0
             || ((item->ai_bits & AI_FOLLOW) != 0
-                && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
+                && (creature->reached_goal
+                    || lara_info.distance > M_RUN_DIST))) {
             item->goal_anim_state = M_STATE_STOP;
         } else if (Creature_CanTargetEnemy(item, &info)) {
             if (info.distance < M_SHOOT_DIST
@@ -283,7 +285,8 @@ static void M_Control(const int16_t item_num)
 
         if ((item->ai_bits & AI_GUARD) != 0
             || ((item->ai_bits & AI_FOLLOW) != 0
-                && (creature->reached_goal || enemy_dist > M_RUN_DIST))) {
+                && (creature->reached_goal
+                    || lara_info.distance > M_RUN_DIST))) {
             item->goal_anim_state = M_STATE_WALK;
         } else if (creature->mood != MOOD_ESCAPE) {
             if (Creature_CanTargetEnemy(item, &info)) {

--- a/src/trx/game/pathing/lot.c
+++ b/src/trx/game/pathing/lot.c
@@ -172,6 +172,7 @@ void LOT_InitialiseSlot(const int16_t item_num, const int32_t slot)
     creature->reached_goal = false;
     creature->hurt_by_lara = false;
     creature->patrol_2 = false;
+    creature->alerted = false;
 
     const OBJECT *const obj = Object_Get(item->object_id);
     creature->lot.setup = obj->lot_setup;


### PR DESCRIPTION
Resolves #5203.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

I had some mistakes in the security guard, punk and SWAT implementations regarding `Creature_CanSeeEnemy` being passed the wrong parameter; resolving that however did not fix the problem with the guards, and it turned out to be fairly subtle. If Lara shoots and kills some creature that becomes alerted, then triggers another creature who responds to being alerted, that creature may potentially re-use the killed enemy's AI slot, and the alerted flag wasn't being cleared there.

Tests:
- Security guard behaviour
- Punk behaviour
- SWAT behaviour