### PR TITLE
demo: enforce normal pickups

### DIFF
--- a/src/trx/game/demo.c
+++ b/src/trx/game/demo.c
@@ -18,6 +18,7 @@
 
 #define L_MODIFY_CONFIG()                                                      \
     X_PROCESS_CONFIG(gameplay.disable_healing_between_levels, false);          \
+    X_PROCESS_CONFIG(gameplay.enable_fast_pickups, false);                     \
     X_PROCESS_CONFIG(gameplay.enable_target_change, false);                    \
     X_PROCESS_CONFIG(gameplay.enable_tr2_jumping, g_TRVersion >= 2);           \
     X_PROCESS_CONFIG(gameplay.enable_tr2_swim_cancel, g_TRVersion >= 2);       \


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This enforces the normal pickup animation in demo mode. aredfan found having fast pickups on doesn't cause a de-sync, but it looks a bit odd as Lara stands idle for a bit too long.
