### PR TITLE
data: fix The End text missing from end credits

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -157,7 +157,7 @@
                 {"type": "play_music", "music_track": 14},
                 {"type": "level_stats"},
                 {"type": "play_music", "music_track": 121},
-                {"type": "display_picture", "credit": true, "path": "theend2_la.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
+                {"type": "display_picture", "credit": true, "path": "theend_la.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit01_eu_la.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit02_la.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit03_la.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -488,7 +488,7 @@
                 {"type": "level_stats"},
                 {"type": "play_fmv", "fmv_id": 4},
                 {"type": "play_music", "music_track": 121},
-                {"type": "display_picture", "credit": true, "path": "theend2.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
+                {"type": "display_picture", "credit": true, "path": "theend.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit01.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit02.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "display_picture", "credit": true, "path": "credit03.webp", "display_time": 5, "fade_in_time": 1.0, "fade_out_time": 1.0},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed replay scenario files saved with a UTF-8 signature not being read correctly
 
 **TR3**:
+- fixed missing "The End" text in the first end credit image (#5441)
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes
 - fixed the Circuit Bulbs in Sleeping with the Fishes not rotating on a central axis in the inventory
 - fixed the inactive seaweed at the start of Sleeping with the Fishes


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5441. Related: https://github.com/LostArtefacts/TRX-data/commit/4ac1e2204a5577e2f1437f6b5397be47adfed95a

Until we publish a new stable version that ships with the new image, the assets will need to be re-downloaded manually from [this link](https://lostartefacts.dev/aux/tr3x/main.zip).