### PR TITLE
Migrate console LUA API

### DIFF
--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -33,6 +33,8 @@ local consts = {}
 local const_order = {}
 local properties = {}
 local property_order = {}
+local namespaces = {}
+local namespace_order = {}
 -- module -> { name -> spec }. What the module's __index dispatches on.
 local module_properties = {}
 local strict_enabled = false
@@ -42,6 +44,36 @@ local function split_path(path)
   local module, name = path:match("^([%w_]+)%.([%w_]+)$")
   assert(module ~= nil, "api path must be 'module.name', got: " .. tostring(path))
   return module, name
+end
+
+-- A path is 'module.name', or 'module.namespace.name' one level deeper.
+-- Anything deeper is a sign the module wants splitting.
+local function path_parts(path)
+  local parts = {}
+  for segment in tostring(path):gmatch("[^.]+") do
+    parts[#parts + 1] = segment
+  end
+  assert(
+    #parts == 2 or #parts == 3,
+    "api path must be 'module.name' or 'module.namespace.name', got: " .. tostring(path)
+  )
+  return parts
+end
+
+-- The module, the table the member hangs off, and the member's own name.
+local function resolve(path)
+  local parts = path_parts(path)
+  local module = parts[1]
+  trx[module] = trx[module] or {}
+  if #parts == 2 then
+    return module, trx[module], parts[2]
+  end
+  local namespace = rawget(trx[module], parts[2])
+  assert(
+    type(namespace) == "table",
+    "api: " .. path .. " needs api.namespace('" .. module .. "." .. parts[2] .. "') declared first"
+  )
+  return module, namespace, parts[3]
 end
 
 function api.module(name, spec)
@@ -129,11 +161,18 @@ api.checkers = {
 -- Also audits the finished surface: an assignment straight onto a module table
 -- works for scripts, but the docs never see it. Refuse to boot instead.
 function api.seal()
+  -- container path ("items", or "console.log") -> set of declared member names.
   local declared = {}
   local function mark(path)
-    local module, name = split_path(path)
-    declared[module] = declared[module] or {}
-    declared[module][name] = true
+    local parts = path_parts(path)
+    local container = parts[1]
+    local name = parts[2]
+    if #parts == 3 then
+      container = parts[1] .. "." .. parts[2]
+      name = parts[3]
+    end
+    declared[container] = declared[container] or {}
+    declared[container][name] = true
   end
   for _, path in ipairs(order) do
     mark(path)
@@ -144,43 +183,88 @@ function api.seal()
   for _, path in ipairs(const_order) do
     mark(path)
   end
+  -- The namespace table itself is a member of its module.
+  for _, path in ipairs(namespace_order) do
+    mark(path)
+  end
 
-  for _, module in ipairs(module_order) do
-    local undeclared = {}
-    for name in pairs(trx[module] or {}) do
-      if not (declared[module] or {})[name] then
-        table.insert(undeclared, "trx." .. module .. "." .. name)
+  local undeclared = {}
+  local function audit(container_path, tbl)
+    for name in pairs(tbl or {}) do
+      if not (declared[container_path] or {})[name] then
+        table.insert(undeclared, "trx." .. container_path .. "." .. name)
       end
-    end
-    if #undeclared > 0 then
-      table.sort(undeclared)
-      error(
-        table.concat(undeclared, ", ")
-          .. ": reachable from scripts but not declared, so the reference cannot describe it. "
-          .. "Declare it with api.define, api.enum, api.const or api.property."
-      )
     end
   end
 
+  for _, module in ipairs(module_order) do
+    audit(module, trx[module])
+  end
+  -- A namespace hides its members one level down, where the module audit above
+  -- cannot see them. Audit it as its own container.
+  for _, path in ipairs(namespace_order) do
+    local module, name = split_path(path)
+    audit(path, rawget(trx[module] or {}, name))
+  end
+
+  if #undeclared > 0 then
+    table.sort(undeclared)
+    error(
+      table.concat(undeclared, ", ")
+        .. ": reachable from scripts but not declared, so the reference cannot describe it. "
+        .. "Declare it with api.define, api.enum, api.const, api.property or api.namespace."
+    )
+  end
+
   sealed = true
+end
+
+-- Declares a grouping table on a module, holding related members under one
+-- name. `call` makes the group itself callable, so calling the group works
+-- alongside calling the members inside it.
+--
+-- A namespace has to be declared before anything inside it: it is the table the
+-- members hang off, and seal() audits its contents just as it audits a module's.
+function api.namespace(path, spec)
+  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  assert(type(spec) == "table", "api.namespace: spec must be a table")
+  local module, name = split_path(path)
+
+  local namespace = {}
+  if spec.call ~= nil then
+    assert(type(spec.call) == "function", "api.namespace: call must be a function")
+    setmetatable(namespace, {
+      __call = function(_, ...)
+        return spec.call(...)
+      end,
+    })
+  end
+
+  trx[module] = trx[module] or {}
+  rawset(trx[module], name, namespace)
+
+  if namespaces[path] == nil then
+    table.insert(namespace_order, path)
+  end
+  namespaces[path] = spec
+  return namespace
 end
 
 function api.define(path, spec)
   assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
   assert(type(spec) == "table", "api.define: spec must be a table")
   assert(type(spec.impl) == "function", "api.define: impl must be a function")
-  local module, name = split_path(path)
+  local _, container, name = resolve(path)
 
   if registry[path] == nil then
     table.insert(order, path)
   end
   registry[path] = spec
 
-  trx[module] = trx[module] or {}
   -- The raw implementation IS the public function. No wrapper, no overhead.
   -- rawset: some module tables guard __newindex, and a declaration is not a
   -- caller poking at the module.
-  rawset(trx[module], name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+  rawset(container, name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
   return spec.impl
 end
 
@@ -188,9 +272,9 @@ end
 function api.strict(enabled)
   strict_enabled = enabled and true or false
   for _, path in ipairs(order) do
-    local module, name = split_path(path)
+    local _, container, name = resolve(path)
     local spec = registry[path]
-    rawset(trx[module], name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+    rawset(container, name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
   end
 end
 
@@ -358,7 +442,15 @@ function api.property(path, spec)
 end
 
 function api.describe()
-  local out = { modules = {}, functions = {}, types = {}, enums = {}, constants = {}, properties = {} }
+  local out = {
+    modules = {},
+    functions = {},
+    types = {},
+    enums = {},
+    constants = {},
+    properties = {},
+    namespaces = {},
+  }
   for _, name in ipairs(module_order) do
     table.insert(out.modules, {
       name = name,
@@ -442,6 +534,17 @@ function api.describe()
       path = path,
       value = spec.value,
       description = spec.description,
+    })
+  end
+  for _, path in ipairs(namespace_order) do
+    local spec = namespaces[path]
+    table.insert(out.namespaces, {
+      path = path,
+      description = spec.description,
+      params = spec.params,
+      returns = spec.returns,
+      examples = spec.examples,
+      callable = spec.call ~= nil,
     })
   end
   for _, path in ipairs(property_order) do

--- a/data/scripting/console.lua
+++ b/data/scripting/console.lua
@@ -1,41 +1,87 @@
 local raw = trxc.console
+local api = trx.api
+
+-- The same LOG_LEVEL the logging module declares. One enum, one declaration:
+-- trx.console.log.generic takes a trx.log.LogLevel.
 local LogLevel = trxc.log.LogLevel
 
-local log = { LogLevel = LogLevel }
-function log.generic(level, ...)
-  raw.log(level, ...)
-end
-function log.info(...)
-  raw.log(LogLevel.INFO, ...)
-end
-function log.warn(...)
-  raw.log(LogLevel.WARNING, ...)
-end
-function log.warning(...)
-  raw.log(LogLevel.WARNING, ...)
-end
-function log.error(...)
-  raw.log(LogLevel.ERROR, ...)
-end
-function log.debug(...)
-  raw.log(LogLevel.DEBUG, ...)
+api.module("console", {
+  order = 5,
+  description = "Module for interacting with the developer console.\n\n"
+    .. "`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to "
+    .. "the terminal and the log file.",
+})
+
+-- The C side walks two stack frames up to find the caller, so every entry point
+-- here keeps exactly one wrapper between the script and raw.log. Extra arguments
+-- are concatenated with spaces by C; the contract is one message.
+local function at(level)
+  return function(message)
+    raw.log(level, message)
+  end
 end
 
-local console = {
-  log = log,
-}
-setmetatable(console.log, {
-  __call = function(_, ...)
-    return console.log.info(...)
+api.namespace("console.log", {
+  description = "Logs a line to the developer console. Calling the group itself logs at `INFO`.",
+  params = { { name = "message", type = "string" } },
+  examples = { [[trx.console.log("hello")]] },
+  call = at(LogLevel.INFO),
+})
+
+api.define("console.log.generic", {
+  description = "Logs at a level chosen at runtime.",
+  params = {
+    { name = "level", type = "integer", enum = "log.LogLevel" },
+    { name = "message", type = "string" },
+  },
+  impl = function(level, message)
+    raw.log(level, message)
   end,
 })
 
-function console.clear()
-  return raw.clear()
-end
+api.define("console.log.info", {
+  description = "Logs an informational message.",
+  params = { { name = "message", type = "string" } },
+  impl = at(LogLevel.INFO),
+})
 
-function console.eval(cmd, opts)
-  return raw.eval(cmd, opts)
-end
+api.define("console.log.warn", {
+  description = "Logs a warning.",
+  params = { { name = "message", type = "string" } },
+  impl = at(LogLevel.WARNING),
+})
 
-trx.console = console
+api.define("console.log.warning", {
+  description = "Logs a warning. An alias of `trx.console.log.warn`.",
+  params = { { name = "message", type = "string" } },
+  impl = at(LogLevel.WARNING),
+})
+
+api.define("console.log.error", {
+  description = "Logs an error.",
+  params = { { name = "message", type = "string" } },
+  impl = at(LogLevel.ERROR),
+})
+
+api.define("console.log.debug", {
+  description = "Logs a debug message.",
+  params = { { name = "message", type = "string" } },
+  impl = at(LogLevel.DEBUG),
+})
+
+api.define("console.eval", {
+  description = "Runs a string as a developer console command. Raises if the command fails.\n\n"
+    .. "Output is silenced by default and appears only in the terminal and the log file. Pass "
+    .. "`{ verbose = true }` to show it in the console as a command typed by the player would.",
+  params = {
+    { name = "command", type = "string", description = "Command to run, as the player would type it." },
+    { name = "opts", type = "table", optional = true, description = "`verbose`: show the command's output." },
+  },
+  examples = { [[trx.console.eval("play 1", { verbose = true })]] },
+  impl = raw.eval,
+})
+
+api.define("console.clear", {
+  description = "Clears the console.",
+  impl = raw.clear,
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
 - removed the `trx.pickup` module; its enum is now `trx.items.PickupMode`; refer to migration notes
+- removed `trx.console.log.LogLevel`, a duplicate of `trx.log.LogLevel`; refer to migration notes
 - removed `trx.music.play_track`, an undocumented alias of `trx.music.play`; refer to migration notes
 
 **TR4**

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -46,11 +46,15 @@ order: 3
    hook. The nine hooks are the whole API, and attaching is unchanged:
    `trx.events.before_control(fn)`.
 
-4. **Update scripts that call `trx.music.play_track`**
+4. **Update scripts that use `trx.console.log.LogLevel`**
+   It was removed. Use `trx.log.LogLevel`, which is the same enum:
+   `trx.console.log.generic(trx.log.LogLevel.ERROR, "...")`.
+
+5. **Update scripts that call `trx.music.play_track`**
    It was an undocumented alias of `trx.music.play` and was removed. Use
    `trx.music.play(id[, opts])`.
 
-5. **Update scripts that set `pickup_mode`**
+6. **Update scripts that set `pickup_mode`**
    The `trx.pickup` module is gone. `pickup_mode` is an item property, so its
    enum now lives with the items: replace `trx.pickup.Mode.PLINTH_LOW` with
    `trx.items.PickupMode.PLINTH_LOW`.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -239,6 +239,95 @@
       "path": "camera.reset"
     },
     {
+      "description": "Logs at a level chosen at runtime.",
+      "params": [
+        {
+          "enum": "log.LogLevel",
+          "name": "level",
+          "type": "integer"
+        },
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.generic"
+    },
+    {
+      "description": "Logs an informational message.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.info"
+    },
+    {
+      "description": "Logs a warning.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.warn"
+    },
+    {
+      "description": "Logs a warning. An alias of `trx.console.log.warn`.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.warning"
+    },
+    {
+      "description": "Logs an error.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.error"
+    },
+    {
+      "description": "Logs a debug message.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log.debug"
+    },
+    {
+      "description": "Runs a string as a developer console command. Raises if the command fails.\n\nOutput is silenced by default and appears only in the terminal and the log file. Pass `{ verbose = true }` to show it in the console as a command typed by the player would.",
+      "examples": [
+        "trx.console.eval(\"play 1\", { verbose = true })"
+      ],
+      "params": [
+        {
+          "description": "Command to run, as the player would type it.",
+          "name": "command",
+          "type": "string"
+        },
+        {
+          "description": "`verbose`: show the command's output.",
+          "name": "opts",
+          "optional": true,
+          "type": "table"
+        }
+      ],
+      "path": "console.eval"
+    },
+    {
+      "description": "Clears the console.",
+      "path": "console.clear"
+    },
+    {
       "description": "Marks an object as an ally of Lara. Every item of that type becomes an ally.",
       "examples": [
         "trx.creatures.add_ally(trx.catalog.objects.monk_1)"
@@ -802,6 +891,11 @@
       "order": 16
     },
     {
+      "description": "Module for interacting with the developer console.\n\n`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to the terminal and the log file.",
+      "name": "console",
+      "order": 5
+    },
+    {
       "description": "Module for controlling certain creature behavior.",
       "name": "creatures",
       "order": 12
@@ -835,6 +929,22 @@
       "description": "Module for playing sound effects.",
       "name": "sound",
       "order": 7
+    }
+  ],
+  "namespaces": [
+    {
+      "callable": true,
+      "description": "Logs a line to the developer console. Calling the group itself logs at `INFO`.",
+      "examples": [
+        "trx.console.log(\"hello\")"
+      ],
+      "params": [
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "path": "console.log"
     }
   ],
   "properties": [

--- a/docs/trx/lua/reference/CONSOLE.md
+++ b/docs/trx/lua/reference/CONSOLE.md
@@ -3,32 +3,82 @@ title: Console
 order: 5
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/console.lua. Edit it there.
+-->
+
 ## Console module
 
 Module for interacting with the developer console.
 
+`trx.console.log` writes to the console overlay in-game, where `trx.log` writes only to the terminal and the log file.
+
 ### Functions
 
-- [lua]`trx.console.log("string1", "string2", ...)`  
-  [lua]`trx.console.log.generic(level, ...)`  
-  [lua]`trx.console.log.info(...)`  
-  [lua]`trx.console.log.error(...)`  
-  [lua]`trx.console.log.warn(...)`  
-  [lua]`trx.console.log.warning(...)`  
-  [lua]`trx.console.log.debug(...)`  
-    Logs a line to the developer console with a specific level.
+- [lua]`trx.console.log(message)`  
+  Logs a line to the developer console. Calling the group itself logs at `INFO`.
 
-- [lua]`trx.console.eval("string"[, opts])`  
-   Evaluates a given string as a developer console command.
+  Parameters:
+  - **`message`** (string).
 
-   By default, output from commands is silenced and only appears in the
-   terminal and the log file. To see output from the commands normally, pass `{ verbose = true }` in `opts`.  
+  Example:
+  ```lua
+  trx.console.log("hello")
+  ```
 
-   Example:
-   > ```lua
-   > trx.console.eval("play 1", { verbose = true })
-   > ```
-   will play the first level and show an according message in the console log.
+- [lua]`trx.console.log.generic(level, message)`  
+  Logs at a level chosen at runtime.
+
+  Parameters:
+  - **`level`** (integer). Compare against `trx.log.LogLevel`.
+  - **`message`** (string).
+
+- [lua]`trx.console.log.info(message)`  
+  Logs an informational message.
+
+  Parameters:
+  - **`message`** (string).
+
+- [lua]`trx.console.log.warn(message)`  
+  Logs a warning.
+
+  Parameters:
+  - **`message`** (string).
+
+- [lua]`trx.console.log.warning(message)`  
+  Logs a warning. An alias of `trx.console.log.warn`.
+
+  Parameters:
+  - **`message`** (string).
+
+- [lua]`trx.console.log.error(message)`  
+  Logs an error.
+
+  Parameters:
+  - **`message`** (string).
+
+- [lua]`trx.console.log.debug(message)`  
+  Logs a debug message.
+
+  Parameters:
+  - **`message`** (string).
+
+- [lua]`trx.console.eval(command, [opts])`  
+  Runs a string as a developer console command. Raises if the command fails.
+
+  Output is silenced by default and appears only in the terminal and the log file. Pass `{ verbose = true }` to show it in the console as a command typed by the player would.
+
+  Parameters:
+  - **`command`** (string). Command to run, as the player would type it.
+  - **`opts`** (table, optional). `verbose`: show the command's output.
+
+  Example:
+  ```lua
+  trx.console.eval("play 1", { verbose = true })
+  ```
 
 - [lua]`trx.console.clear()`  
-    Clears the console.
+  Clears the console.

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -207,6 +207,19 @@ test_lua_log_exe = executable(
 )
 test('lua_log', test_lua_log_exe, suite: 'unit')
 
+# The log bridge rides along: console.lua takes its levels from trxc.log.
+test_lua_console_exe = executable(
+  'test_lua_console',
+  files('unit/test_lua_console.c', 'unit/fake_engine_console.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/lua/console.c', '../trx/game/lua/log.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_console', test_lua_console_exe, suite: 'unit')
+
 test_lua_creatures_exe = executable(
   'test_lua_creatures',
   files('unit/test_lua_creatures.c', 'unit/fake_engine_creatures.c') + test_stubs

--- a/src/tests/unit/fake_engine_console.c
+++ b/src/tests/unit/fake_engine_console.c
@@ -1,0 +1,66 @@
+// The console overlay, reduced to the last line written to it, plus the verbose
+// flag - which is the only engine state trx.console.eval actually manipulates.
+
+#include "fake_engine_console.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+FAKE_CONSOLE_CALLS g_FakeConsoleCalls;
+static bool m_Verbose;
+static COMMAND_RESULT m_EvalResult;
+
+void Console_LogEx(
+    const LOG_LEVEL level, const char *const file, const int line,
+    const char *const func, const char *const fmt, ...)
+{
+    g_FakeConsoleCalls.log_count++;
+    g_FakeConsoleCalls.last_level = level;
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(
+        g_FakeConsoleCalls.last_message,
+        sizeof(g_FakeConsoleCalls.last_message), fmt, args);
+    va_end(args);
+}
+
+void Console_Clear(void)
+{
+    g_FakeConsoleCalls.clear_count++;
+}
+
+COMMAND_RESULT Console_Eval(const char *const cmdline)
+{
+    g_FakeConsoleCalls.eval_count++;
+    snprintf(
+        g_FakeConsoleCalls.last_command,
+        sizeof(g_FakeConsoleCalls.last_command), "%s", cmdline);
+    // The bridge sets verbose around the call and restores it afterwards, so
+    // the value that matters is the one visible from in here.
+    g_FakeConsoleCalls.verbose_during_eval = m_Verbose;
+    return m_EvalResult;
+}
+
+void Console_SetVerbose(const bool verbose)
+{
+    m_Verbose = verbose;
+}
+
+bool Console_IsVerbose(void)
+{
+    return m_Verbose;
+}
+
+void FakeConsole_Reset(void)
+{
+    g_FakeConsoleCalls = (FAKE_CONSOLE_CALLS) {};
+    m_Verbose = false;
+    m_EvalResult = CR_SUCCESS;
+}
+
+void FakeConsole_SetEvalResult(const COMMAND_RESULT result)
+{
+    m_EvalResult = result;
+}

--- a/src/tests/unit/fake_engine_console.h
+++ b/src/tests/unit/fake_engine_console.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <trx/core/log.h>
+#include <trx/game/console/enum.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// The console overlay, reduced to the last line written to it.
+typedef struct {
+    int32_t log_count;
+    LOG_LEVEL last_level;
+    char last_message[256];
+
+    int32_t clear_count;
+
+    int32_t eval_count;
+    char last_command[256];
+    // What Console_Eval saw while it ran, which is what `opts.verbose`
+    // controls.
+    bool verbose_during_eval;
+} FAKE_CONSOLE_CALLS;
+
+extern FAKE_CONSOLE_CALLS g_FakeConsoleCalls;
+
+bool Console_IsVerbose(void);
+
+void FakeConsole_Reset(void);
+
+// The result the next Console_Eval hands back.
+void FakeConsole_SetEvalResult(COMMAND_RESULT result);

--- a/src/tests/unit/lua/console.lua
+++ b/src/tests/unit/lua/console.lua
@@ -1,0 +1,88 @@
+-- The console API as a script actually sees it.
+--
+-- trx.console.log is an api.namespace: a table of functions that is itself
+-- callable. This is where that shape meets a real bridge.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("the log group is callable, and logs at INFO", function()
+  trx.console.log("hello")
+  local calls = fake.calls()
+  assert(calls.log_count == 1, "calling the group did not reach the console")
+  assert(calls.last_message == "hello")
+  assert(calls.last_level == trx.log.LogLevel.INFO, "calling the group must log at INFO")
+end)
+
+test("each level logs at its own level", function()
+  local cases = {
+    { fn = trx.console.log.info, level = trx.log.LogLevel.INFO },
+    { fn = trx.console.log.warn, level = trx.log.LogLevel.WARNING },
+    { fn = trx.console.log.warning, level = trx.log.LogLevel.WARNING },
+    { fn = trx.console.log.error, level = trx.log.LogLevel.ERROR },
+    { fn = trx.console.log.debug, level = trx.log.LogLevel.DEBUG },
+  }
+  for _, case in ipairs(cases) do
+    case.fn("msg")
+    assert(fake.calls().last_level == case.level, "wrong level")
+  end
+  assert(fake.calls().log_count == #cases, "not every level reached the console")
+end)
+
+test("generic logs at the level it is handed", function()
+  trx.console.log.generic(trx.log.LogLevel.ERROR, "boom")
+  local calls = fake.calls()
+  assert(calls.last_level == trx.log.LogLevel.ERROR)
+  assert(calls.last_message == "boom")
+end)
+
+test("the log group carries no level enum of its own", function()
+  -- LOG_LEVEL is declared once, as trx.log.LogLevel. A second copy hanging off
+  -- the console would be a second thing to keep in step.
+  assert(trx.console.log.LogLevel == nil)
+end)
+
+test("eval runs the command", function()
+  trx.console.eval("play 1")
+  local calls = fake.calls()
+  assert(calls.eval_count == 1, "eval did not reach the console")
+  assert(calls.last_command == "play 1")
+end)
+
+test("eval is quiet unless asked to be verbose", function()
+  trx.console.eval("play 1")
+  assert(fake.calls().verbose_during_eval == false, "eval must be quiet by default")
+
+  trx.console.eval("play 1", { verbose = true })
+  assert(fake.calls().verbose_during_eval == true, "verbose did not reach the console")
+end)
+
+test("eval puts the verbose flag back the way it found it", function()
+  trx.console.eval("play 1", { verbose = true })
+  assert(fake.calls().verbose_now == false, "eval left the console verbose")
+end)
+
+test("a command that fails raises, and says why", function()
+  fake.set_eval_result(fake.CommandResult.FAILURE)
+  raises(function()
+    trx.console.eval("kill everything")
+  end, "failure")
+
+  fake.set_eval_result(fake.CommandResult.BAD_INVOCATION)
+  raises(function()
+    trx.console.eval("kill")
+  end, "bad invocation")
+end)
+
+test("clear clears the console", function()
+  trx.console.clear()
+  assert(fake.calls().clear_count == 1)
+end)
+
+test("the raw bridge is not part of the surface", function()
+  -- trxc.console.log is a plain function taking a level. The declaration turns
+  -- it into a namespace, and the raw entry point must not leak alongside it.
+  assert(type(trx.console.log) == "table", "log must be the namespace, not the raw function")
+end)
+
+return h.report()

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -320,8 +320,8 @@ test("seal audits inside a namespace", function()
   api.define("console.log.info", { description = "Info.", impl = function() end })
   api.seal()
 
-  -- A member one level down is exactly the surface the old audit could not see:
-  -- it walked the module table and found `log`, a declared namespace, and stopped.
+  -- Walking the module table alone finds `log`, a declared namespace, and stops.
+  -- Everything hanging off it has to be audited as its own container.
   local api2 = fresh_env()
   api2.module("console", {})
   api2.namespace("console.log", { description = "Logging." })

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -289,6 +289,54 @@ test("properties reach describe()", function()
   assert(out.properties[2].writable == false, "a getter-only property is read-only")
 end)
 
+test("a namespace groups members one level down, and can itself be callable", function()
+  local api = fresh_env()
+  api.module("console", {})
+
+  local logged = {}
+  api.namespace("console.log", {
+    description = "Logging.",
+    call = function(message)
+      return trx.console.log.info(message)
+    end,
+  })
+  api.define("console.log.info", {
+    description = "Info.",
+    impl = function(message)
+      logged[#logged + 1] = message
+      return "ok"
+    end,
+  })
+
+  assert(trx.console.log.info("a") == "ok", "the member is not reachable")
+  assert(trx.console.log("b") == "ok", "the namespace is not callable")
+  assert(logged[1] == "a" and logged[2] == "b", "the call did not reach info()")
+end)
+
+test("seal audits inside a namespace", function()
+  local api = fresh_env()
+  api.module("console", {})
+  api.namespace("console.log", { description = "Logging." })
+  api.define("console.log.info", { description = "Info.", impl = function() end })
+  api.seal()
+
+  -- A member one level down is exactly the surface the old audit could not see:
+  -- it walked the module table and found `log`, a declared namespace, and stopped.
+  local api2 = fresh_env()
+  api2.module("console", {})
+  api2.namespace("console.log", { description = "Logging." })
+  rawset(trx.console.log, "sneaky", function() end)
+  local ok, err = pcall(api2.seal)
+  assert(not ok, "an undeclared member inside a namespace must fail the seal")
+  assert(tostring(err):find("trx.console.log.sneaky", 1, true), "the audit must name it: " .. tostring(err))
+end)
+
+test("a path deeper than a namespace is rejected", function()
+  local api = fresh_env()
+  api.module("console", {})
+  assert(not pcall(api.define, "console.log.deep.deeper", { impl = function() end }), "3 levels deep")
+end)
+
 test("seal blocks further declarations", function()
   local api = fresh_env()
   api.seal()

--- a/src/tests/unit/test_lua_console.c
+++ b/src/tests/unit/test_lua_console.c
@@ -1,0 +1,83 @@
+// The console surface. The assertions live in src/tests/unit/lua/console.lua;
+// this stands up the world they run against.
+//
+// The log bridge is registered alongside it: console.lua takes its levels from
+// trxc.log, so the two share one enum rather than each carrying a copy.
+
+#include "fake_engine_console.h"
+#include "lua_surface.h"
+
+#include <lauxlib.h>
+
+extern void LUA_CreateConsole(lua_State *L);
+extern void LUA_CreateLog(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateConsole(L);
+    LUA_CreateLog(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeConsole_Reset();
+    return 0;
+}
+
+// fake.set_eval_result(result) - what the next Console_Eval hands back.
+static int M_FakeSetEvalResult(lua_State *const L)
+{
+    FakeConsole_SetEvalResult((COMMAND_RESULT)luaL_checkinteger(L, 1));
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, g_FakeConsoleCalls.log_count);
+    lua_setfield(L, -2, "log_count");
+    lua_pushinteger(L, g_FakeConsoleCalls.last_level);
+    lua_setfield(L, -2, "last_level");
+    lua_pushstring(L, g_FakeConsoleCalls.last_message);
+    lua_setfield(L, -2, "last_message");
+    lua_pushinteger(L, g_FakeConsoleCalls.clear_count);
+    lua_setfield(L, -2, "clear_count");
+    lua_pushinteger(L, g_FakeConsoleCalls.eval_count);
+    lua_setfield(L, -2, "eval_count");
+    lua_pushstring(L, g_FakeConsoleCalls.last_command);
+    lua_setfield(L, -2, "last_command");
+    lua_pushboolean(L, g_FakeConsoleCalls.verbose_during_eval);
+    lua_setfield(L, -2, "verbose_during_eval");
+    lua_pushboolean(L, Console_IsVerbose());
+    lua_setfield(L, -2, "verbose_now");
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+    lua_pushcfunction(L, M_FakeSetEvalResult);
+    lua_setfield(L, -2, "set_eval_result");
+
+    lua_newtable(L);
+    lua_pushinteger(L, CR_SUCCESS);
+    lua_setfield(L, -2, "SUCCESS");
+    lua_pushinteger(L, CR_FAILURE);
+    lua_setfield(L, -2, "FAILURE");
+    lua_pushinteger(L, CR_BAD_INVOCATION);
+    lua_setfield(L, -2, "BAD_INVOCATION");
+    lua_setfield(L, -2, "CommandResult");
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "console",
+        .deps = { "log", nullptr },
+        .tests = "console",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/tests/unit/test_update_lua_docs.py
+++ b/src/tests/unit/test_update_lua_docs.py
@@ -273,6 +273,23 @@ class TestLuaDocs(unittest.TestCase):
         self.assertIn("title: Thingamabobs", page)
         self.assertIn("## Thingamabobs module", page)
 
+    def test_a_namespace_reaches_the_page_whether_or_not_it_is_callable(self):
+        """A group's own prose - "these records live in the player's profile" -
+        is not something any member's signature can say."""
+        surface = copy.deepcopy(SURFACE)
+        surface["namespaces"] = [
+            {"path": "things.log", "description": "Logs it.", "callable": True},
+            {"path": "things.stats", "description": "Counts it.", "callable": False},
+        ]
+        page = docs.render_page(surface["modules"][0], surface)
+        self.assertIn("Logs it.", page)
+        self.assertIn("Counts it.", page)
+
+        # Callable renders as a call; a plain group does not pretend to be one.
+        self.assertIn("`trx.things.log()`", page)
+        self.assertIn("`trx.things.stats`", page)
+        self.assertNotIn("`trx.things.stats()`", page)
+
     def test_rendering_is_stable(self):
         """Two runs must agree, or --check would flag spurious drift forever."""
         a = docs.render_page(SURFACE["modules"][0], SURFACE)

--- a/src/tests/unit/test_update_lua_docs.py
+++ b/src/tests/unit/test_update_lua_docs.py
@@ -290,6 +290,17 @@ class TestLuaDocs(unittest.TestCase):
         self.assertIn("`trx.things.stats`", page)
         self.assertNotIn("`trx.things.stats()`", page)
 
+    def test_a_multi_paragraph_description_stays_inside_its_list_item(self):
+        """Indenting only the first line ends the list at the blank line and
+        dumps the remaining paragraphs at the page's top level."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["description"] = "First para.\n\nSecond para."
+        page = docs.render_page(surface["modules"][0], surface)
+        second = next(line for line in page.splitlines() if "Second para." in line)
+        self.assertTrue(
+            second.startswith("  "), f"paragraph escaped its list item: {second!r}"
+        )
+
     def test_rendering_is_stable(self):
         """Two runs must agree, or --check would flag spurious drift forever."""
         a = docs.render_page(SURFACE["modules"][0], SURFACE)

--- a/tools/update_lua_docs
+++ b/tools/update_lua_docs
@@ -119,6 +119,28 @@ def render_function(func: dict) -> list[str]:
     return out
 
 
+def render_namespace(spec: dict) -> list[str]:
+    """A grouping table on a module, holding related members under one name.
+
+    Its members render as ordinary functions, since they carry the full path.
+    What needs a bullet of its own is what the members' signatures cannot say:
+    the group's own description, and, when it is callable, that the group may be
+    called directly.
+    """
+    if spec.get("callable"):
+        head = f"- [lua]`trx.{signature(spec['path'], spec.get('params'))}`  "
+    else:
+        head = f"- [lua]`trx.{spec['path']}`  "
+    out = [head]
+    if spec.get("description"):
+        out.append(f"  {spec['description']}")
+    out.extend(render_params(spec.get("params"), "  "))
+    out.extend(render_returns(spec.get("returns"), "  "))
+    out.extend(render_examples(spec.get("examples"), "  "))
+    out.append("")
+    return out
+
+
 def render_const(spec: dict) -> list[str]:
     out = [f"- [lua]`trx.{spec['path']}` = `{spec['value']}`  "]
     if spec.get("description"):
@@ -249,10 +271,13 @@ def render_page(module: dict, api: dict) -> str:
         for spec in types:
             out.extend(render_type(spec))
 
+    spaces = [n for n in api.get("namespaces", []) if n["path"].startswith(f"{name}.")]
     funcs = [f for f in api["functions"] if f["path"].startswith(f"{name}.")]
-    if funcs:
+    if funcs or spaces:
         out.append("### Functions")
         out.append("")
+        for spec in spaces:
+            out.extend(render_namespace(spec))
         for func in funcs:
             out.extend(render_function(func))
 
@@ -271,6 +296,9 @@ def undocumented(api: dict) -> list[str]:
     for prop in api.get("properties", []):
         if not prop.get("description"):
             out.append(prop["path"])
+    for space in api.get("namespaces", []):
+        if not space.get("description"):
+            out.append(space["path"])
     for enum in api.get("enums", []):
         for value in enum.get("values") or []:
             if not value.get("description"):

--- a/tools/update_lua_docs
+++ b/tools/update_lua_docs
@@ -70,6 +70,16 @@ def render_callback_args(param: dict, indent: str) -> list[str]:
     return out
 
 
+def render_prose(text: str, indent: str) -> list[str]:
+    """A description under a list item, indented so it stays inside the item.
+
+    Descriptions can run to several paragraphs. Indenting only the first line
+    would end the list at the blank line and dump the rest at the page's top
+    level.
+    """
+    return [f"{indent}{line}".rstrip() for line in text.splitlines()]
+
+
 def render_params(params: list[dict] | None, indent: str) -> list[str]:
     if not params:
         return []
@@ -111,7 +121,7 @@ def render_examples(examples: list[str] | None, indent: str) -> list[str]:
 def render_function(func: dict) -> list[str]:
     out = [f"- [lua]`trx.{signature(func['path'], func.get('params'))}`  "]
     if func.get("description"):
-        out.append(f"  {func['description']}")
+        out.extend(render_prose(func["description"], "  "))
     out.extend(render_params(func.get("params"), "  "))
     out.extend(render_returns(func.get("returns"), "  "))
     out.extend(render_examples(func.get("examples"), "  "))
@@ -133,7 +143,7 @@ def render_namespace(spec: dict) -> list[str]:
         head = f"- [lua]`trx.{spec['path']}`  "
     out = [head]
     if spec.get("description"):
-        out.append(f"  {spec['description']}")
+        out.extend(render_prose(spec["description"], "  "))
     out.extend(render_params(spec.get("params"), "  "))
     out.extend(render_returns(spec.get("returns"), "  "))
     out.extend(render_examples(spec.get("examples"), "  "))
@@ -210,7 +220,7 @@ def render_type(spec: dict) -> list[str]:
             f"{INDENT}- [lua]`{name}:{signature(method['name'], method.get('params'))}`  "
         )
         if method.get("description"):
-            out.append(f"{INDENT}  {method['description']}")
+            out.extend(render_prose(method["description"], f"{INDENT}  "))
         out.extend(render_params(method.get("params"), f"{INDENT}  "))
         out.extend(render_returns(method.get("returns"), f"{INDENT}  "))
         out.extend(render_examples(method.get("examples"), f"{INDENT}  "))


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates the console LUA API to the new `api` framework and adds tests.