### PR TITLE
Fix TR3 skybox brightness

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 **TR3**:
 - added support for the `/teatime` console command
 - changed Quad Bike level 3 (The River Ganges) music tracks to be no longer hardcoded; moved the setup to LUA
+- fixed all skyboxes being much too bright and not being affected by the gamma option
 - fixed a missing texture on Winston's nose
 - fixed missing "The End" text in the first end credit image (#5441)
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -286,10 +286,7 @@ void Output_DrawObjectMesh_I(const OBJECT_MESH *const mesh, const CLIP clip)
 
 void Output_DrawSkybox(const OBJECT_MESH *const mesh)
 {
-    float sunset_progress = Output_GetTimeInGame() / Output_GetSunsetDuration();
-    CLAMP(sunset_progress, 0.0f, 1.0f);
-    OutputSource_Objects_StageSkyboxMesh(
-        mesh, SHADE_NEUTRAL + SHADE_SUNSET * sunset_progress);
+    OutputSource_Objects_StageObjectMesh(mesh);
     SceneCompositor_Flush();
 }
 

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -179,7 +179,7 @@ static void M_Stage(const OBJECT_MESH *const mesh)
 
     OUTPUT_LIGHT_INFO light_info = Output_GetLightInfo();
     if (g_TRVersion >= 3 && M_IsMeshSkybox(Object_GetMeshIndex(mesh))) {
-        light_info.tr3_ambient = COLOR_RGB_F_WHITE;
+        light_info.tr3_ambient = (RGB_F) { 0.5f, 0.5f, 0.5f };
         for (int32_t i = 0; i < 3; i++) {
             light_info.tr3_light_color[i] = (RGB_F) { 0.0f, 0.0f, 0.0f };
             light_info.tr3_light_dir_view[i] = (XYZ_32) { 0, 0, 0 };

--- a/src/trx/game/output/sources/objects.c
+++ b/src/trx/game/output/sources/objects.c
@@ -17,7 +17,6 @@ typedef struct {
 typedef struct {
     MEMORY_ARENA_ALLOCATOR alloc;
     MESH_BATCHER *batcher;
-    int16_t skybox_shade;
     size_t mesh_count;
     M_MESH *meshes;
 } M_PRIV;
@@ -155,26 +154,6 @@ static void M_FreeMeshes(M_PRIV *const p)
     Memory_ArenaReset(&p->alloc);
 }
 
-static void M_UpdateShadesSkybox(
-    MESH_INSTANCE *const inst, void *const user_data)
-{
-    const OBJECT_MESH *const mesh = user_data;
-    const M_PRIV *const p = &m_Priv;
-
-    M_MESH *const batch = &p->meshes[Object_GetMeshIndex(mesh)];
-    if (batch->mesh_batch == nullptr) {
-        return;
-    }
-    OUTPUT_MESH_VERTEX *const vertices =
-        Vector_GetData(batch->mesh_batch->vertices);
-
-    const int16_t shade =
-        g_Config.rendering.enable_lighting ? p->skybox_shade : SHADE_NEUTRAL;
-    for (int32_t i = 0; i < batch->mesh_batch->vertices->count; i++) {
-        vertices[i].shade = shade;
-    }
-}
-
 static void M_UpdateFlags(const OBJECT_MESH *const mesh, M_MESH *const batch)
 {
     uint16_t mask = VERT_REFLECTIVE | VERT_NO_LIGHTING;
@@ -274,14 +253,6 @@ void OutputSource_Objects_ObserveObjectMeshUpdate(const int32_t mesh_idx)
     }
     M_UpdateFlags(Object_GetMesh(mesh_idx), batch);
     MeshBatcher_UpdateMeshGeometry(p->batcher, batch->mesh_batch);
-}
-
-void OutputSource_Objects_StageSkyboxMesh(
-    const OBJECT_MESH *const mesh, const int16_t shade)
-{
-    M_PRIV *const p = &m_Priv;
-    p->skybox_shade = shade;
-    M_Stage(mesh);
 }
 
 void OutputSource_Objects_StageObjectMesh(const OBJECT_MESH *const mesh)

--- a/src/trx/game/output/sources/objects.h
+++ b/src/trx/game/output/sources/objects.h
@@ -12,8 +12,6 @@ void OutputSource_Objects_ObserveObjectMeshSwap(
     int32_t mesh_idx_1, int32_t mesh_idx_2);
 void OutputSource_Objects_ObserveObjectMeshUpdate(int32_t mesh_idx);
 
-void OutputSource_Objects_StageSkyboxMesh(
-    const OBJECT_MESH *mesh, int16_t shade);
 void OutputSource_Objects_StageObjectMesh(const OBJECT_MESH *mesh);
 
 const SCENE_SOURCE *OutputSource_Objects_GetSource(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This brings TR3 skyboxes brightness in line with the OG, along with gamma curve, and brightness modulation.