### PR TITLE
objects/vehicles: add heavy property for triggers

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -97,6 +97,7 @@
         // 3. Shakespeare Cliff
         {
             "path": "chunnel.tr2",
+            "script": "chunnel.lua",
             "music_track": 74,
             "lara_outfit": "tr3_nevada",
             "sequence": [

--- a/data/trx/ship/games/tr3/scripts/chunnel.lua
+++ b/data/trx/ship/games/tr3/scripts/chunnel.lua
@@ -1,0 +1,3 @@
+trx.events.before_item_setup(function(level)
+  trx.objects.quad_bike.properties.is_heavy = false
+end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 - added a new console command - `/burn` - to toggle whether or not Lara is on fire
 - added poison Lua property to `O_DART` and `O_DISC`, so that they can poison Lara just like `O_POISON_DART`
 - added the ability for skidoos and quad bikes that are inside or on top of lifts to move when the lift itself moves (#4353)
+- added the ability for skidoos, quad bikes and kayaks to activate heavy triggers (#4354)
+- changed vehicles to allow defining in Lua whether or not they can activate heavy triggers; refer to migration notes
 - changed hard-coded music tracks from Snowmobiles, mine carts, and RIBs to be configurable via Lua
 - changed hard-coded fish and piranha setup to be configurable via Lua
 - changed hard-coded small Cobra radius setup to be configurable via Lua

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1048,6 +1048,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── scripts
 │   │   │   ├── aldwych.lua
 │   │   │   ├── area51.lua
+│   │   │   ├── chunnel.lua
 │   │   │   ├── compound.lua
 │   │   │   ├── crash.lua
 │   │   │   ├── cut8.lua
@@ -2288,6 +2289,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   ├── scripts
     │   │   │   │   ├── aldwych.lua
     │   │   │   │   ├── area51.lua
+    │   │   │   │   ├── chunnel.lua
     │   │   │   │   ├── compound.lua
     │   │   │   │   ├── crash.lua
     │   │   │   │   ├── cut8.lua

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -42,11 +42,18 @@ order: 3
    effects in levels 5 and 7 only. Regular animation commands can be used
    instead to play in any level.
 
-7. **Update AI Patrol 1**
+7. **Update AI Patrol 1**:
    Levels with sequence 14 and 15 are no longer hard-coded to retain
    `O_AI_PATROL_1` items where an enemy should have the AI bits set but also use
    the item as a pathing target. Instead, place two `O_AI_PATROL_1` items in the
    same position to retain behaviour.
+
+8. **Vehicles and heavy triggers**:
+   All vehicle types except for the mounted gun can now activate heavy triggers.
+   This is configurable per object and item in Lua, and the setting is enabled
+   by default. Disable the option in cases where this may interfere with
+   triggers intended for other heavy activators e.g. pushblocks. This is not
+   configurable for the mine cart, which still relies on Lara striking switches.
 
 ### Version 1.6 to 1.7
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -162,6 +162,10 @@ This page lists documented moveable object properties.
 - `battle_track_2 = -1` — Random battle music track pool, slot 2. -1 = disabled.
 - `battle_track_3 = -1` — Random battle music track pool, slot 3. -1 = disabled.
 - `battle_track_4 = -1` — Random battle music track pool, slot 4. -1 = disabled.
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
+
+### `14` O_BOAT
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
 
 ### `15` O_DOG
 - `max_hit_points = 10` — Maximum hit points.
@@ -381,23 +385,31 @@ This page lists documented moveable object properties.
 ### `0` O_LARA
 - `max_hit_points = 1000` — Maximum hit points.
 
+### `14` O_KAYAK
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
+
 ### `15` O_RIB
 - `track_1 = 12 (MX_RIB_THEME)` — Random music track pool, slot 1. -1 = disabled.
 - `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
 - `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
 - `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
 
 ### `16` O_QUAD_BIKE
 - `track_1 = -1` — Random music track pool, slot 1. -1 = disabled.
 - `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
 - `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
 - `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
 
 ### `17` O_MINE_CART
 - `track_1 = 12 (MX_MINE_CART_THEME)` — Random music track pool, slot 1. -1 = disabled.
 - `track_2 = -1` — Random music track pool, slot 2. -1 = disabled.
 - `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
 - `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
+
+### `19` O_UPV
+- `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
 
 ### `20` O_TRIBE_AXEMAN
 - `max_hit_points = 28` — Maximum hit points.

--- a/src/trx/game/objects/vehicles/boat.c
+++ b/src/trx/game/objects/vehicles/boat.c
@@ -750,14 +750,9 @@ static void M_Control(const int16_t item_num)
         Item_UpdateRoom(item_num, room_num);
 
         boat_item->rot.z += p->tilt_angle;
-        lara_item->pos.x = boat_item->pos.x;
-        lara_item->pos.y = boat_item->pos.y;
-        lara_item->pos.z = boat_item->pos.z;
-        lara_item->rot.x = boat_item->rot.x;
-        lara_item->rot.y = boat_item->rot.y;
-        lara_item->rot.z = boat_item->rot.z;
-        Room_TestTriggers(lara_item);
-        Room_TestTriggers(boat_item);
+        lara_item->pos = boat_item->pos;
+        lara_item->rot = boat_item->rot;
+        Vehicle_TestTriggers(lara_item, boat_item);
 
         sector = Room_GetSector(
             (XYZ_32) {
@@ -858,6 +853,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_BOAT, M_Setup)

--- a/src/trx/game/objects/vehicles/common.c
+++ b/src/trx/game/objects/vehicles/common.c
@@ -200,6 +200,17 @@ void Vehicle_PlayOneShotTrackPool(
     Music_SetTrackFlags(track, Music_GetTrackFlags(track) | IF_ONE_SHOT);
 }
 
+void Vehicle_TestTriggers(
+    const ITEM *const lara_item, const ITEM *const vehicle_item)
+{
+    Room_TestTriggers(lara_item);
+    OBJECT_PROPERTY_VALUE value = {};
+    if (ObjectProperty_GetItemValue(vehicle_item, "is_heavy", &value)
+        && value.as_bool) {
+        Room_TestTriggers(vehicle_item);
+    }
+}
+
 void Vehicle_HandleEvent(
     ITEM *const item, const OBJECT_EVENT event, const void *const data)
 {

--- a/src/trx/game/objects/vehicles/common.h
+++ b/src/trx/game/objects/vehicles/common.h
@@ -11,4 +11,5 @@ int32_t Vehicle_GetCollisionAnim(const ITEM *vehicle, XYZ_32 *moved);
 void Vehicle_PlayTrackPool(
     const ITEM *item, const char *key_prefix, MUSIC_PLAY_MODE mode);
 void Vehicle_PlayOneShotTrackPool(const ITEM *item, const char *key_prefix);
+void Vehicle_TestTriggers(const ITEM *lara_item, const ITEM *vehicle_item);
 void Vehicle_HandleEvent(ITEM *item, OBJECT_EVENT event, const void *data);

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -14,6 +14,7 @@
 #include <trx/game/lara/skin/common.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
+#include <trx/game/objects/vehicles/common.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -1159,6 +1160,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 bool Kayak_Control(void)
@@ -1222,8 +1229,7 @@ bool Kayak_Control(void)
         Lara_Vehicle_SyncItemAnim();
         Item_UpdateRoom(Lara_Vehicle_GetIndex(), room_num);
         Item_UpdateRoom(lara_info->item_num, room_num);
-        Room_TestTriggers(lara_item);
-        Room_TestTriggers(item);
+        Vehicle_TestTriggers(lara_item, item);
         g_Camera.target_elevation = -5460;
         g_Camera.target_distance = 2048;
     }

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1327,7 +1327,7 @@ bool QuadBike_Control(void)
     int16_t room_num = item->room_num;
     SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     const int32_t height = Room_GetHeight(sector, item->pos);
-    Room_TestTriggers(lara_item);
+    Vehicle_TestTriggers(lara_item, item);
 
     if (lara_item->hit_points <= 0) {
         killed = true;
@@ -1520,7 +1520,10 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY_INT(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
         OBJECT_PROPERTY_INT(
-            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."));
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_QUAD_BIKE, M_Setup)

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -884,8 +884,7 @@ static void M_Control(const int16_t item_num)
 
     ITEM *const lara_item = Lara_GetItem();
     if (Lara_Vehicle_GetIndex() == item_num) {
-        Room_TestTriggers(lara_item);
-        Room_TestTriggers(item);
+        Vehicle_TestTriggers(lara_item, item);
     }
 
     int32_t water_height = Room_GetWaterHeight(item->pos, room_num);
@@ -1072,7 +1071,10 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY_INT(
             "track_3", -1, "Random music track pool, slot 3. -1 = disabled."),
         OBJECT_PROPERTY_INT(
-            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."));
+            "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_RIB, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -864,7 +864,7 @@ bool Skidoo_Control(void)
         (XYZ_32) { skidoo->pos.x, skidoo->pos.y - 16, skidoo->pos.z },
         &room_num);
     if (skidoo->flags & IF_ONE_SHOT) {
-        Room_TestTriggers(lara_item);
+        Vehicle_TestTriggers(lara_item, skidoo);
         Item_UpdateRoom(Item_GetIndex(skidoo), room_num);
         if (skidoo->pos.y == skidoo->floor) {
             Skidoo_Explode(skidoo);
@@ -892,7 +892,7 @@ bool Skidoo_Control(void)
             lara_item->rot.z = 0;
         }
     }
-    Room_TestTriggers(lara_item);
+    Vehicle_TestTriggers(lara_item, skidoo);
 
     Item_Animate(lara_item);
     if (!dead && drive >= 0 && M_IsArmed(skidoo_data)) {

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -64,7 +64,10 @@ static void M_Setup(OBJECT *const obj)
             "Random battle music track pool, slot 3. -1 = disabled."),
         OBJECT_PROPERTY_INT(
             "battle_track_4", -1,
-            "Random battle music track pool, slot 4. -1 = disabled."));
+            "Random battle music track pool, slot 4. -1 = disabled."),
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_SKIDOO_FAST, M_Setup)

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -8,6 +8,7 @@
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
 #include <trx/game/los.h>
+#include <trx/game/objects/vehicles/common.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
 #include <trx/game/sound.h>
@@ -940,8 +941,7 @@ bool UPV_Control(void)
         }
     }
 
-    Room_TestTriggers(lara_item);
-    Room_TestTriggers(item);
+    Vehicle_TestTriggers(lara_item, item);
 
     if (Lara_Vehicle_GetItem() == nullptr) {
         if (!p->flags.dead) {
@@ -1009,6 +1009,12 @@ static void M_Setup(OBJECT *const obj)
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
+
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_BOOL(
+            "is_heavy", true,
+            "Whether or not this vehicle can activate heavy triggers."));
 }
 
 REGISTER_OBJECT(O_UPV, M_Setup)


### PR DESCRIPTION
Resolves  #4354.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows all vehicles except the mounted gun to activate heavy triggers. This is a configurable Lua property as it may not be desirable in some custom levels. The mine cart is not configurable as it relies on Lara striking switches for nearby triggers to activate.

None of the OG levels have heavy triggers where we've added support for the kayak, skidoo and quad bike - except for Shakespeare Cliff, but the ones there I believe cannot be reached from the quad bike. If I'm mistaken, we can easily add a script if needed.

In the test level, there is a heavy music trigger for each vehicle. The level can then be restarted and the following commands run to disable each type from being heavy.

- [x] `/lua trx.objects.boat.properties.is_heavy = false`
- [x] `/lua trx.objects.kayak.properties.is_heavy = false`
- [x] `/lua trx.objects.quad_bike.properties.is_heavy = false`
- [x] `/lua trx.objects.rib.properties.is_heavy = false`
- [x] `/lua trx.objects.skidoo_fast.properties.is_heavy = false`
- [x] `/lua trx.objects.upv.properties.is_heavy = false`
