### PR TITLE
game-strings: fix Empty Slot capitalization in TR3

### DIFF
--- a/data/trx/ship/games/tr3/strings-de.json5
+++ b/data/trx/ship/games/tr3/strings-de.json5
@@ -15,6 +15,9 @@
             "item_count_fmt": "\\{color 3}%s",
             "object_name_fmt": "\\{color 5}%s",
         },
+        "misc": {
+            "empty_slot_fmt": "- Leerer Slot -",
+        },
         "overlay": {
             "item_count_fmt_pc": "%s",
             "item_count_fmt_ps1": "\\{color 3}%s",

--- a/data/trx/ship/games/tr3/strings-it.json5
+++ b/data/trx/ship/games/tr3/strings-it.json5
@@ -15,6 +15,9 @@
             "item_count_fmt": "\\{color 3}%s",
             "object_name_fmt": "\\{color 5}%s",
         },
+        "misc": {
+            "empty_slot_fmt": "- Slot Vuoto -",
+        },
         "overlay": {
             "item_count_fmt_pc": "%s",
             "item_count_fmt_ps1": "\\{color 3}%s",

--- a/data/trx/ship/games/tr3/strings-pl.json5
+++ b/data/trx/ship/games/tr3/strings-pl.json5
@@ -15,6 +15,9 @@
             "item_count_fmt": "\\{color 3}%s",
             "object_name_fmt": "\\{color 5}%s",
         },
+        "misc": {
+            "empty_slot_fmt": "- Pusty Slot -",
+        },
         "overlay": {
             "item_count_fmt_pc": "%s",
             "item_count_fmt_ps1": "\\{color 3}%s",

--- a/data/trx/ship/games/tr3/strings.json5
+++ b/data/trx/ship/games/tr3/strings.json5
@@ -15,6 +15,9 @@
             "item_count_fmt": "\\{color 3}%s",
             "object_name_fmt": "\\{color 5}%s",
         },
+        "misc": {
+            "empty_slot_fmt": "- Empty Slot -",
+        },
         "overlay": {
             "item_count_fmt_pc": "%s",
             "item_count_fmt_ps1": "\\{color 3}%s",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed Willard's Lair having wrong kill count
 - fixed Reunion having wrong pickup and secret count
 - fixed being able to re-use switches that are intended to only be used once (#5328, regression from 1.1)
+- fixed capitalization of the "Empty Slot" text in passport
 
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the "Empty Slot" text to be shown in Title Case in TR3 instead of ALL CAPS to match the OG.