### PR TITLE
objects/cobra: move radius setup to Lua

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -361,6 +361,7 @@
         // 13. Nevada Desert
         {
             "path": "nevada.tr2",
+            "script": "nevada.lua",
             "music_track": 33,
             "death_tile": "electric",
             "lara_outfit": "tr3_nevada",

--- a/data/trx/ship/games/tr3/scripts/nevada.lua
+++ b/data/trx/ship/games/tr3/scripts/nevada.lua
@@ -1,0 +1,6 @@
+trx.events.before_item_setup(function(level)
+  local props = trx.objects[trx.catalog.objects.cobra].properties
+  props.alert_radius = 1.25
+  props.attack_radius = 0.666667
+  props.forget_radius = 2.5
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added French translation (thanks to Wronschien)
 - removed hard-coded fish and piranha setup and moved to Lua instead
 - removed the limit of at most 8 fish/piranha shoals per level
+- removed hard-coded small Cobra radius setup and moved to Lua instead
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 
 

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1047,6 +1047,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── house.lua
 │   │   │   ├── jungle.lua
 │   │   │   ├── mines.lua
+│   │   │   ├── nevada.lua
 │   │   │   ├── rapids.lua
 │   │   │   ├── shore.lua
 │   │   │   ├── temple.lua
@@ -2274,6 +2275,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── house.lua
     │   │   │   │   ├── jungle.lua
     │   │   │   │   ├── mines.lua
+    │   │   │   │   ├── nevada.lua
     │   │   │   │   ├── rapids.lua
     │   │   │   │   ├── shore.lua
     │   │   │   │   ├── temple.lua

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -14,6 +14,10 @@ order: 3
    triggers, and instead their swim range needs to be defined in Lua. Refer to
    the OG TR3 level scripts for reference.
 
+2. **Update Cobra setup**:
+   Cobras in level sequence 9 and above are no longer hard-coded to have a small
+   attack, forget and alert radius. Use Lua to specify this setup if required.
+
 ### Version 1.6 to 1.7
 
 1. **Update Lua item maximum HP access**:

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -402,6 +402,9 @@ This page lists documented moveable object properties.
 
 ### `69` O_COBRA
 - `max_hit_points = 8` — Maximum hit points.
+- `alert_radius = 1.5` — Alert radius, in sectors.
+- `attack_radius = 1` — Attack radius, in sectors.
+- `forget_radius = 3` — Forget radius, in sectors.
 
 ### `70` O_SHIVA
 - `max_hit_points = 100` — Maximum hit points.

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -9,31 +9,31 @@
 static BITE m_CobraBite = { .pos = { 0, 0, 0 }, .mesh_num = 13 };
 
 typedef enum {
-    COBRA_STATE_WAKING_UP = 0,
-    COBRA_STATE_ALERT = 1,
-    COBRA_STATE_BITE = 2,
-    COBRA_STATE_SLEEP = 3,
-    COBRA_STATE_DEATH = 4,
-} M_COBRA_STATE;
+    M_STATE_WAKING_UP,
+    M_STATE_ALERT,
+    M_STATE_BITE,
+    M_STATE_SLEEP,
+    M_STATE_DEATH,
+} M_STATE;
 
 typedef enum {
-    COBRA_ANIM_SLEEP = 2,
-    COBRA_ANIM_DEATH = 4,
-} M_COBRA_ANIM;
+    M_ANIM_SLEEP = 2,
+    M_ANIM_DEATH = 4,
+} M_ANIM;
 
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     Creature_Initialise(item_num);
-    Item_SwitchToAnim(item, COBRA_ANIM_SLEEP, 45);
-    item->current_anim_state = COBRA_STATE_SLEEP;
-    item->goal_anim_state = COBRA_STATE_SLEEP;
+    Item_SwitchToAnim(item, M_ANIM_SLEEP, 45);
+    item->current_anim_state = M_STATE_SLEEP;
+    item->goal_anim_state = M_STATE_SLEEP;
 }
 
 static bool M_IsTargetable(const ITEM *const item)
 {
     return item->hit_points > 0 && item->status == IS_ACTIVE
-        && item->current_anim_state != COBRA_STATE_SLEEP;
+        && item->current_anim_state != M_STATE_SLEEP;
 }
 
 static bool M_CanTakeDamage(const ITEM *const item)
@@ -72,9 +72,9 @@ static void M_Control(const int16_t item_num)
 
     int16_t angle = 0;
     if (item->hit_points <= 0) {
-        if (item->current_anim_state != COBRA_STATE_DEATH) {
-            Item_SwitchToAnim(item, COBRA_ANIM_DEATH, 0);
-            item->current_anim_state = COBRA_ANIM_DEATH;
+        if (item->current_anim_state != M_STATE_DEATH) {
+            Item_SwitchToAnim(item, M_ANIM_DEATH, 0);
+            item->current_anim_state = M_ANIM_DEATH;
         }
 
         goto finish;
@@ -99,22 +99,22 @@ static void M_Control(const int16_t item_num)
     }
 
     switch (item->current_anim_state) {
-    case COBRA_STATE_WAKING_UP:
+    case M_STATE_WAKING_UP:
         break;
 
-    case COBRA_STATE_ALERT:
+    case M_STATE_ALERT:
         creature->flags = 0;
         if (info.distance > forget_radius) {
-            item->goal_anim_state = COBRA_STATE_SLEEP;
+            item->goal_anim_state = M_STATE_SLEEP;
         } else if (
             lara_item->hit_points > 0
             && ((info.ahead && info.distance < attack_radius)
                 || item->hit_status || lara_item->speed > 15)) {
-            item->goal_anim_state = COBRA_STATE_BITE;
+            item->goal_anim_state = M_STATE_BITE;
         }
         break;
 
-    case COBRA_STATE_BITE:
+    case M_STATE_BITE:
         if (creature->flags != 1 && (item->touch_bits & 0x2000) != 0) {
             creature->flags = 1;
             Lara_TakeDamage(80, true);
@@ -123,10 +123,10 @@ static void M_Control(const int16_t item_num)
         }
         break;
 
-    case COBRA_STATE_SLEEP:
+    case M_STATE_SLEEP:
         creature->flags = 0;
         if (info.distance < alert_radius && lara_item->hit_points > 0) {
-            item->goal_anim_state = COBRA_STATE_WAKING_UP;
+            item->goal_anim_state = M_STATE_WAKING_UP;
         }
         break;
     }

--- a/src/trx/game/objects/creatures/cobra.c
+++ b/src/trx/game/objects/creatures/cobra.c
@@ -1,10 +1,15 @@
 #include <trx/core/utils.h>
 #include <trx/game/creature.h>
-#include <trx/game/game_flow.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/spawn.h>
-#include <trx/version.h>
+
+// clang-format off
+#define M_DEFAULT_ALERT   1.5
+#define M_DEFAULT_ATTACK  1
+#define M_DEFAULT_FORGET  3
+#define M_SETUP_RADIUS(r) (SQUARE(WALL_L * r))
+// clang-format on
 
 static BITE m_CobraBite = { .pos = { 0, 0, 0 }, .mesh_num = 13 };
 
@@ -21,6 +26,14 @@ typedef enum {
     M_ANIM_DEATH = 4,
 } M_ANIM;
 
+typedef struct {
+    struct {
+        int32_t alert;
+        int32_t attack;
+        int32_t forget;
+    } radius;
+} M_PRIV;
+
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -28,6 +41,22 @@ static void M_Initialise(const int16_t item_num)
     Item_SwitchToAnim(item, M_ANIM_SLEEP, 45);
     item->current_anim_state = M_STATE_SLEEP;
     item->goal_anim_state = M_STATE_SLEEP;
+
+    M_PRIV *const p = item->priv;
+    p->radius.alert = M_SETUP_RADIUS(M_DEFAULT_ALERT);
+    p->radius.attack = M_SETUP_RADIUS(M_DEFAULT_ATTACK);
+    p->radius.forget = M_SETUP_RADIUS(M_DEFAULT_FORGET);
+
+    OBJECT_PROPERTY_VALUE radius_val = {};
+    if (ObjectProperty_GetItemValue(item, "alert_radius", &radius_val)) {
+        p->radius.alert = M_SETUP_RADIUS(radius_val.as_double);
+    }
+    if (ObjectProperty_GetItemValue(item, "attack_radius", &radius_val)) {
+        p->radius.attack = M_SETUP_RADIUS(radius_val.as_double);
+    }
+    if (ObjectProperty_GetItemValue(item, "forget_radius", &radius_val)) {
+        p->radius.forget = M_SETUP_RADIUS(radius_val.as_double);
+    }
 }
 
 static bool M_IsTargetable(const ITEM *const item)
@@ -52,18 +81,8 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    int32_t forget_radius = SQUARE(3 * WALL_L);
-    int32_t alert_radius = SQUARE(1.5 * WALL_L);
-    int32_t attack_radius = SQUARE(WALL_L);
-
-    // TODO: do not hardcode this
-    if (g_TRVersion == 3 && GF_BadGetLevelNum() >= 9) {
-        forget_radius = SQUARE(2.5 * WALL_L);
-        alert_radius = SQUARE(1.25 * WALL_L);
-        attack_radius = SQUARE(682);
-    }
-
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
     CREATURE *const creature = item->creature_data;
 
     if (creature == nullptr) {
@@ -104,11 +123,11 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_ALERT:
         creature->flags = 0;
-        if (info.distance > forget_radius) {
+        if (info.distance > p->radius.forget) {
             item->goal_anim_state = M_STATE_SLEEP;
         } else if (
             lara_item->hit_points > 0
-            && ((info.ahead && info.distance < attack_radius)
+            && ((info.ahead && info.distance < p->radius.attack)
                 || item->hit_status || lara_item->speed > 15)) {
             item->goal_anim_state = M_STATE_BITE;
         }
@@ -125,7 +144,7 @@ static void M_Control(const int16_t item_num)
 
     case M_STATE_SLEEP:
         creature->flags = 0;
-        if (info.distance < alert_radius && lara_item->hit_points > 0) {
+        if (info.distance < p->radius.alert && lara_item->hit_points > 0) {
             item->goal_anim_state = M_STATE_WAKING_UP;
         }
         break;
@@ -148,8 +167,8 @@ static void M_Setup(OBJECT *const obj)
     obj->can_take_damage_func = M_CanTakeDamage;
     obj->can_be_projectile_target_func = M_CanBeProjectileTarget;
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->shadow_size = UNIT_SHADOW / 2;
-
     obj->radius = 102;
 
     // obj->non_lot = true; // TODO(TR3)
@@ -163,6 +182,18 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 6)->rot.y = true;
     OBJECT_PROPERTIES(
         obj, OBJECT_PROPERTY_INT("max_hit_points", 8, "Maximum hit points."));
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "alert_radius", M_DEFAULT_ALERT, "Alert radius, in sectors."));
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "attack_radius", M_DEFAULT_ATTACK, "Attack radius, in sectors."));
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "forget_radius", M_DEFAULT_FORGET, "Forget radius, in sectors."));
 }
 
 REGISTER_OBJECT(O_COBRA, M_Setup)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -3,7 +3,6 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/game_buf.h>
-#include <trx/game/game_flow/util.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -13,7 +12,6 @@
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
-#include <trx/version.h>
 
 #include <stdint.h>
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces the hard-coded level sequence check for Cobra radius setup with a Lua approach.

Test:
- [x] Small Cobras in Nevada should behave normally (single added Lua script)
- [x] All other Cobras should behave normally (no Lua here, they will use the default setup)
