### PR TITLE
rooms/floor_data: extend trigger type support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `O_LARA_RIB`
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
-- added support for heavy switch, heavy antitrigger, and monkeyswing trigger types in custom levels
+- added support for heavy switch, heavy antitrigger, crouch, and monkeyswing trigger types in custom levels
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `O_LARA_RIB`
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
+- added support for heavy switch triggers in custom levels
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `O_LARA_RIB`
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
-- added support for heavy switch triggers and heavy antitriggers in custom levels
+- added support for heavy switch, heavy antitrigger, and monkeyswing trigger types in custom levels
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `O_LARA_RIB`
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
-- added support for heavy switch triggers in custom levels
+- added support for heavy switch triggers and heavy antitriggers in custom levels
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `O_LARA_RIB`
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
-- added support for heavy switch, heavy antitrigger, crouch, and monkeyswing trigger types in custom levels
+- added support for heavy switch, heavy antitrigger, crouch, climb, and monkeyswing trigger types in custom levels
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -116,9 +116,7 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     }
     if (trigger->type == TT_SWITCH) {
         item->flags ^= trigger->mask;
-    } else if (
-        trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    } else if (Room_IsAntiTrigger(trigger->type)) {
         item->flags &= ~trigger->mask;
     } else {
         item->flags |= trigger->mask;

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -116,7 +116,9 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     }
     if (trigger->type == TT_SWITCH) {
         item->flags ^= trigger->mask;
-    } else if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER) {
+    } else if (
+        trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         item->flags &= ~trigger->mask;
     } else {
         item->flags |= trigger->mask;

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -263,7 +263,8 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 
     item->timer = 0;
 
-    if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER) {
+    if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         Shoal_TriggerDeactivate(item);
     } else {
         const int32_t leader_num = trigger->timer & 7;

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -11,6 +11,7 @@
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/output/textures.h>
 #include <trx/game/random.h>
+#include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
 #include <trx/version.h>
 
@@ -263,8 +264,7 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 
     item->timer = 0;
 
-    if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    if (Room_IsAntiTrigger(trigger->type)) {
         Shoal_TriggerDeactivate(item);
     } else {
         const int32_t leader_num = trigger->timer & 7;

--- a/src/trx/game/objects/traps/fire_head.c
+++ b/src/trx/game/objects/traps/fire_head.c
@@ -140,7 +140,8 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     }
 
     if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD) {
+        || trigger->type == TT_ANTIPAD
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         return true;
     }
 

--- a/src/trx/game/objects/traps/fire_head.c
+++ b/src/trx/game/objects/traps/fire_head.c
@@ -139,9 +139,7 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
         return true;
     }
 
-    if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    if (trigger == nullptr || Room_IsAntiTrigger(trigger->type)) {
         return true;
     }
 

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -276,9 +276,7 @@ static void M_Control(const int16_t item_num)
 
 static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 {
-    if (trigger != nullptr && trigger->type != TT_ANTIPAD
-        && trigger->type != TT_ANTITRIGGER
-        && trigger->type != TT_HEAVY_ANTITRIGGER) {
+    if (trigger != nullptr && !Room_IsAntiTrigger(trigger->type)) {
         item->hit_points = trigger->timer & 7;
         if (item->hit_points == 0) {
             item->hit_points = 1;

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -277,7 +277,8 @@ static void M_Control(const int16_t item_num)
 static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 {
     if (trigger != nullptr && trigger->type != TT_ANTIPAD
-        && trigger->type != TT_ANTITRIGGER) {
+        && trigger->type != TT_ANTITRIGGER
+        && trigger->type != TT_HEAVY_ANTITRIGGER) {
         item->hit_points = trigger->timer & 7;
         if (item->hit_points == 0) {
             item->hit_points = 1;

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -39,7 +39,8 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     }
 
     if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD) {
+        || trigger->type == TT_ANTIPAD
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         return true;
     }
 

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -38,9 +38,7 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
         return true;
     }
 
-    if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    if (trigger == nullptr || Room_IsAntiTrigger(trigger->type)) {
         return true;
     }
 

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -3,6 +3,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/pathing.h>
+#include <trx/game/rooms.h>
 
 // clang-format off
 #define M_MAX_SLOTS  3
@@ -127,9 +128,7 @@ static void M_SpawnWasp(const ITEM *const spawner_item, const int32_t slot_idx)
 
 static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 {
-    if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    if (trigger == nullptr || Room_IsAntiTrigger(trigger->type)) {
         return true;
     }
 

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -128,7 +128,8 @@ static void M_SpawnWasp(const ITEM *const spawner_item, const int32_t slot_idx)
 static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
 {
     if (trigger == nullptr || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_ANTIPAD) {
+        || trigger->type == TT_ANTIPAD
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         return true;
     }
 

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -89,6 +89,7 @@ typedef enum {
     TT_COMBAT,
     TT_DUMMY,
     TT_ANTITRIGGER,
+    TT_HEAVY_SWITCH,
 } TRIGGER_TYPE;
 
 typedef enum {

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -95,6 +95,7 @@ typedef enum {
     // TR5 uses TT_SKELETON and TT_TIGHTROPE. Numbering reserved to align with
     // level compilers.
     TT_CROUCH = 15,
+    TT_CLIMB,
 } TRIGGER_TYPE;
 
 typedef enum {

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -92,6 +92,9 @@ typedef enum {
     TT_HEAVY_SWITCH,
     TT_HEAVY_ANTITRIGGER,
     TT_MONKEY,
+    // TR5 uses TT_SKELETON and TT_TIGHTROPE. Numbering reserved to align with
+    // level compilers.
+    TT_CROUCH = 15,
 } TRIGGER_TYPE;
 
 typedef enum {

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -90,6 +90,7 @@ typedef enum {
     TT_DUMMY,
     TT_ANTITRIGGER,
     TT_HEAVY_SWITCH,
+    TT_HEAVY_ANTITRIGGER,
 } TRIGGER_TYPE;
 
 typedef enum {

--- a/src/trx/game/rooms/enum.h
+++ b/src/trx/game/rooms/enum.h
@@ -91,6 +91,7 @@ typedef enum {
     TT_ANTITRIGGER,
     TT_HEAVY_SWITCH,
     TT_HEAVY_ANTITRIGGER,
+    TT_MONKEY,
 } TRIGGER_TYPE;
 
 typedef enum {

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -358,6 +358,7 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
     if (is_heavy) {
         switch (trigger->type) {
         case TT_HEAVY:
+        case TT_HEAVY_ANTITRIGGER:
             break;
         case TT_HEAVY_SWITCH:
             const int32_t item_flags = item->flags & IF_CODE_BITS;
@@ -422,6 +423,7 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
         case TT_HEAVY:
         case TT_DUMMY:
         case TT_HEAVY_SWITCH:
+        case TT_HEAVY_ANTITRIGGER:
             return false;
 
         case TT_COMBAT:

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -53,6 +53,20 @@ static const LARA_TRX_STATE m_CrouchStates[] = {
     // clang-format on
 };
 
+static const LARA_TRX_STATE m_ClimbStates[] = {
+    // clang-format off
+    LS_HANG,
+    LS_CLIMB_STANCE,
+    LS_CLIMBING,
+    LS_CLIMB_LEFT,
+    LS_CLIMB_END,
+    LS_CLIMB_RIGHT,
+    LS_CLIMB_DOWN,
+    LS_MONKEY_IDLE,
+    LS_TRX_INVALID, // sentinel
+    // clang-format on
+};
+
 static void (*m_Handlers[TO_NUMBER_OF])(
     const TRIGGER *trigger, const TRIGGER_CMD *cmd,
     TRIGGER_STATUS *status) = {};
@@ -467,6 +481,12 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
         case TT_CROUCH:
             if (!Lara_HasState(m_CrouchStates)) {
+                return false;
+            }
+            break;
+
+        case TT_CLIMB:
+            if (!Lara_HasState(m_ClimbStates)) {
                 return false;
             }
             break;

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -461,3 +461,9 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
     return true;
 }
+
+bool Room_IsAntiTrigger(const TRIGGER_TYPE type)
+{
+    return type == TT_ANTIPAD || type == TT_ANTITRIGGER
+        || type == TT_HEAVY_ANTITRIGGER;
+}

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -346,6 +346,7 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
     TRIGGER_STATUS status = {
         .is_heavy = is_heavy,
+        .heavy_mask = trigger->mask,
         .camera_item = nullptr,
         .switch_off = false,
         .flip_map = false,
@@ -355,7 +356,22 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
     };
 
     if (is_heavy) {
-        if (trigger->type != TT_HEAVY) {
+        switch (trigger->type) {
+        case TT_HEAVY:
+            break;
+        case TT_HEAVY_SWITCH:
+            const int32_t item_flags = item->flags & IF_CODE_BITS;
+            if (item_flags == 0) {
+                return false;
+            }
+
+            if (item_flags < 0) {
+                status.heavy_mask += item_flags;
+            } else if (item_flags != status.heavy_mask) {
+                return false;
+            }
+            break;
+        default:
             return false;
         }
     } else {
@@ -405,6 +421,7 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
         case TT_HEAVY:
         case TT_DUMMY:
+        case TT_HEAVY_SWITCH:
             return false;
 
         case TT_COMBAT:

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -39,6 +39,20 @@ static const LARA_TRX_STATE m_MonkeyStates[] = {
     // clang-format on
 };
 
+static const LARA_TRX_STATE m_CrouchStates[] = {
+    // clang-format off
+    LS_CROUCH_IDLE,
+    LS_CROUCH_ROLL,
+    LS_CROUCH_TURN_LEFT,
+    LS_CROUCH_TURN_RIGHT,
+    LS_CRAWL_IDLE,
+    LS_CRAWL_FORWARD,
+    LS_CRAWL_TURN_LEFT,
+    LS_CRAWL_TURN_RIGHT,
+    LS_TRX_INVALID, // sentinel
+    // clang-format on
+};
+
 static void (*m_Handlers[TO_NUMBER_OF])(
     const TRIGGER *trigger, const TRIGGER_CMD *cmd,
     TRIGGER_STATUS *status) = {};
@@ -447,6 +461,12 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
         case TT_MONKEY:
             if (!Lara_HasState(m_MonkeyStates)) {
+                return false;
+            }
+            break;
+
+        case TT_CROUCH:
+            if (!Lara_HasState(m_CrouchStates)) {
                 return false;
             }
             break;

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -26,6 +26,19 @@
 #define M_TRIG_CAM_GLIDE(t) ((t & 0x3E00) >> 6)
 #define M_LADDER_TYPE(t) ((t & 0x7F00) >> 8)
 
+static const LARA_TRX_STATE m_MonkeyStates[] = {
+    // clang-format off
+    LS_MONKEY_IDLE,
+    LS_MONKEY_FORWARD,
+    LS_MONKEY_LEFT,
+    LS_MONKEY_RIGHT,
+    LS_MONKEY_ROLL,
+    LS_MONKEY_TURN_LEFT,
+    LS_MONKEY_TURN_RIGHT,
+    LS_TRX_INVALID, // sentinel
+    // clang-format on
+};
+
 static void (*m_Handlers[TO_NUMBER_OF])(
     const TRIGGER *trigger, const TRIGGER_CMD *cmd,
     TRIGGER_STATUS *status) = {};
@@ -428,6 +441,12 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
 
         case TT_COMBAT:
             if (lara_info->gun_status != LGS_READY) {
+                return false;
+            }
+            break;
+
+        case TT_MONKEY:
+            if (!Lara_HasState(m_MonkeyStates)) {
                 return false;
             }
             break;

--- a/src/trx/game/rooms/floor_data.h
+++ b/src/trx/game/rooms/floor_data.h
@@ -16,6 +16,7 @@ void Room_RegisterTriggerHandler(
         TRIGGER_STATUS *status));
 bool Room_TestTriggers(const ITEM *item);
 bool Room_TestSectorTrigger(const ITEM *item, const SECTOR *sector);
+bool Room_IsAntiTrigger(TRIGGER_TYPE type);
 
 #define REGISTER_TRIGGER_HANDLER(cmd_type, handle_func)                        \
     __attribute__((constructor)) static void                                   \

--- a/src/trx/game/rooms/triggers/item.c
+++ b/src/trx/game/rooms/triggers/item.c
@@ -56,9 +56,7 @@ static void M_Handle(
         if (trigger->one_shot && g_TRVersion == 3) {
             item->flags |= IF_ONE_SHOT_SWITCH;
         }
-    } else if (
-        trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
-        || trigger->type == TT_HEAVY_ANTITRIGGER) {
+    } else if (Room_IsAntiTrigger(trigger->type)) {
         // TODO investigate unifying as ~(trigger->mask | IF_REVERSE)
         if (g_TRVersion >= 3) {
             item->flags &= ~(IF_CODE_BITS | IF_REVERSE);

--- a/src/trx/game/rooms/triggers/item.c
+++ b/src/trx/game/rooms/triggers/item.c
@@ -13,6 +13,7 @@ static bool M_IsOneShot(const TRIGGER *const trigger, const ITEM *const item)
             return (item->flags & IF_ONE_SHOT_SWITCH) != 0;
         case TT_ANTIPAD:
         case TT_ANTITRIGGER:
+        case TT_HEAVY_ANTITRIGGER:
             return (item->flags & IF_ONE_SHOT_ANTITRIGGER) != 0;
         default:
             break;
@@ -55,7 +56,9 @@ static void M_Handle(
         if (trigger->one_shot && g_TRVersion == 3) {
             item->flags |= IF_ONE_SHOT_SWITCH;
         }
-    } else if (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER) {
+    } else if (
+        trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
+        || trigger->type == TT_HEAVY_ANTITRIGGER) {
         // TODO investigate unifying as ~(trigger->mask | IF_REVERSE)
         if (g_TRVersion >= 3) {
             item->flags &= ~(IF_CODE_BITS | IF_REVERSE);

--- a/src/trx/game/rooms/triggers/item.c
+++ b/src/trx/game/rooms/triggers/item.c
@@ -46,8 +46,12 @@ static void M_Handle(
         }
     }
 
-    if (trigger->type == TT_SWITCH) {
-        item->flags ^= trigger->mask;
+    if (trigger->type == TT_SWITCH || trigger->type == TT_HEAVY_SWITCH) {
+        if (trigger->type == TT_HEAVY_SWITCH) {
+            item->flags ^= status->heavy_mask;
+        } else {
+            item->flags ^= trigger->mask;
+        }
         if (trigger->one_shot && g_TRVersion == 3) {
             item->flags |= IF_ONE_SHOT_SWITCH;
         }

--- a/src/trx/game/rooms/triggers/music.c
+++ b/src/trx/game/rooms/triggers/music.c
@@ -26,9 +26,7 @@ static void M_Handle(
 {
     MUSIC_ID track_id = (MUSIC_ID)(intptr_t)cmd->parameter;
 
-    if (track_id == (MUSIC_ID)0
-        && (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
-            || trigger->type == TT_HEAVY_ANTITRIGGER)) {
+    if (track_id == (MUSIC_ID)0 && Room_IsAntiTrigger(trigger->type)) {
         Music_Stop();
         return;
     }
@@ -53,9 +51,7 @@ static void M_Handle(
 
         if (trigger->type == TT_SWITCH) {
             flags ^= trigger->mask;
-        } else if (
-            trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
-            || trigger->type == TT_HEAVY_ANTITRIGGER) {
+        } else if (Room_IsAntiTrigger(trigger->type)) {
             flags &= -1 - trigger->mask;
         } else if (trigger->mask) {
             flags |= trigger->mask;

--- a/src/trx/game/rooms/triggers/music.c
+++ b/src/trx/game/rooms/triggers/music.c
@@ -27,7 +27,8 @@ static void M_Handle(
     MUSIC_ID track_id = (MUSIC_ID)(intptr_t)cmd->parameter;
 
     if (track_id == (MUSIC_ID)0
-        && (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER)) {
+        && (trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
+            || trigger->type == TT_HEAVY_ANTITRIGGER)) {
         Music_Stop();
         return;
     }
@@ -53,7 +54,8 @@ static void M_Handle(
         if (trigger->type == TT_SWITCH) {
             flags ^= trigger->mask;
         } else if (
-            trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER) {
+            trigger->type == TT_ANTIPAD || trigger->type == TT_ANTITRIGGER
+            || trigger->type == TT_HEAVY_ANTITRIGGER) {
             flags &= -1 - trigger->mask;
         } else if (trigger->mask) {
             flags |= trigger->mask;

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -39,6 +39,7 @@ typedef struct {
     int32_t new_effect;
     bool flip_status;
     bool is_heavy;
+    int32_t heavy_mask;
 } TRIGGER_STATUS;
 
 typedef struct {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds support for heavy switch, heavy antitrigger, monkeyswing, crawl and climb trigger types in custom levels. Test level available.
