### PR TITLE
data: remove intro fmv from LA GF

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -188,7 +188,6 @@
 
     "fmvs": [
         {"path": "logo.rpl", "legal": true},
-        {"path": "intr_eng.rpl"},
     ],
 
     "hidden_config": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 
+**TR3**:
+- fixed TR3:LA playing TR3 intro FMV
+
+
+
 ## [1.5](https://github.com/LostArtefacts/TRX/compare/trx-1.4.2...trx-1.5) - 2026-04-04
 Showcase: https://youtu.be/TTlajgcM9-8
 - added multi-key combo shortcuts (up to 3 keys) with two binding slots per action for both keyboard and controller


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes TR3:LA playing TR3's intro FMV.