### PR TITLE
items: bounds-check Item_Get and clear name on slot reuse

### DIFF
--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -90,7 +90,8 @@ void Item_Reset(void)
 
 ITEM *Item_Get(const int16_t item_num)
 {
-    if (item_num == NO_ITEM || m_Items == nullptr) {
+    if (item_num == NO_ITEM || m_Items == nullptr || item_num < 0
+        || item_num >= MAX_ITEMS) {
         return nullptr;
     }
     return &m_Items[item_num];
@@ -169,6 +170,8 @@ int16_t Item_Create(void)
     const int16_t item_num = m_NextItemFree;
     if (item_num != NO_ITEM) {
         m_Items[item_num].flags = 0;
+        // A recycled slot must not inherit the previous occupant's name.
+        m_Items[item_num].name = nullptr;
         ObjectProperty_ResetItem(&m_Items[item_num]);
         m_NextItemFree = m_Items[item_num].next_item;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`Item_Get` only rejected `NO_ITEM`, so an out-of-range index returned a pointer into uninitialised pool memory. `Item_Create` also left the previous occupant's name on a recycled slot, and names are persisted in savegames.