### PR TITLE
lara/misc: reset hand status on enemy push

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed destroying the Fuse Box to defeat Sophia in City and Reunion not counting as a kill in the level statistics
 - fixed potential freezing issues after moving an item to a different room via Lua
 - fixed crash when issuing `/mod tr1-ub` when playing late TR1 levels
+- fixed Lara being unable to draw weapons if animated interactions are enabled and she is hit by an enemy while moving towards a pickup (#5288, regression from TR1X 4.13)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -931,14 +931,8 @@ bool Lara_MovePosition(const ITEM *const ref_item, const XYZ_32 *const vec)
     ITEM_ADJUST_ROT(lara_item->rot.y, new_rot.y, rotation);
     ITEM_ADJUST_ROT(lara_item->rot.z, new_rot.z, rotation);
 
-    // clang-format off
-    return lara_item->pos.x == new_pos.x
-        && lara_item->pos.y == new_pos.y
-        && lara_item->pos.z == new_pos.z
-        && lara_item->rot.x == new_rot.x
-        && lara_item->rot.y == new_rot.y
-        && lara_item->rot.z == new_rot.z;
-    // clang-format on
+    return XYZ_32_AreEquivalent(lara_item->pos, new_pos)
+        && XYZ_16_AreEquivalent(lara_item->rot, new_rot);
 }
 
 LARA_ANIMATION Lara_AnimToGameID(const LARA_TRX_ANIMATION anim)

--- a/src/trx/game/lara/misc.c
+++ b/src/trx/game/lara/misc.c
@@ -181,6 +181,10 @@ void Lara_TakeHit(ITEM *const lara_item, const int32_t dx, const int32_t dz)
             &lara_item->pos, SPM_NORMAL);
     }
     lara_info->hit_frame++;
+    if (lara_info->interact_target.is_moving
+        && lara_info->gun_status == LGS_HANDS_BUSY) {
+        lara_info->gun_status = LGS_ARMLESS;
+    }
     lara_info->interact_target.is_moving = false;
     lara_info->interact_target.item_num = NO_ITEM;
     CLAMPG(lara_info->hit_frame, 34);


### PR DESCRIPTION
Resolves #5288.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's hand status is reset if an enemy pushes her during animated interactions. I think this goes back to 5af4a06; TR4 doesn't have the interact target reset checks in this function, but I seem to recall it's needed here in TRX for keyholes and suchlike.
