### PR TITLE
tr3/data: update pickup counts

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -166,6 +166,7 @@
                 "coastal_animating_bounds.bin",
                 "lara_guns.bin",
             ],
+            "unobtainable_pickups": 1,
         },
 
         // 6. Crash Site
@@ -456,6 +457,7 @@
                 "tinnos_cameras.bin",
                 "tinnos_flames.bin",
             ],
+            "unobtainable_pickups": 1,
         },
 
         // 19. Meteorite Cavern

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fixed the satellite dish in High Security Compound room 44 being clipped out of view too soon (missing animation bounds) (#5297, regression from 1.1)
 - fixed It's a Madhouse! street lamps being too bright
 - fixed TR3:LA playing TR3 intro FMV
+- fixed Coastal Village and Lost City of Tinnos having the wrong pickup count
 - fixed Willard's Lair having wrong kill count
 - fixed Reunion having wrong pickup and secret count
 - fixed being able to re-use switches that are intended to only be used once (#5328, regression from 1.1)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This marks two unobtainable pickups in Coastal Village and Tinnos.
