### PR TITLE
savegame: fix loading 1.1 saves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed being unable to change FOV after using photo mode without restarting the level (#5246, regression from TR1X 4.15)
 - fixed Lara getting stuck if using crouch-roll near very low ceilings (#5248)
 - fixed Bell in room 48 being shootable from room 55 again (#4949, regression from TRX 1.4 Sophia Reunion targeting fix)
+- fixed certain TR1 1.1 savegames refusing to load (#5252, regression from 1.2)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -592,6 +592,9 @@ void Lara_Skin_SetExtraEquipment(
 void Lara_Skin_SetGunEquipment(
     const LARA_MESH mesh, const LARA_GUN_TYPE gun_type)
 {
+    if (gun_type < 0 || gun_type >= NUM_WEAPONS) {
+        return;
+    }
     M_SetGunEquipment(mesh, gun_type, M_GetCurrentOutfit());
 
     if (mesh == LM_THIGH_L) {

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -350,6 +350,14 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t item_num)
     }
 
     if (obj->save_flags) {
+        if (!JSON_ReadIO_HasKey(io, "flags")) {
+            // TRX 1.1 save-crystal entries were serialized as bare items
+            // without save-state fields. Treat them as default-state crystals
+            // so those legacy saves remain loadable.
+            if (object_id == O_SAVE_CRYSTAL_ITEM) {
+                goto skip_flags;
+            }
+        }
         M_MUST(JSON_READ(io, "flags", &item->flags));
         M_MUST(JSON_READ(io, "timer", &item->timer));
         ITEM_STATUS saved_status = item->status;
@@ -417,6 +425,7 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t item_num)
             }
         }
     }
+skip_flags:
 
     if (M_SHOULD(JSON_PUSH(io, "carried_items"))) {
         CARRIED_ITEM *carried_item = item->carried_item;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5252. Save crystals got `save_flags = 1` in TRX 1.2 which prevents pre-1.1 saves from loading.