### PR TITLE
objects/pickup: fix twinkles + quest item status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.6...develop) - ××××-××-××
+**TR3**:
+- fixed Hand of Rathmore rotating in Sleeping with the Fishes
+
+
 
 ## [1.6](https://github.com/LostArtefacts/TRX/compare/trx-1.5...trx-1.6) - 2026-05-02
 Showcase: https://youtu.be/yTW99iecK3U

--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -38,6 +38,16 @@ static bool M_ShouldCenterDrop(const OBJECT_ID obj_id)
     }
 }
 
+static void M_Drop(ITEM *const pickup)
+{
+    if (Object_IsType(pickup->object_id, g_QuestObjects)) {
+        pickup->status = IS_ACTIVE;
+        Item_AddActive(Item_GetIndex(pickup));
+    } else {
+        pickup->status = IS_INACTIVE;
+    }
+}
+
 static OBJECT_ID M_ConvertDroppedGun(const OBJECT_ID obj_id)
 {
     if (g_GameFlow.convert_dropped_guns && Object_IsType(obj_id, g_GunObjects)
@@ -138,7 +148,7 @@ static void M_AnimateDrop(CARRIED_ITEM *const item)
 
     if (sector->portal_room.pit == NO_ROOM && pickup->pos.y >= height) {
         item->status = DS_DROPPED;
-        pickup->status = IS_INACTIVE;
+        M_Drop(pickup);
         pickup->pos.y = height;
         pickup->fall_speed = 0;
         m_AnimatingCount--;
@@ -351,7 +361,7 @@ void Carrier_SyncItem(
         pickup_item->rot.y = carried_item->rot.y;
         pickup_item->fall_speed = carried_item->fall_speed;
         if (carried_item->status == DS_DROPPED) {
-            pickup_item->status = IS_INACTIVE;
+            M_Drop(pickup_item);
         } else {
             m_AnimatingCount++;
         }
@@ -394,7 +404,7 @@ void Carrier_TestItemDrops(const int16_t item_num)
             ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = carrier->pos;
             pickup->rot = carrier->rot;
-            pickup->status = IS_INACTIVE;
+            M_Drop(pickup);
         }
 
         ITEM *const pickup = Item_Get(item->spawn_num);

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -71,16 +71,6 @@ static const OBJECT_BOUNDS m_PickUpBoundsUW = {
 static const XYZ_32 m_PickupPosition = { .x = 0, .y = 0, .z = -100 };
 static const XYZ_32 m_PickupPositionUW = { .x = 0, .y = -200, .z = -350 };
 
-static const OBJECT_ID m_QuestObjects[] = {
-    // clang-format off
-    O_QUEST_ITEM_1,
-    O_QUEST_ITEM_2,
-    O_QUEST_ITEM_3,
-    O_QUEST_ITEM_4,
-    NO_OBJECT,
-    // clang-format on
-};
-
 typedef struct {
     int32_t aid_timer;
     uint32_t secret_mask;
@@ -135,11 +125,12 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     if ((item->flags & IF_CODE_BITS) != IF_CODE_BITS) {
         item->status = IS_INVISIBLE;
         item->flags |= IF_KILLED;
-    } else if (item->status == IS_INVISIBLE) {
+    } else if (
+        item->status == IS_INVISIBLE
+        || Object_IsType(item->object_id, g_QuestObjects)) {
         item->touch_bits = 0;
         item->status = IS_ACTIVE;
-        const int16_t item_num = Item_GetIndex(item);
-        Item_AddActive(item_num);
+        Item_AddActive(Item_GetIndex(item));
     }
 
     return false;
@@ -233,9 +224,11 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    if (g_TRVersion == 3 && Object_IsType(item->object_id, m_QuestObjects)) {
-        item->rot.y += 1024;
-        M_ControlPickupLights(item);
+    if (Object_IsType(item->object_id, g_QuestObjects)) {
+        if (item->status != IS_INACTIVE) {
+            item->rot.y += 1024;
+            M_ControlPickupLights(item);
+        }
     } else if (g_Config.gameplay.enable_pickup_aids) {
         M_ControlPickupAids(item);
     }
@@ -257,7 +250,7 @@ static void M_DoPickup(const int16_t item_num)
     item->status = IS_INVISIBLE;
     item->flags |= IF_KILLED;
 
-    if (g_TRVersion == 3 && Object_IsType(item->object_id, m_QuestObjects)) {
+    if (Object_IsType(item->object_id, g_QuestObjects)) {
         if (GF_BadGetLevelNum() == 19
             || (GF_BadIsMod("tr3-la") && GF_BadGetLevelNum() == 4)) {
             Item_Kill(item_num);

--- a/src/trx/game/objects/vars.c
+++ b/src/trx/game/objects/vars.c
@@ -233,6 +233,16 @@ const OBJECT_ID g_SecretObjects[] = {
     // clang-format on
 };
 
+const OBJECT_ID g_QuestObjects[] = {
+    // clang-format off
+    O_QUEST_ITEM_1,
+    O_QUEST_ITEM_2,
+    O_QUEST_ITEM_3,
+    O_QUEST_ITEM_4,
+    NO_OBJECT,
+    // clang-format on
+};
+
 const OBJECT_ID g_PickupObjects[] = {
     // clang-format off
     O_PISTOL_ITEM,

--- a/src/trx/game/objects/vars.h
+++ b/src/trx/game/objects/vars.h
@@ -21,6 +21,7 @@ extern const OBJECT_ID g_InvObjects[];
 extern const OBJECT_ID g_WaterSpriteObjects[];
 extern const OBJECT_ID g_BossObjects[];
 extern const OBJECT_ID g_SecretObjects[];
+extern const OBJECT_ID g_QuestObjects[];
 extern const OBJECT_ID g_MovableBlockObjects[];
 extern const OBJECT_ID g_GameSpriteObjects[];
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes Hand of Rathmore rotating in Sleeping with the Fishes, and quest items not showing pickup aid twinkle effects.