### PR TITLE
objects/vehicles: add static collision

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - added animated interaction support to keyholes and puzzle slots (#4471)
 - added an option to control snap interactions for targets such as pickups and switches (Gameplay → Controls → Snap interactions)
 - changed vehicles to allow defining in Lua whether or not they can activate heavy triggers; refer to migration notes
+- change the Skidoo and Quad Bike to allow defining in Lua whether or not they should collide with static meshes (#4285)
 - changed Assault Course Lua record access from `trx.assault_stats` to `trx.assault.stats`
 - changed hard-coded music tracks from Snowmobiles, mine carts, and RIBs to be configurable via Lua
 - changed hard-coded fish and piranha setup to be configurable via Lua

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -216,6 +216,7 @@ This page lists documented moveable object properties.
 - `battle_track_3 = -1` — Random battle music track pool, slot 3. -1 = disabled.
 - `battle_track_4 = -1` — Random battle music track pool, slot 4. -1 = disabled.
 - `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
+- `test_static_collision = false` — Whether or not this vehicle can collide with static meshes.
 
 ### `14` O_BOAT
 - `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
@@ -509,6 +510,7 @@ This page lists documented moveable object properties.
 - `track_3 = -1` — Random music track pool, slot 3. -1 = disabled.
 - `track_4 = -1` — Random music track pool, slot 4. -1 = disabled.
 - `is_heavy = true` — Whether or not this vehicle can activate heavy triggers.
+- `test_static_collision = false` — Whether or not this vehicle can collide with static meshes.
 
 ### `17` O_MINE_CART
 - `track_1 = 12 (MX_MINE_CART_THEME)` — Random music track pool, slot 1. -1 = disabled.

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -733,7 +733,6 @@ bool Collide_TestBoundsCollide(
 
 void Collide_DoProperDetection(ITEM *const item, const XYZ_32 old_pos)
 {
-
     int16_t room_num = item->room_num;
     const SECTOR *sector = Room_GetSector(old_pos, &room_num);
     const int32_t old_height = Room_GetHeight(sector, old_pos);

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -20,6 +20,8 @@
 #include <trx/game/spawn.h>
 #include <trx/version.h>
 
+#define M_STATIC_RADIUS 100
+
 static const BITE m_QuadBites[6] = {
     { .pos = { .x = -56, .y = -32, .z = -380 }, .mesh_num = 0 },
     { .pos = { .x = 56, .y = -32, .z = -380 }, .mesh_num = 0 },
@@ -99,6 +101,7 @@ typedef struct {
     int32_t extra_rotation_count;
     int32_t rear_rot_x_idx[2];
     int32_t front_rot_x_idx[2];
+    bool test_static_collision;
 } M_PRIV;
 
 static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
@@ -221,6 +224,11 @@ static void M_Initialise(const int16_t item_num)
     }
 
     item->extra_rotations = p->extra_rotation;
+
+    OBJECT_PROPERTY_VALUE value = {};
+    if (ObjectProperty_GetItemValue(item, "test_static_collision", &value)) {
+        p->test_static_collision = value.as_bool;
+    }
 }
 
 static int32_t M_GetOnQuadBike(
@@ -433,7 +441,19 @@ static int32_t M_TestHeight(
         return NO_HEIGHT;
     }
 
-    return Room_GetHeight(sector, *pos);
+    const M_PRIV *const p = item->priv;
+    const int32_t height = Room_GetHeight(sector, *pos);
+    if (height == NO_HEIGHT || !p->test_static_collision) {
+        return height;
+    }
+
+    COLL_INFO coll = {};
+    coll.radius = M_STATIC_RADIUS;
+    if (Collide_CollideStaticObjects(
+            &coll, *pos, item->room_num, LARA_HEIGHT)) {
+        return NO_HEIGHT;
+    }
+    return height;
 }
 
 static void M_TriggerExhaustSmoke(
@@ -1525,7 +1545,10 @@ static void M_Setup(OBJECT *const obj)
             "track_4", -1, "Random music track pool, slot 4. -1 = disabled."),
         OBJECT_PROPERTY_BOOL(
             "is_heavy", true,
-            "Whether or not this vehicle can activate heavy triggers."));
+            "Whether or not this vehicle can activate heavy triggers."),
+        OBJECT_PROPERTY_BOOL(
+            "test_static_collision", false,
+            "Whether or not this vehicle can collide with static meshes."));
 }
 
 REGISTER_OBJECT(O_QUAD_BIKE, M_Setup)

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -20,6 +20,7 @@
 
 // clang-format off
 #define M_RADIUS            500
+#define M_STATIC_RADIUS     100
 #define M_SIDE              260
 #define M_FRONT             550
 #define M_SNOW              500
@@ -167,6 +168,11 @@ void Skidoo_Initialise(const int16_t item_num)
     skidoo_data->momentum_angle = item->rot.y;
     skidoo_data->track_mesh = 0;
     skidoo_data->pitch = 0;
+
+    OBJECT_PROPERTY_VALUE value = {};
+    if (ObjectProperty_GetItemValue(item, "test_static_collision", &value)) {
+        skidoo_data->test_static_collision = value.as_bool;
+    }
 }
 
 int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
@@ -273,7 +279,20 @@ int32_t Skidoo_TestHeight(
     out_pos->z = item->pos.z + ((z_off * cy - x_off * sy) >> W2V_SHIFT);
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(*out_pos, &room_num);
-    return Room_GetHeight(sector, *out_pos);
+
+    const SKIDOO_INFO *const p = item->priv;
+    const int32_t height = Room_GetHeight(sector, *out_pos);
+    if (height == NO_HEIGHT || !p->test_static_collision) {
+        return height;
+    }
+
+    COLL_INFO coll = {};
+    coll.radius = M_STATIC_RADIUS;
+    if (Collide_CollideStaticObjects(
+            &coll, *out_pos, item->room_num, LARA_HEIGHT)) {
+        return NO_HEIGHT;
+    }
+    return height;
 }
 
 void Skidoo_DoSnowEffect(const ITEM *const skidoo)
@@ -880,9 +899,7 @@ bool Skidoo_Control(void)
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;
     } else {
-        lara_item->pos.x = skidoo->pos.x;
-        lara_item->pos.y = skidoo->pos.y;
-        lara_item->pos.z = skidoo->pos.z;
+        lara_item->pos = skidoo->pos;
         lara_item->rot.y = skidoo->rot.y;
         if (drive >= 0) {
             lara_item->rot.x = skidoo->rot.x;

--- a/src/trx/game/objects/vehicles/skidoo_common.h
+++ b/src/trx/game/objects/vehicles/skidoo_common.h
@@ -21,6 +21,7 @@ typedef struct {
     int16_t momentum_angle;
     int16_t extra_rotation;
     int32_t pitch;
+    bool test_static_collision;
 } SKIDOO_INFO;
 
 extern const BITE g_Skidoo_LeftGun;

--- a/src/trx/game/objects/vehicles/skidoo_fast.c
+++ b/src/trx/game/objects/vehicles/skidoo_fast.c
@@ -67,7 +67,10 @@ static void M_Setup(OBJECT *const obj)
             "Random battle music track pool, slot 4. -1 = disabled."),
         OBJECT_PROPERTY_BOOL(
             "is_heavy", true,
-            "Whether or not this vehicle can activate heavy triggers."));
+            "Whether or not this vehicle can activate heavy triggers."),
+        OBJECT_PROPERTY_BOOL(
+            "test_static_collision", false,
+            "Whether or not this vehicle can collide with static meshes."));
 }
 
 REGISTER_OBJECT(O_SKIDOO_FAST, M_Setup)


### PR DESCRIPTION
Resolves #4285.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds properties to the skidoo and quad bike to allow them to collide with static meshes. It's hard collision, so similar to hitting a wall - as such if Lara is going fast enough, she will take damage. Let me know if we think this would be better as a config option; I couldn't think of many affected places in OG (the posts near the hut in Tibet was all that came to mind) so I went with object properties instead.

This doesn't extend to the skidoo driver as it would interfere with pathfinding. Custom levels can block off specific sectors where enemies shouldn't travel anyway. If Lara is riding the black skidoo, collision will apply.

Test level available. The following commands can be run to turn the collision on.

`/lua trx.objects.skidoo_fast.properties.test_static_collision = true`
`/lua trx.objects.quad_bike.properties.test_static_collision = true`
