### PR TITLE
output: fix fog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added a new animation command, `ITEM_ACTION_TURN_90`, which will rotate the affected item 90°
 - added dynamic mod discovery from the games/ directory using new `extends` and `name` fields in gameflow.json5
 - changed `--level` to no longer require `-e/--engine` to work
+- fixed 3D pickups and inventory ring view still affected by fog (regression from 1.4)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -378,8 +378,8 @@ void InvRing_Draw(INV_RING *const ring)
     Matrix_GenerateW2V(&view_pos, &view_rot);
     const int32_t old_fog_start = Output_GetFogStart();
     const int32_t old_fog_end = Output_GetFogEnd();
-    Output_SetFogStart(0);
-    Output_SetFogEnd(20 * WALL_L);
+    Output_SetFogStart(20 * WALL_L);
+    Output_SetFogEnd(100 * WALL_L);
 
     InvRing_Light(&draw_ring);
 

--- a/src/trx/game/overlay.c
+++ b/src/trx/game/overlay.c
@@ -506,8 +506,8 @@ void Overlay_DrawGameInfo(void)
         SceneCompositor_Flush();
         const int32_t old_fog_start = Output_GetFogStart();
         const int32_t old_fog_end = Output_GetFogEnd();
-        Output_SetFogStart(0);
-        Output_SetFogEnd(20 * WALL_L);
+        Output_SetFogStart(20 * WALL_L);
+        Output_SetFogEnd(100 * WALL_L);
         M_DrawPickups();
         SceneCompositor_Flush();
         Output_SetFogStart(old_fog_start);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the report from Discord about 3D pickups being drawn semitransparent. The culprit was the fog fix.