### PR TITLE
gym: fix starting Quad timer without mounting it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
     - `O_SPIKE_WALL`
 - removed the limitation of only having two fish sprite types in any level
 - removed the limit of at most 8 fish/piranha shoals per level
+- fixed being able to start the Quad Bike track timer without Lara getting onto the quad bike first (regression from 1.1)
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -346,6 +346,10 @@ void Gym_TrackManager_Reset(const GYM_TRACK_TYPE track)
 
 void Gym_TrackManager_Start(const GYM_TRACK_TYPE track)
 {
+    if (track == GYM_TRACK_QUAD && !M_IsOnQuadBike()) {
+        return;
+    }
+
     M_PRIV *const p = &m_Priv;
     p->active_track_type = track;
 
@@ -371,10 +375,6 @@ void Gym_TrackManager_Start(const GYM_TRACK_TYPE track)
     }
 
     case GYM_TRACK_QUAD: {
-        if (!M_IsOnQuadBike()) {
-            return;
-        }
-
         p->assault_course.timer_active = false;
         p->assault_course.timer_display = false;
         p->assault_course.penalty_frames = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara being able to start the Quad Track timer without mounting the bike (lol).

[record_E2kI0dX.txt](https://github.com/user-attachments/files/28544684/record_E2kI0dX.txt)
