### PR TITLE
data: fix MP5 damage value

### DIFF
--- a/data/trx/ship/games/tr1/weapons.json5
+++ b/data/trx/ship/games/tr1/weapons.json5
@@ -235,7 +235,7 @@
         "aim_speed": 10,
         "shot_accuracy": 8,
         "gun_height": 500,
-        "damage": 3,
+        "damage": 4,
         "ammo": {
             "initial_qty": 60,
             "pickup_qty": 60,

--- a/data/trx/ship/games/tr2/weapons.json5
+++ b/data/trx/ship/games/tr2/weapons.json5
@@ -233,7 +233,7 @@
         "aim_speed": 10,
         "shot_accuracy": 8,
         "gun_height": 500,
-        "damage": 3,
+        "damage": 4,
         "ammo": {
             "initial_qty": 60,
             "pickup_qty": 60,

--- a/data/trx/ship/games/tr3/weapons.json5
+++ b/data/trx/ship/games/tr3/weapons.json5
@@ -240,7 +240,7 @@
         "aim_speed": 10,
         "shot_accuracy": 8,
         "gun_height": 500,
-        "damage": 3,
+        "damage": 4,
         "ammo": {
             "initial_qty": 60,
             "pickup_qty": 60,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - fixed the Strobe Light being clipped out of view too soon in several levels (missing animation bounds) (regression from 1.2)
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.1)
 - fixed Lara entering fast fall speed slightly later than OG when dropping from a ledge (regression from 1.1)
+- fixed the MP5 dealing slightly less damage than OG (regression from 1.1)
 
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This corrects the MP5 to deal 4 damage rather than 3. The M16 deals 3.
