### PR TITLE
data: add TombEditor bare bundles

### DIFF
--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -15,11 +15,17 @@ on:
         type: boolean
         description: "Pack the artifacts into zip"
         required: true
+    outputs:
+      trx_asset:
+        description: "Uploaded artifact name"
+        value: ${{ jobs.build.outputs.trx_asset }}
 
 jobs:
   build:
     name: Build release assets
     runs-on: ubuntu-latest
+    outputs:
+      trx_asset: ${{ steps.vars.outputs.trx_asset }}
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/job_build_te.yml
+++ b/.github/workflows/job_build_te.yml
@@ -1,0 +1,61 @@
+name: Build Tomb Editor bundle
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        description: "Target to build for"
+        required: true
+      zip:
+        type: boolean
+        description: "Pack the artifacts into zip"
+        required: true
+      windows_artifact_name:
+        type: string
+        description: "Windows artifact name to consume"
+        required: true
+
+jobs:
+  build_te:
+    name: Build Tomb Editor bundle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        uses: taiki-e/install-action@just
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Resolve artifact names
+        id: vars
+        run: |
+          echo "win_asset=${{ inputs.windows_artifact_name }}" >> $GITHUB_OUTPUT
+          echo "te_asset=TRX-$(just output-current-version)-TombEditor" >> $GITHUB_OUTPUT
+          echo "te_dir=build/artifacts/te/" >> $GITHUB_OUTPUT
+
+      - name: Download windows build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.vars.outputs.win_asset }}
+          path: build/artifacts/trx/
+
+      - name: Package Tomb Editor bundle
+        run: |
+          if [ "${{ inputs.zip }}" = "1" ] || [ "${{ inputs.zip }}" = "true" ]; then
+            just trx-package-win-te "build/artifacts/trx/${{ steps.vars.outputs.win_asset }}.zip" "${{ steps.vars.outputs.te_dir }}"
+          else
+            just trx-package-win-te "build/artifacts/trx/" "${{ steps.vars.outputs.te_dir }}" --no-zip
+          fi
+
+      - name: Upload TE bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.vars.outputs.te_asset }}
+          path: ${{ steps.vars.outputs.te_dir }}
+          compression-level: 9

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -29,6 +29,17 @@ jobs:
       zip: false
     secrets: inherit
 
+  package_win_te:
+    name: Build Tomb Editor bundle
+    needs:
+      - package_win
+    uses: ./.github/workflows/job_build_te.yml
+    with:
+      target: debug
+      zip: false
+      windows_artifact_name: ${{ needs.package_win.outputs.trx_asset }}
+    secrets: inherit
+
   # package_mac:
   #   name: Mac
   #   if: vars.MACOS_ENABLE == 'true'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,6 +29,18 @@ jobs:
       zip: true
     secrets: inherit
 
+  package_win_te:
+    name: Build Tomb Editor bundle
+    if: vars.PRERELEASE_ENABLE == 'true'
+    needs:
+      - package_win
+    uses: ./.github/workflows/job_build_te.yml
+    with:
+      target: debug
+      zip: true
+      windows_artifact_name: ${{ needs.package_win.outputs.trx_asset }}
+    secrets: inherit
+
   # package_win_installer:
   #   name: Build Windows installer
   #   if: vars.PRERELEASE_ENABLE == 'true'
@@ -57,6 +69,7 @@ jobs:
       - package_linux
       - package_mac
       - package_win
+      - package_win_te
       # - package_win_installer
     with:
       draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,18 @@ jobs:
       zip: false
     secrets: inherit
 
+  package_win_te:
+    name: Build Tomb Editor bundle
+    if: vars.RELEASE_ENABLE == 'true'
+    needs:
+      - package_win
+    uses: ./.github/workflows/job_build_te.yml
+    with:
+      target: release
+      zip: true
+      windows_artifact_name: ${{ needs.package_win.outputs.trx_asset }}
+    secrets: inherit
+
   package_mac:
     name: Build Mac
     if: |
@@ -75,6 +87,7 @@ jobs:
     needs:
       - package_linux
       - package_win
+      - package_win_te
       - package_win_installer
       - package_mac
     with:

--- a/data/te/tr1/Engine/cfg/base_strings-de.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-de.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-de.json5

--- a/data/te/tr1/Engine/cfg/base_strings-en-gb.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-en-gb.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-en-gb.json5

--- a/data/te/tr1/Engine/cfg/base_strings-fr.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-fr.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-fr.json5

--- a/data/te/tr1/Engine/cfg/base_strings-gd.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-gd.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-gd.json5

--- a/data/te/tr1/Engine/cfg/base_strings-it.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-it.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-it.json5

--- a/data/te/tr1/Engine/cfg/base_strings-pl.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-pl.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-pl.json5

--- a/data/te/tr1/Engine/cfg/base_strings-ru.json5
+++ b/data/te/tr1/Engine/cfg/base_strings-ru.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-ru.json5

--- a/data/te/tr1/Engine/cfg/base_strings.json5
+++ b/data/te/tr1/Engine/cfg/base_strings.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings.json5

--- a/data/te/tr1/Engine/cfg/outfits.json5
+++ b/data/te/tr1/Engine/cfg/outfits.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/outfits.json5

--- a/data/te/tr1/Engine/cfg/poses.json5
+++ b/data/te/tr1/Engine/cfg/poses.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/poses.json5

--- a/data/te/tr1/Engine/cfg/presets/tr1-pc.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr1-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-pc.json5

--- a/data/te/tr1/Engine/cfg/presets/tr1-ps1.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr1-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-ps1.json5

--- a/data/te/tr1/Engine/cfg/presets/tr2-pc.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr2-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-pc.json5

--- a/data/te/tr1/Engine/cfg/presets/tr2-ps1.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr2-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-ps1.json5

--- a/data/te/tr1/Engine/cfg/presets/tr3-pc.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr3-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-pc.json5

--- a/data/te/tr1/Engine/cfg/presets/tr3-ps1.json5
+++ b/data/te/tr1/Engine/cfg/presets/tr3-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-ps1.json5

--- a/data/te/tr1/Engine/cfg/shaders/2d.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/2d.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/2d.glsl

--- a/data/te/tr1/Engine/cfg/shaders/billboard.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/billboard.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/billboard.glsl

--- a/data/te/tr1/Engine/cfg/shaders/common.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/common.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/common.glsl

--- a/data/te/tr1/Engine/cfg/shaders/fbo.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/fbo.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/fbo.glsl

--- a/data/te/tr1/Engine/cfg/shaders/lights.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/lights.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/lights.glsl

--- a/data/te/tr1/Engine/cfg/shaders/meshes.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/meshes.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes.glsl

--- a/data/te/tr1/Engine/cfg/shaders/meshes_tr12.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/meshes_tr12.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr12.glsl

--- a/data/te/tr1/Engine/cfg/shaders/meshes_tr3.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/meshes_tr3.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr3.glsl

--- a/data/te/tr1/Engine/cfg/shaders/ui.glsl
+++ b/data/te/tr1/Engine/cfg/shaders/ui.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/ui.glsl

--- a/data/te/tr1/Engine/cfg/ui.json5
+++ b/data/te/tr1/Engine/cfg/ui.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/ui.json5

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_item_actions.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_item_actions.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_item_actions.csv

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_lara_anims.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_lara_anims.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_lara_anims.csv

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_lara_states.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_lara_states.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_lara_states.csv

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_music.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_music.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_music.csv

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_objects.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_objects.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_objects.csv

--- a/data/te/tr1/Engine/games/tr1-custom/catalog_samples.csv
+++ b/data/te/tr1/Engine/games/tr1-custom/catalog_samples.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/catalog_samples.csv

--- a/data/te/tr1/Engine/games/tr1-custom/gameflow.json5
+++ b/data/te/tr1/Engine/games/tr1-custom/gameflow.json5
@@ -1,0 +1,58 @@
+{
+    // NOTE: bad changes to this file may result in crashes.
+    // Lines starting with double slashes are comments and are ignored.
+
+    "engine": 1,
+    "name": "Tomb Raider I Custom Level",
+
+    "main_menu_picture": "title.webp",
+    "savegame_file_fmt": "save_tr1_%02d.dat",
+
+    "injections": [
+        "crystal.bin",
+        "font.bin",
+        "gun_glow.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "photo.bin",
+        "pickup_aid.bin",
+        "uzi_sfx.bin",
+    ],
+
+    "enable_tr2_item_drops": false,
+    "convert_dropped_guns": false,
+
+    "title": {
+        "path": "title.phd",
+        "music_track": 1,
+        "sequence": [
+            {"type": "display_picture", "path": "legal.webp", "legal": true, "display_time": 1, "fade_in_time": 1.0, "fade_out_time": 1.0},
+            {"type": "exit_to_title"},
+        ],
+        "injections": [],
+    },
+
+    "levels": [
+        // Level 1: First level
+        {
+            "path": "level1.phd",
+            "music_track": 2,
+            "lara_outfit": "tr1_classic",
+            "sequence": [
+                {"type": "loop_game"},
+                {"type": "level_stats"},
+                {"type": "level_complete"},
+            ],
+            "injections": [],
+        },
+    ],
+
+    "demos": [],
+    "cutscenes": [],
+    "fmvs": [],
+    "hidden_config": [],
+}

--- a/data/te/tr1/Engine/games/tr1-custom/injections/crystal.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/crystal.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/crystal.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/font.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/font.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/font.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/gun_glow.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/gun_glow.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/gun_glow.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/lara_animations.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/lara_animations.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/lara_animations.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/lara_extra.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/lara_extra.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/lara_extra.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/lara_guns.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/lara_guns.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/lara_guns.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/lara_outfits.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/lara_outfits.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/lara_outfits.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/misc_sprites.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/misc_sprites.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/misc_sprites.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/pda_model.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/pda_model.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/pda_model.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/photo.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/photo.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/photo.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/pickup_aid.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/pickup_aid.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/pickup_aid.bin

--- a/data/te/tr1/Engine/games/tr1-custom/injections/uzi_sfx.bin
+++ b/data/te/tr1/Engine/games/tr1-custom/injections/uzi_sfx.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr1/injections/uzi_sfx.bin

--- a/data/te/tr1/Engine/games/tr1-custom/inv_ring.json5
+++ b/data/te/tr1/Engine/games/tr1-custom/inv_ring.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/inv_ring.json5

--- a/data/te/tr1/Engine/games/tr1-custom/strings.json5
+++ b/data/te/tr1/Engine/games/tr1-custom/strings.json5
@@ -1,0 +1,7 @@
+{
+    "levels": [
+        {
+            "title": "First Level",
+        },
+    ],
+}

--- a/data/te/tr1/Engine/games/tr1-custom/weapons.json5
+++ b/data/te/tr1/Engine/games/tr1-custom/weapons.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr1/weapons.json5

--- a/data/te/tr2/Engine/cfg/base_strings-de.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-de.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-de.json5

--- a/data/te/tr2/Engine/cfg/base_strings-en-gb.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-en-gb.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-en-gb.json5

--- a/data/te/tr2/Engine/cfg/base_strings-fr.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-fr.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-fr.json5

--- a/data/te/tr2/Engine/cfg/base_strings-gd.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-gd.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-gd.json5

--- a/data/te/tr2/Engine/cfg/base_strings-it.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-it.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-it.json5

--- a/data/te/tr2/Engine/cfg/base_strings-pl.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-pl.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-pl.json5

--- a/data/te/tr2/Engine/cfg/base_strings-ru.json5
+++ b/data/te/tr2/Engine/cfg/base_strings-ru.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-ru.json5

--- a/data/te/tr2/Engine/cfg/base_strings.json5
+++ b/data/te/tr2/Engine/cfg/base_strings.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings.json5

--- a/data/te/tr2/Engine/cfg/outfits.json5
+++ b/data/te/tr2/Engine/cfg/outfits.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/outfits.json5

--- a/data/te/tr2/Engine/cfg/poses.json5
+++ b/data/te/tr2/Engine/cfg/poses.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/poses.json5

--- a/data/te/tr2/Engine/cfg/presets/tr1-pc.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr1-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-pc.json5

--- a/data/te/tr2/Engine/cfg/presets/tr1-ps1.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr1-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-ps1.json5

--- a/data/te/tr2/Engine/cfg/presets/tr2-pc.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr2-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-pc.json5

--- a/data/te/tr2/Engine/cfg/presets/tr2-ps1.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr2-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-ps1.json5

--- a/data/te/tr2/Engine/cfg/presets/tr3-pc.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr3-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-pc.json5

--- a/data/te/tr2/Engine/cfg/presets/tr3-ps1.json5
+++ b/data/te/tr2/Engine/cfg/presets/tr3-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-ps1.json5

--- a/data/te/tr2/Engine/cfg/shaders/2d.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/2d.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/2d.glsl

--- a/data/te/tr2/Engine/cfg/shaders/billboard.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/billboard.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/billboard.glsl

--- a/data/te/tr2/Engine/cfg/shaders/common.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/common.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/common.glsl

--- a/data/te/tr2/Engine/cfg/shaders/fbo.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/fbo.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/fbo.glsl

--- a/data/te/tr2/Engine/cfg/shaders/lights.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/lights.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/lights.glsl

--- a/data/te/tr2/Engine/cfg/shaders/meshes.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/meshes.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes.glsl

--- a/data/te/tr2/Engine/cfg/shaders/meshes_tr12.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/meshes_tr12.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr12.glsl

--- a/data/te/tr2/Engine/cfg/shaders/meshes_tr3.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/meshes_tr3.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr3.glsl

--- a/data/te/tr2/Engine/cfg/shaders/ui.glsl
+++ b/data/te/tr2/Engine/cfg/shaders/ui.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/ui.glsl

--- a/data/te/tr2/Engine/cfg/ui.json5
+++ b/data/te/tr2/Engine/cfg/ui.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/ui.json5

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_item_actions.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_item_actions.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_item_actions.csv

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_lara_anims.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_lara_anims.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_lara_anims.csv

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_lara_states.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_lara_states.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_lara_states.csv

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_music.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_music.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_music.csv

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_objects.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_objects.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_objects.csv

--- a/data/te/tr2/Engine/games/tr2-custom/catalog_samples.csv
+++ b/data/te/tr2/Engine/games/tr2-custom/catalog_samples.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/catalog_samples.csv

--- a/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
@@ -1,0 +1,59 @@
+{
+    // NOTE: bad changes to this file may result in crashes.
+    // Lines starting with double slashes are comments and are ignored.
+
+    "engine": 2,
+    "name": "Tomb Raider II Custom Level",
+
+    "main_menu_picture": "title.webp",
+    "savegame_file_fmt": "save_tr2_%02d.dat",
+
+    "injections": [
+        "boat_bits.bin",
+        "crystal.bin",
+        "font.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "photo.bin",
+        "pickup_aid.bin",
+        "secret_models_gm.bin",
+        "secret_models_og.bin",
+    ],
+
+    "enable_tr2_item_drops": true,
+    "convert_dropped_guns": true,
+
+    "title": {
+        "path": "title.tr2",
+        "music_track": 1,
+        "sequence": [
+            {"type": "display_picture", "path": "legal.webp", "legal": true},
+            {"type": "exit_to_title"},
+        ],
+        "injections": [],
+    },
+
+    "levels": [
+        // Level 1: First level
+        {
+            "path": "level1.tr2",
+            "music_track": 2,
+            "lara_outfit": "tr2_classic",
+            "sequence": [
+                {"type": "loop_game"},
+                {"type": "level_stats"},
+                {"type": "level_complete"},
+            ],
+            "injections": [],
+        },
+    ],
+
+    "demos": [],
+    "cutscenes": [],
+    "fmvs": [],
+    "hidden_config": [],
+}

--- a/data/te/tr2/Engine/games/tr2-custom/injections/boat_bits.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/boat_bits.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/boat_bits.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/crystal.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/crystal.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/crystal.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/font.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/font.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/font.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/lara_animations.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/lara_animations.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/lara_animations.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/lara_extra.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/lara_extra.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/lara_extra.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/lara_guns.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/lara_guns.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/lara_guns.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/lara_outfits.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/lara_outfits.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/lara_outfits.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/misc_sprites.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/misc_sprites.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/misc_sprites.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/pda_model.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/pda_model.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/pda_model.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/photo.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/photo.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/photo.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/pickup_aid.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/pickup_aid.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/pickup_aid.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/secret_models_gm.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/secret_models_gm.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/secret_models_gm.bin

--- a/data/te/tr2/Engine/games/tr2-custom/injections/secret_models_og.bin
+++ b/data/te/tr2/Engine/games/tr2-custom/injections/secret_models_og.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr2/injections/secret_models_og.bin

--- a/data/te/tr2/Engine/games/tr2-custom/inv_ring.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/inv_ring.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/inv_ring.json5

--- a/data/te/tr2/Engine/games/tr2-custom/strings.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/strings.json5
@@ -1,0 +1,7 @@
+{
+    "levels": [
+        {
+            "title": "First Level",
+        },
+    ],
+}

--- a/data/te/tr2/Engine/games/tr2-custom/weapons.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/weapons.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr2/weapons.json5

--- a/data/te/tr3/Engine/cfg/base_strings-de.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-de.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-de.json5

--- a/data/te/tr3/Engine/cfg/base_strings-en-gb.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-en-gb.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-en-gb.json5

--- a/data/te/tr3/Engine/cfg/base_strings-fr.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-fr.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-fr.json5

--- a/data/te/tr3/Engine/cfg/base_strings-gd.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-gd.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-gd.json5

--- a/data/te/tr3/Engine/cfg/base_strings-it.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-it.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-it.json5

--- a/data/te/tr3/Engine/cfg/base_strings-pl.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-pl.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-pl.json5

--- a/data/te/tr3/Engine/cfg/base_strings-ru.json5
+++ b/data/te/tr3/Engine/cfg/base_strings-ru.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings-ru.json5

--- a/data/te/tr3/Engine/cfg/base_strings.json5
+++ b/data/te/tr3/Engine/cfg/base_strings.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/base_strings.json5

--- a/data/te/tr3/Engine/cfg/outfits.json5
+++ b/data/te/tr3/Engine/cfg/outfits.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/outfits.json5

--- a/data/te/tr3/Engine/cfg/poses.json5
+++ b/data/te/tr3/Engine/cfg/poses.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/poses.json5

--- a/data/te/tr3/Engine/cfg/presets/tr1-pc.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr1-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-pc.json5

--- a/data/te/tr3/Engine/cfg/presets/tr1-ps1.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr1-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr1-ps1.json5

--- a/data/te/tr3/Engine/cfg/presets/tr2-pc.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr2-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-pc.json5

--- a/data/te/tr3/Engine/cfg/presets/tr2-ps1.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr2-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr2-ps1.json5

--- a/data/te/tr3/Engine/cfg/presets/tr3-pc.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr3-pc.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-pc.json5

--- a/data/te/tr3/Engine/cfg/presets/tr3-ps1.json5
+++ b/data/te/tr3/Engine/cfg/presets/tr3-ps1.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/presets/tr3-ps1.json5

--- a/data/te/tr3/Engine/cfg/shaders/2d.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/2d.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/2d.glsl

--- a/data/te/tr3/Engine/cfg/shaders/billboard.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/billboard.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/billboard.glsl

--- a/data/te/tr3/Engine/cfg/shaders/common.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/common.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/common.glsl

--- a/data/te/tr3/Engine/cfg/shaders/fbo.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/fbo.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/fbo.glsl

--- a/data/te/tr3/Engine/cfg/shaders/lights.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/lights.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/lights.glsl

--- a/data/te/tr3/Engine/cfg/shaders/meshes.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/meshes.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes.glsl

--- a/data/te/tr3/Engine/cfg/shaders/meshes_tr12.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/meshes_tr12.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr12.glsl

--- a/data/te/tr3/Engine/cfg/shaders/meshes_tr3.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/meshes_tr3.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/meshes_tr3.glsl

--- a/data/te/tr3/Engine/cfg/shaders/ui.glsl
+++ b/data/te/tr3/Engine/cfg/shaders/ui.glsl
@@ -1,0 +1,1 @@
+../../../../../trx/ship/cfg/shaders/ui.glsl

--- a/data/te/tr3/Engine/cfg/ui.json5
+++ b/data/te/tr3/Engine/cfg/ui.json5
@@ -1,0 +1,1 @@
+../../../../trx/ship/cfg/ui.json5

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_item_actions.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_item_actions.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_item_actions.csv

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_lara_anims.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_lara_anims.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_lara_anims.csv

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_lara_states.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_lara_states.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_lara_states.csv

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_music.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_music.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_music.csv

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_objects.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_objects.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_objects.csv

--- a/data/te/tr3/Engine/games/tr3-custom/catalog_samples.csv
+++ b/data/te/tr3/Engine/games/tr3-custom/catalog_samples.csv
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/catalog_samples.csv

--- a/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
@@ -1,0 +1,55 @@
+{
+    // NOTE: bad changes to this file may result in crashes.
+    // Lines starting with double slashes are comments and are ignored.
+
+    "engine": 3,
+    "name": "Tomb Raider III Custom Level",
+
+    "main_menu_picture": "title.webp",
+    "savegame_file_fmt": "save_tr3_%02d.dat",
+
+    "injections": [
+        "font.bin",
+        "globe_model.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "pickup_aid.bin",
+    ],
+
+    "enable_tr2_item_drops": true,
+    "convert_dropped_guns": true,
+
+    "title": {
+        "path": "title.tr2",
+        "music_track": 1,
+        "sequence": [
+            {"type": "display_picture", "path": "legal.webp", "legal": true},
+            {"type": "exit_to_title"},
+        ],
+        "injections": [],
+    },
+
+    "levels": [
+        // Level 1: First level
+        {
+            "path": "level1.tr2",
+            "music_track": 2,
+            "lara_outfit": "tr3_classic",
+            "sequence": [
+                {"type": "loop_game"},
+                {"type": "level_stats"},
+                {"type": "level_complete"},
+            ],
+            "injections": [],
+        },
+    ],
+
+    "demos": [],
+    "cutscenes": [],
+    "fmvs": [],
+    "hidden_config": [],
+}

--- a/data/te/tr3/Engine/games/tr3-custom/injections/font.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/font.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/font.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/globe_model.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/globe_model.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/globe_model.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/lara_animations.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/lara_animations.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/lara_animations.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/lara_extra.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/lara_extra.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/lara_extra.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/lara_guns.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/lara_guns.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/lara_guns.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/lara_outfits.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/lara_outfits.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/lara_outfits.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/misc_sprites.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/misc_sprites.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/misc_sprites.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/pda_model.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/pda_model.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/pda_model.bin

--- a/data/te/tr3/Engine/games/tr3-custom/injections/pickup_aid.bin
+++ b/data/te/tr3/Engine/games/tr3-custom/injections/pickup_aid.bin
@@ -1,0 +1,1 @@
+../../../../../../trx/ship/games/tr3/injections/pickup_aid.bin

--- a/data/te/tr3/Engine/games/tr3-custom/inv_ring.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/inv_ring.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/inv_ring.json5

--- a/data/te/tr3/Engine/games/tr3-custom/strings.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/strings.json5
@@ -1,0 +1,7 @@
+{
+    "levels": [
+        {
+            "title": "First Level",
+        },
+    ],
+}

--- a/data/te/tr3/Engine/games/tr3-custom/weapons.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/weapons.json5
@@ -1,0 +1,1 @@
+../../../../../trx/ship/games/tr3/weapons.json5

--- a/data/trx/ship/games/tr2-gm/gameflow.json5
+++ b/data/trx/ship/games/tr2-gm/gameflow.json5
@@ -9,7 +9,6 @@
     "main_menu_picture": "title_eu_gm.webp",
     "savegame_file_fmt": "save_trgm_%02d.dat",
 
-    "demo_version": false,
     "enable_tr2_item_drops": true,
     "convert_dropped_guns": true,
 

--- a/data/trx/ship/games/tr2-level/gameflow.json5
+++ b/data/trx/ship/games/tr2-level/gameflow.json5
@@ -8,7 +8,6 @@
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_custom_%02d.dat",
 
-    "demo_version": false,
     "enable_tr2_item_drops": true,
     "convert_dropped_guns": true,
 

--- a/data/trx/ship/games/tr2/gameflow.json5
+++ b/data/trx/ship/games/tr2/gameflow.json5
@@ -8,7 +8,6 @@
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr2_%02d.dat",
 
-    "demo_version": false,
     "enable_tr2_item_drops": true,
     "convert_dropped_guns": true,
 

--- a/data/trx/ship/games/tr3-level/gameflow.json5
+++ b/data/trx/ship/games/tr3-level/gameflow.json5
@@ -8,7 +8,6 @@
     "main_menu_picture": "title_eu.webp",
     "savegame_file_fmt": "save_tr3_custom_%02d.dat",
 
-    "demo_version": false,
     "enable_tr2_item_drops": true,
     "convert_dropped_guns": true,
 

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -44,10 +44,6 @@
       "type": "string",
       "description": "Path pattern to look for the savegame files."
     },
-    "demo_version": {
-      "type": "boolean",
-      "description": "Legacy demo version flag (scheduled for removal)."
-    },
     "title": {
       "$ref": "#/definitions/title",
       "description": "Configuration for the title screen."

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -894,7 +894,6 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   │   ├── legal_us.webp
 │   │   │   │   ├── london.webp
 │   │   │   │   ├── nevada.webp
-│   │   │   │   ├── nevadafff.webp
 │   │   │   │   ├── southpac.webp
 │   │   │   │   ├── theend2.webp
 │   │   │   │   ├── theend.webp
@@ -2106,7 +2105,6 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   │   ├── legal_us.webp
     │   │   │   │   │   ├── london.webp
     │   │   │   │   │   ├── nevada.webp
-    │   │   │   │   │   ├── nevadafff.webp
     │   │   │   │   │   ├── southpac.webp
     │   │   │   │   │   ├── theend2.webp
     │   │   │   │   │   ├── theend.webp

--- a/docs/trx/game_flow/GLOBAL_PROPERTIES.md
+++ b/docs/trx/game_flow/GLOBAL_PROPERTIES.md
@@ -311,8 +311,6 @@ remains distinct for each game.
     "main_menu_picture": "data/images/title_eu.webp",
     "savegame_file_fmt": "save_tr2_%02d.dat",
 
-    "demo_version": false,
-
     "title": {
         "path": "data/title.tr2",
         "music_track": 60,

--- a/justfile
+++ b/justfile
@@ -96,6 +96,9 @@ trx-build-win-installer target='release' *args: \
 
 trx-package-linux target='debug' *args: (trx-build-linux target) (_docker_run "rrdash/trx-linux" "package" args)
 trx-package-win target='debug' *args: (trx-build-win target) (_docker_run "rrdash/trx-win" "package" args)
+trx-package-win-te artifact_path output *args:
+    python3 tools/update_te_symlinks
+    python3 tools/package_te_bundle.py --artifact {{artifact_path}} --output {{output}} {{args}}
 trx-package-win-installer target='release' *args: \
     (trx-build-win-installer target args) \
     (_docker_run "rrdash/trx-win" "package" "--platform" "win-installer" args)

--- a/tools/package_te_bundle.py
+++ b/tools/package_te_bundle.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from shared.packaging import create_zip
+from shared.versioning import generate_version
+
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+DATA_TE_DIR = REPO_DIR / "data" / "te"
+TE_ENGINES: tuple[str, ...] = ("tr1", "tr2", "tr3")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--asset-suffix",
+        default="TombEditor",
+        type=str,
+    )
+    parser.add_argument("--no-zip", action="store_true")
+    return parser.parse_args()
+
+
+def iter_te_files() -> list[tuple[Path, str]]:
+    source_files: list[tuple[Path, str]] = []
+    for path in sorted(DATA_TE_DIR.rglob("*")):
+        if path.is_dir():
+            continue
+
+        rel_path = path.relative_to(DATA_TE_DIR)
+        if path.is_symlink():
+            real_path = path.resolve(strict=True)
+            source_files.append((real_path, str(rel_path)))
+        else:
+            source_files.append((path, str(rel_path)))
+    return source_files
+
+
+def iter_exe_files(exe_path: Path) -> list[tuple[Path, str]]:
+    return [
+        (exe_path, f"{engine}/Engine/TRX.exe")
+        for engine in TE_ENGINES
+    ]
+
+
+def resolve_exe_from_artifact(artifact_path: Path, temp_root: Path) -> Path:
+    search_root = artifact_path
+    if artifact_path.is_file():
+        unpack_dir = temp_root / "windows_artifact"
+        unpack_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(artifact_path) as handle:
+            handle.extractall(unpack_dir)
+        search_root = unpack_dir
+
+    for path in sorted(search_root.rglob("TRX.exe")):
+        if path.is_file():
+            return path
+    raise FileNotFoundError(
+        f"TRX.exe not found in windows artifact: {artifact_path}"
+    )
+
+
+def create_zip_from_dir(source_dir: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    source_files = [
+        (path, str(path.relative_to(source_dir)))
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file()
+    ]
+    create_zip(output_path, source_files, compresslevel=9)
+
+
+def main() -> None:
+    args = parse_args()
+    version = generate_version()
+    output_stem = f"TRX-{version}-{args.asset_suffix}"
+    output_path = args.output
+
+    if output_path.suffix.lower() != ".zip" and not args.no_zip:
+        output_path = output_path / (
+            f"{args.artifact.name}.zip"
+            if args.artifact.is_dir()
+            else f"{output_stem}.zip"
+        )
+    elif args.no_zip and output_path.suffix.lower() == ".zip":
+        raise ValueError("--no-zip output must be a directory path")
+
+    with tempfile.TemporaryDirectory(prefix="trx-te-bundle-") as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        exe_path = resolve_exe_from_artifact(args.artifact.resolve(), tmpdir_path)
+
+        source_files = [*iter_te_files(), *iter_exe_files(exe_path)]
+        tmp_root = tmpdir_path / "bundle"
+        tmp_root.mkdir(parents=True, exist_ok=True)
+
+        for src_path, rel_path in source_files:
+            dst_path = tmp_root / rel_path
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src_path, dst_path)
+
+        if args.no_zip:
+            output_path.mkdir(parents=True, exist_ok=True)
+            for path in tmp_root.iterdir():
+                dst_path = output_path / path.name
+                if dst_path.exists():
+                    if dst_path.is_dir():
+                        shutil.rmtree(dst_path)
+                    else:
+                        dst_path.unlink()
+                if path.is_dir():
+                    shutil.copytree(path, dst_path)
+                else:
+                    shutil.copy(path, dst_path)
+            print(f"Created {output_path}")
+        else:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            create_zip_from_dir(tmp_root, output_path)
+            print(f"Created {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shared/packaging.py
+++ b/tools/shared/packaging.py
@@ -5,9 +5,16 @@ from pathlib import Path
 
 
 def create_zip(
-    output_path: Path, source_files: Iterable[tuple[Path, str]]
+    output_path: Path,
+    source_files: Iterable[tuple[Path, str]],
+    *,
+    compresslevel: int | None = None,
 ) -> None:
-    with zipfile.ZipFile(output_path, "w") as handle:
+    kwargs = {}
+    if compresslevel is not None:
+        kwargs["compression"] = zipfile.ZIP_DEFLATED
+        kwargs["compresslevel"] = compresslevel
+    with zipfile.ZipFile(output_path, "w", **kwargs) as handle:
         for source_path, archive_name in source_files:
             if not source_path.exists():
                 print(

--- a/tools/update_te_symlinks
+++ b/tools/update_te_symlinks
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA_TE = ROOT / "data" / "te"
+TE_GAMES: tuple[str, ...] = ("tr1", "tr2", "tr3")
+
+GAME_LINKS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("tr1", "tr1-custom"): (
+        "catalog_item_actions.csv",
+        "catalog_lara_anims.csv",
+        "catalog_lara_states.csv",
+        "catalog_music.csv",
+        "catalog_objects.csv",
+        "catalog_samples.csv",
+        "inv_ring.json5",
+        "weapons.json5",
+    ),
+    ("tr2", "tr2-custom"): (
+        "catalog_item_actions.csv",
+        "catalog_lara_anims.csv",
+        "catalog_lara_states.csv",
+        "catalog_music.csv",
+        "catalog_objects.csv",
+        "catalog_samples.csv",
+        "inv_ring.json5",
+        "weapons.json5",
+    ),
+    ("tr3", "tr3-custom"): (
+        "catalog_item_actions.csv",
+        "catalog_lara_anims.csv",
+        "catalog_lara_states.csv",
+        "catalog_music.csv",
+        "catalog_objects.csv",
+        "catalog_samples.csv",
+        "inv_ring.json5",
+        "weapons.json5",
+    ),
+}
+
+INJECTION_LINKS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("tr1", "tr1-custom"): (
+        "crystal.bin",
+        "font.bin",
+        "gun_glow.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "photo.bin",
+        "pickup_aid.bin",
+        "uzi_sfx.bin",
+    ),
+    ("tr2", "tr2-custom"): (
+        "boat_bits.bin",
+        "crystal.bin",
+        "font.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "photo.bin",
+        "pickup_aid.bin",
+        "secret_models_gm.bin",
+        "secret_models_og.bin",
+    ),
+    ("tr3", "tr3-custom"): (
+        "font.bin",
+        "globe_model.bin",
+        "lara_animations.bin",
+        "lara_extra.bin",
+        "lara_guns.bin",
+        "lara_outfits.bin",
+        "misc_sprites.bin",
+        "pda_model.bin",
+        "pickup_aid.bin",
+    ),
+}
+
+
+def remove_te_symlinks() -> None:
+    for path in DATA_TE.rglob("*"):
+        if path.is_symlink():
+            path.unlink()
+
+
+def create_symlink(path: Path, target: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(target)
+
+
+def create_cfg_links() -> None:
+    source_dir = ROOT / "data" / "trx" / "ship" / "cfg"
+    for game in TE_GAMES:
+        target_dir = ROOT / "data" / "te" / game / "Engine" / "cfg"
+        for source_path in sorted(source_dir.rglob("*")):
+            if source_path.is_dir():
+                continue
+            rel_path = source_path.relative_to(source_dir)
+            target_path = target_dir / rel_path
+            target_rel = source_path.relative_to(
+                target_path.parent, walk_up=True
+            )
+            create_symlink(target_path, str(target_rel))
+
+
+def create_game_links() -> None:
+    for (game, custom), names in GAME_LINKS.items():
+        base_dir = ROOT / "data" / "te" / game / "Engine" / "games" / custom
+        target_prefix = Path("../../../../../trx/ship/games") / game
+        (base_dir / "injections").mkdir(parents=True, exist_ok=True)
+        for name in names:
+            create_symlink(base_dir / name, str(target_prefix / name))
+
+
+def create_injection_links() -> None:
+    for (game, custom), names in INJECTION_LINKS.items():
+        base_dir = ROOT / "data" / "te" / game / "Engine" / "games" / custom / "injections"
+        target_prefix = Path("../../../../../../trx/ship/games") / game / "injections"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            create_symlink(base_dir / name, str(target_prefix / name))
+
+
+def main() -> None:
+    remove_te_symlinks()
+    create_cfg_links()
+    create_game_links()
+    create_injection_links()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds a zip with drag'n'drop TombEditor setups that contain bare minimal information to play the game.
I'd appreciate testing this feature with the actual editor as it's pretty much a blind fix.