### PR TITLE
output/state: fix uv-rotate scroll during pause

### DIFF
--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -5,6 +5,7 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/effects.h>
+#include <trx/game/game/state.h>
 #include <trx/game/lara.h>
 #include <trx/game/rooms.h>
 #include <trx/game/shell.h>
@@ -418,7 +419,7 @@ bool Interpolation_IsActive(void)
 
 double Interpolation_GetWorldRate(void)
 {
-    if (!Interpolation_IsActive()) {
+    if (!Interpolation_IsActive() || !Game_IsPlaying()) {
         return 1.0;
     }
     return m_WorldRate;

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -4,6 +4,7 @@
 #include <trx/core/utils.h>
 #include <trx/debug.h>
 #include <trx/game/const.h>
+#include <trx/game/game/state.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/output/common.h>
 #include <trx/game/output/lights.h>
@@ -446,9 +447,12 @@ float Output_GetUVRotateOffset(void)
 {
     // The general uniforms are uploaded at scene begin, before
     // Interpolation_Interpolate() refreshes the world rate for the frame, so
-    // read the raw rate (set right before each draw) instead.
-    const double rate =
-        Interpolation_IsActive() ? Interpolation_GetRate() : 1.0;
+    // read the raw rate (set right before each draw) instead. Frozen
+    // gameplay (pause, inventory) must not replay a stale delta against this
+    // still-live rate, so gate it on Game_IsPlaying() same as the world rate.
+    const double rate = Interpolation_IsActive() && Game_IsPlaying()
+        ? Interpolation_GetRate()
+        : 1.0;
     int32_t delta = m_UVRotatePos - m_UVRotatePosPrev;
     if (delta > 16) {
         delta -= 32;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Interpolation_GetWorldRate()` kept advancing while gameplay was frozen (inventory ring, pause screen), because the interpolation subsystem had no notion of pause state. Any prev/current pair that stops updating on a frozen logic tick but is still blended against this live rate keeps replaying its last delta, producing visible motion during the freeze. This was most visible in the UV-rotating texture scroll, but also affects the skybox layer scroll and a few ambient particle effects that read the world rate.

Gate both the world rate and the raw rate used for the UV-rotate uniform on `Game_IsPlaying()`, which already exists for this purpose.

#### Testing

- [x] TR3 sparks on pause/inventory ring regression checks
- [x] TR3 weather on pause/inventory ring regression checks
- [x] UV rotate bug on pause/inventory ring