### PR TITLE
game_flow/sequencer_misc: ignore invalid FMV references

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added config presets to allow restoring Lara's original moveset with respect to each game
 - improved texture injections for OG levels to avoid overwriting texture pages in files that don't match the injection source (#5669)
 - fixed a potential crash when resurrecting Lara with the fly cheat with an expired flare in her hand (regression from 1.1)
+- fixed a crash in the New Game dialog if the gameflow has a reference to an FMV which itself is not defined in the gameflow (regression from 1.0)
 
 **TR1**:
 - fixed Lara taking exposure damage in certain rooms with injected skybox/wind properties (#5664, regression from 1.8)

--- a/src/trx/game/game_flow/sequencer_misc.c
+++ b/src/trx/game/game_flow/sequencer_misc.c
@@ -241,6 +241,9 @@ bool GF_HasAvailableStory(const SAVEGAME_SLOT_REF slot)
             }
             if (ev->type == GFS_PLAY_FMV) {
                 const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
+                if (fmv_id < 0 || fmv_id >= g_GameFlow.fmv_count) {
+                    continue;
+                }
                 const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
                 if (!fmv->is_legal && !fmv->is_credit) {
                     return true;
@@ -269,6 +272,9 @@ bool GF_HasAvailableStory(const SAVEGAME_SLOT_REF slot)
             }
             if (ev->type == GFS_PLAY_FMV) {
                 const int32_t fmv_id = (int32_t)(intptr_t)ev->data;
+                if (fmv_id < 0 || fmv_id >= g_GameFlow.fmv_count) {
+                    continue;
+                }
                 const GF_FMV *const fmv = &g_GameFlow.fmvs[fmv_id];
                 if (!fmv->is_legal && !fmv->is_credit) {
                     return true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a crash in the New Game dialog if the game flow has references to invalid FMV indices.