### PR TITLE
objects/rx_worker_1: fix walk-to-shoot frame check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -75,6 +75,7 @@
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.1)
 - fixed Lara entering fast fall speed slightly later than OG when dropping from a ledge (regression from 1.1)
 - fixed the MP5 dealing slightly less damage than OG (regression from 1.1)
+- fixed RX Worker 1 not firing at Lara when starting to walk towards her (OG bug)
 
 
 

--- a/src/trx/game/objects/creatures/rx_worker_1.c
+++ b/src/trx/game/objects/creatures/rx_worker_1.c
@@ -347,7 +347,7 @@ static void M_Control(const int16_t item_num)
             torso_y = info.angle;
         }
 
-        if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 17)
+        if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 16)
             || (anim_idx == M_ANIM_AIM_4B && frame_idx == 6)) {
             if (!Creature_Shoot(item, &info, &m_Gun, torso_y, M_DAMAGE)) {
                 item->required_anim_state = M_STATE_WALK;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves RX Worker 1 not firing a shot at Lara when starting to walk towards her. The London guard had the same issue in OG, but this has already been resolved.