### PR TITLE
water-fx: fix ripple intensity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,7 @@
 **TR3**:
 - added support for embedded injections in level files
 - added the TR2 inventory background as an option for the inventory, pause and stats screens
+- fixed water ripples appearing too intense compared to OG (regression from 1.1)
 - fixed missing portals in Aldwych room 87, which could lead to Lara becoming softlocked
 - fixed the ticket booth SFX playing in Aldwych when Lara treads in shallow water
 - fixed the underwater swimming SFX playing when Lara turns to the right in shallow water

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -515,27 +515,15 @@ static void M_DrawRipple(const FX_WATER_RIPPLE *r)
         return;
     }
 
-    // double-sided
-    const XYZ_32 quad_pos[2][4] = {
-        {
-            { r->x - n, r->y, r->z - n },
-            { r->x + n, r->y, r->z - n },
-            { r->x + n, r->y, r->z + n },
-            { r->x - n, r->y, r->z + n },
-        },
-        {
-            { r->x - n, r->y, r->z - n },
-            { r->x - n, r->y, r->z + n },
-            { r->x + n, r->y, r->z + n },
-            { r->x + n, r->y, r->z - n },
-        },
+    const XYZ_32 quad_pos[4] = {
+        { r->x - n, r->y, r->z - n },
+        { r->x + n, r->y, r->z - n },
+        { r->x + n, r->y, r->z + n },
+        { r->x - n, r->y, r->z + n },
     };
     const RGBA_8888 quad_color[4] = { color, color, color, color };
     OutputSource_PolyFX_StageSpriteQuadWorldDepth(
-        sprite_idx, quad_pos[0], quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
-        DRAW_BLEND_ADD);
-    OutputSource_PolyFX_StageSpriteQuadWorldDepth(
-        sprite_idx, quad_pos[1], quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
+        sprite_idx, quad_pos, quad_color, M_RIPPLE_Z_DEPTH_ADJUST,
         DRAW_BLEND_ADD);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TRX was staging each TR3 ripple twice with additive blending, which made the rings appear stronger than in OG TR3.

Use a single staged quad so ripple intensity matches the original effect more closely.

Ref TRX591