### PR TITLE
test-replay: fix parser breaking on UTF BOM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fixed potential crashes in old custom levels that contain invalid room visibility portals (#5447)
 - fixed stutters on certain levels with VSync off on some GPUs (#4975, regression from 1.0)
 - fixed demos being able to overwrite gameplay settings when changing other options during playback (regression from TR1X 4.14 / TR2X 1.4)
+- fixed replay scenario files saved with a UTF-8 signature not being read correctly
 
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -812,6 +812,19 @@ static char *M_SkipWhitespace(char *const line)
     return start;
 }
 
+static char *M_SkipUTF8BOM(char *const line)
+{
+    if (strlen(line) < 3) {
+        return line;
+    }
+
+    const unsigned char *const bytes = (const unsigned char *)line;
+    if (bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+        return line + 3;
+    }
+    return line;
+}
+
 static bool M_IsFrameMarkerLine(const char *const line)
 {
     int32_t delta = 0;
@@ -852,6 +865,8 @@ SHELL_ARGS *TestReplay_Open(const char *path)
         char *const next_line = line + strlen(line) + 1;
         M_StripInlineComment(line);
         char *start = M_SkipWhitespace(line);
+        start = M_SkipUTF8BOM(start);
+        start = M_SkipWhitespace(start);
         if (*start != '\0') {
             Vector_Add(lines, &start);
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the test scenario parser breaking if the scenario file starts with an UTF-8 Byte Order Mark (as often happens when saving text files with Windows-specific text editor apps).