### PR TITLE
objects/strobe-light: move alarm check to Lua

### DIFF
--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -1,3 +1,8 @@
+trx.events.before_item_setup(function(level)
+  local props = trx.objects[trx.catalog.objects.strobe_light].properties
+  props.requires_alarm_active = true
+end)
+
 trx.events.before_level_file(function(level)
   trx.creatures.add_ally(trx.catalog.objects.prisoner)
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - removed hard-coded collision differences for `O_ORCA` in `Sleeping with the Fishes` by using `O_DOLPHIN` instead
 - removed hard-coded level sequence checks to keep Lara burning when she enters a lava swamp room
 - removed the hard-coded longer interval on `O_FLAME_EMITTER_SIDE` in level sequence 7 and moved to Lua instead
+- removed the hard-coded strobe light alarm behaviour in Area 51 and moved it to Lua instead
 - fixed texture bleeding and missized textures on piranhas and tropical fish
 
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -481,6 +481,9 @@ This page lists documented moveable object properties.
 ### `288` O_RAPTOR
 - `max_hit_points = 90` — Maximum hit points.
 
+### `318` O_STROBE_LIGHT
+- `requires_alarm_active = false` — Require an alert event before the light activates.
+
 ### `333` O_FLAME_EMITTER_SIDE
 - `interval = 2` — Interval between flame bursts, in seconds.
 

--- a/src/trx/game/objects/general/lights/strobe_light.c
+++ b/src/trx/game/objects/general/lights/strobe_light.c
@@ -2,7 +2,6 @@
 #include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/game/collision/los.h>
-#include <trx/game/game_flow.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
 #include <trx/game/sound.h>
@@ -11,6 +10,7 @@
 typedef struct {
     int32_t life;
     bool alarm_active;
+    bool requires_alarm_active;
 } M_PRIV;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -25,6 +25,17 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "life", p->life);
     JSONW_WRITE(io, "alarm_active", p->alarm_active);
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    OBJECT_PROPERTY_VALUE requires_alarm_active = {};
+    if (ObjectProperty_GetItemValue(
+            item, "requires_alarm_active", &requires_alarm_active)) {
+        p->requires_alarm_active = requires_alarm_active.as_bool;
+    }
 }
 
 void M_TriggerAlertLight(
@@ -56,7 +67,7 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    if (GF_BadGetLevelNum() == 15 && !p->alarm_active) {
+    if (p->requires_alarm_active && !p->alarm_active) {
         return;
     }
 
@@ -105,9 +116,15 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->priv_load_func = M_LoadPriv;
     obj->priv_save_func = M_SavePriv;
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->event_func = M_HandleEvent;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_BOOL(
+            "requires_alarm_active", false,
+            "Require an alert event before the light activates."));
 }
 
 REGISTER_OBJECT(O_STROBE_LIGHT, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR changes strobe light to no longer hardcode the check for triggered lasers, and declares it in Lua instead.