### PR TITLE
lara/crouch: reset toggle on climb or jump

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed missing SFX when Lara transitions from hanging to crouching (#5070)
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
+- fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -311,6 +311,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
                 item->rot = old_rot;
             } else {
                 item->goal_anim_state = LS(LS_CRAWL_TO_CLIMB);
+                lara->crouching = false;
             }
         }
     } else if (g_Input.left) {

--- a/src/trx/game/lara/state/crouch.c
+++ b/src/trx/game/lara/state/crouch.c
@@ -157,6 +157,7 @@ static void M_CrouchIdle(ITEM *const item, COLL_INFO *const coll)
     } else if (crouch_active && M_CanJumpDown(item, lara)) {
         Lara_AnimateUntil(item, LS(LS_CRAWL_IDLE));
         item->goal_anim_state = LS(LS_CRAWL_JUMP_DOWN);
+        lara->crouching = false;
     }
 }
 
@@ -241,6 +242,7 @@ static void M_CrawlIdle(ITEM *const item, COLL_INFO *const coll)
         item->goal_anim_state = LS(LS_CROUCH_ROLL);
     } else if (M_CanJumpDown(item, lara)) {
         item->goal_anim_state = LS(LS_CRAWL_JUMP_DOWN);
+        lara->crouching = false;
     }
 
     g_Camera.target_elevation = M_CAM_CRAWL_ELEVATION;


### PR DESCRIPTION
Resolves #5703.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures the crouch toggle is reset after landing when either crawling backwards or jumping out of a crawlspace.

Tests:
`/set toggle-crouch 1`
- [x] Crawl backwards off a ledge, Lara should not return to crouch after landing
- [x] In the crawl idle position at a ledge, jump to exit - Lara should not return to crouch after landing
- [x] In the crouch idle position at a ledge, jump to exit - Lara should not return to crouch after landing
