### PR TITLE
gym: fix not penalizing active targets at finish

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
     - `O_SPIKE_WALL`
 - removed the limitation of only having two fish sprite types in any level
 - removed the limit of at most 8 fish/piranha shoals per level
+- fixed missed Assault Course targets not penalizing player's time if Lara crosses the finish line before they collapse (regression from 1.2)
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -55,12 +55,10 @@ static int32_t M_CountAssaultTargets(void)
             continue;
         }
 
-        if ((item->flags & IF_KILLED) == 0
-            && item->timer > GYM_ASSAULT_TARGET_TIME) {
+        if ((item->flags & IF_KILLED) == 0 && item->hit_points > 0) {
             remaining++;
         }
     }
-    LOG_INFO("remaining=%d", remaining);
     return remaining;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Assault Track not penalizing skipped targets if Lara makes it to the finish line before they collapse.

[record_oPYGQnw.txt](https://github.com/user-attachments/files/28544513/record_oPYGQnw.txt)

#### Testing

- [x] Shooting all targets – no penalty expected
- [x] Not shooting any targets at all, finishing before they collapse – full penalty expected
- [x] Not shooting any targets at all, finishing after they collapse – full penalty expected
- [x] Mixed results – some penalty expected