### PR TITLE
gun/control: avoid resetting locked cameras

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed an extra pickup being included in the total statistics if a dragon is used in custom levels independently of Bartoli (regression from 1.3)
 - fixed persistent splashing effects if Lara falls onto spikes in one-click high water (regression from 1.0)
 - fixed game mode options not displaying after having beaten the game, if the option itself is switched off (regression from 1.0)
+- fixed Lara being able to break out of locked cameras activated by heavy triggers by equipping her weapons (regression from 1.1)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/gun/control.c
+++ b/src/trx/game/gun/control.c
@@ -300,6 +300,14 @@ static void M_UpdateGunState(void)
     }
 }
 
+static void M_RequestCombatCamera(void)
+{
+    if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK
+        && !Camera_IsLocked(g_Camera.num)) {
+        g_Camera.type = CAM_COMBAT;
+    }
+}
+
 void Gun_Control(void)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -340,9 +348,7 @@ void Gun_Control(void)
         case LGT_AUTOS:
         case LGT_DESERT_EAGLE:
         case LGT_UZIS:
-            if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
-                g_Camera.type = CAM_COMBAT;
-            }
+            M_RequestCombatCamera();
             Gun_Pistols_Draw(lara->gun_type);
             break;
 
@@ -352,9 +358,7 @@ void Gun_Control(void)
         case LGT_GRENADE:
         case LGT_ROCKET:
         case LGT_HARPOON:
-            if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
-                g_Camera.type = CAM_COMBAT;
-            }
+            M_RequestCombatCamera();
             Gun_Rifle_Draw(lara->gun_type);
             break;
 
@@ -401,10 +405,7 @@ void Gun_Control(void)
     case LGS_READY:
         const bool is_firing = lara->pistol_ammo.ammo != 0 && g_Input.action;
         Lara_Skin_SetCombatFace(is_firing);
-
-        if (g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_LOOK) {
-            g_Camera.type = CAM_COMBAT;
-        }
+        M_RequestCombatCamera();
 
         if (g_Input.action) {
             AMMO_INFO *const ammo = Gun_GetAmmoInfo(lara->gun_type);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This ensures that drawing guns when a heavy locked camera is active will not override the camera mode. Test level available.
