### PR TITLE
misc: fix slope vaulting and interaction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,11 +32,13 @@
 - added savegame crystals to Unfinished Business (#1525)
 - fixed not being able to hear the flood/drain sound effect when using the lever in Tomb of Tihocan room 23
 - fixed Lara not stopping against one-click raised slopes (#5400, regression from 1.4)
+- fixed Lara attempting to vault onto steep slopes when running into them with action held (#5400, regression from 1.4)
 
 **TR2**:
 - added savegame crystals to base levels and The Golden Mask
 - added an option to disable body bag triggers, so that killed enemies will always be visible
 - fixed Lara not stopping against one-click raised slopes (#5400, regression from 1.4)
+- fixed Lara attempting to vault onto steep slopes when running into them with action held (#5400, regression from 1.4)
 
 **TR3**:
 - added Boat (RIB) control
@@ -77,6 +79,7 @@
 - fixed the second boulder at the beginning of Reunion stopping too early (regression from 1.2)
 - fixed Willard increasing the kill count each time he collapses (OG bug)
 - fixed Wasp Emitters generating too many spawns if activated from non one-shot triggers and the player stands for too long on the trigger
+- fixed Lara attempting to vault onto steep slopes when running into them with action held (#5400)
 - fixed Lara being unable to pull up on specific ledges near walls that have invalid triangles within them (regression from 1.1)
 - fixed potential crashes when using grenades on enemies in levels that use the body bag feature (#5378, regression from 1.1)
 - fixed activated one-shot antitriggers not being remembered when loading a save (regression from 1.2)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,10 +31,12 @@
 **TR1**:
 - added savegame crystals to Unfinished Business (#1525)
 - fixed not being able to hear the flood/drain sound effect when using the lever in Tomb of Tihocan room 23
+- fixed Lara not stopping against one-click raised slopes (#5400, regression from 1.4)
 
 **TR2**:
 - added savegame crystals to base levels and The Golden Mask
 - added an option to disable body bag triggers, so that killed enemies will always be visible
+- fixed Lara not stopping against one-click raised slopes (#5400, regression from 1.4)
 
 **TR3**:
 - added Boat (RIB) control

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -63,8 +63,8 @@ static void M_FillSide(
 
     const bool is_on_walkable = M_IsOnWalkable(sector, sample_pos, room_height);
 
-    const bool is_front = side == &coll->side_front;
-    if (is_front) {
+    const bool retest_front = side == &coll->side_front && g_TRVersion >= 3;
+    if (retest_front) {
         XYZ_32 front_probe_pos = sample_pos;
         front_probe_pos.x += probe.x;
         front_probe_pos.z += probe.z;
@@ -79,14 +79,14 @@ static void M_FillSide(
         if (coll->slopes_are_walls
             && (side->type == HT_BIG_SLOPE || side->type == HT_DIAGONAL)
             && side->floor < 0
-            && (!is_front
+            && (!retest_front
                 || (side->floor < coll->side_mid.floor
                     && height < side->floor))) {
             side->floor = -32767;
         } else if (
             coll->slopes_are_pits
             && (side->type == HT_BIG_SLOPE || side->type == HT_DIAGONAL)
-            && side->floor > (is_front ? coll->side_mid.floor : 0)) {
+            && side->floor > (retest_front ? coll->side_mid.floor : 0)) {
             side->floor = STEP_L * 2;
         } else if (
             coll->lava_is_pit && side->floor > 0

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -933,6 +933,15 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     const int32_t mid = STEP_L / 2;
     const ROOM *const room = Room_Get(item->room_num);
 
+    // Prevent Lara vaulting onto a slope when action is held while running
+    // into it. This is consistent with not vaulting when at a stop.
+    if (item->speed != 0) {
+        Lara_FloorFront(item, angle, STEP_L);
+        if (Room_GetHeightType() == HT_BIG_SLOPE) {
+            return false;
+        }
+    }
+
     if (front_floor >= -STEP_L * 2 - mid && front_floor <= -STEP_L * 2 + mid) {
         if (slope || front_floor - front_ceiling < 0
             || left_floor - left_ceiling < 0 || right_floor - right_ceiling < 0


### PR DESCRIPTION
Resolves #5400.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara running forward onto a one-click slope in TR1 and TR2 - a TRX bug inherited from 4c8ec10. An OG place to check is Lost Valley `57 1 3`, turn left and run forward.
It also fixes Lara attempting to vault onto a slope if she runs into it while holding action, such that it is line with her not attempting to vault when at a standstill against the same wall. This is an OG bug in TR3, which TR1 and 2 inherited in 1.4.
Regarding the missing splat animation when Lara hits certain walls in TR1, that was considered an OG bug so the fix will remain as-is (no changes in this PR essentially).