### PR TITLE
input: fix default layouts with /mod

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 - fixed Lara not transitioning immediately to run after vaulting two clicks when forward is held (#5305, regression from 1.3)
 - fixed settings list auto-scroll sometimes stopping after switching to a different mod (regression from 1.4)
+- fixed first-time keyboard keybindings conflicting after switching to a different mod (regression from 1.4)
 
 **TR3**:
 - removed Lara's Home from TR3:LA to stay compatible with the OG and other expansion packs

--- a/src/trx/game/catalog/manager.c
+++ b/src/trx/game/catalog/manager.c
@@ -3,6 +3,7 @@
 #include <trx/core/filesystem.h>
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
+#include <trx/core/utils.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/lara/enum.h>
 #include <trx/game/music/ids.h>
@@ -45,8 +46,7 @@ static const M_ENTRY m_CatalogEntryDefs[] = {
 };
 
 // Number of catalog entries
-static const size_t m_CatalogEntryCount =
-    sizeof(m_CatalogEntryDefs) / sizeof(m_CatalogEntryDefs[0]);
+static const size_t m_CatalogEntryCount = ARRAY_SIZE(m_CatalogEntryDefs);
 
 // Internal map from name to CATALOG_ID
 typedef struct {

--- a/src/trx/game/input/backends/keyboard.c
+++ b/src/trx/game/input/backends/keyboard.c
@@ -1,5 +1,6 @@
 #include <trx/game/input/backends/keyboard.h>
 
+#include <trx/core/utils.h>
 #include <trx/game/input/backends/internal.h>
 #include <trx/game/input/combo.h>
 #include <trx/version.h>
@@ -27,13 +28,15 @@ typedef struct {
 static bool m_KeyboardState[SDL_NUM_SCANCODES] = {};
 static bool m_Conflicts[INPUT_LAYOUT_NUMBER_OF][INPUT_ROLE_NUMBER_OF] = {};
 
-static BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayout[] = {
+static const BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayoutBase[] = {
 // clang-format off
 #define INPUT_KEYBOARD_ASSIGN(role, key) { role, key },
 #include <trx/game/input/backends/keyboard.def>
     { -1, SDL_SCANCODE_UNKNOWN },
     // clang-format on
 };
+
+static BUILTIN_KEYBOARD_LAYOUT m_BuiltinLayout[ARRAY_SIZE(m_BuiltinLayoutBase)];
 
 static KEYBOARD_ROLE_BINDING m_Layout[INPUT_LAYOUT_NUMBER_OF]
                                      [INPUT_ROLE_NUMBER_OF];
@@ -476,6 +479,8 @@ static void M_HandleBuiltInDefaults(void)
 
 static void M_Init(void)
 {
+    memcpy(m_BuiltinLayout, m_BuiltinLayoutBase, sizeof(m_BuiltinLayout));
+
     // first, reset all roles to unbound
     for (INPUT_ROLE role = 0; role < INPUT_ROLE_NUMBER_OF; role++) {
         for (int32_t slot = 0; slot < INPUT_BINDING_SLOTS; slot++) {

--- a/src/trx/game/ui/elements/window.c
+++ b/src/trx/game/ui/elements/window.c
@@ -1,5 +1,6 @@
 #include <trx/game/ui/elements/window.h>
 
+#include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/ui.h>
 #include <trx/version.h>
@@ -10,7 +11,7 @@ typedef struct {
 } M_CONTEXT;
 
 static M_CONTEXT m_ContextStack[16];
-static int32_t m_ContextStackSize = 0;
+static size_t m_ContextStackSize = 0;
 
 static bool M_ShouldShowScrollHints(const UI_WINDOW_SETTINGS *const settings)
 {
@@ -73,9 +74,7 @@ static void M_Title(const char *const title)
 void UI_BeginWindow(UI_WINDOW_SETTINGS settings)
 {
     const bool show_scroll_hints = M_ShouldShowScrollHints(&settings);
-    ASSERT(
-        m_ContextStackSize
-        < (int32_t)(sizeof(m_ContextStack) / sizeof(m_ContextStack[0])));
+    ASSERT(m_ContextStackSize < ARRAY_SIZE(m_ContextStack));
     m_ContextStack[m_ContextStackSize++] = (M_CONTEXT) {
         .settings = settings,
         .show_scroll_hints = show_scroll_hints,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the following bug:

1. Remove `TR2X.json5` and `TR3X.json5` from the `cfg/` folder
2. Launch TR2
3. Select controls then keyboard
4. Change to User Keys 1
5. Issue `/mod tr3`
6. Select controls then keyboard
7. Change to User Keys 1
8. Select the Items tab

Develop: the binding conflict between Automatic Pistols and Desert Eagle.
PR: the conflict no longer occurs and the game behaves as if it was launched the first time with no stale state spillover.

This bug can manifest the other way, start with TR3 then switch to TR2.