### PR TITLE
Rewrite events LUA API

### DIFF
--- a/data/scripting/events.lua
+++ b/data/scripting/events.lua
@@ -1,30 +1,178 @@
 local raw = trxc.events
 local types = trxc.events.EventType
+local api = trx.api
 
-local Event = {}
-function Event.__call(self, callback)
-  local et = self._type
-  return raw.attach(et, callback)
-end
+api.module("events", {
+  order = 2,
+  description = "Lua scripts can listen for game events by attaching a handler to one of the hooks "
+    .. "below. Attaching returns a listener id, which `trx.events.detach` takes.\n\n"
+    .. "A handler attached from a level script is detached automatically when the level ends; one "
+    .. "attached from a global script lives for the whole session.",
+})
 
-local function to_event_name(name)
-  if string.sub(name, 1, 7) == "BEFORE_" then
-    return string.lower(name)
-  elseif string.sub(name, 1, 6) == "AFTER_" then
-    return string.lower(name)
+-- Each hook is a plain function closing over its event type. The type itself is
+-- not public: with nine named hooks there is nothing left for a script to do
+-- with it, and exposing it would only invite raw attach() calls.
+local function hook(event_type)
+  return function(callback)
+    return raw.attach(event_type, callback)
   end
-  return "on_" .. string.lower(name)
 end
 
-local events = { EventType = types }
-for name, et in pairs(types) do
-  local proxy = { _type = et }
-  setmetatable(proxy, Event)
-  events[to_event_name(name)] = proxy
+local LISTENER_ID = {
+  type = "integer",
+  description = "Listener id. Pass it to `trx.events.detach` to stop listening.",
+}
+
+-- The five level-lifecycle events share a signature; only the moment differs.
+local function level_hook(event_type, description, examples)
+  return {
+    description = description,
+    params = {
+      {
+        name = "callback",
+        type = "function",
+        params = {
+          {
+            name = "level_num",
+            type = "integer",
+            description = "Number of the level the event fired for.",
+          },
+        },
+      },
+    },
+    returns = LISTENER_ID,
+    examples = examples,
+    impl = hook(event_type),
+  }
 end
 
-function events.detach(id)
-  raw.detach(id)
-end
+api.define(
+  "events.before_level_file",
+  level_hook(types.BEFORE_LEVEL_FILE, "Happens prior to loading the level file.", {
+    [[trx.events.before_level_file(function(level_num)
+  -- handle pre-file-load setup
+end)]],
+  })
+)
 
-trx.events = events
+api.define(
+  "events.after_level_file",
+  level_hook(
+    types.AFTER_LEVEL_FILE,
+    "Happens after the level finishes loading, prior to loading information from a savegame."
+  )
+)
+
+api.define(
+  "events.before_item_setup",
+  level_hook(
+    types.BEFORE_ITEM_SETUP,
+    "Happens after level items exist, before they are initialized. Use this to set object or "
+      .. "item properties that item initialization reads."
+  )
+)
+
+api.define(
+  "events.after_item_setup",
+  level_hook(types.AFTER_ITEM_SETUP, "Happens after level items exist, after they are initialized.")
+)
+
+api.define(
+  "events.after_level_state",
+  level_hook(
+    types.AFTER_LEVEL_STATE,
+    "Happens after the level finishes loading, after loading information from a savegame. If the "
+      .. "game is started normally, this duplicates `after_level_file`.",
+    {
+      [[trx.events.after_level_state(function(level_num)
+  -- handle post-savegame state restore
+end)]],
+    }
+  )
+)
+
+api.define("events.on_game_start", {
+  description = "Happens after the level finishes loading and the game is about to start. Unlike "
+    .. "`after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade "
+    .. "effects to finish, so it is the place to play sound effects and run game logic.",
+  params = {
+    {
+      name = "callback",
+      type = "function",
+      params = {
+        {
+          name = "level_num",
+          type = "integer",
+          description = "Number of the level being started.",
+        },
+        {
+          name = "is_save",
+          type = "boolean",
+          description = "Whether the level is being resumed from a savegame rather than started fresh.",
+        },
+      },
+    },
+  },
+  returns = LISTENER_ID,
+  impl = hook(types.GAME_START),
+})
+
+api.define("events.on_pickup", {
+  description = "Happens just after Lara picks up an item.",
+  params = {
+    {
+      name = "callback",
+      type = "function",
+      params = {
+        {
+          name = "item_num",
+          type = "integer",
+          description = "1-based index of the item that was picked up.",
+        },
+      },
+    },
+  },
+  returns = LISTENER_ID,
+  examples = {
+    [[trx.events.on_pickup(function(item_num)
+  trx.log.info(trx.items[item_num].object_id)
+end)]],
+  },
+  impl = hook(types.PICKUP),
+})
+
+api.define("events.before_control", {
+  description = "Happens on every logical game frame, before the main game logic runs. The handler "
+    .. "takes no arguments.",
+  params = { { name = "callback", type = "function" } },
+  returns = LISTENER_ID,
+  impl = hook(types.BEFORE_CONTROL),
+})
+
+api.define("events.after_control", {
+  description = "Happens on every logical game frame, after the main game logic runs. The handler "
+    .. "takes no arguments.",
+  params = { { name = "callback", type = "function" } },
+  returns = LISTENER_ID,
+  impl = hook(types.AFTER_CONTROL),
+})
+
+api.define("events.detach", {
+  description = "Removes a previously attached handler, which stops firing immediately.",
+  params = {
+    { name = "listener_id", type = "integer", description = "The id attach returned." },
+  },
+  returns = {
+    type = "boolean",
+    description = "Whether a handler with that id was attached. `false` means it had already been "
+      .. "detached, or the id was never handed out.",
+  },
+  examples = {
+    [[local id = trx.events.before_control(function()
+  -- handle control loop event
+end)
+trx.events.detach(id)]],
+  },
+  impl = raw.detach,
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
+- changed `trx.events.detach()` to return whether a handler was removed
 - changed reflections UV mapping to be more correct
+- removed `trx.events.EventType`; refer to migration notes
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
 
 **TR4**

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -41,6 +41,11 @@ order: 3
      string.
    - Writing to an out-of-range room raises instead of silently doing nothing.
 
+3. **Update scripts that use event types**
+   `trx.events.EventType` was removed, along with the `._type` field on each
+   hook. The nine hooks are the whole API, and attaching is unchanged:
+   `trx.events.before_control(fn)`.
+
 ### Version 1.8 to 1.9
 
 1. **Update Lara pushblock animations**

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -72,6 +72,213 @@
   ],
   "functions": [
     {
+      "description": "Happens prior to loading the level file.",
+      "examples": [
+        "trx.events.before_level_file(function(level_num)\n  -- handle pre-file-load setup\nend)"
+      ],
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level the event fired for.",
+              "name": "level_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.before_level_file",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens after the level finishes loading, prior to loading information from a savegame.",
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level the event fired for.",
+              "name": "level_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.after_level_file",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens after level items exist, before they are initialized. Use this to set object or item properties that item initialization reads.",
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level the event fired for.",
+              "name": "level_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.before_item_setup",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens after level items exist, after they are initialized.",
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level the event fired for.",
+              "name": "level_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.after_item_setup",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens after the level finishes loading, after loading information from a savegame. If the game is started normally, this duplicates `after_level_file`.",
+      "examples": [
+        "trx.events.after_level_state(function(level_num)\n  -- handle post-savegame state restore\nend)"
+      ],
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level the event fired for.",
+              "name": "level_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.after_level_state",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens after the level finishes loading and the game is about to start. Unlike `after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade effects to finish, so it is the place to play sound effects and run game logic.",
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "Number of the level being started.",
+              "name": "level_num",
+              "type": "integer"
+            },
+            {
+              "description": "Whether the level is being resumed from a savegame rather than started fresh.",
+              "name": "is_save",
+              "type": "boolean"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.on_game_start",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens just after Lara picks up an item.",
+      "examples": [
+        "trx.events.on_pickup(function(item_num)\n  trx.log.info(trx.items[item_num].object_id)\nend)"
+      ],
+      "params": [
+        {
+          "name": "callback",
+          "params": [
+            {
+              "description": "1-based index of the item that was picked up.",
+              "name": "item_num",
+              "type": "integer"
+            }
+          ],
+          "type": "function"
+        }
+      ],
+      "path": "events.on_pickup",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.",
+      "params": [
+        {
+          "name": "callback",
+          "type": "function"
+        }
+      ],
+      "path": "events.before_control",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.",
+      "params": [
+        {
+          "name": "callback",
+          "type": "function"
+        }
+      ],
+      "path": "events.after_control",
+      "returns": {
+        "description": "Listener id. Pass it to `trx.events.detach` to stop listening.",
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Removes a previously attached handler, which stops firing immediately.",
+      "examples": [
+        "local id = trx.events.before_control(function()\n  -- handle control loop event\nend)\ntrx.events.detach(id)"
+      ],
+      "params": [
+        {
+          "description": "The id attach returned.",
+          "name": "listener_id",
+          "type": "integer"
+        }
+      ],
+      "path": "events.detach",
+      "returns": {
+        "description": "Whether a handler with that id was attached. `false` means it had already been detached, or the id was never handed out.",
+        "type": "boolean"
+      }
+    },
+    {
       "description": "Retrieves an item by 1-based index or by name.",
       "examples": [
         "local item = trx.items[1]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"
@@ -293,6 +500,11 @@
     }
   ],
   "modules": [
+    {
+      "description": "Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which `trx.events.detach` takes.\n\nA handler attached from a level script is detached automatically when the level ends; one attached from a global script lives for the whole session.",
+      "name": "events",
+      "order": 2
+    },
     {
       "description": "Module for controlling all moveables.",
       "name": "items",

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -3,103 +3,141 @@ title: Events
 order: 2
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/events.lua. Edit it there.
+-->
+
 ## Events module
 
-Lua scripts can listen for game events using the global `events` API.
+Lua scripts can listen for game events by attaching a handler to one of the hooks below. Attaching returns a listener id, which `trx.events.detach` takes.
 
-### API
+A handler attached from a level script is detached automatically when the level ends; one attached from a global script lives for the whole session.
 
-- [lua]`trx.events.before_level_file(callback)`
-- [lua]`trx.events.after_level_file(callback)`
-- [lua]`trx.events.before_item_setup(callback)`
-- [lua]`trx.events.after_item_setup(callback)`
-- [lua]`trx.events.after_level_state(callback)`
-- [lua]`trx.events.on_game_start(callback)`
+### Functions
+
+- [lua]`trx.events.before_level_file(callback)`  
+  Happens prior to loading the level file.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level the event fired for.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+  Example:
+  ```lua
+  trx.events.before_level_file(function(level_num)
+    -- handle pre-file-load setup
+  end)
+  ```
+
+- [lua]`trx.events.after_level_file(callback)`  
+  Happens after the level finishes loading, prior to loading information from a savegame.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level the event fired for.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+- [lua]`trx.events.before_item_setup(callback)`  
+  Happens after level items exist, before they are initialized. Use this to set object or item properties that item initialization reads.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level the event fired for.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+- [lua]`trx.events.after_item_setup(callback)`  
+  Happens after level items exist, after they are initialized.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level the event fired for.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+- [lua]`trx.events.after_level_state(callback)`  
+  Happens after the level finishes loading, after loading information from a savegame. If the game is started normally, this duplicates `after_level_file`.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level the event fired for.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+  Example:
+  ```lua
+  trx.events.after_level_state(function(level_num)
+    -- handle post-savegame state restore
+  end)
+  ```
+
+- [lua]`trx.events.on_game_start(callback)`  
+  Happens after the level finishes loading and the game is about to start. Unlike `after_level_file` and `after_level_state`, this waits for the fade-to-black / cross-fade effects to finish, so it is the place to play sound effects and run game logic.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`level_num`** (integer). Number of the level being started.
+    - **`is_save`** (boolean). Whether the level is being resumed from a savegame rather than started fresh.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
 - [lua]`trx.events.on_pickup(callback)`  
+  Happens just after Lara picks up an item.
+
+  Parameters:
+  - **`callback`** (function).
+    Called with:
+    - **`item_num`** (integer). 1-based index of the item that was picked up.
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
+  Example:
+  ```lua
+  trx.events.on_pickup(function(item_num)
+    trx.log.info(trx.items[item_num].object_id)
+  end)
+  ```
+
 - [lua]`trx.events.before_control(callback)`  
+  Happens on every logical game frame, before the main game logic runs. The handler takes no arguments.
+
+  Parameters:
+  - **`callback`** (function).
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
 - [lua]`trx.events.after_control(callback)`  
-  Register a handler for a game event. Returns `listener_id`.
+  Happens on every logical game frame, after the main game logic runs. The handler takes no arguments.
+
+  Parameters:
+  - **`callback`** (function).
+
+  Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
+
 - [lua]`trx.events.detach(listener_id)`  
-  Remove a previously registered event handler.
+  Removes a previously attached handler, which stops firing immediately.
 
-### Events
+  Parameters:
+  - **`listener_id`** (integer). The id attach returned.
 
-#### `before_level_file`
-Happens prior to loading the level file.
+  Returns: boolean. Whether a handler with that id was attached. `false` means it had already been detached, or the id was never handed out.
 
-Arguments:
-- `level_num`
-
-#### `after_level_file`
-Happens after the level finishes loading, prior to loading information from a
-savegame.
-
-Arguments:
-- `level_num`
-
-#### `before_item_setup`
-Happens after level items exist, before they are initialized. Use this to set
-object or item properties that item initialization reads.
-
-Arguments:
-- `level_num`
-
-#### `after_item_setup`
-Happens after level items exist, after they are initialized.
-
-Arguments:
-- `level_num`
-
-#### `after_level_state`
-Happens after the level finishes loading, after loading information from a
-savegame. If the game is started normally, this duplicates `after_level_file`.
-
-Arguments:
-- `level_num`
-
-#### `on_game_start`
-Happens after the level finishes loading and the game is about to start.
-The difference from `after_level_file` and `after_level_state` is that this waits for the fade-to-black / cross-fade effects to
-finish, and is suitable to play sound effects and run game logic.
-
-Arguments:
-- `level_num`
-- `is_save`
-
-#### `on_pickup`
-Happens just after Lara picks up an item.
-
-Arguments:
-- `item_num`
-
-#### `before_control`
-Happens on every logical game frame, before executing main game logic.
-
-Arguments: none  
-
-#### `after_control`
-Happens on every logical game frame, after executing main game logic.
-
-Arguments: none  
-
-### Examples
-
-```lua
-trx.events.before_level_file(function(level_num)
-  -- handle pre-file-load setup
-end)
-
-trx.events.after_level_state(function(level_num)
-  -- handle post-savegame state restore
-end)
-
-trx.events.on_pickup(function(item_num)
-  trx.console.log(trx.items[item_num].object_id)
-end)
-
-local control_handler = trx.events.before_control(function()
-  -- handle control loop event
-end)
--- detach a handler
-trx.events.detach(control_handler)
-```
+  Example:
+  ```lua
+  local id = trx.events.before_control(function()
+    -- handle control loop event
+  end)
+  trx.events.detach(id)
+  ```

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -155,6 +155,18 @@ test_lua_items_exe = executable(
 )
 test('lua_items', test_lua_items_exe, suite: 'unit')
 
+test_lua_events_exe = executable(
+  'test_lua_events',
+  files('unit/test_lua_events.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/lua/events.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_events', test_lua_events_exe, suite: 'unit')
+
 test_lua_api_seal_exe = executable(
   'test_lua_api_seal',
   files('unit/test_lua_api_seal.c', 'unit/fake_engine_items.c') + test_stubs

--- a/src/tests/unit/lua/events.lua
+++ b/src/tests/unit/lua/events.lua
@@ -1,0 +1,149 @@
+-- The event API as a script actually sees it.
+--
+-- Everything under these assertions is real: trxc.events, the listener registry
+-- in lua/events.c, and data/scripting/events.lua itself. `fake.fire()` calls the
+-- same Lua_FireEvent* entrypoints the engine calls, so a handler here sees
+-- exactly what a handler sees in the game.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("a handler fires, and stops firing once detached", function()
+  local calls = 0
+  local id = trx.events.before_control(function()
+    calls = calls + 1
+  end)
+
+  fake.fire("before_control")
+  fake.fire("before_control")
+  assert(calls == 2, "handler did not fire twice")
+
+  assert(trx.events.detach(id) == true, "detach must report the removal")
+  fake.fire("before_control")
+  assert(calls == 2, "a detached handler kept firing")
+end)
+
+test("detaching twice reports that there was nothing to remove", function()
+  local id = trx.events.after_control(function() end)
+  assert(trx.events.detach(id) == true)
+  assert(trx.events.detach(id) == false, "the second detach must report false")
+  assert(trx.events.detach(99999) == false, "an id never handed out")
+end)
+
+test("the control events pass no arguments", function()
+  -- They used to be fired with a meaningless 0. A handler must see nothing.
+  local seen = "unset"
+  trx.events.before_control(function(...)
+    seen = select("#", ...)
+  end)
+  fake.fire("before_control")
+  assert(seen == 0, "before_control handed the handler an argument")
+end)
+
+test("the level events pass the level number", function()
+  local events = {
+    "before_level_file",
+    "after_level_file",
+    "before_item_setup",
+    "after_item_setup",
+    "after_level_state",
+  }
+  for _, name in ipairs(events) do
+    local seen = nil
+    trx.events[name](function(level_num)
+      seen = level_num
+    end)
+    fake.fire(name, 7)
+    assert(seen == 7, name .. " did not receive the level number")
+  end
+end)
+
+test("on_pickup passes the item number", function()
+  local seen = nil
+  trx.events.on_pickup(function(item_num)
+    seen = item_num
+  end)
+  fake.fire("on_pickup", 42)
+  assert(seen == 42, "on_pickup did not receive the item number")
+end)
+
+test("on_game_start passes the level number and the savegame flag", function()
+  local seen_level, seen_save = nil, nil
+  trx.events.on_game_start(function(level_num, is_save)
+    seen_level, seen_save = level_num, is_save
+  end)
+
+  fake.fire("on_game_start", 3, true)
+  assert(seen_level == 3, "wrong level number")
+  assert(seen_save == true, "is_save must be a boolean, not a truthy number")
+
+  fake.fire("on_game_start", 3, false)
+  assert(seen_save == false, "a fresh start must report false")
+end)
+
+test("every handler attached to an event fires, in order", function()
+  local order = {}
+  trx.events.before_control(function()
+    order[#order + 1] = "first"
+  end)
+  trx.events.before_control(function()
+    order[#order + 1] = "second"
+  end)
+  fake.fire("before_control")
+  assert(#order == 2 and order[1] == "first" and order[2] == "second", "attach order")
+end)
+
+test("a handler only fires for its own event", function()
+  local calls = 0
+  trx.events.before_control(function()
+    calls = calls + 1
+  end)
+  fake.fire("after_control")
+  fake.fire("on_pickup", 1)
+  assert(calls == 0, "a handler fired for someone else's event")
+end)
+
+test("a level script's handlers are dropped when the level ends", function()
+  local level_calls, global_calls = 0, 0
+
+  trx.events.before_control(function()
+    global_calls = global_calls + 1
+  end)
+  fake.as_level_script(function()
+    trx.events.before_control(function()
+      level_calls = level_calls + 1
+    end)
+  end)
+
+  fake.fire("before_control")
+  assert(level_calls == 1 and global_calls == 1, "both should fire while the level runs")
+
+  fake.end_level()
+  fake.fire("before_control")
+  assert(level_calls == 1, "a level handler outlived its level")
+  assert(global_calls == 2, "a global handler was dropped with the level")
+end)
+
+test("attaching something that is not a function raises", function()
+  raises(function()
+    trx.events.before_control(42)
+  end)
+  raises(function()
+    trx.events.before_control()
+  end)
+end)
+
+test("the event type is not part of the surface", function()
+  -- The nine hooks are the whole API. EventType and the `_type` field on the
+  -- callable proxies were internals that leaked; nothing may reach them.
+  assert(trx.events.EventType == nil, "EventType is still reachable")
+  assert(trx.events.attach == nil, "raw attach must not be public")
+
+  -- A hook is a plain function, not a table carrying its event type around.
+  assert(type(trx.events.before_control) == "function", "a hook must be a function")
+  raises(function()
+    return trx.events.before_control._type
+  end)
+end)
+
+return h.report()

--- a/src/tests/unit/test_lua_events.c
+++ b/src/tests/unit/test_lua_events.c
@@ -1,0 +1,133 @@
+// The event surface. The assertions live in src/tests/unit/lua/events.lua; this
+// stands up the world they run against.
+//
+// There is no fake engine here: lua/events.c is self-contained - attach, detach
+// and fire - so `fake.fire()` calls the same Lua_FireEvent* entrypoints the
+// engine calls. That is the point: it pins the declared callback arguments
+// against what C actually pushes.
+
+#include "lua_surface.h"
+
+#include <trx/game/lua/common.h>
+#include <trx/game/lua/events.h>
+
+#include <lauxlib.h>
+#include <string.h>
+
+extern void LUA_CreateEvents(lua_State *L);
+
+static LUA_CONTEXT m_Context = LUA_CONTEXT_GLOBAL;
+
+LUA_CONTEXT Lua_GetScriptContext(void)
+{
+    return m_Context;
+}
+
+void Lua_SetScriptContext(const LUA_CONTEXT context)
+{
+    m_Context = context;
+}
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateEvents(L);
+}
+
+// fake.fire(name, ...) - mirrors the engine's own fire sites, argument for
+// argument. A handler must see exactly what C pushes.
+static int M_FakeFire(lua_State *const L)
+{
+    const char *const name = luaL_checkstring(L, 1);
+
+    if (strcmp(name, "before_control") == 0) {
+        Lua_FireEvent(LUA_EVENT_BEFORE_CONTROL);
+    } else if (strcmp(name, "after_control") == 0) {
+        Lua_FireEvent(LUA_EVENT_AFTER_CONTROL);
+    } else if (strcmp(name, "on_pickup") == 0) {
+        Lua_FireEventInt32(LUA_EVENT_PICKUP, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "on_game_start") == 0) {
+        const LUA_EVENT_ARG args[] = {
+            { .type = LUA_EVENT_ARG_INT32,
+              .value = { .i32 = luaL_checkinteger(L, 2) } },
+            { .type = LUA_EVENT_ARG_BOOL,
+              .value = { .b = lua_toboolean(L, 3) } },
+        };
+        Lua_FireEventEx(LUA_EVENT_GAME_START, args, 2);
+    } else if (strcmp(name, "before_level_file") == 0) {
+        Lua_FireEventInt32(
+            LUA_EVENT_BEFORE_LEVEL_FILE, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "after_level_file") == 0) {
+        Lua_FireEventInt32(LUA_EVENT_AFTER_LEVEL_FILE, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "before_item_setup") == 0) {
+        Lua_FireEventInt32(
+            LUA_EVENT_BEFORE_ITEM_SETUP, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "after_item_setup") == 0) {
+        Lua_FireEventInt32(LUA_EVENT_AFTER_ITEM_SETUP, luaL_checkinteger(L, 2));
+    } else if (strcmp(name, "after_level_state") == 0) {
+        Lua_FireEventInt32(
+            LUA_EVENT_AFTER_LEVEL_STATE, luaL_checkinteger(L, 2));
+    } else {
+        return luaL_error(L, "unknown event: %s", name);
+    }
+    return 0;
+}
+
+// fake.as_level_script(fn) - attach from a level script rather than a global
+// one, so the level-scoped teardown below has something to clear.
+static int M_FakeAsLevelScript(lua_State *const L)
+{
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+    m_Context = LUA_CONTEXT_LEVEL;
+    const int status = lua_pcall(L, 0, 0, 0);
+    m_Context = LUA_CONTEXT_GLOBAL;
+    if (status != LUA_OK) {
+        return lua_error(L);
+    }
+    return 0;
+}
+
+// fake.end_level() - what the engine does when a level ends.
+static int M_FakeEndLevel(lua_State *const L)
+{
+    Lua_ClearLevelListeners();
+    return 0;
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    // Drops every listener, then puts m_L back: Lua_ShutdownEvents clears it,
+    // and the next fire would be a no-op without it.
+    Lua_ShutdownEvents();
+    LUA_CreateEvents(L);
+    m_Context = LUA_CONTEXT_GLOBAL;
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+    lua_pushcfunction(L, M_FakeFire);
+    lua_setfield(L, -2, "fire");
+    lua_pushcfunction(L, M_FakeAsLevelScript);
+    lua_setfield(L, -2, "as_level_script");
+    lua_pushcfunction(L, M_FakeEndLevel);
+    lua_setfield(L, -2, "end_level");
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "events",
+        .tests = "events",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/tests/unit/test_update_lua_docs.py
+++ b/src/tests/unit/test_update_lua_docs.py
@@ -76,7 +76,32 @@ SURFACE = {
             ],
             "returns": {"type": "Widget", "nullable": True},
             "examples": ["local w = trx.things.spawn(1)"],
-        }
+        },
+        {
+            "path": "things.on_poked",
+            "description": "Registers a handler.",
+            "params": [
+                {
+                    "name": "callback",
+                    "type": "function",
+                    "description": "Called when a thing is poked.",
+                    "params": [
+                        {
+                            "name": "strength",
+                            "type": "integer",
+                            "description": "How hard.",
+                        },
+                        {
+                            "name": "id",
+                            "type": "integer",
+                            "enum": "catalog.objects",
+                            "description": "What was poked.",
+                        },
+                    ],
+                }
+            ],
+            "returns": {"type": "integer"},
+        },
     ],
 }
 
@@ -152,6 +177,34 @@ class TestLuaDocs(unittest.TestCase):
         page = docs.render_page(SURFACE["modules"][0], SURFACE)
         self.assertIn("things.spawn(id, [angle])", page)
         self.assertIn("default `0`", page)
+
+    def test_a_callbacks_own_arguments_are_rendered(self):
+        """An event hook takes nothing but a callback, so the callback's
+        signature is the only one worth documenting. Without this the page says
+        `trx.events.on_pickup(callback)` and never mentions that the callback is
+        handed the item number."""
+        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        self.assertIn("Called with:", page)
+        strength = next(
+            line for line in page.splitlines() if "**`strength`**" in line
+        )
+        self.assertIn("How hard.", strength)
+        # Indented under the callback, not hoisted to the function's own params.
+        callback = next(
+            line for line in page.splitlines() if "**`callback`**" in line
+        )
+        self.assertGreater(
+            len(strength) - len(strength.lstrip()),
+            len(callback) - len(callback.lstrip()),
+        )
+        # A callback argument gets the same enum cross-reference a param does.
+        arg = next(line for line in page.splitlines() if "**`id`**" in line)
+        self.assertIn("Compare against `trx.catalog.objects`.", arg)
+
+    def test_a_param_with_no_callback_args_stays_flat(self):
+        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        angle = next(line for line in page.splitlines() if "**`angle`**" in line)
+        self.assertNotIn("Called with:", angle)
 
     def test_nullable_returns_say_so(self):
         page = docs.render_page(SURFACE["modules"][0], SURFACE)

--- a/src/trx/game/cutscene.c
+++ b/src/trx/game/cutscene.c
@@ -263,10 +263,10 @@ static void M_ReplayActors(
     const int32_t end_frame)
 {
     for (int32_t frame_idx = start_frame; frame_idx < end_frame; frame_idx++) {
-        Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
+        Lua_FireEvent(LUA_EVENT_BEFORE_CONTROL);
         cine_data->frame_idx = frame_idx;
         M_Control();
-        Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
+        Lua_FireEvent(LUA_EVENT_AFTER_CONTROL);
     }
 }
 

--- a/src/trx/game/lua/events.c
+++ b/src/trx/game/lua/events.c
@@ -65,22 +65,25 @@ static int32_t M_L_EventsAttach(lua_State *const L)
     return 1;
 }
 
-// trxc.events.detach(id)
+// trxc.events.detach(id) -> bool
 static int32_t M_L_EventsDetach(lua_State *const L)
 {
-    int32_t id = luaL_checkinteger(L, 1);
+    const int32_t id = luaL_checkinteger(L, 1);
     if (m_Listeners == nullptr) {
-        return 0;
+        lua_pushboolean(L, false);
+        return 1;
     }
     for (int32_t i = 0; i < m_Listeners->count; i++) {
         const M_LISTENER *const lst = Vector_Get(m_Listeners, i);
         if (lst->ref == id) {
             luaL_unref(L, LUA_REGISTRYINDEX, lst->ref);
             Vector_RemoveAt(m_Listeners, i);
-            break;
+            lua_pushboolean(L, true);
+            return 1;
         }
     }
-    return 0;
+    lua_pushboolean(L, false);
+    return 1;
 }
 
 void Lua_ClearLevelListeners(void)

--- a/src/trx/game/lua/events.c
+++ b/src/trx/game/lua/events.c
@@ -152,6 +152,11 @@ void Lua_FireEventEx(
     }
 }
 
+void Lua_FireEvent(const LUA_EVENT_TYPE ev)
+{
+    Lua_FireEventEx(ev, nullptr, 0);
+}
+
 void Lua_FireEventInt32(const LUA_EVENT_TYPE ev, const int32_t arg)
 {
     const LUA_EVENT_ARG args[] = {

--- a/src/trx/game/lua/events.h
+++ b/src/trx/game/lua/events.h
@@ -46,5 +46,8 @@ void Lua_ClearLevelListeners(void);
 void Lua_FireEventEx(
     LUA_EVENT_TYPE ev, const LUA_EVENT_ARG *args, int32_t arg_count);
 
+// Fire a Lua event of given type with no arguments
+void Lua_FireEvent(LUA_EVENT_TYPE ev);
+
 // Fire a Lua event of given type with int32 argument
 void Lua_FireEventInt32(LUA_EVENT_TYPE ev, int32_t arg);

--- a/src/trx/game/phase/phase_cutscene.c
+++ b/src/trx/game/phase/phase_cutscene.c
@@ -64,10 +64,10 @@ static void M_Resume(PHASE *const phase)
 
 static PHASE_CONTROL M_Control(PHASE *const phase)
 {
-    Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
+    Lua_FireEvent(LUA_EVENT_BEFORE_CONTROL);
     M_PRIV *const p = phase->priv;
     const GF_COMMAND gf_cmd = Cutscene_Control();
-    Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
+    Lua_FireEvent(LUA_EVENT_AFTER_CONTROL);
     if (gf_cmd.action != GF_NOOP) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,

--- a/src/trx/game/phase/phase_game.c
+++ b/src/trx/game/phase/phase_game.c
@@ -53,9 +53,9 @@ static void M_Resume(PHASE *const phase)
 
 static PHASE_CONTROL M_Control(PHASE *const phase)
 {
-    Lua_FireEventInt32(LUA_EVENT_BEFORE_CONTROL, 0);
+    Lua_FireEvent(LUA_EVENT_BEFORE_CONTROL);
     const GF_COMMAND gf_cmd = Game_Control(false);
-    Lua_FireEventInt32(LUA_EVENT_AFTER_CONTROL, 0);
+    Lua_FireEvent(LUA_EVENT_AFTER_CONTROL);
     if (gf_cmd.action != GF_NOOP) {
         return (PHASE_CONTROL) {
             .action = PHASE_ACTION_END,

--- a/tools/update_lua_docs
+++ b/tools/update_lua_docs
@@ -52,6 +52,24 @@ def describe(spec: dict) -> str:
     return desc
 
 
+def render_callback_args(param: dict, indent: str) -> list[str]:
+    """The arguments a callback parameter is itself called with.
+
+    `params` on a function-typed parameter describes the signature the engine
+    invokes it with - which for an event hook is the only signature that matters,
+    since the hook itself takes nothing but the callback.
+    """
+    args = param.get("params")
+    if not args:
+        return []
+    out = [f"{indent}Called with:"]
+    for arg in args:
+        out.append(
+            f"{indent}- **`{arg['name']}`** ({arg['type']}). {describe(arg)}".rstrip()
+        )
+    return out
+
+
 def render_params(params: list[dict] | None, indent: str) -> list[str]:
     if not params:
         return []
@@ -66,6 +84,7 @@ def render_params(params: list[dict] | None, indent: str) -> list[str]:
         out.append(
             f"{indent}- **`{param['name']}`** ({', '.join(bits)}). {describe(param)}".rstrip()
         )
+        out.extend(render_callback_args(param, f"{indent}  "))
     return out
 
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`trx.events` now declares itself the same way `items` and `rooms` do. The docs page is written from that declaration instead of by hand.

- the nine hooks are just functions now – `EventType` and the proxy tables they used to hang off are gone
- a declaration can now say what arguments a callback gets, which the page used to explain by hand
- `before_control` and `after_control` were quietly passing every handler a `0` for no reason; they don't anymore
- `detach()` tells the caller whether it actually removed anything
- `trx.events.EventType` is now gone; added a note to `MIGRATING.md`