### PR TITLE
data: fix unobtainable pickups and secrets in Reunion

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -184,6 +184,8 @@
                 "lara_guns.bin",
                 "reunion_flames.bin",
             ],
+            "unobtainable_pickups": 1,
+            "unobtainable_secrets": 1,
         },
     ],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed It's a Madhouse! street lamps being too bright
 - fixed TR3:LA playing TR3 intro FMV
 - fixed Willard's Lair having wrong kill count
+- fixed Reunion having wrong pickup and secret count
 
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Reunion having wrong pickup and secret count.