### PR TITLE
lua: fix teleporting issues

### DIFF
--- a/data/scripting/camera.lua
+++ b/data/scripting/camera.lua
@@ -13,6 +13,7 @@ local getters = {
 
 local camera = {
   shake = raw.shake,
+  reset = raw.reset,
 }
 
 setmetatable(camera, {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed the total kill count including allies if hostility policy is set to individual and Lara shoots a hostile enemy (#5255, regression from 1.2)
 - fixed quick-load remaining unavailable while Lara is in her death animation (#5264, regression from 1.3)
 - fixed destroying the Fuse Box to defeat Sophia in City and Reunion not counting as a kill in the level statistics
+- fixed potential freezing issues after moving an item to a different room via Lua
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added an option to show or hide the version text in the title inventory ring (#5235)
 - added optional save/heal crystal counts to level and final statistics (#5180)
 - added the ability for security lasers to activate heavy triggers when tripped by Lara (#5225)
+- added `trx.camera.reset()` to Lua, which will reposition the camera based on Lara's position
 - changed `--level` to no longer require `-e/--engine` to work
 - changed background images on title, inventory, and statistics screens to always use smooth bilinear filtering instead of the pixel-sharp look
 - improved rendering line segments (poison darts, rain drops, SWAT laser sights)

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -33,7 +33,8 @@ end)
 
 ### Teleporting Lara upon picking up a medipack
 
-This will teleport Lara back to the starting point in TR1 Caves.
+This will teleport Lara back to the starting point in TR1 Caves. Resetting the 
+camera may be required in some cases.
 
 ```lua
 trx.events.on_pickup(function(pickup_item)
@@ -43,6 +44,7 @@ trx.events.on_pickup(function(pickup_item)
     y = 3 * 1024,
     z = 3.5 * 1024,
   }
+  trx.camera.reset()
 end)
 ```
 

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -24,3 +24,6 @@ Module for inspecting the active camera state.
   ```lua
   trx.camera.shake(200)
   ```
+
+- [lua]`trx.camera.reset()`  
+  Resets the camera based on Lara's current position.  

--- a/src/trx/game/lua/camera.c
+++ b/src/trx/game/lua/camera.c
@@ -1,4 +1,4 @@
-#include <trx/game/camera/vars.h>
+#include <trx/game/camera.h>
 #include <trx/game/lua/common.h>
 #include <trx/game/rooms/const.h>
 
@@ -59,6 +59,13 @@ static int M_L_CameraShake(lua_State *const L)
     return 0;
 }
 
+// trxc.camera.reset()
+static int M_L_CameraReset(lua_State *const L)
+{
+    Camera_ResetPosition();
+    return 0;
+}
+
 void LUA_CreateCamera(lua_State *const L)
 {
     lua_getglobal(L, "trxc");
@@ -73,6 +80,8 @@ void LUA_CreateCamera(lua_State *const L)
     lua_setfield(L, -2, "get_target_room");
     lua_pushcfunction(L, M_L_CameraShake);
     lua_setfield(L, -2, "shake");
+    lua_pushcfunction(L, M_L_CameraReset);
+    lua_setfield(L, -2, "reset");
     lua_setfield(L, -2, "camera");
     lua_pop(L, 1);
 }

--- a/src/trx/game/lua/items.c
+++ b/src/trx/game/lua/items.c
@@ -180,7 +180,8 @@ static int M_L_ItemSetPos(lua_State *const L)
     lua_getfield(L, 2, "z");
     item->pos.z = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
-    item->room_num = Room_GetIndexFromPos(item->pos);
+    const int16_t room_num = Room_GetIndexFromPos(item->pos);
+    Item_UpdateRoom(idx - 1, room_num);
     return 0;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves a couple of problems when teleporting Lara via Lua. I will share a test level with a script.

- If Lara's room changes after a teleport, the game may freeze when she next crosses a portal
- If TR3 camera mode is used and the camera can't LOS to the new position, it will stay in the old position with Lara gone

I think making the camera reset an additional/optional call is best as builders may want to trigger special cameras in this situation.