### PR TITLE
objects/monkey: fix patrolling monkey behaviour

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,7 @@
 - fixed the Assault Course timer not stopping after playing the Race Track Course first (regression from 1.1)
 - fixed friendly Punk behaviour when looking at Lara (regression from 1.4)
 - fixed Punks leaving AI Guard positions when hostility policy is set to individual and Lara hurts a different Punk (regression from 1.4)
+- fixed patrolling Monkeys becoming agitated when Lara hurts a different Monkey, but remaining fixated on their AI targets instead of Lara (regression from 1.2)
 
 
 

--- a/src/trx/game/objects/creatures/monkey.c
+++ b/src/trx/game/objects/creatures/monkey.c
@@ -195,9 +195,25 @@ static void M_Control(const int16_t item_num)
             item->mesh_bits = -1;
         }
     } else {
+        if (Creature_IsHostile(item)) {
+            creature->alerted = true;
+        } else if (
+            Creature_IsAlly(item) && creature->alerted
+            && !creature->hurt_by_lara
+            && g_Config.gameplay.ally_hostility_policy
+                == ALLY_HOSTILITY_POLICY_INDIVIDUAL) {
+            creature->alerted = false;
+        }
+
         Creature_GetAITarget(creature);
         if (creature->hurt_by_lara
             && g_Config.gameplay.fix_monkey_pickup_priority) {
+            creature->enemy = lara_item;
+        }
+
+        if (Creature_IsHostile(item) && creature->enemy != nullptr
+            && (creature->enemy->object_id == O_AI_PATROL_1
+                || creature->enemy->object_id == O_AI_PATROL_2)) {
             creature->enemy = lara_item;
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes monkeys who are on patrol retaining their AI targets as enemies when they become agitated. It also resolves them becoming agitated when hostility policy is set to individual and Lara hurts a different monkey.
