### PR TITLE
objects/compy: fix box guarding

### DIFF
--- a/src/trx/game/objects/creatures/compy.c
+++ b/src/trx/game/objects/creatures/compy.c
@@ -164,7 +164,7 @@ static void M_Control(const int16_t item_num)
         int16_t room_num = item->room_num;
         SECTOR *const sector = Room_GetSector(creature->target, &room_num);
         const BOX_INFO *const box = Box_GetBox(sector->box);
-        if (box != nullptr && ABS(box->height - item->pos.y) > STEP_L) {
+        if (box == nullptr || ABS(box->height - item->pos.y) > STEP_L) {
             creature->mood = MOOD_BORED;
             p->scared_timer = p->shared->scared_timer;
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes compy creatures sticking by Lara rather than targeting carcasses if nearby. Unreleased regression in 9649080.