### PR TITLE
output: use main texture filter for pickup overlay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed max stats not refreshing after changing unobtainable pickups, kills, or secrets in the gameflow
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 - fixed incorrect transparent and yellow pixels on TR2 and TR3 outfit heads when bilinear filtering is enabled (#5300)
+- fixed rotating 3D pickup notifications following the UI filter setting instead of the in-game texture filter
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)
 - fixed Lara not transitioning immediately to run after vaulting two clicks when forward is held (#5305, regression from 1.3)
 - fixed settings list auto-scroll sometimes stopping after switching to a different mod (regression from 1.4)

--- a/src/trx/game/output/scene_compositor.c
+++ b/src/trx/game/output/scene_compositor.c
@@ -252,3 +252,9 @@ void SceneCompositor_AddSource(const SCENE_SOURCE *const source)
     M_PRIV *const p = &m_Priv;
     Vector_Add(p->sources, &source);
 }
+
+void SceneCompositor_SetSamplerFilter(const TEXTURE_FILTER filter)
+{
+    M_PRIV *const p = &m_Priv;
+    M_SetSamplerFilter(p->sampler_id, filter);
+}

--- a/src/trx/game/output/scene_compositor.h
+++ b/src/trx/game/output/scene_compositor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trx/game/output/scene_source.h>
+#include <trx/gl/enum.h>
 
 void SceneCompositor_Init(void);
 void SceneCompositor_Shutdown(void);
@@ -9,3 +10,4 @@ void SceneCompositor_BeginScene(void);
 void SceneCompositor_EndScene(void);
 void SceneCompositor_Flush(void);
 void SceneCompositor_AnimateTextures(void);
+void SceneCompositor_SetSamplerFilter(TEXTURE_FILTER filter);

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -130,6 +130,7 @@ static XYZ_32 M_VectorViewFromWorld(
 
 static void M_Draw3DPickups(const M_PRIV *const p)
 {
+    SceneCompositor_SetSamplerFilter(g_Config.rendering.texture_filter);
     Output_MeshShader_Bind(Output_GetMeshShader());
 
     for (int32_t i = 0; i < p->scheduled_pickups->count; i++) {
@@ -244,6 +245,8 @@ static void M_Draw3DPickups(const M_PRIV *const p)
             p->objects_source->render_end(p->objects_source);
         }
     }
+
+    SceneCompositor_SetSamplerFilter(g_Config.rendering.ui_filter);
 }
 
 static void M_DrawVertices(const M_PRIV *const p)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the pickup notifications using the UI texture filter instead of ingame texture filter.