### PR TITLE
objects/security_laser: add heavy trigger support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added dynamic mod discovery from the games/ directory using new `extends` and `name` fields in gameflow.json5
 - added expanded statistics screen customization, including per-row toggles and a choice between bare and bordered layouts (Graphic Options → Stats)
 - added optional save/heal crystal counts to level and final statistics (#5180)
+- added the ability for security lasers to activate heavy triggers when tripped by Lara (#5225)
 - changed `--level` to no longer require `-e/--engine` to work
 - improved rendering line segments (poison darts, rain drops, SWAT laser sights)
 - fixed recordings keeping unbound hotkeys active during playback

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -306,6 +306,7 @@ static void M_Control(const int16_t item_num)
     const XZ_32 direction = M_GetLaserDirection(item);
 
     int32_t beam_y = 0;
+    bool tripped = false;
     for (int32_t beam_idx = 0; beam_idx < item->hit_points; beam_idx++) {
         GAME_VECTOR start;
         GAME_VECTOR target;
@@ -325,6 +326,7 @@ static void M_Control(const int16_t item_num)
                     lara_item->room_num, 1);
             }
 
+            tripped = true;
             for (int32_t j = 0; j < Item_GetLevelCount(); j++) {
                 ITEM *const target_item = Item_Get(j);
 
@@ -342,6 +344,10 @@ static void M_Control(const int16_t item_num)
         }
 
         beam_y -= 256;
+    }
+
+    if (tripped) {
+        Room_TestTriggers(item);
     }
 }
 

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -8,6 +8,8 @@
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
 
+#define M_DAMAGE 10
+
 static uint8_t m_LaserShades[32] = {};
 static const int16_t m_DefaultBeamCount = 1;
 
@@ -292,6 +294,44 @@ static void M_Initialise(const int16_t item_num)
     M_LaserSplitterToggle(item);
 }
 
+static void M_DamageLara(const ITEM *const item, const int32_t beam_y)
+{
+    if (item->object_id == O_SECURITY_LASER_ALARM) {
+        return;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    if (item->object_id == O_SECURITY_LASER_KILLER) {
+        Lara_TakeDamage(lara_item->hit_points, false);
+    } else {
+        Lara_TakeDamage(M_DAMAGE, false);
+    }
+
+    Spawn_BloodBath(
+        lara_item->pos.x, item->pos.y + beam_y, lara_item->pos.z,
+        (Random_GetDraw() & 0x7F) + 128, Random_GetDraw() << 1,
+        lara_item->room_num, 1);
+}
+
+static void M_ActivateTriggers(const ITEM *const item)
+{
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        ITEM *const target_item = Item_Get(i);
+        if ((target_item->object_id != O_STROBE_LIGHT
+             && target_item->object_id != O_SENTRY_GUN)
+            || !Item_IsTriggerActive(target_item)) {
+            continue;
+        }
+
+        const OBJECT *const target_obj = Object_Get(target_item->object_id);
+        if (target_obj->event_func != nullptr) {
+            target_obj->event_func(target_item, OBJECT_EVENT_ALERT, nullptr);
+        }
+    }
+
+    Room_TestTriggers(item);
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -312,42 +352,14 @@ static void M_Control(const int16_t item_num)
         GAME_VECTOR target;
 
         if (M_GetLaserSegment(item, direction, beam_y, &start, &target)) {
-            ITEM *const lara_item = Lara_GetItem();
-            if (item->object_id != O_SECURITY_LASER_ALARM) {
-                if (item->object_id == O_SECURITY_LASER_KILLER) {
-                    Lara_TakeDamage(lara_item->hit_points, false);
-                } else {
-                    Lara_TakeDamage(10, false);
-                }
-
-                Spawn_BloodBath(
-                    lara_item->pos.x, item->pos.y + beam_y, lara_item->pos.z,
-                    (Random_GetDraw() & 0x7F) + 128, Random_GetDraw() << 1,
-                    lara_item->room_num, 1);
-            }
-
             tripped = true;
-            for (int32_t j = 0; j < Item_GetLevelCount(); j++) {
-                ITEM *const target_item = Item_Get(j);
-
-                if ((target_item->object_id == O_STROBE_LIGHT
-                     || target_item->object_id == O_SENTRY_GUN)
-                    && Item_IsTriggerActive(target_item)) {
-                    OBJECT *const target_obj =
-                        Object_Get(target_item->object_id);
-                    if (target_obj->event_func != nullptr) {
-                        target_obj->event_func(
-                            target_item, OBJECT_EVENT_ALERT, nullptr);
-                    }
-                }
-            }
+            M_DamageLara(item, beam_y);
         }
-
         beam_y -= 256;
     }
 
     if (tripped) {
-        Room_TestTriggers(item);
+        M_ActivateTriggers(item);
     }
 }
 


### PR DESCRIPTION
Resolves #5225.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds the ability for security lasers to activate heavy triggers when tripped by Lara. The trigger must be on the same tile as the null mesh and it's activated if Lara touches any of the beams. None of the lasers in OG sit on heavy triggers, so this is an unobtrusive change. Test level available.
