### PR TITLE
lara/state/land: prevent sprint-crouch with rifle weapon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed missing default object names for `O_ANIMATING_7`...`O_ANIMATING_10` and `O_FLICKERING_LIGHT` (regression from 1.4)
 - fixed empty centaur statues incorrectly referencing other level items when the centaur object is not loaded
 - fixed TR3 camera mode potentially behaving erratically when loading a level and the look input is held (regression from 1.1)
+- fixed Lara being able to go from run or sprint to crouch while holding a rifle-type weapon (regression from 1.3)
 
 **TR1**:
 - added savegame crystals to Unfinished Business (#1525)

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -147,6 +147,12 @@ static bool M_RequestDuck(LARA_INFO *const lara)
     }
 }
 
+static bool M_RequestRunToCrouch(LARA_INFO *const lara)
+{
+    return (lara->gun_status == LGS_ARMLESS || !Gun_IsRifleType(lara->gun_type))
+        && M_RequestDuck(lara);
+}
+
 static void M_Run(ITEM *const item, COLL_INFO *const coll)
 {
     if (item->hit_points <= 0) {
@@ -179,7 +185,7 @@ static void M_Run(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    if (M_RequestDuck(lara)) {
+    if (M_RequestRunToCrouch(lara)) {
         item->goal_anim_state = M_GetRunToCrouchState();
         return;
     }
@@ -745,7 +751,7 @@ static void M_Sprint(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    if (M_RequestDuck(lara)) {
+    if (M_RequestRunToCrouch(lara)) {
         item->goal_anim_state = M_GetRunToCrouchState();
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara being able to go from run or sprint to crouch when holding a rifle-type weapon.
