### PR TITLE
lara/control: restore TR2 wade depth

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@
 - removed the limit of at most 8 fish/piranha shoals per level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 
+**TR2**:
+- fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
+
 
 
 ## [1.7.1](https://github.com/LostArtefacts/TRX/compare/trx-1.7...trx-1.7.1) - 2026-05-28

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -32,7 +32,7 @@
 #define M_DIVE_TILT_MAX_ALT (100 * DEG_1)        // = 18200
 #define M_RADIUS_SURF       LARA_RADIUS          // = 100
 #define M_RADIUS_UW         300
-#define M_WADE_DEPTH        256
+#define M_WADE_DEPTH        (g_TRVersion >= 3 ? STEP_L : (STEP_L * 3 / 2))
 #define M_LEAN_UNDO_SURF    (LARA_LEAN_UNDO * 2) // = 364
 #define M_LEAN_UNDO_UW      M_LEAN_UNDO_SURF     // = 364
 #define M_LEAN_MAX_UW       (LARA_LEAN_MAX * 2)  // = 4004


### PR DESCRIPTION
Resolves #5574.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores Lara's wade depth in TR2 (and TR1) to 1.5 clicks to fix the softlock in the ticket (room 44). It also fixes being unable to perform a certain glitch in OG, recording below.

[record.txt](https://github.com/user-attachments/files/28418870/record.txt)
