### PR TITLE
objects/propeller: move damage to Lua

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -272,6 +272,7 @@
         // 9. Thames Wharf
         {
             "path": "roofs.tr2",
+            "script": "thames.lua",
             "music_track": 73,
             "lara_outfit": "tr3_catsuit",
             "weather_type": "rain",

--- a/data/trx/ship/games/tr3/scripts/thames.lua
+++ b/data/trx/ship/games/tr3/scripts/thames.lua
@@ -1,0 +1,4 @@
+trx.events.before_item_setup(function(level)
+  trx.objects[trx.catalog.objects.propeller_2].properties.damage = 1000
+  trx.objects[trx.catalog.objects.propeller_3].properties.damage = 1000
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - removed hard-coded fish and piranha setup and moved to Lua instead
 - removed the limit of at most 8 fish/piranha shoals per level
 - removed hard-coded small Cobra radius setup and moved to Lua instead
+- removed the hard-coded propeller damage and moved it to Lua instead
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -227,6 +227,15 @@ This page lists documented moveable object properties.
 ### `54` O_MONK_2
 - `max_hit_points = 30` — Maximum hit points.
 
+### `76` O_PROPELLER_1
+- `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `94` O_PROPELLER_2
+- `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `95` O_PROPELLER_3
+- `damage = 200` — Damage dealt while Lara is touching the propeller.
+
 ### `123` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.
 
@@ -441,6 +450,12 @@ This page lists documented moveable object properties.
 
 ### `82` O_AI_X3
 - `max_hit_points = 0` — Maximum hit points.
+
+### `119` O_PROPELLER_2
+- `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `120` O_PROPELLER_3
+- `damage = 200` — Damage dealt while Lara is touching the propeller.
 
 ### `148` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.

--- a/src/trx/game/objects/traps/propeller.c
+++ b/src/trx/game/objects/traps/propeller.c
@@ -3,12 +3,12 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
-#include <trx/version.h>
 
-#define M_DAMAGE 200
+#define M_DEFAULT_DAMAGE 200
 
 typedef enum {
     // clang-format off
@@ -35,6 +35,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the propeller."));
 }
 
 static void M_SpawnBlood(const ITEM *const item, const int32_t count)
@@ -46,6 +51,16 @@ static void M_SpawnBlood(const ITEM *const item, const int32_t count)
         item->rot.y + DEG_90, lara_item->room_num, count);
 }
 
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
+
 void Propeller_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -54,10 +69,9 @@ void Propeller_Control(const int16_t item_num)
         item->goal_anim_state = M_STATE_ON;
 
         if ((item->touch_bits & 6) != 0) {
-            Lara_TakeDamage(M_DAMAGE, true);
-            if (g_TRVersion == 3 && GF_BadGetLevelNum() == 9) {
-                // TODO: allow assigning trap damage via Lua
-                Lara_GetItem()->hit_points = -1;
+            const ITEM *const lara_item = Lara_GetItem();
+            Lara_TakeDamage(M_GetDamage(item), true);
+            if (lara_item->hit_points <= 0) {
                 M_SpawnBlood(item, 5);
             }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This moves the hardcoded 200 / 1000 underwater propeller damage for Thames Wharf distinction to Lua.