### PR TITLE
inject/editors/floor_data: add reverb support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,9 +34,11 @@
 - fixed a potential crash if 3D pickups are enabled but an item's 3D model isn't loaded or contains no animation data
 
 **TR1**:
+- added support for reverb in custom levels
 - fixed a stray face on the Magnums model (#2073)
 
 **TR2**:
+- added support for reverb in custom levels
 - fixed transparent pixels on the CD player in each level (#4072)
 - fixed a stray face on the Automatic Pistols and Uzis models (#2073)
 - fixed transparent pixels on the Automatic Pistols in Golden Mask levels (#2073)

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -250,6 +250,9 @@ static void M_RoomProperties(
     room->flags.inside      = (flags & 0x40) != 0;
     room->flags.swamp       = (flags & 0x80) != 0;
     // clang-format on
+    if (injection->version >= INJ_VERSION_8) {
+        room->reverb_info = VFile_ReadU8(injection->fp);
+    }
 }
 
 static void M_SectorOverwrite(

--- a/src/trx/game/inject/enum.h
+++ b/src/trx/game/inject/enum.h
@@ -14,7 +14,8 @@ typedef enum {
     INJ_VERSION_5 = 5,
     INJ_VERSION_6 = 6,
     INJ_VERSION_7 = 7,
-    INJ_CURRENT_VERSION = INJ_VERSION_7,
+    INJ_VERSION_8 = 8,
+    INJ_CURRENT_VERSION = INJ_VERSION_8,
 } INJECTION_VERSION;
 
 typedef enum {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows reverb type injection for TR1 and TR2 rooms. Test levels available.

Ref: https://github.com/LostArtefacts/TRXInjectionTool/pull/266
