### PR TITLE
items/actions: play flood/drain SFX always

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added an option to fix inaccurate wall geometry in original levels (Gameplay Options → Fixes → Fix wall geometry)
 - added an option to control how land creatures behave in water (Gameplay Options → General → Creature drown policy) (#5387)
 - changed the PS1 crystal tint option to take effect without having to reload the level
+- changed the `ITEM_ACTION_FLOOD` sound effect to play when underwater rather than only when above water
 - improved weapon setup so picking up a weapon can now give a different amount of ammo than picking up its matching ammo item (#5352)
 - improved `--level PATH` so it accepts relative paths and reports clearer startup errors when the level cannot be launched
 - improved savegame loading if item counts have changed between making the save and loading it
@@ -26,6 +27,7 @@
 
 **TR1**:
 - added savegame crystals to Unfinished Business (#1525)
+- fixed not being able to hear the flood/drain sound effect when using the lever in Tomb of Tihocan room 23
 
 **TR2**:
 - added savegame crystals to base levels and The Golden Mask

--- a/src/trx/game/items/actions/effects.c
+++ b/src/trx/game/items/actions/effects.c
@@ -49,7 +49,7 @@ static void M_Flood(ITEM *const item)
         pos.y += 100 * (LOGIC_FPS - flip_timer);
     }
 
-    Sound_Effect(SFX_FLOOD, &pos, SPM_NORMAL);
+    Sound_Effect(SFX_FLOOD, &pos, SPM_ALWAYS);
     Room_IncrementFlipTimer(1);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes the flood/drain flip effect to always play the SFX, regardless of whether or not the camera is underwater.