### PR TITLE
gym: fix assault and quad track conflicts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@
 - fixed quest item pickup counts incrementing if the item cheat is used and then save/load is repeatedly used (regression from 1.2)
 - fixed not being able to give quest items to Lara on level start via the game flow
 - fixed inaccurate maximum pickup count in Lud's Gate
+- fixed the Assault Course timer not stopping after playing the Race Track Course first (regression from 1.1)
 
 
 

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -354,6 +354,10 @@ void Gym_TrackManager_Start(const GYM_TRACK_TYPE track)
 
     switch (track) {
     case GYM_TRACK_ASSAULT: {
+        p->quad_course.timer_active = false;
+        p->quad_course.timer_display = false;
+        p->quad_course.lap_time_display_timer = 0;
+
         p->assault_course.timer_active = true;
         p->assault_course.timer_display = true;
         p->assault_course.penalty_frames = 0;
@@ -371,12 +375,22 @@ void Gym_TrackManager_Start(const GYM_TRACK_TYPE track)
             return;
         }
 
+        p->assault_course.timer_active = false;
+        p->assault_course.timer_display = false;
+        p->assault_course.penalty_frames = 0;
+        p->assault_course.target_penalty_frames = 0;
+        p->assault_course.penalty_display_timer = 0;
+        p->assault_course.timer_auto_hide_timer = 0;
+        p->assault_course.pad_touched_this_frame = false;
+        p->assault_course.pad_lock = false;
+
         p->quad_course.timer_active = true;
         p->quad_course.timer_display = true;
         break;
+    }
+
     default:
         break;
-    }
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes the Assault Course timer not stopping after playing the Race Track Course first (regression from 1.1).