### PR TITLE
game: fix collision after loading the game

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed stutters on certain levels with VSync off on some GPUs (#4975, regression from 1.0)
 - fixed demos being able to overwrite gameplay settings when changing other options during playback (regression from TR1X 4.14 / TR2X 1.4)
 - fixed replay scenario files saved with a UTF-8 signature not being read correctly
+- fixed Lara getting stuck in void after loading saves made while hanging from ladders (regression from TRX 1.2)
 
 **TR3**:
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -733,46 +733,42 @@ bool Collide_TestBoundsCollide(
 
 void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
 {
-    int32_t ceiling;
-    int32_t height;
-    int32_t oldonobj;
-    int32_t bs;
-    int32_t yang;
 
     int16_t room_num = item->room_num;
     const SECTOR *sector = Room_GetSector(old_pos, &room_num);
-    int32_t oldheight = Room_GetHeight(sector, old_pos);
-    int32_t oldtype = Room_GetHeightType();
+    const int32_t old_height = Room_GetHeight(sector, old_pos);
+    const HEIGHT_TYPE old_type = Room_GetHeightType();
 
     room_num = item->room_num;
     sector = Room_GetSector(item->pos, &room_num);
-    height = Room_GetHeight(sector, item->pos);
+    int32_t height = Room_GetHeight(sector, item->pos);
 
+    bool bs;
     if (item->pos.y >= height) {
-        bs = 0;
+        bs = false;
 
-        if ((oldtype == HT_BIG_SLOPE || oldtype == HT_DIAGONAL)
-            && oldheight < height) {
-            yang = (uint16_t)item->rot.y;
+        if ((old_type == HT_BIG_SLOPE || old_type == HT_DIAGONAL)
+            && old_height < height) {
+            int32_t y_ang = (uint16_t)item->rot.y;
 
             const XZ_16 tilt = Room_GetTiltType(sector, item->pos);
             if (tilt.x < 0) {
-                if (yang >= DEG_180) {
-                    bs = 1;
+                if (y_ang >= DEG_180) {
+                    bs = true;
                 }
             } else if (tilt.x > 0) {
-                if (yang <= DEG_180) {
-                    bs = 1;
+                if (y_ang <= DEG_180) {
+                    bs = true;
                 }
             }
 
             if (tilt.z < 0) {
-                if (yang >= DEG_90 && yang <= DEG_270) {
-                    bs = 1;
+                if (y_ang >= DEG_90 && y_ang <= DEG_270) {
+                    bs = true;
                 }
             } else if (tilt.z > 0) {
-                if (yang <= DEG_90 || yang >= DEG_270) {
-                    bs = 1;
+                if (y_ang <= DEG_90 || y_ang >= DEG_270) {
+                    bs = true;
                 }
             }
         }
@@ -786,7 +782,7 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
             item->rot.y = x_cross && xs ? -item->rot.y : -DEG_180 - item->rot.y;
             item->pos = old_pos;
             item->speed >>= 1;
-        } else if (oldtype != HT_BIG_SLOPE && oldtype != HT_DIAGONAL) {
+        } else if (old_type != HT_BIG_SLOPE && old_type != HT_DIAGONAL) {
             if (item->fall_speed > 0) {
                 if (item->fall_speed > 16) {
                     if (item->object_id == O_GRENADE) {
@@ -1107,7 +1103,7 @@ void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
 
         room_num = item->room_num;
         sector = Room_GetSector(item->pos, &room_num);
-        ceiling = Room_GetCeiling(sector, item->pos);
+        int32_t ceiling = Room_GetCeiling(sector, item->pos);
 
         if (item->pos.y < ceiling) {
             const bool x_cross = ROUND_TO_SECTOR(item->pos.x ^ old_pos.x) != 0;

--- a/src/trx/game/game/control.c
+++ b/src/trx/game/game/control.c
@@ -45,6 +45,7 @@ bool Game_Start(const GF_LEVEL *const level, const GF_SEQUENCE_CONTEXT seq_ctx)
     g_OverlayFlag = 1;
     Camera_Initialise();
     Interpolation_Remember();
+    Interpolation_Interpolate();
 
     Sound_StopAll();
     const bool is_cutscene = level->type == GFL_CUTSCENE;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara warping after loading a save made while she is hanging from a ladder.

When gameplay restarted from the save, Lara's real position was restored correctly, but her interpolated draw position could still contain coordinates from before the load. Releasing Action on the first post-load frame uses a joint position to place Lara into the falling animation, so it could read that stale interpolated position and send her far away from the ladder. The game now refreshes interpolation state as gameplay starts, keeping that first collision check aligned with the loaded save.

The joint interpolation code originates in TRX 1.2 to achieve smoother animations.

#### Testing scenario

```
args "--mod" "tr2" "-l" "1"
config gameplay.enable_fmv 0
config debug.enable_debug_pos 1

@+0:    cmd { tp 25.5 -3.5 33.5 }
@+1:    ● "left ctrl"
        ● "left"
@+26:   ○ "left"
@+15:   ● "down"
@+5:    ○ "down"
@+31:   cmd { save 1 }
@+1:    ○ "left ctrl"
@+1:    cmd { load 1 }
@+60:   quit
```