### PR TITLE
Miscellaneous improvements to damage dealing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - changed the underwater crawling fix to be optional (Gameplay Options → Fixes → Fix underwater crawling)
 - changed max upscaling factor from 8 to 10 (#5347)
 - changed Lua item maximum HP setup to use `item.properties.max_hit_points` instead of `item.max_hit_points`
+- changed flooding and drowning enemies to contribute towards kill count
 - fixed `trx.game.current_level` in Lua being offset by one (#5444)
 - fixed potential crashes in old custom levels that contain invalid room visibility portals (#5447)
 - fixed transparent pixels on TR3 outfit heads when bilinear filtering is enabled (#5438)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed image files not falling back to other supported formats
 - fixed Lara not being able to use keys/puzzles if animated interactions are enabled and previous pickup attempts have failed due to other object collision (#5496)
 - fixed a potential crash if 3D pickups are enabled but an item's 3D model isn't loaded or contains no animation data
+- fixed certain traps triggering Lara's healthbar when she's invulnerable
 
 **TR1**:
 - added support for reverb in custom levels

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1252,8 +1252,8 @@ void Creature_TestBoxDamage(const int16_t item_num)
         return;
     }
 
-    item->hit_points -= M_BOX_DAMAGE;
-    if (item->hit_points <= 0) {
+    Item_TakeDamage(item, M_BOX_DAMAGE, false);
+    if (item->hit_points <= 0 && item->include_in_kill_stats) {
         Stats_AddKill();
     }
 }

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -1195,6 +1195,9 @@ bool Creature_Animate(
             &room_num);
         if (M_TestDrowned(item, bounds, room_num)) {
             item->hit_points = 0;
+            if (item->include_in_kill_stats) {
+                Stats_AddKill();
+            }
         }
     }
 

--- a/src/trx/game/objects/creatures/raptor.c
+++ b/src/trx/game/objects/creatures/raptor.c
@@ -146,8 +146,7 @@ static void M_Attack(ITEM *const item, const AI_INFO *const info)
     raptor->flags |= 1;
     Creature_Effect(item, &m_RaptorBite, Spawn_Blood);
 
-    raptor->enemy->hit_points -= damage / 4;
-    raptor->enemy->hit_status = true;
+    Item_TakeDamage(raptor->enemy, damage / 4, true);
     if (raptor->enemy->hit_points <= 0) {
         raptor->flags |= 2;
     }

--- a/src/trx/game/objects/creatures/trex_alpha.c
+++ b/src/trx/game/objects/creatures/trex_alpha.c
@@ -171,8 +171,7 @@ static void M_Attack(ITEM *const item, ITEM *const target)
         M_KillLara(item);
     } else if (target->object_id == O_RAPTOR) {
         Creature_Effect(item, &m_Bite, Spawn_Blood);
-        target->hit_points -= M_RAPTOR_DAMAGE;
-        target->hit_status = true;
+        Item_TakeDamage(target, M_RAPTOR_DAMAGE, true);
     } else if (target->object_id == O_FLARE_ITEM) {
         target->hit_points = M_FLARE_SEEN;
     }

--- a/src/trx/game/objects/creatures/tribe_axeman.c
+++ b/src/trx/game/objects/creatures/tribe_axeman.c
@@ -247,8 +247,7 @@ static void M_Control(const int16_t item_num)
                 if (Item_IsNearby(enemy, item, M_HIT_RANGE)) {
                     if (creature->flags >= hit_frame->start_frame
                         && creature->flags <= hit_frame->end_frame) {
-                        enemy->hit_points -= 2;
-                        enemy->hit_status = 1;
+                        Item_TakeDamage(enemy, 2, true);
                         Creature_Effect(item, &m_AxeHit, Spawn_Blood);
                         Sound_Effect(SFX_LARA_THUD, &item->pos, SPM_NORMAL);
                     }

--- a/src/trx/game/objects/traps/damocles_sword.c
+++ b/src/trx/game/objects/traps/damocles_sword.c
@@ -86,7 +86,7 @@ static void M_Collision(
         Lara_Col_ItemPush(item, coll, false, true);
     }
     if (item->gravity) {
-        lara_item->hit_points -= M_DAMAGE;
+        Lara_TakeDamage(M_DAMAGE, false);
         int32_t x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256;
         int32_t z = lara_item->pos.z + (Random_GetControl() - 0x4000) / 256;
         int32_t y = lara_item->pos.y - Random_GetControl() / 44;

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -194,9 +194,7 @@ static void M_Collision(
         if (coll->enable_baddie_push) {
             Lara_Col_ItemPush(item, coll, coll->enable_hit, true);
         }
-        if (!g_Config.debug.enable_invulnerability) {
-            lara_item->hit_points -= M_DAMAGE_AIR;
-        }
+        Lara_TakeDamage(M_DAMAGE_AIR, false);
 
         // TODO: handle overflows
         const int32_t dx = lara_item->pos.x - item->pos.x;

--- a/src/trx/game/objects/traps/spikes.c
+++ b/src/trx/game/objects/traps/spikes.c
@@ -34,7 +34,7 @@ static void M_Collision(
         return;
     }
 
-    lara_item->hit_points -= M_DAMAGE;
+    Lara_TakeDamage(M_DAMAGE, false);
     for (int32_t i = 0; i < blood_spawn_count; i++) {
         const XYZ_32 pos = {
             .x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256,

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -976,9 +976,7 @@ static int32_t M_SkidooDynamics(ITEM *const item)
 
         if (Lara_Vehicle_GetItem() == item && quad->velocity == 0xA000
             && speed2 < 0x9FF6) {
-            ITEM *const lara_item = Lara_GetItem();
-            lara_item->hit_points -= (0xA000 - speed2) >> 7;
-            lara_item->hit_status = 1;
+            Lara_TakeDamage((0xA000 - speed2) >> 7, true);
         }
 
         if (quad->velocity > 0 && speed2 < quad->velocity) {

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -935,7 +935,7 @@ bool UPV_Control(void)
             lara->air--;
             if (lara->air < 0) {
                 lara->air = -1;
-                lara_item->hit_points -= 5;
+                Lara_TakeDamage(5, false);
             }
         }
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

- Changes drowning an enemy (either via luring them, or via flip maps) to contribute towards kill count
- Fixes lasers and doors cheat killing unkillable objects such as dragon's half (very esoteric, didn't modify the changelog)
- Fixes quad, UPV, spikes, Damocles sword, and boulders briefly damaging Lara with invulnerability cheat
- Fixes certain enemies killing unkillable objects by not respecting `can_take_damage_func` (very theoretical bug, didn't modify the changelog)