### PR TITLE
lara/flare: fix death handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added footprints to savegames
 - added `O_GENERIC_TRAP_1…10` for custom levels, with properties to set damage, blood intensity and collision details; animations are fully offloaded to data
 - fixed Lara getting stuck in the flare throwing animation if she is killed in this state
+- fixed ghost flare lighting/effects spawning if Lara is killed while drawing or undrawing a flare
 
 ## [1.8.1](https://github.com/LostArtefacts/TRX/compare/trx-1.8...trx-1.8.1) - 2026-06-15
 - added config presets to allow restoring Lara's original moveset with respect to each game

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.8.1...develop) - ××××-××-××
 - added footprints to savegames
 - added `O_GENERIC_TRAP_1…10` for custom levels, with properties to set damage, blood intensity and collision details; animations are fully offloaded to data
+- fixed Lara getting stuck in the flare throwing animation if she is killed in this state
 
 ## [1.8.1](https://github.com/LostArtefacts/TRX/compare/trx-1.8...trx-1.8.1) - 2026-06-15
 - added config presets to allow restoring Lara's original moveset with respect to each game

--- a/src/trx/game/lara/flare.c
+++ b/src/trx/game/lara/flare.c
@@ -13,6 +13,8 @@
 #include <trx/game/sparks.h>
 #include <trx/version.h>
 
+#define M_NO_AGE (-1)
+
 typedef enum {
     // clang-format off
     LA_FLARES_HOLD   = 0,
@@ -259,6 +261,13 @@ static void M_UndrawMeshes(void)
 void Lara_Flare_Control(void)
 {
     LARA_INFO *const lara_info = Lara_GetLaraInfo();
+    const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item->hit_points <= 0 && lara_info->flare.age == M_NO_AGE) {
+        lara_info->flare.control = false;
+        lara_info->gun_status = LGS_ARMLESS;
+        return;
+    }
+
     if (lara_info->gun_status == LGS_ARMLESS) {
         M_ControlArmless();
     } else if (lara_info->gun_status == LGS_HANDS_BUSY) {
@@ -282,6 +291,10 @@ void Lara_Flare_Draw(void)
 
     int32_t frame_num = lara_info->left_arm.frame_num + 1;
     lara_info->flare.control = true;
+
+    if (frame_num < LF_FL_IGNITE) {
+        lara_info->flare.age = M_NO_AGE;
+    }
 
     if (frame_num < LF_FL_DRAW || frame_num > LF_FL_2_HOLD - 1) {
         frame_num = LF_FL_DRAW;
@@ -362,6 +375,7 @@ void Lara_Flare_Undraw(void)
         frame_num_1++;
         if (frame_num_1 == LF_FL_THROW_RELEASE) {
             Lara_Flare_Dispose(true);
+            lara_info->flare.age = M_NO_AGE;
         } else if (frame_num_1 == LF_FL_DRAW) {
             frame_num_1 = 0;
             lara_info->gun_type = lara_info->last_gun_type;

--- a/src/trx/game/lara/state/land.c
+++ b/src/trx/game/lara/state/land.c
@@ -320,6 +320,10 @@ static void M_Stop(ITEM *const item, COLL_INFO *const coll)
     lara->sprinting = false;
 
     if (item->hit_points <= 0) {
+        if (Item_TestAnimEqual(item, LA(LA_FLARE_THROW))) {
+            Item_SwitchToAnim(item, LA(LA_STAND_DEATH), 0);
+            item->current_anim_state = LS(LS_DEATH);
+        }
         item->goal_anim_state = LS(LS_DEATH);
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a few issues when Lara is killed during particular flare states:
- [x] if killed in the flare throwing animation, that animation would loop indefinitely
- [x] if killed in the flare throwing animation and the flare is already thrown, lighting and spark effects would re-spawn in her hand
- [x] if killed in the flare drawing animation and the flare is not yet lit, lighting and spark effects would re-spawn in her hand