### PR TITLE
game_flow/inventory: detect quest items in game flow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,7 @@
 - fixed activated one-shot antitriggers not being remembered when loading a save (regression from 1.2)
 - fixed the Ora Dagger appearing too low in the inventory in Meteorite Cavern (regression from 1.2)
 - fixed quest item pickup counts incrementing if the item cheat is used and then save/load is repeatedly used (regression from 1.2)
+- fixed not being able to give quest items to Lara on level start via the game flow
 
 
 

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -415,6 +415,10 @@ void GF_InventoryModifier_Apply(
     M_ModifyInventory_Item(type, O_LEADBAR_ITEM);
     M_ModifyInventory_Item(type, O_SCION_ITEM_1);
     M_ModifyInventory_Item(type, O_SCION_ITEM_2);
+    M_ModifyInventory_Item(type, O_QUEST_ITEM_1);
+    M_ModifyInventory_Item(type, O_QUEST_ITEM_2);
+    M_ModifyInventory_Item(type, O_QUEST_ITEM_3);
+    M_ModifyInventory_Item(type, O_QUEST_ITEM_4);
 
     if (type == GF_INV_SECRET) {
         M_ModifyInventory_Item(type, O_SMALL_MEDIPACK_ITEM);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the game flow scanner to allow giving quest items when Lara starts a level.

Can test in e.g. Caves of Kaliya with `{"type": "give_item", "object_id": "quest_1", "quantity": 1},`
