### PR TITLE
objects/rib: fix initial water height test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed the push button mesh being offset too far from the wall in each level it appears (OG bug)
 - fixed a missing face on the push button in Antarctica (#5428)
 - fixed Punks repeating their alert sounds and not targeting Lara in all cases (#5456, regression from 1.6)
+- fixed the boat (RIB) briefly having an underwater hue when Lara first climbs on (OG bug)
 - fixed height checks that could make Lara refuse to dismount the Mine Cart in custom levels
 - fixed the Strobe Light being clipped out of view too soon in several levels (missing animation bounds) (regression from 1.2)
 

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -722,7 +722,7 @@ static void M_Control(const int16_t item_num)
     if (p->water == NO_HEIGHT) {
         p->water = height;
     } else {
-        p->water -= 5;
+        p->water += M_SHIFT_Y;
     }
 
     p->left_fallspeed = M_DoDynamics(hfl, p->left_fallspeed, &fl.y);

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -872,7 +872,13 @@ static void M_Control(const int16_t item_num)
     const int32_t hfr = M_TestWaterHeight(item, M_FRONT, M_SIDE, &fr);
 
     int16_t room_num = item->room_num;
-    const SECTOR *sector = Room_GetSector(item->pos, &room_num);
+    const SECTOR *sector = Room_GetSector(
+        (XYZ_32) {
+            item->pos.x,
+            item->pos.y + M_SHIFT_Y,
+            item->pos.z,
+        },
+        &room_num);
     int32_t height = Room_GetHeight(sector, item->pos);
     Room_GetCeiling(sector, item->pos);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes #2787 for the TR3 boat (RIB) by replicating 0c0ce5bcf61449b2c8a9a34976e048cda7c44520.