### PR TITLE
fx/weather: add camera spawn

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
     - `O_LARA_MINE_CART`
 - added Lara's Antarctica beta outfit (#5190)
 - added support for heavy switch, heavy antitrigger, crouch, climb, and monkeyswing trigger types in custom levels
+- changed weather to spawn at the camera's position when fixed cameras are in use (#5516)
 - improved pathfinding checks to guard against potential crashes when enemies are in invalid locations
 - improved vaulting logic for Lara, allowing her to grab the lowest reachable ledge in front of her when only action is held, regardless of room layout (#5205)
 - changed `/set` to refuse level-enforced settings unless `--force` is used

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -22,7 +22,7 @@
 #define M_MAX_WEATHER_ALIVE 16
 
 #define M_RAIN_MAX_DISTANCE 6000
-#define M_RAIN_BASE_Y_OFF (-1024)
+#define M_RAIN_BASE_Y_OFF (-WALL_L)
 #define M_RAIN_BASE_YV 16
 #define M_RAIN_YV_RND_MASK 7
 #define M_RAIN_SPAWN_DIST_MASK 0xFFF
@@ -84,15 +84,23 @@ static bool M_SpawnParticle(XYZ_32 *const pos)
         return false;
     }
 
-    XYZ_32 lara_pos = {};
-    if (!Lara_GetMeshPos(LM_HIPS, &lara_pos)) {
-        lara_pos = lara_item->pos;
+    XYZ_32 base_pos = {};
+    if (g_Camera.type == CAM_FIXED) {
+        base_pos = g_Camera.pos.pos;
+        if (g_Camera.target.y < g_Camera.pos.y) {
+            base_pos.y += M_RAIN_BASE_Y_OFF;
+        }
+    } else {
+        if (!Lara_GetMeshPos(LM_HIPS, &base_pos)) {
+            base_pos = lara_item->pos;
+        }
+        base_pos.y += M_RAIN_BASE_Y_OFF;
     }
 
     const int32_t dist = Random_GetDraw() & M_RAIN_SPAWN_DIST_MASK;
     const int32_t angle = (Random_GetDraw() & M_RAIN_SPAWN_ANGLE_MASK) * 8;
-    *pos = XYZ_32_OffsetYaw(lara_pos, angle, dist);
-    pos->y += M_RAIN_BASE_Y_OFF - (Random_GetDraw() & M_RAIN_Y_RND_MASK);
+    *pos = XYZ_32_OffsetYaw(base_pos, angle, dist);
+    pos->y -= (Random_GetDraw() & M_RAIN_Y_RND_MASK);
 
     int16_t room_num = NO_ROOM;
     if (Room_GetOutsideStatus(*pos, &room_num) != 1) {


### PR DESCRIPTION
Resolves #5516.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates weather to spawn at the camera's position when a fixed camera is in use. I've left the default Y pos change to only happen if the fixed camera's target is above the camera itself (e.g. camera 0 in Meteorite Cavern); otherwise as the fixed position is already pre-calculated it avoids potentially going into the ceiling and no weather spawning as a result (e.g. camera 1 in Meteorite Cavern). For regular camera mode, the current spawning logic remains.