### PR TITLE
config: sort records by time

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed a potential crash when resurrecting Lara with the fly cheat with an expired flare in her hand (regression from 1.1)
 - fixed a crash in the New Game dialog if the gameflow has a reference to an FMV which itself is not defined in the gameflow (regression from 1.0)
 - fixed menu functions (show info, value adjustment, cutscene seek) being affected by gameplay control rebinds (#5666)
+- fixed Assault Course and Quad Bike best times sometimes appearing in the wrong order in the stats screen
 
 **TR1**:
 - fixed Lara taking exposure damage in certain rooms with injected skybox/wind properties (#5664, regression from 1.8)

--- a/src/trx/config/file.c
+++ b/src/trx/config/file.c
@@ -7,6 +7,7 @@
 #include <trx/core/log.h>
 #include <trx/core/memory.h>
 #include <trx/core/strings.h>
+#include <trx/core/utils.h>
 #include <trx/core/vector.h>
 #include <trx/debug.h>
 #include <trx/game/console/history.h>
@@ -27,6 +28,41 @@ static bool M_ProcessOptionValue(
 static bool M_SetOptionValue(const CONFIG_OPTION *option, const void *value);
 static bool M_PushOptionOverride(
     const CONFIG_OPTION *option, const void *value);
+
+static void M_NormalizeGymTrackStats(GYM_TRACK_STATS *const stats)
+{
+    GYM_TRACK_ENTRY sorted_entries[MAX_ASSAULT_TIMES] = {};
+    int32_t count = 0;
+    uint32_t max_attempt_num = 0;
+
+    for (int32_t i = 0; i < MAX_ASSAULT_TIMES; i++) {
+        const GYM_TRACK_ENTRY entry = stats->entries[i];
+        if (entry.time == 0) {
+            continue;
+        }
+
+        if (entry.attempt_num > max_attempt_num) {
+            max_attempt_num = entry.attempt_num;
+        }
+
+        int32_t insert_idx = count;
+        while (insert_idx > 0
+               && sorted_entries[insert_idx - 1].time > entry.time) {
+            sorted_entries[insert_idx] = sorted_entries[insert_idx - 1];
+            insert_idx--;
+        }
+        sorted_entries[insert_idx] = entry;
+        count++;
+    }
+
+    for (int32_t i = 0; i < MAX_ASSAULT_TIMES; i++) {
+        stats->entries[i] = sorted_entries[i];
+    }
+
+    if (stats->total_attempts < max_attempt_num) {
+        stats->total_attempts = max_attempt_num;
+    }
+}
 
 static bool M_ReadFromJSON(
     const char *const default_path, const char *const enforced_path,
@@ -358,6 +394,7 @@ bool ConfigFile_LoadGymTrackStats(
     }
     stats->total_attempts =
         JSON_ObjectGetInt(stats_obj, "total_attempts", stats->total_attempts);
+    M_NormalizeGymTrackStats(stats);
     return true;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that historical unsorted track records always get sorted by best time when launching the game.