### PR TITLE
misc: guard box lookups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.6...develop) - ××××-××-××
+- improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
+
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes
 

--- a/src/trx/game/camera/box_camera.c
+++ b/src/trx/game/camera/box_camera.c
@@ -121,12 +121,9 @@ static const BOX_INFO *M_GetBox(
     const SECTOR *const sector, const int32_t x, const int32_t z,
     const bool generate_box)
 {
-    if (sector->box != NO_BOX) {
-        return Box_GetBox(sector->box);
-    }
-
-    if (!generate_box) {
-        return nullptr;
+    const BOX_INFO *const box = Box_GetBox(sector->box);
+    if (box != nullptr || !generate_box) {
+        return box;
     }
 
     // A level may have blocked specific sector or room pathfinding, so create a

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -347,7 +347,8 @@ void Creature_AIInfo(ITEM *const item, AI_INFO *const info)
     const BOX_INFO *const enemy_box = Box_GetBox(enemy->box_num);
     // TODO: TR3 defines non-LOT creatures, like cobras and handles them
     // differently here and in LOT initialisation.
-    if (((enemy_box->overlap_index & creature->lot.setup.block_mask) != 0)
+    if ((enemy_box != nullptr
+         && (enemy_box->overlap_index & creature->lot.setup.block_mask) != 0)
         || (creature->lot.node[item->box_num].search_num
             == (creature->lot.search_num | BOX_BLOCKED_SEARCH))) {
         info->enemy_zone_num |= BOX_BLOCKED;
@@ -898,14 +899,17 @@ bool Creature_Animate(
     sample_pos.x = item->pos.x;
     sample_pos.z = item->pos.z;
     const SECTOR *sector = Room_GetSector(sample_pos, &room_num);
-    int32_t height = Box_GetBox(sector->box)->height;
-    int16_t next_box = lot->node[sector->box].exit_box;
+    int32_t height =
+        sector->box == NO_BOX ? NO_HEIGHT : Box_GetBox(sector->box)->height;
+    int16_t next_box =
+        sector->box == NO_BOX ? NO_BOX : lot->node[sector->box].exit_box;
     int32_t next_height =
         next_box != NO_BOX ? Box_GetBox(next_box)->height : height;
 
     const bool fly_check = g_TRVersion < 3 || lot->setup.fly == 0;
 
-    const int32_t box_height = Box_GetBox(item->box_num)->height;
+    const int32_t box_height =
+        item->box_num == NO_BOX ? NO_HEIGHT : Box_GetBox(item->box_num)->height;
     if (sector->box == NO_BOX
         || (fly_check && zone[item->box_num] != zone[sector->box])
         || box_height - height > lot->setup.step
@@ -933,8 +937,10 @@ bool Creature_Animate(
         sample_pos.y = y;
         sample_pos.z = item->pos.z;
         sector = Room_GetSector(sample_pos, &room_num);
-        height = Box_GetBox(sector->box)->height;
-        next_box = lot->node[sector->box].exit_box;
+        height =
+            sector->box == NO_BOX ? NO_HEIGHT : Box_GetBox(sector->box)->height;
+        next_box =
+            sector->box == NO_BOX ? NO_BOX : lot->node[sector->box].exit_box;
         next_height =
             next_box != NO_BOX ? Box_GetBox(next_box)->height : height;
     }

--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -163,7 +163,8 @@ static void M_Control(const int16_t item_num)
             XYZ_32_OffsetYaw(item->pos, bits + info.angle + DEG_180, WALL_L);
         int16_t room_num = item->room_num;
         SECTOR *const sector = Room_GetSector(creature->target, &room_num);
-        if (ABS(Box_GetBox(sector->box)->height - item->pos.y) > STEP_L) {
+        const BOX_INFO *const box = Box_GetBox(sector->box);
+        if (box != nullptr && ABS(box->height - item->pos.y) > STEP_L) {
             creature->mood = MOOD_BORED;
             p->scared_timer = p->shared->scared_timer;
         }

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -213,6 +213,20 @@ static int16_t M_TriggerGasThrower(
     return effect_num;
 }
 
+static bool M_IsEnemyBoxSearchable(const ITEM *const enemy)
+{
+    if (enemy == nullptr) {
+        return false;
+    }
+
+    const BOX_INFO *const box = Box_GetBox(enemy->box_num);
+    if (box == nullptr) {
+        return false;
+    }
+
+    return (box->overlap_index & BOX_BLOCKED_SEARCH) != 0;
+}
+
 static void M_Control(const int16_t item_num)
 {
     if (!Creature_Activate(item_num)) {
@@ -238,8 +252,7 @@ static void M_Control(const int16_t item_num)
         Creature_AIInfo(item, &info);
         Creature_Mood(item, &info, true);
 
-        if (Box_GetBox(creature->enemy->box_num)->overlap_index
-            & BOX_BLOCKED_SEARCH) {
+        if (M_IsEnemyBoxSearchable(creature->enemy)) {
             creature->mood = MOOD_ATTACK;
         }
 
@@ -271,8 +284,7 @@ static void M_Control(const int16_t item_num)
                 Creature_CanTargetEnemy(item, &info) && info.bite
                 && info.distance < M_ATTACK_0_RANGE
                 && (lara_info->poison_timer < 256
-                    || (Box_GetBox(creature->enemy->box_num)->overlap_index
-                        & BOX_BLOCKED_SEARCH))) {
+                    || M_IsEnemyBoxSearchable(creature->enemy))) {
                 item->goal_anim_state = M_STATE_AIM_0;
             } else {
                 item->goal_anim_state = M_STATE_RUN;
@@ -306,8 +318,7 @@ static void M_Control(const int16_t item_num)
                 Creature_CanTargetEnemy(item, &info)
                 && info.distance < M_ATTACK_0_RANGE
                 && (lara_info->poison_timer < 256
-                    || (Box_GetBox(creature->enemy->box_num)->overlap_index
-                        & BOX_BLOCKED_SEARCH))) {
+                    || M_IsEnemyBoxSearchable(creature->enemy))) {
                 item->goal_anim_state = M_STATE_STOP;
             } else if (info.distance > M_WALK_RANGE) {
                 item->goal_anim_state = M_STATE_RUN;
@@ -379,8 +390,7 @@ static void M_Control(const int16_t item_num)
 
             if (info.bite && info.distance < M_ATTACK_0_RANGE
                 && (lara_info->poison_timer < 256
-                    || (Box_GetBox(creature->enemy->box_num)->overlap_index
-                        & BOX_BLOCKED_SEARCH))) {
+                    || M_IsEnemyBoxSearchable(creature->enemy))) {
                 item->goal_anim_state = M_STATE_PUNCH_B;
             } else {
                 item->goal_anim_state = M_STATE_STOP;
@@ -454,8 +464,7 @@ static void M_Control(const int16_t item_num)
                     Creature_CanTargetEnemy(item, &info)
                     && info.distance < M_ATTACK_0_RANGE
                     && (lara_info->poison_timer < 256
-                        || (Box_GetBox(creature->enemy->box_num)->overlap_index
-                            & BOX_BLOCKED_SEARCH))) {
+                        || M_IsEnemyBoxSearchable(creature->enemy))) {
                     item->goal_anim_state = M_STATE_STOP;
                 } else if (info.ahead && info.distance < M_WALK_RANGE) {
                     item->goal_anim_state = M_STATE_WALK;

--- a/src/trx/game/objects/creatures/shiva.c
+++ b/src/trx/game/objects/creatures/shiva.c
@@ -273,9 +273,9 @@ static void M_Control(const int16_t item_num)
                     const SECTOR *const sector =
                         Room_GetSector(offset, &room_num);
 
-                    if (creature->flags != 0 || sector->box == 0x7FF
-                        || Box_GetBox(sector->box)->overlap_index
-                            & BOX_BLOCKABLE) {
+                    const BOX_INFO *const box = Box_GetBox(sector->box);
+                    if (creature->flags != 0 || box == nullptr
+                        || (box->overlap_index & BOX_BLOCKABLE) != 0) {
                         item->goal_anim_state = M_STATE_WAIT_DEF;
                     } else {
                         item->goal_anim_state = M_STATE_WALK_BACK;

--- a/src/trx/game/objects/general/door.c
+++ b/src/trx/game/objects/general/door.c
@@ -123,7 +123,7 @@ static void M_InitialisePortal(
 
     int16_t box_num = sector->box;
     const BOX_INFO *const box = Box_GetBox(box_num);
-    if ((box->overlap_index & BOX_BLOCKABLE) == 0) {
+    if (box != nullptr && (box->overlap_index & BOX_BLOCKABLE) == 0) {
         box_num = NO_BOX;
     }
     door_pos->box_num = box_num;

--- a/src/trx/game/objects/general/smashable.c
+++ b/src/trx/game/objects/general/smashable.c
@@ -14,6 +14,9 @@ static void M_SetBoxBlocked(const ITEM *const item, const bool blocked)
     const SECTOR *const sector =
         Room_GetWorldSector(room, item->pos.x, item->pos.z);
     BOX_INFO *const box = Box_GetBox(sector->box);
+    if (box == nullptr) {
+        return;
+    }
 
     if (blocked && (box->overlap_index & BOX_BLOCKABLE) != 0) {
         box->overlap_index |= BOX_BLOCKED;

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -23,15 +23,14 @@ static void M_LaserSplitterToggle(ITEM *const item)
     int16_t room_num = item->room_num;
     SECTOR *sector = Room_GetSector(item->pos, &room_num);
 
-    if ((Box_GetBox(sector->box)->overlap_index & BOX_BLOCKED_SEARCH) == 0) {
+    const BOX_INFO *const box = Box_GetBox(sector->box);
+    if (box == nullptr || (box->overlap_index & BOX_BLOCKED_SEARCH) == 0) {
         return;
     }
 
     const bool is_active = Item_IsTriggerActive(item);
 
-    if (is_active
-        == ((Box_GetBox(sector->box)->overlap_index & BOX_BLOCKED)
-            == BOX_BLOCKED)) {
+    if (is_active == ((box->overlap_index & BOX_BLOCKED) == BOX_BLOCKED)) {
         return;
     }
 
@@ -53,15 +52,15 @@ static void M_LaserSplitterToggle(ITEM *const item)
 
     int32_t x = item->pos.x;
     int32_t z = item->pos.z;
-    while (sector->box != NO_BOX
-           && (Box_GetBox(sector->box)->overlap_index & BOX_BLOCKED_SEARCH)
-               != 0) {
-        if (is_active) {
-            Box_GetBox(sector->box)->overlap_index |= BOX_BLOCKED;
-        } else {
-            Box_GetBox(sector->box)->overlap_index &= ~BOX_BLOCKED;
+    BOX_INFO *next_box;
+    while (sector->box != NO_BOX) {
+        next_box = Box_GetBox(sector->box);
+        if (next_box == nullptr
+            || (next_box->overlap_index & BOX_BLOCKED_SEARCH) == 0) {
+            break;
         }
 
+        TOGGLE_BIT(next_box->overlap_index, BOX_BLOCKED, is_active);
         x += step.x;
         z += step.z;
         sector = Room_GetSector((XYZ_32) { x, item->pos.y, z }, &room_num);

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -65,9 +65,9 @@ int32_t Box_GetCount(void)
 
 BOX_INFO *Box_GetBox(const int32_t box_idx)
 {
-    // TODO: in many cases, NO_BOX is blindly passed here and goes unchecked.
-    // Update each instance to handle NO_BOX safely.
-    return m_Boxes == nullptr ? nullptr : &m_Boxes[box_idx];
+    return m_Boxes == nullptr || box_idx < 0 || box_idx >= m_BoxCount
+        ? nullptr
+        : &m_Boxes[box_idx];
 }
 
 int16_t Box_GetOverlap(const int32_t overlap_idx)
@@ -177,7 +177,8 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
 
 bool Box_UpdateLOT(LOT_INFO *const lot, const int32_t expansion)
 {
-    if (lot->required_box == NO_BOX || lot->required_box == lot->target_box) {
+    if (Box_GetBox(lot->required_box) == nullptr
+        || lot->required_box == lot->target_box) {
         goto end;
     }
 
@@ -202,6 +203,9 @@ void Box_TargetBox(LOT_INFO *const lot, int16_t box_num)
 {
     box_num &= BOX_NUMBER_BITS;
     const BOX_INFO *const box = Box_GetBox(box_num);
+    if (box == nullptr) {
+        return;
+    }
 
     // TODO: determine if the shift is essential
     const int32_t shift = g_TRVersion >= 2 ? 1 : 0;
@@ -227,6 +231,9 @@ bool Box_StalkBox(
     }
 
     const BOX_INFO *const box = Box_GetBox(box_num);
+    if (box == nullptr) {
+        return false;
+    }
 
     // TODO: determine if the shift is essential
     const int32_t shift = g_TRVersion >= 2 ? 1 : 0;
@@ -260,6 +267,9 @@ bool Box_EscapeBox(
     const ITEM *item, const ITEM *const enemy, const int16_t box_num)
 {
     const BOX_INFO *const box = Box_GetBox(box_num);
+    if (box == nullptr) {
+        return false;
+    }
 
     // TODO: determine if the shift is essential
     const int32_t shift = g_TRVersion >= 2 ? 1 : 0;
@@ -286,7 +296,8 @@ bool Box_ValidBox(
     }
 
     const BOX_INFO *const box = Box_GetBox(box_num);
-    if ((box->overlap_index & creature->lot.setup.block_mask) != 0) {
+    if (box == nullptr
+        || (box->overlap_index & creature->lot.setup.block_mask) != 0) {
         return false;
     }
 

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -589,12 +589,8 @@ void Room_AlterFloorHeight(const ITEM *const item, const int32_t height)
     }
 
     BOX_INFO *const box = Box_GetBox(sector->box);
-    if (box->overlap_index & BOX_BLOCKABLE) {
-        if (height < 0) {
-            box->overlap_index |= BOX_BLOCKED;
-        } else {
-            box->overlap_index &= ~BOX_BLOCKED;
-        }
+    if (box != nullptr && (box->overlap_index & BOX_BLOCKABLE) != 0) {
+        TOGGLE_BIT(box->overlap_index, BOX_BLOCKED, height < 0);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This guards all box lookups to check for ones that are beyond the data range, and hence to avoid potential NPEs.

It's possible to trigger a crash on develop by putting Lara in the void and spawning an enemy nearby, but it doesn't always happen due to pathfinding RNG. A good way to test that this change doesn't impact normal pathfinding is verifying the demos play out as normal.

One other thing to verify is that security lasers continue to stop at walls e.g. Area 51 room 14.