### PR TITLE
lara/state/jump: fix hang drop speed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 **TR2**:
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.0)
+- fixed Lara entering fast fall speed slightly later than OG when dropping from a ledge (regression from TR2X 1.2)
 
 **TR3**:
 - added support for the `/teatime` console command
@@ -54,6 +55,7 @@
 - fixed height checks that could make Lara refuse to dismount the Mine Cart in custom levels
 - fixed the Strobe Light being clipped out of view too soon in several levels (missing animation bounds) (regression from 1.2)
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.1)
+- fixed Lara entering fast fall speed slightly later than OG when dropping from a ledge (regression from 1.1)
 
 
 

--- a/src/trx/game/lara/state/jump.c
+++ b/src/trx/game/lara/state/jump.c
@@ -57,7 +57,8 @@ static void M_Compress(ITEM *const item, COLL_INFO *const coll)
 
 static void M_UpJump(ITEM *const item, COLL_INFO *const coll)
 {
-    const int16_t fast_speed = g_Config.gameplay.enable_swing_cancel
+    const int16_t fast_speed =
+        (g_Config.gameplay.enable_swing_cancel && g_TRVersion == 1)
         ? M_SWING_FAST_FALL_SPEED
         : M_FAST_FALL_SPEED;
     if (item->fall_speed > fast_speed) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This reserves the more lenient hang-drop speed to TR1, which is required in Atlantis room 13 to remain compatible with OG. Regression in 279134c.
