### PR TITLE
lara/control: add support for damaging dry rooms

### DIFF
--- a/data/trx/ship/games/tr3/scripts/antarc.lua
+++ b/data/trx/ship/games/tr3/scripts/antarc.lua
@@ -1,7 +1,7 @@
 trx.events.after_level_state(function()
   for i = 1, #trx.rooms do
     local room = trx.rooms[i]
-    room.damaging = true
+    room.damaging = room.underwater
     room.cold = true
   end
 end)

--- a/data/trx/ship/games/tr3/scripts/mines.lua
+++ b/data/trx/ship/games/tr3/scripts/mines.lua
@@ -5,7 +5,7 @@ end)
 trx.events.after_level_state(function()
   for i = 1, #trx.rooms do
     local room = trx.rooms[i]
-    room.damaging = true
+    room.damaging = room.underwater
     room.cold = true
   end
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,11 +38,13 @@
 - added support for fish and piranhas without sacrificing explosion sprites (refer to notes in migration guide) (#4358)
 - added support for bat emitters without sacrificing explosion sprites (refer to notes in migration guide)
 - added the abilty to use animated spikes
+- added support for Lara's breath to show in cold rooms (requires `O_SPARKS_GFX`)
 
 **TR2**:
 - added support for fish and piranhas without sacrificing explosion sprites (refer to notes in migration guide) (#4358)
 - added support for bat emitters without sacrificing explosion sprites (refer to notes in migration guide)
 - added the abilty to use animated spikes
+- added support for Lara's breath to show in cold rooms (requires `O_SPARKS_GFX`)
 - fixed TR2:GM missing opening Eidos Interactive / Core Design FMV (#5609)
 - fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - added Lara's TR2 alpha bomber jacket outfit (#5594)
 - added the ability for skidoos and quad bikes that are inside or on top of lifts to move when the lift itself moves (#4353)
 - added the ability for skidoos, quad bikes and kayaks to activate heavy triggers (#4354)
-- added the ability to configure exposure zones and visible breath separately per room
+- added the ability to configure exposure zones (including above water) and visible breath separately per room
 - added the ability for fish shoals to be affected by surrounding lighting and fog via a `use_room_lighting` property (#5618)
 - changed vehicles to allow defining in Lua whether or not they can activate heavy triggers; refer to migration notes
 - changed Assault Course Lua record access from `trx.assault_stats` to `trx.assault.stats`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed being able to start the Quad Bike track timer without Lara getting onto the quad bike first (regression from 1.1)
 - fixed missed Assault Course targets not penalizing player's time if Lara crosses the finish line before they collapse (regression from 1.2)
 - fixed fish sometimes disappearing when crossing room boundaries (OG bug)
+- fixed Lara's underwater hue being retained when re-entering a RIB and the responsive mesh tint is disabled
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)

--- a/src/trx/game/lara/breath.c
+++ b/src/trx/game/lara/breath.c
@@ -7,15 +7,10 @@
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sparks.h>
-#include <trx/version.h>
 
 static bool M_CanBreatheVisible(const ITEM *const lara_item)
 {
     if (lara_item == nullptr) {
-        return false;
-    }
-
-    if (g_TRVersion != 3) {
         return false;
     }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -834,16 +834,15 @@ static void M_HandleSurface(COLL_INFO *const coll)
 static void M_HandleExposure(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
-    if (!Room_Get(lara_item->room_num)->flags.damaging) {
+    LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    if (lara_info->water_status == LWS_ABOVE_WATER
+        || !Room_Get(lara_item->room_num)->flags.damaging) {
+        lara_info->exposure_timer++;
+        CLAMPG(lara_info->exposure_timer, LARA_MAX_EXPOSURE);
         return;
     }
 
-    LARA_INFO *const lara_info = Lara_GetLaraInfo();
     switch (lara_info->water_status) {
-    case LWS_ABOVE_WATER:
-        lara_info->exposure_timer++;
-        CLAMPG(lara_info->exposure_timer, LARA_MAX_EXPOSURE);
-        break;
     case LWS_WADE:
         lara_info->exposure_timer--;
         break;
@@ -853,6 +852,8 @@ static void M_HandleExposure(void)
         break;
     case LWS_CHEAT:
         lara_info->exposure_timer = LARA_MAX_EXPOSURE;
+        break;
+    default:
         break;
     }
 

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -835,26 +835,25 @@ static void M_HandleExposure(void)
 {
     const ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
-    if (lara_info->water_status == LWS_ABOVE_WATER
-        || !Room_Get(lara_item->room_num)->flags.damaging) {
+
+    if (lara_info->water_status == LWS_CHEAT) {
+        lara_info->exposure_timer = LARA_MAX_EXPOSURE;
+    } else if (Room_Get(lara_item->room_num)->flags.damaging) {
+        switch (lara_info->water_status) {
+        case LWS_ABOVE_WATER:
+        case LWS_WADE:
+            lara_info->exposure_timer--;
+            break;
+        case LWS_UNDERWATER:
+        case LWS_SURFACE:
+            lara_info->exposure_timer -= 2;
+            break;
+        default:
+            break;
+        }
+    } else {
         lara_info->exposure_timer++;
         CLAMPG(lara_info->exposure_timer, LARA_MAX_EXPOSURE);
-        return;
-    }
-
-    switch (lara_info->water_status) {
-    case LWS_WADE:
-        lara_info->exposure_timer--;
-        break;
-    case LWS_UNDERWATER:
-    case LWS_SURFACE:
-        lara_info->exposure_timer -= 2;
-        break;
-    case LWS_CHEAT:
-        lara_info->exposure_timer = LARA_MAX_EXPOSURE;
-        break;
-    default:
-        break;
     }
 
     if (lara_info->exposure_timer < 0) {

--- a/src/trx/game/objects/vehicles/rib.c
+++ b/src/trx/game/objects/vehicles/rib.c
@@ -960,12 +960,21 @@ static void M_Control(const int16_t item_num)
 
         if (room_num != item->room_num) {
             Item_UpdateRoom(item_num, room_num);
-            Item_UpdateRoom(Item_GetIndex(lara_item), room_num);
         }
 
         item->rot.z += p->tilt_angle;
         lara_item->pos = item->pos;
         lara_item->rot = item->rot;
+
+        sector = Room_GetSector(
+            (XYZ_32) {
+                lara_item->pos.x,
+                lara_item->pos.y + M_SHIFT_Y,
+                lara_item->pos.z,
+            },
+            &room_num);
+        Item_UpdateRoom(Item_GetIndex(lara_item), room_num);
+
         Item_Animate(lara_item);
 
         if (lara_item->hit_points > 0) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara's exposure meter not resetting when going from a damaging room to a normal room - not exactly an issue on develop in OG as the Lua scripts set the damaging flag on all rooms, and the previous control logic did the filtering on water status. I've switched it around so the OG scripts mark underwater rooms only as damaging, and this means we can now offer exposure damage when Lara is above water in custom levels.

I've prepared the change TE side to write these rooms flags, so builders will be able to use the checkboxes in the editor. I'll push that PR if the tests here look good. I've made a test level available from that build for TR1 with various cold and damaging room combos.
