### PR TITLE
shell: change Golds' title.tr2+main.sfx handling

### DIFF
--- a/data/trx/ship/games/tr2-gm/gameflow.json5
+++ b/data/trx/ship/games/tr2-gm/gameflow.json5
@@ -13,7 +13,7 @@
     "convert_dropped_guns": true,
 
     "title": {
-        "path": "title_gm.tr2",
+        "path": ["title_gm.tr2", "title.tr2"],
         "music_track": 60,
         "sequence": [
             {"type": "display_picture", "path": "legal_eu_gm.webp", "legal": true},
@@ -29,7 +29,7 @@
         ]
     },
 
-    "sfx_path": "main_gm.sfx",
+    "sfx_path": ["main_gm.sfx", "main.sfx"],
     "injections": [
         "font.bin",
         "lara_animations.bin",

--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -12,7 +12,7 @@
     "convert_dropped_guns": true,
 
     "title": {
-        "path": "title_la.tr2",
+        "path": ["title_la.tr2", "title.tr2"],
         "music_track": 5,
         "sequence": [
             {"type": "display_picture", "path": "legal_eu.webp", "legal": true},
@@ -27,7 +27,7 @@
         35, 36, 73, 74, 75, 76, 77, 78,
     ],
 
-    "sfx_path": "main_la.sfx",
+    "sfx_path": ["main_la.sfx", "main.sfx"],
     "injections": [
         "font.bin",
         "lara_animations.bin",

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -53,7 +53,7 @@
       "description": "Configuration for the title screen."
     },
     "sfx_path": {
-      "type": "string",
+      "$ref": "#/$defs/path",
       "description": "Path to the sound effects (.sfx) file to use in the game."
     },
     "injections": {

--- a/docs/tr3/INSTALLING.md
+++ b/docs/tr3/INSTALLING.md
@@ -158,11 +158,16 @@ If you install everything correctly, your game directory should look more or les
 │   ├── injections
 │   │   ├── aldwych_fd.bin
 │   │   ├── aldwych_pickup_meshes.bin
+│   │   ├── aldwych_textures.bin
 │   │   ├── antarc_airlock.bin
+│   │   ├── antarc_door134_frames.bin
 │   │   ├── antarc_sky.bin
 │   │   ├── area51_sky.bin
+│   │   ├── area51_textures.bin
+│   │   ├── cavern_door131_frames.bin
 │   │   ├── cavern_sky.bin
 │   │   ├── city_textures.bin
+│   │   ├── cliff_door132_frames.bin
 │   │   ├── coastal_airlock.bin
 │   │   ├── coastal_animating_bounds.bin
 │   │   ├── coastal_sky.bin
@@ -183,6 +188,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── cut11_setup.bin
 │   │   ├── cut12_setup.bin
 │   │   ├── font.bin
+│   │   ├── ganges_door131_frames.bin
 │   │   ├── globe_model.bin
 │   │   ├── gym_sky.bin
 │   │   ├── india_sky.bin
@@ -193,7 +199,9 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── lara_outfits.bin
 │   │   ├── london_sky.bin
 │   │   ├── luds_diver_animation.bin
+│   │   ├── luds_textures.bin
 │   │   ├── misc_sprites.bin
+│   │   ├── nevada_door132_frames.bin
 │   │   ├── nevada_sky.bin
 │   │   ├── ora_dagger.bin
 │   │   ├── pda_model.bin
@@ -421,11 +429,16 @@ If you install everything correctly, your game directory should look more or les
     │   │   ├── injections
     │   │   │   ├── aldwych_fd.bin
     │   │   │   ├── aldwych_pickup_meshes.bin
+    │   │   │   ├── aldwych_textures.bin
     │   │   │   ├── antarc_airlock.bin
+    │   │   │   ├── antarc_door134_frames.bin
     │   │   │   ├── antarc_sky.bin
     │   │   │   ├── area51_sky.bin
+    │   │   │   ├── area51_textures.bin
+    │   │   │   ├── cavern_door131_frames.bin
     │   │   │   ├── cavern_sky.bin
     │   │   │   ├── city_textures.bin
+    │   │   │   ├── cliff_door132_frames.bin
     │   │   │   ├── coastal_airlock.bin
     │   │   │   ├── coastal_animating_bounds.bin
     │   │   │   ├── coastal_sky.bin
@@ -446,6 +459,7 @@ If you install everything correctly, your game directory should look more or les
     │   │   │   ├── cut11_setup.bin
     │   │   │   ├── cut12_setup.bin
     │   │   │   ├── font.bin
+    │   │   │   ├── ganges_door131_frames.bin
     │   │   │   ├── globe_model.bin
     │   │   │   ├── gym_sky.bin
     │   │   │   ├── india_sky.bin
@@ -456,7 +470,9 @@ If you install everything correctly, your game directory should look more or les
     │   │   │   ├── lara_outfits.bin
     │   │   │   ├── london_sky.bin
     │   │   │   ├── luds_diver_animation.bin
+    │   │   │   ├── luds_textures.bin
     │   │   │   ├── misc_sprites.bin
+    │   │   │   ├── nevada_door132_frames.bin
     │   │   │   ├── nevada_sky.bin
     │   │   │   ├── ora_dagger.bin
     │   │   │   ├── pda_model.bin

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -806,7 +806,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── level5.tr2
 │   │   │   └── title_gm.tr2
 │   │   ├── gameflow.json5
-│   │   ├── main_gm.sfx
+│   │   ├── main.sfx
 │   │   ├── strings-de.json5
 │   │   ├── strings-fr.json5
 │   │   ├── strings-gd.json5
@@ -910,11 +910,16 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── injections
 │   │   │   ├── aldwych_fd.bin
 │   │   │   ├── aldwych_pickup_meshes.bin
+│   │   │   ├── aldwych_textures.bin
 │   │   │   ├── antarc_airlock.bin
+│   │   │   ├── antarc_door134_frames.bin
 │   │   │   ├── antarc_sky.bin
 │   │   │   ├── area51_sky.bin
+│   │   │   ├── area51_textures.bin
+│   │   │   ├── cavern_door131_frames.bin
 │   │   │   ├── cavern_sky.bin
 │   │   │   ├── city_textures.bin
+│   │   │   ├── cliff_door132_frames.bin
 │   │   │   ├── coastal_airlock.bin
 │   │   │   ├── coastal_animating_bounds.bin
 │   │   │   ├── coastal_sky.bin
@@ -935,6 +940,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── cut11_setup.bin
 │   │   │   ├── cut12_setup.bin
 │   │   │   ├── font.bin
+│   │   │   ├── ganges_door131_frames.bin
 │   │   │   ├── globe_model.bin
 │   │   │   ├── gym_sky.bin
 │   │   │   ├── india_sky.bin
@@ -945,7 +951,9 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── lara_outfits.bin
 │   │   │   ├── london_sky.bin
 │   │   │   ├── luds_diver_animation.bin
+│   │   │   ├── luds_textures.bin
 │   │   │   ├── misc_sprites.bin
+│   │   │   ├── nevada_door132_frames.bin
 │   │   │   ├── nevada_sky.bin
 │   │   │   ├── ora_dagger.bin
 │   │   │   ├── pda_model.bin
@@ -1017,7 +1025,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── willsden.tr2
 │   │   │   └── zoo.tr2
 │   │   ├── gameflow.json5
-│   │   ├── main_la.sfx
+│   │   ├── main.sfx
 │   │   ├── strings-de.json5
 │   │   ├── strings-it.json5
 │   │   ├── strings-pl.json5

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -116,70 +116,6 @@ static M_SEQUENCE_EVENT_HANDLER *M_GetSequenceEventHandlers(void)
     return m_SequenceEventHandlers;
 }
 
-static bool M_LoadSettings(
-    const M_CONTEXT *const ctx, GF_LEVEL_SETTINGS *const settings)
-{
-    JSON_READ_IO *const io = ctx->io;
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_start"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_start.value));
-        settings->fog_start.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_end"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_end.value));
-        settings->fog_end.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_transparency"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_transparency.value));
-        settings->fog_transparency.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_color"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_color.value));
-        settings->fog_color.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "water_color"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->water_color.value));
-        settings->water_color.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "cold_water"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->cold_water.value));
-        settings->cold_water.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "death_tile"))) {
-        const char *tmp_s = nullptr;
-        JSON_MUST(JSON_READ_CURRENT(io, &tmp_s));
-        const int32_t value =
-            EnumMap_Get(ENUM_MAP_NAME(GF_DEATH_TILE), tmp_s, -1);
-        if (value < 0) {
-            JSON_ReadIO_SetError(io, "Invalid death_tile value '%s'", tmp_s);
-            JSON_FAIL();
-        }
-        settings->death_tile.is_present = true;
-        settings->death_tile.value = value;
-        JSON_MUST(JSON_POP(io));
-    }
-
-    if (JSON_OPTIONAL(JSON_PUSH(io, "sfx_path"))) {
-        const char *tmp_s = nullptr;
-        JSON_MUST(JSON_READ_CURRENT(io, &tmp_s));
-        settings->sfx_path = Memory_DupStr(tmp_s);
-        JSON_MUST(JSON_POP(io));
-    }
-    JSON_FINISH();
-}
-
 // Read a "path" value that may be either a plain string or an array of
 // candidate strings tried in order.
 // Pass optional=true to allow the key to be absent (out_path is set to nullptr
@@ -246,6 +182,70 @@ static bool M_ReadPath(
     return ok;
 }
 
+static bool M_LoadSettings(
+    const M_CONTEXT *const ctx, GF_LEVEL_SETTINGS *const settings)
+{
+    JSON_READ_IO *const io = ctx->io;
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_start"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_start.value));
+        settings->fog_start.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_end"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_end.value));
+        settings->fog_end.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_transparency"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_transparency.value));
+        settings->fog_transparency.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "fog_color"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->fog_color.value));
+        settings->fog_color.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "water_color"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->water_color.value));
+        settings->water_color.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "cold_water"))) {
+        JSON_MUST(JSON_READ_CURRENT(io, &settings->cold_water.value));
+        settings->cold_water.is_present = true;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "death_tile"))) {
+        const char *tmp_s = nullptr;
+        JSON_MUST(JSON_READ_CURRENT(io, &tmp_s));
+        const int32_t value =
+            EnumMap_Get(ENUM_MAP_NAME(GF_DEATH_TILE), tmp_s, -1);
+        if (value < 0) {
+            JSON_ReadIO_SetError(io, "Invalid death_tile value '%s'", tmp_s);
+            JSON_FAIL();
+        }
+        settings->death_tile.is_present = true;
+        settings->death_tile.value = value;
+        JSON_MUST(JSON_POP(io));
+    }
+
+    if (JSON_OPTIONAL(JSON_PUSH(io, "sfx_path"))) {
+        JSON_MUST(JSON_POP(io));
+        JSON_SHOULD(M_ReadPath(
+            io, "sfx_path", false, TRX_DYNAMIC_PATH_SFX_FILE,
+            &settings->sfx_path));
+    }
+    JSON_FINISH();
+}
+
 static bool M_LoadLevelItemDrops(
     const M_CONTEXT *const ctx, GF_LEVEL *const level)
 {
@@ -303,7 +303,8 @@ static void M_CopyRootSettingsIntoLevel(
     GF_LEVEL_SETTINGS *const dst, const GF_LEVEL_SETTINGS *const src)
 {
     *dst = *src;
-    dst->sfx_path = nullptr;
+    dst->sfx_path =
+        src->sfx_path != nullptr ? Memory_DupStr(src->sfx_path) : nullptr;
 }
 
 static void M_ReadModMeta(JSON_READ_IO *const io, GF_MOD_META *const meta)

--- a/src/trx/game/level/pipeline.c
+++ b/src/trx/game/level/pipeline.c
@@ -37,25 +37,17 @@ static void M_InitialiseSamplesFromFile(
     M_SAMPLE_ENTRY *entries = nullptr;
     LEVEL_CONTEXT_INFO *const info = &ctx->info;
 
-    if (file_name == nullptr) {
-        file_name = g_GameFlow.settings.sfx_path;
-    }
-    if (file_name == nullptr) {
-        file_name = "main.sfx";
-    }
     MYFILE *fp = nullptr;
-    const char *const full_path =
-        TRXPath_PeekResolve(TRX_DYNAMIC_PATH_SFX_FILE, file_name);
-    if (full_path == nullptr) {
+    if (file_name == nullptr) {
         goto finish;
     }
 
-    fp = File_Open(full_path, FILE_OPEN_READ);
+    fp = File_Open(file_name, FILE_OPEN_READ);
     if (fp == nullptr) {
-        LOG_ERROR("Could not open %s samples file", full_path);
+        LOG_ERROR("Could not open %s samples file", file_name);
         goto finish;
     }
-    LOG_DEBUG("Loading samples from %s", full_path);
+    LOG_DEBUG("Loading samples from %s", file_name);
 
     const int32_t sample_count = info->samples.offset_count;
     entries = Memory_Alloc(sizeof(M_SAMPLE_ENTRY) * sample_count);

--- a/tools/update_install_trees
+++ b/tools/update_install_trees
@@ -319,14 +319,16 @@ OG_FILE_OVERRIDES: dict[str, dict[Path, Path]] = {
         Path("data/main.sfx"): Path("games/tr2/main.sfx"),
     },
     "tr2-gm": {
-        Path("data/main_gm.sfx"): Path("games/tr2-gm/main_gm.sfx"),
+        Path("data/main_gm.sfx"): Path("games/tr2-gm/main.sfx"),
+        Path("data/title_gm.tr2"): Path("games/tr2-gm/levels/title.tr2"),
     },
     "tr3": {
         Path("data/main.sfx"): Path("games/tr3/main.sfx"),
         Path("data/tombpc.dat"): Path("games/tr3/tombpc.dat"),
     },
     "tr3-la": {
-        Path("data/main_la.sfx"): Path("games/tr3-la/main_la.sfx"),
+        Path("data/main_la.sfx"): Path("games/tr3-la/main.sfx"),
+        Path("data/title_la.tr2"): Path("games/tr3-la/levels/title.tr2"),
     },
 }
 
@@ -338,7 +340,7 @@ LEGACY_DOC_CONFIGS = [
             DATA_DIR / "common/ship",
             PROJECT_PATHS[1].data_dir / "ship",
             DATA_REPO_ROOT_DIR / "tr1/ship",
-            DATA_REPO_ROOT_DIR / "tr1ub/ship",
+            DATA_REPO_ROOT_DIR / "tr1-ub/ship",
         ],
         "og_groups": ["tr1", "tr1-ub"],
     },
@@ -349,7 +351,7 @@ LEGACY_DOC_CONFIGS = [
             DATA_DIR / "common/ship",
             PROJECT_PATHS[2].data_dir / "ship",
             DATA_REPO_ROOT_DIR / "tr2/ship",
-            DATA_REPO_ROOT_DIR / "tr2gm/ship",
+            DATA_REPO_ROOT_DIR / "tr2-gm/ship",
         ],
         "og_groups": ["tr2", "tr2-gm"],
     },


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This lets the Golds fall back to the OG golds' default file names for title.tr2 + main.sfx, which is important under new file hierarchy.