### PR TITLE
tr3/data: fix Lud's Gate pickup count

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -295,6 +295,7 @@
                 "luds_textures.bin",
                 "menu_artefacts.bin",
             ],
+            "unobtainable_pickups": 2,
         },
 
         // 12. City

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,7 @@
 - fixed the Ora Dagger appearing too low in the inventory in Meteorite Cavern (regression from 1.2)
 - fixed quest item pickup counts incrementing if the item cheat is used and then save/load is repeatedly used (regression from 1.2)
 - fixed not being able to give quest items to Lara on level start via the game flow
+- fixed inaccurate maximum pickup count in Lud's Gate
 
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This covers the split path in Lud's Gate dictating the maximum possible pickup count. The sphinx room also has a split meaning it's impossible to get everything in that room without glitches.
