### PR TITLE
objects/draw: use base bounds for lighting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - fixed TR2:GM missing opening Eidos Interactive / Core Design FMV (#5609)
 - fixed Lara wading in shallower water compared to OG (#5574, regression from 1.3)
 - fixed Lara shifting too far down in 60fps after grabbing a ladder (regression from TR2X 0.10)
+- fixed the lighting on the submarine at the start of 40 Fathoms not flickering as it falls (regression from 1.2)
 
 **TR3**:
 - added the ability to define the flame interval of `O_FLAME_EMITTER_SIDE` objects

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -187,7 +187,7 @@ bool Object_DrawAnimatingItemWithSwap(
         return false;
     }
 
-    Output_CalculateObjectLighting(item, bounds);
+    Output_CalculateObjectLighting(item, &frames[0]->bounds);
 
     const int16_t *extra_rotation = item->extra_rotations;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves the lighting on the submarine at the start of 40 Fathoms not flickering as it falls.
