### PR TITLE
creature: fix collision code

### DIFF
--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1,5 +1,6 @@
 #include <trx/config.h>
 #include <trx/core/log.h>
+#include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera/vars.h>
 #include <trx/game/collision/los.h>
@@ -800,15 +801,11 @@ void Creature_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
     ITEM *const item = Item_Get(item_num);
-    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    LARA_INFO *const lara = Lara_GetLaraInfo();
     if (!Lara_TestBoundsCollide(item, coll->radius)) {
         return;
     }
     if (!Collide_TestCollision(item, lara_item)) {
-        return;
-    }
-
-    if (!coll->enable_baddie_push) {
         return;
     }
 
@@ -817,10 +814,31 @@ void Creature_Collision(
         return;
     }
 
-    Lara_Col_ItemPush(
-        item, coll,
-        (g_TRVersion >= 2 || item->hit_points > 0) ? coll->enable_hit : false,
-        false);
+    if (coll->enable_baddie_push) {
+        Lara_Col_ItemPush(
+            item, coll,
+            (g_TRVersion >= 2 || item->hit_points > 0) ? coll->enable_hit
+                                                       : false,
+            false);
+    } else if (coll->enable_hit && g_TRVersion == 3) {
+        const BOUNDS_16 *const bounds = &Item_GetBestFrame(item)->bounds;
+        const int32_t s = Math_Sin(lara_item->rot.y);
+        const int32_t c = Math_Cos(lara_item->rot.y);
+        const int32_t x = (bounds->min.x + bounds->max.x) / 2;
+        const int32_t z = (bounds->max.z - bounds->min.z) / 2;
+        const int32_t rx =
+            (lara_item->pos.x - item->pos.x) - ((c * x + s * z) >> W2V_SHIFT);
+        const int32_t rz =
+            (lara_item->pos.z - item->pos.z) - ((c * z - s * x) >> W2V_SHIFT);
+
+        if (bounds->max.z - bounds->min.z > STEP_L) {
+            lara->hit_direction =
+                (lara_item->rot.y + DEG_180 - Math_Atan(rz, rx) + DEG_45)
+                >> W2V_SHIFT;
+            lara->hit_frame++;
+            CLAMPG(lara->hit_frame, 30);
+        }
+    }
 }
 
 bool Creature_Animate(

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -314,7 +314,7 @@ bool Lara_Cheat_EnterFlyMode(void)
     lara_info->hit_effect_count = 0;
     lara_info->hit_effect = nullptr;
     lara_info->hit_frame = 0;
-    lara_info->hit_direction = -1;
+    lara_info->hit_direction = DIR_UNKNOWN;
     lara_info->air = LARA_MAX_AIR;
     lara_info->death_timer = 0;
     lara_info->mesh_effects = 0;
@@ -443,7 +443,7 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
     lara_info->hit_effect_count = 0;
     lara_info->hit_effect = nullptr;
     lara_info->hit_frame = 0;
-    lara_info->hit_direction = -1;
+    lara_info->hit_direction = DIR_UNKNOWN;
     lara_info->air = LARA_MAX_AIR;
     lara_info->death_timer = 0;
     lara_info->mesh_effects = 0;

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -92,7 +92,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     lara_info->flare.frame_num = 0;
     lara_info->calc_fall_speed = 0;
     lara_info->pose_count = 0;
-    lara_info->hit_direction = -1;
+    lara_info->hit_direction = DIR_UNKNOWN;
     lara_info->hit_effect = nullptr;
     lara_info->hit_effect_count = 0;
     lara_info->hit_frame = 0;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -291,7 +291,7 @@ static void M_ObjectCollision(COLL_INFO *const coll)
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    lara_info->hit_direction = -1;
+    lara_info->hit_direction = DIR_UNKNOWN;
     lara_item->hit_status = false;
     if (lara_item->hit_points <= 0) {
         return;
@@ -344,7 +344,7 @@ static void M_ObjectCollision(COLL_INFO *const coll)
         lara_info->hit_effect_count--;
     }
 
-    if (lara_info->hit_direction == -1) {
+    if (lara_info->hit_direction < 0) {
         lara_info->hit_frame = 0;
     }
 }

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -153,7 +153,7 @@ static void M_YetiKill(ITEM *const item, COLL_INFO *const coll)
     g_Camera.target_angle = M_CAM_YETI_KILL_ANGLE;
     g_Camera.target_distance = M_CAM_YETI_KILL_DISTANCE;
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->hit_direction = -1;
+    lara->hit_direction = DIR_UNKNOWN;
     if (Item_TestFrameRange(item, 0, M_LF_YETI_DEATH_TIMER_DELAY)) {
         lara->death_timer = 1;
     }
@@ -164,7 +164,7 @@ static void M_SharkKill(ITEM *const item, COLL_INFO *const coll)
     g_Camera.target_angle = M_CAM_SHARK_KILL_ANGLE;
     g_Camera.target_distance = M_CAM_SHARK_KILL_DISTANCE;
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    lara->hit_direction = -1;
+    lara->hit_direction = DIR_UNKNOWN;
 
     if (Item_TestFrameEqual(item, M_LF_SHARK_DEATH_END)) {
         const int32_t water_height =

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -630,7 +630,7 @@ static void M_Collision(
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->water_status = LWS_ABOVE_WATER;
-    lara->hit_direction = -1;
+    lara->hit_direction = DIR_UNKNOWN;
 
     ITEM *const boat_item = Item_Get(item_num);
 

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -305,7 +305,7 @@ static void M_Collision(
     lara->head_rot.x = 0;
     lara->torso_rot.y = 0;
     lara->torso_rot.x = 0;
-    lara->hit_direction = -1;
+    lara->hit_direction = DIR_UNKNOWN;
     Item_Animate(lara_item);
 
     // TODO: do not hardcode this

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -237,7 +237,7 @@ void Skidoo_Collision(
     Item_SwitchToObjAnim(lara_item, anim_idx, 0, O_LARA_SKIDOO);
     lara_item->current_anim_state = LARA_STATE_SKIDOO_GET_ON;
     lara->gun_status = LGS_ARMLESS;
-    lara->hit_direction = -1;
+    lara->hit_direction = DIR_UNKNOWN;
 
     ITEM *const item = Item_Get(item_num);
     lara_item->pos.x = item->pos.x;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a drift from OG TR3 code in `Creature_Collision` but I don't know of the consequences.
It only sets Lara's hit direction and frame.
Maybe worth checking what happens after defeating Tony and we try to pick up Infada Stone too fast?