### PR TITLE
lara/cheat: dispose expired flare on resurrection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.8...develop) - ××××-××-××
 - added config presets to allow restoring Lara's original moveset with respect to each game
+- fixed a potential crash when resurrecting Lara with the fly cheat with an expired flare in her hand (regression from 1.1)
 
 ## [1.8](https://github.com/LostArtefacts/TRX/compare/trx-1.7.1...trx-1.8) - 2026-06-13
 Showcase: https://youtu.be/dwb3eT2zRHU

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -306,6 +306,11 @@ bool Lara_Cheat_EnterFlyMode(void)
     if (lara_info->extra_anim || lara_item->hit_points < 0) {
         M_ResetGunStatus();
         M_ClearHandWeaponMeshes();
+        if (Lara_Flare_HasExpired()) {
+            Lara_Flare_Dispose(false);
+            lara_info->gun_type = LGT_UNARMED;
+            lara_info->request_gun_type = LGT_UNARMED;
+        }
     } else if (Gun_IsRifleType(lara_info->gun_type)) {
         while (lara_info->gun_item_num != NO_ITEM) {
             Gun_Rifle_Undraw(lara_info->gun_type);

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -459,6 +459,13 @@ finish:
     }
 }
 
+bool Lara_Flare_HasExpired(void)
+{
+    const LARA_INFO *const lara = Lara_GetLaraInfo();
+    return lara->gun_type == LGT_FLARE
+        && (lara->flare.age <= 0 || lara->flare.age >= Flare_GetMaxAge());
+}
+
 bool Lara_Flare_IsMeshActive(void)
 {
     const LARA_SKIN_EQUIPMENT *const equipment =

--- a/src/trx/game/lara/flare.h
+++ b/src/trx/game/lara/flare.h
@@ -1,5 +1,6 @@
 #pragma once
 
+bool Lara_Flare_HasExpired(void);
 bool Lara_Flare_IsMeshActive(void);
 void Lara_Flare_DrawMeshes(void);
 

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -69,8 +69,7 @@ static bool M_CanCrouchRoll(const ITEM *const item, const LARA_INFO *const lara)
         return false;
     }
 
-    if (lara->gun_type == LGT_FLARE
-        && (lara->flare.age <= 0 || lara->flare.age >= Flare_GetMaxAge())) {
+    if (Lara_Flare_HasExpired()) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara does not have a stale flare if she is resurrected with the fly cheat, which was leading to potential crashes in hand position lookups, with arm/frame details having been interrupted on death.
