### PR TITLE
Improve and document env-var path resolution 

### DIFF
--- a/docs/trx/INSTALLING.md
+++ b/docs/trx/INSTALLING.md
@@ -30,6 +30,39 @@
    to ["Manually copying original game files"](#manually-copying-original-game-files)
    section in this document.
 
+## Split installs and custom paths
+
+By default, TRX expects a bundled layout where the executable sits next to
+the `cfg/` and `games/` directories. If you want to keep the executable in a
+different location, such as `/usr/local/bin`, you can override the runtime
+paths with environment variables:
+
+- `TRX_CONFIG_DIR`  
+  Defaults to `<trx_dir>/cfg`.
+- `TRX_CACHE_DIR`  
+  Defaults to `<trx_dir>/cache`.
+- `TRX_GAMES_DIR`  
+  Defaults to `<trx_dir>/games`.
+- `TRX_SCREENSHOTS_DIR`  
+  Defaults to `<trx_dir>/screenshots`.
+- `TRX_SAVES_DIR`  
+  Defaults to `<trx_dir>/saves`.
+
+For example, a wrapper script can keep the binary in one location while
+pointing TRX at a separate game-data directory:
+
+```sh
+#!/bin/sh
+export TRX_GAMES_DIR="$HOME/Work/TRX/games"
+export TRX_CONFIG_DIR="$HOME/Work/TRX/cfg"
+export TRX_SAVES_DIR="$HOME/Work/TRX/saves"
+export TRX_SCREENSHOTS_DIR="$HOME/Work/TRX/screenshots"
+exec /usr/local/bin/TRX.bin "$@"
+```
+
+This is especially useful for package managers and ports that install the
+binary outside the main TRX data tree.
+
 ## Verifying the installation
 
 If you install everything correctly, your game directory should look more or less like this (click to expand):

--- a/src/trx/game/shell/paths.c
+++ b/src/trx/game/shell/paths.c
@@ -210,15 +210,15 @@ static const M_DYNAMIC_PATH_POLICY m_PathPolicies[TRX_DYNAMIC_PATH_NUMBER_OF] = 
             "%mod_dir%/shaders/%rel%",
             "%base_mod_dir%/shaders/%rel%",
             "%trx_dir%/shaders/%rel%",
-            "%trx_dir%/cfg/shaders/%rel%",
+            "%config_dir%/shaders/%rel%",
             nullptr,
         },
         .check_exists = true,
     },
     [TRX_DYNAMIC_PATH_SCREENSHOT_WRITE_FILE] = {
         .patterns = {
-            "%trx_dir%/screenshots/%mod%/%rel%",
-            "%trx_dir%/screenshots/%rel%",
+            "%screenshots_dir%/%mod%/%rel%",
+            "%screenshots_dir%/%rel%",
             nullptr,
         },
         .check_exists = false,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

For #5789 which identified that we still semi-hardcode certain paths to be only usable from TRX dir. This PR exposes these paths via new env vars so that users can choose to place their screenshots/saves in places very different from TRX executable.