### PR TITLE
rope: freeze interpolation while game is paused

### DIFF
--- a/src/trx/game/rope.c
+++ b/src/trx/game/rope.c
@@ -3,6 +3,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
+#include <trx/game/game/state.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -588,8 +589,9 @@ void Rope_AlignLara(ITEM *const item)
 
 static void M_DrawRope(const ROPE *const rope, const int32_t sprite_idx)
 {
-    const double rate =
-        Interpolation_IsActive() ? Interpolation_GetRate() : 1.0;
+    const double rate = (Interpolation_IsActive() && Game_IsPlaying())
+        ? Interpolation_GetRate()
+        : 1.0;
     XYZ_F points[ROPE_SEGMENTS];
     for (int32_t n = 0; n < ROPE_SEGMENTS; n++) {
         const XYZ_32 *const prev = &rope->prev_mesh_segments[n];


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The rope draw path used Interpolation_GetRate() directly, which keeps advancing the sub-frame rate even when the game is paused. In photo mode this made the rope jitter. Gate the rate on Game_IsPlaying() so the rope snaps to the current segments when not playing.

Ref TRX596