### PR TITLE
config: fix default values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.7...develop) - ××××-××-××
+- fixed string-backed configuration settings having wrong values on first launch
 
 ## [1.7](https://github.com/LostArtefacts/TRX/compare/trx-1.6...trx-1.7) - 2026-05-25
 Showcase: https://youtu.be/L1g4tavx23Y

--- a/src/trx/core/json/base.c
+++ b/src/trx/core/json/base.c
@@ -248,7 +248,7 @@ const char *JSON_ValueGetString(
     const JSON_VALUE *const value, const char *const d)
 {
     if (value == nullptr || value->type != JSON_TYPE_STRING) {
-        return nullptr;
+        return d;
     }
     const JSON_STRING *const string = value->payload;
     return string != nullptr ? string->string : d;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes `language`, `bar look` and `bar color` settings having bogus values on the first game launch when the config file is missing.