### PR TITLE
objects/zipline: fix let-go state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 - fixed debug status overlays visible over inventory ring, pause screen and FMVs, including the end credits
 - fixed Lara being able to push/pull a block that is sitting on a collapsible tile about to drop (#5786, regression from 1.8)
 - fixed Lara being unable to pull a block that is sitting directly below a room portal and she has a ceiling directly above her
+- fixed Lara continuing to travel in the zip line state despite the zip line having stopped, allowing her to void in some cases
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fixed Lara being able to push/pull a block that is sitting on a collapsible tile about to drop (#5786, regression from 1.8)
 - fixed Lara being unable to pull a block that is sitting directly below a room portal and she has a ceiling directly above her
 - fixed Lara continuing to travel in the zip line state despite the zip line having stopped, allowing her to void in some cases
+- fixed Lara jittering when letting go of zip lines in some cases (#2823)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/lara/state/jump.c
+++ b/src/trx/game/lara/state/jump.c
@@ -215,16 +215,6 @@ static void M_FastFall(ITEM *const item, COLL_INFO *const coll)
 static void M_Zipline(ITEM *const item, COLL_INFO *const coll)
 {
     g_Camera.target_angle = M_CAM_ZIPLINE_ANGLE;
-
-    if (!g_Input.action) {
-        item->goal_anim_state = LS(LS_JUMP_FORWARD);
-        Lara_Animate(item);
-        item->gravity = true;
-        item->speed = 100;
-        item->fall_speed = 40;
-        LARA_INFO *const lara = Lara_GetLaraInfo();
-        lara->move_angle = item->rot.y;
-    }
 }
 
 // clang-format off

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -4,20 +4,20 @@
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
 
-#define ZIPLINE_MAX_SPEED 100
-#define ZIPLINE_ACCELERATION 5
+#define M_MAX_SPEED 100
+#define M_ACCELERATION 5
 
 typedef struct {
     GAME_VECTOR old_pos;
 } M_PRIV;
 
 typedef enum {
-    ZIPLINE_STATE_EMPTY = 0,
-    ZIPLINE_STATE_GRAB = 1,
-    ZIPLINE_STATE_HANG = 2,
-} ZIPLINE_STATE;
+    M_STATE_EMPTY,
+    M_STATE_GRAB,
+    M_STATE_HANG,
+} M_STATE;
 
-static XYZ_32 m_ZiplineHandlePosition = {
+static const XYZ_32 m_ZiplineHandlePosition = {
     .x = 0,
     .y = 0,
     .z = WALL_L / 2 - 141,
@@ -54,26 +54,26 @@ static void M_Control(const int16_t item_num)
         return;
     }
 
-    if (!(item->flags & IF_ONE_SHOT)) {
+    if ((item->flags & IF_ONE_SHOT) == 0) {
         const M_PRIV *const p = item->priv;
         item->pos = p->old_pos.pos;
         Item_UpdateRoom(item_num, p->old_pos.room_num);
         item->status = IS_INACTIVE;
-        item->goal_anim_state = ZIPLINE_STATE_GRAB;
-        item->current_anim_state = ZIPLINE_STATE_GRAB;
+        item->goal_anim_state = M_STATE_GRAB;
+        item->current_anim_state = M_STATE_GRAB;
         Item_SwitchToAnim(item, 0, 0);
         Item_RemoveActive(item_num);
         return;
     }
 
-    if (item->current_anim_state == ZIPLINE_STATE_GRAB) {
+    if (item->current_anim_state == M_STATE_GRAB) {
         Item_Animate(item);
         return;
     }
 
     Item_Animate(item);
-    if (item->fall_speed < ZIPLINE_MAX_SPEED) {
-        item->fall_speed += ZIPLINE_ACCELERATION;
+    if (item->fall_speed < M_MAX_SPEED) {
+        item->fall_speed += M_ACCELERATION;
     }
 
     item->pos.y += item->fall_speed >> 2;

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -49,10 +49,15 @@ static void M_Initialise(const int16_t item_num)
 
 static void M_LetGo(const ITEM *const item, ITEM *const lara_item)
 {
+    if (lara_item->current_anim_state != LS(LS_ZIPLINE)) {
+        return;
+    }
     Lara_AnimateUntil(lara_item, LS(LS_JUMP_FORWARD));
     lara_item->gravity = true;
     lara_item->speed = item->fall_speed;
     lara_item->fall_speed = item->fall_speed >> 2;
+    LARA_INFO *const lara = Lara_GetLaraInfo();
+    lara->move_angle = item->rot.y;
 }
 
 static void M_Control(const int16_t item_num)
@@ -96,6 +101,9 @@ static void M_Control(const int16_t item_num)
         lara_item->current_anim_state == LS(LS_ZIPLINE);
     if (lara_on_zipline) {
         lara_item->pos = item->pos;
+        if (!g_Input.action) {
+            M_LetGo(item, lara_item);
+        }
     }
 
     XYZ_32 pos = item->pos;

--- a/src/trx/game/objects/general/zipline.c
+++ b/src/trx/game/objects/general/zipline.c
@@ -47,6 +47,14 @@ static void M_Initialise(const int16_t item_num)
     p->old_pos.room_num = item->room_num;
 }
 
+static void M_LetGo(const ITEM *const item, ITEM *const lara_item)
+{
+    Lara_AnimateUntil(lara_item, LS(LS_JUMP_FORWARD));
+    lara_item->gravity = true;
+    lara_item->speed = item->fall_speed;
+    lara_item->fall_speed = item->fall_speed >> 2;
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -102,11 +110,7 @@ static void M_Control(const int16_t item_num)
     }
 
     if (lara_on_zipline) {
-        lara_item->goal_anim_state = LS(LS_JUMP_FORWARD);
-        Lara_Animate(lara_item);
-        lara_item->gravity = true;
-        lara_item->speed = item->fall_speed;
-        lara_item->fall_speed = item->fall_speed >> 2;
+        M_LetGo(item, lara_item);
     }
     Sound_Effect(SFX_ZIPLINE_STOP, &item->pos, SPM_ALWAYS);
     Item_RemoveActive(item_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara not immediately letting go of ziplines when they come to a stop, if that happens on a frame that does not have a state change for the falling animation. It also resolves jittering in some cases when letting go manually, although I was never able to reproduce the issue exactly in #2823. When she lets go, she will now inherit the zip line's speed rather than using arbitrary values.

Resolves #2823 / TRX613
