### PR TITLE
Expose speed of lava wedge, spike ceiling, and spike wall in Lua

### DIFF
--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -300,6 +300,7 @@
         // 10. Aldwych
         {
             "path": "sewer.tr2",
+            "script": "aldwych.lua",
             "music_track": 74,
             "water_particles": true,
             "lara_outfit": "tr3_catsuit",

--- a/data/trx/ship/games/tr3/scripts/aldwych.lua
+++ b/data/trx/ship/games/tr3/scripts/aldwych.lua
@@ -1,3 +1,3 @@
 trx.events.before_item_setup(function(level)
-  trx.objects[trx.catalog.objects.ceiling_spikes].properties.speed = 10
+  trx.objects.ceiling_spikes.properties.speed = 10
 end)

--- a/data/trx/ship/games/tr3/scripts/aldwych.lua
+++ b/data/trx/ship/games/tr3/scripts/aldwych.lua
@@ -1,0 +1,3 @@
+trx.events.before_item_setup(function(level)
+  trx.objects[trx.catalog.objects.ceiling_spikes].properties.speed = 10
+end)

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
-  local props = trx.objects[trx.catalog.objects.strobe_light].properties
+  local props = trx.objects.strobe_light.properties
   props.requires_alarm_active = true
 end)
 

--- a/data/trx/ship/games/tr3/scripts/ganges.lua
+++ b/data/trx/ship/games/tr3/scripts/ganges.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
-  local props = trx.objects[trx.catalog.objects.quad_bike].properties
+  local props = trx.objects.quad_bike.properties
   props.track_1 = 9
   props.track_2 = 12
   props.track_3 = 4

--- a/data/trx/ship/games/tr3/scripts/nevada.lua
+++ b/data/trx/ship/games/tr3/scripts/nevada.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
-  local props = trx.objects[trx.catalog.objects.cobra].properties
+  local props = trx.objects.cobra.properties
   props.alert_radius = 1.25
   props.attack_radius = 0.666667
   props.forget_radius = 2.5

--- a/data/trx/ship/games/tr3/scripts/thames.lua
+++ b/data/trx/ship/games/tr3/scripts/thames.lua
@@ -1,4 +1,4 @@
 trx.events.before_item_setup(function(level)
-  trx.objects[trx.catalog.objects.propeller_2].properties.damage = 1000
-  trx.objects[trx.catalog.objects.propeller_3].properties.damage = 1000
+  trx.objects.propeller_2.properties.damage = 1000
+  trx.objects.propeller_3.properties.damage = 1000
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,10 @@
     - `O_SPINNING_BLADE`
     - `O_SWINGING_AXE`
     - `O_TEETH_TRAP`
+- removed the hard-coded movement speed and moved it to Lua instead for the following objects:
+    - `O_CEILING_SPIKES`
+    - `O_LAVA_WEDGE`
+    - `O_SPIKE_WALL`
 - removed the limitation of only having two fish sprite types in any level
 - removed the limit of at most 8 fish/piranha shoals per level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
@@ -65,7 +69,9 @@
 - changed animated spikes sound effects in specific levels to use animation commands instead
 - changed animated spikes to work outside levels 5 and 7
 - changed `O_AI_PATROL_1` behavior in High Security Compound and Area 51 to be configurable; refer to migration docs
+- removed the hard-coded Aldwych drill speed override and moved it to Lua instead
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats
+- fixed the drill in the Shakespeare Cliff not rotating
 
 
 

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1046,6 +1046,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   │   ├── tower.tr2
 │   │   │   └── triboss.tr2
 │   │   ├── scripts
+│   │   │   ├── aldwych.lua
 │   │   │   ├── area51.lua
 │   │   │   ├── compound.lua
 │   │   │   ├── crash.lua
@@ -2285,6 +2286,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   │   ├── tower.tr2
     │   │   │   │   └── triboss.tr2
     │   │   │   ├── scripts
+    │   │   │   │   ├── aldwych.lua
     │   │   │   │   ├── area51.lua
     │   │   │   │   ├── compound.lua
     │   │   │   │   ├── crash.lua

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -139,6 +139,9 @@ This page lists documented moveable object properties.
 ### `145` O_SCION_ITEM_3
 - `max_hit_points = 5` — Maximum hit points.
 
+### `180` O_LAVA_WEDGE
+- `speed = 25` — Offset applied each frame while the lava wedge advances.
+
 ### `191` O_WINSTON
 - `max_hit_points = 1` — Maximum hit points.
 
@@ -306,9 +309,11 @@ This page lists documented moveable object properties.
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
 ### `85` O_SPIKE_WALL
+- `speed = 16` — Offset applied each frame while the spike wall advances.
 - `damage = 20` — Damage dealt while Lara is touching the spike wall.
 
 ### `87` O_CEILING_SPIKES
+- `speed = 5` — Offset applied each frame while the ceiling spikes descend.
 - `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.
 
 ### `94` O_PROPELLER_2
@@ -590,9 +595,11 @@ This page lists documented moveable object properties.
 - `damage = 200` — Damage dealt when Lara is struck by the falling icicle.
 
 ### `114` O_SPIKE_WALL
+- `speed = 16` — Offset applied each frame while the spike wall advances.
 - `damage = 20` — Damage dealt while Lara is touching the spike wall.
 
 ### `116` O_CEILING_SPIKES
+- `speed = 5` — Offset applied each frame while the ceiling spikes descend.
 - `damage = 20` — Damage dealt while Lara is touching the ceiling spikes.
 
 ### `119` O_PROPELLER_2

--- a/src/trx/game/objects/creatures/atlantean.c
+++ b/src/trx/game/objects/creatures/atlantean.c
@@ -345,6 +345,7 @@ static void M_SetupShooter(OBJECT *const obj)
         return;
     }
     *obj = *Object_Get(O_ATLANTEAN_WINGED);
+    obj->properties = (OBJECT_PROPERTY_SET) {};
     obj->setup_func = M_SetupShooter;
     obj->initialise_func = M_InitialiseGround;
     obj->smartness = M_SHOOTER_SMARTNESS;
@@ -361,6 +362,7 @@ static void M_SetupGround(OBJECT *const obj)
         return;
     }
     *obj = *Object_Get(O_ATLANTEAN_WINGED);
+    obj->properties = (OBJECT_PROPERTY_SET) {};
     obj->setup_func = M_SetupGround;
     obj->initialise_func = M_InitialiseGround;
     obj->lot_setup = LOT_Setup(LOT_SETUP_DEFAULT);

--- a/src/trx/game/objects/traps/lava_wedge.c
+++ b/src/trx/game/objects/traps/lava_wedge.c
@@ -2,10 +2,33 @@
 #include <trx/game/camera.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/property.h>
 #include <trx/game/objects/traps/common.h>
 #include <trx/game/rooms.h>
 
-#define M_SPEED 25
+#define M_DEFAULT_SPEED 25
+
+typedef struct {
+    int32_t speed;
+} M_PRIV;
+
+static int32_t M_GetSpeed(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE speed = {};
+    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
+        return speed.as_int;
+    }
+
+    return M_DEFAULT_SPEED;
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    Trap_Initialise(item_num);
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->speed = M_GetSpeed(item);
+}
 
 static void M_Control(const int16_t item_num)
 {
@@ -21,23 +44,24 @@ static void M_Control(const int16_t item_num)
     Item_UpdateRoom(item_num, room_num);
 
     if (item->status != IS_DEACTIVATED) {
+        const M_PRIV *const p = item->priv;
         XYZ_32 pos = item->pos;
 
         switch (item->rot.y) {
         case 0:
-            item->pos.z += M_SPEED;
+            item->pos.z += p->speed;
             pos.z += 2 * WALL_L;
             break;
         case -DEG_180:
-            item->pos.z -= M_SPEED;
+            item->pos.z -= p->speed;
             pos.z -= 2 * WALL_L;
             break;
         case DEG_90:
-            item->pos.x += M_SPEED;
+            item->pos.x += p->speed;
             pos.x += 2 * WALL_L;
             break;
         default:
-            item->pos.x -= M_SPEED;
+            item->pos.x -= p->speed;
             pos.x -= 2 * WALL_L;
             break;
         }
@@ -72,12 +96,18 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = Trap_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_anim = true;
     obj->save_flags = true;
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "speed", M_DEFAULT_SPEED,
+            "Offset applied each frame while the lava wedge advances."));
 }
 
 REGISTER_OBJECT(O_LAVA_WEDGE, M_Setup)

--- a/src/trx/game/objects/traps/spike_ceiling.c
+++ b/src/trx/game/objects/traps/spike_ceiling.c
@@ -1,5 +1,3 @@
-#include <trx/core/json/util/read_io.h>
-#include <trx/core/json/util/write_io.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/property.h>
@@ -9,27 +7,21 @@
 #include <trx/game/spawn.h>
 
 #define M_DEFAULT_DAMAGE 20
-#define M_SPEED 1
-#define M_STEP_SLOW 5
-#define M_STEP_FAST 10
+#define M_BLOOD_SPEED 1
+#define M_DEFAULT_SPEED 5
 
 typedef struct {
-    int32_t step;
-    bool animate;
+    int32_t speed;
 } M_PRIV;
 
-static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+static int32_t M_GetSpeed(const ITEM *const item)
 {
-    M_PRIV *const p = item->priv;
-    JSON_SHOULD(JSON_READ(io, "step", &p->step));
-    JSON_SHOULD(JSON_READ(io, "animate", &p->animate));
-}
+    OBJECT_PROPERTY_VALUE speed = {};
+    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
+        return speed.as_int;
+    }
 
-static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
-{
-    const M_PRIV *const p = item->priv;
-    JSONW_WRITE(io, "step", p->step);
-    JSONW_WRITE(io, "animate", p->animate);
+    return M_DEFAULT_SPEED;
 }
 
 static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
@@ -44,13 +36,6 @@ static bool M_Trigger(ITEM *const item, const TRIGGER *const trigger)
     }
 
     item->timer = 0;
-    if (trigger->timer == 1) {
-        p->step = M_STEP_FAST;
-        p->animate = true;
-    } else {
-        p->step = M_STEP_SLOW;
-        p->animate = false;
-    }
     return true;
 }
 
@@ -59,19 +44,15 @@ static void M_Initialise(const int16_t item_num)
     Trap_Initialise(item_num);
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
-    if (p != nullptr) {
-        p->step = M_STEP_SLOW;
-        p->animate = false;
-    }
+    p->speed = M_GetSpeed(item);
 }
 
 static void M_Move(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
     const M_PRIV *const p = item->priv;
-    const int32_t step = (p != nullptr && p->step > 0) ? p->step : M_STEP_SLOW;
     int16_t room_num = item->room_num;
-    const XYZ_32 pos = { item->pos.x, item->pos.y + step, item->pos.z };
+    const XYZ_32 pos = { item->pos.x, item->pos.y + p->speed, item->pos.z };
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
     if (Room_GetHeight(sector, pos) < pos.y + WALL_L) {
         item->status = IS_DEACTIVATED;
@@ -99,8 +80,8 @@ static void M_HitLara(ITEM *const item)
 
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
-        lara_item->pos.x, item->pos.y + LARA_HEIGHT, lara_item->pos.z, M_SPEED,
-        item->rot.y, lara_item->room_num, 3);
+        lara_item->pos.x, item->pos.y + LARA_HEIGHT, lara_item->pos.z,
+        M_BLOOD_SPEED, item->rot.y, lara_item->room_num, 3);
     item->touch_bits = 0;
 
     Sound_Effect(SFX_LARA_FLESH_WOUND, &item->pos, SPM_NORMAL);
@@ -121,10 +102,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (Item_IsTriggerActive(item) && item->status != IS_DEACTIVATED) {
-        const M_PRIV *const p = item->priv;
-        if (p != nullptr && p->animate) {
-            Item_Animate(item);
-        }
+        Item_Animate(item);
     }
 }
 
@@ -134,13 +112,14 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision_Trap;
     obj->priv_size = sizeof(M_PRIV);
-    obj->trigger_func = M_Trigger;
-    obj->priv_load_func = M_LoadPriv;
-    obj->priv_save_func = M_SavePriv;
     obj->save_position = true;
     obj->save_flags = true;
+    obj->trigger_func = M_Trigger;
     OBJECT_PROPERTIES(
         obj,
+        OBJECT_PROPERTY_INT(
+            "speed", M_DEFAULT_SPEED,
+            "Offset applied each frame while the ceiling spikes descend."),
         OBJECT_PROPERTY_INT(
             "damage", M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the ceiling spikes."));

--- a/src/trx/game/objects/traps/spike_wall.c
+++ b/src/trx/game/objects/traps/spike_wall.c
@@ -9,7 +9,12 @@
 #include <trx/game/spawn.h>
 
 #define M_DEFAULT_DAMAGE 20
-#define M_SPEED 1
+#define M_BLOOD_SPEED 1
+#define M_DEFAULT_SPEED 16
+
+typedef struct {
+    int32_t speed;
+} M_PRIV;
 
 static int32_t M_GetDamage(const ITEM *const item)
 {
@@ -21,10 +26,29 @@ static int32_t M_GetDamage(const ITEM *const item)
     return M_DEFAULT_DAMAGE;
 }
 
+static int32_t M_GetSpeed(const ITEM *const item)
+{
+    OBJECT_PROPERTY_VALUE speed = {};
+    if (ObjectProperty_GetItemValue(item, "speed", &speed)) {
+        return speed.as_int;
+    }
+
+    return M_DEFAULT_SPEED;
+}
+
+static void M_Initialise(const int16_t item_num)
+{
+    Trap_Initialise(item_num);
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->speed = M_GetSpeed(item);
+}
+
 static void M_Move(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
-    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, M_SPEED << 4);
+    const M_PRIV *const p = item->priv;
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, p->speed);
 
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(pos, &room_num);
@@ -47,7 +71,7 @@ static void M_HitLara(ITEM *const item)
     const ITEM *const lara_item = Lara_GetItem();
     Spawn_BloodBath(
         lara_item->pos.x, lara_item->pos.y - WALL_L / 2, lara_item->pos.z,
-        M_SPEED, item->rot.y, lara_item->room_num, 3);
+        M_BLOOD_SPEED, item->rot.y, lara_item->room_num, 3);
     item->touch_bits = 0;
 
     Sound_Effect(SFX_LARA_FLESH_WOUND, &item->pos, SPM_NORMAL);
@@ -70,13 +94,17 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
-    obj->initialise_func = Trap_Initialise;
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->collision_func = Object_Collision;
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_position = true;
     obj->save_flags = true;
     OBJECT_PROPERTIES(
         obj,
+        OBJECT_PROPERTY_INT(
+            "speed", M_DEFAULT_SPEED,
+            "Offset applied each frame while the spike wall advances."),
         OBJECT_PROPERTY_INT(
             "damage", M_DEFAULT_DAMAGE,
             "Damage dealt while Lara is touching the spike wall."));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Testing:
- [x] Aldwych drill speed
- [x] Spike ceiling speed
- [x] Spike wall speed
- [x] Lava wedge speed
- [x] Interpolation regressions

Additionally this PR fixes a crash when exiting the game in levels that have Atlanteans.