### PR TITLE
objects/movable_block: fix room portal test again

### DIFF
--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -392,9 +392,10 @@ static bool M_TestDoor(ITEM *lara_item, COLL_INFO *coll)
 static bool M_TestSolidPortal(const ITEM *const item)
 {
     const ITEM *const lara_item = Lara_GetItem();
-    int16_t room_num = lara_item->room_num;
-    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
-    const int32_t height = Room_GetHeightEx(sector, item->pos, true, NO_ITEM);
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector = Room_GetSector(lara_item->pos, &room_num);
+    const int32_t height =
+        Room_GetHeightEx(sector, lara_item->pos, true, NO_ITEM);
     return height == NO_HEIGHT;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves Lara being unable to push blocks that are in a 4-click space. Instead of checking if Lara is facing a wall, we test if the block is facing a wall in Lara's direction.
