### PR TITLE
tr3/data: amend Nevada pickup stats

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -333,6 +333,7 @@
                 "nevada_sky.bin",
                 "nevada_door132_frames.bin",
             ],
+            "unobtainable_pickups": 1,
         },
 
         // 14. High Security Compound


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This marks one pickup in Nevada Desert (item 61) as unobtainable.
