### PR TITLE
ui/hud: hide debug labels outside gameplay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - fixed game mode options not displaying after having beaten the game, if the option itself is switched off (regression from 1.0)
 - fixed Lara being able to break out of locked cameras activated by heavy triggers by equipping her weapons (regression from 1.1)
 - fixed the installer not completing normally if an error is encountered during directory clean-up
+- fixed debug status overlays visible over inventory ring, pause screen and FMVs, including the end credits
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/photo_mode.c
+++ b/src/trx/game/photo_mode.c
@@ -35,6 +35,7 @@ typedef struct {
 } M_PRIV;
 
 static M_PRIV m_Priv = {};
+static bool m_Active = false;
 
 static void M_ApplyInterpolation(void)
 {
@@ -258,6 +259,7 @@ void PhotoMode_Start(void)
     Camera_PhotoMode_Enter();
     Music_Pause();
     Sound_PauseAll();
+    m_Active = true;
 }
 
 void PhotoMode_End(void)
@@ -269,6 +271,12 @@ void PhotoMode_End(void)
     g_Config.ui.enable_fps_counter = p->show_fps_counter;
     Music_Unpause();
     Sound_UnpauseAll();
+    m_Active = false;
+}
+
+bool PhotoMode_IsActive(void)
+{
+    return m_Active;
 }
 
 PHASE_CONTROL PhotoMode_Control(void)

--- a/src/trx/game/photo_mode.h
+++ b/src/trx/game/photo_mode.h
@@ -10,6 +10,7 @@ typedef enum {
 
 void PhotoMode_Start(void);
 void PhotoMode_End(void);
+bool PhotoMode_IsActive(void);
 
 PHOTO_MODE PhotoMode_GetCurrentMode(void);
 PHASE_CONTROL PhotoMode_Control(void);

--- a/src/trx/game/ui/hud/overlay.c
+++ b/src/trx/game/ui/hud/overlay.c
@@ -9,6 +9,7 @@
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects/names.h>
+#include <trx/game/photo_mode.h>
 #include <trx/game/ui.h>
 #include <trx/game/ui/scaler.h>
 #include <trx/version.h>
@@ -181,6 +182,10 @@ static void M_Arrow(
 
 static void M_DebugPosTopLeft(void)
 {
+    if (!Game_IsPlaying() && !PhotoMode_IsActive()) {
+        return;
+    }
+
     const ITEM *const lara = Lara_GetItem();
     const LARA_INFO *const lara_info = Lara_GetLaraInfo();
     if (lara == nullptr) {
@@ -251,6 +256,10 @@ static void M_DebugPosTopLeft(void)
 
 static void M_DebugPosTopRight(void)
 {
+    if (!Game_IsPlaying() && !PhotoMode_IsActive()) {
+        return;
+    }
+
     const ITEM *const lara = Lara_GetItem();
     if (lara == nullptr) {
         return;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Debug HUD labels (invulnerability, position, animation, camera) were only gated on Lara_GetItem() != nullptr, unlike every other HUD element in this file which also checks Game_IsPlaying(). Since the Lara item pointer stays stale until the next level loads, the labels could render during FMVs, the pause screen, the inventory ring, and especially the end-credits sequence.

Add the same Game_IsPlaying() guard used elsewhere in this file to M_DebugPosTopLeft and M_DebugPosTopRight.