### PR TITLE
rooms: raise height limit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fixed missing hand grab SFX when Lara is climbing a ladder (#4266)
 - fixed missing and mistimed closing SFX on doors type 1 and 2 in Barkhang Monastery (#4417, #4418)
 - fixed missing SFX when jumping into the boat in Bartoli's Hideout (#4434)
+- fixed geometry issues in rooms 60 and 115 in Furnace of the Gods, which could cause the TR3 camera to become stuck and allow Lara to fly into the ceiling
 
 **TR3**:
 - fixed missing portals in Aldwych room 87, which could lead to Lara becoming softlocked
@@ -39,6 +40,7 @@
 - fixed missing knees shuffle SFX when Lara climbs onto a ledge (#5070)
 - fixed missing SFX when Lara is shimmying (#4996)
 - fixed missing SFX in the Pipeman's death animation (#5036)
+- fixed geometry issues in room 53 in Madubu Gorge, which could cause the TR3 camera to become stuck and allow Lara to fly into the ceiling
 
 
 

--- a/src/trx/game/collision/common.c
+++ b/src/trx/game/collision/common.c
@@ -82,7 +82,7 @@ static void M_FillSide(
             && (!retest_front
                 || (side->floor < coll->side_mid.floor
                     && height < side->floor))) {
-            side->floor = -32767;
+            side->floor = UNDEFINED_HEIGHT;
         } else if (
             coll->slopes_are_pits
             && (side->type == HT_BIG_SLOPE || side->type == HT_DIAGONAL)

--- a/src/trx/game/lara/cheat.c
+++ b/src/trx/game/lara/cheat.c
@@ -373,7 +373,7 @@ bool Lara_Cheat_ExitFlyMode(void)
     }
 
     const ROOM *const room = Room_Get(lara_item->room_num);
-    const int16_t water_height =
+    const int32_t water_height =
         Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
 
     if (room->flags.underwater
@@ -444,7 +444,7 @@ bool Lara_Cheat_Teleport(XYZ_32 pos, int16_t room_num)
     if (lara_info->extra_anim) {
         const ROOM *const room = Room_Get(lara_item->room_num);
         const bool room_submerged = room->flags.underwater;
-        const int16_t water_height =
+        const int32_t water_height =
             Room_GetWaterHeight(lara_item->pos, lara_item->room_num);
 
         if (room_submerged || (water_height != NO_HEIGHT && water_height > 0)) {

--- a/src/trx/game/lara/const.h
+++ b/src/trx/game/lara/const.h
@@ -30,8 +30,8 @@
 #define LARA_DEFLECT_ANGLE (5 * DEG_1) // = 910
 #define LARA_HANG_ANGLE (35 * DEG_1) // = 6370
 
-#define NO_BAD_POS (-NO_HEIGHT) // = 32512
-#define NO_BAD_NEG (NO_HEIGHT) // = -32512
+#define NO_BAD_POS (-NO_HEIGHT) // = 3251200
+#define NO_BAD_NEG (NO_HEIGHT) // = -3251200
 #define STEPUP_HEIGHT ((STEP_L * 3) / 2) // = 384
 #define SLOPE_DIF 60
 

--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -18,6 +18,7 @@
 
 #define M_NO_ROOM_LEGACY 255
 #define M_NO_BOX_TR3_LEGACY 0x7FF
+#define M_NO_HEIGHT_LEGACY (-32512)
 
 static void M_ReadPosition(XYZ_32 *const pos, VFILE *const file)
 {
@@ -304,6 +305,13 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, VFILE *const file)
             }
             if (sector->portal_room.sky == M_NO_ROOM_LEGACY) {
                 sector->portal_room.sky = NO_ROOM;
+            }
+            if (sector->ceiling.height == M_NO_HEIGHT_LEGACY
+                && sector->floor.height == M_NO_HEIGHT_LEGACY) {
+                sector->ceiling.height = NO_HEIGHT;
+            }
+            if (sector->floor.height == M_NO_HEIGHT_LEGACY) {
+                sector->floor.height = NO_HEIGHT;
             }
         }
 

--- a/src/trx/game/objects/creatures/pierre.c
+++ b/src/trx/game/objects/creatures/pierre.c
@@ -249,7 +249,7 @@ static void M_Control(const int16_t item_num)
         }
     }
 
-    int16_t wh = Room_GetWaterHeight(item->pos, item->room_num);
+    const int32_t wh = Room_GetWaterHeight(item->pos, item->room_num);
     if (wh != NO_HEIGHT) {
         item->hit_points = 0;
         LOT_DisableBaddieAI(item_num);

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -119,8 +119,8 @@ static void M_FloorCeiling(
     const bool lara_inside_lift =
         (lara_item->pos.y < lift_bottom) && (lara_item->pos.y > lift_ceiling);
 
-    *out_floor = 0x7FFF;
-    *out_ceiling = -0x7FFF;
+    *out_floor = -UNDEFINED_HEIGHT;
+    *out_ceiling = UNDEFINED_HEIGHT;
 
     if (lara_in_shaft) {
         if (item->current_anim_state == M_STATE_DOOR_CLOSED
@@ -130,7 +130,7 @@ static void M_FloorCeiling(
                 *out_ceiling = lift_ceiling;
             } else {
                 *out_floor = NO_HEIGHT;
-                *out_ceiling = 0x7FFF;
+                *out_ceiling = -UNDEFINED_HEIGHT;
             }
         } else if (point_in_shaft) {
             if (lara_item->pos.y < lift_ceiling) {
@@ -152,7 +152,7 @@ static void M_FloorCeiling(
             *out_ceiling = lift_ceiling;
         } else {
             *out_floor = NO_HEIGHT;
-            *out_ceiling = 0x7FFF;
+            *out_ceiling = -UNDEFINED_HEIGHT;
         }
     }
 }

--- a/src/trx/game/objects/vehicles/kayak.c
+++ b/src/trx/game/objects/vehicles/kayak.c
@@ -171,7 +171,7 @@ static int32_t M_GetInKayak(const int16_t item_num, const COLL_INFO *const coll)
     int16_t room_num = item->room_num;
     const SECTOR *const floor = Room_GetSector(item->pos, &room_num);
     const int32_t h = Room_GetHeight(floor, item->pos);
-    if (h <= -32000) {
+    if (h <= -MAX_HEIGHT) {
         return 0;
     }
 

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -256,7 +256,7 @@ static int32_t M_GetOnQuadBike(
     SECTOR *const sector = Room_GetSector(item->pos, &room_num);
 
     const int32_t h = Room_GetHeight(sector, item->pos);
-    if (h < -32000) {
+    if (h < -MAX_HEIGHT) {
         return 0;
     }
 

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -206,7 +206,7 @@ int32_t Skidoo_CheckGetOn(const int16_t item_num, COLL_INFO *const coll)
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     const int32_t height = Room_GetHeight(sector, item->pos);
-    if (height < -32000) {
+    if (height < -MAX_HEIGHT) {
         return M_GET_ON_NONE;
     }
 

--- a/src/trx/game/objects/vehicles/upv.c
+++ b/src/trx/game/objects/vehicles/upv.c
@@ -144,7 +144,7 @@ static bool M_CanGetOn(const ITEM *const item)
     int16_t room_num = item->room_num;
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     const int32_t h = Room_GetHeight(sector, item->pos);
-    if (h < -32000) {
+    if (h < -MAX_HEIGHT) {
         return false;
     }
 

--- a/src/trx/game/rooms/const.h
+++ b/src/trx/game/rooms/const.h
@@ -6,6 +6,6 @@
 #define NO_ROOM (-1)
 
 #define MAX_SLOPE 2
-#define NO_HEIGHT (-32512)
-#define UNDEFINED_HEIGHT (NO_HEIGHT - (STEP_L - 1)) // = -32767
-#define MAX_HEIGHT 32000
+#define NO_HEIGHT (-3251200)
+#define UNDEFINED_HEIGHT (NO_HEIGHT - (STEP_L - 1)) // = -3251455
+#define MAX_HEIGHT 3200000

--- a/src/trx/game/rooms/const.h
+++ b/src/trx/game/rooms/const.h
@@ -7,4 +7,5 @@
 
 #define MAX_SLOPE 2
 #define NO_HEIGHT (-32512)
+#define UNDEFINED_HEIGHT (NO_HEIGHT - (STEP_L - 1)) // = -32767
 #define MAX_HEIGHT 32000

--- a/src/trx/game/rooms/floor_data.c
+++ b/src/trx/game/rooms/floor_data.c
@@ -159,6 +159,16 @@ static bool M_TestLava(const ITEM *const item)
     return sector->is_death_sector;
 }
 
+static int32_t M_DecodeSplit(int32_t height)
+{
+    // Triangles can be 15 clicks high at most; bit 0x10 is used to wrap to
+    // negative via manual sign extension. OG used 0xFFF0 for 16-bit.
+    if ((height & 0x10) != 0) {
+        height |= 0xFFFFFFF0;
+    }
+    return height << 8;
+}
+
 void Room_ParseFloorData(
     const int16_t *floor_data, const int32_t floor_data_size)
 {
@@ -309,16 +319,10 @@ void Room_ReadTriangulation(
     }
 
     surface->is_split = true;
-    surface->split.h1 = (func_data & 0x03E0) >> 5;
-    surface->split.h2 = (func_data & 0x7C00) >> 10;
-    if ((surface->split.h1 & 0x10) != 0) {
-        surface->split.h1 |= 0xFFF0;
-    }
-    if ((surface->split.h2 & 0x10) != 0) {
-        surface->split.h2 |= 0xFFF0;
-    }
-    surface->split.h1 <<= 8;
-    surface->split.h2 <<= 8;
+    const int32_t split_1 = (func_data & 0x03E0) >> 5;
+    const int32_t split_2 = (func_data & 0x7C00) >> 10;
+    surface->split.h1 = M_DecodeSplit(split_1);
+    surface->split.h2 = M_DecodeSplit(split_2);
 
     for (int32_t i = 0; i < 4; i++) {
         surface->split.tilts[i] = (tilt_data >> (i * 4)) & 0xF;

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -113,17 +113,17 @@ static inline XZ_16 M_GetSplitTilt(
     return tilt;
 }
 
-static int16_t M_GetSplitSurfaceHeight(
+static int32_t M_GetSplitSurfaceHeight(
     const SURFACE surface, const int32_t x, const int32_t z)
 {
     const bool is_ceiling = surface.type == SURFACE_CEILING;
     if (Camera_IsChunky()) {
-        const int16_t ch1 = surface.height + surface.split.h2;
-        const int16_t ch2 = surface.height + surface.split.h1;
+        const int32_t ch1 = surface.height + surface.split.h2;
+        const int32_t ch2 = surface.height + surface.split.h1;
         return is_ceiling ? MAX(ch1, ch2) : MIN(ch1, ch2);
     }
 
-    int16_t height = surface.height;
+    int32_t height = surface.height;
     if (!is_ceiling) {
         m_HeightType = HT_SPLIT_TRI;
     }

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -12,7 +12,7 @@
 #define M_NEG_TILT(T, H) ((T * (H & M_WALL_MASK)) >> 2)
 #define M_POS_TILT(T, H) ((T * ((M_WALL_MASK - H) & M_WALL_MASK)) >> 2)
 
-static int16_t m_AbyssMinHeight = 0;
+static int32_t m_AbyssMinHeight = 0;
 static int32_t m_AbyssMaxHeight = 0;
 static HEIGHT_TYPE m_HeightType = HT_WALL;
 
@@ -350,7 +350,7 @@ SECTOR *Room_GetSkySector(
     return (SECTOR *)sector;
 }
 
-void Room_SetAbyssHeight(const int16_t height)
+void Room_SetAbyssHeight(const int32_t height)
 {
     // Once Lara reaches the min abyss height, she will be killed; she will
     // continue to fall however, so the max height is needed until the inventory

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -11,7 +11,7 @@ SECTOR *Room_GetUnitSector(
 SECTOR *Room_GetPitSector(const SECTOR *sector, int32_t x, int32_t z);
 SECTOR *Room_GetSkySector(const SECTOR *sector, int32_t x, int32_t z);
 
-void Room_SetAbyssHeight(int16_t height);
+void Room_SetAbyssHeight(int32_t height);
 bool Room_IsAbyssHeight(int32_t height);
 
 HEIGHT_TYPE Room_GetHeightType(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This raises the height limit (geometry only) a hundred fold. It resolves issues in some OG levels where ceilings are set to use the legacy no height value. Room meshes continue to be constrained by `int16_t` used in vertices.

I've scanned every level (TR1-5, for sanity) and the two OG cases below are the only ones that use ceilings at `-127` clicks, outside of regular walls.

I initially attempted going to `INT32_MAX/MIN` but this broke a lot of glitch behaviour. A couple of parts of the code also used `-32767` rather than `NO_HEIGHT` - I've retained that idiom, just shifted it in line with the rest. This impacts lifts and Lara's collision when stopping at slopes.

I checked some of our e2e tests and they seem good (although there appears to be a savegame bug in one where it loads the wrong file; it's present on develop - will investigate that separately, but I checked the affected tests to be sure all was OK). So overall, this just needs some general testing:

- [x] the two original level issues (recordings available)
  - [x] Furnace of the Gods end area
  - [x] Madubu Gorge
- [x] bumping into walls
- [x] Lara continues to stop at slopes e.g. running towards one that's too high to stand on
- [x] checking triangle collision
- [x] checking water depths
- [x] lifts - effective walls when the doors are shut
- [x] checking abyss heights in Floating Islands/London
- [x] recording also available for the glitch checks