### PR TITLE
objects/switch: improve enemy switch handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added `O_GENERIC_TRAP_1…10` for custom levels, with properties to set damage, blood intensity and collision details; animations are fully offloaded to data
 - added support for custom levels to use plinth/pedestal pickups by defining the `pickup_mode` property of collectable items; refer to object documentation (#5007)
 - added animation details to the UI debug overlay for Lara's arms, visible when `enable_debug_anim` is on
+- improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
 - fixed Lara getting stuck in the flare throwing animation if she is killed in this state
 - fixed ghost flare lighting/effects spawning if Lara is killed while drawing or undrawing a flare
 - fixed a crash if loading a save that was made on the final frame of Lara's flare control transition animation (#5683)

--- a/src/trx/game/objects/general/switch.c
+++ b/src/trx/game/objects/general/switch.c
@@ -379,6 +379,21 @@ bool Switch_Trigger(const int16_t item_num, const int16_t timer)
         return true;
     }
 
+    if (Object_Get(item->object_id)->intelligent) {
+        // Custom levels often use switch triggers under enemies for events on
+        // death; the following addition is a safer approach for such, rather
+        // than altering item status and timer as though they were regular
+        // switch objects.
+        if (item->status != IS_DEACTIVATED && (item->flags & IF_KILLED) == 0) {
+            return false;
+        }
+        if ((item->flags & IF_ONE_SHOT_SWITCH) != 0) {
+            return false;
+        }
+        item->flags |= IF_ONE_SHOT_SWITCH;
+        return true;
+    }
+
     if (item->status != IS_DEACTIVATED) {
         return false;
     }

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -441,14 +441,16 @@ bool Room_TestSectorTrigger(const ITEM *const item, const SECTOR *const sector)
             const bool switch_result =
                 Switch_Trigger(trigger->item_index, trigger->timer);
             ITEM *const switch_item = Item_Get(trigger->item_index);
-            if (g_TRVersion >= 3 && trigger->one_shot) {
+            const bool intelligent =
+                Object_Get(switch_item->object_id)->intelligent;
+            if (!intelligent && g_TRVersion >= 3 && trigger->one_shot) {
                 switch_item->flags |= IF_ONE_SHOT_SWITCH;
             }
             if (!switch_result) {
                 return false;
             }
-            status.switch_off =
-                switch_item->current_anim_state == SWITCH_STATE_OFF;
+            status.switch_off = !intelligent
+                && switch_item->current_anim_state == SWITCH_STATE_OFF;
             break;
         }
 


### PR DESCRIPTION
Resolves #5682.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This improves handling of dead enemies used as switch triggers by ensuring the item's status is not altered and by adding detection for when the enemy is killed with explosives. This is quite a common trick in custom levels, but it doesn't work in OG with explosives; Tony would work in OG TR3 because of blindly setting then later checking one-shot in the switch trigger, so this approach is much safer all round.

Additional test level available for TR2. It'd be good to double check #5328 again as it touches similar code (looks OK to me).