### PR TITLE
Make flare age customizable

### DIFF
--- a/data/scripting/objects.lua
+++ b/data/scripting/objects.lua
@@ -44,6 +44,11 @@ trx.objects = setmetatable(objects, {
   __index = function(_, key)
     if type(key) == "number" then
       return setmetatable({ object_id = key }, Object)
+    elseif type(key) == "string" then
+      local object_id = trx.catalog.objects[key]
+      if object_id ~= nil then
+        return setmetatable({ object_id = object_id }, Object)
+      end
     end
     return nil
   end,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.7...develop) - ××××-××-××
 - added `O_FLARE_ITEM.burn_time` so custom levels and Lua scripts can change how long flares last (#5544)  
   Example: `trx.objects[trx.catalog.objects.flare_item].properties.burn_time = 1`
+- changed Lua object and item properties to accept whole numbers for decimal values
 - fixed string-backed configuration settings having wrong values on first launch
 - fixed Puna crashing if there is no Lizard to summon present in the same room
 - fixed a potential crash when switching to games that have camera edit injections

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.7...develop) - ××××-××-××
+- added `O_FLARE_ITEM.burn_time` so custom levels and Lua scripts can change how long flares last (#5544)  
+  Example: `trx.objects[trx.catalog.objects.flare_item].properties.burn_time = 1`
 - fixed string-backed configuration settings having wrong values on first launch
 - fixed Puna crashing if there is no Lizard to summon present in the same room
 - fixed a potential crash when switching to games that have camera edit injections
-
-
 
 **TR3**:
 - fixed pickup aids appearing from hidden overlapping rooms

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added `O_FLARE_ITEM.burn_time` so custom levels and Lua scripts can change how long flares last (#5544)  
   Example: `trx.objects[trx.catalog.objects.flare_item].properties.burn_time = 1`
 - changed Lua object and item properties to accept whole numbers for decimal values
+- changed Lua object access to support catalog names such as `trx.objects.flare_item`
 - fixed string-backed configuration settings having wrong values on first launch
 - fixed Puna crashing if there is no Lizard to summon present in the same room
 - fixed a potential crash when switching to games that have camera edit injections

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -114,6 +114,9 @@ This page lists documented moveable object properties.
 ### `191` O_WINSTON
 - `max_hit_points = 1` — Maximum hit points.
 
+### `193` O_FLARE_ITEM
+- `burn_time = 60` — How long the flare burns for, in seconds.
+
 ## Tomb Raider 2
 
 ### `0` O_LARA
@@ -253,6 +256,9 @@ This page lists documented moveable object properties.
 
 ### `132` O_PLAYER_10
 - `max_hit_points = 1` — Maximum hit points.
+
+### `152` O_FLARE_ITEM
+- `burn_time = 60` — How long the flare burns for, in seconds.
 
 ### `214` O_TREX
 - `max_hit_points = 100` — Maximum hit points.
@@ -462,6 +468,9 @@ This page lists documented moveable object properties.
 
 ### `157` O_PLAYER_10
 - `max_hit_points = 1` — Maximum hit points.
+
+### `179` O_FLARE_ITEM
+- `burn_time = 30` — How long the flare burns for, in seconds.
 
 ### `287` O_TREX_ALPHA
 - `max_hit_points = 800` — Maximum hit points.

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -23,7 +23,7 @@ trx.events.before_item_setup(function(level)
   end
 
   -- Boost all wolves HP
-  trx.objects[trx.catalog.objects.wolf].properties.max_hit_points = 30
+  trx.objects.wolf.properties.max_hit_points = 30
 end)
 ```
 

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -25,12 +25,14 @@ Module for controlling game objects.
 ### Functions
 
 - [lua]`trx.objects[object_id]`
+- [lua]`trx.objects.object_name`
 
-  Retrieves an object proxy for the given object ID.
+  Retrieves an object proxy for the given object ID or catalog object name.
 
   Example:
   ```lua
   trx.objects[trx.catalog.objects.wolf].properties.max_hit_points = 30
+  trx.objects.flare_item.properties.burn_time = 1
   for name, value in pairs(trx.objects[trx.catalog.objects.wolf].properties) do
     trx.log.info(name .. " = " .. tostring(value))
   end

--- a/src/trx/game/objects/general/flare_item.c
+++ b/src/trx/game/objects/general/flare_item.c
@@ -14,21 +14,33 @@
 #include <trx/version.h>
 
 // clang-format off
-#define M_FLARE_INTENSITY 12
-#define M_FLARE_FALL_OFF  11
+#define M_FLARE_INTENSITY         12
+#define M_FLARE_FALL_OFF          11
 
-#define M_MAX_FLARE_AGE_TR12   (60 * LOGIC_FPS)                       // = 1800
-#define M_FLARE_OLD_AGE_TR12   (M_MAX_FLARE_AGE_TR12 - 2 * LOGIC_FPS) // = 1740
-#define M_FLARE_YOUNG_AGE_TR12 (LOGIC_FPS)                            // = 30
+#define M_DEFAULT_FLARE_TIME      (g_TRVersion >= 3 ? 30.0 : 60.0)
 
-#define M_MAX_FLARE_AGE_TR3   (30 * LOGIC_FPS)         // = 900
-#define M_FLARE_DYING_AGE_TR3 (M_MAX_FLARE_AGE_TR3 - 90) // = 810
-#define M_FLARE_END_AGE_TR3   (M_MAX_FLARE_AGE_TR3 - 24) // = 876
+#define M_FLARE_OLD_TIME_TR12     2.0
+#define M_FLARE_YOUNG_TIME_TR12   1.0
+
+#define M_FLARE_DYING_TIME_TR3    3.0
+#define M_FLARE_END_TIME_TR3      0.8
 // clang-format on
 
 typedef struct {
     int32_t raw_age;
 } M_PRIV;
+
+static double M_GetBurnTimeSeconds(void)
+{
+    OBJECT_PROPERTY_VALUE value = {};
+    if (!ObjectProperty_GetObjectValue(
+            Object_Get(O_FLARE_ITEM), "burn_time", &value)
+        || value.type != OBJECT_PROPERTY_TYPE_DOUBLE
+        || value.as_double <= 0.0) {
+        return M_DEFAULT_FLARE_TIME;
+    }
+    return value.as_double;
+}
 
 static XYZ_32 M_TransformLocalOffset(
     const XYZ_32 pos, const XYZ_16 rot, const XYZ_32 local_offset)
@@ -189,9 +201,15 @@ end:
 
 static bool M_GenerateLight_TR12(const XYZ_32 pos, const int32_t flare_age)
 {
-    if (flare_age >= M_MAX_FLARE_AGE_TR12) {
+    const int32_t max_age = Flare_GetMaxAge();
+    if (flare_age >= max_age) {
         return false;
     }
+
+    const int32_t young_age =
+        MIN(Flare_GetMaxAge(), M_FLARE_YOUNG_TIME_TR12 * LOGIC_FPS);
+    const int32_t old_age =
+        MAX(0, Flare_GetMaxAge() - M_FLARE_OLD_TIME_TR12 * LOGIC_FPS);
 
     const int32_t random = Random_GetDraw();
     const XYZ_32 light_pos = {
@@ -200,16 +218,15 @@ static bool M_GenerateLight_TR12(const XYZ_32 pos, const int32_t flare_age)
         .z = pos.z,
     };
 
-    if (flare_age < M_FLARE_YOUNG_AGE_TR12) {
-        const int32_t intensity = M_FLARE_INTENSITY
-                * (flare_age - M_FLARE_YOUNG_AGE_TR12)
-                / (2 * M_FLARE_YOUNG_AGE_TR12)
+    if (flare_age < young_age) {
+        const int32_t intensity =
+            M_FLARE_INTENSITY * (flare_age - young_age) / (2 * young_age)
             + M_FLARE_INTENSITY;
         Output_AddDynamicLight(light_pos, intensity, M_FLARE_FALL_OFF);
         return true;
     }
 
-    if (flare_age < M_FLARE_OLD_AGE_TR12) {
+    if (flare_age < old_age) {
         Output_AddDynamicLight(light_pos, M_FLARE_INTENSITY, M_FLARE_FALL_OFF);
         return true;
     }
@@ -226,9 +243,15 @@ static bool M_GenerateLight_TR12(const XYZ_32 pos, const int32_t flare_age)
 
 static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
 {
-    if (flare_age >= M_MAX_FLARE_AGE_TR3) {
+    const int32_t max_age = Flare_GetMaxAge();
+    if (flare_age >= max_age) {
         return false;
     }
+
+    const int32_t dying_age =
+        MAX(0, Flare_GetMaxAge() - M_FLARE_DYING_TIME_TR3 * LOGIC_FPS);
+    const int32_t end_age =
+        MAX(0, Flare_GetMaxAge() - M_FLARE_END_TIME_TR3 * LOGIC_FPS);
 
     const int32_t rnd = Random_GetControl();
     const XYZ_32 light_pos = {
@@ -256,12 +279,12 @@ static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
         g = ((rnd >> 4) & 0x1F) + (flare_age << 2) + 64;
         b = ((rnd >> 8) & 0x1F) + (flare_age << 2) + 16;
         falloff = (rnd & 1) + flare_age + 2;
-    } else if (flare_age < M_FLARE_DYING_AGE_TR3) {
+    } else if (flare_age < dying_age) {
         r = (rnd & 0x3F) + 192;
         g = ((rnd >> 4) & 0x1F) + 128;
         b = ((rnd >> 8) & 0x20) + (((rnd >> 6) & 0x10) << 1);
         falloff = 16;
-    } else if (flare_age < M_FLARE_END_AGE_TR3) {
+    } else if (flare_age < end_age) {
         if (rnd > 0x2000) {
             r = (rnd & 0x3F) + 192;
             g = ((rnd >> 4) & 0x1F) + 64;
@@ -286,7 +309,7 @@ static bool M_GenerateLight_TR3(const XYZ_32 pos, const int32_t flare_age)
         r = (rnd2 & 0x3F) + 192;
         g = (rnd3 & 0x3F) + 64;
         b = rnd4 & 0x1F;
-        falloff = 16 - ((flare_age - M_FLARE_END_AGE_TR3) >> 1);
+        falloff = 16 - ((flare_age - end_age) >> 1);
         Output_AddDynamicLightRGB(light_pos, falloff, (RGB_888) { r, g, b });
         return (rnd & 1) != 0;
     }
@@ -320,7 +343,7 @@ bool Flare_GenerateLight(const XYZ_32 pos, const int32_t flare_age)
 
 int32_t Flare_GetMaxAge(void)
 {
-    return g_TRVersion >= 3 ? M_MAX_FLARE_AGE_TR3 : M_MAX_FLARE_AGE_TR12;
+    return MAX(1, M_GetBurnTimeSeconds() * LOGIC_FPS);
 }
 
 int32_t FlareItem_GetAge(const ITEM *const item)
@@ -354,6 +377,11 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "burn_time", M_DEFAULT_FLARE_TIME,
+            "How long the flare burns for, in seconds."));
 
     if (obj->loaded) {
         for (int32_t i = 0; i < obj->mesh_count; i++) {

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -93,6 +93,62 @@ static void M_ApplyItemValue(
     M_AddEntry(&item->properties, name, object_entry->description, value);
 }
 
+static bool M_CoerceValue(
+    const OBJECT_PROPERTY_VALUE target, const OBJECT_PROPERTY_VALUE input,
+    OBJECT_PROPERTY_VALUE *const out_value)
+{
+    *out_value = input;
+    if (target.type == input.type) {
+        return true;
+    }
+
+    switch (target.type) {
+    case OBJECT_PROPERTY_TYPE_INT:
+        switch (input.type) {
+        case OBJECT_PROPERTY_TYPE_FLOAT:
+            out_value->type = OBJECT_PROPERTY_TYPE_INT;
+            out_value->as_int = input.as_float;
+            return true;
+        case OBJECT_PROPERTY_TYPE_DOUBLE:
+            out_value->type = OBJECT_PROPERTY_TYPE_INT;
+            out_value->as_int = input.as_double;
+            return true;
+        default:
+            return false;
+        }
+    case OBJECT_PROPERTY_TYPE_FLOAT:
+        switch (input.type) {
+        case OBJECT_PROPERTY_TYPE_INT:
+            out_value->type = OBJECT_PROPERTY_TYPE_FLOAT;
+            out_value->as_float = input.as_int;
+            return true;
+        case OBJECT_PROPERTY_TYPE_DOUBLE:
+            out_value->type = OBJECT_PROPERTY_TYPE_FLOAT;
+            out_value->as_float = input.as_double;
+            return true;
+        default:
+            return false;
+        }
+    case OBJECT_PROPERTY_TYPE_DOUBLE:
+        switch (input.type) {
+        case OBJECT_PROPERTY_TYPE_INT:
+            out_value->type = OBJECT_PROPERTY_TYPE_DOUBLE;
+            out_value->as_double = input.as_int;
+            return true;
+        case OBJECT_PROPERTY_TYPE_FLOAT:
+            out_value->type = OBJECT_PROPERTY_TYPE_DOUBLE;
+            out_value->as_double = input.as_float;
+            return true;
+        default:
+            return false;
+        }
+    case OBJECT_PROPERTY_TYPE_BOOL:
+        return false;
+    }
+
+    return false;
+}
+
 void ObjectProperty_ResetObject(OBJECT *const obj)
 {
     Memory_FreePointer(&obj->properties.entries);
@@ -165,10 +221,14 @@ bool ObjectProperty_SetObjectValueRaw(
 {
     OBJECT_PROPERTY_ENTRY *const entry =
         obj == nullptr ? nullptr : M_GetEntry(&obj->properties, name);
-    if (entry == nullptr || entry->value.type != value.type) {
+    if (entry == nullptr) {
         return false;
     }
-    M_ApplyObjectValue(obj, name, &value);
+    OBJECT_PROPERTY_VALUE coerced_value = {};
+    if (!M_CoerceValue(entry->value, value, &coerced_value)) {
+        return false;
+    }
+    M_ApplyObjectValue(obj, name, &coerced_value);
     return true;
 }
 
@@ -198,11 +258,15 @@ bool ObjectProperty_SetItemValueRaw(
 
     const OBJECT_PROPERTY_ENTRY *const object_entry =
         M_GetObjectEntry(Object_TryGet(item->object_id), name);
-    if (object_entry == nullptr || object_entry->value.type != value.type) {
+    if (object_entry == nullptr) {
         return false;
     }
 
-    M_ApplyItemValue(item, name, &value);
+    OBJECT_PROPERTY_VALUE coerced_value = {};
+    if (!M_CoerceValue(object_entry->value, value, &coerced_value)) {
+        return false;
+    }
+    M_ApplyItemValue(item, name, &coerced_value);
     return true;
 }
 

--- a/src/trx/game/objects/property.h
+++ b/src/trx/game/objects/property.h
@@ -54,6 +54,14 @@ typedef OBJECT_PROPERTY_SET ITEM_PROPERTY_SET;
         }                                                                      \
     }
 
+#define OBJECT_PROPERTY_DOUBLE(name_, value_, description_)                    \
+    {                                                                          \
+        .name = name_, .description = description_, .value = {                 \
+            .type = OBJECT_PROPERTY_TYPE_DOUBLE,                               \
+            .as_double = value_                                                \
+        }                                                                      \
+    }
+
 void ObjectProperty_ResetObject(OBJECT *obj);
 void ObjectProperty_ResetItem(ITEM *item);
 void ObjectProperty_ApplyDeclarations(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Resolves #5544. This PR let the builder customize flare age via LUA.

#### Testing

- [x] Default TR1 flare age should default to 60 s
- [x] Default TR2 flare age should default to 60 s
- [x] Default TR3 flare age should default to 30 s
- [x] It should be able to override flare age to any value via `/lua trx.objects[trx.catalog.objects.flare_item].properties.burn_time = XXX` 