### PR TITLE
tests: cover the public LUA API seal

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -144,6 +144,22 @@ test_lua_items_exe = executable(
 )
 test('lua_items', test_lua_items_exe, suite: 'unit')
 
+test_lua_api_seal_exe = executable(
+  'test_lua_api_seal',
+  files('unit/test_lua_api_seal.c', 'unit/fake_engine_items.c') + test_stubs
+    + lua_surface_src
+    + files(
+      '../trx/game/items/fields.c',
+      '../trx/game/lua/items.c',
+      '../trx/game/lua/utils.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_api_seal', test_lua_api_seal_exe, suite: 'unit')
+
 # field.c and lua/struct.c are leaf modules, so the reflection layer and the Lua
 # bridge can be exercised against a synthetic struct type.
 test_lua_struct_exe = executable(

--- a/src/tests/unit/lua/api_seal.lua
+++ b/src/tests/unit/lua/api_seal.lua
@@ -1,0 +1,29 @@
+-- api.type() reaches into the C struct binder: left callable, a script could
+-- re-expose the members the declarations withheld.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("an undeclared member is unreachable before the seal", function()
+  assert(trx.items[1].box_num == nil, "box_num was never declared")
+end)
+
+test("sealing rejects further declarations", function()
+  trx.api.seal()
+
+  raises(function()
+    trx.api.define("items.evil", { impl = function() end })
+  end, "sealed")
+
+  raises(function()
+    trx.api.type("items.Item", {
+      backing = "ITEM",
+      fields = { box_num = { from = "box_num", type = "integer" } },
+    })
+  end, "sealed")
+
+  -- A rejected declaration must not have bound anything on its way out.
+  assert(trx.items[1].box_num == nil, "box_num must still be unreachable")
+end)
+
+return h.report()

--- a/src/tests/unit/test_lua_api_seal.c
+++ b/src/tests/unit/test_lua_api_seal.c
@@ -1,0 +1,45 @@
+// Sealing is a one-way door, so it gets a state of its own. Same world as
+// test_lua_items.c; the assertions live in src/tests/unit/lua/api_seal.lua.
+
+#include "fake_engine_items.h"
+#include "lua_surface.h"
+
+extern void LUA_CreateItems(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateItems(L);
+    (void)luaL_dostring(
+        L,
+        "trx.rooms = setmetatable({}, {\n"
+        "  __index = function(_, n) return { num = n } end })\n");
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeItems_Reset();
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "items",
+        .tests = "api_seal",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Sealing is a one-way door, so it needs a state of its own: the same world as test_lua_items, run until seal() and then past it.