### PR TITLE
collision: fix tilt axes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 - fixed toggle-duck key failing to keep Lara ducked in run-to-duck and sprint-to-duck paths (#5177, regression from 1.4)
 - fixed flipped state of "Pause music in inventory", changed to "Enable music in inventory" (regression from 1.4)
 - fixed final statistics in City of Khamoon counting the optional PS1 mummy when Restore PS1 enemies is disabled (#5188, regression from 1.1)
+- fixed bouncy grenades getting stuck in certain geometry (#5202, regression from 1.2)
+- fixed thrown flares getting stuck in certain geometry (#5202, regression from 1.4)
 
 **TR3**:
 - fixed door 34 in Thames Wharf closing permanently during the flipmap puzzle (#5170, regression from 1.1)

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -767,8 +767,8 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
             yang = (uint16_t)item->rot.y;
 
             const int16_t tilt = Room_GetTiltType(sector, item->pos);
-            const int8_t tiltyoff = tilt >> 8;
-            const int8_t tiltxoff = (int8_t)tilt;
+            const int8_t tiltxoff = tilt >> 8;
+            const int8_t tiltyoff = (int8_t)tilt;
             if (tiltyoff < 0) {
                 if (yang >= DEG_180) {
                     bs = 1;
@@ -834,8 +834,8 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
             item->speed -= item->speed >> 2;
 
             const int16_t tilt = Room_GetTiltType(sector, item->pos);
-            const int8_t tiltyoff = tilt >> 8;
-            const int8_t tiltxoff = (int8_t)tilt;
+            const int8_t tiltxoff = tilt >> 8;
+            const int8_t tiltyoff = (int8_t)tilt;
             if (tiltyoff < 0 && ABS(tiltyoff) - ABS(tiltxoff) >= 2) {
                 if ((uint16_t)item->rot.y > DEG_180) {
                     item->rot.y = -1 - item->rot.y;


### PR DESCRIPTION
Resolves #5202.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the tilt axes when running collision tests for grenades and flares. It matches the shifting done in `Room_GetTiltType`. The OG X/Y naming is quite confusing, but we can perhaps tackle a refactor of this function once the dust settles.
