### PR TITLE
lua: sandbox the scripting environment

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -423,6 +423,7 @@ common_sources = [
   'trx/game/lua/objects.c',
   'trx/game/lua/pickup.c',
   'trx/game/lua/rooms.c',
+  'trx/game/lua/sandbox.c',
   'trx/game/lua/sound.c',
   'trx/game/lua/struct.c',
   'trx/game/lua/utils.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -99,6 +99,17 @@ test_lua_enum_exe = executable(
 )
 test('lua_enum', test_lua_enum_exe, suite: 'unit')
 
+# The sandbox depends on nothing but Lua, so the wall the engine stands up at
+# boot stands up here against a bare state - no modules, no engine.
+test_lua_sandbox_exe = executable(
+  'test_lua_sandbox',
+  files('unit/test_lua_sandbox.c') + test_stubs + files('../trx/game/lua/sandbox.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  build_by_default: false,
+)
+test('lua_sandbox', test_lua_sandbox_exe, suite: 'unit')
+
 # The public Lua surface, driven the way a level script drives it. Everything
 # below the assertions is real - the FIELD_DESC tables, the struct and enum
 # bridges, the trxc modules, and data/scripting/*.lua read from the tree - and

--- a/src/tests/unit/test_lua_sandbox.c
+++ b/src/tests/unit/test_lua_sandbox.c
@@ -1,0 +1,77 @@
+#include "harness.h"
+
+#include <trx/game/lua/sandbox.h>
+
+#include <lauxlib.h>
+#include <lualib.h>
+
+// The wall a level script runs behind, stood up against a bare state.
+
+static lua_State *M_Sandboxed(void)
+{
+    lua_State *const L = luaL_newstate();
+    LUA_OpenSafeLibs(L);
+    LUA_HardenGlobals(L);
+    return L;
+}
+
+// luaL_dostring is the C loader; hardening only removes the Lua-visible load().
+static bool M_Holds(lua_State *const L, const char *const expr)
+{
+    char src[256];
+    snprintf(src, sizeof(src), "return (%s) and true or false", expr);
+    if (luaL_dostring(L, src) != LUA_OK) {
+        lua_pop(L, 1);
+        return false;
+    }
+    const bool result = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+    return result;
+}
+
+TEST(sandbox_drops_the_unsafe_libraries)
+{
+    lua_State *const L = M_Sandboxed();
+    // debug.getupvalue on any trx.* function would recover the raw C bridge.
+    CHECK(M_Holds(L, "debug == nil"));
+    CHECK(M_Holds(L, "os == nil"));
+    CHECK(M_Holds(L, "io == nil"));
+    lua_close(L);
+}
+
+TEST(sandbox_drops_the_base_library_escapes)
+{
+    lua_State *const L = M_Sandboxed();
+    // The base library brings these, so dropping io and os does not close them.
+    CHECK(M_Holds(L, "load == nil"));
+    CHECK(M_Holds(L, "loadfile == nil"));
+    CHECK(M_Holds(L, "dofile == nil"));
+    CHECK(M_Holds(L, "string.dump == nil"));
+    lua_close(L);
+}
+
+TEST(sandbox_drops_the_module_loader)
+{
+    lua_State *const L = M_Sandboxed();
+    CHECK(M_Holds(L, "require == nil"));
+    CHECK(M_Holds(L, "package == nil"));
+    lua_close(L);
+}
+
+TEST(sandbox_locks_the_shared_string_metatable)
+{
+    lua_State *const L = M_Sandboxed();
+    // Left writable, a script rewrites string behaviour for the whole state.
+    CHECK(M_Holds(L, "getmetatable('') == 'locked'"));
+    lua_close(L);
+}
+
+TEST(sandbox_keeps_what_a_script_legitimately_needs)
+{
+    lua_State *const L = M_Sandboxed();
+    CHECK(M_Holds(L, "type(math) == 'table'"));
+    CHECK(M_Holds(L, "type(string) == 'table'"));
+    CHECK(M_Holds(L, "type(table) == 'table'"));
+    CHECK(M_Holds(L, "type(pcall) == 'function'"));
+    lua_close(L);
+}

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -9,6 +9,7 @@
 #include <trx/game/game_flow/common.h>
 #include <trx/game/lua/embedded_scripts.h>
 #include <trx/game/lua/events.h>
+#include <trx/game/lua/sandbox.h>
 
 #include <lauxlib.h>
 #include <lua.h>
@@ -193,7 +194,7 @@ void LUA_Init(void)
 {
     lua_State *const L = luaL_newstate();
     ASSERT(L != nullptr);
-    luaL_openlibs(L);
+    LUA_OpenSafeLibs(L);
 
     lua_newtable(L);
     lua_setglobal(L, "trxc");
@@ -226,6 +227,7 @@ void LUA_Init(void)
 
     M_LoadTRXScripts(L);
     M_SealPublicAPI(L);
+    LUA_HardenGlobals(L);
 }
 
 void LUA_Shutdown(void)

--- a/src/trx/game/lua/sandbox.c
+++ b/src/trx/game/lua/sandbox.c
@@ -1,0 +1,61 @@
+#include <trx/game/lua/sandbox.h>
+
+#include <lauxlib.h>
+#include <lualib.h>
+
+// io and os hand a mod file and shell access. debug defeats the rest:
+// debug.getupvalue on any trx.* function recovers the raw C bridge the module
+// captured in a local.
+void LUA_OpenSafeLibs(lua_State *const L)
+{
+    static const luaL_Reg LIBS[] = {
+        { LUA_GNAME, luaopen_base },
+        { LUA_LOADLIBNAME, luaopen_package },
+        { LUA_COLIBNAME, luaopen_coroutine },
+        { LUA_TABLIBNAME, luaopen_table },
+        { LUA_STRLIBNAME, luaopen_string },
+        { LUA_MATHLIBNAME, luaopen_math },
+        { LUA_UTF8LIBNAME, luaopen_utf8 },
+        { nullptr, nullptr },
+    };
+    for (const luaL_Reg *lib = LIBS; lib->func != nullptr; lib++) {
+        luaL_requiref(L, lib->name, lib->func, 1);
+        lua_pop(L, 1);
+    }
+}
+
+void LUA_HardenGlobals(lua_State *const L)
+{
+    lua_pushnil(L);
+    lua_setglobal(L, "require");
+    lua_pushnil(L);
+    lua_setglobal(L, "package");
+
+    // These come with the base library, not io/os: load() compiles bytecode
+    // through an unhardened loader, dofile()/loadfile() read straight off disk.
+    // Dropping io and os does not close them.
+    lua_pushnil(L);
+    lua_setglobal(L, "load");
+    lua_pushnil(L);
+    lua_setglobal(L, "loadfile");
+    lua_pushnil(L);
+    lua_setglobal(L, "dofile");
+
+    // Serialises a function back to bytecode, feeding the loader above.
+    lua_getglobal(L, "string");
+    if (lua_istable(L, -1)) {
+        lua_pushnil(L);
+        lua_setfield(L, -2, "dump");
+    }
+    lua_pop(L, 1);
+
+    // getmetatable("") is shared by every string, and the string library leaves
+    // it writable.
+    lua_pushliteral(L, "");
+    if (lua_getmetatable(L, -1) != 0) {
+        lua_pushliteral(L, "locked");
+        lua_setfield(L, -2, "__metatable");
+        lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+}

--- a/src/trx/game/lua/sandbox.h
+++ b/src/trx/game/lua/sandbox.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <lua.h>
+
+// The wall a level script runs behind. Depends on nothing but Lua, so a unit
+// test can stand the same wall up against a bare state.
+//
+// Not a hard sandbox for hostile code: every script shares one lua_State.
+
+// The standard library, minus the parts a script has no business having.
+void LUA_OpenSafeLibs(lua_State *L);
+
+// Closes the escapes the base library leaves open. Takes require and package
+// with it, so call it once the trx.* modules have loaded.
+void LUA_HardenGlobals(lua_State *L);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A level script shares the Lua state, so whatever the globals reach, a downloaded mod reaches. Sealing already takes trxc and the registry; this takes the rest - io, os and debug, the base library's load/loadfile/dofile and string.dump, require and package, and the shared string metatable.

Not a hard sandbox for hostile code: all scripts share one lua_State. It lives apart from the module wiring so a test can stand the same wall up against a bare state.