### PR TITLE
objects/pickup: fix pickup list traversal

### DIFF
--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -311,12 +311,13 @@ static void M_GetAllAtLaraPos(const ITEM *const item)
     int16_t pickup_num = Room_Get(item->room_num)->item_num;
     while (pickup_num != NO_ITEM) {
         ITEM *const check_item = Item_Get(pickup_num);
+        const int16_t next_item_num = check_item->next_item;
         if (check_item->pos.x == item->pos.x && check_item->pos.z == item->pos.z
             && Object_Get(check_item->object_id)->collision_func
                 == Pickup_Collision) {
             M_DoPickup(pickup_num);
         }
-        pickup_num = check_item->next_item;
+        pickup_num = next_item_num;
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the game freezing if animated interactions are enabled and Lara tries to pick up multiple items on the same tile. Unreleased regression in 945e46d.
