### PR TITLE
lara/col/land: align to floor on wall hit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fixed Lara becoming clamped and softlocked if a lift descends on top of her
 - fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
 - fixed Lara moving through the floor of a lift if she performs a neutral twist while it's moving (regression from TR1X 4.14/TR2X 1.4)
+- fixed Lara not travelling at the same rate as a moving lift if she hits wall while inside or on top of it (regression from TR1X 4.12/TR2X 1.2)
 - fixed Lara persisting to crouch after landing when either crawling backwards or jumping out of a crawlspace and the crouch toggle option is enabled (#5703, regression from 1.3)
 - fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
 - fixed persistent splashing effects if Lara falls onto spikes in one-click high water (regression from 1.0)

--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -682,8 +682,7 @@ static void M_Splat(ITEM *const item, COLL_INFO *const coll)
 {
     M_Default(item, coll);
     Lara_Col_Shift(coll);
-    if (!g_Config.gameplay.fix_step_glitch && coll->side_mid.floor > -STEP_L
-        && coll->side_mid.floor < STEP_L) {
+    if (coll->side_mid.floor > -STEP_L && coll->side_mid.floor < STEP_L) {
         item->pos.y += coll->side_mid.floor;
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes a regression in ea314a8 which linked the step glitch fix to not aligning Lara with the floor when she has hit a wall. It resolves Lara not travelling with a moving lift in this scenario. The step bug is fixed elsewhere in the run and stop routines.