### PR TITLE
output/lights: fix TR1 lighting room updates

### DIFF
--- a/src/trx/game/output/lights.c
+++ b/src/trx/game/output/lights.c
@@ -672,8 +672,8 @@ void Output_CalculateObjectLightingAt(
     const ITEM *const item, const GAME_VECTOR sample_pos)
 {
     int16_t room_num = sample_pos.room_num;
-    Room_GetSector(sample_pos.pos, &room_num);
     if (g_TRVersion >= 3) {
+        Room_GetSector(sample_pos.pos, &room_num);
         M_TR3_CalculateLightSmoothed(item, sample_pos.pos, Room_Get(room_num));
     } else {
         Output_CalculateLight(sample_pos.pos, room_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the lighting issue present in develop since 2f24b7ca8ffe4a2f2620606894865e45702d2780 which manifests at the start of Vilcabamba:

```
args "--mod" "tr1"
config gameplay.enable_fmv 0
config gameplay.enable_legal 0

@+0:    cmd { set turbo -2 }
@+0:    cmd { play 2 }
@+30:   cmd { play 2 }
@+30:   cmd { exit }
```
