### PR TITLE
output: force bilinear filter in overlay images

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added optional save/heal crystal counts to level and final statistics (#5180)
 - added the ability for security lasers to activate heavy triggers when tripped by Lara (#5225)
 - changed `--level` to no longer require `-e/--engine` to work
+- changed background images on title, inventory, and statistics screens to always use smooth bilinear filtering instead of the pixel-sharp look
 - improved rendering line segments (poison darts, rain drops, SWAT laser sights)
 - fixed recordings keeping unbound hotkeys active during playback
 - fixed being unable to change FOV after using photo mode without restarting the level (#5246, regression from TR1X 4.15)

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -299,7 +299,7 @@ void InvRing_Draw(INV_RING *const ring)
 
     if (ring->mode == INV_TITLE_MODE) {
         if (ring->background_path != nullptr) {
-            Output_Overlay_DrawImage(ring->background_path);
+            Output_Overlay_DrawImageBilinear(ring->background_path);
         }
         Interpolation_Interpolate();
     } else {
@@ -353,7 +353,7 @@ void InvRing_Draw(INV_RING *const ring)
         case BK_IMAGE:
             if (ring->background_path != nullptr
                 && Output_Overlay_LoadImage(ring->background_path)) {
-                Output_Overlay_DrawImage(ring->background_path);
+                Output_Overlay_DrawImageBilinear(ring->background_path);
                 Output_Overlay_DrawBlackRectangle(1.0f - opacity, false);
             } else {
                 Output_Overlay_DrawBlackRectangle(1.0f, false);

--- a/src/trx/game/output/overlay.h
+++ b/src/trx/game/output/overlay.h
@@ -9,6 +9,7 @@ void Output_Overlay_DrawPatternOpacity(bool wave, float opacity);
 void Output_Overlay_DrawBlackRectangle(float opacity, bool post_ui);
 bool Output_Overlay_LoadImage(const char *file_name);
 void Output_Overlay_DrawImage(const char *file_name);
+void Output_Overlay_DrawImageBilinear(const char *file_name);
 void Output_Overlay_DrawImageMono(const char *file_name, float intensity);
 void Output_Overlay_CaptureSnapshot(void);
 void Output_Overlay_DrawSnapshot(float opacity);

--- a/src/trx/game/output/quad.c
+++ b/src/trx/game/output/quad.c
@@ -51,6 +51,7 @@ struct OUTPUT_QUAD {
 
     float opacity;
     float brightness_scale;
+    TEXTURE_FILTER filter_mode;
 
     OUTPUT_QUAD_FIT_MODE fit_mode;
     float src_aspect;
@@ -146,6 +147,7 @@ OUTPUT_QUAD *Output_Quad_Create(void)
     r->effect = OUTPUT_QUAD_EFFECT_NONE;
     r->opacity = 1.0f;
     r->brightness_scale = 1.0f;
+    r->filter_mode = TEXTURE_FILTER_POINT;
     r->repeat.x = 1;
     r->repeat.y = 1;
 
@@ -389,6 +391,13 @@ void Output_Quad_SetBrightnessScale(
     }
 }
 
+void Output_Quad_SetFilter(
+    OUTPUT_QUAD *const r, const TEXTURE_FILTER filter_mode)
+{
+    ASSERT(r != nullptr);
+    r->filter_mode = filter_mode;
+}
+
 void Output_Quad_SetFit(
     OUTPUT_QUAD *const r, const OUTPUT_QUAD_FIT_MODE fit_mode,
     const float src_w, const float src_h)
@@ -443,6 +452,13 @@ void Output_Quad_Render(OUTPUT_QUAD *const r)
     } else {
         glBindTexture(GL_TEXTURE_2D, r->texture);
     }
+    const GLint gl_filter =
+        r->filter_mode == TEXTURE_FILTER_BILINEAR ? GL_LINEAR : GL_NEAREST;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter);
+    GLint prev_sampler = 0;
+    glGetIntegeri_v(GL_SAMPLER_BINDING, 0, &prev_sampler);
+    glBindSampler(0, 0);
 
     const GLboolean was_blend_enabled = glIsEnabled(GL_BLEND);
     if (was_blend_enabled) {
@@ -460,6 +476,7 @@ void Output_Quad_Render(OUTPUT_QUAD *const r)
 
     glDrawArrays(GL_TRIANGLES, 0, r->vertex_count);
 
+    glBindSampler(0, (GLuint)prev_sampler);
     glPolygonMode(GL_FRONT_AND_BACK, bound_polygon_mode[0]);
     if (was_depth_test_enabled) {
         glEnable(GL_DEPTH_TEST);
@@ -485,6 +502,13 @@ void Output_Quad_RenderWithBlend(OUTPUT_QUAD *const r)
     } else {
         glBindTexture(GL_TEXTURE_2D, r->texture);
     }
+    const GLint gl_filter =
+        r->filter_mode == TEXTURE_FILTER_BILINEAR ? GL_LINEAR : GL_NEAREST;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter);
+    GLint prev_sampler = 0;
+    glGetIntegeri_v(GL_SAMPLER_BINDING, 0, &prev_sampler);
+    glBindSampler(0, 0);
 
     const GLboolean was_blend_enabled = glIsEnabled(GL_BLEND);
     GLint prev_blend_src = 0;
@@ -505,6 +529,7 @@ void Output_Quad_RenderWithBlend(OUTPUT_QUAD *const r)
 
     glDrawArrays(GL_TRIANGLES, 0, r->vertex_count);
 
+    glBindSampler(0, (GLuint)prev_sampler);
     glPolygonMode(GL_FRONT_AND_BACK, bound_polygon_mode[0]);
     if (was_depth_test_enabled) {
         glEnable(GL_DEPTH_TEST);

--- a/src/trx/game/output/quad.h
+++ b/src/trx/game/output/quad.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/gl/enum.h>
+
 #include <GL/glew.h>
 #include <stdint.h>
 
@@ -75,6 +77,7 @@ void Output_Quad_SetOpacity(OUTPUT_QUAD *renderer, float opacity);
 // Set brightness scaling multiplier applied in shader.
 void Output_Quad_SetBrightnessScale(
     OUTPUT_QUAD *renderer, float brightness_scale);
+void Output_Quad_SetFilter(OUTPUT_QUAD *renderer, TEXTURE_FILTER filter_mode);
 
 // Configure fitting mode and source aspect ratio handling.
 void Output_Quad_SetFit(

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -59,6 +59,7 @@ typedef struct {
     float desaturation;
     bool flip_y;
     bool use_fit;
+    TEXTURE_FILTER texture_filter;
 } M_DRAW_OP_IMAGE;
 
 typedef struct {
@@ -550,6 +551,7 @@ static void M_DrawOp_Image(const M_DRAW_OP_IMAGE *const op)
     Output_Quad_SetEffect(p->image.renderer, OUTPUT_QUAD_EFFECT_NONE);
     Output_Quad_SetRepeat(p->image.renderer, 1, 1);
     Output_Quad_SetTextureSize(p->image.renderer, nullptr);
+    Output_Quad_SetFilter(p->image.renderer, op->texture_filter);
     Output_SetDesaturation(op->desaturation);
     if (op->use_fit) {
         Output_Quad_SetFit(
@@ -565,6 +567,37 @@ static void M_DrawOp_Image(const M_DRAW_OP_IMAGE *const op)
         Output_Quad_RenderWithBlend(p->image.renderer);
     }
     Output_SetDesaturation(0.0f);
+}
+
+static void M_DrawImageImpl(
+    const char *const file_name, const float intensity,
+    const TEXTURE_FILTER texture_filter)
+{
+    if (!Output_Overlay_LoadImage(file_name)) {
+        return;
+    }
+
+    const M_PRIV *const p = &m_Priv;
+    for (int32_t i = 0; i < M_IMAGE_CACHE_CAPACITY; i++) {
+        const M_IMAGE_CACHE_ENTRY *const e = &p->image.entries[i];
+        if (e->in_use && e->file_name != nullptr
+            && String_Equivalent(e->file_name, file_name)
+            && e->texture.initialized) {
+            M_SCHEDULE_OP(
+                false, M_DrawOp_Image,
+                ((M_DRAW_OP_IMAGE) {
+                    .texture_id = e->texture.id,
+                    .width = e->texture_width,
+                    .height = e->texture_height,
+                    .opacity = 1.0f,
+                    .desaturation = intensity,
+                    .flip_y = false,
+                    .use_fit = true,
+                    .texture_filter = texture_filter,
+                }));
+            return;
+        }
+    }
 }
 
 static void M_DrawOp_Snapshot(const M_DRAW_OP_SNAPSHOT *const op)
@@ -682,6 +715,8 @@ static void M_DrawOp_Pattern(const M_DRAW_OP_PATTERN *const op)
     Output_Quad_SetEffect(
         p->pattern.renderer,
         op->wave ? OUTPUT_QUAD_EFFECT_WAVE : OUTPUT_QUAD_EFFECT_VIGNETTE);
+    Output_Quad_SetFilter(
+        p->pattern.renderer, g_Config.rendering.texture_filter);
     Output_Quad_ClearFit(p->pattern.renderer);
     Output_Quad_SetOpacity(p->pattern.renderer, op->opacity);
     if (op->opacity >= 1.0f) {
@@ -790,36 +825,18 @@ bool Output_Overlay_LoadImage(const char *const file_name)
 
 void Output_Overlay_DrawImage(const char *const file_name)
 {
-    Output_Overlay_DrawImageMono(file_name, 0.0f);
+    M_DrawImageImpl(file_name, 0.0f, TEXTURE_FILTER_POINT);
+}
+
+void Output_Overlay_DrawImageBilinear(const char *const file_name)
+{
+    M_DrawImageImpl(file_name, 0.0f, TEXTURE_FILTER_BILINEAR);
 }
 
 void Output_Overlay_DrawImageMono(
     const char *const file_name, const float intensity)
 {
-    if (!Output_Overlay_LoadImage(file_name)) {
-        return;
-    }
-
-    const M_PRIV *const p = &m_Priv;
-    for (int32_t i = 0; i < M_IMAGE_CACHE_CAPACITY; i++) {
-        const M_IMAGE_CACHE_ENTRY *const e = &p->image.entries[i];
-        if (e->in_use && e->file_name != nullptr
-            && String_Equivalent(e->file_name, file_name)
-            && e->texture.initialized) {
-            M_SCHEDULE_OP(
-                false, M_DrawOp_Image,
-                ((M_DRAW_OP_IMAGE) {
-                    .texture_id = e->texture.id,
-                    .width = e->texture_width,
-                    .height = e->texture_height,
-                    .opacity = 1.0f,
-                    .desaturation = intensity,
-                    .flip_y = false,
-                    .use_fit = true,
-                }));
-            return;
-        }
-    }
+    M_DrawImageImpl(file_name, intensity, TEXTURE_FILTER_POINT);
 }
 
 void Output_Overlay_CaptureSnapshot(void)

--- a/src/trx/game/phase/phase_stats.c
+++ b/src/trx/game/phase/phase_stats.c
@@ -228,7 +228,7 @@ static void M_Draw(PHASE *const phase)
 
     case BK_IMAGE:
         if (p->args.background_path != nullptr) {
-            Output_Overlay_DrawImage(p->args.background_path);
+            Output_Overlay_DrawImageBilinear(p->args.background_path);
         }
         Output_Overlay_DrawBlackRectangle(progress, false);
         break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This forces the background images to use bilinear filtering regardless of user setting, which avoid pixellated look.
Only applies to big images like title screen backgrounds and credit images.
Does not affect patterns which continue to respect the setting.