### PR TITLE
carrier: fix tr3 pickup orientation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats
 - fixed the drill in the Shakespeare Cliff not rotating
 - fixed seeing the fish in Coastal Village spawn due to delayed triggers, most noticeable when fades are disabled
+- fixed dropped pickups not keeping their original facing (regression from 1.2)
 
 
 

--- a/src/trx/game/items/carrier.c
+++ b/src/trx/game/items/carrier.c
@@ -403,7 +403,9 @@ void Carrier_TestItemDrops(const int16_t item_num)
             Item_UpdateRoom(item->spawn_num, carrier->room_num);
             ITEM *const pickup = Item_Get(item->spawn_num);
             pickup->pos = carrier->pos;
-            pickup->rot = carrier->rot;
+            if (g_TRVersion != 3) {
+                pickup->rot = carrier->rot;
+            }
             M_Drop(pickup);
         }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR changes the TR3 drop pickup orientation to match the OG, eg. keep the original pickup orientation, rather than rotating the pickups to their dead carriers' orientation.