### PR TITLE
flyby_mode: allow immediate cancellation

### DIFF
--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -28,7 +28,6 @@ static struct {
         bool spline_to_game;
         bool test_triggers;
         bool pending_trigger_check;
-        bool skip_requested;
         bool look_requested;
         bool look_cancelled;
     } flags;
@@ -225,14 +224,6 @@ static void M_TestTriggers(void)
     m_State.flags.test_triggers = false;
 }
 
-static void M_HandleSkip(const bool is_track_path)
-{
-    if (m_State.flags.skip_requested && !is_track_path) {
-        m_State.current.spline_pos = SPLINE_ONE;
-    }
-    m_State.flags.skip_requested = false;
-}
-
 static void M_HandleLook(const bool no_break)
 {
     // TODO: && game_mode != 1
@@ -280,6 +271,38 @@ bool Camera_FlybyMode_IsActive(void)
     return m_CurrentSequence != M_NO_SEQUENCE;
 }
 
+bool Camera_Flybymode_Cancel(void)
+{
+    if (m_CurrentSequence == M_NO_SEQUENCE) {
+        return false;
+    }
+
+    const FLYBY_SEQUENCE *const sequence =
+        Camera_GetSequence(m_CurrentSequence);
+    const FLYBY_CAMERA *const first_camera =
+        Camera_GetFlybyCamera(sequence->camera_idx);
+    if (first_camera->flags.track_path) {
+        return false;
+    }
+
+    const int32_t last_camera_idx = M_GetLastCamera(sequence);
+    for (int32_t i = m_State.current.camera_idx; i <= last_camera_idx; i++) {
+        const FLYBY_CAMERA *const camera = Camera_GetFlybyCamera(i);
+        if (!camera->flags.test_triggers) {
+            continue;
+        }
+
+        g_Camera.pos.pos = camera->pos;
+        g_Camera.pos.room_num = camera->room_num;
+        m_State.flags.test_triggers = true;
+        M_TestTriggers();
+    }
+
+    Camera_FlybyMode_Deactivate();
+    Camera_ResetPosition();
+    return true;
+}
+
 void Camera_FlybyMode_Deactivate(void)
 {
     m_CurrentSequence = M_NO_SEQUENCE;
@@ -296,11 +319,6 @@ void Camera_FlybyMode_Deactivate(void)
         g_Camera.interp.prev.target = g_Camera.target.pos;
     }
     // TODO: undo fade clip
-}
-
-void Camera_FlybyMode_RequestSkip(void)
-{
-    m_State.flags.skip_requested = true;
 }
 
 void Camera_FlybyMode_RequestLook(void)
@@ -366,7 +384,6 @@ void Camera_FlybyMode_Update(void)
         m_State.current.spline_pos += speed;
     }
 
-    M_HandleSkip(first_camera->flags.track_path);
     M_HandleLook(first_camera->flags.no_break);
     if (!Camera_FlybyMode_IsActive()) {
         return;

--- a/src/trx/game/camera/flyby_mode.h
+++ b/src/trx/game/camera/flyby_mode.h
@@ -5,7 +5,7 @@
 bool Camera_FlybyMode_Activate(int32_t sequence, bool one_shot);
 void Camera_FlybyMode_Deactivate(void);
 bool Camera_FlybyMode_IsActive(void);
+bool Camera_Flybymode_Cancel(void);
 
-void Camera_FlybyMode_RequestSkip(void);
 void Camera_FlybyMode_RequestLook(void);
 void Camera_FlybyMode_Update(void);

--- a/src/trx/game/console/cmd/fly.c
+++ b/src/trx/game/console/cmd/fly.c
@@ -1,16 +1,13 @@
 #include <trx/core/strings.h>
 #include <trx/game/console/registry.h>
+#include <trx/game/flyby_mode.h>
 #include <trx/game/game.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/lara/cheat.h>
 #include <trx/game/lara/common.h>
 
-static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+static COMMAND_RESULT M_TryFly(const COMMAND_CONTEXT *const ctx)
 {
-    if (!Game_IsPlayable()) {
-        return CR_UNAVAILABLE;
-    }
-
     bool enable;
     if (String_ParseBool(ctx->args, &enable)) {
         if (enable) {
@@ -32,6 +29,20 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
         Lara_Cheat_EnterFlyMode();
     }
     return CR_SUCCESS;
+}
+
+static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+{
+    const bool flyby_active = FlybyMode_IsActive();
+    if (!flyby_active && !Game_IsPlayable()) {
+        return CR_UNAVAILABLE;
+    }
+
+    const COMMAND_RESULT result = M_TryFly(ctx);
+    if (result == CR_SUCCESS && flyby_active) {
+        FlybyMode_Cancel();
+    }
+    return result;
 }
 
 REGISTER_CONSOLE_COMMAND("fly", M_Entrypoint, GS_ID("console/cmd/fly/help"))

--- a/src/trx/game/console/cmd/teleport.c
+++ b/src/trx/game/console/cmd/teleport.c
@@ -4,6 +4,7 @@
 #include <trx/game/console/registry.h>
 #include <trx/game/const.h>
 #include <trx/game/creature.h>
+#include <trx/game/flyby_mode.h>
 #include <trx/game/game.h>
 #include <trx/game/game_strings/entries.h>
 #include <trx/game/items.h>
@@ -421,17 +422,8 @@ static bool M_TryParseKeywordNumber(
     return true;
 }
 
-static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+static COMMAND_RESULT M_TryTeleport(const COMMAND_CONTEXT *const ctx)
 {
-    if (!Game_IsPlayable()) {
-        return CR_UNAVAILABLE;
-    }
-
-    const ITEM *const lara_item = Lara_GetItem();
-    if (!lara_item->hit_points) {
-        return CR_UNAVAILABLE;
-    }
-
     float x, y, z;
     if (sscanf(ctx->args, "precise %f %f %f", &x, &y, &z) == 3) {
         return M_TeleportToXYZ(x, y, z, true);
@@ -465,6 +457,25 @@ static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
     }
 
     return M_TeleportToObject(ctx->args);
+}
+
+static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
+{
+    const bool flyby_active = FlybyMode_IsActive();
+    if (!flyby_active && !Game_IsPlayable()) {
+        return CR_UNAVAILABLE;
+    }
+
+    const ITEM *const lara_item = Lara_GetItem();
+    if (lara_item->hit_points <= 0) {
+        return CR_UNAVAILABLE;
+    }
+
+    const COMMAND_RESULT result = M_TryTeleport(ctx);
+    if (result == CR_SUCCESS && flyby_active) {
+        FlybyMode_Cancel();
+    }
+    return result;
 }
 
 REGISTER_CONSOLE_COMMAND("tp", M_Entrypoint, GS_ID("console/cmd/tp/help"))

--- a/src/trx/game/flyby_mode.c
+++ b/src/trx/game/flyby_mode.c
@@ -34,15 +34,34 @@ void FlybyMode_Deactivate(void)
     Camera_FlybyMode_Deactivate();
 }
 
+bool FlybyMode_IsActive(void)
+{
+    return Camera_FlybyMode_IsActive();
+}
+
+bool FlybyMode_Cancel(void)
+{
+    return Camera_Flybymode_Cancel();
+}
+
 void FlybyMode_PreControl(void)
 {
-    if (!Camera_FlybyMode_IsActive()) {
+    if (!FlybyMode_IsActive()) {
         return;
     }
 
-    if (g_InputDB.menu_back && g_Config.gameplay.enable_cinematic_skips) {
-        Camera_FlybyMode_RequestSkip();
+    if (g_InputDB.fly_cheat && g_Config.gameplay.enable_cheats) {
+        FlybyMode_Cancel();
+        return;
     }
+
+    if (g_InputDB.option && g_Config.gameplay.enable_cinematic_skips) {
+        if (FlybyMode_Cancel()) {
+            g_InputDB.option = false;
+        }
+        return;
+    }
+
     if (g_Input.look) {
         Camera_FlybyMode_RequestLook();
     }
@@ -60,7 +79,7 @@ void FlybyMode_PreControl(void)
 
 void FlybyMode_PostControl(void)
 {
-    if (Camera_FlybyMode_IsActive()) {
+    if (FlybyMode_IsActive()) {
         g_Camera.type = CAM_FLYBY_MODE;
         M_RestoreLaraInfo();
     }

--- a/src/trx/game/flyby_mode.h
+++ b/src/trx/game/flyby_mode.h
@@ -4,5 +4,8 @@
 
 void FlybyMode_Activate(int32_t sequence_idx, bool one_shot);
 void FlybyMode_Deactivate(void);
+bool FlybyMode_IsActive(void);
+bool FlybyMode_Cancel(void);
+
 void FlybyMode_PreControl(void);
 void FlybyMode_PostControl(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows cancelling flybys using `/tp` and the fly cheat. If the sequence has nodes that activate heavy triggers, the requests will be ignored until those nodes have been passed, avoiding potential softlocks. I've left the escape key to jump to the next node in the sequence as part of "normal" config/gameplay.

If `/tp` fails e.g. passing an invalid room, the sequence will not be cancelled.