### PR TITLE
lara/mesh: provide left holster fallback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added support for custom levels to use plinth/pedestal pickups by defining the `pickup_mode` property of collectable items; refer to object documentation (#5007)
 - added animation details to the UI debug overlay for Lara's arms, visible when `enable_debug_anim` is on
 - improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
+- fixed Lara having an empty left holster if the option to remember guns between levels is used and she finished with the Desert Eagle (#5697)
 - fixed Lara getting stuck in the flare throwing animation if she is killed in this state
 - fixed ghost flare lighting/effects spawning if Lara is killed while drawing or undrawing a flare
 - fixed a crash if loading a save that was made on the final frame of Lara's flare control transition animation (#5683)

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -56,6 +56,21 @@ static LARA_GUN_TYPE M_DetermineBackGun(void)
     return LGT_UNARMED;
 }
 
+static void M_EnsureDefaultDualPistolMesh(const LARA_GUN_TYPE holster_gun)
+{
+    if (g_Weapons[holster_gun].type != WEAPON_TYPE_SINGLE_PISTOL) {
+        return;
+    }
+
+    for (LARA_GUN_TYPE gun = 0; gun < NUM_WEAPONS; gun++) {
+        if (g_Weapons[gun].type == WEAPON_TYPE_DUAL_PISTOLS
+            && Inv_RequestItem(Gun_GetGunObject(gun)) > 0) {
+            Lara_Skin_SetGunEquipment(LM_THIGH_L, gun);
+            break;
+        }
+    }
+}
+
 static void M_InitialiseCutsceneLevel(void)
 {
     Lara_Skin_SetGunEquipment(LM_THIGH_L, LGT_PISTOLS);
@@ -70,6 +85,7 @@ static void M_InitialiseNormalLevel(const GF_LEVEL *const level)
     if (holster_gun != LGT_UNARMED && holster_gun != LGT_FLARE) {
         Gun_SetLaraHolsterLMesh(holster_gun);
         Gun_SetLaraHolsterRMesh(holster_gun);
+        M_EnsureDefaultDualPistolMesh(holster_gun);
     }
 
     const LARA_GUN_TYPE back_gun = M_DetermineBackGun();


### PR DESCRIPTION
Resolves #5697.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures Lara's left holster is swapped to a suitable mesh if she finished the previous level with the Desert Eagle and the option to remember guns between levels is enabled. The first dual pistol type that she has in her inventory is used.