### PR TITLE
lara/common: undraw guns in start cinematics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed a missing footstep sound when Lara finishes a handstand and when she climbs onto a ledge from a ladder (#5070)
 - fixed missing SFX when Lara transitions from hanging to crouching (#5070)
 - fixed Lara's torso remaining rotated if she grabs a ledge while looking
+- fixed Lara having guns in her hands in custom levels that begin with a cinematic scene if she finished the previous level with guns equipped
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara becoming clamped and softlocked if a lift descends on top of her

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -288,7 +288,8 @@ void Lara_InitialiseInventory(const GF_LEVEL *const level)
         lara_info->back_gun_type = resume->back_gun_type;
     }
 
-    if (!g_Config.gameplay.remember_gun_status) {
+    if (!g_Config.gameplay.remember_gun_status
+        || m_StartAnimState != LS_EXTRA_BREATH) {
         lara_info->gun_status = LGS_ARMLESS;
         lara_info->gun_type = lara_info->last_gun_type;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This avoids Lara having guns in her hands during cinematic starting scenes if she finished the last level with them equipped.

Test steps for TR2:
- comment out the cutscene in Opera House
- comment out weapon removal in Offshore Rig
- finish Opera with guns out
- check Lara's hands in Rig