### PR TITLE
objects/tribe_boss: calculate lizard spawn distance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed Lara getting stuck in the flare throwing animation if she is killed in this state
 - fixed ghost flare lighting/effects spawning if Lara is killed while drawing or undrawing a flare
 - fixed a crash if loading a save that was made on the final frame of Lara's flare control transition animation (#5683)
+- removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 ## [1.8.1](https://github.com/LostArtefacts/TRX/compare/trx-1.8...trx-1.8.1) - 2026-06-15
 - added config presets to allow restoring Lara's original moveset with respect to each game

--- a/src/trx/game/objects/creatures/tribe_boss.c
+++ b/src/trx/game/objects/creatures/tribe_boss.c
@@ -335,9 +335,9 @@ static bool M_TriggerLizard(M_PRIV *const p)
     item->creature_data = nullptr;
     item->mesh_bits = -1;
     item->hit_points = item->max_hit_points;
-    item->active = 0;
+    item->active = false;
     item->status = IS_ACTIVE;
-    item->collidable = 1;
+    item->collidable = true;
     item->flags &= ~(IF_KILLED | IF_ONE_SHOT);
     item->include_in_kill_stats = false;
 
@@ -1099,12 +1099,19 @@ static void M_Initialise(const int16_t item_num)
         p->lizard_room_num = Item_Get(p->lizard_item_num)->room_num;
     }
 
+    XZ_32 delta = { .x = 3, .z = 5 };
+    if (p->lizard_item_num != NO_ITEM) {
+        const ITEM *const lizard = Item_Get(p->lizard_item_num);
+        delta.x = ABS(item->pos.x - lizard->pos.x) / WALL_L;
+        delta.z = ABS(item->pos.z - lizard->pos.z) / WALL_L;
+    }
+
     for (int32_t i = 0; i < 2; i++) {
         const int32_t sign = i == 0 ? -1 : 1;
-        int32_t y_rot = item->rot.y + DEG_180; // after turning
+        const int32_t y_rot = item->rot.y + DEG_180; // after turning
         XYZ_32 pos = item->pos;
-        pos = XYZ_32_OffsetYaw(pos, y_rot, WALL_L * 3);
-        pos = XYZ_32_OffsetYaw(pos, y_rot + DEG_270 * sign, WALL_L * 5);
+        pos = XYZ_32_OffsetYaw(pos, y_rot, WALL_L * delta.x);
+        pos = XYZ_32_OffsetYaw(pos, y_rot + DEG_270 * sign, WALL_L * delta.z);
 
         int16_t room_num = item->room_num;
         const SECTOR *const sector = Room_GetSector(pos, &room_num);


### PR DESCRIPTION
Resolves #5686.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the spawn positions for Puna's lizards by calculating the difference on initialise rather than using XZ (3, 5). The latter matches the OG room layout.