### PR TITLE
objects/punk: fix Punk behaviour

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -93,6 +93,7 @@
 - fixed inaccurate maximum pickup count in Lud's Gate
 - fixed the Assault Course timer not stopping after playing the Race Track Course first (regression from 1.1)
 - fixed friendly Punk behaviour when looking at Lara (regression from 1.4)
+- fixed Punks leaving AI Guard positions when hostility policy is set to individual and Lara hurts a different Punk (regression from 1.4)
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,7 @@
 - fixed not being able to give quest items to Lara on level start via the game flow
 - fixed inaccurate maximum pickup count in Lud's Gate
 - fixed the Assault Course timer not stopping after playing the Race Track Course first (regression from 1.1)
+- fixed friendly Punk behaviour when looking at Lara (regression from 1.4)
 
 
 

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/creature.h>
@@ -283,8 +284,29 @@ static void M_Control(const int16_t item_num)
         creature->enemy = lara_item;
     }
 
+    const bool hurt_by_lara = creature->hurt_by_lara;
+    if (creature->alerted
+        && g_Config.gameplay.ally_hostility_policy
+            == ALLY_HOSTILITY_POLICY_SHARED) {
+        creature->enemy = lara_item;
+    } else if (!hurt_by_lara && creature->enemy == lara_item) {
+        creature->enemy = nullptr;
+    }
+
+    // Enforce the following state to avoid Creature_AIInfo resetting ahead,
+    // bite and distance when the creature is friendly.
+    // TODO: this is common with prisoner behaviour, aim to unify this.
+    ITEM *const enemy = creature->enemy;
+    if (enemy == nullptr) {
+        creature->enemy = lara_item;
+        creature->hurt_by_lara = true;
+    }
+
     AI_INFO info = {};
     Creature_AIInfo(item, &info);
+
+    creature->enemy = enemy;
+    creature->hurt_by_lara = hurt_by_lara;
 
     AI_INFO lara_info = {};
     if (creature->enemy == lara_item) {
@@ -297,14 +319,9 @@ static void M_Control(const int16_t item_num)
         lara_info.distance = XYZ_32_GetLength2((XYZ_32) { dx, 0, dz });
     }
 
-    if (!creature->alerted && creature->enemy == lara_item) {
-        creature->enemy = nullptr;
-    }
-
     Creature_Mood(item, &info, true);
     angle = Creature_Turn(item, creature->maximum_turn);
 
-    ITEM *const enemy = creature->enemy;
     creature->enemy = lara_item;
     if (item->hit_status
         || ((lara_info.distance < M_ALERT_DIST

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -276,6 +276,14 @@ static void M_Control(const int16_t item_num)
         goto finish;
     }
 
+    if (creature->alerted && !creature->hurt_by_lara
+        && g_Config.gameplay.ally_hostility_policy
+            == ALLY_HOSTILITY_POLICY_INDIVIDUAL) {
+        // Avoid Creature_GetAITarget removing AI_GUARD flag outside of shared
+        // hostility.
+        creature->alerted = false;
+    }
+
     ITEM *const lara_item = Lara_GetItem();
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     if (item->ai_bits != 0) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes punks not stopping and looking at Lara when she is within range, and fixes those with AI Guards leaving their positions when hostility policy is set to individual and Lara hurts a different punk.

We'll need to do a full sweep of enemies at some point to handle this kind of behaviour as anything can become an ally; we do have a separate task logged for it.