### PR TITLE
objects/switch: implement one shot

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed TR3:LA playing TR3 intro FMV
 - fixed Willard's Lair having wrong kill count
 - fixed Reunion having wrong pickup and secret count
+- fixed being able to re-use switches that are intended to only be used once (#5328, regression from 1.1)
 
 
 

--- a/src/trx/game/objects/general/switch.c
+++ b/src/trx/game/objects/general/switch.c
@@ -6,6 +6,7 @@
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/version.h>
 
 typedef struct {
     XYZ_32 normal;
@@ -87,6 +88,11 @@ static void M_Control(const int16_t item_num)
         item->timer = 0;
     }
     Item_Animate(item);
+
+    if (g_TRVersion >= 3 && (item->flags & IF_ONE_SHOT_SWITCH) != 0) {
+        item->flags &= ~IF_ONE_SHOT_SWITCH;
+        item->flags |= IF_ONE_SHOT;
+    }
 }
 
 static void M_AlignLara(ITEM *const lara_item, ITEM *const switch_item)
@@ -246,12 +252,16 @@ static void M_CollisionControlled(
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
+    ITEM *const item = Item_Get(item_num);
+    if (g_TRVersion >= 3 && (item->flags & IF_ONE_SHOT) != 0) {
+        return;
+    }
+
     if (g_Config.gameplay.enable_walk_to_items) {
         M_CollisionControlled(item_num, lara_item, coll);
         return;
     }
 
-    ITEM *const item = Item_Get(item_num);
     LARA_INFO *const lara = Lara_GetLaraInfo();
     const OBJECT *const obj = Object_Get(item->object_id);
 

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -441,10 +441,15 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             break;
 
         case TT_SWITCH: {
-            if (!Switch_Trigger(trigger->item_index, trigger->timer)) {
+            const bool switch_result =
+                Switch_Trigger(trigger->item_index, trigger->timer);
+            ITEM *const switch_item = Item_Get(trigger->item_index);
+            if (g_TRVersion >= 3 && trigger->one_shot) {
+                switch_item->flags |= IF_ONE_SHOT_SWITCH;
+            }
+            if (!switch_result) {
                 return false;
             }
-            const ITEM *const switch_item = Item_Get(trigger->item_index);
             switch_off = switch_item->current_anim_state == SWITCH_STATE_OFF;
             break;
         }


### PR DESCRIPTION
Resolves #5328.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates switches in TR3 to react to being one shot. That is, once they're used Lara will never interact with them again. This is version-gated as TR1/2 did not use this concept so it avoids re-evaluating all of the triggers in those games. The implementation is slightly different to OG, to avoid using `item_flags`; rather we mark a temporary flag when testing triggers, then convert it to one shot after the first use.