### PR TITLE
objects/movable_block: fix room portal test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed potential freezing issues after moving an item to a different room via Lua
 - fixed crash when issuing `/mod tr1-ub` when playing late TR1 levels
 - fixed Lara being unable to draw weapons if animated interactions are enabled and she is hit by an enemy while moving towards a pickup (#5288, regression from TR1X 4.13)
+- fixed interaction issues with pushblocks when in shallow water (regression from 1.0)
 
 **TR2**:
 - changed the Detonator Box to no longer hard-code dynamic light output; refer to the migration guide for custom levels

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -193,7 +193,8 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "interaction_rot", p->interaction_rot);
 }
 
-static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
+static bool M_TestCurrentSector(
+    const ITEM *const item, const int32_t block_height)
 {
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
@@ -214,7 +215,9 @@ static bool M_TestCurrentSector(ITEM *item, int32_t block_height)
     return true;
 }
 
-static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
+static bool M_TestPush(
+    const ITEM *const item, const int32_t block_height,
+    const DIRECTION quadrant)
 {
     if (!M_TestCurrentSector(item, block_height)) {
         return false;
@@ -268,7 +271,9 @@ static bool M_TestPush(ITEM *item, int32_t block_height, DIRECTION quadrant)
     return true;
 }
 
-static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
+static bool M_TestPull(
+    const ITEM *const item, const int32_t block_height,
+    const DIRECTION quadrant)
 {
     if (!M_TestCurrentSector(item, block_height)) {
         return false;
@@ -340,7 +345,7 @@ static bool M_TestPull(ITEM *item, int32_t block_height, DIRECTION quadrant)
         return false;
     }
 
-    ITEM *const lara_item = Lara_GetItem();
+    const ITEM *const lara_item = Lara_GetItem();
     base_pos.x = lara_item->pos.x + x_add;
     base_pos.y = lara_item->pos.y;
     base_pos.z = lara_item->pos.z + z_add;
@@ -382,6 +387,15 @@ static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll)
         }
     }
     return false;
+}
+
+static bool M_TestSolidPortal(const ITEM *const item)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    int16_t room_num = lara_item->room_num;
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeightEx(sector, item->pos, true, NO_ITEM);
+    return height == NO_HEIGHT;
 }
 
 static bool M_TestDeathCollision(const ITEM *const item, const ITEM *const lara)
@@ -596,11 +610,8 @@ static void M_Collision(
             return;
         }
 
-        int16_t room_num = lara_item->room_num;
-        Room_GetSector(
-            (XYZ_32) { item->pos.x, item->pos.y - STEP_L / 2, item->pos.z },
-            &room_num);
-        if (room_num != item->room_num) {
+        // Prevent Lara moving a block through a non-passable portal
+        if (M_TestSolidPortal(item)) {
             return;
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This implements an alternative approach to 8a6992e for testing if Lara is trying to interact with a pushblock through a solid portal. It avoids problems with room number tests when Lara and the pushblock are in shallow water.