### PR TITLE
objects/punk: fix alert behaviour

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed the camera being cut off early after placing the Oceanic Masks in Lost City of Tinnos (OG bug)
 - fixed the push button mesh being offset too far from the wall in each level it appears (OG bug)
 - fixed a missing face on the push button in Antarctica (#5428)
+- fixed Punks repeating their alert sounds and not targeting Lara in all cases (#5456, regression from 1.6)
 
 
 

--- a/src/trx/game/objects/creatures/punk.c
+++ b/src/trx/game/objects/creatures/punk.c
@@ -276,7 +276,7 @@ static void M_Control(const int16_t item_num)
         goto finish;
     }
 
-    if (creature->alerted && !creature->hurt_by_lara
+    if (creature->alerted && !creature->hurt_by_lara && Creature_IsAlly(item)
         && g_Config.gameplay.ally_hostility_policy
             == ALLY_HOSTILITY_POLICY_INDIVIDUAL) {
         // Avoid Creature_GetAITarget removing AI_GUARD flag outside of shared
@@ -293,11 +293,12 @@ static void M_Control(const int16_t item_num)
     }
 
     const bool hurt_by_lara = creature->hurt_by_lara;
-    if (creature->alerted
+    if (creature->alerted && Creature_IsHostile(item)
         && g_Config.gameplay.ally_hostility_policy
             == ALLY_HOSTILITY_POLICY_SHARED) {
         creature->enemy = lara_item;
-    } else if (!hurt_by_lara && creature->enemy == lara_item) {
+    } else if (
+        !hurt_by_lara && !creature->alerted && creature->enemy == lara_item) {
         creature->enemy = nullptr;
     }
 


### PR DESCRIPTION
Resolves #5456.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes not taking into account ally/foe status when resetting the alerted flag and enemy pointer on punks.

Testing:
- [x] Hostile punks with hostility policy on shared (e.g. Aldwych)
- [x] Hostile punks with hostility policy on individual (e.g. Aldwych)
- [x] Friendly punks turned hostile with hostility policy on shared (e.g. Luds)
- [x] Friendly punks turned hostile with hostility policy on individual (e.g. Luds)
- [x] Behaviour of those with AI Patrol using both policies in Aldywch
- [x] Behaviour of those with AI Guard using both policies in Luds