### PR TITLE
rooms/geometry: fix water height checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,9 @@
 - fixed stutters on certain levels with VSync off on some GPUs (#4975, regression from 1.0)
 - fixed demos being able to overwrite gameplay settings when changing other options during playback (regression from TR1X 4.14 / TR2X 1.4)
 - fixed replay scenario files saved with a UTF-8 signature not being read correctly
-- fixed Lara getting stuck in void after loading saves made while hanging from ladders (regression from TRX 1.2)
-- fixed Lara not being able to crawl in one-click water rooms (regression from TRX 1.6)
+- fixed Lara getting stuck in void after loading saves made while hanging from ladders (regression from 1.2)
+- fixed Lara not being able to crawl in one-click water rooms (regression from 1.6)
+- fixed water height checks when `Fix wall geometry` is not enabled (regression from 1.6)
 
 **TR3**:
 - fixed missing "The End" text in the first end credit image (#5441)

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -472,8 +472,7 @@ int32_t Room_GetCeilingEx(
 
 int32_t Room_GetWaterHeight(const XYZ_32 pos, const int16_t room_num)
 {
-    return Room_GetWaterHeightEx(
-        pos, room_num, g_Config.gameplay.fix_wall_geometry);
+    return Room_GetWaterHeightEx(pos, room_num, true);
 }
 
 int32_t Room_GetWaterHeightEx(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes some underwater sectors essentially not containing water when `fix_wall_geometry` is off. I had wrongly applied this to `Room_GetWaterHeight` in a4db492 - the flag there is used for different purposes, effectively UPV tests only.

Recording: [water.txt](https://github.com/user-attachments/files/27566660/water.txt)