### PR TITLE
Migrate objects LUA API

### DIFF
--- a/data/scripting/objects.lua
+++ b/data/scripting/objects.lua
@@ -1,55 +1,170 @@
 local raw = trxc.objects
+local api = trx.api
 
-local function make_properties(object_id)
-  return setmetatable({ object_id = object_id }, {
-    __index = function(self, key)
+api.module("objects", {
+  order = 14,
+  title = "Object",
+  description = "Module for the object definitions a level is built from.\n\n"
+    .. "An object is the pattern every item of that type is cut from: a wolf's radius, not this "
+    .. "wolf's. Per-item state lives on the item - see `trx.items`.",
+})
+
+-- Object handles are bare userdata. Their metatable is populated by the api.type
+-- declaration below, and by nothing else: a member of the C OBJECT struct that is
+-- not named here is not reachable from a script at all.
+
+local function make_properties(object)
+  return setmetatable({}, {
+    __index = function(_, key)
       if type(key) ~= "string" then
         return nil
       end
-      return raw.get_property(self.object_id, key)
+      return object:get_property(key)
     end,
-    __newindex = function(self, key, value)
-      raw.set_property(self.object_id, key, value)
+    __newindex = function(_, key, value)
+      object:set_property(key, value)
     end,
-    __pairs = function(self)
-      local property_names = raw.get_property_names(self.object_id)
+    __pairs = function()
+      local names = object:get_property_names()
       local i = 0
       return function()
         i = i + 1
-        local name = property_names[i]
+        local name = names[i]
         if name == nil then
           return nil
         end
-        return name, raw.get_property(self.object_id, name)
+        return name, object:get_property(name)
       end
     end,
   })
 end
 
-local Object = {}
+api.type("objects.Object", {
+  backing = "OBJECT",
+  description = "An object definition.",
 
-Object.__index = function(self, key)
-  if key == "properties" then
-    return make_properties(self.object_id)
-  end
-  return nil
-end
+  fields = {
+    loaded = {
+      from = "loaded",
+      type = "boolean",
+      writable = false,
+      description = "Whether the current level has this object at all. An object it never loaded "
+        .. "still has a definition; this is how a script tells.",
+    },
+    is_intelligent = {
+      from = "intelligent",
+      type = "boolean",
+      writable = false,
+      description = "Whether the object thinks - a creature rather than a door.",
+    },
+    mesh_count = {
+      from = "mesh_count",
+      type = "integer",
+      writable = false,
+      description = "How many meshes the object is built from.",
+    },
+    anim_count = {
+      from = "anim_count",
+      type = "integer",
+      writable = false,
+      description = "How many animations it has.",
+    },
+    radius = {
+      from = "radius",
+      type = "integer",
+      description = "Collision radius.",
+    },
+    shadow_size = {
+      from = "shadow_size",
+      type = "integer",
+      description = "Size of the blob shadow drawn under it, and 0 for none.",
+    },
+    smartness = {
+      from = "smartness",
+      type = "integer",
+      description = "How readily a creature of this type finds its way to Lara.",
+    },
+    pivot_length = {
+      from = "pivot_length",
+      type = "integer",
+      description = "How far in front of itself the object turns about.",
+    },
+    semi_transparent = {
+      from = "semi_transparent",
+      type = "boolean",
+      description = "Whether the object is drawn see-through.",
+    },
+  },
 
-local objects = {
-  swap_mesh = raw.swap_mesh,
-}
+  extensions = {
+    properties = {
+      type = "table",
+      description = "The object's own typed properties, which every item of the type inherits. "
+        .. "Writing here changes the default for all of them; write to `item.properties` to change "
+        .. "one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+      impl = make_properties,
+    },
+  },
 
-trx.objects = setmetatable(objects, {
-  Object = Object,
-  __index = function(_, key)
+  methods = {
+    get_property = {
+      params = { { name = "name", type = "string" } },
+      returns = { type = "any", nullable = true },
+      description = "Reads one of the object's properties. Prefer `object.properties.<name>`.",
+    },
+    set_property = {
+      params = { { name = "name", type = "string" }, { name = "value", type = "any" } },
+      description = "Writes one of the object's properties. Prefer `object.properties.<name> = ...`.",
+    },
+    get_property_names = {
+      returns = { type = "table" },
+      description = "Names of every property this object declares.",
+    },
+  },
+})
+
+api.define("objects.get", {
+  description = "Retrieves an object definition by id or by name.",
+  params = {
+    {
+      name = "key",
+      type = "any",
+      enum = "catalog.objects",
+      description = 'Object id, or its catalog name: `trx.objects["wolf"]`.',
+    },
+  },
+  returns = { type = "Object", nullable = true, description = "`nil` if no such object exists." },
+  examples = {
+    [[local wolf = trx.objects.wolf
+wolf.properties.max_hit_points = 30]],
+  },
+  impl = function(key)
     if type(key) == "number" then
-      return setmetatable({ object_id = key }, Object)
-    elseif type(key) == "string" then
+      return raw.get(key)
+    end
+    if type(key) == "string" then
       local object_id = trx.catalog.objects[key]
-      if object_id ~= nil then
-        return setmetatable({ object_id = object_id }, Object)
-      end
+      return object_id ~= nil and raw.get(object_id) or nil
     end
     return nil
+  end,
+})
+
+api.define("objects.swap_mesh", {
+  description = "Swaps meshes between two objects. With no mesh numbers, swaps all of them.",
+  params = {
+    { name = "object_id1", type = "integer", enum = "catalog.objects" },
+    { name = "object_id2", type = "integer", enum = "catalog.objects" },
+    { name = "mesh_num1", type = "integer", optional = true, description = "Mesh of the first." },
+    { name = "mesh_num2", type = "integer", optional = true, description = "Mesh of the second." },
+  },
+  impl = raw.swap_mesh,
+})
+
+-- trx.objects holds the registered functions; the metatable adds indexing by id
+-- and by name on top, so trx.objects.wolf is the wolf.
+setmetatable(trx.objects, {
+  __index = function(_, key)
+    return trx.objects.get(key)
   end,
 })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- added new Lua object fields, `loaded`, `is_intelligent`, `mesh_count`, `anim_count`, `radius`, `shadow_size`, `smartness`, `pivot_length` and `semi_transparent`
 - added new Lua Lara state, `trx.lara.poison`, `trx.lara.electric`, `trx.lara.is_burning`, `trx.lara.is_crouched`, `trx.lara.is_climbing`, `trx.lara.water_status`, `trx.lara.gun_status` and the dive, death, sprint and pose timers
 - changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`; refer to migration notes
 - added new Lua config functions, `trx.config.override()`, `trx.config.restore()` and `trx.config.is_overridden()`, to change a setting without overwriting the player's own value

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -1249,6 +1249,54 @@
       "path": "music.stop"
     },
     {
+      "description": "Retrieves an object definition by id or by name.",
+      "examples": [
+        "local wolf = trx.objects.wolf\nwolf.properties.max_hit_points = 30"
+      ],
+      "params": [
+        {
+          "description": "Object id, or its catalog name: `trx.objects[\"wolf\"]`.",
+          "enum": "catalog.objects",
+          "name": "key",
+          "type": "any"
+        }
+      ],
+      "path": "objects.get",
+      "returns": {
+        "description": "`nil` if no such object exists.",
+        "nullable": true,
+        "type": "Object"
+      }
+    },
+    {
+      "description": "Swaps meshes between two objects. With no mesh numbers, swaps all of them.",
+      "params": [
+        {
+          "enum": "catalog.objects",
+          "name": "object_id1",
+          "type": "integer"
+        },
+        {
+          "enum": "catalog.objects",
+          "name": "object_id2",
+          "type": "integer"
+        },
+        {
+          "description": "Mesh of the first.",
+          "name": "mesh_num1",
+          "optional": true,
+          "type": "integer"
+        },
+        {
+          "description": "Mesh of the second.",
+          "name": "mesh_num2",
+          "optional": true,
+          "type": "integer"
+        }
+      ],
+      "path": "objects.swap_mesh"
+    },
+    {
       "description": "Retrieves a room by 1-based index.",
       "examples": [
         "local room = trx.rooms[15]\nroom.underwater = true"
@@ -1429,6 +1477,12 @@
       "description": "Module for playing and controlling the soundtrack.",
       "name": "music",
       "order": 6
+    },
+    {
+      "description": "Module for the object definitions a level is built from.\n\nAn object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see `trx.items`.",
+      "name": "objects",
+      "order": 14,
+      "title": "Object"
     },
     {
       "description": "Module for inspecting and altering the rooms of the current level.",
@@ -1900,6 +1954,110 @@
       ],
       "methods": [],
       "path": "lara.Lara"
+    },
+    {
+      "description": "An object definition.",
+      "extensions": [
+        {
+          "description": "The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).",
+          "name": "properties",
+          "type": "table"
+        }
+      ],
+      "fields": [
+        {
+          "description": "How many animations it has.",
+          "name": "anim_count",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Whether the object thinks - a creature rather than a door.",
+          "name": "is_intelligent",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells.",
+          "name": "loaded",
+          "type": "boolean",
+          "writable": false
+        },
+        {
+          "description": "How many meshes the object is built from.",
+          "name": "mesh_count",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "How far in front of itself the object turns about.",
+          "name": "pivot_length",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Collision radius.",
+          "name": "radius",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "Whether the object is drawn see-through.",
+          "name": "semi_transparent",
+          "type": "boolean",
+          "writable": true
+        },
+        {
+          "description": "Size of the blob shadow drawn under it, and 0 for none.",
+          "name": "shadow_size",
+          "type": "integer",
+          "writable": true
+        },
+        {
+          "description": "How readily a creature of this type finds its way to Lara.",
+          "name": "smartness",
+          "type": "integer",
+          "writable": true
+        }
+      ],
+      "methods": [
+        {
+          "description": "Reads one of the object's properties. Prefer `object.properties.<name>`.",
+          "name": "get_property",
+          "params": [
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ],
+          "returns": {
+            "nullable": true,
+            "type": "any"
+          }
+        },
+        {
+          "description": "Names of every property this object declares.",
+          "name": "get_property_names",
+          "returns": {
+            "type": "table"
+          }
+        },
+        {
+          "description": "Writes one of the object's properties. Prefer `object.properties.<name> = ...`.",
+          "name": "set_property",
+          "params": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "any"
+            }
+          ]
+        }
+      ],
+      "path": "objects.Object"
     },
     {
       "description": "A room in the current level.",

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -3,51 +3,86 @@ title: Object
 order: 14
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/objects.lua. Edit it there.
+-->
+
 ## Object module
 
-Module for controlling game objects.
+Module for the object definitions a level is built from.
+
+An object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see `trx.items`.
 
 ### Structures
 
 - [lua]`trx.objects.Object`
 
-    Represents a moveable object type.
+    An object definition.
+
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
 
     Properties:
-    - **`properties`**: Table of typed object properties. Values written here
-      become defaults for future item initialization and spawns; existing items
-      are not changed retroactively.
+    - **`anim_count`**: integer. How many animations it has. *(read-only)*
+    - **`is_intelligent`**: boolean. Whether the object thinks - a creature rather than a door. *(read-only)*
+    - **`loaded`**: boolean. Whether the current level has this object at all. An object it never loaded still has a definition; this is how a script tells. *(read-only)*
+    - **`mesh_count`**: integer. How many meshes the object is built from. *(read-only)*
+    - **`pivot_length`**: integer. How far in front of itself the object turns about.
+    - **`radius`**: integer. Collision radius.
+    - **`semi_transparent`**: boolean. Whether the object is drawn see-through.
+    - **`shadow_size`**: integer. Size of the blob shadow drawn under it, and 0 for none.
+    - **`smartness`**: integer. How readily a creature of this type finds its way to Lara.
 
-    Properties are object-specific; see [Objects](../../OBJECTS.md) for the
-    documented properties on each object. Property tables can be iterated with
-    `pairs()`.
+    Computed properties (derived, not stored on the object):
+    - **`properties`**: table. The object's own typed properties, which every item of the type inherits. Writing here changes the default for all of them; write to `item.properties` to change one item only. Iterable with `pairs()`. See [Objects](../../OBJECTS.md).
+
+    Methods:
+
+    - [lua]`object:get_property(name)`  
+      Reads one of the object's properties. Prefer `object.properties.<name>`.
+
+      Parameters:
+      - **`name`** (string).
+
+      Returns: any or `nil`.
+
+    - [lua]`object:get_property_names()`  
+      Names of every property this object declares.
+
+      Returns: table.
+
+    - [lua]`object:set_property(name, value)`  
+      Writes one of the object's properties. Prefer `object.properties.<name> = ...`.
+
+      Parameters:
+      - **`name`** (string).
+      - **`value`** (any).
 
 ### Functions
 
-- [lua]`trx.objects[object_id]`
-- [lua]`trx.objects.object_name`
+- [lua]`trx.objects.get(key)`  
+  Retrieves an object definition by id or by name.
 
-  Retrieves an object proxy for the given object ID or catalog object name.
+  Parameters:
+  - **`key`** (any). Object id, or its catalog name: `trx.objects["wolf"]`. Compare against `trx.catalog.objects`.
+
+  Returns: Object or `nil`. `nil` if no such object exists.
 
   Example:
   ```lua
-  trx.objects[trx.catalog.objects.wolf].properties.max_hit_points = 30
-  trx.objects.flare_item.properties.burn_time = 1
-  for name, value in pairs(trx.objects[trx.catalog.objects.wolf].properties) do
-    trx.log.info(name .. " = " .. tostring(value))
-  end
+  local wolf = trx.objects.wolf
+  wolf.properties.max_hit_points = 30
   ```
 
-- [lua]`trx.objects.swap_mesh(obj1_id, obj2_id, mesh1_num, mesh2_num)`  
-    Swaps the given meshes of the given objects.  
-    Examples:
-    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.pierre, trx.catalog.objects.larson, 8, 8)`  
-      Pierre now has Larson's head, and vice-versa
+- [lua]`trx.objects.swap_mesh(object_id1, object_id2, [mesh_num1], [mesh_num2])`  
+  Swaps meshes between two objects. With no mesh numbers, swaps all of them.
 
-- [lua]`trx.objects.swap_mesh(obj1_id, obj2_id)`  
-    Similar to above, but this will swap out all meshes rather than specific ones. This works best when both objects have the same mesh count; if one object has fewer meshes than the other, the minimum count will be used.  
-    Examples:
-    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.pierre, trx.catalog.objects.larson)`  
-      Pierre and Larson's meshes are fully swapped
-    - [lua]`trx.objects.swap_mesh(trx.catalog.objects.pierre, trx.catalog.objects.warrior_1)`  
-      Pierre's 15 meshes are now of mutant type; the mutant's first 15 meshes are Pierre's, the rest are default.
+  Parameters:
+  - **`object_id1`** (integer). Compare against `trx.catalog.objects`.
+  - **`object_id2`** (integer). Compare against `trx.catalog.objects`.
+  - **`mesh_num1`** (integer, optional). Mesh of the first.
+  - **`mesh_num2`** (integer, optional). Mesh of the second.

--- a/src/meson.build
+++ b/src/meson.build
@@ -543,6 +543,7 @@ common_sources = [
   'trx/game/objects/effects/splash.c',
   'trx/game/objects/effects/twinkle.c',
   'trx/game/objects/effects/water_sprite.c',
+  'trx/game/objects/fields.c',
   'trx/game/objects/general/ai_node.c',
   'trx/game/objects/general/alarm_sound.c',
   'trx/game/objects/general/animating.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -241,6 +241,23 @@ test('lua_log', test_lua_log_exe, suite: 'unit')
 # The override stack underneath is the real one; only the config facade is faked.
 # trx.lara stands for one C struct, so her fields go through the real reflection
 # layer. Only what is not a field of LARA_INFO is faked.
+# An object is what an item is cut from, so they share a fake engine.
+test_lua_objects_exe = executable(
+  'test_lua_objects',
+  files('unit/test_lua_objects.c', 'unit/fake_engine_items.c') + test_stubs
+    + lua_surface_src
+    + files(
+      '../trx/game/objects/fields.c',
+      '../trx/game/lua/objects.c',
+      '../trx/game/lua/utils.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_objects', test_lua_objects_exe, suite: 'unit')
+
 test_lua_lara_exe = executable(
   'test_lua_lara',
   files('unit/test_lua_lara.c', 'unit/fake_engine_lara.c', 'unit/fake_engine_items.c')

--- a/src/tests/unit/fake_engine_items.c
+++ b/src/tests/unit/fake_engine_items.c
@@ -71,6 +71,11 @@ void FakeItems_Reset(void)
         .intelligent = true,
         .anim_idx = 0,
         .anim_count = FAKE_ANIM_COUNT,
+        .mesh_count = 6,
+        .radius = 341,
+        .shadow_size = 128,
+        .smartness = 0x7fff,
+        .pivot_length = 375,
     };
     m_Objects[FAKE_OBJ_VASE] = (OBJECT) {
         .loaded = true,
@@ -251,6 +256,62 @@ OBJECT *Object_Get(const OBJECT_ID object_id)
         return nullptr;
     }
     return &m_Objects[object_id];
+}
+
+OBJECT *Object_TryGet(const OBJECT_ID object_id)
+{
+    return Object_Get(object_id);
+}
+
+void Object_SwapAllMeshes(const OBJECT_ID obj1_id, const OBJECT_ID obj2_id)
+{
+    g_FakeItemCalls.swap_mesh++;
+}
+
+void Object_SwapMeshEx(
+    const OBJECT_ID obj1_id, const OBJECT_ID obj2_id, const int32_t mesh1_num,
+    const int32_t mesh2_num)
+{
+    g_FakeItemCalls.swap_mesh++;
+}
+
+// The object's own properties, which every item of the type inherits. Only
+// max_hit_points is modelled - the split between an object's default and an
+// item's override is the thing worth testing, not the whole property system.
+bool ObjectProperty_GetObjectValue(
+    const OBJECT *const obj, const char *const name,
+    OBJECT_PROPERTY_VALUE *const out_value)
+{
+    if (obj == nullptr || strcmp(name, "max_hit_points") != 0) {
+        return false;
+    }
+    *out_value = (OBJECT_PROPERTY_VALUE) {
+        .type = OBJECT_PROPERTY_TYPE_INT,
+        .as_int = m_ObjectHP[obj - m_Objects],
+    };
+    return true;
+}
+
+bool ObjectProperty_SetObjectValueRaw(
+    OBJECT *const obj, const char *const name,
+    const OBJECT_PROPERTY_VALUE value)
+{
+    if (obj == nullptr || strcmp(name, "max_hit_points") != 0) {
+        return false;
+    }
+    m_ObjectHP[obj - m_Objects] = value.as_int;
+    return true;
+}
+
+int32_t ObjectProperty_GetObjectNameCount(const OBJECT *const obj)
+{
+    return obj != nullptr ? 1 : 0;
+}
+
+const char *ObjectProperty_GetObjectName(
+    const OBJECT *const obj, const int32_t i)
+{
+    return i == 0 ? "max_hit_points" : nullptr;
 }
 
 bool Object_IsType(const OBJECT_ID object_id, const OBJECT_ID *const test_arr)

--- a/src/tests/unit/fake_engine_items.h
+++ b/src/tests/unit/fake_engine_items.h
@@ -10,6 +10,7 @@
 
 // What the surface asked the engine to do, recorded rather than performed.
 typedef struct {
+    int32_t swap_mesh;
     int32_t creature_die;
     bool creature_die_explode;
     int32_t enable_baddie_ai;

--- a/src/tests/unit/lua/objects.lua
+++ b/src/tests/unit/lua/objects.lua
@@ -1,0 +1,96 @@
+-- The object API as a script actually sees it.
+--
+-- An object is what an item is cut from. trx.objects[id] is a real handle over
+-- the C OBJECT struct, so what is reachable is what objects.Object declares.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("an object is reached by id", function()
+  local wolf = trx.objects[fake.WOLF]
+  assert(wolf ~= nil, "no wolf")
+  assert(wolf.loaded == true)
+  assert(wolf.is_intelligent == true, "a wolf thinks")
+  assert(wolf.radius == 341)
+  assert(wolf.mesh_count == 6)
+end)
+
+test("get() is the same thing as indexing", function()
+  assert(trx.objects.get(fake.WOLF).radius == trx.objects[fake.WOLF].radius)
+end)
+
+test("an object the level never loaded still has a definition", function()
+  local obj = trx.objects[fake.UNLOADED]
+  assert(obj ~= nil, "an unloaded object must still be reachable")
+  assert(obj.loaded == false, "and it must say so")
+end)
+
+test("an object that does not exist is nil", function()
+  assert(trx.objects[9999] == nil)
+  assert(trx.objects.get(9999) == nil)
+end)
+
+test("a vase does not think", function()
+  assert(trx.objects[fake.VASE].is_intelligent == false)
+end)
+
+test("a writable field writes through", function()
+  local wolf = trx.objects[fake.WOLF]
+  wolf.radius = 500
+  assert(trx.objects[fake.WOLF].radius == 500, "the write did not reach the object")
+
+  wolf.shadow_size = 64
+  assert(trx.objects[fake.WOLF].shadow_size == 64)
+end)
+
+test("a field declared read-only cannot be written", function()
+  raises(function()
+    trx.objects[fake.WOLF].loaded = false
+  end)
+  raises(function()
+    trx.objects[fake.WOLF].is_intelligent = false
+  end)
+end)
+
+test("a member of OBJECT nobody declared is not reachable", function()
+  -- The struct has mesh_idx, anim_idx, frame_base and a control function.
+  -- None is declared, so none exists as far as a script is concerned.
+  local wolf = trx.objects[fake.WOLF]
+  assert(wolf.mesh_idx == nil)
+  assert(wolf.anim_idx == nil)
+  assert(wolf.control_func == nil)
+end)
+
+test("properties are the object's own, and every item inherits them", function()
+  local wolf = trx.objects[fake.WOLF]
+  assert(wolf.properties.max_hit_points == 20, "the object's default")
+
+  wolf.properties.max_hit_points = 30
+  assert(trx.objects[fake.WOLF].properties.max_hit_points == 30, "the default did not move")
+end)
+
+test("properties iterate", function()
+  local seen = {}
+  for name, value in pairs(trx.objects[fake.WOLF].properties) do
+    seen[name] = value
+  end
+  assert(seen.max_hit_points == 20, "pairs() did not yield the property")
+end)
+
+test("a property nobody declared reads nil and cannot be written", function()
+  local wolf = trx.objects[fake.WOLF]
+  assert(wolf.properties.nonsense == nil)
+  raises(function()
+    wolf.properties.nonsense = 1
+  end)
+end)
+
+test("swap_mesh reaches the engine", function()
+  trx.objects.swap_mesh(fake.WOLF, fake.VASE)
+  assert(fake.calls().swap_mesh == 1, "the whole-object swap did not land")
+
+  trx.objects.swap_mesh(fake.WOLF, fake.VASE, 1, 2)
+  assert(fake.calls().swap_mesh == 2, "the single-mesh swap did not land")
+end)
+
+return h.report()

--- a/src/tests/unit/test_lua_objects.c
+++ b/src/tests/unit/test_lua_objects.c
@@ -1,0 +1,52 @@
+// The object surface. The assertions live in src/tests/unit/lua/objects.lua;
+// this stands up the world they run against.
+//
+// The object world is the same one the item tests use - an object is what an
+// item is cut from, so they share a fake.
+
+#include "fake_engine_items.h"
+#include "lua_surface.h"
+
+extern void LUA_CreateObjects(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateObjects(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeItems_Reset();
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, g_FakeItemCalls.swap_mesh);
+    lua_setfield(L, -2, "swap_mesh");
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+    lua_pushinteger(L, FAKE_OBJ_WOLF);
+    lua_setfield(L, -2, "WOLF");
+    lua_pushinteger(L, FAKE_OBJ_VASE);
+    lua_setfield(L, -2, "VASE");
+    lua_pushinteger(L, FAKE_OBJ_UNLOADED);
+    lua_setfield(L, -2, "UNLOADED");
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "objects",
+        .tests = "objects",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/trx/game/lua/objects.c
+++ b/src/trx/game/lua/objects.c
@@ -1,4 +1,27 @@
+#include <trx/game/lua/struct.h>
 #include <trx/game/lua/utils.h>
+
+extern const TYPE_DESC TYPE_OBJECT;
+
+// An object is addressed by its id, and an id is valid for the whole session -
+// there is no pool to recycle and nothing to go stale. An object the level did
+// not load still exists as a definition; `loaded` is how a script tells.
+static void *M_Resolve(const LUA_STRUCT_REF *const ref)
+{
+    return Object_TryGet((OBJECT_ID)ref->idx);
+}
+
+// trxc.objects.get(object_id) -> OBJECT handle or nil
+static int M_L_ObjectsGet(lua_State *const L)
+{
+    const OBJECT_ID object_id = luaL_checkinteger(L, 1);
+    if (Object_TryGet(object_id) == nullptr) {
+        lua_pushnil(L);
+        return 1;
+    }
+    LUA_Struct_Push(L, &TYPE_OBJECT, M_Resolve, object_id, 0);
+    return 1;
+}
 
 static void M_PushPropertyValue(
     lua_State *const L, const OBJECT_PROPERTY_VALUE *const value)
@@ -44,14 +67,14 @@ static int M_L_ObjectsSwapMesh(lua_State *const L)
     return 0;
 }
 
-// trxc.objects.get_property(object_id, name) → typed value or nil
-static int M_L_ObjectsGetProperty(lua_State *const L)
+// The object property overlay stays a separate namespace: fields address the
+// OBJECT struct, properties are what the object declares about itself.
+static int M_L_GetProperty(lua_State *const L)
 {
-    const OBJECT_ID object_id = luaL_checkinteger(L, 1);
-    const char *const name = luaL_checkstring(L, 2);
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_OBJECT);
+    const OBJECT *const obj = LUA_Struct_Deref(L, ref);
     OBJECT_PROPERTY_VALUE value = {};
-    if (!ObjectProperty_GetObjectValue(
-            Object_TryGet(object_id), name, &value)) {
+    if (!ObjectProperty_GetObjectValue(obj, luaL_checkstring(L, 2), &value)) {
         lua_pushnil(L);
         return 1;
     }
@@ -59,15 +82,11 @@ static int M_L_ObjectsGetProperty(lua_State *const L)
     return 1;
 }
 
-// trxc.objects.set_property(object_id, name, value)
-static int M_L_ObjectsSetProperty(lua_State *const L)
+static int M_L_SetProperty(lua_State *const L)
 {
-    const OBJECT_ID object_id = luaL_checkinteger(L, 1);
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_OBJECT);
+    OBJECT *const obj = LUA_Struct_Deref(L, ref);
     const char *const name = luaL_checkstring(L, 2);
-    OBJECT *const obj = Object_TryGet(object_id);
-    if (obj == nullptr) {
-        return luaL_error(L, "invalid object id %d", object_id);
-    }
     const OBJECT_PROPERTY_VALUE value = LUA_CheckPropertyValue(L, 3);
     if (!ObjectProperty_SetObjectValueRaw(obj, name, value)) {
         return luaL_error(L, "unknown object property '%s'", name);
@@ -75,11 +94,10 @@ static int M_L_ObjectsSetProperty(lua_State *const L)
     return 0;
 }
 
-// trxc.objects.get_property_names(object_id) → table
-static int M_L_ObjectsGetPropertyNames(lua_State *const L)
+static int M_L_GetPropertyNames(lua_State *const L)
 {
-    const OBJECT_ID object_id = luaL_checkinteger(L, 1);
-    const OBJECT *const obj = Object_TryGet(object_id);
+    LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_OBJECT);
+    const OBJECT *const obj = LUA_Struct_Deref(L, ref);
     lua_newtable(L);
     for (int32_t i = 0; i < ObjectProperty_GetObjectNameCount(obj); i++) {
         lua_pushinteger(L, i + 1);
@@ -89,18 +107,23 @@ static int M_L_ObjectsGetPropertyNames(lua_State *const L)
     return 1;
 }
 
+static const luaL_Reg M_METHODS[] = {
+    { "get_property", M_L_GetProperty },
+    { "set_property", M_L_SetProperty },
+    { "get_property_names", M_L_GetPropertyNames },
+    { nullptr, nullptr },
+};
+
 void LUA_CreateObjects(lua_State *const L)
 {
+    LUA_Struct_Register(L, &TYPE_OBJECT, M_METHODS);
+
     lua_getglobal(L, "trxc");
     lua_newtable(L);
+    lua_pushcfunction(L, M_L_ObjectsGet);
+    lua_setfield(L, -2, "get");
     lua_pushcfunction(L, M_L_ObjectsSwapMesh);
     lua_setfield(L, -2, "swap_mesh");
-    lua_pushcfunction(L, M_L_ObjectsGetProperty);
-    lua_setfield(L, -2, "get_property");
-    lua_pushcfunction(L, M_L_ObjectsSetProperty);
-    lua_setfield(L, -2, "set_property");
-    lua_pushcfunction(L, M_L_ObjectsGetPropertyNames);
-    lua_setfield(L, -2, "get_property_names");
     lua_setfield(L, -2, "objects");
     lua_pop(L, 1);
 }

--- a/src/trx/game/objects/fields.c
+++ b/src/trx/game/objects/fields.c
@@ -1,0 +1,32 @@
+// How to reach the members of OBJECT. Offsets and storage types, nothing else:
+// which of these are public, under what name, and what they mean is declared in
+// data/scripting/objects.lua.
+//
+// An object is the definition every item of that type is cut from - a wolf's
+// radius, not this wolf's. Per-item state lives on the item; see trx.items.
+
+#include <trx/core/field.h>
+#include <trx/game/objects/types.h>
+
+// clang-format off
+static const FIELD_DESC M_OBJECT_FIELDS[] = {
+    // what the level actually has
+    FIELD_RO(OBJECT, loaded),
+    FIELD_RO(OBJECT, intelligent),
+    FIELD_RO(OBJECT, mesh_count),
+    FIELD_RO(OBJECT, anim_count),
+
+    // the numbers that decide how it behaves
+    FIELD(OBJECT, radius),
+    FIELD(OBJECT, shadow_size),
+    FIELD(OBJECT, smartness),
+    FIELD(OBJECT, pivot_length),
+    FIELD(OBJECT, semi_transparent),
+
+    // Deliberately absent: every _func pointer, the mesh and animation indices,
+    // and the frame data. They are how the engine drives an object, and a script
+    // moving them would point it at the wrong meshes.
+};
+// clang-format on
+
+TYPE_DEFINE(OBJECT, M_OBJECT_FIELDS)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates the objects LUA API to the new `api` framework and adds tests.