### PR TITLE
lara/col/crouch: allow hit in crouch idle state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed empty centaur statues incorrectly referencing other level items when the centaur object is not loaded
 - fixed TR3 camera mode potentially behaving erratically when loading a level and the look input is held (regression from 1.1)
 - fixed Lara being able to go from run or sprint to crouch while holding a rifle-type weapon (regression from 1.3)
+- fixed Lara not using hit animations when she is struck while in the crouch idle state (regression from 1.1)
 
 **TR1**:
 - added savegame crystals to Unfinished Business (#1525)

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -690,10 +690,10 @@ const ANIM_FRAME *Lara_GetHitFrame(const ITEM *const item)
     LARA_ANIMATION anim_idx;
     if (lara->is_crouched) {
         switch (lara->hit_direction) {
-        case DIR_EAST:  anim_idx = LA(LA_CROUCH_HIT_LEFT); break;
-        case DIR_SOUTH: anim_idx = LA(LA_CROUCH_HIT_BACK); break;
-        case DIR_WEST:  anim_idx = LA(LA_CROUCH_HIT_RIGHT); break;
-        default:        anim_idx = LA(LA_CROUCH_HIT_FRONT); break;
+        case DIR_EAST:  anim_idx = LA(LA_CROUCH_HIT_RIGHT); break;
+        case DIR_SOUTH: anim_idx = LA(LA_CROUCH_HIT_FRONT); break;
+        case DIR_WEST:  anim_idx = LA(LA_CROUCH_HIT_LEFT); break;
+        default:        anim_idx = LA(LA_CROUCH_HIT_BACK); break;
         }
     } else {
         switch (lara->hit_direction) {

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -116,7 +116,7 @@ static bool M_CanJumpDown(const ITEM *const item, const LARA_INFO *const lara)
 
 static void M_CrouchIdle(ITEM *const item, COLL_INFO *const coll)
 {
-    coll->enable_hit = 0;
+    coll->enable_hit = 1;
     coll->enable_baddie_push = 1;
 
     LARA_INFO *const lara = Lara_GetLaraInfo();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara not using her crouch hit animations.