### PR TITLE
lara/state/climb: reset torso rotation when hanging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed inconsistent tread SFX when Lara turns to the right in shallow water as compared with turning left
 - fixed a missing footstep sound when Lara finishes a handstand and when she climbs onto a ledge from a ladder (#5070)
 - fixed missing SFX when Lara transitions from hanging to crouching (#5070)
+- fixed Lara's torso remaining rotated if she grabs a ledge while looking
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara becoming clamped and softlocked if a lift descends on top of her

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -25,6 +25,10 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->torso_rot.x = 0;
+    lara->torso_rot.y = 0;
+
     if (g_Config.gameplay.look_mode != LOOK_MODE_RESTRICTED && g_Input.look) {
         Lara_Look_UpDown();
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara's torso being rotated when she grabs a ledge while looking. She'll continue to look, but it naturally becomes clamped to the range allowed when hanging.
