### PR TITLE
docs: update --help; update docs on --mod

### DIFF
--- a/data/trx/ship/games/tr1-demo-pc/gameflow.json5
+++ b/data/trx/ship/games/tr1-demo-pc/gameflow.json5
@@ -4,6 +4,7 @@
 
     "engine": 1,
     "extends": "tr1",
+    "name": "TR1 PC Demo",
 
     // path to the main menu background image
     "main_menu_picture": "title.webp",

--- a/data/trx/ship/games/tr1-level/gameflow.json5
+++ b/data/trx/ship/games/tr1-level/gameflow.json5
@@ -3,6 +3,7 @@
 
     "engine": 1,
     "extends": "tr1",
+    "name": "TR1 Direct Level",
 
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tmp_%02d.dat",

--- a/data/trx/ship/games/tr1-ub/gameflow.json5
+++ b/data/trx/ship/games/tr1-ub/gameflow.json5
@@ -4,6 +4,7 @@
 
     "engine": 1,
     "extends": "tr1",
+    "name": "Unfinished Business",
 
     "main_menu_picture": "title_ub.webp",
     "savegame_file_fmt": "save_trub_%02d.dat",

--- a/data/trx/ship/games/tr1/gameflow.json5
+++ b/data/trx/ship/games/tr1/gameflow.json5
@@ -3,6 +3,7 @@
     // Lines starting with double slashes are comments and are ignored.
 
     "engine": 1,
+    "name": "Tomb Raider I",
 
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tr1_%02d.dat",

--- a/data/trx/ship/games/tr2-gm/gameflow.json5
+++ b/data/trx/ship/games/tr2-gm/gameflow.json5
@@ -4,6 +4,7 @@
 
     "engine": 2,
     "extends": "tr2",
+    "name": "The Golden Mask",
 
     "main_menu_picture": "title_eu_gm.webp",
     "savegame_file_fmt": "save_trgm_%02d.dat",

--- a/data/trx/ship/games/tr2-level/gameflow.json5
+++ b/data/trx/ship/games/tr2-level/gameflow.json5
@@ -3,6 +3,7 @@
 
     "engine": 2,
     "extends": "tr2",
+    "name": "TR2 Direct Level",
 
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_custom_%02d.dat",

--- a/data/trx/ship/games/tr2/gameflow.json5
+++ b/data/trx/ship/games/tr2/gameflow.json5
@@ -3,6 +3,7 @@
     // Lines starting with double slashes are comments and are ignored.
 
     "engine": 2,
+    "name": "Tomb Raider II",
 
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_%02d.dat",

--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -4,6 +4,7 @@
 
     "engine": 3,
     "extends": "tr3",
+    "name": "The Lost Artifact",
 
     "main_menu_picture": "title_eu_la.webp",
     "savegame_file_fmt": "save_trla_%02d.dat",

--- a/data/trx/ship/games/tr3-level/gameflow.json5
+++ b/data/trx/ship/games/tr3-level/gameflow.json5
@@ -3,6 +3,7 @@
 
     "engine": 3,
     "extends": "tr3",
+    "name": "TR3 Direct Level",
 
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_custom_%02d.dat",

--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -3,6 +3,7 @@
     // Lines starting with double slashes are comments and are ignored.
 
     "engine": 3,
+    "name": "Tomb Raider III",
 
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_%02d.dat",

--- a/docs/trx/COMMAND_LINE.md
+++ b/docs/trx/COMMAND_LINE.md
@@ -7,12 +7,21 @@ order: 1
 
 Currently the following command line interface options are available:
 
-- `-g`, `--gold` (legacy: `-gold`)  
-  Runs the Unfinished Business or the Golden Mask expansion pack, depending
-  on the game.
+- `--mod <MOD_ID>`  
+  Runs a specific game or mod directly.
+  Available mods:
+  - `tr1` (Tomb Raider I)
+  - `tr1-ub` (Tomb Raider I: Unfinished Business)
+  - `tr1-demo-pc` (Tomb Raider I: PC Demo)
+  - `tr2` (Tomb Raider II)
+  - `tr2-gm` (Tomb Raider II: The Golden Mask)
+  - `tr3` (Tomb Raider III)
+  - `tr3-la` (Tomb Raider III: The Lost Artifact)
 
-- `--demo-pc` (legacy: `-demo_pc`) (TR1 only)  
-  Runs the PC demo level.
+  TRX remembers the last selected game or expansion when no explicit startup
+  option is given. Because of that, `TRX.exe` starts whichever game or
+  expansion was selected most recently. Use `TRX.exe --mod` to force the
+  matching expansion pack from a shortcut.
 
 - `-l <path|num>`, `--level <path|num>`  
   Runs the game immediately launching it into the specified level. If `<path>`
@@ -45,6 +54,20 @@ Currently the following command line interface options are available:
   Suppresses most of output to the standard output, keeping only errors.
   The log file is written to normally.
 
+> [!TIP]
+> If you want `TRX.exe` to start the main game again after using an expansion
+> shortcut, switch back to the main game in the passport first, or launch it
+> with `--mod`/`--engine` from the shortcut as needed.
+
 > [!NOTE]
 > Gameplay capture is considered an internal testing tool, and may be
 > subject to breaking changes without warnings.
+
+# Legacy command line options
+
+- `-g`, `--gold` (legacy: `-gold`)  
+  Runs the Unfinished Business or the Golden Mask expansion pack, depending
+  on the last launched game. Please use `--mod` option instead.
+
+- `--demo-pc` (legacy: `-demo_pc`) (TR1 only)  
+  Runs the PC demo level. Please use `--mod` option instead.

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1049,8 +1049,15 @@ If you install everything correctly, your game directory should look more or les
 
 ## Playing the game
 
-- To play the selected game, run `TRX.exe`.
-- To launch an expansion pack, use the same command line switches as before, for example `TRX.exe --gold`.
+- To play the last selected game or expansion, run `TRX.exe`.
+- To launch a specific base game from a shortcut, use one of the following commands:
+    - `TRX.exe --mod tr1`
+    - `TRX.exe --mod tr2`
+    - `TRX.exe --mod tr3`
+- To launch a specific expansion pack from a shortcut, use one of the following commands:
+    - `TRX.exe --mod tr1-ub`
+    - `TRX.exe --mod tr2-gm`
+    - `TRX.exe --mod tr3-la`
 
 # macOS
 

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -29,28 +29,50 @@ static void M_FreeArgVector(VECTOR *const args)
 
 static void M_ShowHelp(void)
 {
-    puts("Currently available options:");
+    puts("Available options:");
     puts("");
-    if (Shell_GetModByName("tr1-ub") != nullptr) {
-        puts("-g/--gold: launch The Unfinished Business expansion pack.");
-    }
-    if (Shell_GetModByName("tr1-demo-pc") != nullptr) {
-        puts("   --demo-pc: launch the PC demo level file.");
-    }
-    if (Shell_GetModByName("tr2-gm") != nullptr) {
-        puts("-g/--gold: launch The Golden Mask expansion pack.");
-    }
-    puts("--mod <MOD_ID>: launch a specific mod by id (e.g. tr1, tr1-ub).");
-    puts("-l/--level <PATH>: launch a specific level file.");
+    puts("-h/--help: show this help.");
+    puts("   --mod <MOD_ID>: launch a specific game or mod directly.");
+    puts("-e/--engine <1|2|3>: pick a game engine explicitly.");
+    puts("-l/--level <PATH|NUM>: launch a level file or level number.");
     puts("-s/--save <NUM>: launch from a specific save slot (starts at 1).");
-    puts("--test-record <PATH>: record gameplay events to file.");
-    puts("--test-replay <PATH>: replay gameplay events from file.");
-    puts("--headless: replay gameplay without showing a game window.");
-    puts("--headless-fps: control the frame rate at which to run a gameplay.");
-    puts("-q: silence logs and only show errors.");
+    puts("   --test-record <PATH>: record gameplay events to file.");
     puts(
-        "--debug-render-performance: output diagnostic information after each "
+        "   --test-replay/--test-play <PATH>: replay gameplay events from "
+        "file.");
+    puts("   --headless: replay gameplay without showing a game window.");
+    puts(
+        "   --headless-fps <NUM>: control replay frame rate in headless mode.");
+    puts("-q/--quiet: silence logs and only show errors.");
+    puts(
+        "   --debug-render-performance: output diagnostic information after "
+        "each "
         "frame.");
+    puts("");
+
+    puts("Available mods:");
+    for (int32_t i = 0; i < Shell_GetModCount(); i++) {
+        const SHELL_MOD *const mod = Shell_GetMod(i);
+        if (mod == nullptr || !mod->is_available) {
+            continue;
+        }
+        if (mod->mod_type == MOD_DIRECT_LEVEL) {
+            continue;
+        }
+        if (mod->title != nullptr && strcmp(mod->title, mod->name) != 0) {
+            printf("  %s (%s)\n", mod->name, mod->title);
+        } else {
+            printf("  %s\n", mod->name);
+        }
+    }
+    puts("");
+
+    puts("Legacy options:");
+    puts("-g/--gold/-gold: launch the matching Gold expansion pack.");
+    if (Shell_GetModByName("tr1-demo-pc") != nullptr) {
+        puts("   --demo-pc/-demo_pc: launch the TR1 PC demo.");
+    }
+    puts("These options are deprecated; please use --mod instead.");
 }
 
 static int32_t M_GuessEngineVersionFromLevelPath(const char *const path)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This tightens the documentation on `--gold` usage by encouraging using `--mod` instead.
Related: #5327, #5332