### PR TITLE
rope: fix brightness and weave direction

### DIFF
--- a/src/trx/game/rope.c
+++ b/src/trx/game/rope.c
@@ -19,13 +19,17 @@
 #define M_PENDULUM_GRAVITY 0x60000
 #define M_NODE_GRAVITY 0x30000
 #define M_LARA_HAND_OFFSET (-112)
-#define M_SPRITE_IDX 16
 #define M_HALF_WIDTH 24.0f
 
+// OG's DrawRope modulates the rope sprite by a flat 0xFF7F7F7F, i.e. half
+// brightness. The TR4 shader path reads an unlit vertex color as a prelit
+// value on the "128 = neutral" scale and doubles it, so OG's 0x7F modulate
+// has to be halved here to survive that doubling: 0x40/255 * 255/128 = 0.5.
+// Storing 0x7F instead leaves the rope at full bright, ignoring the room.
 static const RGBA_8888 m_RopeColor = {
-    .r = 0x7F,
-    .g = 0x7F,
-    .b = 0x7F,
+    .r = 0x40,
+    .g = 0x40,
+    .b = 0x40,
     .a = 0xFF,
 };
 
@@ -624,10 +628,15 @@ static void M_DrawRope(const ROPE *const rope, const int32_t sprite_idx)
             .y = points[n].y - g_Camera.pos.y,
             .z = points[n].z - g_Camera.pos.z,
         };
+        // cross(to_cam, dir), not cross(dir, to_cam): OG's DrawRope takes the
+        // screen-space perpendicular (-dy, dx) with Y pointing down, which
+        // ends up on the opposite side of the rope from the world-space
+        // cross. Getting this backwards mirrors the sprite's U axis and the
+        // rope's weave leans the wrong way.
         XYZ_F perp = {
-            .x = dir.y * to_cam.z - dir.z * to_cam.y,
-            .y = dir.z * to_cam.x - dir.x * to_cam.z,
-            .z = dir.x * to_cam.y - dir.y * to_cam.x,
+            .x = to_cam.y * dir.z - to_cam.z * dir.y,
+            .y = to_cam.z * dir.x - to_cam.x * dir.z,
+            .z = to_cam.x * dir.y - to_cam.y * dir.x,
         };
         const float length =
             sqrtf(SQUARE(perp.x) + SQUARE(perp.y) + SQUARE(perp.z));


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The rope drew at twice OG's brightness and with its sprite mirrored.

OG's DrawRope() paints the rope quads a flat 0xFF7F7F7F, which D3D applies as a MODULATE factor over the sprite, i.e. half brightness. The TR4 shader path instead reads an unlit vertex color as a prelit value on the "128 = neutral" scale and doubles it, so the stored 0x7F came out at full bright and the rope stopped sitting in the room's gloom. Halving it to 0x40 survives that doubling and lands back on OG's factor: 0x40/255 * 255/128 = 0.5.

The ribbon's perpendicular used cross(dir, to_cam), which falls on the opposite side of the rope from OG's screen-space perpendicular (-dy, dx), taken with Y pointing down. That mirrored the sprite's U axis and left the rope's weave leaning the wrong way.

Resolves TRX614.

