### PR TITLE
objects/movable_block: prevent movement on death

### DIFF
--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -804,7 +804,7 @@ static void M_AnimatePushPull(ITEM *const item)
         if (Item_TestFrameEqual(lara_item, -2)) {
             const bool can_continue = pulling ? M_TestPull(item, WALL_L, dir)
                                               : M_TestPush(item, WALL_L, dir);
-            if (!g_Input.action
+            if (lara_item->hit_points <= 0 || !g_Input.action
                 || !g_Config.gameplay.enable_continuous_pushblocks
                 || !can_continue) {
                 lara_item->goal_anim_state = LS(LS_STOP);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara being able to continue to push/pull blocks after death with the continuous option enabled. A good place to test is the start of Folly - have the lions chomp Lara and try to continue pushing/pulling.