### PR TITLE
input: reset state on shutdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed incorrect transparent and yellow pixels on TR2 and TR3 outfit heads when bilinear filtering is enabled (#5300)
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 - fixed Lara not transitioning immediately to run after vaulting two clicks when forward is held (#5305, regression from 1.3)
+- fixed settings list auto-scroll sometimes stopping after switching to a different mod (regression from 1.4)
 
 **TR3**:
 - fixed the satellite dish in High Security Compound room 44 being clipped out of view too soon (missing animation bounds) (#5297, regression from 1.1)

--- a/src/trx/game/input/common.c
+++ b/src/trx/game/input/common.c
@@ -156,12 +156,27 @@ static INPUT_STATE M_SetPressed(
     return input;
 }
 
+void Input_Reset(void)
+{
+    InputState_Clear(&g_Input);
+    InputState_Clear(&g_InputDB);
+    InputState_Clear(&g_OldInputDB);
+
+    for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
+        M_HOLD_CHECK *const hold_check = &m_HoldChecks[i];
+        hold_check->state = HOLD_INACTIVE;
+        ClockTimer_Sync(&hold_check->delay_timer);
+        ClockTimer_Sync(&hold_check->repeat_timer);
+    }
+}
+
 void Input_Init(void)
 {
     for (int32_t i = 0; m_HoldChecks[i].role != (INPUT_ROLE)-1; i++) {
         m_HoldChecks[i].delay_timer.type = CLOCK_TIMER_REAL;
         m_HoldChecks[i].repeat_timer.type = CLOCK_TIMER_REAL;
     }
+    Input_Reset();
     if (g_Input_Keyboard.init != nullptr) {
         g_Input_Keyboard.init();
     }
@@ -172,6 +187,7 @@ void Input_Init(void)
 
 void Input_Shutdown(void)
 {
+    Input_Reset();
     if (g_Input_Keyboard.shutdown != nullptr) {
         g_Input_Keyboard.shutdown();
     }

--- a/src/trx/game/input/common.h
+++ b/src/trx/game/input/common.h
@@ -35,6 +35,7 @@ void Input_Init(void);
 void Input_Shutdown(void);
 void Input_Discover(void);
 void Input_Update(void);
+void Input_Reset(void);
 
 // Processes a SDL event to update global input state before polling.
 // @param event     Event to process.


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes auto scroll stopping to work reliably when switching mods, which can be reproduced with the following steps:

1. Launch TR1
2. Open the sunglasses dialog, hold up/down to see the scrolling is working
3. Issue `/mod tr2`
4. Open the sunglasses dialog, hold up/down and the scrolling may have stopped

This bug is easier to reproduce when waiting a bit of time for the internal timers drift to accumulate.
