### PR TITLE
effects/flame: support enable_fire_lighting in tr3 flames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed Lara not transitioning immediately to run after vaulting two clicks when forward is held (#5305, regression from 1.3)
 
 **TR3**:
+- fixed Fire Lighting option having no effect
 - fixed the satellite dish in High Security Compound room 44 being clipped out of view too soon (missing animation bounds) (#5297, regression from 1.1)
 - fixed It's a Madhouse! street lamps being too bright
 - fixed TR3:LA playing TR3 intro FMV

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -174,22 +174,23 @@ static void M_TR3_ControlSmall(
         }
     }
 
-    RGB_888 color;
+    if (g_Config.visuals.enable_fire_lighting) {
+        RGB_888 color;
 #if 0
-    // TODO: implement this for Willard
-    if (lara->burn_green) {
-        color.r = (rnd >> 2) & 0x3F;
-        color.g = (rnd & 0x3F) + 192;
-        color.b = ((rnd >> 4) & 0x1F) + 96;
-    } else
+        // TODO: implement this for Willard
+        if (lara->burn_green) {
+            color.r = (rnd >> 2) & 0x3F;
+            color.g = (rnd & 0x3F) + 192;
+            color.b = ((rnd >> 4) & 0x1F) + 96;
+        } else
 #endif
-    {
-        color.r = (rnd & 0x3F) + 192;
-        color.g = ((rnd >> 4) & 0x1F) + 96;
-        color.b = 0;
+        {
+            color.r = (rnd & 0x3F) + 192;
+            color.g = ((rnd >> 4) & 0x1F) + 96;
+            color.b = 0;
+        }
+        Output_AddDynamicLightRGB(lara_item->pos, 13, color);
     }
-
-    Output_AddDynamicLightRGB(lara_item->pos, 13, color);
 
     if (lara_item->room_num != effect->room_num) {
         Effect_UpdateRoom(Effect_GetIndex(effect), lara_item->room_num);
@@ -323,15 +324,21 @@ static void M_TR3_Control(const int16_t effect_num)
         } else {
             dist = (128 - effect->flag1) << 5;
         }
+    }
 
-        const int32_t angle = (((effect->rot.y >> 3) & 0xFFFE) - 4096) & 0x1FFE;
-        const int32_t s = (dist * Math_Sin(angle << 3)) >> W2V_SHIFT;
-        const int32_t c = (dist * Math_Cos(angle << 3)) >> W2V_SHIFT;
-        Output_AddDynamicLightRGB(
-            (XYZ_32) { x + s, y, z + c }, (effect->flag2 != 0) ? 6 : 13, color);
-    } else {
-        Output_AddDynamicLightRGB(
-            (XYZ_32) { x, y, z }, 16 - (effect->frame_num << 2), color);
+    if (g_Config.visuals.enable_fire_lighting) {
+        if (effect->frame_num == FLAME_SIDE) {
+            const int32_t angle =
+                (((effect->rot.y >> 3) & 0xFFFE) - 4096) & 0x1FFE;
+            const int32_t s = (dist * Math_Sin(angle << 3)) >> W2V_SHIFT;
+            const int32_t c = (dist * Math_Cos(angle << 3)) >> W2V_SHIFT;
+            Output_AddDynamicLightRGB(
+                (XYZ_32) { x + s, y, z + c }, (effect->flag2 != 0) ? 6 : 13,
+                color);
+        } else {
+            Output_AddDynamicLightRGB(
+                (XYZ_32) { x, y, z }, 16 - (effect->frame_num << 2), color);
+        }
     }
 
     Sound_Effect(SFX_LOOP_FOR_SMALL_FIRES, &effect->pos, SPM_NORMAL);

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -1,6 +1,7 @@
 #include <trx/game/objects/effects/flame.h>
 
 #include <trx/config.h>
+#include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
@@ -304,9 +305,11 @@ static void M_TR3_Control(const int16_t effect_num)
     }
 
     // Light & proximity damage logic (applies to most flame types).
-    int32_t x = effect->pos.x + ((rnd & 0xF) << 5);
-    int32_t y = effect->pos.y + ((rnd & 0xF0) << 1);
-    int32_t z = effect->pos.z + ((rnd >> 3) & 0x1E0);
+    const XYZ_32 light_pos = {
+        .x = effect->pos.x + ((rnd & 0xF) << 5),
+        .y = effect->pos.y + ((rnd & 0xF0) << 1),
+        .z = effect->pos.z + ((rnd >> 3) & 0x1E0),
+    };
     RGB_888 color = {
         .r = (rnd & 0x3F) + 192,
         .g = ((rnd >> 4) & 0x1F) + 96,
@@ -328,16 +331,14 @@ static void M_TR3_Control(const int16_t effect_num)
 
     if (g_Config.visuals.enable_fire_lighting) {
         if (effect->frame_num == FLAME_SIDE) {
-            const int32_t angle =
-                (((effect->rot.y >> 3) & 0xFFFE) - 4096) & 0x1FFE;
-            const int32_t s = (dist * Math_Sin(angle << 3)) >> W2V_SHIFT;
-            const int32_t c = (dist * Math_Cos(angle << 3)) >> W2V_SHIFT;
+            const int16_t angle =
+                ((((effect->rot.y >> 3) & 0xFFFE) - 4096) & 0x1FFE) << 3;
             Output_AddDynamicLightRGB(
-                (XYZ_32) { x + s, y, z + c }, (effect->flag2 != 0) ? 6 : 13,
-                color);
+                XYZ_32_OffsetYaw(light_pos, angle, dist),
+                (effect->flag2 != 0) ? 6 : 13, color);
         } else {
             Output_AddDynamicLightRGB(
-                (XYZ_32) { x, y, z }, 16 - (effect->frame_num << 2), color);
+                light_pos, 16 - (effect->frame_num << 2), color);
         }
     }
 
@@ -353,9 +354,12 @@ static void M_TR3_Control(const int16_t effect_num)
         }
     } else if (effect->frame_num != FLAME_SMALL) {
         if (Lara_IsNearItem(&effect->pos, M_DAMAGE_PROXIMITY)) {
-            x = lara_item->pos.x - effect->pos.x;
-            z = lara_item->pos.z - effect->pos.z;
-            dist = SQUARE(x) + SQUARE(z);
+            const XYZ_32 delta = {
+                .x = lara_item->pos.x - effect->pos.x,
+                .y = 0,
+                .z = lara_item->pos.z - effect->pos.z,
+            };
+            dist = XYZ_32_GetLength2(delta);
             Lara_TakeDamage(M_TOO_NEAR_DAMAGE, true);
 
             if (dist < 202500) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the "Fire Lighting" option having no effect on TR3 flames.