### PR TITLE
phase/phase_inventory: always stop current music

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed Lara getting stuck in void after loading saves made while hanging from ladders (regression from 1.2)
 - fixed Lara not being able to crawl in one-click water rooms (regression from 1.6)
 - fixed water height checks when `Fix wall geometry` is not enabled (regression from 1.6)
+- fixed level music tracks continuing to play when returning to the main menu if the option not to play the title music is enabled (#5470, regression from TR1X 4.13 / TR2X 1.3)
 
 **TR3**:
 - fixed missing "The End" text in the first end credit image (#5441)

--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -20,11 +20,12 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
 {
     M_PRIV *const p = phase->priv;
 
-    const GF_LEVEL *const level = GF_GetTitleLevel();
-    if (p->mode == INV_TITLE_MODE && g_Config.audio.enable_music_in_menu
-        && level->music_track >= 0) {
+    if (p->mode == INV_TITLE_MODE) {
         Music_Stop();
-        Music_Play_Direct(level->music_track, MPM_LOOP);
+        const GF_LEVEL *const level = GF_GetTitleLevel();
+        if (g_Config.audio.enable_music_in_menu && level->music_track >= 0) {
+            Music_Play_Direct(level->music_track, MPM_LOOP);
+        }
     }
 
     p->ring = InvRing_Open(p->mode);


### PR DESCRIPTION
Resolves #5470.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the current music track is stopped when entering the main menu to avoid it continuing to play if the main title music is disabled. This change does not impact in-game inventory.
