### PR TITLE
data: hide various options

### DIFF
--- a/data/te/tr1/Engine/games/tr1-custom/gameflow.json5
+++ b/data/te/tr1/Engine/games/tr1-custom/gameflow.json5
@@ -54,5 +54,11 @@
     "demos": [],
     "cutscenes": [],
     "fmvs": [],
-    "hidden_config": [],
+    "hidden_config": [
+        "fix_animated_sprites",
+        "fix_item_rots",
+        "fix_floor_data_issues",
+        "fix_texture_issues",
+        "restore_ps1_enemies",
+    ],
 }

--- a/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
@@ -55,5 +55,11 @@
     "demos": [],
     "cutscenes": [],
     "fmvs": [],
-    "hidden_config": [],
+    "hidden_config": [
+        "fix_animated_sprites",
+        "fix_item_rots",
+        "fix_floor_data_issues",
+        "fix_texture_issues",
+        "restore_ps1_enemies",
+    ],
 }

--- a/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
@@ -51,5 +51,11 @@
     "demos": [],
     "cutscenes": [],
     "fmvs": [],
-    "hidden_config": [],
+    "hidden_config": [
+        "fix_animated_sprites",
+        "fix_item_rots",
+        "fix_floor_data_issues",
+        "fix_texture_issues",
+        "restore_ps1_enemies",
+    ],
 }

--- a/data/trx/ship/games/tr3-la/gameflow.json5
+++ b/data/trx/ship/games/tr3-la/gameflow.json5
@@ -220,5 +220,6 @@
         "fix_pipeman_aim",
         "enable_cinematics",
         "fix_animated_spikes",
+        "fix_animated_sprites",
     ],
 }

--- a/data/trx/ship/games/tr3/gameflow.json5
+++ b/data/trx/ship/games/tr3/gameflow.json5
@@ -809,5 +809,6 @@
         "restore_ps1_enemies",
         "change_pierre_spawn",
         "fix_speeches_killing_music",
+        "fix_animated_sprites",
     ],
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - changed animated spikes to work outside levels 5 and 7
 - changed `O_AI_PATROL_1` behavior in High Security Compound and Area 51 to be configurable; refer to migration docs
 - removed the hard-coded Aldwych drill speed override and moved it to Lua instead
+- removed the option to fix animated sprites, which has no relevance in TR3/TR3LA
 - fixed handheld flare sparks appearing inside the flare instead of above the tip
 - fixed TR3:LA referring to a non-existing FMV in the startup logs
 - fixed texture bleeding and missized textures on piranhas, tropical fish and bats


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This hides the `fix animated sprites` option in TR3 as it doesn't apply there. It also updates the bundled TE game flow files to hide several OG-specific options as standard.
