### PR TITLE
objects/centaur_statue: fix initialisation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed boulders stopping too soon on some slopes with low ceilings (#5337, regression from 1.2)
 - fixed persistent damage restoring Lara to full health after inter-level cutscenes (#5364, regression from 1.2)
 - fixed missing default object names for `O_ANIMATING_7`...`O_ANIMATING_10` and `O_FLICKERING_LIGHT` (regression from 1.4)
+- fixed empty centaur statues incorrectly referencing other level items when the centaur object is not loaded
 
 **TR2**
 - added an option to disable body bag triggers, so that killed enemies will always be visible

--- a/src/trx/game/objects/creatures/centaur_statue.c
+++ b/src/trx/game/objects/creatures/centaur_statue.c
@@ -15,14 +15,14 @@ typedef struct {
 
 static void M_Initialise(const int16_t item_num)
 {
-    OBJECT *const obj = Object_Get(O_CENTAUR);
-    if (!obj->loaded) {
-        return;
-    }
-
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    p->centaur_item_num = NO_ITEM;
+
+    OBJECT *const obj = Object_Get(O_CENTAUR);
+    if (!obj->loaded) {
+        p->centaur_item_num = NO_ITEM;
+        return;
+    }
 
     const int16_t centaur_item_num = Item_CreateLevelItem();
     ASSERT(centaur_item_num != NO_ITEM);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes centaur statues defaulting to having item index 0 as their inner centaur when the centaur object itself isn't loaded. Test level available.
