### PR TITLE
Expose traps damage to Lua

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@
     - `O_BLADE`
     - `O_DAMOCLES_SWORD`
     - `O_DART`
+    - `O_FALLING_CEILING_1`
+    - `O_FALLING_CEILING_2`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
     - `O_HOOK`
     - `O_ICICLE`
     - `O_KILLER_STATUE`
+    - `O_LIGHTNING_EMITTER`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
     - `O_FALLING_CEILING_1`
     - `O_FALLING_CEILING_2`
     - `O_HOOK`
+    - `O_ICICLE`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - removed hard-coded small Cobra radius setup and moved to Lua instead
 - removed the hard-coded damage and moved it to Lua instead for the following objects:
     - `O_BLADE`
+    - `O_DAMOCLES_SWORD`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
     - `O_ROLLING_BALL_2`
     - `O_ROLLING_BALL_3`
     - `O_ROLLING_BALL_4`
+    - `O_ROTATING_LASER`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
     - `O_ROLLING_BALL_4`
     - `O_ROTATING_LASER`
     - `O_SECURITY_LASER_DEADLY`
+    - `O_SENTRY_GUN`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
     - `O_SENTRY_GUN`
     - `O_SPIKE_WALL`
     - `O_SPIKES`
+    - `O_SPINNING_BLADE`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,9 +17,12 @@
     - `O_ICICLE`
     - `O_KILLER_STATUE`
     - `O_LIGHTNING_EMITTER`
+    - `O_PENDULUM_1`
+    - `O_PENDULUM_2`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`
+    - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,12 +3,14 @@
 - added an option for Lara to pick items up more quickly, similar to TR4+ (#1365)
 - added `O_DOLPHIN`, which behaves in the same way as `O_ORCA` but has collision underwater
 - added a new console command - `/burn` - to toggle whether or not Lara is on fire
+- added poison Lua property to `O_DART` and `O_DISC`, so that they can poison Lara just like `O_POISON_DART`
 - removed hard-coded fish and piranha setup and moved to Lua instead
 - removed the limit of at most 8 fish/piranha shoals per level
 - removed hard-coded small Cobra radius setup and moved to Lua instead
 - removed the hard-coded damage and moved it to Lua instead for the following objects:
     - `O_BLADE`
     - `O_DAMOCLES_SWORD`
+    - `O_DART`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - removed hard-coded small Cobra radius setup and moved to Lua instead
 - removed the hard-coded damage and moved it to Lua instead for the following objects:
     - `O_BLADE`
+    - `O_CEILING_SPIKES`
     - `O_DAMOCLES_SWORD`
     - `O_DART`
     - `O_FALLING_CEILING_1`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
     - `O_ROLLING_BALL_3`
     - `O_ROLLING_BALL_4`
     - `O_ROTATING_LASER`
+    - `O_SECURITY_LASER_DEADLY`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
     - `O_FALLING_CEILING_2`
     - `O_HOOK`
     - `O_ICICLE`
+    - `O_KILLER_STATUE`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
     - `O_DART`
     - `O_FALLING_CEILING_1`
     - `O_FALLING_CEILING_2`
+    - `O_HOOK`
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
     - `O_SECURITY_LASER_DEADLY`
     - `O_SENTRY_GUN`
     - `O_SPIKE_WALL`
+    - `O_SPIKES`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,10 @@
     - `O_PROPELLER_1`
     - `O_PROPELLER_2`
     - `O_PROPELLER_3`
+    - `O_ROLLING_BALL_1`
+    - `O_ROLLING_BALL_2`
+    - `O_ROLLING_BALL_3`
+    - `O_ROLLING_BALL_4`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,11 @@
 - removed hard-coded fish and piranha setup and moved to Lua instead
 - removed the limit of at most 8 fish/piranha shoals per level
 - removed hard-coded small Cobra radius setup and moved to Lua instead
-- removed the hard-coded propeller damage and moved it to Lua instead
+- removed the hard-coded damage and moved it to Lua instead for the following objects:
+    - `O_BLADE`
+    - `O_PROPELLER_1`
+    - `O_PROPELLER_2`
+    - `O_PROPELLER_3`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
     - `O_ROTATING_LASER`
     - `O_SECURITY_LASER_DEADLY`
     - `O_SENTRY_GUN`
+    - `O_SPIKE_WALL`
     - `O_SWINGING_AXE`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
     - `O_SPIKES`
     - `O_SPINNING_BLADE`
     - `O_SWINGING_AXE`
+    - `O_TEETH_TRAP`
 - removed the limitation of only having two fish sprite types in any level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -280,6 +280,9 @@ This page lists documented moveable object properties.
 ### `84` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
+### `85` O_SPIKE_WALL
+- `damage = 20` — Damage dealt while Lara is touching the spike wall.
+
 ### `87` O_CEILING_SPIKES
 - `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.
 
@@ -539,6 +542,9 @@ This page lists documented moveable object properties.
 
 ### `113` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
+
+### `114` O_SPIKE_WALL
+- `damage = 20` — Damage dealt while Lara is touching the spike wall.
 
 ### `116` O_CEILING_SPIKES
 - `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -103,6 +103,12 @@ This page lists documented moveable object properties.
 ### `43` O_DAMOCLES_SWORD
 - `damage = 100` — Damage dealt when Lara is struck by the falling Damocles sword.
 
+### `53` O_FALLING_CEILING_1
+- `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
+
+### `54` O_FALLING_CEILING_2
+- `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
+
 ### `77` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.
 
@@ -240,6 +246,9 @@ This page lists documented moveable object properties.
 
 ### `76` O_PROPELLER_1
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `79` O_FALLING_CEILING_1
+- `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
 
 ### `81` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
@@ -468,6 +477,9 @@ This page lists documented moveable object properties.
 ### `90` O_POISON_DART
 - `damage = 25` — Damage dealt on hit.
 - `poison = true` — Apply poison buildup in addition to hit damage.
+
+### `107` O_FALLING_CEILING_1
+- `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
 
 ### `111` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -256,6 +256,9 @@ This page lists documented moveable object properties.
 ### `81` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
 
+### `84` O_ICICLE
+- `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
+
 ### `94` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
 
@@ -489,6 +492,9 @@ This page lists documented moveable object properties.
 
 ### `111` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
+
+### `113` O_ICICLE
+- `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
 ### `119` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -109,6 +109,9 @@ This page lists documented moveable object properties.
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
 
+### `42` O_TEETH_TRAP
+- `damage = 400` — Damage dealt while Lara is caught in the teeth trap.
+
 ### `43` O_DAMOCLES_SWORD
 - `damage = 100` — Damage dealt when Lara is struck by the falling Damocles sword.
 
@@ -264,6 +267,9 @@ This page lists documented moveable object properties.
 ### `61` O_DISC
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
+
+### `64` O_TEETH_TRAP
+- `damage = 400` — Damage dealt while Lara is caught in the teeth trap.
 
 ### `76` O_PROPELLER_1
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
@@ -539,6 +545,9 @@ This page lists documented moveable object properties.
 ### `90` O_POISON_DART
 - `damage = 25` — Damage dealt on hit.
 - `poison = true` — Apply poison buildup in addition to hit damage.
+
+### `94` O_TEETH_TRAP
+- `damage = 400` — Damage dealt while Lara is caught in the teeth trap.
 
 ### `106` O_HOOK
 - `damage = 50` — Damage dealt while Lara is touching the hook.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -99,6 +99,9 @@ This page lists documented moveable object properties.
 ### `36` O_SWINGING_AXE
 - `damage = 100` — Damage dealt while Lara is touching the swinging axe.
 
+### `38` O_ROLLING_BALL_1
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
 ### `39` O_DART
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
@@ -249,6 +252,9 @@ This page lists documented moveable object properties.
 ### `58` O_PENDULUM_1
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
 
+### `60` O_ROLLING_BALL_1
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
 ### `61` O_DISC
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
@@ -268,6 +274,9 @@ This page lists documented moveable object properties.
 ### `82` O_KILLER_STATUE
 - `damage = 20` — Damage dealt while Lara is struck by the killer statue.
 
+### `83` O_ROLLING_BALL_2
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
 ### `84` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
@@ -279,6 +288,9 @@ This page lists documented moveable object properties.
 
 ### `96` O_PENDULUM_2
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
+### `101` O_ROLLING_BALL_3
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
 
 ### `123` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.
@@ -498,6 +510,12 @@ This page lists documented moveable object properties.
 ### `86` O_PENDULUM_1
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
 
+### `88` O_ROLLING_BALL_1
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
+### `89` O_ROLLING_BALL_4
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
 ### `90` O_POISON_DART
 - `damage = 25` — Damage dealt on hit.
 - `poison = true` — Apply poison buildup in addition to hit damage.
@@ -511,6 +529,9 @@ This page lists documented moveable object properties.
 ### `111` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
 
+### `112` O_ROLLING_BALL_2
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
+
 ### `113` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
@@ -522,6 +543,9 @@ This page lists documented moveable object properties.
 
 ### `121` O_PENDULUM_2
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
+### `126` O_ROLLING_BALL_3
+- `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
 
 ### `148` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -96,6 +96,9 @@ This page lists documented moveable object properties.
 ### `34` O_TORSO
 - `max_hit_points = 500` — Maximum hit points.
 
+### `36` O_SWINGING_AXE
+- `damage = 100` — Damage dealt while Lara is touching the swinging axe.
+
 ### `39` O_DART
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
@@ -243,6 +246,9 @@ This page lists documented moveable object properties.
 ### `54` O_MONK_2
 - `max_hit_points = 30` — Maximum hit points.
 
+### `58` O_PENDULUM_1
+- `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
 ### `61` O_DISC
 - `damage = 50` — Damage dealt on hit.
 - `poison = false` — Apply poison buildup in addition to hit damage.
@@ -270,6 +276,9 @@ This page lists documented moveable object properties.
 
 ### `95` O_PROPELLER_3
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `96` O_PENDULUM_2
+- `damage = 50` — Damage dealt while Lara is touching the pendulum.
 
 ### `123` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.
@@ -486,6 +495,9 @@ This page lists documented moveable object properties.
 ### `82` O_AI_X3
 - `max_hit_points = 0` — Maximum hit points.
 
+### `86` O_PENDULUM_1
+- `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
 ### `90` O_POISON_DART
 - `damage = 25` — Damage dealt on hit.
 - `poison = true` — Apply poison buildup in addition to hit damage.
@@ -507,6 +519,9 @@ This page lists documented moveable object properties.
 
 ### `120` O_PROPELLER_3
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
+
+### `121` O_PENDULUM_2
+- `damage = 50` — Damage dealt while Lara is touching the pendulum.
 
 ### `148` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -247,6 +247,9 @@ This page lists documented moveable object properties.
 ### `76` O_PROPELLER_1
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
 
+### `78` O_HOOK
+- `damage = 50` — Damage dealt while Lara is touching the hook.
+
 ### `79` O_FALLING_CEILING_1
 - `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
 
@@ -477,6 +480,9 @@ This page lists documented moveable object properties.
 ### `90` O_POISON_DART
 - `damage = 25` — Damage dealt on hit.
 - `poison = true` — Apply poison buildup in addition to hit damage.
+
+### `106` O_HOOK
+- `damage = 50` — Damage dealt while Lara is touching the hook.
 
 ### `107` O_FALLING_CEILING_1
 - `damage = 300` — Damage dealt while Lara is touching the falling ceiling.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -96,6 +96,9 @@ This page lists documented moveable object properties.
 ### `34` O_TORSO
 - `max_hit_points = 500` — Maximum hit points.
 
+### `43` O_DAMOCLES_SWORD
+- `damage = 100` — Damage dealt when Lara is struck by the falling Damocles sword.
+
 ### `77` O_PLAYER_1
 - `max_hit_points = 1` — Maximum hit points.
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -96,6 +96,10 @@ This page lists documented moveable object properties.
 ### `34` O_TORSO
 - `max_hit_points = 500` — Maximum hit points.
 
+### `39` O_DART
+- `damage = 50` — Damage dealt on hit.
+- `poison = false` — Apply poison buildup in addition to hit damage.
+
 ### `43` O_DAMOCLES_SWORD
 - `damage = 100` — Damage dealt when Lara is struck by the falling Damocles sword.
 
@@ -229,6 +233,10 @@ This page lists documented moveable object properties.
 
 ### `54` O_MONK_2
 - `max_hit_points = 30` — Maximum hit points.
+
+### `61` O_DISC
+- `damage = 50` — Damage dealt on hit.
+- `poison = false` — Apply poison buildup in addition to hit damage.
 
 ### `76` O_PROPELLER_1
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
@@ -456,6 +464,10 @@ This page lists documented moveable object properties.
 
 ### `82` O_AI_X3
 - `max_hit_points = 0` — Maximum hit points.
+
+### `90` O_POISON_DART
+- `damage = 25` — Damage dealt on hit.
+- `poison = true` — Apply poison buildup in addition to hit damage.
 
 ### `111` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -274,6 +274,9 @@ This page lists documented moveable object properties.
 ### `79` O_FALLING_CEILING_1
 - `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
 
+### `80` O_SPINNING_BLADE
+- `damage = 100` — Damage dealt while Lara is touching the spinning blade.
+
 ### `81` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
 
@@ -542,6 +545,9 @@ This page lists documented moveable object properties.
 
 ### `107` O_FALLING_CEILING_1
 - `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
+
+### `108` O_SPINNING_BLADE
+- `damage = 100` — Damage dealt while Lara is touching the spinning blade.
 
 ### `111` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -230,6 +230,9 @@ This page lists documented moveable object properties.
 ### `76` O_PROPELLER_1
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
 
+### `81` O_BLADE
+- `damage = 100` — Damage dealt while Lara is touching the blade trap.
+
 ### `94` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
 
@@ -450,6 +453,9 @@ This page lists documented moveable object properties.
 
 ### `82` O_AI_X3
 - `max_hit_points = 0` — Maximum hit points.
+
+### `111` O_BLADE
+- `damage = 100` — Damage dealt while Lara is touching the blade trap.
 
 ### `119` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -256,6 +256,9 @@ This page lists documented moveable object properties.
 ### `81` O_BLADE
 - `damage = 100` — Damage dealt while Lara is touching the blade trap.
 
+### `82` O_KILLER_STATUE
+- `damage = 20` — Damage dealt while Lara is struck by the killer statue.
+
 ### `84` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -460,6 +460,7 @@ This page lists documented moveable object properties.
 - `max_hit_points = 1` — Maximum hit points.
 
 ### `67` O_SECURITY_LASER_DEADLY
+- `damage = 10` — Damage dealt when Lara crosses the security laser.
 - `max_hit_points = 1` — Maximum hit points.
 
 ### `68` O_SECURITY_LASER_KILLER

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -451,6 +451,7 @@ This page lists documented moveable object properties.
 - `max_hit_points = 45` — Maximum hit points.
 
 ### `64` O_SENTRY_GUN
+- `damage = 10` — Damage dealt when the sentry gun hits Lara.
 - `max_hit_points = 100` — Maximum hit points.
 
 ### `65` O_CIVILIAN

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -103,6 +103,9 @@ This page lists documented moveable object properties.
 ### `43` O_DAMOCLES_SWORD
 - `damage = 100` — Damage dealt when Lara is struck by the falling Damocles sword.
 
+### `46` O_LIGHTNING_EMITTER
+- `damage = 400` — Damage dealt when Lara is struck by the lightning emitter.
+
 ### `53` O_FALLING_CEILING_1
 - `damage = 300` — Damage dealt while Lara is touching the falling ceiling.
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -280,6 +280,9 @@ This page lists documented moveable object properties.
 ### `84` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
+### `87` O_CEILING_SPIKES
+- `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.
+
 ### `94` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.
 
@@ -536,6 +539,9 @@ This page lists documented moveable object properties.
 
 ### `113` O_ICICLE
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
+
+### `116` O_CEILING_SPIKES
+- `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.
 
 ### `119` O_PROPELLER_2
 - `damage = 200` — Damage dealt while Lara is touching the propeller.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -99,6 +99,9 @@ This page lists documented moveable object properties.
 ### `36` O_SWINGING_AXE
 - `damage = 100` — Damage dealt while Lara is touching the swinging axe.
 
+### `37` O_SPIKES
+- `damage = 15` — Damage dealt when Lara hits the spikes without dying instantly.
+
 ### `38` O_ROLLING_BALL_1
 - `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
 
@@ -251,6 +254,9 @@ This page lists documented moveable object properties.
 
 ### `58` O_PENDULUM_1
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
+### `59` O_SPIKES
+- `damage = 15` — Damage dealt when Lara hits the spikes without dying instantly.
 
 ### `60` O_ROLLING_BALL_1
 - `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.
@@ -517,6 +523,9 @@ This page lists documented moveable object properties.
 
 ### `86` O_PENDULUM_1
 - `damage = 50` — Damage dealt while Lara is touching the pendulum.
+
+### `87` O_SPIKES
+- `damage = 15` — Damage dealt when Lara hits the spikes without dying instantly.
 
 ### `88` O_ROLLING_BALL_1
 - `air_damage = 100` — Damage dealt when Lara is clipped by a moving boulder without being crushed.

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -586,6 +586,9 @@ This page lists documented moveable object properties.
 ### `288` O_RAPTOR
 - `max_hit_points = 90` — Maximum hit points.
 
+### `291` O_ROTATING_LASER
+- `damage = 25` — Damage dealt while Lara is touching the rotating laser.
+
 ### `318` O_STROBE_LIGHT
 - `requires_alarm_active = false` — Require an alert event before the light activates.
 

--- a/src/trx/game/objects/traps/blade.c
+++ b/src/trx/game/objects/traps/blade.c
@@ -1,41 +1,40 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/spawn.h>
 
 // clang-format off
-#define BLADE_CUT_DAMAGE 100
-#define BLADE_TOUCH_BITS 0b00000010 // = 2
+#define M_DEFAULT_DAMAGE 100
+#define M_TOUCH_BITS 0b00000010 // = 2
 // clang-format on
 
 typedef enum {
-    // clang-format off
-    BLADE_STATE_EMPTY = 0,
-    BLADE_STATE_STOP  = 1,
-    BLADE_STATE_CUT   = 2,
-    // clang-format on
-} BLADE_STATE;
+    M_STATE_EMPTY,
+    M_STATE_STOP,
+    M_STATE_CUT,
+} M_STATE;
 
 typedef enum {
     // clang-format off
-    BLADE_ANIM_RETURN   = 0,
-    BLADE_ANIM_FINISHED = 1,
-    BLADE_ANIM_SET      = 2,
-    BLADE_ANIM_CUT      = 3,
+    M_ANIM_RETURN   = 0,
+    M_ANIM_FINISHED = 1,
+    M_ANIM_SET      = 2,
+    M_ANIM_CUT      = 3,
     // clang-format on
-} BLADE_ANIM;
+} M_ANIM;
 
 static void M_Initialise(const int16_t item_num)
 {
     const OBJECT *const obj = Object_Get(O_BLADE);
     ITEM *const item = Item_Get(item_num);
-    Item_SwitchToAnim(item, BLADE_ANIM_SET, 0);
-    item->current_anim_state = BLADE_STATE_STOP;
+    Item_SwitchToAnim(item, M_ANIM_SET, 0);
+    item->current_anim_state = M_STATE_STOP;
 }
 
 static void M_Stop(ITEM *const item)
 {
     const int16_t anim_idx = Item_GetRelativeAnim(item);
-    if (anim_idx == BLADE_ANIM_CUT) {
+    if (anim_idx == M_ANIM_CUT) {
         const ANIM *const anim = Item_GetAnim(item);
         if (!Item_IsTriggerActive(item) && anim->jump_anim_num == item->anim_num
             && Item_TestFrameEqual(item, -1)) {
@@ -45,7 +44,17 @@ static void M_Stop(ITEM *const item)
         }
     }
 
-    item->goal_anim_state = BLADE_STATE_STOP;
+    item->goal_anim_state = M_STATE_STOP;
+}
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
 }
 
 static void M_Control(const int16_t item_num)
@@ -53,15 +62,15 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
 
     if (Item_IsTriggerActive(item)
-        && item->current_anim_state == BLADE_STATE_STOP) {
-        item->goal_anim_state = BLADE_STATE_CUT;
+        && item->current_anim_state == M_STATE_STOP) {
+        item->goal_anim_state = M_STATE_CUT;
     } else {
         M_Stop(item);
     }
 
-    if ((item->touch_bits & BLADE_TOUCH_BITS) != 0
-        && item->current_anim_state == BLADE_STATE_CUT) {
-        Lara_TakeDamage(BLADE_CUT_DAMAGE, true);
+    if ((item->touch_bits & M_TOUCH_BITS) != 0
+        && item->current_anim_state == M_STATE_CUT) {
+        Lara_TakeDamage(M_GetDamage(item), true);
 
         const ITEM *const lara_item = Lara_GetItem();
         Spawn_BloodBath(
@@ -79,6 +88,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the blade trap."));
 }
 
 REGISTER_OBJECT(O_BLADE, M_Setup)

--- a/src/trx/game/objects/traps/damocles_sword.c
+++ b/src/trx/game/objects/traps/damocles_sword.c
@@ -1,5 +1,6 @@
 #include <trx/core/utils.h>
 #include <trx/game/lara.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -7,7 +8,17 @@
 #include <trx/game/spawn.h>
 
 #define M_ACTIVATE_DIST ((WALL_L * 3) / 2)
-#define M_DAMAGE 100
+#define M_DEFAULT_DAMAGE 100
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Reset(ITEM *const item)
 {
@@ -86,7 +97,7 @@ static void M_Collision(
         Lara_Col_ItemPush(item, coll, false, true);
     }
     if (item->gravity) {
-        Lara_TakeDamage(M_DAMAGE, false);
+        Lara_TakeDamage(M_GetDamage(item), false);
         int32_t x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256;
         int32_t z = lara_item->pos.z + (Random_GetControl() - 0x4000) / 256;
         int32_t y = lara_item->pos.y - Random_GetControl() / 44;
@@ -104,6 +115,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_anim = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when Lara is struck by the falling Damocles sword."));
 }
 
 REGISTER_OBJECT(O_DAMOCLES_SWORD, M_Setup)

--- a/src/trx/game/objects/traps/dart.c
+++ b/src/trx/game/objects/traps/dart.c
@@ -1,6 +1,7 @@
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -9,8 +10,8 @@
 #include <trx/game/spawn.h>
 #include <trx/version.h>
 
-#define M_DART_DAMAGE 50
-#define M_POISON_DART_DAMAGE 25
+#define M_DEFAULT_DAMAGE 50
+#define M_DEFAULT_POISON_DAMAGE 25
 #define M_POISON_AMOUNT 160
 #define M_PITCH (DEG_45 / 2)
 
@@ -18,11 +19,30 @@ typedef struct {
     bool pending_kill;
 } M_PRIV;
 
+static bool M_IsPoison(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE poison = {};
+    if (ObjectProperty_GetItemValue(item, "poison", &poison)) {
+        return poison.as_bool;
+    }
+
+    return item->object_id == O_POISON_DART;
+}
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_IsPoison(item) ? M_DEFAULT_POISON_DAMAGE : M_DEFAULT_DAMAGE;
+}
+
 static void M_DamageLara(const ITEM *const item)
 {
-    const bool is_poison = item->object_id == O_POISON_DART;
-    const int32_t damage = is_poison ? M_POISON_DART_DAMAGE : M_DART_DAMAGE;
-    Lara_TakeDamage(damage, true);
+    const bool is_poison = M_IsPoison(item);
+    Lara_TakeDamage(M_GetDamage(item), true);
     if (is_poison) {
         LARA_INFO *const lara = Lara_GetLaraInfo();
         lara->poison_timer += M_POISON_AMOUNT;
@@ -143,6 +163,12 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT("damage", M_DEFAULT_DAMAGE, "Damage dealt on hit."),
+        OBJECT_PROPERTY_BOOL(
+            "poison", false,
+            "Apply poison buildup in addition to hit damage."));
 }
 
 static void M_SetupPoisonDart(OBJECT *const obj)
@@ -153,6 +179,12 @@ static void M_SetupPoisonDart(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->shadow_size = UNIT_SHADOW / 2;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_POISON_DAMAGE, "Damage dealt on hit."),
+        OBJECT_PROPERTY_BOOL(
+            "poison", true, "Apply poison buildup in addition to hit damage."));
 }
 
 REGISTER_OBJECT(O_DART, M_Setup)

--- a/src/trx/game/objects/traps/falling_ceiling.c
+++ b/src/trx/game/objects/traps/falling_ceiling.c
@@ -1,8 +1,19 @@
 #include <trx/game/lara.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/rooms.h>
 
-#define M_DAMAGE 300
+#define M_DEFAULT_DAMAGE 300
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Control(const int16_t item_num)
 {
@@ -13,7 +24,7 @@ static void M_Control(const int16_t item_num)
         item->gravity = true;
     } else if (
         item->current_anim_state == TRAP_ACTIVATE && item->touch_bits != 0) {
-        Lara_TakeDamage(M_DAMAGE, true);
+        Lara_TakeDamage(M_GetDamage(item), true);
     }
 
     Item_Animate(item);
@@ -47,6 +58,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_anim = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the falling ceiling."));
 }
 
 REGISTER_OBJECT(O_FALLING_CEILING_1, M_Setup)

--- a/src/trx/game/objects/traps/hook.c
+++ b/src/trx/game/objects/traps/hook.c
@@ -2,10 +2,21 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 50
+#define M_DEFAULT_DAMAGE 50
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Control(const int16_t item_num)
 {
@@ -22,7 +33,7 @@ static void M_Control(const int16_t item_num)
     item->enable_interpolation = true;
     if (item->touch_bits != 0) {
         const ITEM *const lara_item = Lara_GetItem();
-        Lara_TakeDamage(M_DAMAGE, true);
+        Lara_TakeDamage(M_GetDamage(item), true);
         Spawn_BloodBath(
             lara_item->pos.x, lara_item->pos.y - WALL_L / 2, lara_item->pos.z,
             lara_item->speed, lara_item->rot.y, lara_item->room_num, 3);
@@ -45,6 +56,11 @@ static void M_Setup(OBJECT *const obj)
     obj->handle_save_func = M_HandleSave;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the hook."));
 }
 
 REGISTER_OBJECT(O_HOOK, M_Setup)

--- a/src/trx/game/objects/traps/icicle.c
+++ b/src/trx/game/objects/traps/icicle.c
@@ -1,10 +1,11 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 
-#define M_DAMAGE 200
+#define M_DEFAULT_DAMAGE 200
 
 typedef enum {
     // clang-format off
@@ -19,6 +20,16 @@ static void M_Reset(ITEM *const item)
 {
     item->mesh_bits = 0xFFFFFFFF;
     Trap_Reset(item);
+}
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
 }
 
 static void M_Control(const int16_t item_num)
@@ -36,7 +47,7 @@ static void M_Control(const int16_t item_num)
             item->fall_speed = 50;
         }
         if (item->touch_bits != 0) {
-            Lara_TakeDamage(M_DAMAGE, true);
+            Lara_TakeDamage(M_GetDamage(item), true);
         }
         break;
 
@@ -76,6 +87,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when Lara is struck by the falling icicle."));
 }
 
 REGISTER_OBJECT(O_ICICLE, M_Setup)

--- a/src/trx/game/objects/traps/killer_statue.c
+++ b/src/trx/game/objects/traps/killer_statue.c
@@ -1,35 +1,44 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/random.h>
 #include <trx/game/spawn.h>
 
-#define KILLER_STATUE_CUT_DAMAGE 20
-#define KILLER_STATUE_TOUCH_BITS 0b10000000 // = 128
+#define M_DEFAULT_DAMAGE 20
+#define M_TOUCH_BITS 0b10000000 // = 128
 // clang-format on
 
 typedef enum {
-    // clang-format off
-    KILLER_STATUE_STATE_EMPTY = 0,
-    KILLER_STATUE_STATE_STOP  = 1,
-    KILLER_STATUE_STATE_CUT   = 2,
-    // clang-format on
-} KILLER_STATUE_STATE;
+    M_STATE_EMPTY,
+    M_STATE_STOP,
+    M_STATE_CUT,
+} M_STATE;
 
 typedef enum {
     // clang-format off
-    KILLER_STATUE_ANIM_RETURN   = 0,
-    KILLER_STATUE_ANIM_FINISHED = 1,
-    KILLER_STATUE_ANIM_CUT      = 2,
-    KILLER_STATUE_ANIM_SET      = 3,
+    M_ANIM_RETURN   = 0,
+    M_ANIM_FINISHED = 1,
+    M_ANIM_CUT      = 2,
+    M_ANIM_SET      = 3,
     // clang-format on
-} KILLER_STATUE_ANIM;
+} M_ANIM;
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Initialise(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     const OBJECT *const obj = Object_Get(item->object_id);
-    Item_SwitchToAnim(item, KILLER_STATUE_ANIM_SET, 0);
-    item->current_anim_state = KILLER_STATUE_STATE_STOP;
+    Item_SwitchToAnim(item, M_ANIM_SET, 0);
+    item->current_anim_state = M_STATE_STOP;
 }
 
 static void M_Control(const int16_t item_num)
@@ -37,15 +46,15 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
 
     if (Item_IsTriggerActive(item)
-        && item->current_anim_state == KILLER_STATUE_STATE_STOP) {
-        item->goal_anim_state = KILLER_STATUE_STATE_CUT;
+        && item->current_anim_state == M_STATE_STOP) {
+        item->goal_anim_state = M_STATE_CUT;
     } else {
-        item->goal_anim_state = KILLER_STATUE_STATE_STOP;
+        item->goal_anim_state = M_STATE_STOP;
     }
 
-    if ((item->touch_bits & KILLER_STATUE_TOUCH_BITS) != 0
-        && item->current_anim_state == KILLER_STATUE_STATE_CUT) {
-        Lara_TakeDamage(KILLER_STATUE_CUT_DAMAGE, true);
+    if ((item->touch_bits & M_TOUCH_BITS) != 0
+        && item->current_anim_state == M_STATE_CUT) {
+        Lara_TakeDamage(M_GetDamage(item), true);
 
         const ITEM *const lara_item = Lara_GetItem();
         Spawn_Blood(
@@ -67,6 +76,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is struck by the killer statue."));
 }
 
 REGISTER_OBJECT(O_KILLER_STATUE, M_Setup)

--- a/src/trx/game/objects/traps/lightning_emitter.c
+++ b/src/trx/game/objects/traps/lightning_emitter.c
@@ -2,12 +2,13 @@
 #include <trx/game/game.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
 #include <trx/game/viewport.h>
 
-#define M_DAMAGE 400
+#define M_DEFAULT_DAMAGE 400
 #define M_STEPS 8
 #define M_RND 64
 #define M_SHOOTS 2
@@ -24,6 +25,16 @@ typedef struct {
     XYZ_32 wibble[M_STEPS];
     XYZ_32 shoot[M_SHOOTS][M_STEPS];
 } M_PRIV;
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Initialise(const int16_t item_num)
 {
@@ -90,7 +101,7 @@ static void M_Control(const int16_t item_num)
             p->target.y = lara_item->pos.y;
             p->target.z = lara_item->pos.z;
 
-            Lara_TakeDamage(M_DAMAGE, true);
+            Lara_TakeDamage(M_GetDamage(item), true);
 
             p->zapped = true;
         } else if (p->no_target) {
@@ -288,6 +299,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = M_Collision;
     obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when Lara is struck by the lightning emitter."));
 }
 
 REGISTER_OBJECT(O_LIGHTNING_EMITTER, M_Setup)

--- a/src/trx/game/objects/traps/pendulum.c
+++ b/src/trx/game/objects/traps/pendulum.c
@@ -4,6 +4,7 @@
 #include <trx/game/effects.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
@@ -14,10 +15,10 @@
 #include <trx/version.h>
 
 // clang-format off
-#define M_AXE_DAMAGE      100
-#define M_PENDULUM_DAMAGE 50
-#define M_MAX_FIRE_DIST   (WALL_L * 16) // = 16384
-#define M_FIRE_FALLOFF    11
+#define M_DEFAULT_AXE_DAMAGE      100
+#define M_DEFAULT_PENDULUM_DAMAGE 50
+#define M_MAX_FIRE_DIST           (WALL_L * 16) // = 16384
+#define M_FIRE_FALLOFF            11
 // clang-format on
 
 typedef struct {
@@ -174,9 +175,15 @@ static void M_KillFireEffect(ITEM *const item)
     }
 }
 
-static inline int16_t M_GetDamage(const OBJECT_ID obj_id)
+static int32_t M_GetDamage(const ITEM *const item)
 {
-    return obj_id == O_SWINGING_AXE ? M_AXE_DAMAGE : M_PENDULUM_DAMAGE;
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return item->object_id == O_SWINGING_AXE ? M_DEFAULT_AXE_DAMAGE
+                                             : M_DEFAULT_PENDULUM_DAMAGE;
 }
 
 static void M_Control(const int16_t item_num)
@@ -217,8 +224,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (working && item->touch_bits != 0) {
-        const int16_t damage = M_GetDamage(item->object_id);
-        Lara_TakeDamage(damage, true);
+        Lara_TakeDamage(M_GetDamage(item), true);
 
         if (p->on_fire) {
             Lara_CatchFire();
@@ -275,12 +281,22 @@ static void M_SetupAxe(OBJECT *const obj)
 {
     M_SetupCommon(obj);
     obj->collision_func = Object_Collision_Trap;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_AXE_DAMAGE,
+            "Damage dealt while Lara is touching the swinging axe."));
 }
 
 static void M_SetupPendulum(OBJECT *const obj)
 {
     M_SetupCommon(obj);
     obj->collision_func = Object_Collision;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_PENDULUM_DAMAGE,
+            "Damage dealt while Lara is touching the pendulum."));
 }
 
 REGISTER_OBJECT(O_SWINGING_AXE, M_SetupAxe)

--- a/src/trx/game/objects/traps/rolling_ball.c
+++ b/src/trx/game/objects/traps/rolling_ball.c
@@ -3,6 +3,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -10,7 +11,7 @@
 #include <trx/game/spawn.h>
 #include <trx/version.h>
 
-#define M_DAMAGE_AIR 100
+#define M_DEFAULT_AIR_DAMAGE 100
 #define M_SHAKE_RANGE (WALL_L * 10) // = 10240
 #define M_CLEARANCE_UNIT (STEP_L * 3) // = 768
 
@@ -40,6 +41,16 @@ static void M_Roll(ITEM *const item)
             g_Camera.bounce = 40 * (dist - M_SHAKE_RANGE) / M_SHAKE_RANGE;
         }
     }
+}
+
+static int32_t M_GetAirDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "air_damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_AIR_DAMAGE;
 }
 
 static bool M_TestStop(const ITEM *const item)
@@ -194,7 +205,7 @@ static void M_Collision(
         if (coll->enable_baddie_push) {
             Lara_Col_ItemPush(item, coll, coll->enable_hit, true);
         }
-        Lara_TakeDamage(M_DAMAGE_AIR, false);
+        Lara_TakeDamage(M_GetAirDamage(item), false);
 
         // TODO: handle overflows
         const int32_t dx = lara_item->pos.x - item->pos.x;
@@ -250,6 +261,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_flags = true;
     obj->save_anim = true;
     obj->load_floor = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "air_damage", M_DEFAULT_AIR_DAMAGE,
+            "Damage dealt when Lara is clipped by a moving boulder without "
+            "being crushed."));
 }
 
 REGISTER_OBJECT(O_ROLLING_BALL_1, M_Setup)

--- a/src/trx/game/objects/traps/rotating_laser.c
+++ b/src/trx/game/objects/traps/rotating_laser.c
@@ -4,10 +4,13 @@
 #include <trx/game/items/col.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
+
+#define M_DEFAULT_DAMAGE 25
 
 typedef struct {
     XYZ_32 origin;
@@ -16,6 +19,16 @@ typedef struct {
     int16_t velocity;
     int16_t reverse_timer;
 } M_PRIV;
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -123,7 +136,7 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const lara_item = Lara_GetItem();
     if (Item_TestBoundsCollide(item, lara_item, 64)) {
-        Lara_TakeDamage(25, false);
+        Lara_TakeDamage(M_GetDamage(item), false);
         Spawn_BloodBathD(
             lara_item->pos.x, item->pos.y - (Random_GetControl() & 0xFF) - 32,
             lara_item->pos.z, (Random_GetControl() & 0x7F) + 128,
@@ -145,6 +158,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the rotating laser."));
 }
 
 REGISTER_OBJECT(O_ROTATING_LASER, M_Setup)

--- a/src/trx/game/objects/traps/security_laser.c
+++ b/src/trx/game/objects/traps/security_laser.c
@@ -2,16 +2,27 @@
 #include <trx/game/lara.h>
 #include <trx/game/los.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 10
+#define M_DEFAULT_DAMAGE 10
 
 static uint8_t m_LaserShades[32] = {};
 static const int16_t m_DefaultBeamCount = 1;
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static bool M_IsTargetable(const ITEM *const item)
 {
@@ -215,7 +226,7 @@ static void M_DamageLara(const ITEM *const item, const int32_t beam_y)
     if (item->object_id == O_SECURITY_LASER_KILLER) {
         Lara_TakeDamage(lara_item->hit_points, false);
     } else {
-        Lara_TakeDamage(M_DAMAGE, false);
+        Lara_TakeDamage(M_GetDamage(item), false);
     }
 
     Spawn_BloodBath(
@@ -308,7 +319,7 @@ static bool M_DrawLaser(const ITEM *const item)
     return true;
 }
 
-static void M_Setup(OBJECT *const obj)
+static void M_SetupCommon(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
@@ -318,12 +329,38 @@ static void M_Setup(OBJECT *const obj)
 
     obj->save_hitpoints = true;
     obj->save_flags = true;
+}
+
+static void M_SetupAlarm(OBJECT *const obj)
+{
+    M_SetupCommon(obj);
     OBJECT_PROPERTIES(
         obj,
         OBJECT_PROPERTY_INT(
             "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
 }
 
-REGISTER_OBJECT(O_SECURITY_LASER_ALARM, M_Setup)
-REGISTER_OBJECT(O_SECURITY_LASER_DEADLY, M_Setup)
-REGISTER_OBJECT(O_SECURITY_LASER_KILLER, M_Setup)
+static void M_SetupDeadly(OBJECT *const obj)
+{
+    M_SetupCommon(obj);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when Lara crosses the security laser."),
+        OBJECT_PROPERTY_INT(
+            "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
+}
+
+static void M_SetupKiller(OBJECT *const obj)
+{
+    M_SetupCommon(obj);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "max_hit_points", m_DefaultBeamCount, "Maximum hit points."));
+}
+
+REGISTER_OBJECT(O_SECURITY_LASER_ALARM, M_SetupAlarm)
+REGISTER_OBJECT(O_SECURITY_LASER_DEADLY, M_SetupDeadly)
+REGISTER_OBJECT(O_SECURITY_LASER_KILLER, M_SetupKiller)

--- a/src/trx/game/objects/traps/sentry_gun.c
+++ b/src/trx/game/objects/traps/sentry_gun.c
@@ -3,10 +3,13 @@
 #include <trx/game/creature.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/output.h>
 #include <trx/game/pathing.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
+
+#define M_DEFAULT_DAMAGE 10
 
 typedef enum {
     M_STATE_FIRE,
@@ -24,6 +27,16 @@ typedef struct {
     bool is_alerted;
     bool has_fired;
 } M_PRIV;
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
@@ -151,10 +164,12 @@ static void M_Control(const int16_t item_num)
 
             if (p->active_muzzle == M_MUZZLE_RIGHT) {
                 Creature_Shoot(
-                    item, &info, &m_FireLeft, creature->joint_rotation[0], 10);
+                    item, &info, &m_FireLeft, creature->joint_rotation[0],
+                    M_GetDamage(item));
             } else {
                 Creature_Shoot(
-                    item, &info, &m_FireRight, creature->joint_rotation[0], 10);
+                    item, &info, &m_FireRight, creature->joint_rotation[0],
+                    M_GetDamage(item));
             }
 
             p->muzzle_flash_timer = 10;
@@ -234,7 +249,11 @@ static void M_Setup(OBJECT *const obj)
     Object_GetBone(obj, 0)->rot.y = true;
     Object_GetBone(obj, 1)->rot.x = true;
     OBJECT_PROPERTIES(
-        obj, OBJECT_PROPERTY_INT("max_hit_points", 100, "Maximum hit points."));
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when the sentry gun hits Lara."),
+        OBJECT_PROPERTY_INT("max_hit_points", 100, "Maximum hit points."));
 }
 
 REGISTER_OBJECT(O_SENTRY_GUN, M_Setup)

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -2,12 +2,13 @@
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 20
+#define M_DEFAULT_DAMAGE 20
 #define M_SPEED 1
 #define M_STEP_SLOW 5
 #define M_STEP_FAST 10
@@ -82,9 +83,19 @@ static void M_Move(const int16_t item_num)
     }
 }
 
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
+
 static void M_HitLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_DAMAGE, true);
+    Lara_TakeDamage(M_GetDamage(item), true);
 
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
@@ -128,6 +139,11 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_save_func = M_SavePriv;
     obj->save_position = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the ceiling spikes."));
 }
 
 REGISTER_OBJECT(O_CEILING_SPIKES, M_Setup)

--- a/src/trx/game/objects/traps/spike_wall.c
+++ b/src/trx/game/objects/traps/spike_wall.c
@@ -2,13 +2,24 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 20
+#define M_DEFAULT_DAMAGE 20
 #define M_SPEED 1
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Move(const int16_t item_num)
 {
@@ -31,7 +42,7 @@ static void M_Move(const int16_t item_num)
 
 static void M_HitLara(ITEM *const item)
 {
-    Lara_TakeDamage(M_DAMAGE, true);
+    Lara_TakeDamage(M_GetDamage(item), true);
 
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
@@ -64,6 +75,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->save_position = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the spike wall."));
 }
 
 REGISTER_OBJECT(O_SPIKE_WALL, M_Setup)

--- a/src/trx/game/objects/traps/spikes.c
+++ b/src/trx/game/objects/traps/spikes.c
@@ -1,12 +1,23 @@
 #include <trx/config.h>
 #include <trx/game/lara.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
 #include <trx/version.h>
 
 #define M_FALL_SPEED_LIMIT (g_TRVersion == 1 ? 0 : GRAVITY)
-#define M_DAMAGE 15
+#define M_DEFAULT_DAMAGE 15
+
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
 
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
@@ -34,7 +45,7 @@ static void M_Collision(
         return;
     }
 
-    Lara_TakeDamage(M_DAMAGE, false);
+    Lara_TakeDamage(M_GetDamage(item), false);
     for (int32_t i = 0; i < blood_spawn_count; i++) {
         const XYZ_32 pos = {
             .x = lara_item->pos.x + (Random_GetControl() - 0x4000) / 256,
@@ -68,8 +79,15 @@ static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
+
     obj->save_anim = true;
     obj->save_flags = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt when Lara hits the spikes without dying instantly."));
 }
 
 REGISTER_OBJECT(O_SPIKES, M_Setup)

--- a/src/trx/game/objects/traps/spinning_blade.c
+++ b/src/trx/game/objects/traps/spinning_blade.c
@@ -2,11 +2,12 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/common.h>
 #include <trx/game/objects/common.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 100
+#define M_DEFAULT_DAMAGE 100
 
 typedef enum {
     // clang-format off
@@ -33,6 +34,16 @@ static void M_Initialise(const int16_t item_num)
     item->current_anim_state = M_STATE_STOP;
 }
 
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -52,7 +63,7 @@ static void M_Control(const int16_t item_num)
 
         flip = true;
         if (item->touch_bits != 0) {
-            Lara_TakeDamage(M_DAMAGE, true);
+            Lara_TakeDamage(M_GetDamage(item), true);
 
             const ITEM *const lara_item = Lara_GetItem();
             Spawn_BloodBath(
@@ -91,6 +102,11 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is touching the spinning blade."));
 }
 
 REGISTER_OBJECT(O_SPINNING_BLADE, M_Setup)

--- a/src/trx/game/objects/traps/teeth_trap.c
+++ b/src/trx/game/objects/traps/teeth_trap.c
@@ -1,8 +1,9 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/spawn.h>
 
-#define M_DAMAGE 400
+#define M_DEFAULT_DAMAGE 400
 #define M_NUM_TEETH 6
 
 typedef enum {
@@ -21,6 +22,16 @@ static const BITE m_Teeth[M_NUM_TEETH] = {
     // clang-format on
 };
 
+static int32_t M_GetDamage(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE damage = {};
+    if (ObjectProperty_GetItemValue(item, "damage", &damage)) {
+        return damage.as_int;
+    }
+
+    return M_DEFAULT_DAMAGE;
+}
+
 static void M_Bite(ITEM *const item, const BITE *const bite)
 {
     XYZ_32 pos = bite->pos;
@@ -36,7 +47,7 @@ static void M_Control(const int16_t item_num)
         item->goal_anim_state = TEETH_TRAP_STATE_NASTY;
         if (item->touch_bits != 0
             && item->current_anim_state == TEETH_TRAP_STATE_NASTY) {
-            Lara_TakeDamage(M_DAMAGE, true);
+            Lara_TakeDamage(M_GetDamage(item), true);
             for (int32_t i = 0; i < M_NUM_TEETH; i++) {
                 M_Bite(item, &m_Teeth[i]);
             }
@@ -54,6 +65,11 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision_Trap;
     obj->save_flags = true;
     obj->save_anim = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "damage", M_DEFAULT_DAMAGE,
+            "Damage dealt while Lara is caught in the teeth trap."));
 }
 
 REGISTER_OBJECT(O_TEETH_TRAP, M_Setup)

--- a/tools/update_object_docs
+++ b/tools/update_object_docs
@@ -28,6 +28,31 @@ def strip_comments(source: str) -> str:
     return re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
 
 
+def parse_c_string(expr: str) -> str:
+    expr = expr.strip()
+    string_pattern = re.compile(r'"(?:\\.|[^"\\])*"')
+
+    parts: list[str] = []
+    pos = 0
+    while pos < len(expr):
+        while pos < len(expr) and expr[pos].isspace():
+            pos += 1
+        if pos >= len(expr):
+            break
+
+        match = string_pattern.match(expr, pos)
+        if match is None:
+            raise ValueError(f"unsupported C string expression: {expr!r}")
+
+        parts.append(ast.literal_eval(match.group(0)))
+        pos = match.end()
+
+    if not parts:
+        raise ValueError(f"expected C string literal: {expr!r}")
+
+    return "".join(parts)
+
+
 def read_local_constants(source: str) -> dict[str, str]:
     constants: dict[str, str] = {
         "NO_ITEM": "-1",
@@ -172,9 +197,9 @@ def iter_object_property_declarations(source: str) -> list[PropertyInfo]:
             name, value, description = parts
             declarations.append(
                 {
-                    "name": ast.literal_eval(name),
+                    "name": parse_c_string(name),
                     "value": " ".join(value.split()),
-                    "description": ast.literal_eval(description),
+                    "description": parse_c_string(description),
                 }
             )
         pos = idx


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR exposes the damage of all traps as a customizable property in Lua.
One-shot kills like getting squished with a push block, Thor's Hammer, or passing through a deadly security laser remain non-customizable.
Additionally, darts and disks can now poison Lara with a new Lua flag.

#### Testing

Regressions in the following traps:

- [x] Blades (The Great Wall)
- [x] Damocles swords
- [x] Darts, discs, poison darts
- [x] Falling ceilings
- [x] Hooks (Diving Area)
- [x] Icicles
- [x] Killer statues (Bartoli's Hideout)
- [x] Lightning emitters (Thor's Room)
- [x] Pendulums / swinging axes (Vilcabamba, Tinnos)
- [x] Boulders
- [x] Rotating lasers
- [x] Security lasers
- [x] Sentry guns
- [x] Spike walls
- [x] Spike ceiling
- [x] Spikes
- [x] Spinning blades (The Great Wall)
- [x] Teeth traps (Tihocan)

