### PR TITLE
objects/wasp_emitter: fix spawned wasp shading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,7 @@
 - fixed Sophia not aiming at Lara properly in Reunion (regression from 1.4)
 - fixed Lara becoming immune to Puna's attacks after getting zapped once with the fly cheat (regression from 1.3)
 - fixed Lara snapping to keyholes, puzzle slots and switches instead of waiting to be at a complete stand-still first (regression from 1.1)
+- fixed wasps that spawn from emitters having incorrect shading, especially noticeable when they are killed (regression from 1.6)
 
 
 

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -64,6 +64,8 @@ static void M_Initialise(const int16_t item_num)
         wasp_item->pos = item->pos;
         wasp_item->rot = item->rot;
         wasp_item->status = IS_INVISIBLE;
+        wasp_item->shade.value_1 = -1;
+        wasp_item->shade.value_2 = -1;
         Item_Initialise(wasp_item_num);
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes wasps having the wrong shade when they are spawned from an emitter.