### PR TITLE
objects/lift: add support to move vehicles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added `O_DOLPHIN`, which behaves in the same way as `O_ORCA` but has collision underwater
 - added a new console command - `/burn` - to toggle whether or not Lara is on fire
 - added poison Lua property to `O_DART` and `O_DISC`, so that they can poison Lara just like `O_POISON_DART`
+- added the ability for skidoos and quad bikes that are inside or on top of lifts to move when the lift itself moves (#4353)
 - changed hard-coded music tracks from Snowmobiles, mine carts, and RIBs to be configurable via Lua
 - changed hard-coded fish and piranha setup to be configurable via Lua
 - changed hard-coded small Cobra radius setup to be configurable via Lua

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -339,7 +339,8 @@ static void M_InterpolateItems(const double ratio)
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
         ITEM *const item = Item_Get(i);
         if (((item->flags & IF_KILLED) || item->status == IS_INACTIVE)
-            && i != lara_vehicle_num) {
+            && i != lara_vehicle_num
+            && XYZ_32_AreEquivalent(item->pos, item->interp.prev.pos)) {
             M_CommitItem(item);
         } else {
             M_InterpolateItem(item, ratio);

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -8,27 +8,29 @@
 #include <trx/game/objects.h>
 #include <trx/game/objects/traps/movable_block.h>
 
-#define LIFT_WAIT_TIME (3 * LOGIC_FPS) // = 90
-#define LIFT_SHIFT 16
-#define LIFT_HEIGHT (STEP_L * 5) // = 1280
-#define LIFT_TRAVEL_DIST (STEP_L * 22)
-#define M_LIFT_NUM_FLOOR_SECTORS 4
-#define M_LIFT_NUM_SECTORS 8
+// clang-format off
+#define M_WAIT_TIME         (3 * LOGIC_FPS) // = 90
+#define M_SHIFT             16
+#define M_HEIGHT            (STEP_L * 5) // = 1280
+#define M_TRAVEL_DIST       (STEP_L * 22)
+#define M_NUM_FLOOR_SECTORS 4
+#define M_NUM_SECTORS       (M_NUM_FLOOR_SECTORS * 2)
+// clang-format on
 
 typedef enum {
-    LIFT_STATE_DOOR_CLOSED = 0,
-    LIFT_STATE_DOOR_OPEN = 1,
-} LIFT_STATE;
+    M_STATE_DOOR_CLOSED,
+    M_STATE_DOOR_OPEN,
+} M_STATE;
 
 typedef enum {
-    LIFT_ANIM_CLOSED = 0,
-} LIFT_ANIM;
+    M_ANIM_CLOSED = 0,
+} M_ANIM;
 
 typedef struct {
     int32_t start_height;
     int32_t wait_time;
     bool is_moving;
-    GAME_VECTOR linked[M_LIFT_NUM_SECTORS];
+    GAME_VECTOR linked[M_NUM_SECTORS];
 } M_PRIV;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -37,7 +39,7 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
     JSON_SHOULD(JSON_READ(io, "start_height", &p->start_height));
     JSON_SHOULD(JSON_READ(io, "wait_time", &p->wait_time));
     JSON_SHOULD(JSON_READ(io, "is_moving", &p->is_moving));
-    for (int32_t i = 0; i < M_LIFT_NUM_SECTORS; i++) {
+    for (int32_t i = 0; i < M_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
         if (JSON_SHOULD(JSON_PUSH(io, key))) {
             JSON_SHOULD(JSON_READ(io, "x", &p->linked[i].pos.x));
@@ -54,7 +56,7 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     JSONW_WRITE(io, "start_height", p->start_height);
     JSONW_WRITE(io, "wait_time", p->wait_time);
     JSONW_WRITE(io, "is_moving", p->is_moving);
-    for (int32_t i = 0; i < M_LIFT_NUM_SECTORS; i++) {
+    for (int32_t i = 0; i < M_NUM_SECTORS; i++) {
         const char *const key = String_FormatStatic("linked_%d", i);
         JSONW_PUSH_OBJECT(io);
         JSONW_WRITE(io, "x", p->linked[i].pos.x);
@@ -119,8 +121,8 @@ static void M_FloorCeiling(
 
     const int32_t lift_bottom = item->pos.y + STEP_L;
     const int32_t lift_floor = item->pos.y;
-    const int32_t lift_ceiling = item->pos.y - LIFT_HEIGHT + STEP_L;
-    const int32_t lift_top = item->pos.y - LIFT_HEIGHT;
+    const int32_t lift_ceiling = item->pos.y - M_HEIGHT + STEP_L;
+    const int32_t lift_top = item->pos.y - M_HEIGHT;
 
     const bool lara_inside_lift = (lara_item->pos.y < lift_bottom) &&
                                   (lara_item->pos.y > lift_ceiling);
@@ -130,7 +132,7 @@ static void M_FloorCeiling(
     *out_ceiling = -0x7FFF;
 
     if (lara_in_shaft) {
-        if (item->current_anim_state == LIFT_STATE_DOOR_CLOSED
+        if (item->current_anim_state == M_STATE_DOOR_CLOSED
             && lara_inside_lift) {
             if (point_in_shaft) {
                 *out_floor = lift_floor;
@@ -154,7 +156,7 @@ static void M_FloorCeiling(
             *out_floor = lift_top;
         } else if (y >= lift_bottom) {
             *out_ceiling = lift_bottom;
-        } else if (item->current_anim_state == LIFT_STATE_DOOR_OPEN) {
+        } else if (item->current_anim_state == M_STATE_DOOR_OPEN) {
             *out_floor = lift_floor;
             *out_ceiling = lift_ceiling;
         } else {
@@ -245,7 +247,7 @@ static void M_GetSectorPositions(
 
             const XYZ_32 pos = {
                 .x = sx * WALL_L + WALL_L / 2,
-                .y = item->pos.y - LIFT_HEIGHT,
+                .y = item->pos.y - M_HEIGHT,
                 .z = sz * WALL_L + WALL_L / 2,
             };
             Vector_Add(sector_pos, &pos);
@@ -278,7 +280,7 @@ static void M_ShiftStackableItems(
     const ITEM *const lift_item, const bool reposition)
 {
     M_PRIV *const p = lift_item->priv;
-    for (int32_t i = 0; i < M_LIFT_NUM_FLOOR_SECTORS; i++) {
+    for (int32_t i = 0; i < M_NUM_FLOOR_SECTORS; i++) {
         MovableBlock_ShiftStackY(
             p->linked[i].pos.y, p->linked[i].pos, lift_item->pos.y,
             lift_item->room_num, reposition);
@@ -286,12 +288,12 @@ static void M_ShiftStackableItems(
             p->linked[i].pos.y = lift_item->pos.y;
         }
     }
-    for (int32_t i = M_LIFT_NUM_FLOOR_SECTORS; i < M_LIFT_NUM_SECTORS; i++) {
+    for (int32_t i = M_NUM_FLOOR_SECTORS; i < M_NUM_SECTORS; i++) {
         MovableBlock_ShiftStackY(
-            p->linked[i].pos.y, p->linked[i].pos,
-            lift_item->pos.y - LIFT_HEIGHT, lift_item->room_num, reposition);
+            p->linked[i].pos.y, p->linked[i].pos, lift_item->pos.y - M_HEIGHT,
+            lift_item->room_num, reposition);
         if (reposition) {
-            p->linked[i].pos.y = lift_item->pos.y - LIFT_HEIGHT;
+            p->linked[i].pos.y = lift_item->pos.y - M_HEIGHT;
         }
     }
 }
@@ -301,28 +303,28 @@ static void M_Control(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     const int32_t bottom = p->start_height;
-    const int32_t top = bottom + LIFT_TRAVEL_DIST;
+    const int32_t top = bottom + M_TRAVEL_DIST;
     const int32_t target = Item_IsTriggerActive(item) ? top : bottom;
 
     if (item->pos.y == target) {
-        item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+        item->goal_anim_state = M_STATE_DOOR_OPEN;
         p->wait_time = 0;
         if (p->is_moving) {
             M_ShiftStackableItems(item, true);
         }
         p->is_moving = false;
-    } else if (p->wait_time < LIFT_WAIT_TIME) {
-        item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
+    } else if (p->wait_time < M_WAIT_TIME) {
+        item->goal_anim_state = M_STATE_DOOR_OPEN;
         p->wait_time++;
         // Prevent Lara from interacting with blocks about to move.
         M_ShiftStackableItems(item, false);
     } else {
-        item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
+        item->goal_anim_state = M_STATE_DOOR_CLOSED;
         p->is_moving = true;
         const int32_t delta = target - item->pos.y;
         const int32_t step = (delta > 0)
-            ? (delta < LIFT_SHIFT ? delta : LIFT_SHIFT)
-            : (delta > -LIFT_SHIFT ? delta : -LIFT_SHIFT);
+            ? (delta < M_SHIFT ? delta : M_SHIFT)
+            : (delta > -M_SHIFT ? delta : -M_SHIFT);
         item->pos.y += step;
         // Raise/lower possible movable blocks on top and check positions on
         // save vs load.

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -298,6 +298,47 @@ static void M_ShiftStackableItems(
     }
 }
 
+static bool M_IsItemInStack(
+    const ITEM *const lift_item, const ITEM *const target_item)
+{
+    int16_t room_num = target_item->room_num;
+    const SECTOR *sector = Room_GetSector(target_item->pos, &room_num);
+    sector = Room_GetPitSector(sector, target_item->pos.x, target_item->pos.z);
+
+    for (WALKABLE *w = sector->walkable; w != nullptr; w = w->next) {
+        if (lift_item == Item_Get(w->item_num)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void M_ShiftTravellingItems(
+    const ITEM *const lift_item, const int32_t delta)
+{
+    // TODO: rather than passing delta to listeners, refactor Room_GetHeight to
+    // be more aware of what's calling it, so that such checks in M_FloorCeiling
+    // that expect Lara only can become more generic.
+    for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
+        ITEM *const item = Item_Get(i);
+        if (item == lift_item) {
+            continue;
+        }
+
+        const OBJECT *const obj = Object_Get(item->object_id);
+        if (obj->event_func == nullptr) {
+            continue;
+        }
+
+        if (!M_IsItemInStack(lift_item, item)) {
+            continue;
+        }
+
+        obj->event_func(
+            item, OBJECT_EVENT_FLOOR_MOVED, (void *)(intptr_t)delta);
+    }
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -329,6 +370,7 @@ static void M_Control(const int16_t item_num)
         // Raise/lower possible movable blocks on top and check positions on
         // save vs load.
         M_ShiftStackableItems(item, false);
+        M_ShiftTravellingItems(item, step);
     }
 
     Item_Animate(item);

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -274,6 +274,28 @@ static void M_Initialise(const int16_t item_num)
     Vector_Free(positions);
 }
 
+static void M_ShiftStackableItems(
+    const ITEM *const lift_item, const bool reposition)
+{
+    M_PRIV *const p = lift_item->priv;
+    for (int32_t i = 0; i < M_LIFT_NUM_FLOOR_SECTORS; i++) {
+        MovableBlock_ShiftStackY(
+            p->linked[i].pos.y, p->linked[i].pos, lift_item->pos.y,
+            lift_item->room_num, reposition);
+        if (reposition) {
+            p->linked[i].pos.y = lift_item->pos.y;
+        }
+    }
+    for (int32_t i = M_LIFT_NUM_FLOOR_SECTORS; i < M_LIFT_NUM_SECTORS; i++) {
+        MovableBlock_ShiftStackY(
+            p->linked[i].pos.y, p->linked[i].pos,
+            lift_item->pos.y - LIFT_HEIGHT, lift_item->room_num, reposition);
+        if (reposition) {
+            p->linked[i].pos.y = lift_item->pos.y - LIFT_HEIGHT;
+        }
+    }
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -286,38 +308,14 @@ static void M_Control(const int16_t item_num)
         item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
         p->wait_time = 0;
         if (p->is_moving) {
-            for (int32_t i = 0; i < M_LIFT_NUM_FLOOR_SECTORS; i++) {
-                MovableBlock_ShiftStackY(
-                    p->linked[i].pos.y, p->linked[i].pos, item->pos.y,
-                    item->room_num, true);
-                // Don't reposition because item->pos links to a single sector.
-                p->linked[i].pos.y = item->pos.y;
-            }
-            for (int32_t i = M_LIFT_NUM_FLOOR_SECTORS; i < M_LIFT_NUM_SECTORS;
-                 i++) {
-                MovableBlock_ShiftStackY(
-                    p->linked[i].pos.y, p->linked[i].pos,
-                    item->pos.y - LIFT_HEIGHT, item->room_num, true);
-                // Don't reposition because item->pos links to a single sector.
-                p->linked[i].pos.y = item->pos.y - LIFT_HEIGHT;
-            }
+            M_ShiftStackableItems(item, true);
         }
         p->is_moving = false;
     } else if (p->wait_time < LIFT_WAIT_TIME) {
         item->goal_anim_state = LIFT_STATE_DOOR_OPEN;
         p->wait_time++;
         // Prevent Lara from interacting with blocks about to move.
-        for (int32_t i = 0; i < M_LIFT_NUM_FLOOR_SECTORS; i++) {
-            MovableBlock_ShiftStackY(
-                p->linked[i].pos.y, p->linked[i].pos, item->pos.y,
-                item->room_num, false);
-        }
-        for (int32_t i = M_LIFT_NUM_FLOOR_SECTORS; i < M_LIFT_NUM_SECTORS;
-             i++) {
-            MovableBlock_ShiftStackY(
-                p->linked[i].pos.y, p->linked[i].pos, item->pos.y - LIFT_HEIGHT,
-                item->room_num, false);
-        }
+        M_ShiftStackableItems(item, false);
     } else {
         item->goal_anim_state = LIFT_STATE_DOOR_CLOSED;
         p->is_moving = true;
@@ -326,19 +324,9 @@ static void M_Control(const int16_t item_num)
             ? (delta < LIFT_SHIFT ? delta : LIFT_SHIFT)
             : (delta > -LIFT_SHIFT ? delta : -LIFT_SHIFT);
         item->pos.y += step;
-        // Raise/lower possible movable blocks on top.
-        for (int32_t i = 0; i < M_LIFT_NUM_FLOOR_SECTORS; i++) {
-            MovableBlock_ShiftStackY(
-                p->linked[i].pos.y, p->linked[i].pos, item->pos.y,
-                item->room_num, false);
-        }
-        // Double check linked positions on save vs load.
-        for (int32_t i = M_LIFT_NUM_FLOOR_SECTORS; i < M_LIFT_NUM_SECTORS;
-             i++) {
-            MovableBlock_ShiftStackY(
-                p->linked[i].pos.y, p->linked[i].pos, item->pos.y - LIFT_HEIGHT,
-                item->room_num, false);
-        }
+        // Raise/lower possible movable blocks on top and check positions on
+        // save vs load.
+        M_ShiftStackableItems(item, false);
     }
 
     Item_Animate(item);

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -54,6 +54,7 @@ typedef struct JSON_WRITE_IO JSON_WRITE_IO;
 typedef enum {
     OBJECT_EVENT_ALERT,
     OBJECT_EVENT_BURNT,
+    OBJECT_EVENT_FLOOR_MOVED,
 } OBJECT_EVENT;
 
 typedef struct OBJECT {

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -199,3 +199,21 @@ void Vehicle_PlayOneShotTrackPool(
     Music_Play_Direct(track, MPM_ONCE);
     Music_SetTrackFlags(track, Music_GetTrackFlags(track) | IF_ONE_SHOT);
 }
+
+void Vehicle_HandleEvent(
+    ITEM *const item, const OBJECT_EVENT event, const void *const data)
+{
+    if (event != OBJECT_EVENT_FLOOR_MOVED) {
+        return;
+    }
+
+    const int32_t shift = (int32_t)(intptr_t)data;
+    item->pos.y += shift;
+    item->floor += shift;
+
+    int16_t room_num = item->room_num;
+    Room_GetSector(item->pos, &room_num);
+    if (room_num != item->room_num) {
+        Item_UpdateRoom(Item_GetIndex(item), room_num);
+    }
+}

--- a/src/trx/game/objects/vehicles/common.h
+++ b/src/trx/game/objects/vehicles/common.h
@@ -2,6 +2,7 @@
 
 #include <trx/game/items/types.h>
 #include <trx/game/music.h>
+#include <trx/game/objects/types.h>
 
 #define VEHICLE_TRACK_POOL_SIZE 4
 
@@ -10,3 +11,4 @@ int32_t Vehicle_GetCollisionAnim(const ITEM *vehicle, XYZ_32 *moved);
 void Vehicle_PlayTrackPool(
     const ITEM *item, const char *key_prefix, MUSIC_PLAY_MODE mode);
 void Vehicle_PlayOneShotTrackPool(const ITEM *item, const char *key_prefix);
+void Vehicle_HandleEvent(ITEM *item, OBJECT_EVENT event, const void *data);

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1422,6 +1422,8 @@ bool QuadBike_Control(void)
 
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     if (!(quad->flags & 0x80)) {
+        Room_GetSector(
+            (XYZ_32) { item->pos.x, item->pos.y - 16, item->pos.z }, &room_num);
         if (room_num != item->room_num) {
             Item_UpdateRoom(Lara_Vehicle_GetIndex(), room_num);
             Item_UpdateRoom(lara->item_num, room_num);
@@ -1502,6 +1504,7 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_save_func = M_SavePriv;
     obj->collision_func = M_Collision;
     obj->draw_func = Object_DrawAnimatingItem;
+    obj->event_func = Vehicle_HandleEvent;
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -860,6 +860,9 @@ bool Skidoo_Control(void)
     skidoo->rot.x += (x_rot - skidoo->rot.x) >> 1;
     skidoo->rot.z += (z_rot - skidoo->rot.z) >> 1;
 
+    Room_GetSector(
+        (XYZ_32) { skidoo->pos.x, skidoo->pos.y - 16, skidoo->pos.z },
+        &room_num);
     if (skidoo->flags & IF_ONE_SHOT) {
         Room_TestTriggers(lara_item);
         Item_UpdateRoom(Item_GetIndex(skidoo), room_num);

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -2,6 +2,7 @@
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/music.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/vehicles/common.h>
 #include <trx/game/objects/vehicles/skidoo_common.h>
 
 static void M_PrivLoad(ITEM *const item, JSON_READ_IO *const io)
@@ -33,6 +34,7 @@ static void M_Setup(OBJECT *const obj)
     obj->initialise_func = Skidoo_Initialise;
     obj->draw_func = Skidoo_Draw;
     obj->collision_func = Skidoo_Collision;
+    obj->event_func = Vehicle_HandleEvent;
     obj->priv_size = sizeof(SKIDOO_INFO);
     obj->priv_load_func = M_PrivLoad;
     obj->priv_save_func = M_PrivSave;


### PR DESCRIPTION
Resolves #4353.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows lifts to notify items within or on top that the floor height has changed when they move. Individual items can then react as necessary. This currently applies to skidoos and quad bikes only when Lara is not mounted (mounted vehicles already respond to the height change).

I don't think anything else can technically end up inside a lift - enemies would never go there for example; however, the setup should in theory make it straight-forward to add other items if ever needed.

TR2 test level available.