### PR TITLE
objects/misc: fix slot and switch interaction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)
 - fixed a very rare crash when loading saves from console during a pause or photo mode
+- fixed Lara embedding into walls during the sprint-slide animation if she tried to interact with a keyhole or puzzle slot at the same time (regression from TR1X 4.14, TR2X 1.4)
 
 **TR1**:
 - added support for fish and piranhas without sacrificing explosion sprites (refer to notes in migration guide) (#4358)
@@ -70,6 +71,7 @@
 - fixed dropped pickups not keeping their original facing (regression from 1.2)
 - fixed Sophia not aiming at Lara properly in Reunion (regression from 1.4)
 - fixed Lara becoming immune to Puna's attacks after getting zapped once with the fly cheat (regression from 1.3)
+- fixed Lara snapping to keyholes, puzzle slots and switches instead of waiting to be at a complete stand-still first (regression from 1.1)
 
 
 

--- a/src/trx/game/objects/general/keyhole.c
+++ b/src/trx/game/objects/general/keyhole.c
@@ -3,6 +3,7 @@
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/sound.h>
+#include <trx/version.h>
 
 #define M_LF_USE_KEYHOLE 104
 
@@ -54,6 +55,22 @@ static void M_MarkDone(ITEM *const receptacle_item)
     receptacle_item->status = IS_ACTIVE;
 }
 
+static bool M_LaraHasValidState(const ITEM *const lara_item)
+{
+    // TODO: unify with pickups, puzzle slots and switches
+    const LARA_TRX_ANIMATION anim = LA_U(Item_GetRelativeAnim(lara_item));
+    const LARA_TRX_STATE state = LS_U(lara_item->current_anim_state);
+    if (g_TRVersion < 3) {
+        if (anim == LA_SPRINT_SLIDE_STAND_RIGHT
+            || anim == LA_SPRINT_SLIDE_STAND_LEFT) {
+            return false;
+        }
+        return state == LS_STOP;
+    }
+
+    return state == LS_STOP && anim == LA_STAND_IDLE;
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -61,7 +78,7 @@ static void M_Collision(
     const OBJECT *const obj = Object_Get(item->object_id);
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
-    if (lara_item->current_anim_state != LS(LS_STOP)) {
+    if (!M_LaraHasValidState(lara_item)) {
         if (lara_item->current_anim_state == LS(LS_USE_KEY)
             && Lara_TestPosition(item, obj->bounds_func())
             && Item_TestFrameEqual(lara_item, M_LF_USE_KEYHOLE)) {

--- a/src/trx/game/objects/general/puzzle_hole.c
+++ b/src/trx/game/objects/general/puzzle_hole.c
@@ -5,6 +5,7 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects/vars.h>
 #include <trx/game/sound.h>
+#include <trx/version.h>
 
 #define M_LF_USE_PUZZLE 80
 
@@ -96,6 +97,22 @@ static void M_Control(const int16_t item_num)
     }
 }
 
+static bool M_LaraHasValidState(const ITEM *const lara_item)
+{
+    // TODO: unify with pickups, keyholes and switches
+    const LARA_TRX_ANIMATION anim = LA_U(Item_GetRelativeAnim(lara_item));
+    const LARA_TRX_STATE state = LS_U(lara_item->current_anim_state);
+    if (g_TRVersion < 3) {
+        if (anim == LA_SPRINT_SLIDE_STAND_RIGHT
+            || anim == LA_SPRINT_SLIDE_STAND_LEFT) {
+            return false;
+        }
+        return state == LS_STOP;
+    }
+
+    return state == LS_STOP && anim == LA_STAND_IDLE;
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -103,7 +120,7 @@ static void M_Collision(
     const OBJECT *const obj = Object_Get(item->object_id);
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
-    if (lara_item->current_anim_state != LS(LS_STOP)) {
+    if (!M_LaraHasValidState(lara_item)) {
         if (lara_item->current_anim_state == LS(LS_USE_PUZZLE)
             && Lara_TestPosition(item, obj->bounds_func())
             && Item_TestFrameEqual(lara_item, M_LF_USE_PUZZLE)) {
@@ -140,7 +157,7 @@ static void M_CollisionDone(
     const LARA_INFO *const lara = Lara_GetLaraInfo();
 
     if (!g_Input.action || lara->gun_status != LGS_ARMLESS || lara_item->gravity
-        || lara_item->current_anim_state != LS(LS_STOP)
+        || !M_LaraHasValidState(lara_item)
         || !Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }

--- a/src/trx/game/objects/general/switch.c
+++ b/src/trx/game/objects/general/switch.c
@@ -249,6 +249,22 @@ static void M_CollisionControlled(
     }
 }
 
+static bool M_LaraHasValidState(const ITEM *const lara_item)
+{
+    // TODO: unify with pickups, keyholes and puzzle slots
+    const LARA_TRX_ANIMATION anim = LA_U(Item_GetRelativeAnim(lara_item));
+    const LARA_TRX_STATE state = LS_U(lara_item->current_anim_state);
+    if (g_TRVersion < 3) {
+        if (anim == LA_SPRINT_SLIDE_STAND_RIGHT
+            || anim == LA_SPRINT_SLIDE_STAND_LEFT) {
+            return false;
+        }
+        return state == LS_STOP;
+    }
+
+    return state == LS_STOP && anim == LA_STAND_IDLE;
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -267,7 +283,7 @@ static void M_Collision(
 
     if (!g_Input.action || item->status != IS_INACTIVE
         || lara->gun_status != LGS_ARMLESS || lara_item->gravity
-        || lara_item->current_anim_state != LS(LS_STOP)
+        || !M_LaraHasValidState(lara_item)
         || !Lara_TestPosition(item, obj->bounds_func())) {
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara embedding into walls if she sprint-slides into a puzzle slot or keyhole with action held. In turn, it fixes Lara in TR3 snapping to these items and switches rather than waiting to be at a complete stand-still. Related to 4bf1157. Recordings available.

We can unify this during implementation of the snap/wait/animated interaction feature we have logged to do.
