### PR TITLE
LUA reflection basis

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -1,9 +1,9 @@
 name: Run unit tests
 
 # The unit suite needs no game data, no level and no replay recordings, so unlike
-# the replay tests it can actually run in CI. It also needs none of the engine's
-# libraries: src/tests is a meson project of its own, so this job installs a
-# compiler and meson and nothing else.
+# the replay tests it can actually run in CI. src/tests is a meson project of its
+# own, so this job installs a compiler, meson, and whatever the tests themselves
+# reach for - never the engine's own libraries.
 
 on:
   - push
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build
+          sudo apt-get install -y meson ninja-build liblua5.4-dev lua5.4
 
       - name: Run unit tests
         run: |

--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -1,0 +1,326 @@
+-- Self-describing public API registry.
+--
+-- Every trx.* function declares its signature alongside its implementation. The
+-- registry is what the docs are generated from, so the reference cannot drift
+-- from the code.
+--
+-- PERFORMANCE: the spec is metadata, NOT a dispatch layer. `trx.items.spawn` is
+-- the raw implementation - calling it costs exactly what calling any Lua
+-- function costs. A generic spec-driven wrapper that validated arguments on
+-- every call measured 26x slower (416ns vs 16ns), which is untenable for
+-- anything a script calls per frame. Argument validation is therefore opt-in:
+-- trx.api.strict(true) rebinds every registered function to a code-generated
+-- checking wrapper (~108ns overhead), which builders can enable while
+-- developing and leave off in play.
+
+-- api.type reports members nobody exposed, so the logger must exist by then.
+-- Module load order is not guaranteed; state the dependency.
+require("trx.log")
+
+-- Captured at module scope: the raw C bridge is removed from the globals once
+-- the trx.* modules have loaded, so builders cannot reach past the public API.
+local struct = trxc.struct
+
+local api = {}
+
+-- path -> spec. Ordered separately so docs come out in declaration order.
+local registry = {}
+local order = {}
+local modules = {}
+local module_order = {}
+local types = {}
+local type_order = {}
+local strict_enabled = false
+local sealed = false
+
+local function split_path(path)
+  local module, name = path:match("^([%w_]+)%.([%w_]+)$")
+  assert(module ~= nil, "api path must be 'module.name', got: " .. tostring(path))
+  return module, name
+end
+
+function api.module(name, spec)
+  assert(type(name) == "string", "api.module: name must be a string")
+  if modules[name] == nil then
+    table.insert(module_order, name)
+  end
+  modules[name] = spec or {}
+end
+
+-- Builds a specialized validating wrapper by generating Lua source for this
+-- exact parameter list. Avoids the per-call table.pack/unpack and spec loop that
+-- made the generic approach 26x slower.
+local function make_checked(fn, path, params)
+  if params == nil or #params == 0 then
+    return fn
+  end
+
+  local names, checks = {}, {}
+  for i, p in ipairs(params) do
+    names[i] = "a" .. i
+    local fail = ("E(%q,%q)"):format(path, p.name)
+    if p.optional then
+      checks[#checks + 1] = ("if a%d==nil then a%d=D[%d] elseif not C[%d](a%d) then %s end"):format(i, i, i, i, i, fail)
+    else
+      checks[#checks + 1] = ("if not C[%d](a%d) then %s end"):format(i, i, fail)
+    end
+  end
+
+  local src = ("local fn,C,D,E=... return function(%s) %s return fn(%s) end"):format(
+    table.concat(names, ","),
+    table.concat(checks, " "),
+    table.concat(names, ",")
+  )
+
+  local checkers, defaults = {}, {}
+  for i, p in ipairs(params) do
+    checkers[i] = api.checkers[p.type] or function()
+      return true
+    end
+    defaults[i] = p.default
+  end
+
+  local function on_fail(where, arg)
+    error(("%s: invalid argument '%s'"):format(where, arg), 3)
+  end
+  return load(src, "=" .. path .. " (checked)")(fn, checkers, defaults, on_fail)
+end
+
+-- Type name -> predicate. Doc-facing type names, not Lua type names.
+api.checkers = {
+  integer = function(v)
+    return math.type(v) == "integer"
+  end,
+  number = function(v)
+    return type(v) == "number"
+  end,
+  string = function(v)
+    return type(v) == "string"
+  end,
+  boolean = function(v)
+    return type(v) == "boolean"
+  end,
+  table = function(v)
+    return type(v) == "table"
+  end,
+  ["function"] = function(v)
+    return type(v) == "function"
+  end,
+  vec3 = function(v)
+    return type(v) == "table" and v.x ~= nil and v.y ~= nil and v.z ~= nil
+  end,
+  Item = function(v)
+    return v ~= nil
+  end,
+  any = function()
+    return true
+  end,
+}
+
+-- Called once, from C, after the trx.* modules have loaded. Declarations are the
+-- engine's to make; a level script re-opening the surface would defeat the point
+-- of declaring it.
+function api.seal()
+  sealed = true
+end
+
+function api.define(path, spec)
+  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  assert(type(spec) == "table", "api.define: spec must be a table")
+  assert(type(spec.impl) == "function", "api.define: impl must be a function")
+  local module, name = split_path(path)
+
+  if registry[path] == nil then
+    table.insert(order, path)
+  end
+  registry[path] = spec
+
+  trx[module] = trx[module] or {}
+  -- The raw implementation IS the public function. No wrapper, no overhead.
+  -- rawset: some module tables guard __newindex, and a declaration is not a
+  -- caller poking at the module.
+  rawset(trx[module], name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+  return spec.impl
+end
+
+-- Rebinds every registered function to (or away from) its checking wrapper.
+function api.strict(enabled)
+  strict_enabled = enabled and true or false
+  for _, path in ipairs(order) do
+    local module, name = split_path(path)
+    local spec = registry[path]
+    rawset(trx[module], name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+  end
+end
+
+function api.is_strict()
+  return strict_enabled
+end
+
+-- Returns the whole surface as plain data: what the docs generator consumes.
+-- Declares a handle type: which C members are public, under what name, plus the
+-- methods and computed members that complete the type.
+--
+-- Nothing is reachable from a handle until it is named here. The C table says
+-- how to reach a member; this says whether it is part of the API and what it is
+-- called. A member C can reach but nobody declares simply does not exist.
+function api.type(path, spec)
+  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  assert(type(spec) == "table", "api.type: spec must be a table")
+  assert(type(spec.backing) == "string", "api.type: backing must be a C type name")
+  local backing = spec.backing
+
+  local declared = {}
+
+  for name, field in pairs(spec.fields or {}) do
+    local from = field.from or name
+    local writable = field.writable ~= false
+    struct.expose_field(backing, name, from, writable)
+    declared[from] = true
+  end
+
+  for name, method in pairs(spec.methods or {}) do
+    struct.expose_method(backing, name, method.from or name)
+  end
+
+  for name, computed in pairs(spec.extensions or {}) do
+    assert(type(computed.impl) == "function", "api.type: extension '" .. name .. "' needs an impl")
+    struct.expose_computed(backing, name, computed.impl)
+  end
+
+  -- Opt-in exposure is silent by nature: forgetting to declare a member means it
+  -- quietly does not exist. Say so, rather than let it vanish unnoticed.
+  local undeclared = {}
+  for _, member in ipairs(struct.members(backing)) do
+    if not declared[member.name] then
+      table.insert(undeclared, member.name)
+    end
+  end
+  if #undeclared > 0 then
+    table.sort(undeclared)
+    trx.log.debug(
+      backing .. ": " .. #undeclared .. " member(s) not exposed to scripts: " .. table.concat(undeclared, ", ")
+    )
+  end
+
+  if types[path] == nil then
+    table.insert(type_order, path)
+  end
+  types[path] = spec
+end
+
+function api.describe()
+  local out = { modules = {}, functions = {}, types = {} }
+  for _, name in ipairs(module_order) do
+    table.insert(out.modules, {
+      name = name,
+      description = modules[name].description,
+      order = modules[name].order,
+    })
+  end
+  for _, path in ipairs(order) do
+    local spec = registry[path]
+    table.insert(out.functions, {
+      path = path,
+      description = spec.description,
+      params = spec.params,
+      returns = spec.returns,
+      examples = spec.examples,
+    })
+  end
+  for _, path in ipairs(type_order) do
+    local spec = types[path]
+    local entry = {
+      path = path,
+      description = spec.description,
+      fields = {},
+      methods = {},
+      extensions = {},
+    }
+    for name, field in pairs(spec.fields or {}) do
+      table.insert(entry.fields, {
+        name = name,
+        type = field.type,
+        writable = field.writable ~= false,
+        description = field.description,
+      })
+    end
+    for name, method in pairs(spec.methods or {}) do
+      table.insert(entry.methods, {
+        name = name,
+        description = method.description,
+        params = method.params,
+        returns = method.returns,
+        examples = method.examples,
+      })
+    end
+    for name, computed in pairs(spec.extensions or {}) do
+      table.insert(entry.extensions, {
+        name = name,
+        type = computed.type,
+        description = computed.description,
+      })
+    end
+    local by_name = function(a, b)
+      return a.name < b.name
+    end
+    table.sort(entry.fields, by_name)
+    table.sort(entry.methods, by_name)
+    table.sort(entry.extensions, by_name)
+    table.insert(out.types, entry)
+  end
+  return out
+end
+
+trx.api = api
+
+-- Minimal JSON encoder. The dump is consumed by tools/update_lua_docs; keeping
+-- the encoding here means the whole API surface - C field tables included - is
+-- serialized from one place.
+local function encode(value, out)
+  local kind = type(value)
+  if value == nil then
+    out[#out + 1] = "null"
+  elseif kind == "boolean" then
+    out[#out + 1] = tostring(value)
+  elseif kind == "number" then
+    out[#out + 1] = tostring(value)
+  elseif kind == "string" then
+    out[#out + 1] = '"' .. value:gsub("\\", "\\\\"):gsub('"', '\\"'):gsub("\n", "\\n"):gsub("\t", "\\t") .. '"'
+  elseif kind == "table" then
+    if value[1] ~= nil or next(value) == nil then
+      out[#out + 1] = "["
+      for i, v in ipairs(value) do
+        if i > 1 then
+          out[#out + 1] = ","
+        end
+        encode(v, out)
+      end
+      out[#out + 1] = "]"
+    else
+      local keys = {}
+      for k in pairs(value) do
+        keys[#keys + 1] = k
+      end
+      table.sort(keys)
+      out[#out + 1] = "{"
+      for i, k in ipairs(keys) do
+        if i > 1 then
+          out[#out + 1] = ","
+        end
+        encode(tostring(k), out)
+        out[#out + 1] = ":"
+        encode(value[k], out)
+      end
+      out[#out + 1] = "}"
+    end
+  end
+  return out
+end
+
+-- The complete public API surface. One registry, one source: whatever is not
+-- declared here is not reachable from a script, so the dump cannot omit anything
+-- that exists.
+function api.to_json()
+  return table.concat(encode(api.describe(), {}))
+end

--- a/src/meson.build
+++ b/src/meson.build
@@ -161,6 +161,7 @@ common_sources = [
   'trx/core/csv.c',
   'trx/core/enum_map.c',
   'trx/core/event_manager.c',
+  'trx/core/field.c',
   'trx/core/filesystem.c',
   'trx/core/hash.c',
   'trx/core/json/base.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -419,6 +419,7 @@ common_sources = [
   'trx/game/lua/pickup.c',
   'trx/game/lua/rooms.c',
   'trx/game/lua/sound.c',
+  'trx/game/lua/struct.c',
   'trx/game/lua/utils.c',
   'trx/game/matrix.c',
   'trx/game/music/backend_cdaudio.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,6 +38,7 @@ endif
 trx_lua_embed = custom_target(
   'trx_lua_embed',
   input: [
+    '../data/scripting/api.lua',
     '../data/scripting/assault.lua',
     '../data/scripting/camera.lua',
     '../data/scripting/catalog.lua',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -74,3 +74,11 @@ test_lua_struct_exe = executable(
   build_by_default: false,
 )
 test('lua_struct', test_lua_struct_exe, suite: 'unit')
+
+# api.lua is read from the repository root, two levels up from this project.
+repo_root = meson.current_source_dir() / '../..'
+
+lua_exe = find_program('lua', 'lua5.4', 'lua5.5', required: false)
+if lua_exe.found()
+  test('api', lua_exe, args: [files('unit/test_api.lua'), repo_root], suite: 'unit')
+endif

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -50,3 +50,11 @@ test_hash_exe = executable(
   build_by_default: false,
 )
 test('hash', test_hash_exe, suite: 'unit')
+
+test_field_exe = executable(
+  'test_field',
+  files('unit/test_field.c') + test_stubs + files('../trx/core/field.c'),
+  include_directories: [src_inc, test_inc],
+  build_by_default: false,
+)
+test('field', test_field_exe, suite: 'unit')

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -19,6 +19,10 @@ project(
 c_compiler = meson.get_compiler('c')
 dep_mathlibrary = c_compiler.find_library('m', required: false)
 
+# The engine takes the dependency name from -Dlua_dep; standing alone, this
+# project has to find Lua itself, and distributions disagree on the name.
+dep_lua = dependency('lua5.4', 'lua-5.4', 'lua54', 'lua')
+
 # <trx/...> resolves against src/; the harness header against src/tests/unit/.
 src_inc = include_directories('..')
 test_inc = include_directories('unit')
@@ -58,3 +62,15 @@ test_field_exe = executable(
   build_by_default: false,
 )
 test('field', test_field_exe, suite: 'unit')
+
+# field.c and lua/struct.c are leaf modules, so the reflection layer and the Lua
+# bridge can be exercised against a synthetic struct type.
+test_lua_struct_exe = executable(
+  'test_lua_struct',
+  files('unit/test_lua_struct.c') + test_stubs
+    + files('../trx/core/field.c', '../trx/game/lua/struct.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  build_by_default: false,
+)
+test('lua_struct', test_lua_struct_exe, suite: 'unit')

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -1,0 +1,169 @@
+-- Unit tests for data/scripting/api.lua, run under a plain Lua interpreter with
+-- a stubbed C bridge. No engine, no binary, no level.
+
+local ROOT = (arg[1] or ".") .. "/"
+
+local failures = 0
+local passed = 0
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    passed = passed + 1
+    print("  PASS  " .. name)
+  else
+    failures = failures + 1
+    print("  FAIL  " .. name)
+    print("        " .. tostring(err))
+  end
+end
+
+-- Records what api.type() asked the C binder to expose, so the tests can assert
+-- on the declaration rather than on a real metatable.
+local function fresh_env()
+  local exposed = { fields = {}, methods = {}, computed = {} }
+  _G.trxc = {
+    struct = {
+      expose_field = function(t, public, from, writable)
+        exposed.fields[public] = { backing = t, from = from, writable = writable }
+      end,
+      expose_method = function(t, public, from)
+        exposed.methods[public] = { backing = t, from = from }
+      end,
+      expose_computed = function(t, public, fn)
+        exposed.computed[public] = fn
+      end,
+      members = function()
+        return {
+          { name = "visible", type = "INT32", writable = true },
+          { name = "secret", type = "INT32", writable = true },
+        }
+      end,
+    },
+  }
+  _G.trx = { log = { debug = function() end, warn = function() end } }
+  _G.require = function() end
+
+  dofile(ROOT .. "data/scripting/api.lua")
+  return trx.api, exposed
+end
+
+test("define exposes the raw impl, with no dispatch wrapper", function()
+  local api = fresh_env()
+  local impl = function(a)
+    return a * 2
+  end
+  api.define("things.double", { params = { { name = "a", type = "integer" } }, impl = impl })
+
+  -- The public function IS the implementation. Anything else means the spec has
+  -- crept into the call path, which measured 26x slower.
+  assert(trx.things.double == impl, "define wrapped the impl")
+  assert(trx.things.double(21) == 42)
+end)
+
+test("strict mode rejects bad args and accepts good ones", function()
+  local api = fresh_env()
+  api.define("things.spawn", {
+    params = {
+      { name = "id", type = "integer" },
+      { name = "pos", type = "vec3" },
+      { name = "angle", type = "integer", optional = true, default = 0 },
+    },
+    impl = function(id, pos, angle)
+      return angle
+    end,
+  })
+
+  api.strict(true)
+  assert(not pcall(trx.things.spawn, "not an integer", { x = 1, y = 1, z = 1 }))
+  assert(not pcall(trx.things.spawn, 1, "not a vec3"))
+  assert(pcall(trx.things.spawn, 1, { x = 1, y = 1, z = 1 }))
+
+  -- An omitted optional argument takes its declared default.
+  assert(trx.things.spawn(1, { x = 1, y = 1, z = 1 }) == 0)
+  assert(trx.things.spawn(1, { x = 1, y = 1, z = 1 }, 7) == 7)
+
+  api.strict(false)
+  assert(pcall(trx.things.spawn, "anything goes now", nil))
+end)
+
+test("type() passes the declaration to the C binder", function()
+  local api, exposed = fresh_env()
+  api.type("things.Widget", {
+    backing = "WIDGET",
+    fields = {
+      shown = { from = "visible", type = "integer", description = "..." },
+      locked = { from = "visible", type = "integer", writable = false },
+    },
+    methods = { poke = { description = "..." } },
+    extensions = {
+      derived = {
+        type = "integer",
+        impl = function()
+          return 1
+        end,
+      },
+    },
+  })
+
+  -- The public name and the C member name are separate: that is the whole point.
+  assert(exposed.fields.shown.from == "visible")
+  assert(exposed.fields.shown.writable == true)
+  assert(exposed.fields.locked.writable == false, "writable=false must be honoured")
+  assert(exposed.methods.poke.from == "poke")
+  assert(exposed.computed.derived ~= nil)
+
+  -- `secret` is reachable by C and named by nobody, so it must not be exposed.
+  assert(exposed.fields.secret == nil, "an undeclared member was exposed")
+end)
+
+test("describe() reports fields, methods and extensions", function()
+  local api = fresh_env()
+  api.module("things", { description = "..." })
+  api.type("things.Widget", {
+    backing = "WIDGET",
+    description = "A widget.",
+    fields = { shown = { from = "visible", type = "integer" } },
+    methods = { poke = { description = "..." } },
+    extensions = {
+      derived = {
+        type = "integer",
+        impl = function() end,
+      },
+    },
+  })
+  api.define("things.count", { impl = function() end })
+
+  local d = api.describe()
+  assert(#d.types == 1, "type missing from describe()")
+  local t = d.types[1]
+
+  -- The bug that started all this: methods and extensions existed but were
+  -- absent from the dump, so the generated docs silently omitted them.
+  assert(#t.fields == 1, "fields missing")
+  assert(#t.methods == 1, "methods missing from describe()")
+  assert(#t.extensions == 1, "extensions missing from describe()")
+  assert(#d.functions == 1, "functions missing")
+end)
+
+test("to_json round-trips the surface", function()
+  local api = fresh_env()
+  api.module("things", {})
+  api.define("things.count", { impl = function() end, description = 'has "quotes" and \\ slashes' })
+  local json = api.to_json()
+  assert(json:find('"things.count"'), "path missing from json")
+  assert(json:find('\\"quotes\\"'), "quotes not escaped")
+end)
+
+test("seal blocks further declarations", function()
+  local api = fresh_env()
+  api.seal()
+
+  -- api.type() reaches into the C struct binder. Leaving it callable would let a
+  -- level script re-expose the members the declarations deliberately withheld.
+  assert(not pcall(api.type, "things.Widget", { backing = "WIDGET" }), "type() after seal")
+  assert(not pcall(api.define, "things.evil", { impl = function() end }), "define() after seal")
+end)
+
+print(("\n%d passed, %d failed, %d total"):format(passed, failures, passed + failures))
+os.exit(failures == 0 and 0 or 1)

--- a/src/tests/unit/test_field.c
+++ b/src/tests/unit/test_field.c
@@ -1,0 +1,300 @@
+#include "harness.h"
+
+#include <trx/core/field.h>
+
+// A synthetic struct. field.c has no engine dependency, so the reflection layer
+// can be exercised in full without loading a level, an item, or anything else.
+typedef struct {
+    bool flag;
+    int8_t i8;
+    uint8_t u8;
+    int16_t i16;
+    uint16_t u16;
+    int32_t i32;
+    uint32_t u32;
+    float f32;
+    double f64;
+    XYZ_16 small_vec;
+    XYZ_32 big_vec;
+    const char *text;
+    int16_t locked;
+    int32_t guarded;
+    struct {
+        bool nested_flag;
+    } group;
+} SAMPLE;
+
+static bool M_GetDoubled(const void *const self, FIELD_VALUE *const out)
+{
+    const SAMPLE *const s = self;
+    *out = (FIELD_VALUE) { .type = FT_INT32, .as_int = s->i32 * 2 };
+    return true;
+}
+
+static const char *M_SetRejecting(void *const self, const FIELD_VALUE *const in)
+{
+    if (in->as_int < 0) {
+        return "must not be negative";
+    }
+    ((SAMPLE *)self)->guarded = in->as_int;
+    return nullptr;
+}
+
+// clang-format off
+static const FIELD_DESC M_SAMPLE_FIELDS[] = {
+    FIELD    (SAMPLE, flag,              FT_BOOL),
+    FIELD    (SAMPLE, i8,                FT_INT8),
+    FIELD    (SAMPLE, u8,                FT_UINT8),
+    FIELD    (SAMPLE, i16,               FT_INT16),
+    FIELD    (SAMPLE, u16,               FT_UINT16),
+    FIELD    (SAMPLE, i32,               FT_INT32),
+    FIELD    (SAMPLE, u32,               FT_UINT32),
+    FIELD    (SAMPLE, f32,               FT_FLOAT),
+    FIELD    (SAMPLE, f64,               FT_DOUBLE),
+    FIELD    (SAMPLE, small_vec,         FT_XYZ_16),
+    FIELD    (SAMPLE, big_vec,           FT_XYZ_32),
+    FIELD    (SAMPLE, text,              FT_STRING),
+    FIELD    (SAMPLE, group.nested_flag, FT_BOOL),
+    FIELD_RO (SAMPLE, locked,            FT_INT16),
+    FIELD_FN ("doubled", FT_INT32, M_GetDoubled, nullptr),
+    FIELD_SET(SAMPLE, guarded, FT_INT32, M_SetRejecting),
+};
+// clang-format on
+
+TYPE_DEFINE(SAMPLE, M_SAMPLE_FIELDS)
+
+static const FIELD_DESC *F(const char *const name)
+{
+    return Field_Find(&TYPE_SAMPLE, name);
+}
+
+TEST(field_find_locates_members_and_misses_absent_ones)
+{
+    CHECK_NOT_NULL(F("i16"));
+    CHECK_EQ_STR(F("i16")->name, "i16");
+    CHECK_NULL(F("no_such_member"));
+}
+
+TEST(field_get_reads_every_scalar_type)
+{
+    const SAMPLE s = {
+        .flag = true,
+        .i8 = -8,
+        .u8 = 200,
+        .i16 = -1234,
+        .u16 = 60000,
+        .i32 = -100000,
+        .u32 = 4000000000u,
+        .f32 = 1.5f,
+        .f64 = 2.25,
+        .text = "hello",
+    };
+    FIELD_VALUE v;
+
+    CHECK(Field_Get(F("flag"), &s, &v));
+    CHECK(v.as_bool);
+    CHECK(Field_Get(F("i8"), &s, &v));
+    CHECK_EQ_INT(v.as_int, -8);
+    CHECK(Field_Get(F("u8"), &s, &v));
+    CHECK_EQ_INT(v.as_int, 200);
+    CHECK(Field_Get(F("i16"), &s, &v));
+    CHECK_EQ_INT(v.as_int, -1234);
+    CHECK(Field_Get(F("u16"), &s, &v));
+    CHECK_EQ_INT(v.as_int, 60000);
+    CHECK(Field_Get(F("i32"), &s, &v));
+    CHECK_EQ_INT(v.as_int, -100000);
+    CHECK(Field_Get(F("u32"), &s, &v));
+    CHECK_EQ_INT(v.as_int, 4000000000LL);
+    CHECK(Field_Get(F("f32"), &s, &v));
+    CHECK(v.as_num == 1.5);
+    CHECK(Field_Get(F("f64"), &s, &v));
+    CHECK(v.as_num == 2.25);
+    CHECK(Field_Get(F("text"), &s, &v));
+    CHECK_EQ_STR(v.as_str, "hello");
+}
+
+// XYZ_16 is widened into the same carrier as XYZ_32, so a caller never has to
+// care which one it is reading.
+TEST(field_get_widens_xyz16_into_the_common_carrier)
+{
+    const SAMPLE s = {
+        .small_vec = { .x = -1, .y = 2, .z = -3 },
+        .big_vec = { .x = 100000, .y = -200000, .z = 300000 },
+    };
+    FIELD_VALUE v;
+
+    CHECK(Field_Get(F("small_vec"), &s, &v));
+    CHECK_EQ_INT(v.as_xyz.x, -1);
+    CHECK_EQ_INT(v.as_xyz.y, 2);
+    CHECK_EQ_INT(v.as_xyz.z, -3);
+
+    CHECK(Field_Get(F("big_vec"), &s, &v));
+    CHECK_EQ_INT(v.as_xyz.x, 100000);
+    CHECK_EQ_INT(v.as_xyz.z, 300000);
+}
+
+TEST(field_set_narrows_on_store)
+{
+    SAMPLE s = {};
+
+    CHECK_NULL(Field_Set(
+        F("i16"), &s, &(FIELD_VALUE) { .type = FT_INT16, .as_int = -4321 }));
+    CHECK_EQ_INT(s.i16, -4321);
+
+    CHECK_NULL(Field_Set(
+        F("small_vec"), &s,
+        &(FIELD_VALUE) {
+            .type = FT_XYZ_16,
+            .as_xyz = { .x = 7, .y = -8, .z = 9 },
+        }));
+    CHECK_EQ_INT(s.small_vec.x, 7);
+    CHECK_EQ_INT(s.small_vec.z, 9);
+
+    CHECK_NULL(Field_Set(
+        F("flag"), &s, &(FIELD_VALUE) { .type = FT_BOOL, .as_bool = true }));
+    CHECK(s.flag);
+}
+
+// offsetof reaches through a nested struct of plain members, which is what lets
+// ROOM.flags.underwater be a reflected field.
+TEST(field_reaches_through_a_nested_struct)
+{
+    SAMPLE s = {};
+    FIELD_VALUE v;
+
+    CHECK_NULL(Field_Set(
+        F("group.nested_flag"), &s,
+        &(FIELD_VALUE) { .type = FT_BOOL, .as_bool = true }));
+    CHECK(s.group.nested_flag);
+
+    CHECK(Field_Get(F("group.nested_flag"), &s, &v));
+    CHECK(v.as_bool);
+}
+
+TEST(field_set_refuses_a_readonly_member)
+{
+    SAMPLE s = { .locked = 5 };
+    const char *const err = Field_Set(
+        F("locked"), &s, &(FIELD_VALUE) { .type = FT_INT16, .as_int = 99 });
+    CHECK_NOT_NULL(err);
+    CHECK_EQ_INT(s.locked, 5); // unchanged
+}
+
+TEST(field_set_rejects_an_out_of_range_value)
+{
+    SAMPLE s = { .i16 = 5 };
+
+    // 99999 does not fit an int16 - it must be rejected, not truncated to a
+    // wrapped value.
+    const char *const err = Field_Set(
+        F("i16"), &s, &(FIELD_VALUE) { .type = FT_INT16, .as_int = 99999 });
+    CHECK_NOT_NULL(err);
+    CHECK_EQ_INT(s.i16, 5); // unchanged
+
+    // The boundary value fits and is stored.
+    CHECK_NULL(Field_Set(
+        F("i16"), &s, &(FIELD_VALUE) { .type = FT_INT16, .as_int = 32767 }));
+    CHECK_EQ_INT(s.i16, 32767);
+
+    // A negative value for an unsigned member is out of range too.
+    CHECK_NOT_NULL(Field_Set(
+        F("u8"), &s, &(FIELD_VALUE) { .type = FT_UINT8, .as_int = -1 }));
+
+    // A vector component past int16 is rejected without a partial store.
+    SAMPLE v = {};
+    CHECK_NOT_NULL(Field_Set(
+        F("small_vec"), &v,
+        &(FIELD_VALUE) {
+            .type = FT_XYZ_16,
+            .as_xyz = { .x = 1, .y = 99999, .z = 3 },
+        }));
+    CHECK_EQ_INT(v.small_vec.x, 0); // unchanged
+}
+
+TEST(computed_member_uses_its_accessor_and_is_readonly)
+{
+    SAMPLE s = { .i32 = 21 };
+    FIELD_VALUE v;
+
+    CHECK(Field_Get(F("doubled"), &s, &v));
+    CHECK_EQ_INT(v.as_int, 42);
+
+    // FIELD_FN with no setter is read-only by construction.
+    CHECK_NOT_NULL(Field_Set(
+        F("doubled"), &s, &(FIELD_VALUE) { .type = FT_INT32, .as_int = 1 }));
+}
+
+TEST(a_validating_setter_can_reject_a_value)
+{
+    SAMPLE s = { .guarded = 7 };
+
+    const char *const err = Field_Set(
+        F("guarded"), &s, &(FIELD_VALUE) { .type = FT_INT32, .as_int = -1 });
+    CHECK_NOT_NULL(err);
+    CHECK_EQ_STR(err, "must not be negative");
+    CHECK_EQ_INT(s.guarded, 7); // rejected, so unchanged
+
+    CHECK_NULL(Field_Set(
+        F("guarded"), &s, &(FIELD_VALUE) { .type = FT_INT32, .as_int = 11 }));
+    CHECK_EQ_INT(s.guarded, 11);
+}
+
+// Found while writing these tests: Field_Find returns the first match, so a
+// name declared twice silently shadows every later entry - a validating setter
+// declared after a plain FIELD would simply never run.
+TEST(duplicate_field_names_are_detected)
+{
+    CHECK_NULL(Field_FindDuplicateName(&TYPE_SAMPLE));
+
+    static const FIELD_DESC BAD_FIELDS[] = {
+        FIELD(SAMPLE, i16, FT_INT16),
+        FIELD(SAMPLE, i32, FT_INT32),
+        FIELD_SET(SAMPLE, i16, FT_INT16, nullptr), // shadowed by the first
+    };
+    static const TYPE_DESC BAD_TYPE = {
+        .name = "BAD",
+        .fields = BAD_FIELDS,
+        .field_count = 3,
+    };
+    CHECK_EQ_STR(Field_FindDuplicateName(&BAD_TYPE), "i16");
+}
+
+TEST(type_sizes_and_names_are_stable)
+{
+    CHECK_EQ_INT(Field_GetTypeSize(FT_BOOL), sizeof(bool));
+    CHECK_EQ_INT(Field_GetTypeSize(FT_INT16), 2);
+    CHECK_EQ_INT(Field_GetTypeSize(FT_UINT32), 4);
+    CHECK_EQ_INT(Field_GetTypeSize(FT_XYZ_16), sizeof(XYZ_16));
+    CHECK_EQ_INT(Field_GetTypeSize(FT_XYZ_32), sizeof(XYZ_32));
+    CHECK_EQ_INT(Field_GetTypeSize(FT_STRING), sizeof(char *));
+
+    CHECK_EQ_STR(Field_GetTypeName(FT_INT16), "INT16");
+    CHECK_EQ_STR(Field_GetTypeName(FT_XYZ_32), "XYZ_32");
+}
+
+// Every declared member's sizeof must match its declared FIELD_TYPE. This is
+// the check that caught a real bug: OBJECT_ID and ITEM_STATUS are 4-byte enums,
+// and tagging either as FT_INT16 would have silently read half the member.
+TEST(field_validate_type_accepts_a_consistent_table)
+{
+    for (int32_t i = 0; i < TYPE_SAMPLE.field_count; i++) {
+        const FIELD_DESC *const f = &TYPE_SAMPLE.fields[i];
+        if (f->get != nullptr && f->set != nullptr) {
+            continue; // fully computed; no backing member to size-check
+        }
+        if (f->get != nullptr && (f->flags & FF_READONLY)) {
+            continue; // read-only computed; never addresses memory
+        }
+        CHECK_EQ_INT(f->size, Field_GetTypeSize(f->type));
+    }
+    Field_ValidateType(&TYPE_SAMPLE); // asserts on mismatch
+}
+
+TEST(types_self_register_and_are_findable_by_name)
+{
+    const TYPE_DESC *const t = Type_GetByName("SAMPLE");
+    CHECK_NOT_NULL(t);
+    CHECK(t == &TYPE_SAMPLE);
+    CHECK_NULL(Type_GetByName("NO_SUCH_TYPE"));
+    CHECK(Type_GetCount() >= 1);
+}

--- a/src/tests/unit/test_lua_struct.c
+++ b/src/tests/unit/test_lua_struct.c
@@ -1,0 +1,305 @@
+#include "harness.h"
+
+#include <trx/game/lua/struct.h>
+
+#include <lauxlib.h>
+#include <lualib.h>
+
+// The struct bridge has no engine dependency, so the invariants the whole
+// design rests on can be asserted against a synthetic type - no level, no
+// items, no assets. These are the properties that make the public API opt-in
+// rather than merely tidy: if any of them regress, a member the declarations
+// deliberately withheld becomes reachable again.
+
+typedef struct {
+    int32_t visible;
+    int32_t secret; // reachable by C, never declared to Lua
+    int16_t locked; // read-only in C
+    bool flag;
+} WIDGET;
+
+// clang-format off
+static const FIELD_DESC M_WIDGET_FIELDS[] = {
+    FIELD    (WIDGET, visible, FT_INT32),
+    FIELD    (WIDGET, secret,  FT_INT32),
+    FIELD    (WIDGET, flag,    FT_BOOL),
+    FIELD_RO (WIDGET, locked,  FT_INT16),
+};
+// clang-format on
+
+TYPE_DEFINE(WIDGET, M_WIDGET_FIELDS)
+
+// A tiny pool so handles can be made stale on demand, the way Item_Kill does.
+#define M_POOL_SIZE 4
+static WIDGET m_Pool[M_POOL_SIZE];
+static uint16_t m_Gen[M_POOL_SIZE];
+static bool m_Dead[M_POOL_SIZE];
+
+static void *M_Resolve(const LUA_STRUCT_REF *const ref)
+{
+    if (ref->idx < 0 || ref->idx >= M_POOL_SIZE || m_Dead[ref->idx]) {
+        return nullptr;
+    }
+    if (m_Gen[ref->idx] != ref->gen) {
+        return nullptr;
+    }
+    return &m_Pool[ref->idx];
+}
+
+static int M_L_Reveal(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_WIDGET);
+    const WIDGET *const w = LUA_Struct_Deref(L, ref);
+    lua_pushinteger(L, w->visible);
+    return 1;
+}
+
+// Exists in C, but no declaration exposes it. It must stay unreachable.
+static int M_L_Backdoor(lua_State *const L)
+{
+    lua_pushstring(L, "the backdoor was reachable");
+    return 1;
+}
+
+static const luaL_Reg M_METHODS[] = {
+    { "reveal", M_L_Reveal },
+    { "backdoor", M_L_Backdoor },
+    { nullptr, nullptr },
+};
+
+static int M_L_GetWidget(lua_State *const L)
+{
+    const int32_t idx = luaL_checkinteger(L, 1);
+    LUA_Struct_Push(L, &TYPE_WIDGET, M_Resolve, idx, m_Gen[idx]);
+    return 1;
+}
+
+// Builds the environment a script would see, then applies the declaration the
+// way data/scripting/*.lua does.
+static lua_State *M_NewState(const char *const declaration)
+{
+    for (int32_t i = 0; i < M_POOL_SIZE; i++) {
+        m_Pool[i] = (WIDGET) { .visible = 10 + i, .secret = 99, .locked = 7 };
+        m_Gen[i] = 1;
+        m_Dead[i] = false;
+    }
+
+    lua_State *const L = luaL_newstate();
+    luaL_openlibs(L);
+    lua_newtable(L);
+    lua_setglobal(L, "trxc");
+
+    LUA_Struct_Register(L, &TYPE_WIDGET, M_METHODS);
+    LUA_CreateStruct(L);
+
+    lua_getglobal(L, "trxc");
+    lua_pushcfunction(L, M_L_GetWidget);
+    lua_setfield(L, -2, "get_widget");
+    lua_pop(L, 1);
+
+    if (declaration != nullptr && luaL_dostring(L, declaration) != LUA_OK) {
+        TEST_FAIL("declaration failed: %s", lua_tostring(L, -1));
+    }
+    return L;
+}
+
+// The declaration every test starts from: `visible` and `flag` are public,
+// `locked` is public but read-only, `reveal` is a method. `secret` and
+// `backdoor` are deliberately withheld.
+static const char DECL[] =
+    "trxc.struct.expose_field('WIDGET', 'visible', 'visible', true)\n"
+    "trxc.struct.expose_field('WIDGET', 'flag', 'flag', true)\n"
+    "trxc.struct.expose_field('WIDGET', 'locked', 'locked', false)\n"
+    "trxc.struct.expose_method('WIDGET', 'reveal', 'reveal')\n"
+    "trxc.struct.expose_computed('WIDGET', 'doubled', function(w)\n"
+    "  return w.visible * 2\n"
+    "end)\n";
+
+// Runs a chunk; returns true if it completed without error.
+static bool M_Run(lua_State *const L, const char *const code)
+{
+    return luaL_dostring(L, code) == LUA_OK;
+}
+
+// Runs a chunk expected to raise. Returns the error message, or nullptr if it
+// unexpectedly succeeded.
+static const char *M_RunExpectingError(lua_State *const L, const char *code)
+{
+    if (luaL_dostring(L, code) == LUA_OK) {
+        return nullptr;
+    }
+    return lua_tostring(L, -1);
+}
+
+TEST(a_declared_field_reads_and_writes)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local w = trxc.get_widget(0)\n"
+        "assert(w.visible == 10, 'read')\n"
+        "w.visible = 55\n"
+        "assert(w.visible == 55, 'write')\n"
+        "w.flag = true\n"
+        "assert(w.flag == true, 'bool')\n"));
+    CHECK_EQ_INT(m_Pool[0].visible, 55);
+    lua_close(L);
+}
+
+// The property the whole design rests on: exposure is opt-in. A member the
+// engine can reach but no declaration named is not merely hidden - it is
+// absent.
+TEST(an_undeclared_field_is_absent_not_hidden)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local w = trxc.get_widget(0)\n"
+        "assert(w.secret == nil, 'an undeclared member leaked')\n"));
+
+    // ...and it cannot be written either.
+    const char *const err =
+        M_RunExpectingError(L, "trxc.get_widget(0).secret = 1");
+    CHECK_NOT_NULL(err);
+    CHECK_EQ_INT(m_Pool[0].secret, 99); // untouched
+    lua_close(L);
+}
+
+TEST(an_undeclared_method_is_unreachable)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local w = trxc.get_widget(0)\n"
+        "assert(w.reveal ~= nil, 'declared method missing')\n"
+        "assert(w:reveal() == 10, 'method call')\n"
+        "assert(w.backdoor == nil, 'an undeclared method leaked')\n"));
+    lua_close(L);
+}
+
+TEST(a_computed_member_is_invoked_on_access)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local w = trxc.get_widget(1)\n"
+        "assert(w.doubled == 22, 'computed member')\n"));
+    lua_close(L);
+}
+
+// C says a member must never be written; Lua may narrow that, but it must not
+// be able to widen it.
+TEST(a_c_readonly_member_cannot_be_declared_writable)
+{
+    lua_State *const L = M_NewState(nullptr);
+    const char *const err = M_RunExpectingError(
+        L, "trxc.struct.expose_field('WIDGET', 'locked', 'locked', true)");
+    CHECK_NOT_NULL(err);
+    lua_close(L);
+}
+
+TEST(writing_a_readonly_field_raises)
+{
+    lua_State *const L = M_NewState(DECL);
+    const char *const err =
+        M_RunExpectingError(L, "trxc.get_widget(0).locked = 1");
+    CHECK_NOT_NULL(err);
+    CHECK_EQ_INT(m_Pool[0].locked, 7); // unchanged
+    lua_close(L);
+}
+
+TEST(writing_an_unknown_field_raises)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK_NOT_NULL(
+        M_RunExpectingError(L, "trxc.get_widget(0).no_such_field = 1"));
+    lua_close(L);
+}
+
+// Declaring a field that C cannot reach must fail loudly at declaration time,
+// not silently produce a member that reads nil forever.
+TEST(declaring_a_nonexistent_member_raises)
+{
+    lua_State *const L = M_NewState(nullptr);
+    CHECK_NOT_NULL(M_RunExpectingError(
+        L,
+        "trxc.struct.expose_field('WIDGET', 'ghost', 'no_such_member', true)"));
+    CHECK_NOT_NULL(M_RunExpectingError(
+        L, "trxc.struct.expose_method('WIDGET', 'ghost', 'no_such_method')"));
+    lua_close(L);
+}
+
+// A handle held across a kill must raise, not silently rebind to whatever
+// reused the slot. This is what the generation counter buys.
+TEST(a_stale_handle_raises_rather_than_rebinding)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(L, "held = trxc.get_widget(2)\nassert(held.visible == 12)\n"));
+
+    // The slot is recycled by a different owner, as Item_Kill + Item_Create do.
+    m_Gen[2]++;
+    m_Pool[2].visible = 5000;
+
+    const char *const err = M_RunExpectingError(L, "return held.visible");
+    CHECK_NOT_NULL(err);
+    if (err != nullptr) {
+        CHECK(strstr(err, "stale") != nullptr);
+    }
+    lua_close(L);
+}
+
+TEST(a_handle_to_a_dead_slot_raises)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(L, "held = trxc.get_widget(3)\n"));
+    m_Dead[3] = true;
+    CHECK_NOT_NULL(M_RunExpectingError(L, "return held.visible"));
+    lua_close(L);
+}
+
+// Without a protected metatable, getmetatable(handle).__raw_methods hands a
+// script every C method the type could offer - including the ones no
+// declaration exposed - which would make opt-in exposure a fiction.
+TEST(the_metatable_is_protected)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local mt = getmetatable(trxc.get_widget(0))\n"
+        "assert(type(mt) ~= 'table', 'the metatable is reachable')\n"
+        "assert(mt == 'WIDGET', 'expected the __metatable sentinel')\n"));
+    lua_close(L);
+}
+
+// pairs() must walk the declared surface, not the C table.
+TEST(pairs_iterates_only_the_declared_fields)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local seen = {}\n"
+        "for k, v in pairs(trxc.get_widget(0)) do seen[k] = v end\n"
+        "assert(seen.visible == 10, 'declared field missing from pairs')\n"
+        "assert(seen.locked == 7, 'declared field missing from pairs')\n"
+        "assert(seen.secret == nil, 'pairs leaked an undeclared member')\n"));
+    lua_close(L);
+}
+
+// trxc.struct.members reports what C can reach, so a script can be told which
+// members nobody exposed. It must not become a way to reach them.
+TEST(struct_members_reports_the_c_surface_for_diagnostics)
+{
+    lua_State *const L = M_NewState(DECL);
+    CHECK(M_Run(
+        L,
+        "local names = {}\n"
+        "for _, m in ipairs(trxc.struct.members('WIDGET')) do\n"
+        "  names[m.name] = m\n"
+        "end\n"
+        "assert(names.secret ~= nil, 'members() should report undeclared "
+        "ones')\n"
+        "assert(names.locked.writable == false, 'locked is read-only in C')\n"
+        "assert(names.visible.writable == true)\n"
+        "assert(names.visible.type == 'INT32')\n"));
+    lua_close(L);
+}

--- a/src/trx/core/field.c
+++ b/src/trx/core/field.c
@@ -1,0 +1,323 @@
+#include <trx/core/field.h>
+
+#include <trx/debug.h>
+
+#include <string.h>
+
+// Types self-register from constructors, so this must be a plain static array:
+// it has to be usable before any engine subsystem is initialised.
+#define M_MAX_TYPES 64
+static const TYPE_DESC *m_Types[M_MAX_TYPES];
+static int32_t m_TypeCount = 0;
+
+void Type_Register(const TYPE_DESC *const type)
+{
+    ASSERT(m_TypeCount < M_MAX_TYPES);
+    m_Types[m_TypeCount++] = type;
+}
+
+int32_t Type_GetCount(void)
+{
+    return m_TypeCount;
+}
+
+const TYPE_DESC *Type_GetAt(const int32_t idx)
+{
+    if (idx < 0 || idx >= m_TypeCount) {
+        return nullptr;
+    }
+    return m_Types[idx];
+}
+
+const TYPE_DESC *Type_GetByName(const char *const name)
+{
+    for (int32_t i = 0; i < m_TypeCount; i++) {
+        if (strcmp(m_Types[i]->name, name) == 0) {
+            return m_Types[i];
+        }
+    }
+    return nullptr;
+}
+
+const char *Field_GetTypeName(const FIELD_TYPE type)
+{
+    switch (type) {
+    case FT_BOOL:
+        return "BOOL";
+    case FT_INT8:
+        return "INT8";
+    case FT_UINT8:
+        return "UINT8";
+    case FT_INT16:
+        return "INT16";
+    case FT_UINT16:
+        return "UINT16";
+    case FT_INT32:
+        return "INT32";
+    case FT_UINT32:
+        return "UINT32";
+    case FT_FLOAT:
+        return "FLOAT";
+    case FT_DOUBLE:
+        return "DOUBLE";
+    case FT_XYZ_16:
+        return "XYZ_16";
+    case FT_XYZ_32:
+        return "XYZ_32";
+    case FT_STRING:
+        return "STRING";
+    }
+    return "UNKNOWN";
+}
+
+size_t Field_GetTypeSize(const FIELD_TYPE type)
+{
+    switch (type) {
+    case FT_BOOL:
+        return sizeof(bool);
+    case FT_INT8:
+        return sizeof(int8_t);
+    case FT_UINT8:
+        return sizeof(uint8_t);
+    case FT_INT16:
+        return sizeof(int16_t);
+    case FT_UINT16:
+        return sizeof(uint16_t);
+    case FT_INT32:
+        return sizeof(int32_t);
+    case FT_UINT32:
+        return sizeof(uint32_t);
+    case FT_FLOAT:
+        return sizeof(float);
+    case FT_DOUBLE:
+        return sizeof(double);
+    case FT_XYZ_16:
+        return sizeof(XYZ_16);
+    case FT_XYZ_32:
+        return sizeof(XYZ_32);
+    case FT_STRING:
+        return sizeof(char *);
+    }
+    return 0;
+}
+
+const char *Field_FindDuplicateName(const TYPE_DESC *const type)
+{
+    for (int32_t i = 0; i < type->field_count; i++) {
+        for (int32_t j = i + 1; j < type->field_count; j++) {
+            if (strcmp(type->fields[i].name, type->fields[j].name) == 0) {
+                return type->fields[i].name;
+            }
+        }
+    }
+    return nullptr;
+}
+
+void Field_ValidateType(const TYPE_DESC *const type)
+{
+    const char *const dupe = Field_FindDuplicateName(type);
+    if (dupe != nullptr) {
+        LOG_ERROR("%s declares '%s' more than once", type->name, dupe);
+        ASSERT_FAIL();
+    }
+
+    for (int32_t i = 0; i < type->field_count; i++) {
+        const FIELD_DESC *const field = &type->fields[i];
+        // Only fields that actually address memory carry a backing member to
+        // check: Field_Get uses the offset when there is no getter, and
+        // Field_Set uses it when there is no setter and the field is writable.
+        const bool reads_member = field->get == nullptr;
+        const bool writes_member =
+            field->set == nullptr && !(field->flags & FF_READONLY);
+        if (!reads_member && !writes_member) {
+            continue;
+        }
+        ASSERT(field->size == Field_GetTypeSize(field->type));
+    }
+}
+
+const FIELD_DESC *Field_Find(
+    const TYPE_DESC *const type, const char *const name)
+{
+    for (int32_t i = 0; i < type->field_count; i++) {
+        if (strcmp(type->fields[i].name, name) == 0) {
+            return &type->fields[i];
+        }
+    }
+    return nullptr;
+}
+
+bool Field_Get(
+    const FIELD_DESC *const field, const void *const self,
+    FIELD_VALUE *const out)
+{
+    if (field->get != nullptr) {
+        return field->get(self, out);
+    }
+
+    const void *const p = (const char *)self + field->offset;
+    out->type = field->type;
+    switch (field->type) {
+    case FT_BOOL:
+        out->as_bool = *(const bool *)p;
+        break;
+    case FT_INT8:
+        out->as_int = *(const int8_t *)p;
+        break;
+    case FT_UINT8:
+        out->as_int = *(const uint8_t *)p;
+        break;
+    case FT_INT16:
+        out->as_int = *(const int16_t *)p;
+        break;
+    case FT_UINT16:
+        out->as_int = *(const uint16_t *)p;
+        break;
+    case FT_INT32:
+        out->as_int = *(const int32_t *)p;
+        break;
+    case FT_UINT32:
+        out->as_int = *(const uint32_t *)p;
+        break;
+    case FT_FLOAT:
+        out->as_num = *(const float *)p;
+        break;
+    case FT_DOUBLE:
+        out->as_num = *(const double *)p;
+        break;
+    case FT_XYZ_32:
+        out->as_xyz = *(const XYZ_32 *)p;
+        break;
+    case FT_XYZ_16: {
+        const XYZ_16 *const v = p;
+        out->as_xyz = (XYZ_32) { .x = v->x, .y = v->y, .z = v->z };
+        break;
+    }
+    case FT_STRING:
+        out->as_str = *(const char *const *)p;
+        break;
+    }
+    return true;
+}
+
+// Returns nullptr if `value` fits the integer `type`, else an error message.
+// The reflection layer is the one place that knows every field's exact width,
+// so it is where an out-of-range store must be rejected rather than silently
+// truncated (e.g. writing 99999 into an int16 member).
+static const char *M_CheckIntRange(const FIELD_TYPE type, const int64_t value)
+{
+    int64_t min = 0;
+    int64_t max = 0;
+    switch (type) {
+    case FT_INT8:
+        min = INT8_MIN;
+        max = INT8_MAX;
+        break;
+    case FT_UINT8:
+        min = 0;
+        max = UINT8_MAX;
+        break;
+    case FT_INT16:
+        min = INT16_MIN;
+        max = INT16_MAX;
+        break;
+    case FT_UINT16:
+        min = 0;
+        max = UINT16_MAX;
+        break;
+    case FT_INT32:
+        min = INT32_MIN;
+        max = INT32_MAX;
+        break;
+    case FT_UINT32:
+        min = 0;
+        max = UINT32_MAX;
+        break;
+    default:
+        return nullptr;
+    }
+    if (value < min || value > max) {
+        return "value out of range for field";
+    }
+    return nullptr;
+}
+
+const char *Field_Set(
+    const FIELD_DESC *const field, void *const self,
+    const FIELD_VALUE *const in)
+{
+    if (field->flags & FF_READONLY) {
+        return "field is read-only";
+    }
+    if (field->set != nullptr) {
+        return field->set(self, in);
+    }
+
+    switch (field->type) {
+    case FT_INT8:
+    case FT_UINT8:
+    case FT_INT16:
+    case FT_UINT16:
+    case FT_INT32:
+    case FT_UINT32: {
+        const char *const err = M_CheckIntRange(field->type, in->as_int);
+        if (err != nullptr) {
+            return err;
+        }
+        break;
+    }
+    case FT_XYZ_16:
+        if (M_CheckIntRange(FT_INT16, in->as_xyz.x) != nullptr
+            || M_CheckIntRange(FT_INT16, in->as_xyz.y) != nullptr
+            || M_CheckIntRange(FT_INT16, in->as_xyz.z) != nullptr) {
+            return "vector component out of range for field";
+        }
+        break;
+    default:
+        break;
+    }
+
+    void *const p = (char *)self + field->offset;
+    switch (field->type) {
+    case FT_BOOL:
+        *(bool *)p = in->as_bool;
+        break;
+    case FT_INT8:
+        *(int8_t *)p = in->as_int;
+        break;
+    case FT_UINT8:
+        *(uint8_t *)p = in->as_int;
+        break;
+    case FT_INT16:
+        *(int16_t *)p = in->as_int;
+        break;
+    case FT_UINT16:
+        *(uint16_t *)p = in->as_int;
+        break;
+    case FT_INT32:
+        *(int32_t *)p = in->as_int;
+        break;
+    case FT_UINT32:
+        *(uint32_t *)p = in->as_int;
+        break;
+    case FT_FLOAT:
+        *(float *)p = in->as_num;
+        break;
+    case FT_DOUBLE:
+        *(double *)p = in->as_num;
+        break;
+    case FT_XYZ_32:
+        *(XYZ_32 *)p = in->as_xyz;
+        break;
+    case FT_XYZ_16:
+        *(XYZ_16 *)p = (XYZ_16) {
+            .x = in->as_xyz.x,
+            .y = in->as_xyz.y,
+            .z = in->as_xyz.z,
+        };
+        break;
+    case FT_STRING:
+        return "string fields require a custom setter";
+    }
+    return nullptr;
+}

--- a/src/trx/core/field.h
+++ b/src/trx/core/field.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <trx/core/math.h>
+#include <trx/core/utils.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+// A FIELD_DESC says how to reach one member of a struct: its storage type and
+// where it lives. That is all. It is mechanism, not contract.
+//
+// It deliberately carries no description and makes no naming decision. The
+// public API - which members are exposed, under what name, with what
+// documentation - is declared in Lua (see data/scripting/api.lua), and that
+// declaration is what builds the metatable. A member listed here is reachable
+// by C; it becomes public only if a script says so.
+//
+// `name` is the C member name and is an internal key, not an API name.
+
+typedef enum {
+    FT_BOOL,
+    FT_INT8,
+    FT_UINT8,
+    FT_INT16,
+    FT_UINT16,
+    FT_INT32,
+    FT_UINT32,
+    FT_FLOAT,
+    FT_DOUBLE,
+    FT_XYZ_16,
+    FT_XYZ_32,
+    FT_STRING,
+} FIELD_TYPE;
+
+// Widened carrier: every integer type rides in as_int, and XYZ_16 rides in
+// as_xyz. FIELD_TYPE says how to narrow on store, so callers never need to.
+typedef struct {
+    FIELD_TYPE type;
+    union {
+        bool as_bool;
+        int64_t as_int;
+        double as_num;
+        XYZ_32 as_xyz;
+        const char *as_str;
+    };
+} FIELD_VALUE;
+
+typedef enum {
+    FF_NONE = 0,
+    // A hard constraint, not a style choice: this member must never be written
+    // through the reflection layer. Lua may narrow a field to read-only, but it
+    // cannot widen one that is marked here.
+    FF_READONLY = 1 << 0,
+} FIELD_FLAGS;
+
+typedef struct {
+    const char *name; // C member name; an internal key, not the public API name
+    FIELD_TYPE type;
+    size_t offset; // used when get/set are null
+    size_t size; // sizeof the member; validated against type at startup
+    uint32_t flags;
+    // Escape hatch for members that are computed, validated, or have side
+    // effects. set() returns nullptr on success, or an error message.
+    bool (*get)(const void *self, FIELD_VALUE *out);
+    const char *(*set)(void *self, const FIELD_VALUE *in);
+} FIELD_DESC;
+
+typedef struct {
+    const char *name;
+    const FIELD_DESC *fields;
+    int32_t field_count;
+} TYPE_DESC;
+
+#define M_FIELD(struct_, member_, type_, flags_)                               \
+    {                                                                          \
+        .name = #member_,                                                      \
+        .type = type_,                                                         \
+        .offset = offsetof(struct_, member_),                                  \
+        .size = sizeof(((struct_ *)nullptr)->member_),                         \
+        .flags = flags_,                                                       \
+    }
+
+// Plain struct member.
+#define FIELD(struct_, member_, type_) M_FIELD(struct_, member_, type_, FF_NONE)
+
+// Plain struct member that must never be written through reflection.
+#define FIELD_RO(struct_, member_, type_)                                      \
+    M_FIELD(struct_, member_, type_, FF_READONLY)
+
+// Plain struct member whose write has side effects or needs validation.
+#define FIELD_SET(struct_, member_, type_, set_)                               \
+    {                                                                          \
+        .name = #member_,                                                      \
+        .type = type_,                                                         \
+        .offset = offsetof(struct_, member_),                                  \
+        .size = sizeof(((struct_ *)nullptr)->member_),                         \
+        .set = set_,                                                           \
+    }
+
+// Computed member with no backing field. Pass nullptr for set_ to make it
+// read-only. `name_` is still a C-side key, not an API name.
+#define FIELD_FN(name_, type_, get_, set_)                                     \
+    {                                                                          \
+        .name = name_,                                                         \
+        .type = type_,                                                         \
+        .get = get_,                                                           \
+        .set = set_,                                                           \
+        .flags = (set_) == nullptr ? FF_READONLY : FF_NONE,                    \
+    }
+
+// Defines a TYPE_DESC and adds it to the global type registry, so consumers
+// that enumerate types (the API binder, the docs dump) need not know which
+// types exist.
+#define TYPE_DEFINE(struct_, fields_)                                          \
+    const TYPE_DESC TYPE_##struct_ = {                                         \
+        .name = #struct_,                                                      \
+        .fields = fields_,                                                     \
+        .field_count = ARRAY_SIZE(fields_),                                    \
+    };                                                                         \
+    __attribute__((constructor)) static void M_RegisterType##struct_(void)     \
+    {                                                                          \
+        Type_Register(&TYPE_##struct_);                                        \
+    }
+
+void Type_Register(const TYPE_DESC *type);
+int32_t Type_GetCount(void);
+const TYPE_DESC *Type_GetAt(int32_t idx);
+const TYPE_DESC *Type_GetByName(const char *name);
+
+// Byte width a given FIELD_TYPE expects to address.
+size_t Field_GetTypeSize(FIELD_TYPE type);
+
+// Stable machine-readable name for a FIELD_TYPE, e.g. "INT16", "XYZ_32".
+const char *Field_GetTypeName(FIELD_TYPE type);
+
+// Returns the first name declared more than once in the table, or nullptr.
+// Field_Find returns the first match, so a duplicate silently shadows every
+// later entry - including a validating setter that then never runs.
+const char *Field_FindDuplicateName(const TYPE_DESC *type);
+
+// Assert every plain member's sizeof matches its declared FIELD_TYPE. Guards
+// against e.g. tagging a 4-byte enum as FT_INT16, which would silently read the
+// wrong half of the member. Call once per type at startup.
+void Field_ValidateType(const TYPE_DESC *type);
+
+const FIELD_DESC *Field_Find(const TYPE_DESC *type, const char *name);
+bool Field_Get(const FIELD_DESC *field, const void *self, FIELD_VALUE *out);
+const char *Field_Set(
+    const FIELD_DESC *field, void *self, const FIELD_VALUE *in);

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -32,6 +32,7 @@ extern void LUA_CreateItems(lua_State *L);
 extern void LUA_CreateLara(lua_State *L);
 extern void LUA_CreateLog(lua_State *L);
 extern void LUA_CreateMusic(lua_State *L);
+extern void LUA_CreateStruct(lua_State *L);
 extern void LUA_CreateSound(lua_State *L);
 extern void LUA_CreateConfig(lua_State *L);
 extern void LUA_CreateRooms(lua_State *L);
@@ -148,14 +149,24 @@ static void M_RequireTRXModule(lua_State *const L, const char *name)
 
 static void M_LoadTRXScripts(lua_State *const L)
 {
+    // Register every module's preload entry before requiring any of them.
+    // Doing both in one pass would mean a module could only ever require one
+    // that happens to appear earlier in the list, which silently couples the
+    // Lua load order to the ordering of the source list in meson.build.
     for (const LUA_EMBEDDED_SCRIPT *script = g_LUA_EmbeddedScripts;
          script->path != nullptr; script++) {
-        LOG_DEBUG("Loading TRX module %s", script->path);
         char *name = M_DeriveTRXModuleName(script->path);
         const char *const chunk_name =
             String_FormatStatic("@trx/%s", script->path);
         M_RegisterTRXPreloadEmbedded(
             L, script->data, script->size, chunk_name, name);
+        Memory_FreePointer(&name);
+    }
+
+    for (const LUA_EMBEDDED_SCRIPT *script = g_LUA_EmbeddedScripts;
+         script->path != nullptr; script++) {
+        LOG_DEBUG("Loading TRX module %s", script->path);
+        char *name = M_DeriveTRXModuleName(script->path);
         M_RequireTRXModule(L, name);
         Memory_FreePointer(&name);
     }
@@ -173,6 +184,7 @@ void LUA_Init(void)
     lua_setglobal(L, "trx");
 
     // Initialize internal modules
+    M_LoadTRXCModule(L, LUA_CreateStruct);
     M_LoadTRXCModule(L, LUA_CreateCatalog);
     M_LoadTRXCModule(L, LUA_CreateCamera);
     M_LoadTRXCModule(L, LUA_CreateConsole);

--- a/src/trx/game/lua/struct.c
+++ b/src/trx/game/lua/struct.c
@@ -1,0 +1,405 @@
+#include <trx/game/lua/struct.h>
+
+#include <string.h>
+
+// Metatable keys. __fields / __methods / __ext are the public surface, and are
+// empty until a script declares it. __raw_methods is every method C could
+// offer; it is never reachable from a handle - Lua selects from it by name.
+static const char M_KEY_FIELDS[] = "__fields";
+static const char M_KEY_METHODS[] = "__methods";
+static const char M_KEY_EXT[] = "__ext";
+static const char M_KEY_RAW_METHODS[] = "__raw_methods";
+
+static void M_PushValue(lua_State *const L, const FIELD_VALUE *const value)
+{
+    switch (value->type) {
+    case FT_BOOL:
+        lua_pushboolean(L, value->as_bool);
+        break;
+    case FT_FLOAT:
+    case FT_DOUBLE:
+        lua_pushnumber(L, value->as_num);
+        break;
+    case FT_STRING:
+        if (value->as_str == nullptr) {
+            lua_pushnil(L);
+        } else {
+            lua_pushstring(L, value->as_str);
+        }
+        break;
+    case FT_XYZ_16:
+    case FT_XYZ_32:
+        lua_newtable(L);
+        lua_pushinteger(L, value->as_xyz.x);
+        lua_setfield(L, -2, "x");
+        lua_pushinteger(L, value->as_xyz.y);
+        lua_setfield(L, -2, "y");
+        lua_pushinteger(L, value->as_xyz.z);
+        lua_setfield(L, -2, "z");
+        break;
+    default:
+        lua_pushinteger(L, value->as_int);
+        break;
+    }
+}
+
+static FIELD_VALUE M_CheckValue(
+    lua_State *const L, const int idx, const FIELD_TYPE type)
+{
+    FIELD_VALUE value = { .type = type };
+    switch (type) {
+    case FT_BOOL:
+        luaL_checktype(L, idx, LUA_TBOOLEAN);
+        value.as_bool = lua_toboolean(L, idx);
+        break;
+    case FT_FLOAT:
+    case FT_DOUBLE:
+        value.as_num = luaL_checknumber(L, idx);
+        break;
+    case FT_STRING:
+        value.as_str = luaL_checkstring(L, idx);
+        break;
+    case FT_XYZ_16:
+    case FT_XYZ_32: {
+        const int abs_idx = lua_absindex(L, idx);
+        luaL_checktype(L, abs_idx, LUA_TTABLE);
+        lua_getfield(L, abs_idx, "x");
+        value.as_xyz.x = luaL_checkinteger(L, -1);
+        lua_getfield(L, abs_idx, "y");
+        value.as_xyz.y = luaL_checkinteger(L, -1);
+        lua_getfield(L, abs_idx, "z");
+        value.as_xyz.z = luaL_checkinteger(L, -1);
+        lua_pop(L, 3);
+        break;
+    }
+    default:
+        value.as_int = luaL_checkinteger(L, idx);
+        break;
+    }
+    return value;
+}
+
+LUA_STRUCT_REF *LUA_Struct_CheckRef(
+    lua_State *const L, const int idx, const TYPE_DESC *const type)
+{
+    return luaL_checkudata(L, idx, type->name);
+}
+
+void *LUA_Struct_Deref(lua_State *const L, LUA_STRUCT_REF *const ref)
+{
+    void *const self = ref->resolve(ref);
+    if (self == nullptr) {
+        luaL_error(L, "stale %s handle", ref->type->name);
+    }
+    return self;
+}
+
+// Upvalue 1 of __index and __newindex maps public name -> FIELD_DESC *. A
+// linear strcmp scan over the field table measured ~43ns per access; this is a
+// single interned-string hash lookup.
+static const FIELD_DESC *M_LookUpField(lua_State *const L, const int key_idx)
+{
+    lua_pushvalue(L, key_idx);
+    lua_rawget(L, lua_upvalueindex(1));
+    const FIELD_DESC *const field = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return field;
+}
+
+static int M_Index(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = lua_touserdata(L, 1);
+
+    const FIELD_DESC *const field = M_LookUpField(L, 2);
+    if (field != nullptr) {
+        FIELD_VALUE value;
+        if (!Field_Get(field, LUA_Struct_Deref(L, ref), &value)) {
+            lua_pushnil(L);
+            return 1;
+        }
+        M_PushValue(L, &value);
+        return 1;
+    }
+
+    // Upvalue 2: methods. Returned as-is; Lua calls them with the userdata as
+    // self, so no rebinding wrapper is needed.
+    lua_pushvalue(L, 2);
+    if (lua_rawget(L, lua_upvalueindex(2)) != LUA_TNIL) {
+        return 1;
+    }
+    lua_pop(L, 1);
+
+    // Upvalue 3: computed members declared in Lua (item.room, item.properties).
+    // Invoked now, with the userdata; the result is the value.
+    lua_pushvalue(L, 2);
+    if (lua_rawget(L, lua_upvalueindex(3)) != LUA_TFUNCTION) {
+        lua_pop(L, 1);
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushvalue(L, 1);
+    lua_call(L, 1, 1);
+    return 1;
+}
+
+static int M_NewIndex(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = lua_touserdata(L, 1);
+
+    const FIELD_DESC *const field = M_LookUpField(L, 2);
+    if (field == nullptr) {
+        return luaL_error(
+            L, "unknown %s field '%s'", ref->type->name, lua_tostring(L, 2));
+    }
+
+    const FIELD_VALUE value = M_CheckValue(L, 3, field->type);
+    const char *const err = Field_Set(field, LUA_Struct_Deref(L, ref), &value);
+    if (err != nullptr) {
+        return luaL_error(
+            L, "cannot set %s.%s: %s", ref->type->name, lua_tostring(L, 2),
+            err);
+    }
+    return 0;
+}
+
+static int M_PairsIter(lua_State *const L)
+{
+    LUA_STRUCT_REF *const ref = lua_touserdata(L, 1);
+
+    // Iterate the declared public fields, not the C table: a member C can reach
+    // but no script declared is not part of the type.
+    lua_pushvalue(L, 2);
+    if (lua_next(L, lua_upvalueindex(1)) == 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    const FIELD_DESC *const field = lua_touserdata(L, -1);
+    lua_pop(L, 1); // value; the public name stays on the stack as the key
+
+    FIELD_VALUE value;
+    if (!Field_Get(field, LUA_Struct_Deref(L, ref), &value)) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_pushvalue(L, -1); // key again, as the iterator's control variable
+    lua_insert(L, -2);
+    M_PushValue(L, &value);
+    return 2;
+}
+
+static int M_Pairs(lua_State *const L)
+{
+    luaL_getmetatable(L, ((LUA_STRUCT_REF *)lua_touserdata(L, 1))->type->name);
+    lua_getfield(L, -1, M_KEY_FIELDS);
+    lua_remove(L, -2);
+    lua_pushcclosure(L, M_PairsIter, 1);
+    lua_pushvalue(L, 1);
+    lua_pushnil(L);
+    return 3;
+}
+
+void LUA_Struct_Register(
+    lua_State *const L, const TYPE_DESC *const type,
+    const luaL_Reg *const methods)
+{
+    Field_ValidateType(type);
+
+    luaL_newmetatable(L, type->name);
+
+    // Everything C could offer, for Lua to select from. Not reachable from a
+    // handle.
+    lua_newtable(L);
+    if (methods != nullptr) {
+        luaL_setfuncs(L, methods, 0);
+    }
+    lua_setfield(L, -2, M_KEY_RAW_METHODS);
+
+    // The public surface: empty until a script declares it.
+    lua_newtable(L); // fields
+    lua_newtable(L); // methods
+    lua_newtable(L); // ext
+
+    lua_pushvalue(L, -3);
+    lua_setfield(L, -5, M_KEY_FIELDS);
+    lua_pushvalue(L, -2);
+    lua_setfield(L, -5, M_KEY_METHODS);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -5, M_KEY_EXT);
+
+    // __index and __newindex close over (fields, methods, ext). Populating
+    // those tables later from Lua is visible here, because the upvalues are the
+    // tables themselves.
+    lua_pushvalue(L, -3);
+    lua_pushvalue(L, -3);
+    lua_pushvalue(L, -3);
+    lua_pushcclosure(L, M_Index, 3);
+    lua_setfield(L, -5, "__index");
+
+    lua_pushvalue(L, -3);
+    lua_pushcclosure(L, M_NewIndex, 1);
+    lua_setfield(L, -5, "__newindex");
+
+    lua_pop(L, 3); // fields, methods, ext
+
+    lua_pushcfunction(L, M_Pairs);
+    lua_setfield(L, -2, "__pairs");
+
+    // Protect the metatable. Without this, getmetatable(item).__raw_methods
+    // hands a script every C method the type could offer, including the ones no
+    // declaration exposed - which would make the opt-in surface a fiction.
+    lua_pushstring(L, type->name);
+    lua_setfield(L, -2, "__metatable");
+
+    lua_pop(L, 1);
+}
+
+void LUA_Struct_Push(
+    lua_State *const L, const TYPE_DESC *const type,
+    void *(*const resolve)(const LUA_STRUCT_REF *), const int32_t idx,
+    const uint32_t gen)
+{
+    LUA_STRUCT_REF *const ref = lua_newuserdatauv(L, sizeof(LUA_STRUCT_REF), 0);
+    *ref = (LUA_STRUCT_REF) {
+        .type = type,
+        .resolve = resolve,
+        .idx = idx,
+        .gen = gen,
+    };
+    luaL_setmetatable(L, type->name);
+}
+
+// --- trxc.struct: how Lua declares the public surface -----------------------
+
+static const TYPE_DESC *M_CheckType(lua_State *const L, const int idx)
+{
+    const char *const name = luaL_checkstring(L, idx);
+    const TYPE_DESC *const type = Type_GetByName(name);
+    if (type == nullptr) {
+        luaL_error(L, "unknown struct type '%s'", name);
+    }
+    return type;
+}
+
+// trxc.struct.members(type) -> { {name=, type=, writable=}, ... }
+//
+// Every member C can reach. Used by the Lua layer to validate a declaration and
+// to report members nobody exposed.
+static int M_L_Members(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    lua_newtable(L);
+    for (int32_t i = 0; i < type->field_count; i++) {
+        const FIELD_DESC *const field = &type->fields[i];
+        lua_newtable(L);
+        lua_pushstring(L, field->name);
+        lua_setfield(L, -2, "name");
+        lua_pushstring(L, Field_GetTypeName(field->type));
+        lua_setfield(L, -2, "type");
+        lua_pushboolean(L, !(field->flags & FF_READONLY));
+        lua_setfield(L, -2, "writable");
+        lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
+}
+
+// trxc.struct.method_names(type) -> { "kill", "activate", ... }
+static int M_L_MethodNames(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, M_KEY_RAW_METHODS);
+
+    lua_newtable(L);
+    int32_t n = 0;
+    lua_pushnil(L);
+    while (lua_next(L, -3) != 0) {
+        lua_pop(L, 1); // value
+        lua_pushvalue(L, -1); // key
+        lua_rawseti(L, -3, ++n);
+    }
+    return 1;
+}
+
+// trxc.struct.expose_field(type, public_name, c_name, writable)
+static int M_L_ExposeField(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    const char *const public_name = luaL_checkstring(L, 2);
+    const char *const c_name = luaL_checkstring(L, 3);
+    const bool writable = lua_toboolean(L, 4);
+
+    const FIELD_DESC *const field = Field_Find(type, c_name);
+    if (field == nullptr) {
+        return luaL_error(
+            L, "%s has no member '%s' (declared as '%s')", type->name, c_name,
+            public_name);
+    }
+    if (writable && (field->flags & FF_READONLY)) {
+        return luaL_error(
+            L, "%s.%s is read-only in C and cannot be declared writable",
+            type->name, c_name);
+    }
+
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, M_KEY_FIELDS);
+    lua_pushstring(L, public_name);
+    lua_pushlightuserdata(L, (void *)field);
+    lua_rawset(L, -3);
+    return 0;
+}
+
+// trxc.struct.expose_method(type, public_name, c_name)
+static int M_L_ExposeMethod(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    const char *const public_name = luaL_checkstring(L, 2);
+    const char *const c_name = luaL_checkstring(L, 3);
+
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, M_KEY_RAW_METHODS);
+    if (lua_getfield(L, -1, c_name) != LUA_TFUNCTION) {
+        return luaL_error(
+            L, "%s has no method '%s' (declared as '%s')", type->name, c_name,
+            public_name);
+    }
+
+    lua_getfield(L, -3, M_KEY_METHODS);
+    lua_pushstring(L, public_name);
+    lua_pushvalue(L, -3); // the C function
+    lua_rawset(L, -3);
+    return 0;
+}
+
+// trxc.struct.expose_computed(type, public_name, fn)
+static int M_L_ExposeComputed(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    const char *const public_name = luaL_checkstring(L, 2);
+    luaL_checktype(L, 3, LUA_TFUNCTION);
+
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, M_KEY_EXT);
+    lua_pushstring(L, public_name);
+    lua_pushvalue(L, 3);
+    lua_rawset(L, -3);
+    return 0;
+}
+
+void LUA_CreateStruct(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+    lua_pushcfunction(L, M_L_Members);
+    lua_setfield(L, -2, "members");
+    lua_pushcfunction(L, M_L_MethodNames);
+    lua_setfield(L, -2, "method_names");
+    lua_pushcfunction(L, M_L_ExposeField);
+    lua_setfield(L, -2, "expose_field");
+    lua_pushcfunction(L, M_L_ExposeMethod);
+    lua_setfield(L, -2, "expose_method");
+    lua_pushcfunction(L, M_L_ExposeComputed);
+    lua_setfield(L, -2, "expose_computed");
+    lua_setfield(L, -2, "struct");
+    lua_pop(L, 1);
+}

--- a/src/trx/game/lua/struct.h
+++ b/src/trx/game/lua/struct.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <trx/core/field.h>
+
+#include <lauxlib.h>
+#include <lualib.h>
+
+// Generic Lua bridge over FIELD_DESC.
+//
+// Registering a type creates its metatable with EMPTY public tables: no field,
+// method or computed member is reachable until a script declares it (see
+// trx.api.type in data/scripting/api.lua). The declaration is what populates
+// the metatable, so the public API is coined in Lua, while dispatch stays in C
+// - routing field reads through Lua costs ~1.5x on the hottest path scripts
+// have.
+
+typedef struct LUA_STRUCT_REF {
+    const TYPE_DESC *type;
+    // Resolves the handle to a live pointer, or nullptr if it went stale (the
+    // slot was recycled, the level was unloaded, the index went out of range).
+    void *(*resolve)(const struct LUA_STRUCT_REF *ref);
+    int32_t idx;
+    uint32_t gen;
+} LUA_STRUCT_REF;
+
+// Creates the type's metatable. `methods` is the full set of C methods the type
+// *can* offer; none of them is exposed until a script names it. Terminate with
+// {nullptr, nullptr}.
+void LUA_Struct_Register(
+    lua_State *L, const TYPE_DESC *type, const luaL_Reg *methods);
+
+// Registers trxc.struct, through which Lua declares the public surface.
+void LUA_CreateStruct(lua_State *L);
+
+// Push a handle userdata for an instance of a registered type.
+void LUA_Struct_Push(
+    lua_State *L, const TYPE_DESC *type,
+    void *(*resolve)(const LUA_STRUCT_REF *), int32_t idx, uint32_t gen);
+
+// Fetch and typecheck a handle at the given stack index.
+LUA_STRUCT_REF *LUA_Struct_CheckRef(
+    lua_State *L, int idx, const TYPE_DESC *type);
+
+// Resolve a handle to a live pointer, raising a Lua error if it is stale.
+void *LUA_Struct_Deref(lua_State *L, LUA_STRUCT_REF *ref);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Two things bother me about how we expose the engine to Lua:
- every field a script can read costs a hand-written getter and setter, so widening the API means more of the same boilerplate each time,
- the docs live apart from the code that implements them, which means they drift.

This is the groundwork for fixing both: describe a struct's members once, declare what's public once, and let the binding and the documentation fall out of that. **Nothing is exposed to builders yet – this PR is only the scaffolding.**

#### `FIELD_DESC`

Each struct now describes its own fields — one line per member, saying what type it is and where it lives. `FIELD()` pulls both straight from the struct definition, and `TYPE_DEFINE` registers the table from a constructor much like `REGISTER_OBJECT`, so anything that wants to walk all scriptable types, can do so without a hand-kept list. `Field_Get` and `Field_Set` give universal read/write access through that metadata; special cases still exist through `FIELD_SET` (validation), `FIELD_FN` (computed values), or `FIELD_RO` (read-only members).

Since the declared type now sits beside the field rather than being derived from it, startup asserts every plain member’s `sizeof` to catch mismatches early instead of corrupting memory quietly.

#### `LUA_Struct`

This layer turns a described type into something Lua can actually hold. `LUA_Struct_Register` builds a metatable so `item.hp = 100` becomes one generic write instead of another binding. Handles use an index and generation instead of a pointer, resolving through a callback on each access. Stale handles throw, rather than poke freed memory. The metatable begins empty by design; describing a field in C means the engine *can* reach it, not that a script *should*.

#### `trx.api`

The public surface is declared on the Lua side. `api.type` lists which members a type exposes, under what names, and with what permissions; `api.define` does the same for functions, keeping the signature glued to its implementation. `api.to_json` then emits the full map for docs, so the reference stays in sync automatically. The spec is metadata only: `api.define` binds raw implementations because a generic validating wrapper was 26× slower (416ns vs 16ns). Validation remains opt‑in through `trx.api.strict(true)`, which code‑generates a checker per signature (~108ns), meant for level‑building not runtime. Field dispatch lives in C for the same reason, roughly 1.5× faster on hot paths.

---

Tests cover the field layer (types, sizes, duplicates, and the custom setters), the Lua bridge (handle reuse, read‑only guards, field round‑trips), and the API registry (declaration, sealing, strict mode, JSON dump). They’re folded into the unit suite from #5800, and CI now installs Lua so they can run on every push.
