### PR TITLE
items/manager: disable creatures on kill all

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - fixed Lara's underwater hue being retained when re-entering a RIB and the responsive mesh tint is disabled
 - fixed a crash with old custom levels that have sectors pointing to invalid floor data (#5568)
 - fixed `O_SCION_ITEM_3` items exploding at inconsistent times if multiple are used in the same level
+- fixed `O_KILL_ALL_TRIGGERED` not fully disabling enemies, allowing Lara to continue targeting them (OG bug)
 - fixed the enemy health bar disappearing later than Lara's own bar when holstering weapons (regression from Tomb1Main 0.2)
 - fixed crystal totals being shown incorrectly after loading a save (#5589, regression from 1.5)
 - fixed a very rare crash when loading saves from console during a pause or photo mode

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -10,6 +10,7 @@
 #include <trx/game/objects.h>
 #include <trx/game/objects/general/shoal.h>
 #include <trx/game/output/const.h>
+#include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sparks.h>
 #include <trx/version.h>
@@ -355,6 +356,12 @@ void Item_KillAllActive(void)
 
             if (Object_IsType(item->object_id, g_ShoalObjects)) {
                 Shoal_TriggerDeactivate(item);
+            } else {
+                const OBJECT *const obj = Object_Get(item->object_id);
+                if (obj->intelligent) {
+                    LOT_DisableBaddieAI(item_num);
+                    item->hit_points = 0;
+                }
             }
         }
         item_num = next_item_num;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the kill all triggered handling to fully disable enemy AI slots and set their hitpoints to 0. This prevents Lara being able to target invisible enemies and fixes potential issues when also using `O_COMBAT_END`.
