### PR TITLE
Migrate Lara LUA API

### DIFF
--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -37,6 +37,8 @@ local namespaces = {}
 local namespace_order = {}
 -- module -> { name -> spec }. What the module's __index dispatches on.
 local module_properties = {}
+-- module -> function returning the handle it stands for.
+local module_instances = {}
 local strict_enabled = false
 local sealed = false
 
@@ -76,12 +78,74 @@ local function resolve(path)
   return module, namespace, parts[3]
 end
 
+-- A module is a plain table, and api.define rawsets its functions straight into
+-- it, so they are found before any of this runs. What this adds is the members a
+-- table cannot hold: computed properties, and - for a module that stands for a
+-- single C struct, as trx.lara stands for Lara - that struct's own fields.
+--
+-- The registry owns the metatable, so a member nobody declared is unreachable
+-- rather than merely undocumented. That matters most here: neither a metatable
+-- getter nor a struct field ever shows up in pairs(), so seal()'s audit cannot
+-- see one.
+local function install_module_meta(module)
+  local props = module_properties[module]
+  local instance = module_instances[module]
+  if props == nil and instance == nil then
+    return
+  end
+
+  trx[module] = trx[module] or {}
+  setmetatable(trx[module], {
+    __index = function(_, key)
+      local prop = props ~= nil and props[key] or nil
+      if prop ~= nil then
+        return prop.get()
+      end
+      if instance ~= nil then
+        local handle = instance()
+        if handle ~= nil then
+          return handle[key]
+        end
+      end
+      return nil
+    end,
+    __newindex = function(_, key, value)
+      local prop = props ~= nil and props[key] or nil
+      if prop ~= nil then
+        if prop.set == nil then
+          error("trx." .. module .. "." .. tostring(key) .. " is read-only", 2)
+        end
+        prop.set(value)
+        return
+      end
+      if instance ~= nil then
+        local handle = instance()
+        if handle ~= nil then
+          -- The struct raises on a member it does not expose, which is what
+          -- makes an undeclared field unreachable rather than silently dropped.
+          handle[key] = value
+          return
+        end
+      end
+      error("Cannot set field '" .. tostring(key) .. "' on trx." .. module, 2)
+    end,
+  })
+end
+
 function api.module(name, spec)
   assert(type(name) == "string", "api.module: name must be a string")
   if modules[name] == nil then
     table.insert(module_order, name)
   end
   modules[name] = spec or {}
+
+  -- A module that stands for one C struct reads and writes that struct's fields
+  -- directly: trx.lara.air is Lara's air. `instance` hands back the handle.
+  if modules[name].instance ~= nil then
+    assert(type(modules[name].instance) == "function", "api.module: instance must be a function")
+    module_instances[name] = modules[name].instance
+    install_module_meta(name)
+  end
 end
 
 -- Builds a specialized validating wrapper by generating Lua source for this
@@ -342,6 +406,17 @@ end
 -- Unlike a struct, an enum is small and wholly public: there is nothing to hide,
 -- so exposure is not opt-in. Every constant must be documented, and documenting
 -- one that does not exist is an error.
+-- The name a constant goes by in Lua. `strip` takes a prefix off the reflected
+-- name: the C spelling is what the data files are keyed by and cannot move, but
+-- trx.lara.ExtraMesh.EXTRA_MESH_OAR only says EXTRA_MESH twice.
+function api.enum_name(spec, reflected_name)
+  local strip = spec.strip
+  if strip ~= nil and reflected_name:sub(1, #strip) == strip then
+    return reflected_name:sub(#strip + 1)
+  end
+  return reflected_name
+end
+
 function api.enum(path, spec)
   assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
   assert(type(spec) == "table", "api.enum: spec must be a table")
@@ -352,9 +427,16 @@ function api.enum(path, spec)
   local public = {}
   local reflected = {}
   for _, constant in ipairs(enum.values(spec.backing)) do
-    assert(spec.values[constant.name] ~= nil, "api.enum: " .. path .. "." .. constant.name .. " is not documented")
-    public[constant.name] = constant.value
-    reflected[constant.name] = true
+    local value_name = api.enum_name(spec, constant.name)
+    -- Stripping a prefix can collide two C constants onto one Lua name, and the
+    -- second would quietly take the first one's place.
+    assert(
+      public[value_name] == nil,
+      "api.enum: " .. path .. "." .. value_name .. " is the name of two constants of " .. spec.backing
+    )
+    assert(spec.values[value_name] ~= nil, "api.enum: " .. path .. "." .. value_name .. " is not documented")
+    public[value_name] = constant.value
+    reflected[value_name] = true
   end
 
   for value_name in pairs(spec.values) do
@@ -410,34 +492,14 @@ function api.property(path, spec)
   end
   properties[path] = spec
 
-  trx[module] = trx[module] or {}
   local props = module_properties[module]
   if props == nil then
     props = {}
     module_properties[module] = props
-    -- api.define uses rawset, so declared functions sit in the table itself and
-    -- are found before __index ever runs.
-    setmetatable(trx[module], {
-      __index = function(_, key)
-        local prop = props[key]
-        if prop == nil then
-          return nil
-        end
-        return prop.get()
-      end,
-      __newindex = function(_, key, value)
-        local prop = props[key]
-        if prop == nil then
-          error("Cannot set field '" .. key .. "' on trx." .. module, 2)
-        end
-        if prop.set == nil then
-          error("trx." .. module .. "." .. tostring(key) .. " is read-only", 2)
-        end
-        prop.set(value)
-      end,
-    })
   end
   props[name] = spec
+
+  install_module_meta(module)
   return spec
 end
 
@@ -515,10 +577,11 @@ function api.describe()
     local spec = enums[path]
     local entry = { path = path, description = spec.description, values = {} }
     for _, constant in ipairs(enum.values(spec.backing)) do
+      local value_name = api.enum_name(spec, constant.name)
       table.insert(entry.values, {
-        name = constant.name,
+        name = value_name,
         value = constant.value,
-        description = spec.values[constant.name],
+        description = spec.values[value_name],
       })
     end
     -- Numeric order: the order the constants are meant to be read in, and stable

--- a/data/scripting/lara.lua
+++ b/data/scripting/lara.lua
@@ -1,54 +1,266 @@
 local raw = trxc.lara
+local api = trx.api
 
-local lara = {
-  set_extra_equipment = raw.set_extra_equipment,
-  clear_equipment = raw.clear_equipment,
-  mesh = raw.mesh,
-  extra_mesh = raw.extra_mesh,
-}
+-- trx.lara stands for one C struct, so reading trx.lara.air reads Lara's air.
+-- What is reachable is what lara.Lara declares below, and nothing else.
+api.module("lara", {
+  order = 3,
+  description = "Module for reading and nudging Lara's own state.\n\n"
+    .. "Her position, room and hit points are not here: she is an item like any other and they "
+    .. "live on it, as `trx.lara.item`.",
+  instance = raw.state,
+})
 
--- Item proxy metatable
-local getters = {
-  exposure_bar = raw.get_exposure_bar,
-  air_bar = raw.get_air_bar,
-  outfit = raw.get_outfit,
-  holsters_visible = raw.are_holsters_visible,
-  has_pistol_weapon = raw.has_pistol_weapon,
-  equipped_gun = raw.get_equipped_gun,
-  extra_anim = raw.get_extra_anim,
-  item = function()
+api.enum("lara.Mesh", {
+  backing = "LARA_MESH",
+  description = "One of the fifteen meshes Lara is built from.",
+  values = {
+    HIPS = "Hips, the mesh the rest hang off.",
+    THIGH_L = "Left thigh.",
+    CALF_L = "Left calf.",
+    FOOT_L = "Left foot.",
+    THIGH_R = "Right thigh.",
+    CALF_R = "Right calf.",
+    FOOT_R = "Right foot.",
+    TORSO = "Torso.",
+    UARM_R = "Right upper arm.",
+    LARM_R = "Right lower arm.",
+    HAND_R = "Right hand.",
+    UARM_L = "Left upper arm.",
+    LARM_L = "Left lower arm.",
+    HAND_L = "Left hand.",
+    HEAD = "Head.",
+  },
+})
+
+-- The C names carry an EXTRA_MESH_ prefix, because cfg/outfits.json5 is keyed by
+-- those exact strings and cannot move. Strip it here rather than say it twice.
+api.enum("lara.ExtraMesh", {
+  backing = "LARA_SKIN_EXTRA_MESH",
+  strip = "EXTRA_MESH_",
+  description = "A mesh Lara can carry on top of one of her own - the dagger in Home Sweet Home, "
+    .. "the oar in a boat.",
+  values = {
+    TR1_BRAID_DEFAULT_HEAD = "Braided head, out of combat.",
+    TR1_BRAID_COMBAT_HEAD = "Braided head, in combat.",
+    TR1_BRAID_DEFAULT_TORSO = "Braided torso.",
+    TR1_BRAID_MAULED_TORSO = "Braided torso, mauled.",
+    TR1_BRAID_GOLD_HEAD = "Braided head, gold.",
+    TR1_BRAID_GOLD_TORSO = "Braided torso, gold.",
+    DAGGER_HAND = "Dagger, in hand.",
+    DAGGER_HIPS = "Dagger, sheathed at the hips.",
+    OAR = "Oar.",
+    SPANNER = "Spanner.",
+    DRINK_CAN = "Drink can.",
+    GLASSES_OPAQUE = "Sunglasses.",
+    GLASSES_TRANSPARENT = "Sunglasses, transparent lenses.",
+    CROWBAR = "Crowbar.",
+  },
+})
+
+api.enum("lara.WaterState", {
+  backing = "LARA_WATER_STATE",
+  description = "Where Lara is with respect to water.",
+  values = {
+    ABOVE_WATER = "On dry land.",
+    UNDERWATER = "Under the surface.",
+    SURFACE = "Swimming at the surface.",
+    WADE = "Wading, feet still on the floor.",
+    CHEAT = "Flying, as the fly cheat leaves her.",
+  },
+})
+
+api.enum("lara.GunState", {
+  backing = "LARA_GUN_STATE",
+  description = "What Lara's hands are doing.",
+  values = {
+    ARMLESS = "Empty-handed.",
+    HANDS_BUSY = "Hands full, so nothing can be drawn.",
+    DRAW = "Drawing a weapon.",
+    UNDRAW = "Putting one away.",
+    READY = "Armed, weapon out.",
+    SPECIAL = "In a scripted sequence.",
+  },
+})
+
+-- The fields of LARA_INFO, named for scripts. The C side says where each member
+-- lives (see src/trx/game/lara/fields.c); this says which of them exist.
+api.type("lara.Lara", {
+  backing = "LARA_INFO",
+  description = "Lara's own state, reachable straight off `trx.lara`.",
+
+  fields = {
+    air_bar = {
+      from = "air",
+      type = "integer",
+      description = "Air remaining underwater, out of 1800. Runs down while she is under.",
+    },
+    exposure_bar = {
+      from = "exposure_timer",
+      type = "integer",
+      description = "Warmth remaining in the cold, out of 600. Only moves in a level whose rooms "
+        .. "carry the `damaging` flag.",
+    },
+    poison = {
+      from = "poison.value",
+      type = "integer",
+      description = "How poisoned Lara is, and 0 when she is not.",
+    },
+    electric = {
+      from = "electric",
+      type = "integer",
+      description = "How badly Lara is being electrocuted, and 0 when she is not.",
+    },
+    is_burning = {
+      from = "burn",
+      type = "boolean",
+      writable = false,
+      description = "Whether Lara is on fire.",
+    },
+    is_crouched = {
+      from = "is_crouched",
+      type = "boolean",
+      writable = false,
+      description = "Whether Lara is crouching.",
+    },
+    is_climbing = {
+      from = "climb_status",
+      type = "boolean",
+      writable = false,
+      description = "Whether Lara is on a climbable wall.",
+    },
+    water_status = {
+      from = "water_status",
+      type = "integer",
+      writable = false,
+      enum = "lara.WaterState",
+      description = "Where Lara is with respect to water.",
+    },
+    gun_status = {
+      from = "gun_status",
+      type = "integer",
+      writable = false,
+      enum = "lara.GunState",
+      description = "What Lara's hands are doing.",
+    },
+    equipped_gun = {
+      from = "gun_type",
+      type = "integer",
+      writable = false,
+      enum = "catalog.weapons",
+      description = "The weapon Lara is holding.",
+    },
+    requested_gun = {
+      from = "request_gun_type",
+      type = "integer",
+      writable = false,
+      enum = "catalog.weapons",
+      description = "The weapon Lara is drawing, while she is drawing it.",
+    },
+    extra_anim = {
+      from = "extra_anim",
+      type = "boolean",
+      writable = false,
+      description = "Whether a scripted animation is driving Lara rather than her own state " .. "machine.",
+    },
+    killed_loyal_item = {
+      from = "killed_loyal_item",
+      type = "boolean",
+      writable = false,
+      description = "Whether Lara has killed one of her own allies, which is what turns the rest " .. "of them on her.",
+    },
+    dive_timer = {
+      from = "dive_timer",
+      type = "integer",
+      writable = false,
+      description = "Frames Lara has been diving for.",
+    },
+    death_timer = {
+      from = "death_timer",
+      type = "integer",
+      writable = false,
+      description = "Frames Lara has been dead for.",
+    },
+    sprint_timer = {
+      from = "sprint_timer",
+      type = "integer",
+      description = "Sprint left in her legs.",
+    },
+    hit_direction = {
+      from = "hit_direction",
+      type = "integer",
+      writable = false,
+      description = "Which way the last hit came from, or -1 if she has not been hit.",
+    },
+    pose_count = {
+      from = "pose_count",
+      type = "integer",
+      writable = false,
+      description = "Frames Lara has stood still for, which is what starts an idle animation.",
+    },
+  },
+})
+
+api.property("lara.item", {
+  type = "Item",
+  description = "Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit "
+    .. "points are read and written there.",
+  get = function()
     return trx.items[raw.get_item()]
   end,
-  target = function()
+})
+
+api.property("lara.target", {
+  type = "Item",
+  description = "The item Lara's guns are locked onto, or `nil` if she has none.",
+  get = function()
     local target = raw.get_target()
-    if target == nil then
-      return nil
-    end
-    return trx.items[target]
+    return target ~= nil and trx.items[target] or nil
   end,
-}
+})
 
-local setters = {
-  exposure_bar = raw.set_exposure_bar,
-  air_bar = raw.set_air_bar,
-  outfit = raw.set_outfit,
-  holsters_visible = raw.set_holsters_visible,
-}
+api.property("lara.outfit", {
+  type = "string",
+  description = "The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.",
+  get = raw.get_outfit,
+  set = raw.set_outfit,
+})
 
-local lara_mt = {
-  __index = function(self, key)
-    local getter = getters[key]
-    return getter and getter() or nil
-  end,
-  __newindex = function(self, key, value)
-    local setter = setters[key]
-    if setter then
-      setter(value)
-      return
-    end
-    error("Cannot set field '" .. key .. "' on trx.lara", 2)
-  end,
-}
+api.property("lara.holsters_visible", {
+  type = "boolean",
+  description = "Whether Lara's holsters are drawn on her hips.",
+  get = raw.are_holsters_visible,
+  set = raw.set_holsters_visible,
+})
 
-setmetatable(lara, lara_mt)
-trx.lara = lara
+api.property("lara.has_pistol_weapon", {
+  type = "boolean",
+  description = "Whether Lara is carrying a pistol-class weapon, which is what decides whether she "
+    .. "has holsters to show at all.",
+  get = raw.has_pistol_weapon,
+})
+
+api.define("lara.set_extra_equipment", {
+  description = "Hangs an extra mesh on one of Lara's own, replacing whatever is there.",
+  params = {
+    { name = "mesh", type = "integer", enum = "lara.Mesh", description = "Which of Lara's meshes." },
+    {
+      name = "extra_mesh",
+      type = "integer",
+      enum = "lara.ExtraMesh",
+      description = "The mesh to hang on it.",
+    },
+  },
+  examples = {
+    [[trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)]],
+  },
+  impl = raw.set_extra_equipment,
+})
+
+api.define("lara.clear_equipment", {
+  description = "Takes the extra mesh back off, leaving Lara's own.",
+  params = {
+    { name = "mesh", type = "integer", enum = "lara.Mesh", description = "Which of Lara's meshes." },
+  },
+  impl = raw.clear_equipment,
+})

--- a/data/trx/ship/games/tr2/scripts/house.lua
+++ b/data/trx/ship/games/tr2/scripts/house.lua
@@ -1,6 +1,6 @@
 trx.events.on_game_start(function(level, is_save)
   trx.lara.holsters_visible = trx.lara.has_pistol_weapon
   if trx.lara.extra_anim == -1 then
-    trx.lara.set_extra_equipment(trx.lara.mesh.hips, trx.lara.extra_mesh.dagger_hips)
+    trx.lara.set_extra_equipment(trx.lara.Mesh.HIPS, trx.lara.ExtraMesh.DAGGER_HIPS)
   end
 end)

--- a/data/trx/ship/games/tr3/scripts/cut8.lua
+++ b/data/trx/ship/games/tr3/scripts/cut8.lua
@@ -4,7 +4,7 @@ local equipment_set = false
 trx.events.after_control(function()
   local lara_item = trx.lara.item
   if lara_item.frame >= drink_frame_num and not equipment_set then
-    trx.lara.set_extra_equipment(trx.lara.mesh.hand_r, trx.lara.extra_mesh.drink_can)
+    trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.DRINK_CAN)
     equipment_set = true
   end
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- added new Lua Lara state, `trx.lara.poison`, `trx.lara.electric`, `trx.lara.is_burning`, `trx.lara.is_crouched`, `trx.lara.is_climbing`, `trx.lara.water_status`, `trx.lara.gun_status` and the dive, death, sprint and pose timers
+- changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`; refer to migration notes
 - added new Lua config functions, `trx.config.override()`, `trx.config.restore()` and `trx.config.is_overridden()`, to change a setting without overwriting the player's own value
 - changed `trx.config.get()` to return the option's own type rather than always a string; refer to migration notes
 - added new Lua assault course functions, `trx.assault.finish()`, `trx.assault.is_running()` and `trx.assault.is_visible()`, and a new property, `trx.assault.active_track`

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -46,7 +46,13 @@ order: 3
    hook. The nine hooks are the whole API, and attaching is unchanged:
    `trx.events.before_control(fn)`.
 
-4. **Update scripts that compare `trx.config.get()` against a string**
+4. **Update scripts that use Lara's mesh tables**
+   `trx.lara.mesh` and `trx.lara.extra_mesh` became declared enums, so their
+   names are upper case: replace `trx.lara.mesh.hand_r` with
+   `trx.lara.Mesh.HAND_R`, and `trx.lara.extra_mesh.oar` with
+   `trx.lara.ExtraMesh.OAR`.
+
+5. **Update scripts that compare `trx.config.get()` against a string**
    It returns the option's own type now: a boolean option reads as a boolean and
    a number as a number. Replace `trx.config.get("flow.cheat_keys") == "true"`
    with `trx.config.get("flow.cheat_keys")`. Colors and enums are still strings.
@@ -56,15 +62,15 @@ order: 3
    while it is running - it leaves the player's own value underneath, and
    `trx.config.restore()` puts it back.
 
-5. **Update scripts that use `trx.console.log.LogLevel`**
+6. **Update scripts that use `trx.console.log.LogLevel`**
    It was removed. Use `trx.log.LogLevel`, which is the same enum:
    `trx.console.log.generic(trx.log.LogLevel.ERROR, "...")`.
 
-6. **Update scripts that call `trx.music.play_track`**
+7. **Update scripts that call `trx.music.play_track`**
    It was an undocumented alias of `trx.music.play` and was removed. Use
    `trx.music.play(id[, opts])`.
 
-7. **Update scripts that set `pickup_mode`**
+8. **Update scripts that set `pickup_mode`**
    The `trx.pickup` module is gone. `pickup_mode` is an item property, so its
    enum now lives with the items: replace `trx.pickup.Mode.PLINTH_LOW` with
    `trx.items.PickupMode.PLINTH_LOW`.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -112,6 +112,230 @@
       ]
     },
     {
+      "description": "One of the fifteen meshes Lara is built from.",
+      "path": "lara.Mesh",
+      "values": [
+        {
+          "description": "Hips, the mesh the rest hang off.",
+          "name": "HIPS",
+          "value": 0
+        },
+        {
+          "description": "Left thigh.",
+          "name": "THIGH_L",
+          "value": 1
+        },
+        {
+          "description": "Left calf.",
+          "name": "CALF_L",
+          "value": 2
+        },
+        {
+          "description": "Left foot.",
+          "name": "FOOT_L",
+          "value": 3
+        },
+        {
+          "description": "Right thigh.",
+          "name": "THIGH_R",
+          "value": 4
+        },
+        {
+          "description": "Right calf.",
+          "name": "CALF_R",
+          "value": 5
+        },
+        {
+          "description": "Right foot.",
+          "name": "FOOT_R",
+          "value": 6
+        },
+        {
+          "description": "Torso.",
+          "name": "TORSO",
+          "value": 7
+        },
+        {
+          "description": "Right upper arm.",
+          "name": "UARM_R",
+          "value": 8
+        },
+        {
+          "description": "Right lower arm.",
+          "name": "LARM_R",
+          "value": 9
+        },
+        {
+          "description": "Right hand.",
+          "name": "HAND_R",
+          "value": 10
+        },
+        {
+          "description": "Left upper arm.",
+          "name": "UARM_L",
+          "value": 11
+        },
+        {
+          "description": "Left lower arm.",
+          "name": "LARM_L",
+          "value": 12
+        },
+        {
+          "description": "Left hand.",
+          "name": "HAND_L",
+          "value": 13
+        },
+        {
+          "description": "Head.",
+          "name": "HEAD",
+          "value": 14
+        }
+      ]
+    },
+    {
+      "description": "A mesh Lara can carry on top of one of her own - the dagger in Home Sweet Home, the oar in a boat.",
+      "path": "lara.ExtraMesh",
+      "values": [
+        {
+          "description": "Braided head, out of combat.",
+          "name": "TR1_BRAID_DEFAULT_HEAD",
+          "value": 0
+        },
+        {
+          "description": "Braided head, in combat.",
+          "name": "TR1_BRAID_COMBAT_HEAD",
+          "value": 1
+        },
+        {
+          "description": "Braided torso.",
+          "name": "TR1_BRAID_DEFAULT_TORSO",
+          "value": 2
+        },
+        {
+          "description": "Braided torso, mauled.",
+          "name": "TR1_BRAID_MAULED_TORSO",
+          "value": 3
+        },
+        {
+          "description": "Braided head, gold.",
+          "name": "TR1_BRAID_GOLD_HEAD",
+          "value": 4
+        },
+        {
+          "description": "Braided torso, gold.",
+          "name": "TR1_BRAID_GOLD_TORSO",
+          "value": 5
+        },
+        {
+          "description": "Dagger, in hand.",
+          "name": "DAGGER_HAND",
+          "value": 6
+        },
+        {
+          "description": "Dagger, sheathed at the hips.",
+          "name": "DAGGER_HIPS",
+          "value": 7
+        },
+        {
+          "description": "Oar.",
+          "name": "OAR",
+          "value": 8
+        },
+        {
+          "description": "Spanner.",
+          "name": "SPANNER",
+          "value": 9
+        },
+        {
+          "description": "Drink can.",
+          "name": "DRINK_CAN",
+          "value": 10
+        },
+        {
+          "description": "Sunglasses.",
+          "name": "GLASSES_OPAQUE",
+          "value": 11
+        },
+        {
+          "description": "Sunglasses, transparent lenses.",
+          "name": "GLASSES_TRANSPARENT",
+          "value": 12
+        },
+        {
+          "description": "Crowbar.",
+          "name": "CROWBAR",
+          "value": 13
+        }
+      ]
+    },
+    {
+      "description": "Where Lara is with respect to water.",
+      "path": "lara.WaterState",
+      "values": [
+        {
+          "description": "On dry land.",
+          "name": "ABOVE_WATER",
+          "value": 0
+        },
+        {
+          "description": "Under the surface.",
+          "name": "UNDERWATER",
+          "value": 1
+        },
+        {
+          "description": "Swimming at the surface.",
+          "name": "SURFACE",
+          "value": 2
+        },
+        {
+          "description": "Flying, as the fly cheat leaves her.",
+          "name": "CHEAT",
+          "value": 3
+        },
+        {
+          "description": "Wading, feet still on the floor.",
+          "name": "WADE",
+          "value": 4
+        }
+      ]
+    },
+    {
+      "description": "What Lara's hands are doing.",
+      "path": "lara.GunState",
+      "values": [
+        {
+          "description": "Empty-handed.",
+          "name": "ARMLESS",
+          "value": 0
+        },
+        {
+          "description": "Hands full, so nothing can be drawn.",
+          "name": "HANDS_BUSY",
+          "value": 1
+        },
+        {
+          "description": "Drawing a weapon.",
+          "name": "DRAW",
+          "value": 2
+        },
+        {
+          "description": "Putting one away.",
+          "name": "UNDRAW",
+          "value": 3
+        },
+        {
+          "description": "Armed, weapon out.",
+          "name": "READY",
+          "value": 4
+        },
+        {
+          "description": "In a scripted sequence.",
+          "name": "SPECIAL",
+          "value": 5
+        }
+      ]
+    },
+    {
       "description": "How a track is played. Pass one as `opts.mode` to `trx.music.play`.",
       "path": "music.PlayMode",
       "values": [
@@ -899,6 +1123,39 @@
       }
     },
     {
+      "description": "Hangs an extra mesh on one of Lara's own, replacing whatever is there.",
+      "examples": [
+        "trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)"
+      ],
+      "params": [
+        {
+          "description": "Which of Lara's meshes.",
+          "enum": "lara.Mesh",
+          "name": "mesh",
+          "type": "integer"
+        },
+        {
+          "description": "The mesh to hang on it.",
+          "enum": "lara.ExtraMesh",
+          "name": "extra_mesh",
+          "type": "integer"
+        }
+      ],
+      "path": "lara.set_extra_equipment"
+    },
+    {
+      "description": "Takes the extra mesh back off, leaving Lara's own.",
+      "params": [
+        {
+          "description": "Which of Lara's meshes.",
+          "enum": "lara.Mesh",
+          "name": "mesh",
+          "type": "integer"
+        }
+      ],
+      "path": "lara.clear_equipment"
+    },
+    {
       "description": "Sine of an angle.",
       "params": [
         {
@@ -1159,6 +1416,11 @@
       "order": 4
     },
     {
+      "description": "Module for reading and nudging Lara's own state.\n\nHer position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.",
+      "name": "lara",
+      "order": 3
+    },
+    {
       "description": "Fixed-point trigonometry, matching the engine's own tables.\n\nTRX angles are 16-bit units where 65536 is a full turn, not radians. Using these rather than Lua's `math` library guarantees a script places things exactly where the engine would.",
       "name": "math",
       "order": 17
@@ -1243,6 +1505,36 @@
       "path": "creatures.hostile_allies",
       "type": "boolean",
       "writable": true
+    },
+    {
+      "description": "Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit points are read and written there.",
+      "path": "lara.item",
+      "type": "Item",
+      "writable": false
+    },
+    {
+      "description": "The item Lara's guns are locked onto, or `nil` if she has none.",
+      "path": "lara.target",
+      "type": "Item",
+      "writable": false
+    },
+    {
+      "description": "The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.",
+      "path": "lara.outfit",
+      "type": "string",
+      "writable": true
+    },
+    {
+      "description": "Whether Lara's holsters are drawn on her hips.",
+      "path": "lara.holsters_visible",
+      "type": "boolean",
+      "writable": true
+    },
+    {
+      "description": "Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all.",
+      "path": "lara.has_pistol_weapon",
+      "type": "boolean",
+      "writable": false
     }
   ],
   "types": [
@@ -1488,6 +1780,126 @@
         }
       ],
       "path": "items.Item"
+    },
+    {
+      "description": "Lara's own state, reachable straight off `trx.lara`.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "Air remaining underwater, out of 1800. Runs down while she is under.",
+          "name": "air_bar",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Frames Lara has been dead for.",
+          "name": "death_timer",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Frames Lara has been diving for.",
+          "name": "dive_timer",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "How badly Lara is being electrocuted, and 0 when she is not.",
+          "name": "electric",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "The weapon Lara is holding.",
+          "enum": "catalog.weapons",
+          "name": "equipped_gun",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Warmth remaining in the cold, out of 600. Only moves in a level whose rooms carry the `damaging` flag.",
+          "name": "exposure_bar",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether a scripted animation is driving Lara rather than her own state machine.",
+          "name": "extra_anim",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "What Lara's hands are doing.",
+          "enum": "lara.GunState",
+          "name": "gun_status",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Which way the last hit came from, or -1 if she has not been hit.",
+          "name": "hit_direction",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Whether Lara is on fire.",
+          "name": "is_burning",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "Whether Lara is on a climbable wall.",
+          "name": "is_climbing",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "Whether Lara is crouching.",
+          "name": "is_crouched",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "Whether Lara has killed one of her own allies, which is what turns the rest of them on her.",
+          "name": "killed_loyal_item",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "How poisoned Lara is, and 0 when she is not.",
+          "name": "poison",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Frames Lara has stood still for, which is what starts an idle animation.",
+          "name": "pose_count",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "The weapon Lara is drawing, while she is drawing it.",
+          "enum": "catalog.weapons",
+          "name": "requested_gun",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Sprint left in her legs.",
+          "name": "sprint_timer",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Where Lara is with respect to water.",
+          "enum": "lara.WaterState",
+          "name": "water_status",
+          "type": "integer",
+          "writable": false
+        }
+      ],
+      "methods": [],
+      "path": "lara.Lara"
     },
     {
       "description": "A room in the current level.",

--- a/docs/trx/lua/reference/LARA.md
+++ b/docs/trx/lua/reference/LARA.md
@@ -3,125 +3,175 @@ title: Lara
 order: 3
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/lara.lua. Edit it there.
+-->
+
 ## Lara module
 
-Module for interacting with the Lara's object.
+Module for reading and nudging Lara's own state.
+
+Her position, room and hit points are not here: she is an item like any other and they live on it, as `trx.lara.item`.
+
+### Properties
+
+- **`trx.lara.item`** (Item). Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit points are read and written there. *(read-only)*
+- **`trx.lara.target`** (Item). The item Lara's guns are locked onto, or `nil` if she has none. *(read-only)*
+- **`trx.lara.outfit`** (string). The outfit Lara is wearing, by name, as defined in `cfg/outfits.json5`.
+- **`trx.lara.holsters_visible`** (boolean). Whether Lara's holsters are drawn on her hips.
+- **`trx.lara.has_pistol_weapon`** (boolean). Whether Lara is carrying a pistol-class weapon, which is what decides whether she has holsters to show at all. *(read-only)*
+
+### Enums
+
+- [lua]`trx.lara.Mesh`
+
+    One of the fifteen meshes Lara is built from.
+
+    - `trx.lara.Mesh.HIPS` = `0`  
+        Hips, the mesh the rest hang off.
+    - `trx.lara.Mesh.THIGH_L` = `1`  
+        Left thigh.
+    - `trx.lara.Mesh.CALF_L` = `2`  
+        Left calf.
+    - `trx.lara.Mesh.FOOT_L` = `3`  
+        Left foot.
+    - `trx.lara.Mesh.THIGH_R` = `4`  
+        Right thigh.
+    - `trx.lara.Mesh.CALF_R` = `5`  
+        Right calf.
+    - `trx.lara.Mesh.FOOT_R` = `6`  
+        Right foot.
+    - `trx.lara.Mesh.TORSO` = `7`  
+        Torso.
+    - `trx.lara.Mesh.UARM_R` = `8`  
+        Right upper arm.
+    - `trx.lara.Mesh.LARM_R` = `9`  
+        Right lower arm.
+    - `trx.lara.Mesh.HAND_R` = `10`  
+        Right hand.
+    - `trx.lara.Mesh.UARM_L` = `11`  
+        Left upper arm.
+    - `trx.lara.Mesh.LARM_L` = `12`  
+        Left lower arm.
+    - `trx.lara.Mesh.HAND_L` = `13`  
+        Left hand.
+    - `trx.lara.Mesh.HEAD` = `14`  
+        Head.
+
+- [lua]`trx.lara.ExtraMesh`
+
+    A mesh Lara can carry on top of one of her own - the dagger in Home Sweet Home, the oar in a boat.
+
+    - `trx.lara.ExtraMesh.TR1_BRAID_DEFAULT_HEAD` = `0`  
+        Braided head, out of combat.
+    - `trx.lara.ExtraMesh.TR1_BRAID_COMBAT_HEAD` = `1`  
+        Braided head, in combat.
+    - `trx.lara.ExtraMesh.TR1_BRAID_DEFAULT_TORSO` = `2`  
+        Braided torso.
+    - `trx.lara.ExtraMesh.TR1_BRAID_MAULED_TORSO` = `3`  
+        Braided torso, mauled.
+    - `trx.lara.ExtraMesh.TR1_BRAID_GOLD_HEAD` = `4`  
+        Braided head, gold.
+    - `trx.lara.ExtraMesh.TR1_BRAID_GOLD_TORSO` = `5`  
+        Braided torso, gold.
+    - `trx.lara.ExtraMesh.DAGGER_HAND` = `6`  
+        Dagger, in hand.
+    - `trx.lara.ExtraMesh.DAGGER_HIPS` = `7`  
+        Dagger, sheathed at the hips.
+    - `trx.lara.ExtraMesh.OAR` = `8`  
+        Oar.
+    - `trx.lara.ExtraMesh.SPANNER` = `9`  
+        Spanner.
+    - `trx.lara.ExtraMesh.DRINK_CAN` = `10`  
+        Drink can.
+    - `trx.lara.ExtraMesh.GLASSES_OPAQUE` = `11`  
+        Sunglasses.
+    - `trx.lara.ExtraMesh.GLASSES_TRANSPARENT` = `12`  
+        Sunglasses, transparent lenses.
+    - `trx.lara.ExtraMesh.CROWBAR` = `13`  
+        Crowbar.
+
+- [lua]`trx.lara.WaterState`
+
+    Where Lara is with respect to water.
+
+    - `trx.lara.WaterState.ABOVE_WATER` = `0`  
+        On dry land.
+    - `trx.lara.WaterState.UNDERWATER` = `1`  
+        Under the surface.
+    - `trx.lara.WaterState.SURFACE` = `2`  
+        Swimming at the surface.
+    - `trx.lara.WaterState.CHEAT` = `3`  
+        Flying, as the fly cheat leaves her.
+    - `trx.lara.WaterState.WADE` = `4`  
+        Wading, feet still on the floor.
+
+- [lua]`trx.lara.GunState`
+
+    What Lara's hands are doing.
+
+    - `trx.lara.GunState.ARMLESS` = `0`  
+        Empty-handed.
+    - `trx.lara.GunState.HANDS_BUSY` = `1`  
+        Hands full, so nothing can be drawn.
+    - `trx.lara.GunState.DRAW` = `2`  
+        Drawing a weapon.
+    - `trx.lara.GunState.UNDRAW` = `3`  
+        Putting one away.
+    - `trx.lara.GunState.READY` = `4`  
+        Armed, weapon out.
+    - `trx.lara.GunState.SPECIAL` = `5`  
+        In a scripted sequence.
+
+### Structures
+
+- [lua]`trx.lara.Lara`
+
+    Lara's own state, reachable straight off `trx.lara`.
+
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
+
+    Properties:
+    - **`air_bar`**: integer. Air remaining underwater, out of 1800. Runs down while she is under.
+    - **`death_timer`**: integer. Frames Lara has been dead for. *(read-only)*
+    - **`dive_timer`**: integer. Frames Lara has been diving for. *(read-only)*
+    - **`electric`**: integer. How badly Lara is being electrocuted, and 0 when she is not.
+    - **`equipped_gun`**: integer. The weapon Lara is holding. Compare against `trx.catalog.weapons`. *(read-only)*
+    - **`exposure_bar`**: integer. Warmth remaining in the cold, out of 600. Only moves in a level whose rooms carry the `damaging` flag.
+    - **`extra_anim`**: boolean. Whether a scripted animation is driving Lara rather than her own state machine. *(read-only)*
+    - **`gun_status`**: integer. What Lara's hands are doing. Compare against `trx.lara.GunState`. *(read-only)*
+    - **`hit_direction`**: integer. Which way the last hit came from, or -1 if she has not been hit. *(read-only)*
+    - **`is_burning`**: boolean. Whether Lara is on fire. *(read-only)*
+    - **`is_climbing`**: boolean. Whether Lara is on a climbable wall. *(read-only)*
+    - **`is_crouched`**: boolean. Whether Lara is crouching. *(read-only)*
+    - **`killed_loyal_item`**: boolean. Whether Lara has killed one of her own allies, which is what turns the rest of them on her. *(read-only)*
+    - **`poison`**: integer. How poisoned Lara is, and 0 when she is not.
+    - **`pose_count`**: integer. Frames Lara has stood still for, which is what starts an idle animation. *(read-only)*
+    - **`requested_gun`**: integer. The weapon Lara is drawing, while she is drawing it. Compare against `trx.catalog.weapons`. *(read-only)*
+    - **`sprint_timer`**: integer. Sprint left in her legs.
+    - **`water_status`**: integer. Where Lara is with respect to water. Compare against `trx.lara.WaterState`. *(read-only)*
 
 ### Functions
 
-- [lua]`trx.lara.item`  
-    Returns [lua]`trx.items.Item` associated with Lara, or [lua]`nil` if the
-    Lara object is not available.
+- [lua]`trx.lara.set_extra_equipment(mesh, extra_mesh)`  
+  Hangs an extra mesh on one of Lara's own, replacing whatever is there.
 
-- [lua]`trx.lara.target`  
-    Read-only - returns Lara's current gun target as [lua]`trx.items.Item`,
-    or [lua]`nil` if no target is locked.
+  Parameters:
+  - **`mesh`** (integer). Which of Lara's meshes. Compare against `trx.lara.Mesh`.
+  - **`extra_mesh`** (integer). The mesh to hang on it. Compare against `trx.lara.ExtraMesh`.
 
-- [lua]`trx.lara.exposure_bar`  
-    Reads/writes Lara's exposure timer. The maximum value is 600.
-    The current level must use damaging rooms flag for this property to work.
+  Example:
+  ```lua
+  trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)
+  ```
 
-- [lua]`trx.lara.air_bar`  
-    Reads/writes Lara's air timer. The maximum value is 1800.  
-      
-    Example:
-    ```lua
-    -- Infinite oxygen
-    trx.events.after_control(function()
-        trx.lara.air_bar = 1800
-    end)
-    ```
+- [lua]`trx.lara.clear_equipment(mesh)`  
+  Takes the extra mesh back off, leaving Lara's own.
 
-- [lua]`trx.lara.outfit`  
-    Reads/writes Lara's outfit name string (for example [lua]`"tr2_diving_suit"`).
-    Outfit names are the keys defined in [md]`cfg/outfits.json5`. Outfits are
-    stored in saves, but writing this value does not change the global config
-    setting, so subsequent levels will adhere to regular outfit changes.
-
-- [lua]`trx.lara.set_extra_equipment(lara_mesh_id, extra_mesh_id)`  
-    Defines a specific extra mesh to be drawn at the same position as the given
-    Lara mesh.
-
-    The extra mesh must be present in the `O_LARA_SKIN_SWAP_EXTRA` object and 
-    should be setup properly in the [outfits JSON](../../OUTFITS.md). Refer
-    to the constants further below.
-
-    Example:
-    ```lua
-    -- Put an oar in Lara's right hand
-    trx.lara.set_extra_equipment(trx.lara.mesh.hand_r, trx.lara.extra_mesh.oar)
-    ```
-
-- [lua]`trx.lara.clear_equipment(lara_mesh_id)`  
-    Removes any equipment on the given Lara mesh. This applies to guns and extra
-    meshes.
-
-- [lua]`trx.lara.holsters_visible`  
-    Hides or shows Lara's holsters. This is used in OG TR1/2 gym and Home Sweet
-    Home levels to maintain original outfit appearance. If Lara picks up a
-    holster type weapon, or the weapon cheat is used, or a gun is given via the
-    console, the holsters will automatically be made visible.
-
-- [lua]`trx.lara.has_pistol_weapon`  
-    Read-only - returns true if Lara has any pistol-type weapon currently in her
-    inventory.
-
-- [lua]`trx.lara.extra_anim`  
-    Read-only - if Lara is currently in an extra anim state, returns the
-    relative animation number of the `O_LARA_EXTRA` object.  
-    Otherwise, returns -1.
-
-- [lua]`trx.lara.equipped_gun`  
-    Read-only - returns Lara's currently equipped gun ID.
-    Compare values using [lua]`trx.catalog.weapons`.
-
-## Mesh constants
-
-- `trx.lara.mesh.hips`  
-    An index to Lara's hips mesh.
-- `trx.lara.mesh.thigh_l`  
-    An index to Lara's left thigh mesh.
-- `trx.lara.mesh.calf_l`  
-    An index to Lara's left calf mesh.
-- `trx.lara.mesh.foot_l`  
-    An index to Lara's left foot mesh.
-- `trx.lara.mesh.thigh_r`  
-    An index to Lara's right thigh mesh.
-- `trx.lara.mesh.calf_r`  
-    An index to Lara's right calf mesh.
-- `trx.lara.mesh.foot_r`  
-    An index to Lara's right foot mesh.
-- `trx.lara.mesh.torso`  
-    An index to Lara's torso mesh.
-- `trx.lara.mesh.uarm_r`  
-    An index to Lara's upper right arm mesh.
-- `trx.lara.mesh.larm_r`  
-    An index to Lara's lower right arm mesh.
-- `trx.lara.mesh.hand_r`  
-    An index to Lara's right hand mesh.
-- `trx.lara.mesh.uarm_l`  
-    An index to Lara's upper left arm mesh.
-- `trx.lara.mesh.larm_l`  
-    An index to Lara's lower left arm mesh.
-- `trx.lara.mesh.hand_l`  
-    An index to Lara's left hand mesh.
-- `trx.lara.mesh.head`  
-    An index to Lara's head mesh.
-
-## Extra mesh constants
-
-- `trx.lara.extra_mesh.dagger_hand`  
-    An index to the dagger mesh used when Lara retrieves it from the dragon and
-    when inspecting it at home.
-- `trx.lara.extra_mesh.dagger_hips`  
-    An index to the dagger mesh that sits on Lara's hips during Home Sweet Home.
-- `trx.lara.extra_mesh.oar`  
-    An index to the oar mesh used when Lara is in the kayak.
-- `trx.lara.extra_mesh.spanner`  
-    An index to the spanner mesh used when Lara is in the minecart.
-- `trx.lara.extra_mesh.drink_can`  
-    An index to the drink can mesh used in the High Security Compound cutscene.
-- `trx.lara.extra_mesh.glasses_opaque`  
-    An index to Lara's opaque sunglasses mesh.
-- `trx.lara.extra_mesh.glasses_transparent`  
-    An index to Lara's transparent sunglasses mesh.
+  Parameters:
+  - **`mesh`** (integer). Which of Lara's meshes. Compare against `trx.lara.Mesh`.

--- a/src/meson.build
+++ b/src/meson.build
@@ -362,6 +362,7 @@ common_sources = [
   'trx/game/lara/control.c',
   'trx/game/lara/draw.c',
   'trx/game/lara/electric.c',
+  'trx/game/lara/fields.c',
   'trx/game/lara/flare.c',
   'trx/game/lara/hair.c',
   'trx/game/lara/interact.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -239,6 +239,27 @@ test('lua_log', test_lua_log_exe, suite: 'unit')
 
 # The log bridge rides along: console.lua takes its levels from trxc.log.
 # The override stack underneath is the real one; only the config facade is faked.
+# trx.lara stands for one C struct, so her fields go through the real reflection
+# layer. Only what is not a field of LARA_INFO is faked.
+test_lua_lara_exe = executable(
+  'test_lua_lara',
+  files('unit/test_lua_lara.c', 'unit/fake_engine_lara.c', 'unit/fake_engine_items.c')
+    + test_stubs
+    + lua_surface_src
+    + files(
+      '../trx/game/items/fields.c',
+      '../trx/game/lara/fields.c',
+      '../trx/game/lua/items.c',
+      '../trx/game/lua/lara.c',
+      '../trx/game/lua/utils.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_lara', test_lua_lara_exe, suite: 'unit')
+
 test_lua_config_exe = executable(
   'test_lua_config',
   files('unit/test_lua_config.c', 'unit/fake_engine_config.c') + test_stubs

--- a/src/tests/unit/fake_engine_lara.c
+++ b/src/tests/unit/fake_engine_lara.c
@@ -1,0 +1,127 @@
+// One Lara, standing still. Her state is a real LARA_INFO, reached through the
+// real reflection layer - that is what is under test. The handful of things
+// that are not fields of it (her item, her outfit, her holsters) are faked
+// here.
+
+#include "fake_engine_lara.h"
+
+#include <trx/game/const.h>
+#include <trx/game/gun/types.h>
+#include <trx/game/items/manager.h>
+#include <trx/game/items/types.h>
+#include <trx/game/lara/skin/types.h>
+
+#include <stdbool.h>
+#include <string.h>
+
+FAKE_LARA_CALLS g_FakeLaraCalls;
+
+static LARA_INFO m_Lara;
+static bool m_HolstersVisible;
+static bool m_HasPistols;
+static LARA_SKIN_TYPE m_Skin;
+
+// The weapon table the bridge walks to decide whether Lara has a pistol at all.
+WEAPON_INFO g_Weapons[NUM_WEAPONS] = {
+    [LGT_PISTOLS] = { .type = WEAPON_TYPE_DUAL_PISTOLS },
+};
+
+LARA_INFO *Lara_GetLaraInfo(void)
+{
+    return &m_Lara;
+}
+
+// Lara is item 1 in the fake level, so trx.lara.item is a live Item handle out
+// of the same pool as any other.
+ITEM *Lara_GetItem(void)
+{
+    return Item_Get(0);
+}
+
+int16_t Item_GetRelativeObjAnim(const ITEM *const item, const OBJECT_ID obj_id)
+{
+    return -1;
+}
+
+OBJECT_ID Gun_GetGunObject(const LARA_GUN_TYPE gun_type)
+{
+    return 0;
+}
+
+bool Inv_RequestItem(const OBJECT_ID obj_id)
+{
+    return m_HasPistols;
+}
+
+LARA_SKIN_TYPE Lara_Skin_GetType(void)
+{
+    return m_Skin;
+}
+
+void Lara_Skin_SetType(const LARA_SKIN_TYPE skin_type)
+{
+    m_Skin = skin_type;
+}
+
+bool Lara_Skin_AreHolstersVisible(void)
+{
+    return m_HolstersVisible;
+}
+
+void Lara_Skin_SetHolstersVisible(const bool visible)
+{
+    m_HolstersVisible = visible;
+}
+
+void Lara_Skin_ClearEquipment(const LARA_MESH mesh)
+{
+    g_FakeLaraCalls.clear_equipment++;
+    g_FakeLaraCalls.last_mesh = mesh;
+}
+
+void Lara_Skin_SetExtraEquipment(
+    const LARA_MESH mesh, const LARA_SKIN_EXTRA_MESH extra_mesh)
+{
+    g_FakeLaraCalls.set_equipment++;
+    g_FakeLaraCalls.last_mesh = mesh;
+    g_FakeLaraCalls.last_extra_mesh = extra_mesh;
+}
+
+bool Lara_Skin_IsOutfitAvailable(const LARA_SKIN_TYPE skin_type)
+{
+    return true;
+}
+
+const char *Lara_Skin_GetOutfitName(const LARA_SKIN_TYPE skin_type)
+{
+    return skin_type == 0 ? "default" : "gold";
+}
+
+LARA_SKIN_TYPE Lara_Skin_FindOutfitByName(const char *const name)
+{
+    if (strcmp(name, "default") == 0) {
+        return 0;
+    }
+    if (strcmp(name, "gold") == 0) {
+        return 1;
+    }
+    return -1;
+}
+
+void FakeLara_Reset(void)
+{
+    memset(&m_Lara, 0, sizeof(m_Lara));
+
+    m_Lara.air = 1800;
+    m_Lara.exposure_timer = 600;
+    m_Lara.water_status = LWS_ABOVE_WATER;
+    m_Lara.gun_status = LGS_ARMLESS;
+    m_Lara.gun_type = LGT_UNARMED;
+    m_Lara.request_gun_type = LGT_UNARMED;
+    m_Lara.hit_direction = -1;
+
+    g_FakeLaraCalls = (FAKE_LARA_CALLS) {};
+    m_HolstersVisible = true;
+    m_HasPistols = true;
+    m_Skin = 0;
+}

--- a/src/tests/unit/fake_engine_lara.h
+++ b/src/tests/unit/fake_engine_lara.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <trx/game/lara/types.h>
+
+#include <stdint.h>
+
+// What the surface asked the engine to do, recorded rather than performed.
+typedef struct {
+    int32_t set_equipment;
+    int32_t clear_equipment;
+    int32_t last_mesh;
+    int32_t last_extra_mesh;
+} FAKE_LARA_CALLS;
+
+extern FAKE_LARA_CALLS g_FakeLaraCalls;
+
+void FakeLara_Reset(void);

--- a/src/tests/unit/lua/lara.lua
+++ b/src/tests/unit/lua/lara.lua
@@ -1,0 +1,97 @@
+-- The Lara API as a script actually sees it.
+--
+-- trx.lara is the first module that stands for a C struct: reading trx.lara.air_bar
+-- reaches into a real LARA_INFO through the reflection layer. What is reachable
+-- is what lara.Lara declares, and nothing else.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("a field reads straight off Lara", function()
+  assert(trx.lara.air_bar == 1800)
+  assert(trx.lara.exposure_bar == 600)
+  assert(trx.lara.poison == 0)
+  assert(trx.lara.is_burning == false)
+  assert(trx.lara.hit_direction == -1, "a negative field must survive as negative")
+end)
+
+test("a writable field writes straight through", function()
+  trx.lara.air_bar = 900
+  assert(trx.lara.air_bar == 900, "the write did not reach Lara")
+
+  trx.lara.poison = 16
+  assert(trx.lara.poison == 16)
+end)
+
+test("a field declared read-only cannot be written", function()
+  raises(function()
+    trx.lara.is_burning = true
+  end)
+  raises(function()
+    trx.lara.water_status = trx.lara.WaterState.UNDERWATER
+  end)
+  assert(trx.lara.is_burning == false, "the write must not have landed")
+end)
+
+test("a member of LARA_INFO nobody declared is not reachable", function()
+  -- The C struct has turn_rate, move_angle, a whole LOT and both arms. None of
+  -- them is declared, so none of them exists as far as a script is concerned.
+  assert(trx.lara.turn_rate == nil)
+  assert(trx.lara.move_angle == nil)
+  assert(trx.lara.lot == nil)
+
+  raises(function()
+    trx.lara.turn_rate = 100
+  end)
+end)
+
+test("an enum field reads as its enum", function()
+  assert(trx.lara.water_status == trx.lara.WaterState.ABOVE_WATER)
+  assert(trx.lara.gun_status == trx.lara.GunState.ARMLESS)
+end)
+
+test("the enums come from C", function()
+  assert(trx.lara.WaterState.ABOVE_WATER == 0)
+  assert(trx.lara.WaterState.UNDERWATER == 1)
+  assert(trx.lara.WaterState.CHEAT == 3)
+
+  assert(trx.lara.GunState.ARMLESS == 0)
+  assert(trx.lara.GunState.READY == 4)
+
+  assert(trx.lara.Mesh.HIPS == 0)
+  assert(trx.lara.Mesh.HEAD == 14)
+end)
+
+test("properties that are not struct fields still work", function()
+  assert(trx.lara.holsters_visible == true)
+  trx.lara.holsters_visible = false
+  assert(trx.lara.holsters_visible == false)
+
+  assert(trx.lara.outfit == "default")
+  assert(trx.lara.has_pistol_weapon == true)
+end)
+
+test("lara.item is her Item handle", function()
+  -- She is item 0 in C and item 1 to a script, like every other item.
+  assert(trx.lara.item ~= nil, "Lara has no item")
+end)
+
+test("equipment names the meshes it was given", function()
+  trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)
+  local calls = fake.calls()
+  assert(calls.set_equipment == 1, "the equipment did not reach the engine")
+  assert(calls.last_mesh == trx.lara.Mesh.HAND_R)
+  assert(calls.last_extra_mesh == trx.lara.ExtraMesh.OAR)
+
+  trx.lara.clear_equipment(trx.lara.Mesh.HAND_R)
+  assert(fake.calls().clear_equipment == 1)
+end)
+
+test("an undeclared name cannot be written onto the module", function()
+  raises(function()
+    trx.lara.nonsense = 1
+  end)
+  assert(trx.lara.nonsense == nil)
+end)
+
+return h.report()

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -44,6 +44,21 @@ local function fresh_env()
     -- and with a gap, so the tests pin what api.lua does with what C hands it.
     enum = {
       values = function(backing)
+        if backing == "PREFIXED_STATE" then
+          -- A C enum whose constants all carry the enum's own name, the way
+          -- LARA_SKIN_EXTRA_MESH does because the data files are keyed by it.
+          return {
+            { name = "WIDGET_OFF", value = 0 },
+            { name = "WIDGET_ON", value = 1 },
+          }
+        end
+        if backing == "COLLIDING_STATE" then
+          -- Two constants that strip onto the same name.
+          return {
+            { name = "WIDGET_ON", value = 1 },
+            { name = "ON", value = 2 },
+          }
+        end
         assert(backing == "WIDGET_STATE", "unknown enum: " .. tostring(backing))
         return {
           { name = "BROKEN", value = 7 },
@@ -335,6 +350,42 @@ test("a path deeper than a namespace is rejected", function()
   local api = fresh_env()
   api.module("console", {})
   assert(not pcall(api.define, "console.log.deep.deeper", { impl = function() end }), "3 levels deep")
+end)
+
+test("strip takes a prefix off a constant's name, by name and not by position", function()
+  local api = fresh_env()
+  api.module("things", {})
+
+  local e = api.enum("things.State", {
+    backing = "PREFIXED_STATE",
+    strip = "WIDGET_",
+    values = { OFF = "off.", ON = "on." },
+  })
+
+  -- The name is derived from the C name; the value is the C value. Nothing here
+  -- depends on the order the constants came back in, and `values` is a hash, so
+  -- it has no order to depend on.
+  assert(e.OFF == 0, "OFF did not resolve to WIDGET_OFF's value")
+  assert(e.ON == 1)
+  assert(e.WIDGET_OFF == nil, "the C spelling must not survive the strip")
+
+  local out = api.describe()
+  assert(out.enums[1].values[1].name == "OFF", "describe() must report the stripped name")
+end)
+
+test("a strip that collides two constants onto one name fails", function()
+  local api = fresh_env()
+  api.module("things", {})
+
+  -- WIDGET_ON strips to ON, and ON is already a constant. Silently letting the
+  -- second take the first one's place would hand a script the wrong number.
+  local ok, err = pcall(api.enum, "things.State", {
+    backing = "COLLIDING_STATE",
+    strip = "WIDGET_",
+    values = { ON = "on." },
+  })
+  assert(not ok, "a collision must not be accepted")
+  assert(tostring(err):find("two constants", 1, true), "the error must say why: " .. tostring(err))
 end)
 
 test("seal blocks further declarations", function()

--- a/src/tests/unit/test_lua_lara.c
+++ b/src/tests/unit/test_lua_lara.c
@@ -1,0 +1,58 @@
+// The Lara surface. The assertions live in src/tests/unit/lua/lara.lua; this
+// stands up the world they run against.
+//
+// trx.lara is a module standing for one C struct, so a read of trx.lara.air
+// goes through the reflection layer into a real LARA_INFO. That is the thing
+// being tested; only what is not a field of it is faked.
+
+#include "fake_engine_items.h"
+#include "fake_engine_lara.h"
+#include "lua_surface.h"
+
+extern void LUA_CreateItems(lua_State *L);
+extern void LUA_CreateLara(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateItems(L);
+    LUA_CreateLara(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeItems_Reset();
+    FakeLara_Reset();
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, g_FakeLaraCalls.set_equipment);
+    lua_setfield(L, -2, "set_equipment");
+    lua_pushinteger(L, g_FakeLaraCalls.clear_equipment);
+    lua_setfield(L, -2, "clear_equipment");
+    lua_pushinteger(L, g_FakeLaraCalls.last_mesh);
+    lua_setfield(L, -2, "last_mesh");
+    lua_pushinteger(L, g_FakeLaraCalls.last_extra_mesh);
+    lua_setfield(L, -2, "last_extra_mesh");
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "lara",
+        .deps = { "items", nullptr },
+        .tests = "lara",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -7,6 +7,7 @@
 #include <trx/game/gym.h>
 #include <trx/game/input/enum.h>
 #include <trx/game/items/enum.h>
+#include <trx/game/lara/enum.h>
 #include <trx/game/lara/skin/types.h>
 #include <trx/game/lara/types.h>
 #include <trx/game/music/enum.h>
@@ -170,6 +171,35 @@ static __attribute__((constructor)) void M_Init(void)
     ENUM_MAP(UI_BAR_TYPE, UI_BAR_ENEMY_HP, "enemy_hp");
     ENUM_MAP(UI_BAR_TYPE, UI_BAR_ALLY_HP, "ally_hp");
     ENUM_MAP(UI_BAR_TYPE, UI_BAR_PROGRESS, "progress");
+
+    ENUM_MAP(LARA_MESH, LM_HIPS, "hips");
+    ENUM_MAP(LARA_MESH, LM_THIGH_L, "thigh_l");
+    ENUM_MAP(LARA_MESH, LM_CALF_L, "calf_l");
+    ENUM_MAP(LARA_MESH, LM_FOOT_L, "foot_l");
+    ENUM_MAP(LARA_MESH, LM_THIGH_R, "thigh_r");
+    ENUM_MAP(LARA_MESH, LM_CALF_R, "calf_r");
+    ENUM_MAP(LARA_MESH, LM_FOOT_R, "foot_r");
+    ENUM_MAP(LARA_MESH, LM_TORSO, "torso");
+    ENUM_MAP(LARA_MESH, LM_UARM_R, "uarm_r");
+    ENUM_MAP(LARA_MESH, LM_LARM_R, "larm_r");
+    ENUM_MAP(LARA_MESH, LM_HAND_R, "hand_r");
+    ENUM_MAP(LARA_MESH, LM_UARM_L, "uarm_l");
+    ENUM_MAP(LARA_MESH, LM_LARM_L, "larm_l");
+    ENUM_MAP(LARA_MESH, LM_HAND_L, "hand_l");
+    ENUM_MAP(LARA_MESH, LM_HEAD, "head");
+
+    ENUM_MAP(LARA_WATER_STATE, LWS_ABOVE_WATER, "above_water");
+    ENUM_MAP(LARA_WATER_STATE, LWS_UNDERWATER, "underwater");
+    ENUM_MAP(LARA_WATER_STATE, LWS_SURFACE, "surface");
+    ENUM_MAP(LARA_WATER_STATE, LWS_CHEAT, "cheat");
+    ENUM_MAP(LARA_WATER_STATE, LWS_WADE, "wade");
+
+    ENUM_MAP(LARA_GUN_STATE, LGS_ARMLESS, "armless");
+    ENUM_MAP(LARA_GUN_STATE, LGS_HANDS_BUSY, "hands_busy");
+    ENUM_MAP(LARA_GUN_STATE, LGS_DRAW, "draw");
+    ENUM_MAP(LARA_GUN_STATE, LGS_UNDRAW, "undraw");
+    ENUM_MAP(LARA_GUN_STATE, LGS_READY, "ready");
+    ENUM_MAP(LARA_GUN_STATE, LGS_SPECIAL, "special");
 
     ENUM_MAP_SELF(LARA_SKIN_BRAID_MODE, BRAID_MODE_NONE);
     ENUM_MAP_SELF(LARA_SKIN_BRAID_MODE, BRAID_MODE_TR1_HEAD_ONLY);

--- a/src/trx/game/lara/fields.c
+++ b/src/trx/game/lara/fields.c
@@ -1,0 +1,46 @@
+// How to reach the members of LARA_INFO. Offsets and storage types, nothing
+// else: which of these are public, under what name, and what they mean is
+// declared in data/scripting/lara.lua.
+//
+// Lara's position, room and hit points are not here. She is an item like any
+// other, and those live on it - see trx.lara.item.
+
+#include <trx/core/field.h>
+#include <trx/game/lara/types.h>
+
+// clang-format off
+static const FIELD_DESC M_LARA_FIELDS[] = {
+    // condition
+    FIELD(LARA_INFO, air),
+    FIELD(LARA_INFO, exposure_timer),
+    FIELD(LARA_INFO, poison.value),
+    FIELD(LARA_INFO, poison.target),
+    FIELD(LARA_INFO, electric),
+    FIELD_RO(LARA_INFO, burn),
+
+    // what she is doing
+    FIELD_RO(LARA_INFO, water_status),
+    FIELD_RO(LARA_INFO, gun_status),
+    FIELD_RO(LARA_INFO, gun_type),
+    FIELD_RO(LARA_INFO, request_gun_type),
+    FIELD_RO(LARA_INFO, is_crouched),
+    FIELD_RO(LARA_INFO, climb_status),
+    FIELD_RO(LARA_INFO, extra_anim),
+    FIELD_RO(LARA_INFO, killed_loyal_item),
+
+    // timers
+    FIELD_RO(LARA_INFO, dive_timer),
+    FIELD_RO(LARA_INFO, death_timer),
+    FIELD(LARA_INFO, sprint_timer),
+    FIELD_RO(LARA_INFO, hit_direction),
+    FIELD_RO(LARA_INFO, hit_frame),
+    FIELD_RO(LARA_INFO, pose_count),
+
+    // Deliberately absent: the arms, the LOT, the mesh pointers, the rope and
+    // interaction state, and the interpolation snapshots. They are how the
+    // engine drives Lara, not a contract, and a script writing them mid-frame
+    // would wedge her.
+};
+// clang-format on
+
+TYPE_DEFINE(LARA_INFO, M_LARA_FIELDS)

--- a/src/trx/game/lua/lara.c
+++ b/src/trx/game/lua/lara.c
@@ -3,8 +3,23 @@
 #include <trx/game/lara.h>
 #include <trx/game/lara/skin/storage.h>
 #include <trx/game/lua/common.h>
+#include <trx/game/lua/struct.h>
 
 #include <lauxlib.h>
+
+extern const TYPE_DESC TYPE_LARA_INFO;
+
+static void *M_Resolve(const LUA_STRUCT_REF *const ref)
+{
+    return Lara_GetLaraInfo();
+}
+
+// trxc.lara.state() -> LARA_INFO handle
+static int M_L_LaraState(lua_State *const L)
+{
+    LUA_Struct_Push(L, &TYPE_LARA_INFO, M_Resolve, 0, 0);
+    return 1;
+}
 
 // item_num = trxc.lara.get_item()
 static int M_L_GetLaraItem(lua_State *const L)
@@ -161,58 +176,11 @@ static int M_L_LaraGetEquippedGun(lua_State *const L)
 
 void LUA_CreateLara(lua_State *const L)
 {
+    LUA_Struct_Register(
+        L, &TYPE_LARA_INFO, (const luaL_Reg[]) { { nullptr, nullptr } });
+
     lua_getglobal(L, "trxc");
     lua_newtable(L);
-
-    lua_newtable(L);
-    lua_pushinteger(L, LM_HIPS);
-    lua_setfield(L, -2, "hips");
-    lua_pushinteger(L, LM_THIGH_L);
-    lua_setfield(L, -2, "thigh_l");
-    lua_pushinteger(L, LM_CALF_L);
-    lua_setfield(L, -2, "calf_l");
-    lua_pushinteger(L, LM_FOOT_L);
-    lua_setfield(L, -2, "foot_l");
-    lua_pushinteger(L, LM_THIGH_R);
-    lua_setfield(L, -2, "thigh_r");
-    lua_pushinteger(L, LM_CALF_R);
-    lua_setfield(L, -2, "calf_r");
-    lua_pushinteger(L, LM_FOOT_R);
-    lua_setfield(L, -2, "foot_r");
-    lua_pushinteger(L, LM_TORSO);
-    lua_setfield(L, -2, "torso");
-    lua_pushinteger(L, LM_UARM_R);
-    lua_setfield(L, -2, "uarm_r");
-    lua_pushinteger(L, LM_LARM_R);
-    lua_setfield(L, -2, "larm_r");
-    lua_pushinteger(L, LM_HAND_R);
-    lua_setfield(L, -2, "hand_r");
-    lua_pushinteger(L, LM_UARM_L);
-    lua_setfield(L, -2, "uarm_l");
-    lua_pushinteger(L, LM_LARM_L);
-    lua_setfield(L, -2, "larm_l");
-    lua_pushinteger(L, LM_HAND_L);
-    lua_setfield(L, -2, "hand_l");
-    lua_pushinteger(L, LM_HEAD);
-    lua_setfield(L, -2, "head");
-    lua_setfield(L, -2, "mesh");
-
-    lua_newtable(L);
-    lua_pushinteger(L, EXTRA_MESH_DAGGER_HAND);
-    lua_setfield(L, -2, "dagger_hand");
-    lua_pushinteger(L, EXTRA_MESH_DAGGER_HIPS);
-    lua_setfield(L, -2, "dagger_hips");
-    lua_pushinteger(L, EXTRA_MESH_OAR);
-    lua_setfield(L, -2, "oar");
-    lua_pushinteger(L, EXTRA_MESH_SPANNER);
-    lua_setfield(L, -2, "spanner");
-    lua_pushinteger(L, EXTRA_MESH_DRINK_CAN);
-    lua_setfield(L, -2, "drink_can");
-    lua_pushinteger(L, EXTRA_MESH_GLASSES_OPAQUE);
-    lua_setfield(L, -2, "glasses_opaque");
-    lua_pushinteger(L, EXTRA_MESH_GLASSES_TRANSPARENT);
-    lua_setfield(L, -2, "glasses_transparent");
-    lua_setfield(L, -2, "extra_mesh");
 
     lua_pushcfunction(L, M_L_GetLaraItem);
     lua_setfield(L, -2, "get_item");
@@ -244,6 +212,9 @@ void LUA_CreateLara(lua_State *const L)
     lua_setfield(L, -2, "get_extra_anim");
     lua_pushcfunction(L, M_L_LaraGetEquippedGun);
     lua_setfield(L, -2, "get_equipped_gun");
+    lua_pushcfunction(L, M_L_LaraState);
+    lua_setfield(L, -2, "state");
+
     lua_setfield(L, -2, "lara");
     lua_pop(L, 1);
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates the Lara LUA API to the new `api` framework and adds tests.
Also, exposes a bit more fields than before.