### PR TITLE
Fix a potential crash on a fresh game start + switch

### DIFF
--- a/src/trx/game/anims/common.c
+++ b/src/trx/game/anims/common.c
@@ -13,6 +13,19 @@ static ANIM_RANGE *m_Ranges = nullptr;
 static ANIM_BONE *m_Bones = nullptr;
 static ANIM m_NullAnim = {};
 
+void Anim_Reset(void)
+{
+    m_AnimCount = 0;
+    m_ChangeCount = 0;
+    m_RangeCount = 0;
+    m_BoneCount = 0;
+    m_Anims = nullptr;
+    m_Changes = nullptr;
+    m_Ranges = nullptr;
+    m_Bones = nullptr;
+    m_NullAnim = (ANIM) {};
+}
+
 void Anim_InitialiseAnims(const int32_t num_anims)
 {
     m_AnimCount = num_anims;

--- a/src/trx/game/anims/common.h
+++ b/src/trx/game/anims/common.h
@@ -5,6 +5,7 @@
 
 #define NO_ANIM (-1)
 
+void Anim_Reset(void);
 void Anim_InitialiseAnims(int32_t num_anims);
 void Anim_InitialiseChanges(int32_t num_changes);
 void Anim_InitialiseRanges(int32_t num_ranges);

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -82,6 +82,8 @@ void Item_SwitchToObjAnim(
     const OBJECT *const obj = Object_Get(obj_id);
     if (obj->anim_idx == NO_ANIM) {
         item->anim_num = NO_ANIM;
+        item->frame_num = 0;
+        return;
     } else {
         item->anim_num = obj->anim_idx + anim_idx;
     }

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -194,8 +194,13 @@ void Item_Initialise(const int16_t item_num)
     const OBJECT *const obj = Object_Get(item->object_id);
 
     Item_SwitchToAnim(item, 0, 0);
-    item->goal_anim_state = Item_GetAnim(item)->current_anim_state;
-    item->current_anim_state = item->goal_anim_state;
+    if (item->anim_num != NO_ANIM) {
+        item->goal_anim_state = Item_GetAnim(item)->current_anim_state;
+        item->current_anim_state = item->goal_anim_state;
+    } else {
+        item->goal_anim_state = 0;
+        item->current_anim_state = 0;
+    }
     item->required_anim_state = 0;
     item->rot.x = 0;
     item->rot.z = 0;

--- a/src/trx/game/level/common.c
+++ b/src/trx/game/level/common.c
@@ -32,6 +32,7 @@ void Level_Unload(void)
     Gym_TrackManager_Reset(GYM_TRACK_ASSAULT);
     Gym_TrackManager_Reset(GYM_TRACK_QUAD);
     Creature_Reset();
+    Anim_Reset();
     Object_Reset();
     Camera_Reset();
     Walkable_Reset();

--- a/src/trx/game/objects/common.c
+++ b/src/trx/game/objects/common.c
@@ -22,6 +22,7 @@ static int32_t m_MeshCount = 0;
 void Object_Reset(void)
 {
     for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
+        ObjectProperty_ResetObject(&m_Objects[i]);
         m_Objects[i].loaded = false;
     }
 

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -14,6 +14,13 @@ struct OBJECT_PROPERTY_ENTRY {
     OBJECT_PROPERTY_VALUE value;
 };
 
+__attribute__((destructor)) static void M_Shutdown(void)
+{
+    for (int32_t i = O_FIRST; i < O_NUMBER_OF; i++) {
+        ObjectProperty_ResetObject(Object_Get(i));
+    }
+}
+
 static OBJECT_PROPERTY_ENTRY *M_GetEntry(
     const OBJECT_PROPERTY_SET *const properties, const char *const name)
 {

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -25,6 +25,7 @@
 #include <trx/game/lara/skin.h>
 #include <trx/game/lua.h>
 #include <trx/game/music.h>
+#include <trx/game/objects.h>
 #include <trx/game/option.h>
 #include <trx/game/output.h>
 #include <trx/game/overlay.h>


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a potential crash that can be triggered with these steps:

1. Delete cache folder
2. Launch TR3
3. Go to Lara's Home (not sure if essential)
4. Return to title
5. Switch games to TR2
    → Crash resulting from Dragon's Lair Bartoli setup in `Stats_CalculateMaxStats`

Also, fixes a negligible memory leak introduced by custom properties.