### PR TITLE
objects/bat-emitter: fix clipping across portals

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 - fixed handheld flare sparks appearing inside the flare instead of above the tip
 - fixed TR3:LA referring to a non-existing FMV in the startup logs
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats
+- fixed bats disappearing after flying out of the room where they spawned
 - fixed the drill in the Shakespeare Cliff not rotating
 - fixed seeing the fish in Coastal Village spawn due to delayed triggers, most noticeable when fades are disabled
 - fixed dropped pickups not keeping their original facing (regression from 1.2)

--- a/src/trx/game/objects/general/bat_emitter.c
+++ b/src/trx/game/objects/general/bat_emitter.c
@@ -360,6 +360,17 @@ static void M_Control(const int16_t item_num)
         p->bats_triggered = true;
     } else {
         M_Update(p);
+
+        if (p->bats_alive) {
+            item->pos = p->bats[0].pos;
+            int16_t room_num = item->room_num;
+            Room_GetSector(item->pos, &room_num);
+            if (room_num != item->room_num) {
+                // Keep the emitter in the same room as the swarm leader so the
+                // bats continue to be drawn after crossing room boundaries.
+                Item_UpdateRoom(item_num, room_num);
+            }
+        }
     }
 
     if (!p->bats_alive) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes bat swarms potentially disappearing from certain camera angles after they fly out of their emitter's room.