### PR TITLE
level/format_tr3: register TR3X loader

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - fixed geometry issues in rooms 60 and 115 in Furnace of the Gods, which could cause the TR3 camera to become stuck and allow Lara to fly into the ceiling
 
 **TR3**:
+- added support for embedded injections in level files
 - fixed missing portals in Aldwych room 87, which could lead to Lara becoming softlocked
 - fixed the ticket booth SFX playing in Aldwych when Lara treads in shallow water
 - fixed the underwater swimming SFX playing when Lara turns to the right in shallow water

--- a/docs/gameflow.schema.json
+++ b/docs/gameflow.schema.json
@@ -232,7 +232,7 @@
         },
         "water_particles": {
           "type": "boolean",
-          "description": "TR3 only. Enables PSX-style underwater water particles in this level."
+          "description": "Enables PSX-style underwater water particles in this level."
         },
         "death_tile": {
           "type": "string",

--- a/docs/trx/game_flow/levels/REGULAR_LEVELS.md
+++ b/docs/trx/game_flow/levels/REGULAR_LEVELS.md
@@ -145,8 +145,8 @@ Following are each of the properties available within a level.
     <td><code>water_particles</code></td>
     <td>Boolean</td>
     <td colspan="2">
-      TR3 only. Enables PSX-style underwater water particles for this level.
-      These follow the weather effects toggle.
+      Enables PSX-style underwater water particles for this level. These follow
+      the weather effects toggle. Requires `O_SPARKS_GFX`.
     </td>
   </tr>
   <tr valign="top">

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -147,6 +147,13 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     return true;
 }
 
+static const LEVEL_FORMAT_LOADER m_LevelLoaderTR3X = {
+    .game_version = 3,
+    .layout = LEVEL_FORMAT_LAYOUT_TR3X,
+    .probe = M_Probe,
+    .load = M_Load,
+};
+
 static const LEVEL_FORMAT_LOADER m_LevelLoaderTR3 = {
     .game_version = 3,
     .layout = LEVEL_FORMAT_LAYOUT_TR3,
@@ -154,4 +161,5 @@ static const LEVEL_FORMAT_LOADER m_LevelLoaderTR3 = {
     .probe = M_Probe,
 };
 
-REGISTER_LEVEL_FORMAT_LOADER(300, m_LevelLoaderTR3)
+REGISTER_LEVEL_FORMAT_LOADER(300, m_LevelLoaderTR3X)
+REGISTER_LEVEL_FORMAT_LOADER(310, m_LevelLoaderTR3)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This registers the TR3X level loader to allow for TE to embed injections. Test level available.

I've also updated the docs regarding water particles as this is no longer limited to TR3 only.
