### PR TITLE
ui: fix passport dialog centering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed potential crashes in old custom levels that contain invalid room visibility portals (#5447)
 - fixed transparent pixels on TR3 outfit heads when bilinear filtering is enabled (#5438)
 - fixed transparent pixels on the TR2 Bomber Jacket outfit sleeve
+- fixed passport dialog appearing off-center when showing long save names (#249)
 - fixed stutters on certain levels with VSync off on some GPUs (#4975, regression from 1.0)
 - fixed demos being able to overwrite gameplay settings when changing other options during playback (regression from TR1X 4.14 / TR2X 1.4)
 - fixed replay scenario files saved with a UTF-8 signature not being read correctly

--- a/src/trx/game/ui/dialogs/base_passport.c
+++ b/src/trx/game/ui/dialogs/base_passport.c
@@ -46,7 +46,11 @@ void UI_BeginBasePassportDialog(void)
 {
     const float modal_y = g_Inv_Mode == INV_TITLE_MODE ? 0.81f : 0.62f;
     UI_BeginModal(0.5f, modal_y);
-    UI_BeginResize(300.0f, -1.0f);
+    UI_BeginResizeEx((UI_RESIZE_SETTINGS) {
+        .w = 300.0f,
+        .h = -1.0f,
+        .align_h = 0.5f,
+    });
 }
 
 void UI_EndBasePassportDialog(void)

--- a/src/trx/game/ui/elements/resize.c
+++ b/src/trx/game/ui/elements/resize.c
@@ -1,22 +1,51 @@
 #include <trx/game/ui/elements/resize.h>
 
 #include <trx/config.h>
+#include <trx/core/utils.h>
 #include <trx/game/ui/helpers.h>
 
 typedef struct {
-    float x;
-    float y;
+    float w;
+    float h;
+    float align_h;
+    float align_v;
 } M_DATA;
 
 static void M_Measure(UI_NODE *const node)
 {
     UI_MeasureWrapper(node);
     const M_DATA *const data = node->data;
-    if (data->x >= 0.0f) {
-        node->measure_w = data->x;
+    if (data->w >= 0.0f) {
+        node->measure_w = data->w;
     }
-    if (data->y >= 0.0f) {
-        node->measure_h = data->y;
+    if (data->h >= 0.0f) {
+        node->measure_h = data->h;
+    }
+}
+
+static void M_Layout(
+    UI_NODE *const node, const float x, const float y, const float w,
+    const float h)
+{
+    UI_LayoutBasic(node, x, y, w, h);
+    const M_DATA *const data = node->data;
+    UI_NODE *child = node->first_child;
+    while (child != nullptr) {
+        float child_w = w;
+        float child_h = h;
+        if (data->w >= 0.0f && data->align_h != 0.0f) {
+            child_w = MAX(child->measure_w, w);
+        }
+        if (data->h >= 0.0f && data->align_v != 0.0f) {
+            child_h = MAX(child->measure_h, h);
+        }
+
+        const float child_x = x + (w - child_w) * data->align_h;
+        const float child_y = y + (h - child_h) * data->align_v;
+        if (child->ops.layout != nullptr) {
+            child->ops.layout(child, child_x, child_y, child_w, child_h);
+        }
+        child = child->next_sibling;
     }
 }
 
@@ -28,20 +57,30 @@ static void M_Draw(const UI_NODE *const node)
     UI_DrawWrapper(node);
 }
 
-void UI_BeginResize(const float x, const float y)
+void UI_BeginResizeEx(const UI_RESIZE_SETTINGS settings)
 {
     UI_NODE *const node = UI_AllocNode(
         &(UI_WIDGET_OPS) {
             .measure = M_Measure,
-            .layout = UI_LayoutWrapper,
+            .layout = M_Layout,
             .draw = M_Draw,
         },
         sizeof(M_DATA));
     M_DATA *const data = node->data;
-    data->x = x * g_Config.ui.text_scale;
-    data->y = y * g_Config.ui.text_scale;
+    data->w = settings.w * g_Config.ui.text_scale;
+    data->h = settings.h * g_Config.ui.text_scale;
+    data->align_h = settings.align_h;
+    data->align_v = settings.align_v;
     UI_AddChild(node);
     UI_PushCurrent(node);
+}
+
+void UI_BeginResize(const float w, const float h)
+{
+    UI_BeginResizeEx((UI_RESIZE_SETTINGS) {
+        .w = w,
+        .h = h,
+    });
 }
 
 void UI_EndResize(void)

--- a/src/trx/game/ui/elements/resize.h
+++ b/src/trx/game/ui/elements/resize.h
@@ -6,5 +6,14 @@
 // A negative size means to use the child's size.
 // A zero value means to hide the child, but participate in the layout pass.
 
-void UI_BeginResize(float x, float y);
+typedef struct {
+    float w;
+    float h;
+    // 0.0 aligns to the start, 0.5 centers, 1.0 aligns to the end.
+    float align_h;
+    float align_v;
+} UI_RESIZE_SETTINGS;
+
+void UI_BeginResize(float w, float h);
+void UI_BeginResizeEx(UI_RESIZE_SETTINGS settings);
 void UI_EndResize(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes passport dialog appearing off-center when showing long text, for example when using quick saves in High Security Compound.