### PR TITLE
objects/misc: replace hard-coded flip map slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@
   - `wait_time`, which defines how long to wait after activation before beginning to move
   - `travel_distance`, which defines how many clicks the lift will travel vertically
   - `speed`, which defines how many world units the lift will travel per frame
+- added properties to the `O_BIG_BOWL` object:
+  - `pour_time`, which defines how long to pour liquid from the bowl
 - changed `Game mode selection` to allow hiding the dialog even after having completed the game (Gameplay → General → Game mode selection)
 - improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
 - fixed Lara having an empty left holster if the option to remember guns between levels is used and she finished with the Desert Eagle (#5697)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added properties to the `O_BIG_BOWL` object:
   - `pour_time`, which defines how long to pour liquid from the bowl
   - `flip_slot`, which defines the flip map slot index to alter once liquid has finished pouring
+- added a `flip_slot` property to the `O_PORTACABIN` object to define the flip map slot index to alter once the cabin has landed
 - changed `Game mode selection` to allow hiding the dialog even after having completed the game (Gameplay → General → Game mode selection)
 - improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
 - fixed Lara having an empty left holster if the option to remember guns between levels is used and she finished with the Desert Eagle (#5697)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `speed`, which defines how many world units the lift will travel per frame
 - added properties to the `O_BIG_BOWL` object:
   - `pour_time`, which defines how long to pour liquid from the bowl
+  - `flip_slot`, which defines the flip map slot index to alter once liquid has finished pouring
 - changed `Game mode selection` to allow hiding the dialog even after having completed the game (Gameplay → General → Game mode selection)
 - improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
 - fixed Lara having an empty left holster if the option to remember guns between levels is used and she finished with the Desert Eagle (#5697)

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -1757,6 +1757,7 @@ This page lists documented moveable object properties.
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (71)</th><th align="center">TR3</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>pour_time</code></td><td colspan="3" align="center">7</td><td>The amount of time hot liquid is poured from the bowl, in seconds.</td></tr>
+<tr><td><code>flip_slot</code></td><td colspan="3" align="center">4</td><td>The flip map slot to alter once liquid has finished pouring. -1 = no flipmap is performed.</td></tr>
 </tbody>
 </table>
 

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -1581,6 +1581,14 @@ This page lists documented moveable object properties.
 </tbody>
 </table>
 
+#### O_PORTACABIN
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1 (162)</th><th align="center">TR2</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>flip_slot</code></td><td colspan="3" align="center">3</td><td>The flip map slot to alter once the cabin has landed. -1 = no flipmap is performed.</td></tr>
+</tbody>
+</table>
+
 #### O_FLAREBOX_ITEM
 <table width="100%">
 <thead><tr><th>Property</th><th align="center">TR1 (187)</th><th align="center">TR2 (151)</th><th align="center">TR3 (178)</th><th>Description</th></tr></thead>

--- a/docs/trx/OBJECTS.md
+++ b/docs/trx/OBJECTS.md
@@ -1752,6 +1752,14 @@ This page lists documented moveable object properties.
 </tbody>
 </table>
 
+#### O_BIG_BOWL
+<table width="100%">
+<thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (71)</th><th align="center">TR3</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>pour_time</code></td><td colspan="3" align="center">7</td><td>The amount of time hot liquid is poured from the bowl, in seconds.</td></tr>
+</tbody>
+</table>
+
 #### O_PLAYER_5
 <table width="100%">
 <thead><tr><th>Property</th><th align="center">TR1</th><th align="center">TR2 (127)</th><th align="center">TR3 (152)</th><th>Description</th></tr></thead>

--- a/src/trx/game/objects/general/big_bowl.c
+++ b/src/trx/game/objects/general/big_bowl.c
@@ -18,6 +18,7 @@ typedef enum {
 typedef struct {
     int32_t pour_time;
     int32_t flip_time;
+    int32_t flip_slot;
 } M_PRIV;
 
 static void M_Initialise(const int16_t item_num)
@@ -25,14 +26,20 @@ static void M_Initialise(const int16_t item_num)
     ITEM *const item = Item_Get(item_num);
     M_PRIV *const p = item->priv;
     p->pour_time = M_DEFAULT_POUR_TIME;
+    p->flip_slot = M_DEFAULT_FLIP_SLOT;
 
     OBJECT_PROPERTY_VALUE value = {};
     if (ObjectProperty_GetItemValue(item, "pour_time", &value)
         && value.as_int > 0) {
         p->pour_time = value.as_int;
     }
+    if (ObjectProperty_GetItemValue(item, "flip_slot", &value)
+        && value.as_int < MAX_FLIP_MAPS) {
+        p->flip_slot = value.as_int;
+    }
 
     CLAMPL(p->pour_time, M_MIN_POUR_TIME);
+    CLAMPL(p->flip_slot, -1);
     p->flip_time = p->pour_time - M_FLIP_TIME_OFFSET;
     p->pour_time *= LOGIC_FPS;
     p->flip_time *= LOGIC_FPS;
@@ -55,6 +62,19 @@ static void M_CreateHotLiquid(const ITEM *const bowl_item)
     }
 }
 
+static bool M_ShouldFlipMap(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->flip_slot >= 0 && item->timer == p->flip_time
+        && !Room_GetFlipStatus();
+}
+
+static void M_FlipMap(const M_PRIV *const p)
+{
+    Room_SetFlipSlotFlags(p->flip_slot, IF_CODE_BITS | IF_ONE_SHOT);
+    Room_FlipMap();
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -63,11 +83,8 @@ static void M_Control(const int16_t item_num)
     if (item->current_anim_state == M_STATE_POUR) {
         M_CreateHotLiquid(item);
         item->timer++;
-        if (item->timer == p->flip_time && !Room_GetFlipStatus()) {
-            // TODO: poorly hardcoded flimap number
-            Room_SetFlipSlotFlags(
-                M_DEFAULT_FLIP_SLOT, IF_CODE_BITS | IF_ONE_SHOT);
-            Room_FlipMap();
+        if (M_ShouldFlipMap(item)) {
+            M_FlipMap(p);
         }
     }
 
@@ -90,7 +107,11 @@ static void M_Setup(OBJECT *const obj)
         OBJECT_PROPERTY_INT(
             "pour_time", M_DEFAULT_POUR_TIME,
             "The amount of time hot liquid is poured from the bowl, in "
-            "seconds."));
+            "seconds."),
+        OBJECT_PROPERTY_INT(
+            "flip_slot", M_DEFAULT_FLIP_SLOT,
+            "The flip map slot to alter once liquid has finished pouring. -1 = "
+            "no flipmap is performed."));
 }
 
 REGISTER_OBJECT(O_BIG_BOWL, M_Setup)

--- a/src/trx/game/objects/general/big_bowl.c
+++ b/src/trx/game/objects/general/big_bowl.c
@@ -3,12 +3,16 @@
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 
+// clang-format off
+#define M_POUR_TIME         7
+#define M_FLIP_TIME         (M_POUR_TIME - 2) // = 5
+#define M_DEFAULT_FLIP_SLOT 4
+// clang-format on
+
 typedef enum {
-    // clang-format off
-    BIG_BOWL_STATE_TIP  = 0,
-    BIG_BOWL_STATE_POUR = 1,
-    // clang-format on
-} BIG_BOWL_STATE;
+    M_STATE_TIP,
+    M_STATE_POUR,
+} M_STATE;
 
 static void M_CreateHotLiquid(const ITEM *const bowl_item)
 {
@@ -31,19 +35,21 @@ static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
 
-    if (item->current_anim_state == BIG_BOWL_STATE_POUR) {
+    if (item->current_anim_state == M_STATE_POUR) {
         M_CreateHotLiquid(item);
         item->timer++;
-        if (item->timer == 5 * LOGIC_FPS && !Room_GetFlipStatus()) {
+        if (item->timer == M_FLIP_TIME * LOGIC_FPS && !Room_GetFlipStatus()) {
             // TODO: poorly hardcoded flimap number
-            Room_SetFlipSlotFlags(4, IF_CODE_BITS | IF_ONE_SHOT);
+            Room_SetFlipSlotFlags(
+                M_DEFAULT_FLIP_SLOT, IF_CODE_BITS | IF_ONE_SHOT);
             Room_FlipMap();
         }
     }
 
     Item_Animate(item);
 
-    if (item->status == IS_DEACTIVATED && item->timer >= LOGIC_FPS * 7) {
+    if (item->status == IS_DEACTIVATED
+        && item->timer >= LOGIC_FPS * M_POUR_TIME) {
         Item_RemoveActive(item_num);
     }
 }

--- a/src/trx/game/objects/general/big_bowl.c
+++ b/src/trx/game/objects/general/big_bowl.c
@@ -4,8 +4,9 @@
 #include <trx/game/rooms.h>
 
 // clang-format off
-#define M_POUR_TIME         7
-#define M_FLIP_TIME         (M_POUR_TIME - 2) // = 5
+#define M_DEFAULT_POUR_TIME 7
+#define M_FLIP_TIME_OFFSET  2
+#define M_MIN_POUR_TIME     (M_FLIP_TIME_OFFSET + 1) // = 3
 #define M_DEFAULT_FLIP_SLOT 4
 // clang-format on
 
@@ -13,6 +14,29 @@ typedef enum {
     M_STATE_TIP,
     M_STATE_POUR,
 } M_STATE;
+
+typedef struct {
+    int32_t pour_time;
+    int32_t flip_time;
+} M_PRIV;
+
+static void M_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->pour_time = M_DEFAULT_POUR_TIME;
+
+    OBJECT_PROPERTY_VALUE value = {};
+    if (ObjectProperty_GetItemValue(item, "pour_time", &value)
+        && value.as_int > 0) {
+        p->pour_time = value.as_int;
+    }
+
+    CLAMPL(p->pour_time, M_MIN_POUR_TIME);
+    p->flip_time = p->pour_time - M_FLIP_TIME_OFFSET;
+    p->pour_time *= LOGIC_FPS;
+    p->flip_time *= LOGIC_FPS;
+}
 
 static void M_CreateHotLiquid(const ITEM *const bowl_item)
 {
@@ -34,11 +58,12 @@ static void M_CreateHotLiquid(const ITEM *const bowl_item)
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if (item->current_anim_state == M_STATE_POUR) {
         M_CreateHotLiquid(item);
         item->timer++;
-        if (item->timer == M_FLIP_TIME * LOGIC_FPS && !Room_GetFlipStatus()) {
+        if (item->timer == p->flip_time && !Room_GetFlipStatus()) {
             // TODO: poorly hardcoded flimap number
             Room_SetFlipSlotFlags(
                 M_DEFAULT_FLIP_SLOT, IF_CODE_BITS | IF_ONE_SHOT);
@@ -48,17 +73,24 @@ static void M_Control(const int16_t item_num)
 
     Item_Animate(item);
 
-    if (item->status == IS_DEACTIVATED
-        && item->timer >= LOGIC_FPS * M_POUR_TIME) {
+    if (item->status == IS_DEACTIVATED && item->timer >= p->pour_time) {
         Item_RemoveActive(item_num);
     }
 }
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->save_flags = true;
     obj->save_anim = true;
+    obj->priv_size = sizeof(M_PRIV);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "pour_time", M_DEFAULT_POUR_TIME,
+            "The amount of time hot liquid is poured from the bowl, in "
+            "seconds."));
 }
 
 REGISTER_OBJECT(O_BIG_BOWL, M_Setup)

--- a/src/trx/game/objects/general/cabin.c
+++ b/src/trx/game/objects/general/cabin.c
@@ -1,13 +1,15 @@
 #include <trx/game/objects.h>
 #include <trx/game/rooms.h>
 
+#define M_DEFAULT_FLIP_SLOT 3
+
 typedef enum {
-    CABIN_STATE_START = 0,
-    CABIN_STATE_DROP_1 = 1,
-    CABIN_STATE_DROP_2 = 2,
-    CABIN_STATE_DROP_3 = 3,
-    CABIN_STATE_FINISH = 4,
-} CABIN_STATE;
+    M_STATE_START,
+    M_STATE_DROP_1,
+    M_STATE_DROP_2,
+    M_STATE_DROP_3,
+    M_STATE_FINISH,
+} M_STATE;
 
 static void M_Control(const int16_t item_num)
 {
@@ -15,21 +17,21 @@ static void M_Control(const int16_t item_num)
 
     if ((item->flags & IF_CODE_BITS) == IF_CODE_BITS) {
         switch (item->current_anim_state) {
-        case CABIN_STATE_START:
-            item->goal_anim_state = CABIN_STATE_DROP_1;
+        case M_STATE_START:
+            item->goal_anim_state = M_STATE_DROP_1;
             break;
-        case CABIN_STATE_DROP_1:
-            item->goal_anim_state = CABIN_STATE_DROP_2;
+        case M_STATE_DROP_1:
+            item->goal_anim_state = M_STATE_DROP_2;
             break;
-        case CABIN_STATE_DROP_2:
-            item->goal_anim_state = CABIN_STATE_DROP_3;
+        case M_STATE_DROP_2:
+            item->goal_anim_state = M_STATE_DROP_3;
             break;
         }
         item->flags = 0;
     }
 
-    if (item->current_anim_state == CABIN_STATE_FINISH) {
-        Room_SetFlipSlotFlags(3, IF_CODE_BITS);
+    if (item->current_anim_state == M_STATE_FINISH) {
+        Room_SetFlipSlotFlags(M_DEFAULT_FLIP_SLOT, IF_CODE_BITS);
         Room_FlipMap();
         Item_Kill(item_num);
     }

--- a/src/trx/game/objects/general/cabin.c
+++ b/src/trx/game/objects/general/cabin.c
@@ -11,9 +11,41 @@ typedef enum {
     M_STATE_FINISH,
 } M_STATE;
 
+typedef struct {
+    int32_t flip_slot;
+} M_PRIV;
+
+static void M_Initialise(const int16_t item_num)
+{
+    ITEM *const item = Item_Get(item_num);
+    M_PRIV *const p = item->priv;
+    p->flip_slot = M_DEFAULT_FLIP_SLOT;
+
+    OBJECT_PROPERTY_VALUE value = {};
+    if (ObjectProperty_GetItemValue(item, "flip_slot", &value)
+        && value.as_int < MAX_FLIP_MAPS) {
+        p->flip_slot = value.as_int;
+    }
+
+    CLAMPL(p->flip_slot, -1);
+}
+
+static bool M_ShouldFlipMap(const ITEM *const item)
+{
+    const M_PRIV *const p = item->priv;
+    return p->flip_slot >= 0;
+}
+
+static void M_FlipMap(const M_PRIV *const p)
+{
+    Room_SetFlipSlotFlags(p->flip_slot, IF_CODE_BITS | IF_ONE_SHOT);
+    Room_FlipMap();
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
+    const M_PRIV *const p = item->priv;
 
     if ((item->flags & IF_CODE_BITS) == IF_CODE_BITS) {
         switch (item->current_anim_state) {
@@ -31,8 +63,9 @@ static void M_Control(const int16_t item_num)
     }
 
     if (item->current_anim_state == M_STATE_FINISH) {
-        Room_SetFlipSlotFlags(M_DEFAULT_FLIP_SLOT, IF_CODE_BITS);
-        Room_FlipMap();
+        if (M_ShouldFlipMap(item)) {
+            M_FlipMap(p);
+        }
         Item_Kill(item_num);
     }
 
@@ -41,11 +74,19 @@ static void M_Control(const int16_t item_num)
 
 static void M_Setup(OBJECT *const obj)
 {
+    obj->initialise_func = M_Initialise;
     obj->control_func = M_Control;
     obj->draw_func = Object_DrawUnclippedItem;
     obj->collision_func = Object_Collision;
     obj->save_anim = true;
     obj->save_flags = true;
+    obj->priv_size = sizeof(M_PRIV);
+    OBJECT_PROPERTIES(
+        obj,
+        OBJECT_PROPERTY_INT(
+            "flip_slot", M_DEFAULT_FLIP_SLOT,
+            "The flip map slot to alter once the cabin has landed. -1 = "
+            "no flipmap is performed."));
 }
 
 REGISTER_OBJECT(O_PORTACABIN, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This replaces the hard-coded flipmap slots referenced by `O_PORTACABIN` and `O_BIG_BOWL` with properties instead. It also adds a property to define how long liquid pours from the big bowl; the flipmap there always happens 2 seconds before the end.

Tests:
- [x] The flip map should happen as normal in Natla's Mines once the cabin lands
- [x] The liquid should pour from the bowl in Ice Palace for 7 seconds
- [x] The flip map should happen as normal in Ice Palace after 5 seconds

Some other test scripts:
```lua
-- no flipmap in Natla's Mines
trx.events.before_item_setup(function(level)
  trx.objects.portacabin.properties.flip_slot = -1
end)
```
```lua
-- longer pour in Ice Palace
trx.events.before_item_setup(function(level)
  trx.objects.big_bowl.properties.pour_time = 12
end)
```