### PR TITLE
test-replay: make mod restore more resilient

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,8 @@
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)
 - fixed a very rare crash when loading saves from console during a pause or photo mode
 - fixed Lara embedding into walls during the sprint-slide animation if she tried to interact with a keyhole or puzzle slot at the same time (regression from TR1X 4.14, TR2X 1.4)
+- fixed recording replays from different mods on the same engine as last played loading the wrong mood
+- fixed recording replays switching the last played mod
 
 **TR1**:
 - added support for fish and piranhas without sacrificing explosion sprites (refer to notes in migration guide) (#4358)

--- a/src/trx/game/console/cmd/mod.c
+++ b/src/trx/game/console/cmd/mod.c
@@ -9,7 +9,7 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
     if (String_IsEmpty(ctx->args)) {
         const SHELL_ARGS *const args = Shell_GetArgs();
-        Console_Log("Currently loaded mod: %s", args->mod->name);
+        Console_Log("Currently loaded mod: %s", args->startup.mod->name);
         return CR_SUCCESS;
     }
 

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -111,20 +111,20 @@ GF_COMMAND GF_DoFrontendSequence(void)
 {
     const SHELL_ARGS *const args = Shell_GetArgs();
     if (args != nullptr) {
-        if (args->save_to_load >= 0) {
+        if (args->startup.save_to_load >= 0) {
             return (GF_COMMAND) {
                 .action = GF_START_SAVED_GAME,
                 .param = Savegame_SlotToParam(
-                    Savegame_NormalSlot(args->save_to_load)),
+                    Savegame_NormalSlot(args->startup.save_to_load)),
             };
         }
 
-        if (args->level_to_select >= 0) {
-            const GF_LEVEL *const level =
-                GF_GetLevelByOrdinalNumber(GFLT_MAIN, args->level_to_select);
+        if (args->startup.level_to_select >= 0) {
+            const GF_LEVEL *const level = GF_GetLevelByOrdinalNumber(
+                GFLT_MAIN, args->startup.level_to_select);
             if (level == nullptr) {
                 Shell_ExitSystemFmt(
-                    "Invalid level number: %d", args->level_to_select);
+                    "Invalid level number: %d", args->startup.level_to_select);
             }
             return (GF_COMMAND) {
                 .action = GF_SELECT_GAME,
@@ -132,7 +132,7 @@ GF_COMMAND GF_DoFrontendSequence(void)
             };
         }
 
-        if (args->level_to_play != nullptr) {
+        if (args->startup.level_to_play != nullptr) {
             return (GF_COMMAND) {
                 .action = GF_START_GAME,
                 .param = 0,

--- a/src/trx/game/level/cache.c
+++ b/src/trx/game/level/cache.c
@@ -183,12 +183,13 @@ const char *LevelCache_GetLevelKey(const GF_LEVEL *const level)
 static const char *M_GetPath(const char *const filename)
 {
     const SHELL_ARGS *const args = Shell_GetArgs();
-    if (args == nullptr || args->mod == nullptr || args->mod->name == nullptr) {
+    if (args == nullptr || args->startup.mod == nullptr
+        || args->startup.mod->name == nullptr) {
         return nullptr;
     }
 
     return String_FormatStatic(
-        "%s/%s/%s", Shell_GetCacheDir(), args->mod->name, filename);
+        "%s/%s/%s", Shell_GetCacheDir(), args->startup.mod->name, filename);
 }
 
 MYFILE *LevelCache_OpenBinaryRead(

--- a/src/trx/game/replay/test_recorder.c
+++ b/src/trx/game/replay/test_recorder.c
@@ -13,6 +13,7 @@
 #include <trx/game/input/common.h>
 #include <trx/game/lara.h>
 #include <trx/game/random.h>
+#include <trx/game/shell/common.h>
 
 #include <stdlib.h>
 #include <string.h>
@@ -154,6 +155,33 @@ static void M_DumpHeader(MYFILE *const fp)
     File_WriteString(fp, "seed_draw %d\n", Random_GetDrawSeed());
 }
 
+static void M_DumpStartup(MYFILE *const fp)
+{
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    if (args == nullptr) {
+        return;
+    }
+
+    if (args->startup.mod != nullptr && args->startup.mod->name != nullptr) {
+        File_WriteString(fp, "startup mod \"%s\"\n", args->startup.mod->name);
+    } else if (args->startup.engine_version > 0) {
+        File_WriteString(
+            fp, "startup engine %d\n", args->startup.engine_version);
+    }
+    if (args->startup.level_to_select >= 0) {
+        File_WriteString(
+            fp, "startup level-num %d\n", args->startup.level_to_select);
+    }
+    if (args->startup.level_to_play != nullptr) {
+        File_WriteString(
+            fp, "startup level-path \"%s\"\n", args->startup.level_to_play);
+    }
+    if (args->startup.save_to_load >= 0) {
+        File_WriteString(
+            fp, "startup save %d\n", args->startup.save_to_load + 1);
+    }
+}
+
 static void M_DumpArguments(MYFILE *const fp, VECTOR *const original_args)
 {
     // Record original arguments passed to the game
@@ -279,6 +307,7 @@ void TestRecorder_Open(const char *path, VECTOR *const original_args)
     }
 
     M_DumpHeader(p->file);
+    M_DumpStartup(p->file);
     M_DumpArguments(p->file, original_args);
     M_DumpConfig(p->file);
     M_DumpBindings(p->file);

--- a/src/trx/game/replay/test_replay.c
+++ b/src/trx/game/replay/test_replay.c
@@ -24,10 +24,23 @@
 #include <string.h>
 
 #define M_DEBUG 0
+typedef struct {
+    bool seen;
+    STARTUP_SETTINGS settings;
+} M_STARTUP_SNAPSHOT;
 
 typedef struct {
     SHELL_ARGS *args;
+    M_STARTUP_SNAPSHOT startup;
+    bool used_deprecated_args;
 } M_PARSE_CTX;
+
+static inline M_PARSE_CTX M_ParseCtxInit(void)
+{
+    return (M_PARSE_CTX) {
+        .startup.settings = { .level_to_select = -1, .save_to_load = -1 },
+    };
+}
 
 typedef struct {
     bool collecting;
@@ -88,6 +101,7 @@ static bool M_ParseExpectEvent(const char *event_str);
 // Header parsers
 static bool M_ParseSeedControl(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseSeedDraw(const char *line, M_PARSE_CTX *ctx);
+static bool M_ParseStartup(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseBindKeyboard(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseBindController(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseArgs(const char *line, M_PARSE_CTX *ctx);
@@ -95,9 +109,9 @@ static bool M_ParseConfig(const char *line, M_PARSE_CTX *ctx);
 static bool M_ParseTestCaseHeader(const char *line, M_PARSE_CTX *ctx);
 
 static const M_HEADER_HANDLER m_HeaderHandlers[] = {
-    M_ParseSeedControl,    M_ParseSeedDraw, M_ParseBindKeyboard,
-    M_ParseBindController, M_ParseArgs,     M_ParseConfig,
-    M_ParseTestCaseHeader, nullptr,
+    M_ParseSeedControl,  M_ParseSeedDraw,       M_ParseStartup,
+    M_ParseBindKeyboard, M_ParseBindController, M_ParseArgs,
+    M_ParseConfig,       M_ParseTestCaseHeader, nullptr,
 };
 
 static const M_EVENT_HANDLER m_EventHandlers[] = {
@@ -223,6 +237,42 @@ static bool M_ParseQuotedPayload(
     *out_start = start + 1;
     *out_len = (size_t)(end - (start + 1));
     return true;
+}
+
+static void M_FreeStartupSnapshot(M_STARTUP_SNAPSHOT *const startup)
+{
+    Memory_FreePointer(&startup->settings.level_to_play);
+}
+
+static void M_ResetParseArgs(M_PARSE_CTX *const ctx)
+{
+    if (ctx->args == nullptr) {
+        return;
+    }
+    Shell_FreeArgs(ctx->args);
+    ctx->args = nullptr;
+}
+
+static SHELL_ARGS *M_BuildArgsFromStartupSnapshot(M_PARSE_CTX *const ctx)
+{
+    if (!ctx->startup.seen) {
+        return nullptr;
+    }
+
+    SHELL_ARGS *const args = Memory_Alloc(sizeof(SHELL_ARGS));
+    args->startup = ctx->startup.settings;
+    ctx->startup.settings.level_to_play = nullptr;
+
+    if (args->startup.mod == nullptr) {
+        if (args->startup.level_to_play != nullptr) {
+            args->startup.mod = Shell_GetModByType(
+                MOD_DIRECT_LEVEL, args->startup.engine_version);
+        } else if (args->startup.engine_version > 0) {
+            args->startup.mod =
+                Shell_GetModByType(MOD_BASE_GAME, args->startup.engine_version);
+        }
+    }
+    return args;
 }
 
 static const char *M_SkipWhitespaceConst(const char *const s)
@@ -719,16 +769,56 @@ static bool M_ParseBindController(
     return false;
 }
 
+static bool M_ParseStartup(const char *const line, M_PARSE_CTX *const ctx)
+{
+    if (strncmp(line, "startup ", 8) != 0) {
+        return false;
+    }
+
+    int32_t int_val = 0;
+    const char *str = nullptr;
+    size_t str_len = 0;
+
+    if (sscanf(line, "startup engine %d", &int_val) == 1) {
+        ctx->startup.settings.engine_version = int_val;
+    } else if (M_ParseQuotedPayload(line, "startup mod", &str, &str_len)) {
+        const char *const mod_name =
+            String_FormatStatic("%.*s", (int)str_len, str);
+        ctx->startup.settings.mod = Shell_GetModByName(mod_name);
+        if (ctx->startup.settings.mod == nullptr) {
+            Shell_ExitSystemFmt(
+                "Replay references unavailable mod '%s'", mod_name);
+        }
+        if (ctx->startup.settings.engine_version <= 0) {
+            ctx->startup.settings.engine_version =
+                ctx->startup.settings.mod->engine_version;
+        }
+    } else if (sscanf(line, "startup level-num %d", &int_val) == 1) {
+        ctx->startup.settings.level_to_select = int_val;
+    } else if (
+        M_ParseQuotedPayload(line, "startup level-path", &str, &str_len)) {
+        Memory_FreePointer(&ctx->startup.settings.level_to_play);
+        ctx->startup.settings.level_to_play =
+            Memory_DupStr(String_FormatStatic("%.*s", (int)str_len, str));
+    } else if (sscanf(line, "startup save %d", &int_val) == 1) {
+        ctx->startup.settings.save_to_load = int_val - 1;
+    } else {
+        return false;
+    }
+
+    ctx->startup.seen = true;
+    return true;
+}
+
 static bool M_ParseArgs(const char *const line, M_PARSE_CTX *const ctx)
 {
     if (strncmp(line, "args", 4) != 0) {
         return false;
     }
 
-    if (ctx->args != nullptr) {
-        Shell_FreeArgs(ctx->args);
-        ctx->args = nullptr;
-    }
+    ctx->used_deprecated_args = true;
+    M_ResetParseArgs(ctx);
+
     // Build an owned argv vector for Shell_ParseArgs adoption.
     VECTOR *raw_args = Vector_Create(sizeof(const char *));
     const char *p = line + 4;
@@ -951,25 +1041,38 @@ SHELL_ARGS *TestReplay_Open(const char *path)
         idx++;
     }
 
-    M_PARSE_CTX ctx = {};
+    M_PARSE_CTX ctx = M_ParseCtxInit();
     for (int32_t i = 0; i < p->headers->count; i++) {
         const char *const ln = *(const char **)Vector_Get(p->headers, i);
-        M_ParseArgs(ln, &ctx);
+        for (int32_t j = 0; m_HeaderHandlers[j]; j++) {
+            if (m_HeaderHandlers[j](ln, &ctx)) {
+                break;
+            }
+        }
     }
     Vector_Free(lines);
     LOG_INFO("Loaded %zu frames for playback", p->frames->count);
-    if (ctx.args == nullptr) {
+    if (ctx.startup.seen) {
+        M_ResetParseArgs(&ctx);
+        ctx.args = M_BuildArgsFromStartupSnapshot(&ctx);
+    } else if (ctx.args == nullptr) {
         ctx.args = Shell_ParseArgs(nullptr);
+    }
+    if (ctx.used_deprecated_args && !ctx.startup.seen) {
+        LOG_WARNING(
+            "Replay uses deprecated 'args' startup header; please re-record "
+            "it");
     }
     if (ctx.args != nullptr && ctx.args->quiet) {
         p->replay_quiet = true;
     }
+    M_FreeStartupSnapshot(&ctx.startup);
     return ctx.args;
 }
 
 void TestReplay_Start(void)
 {
-    M_PARSE_CTX ctx = {};
+    M_PARSE_CTX ctx = M_ParseCtxInit();
     M_PRIV *const p = &m_Priv;
     for (int32_t i = 0; i < p->headers->count; i++) {
         const char *const ln = *(const char **)Vector_Get(p->headers, i);
@@ -986,6 +1089,7 @@ void TestReplay_Start(void)
     }
     g_SavedConfig = g_Config;
     Shell_FreeArgs(ctx.args);
+    M_FreeStartupSnapshot(&ctx.startup);
 }
 
 void TestReplay_Close(void)

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -38,8 +38,9 @@ static const char *M_GetSaveWriteDir(void)
 {
     const char *const saves_dir = TRXPath_Get(TRX_PATH_SAVES_DIR);
     const SHELL_ARGS *const args = Shell_GetArgs();
-    if (args != nullptr && args->mod != nullptr && args->mod->name != nullptr) {
-        return String_FormatStatic("%s/%s", saves_dir, args->mod->name);
+    if (args != nullptr && args->startup.mod != nullptr
+        && args->startup.mod->name != nullptr) {
+        return String_FormatStatic("%s/%s", saves_dir, args->startup.mod->name);
     }
     return saves_dir;
 }

--- a/src/trx/game/shell/args.c
+++ b/src/trx/game/shell/args.c
@@ -98,10 +98,10 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
     SHELL_ARGS *const result = Memory_Alloc(sizeof(SHELL_ARGS));
     bool wants_gold = false;
     bool explicit_engine_version = false;
-    result->save_to_load = -1;
-    result->level_to_select = -1;
+    result->startup.save_to_load = -1;
+    result->startup.level_to_select = -1;
     result->original_args = args;
-    result->engine_version = 0;
+    result->startup.engine_version = 0;
 
     // First pass: set the engine version.
     for (int32_t i = 0; args != nullptr && i < args->count; i++) {
@@ -109,16 +109,16 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         const char *const next_arg =
             i + 1 < args->count ? *(char **)Vector_Get(args, i + 1) : nullptr;
         if (!strcmp(arg, "-e") || !strcmp(arg, "--engine")) {
-            String_ParseInteger(next_arg, &result->engine_version);
-            CLAMP(result->engine_version, 1, 3);
+            String_ParseInteger(next_arg, &result->startup.engine_version);
+            CLAMP(result->startup.engine_version, 1, 3);
             explicit_engine_version = true;
             i++;
         }
     }
-    if (result->engine_version <= 0 && g_TRVersion > 0) {
+    if (result->startup.engine_version <= 0 && g_TRVersion > 0) {
         // Hydrate recordings using old-style directory tree to use
         // runtime engine version if they miss it.
-        result->engine_version = g_TRVersion;
+        result->startup.engine_version = g_TRVersion;
     }
 
     // Second pass: remaining options.
@@ -142,12 +142,12 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
 
         if (!strcmp(arg, "--demo-pc") || !strcmp(arg, "-demo_pc")) {
-            result->mod = Shell_GetModByName("tr1-demo-pc");
+            result->startup.mod = Shell_GetModByName("tr1-demo-pc");
         }
         if (!strcmp(arg, "--mod") && next_arg != nullptr) {
             const SHELL_MOD *const mod = Shell_GetModByName(next_arg);
             if (mod != nullptr) {
-                result->mod = mod;
+                result->startup.mod = mod;
             }
             i++;
         }
@@ -156,10 +156,11 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
             && next_arg != nullptr) {
             int32_t lvnum = -1;
             if (String_ParseInteger(next_arg, &lvnum)) {
-                result->level_to_select = lvnum;
-                if (result->mod == nullptr && result->engine_version > 0) {
-                    result->mod = Shell_GetModByType(
-                        MOD_BASE_GAME, result->engine_version);
+                result->startup.level_to_select = lvnum;
+                if (result->startup.mod == nullptr
+                    && result->startup.engine_version > 0) {
+                    result->startup.mod = Shell_GetModByType(
+                        MOD_BASE_GAME, result->startup.engine_version);
                 }
             } else {
                 char **const level_arg = Vector_Get(args, i + 1);
@@ -168,10 +169,10 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                 const char *const resolved_level_path =
                     TRXPath_PeekResolveUserPath(
                         TRX_DYNAMIC_PATH_LEVEL_FILE, next_arg);
-                result->level_to_play = resolved_level_path != nullptr
+                result->startup.level_to_play = resolved_level_path != nullptr
                     ? Memory_DupStr(resolved_level_path)
                     : nullptr;
-                if (result->level_to_play == nullptr) {
+                if (result->startup.level_to_play == nullptr) {
                     Shell_ExitSystemFmt(
                         "Cannot find level file '%s'. Relative paths are "
                         "resolved from the current working directory, then "
@@ -179,33 +180,34 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
                         next_arg);
                 }
                 Memory_Free(*level_arg);
-                *level_arg = (char *)result->level_to_play;
+                *level_arg = (char *)result->startup.level_to_play;
 
-                if (result->engine_version == 0) {
-                    result->engine_version = M_GuessEngineVersionFromLevelPath(
-                        result->level_to_play);
+                if (result->startup.engine_version == 0) {
+                    result->startup.engine_version =
+                        M_GuessEngineVersionFromLevelPath(
+                            result->startup.level_to_play);
                 }
-                if (result->engine_version == 0) {
+                if (result->startup.engine_version == 0) {
                     Shell_ExitSystem(
                         "Cannot determine engine version for --level. "
                         "Please provide --engine.");
                 }
-                result->mod = Shell_GetModByType(
-                    MOD_DIRECT_LEVEL, result->engine_version);
-                if (result->mod == nullptr) {
+                result->startup.mod = Shell_GetModByType(
+                    MOD_DIRECT_LEVEL, result->startup.engine_version);
+                if (result->startup.mod == nullptr) {
                     Shell_ExitSystemFmt(
                         "Engine %d does not support --level with a file path "
                         "because no direct-level mod is available for that "
                         "engine.",
-                        result->engine_version);
+                        result->startup.engine_version);
                 }
             }
             i++;
         }
         if ((!strcmp(arg, "-s") || !strcmp(arg, "--save"))
             && next_arg != nullptr) {
-            if (String_ParseInteger(next_arg, &result->save_to_load)) {
-                result->save_to_load--;
+            if (String_ParseInteger(next_arg, &result->startup.save_to_load)) {
+                result->startup.save_to_load--;
             }
             i++;
         }
@@ -236,21 +238,24 @@ SHELL_ARGS *Shell_ParseArgs(VECTOR *const args)
         }
     }
 
-    if (result->mod == nullptr) {
-        result->mod = Shell_SelectStartupMod(result->engine_version);
+    if (result->startup.mod == nullptr) {
+        result->startup.mod =
+            Shell_SelectStartupMod(result->startup.engine_version);
     }
-    if (!explicit_engine_version && result->mod != nullptr) {
-        result->engine_version = result->mod->engine_version;
+    if (!explicit_engine_version && result->startup.mod != nullptr) {
+        result->startup.engine_version = result->startup.mod->engine_version;
     }
     if (wants_gold) {
-        const int32_t engine_version = result->engine_version != 0
-            ? result->engine_version
-            : (result->mod != nullptr ? result->mod->engine_version : 0);
+        const int32_t engine_version = result->startup.engine_version != 0
+            ? result->startup.engine_version
+            : (result->startup.mod != nullptr
+                   ? result->startup.mod->engine_version
+                   : 0);
         const SHELL_MOD *const gold_mod =
             Shell_GetModByType(MOD_EXPANSION_PACK, engine_version);
         if (gold_mod != nullptr) {
-            result->mod = gold_mod;
-            result->engine_version = gold_mod->engine_version;
+            result->startup.mod = gold_mod;
+            result->startup.engine_version = gold_mod->engine_version;
         }
     }
 

--- a/src/trx/game/shell/args.h
+++ b/src/trx/game/shell/args.h
@@ -4,15 +4,19 @@
 #include <trx/game/shell/mod.h>
 
 typedef struct {
-    // Owned argv snapshot used as backing storage for pointer-valued fields
-    // (e.g. level/replay/test paths). Freed by Shell_FreeArgs.
-    VECTOR *original_args;
-
     int32_t engine_version;
     const SHELL_MOD *mod;
     int32_t level_to_select;
     const char *level_to_play;
     int32_t save_to_load;
+} STARTUP_SETTINGS;
+
+typedef struct {
+    // Owned argv snapshot used as backing storage for pointer-valued fields
+    // (e.g. level/replay/test paths). Freed by Shell_FreeArgs.
+    VECTOR *original_args;
+
+    STARTUP_SETTINGS startup;
     const char *test_record_path;
     const char *test_replay_path;
     bool headless;

--- a/src/trx/game/shell/flow.c
+++ b/src/trx/game/shell/flow.c
@@ -237,7 +237,7 @@ static void M_PrepareSystem(void)
     if (test_replay_path != nullptr) {
         // Allow inferring engine version from outer args for replays lacking
         // embedded info (created with the old directory layout).
-        g_TRVersion = s->args->engine_version;
+        g_TRVersion = s->args->startup.engine_version;
         SHELL_ARGS *const tmp_args = TestReplay_Open(test_replay_path);
         if (tmp_args != nullptr) {
             tmp_args->headless = s->args->headless;
@@ -249,14 +249,18 @@ static void M_PrepareSystem(void)
         Shell_ExitSystem("--headless can only be used with --test-replay");
     }
 
-    g_TRVersion = s->args->engine_version;
+    g_TRVersion = s->args->startup.engine_version;
     LOG_INFO("Engine version: %d", g_TRVersion);
-    LOG_INFO("Mod: %s", s->args->mod != nullptr ? s->args->mod->name : nullptr);
-    if (s->args->engine_version <= 0 || s->args->mod == nullptr) {
+    LOG_INFO(
+        "Mod: %s",
+        s->args->startup.mod != nullptr ? s->args->startup.mod->name : nullptr);
+    if (s->args->startup.engine_version <= 0
+        || s->args->startup.mod == nullptr) {
         Shell_ExitSystem("No playable mods available.");
     }
-    if (s->args->mod->mod_type != MOD_DIRECT_LEVEL) {
-        ShellState_RememberLastPlayedMod(s->args->mod->name);
+    if (s->args->startup.mod->mod_type != MOD_DIRECT_LEVEL
+        && test_replay_path == nullptr) {
+        ShellState_RememberLastPlayedMod(s->args->startup.mod->name);
     }
 
     Config_ApplyDefaultSettings();
@@ -290,7 +294,8 @@ static void M_PrepareSystem(void)
         if (engine_config_path == nullptr) {
             Shell_ExitSystem("Failed to resolve engine config path");
         }
-        Config_Read(engine_config_path, Shell_GetGameFlowPath(s->args->mod));
+        Config_Read(
+            engine_config_path, Shell_GetGameFlowPath(s->args->startup.mod));
         Memory_FreePointer(&engine_config_path);
 
         if (s->args->test_record_path != nullptr) {
@@ -337,7 +342,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
 
     M_InitModules();
     M_PrepareSystem();
-    if (s->args->mod == nullptr) {
+    if (s->args->startup.mod == nullptr) {
         Shell_ExitSystem("No --mod specified.");
         return 1;
     }
@@ -350,7 +355,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
     }
 
     GF_Init();
-    GF_LoadFromFile(Shell_GetGameFlowPath(s->args->mod));
+    GF_LoadFromFile(Shell_GetGameFlowPath(s->args->startup.mod));
 
     GameStringManager_ClearSourceFiles();
     const char *const common_strings_path = Shell_GetCommonStringsPath();
@@ -358,19 +363,22 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
         Shell_ExitSystem("Missing common strings file");
     }
     GameStringManager_AddSourceFile(common_strings_path, false);
-    if (s->args->mod->base_mod != nullptr) {
+    if (s->args->startup.mod->base_mod != nullptr) {
         const char *const base_strings_path =
-            Shell_GetBaseGameStringsPath(s->args->mod);
+            Shell_GetBaseGameStringsPath(s->args->startup.mod);
         if (base_strings_path == nullptr) {
             Shell_ExitSystemFmt(
-                "Missing base mod strings file for '%s'", s->args->mod->name);
+                "Missing base mod strings file for '%s'",
+                s->args->startup.mod->name);
         }
         GameStringManager_AddSourceFile(base_strings_path, false);
     }
-    const char *const mod_strings_path = Shell_GetGameStringsPath(s->args->mod);
+    const char *const mod_strings_path =
+        Shell_GetGameStringsPath(s->args->startup.mod);
     if (mod_strings_path == nullptr) {
         Shell_ExitSystemFmt(
-            "Missing strings file for selected mod '%s'", s->args->mod->name);
+            "Missing strings file for selected mod '%s'",
+            s->args->startup.mod->name);
     }
     GameStringManager_AddSourceFile(mod_strings_path, true);
     GameStringManager_DiscoverLanguages();
@@ -453,7 +461,7 @@ int32_t Shell_Main(const SHELL_ARGS *const args)
             break;
 
         case GF_EXIT_TO_TITLE:
-            if (s->args->level_to_play != nullptr) {
+            if (s->args->startup.level_to_play != nullptr) {
                 gf_cmd = (GF_COMMAND) { .action = GF_EXIT_GAME };
             } else if (g_GameFlow.title_level == nullptr) {
                 Shell_ExitSystem("Missing title level");

--- a/src/trx/game/shell/main.c
+++ b/src/trx/game/shell/main.c
@@ -33,10 +33,11 @@ int main(int argc, char *argv[])
 
     LOG_INFO("Starting %s", g_TRXVersion);
     Shell_ValidateMods();
-    if (args->mod == nullptr || !args->mod->is_valid) {
-        args->mod = Shell_SelectStartupMod(args->engine_version);
-        if (args->mod != nullptr && args->engine_version == 0) {
-            args->engine_version = args->mod->engine_version;
+    if (args->startup.mod == nullptr || !args->startup.mod->is_valid) {
+        args->startup.mod =
+            Shell_SelectStartupMod(args->startup.engine_version);
+        if (args->startup.mod != nullptr && args->startup.engine_version == 0) {
+            args->startup.engine_version = args->startup.mod->engine_version;
         }
     }
 
@@ -58,10 +59,12 @@ int main(int argc, char *argv[])
                 LOG_INFO("Switching mod to: %s", mod->name);
                 SHELL_ARGS *const next_args = Memory_Alloc(sizeof(SHELL_ARGS));
                 *next_args = (SHELL_ARGS) {
-                    .engine_version = mod->engine_version,
-                    .mod = mod,
-                    .level_to_select = -1,
-                    .save_to_load = -1,
+                    .startup = {
+                        .engine_version = mod->engine_version,
+                        .mod = mod,
+                        .level_to_select = -1,
+                        .save_to_load = -1,
+                    },
                     .headless = Shell_GetPrevHeadless(),
                     .quiet = Shell_GetPrevQuiet(),
                 };

--- a/src/trx/game/shell/mod.c
+++ b/src/trx/game/shell/mod.c
@@ -277,10 +277,12 @@ void Shell_ValidateMods(void)
         }
 
         const SHELL_ARGS args = {
-            .engine_version = mod->engine_version,
-            .mod = mod,
-            .level_to_select = -1,
-            .save_to_load = -1,
+            .startup = {
+                .engine_version = mod->engine_version,
+                .mod = mod,
+                .level_to_select = -1,
+                .save_to_load = -1,
+            },
         };
         g_TRVersion = mod->engine_version;
         TRXPath_Init(&args);
@@ -392,11 +394,12 @@ bool Shell_IsCurrentMod(const char *const name)
     }
 
     const SHELL_ARGS *const args = Shell_GetArgs();
-    if (args == nullptr || args->mod == nullptr || args->mod->name == nullptr) {
+    if (args == nullptr || args->startup.mod == nullptr
+        || args->startup.mod->name == nullptr) {
         return false;
     }
 
-    return strcmp(args->mod->name, name) == 0;
+    return strcmp(args->startup.mod->name, name) == 0;
 }
 
 const char *Shell_GetCommonStringsPath(void)

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -511,8 +511,8 @@ static const char *M_GetCurrentModID(void)
     if (m_Context.mod_chain_count > 0) {
         return m_Context.mod_chain[0];
     }
-    if (m_Context.args != nullptr && m_Context.args->mod != nullptr) {
-        return m_Context.args->mod->name;
+    if (m_Context.args != nullptr && m_Context.args->startup.mod != nullptr) {
+        return m_Context.args->startup.mod->name;
     }
     return nullptr;
 }
@@ -536,16 +536,17 @@ static const char *M_GetBaseModID(void)
     if (m_Context.mod_chain_count > 1) {
         return m_Context.mod_chain[1];
     }
-    if (m_Context.args != nullptr && m_Context.args->mod != nullptr) {
-        return m_Context.args->mod->base_mod;
+    if (m_Context.args != nullptr && m_Context.args->startup.mod != nullptr) {
+        return m_Context.args->startup.mod->base_mod;
     }
     return nullptr;
 }
 
 static const char *M_GetDirectLevelArg(void)
 {
-    return m_Context.args != nullptr && m_Context.args->level_to_play != nullptr
-        ? m_Context.args->level_to_play
+    return m_Context.args != nullptr
+            && m_Context.args->startup.level_to_play != nullptr
+        ? m_Context.args->startup.level_to_play
         : "";
 }
 
@@ -721,11 +722,11 @@ char *TRXPath_ExpandVars(const char *const in)
 static void M_BuildModChain(const SHELL_ARGS *const args)
 {
     m_Context.mod_chain_count = 0;
-    if (args == nullptr || args->mod == nullptr) {
+    if (args == nullptr || args->startup.mod == nullptr) {
         return;
     }
 
-    const SHELL_MOD *mod = args->mod;
+    const SHELL_MOD *mod = args->startup.mod;
     while (mod != nullptr && m_Context.mod_chain_count < M_MAX_MOD_CHAIN) {
         for (int32_t i = 0; i < m_Context.mod_chain_count; i++) {
             if (strcmp(m_Context.mod_chain[i], mod->name) == 0) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes two bugs with recording replays.

#### Involuntary changing the mod

1. Run `TRX --mod tr3-la`, quit
2. Run `TRX --test-record test.txt --mod tr3`, quit
3. Run `TRX`: it should play `tr3-la`, not `tr3`

#### Replaying the wrong mod

1. Run `TRX --mod tr3`, quit
2. Run `TRX --test-record test.txt -e 3`, quit
3. Run `TRX --mod tr3-la`, quit
4. Run `TRX --test-replay test.txt`, it should play TR3, not TR3:LA