### PR TITLE
objects/rocket: fix triggering water splash on land tiles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed bad positioning of light static meshes in Aldwych that could result in Lara not grabbing certain ledges (#5181)
 - fixed several missing textures in Lud's Gate room 77
 - fixed Tony's fireballs flying the wrong way and piling up after loading a save (regression from 1.1)
+- fixed rockets exploding underwater being able to create a water splash in the wrong place (regression from 1.1)
 
 
 

--- a/src/trx/game/objects/general/rocket.c
+++ b/src/trx/game/objects/general/rocket.c
@@ -350,6 +350,10 @@ static void M_Control(const int16_t item_num)
     }
 
     if (explode) {
+        if (was_underwater) {
+            item->pos = old_pos.pos;
+            Item_UpdateRoom(item_num, old_pos.room_num);
+        }
         M_Explode(item_num, old_pos.pos);
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes rockets exploding underwater being able to create a water splash in the wrong place (regression from 1.1).