### PR TITLE
Migrate assault course LUA API

### DIFF
--- a/data/scripting/assault.lua
+++ b/data/scripting/assault.lua
@@ -1,23 +1,116 @@
 local raw = trxc.assault
-local Track = raw.Track
+local api = trx.api
 
-trx.assault = {
-  Track = Track,
-  stats = {
-    add_record = raw.stats.record,
-    remove_record = raw.stats.remove,
-    list_records = raw.stats.list,
+api.module("assault", {
+  order = 14,
+  title = "Assault course",
+  description = "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
+})
+
+local Track = api.enum("assault.Track", {
+  backing = "GYM_TRACK_TYPE",
+  description = "A timed gym track.",
+  values = {
+    COURSE = "Lara's assault course.",
+    QUAD = "The quad bike circuit.",
   },
-}
+})
 
-function trx.assault.start(track)
-  raw.start(track or Track.COURSE)
+-- Every track-taking function defaults to the assault course, which is what a
+-- script means when it does not say.
+local function track_param()
+  return {
+    name = "track",
+    type = "integer",
+    optional = true,
+    default = "trx.assault.Track.COURSE",
+    enum = "assault.Track",
+  }
 end
 
-function trx.assault.stop(track)
-  raw.stop(track or Track.COURSE)
-end
+api.define("assault.start", {
+  description = "Starts the timer and clears its state. Raises outside a gym level.",
+  params = { track_param() },
+  impl = raw.start,
+})
 
-function trx.assault.reset(track)
-  raw.reset(track or Track.COURSE)
-end
+api.define("assault.stop", {
+  description = "Stops the timer, leaving it on screen. Raises outside a gym level.",
+  params = { track_param() },
+  impl = raw.stop,
+})
+
+api.define("assault.finish", {
+  description = "Stops the timer as completing the track does, rather than as an abort. Raises "
+    .. "outside a gym level.",
+  params = { track_param() },
+  impl = raw.finish,
+})
+
+api.define("assault.reset", {
+  description = "Stops the timer and clears its state. Raises outside a gym level.",
+  params = { track_param() },
+  impl = raw.reset,
+})
+
+api.define("assault.is_running", {
+  description = "Whether the timer is counting. False outside a gym level.",
+  params = { track_param() },
+  returns = { type = "boolean" },
+  impl = raw.is_running,
+})
+
+api.define("assault.is_visible", {
+  description = "Whether the timer is shown on screen. It stays visible after `stop`.",
+  params = { track_param() },
+  returns = { type = "boolean" },
+  impl = raw.is_visible,
+})
+
+api.property("assault.active_track", {
+  type = "integer",
+  enum = "assault.Track",
+  description = "The track Lara is currently running, or `nil` if none.",
+  get = raw.get_active_track,
+})
+
+api.namespace("assault.stats", {
+  description = "The Assault Course record table, as shown on the stats screen. The records are "
+    .. "stored in the player's profile, so writing to them outlives the level.",
+})
+
+api.define("assault.stats.add_record", {
+  description = "Files a new record, inserting it in time order and bumping the attempt count.",
+  params = {
+    { name = "time", type = "number", description = "Time in seconds. Must be greater than zero." },
+  },
+  returns = {
+    type = "boolean",
+    description = "`false` if the table is full and the time is slower than every record in it.",
+  },
+  examples = { [[trx.assault.stats.add_record(30.0)]] },
+  impl = raw.stats.record,
+})
+
+api.define("assault.stats.remove_record", {
+  description = "Removes a record, closing the gap behind it.",
+  params = {
+    { name = "record_id", type = "integer", description = "1-based position in the table." },
+  },
+  returns = { type = "boolean", description = "`false` if there is no record at that position." },
+  impl = raw.stats.remove,
+})
+
+api.define("assault.stats.list_records", {
+  description = "The records, fastest first.",
+  returns = {
+    type = "table",
+    description = "List of `{ time = seconds, attempt_num = which attempt it was }`.",
+  },
+  examples = {
+    [[for _, record in ipairs(trx.assault.stats.list_records()) do
+  trx.log.info(("attempt %d: %.2fs"):format(record.attempt_num, record.time))
+end]],
+  },
+  impl = raw.stats.list,
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- added new Lua assault course functions, `trx.assault.finish()`, `trx.assault.is_running()` and `trx.assault.is_visible()`, and a new property, `trx.assault.active_track`
 - changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
 - changed `trx.events.detach()` to return whether a handler was removed
 - changed reflections UV mapping to be more correct

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -49,6 +49,22 @@
       ]
     },
     {
+      "description": "A timed gym track.",
+      "path": "assault.Track",
+      "values": [
+        {
+          "description": "The quad bike circuit.",
+          "name": "QUAD",
+          "value": 0
+        },
+        {
+          "description": "Lara's assault course.",
+          "name": "COURSE",
+          "value": 1
+        }
+      ]
+    },
+    {
       "description": "The values `item.status` can take.",
       "path": "items.Status",
       "values": [
@@ -219,6 +235,134 @@
         }
       ],
       "path": "log.debug"
+    },
+    {
+      "description": "Starts the timer and clears its state. Raises outside a gym level.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.start"
+    },
+    {
+      "description": "Stops the timer, leaving it on screen. Raises outside a gym level.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.stop"
+    },
+    {
+      "description": "Stops the timer as completing the track does, rather than as an abort. Raises outside a gym level.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.finish"
+    },
+    {
+      "description": "Stops the timer and clears its state. Raises outside a gym level.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.reset"
+    },
+    {
+      "description": "Whether the timer is counting. False outside a gym level.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.is_running",
+      "returns": {
+        "type": "boolean"
+      }
+    },
+    {
+      "description": "Whether the timer is shown on screen. It stays visible after `stop`.",
+      "params": [
+        {
+          "default": "trx.assault.Track.COURSE",
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "assault.is_visible",
+      "returns": {
+        "type": "boolean"
+      }
+    },
+    {
+      "description": "Files a new record, inserting it in time order and bumping the attempt count.",
+      "examples": [
+        "trx.assault.stats.add_record(30.0)"
+      ],
+      "params": [
+        {
+          "description": "Time in seconds. Must be greater than zero.",
+          "name": "time",
+          "type": "number"
+        }
+      ],
+      "path": "assault.stats.add_record",
+      "returns": {
+        "description": "`false` if the table is full and the time is slower than every record in it.",
+        "type": "boolean"
+      }
+    },
+    {
+      "description": "Removes a record, closing the gap behind it.",
+      "params": [
+        {
+          "description": "1-based position in the table.",
+          "name": "record_id",
+          "type": "integer"
+        }
+      ],
+      "path": "assault.stats.remove_record",
+      "returns": {
+        "description": "`false` if there is no record at that position.",
+        "type": "boolean"
+      }
+    },
+    {
+      "description": "The records, fastest first.",
+      "examples": [
+        "for _, record in ipairs(trx.assault.stats.list_records()) do\n  trx.log.info((\"attempt %d: %.2fs\"):format(record.attempt_num, record.time))\nend"
+      ],
+      "path": "assault.stats.list_records",
+      "returns": {
+        "description": "List of `{ time = seconds, attempt_num = which attempt it was }`.",
+        "type": "table"
+      }
     },
     {
       "description": "Shakes the camera by setting its bounce value. Positive values shake it upward, negative values downward.",
@@ -886,6 +1030,12 @@
       "title": "Logging"
     },
     {
+      "description": "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
+      "name": "assault",
+      "order": 14,
+      "title": "Assault course"
+    },
+    {
       "description": "Module for inspecting the active camera state.",
       "name": "camera",
       "order": 16
@@ -933,6 +1083,11 @@
   ],
   "namespaces": [
     {
+      "callable": false,
+      "description": "The Assault Course record table, as shown on the stats screen. The records are stored in the player's profile, so writing to them outlives the level.",
+      "path": "assault.stats"
+    },
+    {
       "callable": true,
       "description": "Logs a line to the developer console. Calling the group itself logs at `INFO`.",
       "examples": [
@@ -948,6 +1103,13 @@
     }
   ],
   "properties": [
+    {
+      "description": "The track Lara is currently running, or `nil` if none.",
+      "enum": "assault.Track",
+      "path": "assault.active_track",
+      "type": "integer",
+      "writable": false
+    },
     {
       "description": "Current camera position.",
       "path": "camera.pos",

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -3,43 +3,106 @@ title: Assault course
 order: 14
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/assault.lua. Edit it there.
+-->
+
 ## Assault course module
 
 Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
+### Properties
+
+- **`trx.assault.active_track`** (integer). The track Lara is currently running, or `nil` if none. Compare against `trx.assault.Track`. *(read-only)*
+
 ### Enums
 
 - [lua]`trx.assault.Track`
-    Values: `COURSE`, `QUAD`.
 
-### Properties
+    A timed gym track.
 
-- [lua]`trx.assault.stats`
-    Table for controlling Assault Course records.
+    - `trx.assault.Track.QUAD` = `0`  
+        The quad bike circuit.
+    - `trx.assault.Track.COURSE` = `1`  
+        Lara's assault course.
 
 ### Functions
+
+- [lua]`trx.assault.stats`  
+  The Assault Course record table, as shown on the stats screen. The records are stored in the player's profile, so writing to them outlives the level.
 
 - [lua]`trx.assault.start([track])`  
-    Starts the given timer and resets its state. Defaults to `trx.assault.Track.COURSE`.
+  Starts the timer and clears its state. Raises outside a gym level.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
 - [lua]`trx.assault.stop([track])`  
-    Stops the given timer while keeping it visible. Defaults to `trx.assault.Track.COURSE`.
+  Stops the timer, leaving it on screen. Raises outside a gym level.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+
+- [lua]`trx.assault.finish([track])`  
+  Stops the timer as completing the track does, rather than as an abort. Raises outside a gym level.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
 - [lua]`trx.assault.reset([track])`  
-    Stops the given timer and clears its state. Defaults to `trx.assault.Track.COURSE`.
+  Stops the timer and clears its state. Raises outside a gym level.
 
-## Assault course stats
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
-### Functions
+- [lua]`trx.assault.is_running([track])`  
+  Whether the timer is counting. False outside a gym level.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+
+  Returns: boolean.
+
+- [lua]`trx.assault.is_visible([track])`  
+  Whether the timer is shown on screen. It stays visible after `stop`.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
+
+  Returns: boolean.
 
 - [lua]`trx.assault.stats.add_record(time)`  
-    Adds a new record with the given time in seconds. Increments the internal attempt number.
+  Files a new record, inserting it in time order and bumping the attempt count.
+
+  Parameters:
+  - **`time`** (number). Time in seconds. Must be greater than zero.
+
+  Returns: boolean. `false` if the table is full and the time is slower than every record in it.
+
+  Example:
+  ```lua
+  trx.assault.stats.add_record(30.0)
+  ```
 
 - [lua]`trx.assault.stats.remove_record(record_id)`  
-    Removes a record at the given position, with ids starting from 1.
+  Removes a record, closing the gap behind it.
+
+  Parameters:
+  - **`record_id`** (integer). 1-based position in the table.
+
+  Returns: boolean. `false` if there is no record at that position.
 
 - [lua]`trx.assault.stats.list_records()`  
-    Returns a list of record times.
-    Structure:
-    - `time`: time in seconds.
-    - `attempt_num`: which attempt this was.
+  The records, fastest first.
+
+  Returns: table. List of `{ time = seconds, attempt_num = which attempt it was }`.
+
+  Example:
+  ```lua
+  for _, record in ipairs(trx.assault.stats.list_records()) do
+    trx.log.info(("attempt %d: %.2fs"):format(record.attempt_num, record.time))
+  end
+  ```

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -155,6 +155,18 @@ test_lua_items_exe = executable(
 )
 test('lua_items', test_lua_items_exe, suite: 'unit')
 
+test_lua_assault_exe = executable(
+  'test_lua_assault',
+  files('unit/test_lua_assault.c', 'unit/fake_engine_assault.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/lua/assault.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_assault', test_lua_assault_exe, suite: 'unit')
+
 # rooms rides along: trx.camera.room hands back a trx.rooms.Room.
 test_lua_camera_exe = executable(
   'test_lua_camera',

--- a/src/tests/unit/fake_engine_assault.c
+++ b/src/tests/unit/fake_engine_assault.c
@@ -1,0 +1,104 @@
+// The gym track manager, reduced to the flags the surface can see, plus the
+// record table - which lives in the player's config, not in the level.
+
+#include "fake_engine_assault.h"
+
+#include <trx/config/types.h>
+#include <trx/config/vars.h>
+
+#include <stdbool.h>
+
+CONFIG g_Config;
+FAKE_ASSAULT_CALLS g_FakeAssaultCalls;
+
+static bool m_InGym;
+static bool m_Running[GYM_TRACK_NUMBER_OF];
+static bool m_Visible[GYM_TRACK_NUMBER_OF];
+static GYM_TRACK_TYPE m_ActiveTrack;
+
+bool Game_IsInGym(void)
+{
+    return m_InGym;
+}
+
+bool Config_Update(void)
+{
+    g_FakeAssaultCalls.config_writes++;
+    return true;
+}
+
+bool Gym_TrackManager_HasStats(const GYM_TRACK_TYPE track)
+{
+    return m_InGym;
+}
+
+GYM_TRACK_TYPE Gym_TrackManager_GetActiveTrackType(void)
+{
+    return m_ActiveTrack;
+}
+
+bool Gym_TrackManager_IsTimerActive(const GYM_TRACK_TYPE track)
+{
+    return m_Running[track];
+}
+
+bool Gym_TrackManager_IsTimerDisplay(const GYM_TRACK_TYPE track)
+{
+    return m_Visible[track];
+}
+
+void Gym_TrackManager_Start(const GYM_TRACK_TYPE track)
+{
+    g_FakeAssaultCalls.start++;
+    g_FakeAssaultCalls.last_track = track;
+}
+
+void Gym_TrackManager_Stop(const GYM_TRACK_TYPE track)
+{
+    g_FakeAssaultCalls.stop++;
+    g_FakeAssaultCalls.last_track = track;
+}
+
+void Gym_TrackManager_Reset(const GYM_TRACK_TYPE track)
+{
+    g_FakeAssaultCalls.reset++;
+    g_FakeAssaultCalls.last_track = track;
+}
+
+void Gym_TrackManager_Finish(const GYM_TRACK_TYPE track)
+{
+    g_FakeAssaultCalls.finish++;
+    g_FakeAssaultCalls.last_track = track;
+}
+
+void FakeAssault_Reset(void)
+{
+    g_Config = (CONFIG) {};
+    g_FakeAssaultCalls = (FAKE_ASSAULT_CALLS) {};
+    m_InGym = true;
+    m_ActiveTrack = GYM_TRACK_NONE;
+    for (int32_t i = 0; i < GYM_TRACK_NUMBER_OF; i++) {
+        m_Running[i] = false;
+        m_Visible[i] = false;
+    }
+}
+
+void FakeAssault_SetInGym(const bool in_gym)
+{
+    m_InGym = in_gym;
+}
+
+void FakeAssault_SetRunning(const GYM_TRACK_TYPE track, const bool running)
+{
+    m_Running[track] = running;
+}
+
+void FakeAssault_SetVisible(const GYM_TRACK_TYPE track, const bool visible)
+{
+    m_Visible[track] = visible;
+}
+
+void FakeAssault_SetActiveTrack(const GYM_TRACK_TYPE track)
+{
+    m_ActiveTrack = track;
+}

--- a/src/tests/unit/fake_engine_assault.h
+++ b/src/tests/unit/fake_engine_assault.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <trx/game/gym.h>
+
+#include <stdint.h>
+
+// What the surface asked the track manager to do, recorded rather than
+// performed. The track is remembered because every verb takes one, and getting
+// the default wrong is the easiest mistake for a declaration to make.
+typedef struct {
+    int32_t start;
+    int32_t stop;
+    int32_t reset;
+    int32_t finish;
+    GYM_TRACK_TYPE last_track;
+    int32_t config_writes;
+} FAKE_ASSAULT_CALLS;
+
+extern FAKE_ASSAULT_CALLS g_FakeAssaultCalls;
+
+void FakeAssault_Reset(void);
+
+// Outside a gym level the timers do not exist, and every verb raises.
+void FakeAssault_SetInGym(bool in_gym);
+void FakeAssault_SetRunning(GYM_TRACK_TYPE track, bool running);
+void FakeAssault_SetVisible(GYM_TRACK_TYPE track, bool visible);
+void FakeAssault_SetActiveTrack(GYM_TRACK_TYPE track);

--- a/src/tests/unit/lua/assault.lua
+++ b/src/tests/unit/lua/assault.lua
@@ -1,0 +1,154 @@
+-- The assault course API as a script actually sees it.
+--
+-- trx.assault.stats is an api.namespace that is not callable, and every verb
+-- takes an optional track, so this is where the default-track path is pinned.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("a verb with no track means the assault course", function()
+  trx.assault.start()
+  local calls = fake.calls()
+  assert(calls.start == 1, "start did not reach the track manager")
+  assert(calls.last_track == trx.assault.Track.COURSE, "the default track must be the course")
+end)
+
+test("a verb takes the track it is given", function()
+  trx.assault.start(trx.assault.Track.QUAD)
+  assert(fake.calls().last_track == trx.assault.Track.QUAD)
+
+  trx.assault.stop(trx.assault.Track.COURSE)
+  local calls = fake.calls()
+  assert(calls.stop == 1)
+  assert(calls.last_track == trx.assault.Track.COURSE)
+end)
+
+test("finish is not stop", function()
+  -- Completing the track and abandoning it are different endings; the surface
+  -- could reach only the second one.
+  trx.assault.finish()
+  local calls = fake.calls()
+  assert(calls.finish == 1, "finish did not reach the track manager")
+  assert(calls.stop == 0, "finish must not be a stop")
+end)
+
+test("reset clears the timer", function()
+  trx.assault.reset()
+  assert(fake.calls().reset == 1)
+end)
+
+test("the timers do not exist outside a gym level", function()
+  fake.set_in_gym(false)
+  for _, verb in ipairs({ "start", "stop", "reset", "finish" }) do
+    raises(function()
+      trx.assault[verb]()
+    end)
+  end
+  assert(fake.calls().start == 0, "a verb outside the gym must not reach the engine")
+end)
+
+test("is_running and is_visible answer without raising outside a gym", function()
+  -- Asking whether a timer runs is a fair question anywhere. The answer outside
+  -- a gym is false, not an error.
+  fake.set_in_gym(false)
+  assert(trx.assault.is_running() == false)
+  assert(trx.assault.is_visible() == false)
+end)
+
+test("is_running follows the timer", function()
+  assert(trx.assault.is_running() == false)
+  fake.set_running(trx.assault.Track.COURSE, true)
+  assert(trx.assault.is_running() == true)
+  -- Per track, not global.
+  assert(trx.assault.is_running(trx.assault.Track.QUAD) == false)
+end)
+
+test("is_visible is not is_running: a stopped timer stays on screen", function()
+  fake.set_visible(trx.assault.Track.COURSE, true)
+  assert(trx.assault.is_visible() == true)
+  assert(trx.assault.is_running() == false)
+end)
+
+test("active_track is nil when Lara is running nothing", function()
+  assert(trx.assault.active_track == nil, "no track means nil, not zero")
+
+  -- QUAD is 0 in the C enum, so a naive bridge would report it as nothing.
+  fake.set_active_track(trx.assault.Track.QUAD)
+  assert(trx.assault.active_track == trx.assault.Track.QUAD, "QUAD is 0 and must survive")
+
+  fake.set_active_track(trx.assault.Track.COURSE)
+  assert(trx.assault.active_track == trx.assault.Track.COURSE)
+end)
+
+test("active_track is read-only", function()
+  raises(function()
+    trx.assault.active_track = trx.assault.Track.QUAD
+  end, "read-only")
+end)
+
+test("records go in fastest first, and carry the attempt they came from", function()
+  assert(trx.assault.stats.add_record(30.0) == true)
+  assert(trx.assault.stats.add_record(20.0) == true)
+  assert(trx.assault.stats.add_record(40.0) == true)
+
+  local records = trx.assault.stats.list_records()
+  assert(#records == 3, "wrong number of records")
+  assert(records[1].time == 20.0, "records must be sorted by time")
+  assert(records[2].time == 30.0)
+  assert(records[3].time == 40.0)
+
+  -- The attempt number counts entries filed, not the position in the table.
+  assert(records[1].attempt_num == 2, "the 20s run was the second attempt")
+  assert(records[2].attempt_num == 1)
+  assert(records[3].attempt_num == 3)
+end)
+
+test("a record is written through to the player's profile", function()
+  trx.assault.stats.add_record(30.0)
+  assert(fake.calls().config_writes == 1, "the record was not persisted")
+end)
+
+test("removing a record closes the gap behind it", function()
+  trx.assault.stats.add_record(10.0)
+  trx.assault.stats.add_record(20.0)
+  trx.assault.stats.add_record(30.0)
+
+  assert(trx.assault.stats.remove_record(2) == true)
+
+  local records = trx.assault.stats.list_records()
+  assert(#records == 2)
+  assert(records[1].time == 10.0)
+  assert(records[2].time == 30.0, "the gap was not closed")
+end)
+
+test("removing a record that is not there reports false", function()
+  assert(trx.assault.stats.remove_record(1) == false, "there is nothing to remove")
+
+  trx.assault.stats.add_record(10.0)
+  assert(trx.assault.stats.remove_record(2) == false, "slot 2 is empty")
+  assert(trx.assault.stats.remove_record(1) == true)
+end)
+
+test("records are 1-based, and out of range raises", function()
+  raises(function()
+    trx.assault.stats.remove_record(0)
+  end)
+  raises(function()
+    trx.assault.stats.remove_record(11)
+  end)
+end)
+
+test("a time of zero or less raises", function()
+  raises(function()
+    trx.assault.stats.add_record(0)
+  end)
+  raises(function()
+    trx.assault.stats.add_record(-1)
+  end)
+end)
+
+test("stats is a table, not a function", function()
+  assert(type(trx.assault.stats) == "table")
+end)
+
+return h.report()

--- a/src/tests/unit/test_lua_assault.c
+++ b/src/tests/unit/test_lua_assault.c
@@ -1,0 +1,91 @@
+// The assault course surface. The assertions live in
+// src/tests/unit/lua/assault.lua; this stands up the world they run against.
+
+#include "fake_engine_assault.h"
+#include "lua_surface.h"
+
+#include <lauxlib.h>
+
+extern void LUA_CreateAssault(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateAssault(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeAssault_Reset();
+    return 0;
+}
+
+static int M_FakeSetInGym(lua_State *const L)
+{
+    FakeAssault_SetInGym(lua_toboolean(L, 1));
+    return 0;
+}
+
+static int M_FakeSetRunning(lua_State *const L)
+{
+    FakeAssault_SetRunning(
+        (GYM_TRACK_TYPE)luaL_checkinteger(L, 1), lua_toboolean(L, 2));
+    return 0;
+}
+
+static int M_FakeSetVisible(lua_State *const L)
+{
+    FakeAssault_SetVisible(
+        (GYM_TRACK_TYPE)luaL_checkinteger(L, 1), lua_toboolean(L, 2));
+    return 0;
+}
+
+static int M_FakeSetActiveTrack(lua_State *const L)
+{
+    FakeAssault_SetActiveTrack(
+        lua_isnil(L, 1) ? GYM_TRACK_NONE
+                        : (GYM_TRACK_TYPE)luaL_checkinteger(L, 1));
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, g_FakeAssaultCalls.start);
+    lua_setfield(L, -2, "start");
+    lua_pushinteger(L, g_FakeAssaultCalls.stop);
+    lua_setfield(L, -2, "stop");
+    lua_pushinteger(L, g_FakeAssaultCalls.reset);
+    lua_setfield(L, -2, "reset");
+    lua_pushinteger(L, g_FakeAssaultCalls.finish);
+    lua_setfield(L, -2, "finish");
+    lua_pushinteger(L, g_FakeAssaultCalls.last_track);
+    lua_setfield(L, -2, "last_track");
+    lua_pushinteger(L, g_FakeAssaultCalls.config_writes);
+    lua_setfield(L, -2, "config_writes");
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+    lua_pushcfunction(L, M_FakeSetInGym);
+    lua_setfield(L, -2, "set_in_gym");
+    lua_pushcfunction(L, M_FakeSetRunning);
+    lua_setfield(L, -2, "set_running");
+    lua_pushcfunction(L, M_FakeSetVisible);
+    lua_setfield(L, -2, "set_visible");
+    lua_pushcfunction(L, M_FakeSetActiveTrack);
+    lua_setfield(L, -2, "set_active_track");
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "assault",
+        .tests = "assault",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -4,6 +4,7 @@
 #include <trx/game/game_buf.h>
 #include <trx/game/game_flow/types.h>
 #include <trx/game/gun/types.h>
+#include <trx/game/gym.h>
 #include <trx/game/input/enum.h>
 #include <trx/game/items/enum.h>
 #include <trx/game/lara/skin/types.h>
@@ -61,6 +62,11 @@ static __attribute__((constructor)) void M_Init(void)
     ENUM_MAP(GAME_BUFFER, GBUF_SAMPLE_INFOS, "Sample information");
     ENUM_MAP(GAME_BUFFER, GBUF_SAMPLES, "Samples");
     ENUM_MAP(GAME_BUFFER, GBUF_WALKABLES, "Walkables buffer");
+
+    // GYM_TRACK_NONE and GYM_TRACK_NUMBER_OF are sentinels, not tracks: leaving
+    // them unmapped keeps them out of trx.assault.Track.
+    ENUM_MAP(GYM_TRACK_TYPE, GYM_TRACK_ASSAULT, "course");
+    ENUM_MAP(GYM_TRACK_TYPE, GYM_TRACK_QUAD, "quad");
 
     ENUM_MAP(ITEM_STATUS, IS_INACTIVE, "inactive");
     ENUM_MAP(ITEM_STATUS, IS_ACTIVE, "active");

--- a/src/trx/game/lua/assault.c
+++ b/src/trx/game/lua/assault.c
@@ -120,6 +120,44 @@ static int M_L_AssaultReset(lua_State *const L)
     return 0;
 }
 
+// trxc.assault.finish([track])
+static int M_L_AssaultFinish(lua_State *const L)
+{
+    const GYM_TRACK_TYPE track = M_GetTrack(L);
+    M_CheckTimerAvailable(L, track);
+    Gym_TrackManager_Finish(track);
+    return 0;
+}
+
+// trxc.assault.is_running([track]) -> bool
+//
+// No availability check: asking whether a timer runs is a fair question outside
+// a gym level, and the answer there is simply false.
+static int M_L_AssaultIsRunning(lua_State *const L)
+{
+    lua_pushboolean(L, Gym_TrackManager_IsTimerActive(M_GetTrack(L)));
+    return 1;
+}
+
+// trxc.assault.is_visible([track]) -> bool
+static int M_L_AssaultIsVisible(lua_State *const L)
+{
+    lua_pushboolean(L, Gym_TrackManager_IsTimerDisplay(M_GetTrack(L)));
+    return 1;
+}
+
+// trxc.assault.get_active_track() -> track or nil
+static int M_L_AssaultGetActiveTrack(lua_State *const L)
+{
+    const GYM_TRACK_TYPE track = Gym_TrackManager_GetActiveTrackType();
+    if (track == GYM_TRACK_NONE) {
+        lua_pushnil(L);
+    } else {
+        lua_pushinteger(L, (lua_Integer)track);
+    }
+    return 1;
+}
+
 static int M_L_AssaultRecord(lua_State *const L)
 {
     if (!Gym_TrackManager_HasStats(GYM_TRACK_ASSAULT)) {
@@ -193,6 +231,14 @@ void LUA_CreateAssault(lua_State *const L)
     lua_setfield(L, -2, "stop");
     lua_pushcfunction(L, M_L_AssaultReset);
     lua_setfield(L, -2, "reset");
+    lua_pushcfunction(L, M_L_AssaultFinish);
+    lua_setfield(L, -2, "finish");
+    lua_pushcfunction(L, M_L_AssaultIsRunning);
+    lua_setfield(L, -2, "is_running");
+    lua_pushcfunction(L, M_L_AssaultIsVisible);
+    lua_setfield(L, -2, "is_visible");
+    lua_pushcfunction(L, M_L_AssaultGetActiveTrack);
+    lua_setfield(L, -2, "get_active_track");
 
     lua_newtable(L);
     lua_pushcfunction(L, M_L_AssaultRecord);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates the assault course LUA API to the new `api` framework and adds tests.