### PR TITLE
data/te: Add main.sfx entry

### DIFF
--- a/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
+++ b/data/te/tr2/Engine/games/tr2-custom/gameflow.json5
@@ -4,6 +4,7 @@
 
     "engine": 2,
     "name": "Tomb Raider II Custom Level",
+    "sfx_path": "main.sfx",
 
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tr2_%02d.dat",

--- a/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
+++ b/data/te/tr3/Engine/games/tr3-custom/gameflow.json5
@@ -4,7 +4,7 @@
 
     "engine": 3,
     "name": "Tomb Raider III Custom Level",
-
+    "sfx_path": "main.sfx",
     "main_menu_picture": "title.webp",
     "savegame_file_fmt": "save_tr3_%02d.dat",
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [ ] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds on TRX Tomb Editor release on the gameflow files, the main.sfx entry. This is for directly have the main.sfx entry on the gameflow on the Tomb Editor release, without having to write the entry manually