### PR TITLE
lara/col/crouch: fix crawling underwater

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - improved savegame loading if item counts have changed between making the save and loading it
 - fixed max stats not refreshing after changing unobtainable pickups, kills, or secrets in the gameflow
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
+- fixed Lara being able to crawl and crouch-roll too far into water from land
 - fixed incorrect transparent and yellow pixels on TR2 and TR3 outfit heads when bilinear filtering is enabled (#5300)
 - fixed rotating 3D pickup notifications following the UI filter setting instead of the in-game texture filter
 - fixed climbing issues on ladders that are against walls that (incorrectly) contain tilt data within them (#5304, regression from 1.1)

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -66,6 +66,17 @@ static bool M_HasStaticBehind(const ITEM *const item, const int16_t angle)
         &test, x, item->pos.y, z, item->room_num, 300);
 }
 
+static bool M_IsBadDestination(const ITEM *const item, const int16_t angle)
+{
+    XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, angle, STEP_L);
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    pos.y = Room_GetHeight(sector, pos) - STEP_L;
+    Room_GetSector(pos, &room_num);
+    const ROOM *const room = Room_Get(room_num);
+    return room->flags.swamp || room->flags.underwater;
+}
+
 static void M_Crouch(ITEM *const item, COLL_INFO *const coll)
 {
     item->gravity = false;
@@ -139,7 +150,8 @@ static void M_CrouchRoll(ITEM *const item, COLL_INFO *const coll)
             coll->side_mid.ceiling >= M_CROUCH_CEILING_THRESHOLD;
 
         if (coll->side_mid.floor < coll->bad_neg
-            || coll->side_front.floor > coll->bad_pos) {
+            || coll->side_front.floor > coll->bad_pos
+            || M_IsBadDestination(item, lara->move_angle)) {
             item->pos = coll->old;
             return;
         }
@@ -336,7 +348,8 @@ static void M_CrawlForward(ITEM *const item, COLL_INFO *const coll)
         -LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 
-    if (M_DeflectEdgeCrawl(item, coll)) {
+    if (M_DeflectEdgeCrawl(item, coll)
+        || M_IsBadDestination(item, lara->move_angle)) {
         item->current_anim_state = LS(LS_CRAWL_IDLE);
         item->goal_anim_state = LS(LS_CRAWL_IDLE);
         if (!Item_TestAnimEqual(item, LA(LA_CRAWL_IDLE))) {
@@ -380,7 +393,8 @@ static void M_CrawlBack(ITEM *const item, COLL_INFO *const coll)
         -LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 
-    if (M_DeflectEdgeCrawl(item, coll)) {
+    if (M_DeflectEdgeCrawl(item, coll)
+        || M_IsBadDestination(item, lara->move_angle)) {
         item->current_anim_state = LS(LS_CRAWL_IDLE);
         item->goal_anim_state = LS(LS_CRAWL_IDLE);
         if (!Item_TestAnimEqual(item, LA(LA_CRAWL_IDLE))) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara from crawling and crouch-rolling too far into water or swamp rooms. Let me know if we think this should be more or less tolerant in terms of how far she can go into the water. Also not sure about making it optional, given it can cause issues with Lara not being able to use her hands if she ventures too far.