### PR TITLE
stats: fix secret glyph resolution

### DIFF
--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 
-#define M_CACHE_VERSION 5
+#define M_CACHE_VERSION 6
 #define M_CACHE_FILENAME "max_stats.cache.json"
 
 static LEVEL_MAX_STATS *m_Stats = nullptr;

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -214,9 +214,16 @@ static void M_FormatIconSecrets(
         }
         const OBJECT_ID obj_id = Stats_GetSecretObject(i);
         if (obj_id != NO_OBJECT) {
+            int32_t secret_num = 0;
+            for (int32_t j = 0; g_SecretObjects[j] != NO_OBJECT; j++) {
+                if (g_SecretObjects[j] == obj_id) {
+                    secret_num = j + 1;
+                    break;
+                }
+            }
             ptr += sprintf(
                 ptr, has_secret ? "\\{secret %d}" : "\\{i}\\{secret %d}\\{/i}",
-                obj_id + 1 - O_SECRET_1);
+                secret_num);
         }
         if (has_secret) {
             num_secrets++;

--- a/src/trx/game/ui/text.c
+++ b/src/trx/game/ui/text.c
@@ -543,7 +543,7 @@ static void M_Process(
 
         if (glyph->role == GLYPH_SECRET) {
             const int16_t sprite_idx =
-                Object_Get(O_SECRET_1 + glyph->mesh_idx)->mesh_idx;
+                Object_Get(g_SecretObjects[glyph->mesh_idx])->mesh_idx;
             const SPRITE_TEXTURE *const sprite =
                 Output_GetSpriteTexture(sprite_idx);
             const float input_scale_h =


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Secret icon glyphs were derived by adding an offset to `O_SECRET_1` and, inversely, subtracting `O_SECRET_1` from an assigned object id. This assumed `O_SECRET_1/2/3` were contiguous in the `OBJECT_ID` enum, which broke once 1815ac5aa interleaved each secret's `_OPTION` counterpart between them, making `O_SECRET_3` resolve to index 4 instead of 2 (rendered as "secret 5" in the stats screen).

Both spots now look up the index via `g_SecretObjects[]` instead of doing arithmetic on enum values, so they no longer depend on object ordering. Also bumps the stats cache version, since a stale cache built before the reorder still stores object ids from the old enum layout.

Ref TRX603