### PR TITLE
camera/los_camera: use mesh fallback on level load

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed persistent damage restoring Lara to full health after inter-level cutscenes (#5364, regression from 1.2)
 - fixed missing default object names for `O_ANIMATING_7`...`O_ANIMATING_10` and `O_FLICKERING_LIGHT` (regression from 1.4)
 - fixed empty centaur statues incorrectly referencing other level items when the centaur object is not loaded
+- fixed TR3 camera mode potentially behaving erratically when loading a level and the look input is held (regression from 1.1)
 
 **TR1**:
 - added savegame crystals to Unfinished Business (#1525)

--- a/src/trx/game/camera/los_camera.c
+++ b/src/trx/game/camera/los_camera.c
@@ -577,7 +577,11 @@ static XYZ_32 M_GetHeadPos(const int32_t x, const int32_t y, const int32_t z)
         .y = y,
         .z = z,
     };
-    Lara_GetMeshPos(LM_HEAD, &pos);
+    if (!Lara_GetMeshPos(LM_HEAD, &pos)) {
+        // If look is held while loading a level, Lara won't have been drawn yet
+        // so ensure a valid fallback position is used.
+        Collide_GetJointAbsPosition(Lara_GetItem(), &pos, LM_HEAD);
+    }
     return pos;
 }
 

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -209,6 +209,9 @@ void Item_Initialise(const int16_t item_num)
     item->priv = nullptr;
     item->carried_item = nullptr;
 
+    item->interp.result.pos = item->pos;
+    item->interp.result.rot = item->rot;
+
     item->active = false;
     item->status = IS_INACTIVE;
     item->gravity = false;

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -138,6 +138,7 @@ void Lara_Initialise(const GF_LEVEL *const level)
     lara_info->poison_timer = 0;
     lara_info->tr3_smoke_count_l = 0;
     lara_info->tr3_smoke_count_r = 0;
+    lara_info->mesh_pos_matrices_valid = false;
 
     LOT_InitialiseLOT(&lara_info->lot);
     lara_info->lot.setup.step = WALL_L * 20;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that if look is held while loading a level and the TR3 camera is in use, that a valid mesh position for Lara's head is guaranteed rather than using the last drawn position. Initialising `item->interp.result` is required so that `Collide_GetJointAbsPosition` can run effectively, otherwise it uses an empty position on the first frame.
