### PR TITLE
objects/tribe-boss: fix zaps sometimes not working

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,7 @@
 - fixed seeing the fish in Coastal Village spawn due to delayed triggers, most noticeable when fades are disabled
 - fixed dropped pickups not keeping their original facing (regression from 1.2)
 - fixed Sophia not aiming at Lara properly in Reunion (regression from 1.4)
+- fixed Lara becoming immune to Puna's attacks after getting zapped once with the fly cheat (regression from 1.3)
 
 
 

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -550,7 +550,8 @@ static void M_TriggerElectricBeam(
         ITEM *const lara_item = Lara_GetItem();
         if (lara_info->electric == 0 && !copy && p->attack_type == M_ATTACK_HEAD
             && M_LaraOnLOS(src, &target)
-            && !g_Config.debug.enable_invulnerability) {
+            && !g_Config.debug.enable_invulnerability
+            && lara_info->water_status != LWS_CHEAT) {
             Lara_TakeDamage(
                 M_GetDamage(item, "head_beam_damage", M_HEAD_BEAM_DAMAGE),
                 true);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Puna's lightnings not affecting Lara after she enters the fly cheat, gets zapped one or more times, and then exits the fly cheat.

(It prevents Lara from receiving the electricity status when she gets zapped with the fly cheat on.)