### PR TITLE
lara/draw: hide Lara and shadow when using binoculars

### DIFF
--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -409,7 +409,8 @@ bool Lara_Draw(const ITEM *const item)
     const ITEM *const lara_item = Lara_GetItem();
     m_IsLara = item == lara_item;
     if (m_IsLara
-        && (item->status == IS_INVISIBLE || (item->flags & IF_ONE_SHOT) != 0)) {
+        && (item->status == IS_INVISIBLE || (item->flags & IF_ONE_SHOT) != 0
+            || item->mesh_bits == 0)) {
         return false;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

When binoculars are active the camera clears lara_item->mesh_bits, which in the OG gates the entire DrawLara call (meshes, hair and shadow). TRX only honored mesh_bits per-mesh, so the braid and shadow stayed visible. Skip Lara_Draw entirely when mesh_bits is zero, matching the OG.

Ref TRX574