### PR TITLE
savegame: fix reading item flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fixed Wasp Emitters generating too many spawns if activated from non one-shot triggers and the player stands for too long on the trigger
 - fixed Lara being unable to pull up on specific ledges near walls that have invalid triangles within them (regression from 1.1)
 - fixed potential crashes when using grenades on enemies in levels that use the body bag feature (#5378, regression from 1.1)
+- fixed activated one-shot antitriggers not being remembered when loading a save (regression from 1.2)
 
 
 

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -195,9 +195,6 @@ static void M_LoadPostprocess(void)
             item->floor = Room_GetHeight(sector, item->pos);
         }
 
-        if (obj->save_flags != 0) {
-            item->flags &= 0xFF00;
-        }
         // TODO: make this engine-agnostic
         if (g_TRVersion == 1 && obj->handle_save_func != nullptr) {
             obj->handle_save_func(item, SAVEGAME_STAGE_AFTER_LOAD);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that TR3's special one shot flags are retained on items when loading a save. I'm wondering if we can remove the masking on load but I'm not sure of the consequences, so this is probably safest for now.