### PR TITLE
rooms/floor_data: ignore invalid indices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added French translation (thanks to Wronschien)
 - removed hard-coded fish and piranha setup and moved to Lua instead
 - removed the limit of at most 8 fish/piranha shoals per level
+- fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 
 
 

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -123,7 +123,8 @@ static void M_InsertFloorData(
     }
 
     if (data_length == 0) {
-        Room_PopulateSectorData(sector, nullptr, NULL_FD_INDEX, NULL_FD_INDEX);
+        Room_PopulateSectorData(
+            sector, nullptr, 0, NULL_FD_INDEX, NULL_FD_INDEX);
         return;
     }
 
@@ -138,7 +139,7 @@ static void M_InsertFloorData(
     // This will reset all FD properties in the sector based on the raw data
     // imported. We pass a dummy null index to allow it to read from the
     // beginning of the array.
-    Room_PopulateSectorData(sector, data, 0, NULL_FD_INDEX);
+    Room_PopulateSectorData(sector, data, data_length, 0, NULL_FD_INDEX);
     Memory_FreePointer(&data);
 }
 

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -431,7 +431,7 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, VFILE *const file)
     int16_t *floor_data = Memory_Alloc(sizeof(int16_t) * floor_data_size);
     VFile_Read(file, floor_data, sizeof(int16_t) * floor_data_size);
 
-    Room_ParseFloorData(floor_data);
+    Room_ParseFloorData(floor_data, floor_data_size);
     Memory_FreePointer(&floor_data);
 
     Room_BuildOutsideTable();

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -159,20 +159,22 @@ static bool M_TestLava(const ITEM *const item)
     return sector->is_death_sector;
 }
 
-void Room_ParseFloorData(const int16_t *floor_data)
+void Room_ParseFloorData(
+    const int16_t *floor_data, const int32_t floor_data_size)
 {
     for (int32_t i = 0; i < Room_GetCount(); i++) {
         const ROOM *const room = Room_Get(i);
         for (int32_t j = 0; j < room->size.x * room->size.z; j++) {
             SECTOR *const sector = &room->sectors[j];
             Room_PopulateSectorData(
-                sector, floor_data, sector->idx, M_NULL_INDEX);
+                sector, floor_data, floor_data_size, sector->idx, M_NULL_INDEX);
         }
     }
 }
 
 void Room_PopulateSectorData(
-    SECTOR *const sector, const int16_t *floor_data, const uint16_t start_index,
+    SECTOR *const sector, const int16_t *floor_data,
+    const int32_t floor_data_size, const uint16_t start_index,
     const uint16_t null_index)
 {
     sector->floor.type = SURFACE_FLOOR;
@@ -189,7 +191,8 @@ void Room_PopulateSectorData(
     sector->ladder = LADDER_NONE;
     sector->mine_cart_type = MINE_CART_NONE;
 
-    if (start_index == null_index || floor_data == nullptr) {
+    if (start_index == null_index || floor_data == nullptr
+        || start_index >= floor_data_size) {
         return;
     }
 

--- a/src/trx/game/rooms/floor_data.h
+++ b/src/trx/game/rooms/floor_data.h
@@ -2,10 +2,10 @@
 
 #include <trx/game/rooms/types.h>
 
-void Room_ParseFloorData(const int16_t *floor_data);
+void Room_ParseFloorData(const int16_t *floor_data, int32_t floor_data_size);
 void Room_PopulateSectorData(
-    SECTOR *sector, const int16_t *floor_data, uint16_t start_index,
-    uint16_t null_index);
+    SECTOR *sector, const int16_t *floor_data, int32_t floor_data_size,
+    uint16_t start_index, uint16_t null_index);
 void Room_ReadTriangulation(
     SURFACE *surface, int16_t func_data, int16_t tilt_data);
 


### PR DESCRIPTION
Resolves #5568.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Some custom levels can apparently produce sectors that point to floor data beyond the raw range, so this ensures no attempts at parsing are made in such cases. Room 130, [16,16] was at fault in the OP, I suspect it was an editor bug at the time.