### PR TITLE
misc: fix old custom level issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.6...develop) - ××××-××-××
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - fixed `trx.game.current_level` in Lua being offset by one (#5444)
+- fixed potential crashes in old custom levels that contain invalid room visibility portals (#5447)
 
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -252,13 +252,23 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, VFILE *const file)
             room->portals = GameBuf_Alloc(
                 sizeof(PORTAL) * num_portals + sizeof(PORTALS),
                 GBUF_ROOM_PORTALS);
-            room->portals->count = num_portals;
+            room->portals->count = 0;
             for (int32_t j = 0; j < num_portals; j++) {
-                PORTAL *const portal = &room->portals->portal[j];
+                PORTAL *const portal =
+                    &room->portals->portal[room->portals->count];
                 portal->room_num = VFile_ReadS16(file);
                 M_ReadVertex(&portal->normal, file);
                 for (int32_t k = 0; k < 4; k++) {
                     M_ReadVertex(&portal->vertex[k], file);
+                }
+
+                if (portal->room_num >= 0 && portal->room_num < num_rooms) {
+                    room->portals->count++;
+                } else {
+                    LOG_WARNING(
+                        "Ignoring invalid portal from room %d to %d", i,
+                        portal->room_num);
+                    *portal = (PORTAL) {};
                 }
             }
         }

--- a/src/trx/game/pathing/box.c
+++ b/src/trx/game/pathing/box.c
@@ -125,6 +125,9 @@ bool Box_SearchLOT(LOT_INFO *const lot, const int32_t expansion)
             }
 
             const BOX_INFO *const box = Box_GetBox(box_num);
+            if (box == nullptr) {
+                continue;
+            }
             const int32_t change = box->height - head_box->height;
             if (change > lot->setup.step || change < lot->setup.drop) {
                 continue;


### PR DESCRIPTION
Resolves #5447.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This guards against invalid visibility portals that can exist in older custom levels. The adjoining room number is now validated and if outside of the room range, it will be ignored. The linked Silas level also contains some bad box references in the overlaps list, so this is now guarded against.