### PR TITLE
objects/scion3: make individual counter property

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed fish shoals not picking up the underwater tint correctly
 - fixed Lara's underwater hue being retained when re-entering a RIB and the responsive mesh tint is disabled
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
+- fixed `O_SCION_ITEM_3` items exploding at inconsistent times if multiple are used in the same level
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)
 - fixed a very rare crash when loading saves from console during a pause or photo mode

--- a/src/trx/game/objects/general/scion3.c
+++ b/src/trx/game/objects/general/scion3.c
@@ -9,6 +9,10 @@
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 
+typedef struct {
+    int32_t counter;
+} M_PRIV;
+
 static bool M_ShouldSpawnBlood(const ITEM *const item)
 {
     return !g_Config.visuals.fix_texture_issues;
@@ -21,7 +25,6 @@ static bool M_CanTakeDamage(const ITEM *const item)
 
 static void M_Control(const int16_t item_num)
 {
-    static int32_t counter = 0;
     ITEM *const item = Item_Get(item_num);
 
     if (Item_IsTriggerActive(item)) {
@@ -31,20 +34,21 @@ static void M_Control(const int16_t item_num)
         item->status = IS_ACTIVE;
     }
 
+    M_PRIV *const p = item->priv;
     if (item->hit_points > 0) {
-        counter = 0;
+        p->counter = 0;
         Item_Animate(item);
         return;
     }
 
-    if (counter == 0) {
+    if (p->counter == 0) {
         item->status = IS_INVISIBLE;
         item->hit_points = 0;
         Room_TestTriggers(item);
         Item_RemoveDrawn(item_num);
     }
 
-    if (counter % 10 == 0) {
+    if (p->counter % 10 == 0) {
         int16_t effect_num = Effect_Create(item->room_num);
         if (effect_num != NO_EFFECT) {
             EFFECT *effect = Effect_Get(effect_num);
@@ -61,8 +65,8 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    counter++;
-    if (counter >= LOGIC_FPS * 3) {
+    p->counter++;
+    if (p->counter >= LOGIC_FPS * 3) {
         Item_Kill(item_num);
     }
 }
@@ -73,6 +77,7 @@ static void M_Setup(OBJECT *const obj)
     obj->can_take_damage_func = M_CanTakeDamage;
     obj->should_spawn_blood_func = M_ShouldSpawnBlood;
 
+    obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
     obj->save_hitpoints = true;
     OBJECT_PROPERTIES(


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves multiple scions in the same custom level exploding at inconsistent times by moving the shared counter into a private property.

Test level available.
