### PR TITLE
stats/scan: include dagger pickup from Bartoli only

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
+- fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/stats/scan.c
+++ b/src/trx/game/stats/scan.c
@@ -137,8 +137,9 @@ static void M_CheckTriggers(
                 if (Object_Get(O_DRAGON_BACK)->loaded
                     && Object_Get(O_DRAGON_FRONT)->loaded) {
                     M_IncludeKillableItem(stats, item_num);
-                    if (Object_Get(O_PUZZLE_OPTION_2)->loaded
-                        || Object_Get(O_PUZZLE_ITEM_2)->loaded) {
+                    if (item->object_id == O_BARTOLI
+                        && (Object_Get(O_PUZZLE_OPTION_2)->loaded
+                            || Object_Get(O_PUZZLE_ITEM_2)->loaded)) {
                         LOG_TRACE("+1 pickup from dragon");
                         stats->max_pickup_count++;
                     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resolves the dagger being included as a pickup if the dragon is setup to be triggered without the Bartoli transformation. The test level from #5014 can be used to verify.