### PR TITLE
objects/thors_hammer: adopt walkable setup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fixed Lara having guns in her hands in custom levels that begin with a cinematic scene if she finished the previous level with guns equipped
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
+- fixed Lara being killed by Thor's Hammer in custom levels even when the hammer does not touch her head
 - fixed Lara becoming clamped and softlocked if a lift descends on top of her
 - fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
 - fixed Lara moving through the floor of a lift if she performs a neutral twist while it's moving (regression from TR1X 4.14/TR2X 1.4)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed Lara's shadow appearing at the top of a pushblock after having pulled it until she returns to a standstill (#1576)
 - fixed Lara being killed by pushblocks if she pulls one onto a trapdoor that is set to be triggered by that pushblock
 - fixed Lara being killed by Thor's Hammer in custom levels even when the hammer does not touch her head
+- fixed an invisible block appearing below Thor's Hammer in custom levels when it is not used at floor level
 - fixed Lara becoming clamped and softlocked if a lift descends on top of her
 - fixed Lara moving through the floor of a lift if she picks up a flare while it's moving
 - fixed Lara moving through the floor of a lift if she performs a neutral twist while it's moving (regression from TR1X 4.14/TR2X 1.4)

--- a/src/trx/game/objects/traps/thors_hammer.c
+++ b/src/trx/game/objects/traps/thors_hammer.c
@@ -35,6 +35,36 @@ static void M_InitialiseHandle(const int16_t item_num)
     p->head_item_num = head_item_num;
 }
 
+static bool M_ShouldKillLara(const ITEM *const item)
+{
+    const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item->hit_points < 0 || g_Config.debug.enable_invulnerability) {
+        return false;
+    }
+
+    const XYZ_32 pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, M_HEAD_DIST);
+    if (lara_item->pos.x <= pos.x - M_DEATH_RADIUS
+        || lara_item->pos.x >= pos.x + M_DEATH_RADIUS
+        || lara_item->pos.z <= pos.z - M_DEATH_RADIUS
+        || lara_item->pos.z >= pos.z + M_DEATH_RADIUS) {
+        return false;
+    }
+
+    return true;
+}
+
+static void M_KillLara(const ITEM *const item)
+{
+    ITEM *const lara_item = Lara_GetItem();
+    lara_item->hit_points = -1;
+    lara_item->pos.y = item->floor;
+    lara_item->gravity = false;
+    lara_item->enable_shadow = false;
+    lara_item->current_anim_state = LS(LS_SPECIAL);
+    lara_item->goal_anim_state = LS(LS_SPECIAL);
+    Item_SwitchToAnim(lara_item, LA(LA_BOULDER_DEATH), 0);
+}
+
 static void M_ControlHandle(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -60,72 +90,21 @@ static void M_ControlHandle(const int16_t item_num)
 
     case M_STATE_ACTIVE: {
         const int32_t frame_num = Item_GetRelativeFrame(item);
-        if (frame_num > 30) {
-            int32_t x = item->pos.x;
-            int32_t z = item->pos.z;
-
-            switch (item->rot.y) {
-            case 0:
-                z += M_HEAD_DIST;
-                break;
-            case DEG_90:
-                x += M_HEAD_DIST;
-                break;
-            case -DEG_90:
-                x -= M_HEAD_DIST;
-                break;
-            case -DEG_180:
-                z -= M_HEAD_DIST;
-                break;
-            }
-
-            if (lara_item->hit_points >= 0
-                && !g_Config.debug.enable_invulnerability
-                && lara_item->pos.x > x - M_DEATH_RADIUS
-                && lara_item->pos.x < x + M_DEATH_RADIUS
-                && lara_item->pos.z > z - M_DEATH_RADIUS
-                && lara_item->pos.z < z + M_DEATH_RADIUS) {
-                lara_item->hit_points = -1;
-                lara_item->pos.y = item->pos.y;
-                lara_item->gravity = false;
-                lara_item->current_anim_state = LS(LS_SPECIAL);
-                lara_item->goal_anim_state = LS(LS_SPECIAL);
-                Item_SwitchToAnim(lara_item, LA(LA_BOULDER_DEATH), 0);
-            }
+        if (frame_num > 30 && M_ShouldKillLara(item)) {
+            M_KillLara(item);
         }
         break;
     }
 
     case M_STATE_DONE: {
-        int32_t x = item->pos.x;
-        int32_t z = item->pos.z;
-        int32_t old_x = x;
-        int32_t old_z = z;
-
         Room_TestTriggers(item);
 
-        switch (item->rot.y) {
-        case 0:
-            z += M_HEAD_DIST;
-            break;
-        case DEG_90:
-            x += M_HEAD_DIST;
-            break;
-        case -DEG_90:
-            x -= M_HEAD_DIST;
-            break;
-        case -DEG_180:
-            z -= M_HEAD_DIST;
-            break;
-        }
-
-        item->pos.x = x;
-        item->pos.z = z;
+        const XYZ_32 old_pos = item->pos;
+        item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, M_HEAD_DIST);
         if (lara_item->hit_points >= 0) {
             Room_AlterFloorHeight(item, -M_HEAD_HEIGHT);
         }
-        item->pos.x = old_x;
-        item->pos.z = old_z;
+        item->pos = old_pos;
 
         Item_RemoveActive(item_num);
         item->status = IS_DEACTIVATED;

--- a/src/trx/game/objects/traps/thors_hammer.c
+++ b/src/trx/game/objects/traps/thors_hammer.c
@@ -2,6 +2,7 @@
 #include <trx/debug.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
+#include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 
 #define M_HEAD_DIST (WALL_L * 3) // = 3072
@@ -33,6 +34,7 @@ static void M_InitialiseHandle(const int16_t item_num)
     head_item->shade.value_1 = hand_item->shade.value_1;
     Item_Initialise(head_item_num);
     p->head_item_num = head_item_num;
+    Walkable_AllocateNodes(hand_item, 1);
 }
 
 static bool M_ShouldKillLara(const ITEM *const item)
@@ -65,6 +67,20 @@ static void M_KillLara(const ITEM *const item)
     lara_item->current_anim_state = LS(LS_SPECIAL);
     lara_item->goal_anim_state = LS(LS_SPECIAL);
     Item_SwitchToAnim(lara_item, LA(LA_BOULDER_DEATH), 0);
+}
+
+static void M_UpdateBox(const ITEM *const item, const bool blocked)
+{
+    int16_t room_num = item->room_num;
+    const XYZ_32 head_pos =
+        XYZ_32_OffsetYaw(item->pos, item->rot.y, M_HEAD_DIST);
+    const SECTOR *const sector = Room_GetSector(head_pos, &room_num);
+    if (sector->floor.height == item->pos.y && sector->box != NO_BOX) {
+        BOX_INFO *const box = Box_GetBox(sector->box);
+        if (box != nullptr && (box->overlap_index & BOX_BLOCKABLE) != 0) {
+            TOGGLE_BIT(box->overlap_index, BOX_BLOCKED, blocked);
+        }
+    }
 }
 
 static void M_ControlHandle(const int16_t item_num)
@@ -100,14 +116,7 @@ static void M_ControlHandle(const int16_t item_num)
 
     case M_STATE_DONE: {
         Room_TestTriggers(item);
-
-        const XYZ_32 old_pos = item->pos;
-        item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y, M_HEAD_DIST);
-        if (lara_item->hit_points >= 0) {
-            Room_AlterFloorHeight(item, -M_HEAD_HEIGHT);
-        }
-        item->pos = old_pos;
-
+        M_UpdateBox(item, true);
         Item_RemoveActive(item_num);
         item->status = IS_DEACTIVATED;
         break;
@@ -148,12 +157,59 @@ static void M_CollisionHead(
     }
 }
 
+static void M_AddWalkable(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    const XYZ_32 head_pos =
+        XYZ_32_OffsetYaw(item->pos, item->rot.y, M_HEAD_DIST);
+    Walkable_Add(item_num, head_pos);
+}
+
+static int32_t M_GetFloorHeight(
+    const ITEM *const item, const XYZ_32 pos, const int32_t height)
+{
+    if (item->current_anim_state != M_STATE_DONE) {
+        return height;
+    }
+
+    if (Lara_GetItem()->hit_points <= 0) {
+        return height;
+    }
+
+    if (pos.y > item->pos.y) {
+        return height;
+    }
+
+    return MIN(item->pos.y - M_HEAD_HEIGHT, height);
+}
+
+static int32_t M_GetCeilingHeight(
+    const ITEM *const item, const XYZ_32 pos, const int32_t height)
+{
+    if (item->current_anim_state != M_STATE_DONE) {
+        return height;
+    }
+
+    if (Lara_GetItem()->hit_points <= 0) {
+        return height;
+    }
+
+    if (pos.y <= item->pos.y || item->pos.y <= height) {
+        return height;
+    }
+
+    return item->pos.y + STEP_L;
+}
+
 static void M_SetupHandle(OBJECT *const obj)
 {
     obj->initialise_func = M_InitialiseHandle;
     obj->control_func = M_ControlHandle;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = M_CollisionHandle;
+    obj->add_walkable_func = M_AddWalkable;
+    obj->floor_height_func = M_GetFloorHeight;
+    obj->ceiling_height_func = M_GetCeilingHeight;
     obj->priv_size = sizeof(M_PRIV);
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/traps/thors_hammer.c
+++ b/src/trx/game/objects/traps/thors_hammer.c
@@ -50,7 +50,9 @@ static bool M_ShouldKillLara(const ITEM *const item)
         return false;
     }
 
-    return true;
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(lara_item);
+    const int32_t lara_height = ABS(bounds->max.y - bounds->min.y);
+    return lara_item->pos.y - lara_height <= item->pos.y;
 }
 
 static void M_KillLara(const ITEM *const item)

--- a/src/trx/game/objects/traps/thors_hammer.c
+++ b/src/trx/game/objects/traps/thors_hammer.c
@@ -4,12 +4,16 @@
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 
+#define M_HEAD_DIST (WALL_L * 3) // = 3072
+#define M_HEAD_HEIGHT (WALL_L * 2) // = 2048
+#define M_DEATH_RADIUS (WALL_L / 2 + 8) // = 520
+
 typedef enum {
-    THOR_HAMMER_STATE_SET = 0,
-    THOR_HAMMER_STATE_TEASE = 1,
-    THOR_HAMMER_STATE_ACTIVE = 2,
-    THOR_HAMMER_STATE_DONE = 3,
-} THOR_HAMMER_STATE;
+    M_STATE_SET,
+    M_STATE_TEASE,
+    M_STATE_ACTIVE,
+    M_STATE_DONE,
+} M_STATE;
 
 typedef struct {
     int16_t head_item_num;
@@ -37,24 +41,24 @@ static void M_ControlHandle(const int16_t item_num)
     ITEM *const lara_item = Lara_GetItem();
 
     switch (item->current_anim_state) {
-    case THOR_HAMMER_STATE_SET:
+    case M_STATE_SET:
         if (Item_IsTriggerActive(item)) {
-            item->goal_anim_state = THOR_HAMMER_STATE_TEASE;
+            item->goal_anim_state = M_STATE_TEASE;
         } else {
             Item_RemoveActive(item_num);
             item->status = IS_INACTIVE;
         }
         break;
 
-    case THOR_HAMMER_STATE_TEASE:
+    case M_STATE_TEASE:
         if (Item_IsTriggerActive(item)) {
-            item->goal_anim_state = THOR_HAMMER_STATE_ACTIVE;
+            item->goal_anim_state = M_STATE_ACTIVE;
         } else {
-            item->goal_anim_state = THOR_HAMMER_STATE_SET;
+            item->goal_anim_state = M_STATE_SET;
         }
         break;
 
-    case THOR_HAMMER_STATE_ACTIVE: {
+    case M_STATE_ACTIVE: {
         const int32_t frame_num = Item_GetRelativeFrame(item);
         if (frame_num > 30) {
             int32_t x = item->pos.x;
@@ -62,23 +66,25 @@ static void M_ControlHandle(const int16_t item_num)
 
             switch (item->rot.y) {
             case 0:
-                z += WALL_L * 3;
+                z += M_HEAD_DIST;
                 break;
             case DEG_90:
-                x += WALL_L * 3;
+                x += M_HEAD_DIST;
                 break;
             case -DEG_90:
-                x -= WALL_L * 3;
+                x -= M_HEAD_DIST;
                 break;
             case -DEG_180:
-                z -= WALL_L * 3;
+                z -= M_HEAD_DIST;
                 break;
             }
 
             if (lara_item->hit_points >= 0
                 && !g_Config.debug.enable_invulnerability
-                && lara_item->pos.x > x - 520 && lara_item->pos.x < x + 520
-                && lara_item->pos.z > z - 520 && lara_item->pos.z < z + 520) {
+                && lara_item->pos.x > x - M_DEATH_RADIUS
+                && lara_item->pos.x < x + M_DEATH_RADIUS
+                && lara_item->pos.z > z - M_DEATH_RADIUS
+                && lara_item->pos.z < z + M_DEATH_RADIUS) {
                 lara_item->hit_points = -1;
                 lara_item->pos.y = item->pos.y;
                 lara_item->gravity = false;
@@ -90,7 +96,7 @@ static void M_ControlHandle(const int16_t item_num)
         break;
     }
 
-    case THOR_HAMMER_STATE_DONE: {
+    case M_STATE_DONE: {
         int32_t x = item->pos.x;
         int32_t z = item->pos.z;
         int32_t old_x = x;
@@ -100,23 +106,23 @@ static void M_ControlHandle(const int16_t item_num)
 
         switch (item->rot.y) {
         case 0:
-            z += WALL_L * 3;
+            z += M_HEAD_DIST;
             break;
         case DEG_90:
-            x += WALL_L * 3;
+            x += M_HEAD_DIST;
             break;
         case -DEG_90:
-            x -= WALL_L * 3;
+            x -= M_HEAD_DIST;
             break;
         case -DEG_180:
-            z -= WALL_L * 3;
+            z -= M_HEAD_DIST;
             break;
         }
 
         item->pos.x = x;
         item->pos.z = z;
         if (lara_item->hit_points >= 0) {
-            Room_AlterFloorHeight(item, -WALL_L * 2);
+            Room_AlterFloorHeight(item, -M_HEAD_HEIGHT);
         }
         item->pos.x = old_x;
         item->pos.z = old_z;
@@ -156,7 +162,7 @@ static void M_CollisionHead(
         return;
     }
     if (coll->enable_baddie_push
-        && item->current_anim_state != THOR_HAMMER_STATE_ACTIVE) {
+        && item->current_anim_state != M_STATE_ACTIVE) {
         Lara_Col_ItemPush(item, coll, false, true);
     }
 }

--- a/src/trx/game/rooms/geometry.c
+++ b/src/trx/game/rooms/geometry.c
@@ -5,7 +5,6 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/objects.h>
-#include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
 
 #define M_WALL_MASK (WALL_L - 1)
@@ -538,57 +537,6 @@ int32_t Room_GetWaterHeightEx(
             sector = Room_GetWorldSector(room, x, z);
         }
         return NO_HEIGHT;
-    }
-}
-
-void Room_AlterFloorHeight(const ITEM *const item, const int32_t height)
-{
-    if (height == 0) {
-        return;
-    }
-
-    int16_t portal_room;
-    SECTOR *sector;
-    const ROOM *room = Room_Get(item->room_num);
-
-    do {
-        int32_t z_sector = (item->pos.z - room->pos.z) >> WALL_SHIFT;
-        int32_t x_sector = (item->pos.x - room->pos.x) >> WALL_SHIFT;
-
-        if (z_sector <= 0) {
-            z_sector = 0;
-            CLAMP(x_sector, 1, room->size.x - 2);
-        } else if (z_sector >= room->size.z - 1) {
-            z_sector = room->size.z - 1;
-            CLAMP(x_sector, 1, room->size.x - 2);
-        } else {
-            CLAMP(x_sector, 0, room->size.x - 1);
-        }
-
-        sector = Room_GetUnitSector(room, x_sector, z_sector);
-        portal_room = sector->portal_room.wall;
-        if (portal_room != NO_ROOM) {
-            room = Room_Get(portal_room);
-        }
-    } while (portal_room != NO_ROOM);
-
-    const SECTOR *const sky_sector =
-        Room_GetSkySector(sector, item->pos.x, item->pos.z);
-    sector = Room_GetPitSector(sector, item->pos.x, item->pos.z);
-
-    if (sector->floor.height != NO_HEIGHT) {
-        sector->floor.height += ROUND_TO_CLICK(height);
-        if (sector->floor.height == sky_sector->ceiling.height) {
-            sector->floor.height = NO_HEIGHT;
-        }
-    } else {
-        sector->floor.height =
-            sky_sector->ceiling.height + ROUND_TO_CLICK(height);
-    }
-
-    BOX_INFO *const box = Box_GetBox(sector->box);
-    if (box != nullptr && (box->overlap_index & BOX_BLOCKABLE) != 0) {
-        TOGGLE_BIT(box->overlap_index, BOX_BLOCKED, height < 0);
     }
 }
 

--- a/src/trx/game/rooms/geometry.h
+++ b/src/trx/game/rooms/geometry.h
@@ -27,7 +27,6 @@ int32_t Room_GetFloorHeightForSector(
 
 int32_t Room_GetWaterHeight(XYZ_32 pos, int16_t room_num);
 int32_t Room_GetWaterHeightEx(XYZ_32 pos, int16_t room_num, bool fix_tilts);
-void Room_AlterFloorHeight(const ITEM *item, int32_t height);
 
 int32_t Room_FindGridShift(int32_t src, int32_t dst);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes problems with Thor's Hammer when it's not used at floor level, namely that Lara could be killed when standing below one that doesn't touch her, and an invisible block appearing at floor level. The hammer head now behaves as a walkable, although standing on it is not possible given the object's collision. So it remains in line with OG in that respect.

I've had to retain the check for Lara's HP in whether or not to recognise the height, as otherwise the camera gets thrown to the top when Lara is killed. Using the same approach as killer pushblocks gave different results compared to OG, so this is maybe something we can come back to with the floor/height context refactor that's planned.

Tests:
- [x] check Lara is killed normally in Folly when the hammer lands on her
- [x] check Lara can dodge the hammer normally in Folly
- [x] check the collision once the hammer has fallen (e.g. camera should not creep inside the mesh)
- [x] additional test level available with hammers at different heights