### PR TITLE
objects/vehicles: move music tracks to Lua

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,10 @@
 - added `O_DOLPHIN`, which behaves in the same way as `O_ORCA` but has collision underwater
 - added a new console command - `/burn` - to toggle whether or not Lara is on fire
 - added poison Lua property to `O_DART` and `O_DISC`, so that they can poison Lara just like `O_POISON_DART`
-- removed hard-coded fish and piranha setup and moved to Lua instead
-- removed the limit of at most 8 fish/piranha shoals per level
-- removed hard-coded small Cobra radius setup and moved to Lua instead
-- removed the hard-coded damage and moved it to Lua instead for the following objects:
+- changed hard-coded music tracks from Snowmobiles, mine carts, and RIBs to be configurable via Lua
+- changed hard-coded fish and piranha setup to be configurable via Lua
+- changed hard-coded small Cobra radius setup to be configurable via Lua
+- changed the hard-coded traps damage to be configurable via Lua. Objects affected:
     - `O_BLADE`
     - `O_CEILING_SPIKES`
     - `O_DAMOCLES_SWORD`
@@ -36,6 +36,7 @@
     - `O_SWINGING_AXE`
     - `O_TEETH_TRAP`
 - removed the limitation of only having two fish sprite types in any level
+- removed the limit of at most 8 fish/piranha shoals per level
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 
@@ -54,14 +55,14 @@
 - added the ability to define the flame interval of `O_FLAME_EMITTER_SIDE` objects
 - added an option to fix animated spikes resetting when loading a save (Gameplay → Fixes → Fix animated spikes)
 - changed piranhas, tropical fish and bat emitters to use dedicated sprite objects; refer to migration guide
-- removed the hard-coded end-level behaviour when picking up artefacts in specific levels and moved to Lua instead
-- removed hard-coded collision differences for `O_ORCA` in `Sleeping with the Fishes` by using `O_DOLPHIN` instead
-- removed hard-coded level sequence checks to keep Lara burning when she enters a lava swamp room
-- removed the hard-coded longer interval on `O_FLAME_EMITTER_SIDE` in level sequence 7 and moved to Lua instead
-- removed the hard-coded strobe light alarm behaviour in Area 51 and moved it to Lua instead
-- removed hard-coded level sequence specific sound effects for animated spikes and moved to animation commands instead
-- removed the hard-coded constraint of only being able to use animated spikes in levels 5 and 7
-- removed the hard-coded `O_AI_PATROL_1` behaviour in High Security Compound and Area 51; refer to migration docs
+- changed artefact pickup end-level behavior in specific levels to be configurable via Lua
+- changed `O_ORCA` special collision in `Sleeping with the Fishes` by introducing a `O_DOLPHIN` instead
+- changed lava swamp burning behavior to no longer reference specific levels
+- changed the longer `O_FLAME_EMITTER_SIDE` interval in level 7 to be configurable via Lua
+- changed the strobe light alarm behavior in level 15 to be configurable via Lua
+- changed animated spikes sound effects in specific levels to use animation commands instead
+- changed animated spikes to work outside levels 5 and 7
+- changed `O_AI_PATROL_1` behavior in High Security Compound and Area 51 to be configurable; refer to migration docs
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats
 
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -150,6 +150,16 @@ This page lists documented moveable object properties.
 ### `0` O_LARA
 - `max_hit_points = 1000` — Maximum hit points.
 
+### `13` O_SKIDOO_FAST
+- `track_1 = 48 (MX_SKIDOO_THEME)` — Random music track pool, slot 1. -1 = disabled.
+- `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
+- `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
+- `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+- `battle_track_1 = 49 (MX_BATTLE_THEME)` — Random battle music track pool, slot 1. -1 = disabled.
+- `battle_track_2 = -1` — Random battle music track pool, slot 2. -1 = disabled.
+- `battle_track_3 = -1` — Random battle music track pool, slot 3. -1 = disabled.
+- `battle_track_4 = -1` — Random battle music track pool, slot 4. -1 = disabled.
+
 ### `15` O_DOG
 - `max_hit_points = 10` — Maximum hit points.
 
@@ -366,8 +376,20 @@ This page lists documented moveable object properties.
 ### `0` O_LARA
 - `max_hit_points = 1000` — Maximum hit points.
 
+### `15` O_RIB
+- `track_1 = 12 (MX_RIB_THEME)` — Random music track pool, slot 1. -1 = disabled.
+- `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
+- `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
+- `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+
 ### `16` O_QUAD_BIKE
 - `track_1 = -1` — Random music track pool, slot 1. -1 = disabled.
+- `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
+- `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
+- `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+
+### `17` O_MINE_CART
+- `track_1 = 12 (MX_MINE_CART_THEME)` — Random music track pool, slot 1. -1 = disabled.
 - `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
 - `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
 - `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -1,3 +1,5 @@
+#include <trx/game/objects/vehicles/common.h>
+
 #include <trx/config.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
@@ -6,12 +8,16 @@
 #include <trx/game/game.h>
 #include <trx/game/game_flow.h>
 #include <trx/game/game_strings/table.h>
+#include <trx/game/items/enum.h>
 #include <trx/game/lara.h>
 #include <trx/game/level.h>
 #include <trx/game/music.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/output.h>
+#include <trx/game/random.h>
 #include <trx/game/viewport.h>
+
+#include <stdio.h>
 
 typedef enum {
     LA_VEHICLE_HIT_LEFT = 11,
@@ -19,6 +25,31 @@ typedef enum {
     LA_VEHICLE_HIT_FRONT = 13,
     LA_VEHICLE_HIT_BACK = 14,
 } LARA_ANIM_VEHICLE;
+
+static int32_t M_LoadTrackPool(
+    const ITEM *const item, const char *const key_prefix,
+    MUSIC_ID *const out_tracks, const int32_t max_tracks)
+{
+    if (item == nullptr || key_prefix == nullptr || out_tracks == nullptr
+        || max_tracks <= 0) {
+        return 0;
+    }
+
+    int32_t track_count = 0;
+    for (int32_t i = 0; i < VEHICLE_TRACK_POOL_SIZE && track_count < max_tracks;
+         i++) {
+        char key[32];
+        snprintf(key, sizeof(key), "%s_%d", key_prefix, i + 1);
+
+        OBJECT_PROPERTY_VALUE value = {};
+        if (ObjectProperty_GetItemValue(item, key, &value)
+            && value.as_int >= 0) {
+            out_tracks[track_count++] = value.as_int;
+        }
+    }
+
+    return track_count;
+}
 
 int32_t Vehicle_DoShift(
     ITEM *const vehicle, const XYZ_32 *const pos, const XYZ_32 *const old)
@@ -133,4 +164,38 @@ int32_t Vehicle_GetCollisionAnim(const ITEM *const vehicle, XYZ_32 *const moved)
     }
 
     return 0;
+}
+
+void Vehicle_PlayTrackPool(
+    const ITEM *const item, const char *const key_prefix,
+    const MUSIC_PLAY_MODE mode)
+{
+    MUSIC_ID tracks[VEHICLE_TRACK_POOL_SIZE];
+    const int32_t track_count =
+        M_LoadTrackPool(item, key_prefix, tracks, ARRAY_SIZE(tracks));
+    if (track_count <= 0) {
+        return;
+    }
+    Music_Play_Direct(tracks[Random_GetControl() % track_count], mode);
+}
+
+void Vehicle_PlayOneShotTrackPool(
+    const ITEM *const item, const char *const key_prefix)
+{
+    MUSIC_ID tracks[VEHICLE_TRACK_POOL_SIZE];
+    const int32_t track_count =
+        M_LoadTrackPool(item, key_prefix, tracks, ARRAY_SIZE(tracks));
+    if (track_count <= 0) {
+        return;
+    }
+
+    for (int32_t i = 0; i < track_count; i++) {
+        if ((Music_GetTrackFlags(tracks[i]) & IF_ONE_SHOT) != 0) {
+            return;
+        }
+    }
+
+    const MUSIC_ID track = tracks[Random_GetControl() % track_count];
+    Music_Play_Direct(track, MPM_ONCE);
+    Music_SetTrackFlags(track, Music_GetTrackFlags(track) | IF_ONE_SHOT);
 }

--- a/src/trx/game/objects/vehicles/common.h
+++ b/src/trx/game/objects/vehicles/common.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <trx/game/items/types.h>
+#include <trx/game/music.h>
+
+#define VEHICLE_TRACK_POOL_SIZE 4
 
 int32_t Vehicle_DoShift(ITEM *vehicle, const XYZ_32 *pos, const XYZ_32 *old);
 int32_t Vehicle_GetCollisionAnim(const ITEM *vehicle, XYZ_32 *moved);
+void Vehicle_PlayTrackPool(
+    const ITEM *item, const char *key_prefix, MUSIC_PLAY_MODE mode);
+void Vehicle_PlayOneShotTrackPool(const ITEM *item, const char *key_prefix);

--- a/src/trx/game/objects/vehicles/mine_cart.c
+++ b/src/trx/game/objects/vehicles/mine_cart.c
@@ -7,6 +7,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/vehicles/common.h>
 #include <trx/game/output.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
@@ -267,7 +268,7 @@ static void M_Collision(
     p->flags.stopped = false;
     p->flags.suppress_anim = false;
 
-    Music_Play(MX_MINE_CART_THEME, MPM_ONCE);
+    Vehicle_PlayTrackPool(item, "track", MPM_ONCE);
 }
 
 static void M_CheckStrikeSwitch(ITEM *const item)
@@ -867,6 +868,18 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
     obj->save_flags = true;
     obj->save_position = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "track_1", Music_ToGameID(MX_MINE_CART_THEME),
+            "Random music track pool, slot 1. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."));
 }
 
 bool MineCart_Control(void)

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -12,6 +12,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/vehicles/common.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
@@ -94,8 +95,6 @@ typedef struct {
 
 typedef struct {
     M_QUAD_BIKE_INFO quad;
-    MUSIC_ID music_tracks[4];
-    int32_t music_track_count;
     int16_t *extra_rotation;
     int32_t extra_rotation_count;
     int32_t rear_rot_x_idx[2];
@@ -211,15 +210,6 @@ static void M_Initialise(const int16_t item_num)
     M_PRIV *const p = item->priv;
 
     p->quad.momentum_angle = item->rot.y;
-    p->music_track_count = 0;
-    const char *const keys[4] = { "track_1", "track_2", "track_3", "track_4" };
-    for (int32_t i = 0; i < 4; i++) {
-        OBJECT_PROPERTY_VALUE val = {};
-        ObjectProperty_GetItemValue(item, keys[i], &val);
-        if (val.as_int >= 0) {
-            p->music_tracks[p->music_track_count++] = val.as_int;
-        }
-    }
 
     const OBJECT *const obj = Object_Get(item->object_id);
     M_CalcExtraRotationLayout(obj, p);
@@ -336,10 +326,8 @@ static void M_Collision(
     {
         const bool is_ambient =
             Music_GetCurrentPlayingTrack() == Music_GetCurrentLoopedTrack();
-        if (is_ambient && p->music_track_count > 0) {
-            Music_Play_Direct(
-                p->music_tracks[Random_GetControl() % p->music_track_count],
-                MPM_ONCE);
+        if (is_ambient) {
+            Vehicle_PlayTrackPool(item, "track", MPM_ONCE);
         }
     }
 

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -264,7 +264,7 @@ static void M_Collision(
         item->status = IS_ACTIVE;
     }
 
-    Music_Play(MX_RIB_THEME, MPM_ONCE);
+    Vehicle_PlayTrackPool(item, "track", MPM_ONCE);
 }
 
 static bool M_UserControl(ITEM *const item)
@@ -1061,6 +1061,18 @@ static void M_Setup(OBJECT *const obj)
     obj->save_anim = true;
 
     Object_GetBone(obj, 1)->rot.z = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "track_1", Music_ToGameID(MX_RIB_THEME),
+            "Random music track pool, slot 1. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."));
 }
 
 REGISTER_OBJECT(O_RIB, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -10,7 +10,6 @@
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
-#include <trx/game/music.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/objects/vehicles/common.h>
 #include <trx/game/objects/vehicles/skidoo_armed.h>
@@ -636,13 +635,8 @@ void Skidoo_Animation(
         break;
 
     case M_STATE_STILL: {
-        const int32_t music_track = Music_ToGameID(
-            M_IsArmed(skidoo_data) ? MX_BATTLE_THEME : MX_SKIDOO_THEME);
-        const uint16_t music_flags = Music_GetTrackFlags(music_track);
-        if (!(music_flags & IF_ONE_SHOT)) {
-            Music_Play_Direct(music_track, MPM_ONCE);
-            Music_SetTrackFlags(music_track, music_flags | IF_ONE_SHOT);
-        }
+        Vehicle_PlayOneShotTrackPool(
+            skidoo, M_IsArmed(skidoo_data) ? "battle_track" : "track");
 
         if (dead) {
             lara_item->goal_anim_state = M_STATE_DEATH;

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -1,5 +1,6 @@
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
+#include <trx/game/music.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
 
@@ -38,6 +39,30 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "track_1", Music_ToGameID(MX_SKIDOO_THEME),
+            "Random music track pool, slot 1. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_2", -1, "Random music track pool, slot 2. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "battle_track_1", Music_ToGameID(MX_BATTLE_THEME),
+            "Random battle music track pool, slot 1. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "battle_track_2", -1,
+            "Random battle music track pool, slot 2. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "battle_track_3", -1,
+            "Random battle music track pool, slot 3. -1 = disabled."),
+        OBJECT_PROPERTY_INT(
+            "battle_track_4", -1,
+            "Random battle music track pool, slot 4. -1 = disabled."));
 }
 
 REGISTER_OBJECT(O_SKIDOO_FAST, M_Setup)

--- a/tools/update_object_docs
+++ b/tools/update_object_docs
@@ -14,9 +14,24 @@ OUTPUT = ROOT / "docs/trx/OBJECTS.md"
 HEADER_SOURCE = ROOT / "src/trx/game"
 
 GAMES = [
-    ("Tomb Raider 1", 1, ROOT / "data/trx/ship/games/tr1/catalog_objects.csv"),
-    ("Tomb Raider 2", 2, ROOT / "data/trx/ship/games/tr2/catalog_objects.csv"),
-    ("Tomb Raider 3", 3, ROOT / "data/trx/ship/games/tr3/catalog_objects.csv"),
+    (
+        "Tomb Raider 1",
+        1,
+        ROOT / "data/trx/ship/games/tr1/catalog_objects.csv",
+        ROOT / "data/trx/ship/games/tr1/catalog_music.csv",
+    ),
+    (
+        "Tomb Raider 2",
+        2,
+        ROOT / "data/trx/ship/games/tr2/catalog_objects.csv",
+        ROOT / "data/trx/ship/games/tr2/catalog_music.csv",
+    ),
+    (
+        "Tomb Raider 3",
+        3,
+        ROOT / "data/trx/ship/games/tr3/catalog_objects.csv",
+        ROOT / "data/trx/ship/games/tr3/catalog_music.csv",
+    ),
 ]
 
 PropertyInfo = dict[str, str]
@@ -298,6 +313,17 @@ def read_catalog(path: Path) -> list[tuple[str, str]]:
     return rows
 
 
+def read_music_catalog(path: Path) -> dict[str, str]:
+    rows: dict[str, str] = {}
+    with path.open(newline="") as fh:
+        for row in csv.reader(fh, skipinitialspace=True):
+            if len(row) < 2:
+                continue
+            game_id, music_id = row[:2]
+            rows[music_id.strip()] = game_id.strip()
+    return rows
+
+
 def resolve_identifiers(expr: str, constants: dict[str, str], game_version: int) -> str:
     expr = expr.replace("g_TRVersion", str(game_version))
     for _ in range(16):
@@ -326,8 +352,41 @@ def convert_ternary(expr: str) -> str:
         )
 
 
+class MusicToGameIDTransformer(ast.NodeTransformer):
+    def __init__(self, music_catalog: dict[str, str]) -> None:
+        self.music_catalog = music_catalog
+
+    @staticmethod
+    def get_music_symbol(node: ast.AST) -> str | None:
+        if not isinstance(node, ast.Call):
+            return None
+        if not isinstance(node.func, ast.Name) or node.func.id != "Music_ToGameID":
+            return None
+        if len(node.args) != 1 or node.keywords:
+            return None
+        arg = node.args[0]
+        if not isinstance(arg, ast.Name):
+            return None
+        return arg.id
+
+    def visit_Call(self, node: ast.Call) -> ast.AST:
+        self.generic_visit(node)
+
+        music_symbol = self.get_music_symbol(node)
+        if music_symbol is None:
+            return node
+
+        mapped_id = self.music_catalog.get(music_symbol)
+        if mapped_id is None:
+            return node
+        return ast.copy_location(ast.Constant(value=int(mapped_id)), node)
+
+
 def evaluate_expression(
-    expr: str, constants: dict[str, str], game_version: int
+    expr: str,
+    constants: dict[str, str],
+    game_version: int,
+    music_catalog: dict[str, str],
 ) -> str:
     expr = convert_ternary(resolve_identifiers(expr, constants, game_version))
     try:
@@ -335,30 +394,24 @@ def evaluate_expression(
     except SyntaxError:
         return expr
 
+    tree = MusicToGameIDTransformer(music_catalog).visit(tree)
+    ast.fix_missing_locations(tree)
+
     allowed_nodes = (
         ast.Expression,
         ast.Constant,
+        ast.Call,
+        ast.Name,
+        ast.Load,
         ast.UnaryOp,
         ast.BinOp,
         ast.BoolOp,
         ast.Compare,
         ast.IfExp,
-        ast.USub,
-        ast.UAdd,
-        ast.Add,
-        ast.Sub,
-        ast.Mult,
-        ast.Div,
-        ast.FloorDiv,
-        ast.Mod,
-        ast.Eq,
-        ast.NotEq,
-        ast.Lt,
-        ast.LtE,
-        ast.Gt,
-        ast.GtE,
-        ast.And,
-        ast.Or,
+        ast.unaryop,
+        ast.operator,
+        ast.boolop,
+        ast.cmpop,
     )
     if not all(isinstance(node, allowed_nodes) for node in ast.walk(tree)):
         return expr
@@ -372,8 +425,20 @@ def evaluate_expression(
     return str(value)
 
 
+def extract_music_symbol(expr: str) -> str | None:
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError:
+        return None
+
+    return MusicToGameIDTransformer.get_music_symbol(tree.body)
+
+
 def format_value(
-    object_properties: PropertyMap, name: str, game_version: int
+    object_properties: PropertyMap,
+    name: str,
+    game_version: int,
+    music_catalog: dict[str, str],
 ) -> str | None:
     if name not in object_properties:
         return None
@@ -384,17 +449,22 @@ def format_value(
     if not isinstance(info, dict):
         return None
     expr = info["value"]
-    value = evaluate_expression(expr, constants, game_version)
+    value = evaluate_expression(expr, constants, game_version, music_catalog)
     return value
 
 
 def format_property(
-    object_properties: PropertyMap, name: str, game_version: int
+    object_properties: PropertyMap,
+    name: str,
+    game_version: int,
+    music_catalog: dict[str, str],
 ) -> str | None:
-    value = format_value(object_properties, name, game_version)
+    value = format_value(object_properties, name, game_version, music_catalog)
     info = object_properties[name]
     if value is None or not isinstance(info, dict):
         return None
+    if (music_symbol := extract_music_symbol(info["value"])) is not None:
+        value = f"{value} ({music_symbol})"
     return f"- `{name} = {value}` — {info['description']}"
 
 
@@ -412,7 +482,8 @@ def main() -> None:
         "This page lists documented moveable object properties.",
     ]
 
-    for game_name, game_version, catalog_path in GAMES:
+    for game_name, game_version, catalog_path, music_catalog_path in GAMES:
+        music_catalog = read_music_catalog(music_catalog_path)
         lines.extend(["", f"## {game_name}"])
         for game_id, object_id in read_catalog(catalog_path):
             object_properties = registered_properties.get(object_id)
@@ -426,7 +497,11 @@ def main() -> None:
             property_lines = [
                 line
                 for name in property_names
-                if (line := format_property(object_properties, name, game_version))
+                if (
+                    line := format_property(
+                        object_properties, name, game_version, music_catalog
+                    )
+                )
                 is not None
             ]
             if not property_lines:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR makes Snowmobile, mine cart, and RIB music tracks configurable through Lua bringing their setup in line with the existing Quad Bike pattern.

**NOTE:** the properties for the new vehicles provide default values compatible with the OG. This is _different_ from the Quad Bike which got moved entirely to Lua and by default doesn't play anything. Unlike other vehicles, Quad Bike only plays some music in Ganges; on the other hand, the rest of the vehicles only appear in their single respective levels. LMK if we want to change anything here.

**NOTE 2:** I was thinking of introducing slots in the catalog `O_QUAD_BIKE_THEME_1-4` etc., and forgoing custom properties altogether. The problem with this is that we lose ability to change the music tracks from level to level and thus I decided against it.

#### Testing

- [x] Mount a Quad Bike
- [x] Mount a Snowmobile
- [x] Mount a mine cart
- [x] Mount a RIB

Expected outcome: no regressions; TR3 vehicles play more than 1 random tracks
