### PR TITLE
rooms: split cold_water into per-room properties

### DIFF
--- a/data/scripting/rooms.lua
+++ b/data/scripting/rooms.lua
@@ -7,6 +7,8 @@ local getters = {
   end,
   underwater = raw.get_underwater,
   wind = raw.get_wind,
+  damaging = raw.get_damaging,
+  cold = raw.get_cold,
   flip_status = raw.get_flip_status,
   flipped_room = function(self, key)
     local flipped_room = raw.get_flipped_room(self)
@@ -32,6 +34,8 @@ local getters = {
 local setters = {
   underwater = raw.set_underwater,
   wind = raw.set_wind,
+  damaging = raw.set_damaging,
+  cold = raw.set_cold,
 }
 
 local Room = {}

--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -461,9 +461,9 @@
         // 16. Antarctica
         {
             "path": "antarc.tr2",
+            "script": "antarc.lua",
             "music_track": 28,
             "lara_outfit": "tr3_antarctica",
-            "cold_water": true,
             "weather_type": "snow",
             "sequence": [
                 {"type": "play_fmv", "fmv_id": 3},
@@ -491,7 +491,6 @@
             "script": "mines.lua",
             "music_track": 30,
             "lara_outfit": "tr3_antarctica",
-            "cold_water": true,
             "sequence": [
                 {"type": "loading_screen", "path": "antarc.webp", "fade_in_time": 1.0, "fade_out_time": 1.0},
                 {"type": "remove_scions"},

--- a/data/trx/ship/games/tr3/scripts/antarc.lua
+++ b/data/trx/ship/games/tr3/scripts/antarc.lua
@@ -1,7 +1,3 @@
-trx.events.before_level_file(function(level)
-  trx.creatures.add_ally(trx.catalog.objects.rx_worker_3)
-end)
-
 trx.events.after_level_state(function()
   for i = 1, #trx.rooms do
     local room = trx.rooms[i]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - added Lara's TR2 alpha bomber jacket outfit (#5594)
 - added the ability for skidoos and quad bikes that are inside or on top of lifts to move when the lift itself moves (#4353)
 - added the ability for skidoos, quad bikes and kayaks to activate heavy triggers (#4354)
+- added the ability to configure exposure zones and visible breath separately per room
 - changed vehicles to allow defining in Lua whether or not they can activate heavy triggers; refer to migration notes
 - changed Assault Course Lua record access from `trx.assault_stats` to `trx.assault.stats`
 - changed hard-coded music tracks from Snowmobiles, mine carts, and RIBs to be configurable via Lua

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -234,9 +234,6 @@
           "type": "boolean",
           "description": "TR3 only. Enables PSX-style underwater water particles in this level."
         },
-        "cold_water": {
-          "type": "boolean"
-        },
         "death_tile": {
           "type": "string",
           "description": "Defines death-tile behavior (for TR3 only).",

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -61,6 +61,15 @@ order: 3
    triggers intended for other heavy activators e.g. pushblocks. This is not
    configurable for the mine cart, which still relies on Lara striking switches.
 
+10. **Replace `cold_water` with room flags**:
+   The `cold_water` game-flow property has been removed. Use room flags instead:
+   - `damaging` controls Lara's exposure meter.
+   - `cold` controls Lara's visible breath.
+
+   You can set these flags from Lua:
+   - `trx.rooms[room_num].damaging = true`
+   - `trx.rooms[room_num].cold = true`
+
 ### Version 1.6 to 1.7
 
 1. **Update Lua item maximum HP access**:

--- a/docs/trx/game_flow/GLOBAL_PROPERTIES.md
+++ b/docs/trx/game_flow/GLOBAL_PROPERTIES.md
@@ -76,16 +76,6 @@ remains distinct for each game.
   </tr>
   <tr valign="top">
     <td>
-      <a name="cold-water"></a>
-      <code>cold_water</code>
-    </td>
-    <td>Boolean</td>
-    <td>
-      Enables an exposure meter for Lara when she is in cold water.
-    </td>
-  </tr>
-  <tr valign="top">
-    <td>
       <a name="convert-dropped-guns"></a>
       <code>convert_dropped_guns</code>
     </td>

--- a/docs/trx/game_flow/levels/REGULAR_LEVELS.md
+++ b/docs/trx/game_flow/levels/REGULAR_LEVELS.md
@@ -25,7 +25,6 @@ Following are each of the properties available within a level.
     "water_particles": true,
     "death_tile": "rapids",
     "water_color": [0.7, 0.5, 0.85],
-    "cold_water": true,
     "fog_transparency": false,
     "fog_color": [0, 0, 0],
     "fog_start": 34.0,
@@ -157,17 +156,6 @@ Following are each of the properties available within a level.
       TR3 only. Controls the per-level death tile behavior.
       Valid values: <code>lava</code>, <code>rapids</code>, <code>electric</code>.
       Omit for lava.
-    </td>
-  </tr>
-  <tr valign="top">
-    <td>
-      <a name="cold-water"></a>
-      <code>cold_water</code>
-    </td>
-    <td>Boolean</td>
-    <td colspan="2">
-      Can be customized per level. See <a href="../GLOBAL_PROPERTIES.md#cold-water">the global property</a>
-      for details.
     </td>
   </tr>
   <tr valign="top">

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -18,9 +18,8 @@ Module for interacting with the Lara's object.
     or [lua]`nil` if no target is locked.
 
 - [lua]`trx.lara.exposure_bar`  
-    Reads/writes exposure timer (cold water bar). The maximum value is 600.
-    If the cold bar setting is disabled on the game flow level, the health must
-    be managed manually from LUA.
+    Reads/writes Lara's exposure timer. The maximum value is 600.
+    The current level must use damaging rooms flag for this property to work.
 
 - [lua]`trx.lara.air_bar`  
     Reads/writes Lara's air timer. The maximum value is 1800.  

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -25,6 +25,8 @@ Module for inspecting all rooms in the current level.
     - **`num`**: 1-based room number.
     - **`underwater`**: Whether the room is underwater or not.
     - **`wind`**: Whether the room has breeze enabled or not. (Requires the player to have breeze enabled in the game settings).
+    - **`damaging`**: Whether the room uses Lara's exposure meter.
+    - **`cold`**: Whether Lara's breath is visible in the room.
     - **`bounds`**: a table with world-coordinate bounds of the room. The table contains:
       - **`min_x`**: minimum x coordinate.
       - **`min_y`**: minimum y coordinate.
@@ -39,6 +41,8 @@ Module for inspecting all rooms in the current level.
     Writable properties:
     - `underwater`
     - `wind`
+    - `damaging`
+    - `cold`
 
 ### Functions
 

--- a/src/trx/game/game_flow/reader.c
+++ b/src/trx/game/game_flow/reader.c
@@ -228,12 +228,6 @@ static bool M_LoadSettings(
         JSON_MUST(JSON_POP(io));
     }
 
-    if (JSON_OPTIONAL(JSON_PUSH(io, "cold_water"))) {
-        JSON_MUST(JSON_READ_CURRENT(io, &settings->cold_water.value));
-        settings->cold_water.is_present = true;
-        JSON_MUST(JSON_POP(io));
-    }
-
     if (JSON_OPTIONAL(JSON_PUSH(io, "death_tile"))) {
         const char *tmp_s = nullptr;
         JSON_MUST(JSON_READ_CURRENT(io, &tmp_s));

--- a/src/trx/game/game_flow/types.h
+++ b/src/trx/game/game_flow/types.h
@@ -93,10 +93,6 @@ typedef struct {
     char *sfx_path;
     struct {
         bool is_present;
-        bool value;
-    } cold_water;
-    struct {
-        bool is_present;
         int32_t value;
     } death_tile;
 } GF_LEVEL_SETTINGS;

--- a/src/trx/game/inject/editors/floor_data.c
+++ b/src/trx/game/inject/editors/floor_data.c
@@ -250,6 +250,8 @@ static void M_RoomProperties(
     room->flags.wind        = (flags & 0x20) != 0;
     room->flags.inside      = (flags & 0x40) != 0;
     room->flags.swamp       = (flags & 0x80) != 0;
+    room->flags.damaging    = (flags & 0x100) != 0;
+    room->flags.cold        = (flags & 0x200) != 0;
     // clang-format on
     if (injection->version >= INJ_VERSION_8) {
         room->reverb_info = VFile_ReadU8(injection->fp);

--- a/src/trx/game/lara/breath.c
+++ b/src/trx/game/lara/breath.c
@@ -3,7 +3,6 @@
 #include <trx/core/utils.h>
 #include <trx/game/collision.h>
 #include <trx/game/lara.h>
-#include <trx/game/level/settings.h>
 #include <trx/game/output/state.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -20,7 +19,7 @@ static bool M_CanBreatheVisible(const ITEM *const lara_item)
         return false;
     }
 
-    if (!Level_HasColdWater()) {
+    if (!Room_Get(lara_item->room_num)->flags.cold) {
         return false;
     }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -10,7 +10,6 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/breath.h>
 #include <trx/game/lara/electric.h>
-#include <trx/game/level/settings.h>
 #include <trx/game/music.h>
 #include <trx/game/output.h>
 #include <trx/game/pathing.h>
@@ -835,7 +834,8 @@ static void M_HandleSurface(COLL_INFO *const coll)
 
 static void M_HandleExposure(void)
 {
-    if (!Level_HasColdWater()) {
+    const ITEM *const lara_item = Lara_GetItem();
+    if (!Room_Get(lara_item->room_num)->flags.damaging) {
         return;
     }
 

--- a/src/trx/game/level/settings.c
+++ b/src/trx/game/level/settings.c
@@ -49,20 +49,6 @@ float Level_GetFogEnd(void)
     return g_Config.visuals.fog_end;
 }
 
-bool Level_HasColdWater(void)
-{
-    const GF_LEVEL *const level = GF_GetCurrentLevel();
-    if (level != nullptr && level->settings.cold_water.is_present) {
-        return level->settings.cold_water.value;
-    }
-
-    if (g_GameFlow.settings.cold_water.is_present) {
-        return g_GameFlow.settings.cold_water.value;
-    }
-
-    return false;
-}
-
 GF_DEATH_TILE Level_GetDeathTile(void)
 {
     const GF_LEVEL *const level = GF_GetCurrentLevel();

--- a/src/trx/game/level/settings.h
+++ b/src/trx/game/level/settings.h
@@ -7,5 +7,4 @@ RGB_888 Level_GetWaterColor(void);
 RGBA_8888 Level_GetFogColor(void);
 float Level_GetFogStart(void);
 float Level_GetFogEnd(void);
-bool Level_HasColdWater(void);
 GF_DEATH_TILE Level_GetDeathTile(void);

--- a/src/trx/game/lua/rooms.c
+++ b/src/trx/game/lua/rooms.c
@@ -55,6 +55,22 @@ static int M_L_RoomGetWind(lua_State *const L)
     return 1;
 }
 
+// trxc.rooms.get_damaging(index) → bool or nil
+static int M_L_RoomGetDamaging(lua_State *const L)
+{
+    M_ROOM_GETTER(L);
+    lua_pushboolean(L, room->flags.damaging);
+    return 1;
+}
+
+// trxc.rooms.get_cold(index) → bool or nil
+static int M_L_RoomGetCold(lua_State *const L)
+{
+    M_ROOM_GETTER(L);
+    lua_pushboolean(L, room->flags.cold);
+    return 1;
+}
+
 // trxc.rooms.get_flip_status(index) → integer
 static int M_L_RoomGetFlipStatus(lua_State *const L)
 {
@@ -88,6 +104,22 @@ static int M_L_RoomSetWind(lua_State *const L)
 {
     M_ROOM_SETTER(L);
     room->flags.wind = lua_toboolean(L, 2);
+    return 1;
+}
+
+// trxc.rooms.set_damaging(index, bool)
+static int M_L_RoomSetDamaging(lua_State *const L)
+{
+    M_ROOM_SETTER(L);
+    room->flags.damaging = lua_toboolean(L, 2);
+    return 1;
+}
+
+// trxc.rooms.set_cold(index, bool)
+static int M_L_RoomSetCold(lua_State *const L)
+{
+    M_ROOM_SETTER(L);
+    room->flags.cold = lua_toboolean(L, 2);
     return 1;
 }
 
@@ -164,10 +196,18 @@ void LUA_CreateRooms(lua_State *const L)
     lua_setfield(L, -2, "get_underwater");
     lua_pushcfunction(L, M_L_RoomGetWind);
     lua_setfield(L, -2, "get_wind");
+    lua_pushcfunction(L, M_L_RoomGetDamaging);
+    lua_setfield(L, -2, "get_damaging");
+    lua_pushcfunction(L, M_L_RoomGetCold);
+    lua_setfield(L, -2, "get_cold");
     lua_pushcfunction(L, M_L_RoomSetUnderwater);
     lua_setfield(L, -2, "set_underwater");
     lua_pushcfunction(L, M_L_RoomSetWind);
     lua_setfield(L, -2, "set_wind");
+    lua_pushcfunction(L, M_L_RoomSetDamaging);
+    lua_setfield(L, -2, "set_damaging");
+    lua_pushcfunction(L, M_L_RoomSetCold);
+    lua_setfield(L, -2, "set_cold");
     lua_pushcfunction(L, M_L_RoomGetBounds);
     lua_setfield(L, -2, "get_bounds");
     lua_pushcfunction(L, M_L_RoomGetFlipStatus);

--- a/src/trx/game/rooms/types.h
+++ b/src/trx/game/rooms/types.h
@@ -179,6 +179,8 @@ typedef struct {
         bool inside;
         bool dynamic_lit;
         bool swamp;
+        bool damaging;
+        bool cold;
     } flags;
 
     ROOM_DRAWSET drawn_items;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR replaces the `cold_water` game flow property with per-room `damaging` and `cold` flags. That lets builders control Lara's exposure damage and visible breath independently instead of being forced to enable both together for an entire level.

For the shipped TR3 content that previously used `cold_water`, Antarctica and RX-Tech Mines now enable both flags for all rooms via Lua to maintain BC. This also adds Lua room accessors for the new flags and updates injection room-property support for future OOTB TombEditor support.

#### Testing

- [x] Start TR3 Antarctica and enter water
  Expected outcome: Lara's exposure bar behaves as before
- [x] Start TR3 Antarctica and stay on land
  Expected outcome: Lara's breath is visible
- [x] Start TR3 RX-Tech Mines and enter water
  Expected outcome: Lara's exposure bar behaves as before
- [x] Start TR3 RX-Tech Mines and stay on land
  Expected outcome: Lara's breath is visible
- [x] Start any other level
  Expected outcome: Lara's breath is no longer visible and she doesn't get damaged by water
