### PR TITLE
camera/box_camera: guard no height in shift

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - improved `--level PATH` so it accepts relative paths and reports clearer startup errors when the level cannot be launched
 - improved savegame loading if item counts have changed between making the save and loading it
 - fixed max stats not refreshing after changing unobtainable pickups, kills, or secrets in the gameflow
+- fixed TR1 and TR2 camera modes potentially going out of bounds in some rare scenarios
 - fixed Lara rapidly switching animations when shimmying across the top of a ladder (#5295)
 - fixed Lara being able to crawl and crouch-roll too far into water from land
 - fixed incorrect transparent and yellow pixels on TR2 and TR3 outfit heads when bilinear filtering is enabled (#5300)

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -518,26 +518,33 @@ static void M_Move(const GAME_VECTOR *const target, const int32_t speed)
         }
     }
 
-    height -= STEP_L;
+    if (height != NO_HEIGHT) {
+        height -= STEP_L;
+    }
     if (pos.y >= height && target->y >= height) {
         LOS_Check(&g_Camera.target, &pos, false);
         sector = Room_GetSector(pos.pos, &pos.room_num);
-        height = Room_GetHeight(sector, pos.pos) - STEP_L;
+        height = Room_GetHeight(sector, pos.pos);
+        if (height != NO_HEIGHT) {
+            height -= STEP_L;
+        }
     }
 
-    g_Camera.pos = pos;
-
-    int32_t ceiling = Room_GetCeiling(sector, pos.pos) + STEP_L;
-    if (height < ceiling) {
+    int32_t ceiling = Room_GetCeiling(sector, pos.pos);
+    if (ceiling != NO_HEIGHT) {
+        ceiling += STEP_L;
+    }
+    if (height != NO_HEIGHT && ceiling != NO_HEIGHT && height < ceiling) {
         ceiling = (height + ceiling) >> 1;
         height = ceiling;
     }
 
+    g_Camera.pos = pos;
     Camera_ApplyBounce();
 
-    if (g_Camera.pos.y > height) {
+    if (height != NO_HEIGHT && g_Camera.pos.y > height) {
         g_Camera.shift = height - g_Camera.pos.y;
-    } else if (g_Camera.pos.y < ceiling) {
+    } else if (ceiling != NO_HEIGHT && g_Camera.pos.y < ceiling) {
         g_Camera.shift = ceiling - g_Camera.pos.y;
     } else {
         g_Camera.shift = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This guards `g_Camera.shift` against using `NO_HEIGHT` in some rare cases. This is used only in the TR1/2 camera; TR3's camera bakes the shift into the Y pos as standard, and has its own strict checks in place already. Although we've only noticed it in the Venice demo since 1.2 (81e5d1e), this is ultimately an OG bug, I just think it's quite rare.