### PR TITLE
collision/los: test mid smashable position

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed Lara not being able to crawl in one-click water rooms (regression from 1.6)
 - fixed water height checks when `Fix wall geometry` is not enabled (regression from 1.6)
 - fixed level music tracks continuing to play when returning to the main menu if the option not to play the title music is enabled (#5470, regression from TR1X 4.13 / TR2X 1.3)
+- fixed being unable to smash items that are placed inside geometry but have bounds that extend into regular space (#5483, regression from 1.3)
 
 **TR3**:
 - fixed missing "The End" text in the first end credit image (#5441)

--- a/src/trx/game/collision/los.c
+++ b/src/trx/game/collision/los.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/utils.h>
 #include <trx/game/items.h>
+#include <trx/game/matrix.h>
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 
@@ -37,6 +38,28 @@ static inline bool M_RoomInLOSRooms(const int16_t room_num)
         }
     }
     return false;
+}
+
+static XYZ_32 M_GetMidPos(const ITEM *const item)
+{
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
+    const XYZ_32 mid = {
+        .x = (bounds->min.x + bounds->max.x) / 2,
+        .y = (bounds->min.y + bounds->max.y) / 2,
+        .z = (bounds->min.z + bounds->max.z) / 2,
+    };
+
+    Matrix_PushUnit();
+    Matrix_Rot16(item->rot);
+    Matrix_TranslateRel32(mid);
+    const XYZ_32 pos = {
+        .x = item->pos.x + (g_MatrixPtr->_03 >> W2V_SHIFT),
+        .y = item->pos.y + (g_MatrixPtr->_13 >> W2V_SHIFT),
+        .z = item->pos.z + (g_MatrixPtr->_23 >> W2V_SHIFT),
+    };
+    Matrix_Pop();
+
+    return pos;
 }
 
 // This routine transforms the world-space LOS segment [start,target] into the
@@ -172,7 +195,7 @@ int32_t LOS_CheckSmashable(
         {
             GAME_VECTOR start_tmp = start;
             GAME_VECTOR target_tmp = {
-                .pos = item->pos,
+                .pos = M_GetMidPos(item),
             };
             if (!LOS_Check(&start_tmp, &target_tmp, false)) {
                 continue;


### PR DESCRIPTION
Resolves #5483.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates smashable LOS checks to use an item's mid position to cater for cases where an item may be positioned inside geometry, but is big enough that it extends into valid space. `test-bell-smash` for TR2 continues to pass. I'm not sure I like this approach, LMK what you think.

<details>

Waypoint shows item position, but meshes extend out into normal space.

<img width="920" height="662" alt="image" src="https://github.com/user-attachments/assets/98f44e42-b855-4d53-a319-2434baeb9ea7" />
</details>
