### PR TITLE
output/sky: fix skybox brightness regression

### DIFF
--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -242,16 +242,6 @@ static void M_DrawScreenQuad(
     });
 }
 
-void Output_DrawBlackRectangle(const int32_t opacity)
-{
-    const int32_t sx = 0;
-    const int32_t sy = 0;
-    const int32_t sw = Viewport_GetWidth(VIEWPORT_UI);
-    const int32_t sh = Viewport_GetHeight(VIEWPORT_UI);
-    const RGBA_8888 background = { 0, 0, 0, opacity };
-    Output_DrawScreenFlatQuad(sx, sy, 0, sw, sh, background);
-}
-
 void Output_DrawRoom(const ROOM *const room, const bool is_outside)
 {
     OutputSource_Rooms_StageRoom(room);
@@ -282,12 +272,6 @@ void Output_DrawObjectMesh_I(const OBJECT_MESH *const mesh, const CLIP clip)
     Matrix_Interpolate();
     Output_DrawObjectMesh(mesh, clip);
     Matrix_Pop();
-}
-
-void Output_DrawSkybox(const OBJECT_MESH *const mesh)
-{
-    OutputSource_Objects_StageObjectMesh(mesh);
-    SceneCompositor_Flush();
 }
 
 void Output_DrawShadow(

--- a/src/trx/game/output/draw.h
+++ b/src/trx/game/output/draw.h
@@ -5,7 +5,6 @@
 #include <trx/game/output/types.h>
 #include <trx/game/rooms/types.h>
 
-void Output_DrawSkybox(const OBJECT_MESH *mesh);
 void Output_DrawObjectMesh(const OBJECT_MESH *mesh, CLIP clip);
 void Output_DrawObjectMesh_I(const OBJECT_MESH *mesh, CLIP clip);
 void Output_DrawRoom(const ROOM *room, bool is_outside);
@@ -15,9 +14,6 @@ void Output_DrawSprite(
     DRAW_TYPE draw_type);
 void Output_DrawShadow(int16_t size, const BOUNDS_16 *bounds, const ITEM *item);
 void Output_DrawLightningSegment(const LIGHTNING_SEGMENT segment);
-
-// Fades
-void Output_DrawBlackRectangle(int32_t opacity);
 
 // UI
 void Output_DrawScreenSprite(

--- a/src/trx/game/output/sky.c
+++ b/src/trx/game/output/sky.c
@@ -272,7 +272,7 @@ static void M_AdjustLightInfo(OUTPUT_LIGHT_INFO *const info)
 }
 
 static const OUTPUT_OBJECT_MESH_POLICY m_SkyboxMeshPolicy = {
-    .vertex_flags = VERT_USE_OWN_LIGHT | VERT_NO_LIGHTING,
+    .vertex_flags = 0,
     .get_face_pass = M_GetFacePass,
     .get_vertex_color = M_GetVertexColor,
     .get_vertex_shade = M_GetVertexShade,
@@ -352,7 +352,8 @@ bool Output_Sky_Draw(void)
         OutputSource_Sky_StageFogGradient(
             g_WMatrixPtr, mesh, Output_GetFogColor());
     }
-    Output_DrawSkybox(mesh);
+    OutputSource_Objects_StageObjectMesh(mesh);
+    SceneCompositor_Flush();
     Matrix_Pop();
     return true;
 }


### PR DESCRIPTION

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The TRX600 fix set `VERT_NO_LIGHTING` on the skybox mesh policy to stop nearby dynamic lights (e.g. the binoculars) from lighting the horizon. That flag also skips fog in the shader, so TR3 skyboxes lost their fog gradient and read as too bright.

`VERT_USE_OWN_LIGHT` was the actual cause of TRX600: it made the object-lit horizon mesh eligible for the shader's dynamic point-light term, on top of the object-light path it already uses for its base color. Dropping `vertex_flags` to 0 removes that stray bit (`M_AddObjectFace` still assigns the correct light-family flag per mesh) and lets fog apply normally again.

Resolves TRX604.
Ref TRX600.

#### Testing

- [x] Regression tests across Karnak, Coastal Ruins, and Mastabas
- [x] Regression tests in TR3 levels
- [x] Adjusting game brightness in TR3
- [x] Adjusting game brightness in TR4
- [x] Using binos torch in TR3
- [x] Using binos torch in TR4