### PR TITLE
data: fix hidden game flow settings

### DIFF
--- a/data/trx/ship/games/tr1-ub/gameflow.json5
+++ b/data/trx/ship/games/tr1-ub/gameflow.json5
@@ -183,7 +183,7 @@
         "fix_monkey_pickup_priority",
         "restore_ps1_enemies",
         "disable_trex_collision",
-        "fix_tihocan_secret_sound",
+        "fix_chainblock_secret_sound",
         "fix_animated_sprites",
         "enable_ally_targeting",
         "enable_weather",

--- a/data/trx/ship/games/tr2-gm/gameflow.json5
+++ b/data/trx/ship/games/tr2-gm/gameflow.json5
@@ -214,7 +214,6 @@
     "hidden_config": [
         "enable_cutscenes",       // TR2G has no cutscenes
         "enable_demo",            // TR2G has no demos
-        "enable_fmv",             // TR2G has no FMVs
         "enable_item_examining",  // TR2G has no special item descriptions
         "fix_alligator_ai",       // TR2G has no alligators
         "fix_animated_sprites",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,8 +43,10 @@
 **TR1**:
 - added Lara's PS1 shimmying sound effects (Sound → Misc → PS1 SFX replacements) (#943)
 - fixed missing hand grab SFX when Lara is climbing a ladder (#4266)
+- removed the option to fix the chain block sound via the UI in Unfinished Business
 
 **TR2**:
+- added the option to toggle FMVs via the UI in The Golden Mask
 - fixed Lara not greeting the player at the start of the assault course (regression from 1.8)
 - fixed missing hand grab SFX when Lara is climbing a ladder (#4266)
 - fixed missing and mistimed closing SFX on doors type 1 and 2 in Barkhang Monastery (#4417, #4418)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This corrects the chainblock sound fix option not being hidden in TR1UB and makes the FMV toggle option available in TR2GM.