### PR TITLE
phase/cutscene: cross fade from game

### DIFF
--- a/src/trx/game/game_flow/sequencer.h
+++ b/src/trx/game/game_flow/sequencer.h
@@ -10,13 +10,13 @@ GF_COMMAND GF_ShowInventory(INVENTORY_MODE inv_mode);
 bool GF_ShowInventoryKeys(OBJECT_ID receptacle_type_id);
 GF_COMMAND GF_RunTitle(void);
 GF_COMMAND GF_RunDemo(int32_t demo_num);
-GF_COMMAND GF_RunCutscene(int32_t cutscene_num);
+GF_COMMAND GF_RunCutscene(int32_t cutscene_num, bool cross_fade_in);
 GF_COMMAND GF_RunGame(const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx);
 GF_COMMAND GF_RunGlobeSelect(const char *background_path);
 
 GF_COMMAND GF_DoFrontendSequence(void);
 GF_COMMAND GF_DoDemoSequence(int32_t demo_num);
-GF_COMMAND GF_DoCutsceneSequence(int32_t cutscene_num);
+GF_COMMAND GF_DoCutsceneSequence(int32_t cutscene_num, bool cross_fade_in);
 
 GF_COMMAND GF_InterpretSequence(
     const GF_LEVEL *level, GF_SEQUENCE_CONTEXT seq_ctx, void *seq_ctx_arg);

--- a/src/trx/game/game_flow/sequencer_events.c
+++ b/src/trx/game/game_flow/sequencer_events.c
@@ -174,7 +174,7 @@ M_GF_HANDLER(M_HandlePlayLevel)
     if (level->type == GFL_DEMO) {
         gf_cmd = GF_RunDemo(level->num);
     } else if (level->type == GFL_CUTSCENE) {
-        gf_cmd = GF_RunCutscene(level->num);
+        gf_cmd = GF_RunCutscene(level->num, (bool)(intptr_t)seq_ctx_arg);
     } else {
         if (seq_ctx != GFSC_SAVED && level != GF_GetFirstLevel()) {
             Lara_RevertToPistolsIfNeeded();
@@ -191,9 +191,13 @@ M_GF_HANDLER(M_HandlePlayCutscene)
 {
     GF_COMMAND gf_cmd = { .action = GF_NOOP };
     const GF_SEQUENCE_EVENT *const event = &sequence->events[event_idx];
+    const GF_SEQUENCE_EVENT *const prev_event =
+        event_idx > 0 ? &sequence->events[event_idx - 1] : nullptr;
     const int16_t cutscene_num = (int16_t)(intptr_t)event->data;
+    const bool cross_fade_in =
+        prev_event != nullptr && prev_event->type == GFS_LOOP_GAME;
     if (seq_ctx != GFSC_SAVED && g_Config.gameplay.enable_cutscenes) {
-        gf_cmd = GF_DoCutsceneSequence(cutscene_num);
+        gf_cmd = GF_DoCutsceneSequence(cutscene_num, cross_fade_in);
         if (gf_cmd.action == GF_LEVEL_COMPLETE) {
             gf_cmd.action = GF_NOOP;
         }

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -77,9 +77,12 @@ GF_COMMAND GF_RunDemo(const int32_t demo_num)
     return gf_cmd;
 }
 
-GF_COMMAND GF_RunCutscene(const int32_t cutscene_num)
+GF_COMMAND GF_RunCutscene(const int32_t cutscene_num, const bool cross_fade_in)
 {
-    PHASE *const cutscene_phase = Phase_Cutscene_Create(cutscene_num);
+    PHASE *const cutscene_phase = Phase_Cutscene_Create((PHASE_CUTSCENE_ARGS) {
+        .level_num = cutscene_num,
+        .cross_fade_in = cross_fade_in,
+    });
     const GF_COMMAND gf_cmd = PhaseExecutor_Run(cutscene_phase);
     Phase_Cutscene_Destroy(cutscene_phase);
     return gf_cmd;
@@ -181,14 +184,16 @@ GF_COMMAND GF_DoDemoSequence(int32_t demo_num)
     return GF_InterpretSequence(level, GFSC_NORMAL, nullptr);
 }
 
-GF_COMMAND GF_DoCutsceneSequence(const int32_t cutscene_num)
+GF_COMMAND GF_DoCutsceneSequence(
+    const int32_t cutscene_num, const bool cross_fade_in)
 {
     const GF_LEVEL *const level = GF_GetLevel(GFLT_CUTSCENES, cutscene_num);
     if (level == nullptr) {
         LOG_ERROR("Missing cutscene: %d", cutscene_num);
         return (GF_COMMAND) { .action = GF_NOOP };
     }
-    return GF_InterpretSequence(level, GFSC_NORMAL, nullptr);
+    return GF_InterpretSequence(
+        level, GFSC_NORMAL, (void *)(intptr_t)cross_fade_in);
 }
 
 GF_COMMAND GF_PlayAvailableStory(const SAVEGAME_SLOT_REF slot)

--- a/src/trx/game/phase/phase_cutscene.c
+++ b/src/trx/game/phase/phase_cutscene.c
@@ -1,20 +1,40 @@
 #include <trx/game/phase/phase_cutscene.h>
 
+#include <trx/config.h>
 #include <trx/core/memory.h>
 #include <trx/game/cutscene.h>
+#include <trx/game/fader.h>
 #include <trx/game/game.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/lua/events.h>
 #include <trx/game/output.h>
+#include <trx/game/output/overlay.h>
+#include <trx/version.h>
+
+#define M_CROSS_FADE_DURATION 0.5f
 
 typedef struct {
-    int32_t level_num;
+    PHASE_CUTSCENE_ARGS args;
+    FADER cross_fader;
 } M_PRIV;
+
+static bool M_UsesCrossFadeIn(PHASE *const phase)
+{
+    M_PRIV *const p = phase->priv;
+    return p->args.cross_fade_in && g_Config.visuals.enable_fade_effects
+        && g_TRVersion == 3;
+}
 
 static PHASE_CONTROL M_Start(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
-    if (!Cutscene_Start(p->level_num)) {
+    if (phase->uses_cross_fade_in != nullptr
+        && phase->uses_cross_fade_in(phase)) {
+        Output_Overlay_CaptureSnapshot();
+        Fader_InitTo(&p->cross_fader, 1.0f, 0.0f, M_CROSS_FADE_DURATION);
+    }
+
+    if (!Cutscene_Start(p->args.level_num)) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,
             .gf_cmd = { .action = GF_NOOP },
@@ -61,13 +81,17 @@ static void M_Draw(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
     Cutscene_Draw();
+    if (phase->uses_cross_fade_in != nullptr
+        && phase->uses_cross_fade_in(phase)) {
+        Output_Overlay_DrawSnapshot(Fader_GetCurrentValue(&p->cross_fader));
+    }
 }
 
-PHASE *Phase_Cutscene_Create(const int32_t level_num)
+PHASE *Phase_Cutscene_Create(const PHASE_CUTSCENE_ARGS args)
 {
     PHASE *const phase = Memory_Alloc(sizeof(PHASE));
     M_PRIV *const p = Memory_Alloc(sizeof(M_PRIV));
-    p->level_num = level_num;
+    p->args = args;
     phase->priv = p;
     phase->start = M_Start;
     phase->end = M_End;
@@ -75,6 +99,7 @@ PHASE *Phase_Cutscene_Create(const int32_t level_num)
     phase->resume = M_Resume;
     phase->control = M_Control;
     phase->draw = M_Draw;
+    phase->uses_cross_fade_in = M_UsesCrossFadeIn;
     return phase;
 }
 

--- a/src/trx/game/phase/phase_cutscene.h
+++ b/src/trx/game/phase/phase_cutscene.h
@@ -2,5 +2,10 @@
 
 #include <trx/game/phase/types.h>
 
-PHASE *Phase_Cutscene_Create(int32_t level_num);
+typedef struct {
+    int32_t level_num;
+    bool cross_fade_in;
+} PHASE_CUTSCENE_ARGS;
+
+PHASE *Phase_Cutscene_Create(PHASE_CUTSCENE_ARGS args);
 void Phase_Cutscene_Destroy(PHASE *phase);

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -430,7 +430,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
             break;
 
         case GF_START_CINE:
-            gf_cmd = GF_DoCutsceneSequence(gf_cmd.param);
+            gf_cmd = GF_DoCutsceneSequence(gf_cmd.param, false);
             break;
 
         case GF_START_DEMO:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds cross-fades to TR3 when finishing a level and starting the subsequent cutscene.
This should only affect TR3.
All TR3 cutscenes play before stat screens so this change should apply to all TR3 cutscenes.