### PR TITLE
lua: fix current level index and docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.6...develop) - ××××-××-××
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
+- fixed `trx.game.current_level` in Lua being offset by one (#5444)
 
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -19,7 +19,7 @@ local hp_lut = {
 }
 
 -- Adjust HP of enemies when the level loads
-trx.events.after_level_state(function(level)
+trx.events.after_level_file(function(level)
   for i = 1, #trx.items do
     local item = trx.items[i]
     local hp = hp_lut[item.object_id]

--- a/src/trx/game/lua/game.c
+++ b/src/trx/game/lua/game.c
@@ -84,7 +84,7 @@ static int M_L_GameLevelGetCurrentLevelTable(lua_State *const L)
 static int M_L_GameLevelGetCurrentLevelIndex(lua_State *const L)
 {
     const GF_LEVEL *const lvl = GF_GetCurrentLevel();
-    lua_pushinteger(L, lvl != nullptr ? lvl->num : -1);
+    lua_pushinteger(L, lvl != nullptr ? lvl->num + 1 : -1);
     return 1;
 }
 


### PR DESCRIPTION
Resolves #5444.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This aligns the current level index to Lua's indexing when using the getter (the other functions already do the reverse).

It also corrects the enemy HP example to use `after_level_file`, otherwise setting the HP in `after_level_state` will overwrite values restored by the savegame.
