### PR TITLE
objects/wasp_emitter: improve spawning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,8 @@
 - restored the animated mine cart tracks in RX-Tech Mines
 - restored the missing flamethrower blast sound effect in RX-Tech Mines and Meteorite Cavern
 - removed Lara's Home from TR3:LA to stay compatible with the OG and other expansion packs
+- removed the need to define Wasp items near to Wasp Emitters
+- fixed Wasp Emitters not spawning items if previously spawned Wasps are still active and unreachable
 - fixed letterboxing of images on 16:10 resolution
 - fixed TR3:LA images missing from release zips and the installer (#5390, regression from 1.5)
 - fixed Fire Lighting option having no effect

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -51,32 +51,33 @@ static void M_Initialise(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
-        p->slots[i] = NO_ITEM;
-    }
-}
-
-static void M_PopulateSlots(M_PRIV *const p)
-{
-    int32_t count = 0;
-    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
-        ITEM *const item = Item_Get(i);
-        if (item->object_id != O_WASP_MUTANT
-            || (item->ai_bits & AI_MODIFY) == 0) {
+        const int16_t wasp_item_num = Item_CreateLevelItem();
+        p->slots[i] = wasp_item_num;
+        if (wasp_item_num == NO_ITEM) {
             continue;
         }
 
-        p->slots[count++] = i;
-        if (count >= M_MAX_SLOTS) {
-            break;
-        }
+        ITEM *const wasp_item = Item_Get(wasp_item_num);
+        wasp_item->object_id = O_WASP_MUTANT;
+        wasp_item->room_num = item->room_num;
+        wasp_item->pos = item->pos;
+        wasp_item->rot = item->rot;
+        wasp_item->status = IS_INVISIBLE;
+        Item_Initialise(wasp_item_num);
     }
+}
+
+static const ITEM *M_GetWaspItem(const M_PRIV *const p, const int32_t slot_idx)
+{
+    const int16_t item_num = p->slots[slot_idx];
+    return item_num == NO_ITEM ? nullptr : Item_Get(item_num);
 }
 
 static int32_t M_GetEmptySlot(const M_PRIV *const p)
 {
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
-        const ITEM *const item = Item_Get(p->slots[i]);
-        if (item->creature_data == nullptr) {
+        const ITEM *const item = M_GetWaspItem(p, i);
+        if (item != nullptr && item->creature_data == nullptr) {
             return i;
         }
     }
@@ -87,8 +88,8 @@ static int32_t M_GetActiveCount(const M_PRIV *const p)
 {
     int32_t count = 0;
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
-        const ITEM *const item = Item_Get(p->slots[i]);
-        if (item->active) {
+        const ITEM *const item = M_GetWaspItem(p, i);
+        if (item != nullptr && item->active) {
             count++;
         }
     }
@@ -145,11 +146,6 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     if (!item->active || p->spawn_count >= p->spawn_total) {
-        return;
-    }
-
-    if (p->slots[0] == NO_ITEM) {
-        M_PopulateSlots(p);
         return;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This improves wasp emitter spawning by ensuring that each nest has the default number of items allocated, as opposed to only three being shared throughout a single level.