### PR TITLE
lara: handle misc TR4 behaviour

### DIFF
--- a/src/trx/game/anims/commands.c
+++ b/src/trx/game/anims/commands.c
@@ -62,7 +62,7 @@ static bool M_ParseCommand(
         const int16_t effect_data = *data_ptr++;
         cmd_data->effect_num = effect_data & 0x3FFF;
         cmd_data->fx_type = 0;
-        if (command->type == AC_EFFECT && g_TRVersion == 3) {
+        if (command->type == AC_EFFECT && g_TRVersion >= 3) {
             cmd_data->fx_type = effect_data & 0xC000;
             cmd_data->environment = ACE_ALL;
         } else {

--- a/src/trx/game/lara/common.c
+++ b/src/trx/game/lara/common.c
@@ -622,7 +622,7 @@ void Lara_Animate(ITEM *const item)
                 break;
             }
 
-            if (g_TRVersion == 3) {
+            if (g_TRVersion >= 3) {
                 ItemAction_RunDirectWithFX(
                     data->effect_num, item, data->fx_type);
                 break;

--- a/src/trx/game/lara/control.c
+++ b/src/trx/game/lara/control.c
@@ -153,7 +153,7 @@ static void M_WaterCurrent_TR12(COLL_INFO *const coll)
     coll->old_pos = lara_item->pos;
 }
 
-static void M_WaterCurrent_TR3(COLL_INFO *const coll)
+static void M_WaterCurrent_TR34(COLL_INFO *const coll)
 {
     ITEM *const lara_item = Lara_GetItem();
     LARA_INFO *const lara = Lara_GetLaraInfo();
@@ -245,7 +245,8 @@ static void M_WaterCurrent_TR3(COLL_INFO *const coll)
         break;
     }
 
-    if (coll->side_mid.floor < 0) {
+    if (coll->side_mid.floor < 0
+        && (g_TRVersion == 3 || coll->side_mid.floor != NO_HEIGHT)) {
         lara_item->pos.y += coll->side_mid.floor;
     }
 
@@ -258,7 +259,7 @@ static void M_WaterCurrent(COLL_INFO *const coll)
     if (g_TRVersion < 3) {
         M_WaterCurrent_TR12(coll);
     } else {
-        M_WaterCurrent_TR3(coll);
+        M_WaterCurrent_TR34(coll);
     }
 }
 
@@ -370,7 +371,7 @@ static void M_UpdateEnvironment(void)
         water_height == NO_HEIGHT ? NO_HEIGHT : item->pos.y - water_height;
     lara_info->water_surface_dist = -water_height_diff;
 
-    if (g_TRVersion == 3) {
+    if (g_TRVersion >= 3) {
         FX_Water_WadeSplash(item, water_height, water_depth);
     } else if (
         g_Config.gameplay.enable_wading

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -310,7 +310,7 @@ void Lara_Hair_Control(const bool in_cutscene)
         s->pos.y += m_HairVelocity[i].y * 3 / 4;
         s->pos.z += m_HairVelocity[i].z * 3 / 4;
 
-        if (g_TRVersion == 3) {
+        if (g_TRVersion >= 3) {
             if (lara_info->water_status == LWS_ABOVE_WATER
                 && Room_Get(room_num)->flags.wind) {
                 s->pos.x += smoke_wind.x;

--- a/src/trx/game/rooms/triggers/camera.c
+++ b/src/trx/game/rooms/triggers/camera.c
@@ -63,7 +63,7 @@ static void M_HandleSink(
     TRIGGER_STATUS *const status)
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
-    if (g_TRVersion == 3) {
+    if (g_TRVersion >= 3) {
         lara->current.active = 1 + (int16_t)(intptr_t)cmd->parameter;
     } else {
         const OBJECT_VECTOR *const sink =

--- a/src/trx/game/sparks/manager.c
+++ b/src/trx/game/sparks/manager.c
@@ -242,7 +242,7 @@ static void M_UpdateWind(void)
         return;
     }
 
-    if (g_TRVersion != 3) {
+    if (g_TRVersion < 3) {
         const ITEM *const lara_item = Lara_GetItem();
         if (lara_item == nullptr) {
             m_HairWindZ = 0;

--- a/src/trx/game/spawn.c
+++ b/src/trx/game/spawn.c
@@ -54,7 +54,7 @@ XYZ_32 Spawn_GetRayPos(
 
 void Spawn_Splash(const ITEM *const item)
 {
-    if (g_TRVersion == 3) {
+    if (g_TRVersion >= 3) {
         FX_Water_Splash(item);
         return;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates some of Lara's behaviour previously gated by TR3 version checks. There are a lot more of these to do but these are some simple ones to get past a few blocks (well, mainly the first issue)
- [x] water currents should behave; the setup is identical to TR3 bar an additional `NO_HEIGHT` check. That particular check is in a lot of places in Lara's control in TR4 so I think it should eventually be added to the "wall glitch behaviour" enum.
- [x] Lara's footstep sounds should play for both feet, not just one e.g. on sand at start of Karnak.
- [x] Lara's hair/wind behaviour updated (I think this was the issue I was seeing before in Coastal where it was getting stuck; aredfan noticed the different direction in Karnak).
- [x] splash effects and sounds now spawn (spark sprites to be updated later).