### PR TITLE
items: remove body bag linked list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed Willard increasing the kill count each time he collapses (OG bug)
 - fixed Wasp Emitters generating too many spawns if activated from non one-shot triggers and the player stands for too long on the trigger
 - fixed Lara being unable to pull up on specific ledges near walls that have invalid triangles within them (regression from 1.1)
+- fixed potential crashes when using grenades on enemies in levels that use the body bag feature (#5378, regression from 1.1)
 
 
 

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1276,11 +1276,6 @@ void Creature_Die(const int16_t item_num, const bool explode)
     }
     item->flags |= IF_ONE_SHOT;
 
-    if (item->clear_body) {
-        item->next_active = Item_GetPrevActive();
-        Item_SetPrevActive(item_num);
-    }
-
     Carrier_TestItemDrops(item_num);
 }
 

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -20,7 +20,6 @@ static int32_t m_LevelItemCount = 0;
 static int16_t m_MaxUsedItemCount = 0;
 static ITEM *m_Items = nullptr;
 static int16_t m_NextItemActive = NO_ITEM;
-static int16_t m_PrevItemActive = NO_ITEM;
 static int16_t m_NextItemFree = NO_ITEM;
 
 static inline bool M_ItemBoundsIntersectsPortal(
@@ -63,7 +62,6 @@ void Item_InitialiseItems(const int32_t num_items)
     m_MaxUsedItemCount = num_items;
     m_NextItemFree = num_items;
     m_NextItemActive = NO_ITEM;
-    m_PrevItemActive = NO_ITEM;
 
     for (int32_t i = m_NextItemFree; i < MAX_ITEMS - 1; i++) {
         ITEM *const item = &m_Items[i];
@@ -147,16 +145,6 @@ int32_t Item_GetTotalCount(void)
 int16_t Item_GetNextActive(void)
 {
     return m_NextItemActive;
-}
-
-int16_t Item_GetPrevActive(void)
-{
-    return m_PrevItemActive;
-}
-
-void Item_SetPrevActive(const int16_t item_num)
-{
-    m_PrevItemActive = item_num;
 }
 
 int16_t Item_Create(void)
@@ -406,14 +394,14 @@ void Item_ClearKilled(void)
 {
     // Remove corpses and other killed items. Part of OG performance
     // improvements, generously used in Opera House and Barkhang Monastery
-    int16_t link_num = Item_GetPrevActive();
-    while (link_num != NO_ITEM) {
-        ITEM *const item = Item_Get(link_num);
-        Item_Kill(link_num);
-        link_num = item->next_active;
-        item->next_active = NO_ITEM;
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (obj->intelligent && item->clear_body && item->hit_points <= 0
+            && (item->flags & IF_KILLED) == 0) {
+            Item_Kill(i);
+        }
     }
-    Item_SetPrevActive(NO_ITEM);
 }
 
 void Item_AddActive(const int16_t item_num)

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -12,8 +12,6 @@ int32_t Item_GetLevelCount(void);
 int32_t Item_GetTotalCount(void);
 
 int16_t Item_GetNextActive(void);
-int16_t Item_GetPrevActive(void);
-void Item_SetPrevActive(int16_t item_num);
 
 int16_t Item_Create(void);
 int16_t Item_CreateLevelItem(void);

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -418,11 +418,6 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t item_num)
         } else if (obj->intelligent) {
             item->creature_data = nullptr;
             item->extra_rotations = nullptr;
-            if (item->clear_body && item->hit_points <= 0
-                && (item->flags & IF_KILLED) == 0) {
-                item->next_active = Item_GetPrevActive();
-                Item_SetPrevActive(item_num);
-            }
         }
     }
 skip_flags:


### PR DESCRIPTION
Resolves #5378.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes complications with the body bag linked list potentially overlapping the active item linked list, especially with grenades and rockets reusing items.

I'll follow this up with a separate PR to harden creature activation, as the crash was occurring by re-activating an enemy who had been killed near the start of the level. And I'll add another change to make body bags optional later.