### PR TITLE
tools/installer: use safer directory deletion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - fixed persistent splashing effects if Lara falls onto spikes in one-click high water (regression from 1.0)
 - fixed game mode options not displaying after having beaten the game, if the option itself is switched off (regression from 1.0)
 - fixed Lara being able to break out of locked cameras activated by heavy triggers by equipping her weapons (regression from 1.1)
+- fixed the installer not completing normally if an error is encountered during directory clean-up
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/tools/installer/TRX_Installer/InstallFileHelper.cs
+++ b/tools/installer/TRX_Installer/InstallFileHelper.cs
@@ -53,4 +53,35 @@ internal static class InstallFileHelper
             progress.SetInnerProgress(copied, Math.Max(1, files.Length));
         }
     }
+
+    public static async Task DeleteDirectory(string path, bool recursive)
+    {
+        foreach (var file in Directory.EnumerateFiles(path))
+        {
+            try
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+            catch { }
+            try
+            {
+                File.Delete(file);
+            }
+            catch { }
+        }
+
+        if (recursive)
+        {
+            foreach (var subDir in Directory.EnumerateDirectories(path))
+            {
+                await DeleteDirectory(subDir, true);
+            }
+        }
+
+        try
+        {
+            Directory.Delete(path, false);
+        }
+        catch { }
+    }
 }

--- a/tools/installer/TRX_Installer/InstallerService.cs
+++ b/tools/installer/TRX_Installer/InstallerService.cs
@@ -175,7 +175,7 @@ internal class InstallerService
             unitIndex++;
         }
 
-        return $"{size:0.#} {units[unitIndex]}";
+        return $"{size:0.0} {units[unitIndex]}";
     }
 
     private static async Task ExtractEmbeddedReleaseAsync(string targetDirectory, IInstallerProgress progress)

--- a/tools/installer/TRX_Installer/InstallerService.cs
+++ b/tools/installer/TRX_Installer/InstallerService.cs
@@ -81,7 +81,11 @@ internal class InstallerService
                     && !name.EndsWith("-level", StringComparison.OrdinalIgnoreCase))
                 {
                     progress.AppendLog($"Removing {name}");
-                    await Task.Run(() => Directory.Delete(dir, recursive: true));
+                    await InstallFileHelper.DeleteDirectory(dir, recursive: true);
+                    if (Directory.Exists(dir))
+                    {
+                        progress.AppendLog($"Failed to completely remove {name}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates the installer to catch any errors that occur when attempting to delete directories that aren't required. It will attempt to clear read-only flags on files that would otherwise throw when trying to delete; for other cases e.g. files being open in other programs, it will just skip over them and a final warning message will be logged.

It also amends the download progress value label to remain at a constant width by always showing one decimal place.

I tested this as follows.
- install TR2GM
- navigate into the TR2GM folder and change one of the files to be read-only e.g. a loading picture
- launch the installer again
- deselect TR2GM
- select TR3LA
- the TR3LA install should complete, and the TR2GM folder should be cleared out