### PR TITLE
objects/detonator_box: fix bounds and rotation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels
+- fixed the Detonator Box being difficult to activate when selecting the key manually from the inventory (#5215, regression from TR2X 1.3)
 
 **TR3**:
 - added Security Laser (Alarm) control

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels
 - fixed the Detonator Box being difficult to activate when selecting the key manually from the inventory (#5215, regression from TR2X 1.3)
+- fixed the Detonator Box rotating if Lara interacts with it but then doesn't pick the key from the inventory (#5215, regression from TR2X 1.3)
 
 **TR3**:
 - added Security Laser (Alarm) control

--- a/src/trx/game/objects/general/detonator_box.c
+++ b/src/trx/game/objects/general/detonator_box.c
@@ -35,6 +35,7 @@ static void M_ConsumeKeyItem(ITEM *const receptacle_item)
 
 static void M_Use(ITEM *const lara_item, ITEM *const receptacle_item)
 {
+    receptacle_item->rot.y = lara_item->rot.y;
     Lara_AlignPosition(receptacle_item, &m_Position);
 
     Lara_SwitchToExtraState(LS_EXTRA_PLUNGER);
@@ -107,9 +108,7 @@ static void M_Collision(
         goto normal_collision;
     }
 
-    if (item->object_id == O_GONG) {
-        item->rot = old_rot;
-    }
+    item->rot = old_rot;
 
     if (!GF_ShowInventoryKeys(item->object_id)) {
         Lara_RefuseInteraction();

--- a/src/trx/game/objects/general/detonator_box.c
+++ b/src/trx/game/objects/general/detonator_box.c
@@ -14,12 +14,12 @@ static XYZ_32 m_Position = { .x = 0, .y = 0, .z = 0 };
 
 static const OBJECT_BOUNDS m_Bounds = {
     .shift = {
-        .min = { .x = -WALL_L / 2, .y = -100, .z = -WALL_L / 2 - 300, },
-        .max = { .x = +WALL_L, .y = +100, .z = -WALL_L / 2 + 100, },
+        .min = { .x = -WALL_L / 4, .y = -100, .z = -WALL_L / 4, },
+        .max = { .x = +WALL_L / 4, .y = +100, .z = +WALL_L / 4, },
     },
     .rot = {
-        .min = { .x = -30 * DEG_1, .y = 0, .z = 0, },
-        .max = { .x = +30 * DEG_1, .y = 0, .z = 0, },
+        .min = { .x = -10 * DEG_1, .y = 0, .z = 0, },
+        .max = { .x = +10 * DEG_1, .y = 0, .z = 0, },
     },
     .ignore_rot = true,
 };
@@ -125,7 +125,7 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
-    obj->bounds_func = Pickup_Bounds;
+    obj->bounds_func = M_Bounds;
     obj->save_flags = true;
     obj->save_anim = true;
 }


### PR DESCRIPTION
Resolves #5215.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replicates pickup bounds used by the Detonator Box (which is OG) into its own module, so allowing it to use the `ignore_rot` property such that it can be activated manually from the inventory. It also prevents it remaining rotated if Lara begins interacting with it but then cancels out of the inventory.
