### PR TITLE
test-replay: fix unbinding default keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added a new animation command, `ITEM_ACTION_TURN_90`, which will rotate the affected item 90°
 - added dynamic mod discovery from the games/ directory using new `extends` and `name` fields in gameflow.json5
 - changed `--level` to no longer require `-e/--engine` to work
+- fixed recordings keeping unbound hotkeys active during playback
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -228,10 +228,11 @@ static void M_DumpBindings(MYFILE *const fp)
                 g_Config.input.keyboard_layout, role, 0, bind)) {
             const SDL_Scancode sc =
                 JSON_ObjectGetInt(bind, "scancode", SDL_SCANCODE_UNKNOWN);
+            const char *const key_desc =
+                sc == SDL_SCANCODE_UNKNOWN ? "" : Input_KeyDescFromSDL(sc, 0);
             File_WriteString(
                 fp, "bind keyboard %s \"%s\"\n",
-                ENUM_MAP_TO_STRING(INPUT_ROLE, role),
-                Input_KeyDescFromSDL(sc, 0));
+                ENUM_MAP_TO_STRING(INPUT_ROLE, role), key_desc);
         }
         JSON_ObjectFree(bind);
     }

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -665,16 +665,18 @@ static bool M_ParseBindKeyboard(const char *const line, M_PARSE_CTX *const ctx)
     }
     const char *const start = strchr(p, '"');
     const char *const end = start ? strrchr(start + 1, '"') : nullptr;
-    if (start == nullptr || end == nullptr || end <= start + 1) {
+    if (start == nullptr || end == nullptr || end < start + 1) {
         LOG_WARNING("Malformed bind keyboard instruction: %s", line);
         return false;
     }
     const size_t slen = end - (start + 1);
     const char *desc = String_FormatStatic("%.*s", slen, start + 1);
-    SDL_Scancode sc;
-    SDL_Keymod mod;
-    if (!Input_ParseKeyDesc(desc, &sc, &mod)) {
-        return false;
+    SDL_Scancode sc = SDL_SCANCODE_UNKNOWN;
+    SDL_Keymod mod = KMOD_NONE;
+    if (desc[0] != '\0') {
+        if (!Input_ParseKeyDesc(desc, &sc, &mod)) {
+            return false;
+        }
     }
     JSON_OBJECT *const bind = JSON_ObjectNew();
     JSON_ObjectAppendInt(bind, "scancode", sc);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes unbinding keys in the recordings:

> bind keyboard toggle_bilinear_filter "(null)"
> bind keyboard cycle_lighting_contrast "(null)"

becomes saved instead as

> bind keyboard toggle_bilinear_filter ""
> bind keyboard cycle_lighting_contrast ""

and is properly recognized by the recording replay.