### PR TITLE
lara/draw: fix lighting

### DIFF
--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -17,14 +17,22 @@
 static bool m_CacheMatrices = false;
 static bool m_IsLara = true;
 
-static GAME_VECTOR M_GetLaraLightSample(const ITEM *const item)
+static void M_CalculateLight(
+    const ITEM *const item, const ANIM_FRAME *const frame)
 {
-    GAME_VECTOR sample_pos = {
-        .pos = { 0, 0, 0 },
-        .room_num = item->room_num,
-    };
-    Lara_GetJointAbsPosition(&sample_pos.pos, LM_TORSO);
-    return sample_pos;
+    if (g_TRVersion >= 3) {
+        GAME_VECTOR sample_pos = {
+            .pos = { 0, 0, 0 },
+            .room_num = item->room_num,
+        };
+        if (!Lara_GetMeshPos(LM_TORSO, &sample_pos.pos)) {
+            Lara_GetJointAbsPosition(&sample_pos.pos, LM_TORSO);
+        }
+        Room_GetSector(sample_pos.pos, &sample_pos.room_num);
+        Output_CalculateObjectLightingAt(item, sample_pos);
+    } else {
+        Output_CalculateObjectLighting(item, &frame->bounds);
+    }
 }
 
 static void M_CacheMatrix(const LARA_MESH mesh)
@@ -164,12 +172,11 @@ static bool M_Draw_I(
     }
 
     m_CacheMatrices = m_IsLara;
+    Matrix_Push();
+    M_CalculateLight(item, frame1);
     if (m_CacheMatrices) {
         lara->mesh_pos_matrices_valid = false;
     }
-
-    Matrix_Push();
-    Output_CalculateObjectLightingAt(item, M_GetLaraLightSample(item));
 
     const ANIM_BONE *const bone =
         m_IsLara ? Lara_Skin_GetBoneBase() : Object_GetBone(obj, 0);
@@ -455,12 +462,11 @@ bool Lara_Draw(const ITEM *const item)
     }
 
     m_CacheMatrices = m_IsLara;
+    Matrix_Push();
+    M_CalculateLight(item, frame);
     if (m_CacheMatrices) {
         lara->mesh_pos_matrices_valid = false;
     }
-
-    Matrix_Push();
-    Output_CalculateObjectLightingAt(item, M_GetLaraLightSample(item));
 
     const ANIM_BONE *const bone =
         m_IsLara ? Lara_Skin_GetBoneBase() : Object_GetBone(obj, 0);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Fixes unreleased regression from 2f24b7ca8ffe4a2f2620606894865e45702d2780.
Important to retest https://github.com/LostArtefacts/TRX/pull/5345 and https://github.com/LostArtefacts/TRX/pull/5366 .

The lighting change is now version-gated so that it does not affect TR1/2.
The bug is unreleased.