### PR TITLE
shaders: fix TR3 choppy effect discontinuity

### DIFF
--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -53,6 +53,7 @@ vec3 waterWibble(vec4 worldPosition, vec4 screenPosition)
 
 void main(void) {
     vec4 worldPos = uMatModel * vec4(inPosition.xyz, 1.0);
+    vec4 lightWorldPos = worldPos;
 
     if ((inFlags & VERT_MOVE) != 0u) {
         float waterMul = (uWaterEffect != 0) ? 1.0 : 0.0;
@@ -88,7 +89,7 @@ void main(void) {
     // the flat polygon's palette color). Keep the lighting component separate
     // from the base color so gamma is applied in the right place.
     LightingResult lr =
-        light(inShade, gFlags, inNormal.xyz, worldPos, inNormal.w);
+        light(inShade, gFlags, inNormal.xyz, lightWorldPos, inNormal.w);
     gShade = lr.shade;
 
     float gamma_exp = 1.0 / ((uGamma / 10.0) * 4.0);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,7 @@
 - added support for the `/teatime` console command
 - changed Quad Bike level 3 (The River Ganges) music tracks to be no longer hardcoded; moved the setup to LUA
 - fixed all skyboxes being much too bright and not being affected by the gamma option
+- fixed harsh lighting transitions on vertices using glow effect
 - fixed a missing texture on Winston's nose
 - fixed missing "The End" text in the first end credit image (#5441)
 - fixed Hand of Rathmore rotating in Sleeping with the Fishes


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes occasional harsh lighting transitions on TR3 water surfaces using the glow & move effect.
The shader displaced the vertex first, then sampled the water lighting from the displaced position instead of the original one. The problem with this is that the vertex position serves directly as a seed for a phase shift, and even tiny changes can result in discontinuity.