### PR TITLE
objects/pickup: reset interact target on failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed being unable to smash items that are placed inside geometry but have bounds that extend into regular space (#5483, regression from 1.3)
 - fixed a potential crash when colliding with items that have no animation data (#5488)
 - fixed image files not falling back to other supported formats
+- fixed Lara not being able to use keys/puzzles if animated interactions are enabled and previous pickup attempts have failed due to other object collision (#5496)
 
 **TR2**:
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.0)

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -335,6 +335,11 @@ static void M_DoControlled(const int16_t item_num, ITEM *const lara_item)
         }
 
         goto cleanup;
+    } else if (
+        lara_item->current_anim_state != LS(LS_PICKUP)
+        && !lara->interact_target.is_moving
+        && lara->interact_target.item_num == item_num) {
+        lara->interact_target.item_num = NO_ITEM;
     }
 
     if (lara->interact_target.item_num != item_num) {


### PR DESCRIPTION
Resolves #5496.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resets Lara's interact target item number if moving to the item fails during pickup. I think we should retain the object collision on Randy/Rory as that's in line with how it would behave in TR4 - you'd have to use crawl to get the items.

Fixing the save itself in the OP would require entering/exiting the fly cheat or going to another pickup item and successfully collecting it.