### PR TITLE
lara/col/land: reset fall speed on spike death

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
 - fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
+- fixed persistent splashing effects if Lara falls onto spikes in one-click high water (regression from 1.0)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -663,6 +663,11 @@ static void M_Death(ITEM *const item, COLL_INFO *const coll)
     item->pos.y += coll->side_mid.floor;
     item->hit_points = -1;
     lara->air = -1;
+
+    if (Item_TestAnimEqual(item, LA(LA_SPIKE_DEATH))
+        && Item_TestFrameEqual(item, 1)) {
+        item->fall_speed = 0;
+    }
 }
 
 static void M_Splat(ITEM *const item, COLL_INFO *const coll)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes intense splash effects if Lara lands on spikes in one-click water. Test level available.