### PR TITLE
rooms/floor_data: ignore invalid triggers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@
 - fixed incorrect textures in Willard's Lair rooms 11, 52 and 56
 - fixed being unable to obtain the final secret in Aldwych due to Punk behaviour (#5533, regression from 1.6)
 - fixed Punks 190 and 199 having swapped fire sticks (#5533, regression from 1.4)
+- fixed incorrectly defined dummy triggers in certain old custom levels conflicting with normal triggers (#5537, regression from TR1X 4.8)
 
 
 

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -93,23 +93,24 @@ static const int16_t *M_ReadTrigger(
         }
     }
 
-    TRIGGER_CMD *cmd;
-    if (sector->trigger == nullptr) {
-        sector->trigger = trigger;
-        sector->trigger->command =
-            GameBuf_Alloc(sizeof(TRIGGER_CMD), GBUF_FLOOR_DATA);
-        cmd = sector->trigger->command;
-    } else {
+    if (sector->trigger != nullptr) {
         // Some old TRLEs have incorrectly formatted floor data, with multiple
-        // trigger entries defined where regular triggers overlap dummies. In
-        // this case we link the new commands onto the old.
-        cmd = sector->trigger->command;
-        while (cmd->next_cmd != nullptr) {
-            cmd = cmd->next_cmd;
-        }
-        cmd->next_cmd = GameBuf_Alloc(sizeof(TRIGGER_CMD), GBUF_FLOOR_DATA);
-        cmd = cmd->next_cmd;
+        // trigger entries defined where regular triggers overlap dummies.
+        // Ignore the data as dummy triggers are no longer essential.
+        int16_t command;
+        do {
+            command = *data++;
+            if (M_TRIG_CMD_TYPE(command) == TO_CAMERA) {
+                command = *data++;
+            }
+        } while (!M_IS_DONE(command));
+        goto finish;
     }
+
+    sector->trigger = trigger;
+    sector->trigger->command =
+        GameBuf_Alloc(sizeof(TRIGGER_CMD), GBUF_FLOOR_DATA);
+    TRIGGER_CMD *cmd = sector->trigger->command;
 
     while (true) {
         int16_t command = *data++;
@@ -138,6 +139,7 @@ static const int16_t *M_ReadTrigger(
         cmd = cmd->next_cmd;
     }
 
+finish:
     return data;
 }
 


### PR DESCRIPTION
Resolves #5537.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces the fix in 13a2f31 for old custom levels having more than one trigger on a sector by now ignoring anything but the first rather than appending the commands. It avoids duplicating commands for items, which can cause them to activate then immediately deactivate on the same trigger, in the case of a switch.

`/tp i16` in the OP can be checked (trapdoors should open with the switch), as well as `/tp i61` in [Nordic Adventure](https://trcustoms.org/levels/3146) level 1 (breakable tile should break).
