### PR TITLE
objects/flame_emitter: add side interval property

### DIFF
--- a/data/trx/ship/games/tr3/scripts/rapids.lua
+++ b/data/trx/ship/games/tr3/scripts/rapids.lua
@@ -2,4 +2,6 @@ trx.events.before_item_setup(function(level)
   -- Setup shoals
   trx.items[16].properties.range = { x = 6, y = 5, z = 10 }
   trx.items[52].properties.range = { x = 18, y = 8, z = 18 }
+
+  trx.objects.flame_emitter_side.properties.interval = 4
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,11 @@
 - fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
 
 **TR3**:
+- added the ability to define the flame interval of `O_FLAME_EMITTER_SIDE` objects
 - removed the hard-coded end-level behaviour when picking up artefacts in specific levels and moved to Lua instead
 - removed hard-coded collision differences for `O_ORCA` in `Sleeping with the Fishes` by using `O_DOLPHIN` instead
 - removed hard-coded level sequence checks to keep Lara burning when she enters a lava swamp room
+- removed the hard-coded longer interval on `O_FLAME_EMITTER_SIDE` in level sequence 7 and moved to Lua instead
 
 
 

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -23,6 +23,11 @@ order: 3
    Lua or regular pickup triggers instead; refer to the OG TR3 level scripts for
    reference.
 
+4. **Update side flame emitters**:
+   `O_FLAME_EMITTER_SIDE` instances will no longer have a hard-coded 4 second
+   interval in level sequence 7; all instances will default to 2 seconds. Refer
+   to the Madubu Gorge Lua script to alter the interval.
+
 ### Version 1.6 to 1.7
 
 1. **Update Lua item maximum HP access**:

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -481,6 +481,9 @@ This page lists documented moveable object properties.
 ### `288` O_RAPTOR
 - `max_hit_points = 90` — Maximum hit points.
 
+### `333` O_FLAME_EMITTER_SIDE
+- `interval = 2` — Interval between flame bursts, in seconds.
+
 ### `338` O_PIRAHNAS
 - `range = ((XYZ_32) { 1, 1, 1 })` — Swim range, in quarter tiles.
 

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -282,13 +282,7 @@ static void M_TR3_ControlSide(
             effect->flag1 -= 2;
         } else {
             effect->flag1 = 128;
-
-            // TODO: do not hardcode this
-            if (GF_BadGetLevelNum() == 7) {
-                effect->flag2 = 120;
-            } else {
-                effect->flag2 = 60;
-            }
+            effect->flag2 = effect->speed;
         }
     }
 }

--- a/src/trx/game/objects/traps/flame_emitter.c
+++ b/src/trx/game/objects/traps/flame_emitter.c
@@ -1,12 +1,15 @@
 #include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
+#include <trx/game/const.h>
 #include <trx/game/effects.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/effects/flame.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
 #include <trx/version.h>
+
+#define M_DEFAULT_SIDE_INTERVAL 2.0
 
 typedef struct {
     int16_t effect_num;
@@ -65,6 +68,17 @@ static void M_Initialise(const int16_t item_num)
     p->effect_num = NO_EFFECT;
 }
 
+static int32_t M_GetSideDuration(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE value = {};
+    if (!ObjectProperty_GetItemValue(item, "interval", &value)
+        || value.type != OBJECT_PROPERTY_TYPE_DOUBLE
+        || value.as_double <= 0.0) {
+        return M_DEFAULT_SIDE_INTERVAL * LOGIC_FPS;
+    }
+    return value.as_double * LOGIC_FPS;
+}
+
 static void M_ControlCommon(
     const int16_t item_num, const FLAME_INIT_FUNC init_func)
 {
@@ -74,6 +88,9 @@ static void M_ControlCommon(
         M_KillIfAlive(item);
     } else if (p->effect_num == NO_EFFECT) {
         p->effect_num = M_Spawn(item, init_func);
+    } else if (item->object_id == O_FLAME_EMITTER_SIDE) {
+        EFFECT *const effect = Effect_Get(p->effect_num);
+        effect->speed = M_GetSideDuration(item);
     }
 }
 
@@ -108,6 +125,7 @@ static void M_InitSide(EFFECT *const effect, const ITEM *const item)
     effect->frame_num = FLAME_SIDE;
     effect->flag1 = 0;
     effect->flag2 = 0;
+    effect->speed = M_GetSideDuration(item);
 }
 
 static void M_Control(const int16_t item_num)
@@ -161,6 +179,11 @@ static void M_SetupJet(OBJECT *const obj)
 static void M_SetupSide(OBJECT *const obj)
 {
     M_SetupCommon(obj, M_ControlSide);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_DOUBLE(
+            "interval", M_DEFAULT_SIDE_INTERVAL,
+            "Interval between flame bursts, in seconds."));
 }
 
 REGISTER_OBJECT(O_FLAME_EMITTER, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds an interval property for `O_FLAME_EMITTER_SIDE` to allow moving the longer interval in Madubu Gorge to Lua. This should be compatible with existing saves where flames are activated, and can be tested at runtime with e.g. `/lua trx.objects.flame_emitter_side.properties.interval = 10`.

Not entirely sold on the extra `flag3` on the `EFFECT` but I couldn't think of a neater way to pass the value across. LMK what you think.
