### PR TITLE
tr3/data: fix animating diver

### DIFF
--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -137,6 +137,7 @@
                 "undersea_fd.bin",
                 "undersea_textures.bin",
                 "undersea_objects.bin",
+                "luds_diver_animation.bin",
             ],
         },
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats
 - fixed bats disappearing after flying out of the room where they spawned
 - fixed the drill in the Shakespeare Cliff not rotating
+- fixed the animating diver in Sleeping with the Fishes remaining visible in a default pose after diving into the water
 - fixed seeing the fish in Coastal Village spawn due to delayed triggers, most noticeable when fades are disabled
 - fixed dropped pickups not keeping their original facing (regression from 1.2)
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the animating diver in Sleeping with the Fishes finishing on a bad animation. This is the same solution as in Lud's Gate - 59413ed.
