### PR TITLE
flyby: improve room checks and add injection support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
   - `pour_time`, which defines how long to pour liquid from the bowl
   - `flip_slot`, which defines the flip map slot index to alter once liquid has finished pouring
 - added a `flip_slot` property to the `O_PORTACABIN` object to define the flip map slot index to alter once the cabin has landed
+- added support for flyby camera sequences
 - changed `Game mode selection` to allow hiding the dialog even after having completed the game (Gameplay → General → Game mode selection)
 - improved handling of dead enemies used as switch triggers in custom levels by not altering their activation status and by adding detection for having been exploded (#5682)
 - fixed the Gameplay settings dialog layout so settings lists and presets use the available space more consistently

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -43,7 +43,6 @@ static int32_t M_GetLastCamera(const FLYBY_SEQUENCE *const sequence)
 
 static void M_PrepareSequence(const int32_t sequence_idx)
 {
-    g_Camera.type = CAM_FLYBY_MODE;
     m_CurrentSequence = sequence_idx;
     m_State.initial.camera_pos = g_Camera.pos;
     m_State.initial.camera_target = g_Camera.target;
@@ -60,6 +59,9 @@ static void M_PrepareSequence(const int32_t sequence_idx)
     const FLYBY_CAMERA *const camera =
         Camera_GetFlybyCamera(sequence->camera_idx);
     const int32_t last_camera_idx = M_GetLastCamera(sequence);
+
+    g_Camera.type = CAM_FLYBY_MODE;
+    g_Camera.pos.room_num = camera->room_num;
 
     m_State.current.camera_idx = sequence->camera_idx;
     m_State.current.spline_pos = 0;
@@ -172,6 +174,42 @@ static void M_PrepareSplineToGame(void)
     m_State.data.fov[3] = m_State.data.fov[2];
 
     g_Camera = cam_info;
+}
+
+static bool M_TryResolveRoom(
+    const XYZ_32 pos, int16_t start_room, int16_t *const out_room)
+{
+    Room_GetSector(pos, &start_room);
+    if (!Room_PointInside(Room_Get(start_room), pos)) {
+        return false;
+    }
+
+    *out_room = start_room;
+    return true;
+}
+
+static int16_t M_GetBestRoomNum(
+    const XYZ_32 current_pos, const FLYBY_CAMERA *const camera)
+{
+    // Handle cases where the current spline position wants to use the next
+    // node's room number, but normal x/z/y traversal (Room_GetSector) is
+    // not possible. Try y/x/z, then fallback to the previous camera room.
+    int16_t room_num;
+    if (M_TryResolveRoom(current_pos, camera->room_num, &room_num)) {
+        return room_num;
+    }
+
+    const XYZ_32 y_first_pos = {
+        .x = camera->pos.x,
+        .y = current_pos.y,
+        .z = camera->pos.z,
+    };
+    if (M_TryResolveRoom(y_first_pos, camera->room_num, &room_num)
+        && M_TryResolveRoom(current_pos, room_num, &room_num)) {
+        return room_num;
+    }
+
+    return g_Camera.pos.room_num;
 }
 
 static void M_TestTriggers(void)
@@ -348,8 +386,8 @@ void Camera_FlybyMode_Update(void)
         }
     }
 
-    g_Camera.pos.room_num = current_camera->room_num;
-    Room_GetSector(g_Camera.pos.pos, &g_Camera.pos.room_num);
+    const int16_t room_num = M_GetBestRoomNum(pos, current_camera);
+    g_Camera.pos.room_num = room_num;
     g_Camera.target.room_num = g_Camera.pos.room_num;
     Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
     g_Camera.roll = roll;

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -390,6 +390,7 @@ void Camera_FlybyMode_Update(void)
     g_Camera.pos.room_num = room_num;
     g_Camera.target.room_num = g_Camera.pos.room_num;
     Room_GetSector(g_Camera.target.pos, &g_Camera.target.room_num);
+    g_Camera.shift = 0;
     g_Camera.roll = roll;
     Viewport_AlterFOV(fov, FOV_MODE_GAME);
 

--- a/src/trx/game/inject/data/camera.c
+++ b/src/trx/game/inject/data/camera.c
@@ -21,6 +21,15 @@ static void M_HandleCineFrames(
     }
 }
 
+static void M_HandleFlybyCameras(
+    const INJECTION *const injection, const int32_t data_count)
+{
+    LEVEL_CONTEXT_INFO *const level_info = Level_Context_GetInfo();
+    Level_Section_AppendFlybyCameras(
+        level_info->cameras.flyby_count, data_count, injection->fp);
+    level_info->cameras.flyby_count += data_count;
+}
+
 static void M_HandleCameraData(
     const INJECTION_CONTEXT *const ctx, const INJECTION_CHUNK chunk)
 {
@@ -38,6 +47,9 @@ static void M_HandleCameraData(
         switch (data_type) {
         case IDT_CINEMATIC_FRAMES:
             M_HandleCineFrames(chunk.injection, data_count);
+            break;
+        case IDT_FLYBY_CAMERAS:
+            M_HandleFlybyCameras(chunk.injection, data_count);
             break;
         default:
             LOG_WARNING("Unknown data type: %d", data_type);

--- a/src/trx/game/inject/enum.h
+++ b/src/trx/game/inject/enum.h
@@ -92,7 +92,8 @@ typedef enum {
     IDT_ANIM_TEXTURES    = 35,
     IDT_OBJ_LINK_EDITS   = 36,
     IDT_ITEM_NAME_EDITS  = 37,
-    IDT_NUMBER_OF        = 38,
+    IDT_FLYBY_CAMERAS    = 38,
+    IDT_NUMBER_OF        = 39,
 } INJECTION_DATA_TYPE;
 
 typedef enum {

--- a/src/trx/game/level/context.h
+++ b/src/trx/game/level/context.h
@@ -65,6 +65,10 @@ typedef struct {
         LEVEL_TR4_AI_ITEM_INFO *ai_items;
     } tr4;
 
+    struct {
+        int32_t flyby_count;
+    } cameras;
+
     int32_t mesh_ptr_count;
 } LEVEL_CONTEXT_INFO;
 

--- a/src/trx/game/level/format/format_tr1.c
+++ b/src/trx/game/level/format/format_tr1.c
@@ -145,6 +145,7 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     }
 
     Level_Section_ReadCamerasAndSinks(ctx, file);
+    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);

--- a/src/trx/game/level/format/format_tr2.c
+++ b/src/trx/game/level/format/format_tr2.c
@@ -128,6 +128,7 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     Level_Section_ReadSpriteTextures(ctx, file);
     Level_Section_ReadSpriteSequences(ctx, file);
     Level_Section_ReadCamerasAndSinks(ctx, file);
+    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -127,6 +127,7 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     Level_Section_ReadSpriteTextures(ctx, file);
     Level_Section_ReadSpriteSequences(ctx, file);
     Level_Section_ReadCamerasAndSinks(ctx, file);
+    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
 

--- a/src/trx/game/level/sections/append.h
+++ b/src/trx/game/level/sections/append.h
@@ -22,3 +22,5 @@ void Level_Section_AppendObjectTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
 void Level_Section_AppendSpriteTextures(
     int32_t base_idx, int16_t base_page_idx, int32_t num_textures, VFILE *file);
+void Level_Section_AppendFlybyCameras(
+    int32_t base_idx, int32_t num_cameras, VFILE *file);

--- a/src/trx/game/level/sections/cinematics.c
+++ b/src/trx/game/level/sections/cinematics.c
@@ -63,14 +63,29 @@ void Level_Section_ReadCamerasAndSinks(
 
 void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *const ctx, VFILE *const file)
 {
+    const int32_t inject_count = Inject_GetDataCount(IDT_FLYBY_CAMERAS);
+    if (ctx->loader->game_version < 4) {
+        Camera_InitialiseFlybys(inject_count);
+        return;
+    }
+
     BENCHMARK benchmark = Benchmark_Start();
     const int16_t num_cameras = VFile_ReadS16(file);
+    LEVEL_CONTEXT_INFO *const info = &ctx->info;
+    info->cameras.flyby_count = num_cameras;
     VFile_Skip(file, sizeof(int16_t)); // reserved padding
-    Camera_InitialiseFlybys(num_cameras); // TODO: detect injections
+    Camera_InitialiseFlybys(num_cameras + inject_count);
     LOG_INFO("flyby cameras: %d", num_cameras);
+    Level_Section_AppendFlybyCameras(0, num_cameras, file);
 
+    Benchmark_End(&benchmark, nullptr);
+}
+
+void Level_Section_AppendFlybyCameras(
+    const int32_t base_idx, const int32_t num_cameras, VFILE *const file)
+{
     for (int32_t i = 0; i < num_cameras; i++) {
-        FLYBY_CAMERA *const camera = Camera_GetFlybyCamera(i);
+        FLYBY_CAMERA *const camera = Camera_GetFlybyCamera(base_idx + i);
         M_ReadPosition(&camera->pos, file);
         M_ReadPosition(&camera->target, file);
         camera->sequence = VFile_ReadU8(file);
@@ -102,8 +117,6 @@ void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *const ctx, VFILE *const file)
         camera->flags.one_shot         = (flags & 0x8000) != 0;
         // clang-format on
     }
-
-    Benchmark_End(&benchmark, nullptr);
 }
 
 void Level_Section_ReadDemoData(LEVEL_CONTEXT *const ctx, VFILE *const file)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This improves room number checks for flyby cameras, resolving the clipping problems in Alexandria and Temple of Horus.

It also adds injection support, which will allow custom levels to use them. I've supplied a test injection to try this in Obelisk of Khamoon.

Ref: https://github.com/LostArtefacts/TRXInjectionTool/pull/303