### PR TITLE
stats: update HSC/Area51 kill stats

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -355,6 +355,8 @@
                 "lara_guns.bin",
                 "compound_cine.bin",
             ],
+            "unobtainable_kills": 9,
+            "unobtainable_ally_kills": 8,
         },
 
         // 15. Area 51

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - added Hook control
 - restored the cutscene at the beginning of High Security Compound
 - changed Area 51 Rocket to no longer hardcode room 52 as the fire blast room; instead it checks for presence of an upwards portal pointing to the rocket room
+- changed enemies who are killed by lasers to be included in the stats
 
 
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -15,6 +15,8 @@
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
+#include <trx/game/spawn.h>
+#include <trx/game/stats.h>
 #include <trx/version.h>
 
 // clang-format off
@@ -31,6 +33,7 @@
 #define M_JOINT_ARC        0x3000
 #define M_MAX_X_ROT        (20 * DEG_1) // = 3640
 #define M_BITE_DISTANCE    (g_TRVersion < 3 ? STEP_L : STEP_L * 2)
+#define M_BOX_DAMAGE       20
 // clang-format on
 
 static const LARA_TRX_STATE m_CrouchShiftStates[] = {
@@ -1190,6 +1193,33 @@ void Creature_SpecialKill(
     Lara_SwitchToExtraState(lara_kill_state);
 
     g_Camera.pos.room_num = lara_item->room_num;
+}
+
+void Creature_TestBoxDamage(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    if (item->box_num == NO_BOX
+        || (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) == 0) {
+        return;
+    }
+
+    const XYZ_32 pos = {
+        .x = item->pos.x,
+        .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
+        .z = item->pos.z,
+    };
+    Spawn_BloodBath(
+        pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
+        Random_GetControl() << 1, item->room_num, 3);
+
+    if (item->hit_points <= 0) {
+        return;
+    }
+
+    item->hit_points -= M_BOX_DAMAGE;
+    if (item->hit_points <= 0) {
+        Stats_AddKill();
+    }
 }
 
 void Creature_Die(const int16_t item_num, const bool explode)

--- a/src/trx/game/creature/common.h
+++ b/src/trx/game/creature/common.h
@@ -28,6 +28,7 @@ bool Creature_Animate(int16_t item_num, int16_t angle, int16_t tilt);
 
 void Creature_SpecialKill(
     ITEM *item, int32_t kill_anim, int32_t kill_state, int32_t lara_kill_state);
+void Creature_TestBoxDamage(int16_t item_num);
 void Creature_Die(int16_t item_num, bool explode);
 int32_t Creature_Vault(
     int16_t item_num, int16_t angle, int32_t vault, int32_t shift);

--- a/src/trx/game/objects/creatures/civilian.c
+++ b/src/trx/game/objects/creatures/civilian.c
@@ -9,7 +9,6 @@
 // clang-format off
 #define M_RADIUS         (WALL_L / 10)          // = 102
 #define M_HIT_POINTS     15
-#define M_BOX_DAMAGE     20
 #define M_PUNCH_1_DAMAGE 40
 #define M_PUNCH_3_DAMAGE 50
 #define M_TOUCH_BITS     0b00100100'00000000
@@ -108,18 +107,7 @@ static void M_Control(const int16_t item_num)
     int16_t torso_x = 0;
     int16_t torso_y = 0;
 
-    if (item->box_num != NO_BOX
-        && (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) != 0) {
-        const XYZ_32 pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
-            .z = item->pos.z,
-        };
-        Spawn_BloodBath(
-            pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
-            Random_GetControl() << 1, item->room_num, 3);
-        item->hit_points -= M_BOX_DAMAGE;
-    }
+    Creature_TestBoxDamage(item_num);
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {

--- a/src/trx/game/objects/creatures/mp_1.c
+++ b/src/trx/game/objects/creatures/mp_1.c
@@ -9,7 +9,6 @@
 // clang-format off
 #define M_RADIUS          (WALL_L / 5)           // = 204
 #define M_HIT_POINTS      25
-#define M_BOX_DAMAGE      20
 #define M_PUNCH_1_DAMAGE  80
 #define M_PUNCH_3_DAMAGE  100
 #define M_KICK_DAMAGE     150
@@ -154,18 +153,7 @@ static void M_Control(const int16_t item_num)
     int16_t torso_x = 0;
     int16_t torso_y = 0;
 
-    if (item->box_num != NO_BOX
-        && (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) != 0) {
-        const XYZ_32 pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
-            .z = item->pos.z,
-        };
-        Spawn_BloodBath(
-            pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
-            Random_GetControl() << 1, item->room_num, 3);
-        item->hit_points -= M_BOX_DAMAGE;
-    }
+    Creature_TestBoxDamage(item_num);
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {

--- a/src/trx/game/objects/creatures/mp_2.c
+++ b/src/trx/game/objects/creatures/mp_2.c
@@ -10,7 +10,6 @@
 // clang-format off
 #define M_RADIUS          (WALL_L / 10)          // = 102
 #define M_HIT_POINTS      28
-#define M_BOX_DAMAGE      20
 #define M_DAMAGE          32
 #define M_ALERT_DIST      SQUARE(WALL_L)         // = 1048576
 #define M_WALK_DIST       SQUARE(WALL_L * 3 / 2) // = 2359296
@@ -150,18 +149,7 @@ static void M_Control(const int16_t item_num)
     int16_t torso_x = 0;
     int16_t torso_y = 0;
 
-    if (item->box_num != NO_BOX
-        && (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) != 0) {
-        const XYZ_32 pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
-            .z = item->pos.z,
-        };
-        Spawn_BloodBath(
-            pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
-            Random_GetControl() << 1, item->room_num, 3);
-        item->hit_points -= M_BOX_DAMAGE;
-    }
+    Creature_TestBoxDamage(item_num);
 
     if (item->hit_points <= 0) {
         item->hit_points = 0;

--- a/src/trx/game/objects/creatures/prisoner.c
+++ b/src/trx/game/objects/creatures/prisoner.c
@@ -10,7 +10,6 @@
 // clang-format off
 #define M_RADIUS         (WALL_L / 10)          // = 102
 #define M_HIT_POINTS     20
-#define M_BOX_DAMAGE     20
 #define M_PUNCH_1_DAMAGE 40
 #define M_PUNCH_3_DAMAGE 50
 #define M_TOUCH_BITS     0b00100100'00000000
@@ -149,18 +148,7 @@ static void M_Control(const int16_t item_num)
     int16_t torso_x = 0;
     int16_t torso_y = 0;
 
-    if (item->box_num != NO_BOX
-        && (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) != 0) {
-        const XYZ_32 pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
-            .z = item->pos.z,
-        };
-        Spawn_BloodBath(
-            pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
-            Random_GetControl() << 1, item->room_num, 3);
-        item->hit_points -= M_BOX_DAMAGE;
-    }
+    Creature_TestBoxDamage(item_num);
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {

--- a/src/trx/game/objects/creatures/swat.c
+++ b/src/trx/game/objects/creatures/swat.c
@@ -10,7 +10,6 @@
 // clang-format off
 #define M_RADIUS       (WALL_L / 10)      // = 102
 #define M_HIT_POINTS   45
-#define M_BOX_DAMAGE   20
 #define M_DAMAGE       28
 #define M_ALERT_DIST   SQUARE(WALL_L)     // = 1048576
 #define M_ALERT_HEIGHT (WALL_L * 2)       // = 2048
@@ -115,18 +114,7 @@ static void M_Control(const int16_t item_num)
     int16_t torso_x = 0;
     int16_t torso_y = 0;
 
-    if (item->box_num != NO_BOX
-        && (Box_GetBox(item->box_num)->overlap_index & BOX_BLOCKED) != 0) {
-        const XYZ_32 pos = {
-            .x = item->pos.x,
-            .y = item->pos.y - (Random_GetControl() & 0xFF) - 32,
-            .z = item->pos.z,
-        };
-        Spawn_BloodBath(
-            pos.x, pos.y, pos.z, (Random_GetControl() & 0x7F) + STEP_L / 2,
-            Random_GetControl() << 1, item->room_num, 3);
-        item->hit_points -= M_BOX_DAMAGE;
-    }
+    Creature_TestBoxDamage(item_num);
 
     if (item->hit_points <= 0) {
         if (item->current_anim_state != M_STATE_DEATH) {

--- a/src/trx/game/stats/scan.c
+++ b/src/trx/game/stats/scan.c
@@ -146,6 +146,7 @@ static void M_CheckTriggers(
 
             case O_EEL:
             case O_BIG_EEL:
+            case O_ORCA:
                 break;
 
             case O_SCION_ITEM_3:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This marks Orcas to not be included in the kill total, in a similar way to how we exclude TR2 eels. I've also amended the unobtainable kills in HSC, but would appreciate a sanity check in particular of this. Following are those I believe cannot be killed (by Lara) without using cheats as they're all before the point of no return.

<details>

| Index | Type     |
|-------|----------|
| 0     | Prisoner |
| 4     | Prisoner |
| 5     | Prisoner |
| 17    | MP 2     |
| 126   | MP 1     |
| 132   | Prisoner |
| 147   | Prisoner |
| 148   | Prisoner |
| 149   | Prisoner |
| 156   | Prisoner |
| 165   | MP 1     |
| 180   | MP 1     |
| 185   | Sentry   |
| ~~188~~   | ~~MP 2~~     |
| 194   | Sentry   |
| 207   | Sentry   |
| 209   | MP 1     |
| 213   | Sentry   |
</details>
