### PR TITLE
overlay: fix capturing fog

### DIFF
--- a/data/trx/ship/cfg/shaders/2d.glsl
+++ b/data/trx/ship/cfg/shaders/2d.glsl
@@ -18,6 +18,8 @@ uniform float uOpacity;
 uniform float uBrightnessScale;
 uniform int uFitMode;      // 0=stretch,1=letterbox,2=crop,3=smart
 uniform float uSrcAspect;  // src_w/src_h
+uniform float uDesaturation; // 0 = original, 1 = monochrome
+uniform vec3 uGlobalTint;    // (1,1,1) = no tint
 
 #ifdef VERTEX
 
@@ -142,9 +144,11 @@ void main(void) {
     }
 
     if (uDesaturation > 0.0) {
-        float luma = dot(outColor.rgb, vec3(0.299, 0.587, 0.114));
-        outColor.rgb = mix(outColor.rgb, vec3(luma), clamp(uDesaturation, 0.0, 1.0));
+        const vec3 luma = vec3(0.2126, 0.7152, 0.0722);
+        float y = dot(outColor.rgb, luma) * 0.5;
+        outColor.rgb = mix(outColor.rgb, vec3(y), clamp(uDesaturation, 0.0, 1.0));
     }
+    outColor.rgb *= uGlobalTint;
 
     outColor.rgb *= uUIBrightnessMultiplier * uBrightnessScale;
 

--- a/data/trx/ship/cfg/shaders/common.glsl
+++ b/data/trx/ship/cfg/shaders/common.glsl
@@ -28,7 +28,6 @@
 #define LIGHTING_CONTRAST_HIGH   2
 
 layout(std140) uniform Globals {
-    vec4 uGlobalTint;
     vec4 uFogColor;
     vec2 uFogDistance; // x = fog start, y = fog end
     vec2 uViewportSize;
@@ -37,7 +36,6 @@ layout(std140) uniform Globals {
     float uBrightnessMultiplier;
     float uUIBrightnessMultiplier;
     float uGamma;
-    float uDesaturation;
     float uSunsetDuration;
     float uMinShade;
     int uBillboardLockMode;

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -221,15 +221,6 @@ void main(void) {
     texColor.rgb *= uBrightnessMultiplier;
     texColor.rgb *= uTint;
 
-    // Optional desaturation (0 = original, 1 = monochrome).
-    if (uDesaturation > 0.0) {
-        const vec3 luma = vec3(0.2126, 0.7152, 0.0722);
-        float y = dot(texColor.rgb, luma) * 0.5;
-        texColor.rgb = mix(texColor.rgb, vec3(y), clamp(uDesaturation, 0.0, 1.0));
-    }
-
-    texColor *= uGlobalTint;
-
     outColor = texColor;
 }
 

--- a/src/trx/game/inventory_ring/control.c
+++ b/src/trx/game/inventory_ring/control.c
@@ -900,7 +900,12 @@ INV_RING *InvRing_Open(const INVENTORY_MODE mode)
     ring->background_style = mode == INV_TITLE_MODE
         ? BK_IMAGE
         : g_Config.ui.inventory_background_style;
-    ring->background_path = ring->background_style == BK_IMAGE
+    // main_menu_background_path is the title screen's background image;
+    // there is no separate configurable image for in-game inventory modes,
+    // so BK_IMAGE outside of INV_TITLE_MODE falls back to no image rather
+    // than incorrectly showing the title screen background mid-game.
+    ring->background_path =
+        mode == INV_TITLE_MODE && ring->background_style == BK_IMAGE
         ? g_GameFlow.main_menu_background_path
         : nullptr;
 

--- a/src/trx/game/inventory_ring/draw.c
+++ b/src/trx/game/inventory_ring/draw.c
@@ -307,62 +307,10 @@ void InvRing_Draw(INV_RING *const ring)
             ? Fader_GetCurrentValue(&ring->back_fader)
             : ring->back_fader.args.target;
 
-        switch (ring->background_style) {
-        case BK_NONE:
-            if (ring->mode != INV_GLOBE_SELECT_MODE) {
-                Output_Overlay_DrawGame();
-            }
-            break;
-
-        case BK_TRANSPARENT_MEDIUM:
-            Output_Overlay_DrawGame();
-            Output_Overlay_DrawBlackRectangle(opacity * 0.5f, false);
-            break;
-
-        case BK_TRANSPARENT_DARK:
-            Output_Overlay_DrawGame();
-            Output_Overlay_DrawBlackRectangle(opacity * 0.8f, false);
-            break;
-
-        case BK_BLACK:
-            Output_Overlay_DrawGame();
-            Output_Overlay_DrawBlackRectangle(opacity * 1.0f, false);
-            break;
-
-        case BK_MONOCHROME:
-            Output_Overlay_DrawGameMono(opacity);
-            break;
-
-        case BK_MONOCHROME_COOL:
-            Output_Overlay_DrawGameMonoCool(opacity);
-            break;
-
-        case BK_MONOCHROME_WARM:
-            Output_Overlay_DrawGameMonoWarm(opacity);
-            break;
-
-        case BK_PATTERN_STATIC:
-        case BK_PATTERN_WAVE:
-            if (opacity < 1.0f) {
-                Output_Overlay_DrawGame();
-            }
-            Output_Overlay_DrawPatternOpacity(
-                ring->background_style == BK_PATTERN_WAVE, opacity);
-            break;
-
-        case BK_IMAGE:
-            if (ring->background_path != nullptr
-                && Output_Overlay_LoadImage(ring->background_path)) {
-                Output_Overlay_DrawImageBilinear(ring->background_path);
-                Output_Overlay_DrawBlackRectangle(1.0f - opacity, false);
-            } else {
-                Output_Overlay_DrawBlackRectangle(1.0f, false);
-            }
-            break;
-
-        default:
-            Output_Overlay_DrawGame();
-            break;
+        if (ring->background_style != BK_NONE
+            || ring->mode != INV_GLOBE_SELECT_MODE) {
+            Output_Overlay_DrawBackground(
+                ring->background_style, opacity, ring->background_path);
         }
     }
     Output_Flush();

--- a/src/trx/game/output/overlay.h
+++ b/src/trx/game/output/overlay.h
@@ -1,9 +1,14 @@
 #pragma once
 
-void Output_Overlay_DrawGame(void);
-void Output_Overlay_DrawGameMono(float desaturation);
-void Output_Overlay_DrawGameMonoCool(float desaturation);
-void Output_Overlay_DrawGameMonoWarm(float desaturation);
+#include <trx/config/enum.h>
+#include <trx/core/colors.h>
+
+typedef struct {
+    float opacity;
+    float desaturation; // 0 = off
+    RGB_F tint; // COLOR_RGB_F_WHITE = no tint
+} OUTPUT_SNAPSHOT_SETTINGS;
+
 void Output_Overlay_DrawPattern(bool wave);
 void Output_Overlay_DrawPatternOpacity(bool wave, float opacity);
 void Output_Overlay_DrawBlackRectangle(float opacity, bool post_ui);
@@ -12,5 +17,9 @@ void Output_Overlay_DrawImage(const char *file_name);
 void Output_Overlay_DrawImageBilinear(const char *file_name);
 void Output_Overlay_DrawImageMono(const char *file_name, float intensity);
 void Output_Overlay_CaptureSnapshot(void);
+void Output_Overlay_CaptureGameSnapshot(void);
 void Output_Overlay_DrawSnapshot(float opacity);
+void Output_Overlay_DrawSnapshotEx(const OUTPUT_SNAPSHOT_SETTINGS *settings);
+void Output_Overlay_DrawBackground(
+    BACKGROUND_TYPE style, float opacity, const char *image_path);
 void Output_Overlay_BeginTransitionFadeOut(float duration, float start);

--- a/src/trx/game/output/quad.c
+++ b/src/trx/game/output/quad.c
@@ -17,6 +17,8 @@ typedef enum {
     M_UNIFORM_BRIGHTNESS_SCALE,
     M_UNIFORM_FIT_MODE,
     M_UNIFORM_SRC_ASPECT,
+    M_UNIFORM_DESATURATION,
+    M_UNIFORM_GLOBAL_TINT,
     M_UNIFORM_NUMBER_OF,
 } M_UNIFORM;
 
@@ -55,6 +57,9 @@ struct OUTPUT_QUAD {
 
     OUTPUT_QUAD_FIT_MODE fit_mode;
     float src_aspect;
+
+    float desaturation;
+    RGB_F global_tint;
 
     bool use_external_texture;
     GLuint external_texture_id;
@@ -154,6 +159,9 @@ OUTPUT_QUAD *Output_Quad_Create(void)
     r->fit_mode = OUTPUT_QUAD_FIT_STRETCH;
     r->src_aspect = 1.0f;
 
+    r->desaturation = 0.0f;
+    r->global_tint = COLOR_RGB_F_WHITE;
+
     r->vertices = nullptr;
     r->vertex_count = 6;
     r->use_external_texture = false;
@@ -196,6 +204,10 @@ OUTPUT_QUAD *Output_Quad_Create(void)
         Output_Shader_LookupUniform(r->shader, "uFitMode");
     r->loc[M_UNIFORM_SRC_ASPECT] =
         Output_Shader_LookupUniform(r->shader, "uSrcAspect");
+    r->loc[M_UNIFORM_DESATURATION] =
+        Output_Shader_LookupUniform(r->shader, "uDesaturation");
+    r->loc[M_UNIFORM_GLOBAL_TINT] =
+        Output_Shader_LookupUniform(r->shader, "uGlobalTint");
 
     M_BindProgram(r);
     glUniform1i(r->loc[M_UNIFORM_TEXTURE_MAIN], 0);
@@ -205,6 +217,10 @@ OUTPUT_QUAD *Output_Quad_Create(void)
     glUniform1f(r->loc[M_UNIFORM_BRIGHTNESS_SCALE], r->brightness_scale);
     glUniform1i(r->loc[M_UNIFORM_FIT_MODE], (int32_t)r->fit_mode);
     glUniform1f(r->loc[M_UNIFORM_SRC_ASPECT], r->src_aspect);
+    glUniform1f(r->loc[M_UNIFORM_DESATURATION], r->desaturation);
+    glUniform3f(
+        r->loc[M_UNIFORM_GLOBAL_TINT], r->global_tint.r, r->global_tint.g,
+        r->global_tint.b);
     TRX_GL_CheckError();
 
     return r;
@@ -396,6 +412,31 @@ void Output_Quad_SetFilter(
 {
     ASSERT(r != nullptr);
     r->filter_mode = filter_mode;
+}
+
+void Output_Quad_SetDesaturation(OUTPUT_QUAD *const r, const float desaturation)
+{
+    ASSERT(r != nullptr);
+
+    if (r->desaturation != desaturation) {
+        M_BindProgram(r);
+        glUniform1f(r->loc[M_UNIFORM_DESATURATION], desaturation);
+        TRX_GL_CheckError();
+        r->desaturation = desaturation;
+    }
+}
+
+void Output_Quad_SetGlobalTint(OUTPUT_QUAD *const r, const RGB_F tint)
+{
+    ASSERT(r != nullptr);
+
+    if (r->global_tint.r != tint.r || r->global_tint.g != tint.g
+        || r->global_tint.b != tint.b) {
+        M_BindProgram(r);
+        glUniform3f(r->loc[M_UNIFORM_GLOBAL_TINT], tint.r, tint.g, tint.b);
+        TRX_GL_CheckError();
+        r->global_tint = tint;
+    }
 }
 
 void Output_Quad_SetFit(

--- a/src/trx/game/output/quad.h
+++ b/src/trx/game/output/quad.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/colors.h>
 #include <trx/gl/enum.h>
 
 #include <GL/glew.h>
@@ -78,6 +79,11 @@ void Output_Quad_SetOpacity(OUTPUT_QUAD *renderer, float opacity);
 void Output_Quad_SetBrightnessScale(
     OUTPUT_QUAD *renderer, float brightness_scale);
 void Output_Quad_SetFilter(OUTPUT_QUAD *renderer, TEXTURE_FILTER filter_mode);
+
+// Set desaturation intensity (0 = original, 1 = monochrome).
+void Output_Quad_SetDesaturation(OUTPUT_QUAD *renderer, float desaturation);
+// Set output color tint multiplier (COLOR_RGB_F_WHITE = no tint).
+void Output_Quad_SetGlobalTint(OUTPUT_QUAD *renderer, RGB_F tint);
 
 // Configure fitting mode and source aspect ratio handling.
 void Output_Quad_SetFit(

--- a/src/trx/game/output/sky.c
+++ b/src/trx/game/output/sky.c
@@ -252,8 +252,8 @@ static void M_AdjustLightInfo(OUTPUT_LIGHT_INFO *const info)
     if (g_TRVersion < 3) {
         return;
     }
-    info->tr3_ambient = g_TRVersion == 4 ? (RGB_F) { 1.0f, 1.0f, 1.0f }
-                                         : (RGB_F) { 0.5f, 0.5f, 0.5f };
+    info->tr3_ambient =
+        g_TRVersion == 4 ? COLOR_RGB_F_WHITE : (RGB_F) { 0.5f, 0.5f, 0.5f };
     for (int32_t i = 0; i < 3; i++) {
         info->tr3_light_color[i] = (RGB_F) { 0.0f, 0.0f, 0.0f };
         info->tr3_light_dir_view[i] = (XYZ_32) { 0, 0, 0 };

--- a/src/trx/game/output/sources/overlay.c
+++ b/src/trx/game/output/sources/overlay.c
@@ -21,6 +21,7 @@
 #include <trx/game/output/state.h>
 #include <trx/game/output/textures.h>
 #include <trx/game/viewport.h>
+#include <trx/gl/renderer.h>
 #include <trx/gl/texture.h>
 #include <trx/gl/utils.h>
 
@@ -68,6 +69,8 @@ typedef struct {
     int32_t width;
     int32_t height;
     float opacity;
+    float desaturation;
+    RGB_F tint;
 } M_DRAW_OP_SNAPSHOT;
 
 typedef struct {
@@ -210,8 +213,10 @@ static bool M_PrepareViewportCopy(
     return *copy_width > 0 && *copy_height > 0;
 }
 
-static void M_CopyPresentedFrameToTexture(
-    TRX_GL_TEXTURE *const texture, const int32_t width, const int32_t height)
+static void M_CopyFboToTexture(
+    const VIEWPORT_SPACE viewport, const GLuint src_fbo,
+    const bool src_is_default_fbo, TRX_GL_TEXTURE *const texture,
+    const int32_t width, const int32_t height)
 {
     if (texture == nullptr || !texture->initialized || width <= 0
         || height <= 0) {
@@ -222,24 +227,31 @@ static void M_CopyPresentedFrameToTexture(
     int32_t copy_width = 0;
     int32_t copy_height = 0;
     if (!M_PrepareViewportCopy(
-            VIEWPORT_TARGET, width, height, &rect, &copy_width, &copy_height)) {
+            viewport, width, height, &rect, &copy_width, &copy_height)) {
         return;
     }
 
     GLint prev_read_fbo = 0;
     glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prev_read_fbo);
     GLint prev_read_buffer = 0;
-    glGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+    if (src_is_default_fbo) {
+        glGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+    }
 
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-    glReadBuffer(GL_FRONT);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, src_fbo);
+    if (src_is_default_fbo) {
+        // The presented (just-swapped) frame lives in the front buffer.
+        glReadBuffer(GL_FRONT);
+    }
 
     TRX_GL_Texture_Bind(texture);
     glCopyTexSubImage2D(
         GL_TEXTURE_2D, 0, 0, 0, rect.x, rect.y, copy_width, copy_height);
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, (GLuint)prev_read_fbo);
-    glReadBuffer(prev_read_buffer);
+    if (src_is_default_fbo) {
+        glReadBuffer(prev_read_buffer);
+    }
     TRX_GL_CheckError();
 }
 
@@ -552,7 +564,7 @@ static void M_DrawOp_Image(const M_DRAW_OP_IMAGE *const op)
     Output_Quad_SetRepeat(p->image.renderer, 1, 1);
     Output_Quad_SetTextureSize(p->image.renderer, nullptr);
     Output_Quad_SetFilter(p->image.renderer, op->texture_filter);
-    Output_SetDesaturation(op->desaturation);
+    Output_Quad_SetDesaturation(p->image.renderer, op->desaturation);
     if (op->use_fit) {
         Output_Quad_SetFit(
             p->image.renderer, OUTPUT_QUAD_FIT_SMART, (float)op->width,
@@ -566,7 +578,6 @@ static void M_DrawOp_Image(const M_DRAW_OP_IMAGE *const op)
     } else {
         Output_Quad_RenderWithBlend(p->image.renderer);
     }
-    Output_SetDesaturation(0.0f);
 }
 
 static void M_DrawImageImpl(
@@ -615,8 +626,12 @@ static void M_DrawOp_Snapshot(const M_DRAW_OP_SNAPSHOT *const op)
     Output_Quad_SetEffect(p->snapshot.renderer, OUTPUT_QUAD_EFFECT_NONE);
     Output_Quad_SetRepeat(p->snapshot.renderer, 1, 1);
     Output_Quad_SetTextureSize(p->snapshot.renderer, nullptr);
+    Output_Quad_SetFilter(
+        p->snapshot.renderer, g_Config.rendering.upscaling_filter);
     Output_Quad_ClearFit(p->snapshot.renderer);
     Output_Quad_SetOpacity(p->snapshot.renderer, op->opacity);
+    Output_Quad_SetDesaturation(p->snapshot.renderer, op->desaturation);
+    Output_Quad_SetGlobalTint(p->snapshot.renderer, op->tint);
     Output_Quad_RenderWithBlend(p->snapshot.renderer);
 }
 
@@ -726,10 +741,11 @@ static void M_DrawOp_Pattern(const M_DRAW_OP_PATTERN *const op)
     }
 }
 
-static void M_EnsureSnapshotTexture(M_PRIV *const p)
+static void M_EnsureSnapshotTexture(
+    M_PRIV *const p, const VIEWPORT_SPACE viewport)
 {
-    const int32_t w = Viewport_GetWidth(VIEWPORT_TARGET);
-    const int32_t h = Viewport_GetHeight(VIEWPORT_TARGET);
+    const int32_t w = Viewport_GetWidth(viewport);
+    const int32_t h = Viewport_GetHeight(viewport);
     if (w <= 0 || h <= 0) {
         return;
     }
@@ -778,6 +794,7 @@ static void M_RenderBegin(const SCENE_SOURCE *const source)
                 .width = p->snapshot.state.width,
                 .height = p->snapshot.state.height,
                 .opacity = opacity,
+                .tint = COLOR_RGB_F_WHITE,
             }));
 
         if (!Fader_IsActive(&p->snapshot.transition_fader)) {
@@ -839,20 +856,8 @@ void Output_Overlay_DrawImageMono(
     M_DrawImageImpl(file_name, intensity, TEXTURE_FILTER_POINT);
 }
 
-void Output_Overlay_CaptureSnapshot(void)
+static void M_FinishSnapshotCapture(M_PRIV *const p)
 {
-    M_PRIV *const p = &m_Priv;
-    p->snapshot.transition_active = false;
-    p->snapshot.state.has_content = false;
-
-    M_EnsureSnapshotTexture(p);
-    if (!p->snapshot.state.texture.initialized) {
-        return;
-    }
-
-    M_CopyPresentedFrameToTexture(
-        &p->snapshot.state.texture, p->snapshot.state.width,
-        p->snapshot.state.height);
     p->snapshot.state.has_content = true;
 
     // Remove the captured brightness so we can reapply the current multiplier.
@@ -862,14 +867,70 @@ void Output_Overlay_CaptureSnapshot(void)
         p->snapshot.renderer, 1.0f / p->snapshot.state.captured_brightness);
 }
 
+void Output_Overlay_CaptureSnapshot(void)
+{
+    M_PRIV *const p = &m_Priv;
+    p->snapshot.transition_active = false;
+    p->snapshot.state.has_content = false;
+
+    M_EnsureSnapshotTexture(p, VIEWPORT_TARGET);
+    if (!p->snapshot.state.texture.initialized) {
+        return;
+    }
+
+    // The presented frame includes UI/console; this captures everything
+    // that was on screen at the moment of the call.
+    M_CopyFboToTexture(
+        VIEWPORT_TARGET, 0, true, &p->snapshot.state.texture,
+        p->snapshot.state.width, p->snapshot.state.height);
+    M_FinishSnapshotCapture(p);
+}
+
+void Output_Overlay_CaptureGameSnapshot(void)
+{
+    M_PRIV *const p = &m_Priv;
+    p->snapshot.transition_active = false;
+    p->snapshot.state.has_content = false;
+
+    // The geometry FBO is rendered at VIEWPORT_GAME's resolution, which is
+    // lower than VIEWPORT_TARGET whenever an upscaling factor is active;
+    // size the snapshot texture to match so the capture isn't clamped into
+    // a corner of an oversized texture.
+    M_EnsureSnapshotTexture(p, VIEWPORT_GAME);
+    if (!p->snapshot.state.texture.initialized) {
+        return;
+    }
+
+    Interpolation_Disable();
+    TRX_GL_Renderer_BindGeometryFbo();
+
+    SceneCompositor_BeginScene();
+    Game_Draw(false);
+    SceneCompositor_EndScene();
+    Interpolation_Enable();
+
+    M_CopyFboToTexture(
+        VIEWPORT_GAME, TRX_GL_Renderer_GetGeometryFboId(), false,
+        &p->snapshot.state.texture, p->snapshot.state.width,
+        p->snapshot.state.height);
+    M_FinishSnapshotCapture(p);
+}
+
 void Output_Overlay_DrawSnapshot(const float opacity)
+{
+    Output_Overlay_DrawSnapshotEx(&(OUTPUT_SNAPSHOT_SETTINGS) {
+        .opacity = opacity, .tint = COLOR_RGB_F_WHITE });
+}
+
+void Output_Overlay_DrawSnapshotEx(
+    const OUTPUT_SNAPSHOT_SETTINGS *const settings)
 {
     const M_PRIV *const p = &m_Priv;
     if (!p->snapshot.state.has_content
         || !p->snapshot.state.texture.initialized) {
         return;
     }
-    if (opacity <= 0.0f) {
+    if (settings->opacity <= 0.0f) {
         return;
     }
 
@@ -879,7 +940,9 @@ void Output_Overlay_DrawSnapshot(const float opacity)
             .texture_id = p->snapshot.state.texture.id,
             .width = p->snapshot.state.width,
             .height = p->snapshot.state.height,
-            .opacity = opacity,
+            .opacity = settings->opacity,
+            .desaturation = settings->desaturation,
+            .tint = settings->tint,
         }));
 }
 
@@ -908,38 +971,81 @@ void Output_Overlay_BeginTransitionFadeOut(
     Fader_InitTo(&p->snapshot.transition_fader, start, 0.0f, duration);
 }
 
-void Output_Overlay_DrawGame(void)
+void Output_Overlay_DrawBackground(
+    const BACKGROUND_TYPE style, const float opacity,
+    const char *const image_path)
 {
-    Interpolation_Disable();
-    Game_Draw(false);
-    Interpolation_Enable();
-}
+    switch (style) {
+    case BK_TRANSPARENT_MEDIUM:
+        Output_Overlay_DrawSnapshot(1.0f);
+        Output_Overlay_DrawBlackRectangle(opacity * 0.5f, false);
+        break;
 
-void Output_Overlay_DrawGameMonoCool(const float desaturation)
-{
-    Output_SetDesaturation(desaturation);
-    Output_SetGlobalTint(Color_Mix(
-        COLOR_RGB_F_WHITE, ((RGB_F) { 0.666f, 0.666f, 1.0f }), desaturation));
-    Output_Overlay_DrawGame();
-    Output_SetGlobalTint(COLOR_RGB_F_WHITE);
-    Output_SetDesaturation(0.0f);
-}
+    case BK_TRANSPARENT_DARK:
+        Output_Overlay_DrawSnapshot(1.0f);
+        Output_Overlay_DrawBlackRectangle(opacity * 0.8f, false);
+        break;
 
-void Output_Overlay_DrawGameMonoWarm(const float desaturation)
-{
-    Output_SetDesaturation(desaturation);
-    Output_SetGlobalTint(Color_Mix(
-        COLOR_RGB_F_WHITE, ((RGB_F) { 1.0f, 0.666f, 0.666f }), desaturation));
-    Output_Overlay_DrawGame();
-    Output_SetGlobalTint(COLOR_RGB_F_WHITE);
-    Output_SetDesaturation(0.0f);
-}
+    case BK_BLACK:
+        Output_Overlay_DrawSnapshot(1.0f);
+        Output_Overlay_DrawBlackRectangle(opacity, false);
+        break;
 
-void Output_Overlay_DrawGameMono(const float desaturation)
-{
-    Output_SetDesaturation(desaturation);
-    Output_Overlay_DrawGame();
-    Output_SetDesaturation(0.0f);
+    case BK_MONOCHROME:
+        Output_Overlay_DrawSnapshotEx(&(OUTPUT_SNAPSHOT_SETTINGS) {
+            .opacity = 1.0f,
+            .desaturation = opacity,
+            .tint = COLOR_RGB_F_WHITE,
+        });
+        break;
+
+    case BK_MONOCHROME_COOL:
+        Output_Overlay_DrawSnapshotEx(&(OUTPUT_SNAPSHOT_SETTINGS) {
+            .opacity = 1.0f,
+            .desaturation = opacity,
+            .tint = Color_Mix(
+                COLOR_RGB_F_WHITE, ((RGB_F) { 0.666f, 0.666f, 1.0f }), opacity),
+        });
+        break;
+
+    case BK_MONOCHROME_WARM:
+        Output_Overlay_DrawSnapshotEx(&(OUTPUT_SNAPSHOT_SETTINGS) {
+            .opacity = 1.0f,
+            .desaturation = opacity,
+            .tint = Color_Mix(
+                COLOR_RGB_F_WHITE, ((RGB_F) { 1.0f, 0.666f, 0.666f }), opacity),
+        });
+        break;
+
+    case BK_PATTERN_STATIC:
+    case BK_PATTERN_WAVE:
+        if (opacity < 1.0f) {
+            Output_Overlay_DrawSnapshot(1.0f);
+        }
+        Output_Overlay_DrawPatternOpacity(style == BK_PATTERN_WAVE, opacity);
+        break;
+
+    case BK_IMAGE:
+        if (image_path == nullptr) {
+            // No image configured (e.g. pause screen): behave like
+            // BK_TRANSPARENT_DARK.
+            Output_Overlay_DrawSnapshot(1.0f);
+            Output_Overlay_DrawBlackRectangle(opacity * 0.8f, false);
+        } else if (Output_Overlay_LoadImage(image_path)) {
+            Output_Overlay_DrawImageBilinear(image_path);
+            Output_Overlay_DrawBlackRectangle(opacity, false);
+        } else {
+            // Image configured but failed to load: hide the background
+            // entirely rather than show something unintended.
+            Output_Overlay_DrawBlackRectangle(1.0f, false);
+        }
+        break;
+
+    case BK_NONE:
+    default:
+        Output_Overlay_DrawSnapshot(1.0f);
+        break;
+    }
 }
 
 void Output_Overlay_DrawBlackRectangle(const float opacity, const bool post_ui)

--- a/src/trx/game/output/sources/sky.c
+++ b/src/trx/game/output/sources/sky.c
@@ -113,7 +113,7 @@ static void M_RenderFogGradient(M_PRIV *const p)
         OUTPUT_MESH_ATTR_FLAGS,
         VERT_FLAT_SHADED | VERT_NO_LIGHTING | VERT_NO_WIBBLE
             | VERT_NO_ALPHA_DISCARD);
-    Output_MeshShader_UploadTint(p->shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
+    Output_MeshShader_UploadTint(p->shader, COLOR_RGB_F_WHITE);
     Output_MeshShader_UploadModelMatrix(p->shader, &p->gradient_wmatrix);
     // Like OG, the skybox is drawn without backface culling.
     glDisable(GL_CULL_FACE);
@@ -163,7 +163,7 @@ static void M_RenderPass(
         flags |= VERT_FLAT_SHADED;
     }
     glVertexAttribI1ui(OUTPUT_MESH_ATTR_FLAGS, flags);
-    Output_MeshShader_UploadTint(p->shader, (RGB_F) { 1.0f, 1.0f, 1.0f });
+    Output_MeshShader_UploadTint(p->shader, COLOR_RGB_F_WHITE);
 
     for (int32_t i = 0; i < p->layer_count; i++) {
         const M_LAYER *const layer = &p->layers[i];

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -50,12 +50,9 @@ static bool m_IsWibbleEffect = false;
 static bool m_IsWaterEffect = false;
 static bool m_IsShadeEffect = false;
 static bool m_IsSkyboxEnabled = false;
-static float m_Desaturation = 0.0f;
 
 static int32_t m_TintOverrideDepth = 0;
 static RGB_F m_TintOverrideStack[8] = {};
-
-static RGB_F m_GlobalTint = { 1.0f, 1.0f, 1.0f };
 
 float Output_GetTime(void)
 {
@@ -161,24 +158,6 @@ bool Output_GetWibbleEffect(void)
     return m_IsWibbleEffect;
 }
 
-float Output_GetDesaturation(void)
-{
-    return m_Desaturation;
-}
-
-void Output_SetDesaturation(const float desaturation)
-{
-    if (m_Desaturation == desaturation) {
-        return;
-    }
-    m_Desaturation = desaturation;
-
-    const OUTPUT_UNIFORMS *const uniforms = Output_GetUniforms();
-    if (uniforms != nullptr) {
-        Output_Uniforms_UploadDesaturation(uniforms, m_Desaturation);
-    }
-}
-
 void Output_SetFogColor(const RGBA_8888 color)
 {
     m_FogColor.r = color.r / 255.0f;
@@ -197,20 +176,6 @@ void Output_SetWaterColor(const RGB_888 color)
     m_WaterColor.r = color.r / 255.0f;
     m_WaterColor.g = color.g / 255.0f;
     m_WaterColor.b = color.b / 255.0f;
-}
-
-RGB_F Output_GetGlobalTint(void)
-{
-    return m_GlobalTint;
-}
-
-void Output_SetGlobalTint(const RGB_F tint)
-{
-    m_GlobalTint = tint;
-    const OUTPUT_UNIFORMS *const uniforms = Output_GetUniforms();
-    if (uniforms != nullptr) {
-        Output_Uniforms_UploadGlobalTint(uniforms, m_GlobalTint);
-    }
 }
 
 RGB_F Output_GetTint(void)

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -30,10 +30,6 @@ void Output_PushTintOverride(RGB_F tint);
 void Output_PopTintOverride(void);
 bool Output_GetWaterEffect(void);
 bool Output_GetWibbleEffect(void);
-float Output_GetDesaturation(void);
-void Output_SetDesaturation(float desaturation);
-RGB_F Output_GetGlobalTint(void);
-void Output_SetGlobalTint(RGB_F tint);
 
 RGBA_F Output_GetFogColor(void);
 int32_t Output_GetFogStart(void);

--- a/src/trx/game/output/uniforms.c
+++ b/src/trx/game/output/uniforms.c
@@ -18,7 +18,6 @@
 #include <string.h>
 
 #define M_GLOBAL_MEMBERS                                                       \
-    X_DECLARE_MEMBER(float, global_tint, [4])                                  \
     X_DECLARE_MEMBER(float, fog_color, [4])                                    \
     X_DECLARE_MEMBER(float, fog_distance, [2])                                 \
     X_DECLARE_MEMBER(float, viewport_size, [2])                                \
@@ -27,7 +26,6 @@
     X_DECLARE_MEMBER(float, brightness_multiplier)                             \
     X_DECLARE_MEMBER(float, ui_brightness_multiplier)                          \
     X_DECLARE_MEMBER(float, gamma)                                             \
-    X_DECLARE_MEMBER(float, desaturation)                                      \
     X_DECLARE_MEMBER(float, sunset_duration)                                   \
     X_DECLARE_MEMBER(float, min_shade)                                         \
     X_DECLARE_MEMBER(int, billboard_lock_mode)                                 \
@@ -157,7 +155,6 @@ void Output_Uniforms_UploadGeneral(const OUTPUT_UNIFORMS *const uniforms)
         .brightness_multiplier = g_Config.visuals.game_brightness,
         .ui_brightness_multiplier = g_Config.visuals.ui_brightness,
         .gamma = g_Config.visuals.gamma,
-        .desaturation = Output_GetDesaturation(),
         .sunset_duration = Output_GetSunsetDuration(),
         .tr_version = g_TRVersion,
         .uv_rotate_offset = Output_GetUVRotateOffset(),
@@ -178,12 +175,6 @@ void Output_Uniforms_UploadGeneral(const OUTPUT_UNIFORMS *const uniforms)
             Output_GetFogColor().b,
             Output_GetFogColor().a,
         },
-        .global_tint = {
-            Output_GetGlobalTint().r,
-            Output_GetGlobalTint().g,
-            Output_GetGlobalTint().b,
-            1.0f,
-        },
     };
 
     glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
@@ -201,28 +192,6 @@ void Output_Uniforms_UploadFogDistance(
         glBufferSubData, GL_UNIFORM_BUFFER,
         offsetof(M_UNIFORM_GENERAL, fog_distance), sizeof(fog_distance),
         &fog_distance);
-}
-
-void Output_Uniforms_UploadDesaturation(
-    const OUTPUT_UNIFORMS *const uniforms, const float desaturation)
-{
-    ASSERT(uniforms != nullptr);
-    float clamped = desaturation;
-    CLAMP(clamped, 0.0f, 1.0f);
-    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
-    TRX_GL_TRACK_SUBDATA(
-        glBufferSubData, GL_UNIFORM_BUFFER,
-        offsetof(M_UNIFORM_GENERAL, desaturation), sizeof(clamped), &clamped);
-}
-
-void Output_Uniforms_UploadGlobalTint(
-    const OUTPUT_UNIFORMS *const uniforms, const RGB_F tint)
-{
-    ASSERT(uniforms != nullptr);
-    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->general);
-    TRX_GL_TRACK_SUBDATA(
-        glBufferSubData, GL_UNIFORM_BUFFER,
-        offsetof(M_UNIFORM_GENERAL, global_tint), sizeof(tint), &tint);
 }
 
 void Output_Uniforms_UploadGameBrightnessMultiplier(

--- a/src/trx/game/output/uniforms.h
+++ b/src/trx/game/output/uniforms.h
@@ -39,7 +39,3 @@ void Output_Uniforms_UploadOwnLight(
 
 void Output_Uniforms_UploadFogDistance(
     const OUTPUT_UNIFORMS *uniforms, float start, float end);
-void Output_Uniforms_UploadDesaturation(
-    const OUTPUT_UNIFORMS *uniforms, float desaturation);
-void Output_Uniforms_UploadGlobalTint(
-    const OUTPUT_UNIFORMS *uniforms, RGB_F tint);

--- a/src/trx/game/phase/phase_inventory.c
+++ b/src/trx/game/phase/phase_inventory.c
@@ -35,6 +35,11 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
             .gf_cmd = { .action = GF_NOOP },
         };
     }
+    if (p->mode != INV_TITLE_MODE) {
+        // Title mode draws its own background image, not a game snapshot;
+        // the title level's room data isn't set up for a live scene render.
+        Output_Overlay_CaptureGameSnapshot();
+    }
     return (PHASE_CONTROL) { .action = PHASE_ACTION_CONTINUE };
 }
 

--- a/src/trx/game/phase/phase_pause.c
+++ b/src/trx/game/phase/phase_pause.c
@@ -63,6 +63,7 @@ static void M_PauseGame(M_PRIV *const p)
     p->action = GF_NOOP;
     Music_Pause();
     Sound_PauseAll();
+    Output_Overlay_CaptureGameSnapshot();
     M_FadeIn(p);
 }
 
@@ -179,53 +180,8 @@ static void M_Draw(PHASE *const phase)
     const float progress = g_Config.ui.pause_fade_effects
         ? Fader_GetCurrentValue(&p->fader)
         : p->fader.args.target;
-    switch (g_Config.ui.pause_background_style) {
-    case BK_NONE:
-        Output_Overlay_DrawGame();
-        break;
-
-    case BK_TRANSPARENT_MEDIUM:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress * 0.5f, false);
-        break;
-
-    case BK_TRANSPARENT_DARK:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress * 0.8f, false);
-        break;
-
-    case BK_BLACK:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress, false);
-        break;
-
-    case BK_MONOCHROME:
-        Output_Overlay_DrawGameMono(progress);
-        break;
-
-    case BK_MONOCHROME_COOL:
-        Output_Overlay_DrawGameMonoCool(progress);
-        break;
-
-    case BK_MONOCHROME_WARM:
-        Output_Overlay_DrawGameMonoWarm(progress);
-        break;
-
-    case BK_PATTERN_STATIC:
-    case BK_PATTERN_WAVE:
-        if (progress < 1.0f) {
-            Output_Overlay_DrawGame();
-        }
-        Output_Overlay_DrawPatternOpacity(
-            g_Config.ui.pause_background_style == BK_PATTERN_WAVE, progress);
-        break;
-
-    case BK_IMAGE:
-    default:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress * 0.8f, false);
-        break;
-    }
+    Output_Overlay_DrawBackground(
+        g_Config.ui.pause_background_style, progress, nullptr);
 
     if (p->state == STATE_ASK) {
         UI_Pause(&p->ui.state);

--- a/src/trx/game/phase/phase_stats.c
+++ b/src/trx/game/phase/phase_stats.c
@@ -74,6 +74,8 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
         }
     }
 
+    Output_Overlay_CaptureGameSnapshot();
+
     switch (p->args.background_type) {
     case BK_IMAGE:
         if (p->args.background_path == nullptr) {
@@ -101,6 +103,9 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
     } else {
         if (p->args.background_type == BK_PATTERN_STATIC
             || p->args.background_type == BK_PATTERN_WAVE) {
+            // Patterns are displayed at full opacity immediately rather
+            // than fading in.
+            Fader_InitTo(&p->back_fader, 1.0f, 1.0f, 0.0f);
             p->state = STATE_DISPLAY;
         } else {
             p->state = STATE_FADE_IN;
@@ -194,54 +199,8 @@ static void M_Draw(PHASE *const phase)
     const float progress = M_EnableFade(p)
         ? Fader_GetCurrentValue(&p->back_fader)
         : p->back_fader.args.target;
-    switch (p->args.background_type) {
-    case BK_NONE:
-        Output_Overlay_DrawGame();
-        break;
-
-    case BK_TRANSPARENT_MEDIUM:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress * 0.5f, false);
-        break;
-
-    case BK_TRANSPARENT_DARK:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress * 0.8f, false);
-        break;
-
-    case BK_BLACK:
-        Output_Overlay_DrawGame();
-        Output_Overlay_DrawBlackRectangle(progress, false);
-        break;
-
-    case BK_MONOCHROME:
-        Output_Overlay_DrawGameMono(progress);
-        break;
-
-    case BK_MONOCHROME_COOL:
-        Output_Overlay_DrawGameMonoCool(progress);
-        break;
-
-    case BK_MONOCHROME_WARM:
-        Output_Overlay_DrawGameMonoWarm(progress);
-        break;
-
-    case BK_IMAGE:
-        if (p->args.background_path != nullptr) {
-            Output_Overlay_DrawImageBilinear(p->args.background_path);
-        }
-        Output_Overlay_DrawBlackRectangle(progress, false);
-        break;
-
-    case BK_PATTERN_STATIC:
-    case BK_PATTERN_WAVE:
-        Output_Overlay_DrawPattern(p->args.background_type == BK_PATTERN_WAVE);
-        Output_Overlay_DrawBlackRectangle(progress, false);
-        break;
-
-    default:
-        break;
-    }
+    Output_Overlay_DrawBackground(
+        p->args.background_type, progress, p->args.background_path);
 
     if (p->ui_active) {
         UI_StatsDialog(p->ui_state);

--- a/src/trx/gl/renderer.c
+++ b/src/trx/gl/renderer.c
@@ -197,3 +197,9 @@ void TRX_GL_Renderer_BindUiFbo(void)
     M_CONTEXT *const p = (M_CONTEXT *)g_TRX_GL_Renderer.priv;
     TRX_GL_FBO_Bind(&p->ui_fbo);
 }
+
+GLuint TRX_GL_Renderer_GetGeometryFboId(void)
+{
+    const M_CONTEXT *const p = (const M_CONTEXT *)g_TRX_GL_Renderer.priv;
+    return p->geometry_fbo.fbo;
+}

--- a/src/trx/gl/renderer.h
+++ b/src/trx/gl/renderer.h
@@ -2,6 +2,8 @@
 
 #include <trx/gl/config.h>
 
+#include <GL/glew.h>
+
 typedef struct TRX_GL_Renderer {
     void (*init)(struct TRX_GL_Renderer *renderer, const TRX_GL_CONFIG *config);
     void (*shutdown)(struct TRX_GL_Renderer *renderer);
@@ -16,3 +18,6 @@ void TRX_GL_Renderer_BindGeometryFbo(void);
 
 // Bind the UI framebuffer for rendering the UI overlay.
 void TRX_GL_Renderer_BindUiFbo(void);
+
+// Get the GL object id of the geometry framebuffer (3D scene only, no UI).
+GLuint TRX_GL_Renderer_GetGeometryFboId(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR fixes monochrome inventory ring modes having problems with the fog in areas where it's not occluded by any mesh:

<img width="3840" height="2160" alt="20260707_132954_Desert_Railroad" src="https://github.com/user-attachments/assets/91e92c22-90e0-4a9a-b53a-2d18f58b7af8" />

It accomplishes it by switching away from drawing the game on every tick underneath the inventory ring / stats screen / pause screen to using snapshots.

#### Testing

Since it's pretty much a rewrite of the backgrounds that reuses the snapshot capture system to achieve more predictable postprocessing, we need to do very robust regression testing.

- [x] Upscaling factor
- [x] Upscaling filter
- [x] Texture filter
- [x] All inventory modes
- [ ] All stats modes
- [x] All pause modes
- [ ] Final stats
- [x] Loading screens regressions
- [x] Fades on/off
- [x] Neither UI or console shows up in the captured backgrounds