### PR TITLE
data: remove Lara's Home selection from TR3:LA

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -39,22 +39,8 @@
     ],
 
     "levels": [
-        // 0. Lara's Home
-        {
-            "type": "gym",
-            "path": "house.tr2",
-            "music_track": -1,
-            "lara_outfit": "tr3_gym",
-            "sequence": [
-                {"type": "loading_screen", "path": "house.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
-                {"type": "loop_game"},
-                {"type": "level_stats"},
-            ],
-            "injections": [
-                "gym_sky.bin",
-                "lara_gym_guns.bin",
-            ],
-        },
+        // 0. Legacy savegame placeholder
+        {"type": "dummy"},
 
         // 1. Highland Fling
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fixed settings list auto-scroll sometimes stopping after switching to a different mod (regression from 1.4)
 
 **TR3**:
+- removed Lara's Home from TR3:LA to stay compatible with the OG and other expansion packs
 - fixed Fire Lighting option having no effect
 - fixed the satellite dish in High Security Compound room 44 being clipped out of view too soon (missing animation bounds) (#5297, regression from 1.1)
 - fixed It's a Madhouse! street lamps being too bright


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR removes Lara's Home from TR3:LA to stay compatible with the OG and other expansion packs.
