### PR TITLE
lara/col/land: fix underwater flare pickup

### DIFF
--- a/src/trx/game/lara/col/land.c
+++ b/src/trx/game/lara/col/land.c
@@ -323,7 +323,8 @@ static void M_Pickup(ITEM *const item, COLL_INFO *const coll)
 static void M_FlarePickup(ITEM *const item, COLL_INFO *const coll)
 {
     M_Default(item, coll);
-    if (coll->side_mid.floor <= STEPUP_HEIGHT) {
+    if (coll->side_mid.floor <= STEPUP_HEIGHT
+        && Item_TestAnimEqual(item, LA(LA_FLARE_PICKUP))) {
         item->pos.y += coll->side_mid.floor;
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara shifting into the floor when picking up a flare underwater. Regression from the fix for picking up a flare inside lifts (unreleased).