### PR TITLE
game/overlay: guard for missing pickup animations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed a potential crash when colliding with items that have no animation data (#5488)
 - fixed image files not falling back to other supported formats
 - fixed Lara not being able to use keys/puzzles if animated interactions are enabled and previous pickup attempts have failed due to other object collision (#5496)
+- fixed a potential crash if 3D pickups are enabled but an item's 3D model isn't loaded or contains no animation data
 
 **TR2**:
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.0)

--- a/src/trx/game/output/sources/ui.c
+++ b/src/trx/game/output/sources/ui.c
@@ -145,6 +145,9 @@ static void M_Draw3DPickups(const M_PRIV *const p)
             Vector_Get(p->scheduled_pickups, i);
         const ANIM_FRAME *const frame =
             Object_GetAnim(pickup->object, 0)->frame_ptr;
+        if (frame == nullptr) {
+            continue;
+        }
 
         const VIEWPORT_RECT pickup_rect = OutputSource_UI_GetPickupRect(pickup);
         const XYZ_32 origin = {

--- a/src/trx/game/overlay.c
+++ b/src/trx/game/overlay.c
@@ -605,8 +605,13 @@ void Overlay_AddDisplayPickup(const OBJECT_ID obj_id)
         const INVENTORY_ITEM *const inv_item = InvRing_GetInvItem(obj_id);
         pickup->phase = DPP_EASE_IN;
         pickup->object_id = obj_id;
-        pickup->display.object =
-            inv_object_id != NO_OBJECT ? Object_Get(inv_object_id) : nullptr;
+        pickup->display.object = nullptr;
+        if (inv_object_id != NO_OBJECT) {
+            const OBJECT *const obj = Object_Get(inv_object_id);
+            if (obj->loaded && obj->anim_idx != NO_ANIM) {
+                pickup->display.object = obj;
+            }
+        }
         pickup->display.grid_x = grid_x;
         pickup->display.grid_y = grid_y;
         pickup->start_rot = inv_item != nullptr ? inv_item->y_rot_sel : 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

If 3D pickups are enabled but the game has fallen back to drawing a sprite in the world view because of missing animations, this update will mean the HUD will do the same. An additional guard is added to the output to check for null frames.

A simple test is excluding the secrets injection file from TR2 and having 3D pickups enabled.