### PR TITLE
objects/pickup: move quest behaviour to Lua

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -152,6 +152,7 @@
         // 4. Caves of Kaliya
         {
             "path": "tonyboss.tr2",
+            "script": "tonyboss.lua",
             "music_track": 30,
             "lara_outfit": "tr3_classic",
             "sequence": [
@@ -243,6 +244,7 @@
         // 8. Temple of Puna
         {
             "path": "triboss.tr2",
+            "script": "triboss.lua",
             "music_track": 30,
             "lara_outfit": "tr3_south_pacific",
             "sequence": [
@@ -337,6 +339,7 @@
         // 12. City
         {
             "path": "office.tr2",
+            "script": "office.lua",
             "music_track": 78,
             "lara_outfit": "tr3_catsuit",
             "weather_type": "rain",

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -1,3 +1,10 @@
 trx.events.before_level_file(function(level)
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
 end)
+
+trx.events.on_pickup(function(pickup_item)
+  local item = trx.items[pickup_item + 1]
+  if item.object_id == trx.catalog.objects.quest_item_2 then
+    trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
+  end
+end)

--- a/data/trx/ship/games/tr3/scripts/office.lua
+++ b/data/trx/ship/games/tr3/scripts/office.lua
@@ -1,0 +1,6 @@
+trx.events.on_pickup(function(pickup_item)
+  local item = trx.items[pickup_item + 1]
+  if item.object_id == trx.catalog.objects.quest_item_3 then
+    trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
+  end
+end)

--- a/data/trx/ship/games/tr3/scripts/tonyboss.lua
+++ b/data/trx/ship/games/tr3/scripts/tonyboss.lua
@@ -1,0 +1,6 @@
+trx.events.on_pickup(function(pickup_item)
+  local item = trx.items[pickup_item + 1]
+  if item.object_id == trx.catalog.objects.quest_item_1 then
+    trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
+  end
+end)

--- a/data/trx/ship/games/tr3/scripts/triboss.lua
+++ b/data/trx/ship/games/tr3/scripts/triboss.lua
@@ -1,0 +1,6 @@
+trx.events.on_pickup(function(pickup_item)
+  local item = trx.items[pickup_item + 1]
+  if item.object_id == trx.catalog.objects.quest_item_4 then
+    trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
+  end
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
 **TR2**:
 - fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
 
+**TR3**:
+- removed the hard-coded end-level behaviour when picking up artefacts in specific levels and moved to Lua instead
+
 
 
 ## [1.7.1](https://github.com/LostArtefacts/TRX/compare/trx-1.7...trx-1.7.1) - 2026-05-28

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1048,10 +1048,13 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── jungle.lua
 │   │   │   ├── mines.lua
 │   │   │   ├── nevada.lua
+│   │   │   ├── office.lua
 │   │   │   ├── rapids.lua
 │   │   │   ├── shore.lua
 │   │   │   ├── temple.lua
+│   │   │   ├── tonyboss.lua
 │   │   │   ├── tower.lua
+│   │   │   ├── triboss.lua
 │   │   │   └── zoo.lua
 │   │   ├── catalog_item_actions.csv
 │   │   ├── catalog_lara_anims.csv
@@ -2276,10 +2279,13 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── jungle.lua
     │   │   │   │   ├── mines.lua
     │   │   │   │   ├── nevada.lua
+    │   │   │   │   ├── office.lua
     │   │   │   │   ├── rapids.lua
     │   │   │   │   ├── shore.lua
     │   │   │   │   ├── temple.lua
+    │   │   │   │   ├── tonyboss.lua
     │   │   │   │   ├── tower.lua
+    │   │   │   │   ├── triboss.lua
     │   │   │   │   └── zoo.lua
     │   │   │   ├── catalog_item_actions.csv
     │   │   │   ├── catalog_lara_anims.csv

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -18,6 +18,11 @@ order: 3
    Cobras in level sequence 9 and above are no longer hard-coded to have a small
    attack, forget and alert radius. Use Lua to specify this setup if required.
 
+3. **Update quest item end-level handling**:
+   TR3's quest items will no longer end the level by default when picked up. Use
+   Lua or regular pickup triggers instead; refer to the OG TR3 level scripts for
+   reference.
+
 ### Version 1.6 to 1.7
 
 1. **Update Lua item maximum HP access**:

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -287,19 +287,7 @@ static void M_DoPickup(const int16_t item_num)
     Lua_FireEventInt32(LUA_EVENT_PICKUP, item_num); // LUA uses 1-indexing
 
     item->status = IS_INVISIBLE;
-    item->flags |= IF_KILLED;
-
-    if (Object_IsType(item->object_id, g_QuestObjects)) {
-        if (GF_BadGetLevelNum() == 19
-            || (GF_BadIsMod("tr3-la") && GF_BadGetLevelNum() == 4)) {
-            Item_Kill(item_num);
-        } else {
-            Game_SetIsLevelComplete(true);
-        }
-    } else {
-        Item_RemoveDrawn(item_num);
-        Item_RemoveActive(item_num);
-    }
+    Item_Kill(item_num);
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->interact_target.is_moving = false;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This changes quest item pickups to no longer finish the level by default, and instead adds event handlers for those specific levels in TR3 that need it via Lua. I've also streamlined to use `Item_Kill` on pickup for all items as it handles setting the flags and removing the drawn/active item already, so that reduces a couple of extra calls.

We could have done this in a couple of other ways; I opted for a consistent script setup, but LMK what you think:
- floor data pickup triggers for artefacts that don't move (Tony, Puna, Area51 - Sophia would still need a Lua pickup event though)
- an `end_level` object/item property (feels a little redundant IMO given triggers and events already exist)

Tests
- [x] Level should end on pickup in
  - [x] Kaliya
  - [x] Puna
  - [x] City
  - [x] Area 51
- [x] Level should not end on pickup in
  - [x] Meteorite Cavern
  - [x] Sleeping with the Fishes
- [x] Meteorite Cavern should still be beatable as normal (pickup triggers for the flip map and final gate)
- [x] Regular pickups should behave normally - should disappear on pickup and shouldn't re-appear after save/load