### PR TITLE
objects/pickup: fix spark-based pickup aid positioning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.7...develop) - ××××-××-××
 
+**TR3**:
+- fixed pickup aids appearing from hidden overlapping rooms
+
+
+
 ## [1.7](https://github.com/LostArtefacts/TRX/compare/trx-1.6...trx-1.7) - 2026-05-25
 Showcase: https://youtu.be/L1g4tavx23Y
 - added object and item property tables for Lua scripts, including `max_hit_points` defaults

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -150,6 +150,18 @@ static void M_SpawnPickupAid(const ITEM *const item)
         return;
     }
 
+    bool item_visible = false;
+    for (int32_t i = 0; i < Room_DrawGetCount(); i++) {
+        const int16_t draw_room_num = Room_DrawGetRoom(i);
+        if (draw_room_num == item->room_num) {
+            item_visible = true;
+            break;
+        }
+    }
+    if (!item_visible) {
+        return;
+    }
+
     const GAME_VECTOR pos = {
         .x = item->pos.x + 20 * (Random_GetDraw() - 0x4000) / 0x4000,
         .y = item->pos.y - ABS(frame->bounds.max.y - frame->bounds.min.y)

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -440,6 +440,9 @@ void Room_MarkToBeDrawn(const int16_t room_num)
 
 int32_t Room_DrawGetCount(void)
 {
+    if (m_RoomsToDraw == nullptr) {
+        return 0;
+    }
     return m_RoomsToDraw->count;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes pickup aids being visible through pushblocks or via overlapping rooms.

<img width="1793" height="1009" alt="image" src="https://github.com/user-attachments/assets/dfcae487-9367-45d3-b301-25693cae9b1a" />

We need to test occlusion in comprehensive scenarios. 
I suspect this fix will cause the pickup aids to no longer work through fences and transparent windows :expressionless: 