### PR TITLE
objects/lift: add functionality to kill Lara

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed missing SFX when Lara transitions from hanging to crouching (#5070)
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
+- fixed Lara becoming clamped and softlocked if a lift descends on top of her
 - fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
 - fixed Lara moving through the floor of a lift if she performs a neutral twist while it's moving (regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
+- fixed Lara moving through the floor of a lift if she performs a neutral twist while it's moving (regression from TR1X 4.14/TR2X 1.4)
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
 - fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed missing SFX when Lara transitions from hanging to crouching (#5070)
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
+- fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
 - fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -327,6 +327,8 @@ static void M_NeutralJumpRoll(ITEM *const item, COLL_INFO *const coll)
         item->current_anim_state = LS(LS_STOP);
         item->speed = 0;
         item->pos = coll->old_pos;
+    } else if (coll->side_mid.floor <= STEPUP_HEIGHT) {
+        item->pos.y += coll->side_mid.floor;
     }
 }
 

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -320,6 +320,14 @@ static void M_Pickup(ITEM *const item, COLL_INFO *const coll)
     }
 }
 
+static void M_FlarePickup(ITEM *const item, COLL_INFO *const coll)
+{
+    M_Default(item, coll);
+    if (coll->side_mid.floor <= STEPUP_HEIGHT) {
+        item->pos.y += coll->side_mid.floor;
+    }
+}
+
 static void M_PullUp(ITEM *const item, COLL_INFO *const coll)
 {
     M_Default(item, coll);
@@ -953,7 +961,7 @@ REGISTER_LARA_COL(LS_GYMNAST,      M_Default)
 REGISTER_LARA_COL(LS_WATER_OUT,    M_Default)
 REGISTER_LARA_COL(LS_PULL_UP,      M_PullUp)
 REGISTER_LARA_COL(LS_CONTROLLED,   M_Default)
-REGISTER_LARA_COL(LS_FLARE_PICKUP, M_Default)
+REGISTER_LARA_COL(LS_FLARE_PICKUP, M_FlarePickup)
 REGISTER_LARA_COL(LS_WALK,         M_Walk)
 REGISTER_LARA_COL(LS_WALK_BACK,    M_WalkBack)
 REGISTER_LARA_COL(LS_STEP_RIGHT,   M_SideStep)

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -1,3 +1,4 @@
+#include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/core/log.h>
@@ -7,6 +8,8 @@
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/objects/traps/movable_block.h>
+#include <trx/game/random.h>
+#include <trx/game/spawn.h>
 
 // clang-format off
 #define M_WAIT_TIME         (3 * LOGIC_FPS) // = 90
@@ -262,6 +265,64 @@ static void M_Initialise(const int16_t item_num)
     Vector_Free(positions);
 }
 
+static void M_KillLara(ITEM *const lara)
+{
+    if (lara->hit_points <= 0) {
+        return;
+    }
+
+    lara->hit_points = -1;
+    lara->pos.y = lara->floor;
+    lara->speed = 0;
+    lara->fall_speed = 0;
+    lara->gravity = false;
+    lara->rot.x = 0;
+    lara->rot.z = 0;
+    lara->current_anim_state = LS(LS_SPECIAL);
+    lara->goal_anim_state = LS(LS_SPECIAL);
+    Item_SwitchToAnim(lara, LA(LA_BOULDER_DEATH), 0);
+
+    for (int32_t i = 0; i < 15; i++) {
+        const int32_t x = lara->pos.x + (Random_GetControl() - 0x4000) / 256;
+        const int32_t z = lara->pos.z + (Random_GetControl() - 0x4000) / 256;
+        const int32_t y = lara->pos.y - Random_GetControl() / 64;
+        const int32_t d = lara->rot.y + (Random_GetControl() - 0x4000) / 8;
+        Spawn_Blood(x, y, z, M_SHIFT * 2, d, lara->room_num);
+    }
+}
+
+static void M_Collision(
+    const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
+{
+    const ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
+    if (!p->is_moving) {
+        return;
+    }
+
+    if (lara_item->pos.y < item->pos.y + STEP_L) {
+        return;
+    }
+
+    const XZ_32 lift_tile = M_GetTile(item->pos);
+    const XZ_32 lara_tile = M_GetTile(lara_item->pos);
+    const XZ_32 offset = M_GetShaftOffset(item->rot.y);
+    if (!M_IsTileInShaft(lara_tile, lift_tile, offset)) {
+        return;
+    }
+
+    if (!Lara_TestBoundsCollide(item, 0)) {
+        return;
+    }
+
+    if (g_Config.debug.enable_invulnerability) {
+        lara_item->pos.y = item->pos.y;
+        Lara_UpdateRoomToHeight(0);
+    } else {
+        M_KillLara(lara_item);
+    }
+}
+
 static void M_ShiftStackableItems(
     const ITEM *const lift_item, const bool reposition)
 {
@@ -382,6 +443,7 @@ static void M_AddWalkable(const int16_t item_num)
 static void M_Setup(OBJECT *const obj)
 {
     obj->initialise_func = M_Initialise;
+    obj->collision_func = M_Collision;
     obj->control_func = M_Control;
     obj->floor_height_func = M_GetFloorHeight;
     obj->ceiling_height_func = M_GetCeilingHeight;

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -66,67 +66,55 @@ static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
     }
 }
 
+static XZ_32 M_GetTile(const XYZ_32 pos)
+{
+    return (XZ_32) {
+        .x = pos.x >> WALL_SHIFT,
+        .z = pos.z >> WALL_SHIFT,
+    };
+}
+
+static XZ_32 M_GetShaftOffset(const int16_t angle)
+{
+    const DIRECTION direction = Math_GetDirection(angle);
+    switch (direction) {
+        // clang-format off
+    case DIR_NORTH: return (XZ_32) { -1, +1 };
+    case DIR_EAST:  return (XZ_32) { +1, +1 };
+    case DIR_SOUTH: return (XZ_32) { +1, -1 };
+    case DIR_WEST:  return (XZ_32) { -1, -1 };
+    default:        return (XZ_32) { +0, +0 };
+        // clang-format on
+    }
+}
+
+static bool M_IsTileInShaft(
+    const XZ_32 tile, const XZ_32 shaft_tile, const XZ_32 offset)
+{
+    return (tile.x == shaft_tile.x || tile.x + offset.x == shaft_tile.x)
+        && (tile.z == shaft_tile.z || tile.z + offset.z == shaft_tile.z);
+}
+
 static void M_FloorCeiling(
     const ITEM *const item, const XYZ_32 pos, int32_t *const out_floor,
     int32_t *const out_ceiling)
 {
-    const XZ_32 lift_tile = {
-        .x = item->pos.x >> WALL_SHIFT,
-        .z = item->pos.z >> WALL_SHIFT,
-    };
-
     ITEM *const lara_item = Lara_GetItem();
-    const XZ_32 lara_tile = {
-        .x = lara_item->pos.x >> WALL_SHIFT,
-        .z = lara_item->pos.z >> WALL_SHIFT,
-    };
+    const XZ_32 lift_tile = M_GetTile(item->pos);
+    const XZ_32 lara_tile = M_GetTile(lara_item->pos);
+    const XZ_32 test_tile = M_GetTile(pos);
+    const XZ_32 offset = M_GetShaftOffset(item->rot.y);
 
-    const XZ_32 test_tile = {
-        .x = pos.x >> WALL_SHIFT,
-        .z = pos.z >> WALL_SHIFT,
-    };
-
-    const DIRECTION direction = Math_GetDirection(item->rot.y);
-    int32_t dx = 0;
-    int32_t dz = 0;
-    switch (direction) {
-    case DIR_NORTH:
-        dx = -1;
-        dz = 1;
-        break;
-    case DIR_EAST:
-        dx = 1;
-        dz = 1;
-        break;
-    case DIR_SOUTH:
-        dx = 1;
-        dz = -1;
-        break;
-    case DIR_WEST:
-        dx = -1;
-        dz = -1;
-        break;
-    default:
-        break;
-    }
-
-    // clang-format off
-    const bool point_in_shaft =
-        (test_tile.x == lift_tile.x || test_tile.x + dx == lift_tile.x) &&
-        (test_tile.z == lift_tile.z || test_tile.z + dz == lift_tile.z);
-
-    const bool lara_in_shaft =
-        (lara_tile.x == lift_tile.x || lara_tile.x + dx == lift_tile.x) &&
-        (lara_tile.z == lift_tile.z || lara_tile.z + dz == lift_tile.z);
+    const bool point_in_shaft = M_IsTileInShaft(test_tile, lift_tile, offset);
+    const bool lara_in_shaft = M_IsTileInShaft(lara_tile, lift_tile, offset);
 
     const int32_t lift_bottom = item->pos.y + STEP_L;
     const int32_t lift_floor = item->pos.y;
     const int32_t lift_ceiling = item->pos.y - M_HEIGHT + STEP_L;
     const int32_t lift_top = item->pos.y - M_HEIGHT;
 
-    const bool lara_inside_lift = (lara_item->pos.y < lift_bottom) &&
-                                  (lara_item->pos.y > lift_ceiling);
-    // clang-format on
+    const bool lara_inside_lift =
+        (lara_item->pos.y < lift_bottom) && (lara_item->pos.y > lift_ceiling);
 
     *out_floor = 0x7FFF;
     *out_ceiling = -0x7FFF;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds functionality to lifts to kill Lara if they descend directly on top of her. It essentially resolves a softlock in this situation where she would become clamped. This wouldn't impact OG levels as there is space below each lift instance there. Test level available, which includes one facing each direction and a few different gaps below the lift where Lara can stand.

If immunity is on, Lara will instead pop inside the lift. LMK if we want to make the behaviour optional, similar to killer pushblocks.