### PR TITLE
objects/sophia: fix not awarding kill

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed certain TR1 1.1 savegames refusing to load (#5252, regression from 1.2)
 - fixed the total kill count including allies if hostility policy is set to individual and Lara shoots a hostile enemy (#5255, regression from 1.2)
 - fixed quick-load remaining unavailable while Lara is in her death animation (#5264, regression from 1.3)
+- fixed destroying the Fuse Box to defeat Sophia in City and Reunion not counting as a kill in the level statistics
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/objects/creatures/sophia.c
+++ b/src/trx/game/objects/creatures/sophia.c
@@ -17,6 +17,7 @@
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
 #include <trx/game/sparks.h>
+#include <trx/game/stats.h>
 
 // clang-format off
 #define M_SMALL_FLASH    10
@@ -324,6 +325,7 @@ static void M_Control(const int16_t item_num)
     if (p->death_counter == 0 && p->fuse_box_num != NO_ITEM) {
         const ITEM *const fuse_box = Item_Get(p->fuse_box_num);
         if (!Item_TestAnimEqual(fuse_box, 0)) {
+            Stats_AddKill();
             p->death_counter = 1;
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes destroying the Fuse Box to defeat Sophia in City and Reunion not counting as a kill in the level statistics.
