### PR TITLE
lara/state/jump: use swing fast fall speed in TR3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - changed `trx.events.detach()` to return whether a handler was removed
 - changed reflections UV mapping to be more correct
 - removed `trx.events.EventType`; refer to migration notes
+- fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
 
 **TR4**

--- a/src/trx/game/lara/state/jump.c
+++ b/src/trx/game/lara/state/jump.c
@@ -58,7 +58,7 @@ static void M_Compress(ITEM *const item, COLL_INFO *const coll)
 static void M_UpJump(ITEM *const item, COLL_INFO *const coll)
 {
     const int16_t fast_speed =
-        (g_Config.gameplay.enable_swing_cancel && g_TRVersion == 1)
+        (g_Config.gameplay.enable_swing_cancel && g_TRVersion != 2)
         ? M_SWING_FAST_FALL_SPEED
         : M_FAST_FALL_SPEED;
     if (item->fall_speed > fast_speed) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates TR3 to use swing-cancel aware fast fall speed to allow Lara to grab a secret ledge in Jungle. The version-gate remains for TR2 to avoid regressing a drop in Bartoli's Hideout room 7.

Resolves #5818 / TRX636.
