### PR TITLE
lara/col/crouch: fix crouch roll clamp

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - improved rendering line segments (poison darts, rain drops, SWAT laser sights)
 - fixed recordings keeping unbound hotkeys active during playback
 - fixed being unable to change FOV after using photo mode without restarting the level (#5246, regression from 1.0)
+- fixed Lara getting stuck if using crouch-roll near very low ceilings (#5248)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -142,7 +142,10 @@ static void M_CrouchRoll(ITEM *const item, COLL_INFO *const coll)
 
         Lara_Col_Shift(coll);
 
-        if (!Lara_Col_TestCeiling(item, coll)) {
+        if (coll->coll_type == COLL_TOP || coll->coll_type == COLL_CLAMP) {
+            item->pos = coll->old;
+            item->speed = 0;
+        } else {
             item->pos.y += coll->side_mid.floor;
         }
     }


### PR DESCRIPTION
Resolves #5248.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Lara_Col_TestCeiling` can blindly switch to `LA_STAND_STILL`, which can result in Lara standing up immediately if she has hit a ceiling while crouch  rolling. This copies the fundamentals of that function directly into the collision routine for crouch roll, crucially to clamp Lara's position and reset her speed only.
