### PR TITLE
lara/col/climb: fix ladders next to no-space

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.5...develop) - ××××-××-××
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
+- fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...trx-1.5) - 2026-04-04
 Showcase: https://youtu.be/TTlajgcM9-8

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -456,7 +456,7 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
     sample_pos.x = x2;
     sample_pos.z = z2;
     sector = Room_GetSector(sample_pos, &room_num);
-    height = Room_GetHeight(sector, sample_pos);
+    height = Room_GetHeightEx(sector, sample_pos, true, NO_ITEM);
     if (height == NO_HEIGHT) {
         *ledge = NO_HEIGHT;
         return CLIMB_RESULT_POS;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes being unable to climb a ladder that's against a wall which has tilt floor data inside it (no-space). The problem is that tilts mess with `NO_HEIGHT` and so the climb up test fails once Lara reaches the initial vertical room boundary.

<details>

<img width="834" height="467" alt="image" src="https://github.com/user-attachments/assets/dd432728-c440-41e4-9cb9-a7d434b6171f" />
</details>

Pending ticket split for correct changelog entry.