### PR TITLE
stats: fix level counter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@
 - fixed missing SFX when Lara is shimmying (#4996)
 - fixed missing SFX in the Pipeman's death animation (#5036)
 - fixed geometry issues in room 53 in Madubu Gorge, which could cause the TR3 camera to become stuck and allow Lara to fly into the ceiling
+- fixed the stats level counter not taking into account level progression and using the level's default number instead (#5757, regression from 1.2)
 
 **TR4**:
 - added very rudimentary support for TR4 levels

--- a/src/trx/game/option/stats.c
+++ b/src/trx/game/option/stats.c
@@ -6,6 +6,7 @@
 #include <trx/game/gym.h>
 #include <trx/game/input.h>
 #include <trx/game/lara.h>
+#include <trx/game/savegame.h>
 #include <trx/game/sound.h>
 #include <trx/game/ui.h>
 
@@ -34,6 +35,7 @@ static void M_Init(M_PRIV *const p, INVENTORY_ITEM *const inv_item)
             ? UI_STATS_DIALOG_STYLE_BARE
             : UI_STATS_DIALOG_STYLE_BORDERED,
         .level_num = Game_GetCurrentLevel()->num,
+        .display_level_num = Savegame_GetCompletedLevelCount() + 1,
     });
 }
 

--- a/src/trx/game/phase/phase_stats.c
+++ b/src/trx/game/phase/phase_stats.c
@@ -8,6 +8,7 @@
 #include <trx/game/game_flow.h>
 #include <trx/game/input.h>
 #include <trx/game/output.h>
+#include <trx/game/savegame.h>
 #include <trx/game/shell.h>
 #include <trx/game/ui.h>
 
@@ -64,6 +65,7 @@ static PHASE_CONTROL M_Start(PHASE *const phase)
                                             : UI_STATS_DIALOG_STYLE_BORDERED,
             .level_num = p->args.level_num != -1 ? p->args.level_num
                                                  : Game_GetCurrentLevel()->num,
+            .display_level_num = Savegame_GetCompletedLevelCount() + 1,
         });
         if (p->args.show_final_stats
             && !UI_StatsDialog_HasVisibleRows(p->ui_state)) {

--- a/src/trx/game/savegame/common.c
+++ b/src/trx/game/savegame/common.c
@@ -901,6 +901,20 @@ void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *const level)
     M_DetermineLegacyGunTypes(resume);
 }
 
+int32_t Savegame_GetCompletedLevelCount(void)
+{
+    int32_t count = 0;
+    const GF_LEVEL_TABLE *const level_table = GF_GetLevelTable(GFLT_MAIN);
+    for (int32_t i = 0; i < level_table->count; i++) {
+        const GF_LEVEL *const level = &level_table->levels[i];
+        const RESUME_INFO *const current = Savegame_GetCurrentInfo(level);
+        if (current != nullptr && current->level_completed) {
+            count++;
+        }
+    }
+    return count;
+}
+
 void Savegame_ProcessItemsBeforeSave(void)
 {
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {

--- a/src/trx/game/savegame/common.h
+++ b/src/trx/game/savegame/common.h
@@ -61,6 +61,7 @@ void Savegame_CarryCurrentInfoToNextLevel(
     const GF_LEVEL *src_level, const GF_LEVEL *dst_level);
 void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *level);
 void Savegame_ApplyLogicToCurrentInfo(const GF_LEVEL *level);
+int32_t Savegame_GetCompletedLevelCount(void);
 
 int32_t Savegame_GetSlotCount(SAVEGAME_SLOT_POOL pool);
 SAVEGAME_SLOT_REF Savegame_GetNextQuickSlot(void);

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -283,9 +283,7 @@ static void M_RowFromRole(
         M_Row(
             s, GS("general/stats/level"),
             String_FormatStatic(
-                GS("general/stats/detail_fmt"),
-                GF_GetLevelOrdinalNumber(
-                    GFLT_MAIN, GF_GetLevel(GFLT_MAIN, s->args.level_num)),
+                GS("general/stats/detail_fmt"), s->args.display_level_num,
                 GF_GetLevelCount(GFLT_MAIN)));
         break;
 

--- a/src/trx/game/ui/dialogs/stats.h
+++ b/src/trx/game/ui/dialogs/stats.h
@@ -18,6 +18,7 @@ typedef struct {
     UI_STATS_DIALOG_MODE mode;
     UI_STATS_DIALOG_STYLE style;
     int32_t level_num;
+    int32_t display_level_num;
 } UI_STATS_DIALOG_ARGS;
 
 typedef struct UI_STATS_DIALOG_STATE UI_STATS_DIALOG_STATE;


### PR DESCRIPTION
Resolves #5757.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the stats to show the sequential level number based on the number of completed levels, rather than its defined game-flow table number.
