### PR TITLE
demo: fix overriding user config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed `trx.game.current_level` in Lua being offset by one (#5444)
 - fixed potential crashes in old custom levels that contain invalid room visibility portals (#5447)
 - fixed stutters on certain levels with VSync off on some GPUs (#4975, regression from 1.0)
+- fixed demos being able to overwrite gameplay settings when changing other options during playback (regression from TR1X 4.14 / TR2X 1.4)
 
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/src/trx/config/common.c
+++ b/src/trx/config/common.c
@@ -6,6 +6,7 @@
 #include <trx/config/vars.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/vars.h>
 #include <trx/game/game_strings/entries.h>
@@ -14,12 +15,170 @@
 #include <stdio.h>
 #include <string.h>
 
+#define CONFIG_OVERRIDE_MAX_DEPTH 3
+
 // In-memory list of pointers to config options enforced by the game flow.
 static VECTOR *m_EnforcedOptions = nullptr;
 // In-memory list of pointers to config options hidden by the game flow.
 static VECTOR *m_HiddenOptions = nullptr;
+// In-memory list of runtime config overrides.
+static VECTOR *m_OverrideOptions = nullptr;
 
 static EVENT_MANAGER *m_EventManager = nullptr;
+
+typedef union {
+    bool bool_value;
+    int32_t int32_value;
+    float float_value;
+    double double_value;
+    RGB_888 rgb888_value;
+    char *string_value;
+} M_CONFIG_VALUE;
+
+typedef struct {
+    const CONFIG_OPTION *option;
+    M_CONFIG_VALUE base_value;
+    M_CONFIG_VALUE override_values[CONFIG_OVERRIDE_MAX_DEPTH];
+    int32_t depth;
+} M_CONFIG_OVERRIDE;
+
+static void M_CopyOptionValue(
+    const CONFIG_OPTION *const option, M_CONFIG_VALUE *const dst,
+    const void *const src)
+{
+    ASSERT(option != nullptr);
+    ASSERT(dst != nullptr);
+    ASSERT(src != nullptr);
+
+    switch (option->type) {
+    case COT_BOOL:
+        dst->bool_value = *(const bool *)src;
+        break;
+    case COT_INT32:
+        dst->int32_value = *(const int32_t *)src;
+        break;
+    case COT_ENUM:
+        dst->int32_value = *(const int *)src;
+        break;
+    case COT_FLOAT:
+    case COT_FLOAT_PERCENT:
+        dst->float_value = *(const float *)src;
+        break;
+    case COT_DOUBLE:
+        dst->double_value = *(const double *)src;
+        break;
+    case COT_RGB888:
+        dst->rgb888_value = *(const RGB_888 *)src;
+        break;
+    case COT_STRING:
+    case COT_DYNAMIC_ENUM:
+        dst->string_value = *(char *const *)src != nullptr
+            ? Memory_DupStr(*(char *const *)src)
+            : nullptr;
+        break;
+    }
+}
+
+static void M_FreeOptionValue(
+    const CONFIG_OPTION *const option, M_CONFIG_VALUE *const value)
+{
+    ASSERT(option != nullptr);
+    ASSERT(value != nullptr);
+
+    if (option->type == COT_STRING || option->type == COT_DYNAMIC_ENUM) {
+        Memory_FreePointer(&value->string_value);
+    }
+}
+
+static const void *M_GetOptionValuePtr(
+    const CONFIG_OPTION *const option, const M_CONFIG_VALUE *const value)
+{
+    ASSERT(option != nullptr);
+    ASSERT(value != nullptr);
+
+    switch (option->type) {
+    case COT_BOOL:
+        return &value->bool_value;
+    case COT_INT32:
+    case COT_ENUM:
+        return &value->int32_value;
+    case COT_FLOAT:
+    case COT_FLOAT_PERCENT:
+        return &value->float_value;
+    case COT_DOUBLE:
+        return &value->double_value;
+    case COT_RGB888:
+        return &value->rgb888_value;
+    case COT_STRING:
+    case COT_DYNAMIC_ENUM:
+        return &value->string_value;
+    }
+    return nullptr;
+}
+
+static void M_ApplyOptionValue(
+    const CONFIG_OPTION *const option, const M_CONFIG_VALUE *const value)
+{
+    ASSERT(option != nullptr);
+    ASSERT(value != nullptr);
+
+    switch (option->type) {
+    case COT_BOOL:
+        *(bool *)option->target = value->bool_value;
+        break;
+    case COT_INT32:
+        *(int32_t *)option->target = value->int32_value;
+        break;
+    case COT_ENUM:
+        *(int *)option->target = value->int32_value;
+        break;
+    case COT_FLOAT:
+    case COT_FLOAT_PERCENT:
+        *(float *)option->target = value->float_value;
+        break;
+    case COT_DOUBLE:
+        *(double *)option->target = value->double_value;
+        break;
+    case COT_RGB888:
+        *(RGB_888 *)option->target = value->rgb888_value;
+        break;
+    case COT_STRING:
+    case COT_DYNAMIC_ENUM: {
+        char **const p = (char **)option->target;
+        char *const old = *p;
+        *p = value->string_value != nullptr ? Memory_DupStr(value->string_value)
+                                            : nullptr;
+        Memory_Free(old);
+        break;
+    }
+    }
+}
+
+static int32_t M_GetOverrideIndex(const void *const target)
+{
+    if (m_OverrideOptions == nullptr) {
+        return -1;
+    }
+
+    for (int32_t i = 0; i < m_OverrideOptions->count; i++) {
+        const M_CONFIG_OVERRIDE *const override =
+            Vector_Get(m_OverrideOptions, i);
+        if (override->option->target == target) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void M_FreeOverride(M_CONFIG_OVERRIDE *const override)
+{
+    ASSERT(override != nullptr);
+
+    M_FreeOptionValue(override->option, &override->base_value);
+    for (int32_t i = 0; i < override->depth; i++) {
+        M_FreeOptionValue(override->option, &override->override_values[i]);
+    }
+}
 
 static void M_FreeStringOptionValues(void)
 {
@@ -53,6 +212,15 @@ __attribute__((destructor)) static void M_Shutdown(void)
     if (m_HiddenOptions != nullptr) {
         Vector_Free(m_HiddenOptions);
         m_HiddenOptions = nullptr;
+    }
+    if (m_OverrideOptions != nullptr) {
+        for (int32_t i = 0; i < m_OverrideOptions->count; i++) {
+            M_CONFIG_OVERRIDE *const override =
+                Vector_Get(m_OverrideOptions, i);
+            M_FreeOverride(override);
+        }
+        Vector_Free(m_OverrideOptions);
+        m_OverrideOptions = nullptr;
     }
 }
 
@@ -138,6 +306,85 @@ bool Config_Write(void)
     return ConfigFile_Write(&args);
 }
 
+bool Config_PushOptionOverride(
+    const void *const target, const void *const value)
+{
+    ASSERT(target != nullptr);
+    ASSERT(value != nullptr);
+
+    const CONFIG_OPTION *const option = Config_GetOption(target);
+    if (option == nullptr) {
+        return false;
+    }
+    if (option->type == COT_DYNAMIC_ENUM
+        && !Config_DynamicEnum_IsValidValue(option, *(char *const *)value)) {
+        return false;
+    }
+
+    if (m_OverrideOptions == nullptr) {
+        m_OverrideOptions = Vector_Create(sizeof(M_CONFIG_OVERRIDE));
+    }
+
+    int32_t override_idx = M_GetOverrideIndex(target);
+    if (override_idx == -1) {
+        M_CONFIG_OVERRIDE override = {
+            .option = option,
+            .depth = 0,
+        };
+        M_CopyOptionValue(option, &override.base_value, option->target);
+        Vector_Add(m_OverrideOptions, &override);
+        override_idx = m_OverrideOptions->count - 1;
+    }
+
+    M_CONFIG_OVERRIDE *const override =
+        Vector_Get(m_OverrideOptions, override_idx);
+    if (override->depth >= CONFIG_OVERRIDE_MAX_DEPTH) {
+        return false;
+    }
+
+    M_CONFIG_VALUE *const override_value =
+        &override->override_values[override->depth];
+    M_CopyOptionValue(option, override_value, value);
+    override->depth++;
+    M_ApplyOptionValue(option, override_value);
+    return true;
+}
+
+bool Config_PopOptionOverride(const void *const target)
+{
+    ASSERT(target != nullptr);
+
+    const int32_t override_idx = M_GetOverrideIndex(target);
+    if (override_idx == -1) {
+        return false;
+    }
+
+    M_CONFIG_OVERRIDE *const override =
+        Vector_Get(m_OverrideOptions, override_idx);
+    ASSERT(override->depth > 0);
+
+    override->depth--;
+    M_FreeOptionValue(
+        override->option, &override->override_values[override->depth]);
+
+    if (override->depth == 0) {
+        M_ApplyOptionValue(override->option, &override->base_value);
+        M_FreeOverride(override);
+        Vector_RemoveAt(m_OverrideOptions, override_idx);
+    } else {
+        M_ApplyOptionValue(
+            override->option, &override->override_values[override->depth - 1]);
+    }
+
+    return true;
+}
+
+bool Config_IsOptionOverridden(const void *const target)
+{
+    ASSERT(target != nullptr);
+    return M_GetOverrideIndex(target) != -1;
+}
+
 int32_t Config_SubscribeChanges(
     const EVENT_LISTENER listener, void *const user_data)
 {
@@ -165,6 +412,20 @@ const CONFIG_OPTION *Config_GetOption(const void *const target)
         option++;
     }
     return nullptr;
+}
+
+const void *Config_GetOptionValueForSave(const CONFIG_OPTION *const option)
+{
+    ASSERT(option != nullptr);
+
+    const int32_t override_idx = M_GetOverrideIndex(option->target);
+    if (override_idx == -1) {
+        return option->target;
+    }
+
+    const M_CONFIG_OVERRIDE *const override =
+        Vector_Get(m_OverrideOptions, override_idx);
+    return M_GetOptionValuePtr(option, &override->base_value);
 }
 
 bool Config_IsOptionEnforced(const void *const target)

--- a/src/trx/config/common.h
+++ b/src/trx/config/common.h
@@ -10,8 +10,12 @@ void Config_ApplyDefaultSettings(void);
 bool Config_Read(const char *default_path, const char *enforced_path);
 bool Config_Write(void);
 bool Config_Update(void);
+bool Config_PushOptionOverride(const void *target, const void *value);
+bool Config_PopOptionOverride(const void *target);
+bool Config_IsOptionOverridden(const void *target);
 
 const CONFIG_OPTION *Config_GetOptionMap(void);
+const void *Config_GetOptionValueForSave(const CONFIG_OPTION *option);
 
 int32_t Config_SubscribeChanges(EVENT_LISTENER listener, void *user_data);
 void Config_UnsubscribeChanges(int32_t listener_id);

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -251,49 +251,50 @@ void ConfigFile_DumpOptions(JSON_OBJECT *root_obj, const CONFIG_OPTION *options)
 {
     const CONFIG_OPTION *opt = options;
     while (opt->target != nullptr) {
+        const void *const value = Config_GetOptionValueForSave(opt);
         switch (opt->type) {
         case COT_BOOL:
             JSON_ObjectAppendBool(
                 root_obj, Config_ResolveOptionName(opt->name),
-                *(bool *)opt->target);
+                *(const bool *)value);
             break;
 
         case COT_INT32:
             JSON_ObjectAppendInt(
                 root_obj, Config_ResolveOptionName(opt->name),
-                *(int32_t *)opt->target);
+                *(const int32_t *)value);
             break;
 
         case COT_FLOAT:
         case COT_FLOAT_PERCENT:
             JSON_ObjectAppendDouble(
                 root_obj, Config_ResolveOptionName(opt->name),
-                *(float *)opt->target);
+                *(const float *)value);
             break;
 
         case COT_DOUBLE:
             JSON_ObjectAppendDouble(
                 root_obj, Config_ResolveOptionName(opt->name),
-                *(double *)opt->target);
+                *(const double *)value);
             break;
 
         case COT_ENUM:
             ConfigFile_WriteEnum(
                 root_obj, Config_ResolveOptionName(opt->name),
-                *(int *)opt->target, (const char *)opt->param);
+                *(const int32_t *)value, (const char *)opt->param);
             break;
 
         case COT_STRING:
         case COT_DYNAMIC_ENUM:
-            if (*(char **)opt->target != nullptr) {
+            if (*(char *const *)value != nullptr) {
                 JSON_ObjectAppendString(
                     root_obj, Config_ResolveOptionName(opt->name),
-                    *(char **)opt->target);
+                    *(char *const *)value);
             }
             break;
 
         case COT_RGB888: {
-            const RGB_888 *const color = (RGB_888 *)opt->target;
+            const RGB_888 *const color = (const RGB_888 *)value;
             char tmp[10];
             sprintf(tmp, "#%02X%02X%02X", color->r, color->g, color->b);
             JSON_ObjectAppendString(

--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -41,10 +41,7 @@
 typedef struct {
     const uint32_t *demo_ptr;
     const GF_LEVEL *level;
-    struct {
-        CONFIG config;
-        GAME_BONUS_FLAG bonus_flag;
-    } old_config;
+    GAME_BONUS_FLAG old_bonus_flag;
     uint32_t *data;
 } M_PRIV;
 
@@ -55,20 +52,23 @@ static void M_PrepareConfig(M_PRIV *const p)
 {
     // Changing certains settings affects negatively the original game demo
     // data, so temporarily turn off all relevant enhancements.
-    p->old_config.config = g_Config;
-    p->old_config.bonus_flag = Game_GetBonusFlag();
+    p->old_bonus_flag = Game_GetBonusFlag();
     Game_SetBonusFlag(GBF_NONE);
-#define X_PROCESS_CONFIG(var, value) g_Config.var = value;
+#define X_PROCESS_CONFIG(var, value)                                           \
+    ASSERT(Config_PushOptionOverride(                                          \
+        &g_Config.var, &(typeof(g_Config.var)) { value }));
     L_MODIFY_CONFIG();
 #undef X_PROCESS_CONFIG
 }
 
 static void M_RestoreConfig(M_PRIV *const p)
 {
-    Game_SetBonusFlag(p->old_config.bonus_flag);
-#define X_PROCESS_CONFIG(var, value) g_Config.var = p->old_config.config.var;
+    Game_SetBonusFlag(p->old_bonus_flag);
+#define X_PROCESS_CONFIG(var, value)                                           \
+    ASSERT(Config_PopOptionOverride(&g_Config.var));
     L_MODIFY_CONFIG();
 #undef X_PROCESS_CONFIG
+    Config_Update();
 }
 
 void Demo_LoadData(VFILE *const file, const size_t size)
@@ -170,6 +170,7 @@ bool Demo_Start(const int32_t level_num)
 
     if (p->data == nullptr) {
         LOG_ERROR("Level '%s' has no demo data", p->level->path);
+        M_RestoreConfig(p);
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents changes made to user settings during demo playback (like toggling the FPS counter with F2) from unintentionally saving temporarily enforced settings (such as wall glitch mode).

As a follow-up PR, I would like to migrate enforced config API to use the push/pop approach introduced in this PR.