### PR TITLE
lua/docs: reject a declaration with no description

### DIFF
--- a/src/tests/unit/test_update_lua_docs.py
+++ b/src/tests/unit/test_update_lua_docs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import unittest
 
@@ -55,6 +56,9 @@ SURFACE = {
                 {"name": "BROKEN", "value": 7, "description": "It is broken."},
             ],
         }
+    ],
+    "constants": [
+        {"path": "things.WALL_L", "value": 1024, "description": "One sector."}
     ],
     "functions": [
         {
@@ -163,6 +167,28 @@ class TestLuaDocs(unittest.TestCase):
         a = docs.render_page(SURFACE["modules"][0], SURFACE)
         b = docs.render_page(SURFACE["modules"][0], SURFACE)
         self.assertEqual(a, b)
+
+    def test_a_declared_member_with_no_description_is_reported(self):
+        """A member with no description still reaches scripts; it just renders
+        blank."""
+        self.assertEqual(docs.undocumented(SURFACE), [])
+
+        cases = [
+            (("functions", 0), "things.spawn"),
+            (("constants", 0), "things.WALL_L"),
+            (("enums", 0, "values", 1), "things.State.ON"),
+            (("types", 0, "fields", 0), "things.Widget.shown"),
+            (("types", 0, "methods", 0), "things.Widget.poke"),
+            (("types", 0, "extensions", 0), "things.Widget.derived"),
+        ]
+        for path, expected in cases:
+            with self.subTest(member=expected):
+                surface = copy.deepcopy(SURFACE)
+                target = surface
+                for key in path:
+                    target = target[key]
+                del target["description"]
+                self.assertEqual(docs.undocumented(surface), [expected])
 
     def test_dump_extracts_the_json_from_a_noisy_stream(self):
         """The engine logs to stdout alongside the JSON, so the payload must be

--- a/tools/update_lua_docs
+++ b/tools/update_lua_docs
@@ -222,6 +222,27 @@ def render_page(module: dict, api: dict) -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
+def undocumented(api: dict) -> list[str]:
+    """Declared names carrying no description - they render as a blank line."""
+    out = []
+    for func in api.get("functions", []):
+        if not func.get("description"):
+            out.append(func["path"])
+    for const in api.get("constants", []):
+        if not const.get("description"):
+            out.append(const["path"])
+    for enum in api.get("enums", []):
+        for value in enum.get("values") or []:
+            if not value.get("description"):
+                out.append(f"{enum['path']}.{value['name']}")
+    for spec in api.get("types", []):
+        for kind in ("fields", "methods", "extensions"):
+            for member in spec.get(kind) or []:
+                if not member.get("description"):
+                    out.append(f"{spec['path']}.{member['name']}")
+    return out
+
+
 def dump_api(binary: Path) -> str:
     result = subprocess.run(
         [str(binary), "--dump-lua-api"], capture_output=True, text=True, check=True
@@ -263,6 +284,14 @@ def main() -> int:
             f"  just lua-api-dump"
         )
     api = json.loads(API_JSON.read_text())
+
+    blank = undocumented(api)
+    if blank:
+        print("error: declared with no description:", file=sys.stderr)
+        for path in blank:
+            print(f"  {path}", file=sys.stderr)
+        print("document it in data/scripting/, next to the declaration", file=sys.stderr)
+        return 1
 
     stale = []
     for module in api["modules"]:


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A declared member with no description still reaches scripts - it just renders as a blank line in the generated page. Fail the generator instead of shipping the hole.