### PR TITLE
output: do not redraw the same statics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 
+**TR3**:
+- fixed It's a Madhouse! street lamps being too bright
+
+
+
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...trx-1.5) - 2026-04-04
 Showcase: https://youtu.be/TTlajgcM9-8
 - added multi-key combo shortcuts (up to 3 keys) with two binding slots per action for both keyboard and controller

--- a/src/trx/game/inject/editors/rooms.c
+++ b/src/trx/game/inject/editors/rooms.c
@@ -310,6 +310,7 @@ static void M_AddRoomStatic3D(const INJECTION *const injection)
         mesh->shade.value_2 = mesh->shade.value_1;
     }
     mesh->static_num = VFile_ReadS16(injection->fp);
+    mesh->draw_num = -1;
 
     room->num_static_meshes++;
 }

--- a/src/trx/game/level/finalize/rooms.c
+++ b/src/trx/game/level/finalize/rooms.c
@@ -2,6 +2,7 @@
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/core/vector.h>
+#include <trx/debug.h>
 #include <trx/game/game_buf.h>
 #include <trx/game/level/finalize.h>
 #include <trx/game/objects.h>
@@ -67,6 +68,7 @@ static void M_ComputePortalBounds(void)
 static void M_FixStaticsVisibility(void)
 {
     int32_t total_rooms = Room_GetCount();
+    int32_t draw_num = 0;
     VECTOR **room_stat_vecs =
         Memory_Alloc(sizeof(*room_stat_vecs) * total_rooms);
 
@@ -76,6 +78,8 @@ static void M_FixStaticsVisibility(void)
         for (int32_t m = 0; m < room->num_static_meshes; m++) {
             STATIC_MESH *const static_mesh = &room->static_meshes[m];
             if (Object_IsValidStatid3D(static_mesh->static_num)) {
+                ASSERT(draw_num < MAX_ITEMS);
+                static_mesh->draw_num = draw_num++;
                 Vector_Add(room_stat_vecs[i], static_mesh);
             } else {
                 LOG_WARNING(

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -368,6 +368,7 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, VFILE *const file)
             mesh->rot.y = VFile_ReadS16(file);
             M_ReadShade(loader, &mesh->shade, file);
             mesh->static_num = VFile_ReadS16(file);
+            mesh->draw_num = -1;
         }
 
         room->flipped_room = VFile_ReadS16(file);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -78,6 +78,7 @@ static inline void M_DrawSet_ForEach(
 }
 
 static VECTOR *m_RoomsToDraw = nullptr;
+static ROOM_DRAWSET m_DrawnStatics = {};
 
 static int32_t m_Outside;
 static int32_t m_OutsideRight;
@@ -375,6 +376,9 @@ static void M_DrawSingleRoom(const ROOM *const room)
 
     for (int32_t i = 0; i < room->num_static_meshes; i++) {
         const STATIC_MESH *const mesh = &room->static_meshes[i];
+        if (M_DrawSet_Has(&m_DrawnStatics, mesh->draw_num)) {
+            continue;
+        }
         const STATIC_OBJECT_3D *const obj =
             Object_Get3DStatic(mesh->static_num);
         if (!obj->visible) {
@@ -386,6 +390,7 @@ static void M_DrawSingleRoom(const ROOM *const room)
         Matrix_RotY(mesh->rot.y);
         const CLIP clip = Output_CheckBoundsClip(&obj->draw_bounds);
         if (clip != CLIP_NOT_VISIBLE) {
+            M_DrawSet_Add(&m_DrawnStatics, mesh->draw_num);
             Output_CalculateStaticMeshLight(mesh->pos, mesh->shade, room);
             Object_DrawMesh(obj->mesh_idx, clip, false);
             if (g_Config.debug.enable_debug_bounding_boxes) {
@@ -421,6 +426,7 @@ static void M_DrawSingleRoom(const ROOM *const room)
 void Room_DrawReset(void)
 {
     M_EnsureRoomsToDraw();
+    M_DrawSet_Init(&m_DrawnStatics);
     Vector_Clear(m_RoomsToDraw);
 }
 

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -131,6 +131,7 @@ typedef struct {
     RGBA_8888 color;
     SHADE shade;
     int16_t static_num;
+    int16_t draw_num;
 } STATIC_MESH;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The gazebo fix for Bartoli's Hideout ensures the game attempts to draw statics from all rooms they intersect with (barring unrelated overlapping rooms).

However this causes certain statics to get drawn twice.

OG: 
<img width="1440" height="1080" alt="image" src="https://github.com/user-attachments/assets/0514653e-65b5-41bf-acd4-b8daaec8f235" />
TRX:
<img width="1793" height="1009" alt="image" src="https://github.com/user-attachments/assets/2bfe1618-5bb0-467a-aac0-bdc5e5f4e077" />

#### Testing

- [x] Statics that are known to disappear under weird camera angles such as Bartoli's Hideout gazebo
- [x] It's a Madhouse! lamps OG appearance adherence