### PR TITLE
lara/state/land: fix vault to run transition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.5...develop) - ××××-××-××
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
+- fixed Lara not transitioning immediately to run after vaulting two clicks when forward is held (#5305, regression from 1.3)
 
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...trx-1.5) - 2026-04-04
 Showcase: https://youtu.be/TTlajgcM9-8

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -75,6 +75,14 @@ static void M_Default(ITEM *const item, COLL_INFO *const coll)
     coll->enable_baddie_push = 0;
 }
 
+static void M_PullUp(ITEM *const item, COLL_INFO *const coll)
+{
+    M_Default(item, coll);
+    if (g_Input.forward && Item_TestAnimEqual(item, LA(LA_CLIMB_2CLICK_END))) {
+        item->goal_anim_state = LS(LS_RUN);
+    }
+}
+
 static void M_Walk(ITEM *const item, COLL_INFO *const coll)
 {
     if (item->hit_points <= 0) {
@@ -767,8 +775,8 @@ static void M_SprintRoll(ITEM *const item, COLL_INFO *const coll)
 }
 
 // clang-format off
-REGISTER_LARA_STATE(LS_PULL_UP,      M_Default)
 REGISTER_LARA_STATE(LS_GYMNAST,      M_Default)
+REGISTER_LARA_STATE(LS_PULL_UP,      M_PullUp)
 REGISTER_LARA_STATE(LS_WALK,         M_Walk)
 REGISTER_LARA_STATE(LS_RUN,          M_Run)
 REGISTER_LARA_STATE(LS_STOP,         M_Stop)


### PR DESCRIPTION
Resolves #5305.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The fixes in #4950 involved changing the state ID of the animation in question, hence its original input checks were no longer being handled. The animation only has a change for running forward so that's the minimum added here.