### PR TITLE
Add multi-key combo shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ running all 3 games), please refer to [this document](docs/CHANGELOG.md).
     TRX supports a wide variety of controllers out of the box with no
     additional software required. The keyboard or controller controls
     can be fully customized in the Controls menu with multiple layouts.
+    Multi-key combo shortcuts (up to 3 keys) and two binding slots per
+    action are also supported.
 
 6. **What about TR3 support?**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...develop) - ××××-××-××
+- added multi-key combo shortcuts (up to 3 keys) with two binding slots per action for both keyboard and controller
 - added remembering of the last played mod
 - added a new console command, `/tp enemy`, to cycle Lara through hostile creatures in the current level
 - added a new animation command, `ITEM_ACTION_TURN_90`, which will rotate the affected item 90°

--- a/src/trx/config/priv.c
+++ b/src/trx/config/priv.c
@@ -119,12 +119,15 @@ static void M_DumpInputLayout(
 
     bool has_elements = false;
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
-        JSON_OBJECT *const bind_obj = JSON_ObjectNew();
-        if (Input_AssignToJSONObject(backend, layout, bind_obj, role)) {
-            has_elements = true;
-            JSON_ArrayAppendObject(arr, bind_obj);
-        } else {
-            JSON_ObjectFree(bind_obj);
+        for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+            JSON_OBJECT *const bind_obj = JSON_ObjectNew();
+            if (Input_AssignToJSONObject(
+                    backend, layout, bind_obj, role, slot)) {
+                has_elements = true;
+                JSON_ArrayAppendObject(arr, bind_obj);
+            } else {
+                JSON_ObjectFree(bind_obj);
+            }
         }
     }
 

--- a/src/trx/game/input/backends/base.h
+++ b/src/trx/game/input/backends/base.h
@@ -12,12 +12,15 @@ typedef struct {
     void (*process_event)(const SDL_Event *event);
     bool (*is_pressed)(INPUT_LAYOUT layout, INPUT_ROLE role);
     bool (*is_role_conflicted)(INPUT_LAYOUT layout, INPUT_ROLE role);
-    const char *(*get_name)(INPUT_LAYOUT layout, INPUT_ROLE role);
-    void (*unassign_role)(INPUT_LAYOUT layout, INPUT_ROLE role);
+    const char *(*get_name)(INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
+    void (*unassign_role)(INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
     bool (*assign_from_json_object)(
-        INPUT_LAYOUT layout, INPUT_ROLE role, JSON_OBJECT *bind_obj);
+        INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot,
+        JSON_OBJECT *bind_obj);
     bool (*assign_to_json_object)(
-        INPUT_LAYOUT layout, INPUT_ROLE role, JSON_OBJECT *bind_obj);
+        INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot,
+        JSON_OBJECT *bind_obj);
     void (*reset_layout)(INPUT_LAYOUT layout);
-    bool (*read_and_assign)(INPUT_LAYOUT layout, INPUT_ROLE role);
+    bool (*read_and_assign)(INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
+    void (*resolve_combos)(INPUT_LAYOUT layout, INPUT_STATE *result);
 } INPUT_BACKEND_IMPL;

--- a/src/trx/game/input/backends/controller.c
+++ b/src/trx/game/input/backends/controller.c
@@ -5,6 +5,7 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_gamecontroller.h>
+#include <string.h>
 
 typedef enum {
     BT_BUTTON = 0,
@@ -91,7 +92,17 @@ static BUILTIN_CONTROLLER_LAYOUT m_BuiltinLayout[] = {
 #define M_NAME_Y              "\\{controller button y}"
 // clang-format on
 
-static CONTROLLER_MAP m_Layout[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF];
+typedef struct {
+    int32_t key_count;
+    CONTROLLER_MAP keys[INPUT_COMBO_MAX_KEYS];
+} CONTROLLER_BINDING;
+
+typedef struct {
+    CONTROLLER_BINDING slots[INPUT_BINDING_SLOTS];
+} CONTROLLER_ROLE_BINDING;
+
+static CONTROLLER_ROLE_BINDING m_Layout[INPUT_LAYOUT_NUMBER_OF]
+                                       [INPUT_ROLE_NUMBER_OF];
 
 static SDL_GameController *m_Controller = nullptr;
 static const char *m_ControllerName = nullptr;
@@ -236,37 +247,93 @@ static int16_t M_JoyAxis(const SDL_GameControllerAxis axis)
     return m_AxisState[axis];
 }
 
-static bool M_GetBindState(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static bool M_CheckMap(const CONTROLLER_MAP *const map)
 {
-    const CONTROLLER_MAP assigned = m_Layout[layout][role];
-    if (assigned.type == BT_BUTTON) {
-        return M_JoyBtn(assigned.bind.button);
+    if (map->type == BT_BUTTON) {
+        return M_JoyBtn(map->bind.button);
     } else {
-        return M_JoyAxis(assigned.bind.axis) == assigned.axis_dir;
+        return M_JoyAxis(map->bind.axis) == map->axis_dir;
     }
 }
 
-static int16_t M_GetUniqueBind(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static bool M_CheckBinding(const CONTROLLER_BINDING *const bind)
 {
-    const CONTROLLER_MAP assigned = m_Layout[layout][role];
-    if (assigned.type == BT_AXIS) {
-        // Add SDL_CONTROLLER_BUTTON_MAX as an axis offset because button and
-        // axis enum values overlap. Also offset depending on axis direction.
-        if (assigned.axis_dir == -1) {
-            return assigned.bind.axis + SDL_CONTROLLER_BUTTON_MAX;
-        } else {
-            return assigned.bind.axis + SDL_CONTROLLER_BUTTON_MAX + 10;
+    if (bind->key_count == 0) {
+        return false;
+    }
+    for (int32_t k = 0; k < bind->key_count; k++) {
+        if (!M_CheckMap(&bind->keys[k])) {
+            return false;
         }
     }
-    return assigned.bind.button;
+    return true;
+}
+
+static bool M_IsMapImmediate(
+    const INPUT_LAYOUT layout, const CONTROLLER_MAP *const map);
+
+static bool M_GetBindState(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+{
+    for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+        const CONTROLLER_BINDING *bind = &m_Layout[layout][role].slots[slot];
+        if (bind->key_count >= 2 && M_IsMapImmediate(layout, &bind->keys[0])) {
+            continue;
+        }
+        if (M_CheckBinding(bind)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static const CONTROLLER_BINDING *M_GetBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    return &m_Layout[layout][role].slots[slot];
+}
+
+static bool M_MapsEqual(
+    const CONTROLLER_MAP *const a, const CONTROLLER_MAP *const b)
+{
+    if (a->type != b->type) {
+        return false;
+    }
+    if (a->type == BT_BUTTON) {
+        return a->bind.button == b->bind.button;
+    }
+    return a->bind.axis == b->bind.axis && a->axis_dir == b->axis_dir;
+}
+
+static bool M_BindingsEqual(
+    const CONTROLLER_BINDING *const a, const CONTROLLER_BINDING *const b)
+{
+    if (a->key_count != b->key_count || a->key_count == 0) {
+        return false;
+    }
+    for (int32_t i = 0; i < a->key_count; i++) {
+        if (!M_MapsEqual(&a->keys[i], &b->keys[i])) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static bool M_CheckConflict(
     const INPUT_LAYOUT layout, const INPUT_ROLE role1, const INPUT_ROLE role2)
 {
-    const int16_t bind1 = M_GetUniqueBind(layout, role1);
-    const int16_t bind2 = M_GetUniqueBind(layout, role2);
-    return bind1 == bind2;
+    for (int32_t s1 = 0; s1 < INPUT_BINDING_SLOTS; s1++) {
+        const CONTROLLER_BINDING *b1 = M_GetBinding(layout, role1, s1);
+        if (b1->key_count == 0) {
+            continue;
+        }
+        for (int32_t s2 = 0; s2 < INPUT_BINDING_SLOTS; s2++) {
+            const CONTROLLER_BINDING *b2 = M_GetBinding(layout, role2, s2);
+            if (M_BindingsEqual(b1, b2)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 static void M_AssignConflict(
@@ -275,51 +342,83 @@ static void M_AssignConflict(
     m_Conflicts[layout][role] = conflict;
 }
 
+static bool M_ComboStartsWithImmediate(
+    const INPUT_LAYOUT layout, const CONTROLLER_BINDING *const bind);
+
 static void M_CheckConflicts(const INPUT_LAYOUT layout)
 {
     Input_ConflictHelper(layout, M_CheckConflict, M_AssignConflict);
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (m_Conflicts[layout][role]) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const CONTROLLER_BINDING *b = M_GetBinding(layout, role, s);
+            if (M_ComboStartsWithImmediate(layout, b)) {
+                m_Conflicts[layout][role] = true;
+                break;
+            }
+        }
+    }
 }
 
 static int16_t M_GetAssignedButtonType(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role)
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    return m_Layout[layout][role].type;
+    const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
+    return bind->key_count > 0 ? bind->keys[0].type : BT_BUTTON;
 }
 
 static int16_t M_GetAssignedBind(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role)
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    const CONTROLLER_MAP assigned = m_Layout[layout][role];
-    if (assigned.type == BT_BUTTON) {
-        return assigned.bind.button;
+    const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
+    if (bind->key_count == 0) {
+        return SDL_CONTROLLER_BUTTON_INVALID;
+    }
+    const CONTROLLER_MAP *map = &bind->keys[0];
+    if (map->type == BT_BUTTON) {
+        return map->bind.button;
     } else {
-        return assigned.bind.axis;
+        return map->bind.axis;
     }
 }
 
 static int16_t M_GetAssignedAxisDir(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role)
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    return m_Layout[layout][role].axis_dir;
+    const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
+    return bind->key_count > 0 ? bind->keys[0].axis_dir : 0;
+}
+
+static void M_AssignBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
+    const CONTROLLER_BINDING *const bind)
+{
+    m_Layout[layout][role].slots[slot] = *bind;
+    M_CheckConflicts(layout);
 }
 
 static void M_AssignButton(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int16_t button)
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
+    const int16_t button)
 {
-    m_Layout[layout][role].type = BT_BUTTON;
-    m_Layout[layout][role].bind.button = button;
-    m_Layout[layout][role].axis_dir = 0;
-    M_CheckConflicts(layout);
+    const CONTROLLER_BINDING bind = {
+        .key_count = button != SDL_CONTROLLER_BUTTON_INVALID ? 1 : 0,
+        .keys = { { BT_BUTTON, { .button = button }, 0 } },
+    };
+    M_AssignBinding(layout, role, slot, &bind);
 }
 
 static void M_AssignAxis(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int16_t axis,
-    const int16_t axis_dir)
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
+    const int16_t axis, const int16_t axis_dir)
 {
-    m_Layout[layout][role].type = BT_AXIS;
-    m_Layout[layout][role].bind.axis = axis;
-    m_Layout[layout][role].axis_dir = axis_dir;
-    M_CheckConflicts(layout);
+    const CONTROLLER_BINDING bind = {
+        .key_count = 1,
+        .keys = { { BT_AXIS, { .axis = axis }, axis_dir } },
+    };
+    M_AssignBinding(layout, role, slot, &bind);
 }
 
 static SDL_GameController *M_FindController(void)
@@ -352,8 +451,7 @@ static SDL_GameController *M_FindController(void)
 static void M_ResetLayout(const INPUT_LAYOUT layout)
 {
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
-        const CONTROLLER_MAP default_btn = m_Layout[INPUT_LAYOUT_DEFAULT][role];
-        m_Layout[layout][role] = default_btn;
+        m_Layout[layout][role] = m_Layout[INPUT_LAYOUT_DEFAULT][role];
     }
     M_CheckConflicts(layout);
 }
@@ -369,16 +467,21 @@ static void M_Discover(void)
 
 static void M_Init(void)
 {
-    // first, reset the roles to null
+    // first, reset all roles to unbound
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
-        m_Layout[INPUT_LAYOUT_DEFAULT][role] = (CONTROLLER_MAP) {
-            BT_BUTTON, { SDL_CONTROLLER_BUTTON_INVALID }, 0
-        };
+        for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+            m_Layout[INPUT_LAYOUT_DEFAULT][role].slots[slot] =
+                (CONTROLLER_BINDING) { .key_count = 0 };
+        }
     }
-    // then load actually defined default bindings
+    // then load actually defined default bindings into slot 0
     for (int32_t i = 0; m_BuiltinLayout[i].role != (INPUT_ROLE)-1; i++) {
         const BUILTIN_CONTROLLER_LAYOUT *const builtin = &m_BuiltinLayout[i];
-        m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role] = builtin->map;
+        m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role].slots[0] =
+            (CONTROLLER_BINDING) {
+                .key_count = 1,
+                .keys = { builtin->map },
+            };
     }
     M_CheckConflicts(INPUT_LAYOUT_DEFAULT);
 
@@ -477,83 +580,479 @@ static bool M_IsRoleConflicted(const INPUT_LAYOUT layout, const INPUT_ROLE role)
     return m_Conflicts[layout][role];
 }
 
-static const char *M_GetName(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static const char *M_GetMapName(const CONTROLLER_MAP *const map)
 {
-    const CONTROLLER_MAP check = m_Layout[layout][role];
-    if (check.type == BT_BUTTON) {
-        return M_GetButtonName(check.bind.button);
+    if (map->type == BT_BUTTON) {
+        return M_GetButtonName(map->bind.button);
     } else {
-        return M_GetAxisName(check.bind.axis, check.axis_dir);
+        return M_GetAxisName(map->bind.axis, map->axis_dir);
     }
 }
 
-static void M_UnassignRole(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static const char *M_GetName(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    M_AssignButton(layout, role, -1);
+    const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
+    if (bind->key_count == 0) {
+        return nullptr;
+    }
+    if (bind->key_count == 1) {
+        return M_GetMapName(&bind->keys[0]);
+    }
+    // Build composite name for multi-key combo
+    static char buf[256];
+    buf[0] = '\0';
+    for (int32_t k = 0; k < bind->key_count; k++) {
+        if (k > 0) {
+            strcat(buf, "+");
+        }
+        const char *name = M_GetMapName(&bind->keys[k]);
+        if (name != nullptr) {
+            strcat(buf, name);
+        }
+    }
+    return buf;
+}
+
+static void M_UnassignRole(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    const CONTROLLER_BINDING empty = { .key_count = 0 };
+    M_AssignBinding(layout, role, slot, &empty);
 }
 
 static bool M_AssignFromJSONObject(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role,
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
     JSON_OBJECT *const bind_obj)
 {
-    int16_t button_type = M_GetAssignedButtonType(layout, role);
-    button_type = JSON_ObjectGetInt(bind_obj, "button_type", button_type);
-
-    int16_t bind = M_GetAssignedBind(layout, role);
-    bind = JSON_ObjectGetInt(bind_obj, "bind", bind);
-
-    int16_t axis_dir = M_GetAssignedAxisDir(layout, role);
-    axis_dir = JSON_ObjectGetInt(bind_obj, "axis_dir", axis_dir);
-
-    if (button_type == BT_BUTTON) {
-        M_AssignButton(layout, role, bind);
+    JSON_ARRAY *const combo_arr = JSON_ObjectGetArray(bind_obj, "combo");
+    if (combo_arr != nullptr) {
+        // New combo format: "combo": [{button_type, bind, axis_dir}, ...]
+        const int32_t count = combo_arr->length < INPUT_COMBO_MAX_KEYS
+            ? (int32_t)combo_arr->length
+            : INPUT_COMBO_MAX_KEYS;
+        CONTROLLER_BINDING cb = { .key_count = count };
+        for (int32_t i = 0; i < count; i++) {
+            JSON_OBJECT *const key_obj = JSON_ArrayGetObject(combo_arr, i);
+            cb.keys[i].type =
+                JSON_ObjectGetInt(key_obj, "button_type", BT_BUTTON);
+            const int16_t b = JSON_ObjectGetInt(
+                key_obj, "bind", SDL_CONTROLLER_BUTTON_INVALID);
+            if (cb.keys[i].type == BT_BUTTON) {
+                cb.keys[i].bind.button = b;
+            } else {
+                cb.keys[i].bind.axis = b;
+            }
+            cb.keys[i].axis_dir = JSON_ObjectGetInt(key_obj, "axis_dir", 0);
+        }
+        M_AssignBinding(layout, role, slot, &cb);
     } else {
-        M_AssignAxis(layout, role, bind, axis_dir);
+        // Legacy single-key format
+        int16_t button_type = M_GetAssignedButtonType(layout, role, slot);
+        button_type = JSON_ObjectGetInt(bind_obj, "button_type", button_type);
+
+        int16_t bind = M_GetAssignedBind(layout, role, slot);
+        bind = JSON_ObjectGetInt(bind_obj, "bind", bind);
+
+        int16_t axis_dir = M_GetAssignedAxisDir(layout, role, slot);
+        axis_dir = JSON_ObjectGetInt(bind_obj, "axis_dir", axis_dir);
+
+        if (button_type == BT_BUTTON) {
+            M_AssignButton(layout, role, slot, bind);
+        } else {
+            M_AssignAxis(layout, role, slot, bind, axis_dir);
+        }
     }
     return true;
 }
 
 static bool M_AssignToJSONObject(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role,
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
     JSON_OBJECT *const bind_obj)
 {
-    const int16_t default_button_type =
-        M_GetAssignedButtonType(INPUT_LAYOUT_DEFAULT, role);
-    const int16_t default_axis_dir =
-        M_GetAssignedAxisDir(INPUT_LAYOUT_DEFAULT, role);
-    const int16_t default_bind = M_GetAssignedBind(INPUT_LAYOUT_DEFAULT, role);
+    const CONTROLLER_BINDING *user = M_GetBinding(layout, role, slot);
+    const CONTROLLER_BINDING *def =
+        M_GetBinding(INPUT_LAYOUT_DEFAULT, role, slot);
 
-    const int16_t user_button_type = M_GetAssignedButtonType(layout, role);
-    const int16_t user_axis_dir = M_GetAssignedAxisDir(layout, role);
-    const int16_t user_bind = M_GetAssignedBind(layout, role);
-
-    if (user_button_type == default_button_type
-        && user_axis_dir == default_axis_dir && user_bind == default_bind) {
+    if (M_BindingsEqual(user, def)
+        || (user->key_count == 0 && def->key_count == 0)) {
         return false;
     }
 
-    JSON_ObjectAppendInt(bind_obj, "button_type", user_button_type);
-    JSON_ObjectAppendInt(bind_obj, "bind", user_bind);
-    JSON_ObjectAppendInt(bind_obj, "axis_dir", user_axis_dir);
+    if (user->key_count == 0) {
+        // Explicitly unbound
+        JSON_ObjectAppendInt(bind_obj, "button_type", (int16_t)BT_BUTTON);
+        JSON_ObjectAppendInt(
+            bind_obj, "bind", (int16_t)SDL_CONTROLLER_BUTTON_INVALID);
+        JSON_ObjectAppendInt(bind_obj, "axis_dir", (int16_t)0);
+    } else if (user->key_count == 1) {
+        // Single key (legacy format for backward compat)
+        const CONTROLLER_MAP *map = &user->keys[0];
+        JSON_ObjectAppendInt(bind_obj, "button_type", map->type);
+        JSON_ObjectAppendInt(
+            bind_obj, "bind",
+            map->type == BT_BUTTON ? map->bind.button : map->bind.axis);
+        JSON_ObjectAppendInt(bind_obj, "axis_dir", map->axis_dir);
+    } else {
+        // Multi-key combo
+        JSON_ARRAY *const arr = JSON_ArrayNew();
+        for (int32_t i = 0; i < user->key_count; i++) {
+            const CONTROLLER_MAP *map = &user->keys[i];
+            JSON_OBJECT *const key_obj = JSON_ObjectNew();
+            JSON_ObjectAppendInt(key_obj, "button_type", map->type);
+            JSON_ObjectAppendInt(
+                key_obj, "bind",
+                map->type == BT_BUTTON ? map->bind.button : map->bind.axis);
+            JSON_ObjectAppendInt(key_obj, "axis_dir", map->axis_dir);
+            JSON_ArrayAppendObject(arr, key_obj);
+        }
+        JSON_ObjectAppendArray(bind_obj, "combo", arr);
+    }
     return true;
 }
 
-static bool M_ReadAndAssign(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+// Per-button/axis tracking for combo prefix deferral.
+// Index: buttons use their enum directly, axes use
+// SDL_CONTROLLER_BUTTON_MAX + axis*2 + (axis_dir == 1 ? 1 : 0).
+#define M_PREFIX_SLOTS (SDL_CONTROLLER_BUTTON_MAX + SDL_CONTROLLER_AXIS_MAX * 2)
+static bool m_PrefixWasHeld[M_PREFIX_SLOTS];
+static bool m_PrefixComboFired[M_PREFIX_SLOTS];
+
+static int32_t M_MapToPrefixIdx(const CONTROLLER_MAP *const map)
 {
-    for (SDL_GameControllerButton button = 0;
-         button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-        if (M_JoyBtn(button)) {
-            M_AssignButton(layout, role, button);
-            return true;
+    if (map->type == BT_BUTTON) {
+        return map->bind.button;
+    }
+    return SDL_CONTROLLER_BUTTON_MAX + map->bind.axis * 2
+        + (map->axis_dir == 1 ? 1 : 0);
+}
+
+static bool M_IsInputHeld(const CONTROLLER_MAP *const map)
+{
+    return M_CheckMap(map);
+}
+
+static bool M_IsComboInput(
+    const INPUT_LAYOUT layout, const CONTROLLER_MAP *const map)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const CONTROLLER_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count < 2) {
+                continue;
+            }
+            for (int32_t k = 0; k < b->key_count; k++) {
+                if (M_MapsEqual(&b->keys[k], map)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+static INPUT_ROLE M_FindSingleInputRole(
+    const INPUT_LAYOUT layout, const CONTROLLER_MAP *const map)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (Input_IsRoleImmediate(r)) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const CONTROLLER_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count == 1 && M_MapsEqual(&b->keys[0], map)) {
+                return r;
+            }
+        }
+    }
+    return (INPUT_ROLE)-1;
+}
+
+static bool M_IsProperSubset(
+    const CONTROLLER_BINDING *const sub, const CONTROLLER_BINDING *const super)
+{
+    if (sub->key_count == 0 || sub->key_count >= super->key_count) {
+        return false;
+    }
+    for (int32_t i = 0; i < sub->key_count; i++) {
+        bool found = false;
+        for (int32_t j = 0; j < super->key_count; j++) {
+            if (M_MapsEqual(&sub->keys[i], &super->keys[j])) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static const CONTROLLER_BINDING *M_GetPressedBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role)
+{
+    for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+        const CONTROLLER_BINDING *bind = M_GetBinding(layout, role, slot);
+        if (M_CheckBinding(bind)) {
+            return bind;
+        }
+    }
+    return nullptr;
+}
+
+static void M_ResolvePrefixDeferral(
+    const INPUT_LAYOUT layout, INPUT_STATE *const result,
+    const CONTROLLER_MAP *const map)
+{
+    const int32_t idx = M_MapToPrefixIdx(map);
+    const bool held = M_IsInputHeld(map);
+
+    if (held && M_IsComboInput(layout, map)) {
+        const INPUT_ROLE role = M_FindSingleInputRole(layout, map);
+        if (role != (INPUT_ROLE)-1) {
+            InputState_ClearRole(result, role);
+        }
+    }
+
+    if (!held && m_PrefixWasHeld[idx] && !m_PrefixComboFired[idx]) {
+        const INPUT_ROLE role = M_FindSingleInputRole(layout, map);
+        if (role != (INPUT_ROLE)-1) {
+            InputState_SetRole(result, role, true);
+        }
+    }
+
+    m_PrefixWasHeld[idx] = held;
+}
+
+// Check if a binding is a proper subset of ANY binding in the layout.
+static bool M_HasLongerCombo(
+    const INPUT_LAYOUT layout, const INPUT_ROLE skip_role,
+    const CONTROLLER_BINDING *const bind)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (r == skip_role) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const CONTROLLER_BINDING *b = M_GetBinding(layout, r, s);
+            if (M_IsProperSubset(bind, b)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Per-role deferral tracking for combo disambiguation.
+static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
+static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
+
+static void M_ResolveCombos(
+    const INPUT_LAYOUT layout, INPUT_STATE *const result)
+{
+    // Phase 1: Collect active bindings.
+    const CONTROLLER_BINDING *active[INPUT_ROLE_NUMBER_OF] = {};
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (InputState_GetRole(*result, role)) {
+            active[role] = M_GetPressedBinding(layout, role);
+        }
+    }
+
+    // Phase 2: Subset suppression — longer active combos suppress shorter.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr) {
+            continue;
+        }
+        for (INPUT_ROLE other = 0; other < INPUT_ROLE_NUMBER_OF; other++) {
+            if (other == role || active[other] == nullptr) {
+                continue;
+            }
+            if (M_IsProperSubset(active[role], active[other])) {
+                InputState_ClearRole(result, role);
+                break;
+            }
+        }
+    }
+
+    // Phase 3: Combo deferral — if an active combo's binding is a proper
+    // subset of some (not necessarily active) longer binding, defer it.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr) {
+            continue;
+        }
+        if (Input_IsRoleImmediate(role) && active[role]->key_count <= 1) {
+            continue;
+        }
+        if (M_HasLongerCombo(layout, role, active[role])) {
+            InputState_ClearRole(result, role);
+            if (!m_RoleWasActive[role]) {
+                m_RoleLongerFired[role] = false;
+            }
+            m_RoleWasActive[role] = true;
+        }
+    }
+
+    // Reset prefix tracking for newly pressed inputs.
+    for (SDL_GameControllerButton btn = 0; btn < SDL_CONTROLLER_BUTTON_MAX;
+         btn++) {
+        const int32_t idx = (int32_t)btn;
+        if (M_JoyBtn(btn) && !m_PrefixWasHeld[idx]) {
+            m_PrefixComboFired[idx] = false;
         }
     }
     for (SDL_GameControllerAxis axis = 0; axis < SDL_CONTROLLER_AXIS_MAX;
          axis++) {
-        int16_t axis_dir = M_JoyAxis(axis);
-        if (axis_dir != 0) {
-            M_AssignAxis(layout, role, axis, axis_dir);
+        for (int16_t dir = -1; dir <= 1; dir += 2) {
+            const CONTROLLER_MAP map = { BT_AXIS, { .axis = axis }, dir };
+            const int32_t idx = M_MapToPrefixIdx(&map);
+            if (M_JoyAxis(axis) == dir && !m_PrefixWasHeld[idx]) {
+                m_PrefixComboFired[idx] = false;
+            }
+        }
+    }
+
+    // Phase 4: Mark longer-combo-fired state.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr || active[role]->key_count < 2) {
+            continue;
+        }
+        for (int32_t k = 0; k < active[role]->key_count; k++) {
+            const int32_t idx = M_MapToPrefixIdx(&active[role]->keys[k]);
+            m_PrefixComboFired[idx] = true;
+        }
+        for (INPUT_ROLE other = 0; other < INPUT_ROLE_NUMBER_OF; other++) {
+            if (!m_RoleWasActive[other]) {
+                continue;
+            }
+            const CONTROLLER_BINDING *ob = M_GetPressedBinding(layout, other);
+            if (ob != nullptr && M_IsProperSubset(ob, active[role])) {
+                m_RoleLongerFired[other] = true;
+            }
+        }
+    }
+
+    // Phase 5: Fire deferred roles on release.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (!m_RoleWasActive[role]) {
+            continue;
+        }
+        const CONTROLLER_BINDING *bind = M_GetPressedBinding(layout, role);
+        if (bind != nullptr) {
+            continue;
+        }
+        if (!m_RoleLongerFired[role]) {
+            InputState_SetRole(result, role, true);
+        }
+        m_RoleWasActive[role] = false;
+        m_RoleLongerFired[role] = false;
+    }
+
+    // Phase 6: Single-input prefix deferral.
+    for (SDL_GameControllerButton btn = 0; btn < SDL_CONTROLLER_BUTTON_MAX;
+         btn++) {
+        const CONTROLLER_MAP map = { BT_BUTTON, { .button = btn }, 0 };
+        M_ResolvePrefixDeferral(layout, result, &map);
+    }
+    for (SDL_GameControllerAxis axis = 0; axis < SDL_CONTROLLER_AXIS_MAX;
+         axis++) {
+        for (int16_t dir = -1; dir <= 1; dir += 2) {
+            const CONTROLLER_MAP map = { BT_AXIS, { .axis = axis }, dir };
+            M_ResolvePrefixDeferral(layout, result, &map);
+        }
+    }
+}
+
+// Check whether a controller map is bound to any immediate role.
+static bool M_IsMapImmediate(
+    const INPUT_LAYOUT layout, const CONTROLLER_MAP *const map)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (!Input_IsRoleImmediate(r)) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const CONTROLLER_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count == 1 && M_MapsEqual(&b->keys[0], map)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool M_ComboStartsWithImmediate(
+    const INPUT_LAYOUT layout, const CONTROLLER_BINDING *const bind)
+{
+    if (bind->key_count < 2) {
+        return false;
+    }
+    return M_IsMapImmediate(layout, &bind->keys[0]);
+}
+
+// Combo capture state for listen mode.
+static CONTROLLER_BINDING m_CaptureBuffer = { .key_count = 0 };
+static bool m_CaptureActive = false;
+
+static bool M_CaptureHasMap(const CONTROLLER_MAP *const map)
+{
+    for (int32_t i = 0; i < m_CaptureBuffer.key_count; i++) {
+        if (M_MapsEqual(&m_CaptureBuffer.keys[i], map)) {
             return true;
         }
+    }
+    return false;
+}
+
+static bool M_ReadAndAssign(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    // Count currently held inputs and accumulate new ones into the buffer.
+    bool any_held = false;
+    for (SDL_GameControllerButton button = 0;
+         button < SDL_CONTROLLER_BUTTON_MAX; button++) {
+        if (!M_JoyBtn(button)) {
+            continue;
+        }
+        any_held = true;
+        const CONTROLLER_MAP map = { BT_BUTTON, { .button = button }, 0 };
+        if (!M_CaptureHasMap(&map)
+            && m_CaptureBuffer.key_count < INPUT_COMBO_MAX_KEYS) {
+            m_CaptureBuffer.keys[m_CaptureBuffer.key_count++] = map;
+        }
+        m_CaptureActive = true;
+    }
+    for (SDL_GameControllerAxis axis = 0; axis < SDL_CONTROLLER_AXIS_MAX;
+         axis++) {
+        const int16_t axis_dir = M_JoyAxis(axis);
+        if (axis_dir == 0) {
+            continue;
+        }
+        any_held = true;
+        const CONTROLLER_MAP map = { BT_AXIS, { .axis = axis }, axis_dir };
+        if (!M_CaptureHasMap(&map)
+            && m_CaptureBuffer.key_count < INPUT_COMBO_MAX_KEYS) {
+            m_CaptureBuffer.keys[m_CaptureBuffer.key_count++] = map;
+        }
+        m_CaptureActive = true;
+    }
+
+    // If the first input captured is bound to an immediate role (movement,
+    // action, etc.), assign as single key right away — don't wait for combo.
+    if (m_CaptureActive && m_CaptureBuffer.key_count == 1 && any_held
+        && M_IsMapImmediate(layout, &m_CaptureBuffer.keys[0])) {
+        M_AssignBinding(layout, role, slot, &m_CaptureBuffer);
+        m_CaptureBuffer.key_count = 0;
+        m_CaptureActive = false;
+        return true;
+    }
+
+    // All inputs released after at least one was captured — assign the chord.
+    if (!any_held && m_CaptureActive) {
+        M_AssignBinding(layout, role, slot, &m_CaptureBuffer);
+        m_CaptureBuffer.key_count = 0;
+        m_CaptureActive = false;
+        return true;
     }
     return false;
 }
@@ -572,4 +1071,5 @@ INPUT_BACKEND_IMPL g_Input_Controller = {
     .assign_to_json_object = M_AssignToJSONObject,
     .reset_layout = M_ResetLayout,
     .read_and_assign = M_ReadAndAssign,
+    .resolve_combos = M_ResolveCombos,
 };

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -4,6 +4,7 @@
 #include <trx/version.h>
 
 #include <SDL2/SDL_keyboard.h>
+#include <string.h>
 
 // Key state table updated via SDL events.
 #define KEY_DOWN(a) (m_KeyboardState[(a)])
@@ -12,6 +13,15 @@ typedef struct {
     INPUT_ROLE role;
     SDL_Scancode scancode;
 } BUILTIN_KEYBOARD_LAYOUT;
+
+typedef struct {
+    int32_t key_count;
+    SDL_Scancode keys[INPUT_COMBO_MAX_KEYS];
+} KEYBOARD_BINDING;
+
+typedef struct {
+    KEYBOARD_BINDING slots[INPUT_BINDING_SLOTS];
+} KEYBOARD_ROLE_BINDING;
 
 static bool m_KeyboardState[SDL_NUM_SCANCODES] = {};
 static bool m_Conflicts[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF] = {};
@@ -24,7 +34,8 @@ static BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayout[] = {
     // clang-format on
 };
 
-static SDL_Scancode m_Layout[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF];
+static KEYBOARD_ROLE_BINDING m_Layout[INPUT_LAYOUT_NUMBER_OF]
+                                     [INPUT_ROLE_NUMBER_OF];
 
 // Update internal controller button/axis state from SDL events.
 // @param event     Event to process.
@@ -288,9 +299,11 @@ static const char *M_GetScancodeName(SDL_Scancode scancode)
     // clang-format on
 }
 
-static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static bool M_CheckScancode(const SDL_Scancode scancode)
 {
-    SDL_Scancode scancode = m_Layout[layout][role];
+    if (scancode == SDL_SCANCODE_UNKNOWN) {
+        return false;
+    }
     if (scancode == SDL_SCANCODE_RETURN && KEY_DOWN(SDL_SCANCODE_LALT)) {
         return false;
     }
@@ -324,17 +337,73 @@ static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
     return false;
 }
 
-static SDL_Scancode M_GetAssignedScancode(INPUT_LAYOUT layout, INPUT_ROLE role)
+static bool M_CheckBinding(const KEYBOARD_BINDING *const bind)
 {
-    return m_Layout[layout][role];
+    if (bind->key_count == 0) {
+        return false;
+    }
+    for (int32_t k = 0; k < bind->key_count; k++) {
+        if (!M_CheckScancode(bind->keys[k])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool M_IsScancodeImmediate(
+    const INPUT_LAYOUT layout, const SDL_Scancode scancode);
+
+static bool M_Key(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+{
+    for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+        const KEYBOARD_BINDING *bind = &m_Layout[layout][role].slots[slot];
+        if (bind->key_count >= 2
+            && M_IsScancodeImmediate(layout, bind->keys[0])) {
+            continue;
+        }
+        if (M_CheckBinding(bind)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static const KEYBOARD_BINDING *M_GetBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    return &m_Layout[layout][role].slots[slot];
+}
+
+static bool M_BindingsEqual(
+    const KEYBOARD_BINDING *const a, const KEYBOARD_BINDING *const b)
+{
+    if (a->key_count != b->key_count || a->key_count == 0) {
+        return false;
+    }
+    for (int32_t i = 0; i < a->key_count; i++) {
+        if (a->keys[i] != b->keys[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static bool M_CheckConflict(
     const INPUT_LAYOUT layout, const INPUT_ROLE role1, const INPUT_ROLE role2)
 {
-    const SDL_Scancode scancode1 = M_GetAssignedScancode(layout, role1);
-    const SDL_Scancode scancode2 = M_GetAssignedScancode(layout, role2);
-    return scancode1 == scancode2;
+    for (int32_t s1 = 0; s1 < INPUT_BINDING_SLOTS; s1++) {
+        const KEYBOARD_BINDING *b1 = M_GetBinding(layout, role1, s1);
+        if (b1->key_count == 0) {
+            continue;
+        }
+        for (int32_t s2 = 0; s2 < INPUT_BINDING_SLOTS; s2++) {
+            const KEYBOARD_BINDING *b2 = M_GetBinding(layout, role2, s2);
+            if (M_BindingsEqual(b1, b2)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 static void M_AssignConflict(
@@ -343,25 +412,38 @@ static void M_AssignConflict(
     m_Conflicts[layout][role] = conflict;
 }
 
+static bool M_ComboStartsWithImmediate(
+    const INPUT_LAYOUT layout, const KEYBOARD_BINDING *const bind);
+
 static void M_CheckConflicts(const INPUT_LAYOUT layout)
 {
     Input_ConflictHelper(layout, M_CheckConflict, M_AssignConflict);
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (m_Conflicts[layout][role]) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const KEYBOARD_BINDING *b = M_GetBinding(layout, role, s);
+            if (M_ComboStartsWithImmediate(layout, b)) {
+                m_Conflicts[layout][role] = true;
+                break;
+            }
+        }
+    }
 }
 
-static void M_AssignScancode(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role,
-    const SDL_Scancode scancode)
+static void M_AssignBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
+    const KEYBOARD_BINDING *const bind)
 {
-    m_Layout[layout][role] = scancode;
+    m_Layout[layout][role].slots[slot] = *bind;
     M_CheckConflicts(layout);
 }
 
 static void M_ResetLayout(const INPUT_LAYOUT layout)
 {
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
-        const SDL_Scancode scancode =
-            M_GetAssignedScancode(INPUT_LAYOUT_DEFAULT, role);
-        m_Layout[layout][role] = scancode;
+        m_Layout[layout][role] = m_Layout[INPUT_LAYOUT_DEFAULT][role];
     }
     M_CheckConflicts(layout);
 }
@@ -403,16 +485,23 @@ static void M_HandleBuiltInDefaults(void)
 
 static void M_Init(void)
 {
-    // first, reset the roles to null
+    // first, reset all roles to unbound
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
-        m_Layout[INPUT_LAYOUT_DEFAULT][role] = SDL_SCANCODE_UNKNOWN;
+        for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+            m_Layout[INPUT_LAYOUT_DEFAULT][role].slots[slot] =
+                (KEYBOARD_BINDING) { .key_count = 0 };
+        }
     }
     // allow specific engines to re-assign default bindings
     M_HandleBuiltInDefaults();
-    // then load actually defined default bindings
+    // then load actually defined default bindings into slot 0
     for (int32_t i = 0; m_BuiltinLayout[i].role != (INPUT_ROLE)-1; i++) {
         const BUILTIN_KEYBOARD_LAYOUT *const builtin = &m_BuiltinLayout[i];
-        m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role] = builtin->scancode;
+        m_Layout[INPUT_LAYOUT_DEFAULT][builtin->role].slots[0] =
+            (KEYBOARD_BINDING) {
+                .key_count = builtin->scancode != SDL_SCANCODE_UNKNOWN ? 1 : 0,
+                .keys = { builtin->scancode },
+            };
     }
     M_CheckConflicts(INPUT_LAYOUT_DEFAULT);
 
@@ -442,50 +531,383 @@ static bool M_IsRoleConflicted(const INPUT_LAYOUT layout, const INPUT_ROLE role)
     return m_Conflicts[layout][role];
 }
 
-static const char *M_GetName(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static const char *M_GetName(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    return M_GetScancodeName(m_Layout[layout][role]);
+    const KEYBOARD_BINDING *bind = M_GetBinding(layout, role, slot);
+    if (bind->key_count == 0) {
+        return nullptr;
+    }
+    if (bind->key_count == 1) {
+        return M_GetScancodeName(bind->keys[0]);
+    }
+    // Build composite name for multi-key combo
+    static char buf[256];
+    buf[0] = '\0';
+    for (int32_t k = 0; k < bind->key_count; k++) {
+        if (k > 0) {
+            strcat(buf, "+");
+        }
+        const char *name = M_GetScancodeName(bind->keys[k]);
+        if (name != nullptr) {
+            strcat(buf, name);
+        }
+    }
+    return buf;
 }
 
-static void M_UnassignRole(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+static void M_UnassignRole(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
 {
-    M_AssignScancode(layout, role, SDL_SCANCODE_UNKNOWN);
+    const KEYBOARD_BINDING empty = { .key_count = 0 };
+    M_AssignBinding(layout, role, slot, &empty);
 }
 
 static bool M_AssignFromJSONObject(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role,
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
     JSON_OBJECT *const bind_obj)
 {
-    const SDL_Scancode default_scancode = M_GetAssignedScancode(layout, role);
-    const SDL_Scancode user_scancode =
-        JSON_ObjectGetInt(bind_obj, "scancode", default_scancode);
-    M_AssignScancode(layout, role, user_scancode);
+    JSON_ARRAY *const combo_arr = JSON_ObjectGetArray(bind_obj, "combo");
+    if (combo_arr != nullptr) {
+        // New combo format: "combo": [scancode1, scancode2, ...]
+        const int32_t count = combo_arr->length < INPUT_COMBO_MAX_KEYS
+            ? (int32_t)combo_arr->length
+            : INPUT_COMBO_MAX_KEYS;
+        KEYBOARD_BINDING bind = { .key_count = count };
+        for (int32_t i = 0; i < count; i++) {
+            bind.keys[i] = JSON_ArrayGetInt(combo_arr, i, SDL_SCANCODE_UNKNOWN);
+        }
+        M_AssignBinding(layout, role, slot, &bind);
+    } else {
+        // Legacy single-key format: "scancode": N
+        const KEYBOARD_BINDING *current = M_GetBinding(layout, role, slot);
+        const SDL_Scancode default_sc =
+            current->key_count > 0 ? current->keys[0] : SDL_SCANCODE_UNKNOWN;
+        const SDL_Scancode user_sc =
+            JSON_ObjectGetInt(bind_obj, "scancode", default_sc);
+        const KEYBOARD_BINDING bind = {
+            .key_count = user_sc != SDL_SCANCODE_UNKNOWN ? 1 : 0,
+            .keys = { user_sc },
+        };
+        M_AssignBinding(layout, role, slot, &bind);
+    }
     return true;
 }
 
 static bool M_AssignToJSONObject(
-    const INPUT_LAYOUT layout, const INPUT_ROLE role,
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot,
     JSON_OBJECT *const bind_obj)
 {
-    const SDL_Scancode default_scancode =
-        M_GetAssignedScancode(INPUT_LAYOUT_DEFAULT, role);
-    const SDL_Scancode user_scancode = M_GetAssignedScancode(layout, role);
+    const KEYBOARD_BINDING *user = M_GetBinding(layout, role, slot);
+    const KEYBOARD_BINDING *def =
+        M_GetBinding(INPUT_LAYOUT_DEFAULT, role, slot);
 
-    if (user_scancode == default_scancode) {
+    if (M_BindingsEqual(user, def)
+        || (user->key_count == 0 && def->key_count == 0)) {
         return false;
     }
 
-    JSON_ObjectAppendInt(bind_obj, "scancode", user_scancode);
+    if (user->key_count <= 1) {
+        // Single key: use legacy "scancode" for backward compatibility
+        JSON_ObjectAppendInt(
+            bind_obj, "scancode",
+            user->key_count == 1 ? user->keys[0] : SDL_SCANCODE_UNKNOWN);
+    } else {
+        // Multi-key combo
+        JSON_ARRAY *const arr = JSON_ArrayNew();
+        for (int32_t i = 0; i < user->key_count; i++) {
+            JSON_ArrayAppendInt(arr, user->keys[i]);
+        }
+        JSON_ObjectAppendArray(bind_obj, "combo", arr);
+    }
     return true;
 }
 
-static bool M_ReadAndAssign(const INPUT_LAYOUT layout, const INPUT_ROLE role)
+// Per-scancode tracking for combo prefix deferral.
+static bool m_PrefixWasHeld[SDL_NUM_SCANCODES];
+static bool m_PrefixComboFired[SDL_NUM_SCANCODES];
+
+static bool M_IsComboKey(const INPUT_LAYOUT layout, const SDL_Scancode sc)
 {
-    for (SDL_Scancode scancode = 0; scancode < SDL_NUM_SCANCODES; scancode++) {
-        if (KEY_DOWN(scancode)) {
-            M_AssignScancode(layout, role, scancode);
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const KEYBOARD_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count < 2) {
+                continue;
+            }
+            for (int32_t k = 0; k < b->key_count; k++) {
+                if (b->keys[k] == sc) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+static INPUT_ROLE M_FindSingleKeyRole(
+    const INPUT_LAYOUT layout, const SDL_Scancode sc)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (Input_IsRoleImmediate(r)) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const KEYBOARD_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count == 1 && b->keys[0] == sc) {
+                return r;
+            }
+        }
+    }
+    return (INPUT_ROLE)-1;
+}
+
+static bool M_IsProperSubset(
+    const KEYBOARD_BINDING *const sub, const KEYBOARD_BINDING *const super)
+{
+    if (sub->key_count == 0 || sub->key_count >= super->key_count) {
+        return false;
+    }
+    for (int32_t i = 0; i < sub->key_count; i++) {
+        bool found = false;
+        for (int32_t j = 0; j < super->key_count; j++) {
+            if (sub->keys[i] == super->keys[j]) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static const KEYBOARD_BINDING *M_GetPressedBinding(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role)
+{
+    for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+        const KEYBOARD_BINDING *bind = M_GetBinding(layout, role, slot);
+        if (M_CheckBinding(bind)) {
+            return bind;
+        }
+    }
+    return nullptr;
+}
+
+// Check if a binding is a proper subset of ANY binding in the layout.
+static bool M_HasLongerCombo(
+    const INPUT_LAYOUT layout, const INPUT_ROLE skip_role,
+    const KEYBOARD_BINDING *const bind)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (r == skip_role) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const KEYBOARD_BINDING *b = M_GetBinding(layout, r, s);
+            if (M_IsProperSubset(bind, b)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Per-role deferral tracking for combo disambiguation.
+static bool m_RoleWasActive[INPUT_ROLE_NUMBER_OF];
+static bool m_RoleLongerFired[INPUT_ROLE_NUMBER_OF];
+
+static void M_ResolveCombos(
+    const INPUT_LAYOUT layout, INPUT_STATE *const result)
+{
+    // Phase 1: Collect active bindings.
+    const KEYBOARD_BINDING *active[INPUT_ROLE_NUMBER_OF] = {};
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (InputState_GetRole(*result, role)) {
+            active[role] = M_GetPressedBinding(layout, role);
+        }
+    }
+
+    // Phase 2: Subset suppression — longer active combos suppress shorter.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr) {
+            continue;
+        }
+        for (INPUT_ROLE other = 0; other < INPUT_ROLE_NUMBER_OF; other++) {
+            if (other == role || active[other] == nullptr) {
+                continue;
+            }
+            if (M_IsProperSubset(active[role], active[other])) {
+                InputState_ClearRole(result, role);
+                break;
+            }
+        }
+    }
+
+    // Phase 3: Combo deferral — if an active combo's binding is a proper
+    // subset of some (not necessarily active) longer binding, defer it.
+    // This handles both single-key and multi-key prefix disambiguation.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr) {
+            continue;
+        }
+        if (Input_IsRoleImmediate(role) && active[role]->key_count <= 1) {
+            continue;
+        }
+        if (M_HasLongerCombo(layout, role, active[role])) {
+            InputState_ClearRole(result, role);
+            if (!m_RoleWasActive[role]) {
+                m_RoleLongerFired[role] = false;
+            }
+            m_RoleWasActive[role] = true;
+        }
+    }
+
+    // Reset prefix tracking for newly pressed keys.
+    for (SDL_Scancode sc = 0; sc < SDL_NUM_SCANCODES; sc++) {
+        if (KEY_DOWN(sc) && !m_PrefixWasHeld[sc]) {
+            m_PrefixComboFired[sc] = false;
+        }
+    }
+
+    // Phase 4: Mark longer-combo-fired state.
+    // When a combo fires, mark all shorter deferred combos as superseded.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (active[role] == nullptr || active[role]->key_count < 2) {
+            continue;
+        }
+        // Mark scancodes for single-key prefix deferral.
+        for (int32_t k = 0; k < active[role]->key_count; k++) {
+            m_PrefixComboFired[active[role]->keys[k]] = true;
+        }
+        // Mark shorter deferred roles as superseded.
+        for (INPUT_ROLE other = 0; other < INPUT_ROLE_NUMBER_OF; other++) {
+            if (!m_RoleWasActive[other]) {
+                continue;
+            }
+            const KEYBOARD_BINDING *ob = M_GetPressedBinding(layout, other);
+            if (ob != nullptr && M_IsProperSubset(ob, active[role])) {
+                m_RoleLongerFired[other] = true;
+            }
+        }
+    }
+
+    // Phase 5: Fire deferred roles on release.
+    // When a deferred role's binding is no longer fully pressed and no
+    // longer combo fired, inject the role for one frame.
+    for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
+        if (!m_RoleWasActive[role]) {
+            continue;
+        }
+        const KEYBOARD_BINDING *bind = M_GetPressedBinding(layout, role);
+        if (bind != nullptr) {
+            continue;
+        }
+        // Binding is no longer fully held — release transition.
+        if (!m_RoleLongerFired[role]) {
+            InputState_SetRole(result, role, true);
+        }
+        m_RoleWasActive[role] = false;
+        m_RoleLongerFired[role] = false;
+    }
+
+    // Phase 6: Single-key prefix deferral (unchanged).
+    for (SDL_Scancode sc = 0; sc < SDL_NUM_SCANCODES; sc++) {
+        const bool held = KEY_DOWN(sc);
+
+        if (held && M_IsComboKey(layout, sc)) {
+            const INPUT_ROLE role = M_FindSingleKeyRole(layout, sc);
+            if (role != (INPUT_ROLE)-1) {
+                InputState_ClearRole(result, role);
+            }
+        }
+
+        if (!held && m_PrefixWasHeld[sc] && !m_PrefixComboFired[sc]) {
+            const INPUT_ROLE role = M_FindSingleKeyRole(layout, sc);
+            if (role != (INPUT_ROLE)-1) {
+                InputState_SetRole(result, role, true);
+            }
+        }
+
+        m_PrefixWasHeld[sc] = held;
+    }
+}
+
+// Check whether a scancode is bound to any immediate role in the given layout.
+static bool M_IsScancodeImmediate(
+    const INPUT_LAYOUT layout, const SDL_Scancode scancode)
+{
+    for (INPUT_ROLE r = 0; r < INPUT_ROLE_NUMBER_OF; r++) {
+        if (!Input_IsRoleImmediate(r)) {
+            continue;
+        }
+        for (int32_t s = 0; s < INPUT_BINDING_SLOTS; s++) {
+            const KEYBOARD_BINDING *b = M_GetBinding(layout, r, s);
+            if (b->key_count == 1 && b->keys[0] == scancode) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool M_ComboStartsWithImmediate(
+    const INPUT_LAYOUT layout, const KEYBOARD_BINDING *const bind)
+{
+    if (bind->key_count < 2) {
+        return false;
+    }
+    return M_IsScancodeImmediate(layout, bind->keys[0]);
+}
+
+// Combo capture state for listen mode.
+static KEYBOARD_BINDING m_CaptureBuffer = { .key_count = 0 };
+static bool m_CaptureActive = false;
+
+static bool M_CaptureHasKey(const SDL_Scancode scancode)
+{
+    for (int32_t i = 0; i < m_CaptureBuffer.key_count; i++) {
+        if (m_CaptureBuffer.keys[i] == scancode) {
             return true;
         }
+    }
+    return false;
+}
+
+static bool M_ReadAndAssign(
+    const INPUT_LAYOUT layout, const INPUT_ROLE role, const int32_t slot)
+{
+    // Count currently held keys and accumulate new ones into the buffer.
+    bool any_held = false;
+    for (SDL_Scancode sc = 0; sc < SDL_NUM_SCANCODES; sc++) {
+        if (!KEY_DOWN(sc)) {
+            continue;
+        }
+        any_held = true;
+        if (!M_CaptureHasKey(sc)
+            && m_CaptureBuffer.key_count < INPUT_COMBO_MAX_KEYS) {
+            m_CaptureBuffer.keys[m_CaptureBuffer.key_count++] = sc;
+        }
+        m_CaptureActive = true;
+    }
+
+    // If the first key captured is bound to an immediate role (movement,
+    // action, etc.), assign as single key right away — don't wait for combo.
+    if (m_CaptureActive && m_CaptureBuffer.key_count == 1 && any_held
+        && M_IsScancodeImmediate(layout, m_CaptureBuffer.keys[0])) {
+        M_AssignBinding(layout, role, slot, &m_CaptureBuffer);
+        m_CaptureBuffer.key_count = 0;
+        m_CaptureActive = false;
+        return true;
+    }
+
+    // All keys released after at least one was captured — assign the chord.
+    if (!any_held && m_CaptureActive) {
+        M_AssignBinding(layout, role, slot, &m_CaptureBuffer);
+        m_CaptureBuffer.key_count = 0;
+        m_CaptureActive = false;
+        return true;
     }
     return false;
 }
@@ -504,4 +926,5 @@ INPUT_BACKEND_IMPL g_Input_Keyboard = {
     .assign_to_json_object = M_AssignToJSONObject,
     .reset_layout = M_ResetLayout,
     .read_and_assign = M_ReadAndAssign,
+    .resolve_combos = M_ResolveCombos,
 };

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -57,6 +57,22 @@ static bool m_IsRoleHardcoded[INPUT_ROLE_NUMBER_OF] = {
     // clang-format on
 };
 
+static bool m_IsRoleImmediate[INPUT_ROLE_NUMBER_OF] = {
+    // clang-format off
+    [INPUT_ROLE_UP]          = true,
+    [INPUT_ROLE_DOWN]        = true,
+    [INPUT_ROLE_LEFT]        = true,
+    [INPUT_ROLE_RIGHT]       = true,
+    [INPUT_ROLE_JUMP]        = true,
+    [INPUT_ROLE_ACTION]      = true,
+    [INPUT_ROLE_ROLL]        = true,
+    [INPUT_ROLE_STEP_LEFT]   = true,
+    [INPUT_ROLE_STEP_RIGHT]  = true,
+    [INPUT_ROLE_CROUCH]      = true,
+    [INPUT_ROLE_SPRINT]      = true,
+    // clang-format on
+};
+
 static bool m_IsRoleNonUnbindable[INPUT_ROLE_NUMBER_OF] = {
     // clang-format off
     [INPUT_ROLE_UP]          = true,
@@ -169,6 +185,11 @@ bool Input_IsRoleUnbindable(const INPUT_ROLE role)
     return !m_IsRoleNonUnbindable[role];
 }
 
+bool Input_IsRoleImmediate(const INPUT_ROLE role)
+{
+    return m_IsRoleImmediate[role];
+}
+
 bool Input_IsPressed(const INPUT_ROLE role)
 {
     return M_IsPressed(g_Input, role);
@@ -195,7 +216,7 @@ bool Input_IsKeyConflicted(
 
 bool Input_ReadAndAssignRole(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
-    const INPUT_ROLE role)
+    const INPUT_ROLE role, const int32_t slot)
 {
     // Check for canceling from other devices
     for (INPUT_BACKEND other_backend = 0;
@@ -209,21 +230,21 @@ bool Input_ReadAndAssignRole(
         }
     }
 
-    return M_GetBackend(backend)->read_and_assign(layout, role);
+    return M_GetBackend(backend)->read_and_assign(layout, role, slot);
 }
 
 void Input_UnassignRole(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
-    const INPUT_ROLE role)
+    const INPUT_ROLE role, const int32_t slot)
 {
-    M_GetBackend(backend)->unassign_role(layout, role);
+    M_GetBackend(backend)->unassign_role(layout, role, slot);
 }
 
 const char *Input_GetKeyName(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
-    const INPUT_ROLE role)
+    const INPUT_ROLE role, const int32_t slot)
 {
-    return M_GetBackend(backend)->get_name(layout, role);
+    return M_GetBackend(backend)->get_name(layout, role, slot);
 }
 
 void Input_ResetLayout(const INPUT_BACKEND backend, const INPUT_LAYOUT layout)
@@ -333,17 +354,22 @@ bool Input_AssignFromJSONObject(
         return false;
     }
 
+    const int32_t slot = JSON_ObjectGetInt(bind_obj, "slot", 0);
     return M_GetBackend(backend)->assign_from_json_object(
-        layout, role, bind_obj);
+        layout, role, slot, bind_obj);
 }
 
 bool Input_AssignToJSONObject(
     const INPUT_BACKEND backend, const INPUT_LAYOUT layout,
-    JSON_OBJECT *const bind_obj, const INPUT_ROLE role)
+    JSON_OBJECT *const bind_obj, const INPUT_ROLE role, const int32_t slot)
 {
     JSON_ObjectAppendString(
         bind_obj, "role", ENUM_MAP_TO_STRING(INPUT_ROLE, role));
-    return M_GetBackend(backend)->assign_to_json_object(layout, role, bind_obj);
+    if (slot != 0) {
+        JSON_ObjectAppendInt(bind_obj, "slot", slot);
+    }
+    return M_GetBackend(backend)->assign_to_json_object(
+        layout, role, slot, bind_obj);
 }
 
 const char *const *Input_GetLayoutNamePtr(const INPUT_LAYOUT layout)
@@ -465,4 +491,20 @@ bool InputState_IsAnyPressed(const INPUT_STATE state)
         }
     }
     return false;
+}
+
+bool InputState_GetRole(const INPUT_STATE state, const INPUT_ROLE role)
+{
+    return M_IsPressed(state, role);
+}
+
+void InputState_SetRole(
+    INPUT_STATE *const state, const INPUT_ROLE role, const bool value)
+{
+    *state = M_SetPressed(*state, role, value);
+}
+
+void InputState_ClearRole(INPUT_STATE *const state, const INPUT_ROLE role)
+{
+    *state = M_SetPressed(*state, role, false);
 }

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -6,6 +6,9 @@
 #include <SDL2/SDL_events.h>
 #include <stdint.h>
 
+#define INPUT_COMBO_MAX_KEYS 3
+#define INPUT_BINDING_SLOTS 2
+
 typedef enum {
 #define X_INPUT_ROLE(role_name, state_name) role_name,
 #include <trx/game/input/roles.def>
@@ -45,6 +48,10 @@ bool Input_IsRoleRebindable(INPUT_ROLE role);
 // Checks whether the given role can be completely unbound by the player.
 bool Input_IsRoleUnbindable(INPUT_ROLE role);
 
+// Checks whether the given role uses keys that fire immediately and cannot
+// be the first key of a combo (movement, jump, action, draw weapon).
+bool Input_IsRoleImmediate(INPUT_ROLE role);
+
 // Returns whether the key assigned to the given role is also used elsewhere
 // within the custom layout.
 bool Input_IsKeyConflicted(
@@ -66,18 +73,18 @@ bool Input_IsPressedEx(
 // If there is anything pressed, assigns the pressed key to the given key role
 // and returns true. If nothing is pressed, immediately returns false.
 bool Input_ReadAndAssignRole(
-    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role);
+    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
 
 // Remove assigned key from a given key role.
 void Input_UnassignRole(
-    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role);
+    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
 
 // Get a stable pointer to the layout human-readable name.
 const char *const *Input_GetLayoutNamePtr(const INPUT_LAYOUT layout);
 
 // Given the input layout and input key role, get the assigned key name.
 const char *Input_GetKeyName(
-    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role);
+    INPUT_BACKEND backend, INPUT_LAYOUT layout, INPUT_ROLE role, int32_t slot);
 
 // Reset a given layout to the default.
 void Input_ResetLayout(INPUT_BACKEND backend, INPUT_LAYOUT layout);
@@ -100,10 +107,12 @@ bool Input_AssignFromJSONObject(
 // configuration.
 bool Input_AssignToJSONObject(
     INPUT_BACKEND backend, INPUT_LAYOUT layout, JSON_OBJECT *bind_obj,
-    INPUT_ROLE role);
+    INPUT_ROLE role, int32_t slot);
 
+// Return a copy of the input state with only newly pressed roles set.
 INPUT_STATE Input_GetDebounced(const INPUT_STATE input);
 
+// Get the human-readable name of the given role.
 const char *Input_GetRoleName(INPUT_ROLE role);
 
 // Serialize a scancode and modifier mask into a human-readable key
@@ -116,6 +125,20 @@ const char *Input_KeyDescFromSDL(SDL_Scancode scancode, SDL_Keymod mod);
 bool Input_ParseKeyDesc(
     const char *desc, SDL_Scancode *scancode, SDL_Keymod *mod);
 
+// Reset all roles in the input state to inactive.
 void InputState_Clear(INPUT_STATE *state);
+
+// Copy the source input state into the destination.
 void InputState_Copy(INPUT_STATE *dst, INPUT_STATE src);
+
+// Check whether any role is active in the input state.
 bool InputState_IsAnyPressed(INPUT_STATE state);
+
+// Check whether the given role is active in the input state.
+bool InputState_GetRole(INPUT_STATE state, INPUT_ROLE role);
+
+// Set or clear the given role in the input state.
+void InputState_SetRole(INPUT_STATE *state, INPUT_ROLE role, bool value);
+
+// Clear the given role in the input state.
+void InputState_ClearRole(INPUT_STATE *state, INPUT_ROLE role);

--- a/src/trx/game/input/update.c
+++ b/src/trx/game/input/update.c
@@ -27,6 +27,11 @@ void Input_Update(void)
     M_UpdateFromBackend(
         &g_Input, &g_Input_Controller, g_Config.input.controller_layout);
 
+    // Suppress roles whose bindings are subsets of longer active combos.
+    g_Input_Keyboard.resolve_combos(g_Config.input.keyboard_layout, &g_Input);
+    g_Input_Controller.resolve_combos(
+        g_Config.input.controller_layout, &g_Input);
+
     g_Input.camera_reset |= g_Input.look;
     g_Input.menu_up |= g_Input.forward;
     g_Input.menu_down |= g_Input.back;

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -225,7 +225,7 @@ static void M_DumpBindings(MYFILE *const fp)
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
         JSON_OBJECT *bind = JSON_ObjectNew();
         if (g_Input_Keyboard.assign_to_json_object(
-                g_Config.input.keyboard_layout, role, bind)) {
+                g_Config.input.keyboard_layout, role, 0, bind)) {
             const SDL_Scancode sc =
                 JSON_ObjectGetInt(bind, "scancode", SDL_SCANCODE_UNKNOWN);
             File_WriteString(
@@ -239,7 +239,7 @@ static void M_DumpBindings(MYFILE *const fp)
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
         JSON_OBJECT *bind = JSON_ObjectNew();
         if (g_Input_Controller.assign_to_json_object(
-                g_Config.input.controller_layout, role, bind)) {
+                g_Config.input.controller_layout, role, 0, bind)) {
             const int32_t bt = JSON_ObjectGetInt(bind, "button_type", 0);
             const int32_t b = JSON_ObjectGetInt(bind, "bind", 0);
             const int32_t ad = JSON_ObjectGetInt(bind, "axis_dir", 0);

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -680,7 +680,7 @@ static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
     JSON_ObjectAppendInt(bind, "scancode", sc);
     JSON_ObjectAppendInt(bind, "mod", mod);
     g_Input_Keyboard.assign_from_json_object(
-        g_Config.input.keyboard_layout, role, bind);
+        g_Config.input.keyboard_layout, role, 0, bind);
     JSON_ObjectFree(bind);
     return true;
 }
@@ -710,7 +710,7 @@ static bool M_ParseBindController(
         JSON_ObjectAppendInt(bind, "bind", b);
         JSON_ObjectAppendInt(bind, "axis_dir", ad);
         g_Input_Controller.assign_from_json_object(
-            g_Config.input.controller_layout, role, bind);
+            g_Config.input.controller_layout, role, 0, bind);
         JSON_ObjectFree(bind);
         return true;
     }

--- a/src/trx/game/ui/dialogs/controls_editor.c
+++ b/src/trx/game/ui/dialogs/controls_editor.c
@@ -221,7 +221,8 @@ static void M_UnbindKey(void *const arg)
     Sound_Effect(
         g_TRVersion == 1 ? SFX_MENU_GAMEBOY : SFX_MENU_SPINOUT, nullptr,
         SPM_NORMAL);
-    Input_UnassignRole(s->backend, s->active_layout, s->active_role);
+    Input_UnassignRole(
+        s->backend, s->active_layout, s->active_role, s->active_slot);
     g_Config.dirty = true;
     Config_Update();
 }
@@ -315,10 +316,15 @@ static UI_CONTROLS_CHOICE M_NavigateInputs(UI_CONTROLS_EDITOR_STATE *const s)
     } else if (g_InputDB.menu_back) {
         return UI_CONTROLS_CHOICE_GO_BACK;
     } else if (
-        UI_TabSwitch_Control(s->controls_tab_switch, UI_TAB_SWITCH_NORMAL)) {
+        UI_TabSwitch_Control(s->controls_tab_switch, UI_TAB_SWITCH_NO_ARROWS)) {
         s->active_group = &m_Groups[s->controls_tab_switch->active_tab_idx];
         UI_Scrollable_SetMaxItems(
             &s->scroll, M_GetInputRoleCount(s->active_group));
+    } else if (g_InputDB.menu_left) {
+        s->active_slot =
+            (s->active_slot - 1 + INPUT_BINDING_SLOTS) % INPUT_BINDING_SLOTS;
+    } else if (g_InputDB.menu_right) {
+        s->active_slot = (s->active_slot + 1) % INPUT_BINDING_SLOTS;
     } else if (g_InputDB.menu_up) {
         if (!UI_Scrollable_SelectPrev(&s->scroll, false)) {
             s->phase = M_PHASE_NAVIGATE_GROUP;
@@ -350,7 +356,7 @@ static UI_CONTROLS_CHOICE M_NavigateInputsDebounce(
 static UI_CONTROLS_CHOICE M_Listen(UI_CONTROLS_EDITOR_STATE *const s)
 {
     if (!Input_ReadAndAssignRole(
-            s->backend, s->active_layout, s->active_role)) {
+            s->backend, s->active_layout, s->active_role, s->active_slot)) {
         return UI_CONTROLS_CHOICE_NOOP;
     }
 
@@ -407,31 +413,40 @@ static void M_InputLabel(
     }
 }
 
-static void M_InputChoice(
-    UI_CONTROLS_EDITOR_STATE *const s, const UI_CONTROLS_EDITOR_ROW *const row)
+static void M_InputSlot(
+    UI_CONTROLS_EDITOR_STATE *const s, const UI_CONTROLS_EDITOR_ROW *const row,
+    const int32_t slot)
 {
     const bool is_flashing =
         Input_IsKeyConflicted(s->backend, s->active_layout, row->role);
-    const bool is_selected = s->active_role == row->role
+    const bool is_active_row = s->active_role == row->role;
+    const bool is_listening = is_active_row && s->active_slot == slot
         && (s->phase == M_PHASE_LISTEN
             || s->phase == M_PHASE_NAVIGATE_INPUTS_DEBOUNCE);
+    const bool is_slot_selected = is_active_row && s->active_slot == slot
+        && (s->phase == M_PHASE_NAVIGATE_INPUTS
+            || s->phase == M_PHASE_LISTEN_DEBOUNCE);
 
     if (is_flashing) {
         UI_BeginFlash(&s->flash);
     }
-    if (is_selected) {
+    if (is_listening || is_slot_selected) {
         UI_BeginFrame(UI_FRAME_SELECTED_OPTION);
     }
     const char *key_name =
-        Input_GetKeyName(s->backend, s->active_layout, row->role);
+        Input_GetKeyName(s->backend, s->active_layout, row->role, slot);
     if (key_name == nullptr) {
-        UI_Label("");
+        if (s->active_layout != INPUT_LAYOUT_DEFAULT) {
+            UI_Label("—");
+        } else {
+            UI_Label("");
+        }
     } else if (!M_IsRoleUsable(row->role)) {
         UI_LabelFmt("\\{dim}%s\\{/dim}", key_name);
     } else {
         UI_Label(key_name);
     }
-    if (is_selected) {
+    if (is_listening || is_slot_selected) {
         UI_EndFrame();
     }
     if (is_flashing) {
@@ -453,11 +468,13 @@ static void M_Group(
 
         const UI_CONTROLS_EDITOR_ROW *const row = &group->rows[row_idx];
         UI_BeginStack(UI_STACK_HORIZONTAL);
-        UI_BeginResize(s->input_size, -1.0f);
-        UI_BeginAnchor(0.0f, 0.5f);
-        M_InputChoice(s, row);
-        UI_EndAnchor();
-        UI_EndResize();
+        for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {
+            UI_BeginResize(s->input_size, -1.0f);
+            UI_BeginAnchor(0.0f, 0.5f);
+            M_InputSlot(s, row, slot);
+            UI_EndAnchor();
+            UI_EndResize();
+        }
         UI_BeginResize(s->label_size, -1.0f);
         UI_BeginAnchor(0.0f, 0.5f);
         M_InputLabel(s, row);
@@ -491,6 +508,7 @@ void UI_ControlsEditor_Init(
 {
     s->backend = backend;
     s->active_layout = layout;
+    s->active_slot = 0;
     s->phase = M_PHASE_NAVIGATE_LAYOUT;
 
     s->events = events;

--- a/src/trx/game/ui/dialogs/controls_editor.h
+++ b/src/trx/game/ui/dialogs/controls_editor.h
@@ -26,6 +26,7 @@ typedef struct {
     INPUT_BACKEND backend;
     INPUT_LAYOUT active_layout;
     INPUT_ROLE active_role;
+    int32_t active_slot;
     const UI_CONTROLS_EDITOR_GROUP *active_group;
     UI_FLASH_STATE flash;
     EVENT_MANAGER *events;

--- a/src/trx/game/ui/dialogs/photo_mode.c
+++ b/src/trx/game/ui/dialogs/photo_mode.c
@@ -19,7 +19,7 @@ static bool M_HasIcon(const INPUT_ROLE role)
 {
     return Input_GetKeyName(
                g_Config.input.backend,
-               g_Config.input.layout[g_Config.input.backend], role)
+               g_Config.input.layout[g_Config.input.backend], role, 0)
         != nullptr;
 }
 

--- a/src/trx/game/ui/elements/progress_button.c
+++ b/src/trx/game/ui/elements/progress_button.c
@@ -59,7 +59,7 @@ void UI_ProgressButton_Free(UI_PROGRESS_BUTTON_STATE *s)
 void UI_ProgressButton(UI_PROGRESS_BUTTON_STATE *const s)
 {
     const char *const key_name =
-        Input_GetKeyName(s->backend, INPUT_LAYOUT_DEFAULT, s->role);
+        Input_GetKeyName(s->backend, INPUT_LAYOUT_DEFAULT, s->role, 0);
     if (key_name == nullptr) {
         return;
     }

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -266,7 +266,7 @@ static const M_GLYPH_INFO *M_GetResolvedGlyph(const M_GLYPH_INFO *glyph)
     }
     const char *const key_name = Input_GetKeyName(
         g_Config.input.backend, g_Config.input.layout[g_Config.input.backend],
-        glyph->input_role);
+        glyph->input_role, 0);
     // NOTE: this aliasing approach assumes that Input_GetKeyName returns
     // text that resolves to a single glyph.
     M_GLYPH_MAP_ENTRY *entry = nullptr;


### PR DESCRIPTION
Add multi-key combo bindings (up to 3 keys) with two binding slots per action. Combos are captured in listen mode, resolved at runtime with subset suppression and prefix deferral, and persisted to JSON for both keyboard and controller backends.

Keys bound to movement, jump, action, roll, sidestep, crouch or sprint cannot start combos. Bindings that start with one of these keys are flagged as conflicted in the controls editor.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds multi-key combo shortcut support for both keyboard and controller backends. Players can now bind up to 3 keys as a chord to trigger an action, with two binding slots available per action.

Key features:
- **Combo capture**: In listen mode, keys are accumulated until all are released, then assigned as a chord binding
- **Combo resolution**: A 6-phase resolver handles subset suppression, prefix deferral, and fire-on-release for deferred single-key actions
- **Controller combo serialization**: Multi-key controller combos are persisted as a `"combo"` JSON array, matching the keyboard backend format
- **Immediate-role protection**: Keys bound to movement, jump, action, roll, sidestep, crouch or sprint cannot start combos; such bindings flash as conflicted in the controls editor and are blocked at runtime