### PR TITLE
effects: save flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 - fixed bad vertices in staircase static meshes in Aldwych and Lud's Gate, allowing for visible gaps in geometry (#5182)
 - fixed bad positioning of light static meshes in Aldwych that could result in Lara not grabbing certain ledges (#5181)
 - fixed several missing textures in Lud's Gate room 77
+- fixed Tony's fireballs flying the wrong way and piling up after loading a save (regression from 1.1)
 
 
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -515,6 +515,8 @@ static bool M_ReadEffect(JSON_READ_IO *const io)
     }
     M_MUST(JSON_READ(io, "counter", &effect->counter));
     M_MUST(JSON_READ(io, "shade", &effect->shade));
+    JSON_SHOULD(JSON_READ(io, "flag1", &effect->flag1));
+    JSON_SHOULD(JSON_READ(io, "flag2", &effect->flag2));
     M_FINISH();
 }
 

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -351,6 +351,8 @@ void SG_File_DumpEffects(JSON_WRITE_IO *const io)
         JSONW_WRITE(io, "frame_number", effect->frame_num);
         JSONW_WRITE(io, "counter", effect->counter);
         JSONW_WRITE(io, "shade", effect->shade);
+        JSONW_WRITE(io, "flag1", effect->flag1);
+        JSONW_WRITE(io, "flag2", effect->flag2);
         JSONW_POP_AND_APPEND(io);
     }
     JSONW_POP_AND_SET(io, "effects");


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes Tony's fireballs flying the wrong way and piling up after loading a save (regression from 1.1).