### PR TITLE
src/meson: improve packaging build overrides

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 project(
   'TRX',
   'c',
+  version: 'undefined',
   default_options: [
     'c_std=c2x',
     'warning_level=3',
@@ -12,14 +13,27 @@ project(
 fs = import('fs')
 
 staticdeps = get_option('staticdeps')
+trx_version = get_option('trx_version')
 # Always dynamically link on macOS
 if host_machine.system() == 'darwin'
   staticdeps = false
 endif
 
 c_compiler = meson.get_compiler('c')
-git = find_program('git', required: true)
 python3 = find_program('python3', required: true)
+
+if trx_version == ''
+  version_result = run_command(
+    python3,
+    meson.project_source_root() + '/../tools/get_version',
+    check: false,
+  )
+  if version_result.returncode() == 0
+    trx_version = version_result.stdout().strip()
+  else
+    trx_version = '?'
+  endif
+endif
 
 trx_lua_embed = custom_target(
   'trx_lua_embed',
@@ -94,7 +108,7 @@ dep_pcre2 = dependency('libpcre2-8', static: staticdeps)
 dep_backtrace = c_compiler.find_library('backtrace', static: true, required: false)
 dep_swscale = dependency('libswscale', static: staticdeps)
 dep_swresample = dependency('libswresample', static: staticdeps)
-dep_lua = dependency('lua', static: staticdeps)
+dep_lua = dependency(get_option('lua_dep'), static: staticdeps)
 c_compiler.check_header('uthash.h', required: true)
 dep_mathlibrary = c_compiler.find_library('m', static: staticdeps, required: false)
 
@@ -853,13 +867,27 @@ endif
 trx_init = custom_target(
   'trx_fake_init',
   output: ['trx_init.c'],
-  command: [python3, meson.project_source_root() + '/../tools/generate_init', '-o', meson.current_build_dir() / '@OUTPUT0@'],
+  command: [
+    python3,
+    meson.project_source_root() + '/../tools/generate_init',
+    '--version',
+    trx_version,
+    '-o',
+    meson.current_build_dir() / '@OUTPUT0@',
+  ],
   build_always_stale: true,
 )
 trx_version_rc = custom_target(
   'trx_fake_version',
   output: ['trx_version.rc'],
-  command: [python3, meson.project_source_root() + '/../tools/generate_rcfile', '-o', '@OUTPUT0@'],
+  command: [
+    python3,
+    meson.project_source_root() + '/../tools/generate_rcfile',
+    '--version',
+    trx_version,
+    '-o',
+    '@OUTPUT0@',
+  ],
   build_always_stale: true,
 )
 trx_icon_rc = custom_target(

--- a/src/meson.options
+++ b/src/meson.options
@@ -1,1 +1,3 @@
 option('staticdeps', type: 'boolean', value: true, description: 'Try to build against static dependencies. default: true')
+option('trx_version', type: 'string', value: '', description: 'Override the TRX version string used by Meson and generated build files.')
+option('lua_dep', type: 'string', value: 'lua', description: 'Override the dependency() name used for Lua.')

--- a/tools/generate_init
+++ b/tools/generate_init
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import re
 from pathlib import Path
 
 from shared.versioning import generate_version
@@ -13,27 +12,33 @@ const char *g_TRXVersion = "TRX {version}";
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--output", type=Path)
+    parser.add_argument("--version", type=str, default="")
     return parser.parse_args()
 
 
-def get_init_c() -> str:
+def get_init_c(version: str) -> str:
     return TEMPLATE.format(
-        version=generate_version()
+        version=version
     )
 
 
-def update_init_c(output_path: Path) -> None:
-    new_text = get_init_c()
+def update_init_c(output_path: Path, version: str) -> None:
+    new_text = get_init_c(version=version)
     if not output_path.exists() or output_path.read_text() != new_text:
         output_path.write_text(new_text)
 
 
+def get_version(args: argparse.Namespace) -> str:
+    return args.version or generate_version()
+
+
 def main() -> None:
     args = parse_args()
+    version = get_version(args)
     if args.output:
-        update_init_c(output_path=args.output)
+        update_init_c(output_path=args.output, version=version)
     else:
-        print(get_init_c(), end="")
+        print(get_init_c(version=version), end="")
 
 
 if __name__ == "__main__":

--- a/tools/generate_rcfile
+++ b/tools/generate_rcfile
@@ -9,6 +9,7 @@ from shared.versioning import generate_version
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--output", type=Path, nargs="+")
+    parser.add_argument("--version", type=str, default="")
     return parser.parse_args()
 
 
@@ -25,7 +26,7 @@ def write_rc_template(
 
 def main() -> None:
     args = parse_args()
-    version = generate_version()
+    version = args.version or generate_version()
 
     for output_path in args.output or []:
         write_rc_template(

--- a/tools/get_version
+++ b/tools/get_version
@@ -1,17 +1,12 @@
 #!/usr/bin/env python3
-import argparse
+from pathlib import Path
 
 from shared.versioning import generate_version
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    return parser.parse_args()
-
-
 def main() -> None:
-    args = parse_args()
-    print(generate_version(), end="")
+    repo_dir = Path(__file__).resolve().parent.parent
+    print(generate_version(repo_dir=repo_dir))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Add Meson options to override the generated TRX version string and the Lua dependency name for packaged builds.

When no explicit version is provided, Meson now resolves it through the shared versioning tool instead of duplicating the git describe logic in the build file. The generated build files still receive the resolved version override, while Meson's own project version remains unchanged.

This lets packagers inject a release version and versioned Lua package name without maintaining local patches for the build.

Resolves #5789.