### PR TITLE
objects/mp_2: fix walk-to-shoot frame check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,7 +77,7 @@
 - fixed the menu SFX not playing when opening the Controls option (#5476, regression from 1.1)
 - fixed Lara entering fast fall speed slightly later than OG when dropping from a ledge (regression from 1.1)
 - fixed the MP5 dealing slightly less damage than OG (regression from 1.1)
-- fixed RX Worker 1 not firing at Lara when starting to walk towards her (OG bug)
+- fixed MP 2 and RX Worker 1 not firing at Lara when starting to walk towards her (OG bug)
 - fixed incorrect textures in It's a Madhouse! room 97 and missing/incorrect textures on lamps and orbs
 - fixed incorrect texture sounds in It's a Madhouse rooms 66, 69 and 133
 - fixed floating spikes in It's a Madhouse! (#5520)

--- a/src/trx/game/objects/creatures/mp_2.c
+++ b/src/trx/game/objects/creatures/mp_2.c
@@ -380,7 +380,7 @@ static void M_Control(const int16_t item_num)
             torso_x = info.x_angle;
         }
 
-        if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 17)
+        if ((anim_idx == M_ANIM_AIM_4A && frame_idx == 16)
             || (anim_idx == M_ANIM_AIM_4B && frame_idx == 6)) {
             if (!Creature_Shoot(item, &info, &m_Gun, torso_y, M_DAMAGE)) {
                 item->required_anim_state = M_STATE_WALK;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves MP 2 not firing a shot at Lara when starting to walk towards her.