### PR TITLE
inject/editors/items: skip camera edits in stats mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.7...develop) - ××××-××-××
 - fixed string-backed configuration settings having wrong values on first launch
 - fixed Puna crashing if there is no Lizard to summon present in the same room
+- fixed a potential crash when switching to games that have camera edit injections
 
 
 

--- a/src/trx/game/inject/editors/items.c
+++ b/src/trx/game/inject/editors/items.c
@@ -62,6 +62,9 @@ static void M_CameraEdits(
         };
         const int16_t room_num = VFile_ReadS16(injection->fp);
         const int16_t flags = VFile_ReadS16(injection->fp);
+        if (ctx->mode == INJECTION_MODE_STATS) {
+            continue;
+        }
 
         if (camera_num < 0 || camera_num >= Camera_GetFixedObjectCount()) {
             LOG_WARNING(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids injecting camera edits in stats mode to prevent potential crashes when switching games.