### PR TITLE
collision: use XYZ_32 in signatures

### DIFF
--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -417,17 +417,17 @@ void Collide_GetCollisionInfo(
     }
 
     if (coll->side_mid.floor == NO_HEIGHT) {
-        coll->shift.x = coll->old.x - pos.x;
-        coll->shift.y = coll->old.y - pos.y;
-        coll->shift.z = coll->old.z - pos.z;
+        coll->shift.x = coll->old_pos.x - pos.x;
+        coll->shift.y = coll->old_pos.y - pos.y;
+        coll->shift.z = coll->old_pos.z - pos.z;
         coll->coll_type = COLL_FRONT;
         return;
     }
 
     if (coll->side_mid.floor - coll->side_mid.ceiling <= 0) {
-        coll->shift.x = coll->old.x - pos.x;
-        coll->shift.y = coll->old.y - pos.y;
-        coll->shift.z = coll->old.z - pos.z;
+        coll->shift.x = coll->old_pos.x - pos.x;
+        coll->shift.y = coll->old_pos.y - pos.y;
+        coll->shift.z = coll->old_pos.z - pos.z;
         coll->coll_type = COLL_CLAMP;
         return;
     }
@@ -442,13 +442,13 @@ void Collide_GetCollisionInfo(
         || coll->side_front.ceiling > coll->bad_ceiling) {
         if (coll->side_front.type == HT_DIAGONAL
             || coll->side_front.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - pos.x;
-            coll->shift.z = coll->old.z - pos.z;
+            coll->shift.x = coll->old_pos.x - pos.x;
+            coll->shift.z = coll->old_pos.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
             case DIR_SOUTH:
-                coll->shift.x = coll->old.x - pos.x;
+                coll->shift.x = coll->old_pos.x - pos.x;
                 coll->shift.z =
                     Room_FindGridShift(pos.z + probe_front.z, pos.z);
                 break;
@@ -457,7 +457,7 @@ void Collide_GetCollisionInfo(
             case DIR_WEST:
                 coll->shift.x =
                     Room_FindGridShift(pos.x + probe_front.x, pos.x);
-                coll->shift.z = coll->old.z - pos.z;
+                coll->shift.z = coll->old_pos.z - pos.z;
                 break;
 
             default:
@@ -470,9 +470,9 @@ void Collide_GetCollisionInfo(
     }
 
     if (coll->side_front.ceiling >= coll->bad_ceiling) {
-        coll->shift.x = coll->old.x - pos.x;
-        coll->shift.y = coll->old.y - pos.y;
-        coll->shift.z = coll->old.z - pos.z;
+        coll->shift.x = coll->old_pos.x - pos.x;
+        coll->shift.y = coll->old_pos.y - pos.y;
+        coll->shift.z = coll->old_pos.z - pos.z;
         coll->coll_type = COLL_TOP_FRONT;
         return;
     }
@@ -480,8 +480,8 @@ void Collide_GetCollisionInfo(
     if (coll->side_left.floor > coll->bad_pos
         || coll->side_left.floor < coll->bad_neg) {
         if (coll->side_left.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - pos.x;
-            coll->shift.z = coll->old.z - pos.z;
+            coll->shift.x = coll->old_pos.x - pos.x;
+            coll->shift.z = coll->old_pos.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
@@ -508,8 +508,8 @@ void Collide_GetCollisionInfo(
     if (coll->side_right.floor > coll->bad_pos
         || coll->side_right.floor < coll->bad_neg) {
         if (coll->side_right.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - pos.x;
-            coll->shift.z = coll->old.z - pos.z;
+            coll->shift.x = coll->old_pos.x - pos.x;
+            coll->shift.z = coll->old_pos.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
@@ -629,7 +629,7 @@ bool Collide_CollideStaticObjects(
             case DIR_NORTH:
                 if (shifter.x > coll->radius || shifter.x < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
-                    coll->shift.x = coll->old.x - pos.x;
+                    coll->shift.x = coll->old_pos.x - pos.x;
                     coll->shift.z = shifter.z;
                 } else if (shifter.x > 0) {
                     coll->coll_type = COLL_LEFT;
@@ -646,7 +646,7 @@ bool Collide_CollideStaticObjects(
                 if (shifter.z > coll->radius || shifter.z < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
                     coll->shift.x = shifter.x;
-                    coll->shift.z = coll->old.z - pos.z;
+                    coll->shift.z = coll->old_pos.z - pos.z;
                 } else if (shifter.z > 0) {
                     coll->coll_type = COLL_RIGHT;
                     coll->shift.x = 0;
@@ -661,7 +661,7 @@ bool Collide_CollideStaticObjects(
             case DIR_SOUTH:
                 if (shifter.x > coll->radius || shifter.x < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
-                    coll->shift.x = coll->old.x - pos.x;
+                    coll->shift.x = coll->old_pos.x - pos.x;
                     coll->shift.z = shifter.z;
                 } else if (shifter.x > 0) {
                     coll->coll_type = COLL_RIGHT;
@@ -678,7 +678,7 @@ bool Collide_CollideStaticObjects(
                 if (shifter.z > coll->radius || shifter.z < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
                     coll->shift.x = shifter.x;
-                    coll->shift.z = coll->old.z - pos.z;
+                    coll->shift.z = coll->old_pos.z - pos.z;
                 } else if (shifter.z > 0) {
                     coll->coll_type = COLL_LEFT;
                     coll->shift.x = 0;

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -295,8 +295,8 @@ void Collide_GetJointAbsPosition(
 }
 
 void Collide_GetCollisionInfo(
-    COLL_INFO *const coll, const int32_t x_pos, const int32_t y_pos,
-    const int32_t z_pos, int16_t room_num, int32_t obj_height)
+    COLL_INFO *const coll, const XYZ_32 pos, int16_t room_num,
+    int32_t obj_height)
 {
     coll->coll_type = COLL_NONE;
     coll->shift.x = 0;
@@ -311,17 +311,15 @@ void Collide_GetCollisionInfo(
         obj_height = -obj_height;
     }
 
-    int32_t x = x_pos;
-    int32_t z = z_pos;
-    const int32_t y = y_pos - obj_height;
+    const int32_t y = pos.y - obj_height;
     const int32_t y_top = y - M_HEADROOM;
 
-    const XYZ_32 sample_pos = { .x = x, .y = y_top, .z = z };
+    const XYZ_32 sample_pos = { .x = pos.x, .y = y_top, .z = pos.z };
     const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
     int32_t height = Room_GetHeight(sector, sample_pos);
-    int32_t room_height = height;
+    const int32_t room_height = height;
     if (height != NO_HEIGHT) {
-        height -= y_pos;
+        height -= pos.y;
     }
     int32_t ceiling = Room_GetCeiling(sector, sample_pos);
     if (ceiling != NO_HEIGHT) {
@@ -337,8 +335,8 @@ void Collide_GetCollisionInfo(
         coll->tilt = (XZ_16) {};
     } else {
         const ITEM *const lara_item = Lara_GetItem();
-        coll->tilt =
-            Room_GetTiltType(sector, (XYZ_32) { x, lara_item->pos.y, z });
+        coll->tilt = Room_GetTiltType(
+            sector, (XYZ_32) { pos.x, lara_item->pos.y, pos.z });
     }
 
     XZ_32 probe_left = {};
@@ -389,33 +387,27 @@ void Collide_GetCollisionInfo(
         room_num = prev_room_num;
     }
 
-    const XYZ_32 probe_base = { x_pos, y_pos, z_pos };
     M_FillSide(
-        coll, &coll->side_front, probe_base, probe_front, obj_height,
-        &room_num);
+        coll, &coll->side_front, pos, probe_front, obj_height, &room_num);
 
     int16_t room_num2;
     room_num2 = prev_room_num;
-    M_FillSide(
-        coll, &coll->side_left, probe_base, probe_left, obj_height, &room_num2);
+    M_FillSide(coll, &coll->side_left, pos, probe_left, obj_height, &room_num2);
     room_num2 = prev_room_num;
     M_FillSide(
-        coll, &coll->side_right, probe_base, probe_right, obj_height,
-        &room_num2);
+        coll, &coll->side_right, pos, probe_right, obj_height, &room_num2);
 
+    M_FillSide(coll, &coll->side_left2, pos, probe_left, obj_height, &room_num);
     M_FillSide(
-        coll, &coll->side_left2, probe_base, probe_left, obj_height, &room_num);
-    M_FillSide(
-        coll, &coll->side_right2, probe_base, probe_right, obj_height,
-        &room_num);
+        coll, &coll->side_right2, pos, probe_right, obj_height, &room_num);
 
     const int16_t static_room_num = g_TRVersion >= 3 ? prev_room_num : room_num;
     if (Collide_CollideStaticObjects(
-            coll, x_pos, y_pos, z_pos, static_room_num, obj_height)) {
+            coll, pos.x, pos.y, pos.z, static_room_num, obj_height)) {
         const XYZ_32 test_pos = {
-            .x = x_pos + coll->shift.x,
-            .y = y_pos,
-            .z = z_pos + coll->shift.z,
+            .x = pos.x + coll->shift.x,
+            .y = pos.y,
+            .z = pos.z + coll->shift.z,
         };
         sector = Room_GetSector(test_pos, &room_num);
         if (Room_GetHeight(sector, test_pos) < test_pos.y - WALL_L / 2
@@ -426,17 +418,17 @@ void Collide_GetCollisionInfo(
     }
 
     if (coll->side_mid.floor == NO_HEIGHT) {
-        coll->shift.x = coll->old.x - x_pos;
-        coll->shift.y = coll->old.y - y_pos;
-        coll->shift.z = coll->old.z - z_pos;
+        coll->shift.x = coll->old.x - pos.x;
+        coll->shift.y = coll->old.y - pos.y;
+        coll->shift.z = coll->old.z - pos.z;
         coll->coll_type = COLL_FRONT;
         return;
     }
 
     if (coll->side_mid.floor - coll->side_mid.ceiling <= 0) {
-        coll->shift.x = coll->old.x - x_pos;
-        coll->shift.y = coll->old.y - y_pos;
-        coll->shift.z = coll->old.z - z_pos;
+        coll->shift.x = coll->old.x - pos.x;
+        coll->shift.y = coll->old.y - pos.y;
+        coll->shift.z = coll->old.z - pos.z;
         coll->coll_type = COLL_CLAMP;
         return;
     }
@@ -451,22 +443,22 @@ void Collide_GetCollisionInfo(
         || coll->side_front.ceiling > coll->bad_ceiling) {
         if (coll->side_front.type == HT_DIAGONAL
             || coll->side_front.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - x;
-            coll->shift.z = coll->old.z - z;
+            coll->shift.x = coll->old.x - pos.x;
+            coll->shift.z = coll->old.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
             case DIR_SOUTH:
-                coll->shift.x = coll->old.x - x_pos;
+                coll->shift.x = coll->old.x - pos.x;
                 coll->shift.z =
-                    Room_FindGridShift(z_pos + probe_front.z, z_pos);
+                    Room_FindGridShift(pos.z + probe_front.z, pos.z);
                 break;
 
             case DIR_EAST:
             case DIR_WEST:
                 coll->shift.x =
-                    Room_FindGridShift(x_pos + probe_front.x, x_pos);
-                coll->shift.z = coll->old.z - z_pos;
+                    Room_FindGridShift(pos.x + probe_front.x, pos.x);
+                coll->shift.z = coll->old.z - pos.z;
                 break;
 
             default:
@@ -479,9 +471,9 @@ void Collide_GetCollisionInfo(
     }
 
     if (coll->side_front.ceiling >= coll->bad_ceiling) {
-        coll->shift.x = coll->old.x - x_pos;
-        coll->shift.y = coll->old.y - y_pos;
-        coll->shift.z = coll->old.z - z_pos;
+        coll->shift.x = coll->old.x - pos.x;
+        coll->shift.y = coll->old.y - pos.y;
+        coll->shift.z = coll->old.z - pos.z;
         coll->coll_type = COLL_TOP_FRONT;
         return;
     }
@@ -489,20 +481,20 @@ void Collide_GetCollisionInfo(
     if (coll->side_left.floor > coll->bad_pos
         || coll->side_left.floor < coll->bad_neg) {
         if (coll->side_left.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - x;
-            coll->shift.z = coll->old.z - z;
+            coll->shift.x = coll->old.x - pos.x;
+            coll->shift.z = coll->old.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
             case DIR_SOUTH:
                 coll->shift.x = Room_FindGridShift(
-                    x_pos + probe_left.x, x_pos + probe_front.x);
+                    pos.x + probe_left.x, pos.x + probe_front.x);
                 break;
 
             case DIR_EAST:
             case DIR_WEST:
                 coll->shift.z = Room_FindGridShift(
-                    z_pos + probe_left.z, z_pos + probe_front.z);
+                    pos.z + probe_left.z, pos.z + probe_front.z);
                 break;
 
             default:
@@ -517,20 +509,20 @@ void Collide_GetCollisionInfo(
     if (coll->side_right.floor > coll->bad_pos
         || coll->side_right.floor < coll->bad_neg) {
         if (coll->side_right.type == HT_SPLIT_TRI) {
-            coll->shift.x = coll->old.x - x;
-            coll->shift.z = coll->old.z - z;
+            coll->shift.x = coll->old.x - pos.x;
+            coll->shift.z = coll->old.z - pos.z;
         } else {
             switch (coll->quadrant) {
             case DIR_NORTH:
             case DIR_SOUTH:
                 coll->shift.x = Room_FindGridShift(
-                    x_pos + probe_right.x, x_pos + probe_front.x);
+                    pos.x + probe_right.x, pos.x + probe_front.x);
                 break;
 
             case DIR_EAST:
             case DIR_WEST:
                 coll->shift.z = Room_FindGridShift(
-                    z_pos + probe_right.z, z_pos + probe_front.z);
+                    pos.z + probe_right.z, pos.z + probe_front.z);
                 break;
 
             default:

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -402,8 +402,7 @@ void Collide_GetCollisionInfo(
         coll, &coll->side_right2, pos, probe_right, obj_height, &room_num);
 
     const int16_t static_room_num = g_TRVersion >= 3 ? prev_room_num : room_num;
-    if (Collide_CollideStaticObjects(
-            coll, pos.x, pos.y, pos.z, static_room_num, obj_height)) {
+    if (Collide_CollideStaticObjects(coll, pos, static_room_num, obj_height)) {
         const XYZ_32 test_pos = {
             .x = pos.x + coll->shift.x,
             .y = pos.y,
@@ -536,21 +535,20 @@ void Collide_GetCollisionInfo(
 }
 
 bool Collide_CollideStaticObjects(
-    COLL_INFO *const coll, const int32_t x, const int32_t y, const int32_t z,
-    const int16_t room_num, const int32_t height)
+    COLL_INFO *const coll, const XYZ_32 pos, const int16_t room_num,
+    const int32_t height)
 {
     coll->hit_static = 0;
 
-    const int32_t in_x_min = x - coll->radius;
-    const int32_t in_x_max = x + coll->radius;
-    const int32_t in_y_min = y - height;
-    const int32_t in_y_max = y;
-    const int32_t in_z_min = z - coll->radius;
-    const int32_t in_z_max = z + coll->radius;
+    const int32_t in_x_min = pos.x - coll->radius;
+    const int32_t in_x_max = pos.x + coll->radius;
+    const int32_t in_y_min = pos.y - height;
+    const int32_t in_y_max = pos.y;
+    const int32_t in_z_min = pos.z - coll->radius;
+    const int32_t in_z_max = pos.z + coll->radius;
     XYZ_32 shifter = { .x = 0, .z = 0 };
 
-    Room_GetNearbyRooms(
-        (XYZ_32) { x, y, z }, coll->radius + 50, height + 50, room_num);
+    Room_GetNearbyRooms(pos, coll->radius + 50, height + 50, room_num);
 
     for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
         const ROOM *const room = Room_Get(Room_DrawGetRoom(i));
@@ -631,7 +629,7 @@ bool Collide_CollideStaticObjects(
             case DIR_NORTH:
                 if (shifter.x > coll->radius || shifter.x < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
-                    coll->shift.x = coll->old.x - x;
+                    coll->shift.x = coll->old.x - pos.x;
                     coll->shift.z = shifter.z;
                 } else if (shifter.x > 0) {
                     coll->coll_type = COLL_LEFT;
@@ -648,7 +646,7 @@ bool Collide_CollideStaticObjects(
                 if (shifter.z > coll->radius || shifter.z < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
                     coll->shift.x = shifter.x;
-                    coll->shift.z = coll->old.z - z;
+                    coll->shift.z = coll->old.z - pos.z;
                 } else if (shifter.z > 0) {
                     coll->coll_type = COLL_RIGHT;
                     coll->shift.x = 0;
@@ -663,7 +661,7 @@ bool Collide_CollideStaticObjects(
             case DIR_SOUTH:
                 if (shifter.x > coll->radius || shifter.x < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
-                    coll->shift.x = coll->old.x - x;
+                    coll->shift.x = coll->old.x - pos.x;
                     coll->shift.z = shifter.z;
                 } else if (shifter.x > 0) {
                     coll->coll_type = COLL_RIGHT;
@@ -680,7 +678,7 @@ bool Collide_CollideStaticObjects(
                 if (shifter.z > coll->radius || shifter.z < -coll->radius) {
                     coll->coll_type = COLL_FRONT;
                     coll->shift.x = shifter.x;
-                    coll->shift.z = coll->old.z - z;
+                    coll->shift.z = coll->old.z - pos.z;
                 } else if (shifter.z > 0) {
                     coll->coll_type = COLL_LEFT;
                     coll->shift.x = 0;

--- a/src/trx/game/collision/common.h
+++ b/src/trx/game/collision/common.h
@@ -10,8 +10,7 @@ void Collide_GetJointAbsPosition(
     const ITEM *item, XYZ_32 *out_vec, int32_t joint);
 
 void Collide_GetCollisionInfo(
-    COLL_INFO *coll, int32_t x, int32_t y, int32_t z, int16_t room_num,
-    int32_t obj_height);
+    COLL_INFO *coll, XYZ_32 pos, int16_t room_num, int32_t obj_height);
 
 bool Collide_CollideStaticObjects(
     COLL_INFO *coll, int32_t x, int32_t y, int32_t z, int16_t room_num,

--- a/src/trx/game/collision/common.h
+++ b/src/trx/game/collision/common.h
@@ -13,8 +13,7 @@ void Collide_GetCollisionInfo(
     COLL_INFO *coll, XYZ_32 pos, int16_t room_num, int32_t obj_height);
 
 bool Collide_CollideStaticObjects(
-    COLL_INFO *coll, int32_t x, int32_t y, int32_t z, int16_t room_num,
-    int32_t height);
+    COLL_INFO *coll, XYZ_32 pos, int16_t room_num, int32_t height);
 bool Collide_TestBoundsCollide(
     const COLL_ITEM *src_item, const COLL_ITEM *dst_item, int32_t radius);
 

--- a/src/trx/game/collision/types.h
+++ b/src/trx/game/collision/types.h
@@ -33,7 +33,7 @@ typedef struct {
     int32_t bad_neg;
     int32_t bad_ceiling;
     XYZ_32 shift;
-    XYZ_32 old;
+    XYZ_32 old_pos;
     int16_t old_anim_state;
     int16_t old_anim_num;
     int16_t old_frame_num;

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -73,16 +73,17 @@ static void M_Push(
     coll->bad_neg = -STEPUP_HEIGHT;
     coll->bad_ceiling = 0;
     coll->facing = Math_Atan(
-        target_item->pos.z - coll->old.z, target_item->pos.x - coll->old.x);
+        target_item->pos.z - coll->old_pos.z,
+        target_item->pos.x - coll->old_pos.x);
     Collide_GetCollisionInfo(
         coll, target_item->pos, target_item->room_num, LARA_HEIGHT);
     coll->facing = old_facing;
 
     if (coll->coll_type != COLL_NONE) {
-        target_item->pos.x = coll->old.x;
-        target_item->pos.z = coll->old.z;
+        target_item->pos.x = coll->old_pos.x;
+        target_item->pos.z = coll->old_pos.z;
     } else {
-        coll->old = target_item->pos;
+        coll->old_pos = target_item->pos;
         Lara_UpdateRoomToHeight(-10);
     }
 

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -75,8 +75,7 @@ static void M_Push(
     coll->facing = Math_Atan(
         target_item->pos.z - coll->old.z, target_item->pos.x - coll->old.x);
     Collide_GetCollisionInfo(
-        coll, target_item->pos.x, target_item->pos.y, target_item->pos.z,
-        target_item->room_num, LARA_HEIGHT);
+        coll, target_item->pos, target_item->room_num, LARA_HEIGHT);
     coll->facing = old_facing;
 
     if (coll->coll_type != COLL_NONE) {
@@ -116,9 +115,7 @@ void Lara_Col_GetInfo(const ITEM *const item, COLL_INFO *const coll)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
     coll->facing = lara->move_angle;
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        LARA_HEIGHT);
+    Collide_GetCollisionInfo(coll, item->pos, item->room_num, LARA_HEIGHT);
 }
 
 void Lara_Col_Shift(COLL_INFO *const coll)

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -312,7 +312,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
             if ((item->current_anim_state != LS(LS_SHIMMY_LEFT)
                  && item->current_anim_state != LS(LS_SHIMMY_RIGHT))
                 || M_TestHangStop(item, coll, flag, &height_diff)) {
-                item->pos = coll->old;
+                item->pos = coll->old_pos;
                 item->goal_anim_state = LS(LS_HANG);
                 item->current_anim_state = LS(LS_HANG);
                 Item_SwitchToAnim(item, LA(LA_REACH_TO_HANG), M_LF_HANG);
@@ -350,7 +350,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
 
     int32_t height_diff = 0;
     if (M_TestHangStop(item, coll, flag, &height_diff)) {
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
         if (item->current_anim_state == LS(LS_SHIMMY_LEFT)
             || item->current_anim_state == LS(LS_SHIMMY_RIGHT)) {
             item->goal_anim_state = LS(LS_HANG);
@@ -751,13 +751,13 @@ static void M_SideLadder(ITEM *const item, COLL_INFO *const coll)
         do {
             Item_Animate(item);
         } while (item->current_anim_state != LS(LS_HANG));
-        item->pos.x = coll->old.x;
-        item->pos.z = coll->old.z;
+        item->pos.x = coll->old_pos.x;
+        item->pos.z = coll->old_pos.z;
         return;
     }
 
-    item->pos.x = coll->old.x;
-    item->pos.z = coll->old.z;
+    item->pos.x = coll->old_pos.x;
+    item->pos.z = coll->old_pos.z;
     item->goal_anim_state = LS(LS_CLIMB_STANCE);
     item->current_anim_state = LS(LS_CLIMB_STANCE);
     if (coll->old_anim_state == LS(LS_CLIMB_STANCE)) {

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -147,14 +147,14 @@ static void M_CrouchRoll(ITEM *const item, COLL_INFO *const coll)
         if (coll->side_mid.floor < coll->bad_neg
             || coll->side_front.floor > coll->bad_pos
             || M_IsBadDestination(item, lara->move_angle)) {
-            item->pos = coll->old;
+            item->pos = coll->old_pos;
             return;
         }
 
         Lara_Col_Shift(coll);
 
         if (coll->coll_type == COLL_TOP || coll->coll_type == COLL_CLAMP) {
-            item->pos = coll->old;
+            item->pos = coll->old_pos;
             item->speed = 0;
         } else {
             item->pos.y += coll->side_mid.floor;

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -59,11 +59,8 @@ static bool M_HasStaticBehind(const ITEM *const item, const int16_t angle)
     COLL_INFO test = {
         .radius = 50,
     };
-
-    const int32_t x = item->pos.x + ((Math_Sin(angle) * 512) >> W2V_SHIFT);
-    const int32_t z = item->pos.z + ((Math_Cos(angle) * 512) >> W2V_SHIFT);
-    return Collide_CollideStaticObjects(
-        &test, x, item->pos.y, z, item->room_num, 300);
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, angle, STEP_L * 2);
+    return Collide_CollideStaticObjects(&test, pos, item->room_num, 300);
 }
 
 static bool M_IsBadDestination(const ITEM *const item, const int16_t angle)

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -94,8 +94,7 @@ static void M_Crouch(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_walls = 1;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        -LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, -LARA_HEIGHT_CROUCH);
 
     if (Lara_Col_Fallen(item, coll)) {
         lara->gun_status = LGS_ARMLESS;
@@ -140,8 +139,7 @@ static void M_CrouchRoll(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_walls = 1;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        -LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, -LARA_HEIGHT_CROUCH);
 
     if (Lara_Col_Fallen(item, coll)) {
         lara->gun_status = LGS_ARMLESS;
@@ -184,8 +182,7 @@ static void M_CrouchTurn(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_walls = 1;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, LARA_HEIGHT_CROUCH);
 
     if (Lara_Col_Fallen(item, coll)) {
         lara->gun_status = LGS_ARMLESS;
@@ -224,8 +221,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
     coll->slopes_are_pits = 1;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 
     if (Lara_Col_Fallen(item, coll)) {
@@ -344,8 +340,7 @@ static void M_CrawlForward(ITEM *const item, COLL_INFO *const coll)
     coll->facing = lara->move_angle;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        -LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, -LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 
     if (M_DeflectEdgeCrawl(item, coll)
@@ -366,8 +361,7 @@ static void M_CrawlForward(ITEM *const item, COLL_INFO *const coll)
 static void M_CrawlTurn(ITEM *const item, COLL_INFO *const coll)
 {
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 }
 
@@ -389,8 +383,7 @@ static void M_CrawlBack(ITEM *const item, COLL_INFO *const coll)
     coll->facing = lara->move_angle;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        -LARA_HEIGHT_CROUCH);
+        coll, item->pos, item->room_num, -LARA_HEIGHT_CROUCH);
     Lara_Col_CrawlTilt(item);
 
     if (M_DeflectEdgeCrawl(item, coll)
@@ -428,8 +421,7 @@ static void M_CrawlToClimb(ITEM *const item, COLL_INFO *const coll)
     coll->facing = lara->move_angle;
 
     Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        M_CRAWL_TO_HANG_HEIGHT);
+        coll, item->pos, item->room_num, M_CRAWL_TO_HANG_HEIGHT);
 
     int32_t edge = 0;
     const EDGE_CATCH edge_catch = Lara_Col_TestEdgeCatch(item, coll, &edge);

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -299,7 +299,7 @@ static void M_Compress(ITEM *const item, COLL_INFO *const coll)
         item->gravity = false;
         item->speed = 0;
         item->fall_speed = 0;
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
     }
 
     if (g_TRVersion >= 2 && coll->side_mid.floor > -STEP_L
@@ -323,7 +323,7 @@ static void M_NeutralJumpRoll(ITEM *const item, COLL_INFO *const coll)
         item->goal_anim_state = LS(LS_STOP);
         item->current_anim_state = LS(LS_STOP);
         item->speed = 0;
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
     }
 }
 

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -344,8 +344,7 @@ static void M_UpJump(ITEM *const item, COLL_INFO *const coll)
         coll->facing += DEG_180;
     }
 
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num, 870);
+    Collide_GetCollisionInfo(coll, item->pos, item->room_num, 870);
     if (M_TestHangJumpUp(item, coll)) {
         return;
     }

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -110,7 +110,8 @@ static bool M_CanControlDrop(
         .slopes_are_pits = 1,
         .slopes_are_walls = 1,
     };
-    Collide_GetCollisionInfo(&old_coll, coll->old, item->room_num, LARA_HEIGHT);
+    Collide_GetCollisionInfo(
+        &old_coll, coll->old_pos, item->room_num, LARA_HEIGHT);
 
     if (old_coll.side_mid.floor != 0) {
         return false;
@@ -256,7 +257,7 @@ bool Lara_Col_TestCeiling(ITEM *const item, const COLL_INFO *const coll)
     lara->sprinting = false;
     lara->crouching = false;
 
-    item->pos = coll->old;
+    item->pos = coll->old_pos;
     item->goal_anim_state = LS(LS_STOP);
     item->current_anim_state = LS(LS_STOP);
     Item_SwitchToAnim(item, LA(LA_STAND_STILL), 0);

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -110,9 +110,7 @@ static bool M_CanControlDrop(
         .slopes_are_pits = 1,
         .slopes_are_walls = 1,
     };
-    Collide_GetCollisionInfo(
-        &old_coll, coll->old.x, coll->old.y, coll->old.z, item->room_num,
-        LARA_HEIGHT);
+    Collide_GetCollisionInfo(&old_coll, coll->old, item->room_num, LARA_HEIGHT);
 
     if (old_coll.side_mid.floor != 0) {
         return false;

--- a/src/trx/game/lara/col/monkey.c
+++ b/src/trx/game/lara/col/monkey.c
@@ -77,9 +77,7 @@ static void M_GetMonkeyCollisionInfo(
     coll->radius = M_MONKEY_RADIUS;
     coll->slopes_are_walls = slopes_are_walls;
 
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        M_MONKEY_HEIGHT);
+    Collide_GetCollisionInfo(coll, item->pos, item->room_num, M_MONKEY_HEIGHT);
 }
 
 static bool M_IsDirOctant(const int16_t rot)

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -157,9 +157,9 @@ static void M_CommonSurface(ITEM *const item, COLL_INFO *const coll)
     if (g_Config.gameplay.enable_wading) {
         obj_height += 100;
     }
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y + M_HEIGHT_SURF, item->pos.z,
-        item->room_num, obj_height);
+    XYZ_32 coll_pos = item->pos;
+    coll_pos.y += M_HEIGHT_SURF;
+    Collide_GetCollisionInfo(coll, coll_pos, item->room_num, obj_height);
 
     Lara_Col_Shift(coll);
 
@@ -250,9 +250,9 @@ static void M_Swim(ITEM *const item, COLL_INFO *const coll)
         height = LARA_HEIGHT_UW;
     }
 
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y + height / 2, item->pos.z,
-        item->room_num, height);
+    XYZ_32 coll_pos = item->pos;
+    coll_pos.y += height / 2;
+    Collide_GetCollisionInfo(coll, coll_pos, item->room_num, height);
     Lara_Col_Shift(coll);
 
     switch (coll->coll_type) {

--- a/src/trx/game/lara/col/swim.c
+++ b/src/trx/game/lara/col/swim.c
@@ -126,7 +126,7 @@ static void M_TestWaterDepth(ITEM *const item, const COLL_INFO *const coll)
         Lara_GetWaterDepth(item->pos.x, item->pos.y, item->pos.z, room_num);
 
     if (g_Config.gameplay.fix_water_exit && water_depth == NO_HEIGHT) {
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
         item->fall_speed = 0;
         return;
     }
@@ -173,7 +173,7 @@ static void M_CommonSurface(ITEM *const item, COLL_INFO *const coll)
             && (coll->side_mid.type == HT_BIG_SLOPE
                 || coll->side_mid.type == HT_DIAGONAL))) {
         item->fall_speed = 0;
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
     }
 
     const int32_t water_height = Room_GetWaterHeight(item->pos, item->room_num);
@@ -285,7 +285,7 @@ static void M_Swim(ITEM *const item, COLL_INFO *const coll)
         break;
 
     case COLL_CLAMP:
-        item->pos = coll->old;
+        item->pos = coll->old_pos;
         item->fall_speed = 0;
         return;
     }

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -110,9 +110,9 @@ static void M_WaterCurrent_TR12(COLL_INFO *const coll)
     lara->current.active = 0;
     coll->facing = Math_Atan(
         lara_item->pos.z - coll->old.z, lara_item->pos.x - coll->old.x);
-    Collide_GetCollisionInfo(
-        coll, lara_item->pos.x, lara_item->pos.y + LARA_HEIGHT_UW / 2,
-        lara_item->pos.z, room_num, LARA_HEIGHT_UW);
+    XYZ_32 coll_pos = lara_item->pos;
+    coll_pos.y += LARA_HEIGHT_UW / 2;
+    Collide_GetCollisionInfo(coll, coll_pos, room_num, LARA_HEIGHT_UW);
 
     switch (coll->coll_type) {
     case COLL_FRONT:
@@ -213,9 +213,10 @@ static void M_WaterCurrent_TR3(COLL_INFO *const coll)
     lara->current.active = 0;
     coll->facing = Math_Atan(
         lara_item->pos.z - coll->old.z, lara_item->pos.x - coll->old.x);
+    XYZ_32 coll_pos = lara_item->pos;
+    coll_pos.y += LARA_HEIGHT_UW / 2;
     Collide_GetCollisionInfo(
-        coll, lara_item->pos.x, lara_item->pos.y + 200, lara_item->pos.z,
-        lara_item->room_num, 400);
+        coll, coll_pos, lara_item->room_num, LARA_HEIGHT_UW);
 
     switch (coll->coll_type) {
     case COLL_FRONT:

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -109,7 +109,7 @@ static void M_WaterCurrent_TR12(COLL_INFO *const coll)
 
     lara->current.active = 0;
     coll->facing = Math_Atan(
-        lara_item->pos.z - coll->old.z, lara_item->pos.x - coll->old.x);
+        lara_item->pos.z - coll->old_pos.z, lara_item->pos.x - coll->old_pos.x);
     XYZ_32 coll_pos = lara_item->pos;
     coll_pos.y += LARA_HEIGHT_UW / 2;
     Collide_GetCollisionInfo(coll, coll_pos, room_num, LARA_HEIGHT_UW);
@@ -151,7 +151,7 @@ static void M_WaterCurrent_TR12(COLL_INFO *const coll)
     }
     Lara_Col_Shift(coll);
 
-    coll->old = lara_item->pos;
+    coll->old_pos = lara_item->pos;
 }
 
 static void M_WaterCurrent_TR3(COLL_INFO *const coll)
@@ -212,7 +212,7 @@ static void M_WaterCurrent_TR3(COLL_INFO *const coll)
     lara_item->pos.z += lara->current.vel.z >> 8;
     lara->current.active = 0;
     coll->facing = Math_Atan(
-        lara_item->pos.z - coll->old.z, lara_item->pos.x - coll->old.x);
+        lara_item->pos.z - coll->old_pos.z, lara_item->pos.x - coll->old_pos.x);
     XYZ_32 coll_pos = lara_item->pos;
     coll_pos.y += LARA_HEIGHT_UW / 2;
     Collide_GetCollisionInfo(
@@ -251,7 +251,7 @@ static void M_WaterCurrent_TR3(COLL_INFO *const coll)
     }
 
     Lara_Col_Shift(coll);
-    coll->old = lara_item->pos;
+    coll->old_pos = lara_item->pos;
 }
 
 static void M_WaterCurrent(COLL_INFO *const coll)
@@ -592,7 +592,7 @@ static void M_HandleAboveWater(COLL_INFO *const coll)
     ITEM *const item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
 
-    coll->old = item->pos;
+    coll->old_pos = item->pos;
     coll->old_anim_state = item->current_anim_state;
     coll->old_anim_num = item->anim_num;
     coll->old_frame_num = item->frame_num;
@@ -692,7 +692,7 @@ static void M_HandleUnderwater(COLL_INFO *const coll)
     ITEM *const item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
 
-    coll->old = item->pos;
+    coll->old_pos = item->pos;
     coll->radius = M_RADIUS_UW;
 
     coll->bad_pos = NO_BAD_POS;
@@ -780,7 +780,7 @@ static void M_HandleSurface(COLL_INFO *const coll)
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
     g_Camera.target_elevation = CAM_WADE_ELEVATION;
 
-    coll->old = item->pos;
+    coll->old_pos = item->pos;
     coll->radius = M_RADIUS_SURF;
 
     coll->bad_pos = NO_BAD_POS;

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -219,9 +219,7 @@ static void M_WillardKill(ITEM *const item, COLL_INFO *const coll)
 
 static void M_RapidsDrown(ITEM *const item, COLL_INFO *const coll)
 {
-    Collide_GetCollisionInfo(
-        coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-        LARA_HEIGHT);
+    Collide_GetCollisionInfo(coll, item->pos, item->room_num, LARA_HEIGHT);
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -248,8 +248,7 @@ static bool M_TestPush(
         .quadrant = quadrant,
         .radius = 500,
     };
-    if (Collide_CollideStaticObjects(
-            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, 1000)) {
+    if (Collide_CollideStaticObjects(&coll, base_pos, room_num, 1000)) {
         return false;
     }
 
@@ -311,8 +310,7 @@ static bool M_TestPull(
         .quadrant = quadrant,
         .radius = 500,
     };
-    if (Collide_CollideStaticObjects(
-            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, 1000)) {
+    if (Collide_CollideStaticObjects(&coll, base_pos, room_num, 1000)) {
         return false;
     }
 
@@ -353,8 +351,7 @@ static bool M_TestPull(
     sector = Room_GetSector(base_pos, &room_num);
     coll.radius = LARA_RADIUS;
     coll.quadrant = (quadrant + 2) & 3;
-    if (Collide_CollideStaticObjects(
-            &coll, base_pos.x, base_pos.y, base_pos.z, room_num, LARA_HEIGHT)) {
+    if (Collide_CollideStaticObjects(&coll, base_pos, room_num, LARA_HEIGHT)) {
         return false;
     }
 

--- a/src/trx/game/objects/vehicles/mine_cart.c
+++ b/src/trx/game/objects/vehicles/mine_cart.c
@@ -636,8 +636,7 @@ static void M_UserControl(ITEM *const item)
             .quadrant = Math_GetDirection(item->rot.y),
         };
         if (Collide_CollideStaticObjects(
-                &coll, item->pos.x, item->pos.y, item->pos.z, item->room_num,
-                STEP_L * 3)) {
+                &coll, item->pos, item->room_num, STEP_L * 3)) {
             Item_SwitchToObjAnim(
                 lara_item, M_ANIM_HIT_BEAM, 0, O_LARA_VEHICLE_ANIM);
             lara_item->current_anim_state = M_STATE_HIT_BEAM;

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -698,9 +698,9 @@ static void M_BackgroundCollision(
     CLAMPL(h, 200);
 
     coll.bad_neg = -h;
-    Collide_GetCollisionInfo(
-        &coll, item->pos.x, item->pos.y + h / 2, item->pos.z, item->room_num,
-        h);
+    XYZ_32 coll_pos = item->pos;
+    coll_pos.y += h / 2;
+    Collide_GetCollisionInfo(&coll, coll_pos, item->room_num, h);
     Collide_ShiftItem(item, &coll);
 
     switch (coll.coll_type) {

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -677,7 +677,7 @@ static void M_BackgroundCollision(
         .bad_pos = -NO_HEIGHT,
         .bad_neg = -400,
         .bad_ceiling = 400,
-        .old = item->pos,
+        .old_pos = item->pos,
         .radius = 300,
         .slopes_are_walls = false,
         .slopes_are_pits = false,
@@ -733,7 +733,7 @@ static void M_BackgroundCollision(
         break;
 
     case COLL_CLAMP:
-        item->pos = coll.old;
+        item->pos = coll.old_pos;
         p->vel = 0;
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the main collision functions to accept `XYZ_32` rather than individual components, and renames `coll->old` to `coll->old_pos`. Somewhat related to #5205 as I have an idea for that.

Should only need a quick test around geometry collision and hitting statics; I've run the recent e2e test from the tilts refactor as that covers a lot, and that's still passing.