### PR TITLE
objects/security_laser: use common LOS check

### DIFF
--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -51,18 +51,18 @@ static inline bool M_RoomInLOSRooms(const int16_t room_num)
 // @param target World-space ray end
 // @param item   Item to check
 // @return       Whether the item collides with the segment
-static bool M_ItemIntersectSegment(
-    const XYZ_32 start, const XYZ_32 target, const ITEM *const item,
-    XYZ_32 *const out_hit_pos)
+bool LOS_CheckItemIntersectSegment(
+    const GAME_VECTOR *const start, GAME_VECTOR *const target,
+    const ITEM *const item)
 {
-    const double dx = target.x - start.x;
-    const double dy = target.y - start.y;
-    const double dz = target.z - start.z;
+    const double dx = target->x - start->x;
+    const double dy = target->y - start->y;
+    const double dz = target->z - start->z;
 
     // Translate into object-local space
-    const double ox = start.x - item->pos.x;
-    const double oy = start.y - item->pos.y;
-    const double oz = start.z - item->pos.z;
+    const double ox = start->x - item->pos.x;
+    const double oy = start->y - item->pos.y;
+    const double oz = start->z - item->pos.z;
 
     // Unrotate by -rot.y around Y axis
     const float c = cosf(-item->rot.y * M_PI / DEG_180);
@@ -132,12 +132,10 @@ static bool M_ItemIntersectSegment(
         return false;
     }
 
-    if (out_hit_pos != nullptr) {
-        // world-space hit position = start + t0 * (target-start)
-        out_hit_pos->x = start.x + t0 * dx;
-        out_hit_pos->y = start.y + t0 * dy;
-        out_hit_pos->z = start.z + t0 * dz;
-    }
+    // world-space hit position = start + t0 * (target-start)
+    target->x = start->x + t0 * dx;
+    target->y = start->y + t0 * dy;
+    target->z = start->z + t0 * dz;
 
     return true;
 }
@@ -165,8 +163,8 @@ int32_t LOS_CheckSmashable(
             continue;
         }
 
-        XYZ_32 hit_pos;
-        if (!M_ItemIntersectSegment(start.pos, target.pos, item, &hit_pos)) {
+        GAME_VECTOR hit_pos = target;
+        if (!LOS_CheckItemIntersectSegment(&start, &hit_pos, item)) {
             continue;
         }
 
@@ -187,7 +185,7 @@ int32_t LOS_CheckSmashable(
             best_dist = dist;
             best_item_num = item_num;
             if (out_hit_pos != nullptr) {
-                *out_hit_pos = hit_pos;
+                *out_hit_pos = hit_pos.pos;
             }
         }
     }

--- a/src/trx/game/collision/los.h
+++ b/src/trx/game/collision/los.h
@@ -4,5 +4,7 @@
 
 bool LOS_Check(
     const GAME_VECTOR *start, GAME_VECTOR *target, bool use_detailed_clipping);
+bool LOS_CheckItemIntersectSegment(
+    const GAME_VECTOR *start, GAME_VECTOR *target, const ITEM *item);
 int32_t LOS_CheckSmashable(
     GAME_VECTOR start, GAME_VECTOR target, XYZ_32 *out_hit_pos);

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -66,94 +66,6 @@ static void M_LaserSplitterToggle(ITEM *const item)
     }
 }
 
-static bool M_IsLaraOnLOS(
-    const GAME_VECTOR *const start, const GAME_VECTOR *const target)
-{
-    const ITEM *const lara_item = Lara_GetItem();
-    const XYZ_32 delta = {
-        .x = target->x - start->x,
-        .y = target->y - start->y,
-        .z = target->z - start->z,
-    };
-    struct {
-        int16_t min, max;
-    } x_extent, z_extent;
-
-    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(lara_item);
-
-    if ((lara_item->rot.y + DEG_45) & DEG_90) {
-        x_extent.min = bounds->min.z;
-        x_extent.max = bounds->max.z;
-        z_extent.min = bounds->min.x;
-        z_extent.max = bounds->max.x;
-    } else {
-        x_extent.min = bounds->min.x;
-        x_extent.max = bounds->max.x;
-        z_extent.min = bounds->min.z;
-        z_extent.max = bounds->max.z;
-    }
-
-    int32_t flag = 0;
-
-    if (ABS(delta.z) > ABS(delta.x)) {
-        int32_t dist = lara_item->pos.z - start->z + z_extent.min;
-
-        for (int32_t i = 0; i < 2; i++) {
-            if ((delta.z ^ dist) >= 0) {
-                const int32_t y = delta.y * dist / delta.z;
-
-                if (y > lara_item->pos.y - start->y + bounds->min.y
-                    && y < lara_item->pos.y - start->y + bounds->max.y) {
-                    const int32_t x = delta.x * dist / delta.z;
-
-                    if (x < lara_item->pos.x + x_extent.min - start->x) {
-                        flag |= 1;
-                    } else if (x > lara_item->pos.x + x_extent.max - start->x) {
-                        flag |= 2;
-                    } else {
-                        return true;
-                    }
-                }
-            }
-
-            dist = lara_item->pos.z - start->z + z_extent.max;
-        }
-
-        if (flag == 3) {
-            return true;
-        }
-    } else {
-        int32_t dist = lara_item->pos.x + x_extent.min - start->x;
-
-        for (int32_t i = 0; i < 2; i++) {
-            if ((delta.x ^ dist) >= 0) {
-                const int32_t y = delta.y * dist / delta.x;
-
-                if (y > lara_item->pos.y - start->y + bounds->min.y
-                    && y < lara_item->pos.y - start->y + bounds->max.y) {
-                    const int32_t z = delta.z * dist / delta.x;
-
-                    if (z < lara_item->pos.z - start->z + z_extent.min) {
-                        flag |= 1;
-                    } else if (z > lara_item->pos.z - start->z + z_extent.max) {
-                        flag |= 2;
-                    } else {
-                        return true;
-                    }
-                }
-            }
-
-            dist = lara_item->pos.x + x_extent.max - start->x;
-        }
-
-        if (flag == 3) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static void M_UpdateLaserShades(void)
 {
     for (int32_t shade_idx = 0; shade_idx < 32; shade_idx++) {
@@ -227,7 +139,7 @@ static bool M_GetLaserSegment(
     t->z = item->pos.z - (dir.z << 5);
 
     LOS_Check(s, t, true);
-    return M_IsLaraOnLOS(s, t);
+    return LOS_CheckItemIntersectSegment(s, t, Lara_GetItem());
 }
 
 static void M_DrawLaserBeam(
@@ -373,17 +285,8 @@ static bool M_DrawLaser(const ITEM *const item)
     for (int32_t beam_idx = 0; beam_idx < item->hit_points; beam_idx++) {
         GAME_VECTOR start;
         GAME_VECTOR target;
-        if (M_GetLaserSegment(item, direction, beam_y, &start, &target)) {
-            const ITEM *const lara_item = Lara_GetItem();
-            if (item->rot.y == 0 || item->rot.y == -DEG_180) {
-                target.z = lara_item->pos.z;
-            } else {
-                target.x = lara_item->pos.x;
-            }
-        }
-
+        M_GetLaserSegment(item, direction, beam_y, &start, &target);
         M_DrawLaserBeam(&start, &target, color);
-
         beam_y -= 256;
     }
     return true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids Lara being able to trip lasers through walls/geometry. Recording attached in Area 51 showing the issue; I'll also share a test level.

[laser.txt](https://github.com/user-attachments/files/26331313/laser.txt)

This might be a naïve approach, but LMK what you think. I think because OG handled the collision during drawing (bad), the clipping would have meant this was implicitly handled.
