### PR TITLE
misc: fix compile warnings

### DIFF
--- a/src/trx/core/colors.h
+++ b/src/trx/core/colors.h
@@ -39,29 +39,21 @@ RGBA_8888 Color_MixRGBA8888_Impl(
     _Generic(                                                                  \
         (color),                                                               \
         RGB_888: Color_RGB888ToRGBA8888_Impl,                                  \
-        const RGB_888: Color_RGB888ToRGBA8888_Impl,                            \
-        RGB_F: Color_RGBFToRGBAF_Impl,                                         \
-        const RGB_F: Color_RGBFToRGBAF_Impl)(color)
+        RGB_F: Color_RGBFToRGBAF_Impl)(color)
 
 #define Color_RGBToRGBAEx(color, alpha)                                        \
     _Generic(                                                                  \
         (color),                                                               \
         RGB_888: Color_RGB888ToRGBA8888Ex_Impl,                                \
-        const RGB_888: Color_RGB888ToRGBA8888Ex_Impl,                          \
-        RGB_F: Color_RGBFToRGBAFEx_Impl,                                       \
-        const RGB_F: Color_RGBFToRGBAFEx_Impl)(color, alpha)
+        RGB_F: Color_RGBFToRGBAFEx_Impl)(color, alpha)
 
 #define Color_Mix(color_1, color_2, ratio)                                     \
     _Generic(                                                                  \
         (color_1),                                                             \
         RGB_F: Color_MixRGBF_Impl,                                             \
-        const RGB_F: Color_MixRGBF_Impl,                                       \
         RGBA_F: Color_MixRGBAF_Impl,                                           \
-        const RGBA_F: Color_MixRGBAF_Impl,                                     \
         RGB_888: Color_MixRGB888_Impl,                                         \
-        const RGB_888: Color_MixRGB888_Impl,                                   \
-        RGBA_8888: Color_MixRGBA8888_Impl,                                     \
-        const RGBA_8888: Color_MixRGBA8888_Impl)(color_1, color_2, ratio)
+        RGBA_8888: Color_MixRGBA8888_Impl)(color_1, color_2, ratio)
 
 RGB_888 Color_HSLToRGB(float h, float s, float l);
 void Color_RGBToHSL(RGB_888 color, float *out_h, float *out_s, float *out_l);

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -96,6 +96,9 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
+    int16_t angle = 0;
+    int16_t torso = 0;
+    int16_t head = 0;
 
     if (p->carcass_item_num == NO_ITEM) {
         M_FindCarcass(item);
@@ -176,9 +179,9 @@ static void M_Control(const int16_t item_num)
         break;
     }
 
-    const int16_t angle = Creature_Turn(item, creature->maximum_turn);
-    const int16_t torso = info.ahead ? info.angle : 0;
-    const int16_t head = -(info.angle / 4);
+    angle = Creature_Turn(item, creature->maximum_turn);
+    torso = info.ahead ? info.angle : 0;
+    head = -(info.angle / 4);
     item->timer++;
 
     if (item->hit_status && item->timer > 200 && Random_GetControl() < 0xC1C) {

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -3,6 +3,7 @@
 #include <trx/av/audio.h>
 #include <trx/config.h>
 #include <trx/core/log.h>
+#include <trx/core/math/geom.h>
 #include <trx/core/memory.h>
 #include <trx/game/camera.h>
 #include <trx/game/game_buf.h>
@@ -101,20 +102,18 @@ static int32_t M_GetDistance(
     if (pos == nullptr) {
         return 0;
     }
-    const int32_t dx = pos->x - g_Camera.mic_pos.x;
-    const int32_t dy = pos->y - g_Camera.mic_pos.y;
-    const int32_t dz = pos->z - g_Camera.mic_pos.z;
-    if (ABS(dx) > sample->range || ABS(dy) > sample->range
-        || ABS(dz) > sample->range) {
+    const XYZ_32 delta = {
+        .x = pos->x - g_Camera.mic_pos.x,
+        .y = pos->y - g_Camera.mic_pos.y,
+        .z = pos->z - g_Camera.mic_pos.z,
+    };
+    const int32_t distance = XYZ_32_GetLength(delta);
+    if (distance > sample->range) {
         return INT32_MAX;
-    }
-    const uint32_t distance = SQUARE(dx) + SQUARE(dy) + SQUARE(dz);
-    if (distance > SQUARE(sample->range)) {
-        return INT32_MAX;
-    } else if (distance < SQUARE(M_SOUND_CLOSE_RANGE)) {
+    } else if (distance < M_SOUND_CLOSE_RANGE) {
         return 0;
     } else {
-        return Math_Sqrt(distance) - M_SOUND_CLOSE_RANGE;
+        return distance - M_SOUND_CLOSE_RANGE;
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes some of the warnings found out by Mac builds which use Clang instead of gcc.