### PR TITLE
objects: fix revivable objects

### DIFF
--- a/src/trx/game/objects/creatures/dragon.c
+++ b/src/trx/game/objects/creatures/dragon.c
@@ -330,7 +330,6 @@ static void M_ControlBack(const int16_t item_num)
     int16_t angle = 0;
     int16_t head = 0;
     CREATURE *const creature = dragon_front_item->creature_data;
-    const OBJECT *const front_obj = Object_Get(O_DRAGON_FRONT);
     const bool is_two_phase = M_IsTwoPhaseMode(dragon_back_item);
 
     if (dragon_front_item->hit_points <= 0) {
@@ -347,7 +346,8 @@ static void M_ControlBack(const int16_t item_num)
                     dragon_front_item->goal_anim_state = M_STATE_STOP;
                 }
                 if (creature->flags > M_LIVE_TIME + M_ALMOST_LIVE) {
-                    dragon_front_item->hit_points = front_obj->hit_points / 2;
+                    dragon_front_item->hit_points =
+                        dragon_front_item->max_hit_points / 2;
                 }
             } else if (creature->flags == M_ONE_PHASE_TIME) {
                 M_MarkDragonDead(dragon_back_item);

--- a/src/trx/game/objects/creatures/lizard.c
+++ b/src/trx/game/objects/creatures/lizard.c
@@ -519,7 +519,6 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Creature_Collision;
 
     obj->shadow_size = UNIT_SHADOW / 2;
-
     obj->radius = 204;
     obj->pivot_length = 0;
     obj->lot_setup = LOT_Setup(LOT_SETUP_CLIMBER);

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -311,7 +311,7 @@ static void M_TriggerLizard(M_PRIV *const p)
     item->flags = 0;
     item->creature_data = nullptr;
     item->mesh_bits = -1;
-    item->hit_points = Object_Get(O_LIZARD)->hit_points;
+    item->hit_points = item->max_hit_points;
     item->active = 0;
     item->status = IS_ACTIVE;
     item->collidable = 1;

--- a/src/trx/game/objects/general/assault_target.c
+++ b/src/trx/game/objects/general/assault_target.c
@@ -46,7 +46,7 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "targetable", p->targetable);
 }
 
-static void M_ResetItemState(ITEM *const item, const OBJECT *const obj)
+static void M_ResetItemState(ITEM *const item)
 {
     Item_SwitchToAnim(item, 0, 0);
     const ANIM *const anim = Item_GetAnim(item);
@@ -57,14 +57,12 @@ static void M_ResetItemState(ITEM *const item, const OBJECT *const obj)
     item->rot.x = 0;
     item->rot.z = 0;
     item->timer = 0;
-    item->hit_points = obj->hit_points;
-    item->max_hit_points = obj->hit_points;
+    item->hit_points = item->max_hit_points;
 }
 
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const OBJECT *const obj = Object_Get(item->object_id);
 
     if (item->active) {
         Item_RemoveActive(item_num);
@@ -85,7 +83,7 @@ static void M_Initialise(const int16_t item_num)
     item->flags = 0;
     item->collidable = true;
 
-    M_ResetItemState(item, obj);
+    M_ResetItemState(item);
 }
 
 static void M_Control(const int16_t item_num)

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -52,7 +52,6 @@ void Object_SetupAllObjects(void)
         obj->can_be_projectile_target_func = nullptr;
         obj->can_be_exploded_func = nullptr;
         obj->get_mesh_index_func = nullptr;
-        obj->hit_points = 0;
         obj->pivot_length = 0;
         obj->radius = M_DEFAULT_RADIUS;
         obj->shadow_size = 0;

--- a/src/trx/game/objects/traps/raptor_emitter.c
+++ b/src/trx/game/objects/traps/raptor_emitter.c
@@ -25,7 +25,7 @@ static void M_SpawnRaptor(const ITEM *const spawner_item, int32_t slot_idx)
     raptor_item->required_anim_state = 0;
     raptor_item->flags &= ~(IF_INVISIBLE | IF_KILLED | 3); // 3?
     raptor_item->creature_data = nullptr;
-    raptor_item->hit_points = Object_Get(raptor_item->object_id)->hit_points;
+    raptor_item->hit_points = raptor_item->max_hit_points;
     raptor_item->mesh_bits = -1;
     raptor_item->status = IS_ACTIVE;
     raptor_item->collidable = true;

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -110,7 +110,7 @@ static void M_SpawnWasp(const ITEM *const spawner_item, const int32_t slot_idx)
     wasp_item->required_anim_state = 0;
     wasp_item->flags &= ~(IF_INVISIBLE | IF_KILLED | 3);
     wasp_item->creature_data = nullptr;
-    wasp_item->hit_points = Object_Get(wasp_item->object_id)->hit_points;
+    wasp_item->hit_points = wasp_item->max_hit_points;
     wasp_item->mesh_bits = -1;
     wasp_item->status = IS_ACTIVE;
     wasp_item->collidable = true;

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -104,7 +104,6 @@ typedef struct OBJECT {
 
     int16_t anim_idx;
     int16_t anim_count;
-    int16_t hit_points;
     int16_t pivot_length;
     int16_t radius;
     int16_t shadow_size;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the hit points not working with the following "revivable" objects:
- [x] Raptors (Crash Site)
- [x] Lizards (Puna)
- [x] Wasps (Tinnos)
- [x] Dragon (TR2)
- [x] Assault Target (Lara's Home)