### PR TITLE
Add basic test harness

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -1,0 +1,38 @@
+name: Run unit tests
+
+# The unit suite needs no game data, no level and no replay recordings, so unlike
+# the replay tests it can actually run in CI. It also needs none of the engine's
+# libraries: src/tests is a meson project of its own, so this job installs a
+# compiler and meson and nothing else.
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  unit:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build
+
+      - name: Run unit tests
+        run: |
+          meson setup build/tests src/tests
+          meson test -C build/tests --suite unit --print-errorlogs
+
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-log
+          path: build/tests/meson-logs/testlog.txt

--- a/justfile
+++ b/justfile
@@ -102,3 +102,10 @@ trx-package-win-te artifact_path output *args:
 trx-package-win-installer target='release' *args: \
     (trx-build-win-installer target args) \
     (_docker_run "rrdash/trx-win" "package" "--platform" "win-installer" args)
+
+# Run the unit tests. The tests are a separate meson project.
+[group('test')]
+test *args='--suite unit':
+    #!/usr/bin/env sh
+    meson setup build/tests src/tests >/dev/null 2>&1 || meson setup --reconfigure build/tests src/tests >/dev/null
+    meson test -C build/tests --print-errorlogs {{args}}

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,0 +1,52 @@
+# The unit tests are their own project, deliberately.
+#
+# They need no game data, no level, no replay and no TRX binary - and building
+# them apart from the engine is what keeps that true. The engine needs SDL, the
+# ffmpeg libraries, GLEW and PCRE2 to configure at all; none of that is required
+# to exercise a leaf module, so none of it is here. If a test ever does need the
+# engine, it will fail to configure rather than quietly grow a dependency on it.
+#
+# `meson test` needs only an exit code, so the harness is a header, not a
+# dependency.
+
+project(
+  'TRX unit tests',
+  'c',
+  default_options: ['c_std=c2x', 'warning_level=3'],
+  meson_version: '>=1.3.0',
+)
+
+c_compiler = meson.get_compiler('c')
+dep_mathlibrary = c_compiler.find_library('m', required: false)
+
+# <trx/...> resolves against src/; the harness header against src/tests/unit/.
+src_inc = include_directories('..')
+test_inc = include_directories('unit')
+test_stubs = files('unit/stubs.c')
+
+test_vector_exe = executable(
+  'test_vector',
+  files('unit/test_vector.c') + test_stubs
+    + files('../trx/core/vector.c', '../trx/core/memory.c'),
+  include_directories: [src_inc, test_inc],
+  build_by_default: false,
+)
+test('vector', test_vector_exe, suite: 'unit')
+
+test_math_func_exe = executable(
+  'test_math_func',
+  files('unit/test_math_func.c') + test_stubs
+    + files('../trx/core/math/func.c', '../trx/core/math/geom.c', '../trx/core/math/trig.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_mathlibrary],
+  build_by_default: false,
+)
+test('math_func', test_math_func_exe, suite: 'unit')
+
+test_hash_exe = executable(
+  'test_hash',
+  files('unit/test_hash.c') + test_stubs + files('../trx/core/hash.c'),
+  include_directories: [src_inc, test_inc],
+  build_by_default: false,
+)
+test('hash', test_hash_exe, suite: 'unit')

--- a/src/tests/unit/harness.h
+++ b/src/tests/unit/harness.h
@@ -1,0 +1,109 @@
+#pragma once
+
+// Minimal test harness. Tests self-register from constructors, the same pattern
+// REGISTER_OBJECT and TYPE_DEFINE already use, so a test file needs no manual
+// registration list. main() reports and exits non-zero on failure, which is the
+// entire protocol `meson test` requires.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    const char *name;
+    void (*func)(void);
+} TEST_CASE;
+
+#define TEST_MAX_CASES 128
+static TEST_CASE m_TestCases[TEST_MAX_CASES];
+static int m_TestCaseCount = 0;
+static int m_TestFails = 0; // failures in the case being run
+static int m_TestTotalFails = 0;
+
+static void Test_Register(const char *name, void (*func)(void))
+{
+    if (m_TestCaseCount < TEST_MAX_CASES) {
+        m_TestCases[m_TestCaseCount++] = (TEST_CASE) { name, func };
+    }
+}
+
+#define TEST(name_)                                                            \
+    static void name_(void);                                                   \
+    __attribute__((constructor)) static void M_Register_##name_(void)          \
+    {                                                                          \
+        Test_Register(#name_, name_);                                          \
+    }                                                                          \
+    static void name_(void)
+
+#define TEST_FAIL(fmt_, ...)                                                   \
+    do {                                                                       \
+        printf("    %s:%d: " fmt_ "\n", __FILE__, __LINE__, ##__VA_ARGS__);    \
+        m_TestFails++;                                                         \
+    } while (0)
+
+#define CHECK(cond_)                                                           \
+    do {                                                                       \
+        if (!(cond_)) {                                                        \
+            TEST_FAIL("expected: %s", #cond_);                                 \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_EQ_INT(actual_, expected_)                                       \
+    do {                                                                       \
+        const long long a_ = (long long)(actual_);                             \
+        const long long e_ = (long long)(expected_);                           \
+        if (a_ != e_) {                                                        \
+            TEST_FAIL("%s: expected %lld, got %lld", #actual_, e_, a_);        \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_EQ_STR(actual_, expected_)                                       \
+    do {                                                                       \
+        const char *a_ = (actual_);                                            \
+        const char *e_ = (expected_);                                          \
+        if (a_ == nullptr || strcmp(a_, e_) != 0) {                            \
+            TEST_FAIL(                                                         \
+                "%s: expected \"%s\", got \"%s\"", #actual_, e_,               \
+                a_ != nullptr ? a_ : "(null)");                                \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NULL(ptr_)                                                       \
+    do {                                                                       \
+        if ((ptr_) != nullptr) {                                               \
+            TEST_FAIL("%s: expected null", #ptr_);                             \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NOT_NULL(ptr_)                                                   \
+    do {                                                                       \
+        if ((ptr_) == nullptr) {                                               \
+            TEST_FAIL("%s: expected non-null", #ptr_);                         \
+        }                                                                      \
+    } while (0)
+
+static int Test_Main(void)
+{
+    int passed = 0;
+    for (int i = 0; i < m_TestCaseCount; i++) {
+        m_TestFails = 0;
+        m_TestCases[i].func();
+        if (m_TestFails == 0) {
+            printf("  PASS  %s\n", m_TestCases[i].name);
+            passed++;
+        } else {
+            printf(
+                "  FAIL  %s (%d check(s))\n", m_TestCases[i].name, m_TestFails);
+            m_TestTotalFails++;
+        }
+    }
+    printf(
+        "\n%d passed, %d failed, %d total\n", passed, m_TestTotalFails,
+        m_TestCaseCount);
+    return m_TestTotalFails == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int main(void)
+{
+    return Test_Main();
+}

--- a/src/tests/unit/stubs.c
+++ b/src/tests/unit/stubs.c
@@ -1,0 +1,24 @@
+// The only engine symbol the code under test reaches for is the logger, via
+// ASSERT. Stubbing it keeps the unit tests free of the platform log backend,
+// and therefore free of the engine entirely.
+
+#include <trx/core/log.h>
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+void Log_Message(
+    const LOG_LEVEL level, const char *const file, const int32_t line,
+    const char *const func, const char *const fmt, ...)
+{
+    (void)level;
+    (void)file;
+    (void)line;
+    (void)func;
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fputc('\n', stderr);
+}

--- a/src/tests/unit/test_hash.c
+++ b/src/tests/unit/test_hash.c
@@ -1,0 +1,68 @@
+#include "harness.h"
+
+#include <trx/core/hash.h>
+
+// FNV-1a. Savegames and caches key off these, so the values are a wire format:
+// changing them silently invalidates whatever was hashed with the old ones.
+
+TEST(the_empty_hash_is_the_fnv_offset_basis)
+{
+    CHECK(Hash_FNV1a64_Init() == HASH_FNV1A64_BASE);
+    CHECK(Hash_FNV1a64_Init() == 14695981039346656037ULL);
+}
+
+TEST(hashing_is_order_dependent)
+{
+    const uint64_t ab = Hash_FNV1a64_UpdateU32(
+        Hash_FNV1a64_UpdateU32(Hash_FNV1a64_Init(), 1), 2);
+    const uint64_t ba = Hash_FNV1a64_UpdateU32(
+        Hash_FNV1a64_UpdateU32(Hash_FNV1a64_Init(), 2), 1);
+    CHECK(ab != ba);
+}
+
+TEST(hashing_is_deterministic_across_calls)
+{
+    CHECK(
+        Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), "lara")
+        == Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), "lara"));
+    CHECK(
+        Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), "lara")
+        != Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), "larson"));
+}
+
+TEST(string_updates_are_length_prefixed_so_a_split_cannot_collide)
+{
+    // Hashing "ab" then "c" must not land on the same value as "a" then "bc".
+    // Without the length prefix the byte stream would be identical and the two
+    // would collide - which is why Hash_FNV1a64_UpdateString hashes the length
+    // first. Drop that, and two different key sequences share a hash.
+    uint64_t left = Hash_FNV1a64_Init();
+    left = Hash_FNV1a64_UpdateString(left, "ab");
+    left = Hash_FNV1a64_UpdateString(left, "c");
+
+    uint64_t right = Hash_FNV1a64_Init();
+    right = Hash_FNV1a64_UpdateString(right, "a");
+    right = Hash_FNV1a64_UpdateString(right, "bc");
+
+    CHECK(left != right);
+}
+
+TEST(a_null_string_is_not_the_same_as_an_empty_one)
+{
+    const uint64_t null_hash =
+        Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), nullptr);
+    const uint64_t empty_hash =
+        Hash_FNV1a64_UpdateString(Hash_FNV1a64_Init(), "");
+    // Both hash a zero length; the empty string then hashes zero bytes on top.
+    // They happen to coincide - pin it down so a change to either path is a
+    // deliberate one.
+    CHECK(null_hash == empty_hash);
+}
+
+TEST(u32_and_u64_updates_are_distinct)
+{
+    // Same numeric value, different widths, therefore different byte counts.
+    CHECK(
+        Hash_FNV1a64_UpdateU32(Hash_FNV1a64_Init(), 1)
+        != Hash_FNV1a64_UpdateU64(Hash_FNV1a64_Init(), 1));
+}

--- a/src/tests/unit/test_math_func.c
+++ b/src/tests/unit/test_math_func.c
@@ -1,0 +1,70 @@
+#include "harness.h"
+
+#include <trx/core/math/func.h>
+
+// Pure integer maths, no engine behind it. These are the routines the geometry
+// code leans on, and the sign and boundary cases are exactly what nobody checks
+// by playing the game.
+
+TEST(floor_div_rounds_toward_negative_infinity)
+{
+    // C division truncates toward zero: -1 / 4 == 0. Floor division must give
+    // -1. The distinction is the whole reason this function exists - a position
+    // one unit left of a sector boundary belongs to the sector on the left, and
+    // plain division would put it on the right.
+    CHECK_EQ_INT(Math_FloorDiv(-1, 4), -1);
+    CHECK_EQ_INT(-1 / 4, 0); // what it must not do
+
+    CHECK_EQ_INT(Math_FloorDiv(-4, 4), -1);
+    CHECK_EQ_INT(Math_FloorDiv(-5, 4), -2);
+    CHECK_EQ_INT(Math_FloorDiv(-8, 4), -2);
+}
+
+TEST(floor_div_is_plain_division_for_non_negative_operands)
+{
+    CHECK_EQ_INT(Math_FloorDiv(0, 4), 0);
+    CHECK_EQ_INT(Math_FloorDiv(3, 4), 0);
+    CHECK_EQ_INT(Math_FloorDiv(4, 4), 1);
+    CHECK_EQ_INT(Math_FloorDiv(7, 4), 1);
+}
+
+TEST(integer_sqrt_is_exact_on_perfect_squares)
+{
+    CHECK_EQ_INT(Math_Sqrt(0), 0);
+    CHECK_EQ_INT(Math_Sqrt(1), 1);
+    CHECK_EQ_INT(Math_Sqrt(4), 2);
+    CHECK_EQ_INT(Math_Sqrt(100), 10);
+    CHECK_EQ_INT(Math_Sqrt(65536), 256);
+    CHECK_EQ_INT(Math_Sqrt(1000000), 1000);
+}
+
+TEST(integer_sqrt_truncates_between_squares)
+{
+    // Not rounded: 8 lies between 2*2 and 3*3, and the answer is 2.
+    CHECK_EQ_INT(Math_Sqrt(2), 1);
+    CHECK_EQ_INT(Math_Sqrt(3), 1);
+    CHECK_EQ_INT(Math_Sqrt(8), 2);
+    CHECK_EQ_INT(Math_Sqrt(99), 9);
+    CHECK_EQ_INT(Math_Sqrt(101), 10);
+}
+
+TEST(sqrt64_agrees_with_sqrt_and_reaches_past_32_bits)
+{
+    CHECK_EQ_INT(Math_Sqrt64(0), 0);
+    CHECK_EQ_INT(Math_Sqrt64(144), 12);
+    CHECK_EQ_INT(Math_Sqrt64(1000000), 1000);
+    // A distance squared can overflow 32 bits, which is why this exists.
+    CHECK_EQ_INT(Math_Sqrt64(1ULL << 40), 1ULL << 20);
+}
+
+TEST(gcd_reduces_and_handles_zero_from_either_side)
+{
+    CHECK_EQ_INT(Math_GCD(12, 18), 6);
+    CHECK_EQ_INT(Math_GCD(18, 12), 6);
+    CHECK_EQ_INT(Math_GCD(7, 13), 1); // coprime
+    CHECK_EQ_INT(Math_GCD(9, 9), 9);
+
+    // Zero is the identity - and the loop must not divide by it.
+    CHECK_EQ_INT(Math_GCD(5, 0), 5);
+    CHECK_EQ_INT(Math_GCD(0, 5), 5);
+}

--- a/src/tests/unit/test_vector.c
+++ b/src/tests/unit/test_vector.c
@@ -1,0 +1,196 @@
+#include "harness.h"
+
+#include <trx/core/vector.h>
+
+// VECTOR is what the config option map, the item lists and the savegame code
+// are all built on, and none of it was covered. The container is generic - it
+// memcpy's item_size bytes around - so the interesting behaviour is all in the
+// shifting and the regrowth, not in any one caller.
+
+static VECTOR *M_Of(const int32_t *const values, const int32_t count)
+{
+    VECTOR *const vector = Vector_Create(sizeof(int32_t));
+    for (int32_t i = 0; i < count; i++) {
+        Vector_Add(vector, &values[i]);
+    }
+    return vector;
+}
+
+static int32_t M_At(const VECTOR *const vector, const int32_t index)
+{
+    return *(int32_t *)Vector_Get(vector, index);
+}
+
+TEST(adding_appends_in_order)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 30 }, 3);
+    CHECK_EQ_INT(vector->count, 3);
+    CHECK_EQ_INT(M_At(vector, 0), 10);
+    CHECK_EQ_INT(M_At(vector, 2), 30);
+    Vector_Free(vector);
+}
+
+TEST(growing_past_the_initial_capacity_keeps_every_element)
+{
+    // The default capacity is 4, so this forces several reallocs. A regrowth
+    // that lost or reordered elements would go unnoticed until some caller
+    // read back the wrong item.
+    VECTOR *const vector = Vector_Create(sizeof(int32_t));
+    for (int32_t i = 0; i < 100; i++) {
+        Vector_Add(vector, &i);
+    }
+    CHECK_EQ_INT(vector->count, 100);
+    CHECK(vector->capacity >= 100);
+    for (int32_t i = 0; i < 100; i++) {
+        CHECK_EQ_INT(M_At(vector, i), i);
+    }
+    Vector_Free(vector);
+}
+
+TEST(inserting_shifts_the_later_elements_up)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 30 }, 2);
+    Vector_Insert(vector, 1, &(int32_t) { 20 });
+    CHECK_EQ_INT(vector->count, 3);
+    CHECK_EQ_INT(M_At(vector, 0), 10);
+    CHECK_EQ_INT(M_At(vector, 1), 20);
+    CHECK_EQ_INT(M_At(vector, 2), 30);
+
+    // Inserting at the count is the same as appending.
+    Vector_Insert(vector, vector->count, &(int32_t) { 40 });
+    CHECK_EQ_INT(M_At(vector, 3), 40);
+
+    // ...and at 0 everything else moves up.
+    Vector_Insert(vector, 0, &(int32_t) { 5 });
+    CHECK_EQ_INT(M_At(vector, 0), 5);
+    CHECK_EQ_INT(M_At(vector, 1), 10);
+    CHECK_EQ_INT(vector->count, 5);
+    Vector_Free(vector);
+}
+
+TEST(removing_shifts_the_later_elements_down)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 30, 40 }, 4);
+    Vector_RemoveAt(vector, 1);
+    CHECK_EQ_INT(vector->count, 3);
+    CHECK_EQ_INT(M_At(vector, 0), 10);
+    CHECK_EQ_INT(M_At(vector, 1), 30);
+    CHECK_EQ_INT(M_At(vector, 2), 40);
+
+    // Removing the last element shifts nothing, which is the case an
+    // off-by-one in the memmove length would get wrong.
+    Vector_RemoveAt(vector, vector->count - 1);
+    CHECK_EQ_INT(vector->count, 2);
+    CHECK_EQ_INT(M_At(vector, 1), 30);
+    Vector_Free(vector);
+}
+
+TEST(removing_by_value_removes_only_the_first_match)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 10 }, 3);
+    CHECK(Vector_Remove(vector, &(int32_t) { 10 }));
+    CHECK_EQ_INT(vector->count, 2);
+    CHECK_EQ_INT(M_At(vector, 0), 20);
+    CHECK_EQ_INT(M_At(vector, 1), 10);
+
+    // A value that is not there is not an error, and changes nothing.
+    CHECK(!Vector_Remove(vector, &(int32_t) { 99 }));
+    CHECK_EQ_INT(vector->count, 2);
+    Vector_Free(vector);
+}
+
+TEST(index_of_finds_the_first_match_and_last_index_of_the_last)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 10 }, 3);
+    CHECK_EQ_INT(Vector_IndexOf(vector, &(int32_t) { 10 }), 0);
+    CHECK_EQ_INT(Vector_LastIndexOf(vector, &(int32_t) { 10 }), 2);
+    CHECK_EQ_INT(Vector_IndexOf(vector, &(int32_t) { 99 }), -1);
+    CHECK(Vector_Contains(vector, &(int32_t) { 20 }));
+    CHECK(!Vector_Contains(vector, &(int32_t) { 99 }));
+    Vector_Free(vector);
+}
+
+TEST(swapping_and_reversing_move_the_right_elements)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 30, 40 }, 4);
+    Vector_Swap(vector, 0, 3);
+    CHECK_EQ_INT(M_At(vector, 0), 40);
+    CHECK_EQ_INT(M_At(vector, 3), 10);
+
+    Vector_Reverse(vector);
+    CHECK_EQ_INT(M_At(vector, 0), 10);
+    CHECK_EQ_INT(M_At(vector, 1), 30);
+    CHECK_EQ_INT(M_At(vector, 2), 20);
+    CHECK_EQ_INT(M_At(vector, 3), 40);
+    Vector_Free(vector);
+}
+
+TEST(reversing_an_odd_number_of_elements_keeps_the_middle_one_put)
+{
+    VECTOR *const vector = M_Of((int32_t[]) { 10, 20, 30 }, 3);
+    Vector_Reverse(vector);
+    CHECK_EQ_INT(M_At(vector, 0), 30);
+    CHECK_EQ_INT(M_At(vector, 1), 20);
+    CHECK_EQ_INT(M_At(vector, 2), 10);
+    Vector_Free(vector);
+}
+
+TEST(clearing_drops_the_count_but_keeps_the_capacity)
+{
+    VECTOR *const vector = Vector_Create(sizeof(int32_t));
+    for (int32_t i = 0; i < 50; i++) {
+        Vector_Add(vector, &i);
+    }
+    const int32_t grown_capacity = vector->capacity;
+
+    // Callers clear and refill a vector every frame - hence keeping the buffer.
+    Vector_Clear(vector);
+    CHECK_EQ_INT(vector->count, 0);
+    CHECK_EQ_INT(vector->capacity, grown_capacity);
+
+    // ClearRealloc is the one that hands the memory back.
+    Vector_ClearRealloc(vector);
+    CHECK_EQ_INT(vector->count, 0);
+    CHECK(vector->capacity < grown_capacity);
+
+    // Either way the vector is still usable.
+    Vector_Add(vector, &(int32_t) { 7 });
+    CHECK_EQ_INT(M_At(vector, 0), 7);
+    Vector_Free(vector);
+}
+
+TEST(expanding_reserves_room_the_caller_can_write_into)
+{
+    VECTOR *const vector = Vector_Create(sizeof(int32_t));
+    int32_t *const room = Vector_Expand(vector, 3);
+    CHECK_EQ_INT(vector->count, 3);
+    room[0] = 10;
+    room[2] = 30;
+    CHECK_EQ_INT(M_At(vector, 0), 10);
+    CHECK_EQ_INT(M_At(vector, 2), 30);
+    Vector_Free(vector);
+}
+
+TEST(a_vector_of_structs_moves_whole_items_not_bytes)
+{
+    // item_size is whatever the caller says, so a shift that used the wrong
+    // stride would corrupt every element after the one removed.
+    typedef struct {
+        int32_t id;
+        double weight;
+    } M_ENTRY;
+
+    VECTOR *const vector = Vector_Create(sizeof(M_ENTRY));
+    for (int32_t i = 0; i < 5; i++) {
+        Vector_Add(vector, &(M_ENTRY) { .id = i, .weight = i * 1.5 });
+    }
+    Vector_RemoveAt(vector, 0);
+
+    CHECK_EQ_INT(vector->count, 4);
+    for (int32_t i = 0; i < 4; i++) {
+        const M_ENTRY *const entry = Vector_Get(vector, i);
+        CHECK_EQ_INT(entry->id, i + 1);
+        CHECK(entry->weight == (i + 1) * 1.5);
+    }
+    Vector_Free(vector);
+}

--- a/tools/shared/linting.py
+++ b/tools/shared/linting.py
@@ -93,7 +93,10 @@ def lint_const_primitives(
 def lint_meson_build_sort_order(
     context: LintContext, path: Path
 ) -> Iterable[LintWarning]:
-    if path.name != "meson.build" or path.parent.name == "dwarfstack":
+    # The rule keeps the engine's source list ordered. Projects that have no
+    # such list - the vendored dwarfstack, and the unit tests, which name their
+    # sources per test executable - have nothing to sort.
+    if path.name != "meson.build" or path.parent.name in ("dwarfstack", "tests"):
         return
     pattern = re.compile(r"\bcommon_sources\s*=\s*\[(.*?)\]", re.S)
     match = pattern.search(path.read_text())


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Our tests currently need a level, game data and a recorded replay, which means they can't run in CI. This adds a small unit test harness for the parts that don't need any of that. It's a single header – tests self-register from constructors, like `REGISTER_OBJECT` does, since meson test only needs an exit code.

The tests live in their own meson project under `src/tests`. The engine needs SDL, ffmpeg, GLEW and PCRE2 just to configure, and none of that is needed to test a vector, so keeping them separate means the CI job only installs meson and ninja-build and can run on every push. Locally it's `just test`.

Starts with `VECTOR` (insert/remove shifting, regrowth, remove-by-value, and a struct-typed vector to check the stride), `Math_FloorDiv` and the integer sqrt boundaries, and FNV-1a including the length-prefixing in `Hash_FNV1a64_UpdateString`.

The meson sort-order lint skips `src/tests`, same as dwarfstack, as there's no `common_sources` there to sort.

This is not without its shortcomings, of course: it's not yet evident how to do light tests for modules that use global state, or use a lot of dependencies… but it is a start.
