### PR TITLE
misc: harden creature activation

### DIFF
--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -281,7 +281,7 @@ bool Creature_Activate(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     if (item->status != IS_INVISIBLE) {
-        return true;
+        return item->creature_data != nullptr;
     }
 
     if (!LOT_EnableBaddieAI(item_num, false)) {

--- a/src/trx/game/objects/creatures/ape.c
+++ b/src/trx/game/objects/creatures/ape.c
@@ -100,15 +100,11 @@ static bool M_Vault(int16_t item_num, int16_t angle)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const ape = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/baldy.c
+++ b/src/trx/game/objects/creatures/baldy.c
@@ -49,15 +49,11 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const baldy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/bat.c
+++ b/src/trx/game/objects/creatures/bat.c
@@ -55,15 +55,11 @@ static void M_FixEmbeddedPosition(int16_t item_num)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const bat = item->creature_data;
     int16_t angle = 0;
     if (item->hit_points <= 0) {

--- a/src/trx/game/objects/creatures/centaur.c
+++ b/src/trx/game/objects/creatures/centaur.c
@@ -33,15 +33,11 @@ static BITE m_CentaurRear = { .pos = { 50, 30, 0 }, .mesh_num = 5 };
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const centaur = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/centaur_statue.c
+++ b/src/trx/game/objects/creatures/centaur_statue.c
@@ -69,7 +69,7 @@ static void M_Control(const int16_t item_num)
             ITEM *const centaur = Item_Get(p->centaur_item_num);
             centaur->touch_bits = 0;
             Item_AddActive(p->centaur_item_num);
-            LOT_EnableBaddieAI(p->centaur_item_num, 1);
+            LOT_EnableBaddieAI(p->centaur_item_num, true);
             centaur->status = IS_ACTIVE;
             Sound_Effect(SFX_EXPLOSION_1, &centaur->pos, SPM_NORMAL);
         } else {

--- a/src/trx/game/objects/creatures/cowboy.c
+++ b/src/trx/game/objects/creatures/cowboy.c
@@ -47,15 +47,11 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const cowboy = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/larson.c
+++ b/src/trx/game/objects/creatures/larson.c
@@ -45,15 +45,11 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const person = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/lion.c
+++ b/src/trx/game/objects/creatures/lion.c
@@ -41,15 +41,11 @@ static BITE m_LionBite = { .pos = { -2, -10, 132 }, .mesh_num = 21 };
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const lion = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/mutant.c
+++ b/src/trx/game/objects/creatures/mutant.c
@@ -63,15 +63,11 @@ static void M_Initialise2(const int16_t item_num)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const flyer = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/natla.c
+++ b/src/trx/game/objects/creatures/natla.c
@@ -61,15 +61,11 @@ static bool M_IsTargetable(const ITEM *const item)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const natla = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -88,11 +88,8 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
     CREATURE *const pierre = item->creature_data;

--- a/src/trx/game/objects/creatures/pod.c
+++ b/src/trx/game/objects/creatures/pod.c
@@ -92,7 +92,7 @@ static void M_Control(const int16_t item_num)
                 if (Object_Get(bug->object_id)->loaded) {
                     bug->touch_bits = 0;
                     Item_AddActive(p->bug_item_num);
-                    if (LOT_EnableBaddieAI(p->bug_item_num, 0)) {
+                    if (LOT_EnableBaddieAI(p->bug_item_num, false)) {
                         bug->status = IS_ACTIVE;
                     } else {
                         bug->status = IS_INVISIBLE;

--- a/src/trx/game/objects/creatures/rat.c
+++ b/src/trx/game/objects/creatures/rat.c
@@ -61,15 +61,11 @@ static void M_HandleSave(ITEM *const item, const SAVEGAME_STAGE stage)
 
 static void M_ControlRat(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const rat = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;
@@ -149,15 +145,11 @@ static void M_ControlRat(const int16_t item_num)
 
 static void M_ControlVole(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     int16_t head = 0;
     int16_t angle = 0;
 

--- a/src/trx/game/objects/creatures/skate_kid.c
+++ b/src/trx/game/objects/creatures/skate_kid.c
@@ -76,16 +76,12 @@ static void M_Initialise(const int16_t item_num)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-    M_PRIV *const p = item->priv;
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
     CREATURE *const kid = item->creature_data;
     int16_t head = 0;
     int16_t angle = 0;

--- a/src/trx/game/objects/creatures/torso.c
+++ b/src/trx/game/objects/creatures/torso.c
@@ -64,15 +64,11 @@ static void M_KillLara(ITEM *const item)
 
 static void M_Control(const int16_t item_num)
 {
-    ITEM *const item = Item_Get(item_num);
-
-    if (item->status == IS_INVISIBLE) {
-        if (!LOT_EnableBaddieAI(item_num, 0)) {
-            return;
-        }
-        item->status = IS_ACTIVE;
+    if (!Creature_Activate(item_num)) {
+        return;
     }
 
+    ITEM *const item = Item_Get(item_num);
     CREATURE *const torso = item->creature_data;
     int16_t head = 0;
     ITEM *const lara_item = Lara_GetItem();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that a creature is interpreted as being active as long as its creature data is set. It avoids issues whereby re-activating a dead enemy would allow its control routine to run, which assumes `item->creature_data` is not null.

Tests:
- General checks around killing enemies, save/load and ensuring they remain visible
- Dead water creatures should continue to animate on the water surface (they always retain a baddie slot ultimately, so control will always run)
