### PR TITLE
camera/photo_mode: fix resetting FOV on exit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed `--level` to no longer require `-e/--engine` to work
 - improved rendering line segments (poison darts, rain drops, SWAT laser sights)
 - fixed recordings keeping unbound hotkeys active during playback
+- fixed being unable to change FOV after using photo mode without restarting the level (#5246, regression from 1.0)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -41,7 +41,7 @@ static void M_ResetCamera(const bool exiting)
     g_Camera = exiting ? m_OriginalCamera : m_StartingCamera;
     // ensure Camera_EnsureEnvironment() picks up the flag change
     g_Camera.underwater = camera.underwater;
-    Viewport_AlterFOV(m_OriginalFOV, m_OriginalFOVMode);
+    Viewport_AlterFOV(exiting ? -1 : m_OriginalFOV, m_OriginalFOVMode);
     m_CurrentFOV = m_OriginalFOV / DEG_1;
 }
 


### PR DESCRIPTION
Resolves #5246.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resets FOV to -1 when exiting photo mode, similar to when exiting an in-game cinematic. If photo mode is used during one of those cinematics that has its own FOV setup e.g. HSC start anim, the cine camera will apply the correct FOV on the same frame, so the visuals should remain consistent.
