### PR TITLE
output/sky: fix TR2 skybox brightness

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
 
 
 
 ## [1.9.1](https://github.com/LostArtefacts/TRX/compare/trx-1.9...trx-1.9.1) - 2026-07-12
 - fixed Lara's arms becoming locked if she draws a flare on a specific frame after pulling into a crawlspace from a ladder (#5801, regression from 1.3)
 - fixed bad animation frames on some switches in Lud's Gate (#5804, regression from 1.6)
-- fixed enemies and objects animating erratically in savegames carried over from an earlier version of the game (#5802)
+- fixed enemies and objects animating erratically in savegames carried over from an earlier version of the game (#5802, regression from 1.9)
 
 
 

--- a/src/trx/game/output/sky.c
+++ b/src/trx/game/output/sky.c
@@ -239,10 +239,9 @@ static bool M_GetVertexColor(
 static bool M_GetVertexShade(
     const FACE *const face, const int32_t vertex_idx, int32_t *const shade)
 {
-    if (g_TRVersion < 3) {
-        return false;
-    }
-    *shade = 0;
+    // TR1/2 spell "no dimming" as SHADE_NEUTRAL: their shade multiplier is
+    // 2 - shade / SHADE_NEUTRAL, so a 0 shade would double the texture.
+    *shade = g_TRVersion < 3 ? SHADE_NEUTRAL : 0;
     return true;
 }
 
@@ -271,7 +270,7 @@ static void M_AdjustLightInfo(OUTPUT_LIGHT_INFO *const info)
     }
 }
 
-static const OUTPUT_OBJECT_MESH_POLICY m_SkyboxMeshPolicy = {
+static OUTPUT_OBJECT_MESH_POLICY m_SkyboxMeshPolicy = {
     .vertex_flags = 0,
     .get_face_pass = M_GetFacePass,
     .get_vertex_color = M_GetVertexColor,
@@ -285,6 +284,11 @@ void Output_Sky_ObserveLevelLoad(void)
     if (!skybox->loaded) {
         return;
     }
+    // Pin TR1/2 to the own-light path so the horizon reads only the sky shade
+    // adder, whichever way the level's mesh data is lit. TR3/TR4 must keep the
+    // path their mesh data selects: forcing own light there makes the horizon
+    // eligible for the dynamic point-light term (the binoculars lighting it).
+    m_SkyboxMeshPolicy.vertex_flags = g_TRVersion < 3 ? VERT_USE_OWN_LIGHT : 0;
     for (int32_t i = 0; i < skybox->mesh_count; i++) {
         OutputSource_Objects_AddMeshPolicy(
             skybox->mesh_idx + i, &m_SkyboxMeshPolicy);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Dropping the skybox `vertex_flags` to 0 fixed TR3 fog and the TR4 binoculars, but `VERT_NO_LIGHTING` was the only thing giving TR1/2 its neutral horizon lighting - the policy's other callbacks both bail out below TR3. Without it the mesh reached the shader with a 0 shade, and TR1/2's `2 - shade / SHADE_NEUTRAL` multiplier doubled the texture.

Feed TR1/2 a `SHADE_NEUTRAL` vertex shade (their spelling of "no dimming") and pin them to the own-light path, so the horizon reads only the sky shade adder regardless of how the level's mesh data is lit. Fog keeps applying, and the Bartoli's Hideout sunset dims the sky again.