### PR TITLE
level/sections/rooms: add swamp version gate

### DIFF
--- a/src/trx/game/level/sections/rooms.c
+++ b/src/trx/game/level/sections/rooms.c
@@ -481,7 +481,8 @@ void Level_Section_ReadRooms(LEVEL_CONTEXT *const ctx, VFILE *const file)
         room->flags.dynamic_lit = (flags & 0x10) != 0;
         room->flags.wind        = (flags & 0x20) != 0;
         room->flags.inside      = (flags & 0x40) != 0;
-        room->flags.swamp       = (flags & 0x80) != 0;
+        room->flags.swamp       = (flags & 0x80) != 0 && g_TRVersion < 4;
+        // TODO: 0x80 marks no_lens_flare in TR4+
         // clang-format on
 
         OUTPUT_ROOM_BIND *const bind = Output_Bind_GetRoom(room);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes no lens flare flags being interpreted as swamps in TR4. This can later be standardized in injections if swamps are to be made available.