### PR TITLE
items/col: guard against null frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed water height checks when `Fix wall geometry` is not enabled (regression from 1.6)
 - fixed level music tracks continuing to play when returning to the main menu if the option not to play the title music is enabled (#5470, regression from TR1X 4.13 / TR2X 1.3)
 - fixed being unable to smash items that are placed inside geometry but have bounds that extend into regular space (#5483, regression from 1.3)
+- fixed a potential crash when colliding with items that have no animation data (#5488)
 
 **TR2**:
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.0)

--- a/src/trx/game/items/col.c
+++ b/src/trx/game/items/col.c
@@ -48,13 +48,19 @@ bool Item_TestBoundsCollide(
     const ITEM *const src_item, const ITEM *const dst_item,
     const int32_t radius)
 {
+    const ANIM_FRAME *const src_frame = Item_GetBestFrame(src_item);
+    const ANIM_FRAME *const dst_frame = Item_GetBestFrame(dst_item);
+    if (src_frame == nullptr || dst_frame == nullptr) {
+        return false;
+    }
+
     const COLL_ITEM src = {
-        .bounds = Item_GetBestFrame(src_item)->bounds,
+        .bounds = src_frame->bounds,
         .pos = src_item->pos,
         .rot = src_item->rot,
     };
     const COLL_ITEM dst = {
-        .bounds = Item_GetBestFrame(dst_item)->bounds,
+        .bounds = dst_frame->bounds,
         .pos = dst_item->pos,
         .rot = dst_item->rot,
     };


### PR DESCRIPTION
Resolves #5488.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids trying to read frame bounds in collision tests for objects that contain none.