### PR TITLE
shell: hydrate engine from selected mod

### DIFF
--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -134,6 +134,10 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             int32_t lvnum = -1;
             if (String_ParseInteger(next_arg, &lvnum)) {
                 result->level_to_select = lvnum;
+                if (result->mod == nullptr && result->engine_version > 0) {
+                    result->mod = Shell_GetModByType(
+                        MOD_BASE_GAME, result->engine_version);
+                }
             } else {
                 result->level_to_play = next_arg;
                 if (result->engine_version == 0) {

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -74,6 +74,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
 {
     SHELL_ARGS *const result = Memory_Alloc(sizeof(SHELL_ARGS));
     bool wants_gold = false;
+    bool explicit_engine_version = false;
     result->save_to_load = -1;
     result->level_to_select = -1;
     result->original_args = args;
@@ -87,6 +88,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         if (!strcmp(arg, "-e") || !strcmp(arg, "--engine")) {
             String_ParseInteger(next_arg, &result->engine_version);
             CLAMP(result->engine_version, 1, 3);
+            explicit_engine_version = true;
             i++;
         }
     }
@@ -185,7 +187,7 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
     if (result->mod == nullptr) {
         result->mod = Shell_SelectStartupMod(result->engine_version);
     }
-    if (result->engine_version == 0 && result->mod != nullptr) {
+    if (!explicit_engine_version && result->mod != nullptr) {
         result->engine_version = result->mod->engine_version;
     }
     if (wants_gold) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes shell argument hydration so selecting a mod also picks up the matching engine version unless the engine was explicitly requested.

This helps replay and command-line flows stay consistent when switching between TR1/TR2/TR3 mods. In practice, it avoids cases where the shell could keep an inherited engine version even though the selected mod belongs to a different game.

Example: launching these replays in sequence would fail:

```
./test/trx/TRX --test-replay test/trx/tests/test-tr1-targetables.txt --headless -q
./test/trx/TRX --test-replay test/trx/tests/test-tr3-targetables.txt --headless -q
```

You'd have to pass mod explicitly for the commands to succeed:

```
./test/trx/TRX --mod tr1 --test-replay test/trx/tests/test-tr1-targetables.txt --headless -q
./test/trx/TRX --mod tr3 --test-replay test/trx/tests/test-tr3-targetables.txt --headless -q
```

[test-tr1-targetables.txt](https://github.com/user-attachments/files/26332575/test-tr1-targetables.txt)
[test-tr3-targetables.txt](https://github.com/user-attachments/files/26332576/test-tr3-targetables.txt)
