### PR TITLE
output: do not cap sparks scaling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 **TR3**:
 - added the ability to define the flame interval of `O_FLAME_EMITTER_SIDE` objects
 - added an option to fix animated spikes resetting when loading a save (Gameplay → Fixes → Fix animated spikes)
+- changed spark effects to no longer cap their screen size, so they scale more naturally when zooming in photo mode
 - changed piranhas, tropical fish and bat emitters to use dedicated sprite objects; refer to migration guide
 - changed artefact pickup end-level behavior in specific levels to be configurable via Lua
 - changed `O_ORCA` special collision in `Sleeping with the Fishes` by introducing a `O_DOLPHIN` instead

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -718,23 +718,6 @@ void OutputSource_PolyFX_StageSpark(const SPARK *const spark)
         const int32_t scalar = spark->scalar;
         sw = (int32_t)(((((int64_t)sw * g_PhdPersp) << scalar) / vpos_z));
         sh = (int32_t)(((((int64_t)sh * g_PhdPersp) << scalar) / vpos_z));
-
-        if (use_sprite) {
-            const int32_t max_w = render_width << scalar;
-            const int32_t max_h = render_height << scalar;
-            int32_t min_wh = 4;
-            if ((spark->flags & SPARK_F_ATTACHED_NODE) != 0U
-                && spark->node_num == 0U) {
-                min_wh = 2;
-            }
-            CLAMP(sw, min_wh, max_w);
-            CLAMP(sh, min_wh, max_h);
-        } else {
-            const int32_t max_w = render_width << 2;
-            const int32_t max_h = render_height << 2;
-            CLAMP(sw, 1, max_w);
-            CLAMP(sh, 1, max_h);
-        }
     }
 
     const float w = ((sw / 2.0f) * (float)vpos_z) / (float)g_PhdPersp;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR changes spark effects to no longer cap their screen size, so they scale more naturally when zooming in photo mode.

Before:

<img width="3840" height="2160" alt="20260604_175459_Jungle" src="https://github.com/user-attachments/assets/ff92de53-6c05-4c74-aa38-8ae95c48841d" />

After:

<img width="3840" height="2160" alt="20260604_175444_Jungle" src="https://github.com/user-attachments/assets/33f2dc45-f84e-41b1-905c-1e01495ea0d8" />

#### Testing

Play with various spark-generating actors like guns, vehicles, water surfaces etc. and watch out for any obvious regressions or visual glitches.