### PR TITLE
objects/movable_block: fix stack and pull interaction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
 - fixed Lara being able to break out of locked cameras activated by heavy triggers by equipping her weapons (regression from 1.1)
 - fixed the installer not completing normally if an error is encountered during directory clean-up
 - fixed debug status overlays visible over inventory ring, pause screen and FMVs, including the end credits
+- fixed Lara being able to push/pull a block that is sitting on a collapsible tile about to drop (#5786, regression from 1.8)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@
 - added support for flyby camera sequences
 - added the ability for Lara to shimmy around corners, TR4 style (Gameplay → Controls → Corner shimmying) (#1375, #4370)
 - added an option to make Binoculars available in the inventory (Gameplay → General → Binoculars)
+- added rope mechanics for custom levels
+- added climbing poles for custom levels
 - changed `Game mode selection` to allow hiding the dialog even after having completed the game (Gameplay → General → Game mode selection)
 - changed `O_SPARKS_GFX` sprite ordering and contents - refer to migration guide
 - improved the `-l` command line option to match installed level titles when no file path is found

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - fixed the installer not completing normally if an error is encountered during directory clean-up
 - fixed debug status overlays visible over inventory ring, pause screen and FMVs, including the end credits
 - fixed Lara being able to push/pull a block that is sitting on a collapsible tile about to drop (#5786, regression from 1.8)
+- fixed Lara being unable to pull a block that is sitting directly below a room portal and she has a ceiling directly above her
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -1244,6 +1244,7 @@ If you install everything correctly, your game directory should look more or les
 │   │   ├── catalog_samples.csv
 │   │   ├── gameflow.json5
 │   │   ├── inv_ring.json5
+│   │   ├── strings-de.json5
 │   │   ├── strings-it.json5
 │   │   ├── strings.json5
 │   │   └── weapons.json5
@@ -2562,6 +2563,7 @@ Inside `TRX.app`, `Contents/Resources` should use the same combined layout as th
     │   │   │   ├── catalog_samples.csv
     │   │   │   ├── gameflow.json5
     │   │   │   ├── inv_ring.json5
+    │   │   │   ├── strings-de.json5
     │   │   │   ├── strings-it.json5
     │   │   │   ├── strings.json5
     │   │   │   └── weapons.json5

--- a/src/trx/game/objects/traps/falling_block.c
+++ b/src/trx/game/objects/traps/falling_block.c
@@ -33,14 +33,28 @@ static void M_Initialise(const int16_t item_num)
     Walkable_AllocateNodes(item, 1);
 }
 
-static void M_DropStack(const ITEM *const item)
+static XYZ_32 M_GetStackPos(const ITEM *const item)
 {
     const int32_t origin = M_GetOrigin(item);
-    const XYZ_32 drop_pos = {
+    return (XYZ_32) {
         .x = item->pos.x,
         .y = item->pos.y + origin,
         .z = item->pos.z,
     };
+}
+
+static void M_LockStack(const ITEM *const item)
+{
+    // Once the floor begins to break, any walkables on the stack cannot be
+    // moved by Lara.
+    const XYZ_32 drop_pos = M_GetStackPos(item);
+    MovableBlock_LockStack(drop_pos, item->room_num);
+}
+
+static void M_DropStack(const ITEM *const item)
+{
+    // Once the floor has broken, drop any stacked walkables.
+    const XYZ_32 drop_pos = M_GetStackPos(item);
     MovableBlock_DropStack(drop_pos, item->room_num);
 }
 
@@ -95,7 +109,10 @@ static void M_Control(const int16_t item_num)
             Item_RemoveActive(item_num);
             return;
         }
-        item->goal_anim_state = TRAP_ACTIVATE;
+        if (item->goal_anim_state != TRAP_ACTIVATE) {
+            item->goal_anim_state = TRAP_ACTIVATE;
+            M_LockStack(item);
+        }
         p->heavy_triggered = false;
         break;
 

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -352,7 +352,6 @@ static bool M_TestPull(
     // Test Lara destination sector.
     base_pos.x += x_add;
     base_pos.z += z_add;
-    room_num = item->room_num;
     sector = Room_GetSector(base_pos, &room_num);
     if (Room_GetHeight(sector, base_pos) != base_pos.y) {
         return false;

--- a/src/trx/game/objects/traps/movable_block.c
+++ b/src/trx/game/objects/traps/movable_block.c
@@ -1128,15 +1128,30 @@ void MovableBlock_UpdateBox(const ITEM *const item, const bool blocked)
     }
 }
 
-void MovableBlock_DropStack(const XYZ_32 drop_pos, int16_t room_num)
+void MovableBlock_LockStack(const XYZ_32 drop_pos, const int16_t room_num)
 {
-    VECTOR *stack = Vector_Create(sizeof(int16_t));
+    VECTOR *const stack = Vector_Create(sizeof(int16_t));
+    M_GetStack(stack, drop_pos, drop_pos.y, -WALL_L, room_num);
+
+    for (int16_t i = 0; i < stack->count; i++) {
+        const int16_t item_num = *(const int16_t *)Vector_Get(stack, i);
+        ITEM *const item = Item_Get(item_num);
+        M_SetForcedMoving(item, true);
+    }
+
+    Vector_Free(stack);
+}
+
+void MovableBlock_DropStack(const XYZ_32 drop_pos, const int16_t room_num)
+{
+    VECTOR *const stack = Vector_Create(sizeof(int16_t));
     M_GetStack(stack, drop_pos, drop_pos.y, -WALL_L, room_num);
 
     for (int16_t i = stack->count - 1; i >= 0; i--) {
         const int16_t item_num = *(const int16_t *)Vector_Get(stack, i);
         ITEM *const item = Item_Get(item_num);
         M_SetGravityFrames(item, i);
+        M_SetForcedMoving(item, false);
         item->status = IS_ACTIVE;
         Item_AddActive(item_num);
         Item_Animate(item);

--- a/src/trx/game/objects/traps/movable_block.h
+++ b/src/trx/game/objects/traps/movable_block.h
@@ -6,6 +6,8 @@
 // Block or unblock a block's box overlap index.
 void MovableBlock_UpdateBox(const ITEM *item, bool blocked);
 
+// Lock a stack that is about to drop.
+void MovableBlock_LockStack(XYZ_32 drop_pos, int16_t room_num);
 // Drop a stack of blocks.
 void MovableBlock_DropStack(XYZ_32 drop_pos, int16_t room_num);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents a pushblock that is sitting on a collapsible tile that has begun animating from being able to be moved by Lara. We hook into the same premise as when a lift is moving a pushblock. Once the tile actually breaks and the pushblock has gravity, the lock is lifted for when it hits the floor.

It also fixes a second bug (discussed with Gizzy) in the provided level that's unique to the geometry setup there (screenshot below). The pull test was using the room number obtained from the block's original position minus its height, which was traversing up into the portal above. By then resetting the room number and testing Lara's destination sector, portal traversal was failing from the top room because of the wall. We now just use the room number already obtained from the block's destination sector, then traverse through to Lara's destination.

<details>

<img width="800" height="611" alt="image" src="https://github.com/user-attachments/assets/d1925574-a5ea-420f-b9ff-14f9d71ad039" />
</details>

Fixes TRX609/ resolves #5786.
