### PR TITLE
lara/col/climb: fix shimmying across ladders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.5...develop) - ××××-××-××
+- fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...trx-1.5) - 2026-04-04
 Showcase: https://youtu.be/TTlajgcM9-8

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -270,7 +270,12 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     coll->bad_ceiling = 0;
     Lara_Col_GetInfo(item, coll);
 
-    if (lara->climb_status) {
+    // Note lara->climb_status does not mean she is using a ladder, rather the
+    // floor data below her supports it.
+    const bool can_use_ladder = lara->climb_status
+        && item->current_anim_state != LS(LS_SHIMMY_LEFT)
+        && item->current_anim_state != LS(LS_SHIMMY_RIGHT);
+    if (can_use_ladder) {
         if (!g_Input.action || item->hit_points <= 0) {
             XYZ_32 pos = {
                 .x = 0,
@@ -296,9 +301,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
         }
 
         if (!Lara_Col_TestLadderHang(item, coll)) {
-            item->pos.x = coll->old.x;
-            item->pos.y = coll->old.y;
-            item->pos.z = coll->old.z;
+            item->pos = coll->old;
             item->goal_anim_state = LS(LS_HANG);
             item->current_anim_state = LS(LS_HANG);
             Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves Lara's shimmy getting interrupted by repeatedly forcing her to `LS_HANG`. The hang test inferred `lara->climb_status` to mean she was on a ladder, whereas it only means the floor data below her supports it.

Pending ticket split for correct changelog entry.