### PR TITLE
lara/col/jump: fix ladder shift

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@
 - added support for Lara's breath to show in cold rooms (requires `O_SPARKS_GFX`)
 - fixed TR2:GM missing opening Eidos Interactive / Core Design FMV (#5609)
 - fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
+- fixed Lara shifting too far down in 60fps after grabbing a ladder (regression from TR2X 0.10)
 
 **TR3**:
 - added the ability to define the flame interval of `O_FLAME_EMITTER_SIDE` objects
@@ -90,6 +91,7 @@
 - fixed Lara becoming immune to Puna's attacks after getting zapped once with the fly cheat (regression from 1.3)
 - fixed Lara snapping to keyholes, puzzle slots and switches instead of waiting to be at a complete stand-still first (regression from 1.1)
 - fixed wasps that spawn from emitters having incorrect shading, especially noticeable when they are killed (regression from 1.6)
+- fixed Lara shifting too far down in 60fps after grabbing a ladder (regression from 1.1)
 
 
 

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -240,7 +240,10 @@ static bool M_TestHangJumpUp(ITEM *const item, COLL_INFO *const coll)
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
     } else {
-        item->pos.y = edge - bounds->min.y + (g_TRVersion >= 3 ? 4 : 0);
+        item->pos.y = edge - bounds->min.y;
+        // XXX: prevent interpolation in 60fps shifting Lara below the edge
+        // catch position then making her drift back up to it.
+        item->interp.prev.pos.y = item->pos.y - item->fall_speed;
     }
     item->pos.x += coll->shift.x;
     item->pos.z += coll->shift.z;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara shifting too far down in 60fps after grabbing a ladder using either action alone or jump then action.