### PR TITLE
savegame: store item mesh bits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fixed Lara being unable to pull a block that is sitting directly below a room portal and she has a ceiling directly above her
 - fixed Lara continuing to travel in the zip line state despite the zip line having stopped, allowing her to void in some cases
 - fixed Lara jittering when letting go of zip lines in some cases (#2823)
+- fixed Lara's lower meshes re-appearing after saving and loading in the kayak (regression from 1.3)
 - removed the hard-coded spawn distance between Puna and his Lizards (#5686)
 
 **TR1**:

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -414,6 +414,14 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t read_index)
         M_FAIL();
     }
 
+    {
+        // Introduced in TRX 1.9
+        int32_t mesh_bits;
+        if (M_SHOULD(JSON_READ(io, "mesh_bits", &mesh_bits))) {
+            item->mesh_bits = (uint32_t)mesh_bits;
+        }
+    }
+
     // Not sure why some items do not have their their position saved,
     // despite OBJECT telling them to.
     if (obj->save_position && JSON_ReadIO_HasKey(io, "room_num")) {

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -116,6 +116,7 @@ static void M_WriteItem(
 
     const OBJECT *const obj = Object_Get(item->object_id);
     JSONW_WRITE(io, "object_id", Object_ToGameID(item->object_id));
+    JSONW_WRITE(io, "mesh_bits", item->mesh_bits);
 
     if (obj->save_position) {
         M_WriteXYZ32(io, "pos", item->pos);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This stores item mesh bits in the savegame, resolving Lara's lower meshes re-appearing after loading in the kayak.

Resolves TRX617
