### PR TITLE
savegame: clear key item counts before load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - fixed potential crashes when using grenades on enemies in levels that use the body bag feature (#5378, regression from 1.1)
 - fixed activated one-shot antitriggers not being remembered when loading a save (regression from 1.2)
 - fixed the Ora Dagger appearing too low in the inventory in Meteorite Cavern (regression from 1.2)
+- fixed quest item pickup counts incrementing if the item cheat is used and then save/load is repeatedly used (regression from 1.2)
 
 
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -835,7 +835,9 @@ bool SG_File_LoadInventory(JSON_READ_IO *const io)
     for (int32_t i = 0; objects[i].key != nullptr; i++) {
         int16_t qty;
         if (JSON_READ(io, objects[i].key, &qty)) {
-            Inv_RemoveItem(objects[i].object_id);
+            while (Inv_RequestItem(objects[i].object_id) != 0) {
+                Inv_RemoveItem(objects[i].object_id);
+            }
             Inv_AddItemNTimes(objects[i].object_id, qty);
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures key item, puzzle and quest counts are reset before applying the value from the savegame during load. As quest items are carried between levels, `Lara_InitialiseInventory` handles the additions for regular context, so during SG loading, the values get incremented too often.
