### PR TITLE
shell/paths: guess common image extensions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - fixed level music tracks continuing to play when returning to the main menu if the option not to play the title music is enabled (#5470, regression from TR1X 4.13 / TR2X 1.3)
 - fixed being unable to smash items that are placed inside geometry but have bounds that extend into regular space (#5483, regression from 1.3)
 - fixed a potential crash when colliding with items that have no animation data (#5488)
+- fixed image files not falling back to other supported formats
 
 **TR2**:
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.0)

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -77,6 +77,10 @@ static const char *m_FMVExtensions[] = {
     ".mp4", ".mkv", ".mpeg", ".avi", ".webm", ".ogv", ".rpl", ".fmv", nullptr,
 };
 
+static const char *m_ImageExtensions[] = {
+    ".webp", ".png", ".jpg", ".jpeg", ".pcx", ".bmp", nullptr,
+};
+
 static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = {
     [TRX_DYNAMIC_PATH_COMMON_CONFIG] = {
         .patterns = {
@@ -133,6 +137,7 @@ static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = 
             "%trx_dir%/%rel%",
             nullptr,
         },
+        .extensions = m_ImageExtensions,
         .check_exists = true,
     },
     [TRX_DYNAMIC_PATH_INJECTION_FILE] = {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes .png/.jpg files not being loaded if their .webp equivalent is deleted.