### PR TITLE
Migrate game LUA API

### DIFF
--- a/data/scripting/game.lua
+++ b/data/scripting/game.lua
@@ -1,93 +1,192 @@
 local raw = trxc.game
+local api = trx.api
 
-local function make_level(table_type, i)
-  return {
-    num = raw.get_level_num(table_type, i),
-    name = raw.get_level_name(table_type, i),
-    path = raw.get_level_path(table_type, i),
-    type = raw.get_level_type(table_type, i),
-  }
-end
+api.module("game", {
+  order = 11,
+  description = "Module for the game flow: which levels there are, and which one is being played.",
+})
 
-local function make_levels(table_type)
-  local count = raw.count_levels(table_type)
+local LevelTable = api.enum("game.LevelTable", {
+  backing = "GF_LEVEL_TABLE_TYPE",
+  description = "One of the lists of levels the game flow declares.",
+  values = {
+    TITLE = "The title screen.",
+    MAIN = "The levels of the game proper.",
+    CUTSCENES = "The cutscenes.",
+    DEMOS = "The demos that play when the title screen is left alone.",
+  },
+})
+
+api.enum("game.LevelType", {
+  backing = "GF_LEVEL_TYPE",
+  description = "What kind of level it is.",
+  values = {
+    TITLE = "The title screen.",
+    NORMAL = "An ordinary level.",
+    CUTSCENE = "A cutscene.",
+    DEMO = "A demo.",
+    GYM = "Lara's home, which has no level number.",
+    BONUS = "A bonus level, played once the game is finished.",
+    DUMMY = "Not a level. Kept only because old savegames refer to it.",
+    CURRENT = "Not a level. Kept only because old savegames refer to it.",
+  },
+})
+
+api.type("game.Level", {
+  backing = "GF_LEVEL",
+  description = "A level, as the game flow file declares it. Everything on it is read-only: a "
+    .. "level is what the game flow says it is.",
+
+  fields = {
+    num = {
+      from = "num",
+      type = "integer",
+      writable = false,
+      description = "The number the level goes by. Not its place in the table: levels the game "
+        .. "flow skips do not count, and a gym level has no number at all and reads 0.",
+    },
+    type = {
+      from = "type",
+      type = "integer",
+      writable = false,
+      enum = "game.LevelType",
+      description = "What kind of level it is.",
+    },
+    title = {
+      from = "title",
+      type = "string",
+      writable = false,
+      description = "The level's name, as shown to the player.",
+    },
+    path = {
+      from = "path",
+      type = "string",
+      writable = false,
+      description = "Path to the level file.",
+    },
+    script_path = {
+      from = "script_path",
+      type = "string",
+      writable = false,
+      description = "Path to the Lua script that runs when the level loads, or `nil` if it has none.",
+    },
+    lara_outfit = {
+      from = "lara_outfit",
+      type = "string",
+      writable = false,
+      description = "The outfit Lara starts the level in.",
+    },
+    music_track = {
+      from = "music_track",
+      type = "integer",
+      writable = false,
+      enum = "catalog.music",
+      description = "The track that plays when the level starts.",
+    },
+    water_particles = {
+      from = "water_particles",
+      type = "boolean",
+      writable = false,
+      description = "Whether bubbles rise through the level's water.",
+    },
+    unobtainable_pickups = {
+      from = "unobtainable.pickups",
+      type = "integer",
+      writable = false,
+      description = "Pickups the stats screen must not hold against the player, because they " .. "cannot be got.",
+    },
+    unobtainable_kills = {
+      from = "unobtainable.kills",
+      type = "integer",
+      writable = false,
+      description = "Kills the stats screen must not hold against the player.",
+    },
+    unobtainable_ally_kills = {
+      from = "unobtainable.ally_kills",
+      type = "integer",
+      writable = false,
+      description = "Ally kills the stats screen must not hold against the player.",
+    },
+    unobtainable_secrets = {
+      from = "unobtainable.secrets",
+      type = "integer",
+      writable = false,
+      description = "Secrets the stats screen must not hold against the player.",
+    },
+  },
+})
+
+local function level_list(table_type)
   local levels = {}
-  for i = 1, count do
-    levels[i] = make_level(table_type, i)
+  for i = 1, raw.count_levels(table_type) do
+    levels[i] = raw.get_level(table_type, i)
   end
   return levels
 end
 
-local table_map = {
-  levels = raw.LevelTable.MAIN,
-  demos = raw.LevelTable.DEMOS,
-  cutscenes = raw.LevelTable.CUTSCENES,
-}
-
--- settings system
-local Settings = (function()
-  local function config_entry(path)
-    return {
-      get = function()
-        return trx.config.get(path)
-      end,
-      set = function(value)
-        trx.config.set(path, value)
-      end,
-    }
-  end
-
-  local registry = {
-    lockout_option_ring = config_entry("flow.lockout_option_ring"),
-    load_save_disabled = config_entry("flow.load_save_disabled"),
-    play_any_level = config_entry("flow.play_any_level"),
-    demo_delay = config_entry("flow.demo_delay"),
-    cheat_keys = config_entry("flow.cheat_keys"),
-  }
-
-  return setmetatable({}, {
-    __index = function(_, key)
-      local r = registry[key]
-      return r and r.get() or nil
-    end,
-    __newindex = function(_, key, value)
-      local r = registry[key]
-      if not r then
-        error("Cannot set field '" .. key .. "' on Settings")
-      end
-      r.set(value)
-    end,
-  })
-end)()
-
-local dynamic_getters = {
-  current_level = function()
-    return make_level(raw.get_current_level_table(), raw.get_current_level_idx())
+api.property("game.levels", {
+  type = "table",
+  description = "The levels of the game proper, in order, as a list of `trx.game.Level`.",
+  get = function()
+    return level_list(LevelTable.MAIN)
   end,
-  version = raw.get_version,
-  trx_version = raw.get_trx_version,
-}
+})
 
-trx.game = setmetatable({
-  LevelTable = raw.LevelTable,
-  LevelType = raw.LevelType,
-  settings = Settings,
-  play_level = raw.play_level,
-  play_cutscene = raw.play_cutscene,
-  play_demo = raw.play_demo,
-}, {
-  __index = function(self, key)
-    local table_type = table_map[key]
-    if table_type then
-      local t = make_levels(table_type)
-      rawset(self, key, t)
-      return t
-    end
+api.property("game.cutscenes", {
+  type = "table",
+  description = "The cutscenes, as a list of `trx.game.Level`.",
+  get = function()
+    return level_list(LevelTable.CUTSCENES)
+  end,
+})
 
-    local getter = dynamic_getters[key]
-    return getter and getter() or nil
+api.property("game.demos", {
+  type = "table",
+  description = "The demos, as a list of `trx.game.Level`.",
+  get = function()
+    return level_list(LevelTable.DEMOS)
   end,
-  __newindex = function(self, key, value)
-    error("Cannot set field '" .. key .. "' on trx.game")
-  end,
+})
+
+api.property("game.current_level", {
+  type = "Level",
+  description = "The level being played, or `nil` if none is.",
+  get = raw.get_current_level,
+})
+
+api.property("game.version", {
+  type = "integer",
+  description = "Which Tomb Raider this build is: 1, 2, 3 or 4.",
+  get = raw.get_version,
+})
+
+api.property("game.trx_version", {
+  type = "string",
+  description = "The TRX version string.",
+  get = raw.get_trx_version,
+})
+
+api.define("game.play_level", {
+  description = "Starts a level of the game proper.",
+  params = {
+    { name = "num", type = "integer", description = "The level's number." },
+  },
+  examples = { [[trx.game.play_level(1)]] },
+  impl = raw.play_level,
+})
+
+api.define("game.play_cutscene", {
+  description = "Plays a cutscene.",
+  params = {
+    { name = "num", type = "integer", description = "The cutscene's number." },
+  },
+  impl = raw.play_cutscene,
+})
+
+api.define("game.play_demo", {
+  description = "Plays a demo.",
+  params = {
+    { name = "num", type = "integer", description = "The demo's number." },
+  },
+  impl = raw.play_demo,
 })

--- a/data/scripting/game.lua
+++ b/data/scripting/game.lua
@@ -87,7 +87,7 @@ api.type("game.Level", {
       from = "water_particles",
       type = "boolean",
       writable = false,
-      description = "Whether bubbles rise through the level's water.",
+      description = "Whether water particles are visible in the level's water.",
     },
     unobtainable_pickups = {
       from = "unobtainable.pickups",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,23 +1,23 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
-- added a new Lua module, `trx.math`
-- added new Lua level fields, `script_path`, `lara_outfit`, `music_track`, `water_particles` and the unobtainable pickup, kill and secret counts
 - added `trx.game.LevelType.TITLE`, and a `demo` level type to the game flow, which could not be named before
-- removed `trx.game.settings`, which duplicated `trx.config`; refer to migration notes
-- added new Lua object fields, `loaded`, `is_intelligent`, `mesh_count`, `anim_count`, `radius`, `shadow_size`, `smartness`, `pivot_length` and `semi_transparent`
+- added a new Lua module, `trx.math`
 - added new Lua Lara state, `trx.lara.poison`, `trx.lara.electric`, `trx.lara.is_burning`, `trx.lara.is_crouched`, `trx.lara.is_climbing`, `trx.lara.water_status`, `trx.lara.gun_status` and the dive, death, sprint and pose timers
-- changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`; refer to migration notes
-- added new Lua config functions, `trx.config.override()`, `trx.config.restore()` and `trx.config.is_overridden()`, to change a setting without overwriting the player's own value
-- changed `trx.config.get()` to return the option's own type rather than always a string; refer to migration notes
 - added new Lua assault course functions, `trx.assault.finish()`, `trx.assault.is_running()` and `trx.assault.is_visible()`, and a new property, `trx.assault.active_track`
-- changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
+- added new Lua config functions, `trx.config.override()`, `trx.config.restore()` and `trx.config.is_overridden()`, to change a setting without overwriting the player's own value
+- added new Lua level fields, `script_path`, `lara_outfit`, `music_track`, `water_particles` and the unobtainable pickup, kill and secret counts
+- added new Lua object fields, `loaded`, `is_intelligent`, `mesh_count`, `anim_count`, `radius`, `shadow_size`, `smartness`, `pivot_length` and `semi_transparent`
+- changed `trx.config.get()` to return the option's own type rather than always a string; refer to migration notes
 - changed `trx.events.detach()` to return whether a handler was removed
+- changed `trx.events` handlers to no longer receive a dummy argument in `before_control` and `after_control`
+- changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`; refer to migration notes
 - changed reflections UV mapping to be more correct
-- removed `trx.events.EventType`; refer to migration notes
-- fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
-- removed the `trx.pickup` module; its enum is now `trx.items.PickupMode`; refer to migration notes
+- fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - removed `trx.console.log.LogLevel`, a duplicate of `trx.log.LogLevel`; refer to migration notes
+- removed `trx.events.EventType`; refer to migration notes
+- removed `trx.game.settings`, which duplicated `trx.config`; refer to migration notes
 - removed `trx.music.play_track`, an undocumented alias of `trx.music.play`; refer to migration notes
+- removed the `trx.pickup` module; its enum is now `trx.items.PickupMode`; refer to migration notes
 
 **TR4**
 - added reflections

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - added a new Lua module, `trx.math`
+- added new Lua level fields, `script_path`, `lara_outfit`, `music_track`, `water_particles` and the unobtainable pickup, kill and secret counts
+- added `trx.game.LevelType.TITLE`, and a `demo` level type to the game flow, which could not be named before
+- removed `trx.game.settings`, which duplicated `trx.config`; refer to migration notes
 - added new Lua object fields, `loaded`, `is_intelligent`, `mesh_count`, `anim_count`, `radius`, `shadow_size`, `smartness`, `pivot_length` and `semi_transparent`
 - added new Lua Lara state, `trx.lara.poison`, `trx.lara.electric`, `trx.lara.is_burning`, `trx.lara.is_crouched`, `trx.lara.is_climbing`, `trx.lara.water_status`, `trx.lara.gun_status` and the dive, death, sprint and pose timers
 - changed `trx.lara.mesh` and `trx.lara.extra_mesh` to declared enums, `trx.lara.Mesh` and `trx.lara.ExtraMesh`; refer to migration notes

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -46,13 +46,20 @@ order: 3
    hook. The nine hooks are the whole API, and attaching is unchanged:
    `trx.events.before_control(fn)`.
 
-4. **Update scripts that use Lara's mesh tables**
+4. **Update scripts that use `trx.game.settings`**
+   It was removed. It was five aliases over config options, and it wrote through
+   `trx.config.set`, which keeps the change. Use `trx.config` directly, and
+   prefer `trx.config.override` for anything a level wants only while it runs:
+   - Before: `trx.game.settings.play_any_level = true`
+   - After: `trx.config.override("flow.play_any_level", true)`
+
+5. **Update scripts that use Lara's mesh tables**
    `trx.lara.mesh` and `trx.lara.extra_mesh` became declared enums, so their
    names are upper case: replace `trx.lara.mesh.hand_r` with
    `trx.lara.Mesh.HAND_R`, and `trx.lara.extra_mesh.oar` with
    `trx.lara.ExtraMesh.OAR`.
 
-5. **Update scripts that compare `trx.config.get()` against a string**
+6. **Update scripts that compare `trx.config.get()` against a string**
    It returns the option's own type now: a boolean option reads as a boolean and
    a number as a number. Replace `trx.config.get("flow.cheat_keys") == "true"`
    with `trx.config.get("flow.cheat_keys")`. Colors and enums are still strings.
@@ -62,15 +69,15 @@ order: 3
    while it is running - it leaves the player's own value underneath, and
    `trx.config.restore()` puts it back.
 
-6. **Update scripts that use `trx.console.log.LogLevel`**
+7. **Update scripts that use `trx.console.log.LogLevel`**
    It was removed. Use `trx.log.LogLevel`, which is the same enum:
    `trx.console.log.generic(trx.log.LogLevel.ERROR, "...")`.
 
-7. **Update scripts that call `trx.music.play_track`**
+8. **Update scripts that call `trx.music.play_track`**
    It was an undocumented alias of `trx.music.play` and was removed. Use
    `trx.music.play(id[, opts])`.
 
-8. **Update scripts that set `pickup_mode`**
+9. **Update scripts that set `pickup_mode`**
    The `trx.pickup` module is gone. `pickup_mode` is an item property, so its
    enum now lives with the items: replace `trx.pickup.Mode.PLINTH_LOW` with
    `trx.items.PickupMode.PLINTH_LOW`.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -1814,7 +1814,7 @@
           "writable": false
         },
         {
-          "description": "Whether bubbles rise through the level's water.",
+          "description": "Whether water particles are visible in the level's water.",
           "name": "water_particles",
           "type": "boolean",
           "writable": false

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -65,6 +65,78 @@
       ]
     },
     {
+      "description": "One of the lists of levels the game flow declares.",
+      "path": "game.LevelTable",
+      "values": [
+        {
+          "description": "The title screen.",
+          "name": "TITLE",
+          "value": 0
+        },
+        {
+          "description": "The levels of the game proper.",
+          "name": "MAIN",
+          "value": 1
+        },
+        {
+          "description": "The cutscenes.",
+          "name": "CUTSCENES",
+          "value": 2
+        },
+        {
+          "description": "The demos that play when the title screen is left alone.",
+          "name": "DEMOS",
+          "value": 3
+        }
+      ]
+    },
+    {
+      "description": "What kind of level it is.",
+      "path": "game.LevelType",
+      "values": [
+        {
+          "description": "The title screen.",
+          "name": "TITLE",
+          "value": 0
+        },
+        {
+          "description": "An ordinary level.",
+          "name": "NORMAL",
+          "value": 1
+        },
+        {
+          "description": "A cutscene.",
+          "name": "CUTSCENE",
+          "value": 2
+        },
+        {
+          "description": "A demo.",
+          "name": "DEMO",
+          "value": 3
+        },
+        {
+          "description": "Lara's home, which has no level number.",
+          "name": "GYM",
+          "value": 4
+        },
+        {
+          "description": "A bonus level, played once the game is finished.",
+          "name": "BONUS",
+          "value": 5
+        },
+        {
+          "description": "Not a level. Kept only because old savegames refer to it.",
+          "name": "DUMMY",
+          "value": 6
+        },
+        {
+          "description": "Not a level. Kept only because old savegames refer to it.",
+          "name": "CURRENT",
+          "value": 7
+        }
+      ]
+    },
+    {
       "description": "The values `item.status` can take.",
       "path": "items.Status",
       "values": [
@@ -1024,6 +1096,42 @@
       }
     },
     {
+      "description": "Starts a level of the game proper.",
+      "examples": [
+        "trx.game.play_level(1)"
+      ],
+      "params": [
+        {
+          "description": "The level's number.",
+          "name": "num",
+          "type": "integer"
+        }
+      ],
+      "path": "game.play_level"
+    },
+    {
+      "description": "Plays a cutscene.",
+      "params": [
+        {
+          "description": "The cutscene's number.",
+          "name": "num",
+          "type": "integer"
+        }
+      ],
+      "path": "game.play_cutscene"
+    },
+    {
+      "description": "Plays a demo.",
+      "params": [
+        {
+          "description": "The demo's number.",
+          "name": "num",
+          "type": "integer"
+        }
+      ],
+      "path": "game.play_demo"
+    },
+    {
       "description": "Retrieves an item by 1-based index or by name.",
       "examples": [
         "local item = trx.items[1]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"
@@ -1459,6 +1567,11 @@
       "order": 2
     },
     {
+      "description": "Module for the game flow: which levels there are, and which one is being played.",
+      "name": "game",
+      "order": 11
+    },
+    {
       "description": "Module for controlling all moveables.",
       "name": "items",
       "order": 4
@@ -1561,6 +1674,42 @@
       "writable": true
     },
     {
+      "description": "The levels of the game proper, in order, as a list of `trx.game.Level`.",
+      "path": "game.levels",
+      "type": "table",
+      "writable": false
+    },
+    {
+      "description": "The cutscenes, as a list of `trx.game.Level`.",
+      "path": "game.cutscenes",
+      "type": "table",
+      "writable": false
+    },
+    {
+      "description": "The demos, as a list of `trx.game.Level`.",
+      "path": "game.demos",
+      "type": "table",
+      "writable": false
+    },
+    {
+      "description": "The level being played, or `nil` if none is.",
+      "path": "game.current_level",
+      "type": "Level",
+      "writable": false
+    },
+    {
+      "description": "Which Tomb Raider this build is: 1, 2, 3 or 4.",
+      "path": "game.version",
+      "type": "integer",
+      "writable": false
+    },
+    {
+      "description": "The TRX version string.",
+      "path": "game.trx_version",
+      "type": "string",
+      "writable": false
+    },
+    {
       "description": "Lara's own `trx.items.Item`, or `nil` outside a level. Her position, room and hit points are read and written there.",
       "path": "lara.item",
       "type": "Item",
@@ -1592,6 +1741,88 @@
     }
   ],
   "types": [
+    {
+      "description": "A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.",
+      "extensions": [],
+      "fields": [
+        {
+          "description": "The outfit Lara starts the level in.",
+          "name": "lara_outfit",
+          "type": "string",
+          "writable": false
+        },
+        {
+          "description": "The track that plays when the level starts.",
+          "enum": "catalog.music",
+          "name": "music_track",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0.",
+          "name": "num",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Path to the level file.",
+          "name": "path",
+          "type": "string",
+          "writable": false
+        },
+        {
+          "description": "Path to the Lua script that runs when the level loads, or `nil` if it has none.",
+          "name": "script_path",
+          "type": "string",
+          "writable": false
+        },
+        {
+          "description": "The level's name, as shown to the player.",
+          "name": "title",
+          "type": "string",
+          "writable": false
+        },
+        {
+          "description": "What kind of level it is.",
+          "enum": "game.LevelType",
+          "name": "type",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Ally kills the stats screen must not hold against the player.",
+          "name": "unobtainable_ally_kills",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Kills the stats screen must not hold against the player.",
+          "name": "unobtainable_kills",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Pickups the stats screen must not hold against the player, because they cannot be got.",
+          "name": "unobtainable_pickups",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Secrets the stats screen must not hold against the player.",
+          "name": "unobtainable_secrets",
+          "type": "integer",
+          "writable": false
+        },
+        {
+          "description": "Whether bubbles rise through the level's water.",
+          "name": "water_particles",
+          "type": "boolean",
+          "writable": false
+        }
+      ],
+      "methods": [],
+      "path": "game.Level"
+    },
     {
       "description": "An item, also known as a moveable.",
       "extensions": [

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -81,7 +81,7 @@ Module for the game flow: which levels there are, and which one is being played.
     - **`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
     - **`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
     - **`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
-    - **`water_particles`**: boolean. Whether bubbles rise through the level's water. *(read-only)*
+    - **`water_particles`**: boolean. Whether water particles are visible in the level's water. *(read-only)*
 
 ### Functions
 

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -3,69 +3,107 @@ title: Game
 order: 11
 ---
 
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/game.lua. Edit it there.
+-->
+
 ## Game module
 
-Module for retrieving game version and level tables.
+Module for the game flow: which levels there are, and which one is being played.
+
+### Properties
+
+- **`trx.game.levels`** (table). The levels of the game proper, in order, as a list of `trx.game.Level`. *(read-only)*
+- **`trx.game.cutscenes`** (table). The cutscenes, as a list of `trx.game.Level`. *(read-only)*
+- **`trx.game.demos`** (table). The demos, as a list of `trx.game.Level`. *(read-only)*
+- **`trx.game.current_level`** (Level). The level being played, or `nil` if none is. *(read-only)*
+- **`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
+- **`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
+
+### Enums
+
+- [lua]`trx.game.LevelTable`
+
+    One of the lists of levels the game flow declares.
+
+    - `trx.game.LevelTable.TITLE` = `0`  
+        The title screen.
+    - `trx.game.LevelTable.MAIN` = `1`  
+        The levels of the game proper.
+    - `trx.game.LevelTable.CUTSCENES` = `2`  
+        The cutscenes.
+    - `trx.game.LevelTable.DEMOS` = `3`  
+        The demos that play when the title screen is left alone.
+
+- [lua]`trx.game.LevelType`
+
+    What kind of level it is.
+
+    - `trx.game.LevelType.TITLE` = `0`  
+        The title screen.
+    - `trx.game.LevelType.NORMAL` = `1`  
+        An ordinary level.
+    - `trx.game.LevelType.CUTSCENE` = `2`  
+        A cutscene.
+    - `trx.game.LevelType.DEMO` = `3`  
+        A demo.
+    - `trx.game.LevelType.GYM` = `4`  
+        Lara's home, which has no level number.
+    - `trx.game.LevelType.BONUS` = `5`  
+        A bonus level, played once the game is finished.
+    - `trx.game.LevelType.DUMMY` = `6`  
+        Not a level. Kept only because old savegames refer to it.
+    - `trx.game.LevelType.CURRENT` = `7`  
+        Not a level. Kept only because old savegames refer to it.
 
 ### Structures
 
 - [lua]`trx.game.Level`
 
-    Represents a level entry.
+    A level, as the game flow file declares it. Everything on it is read-only: a level is what the game flow says it is.
+
+    Handles are live references: if the underlying object is destroyed,
+    using the handle raises an error rather than silently reading an
+    unrelated one.
 
     Properties:
-
-    - **`num`**: Integer ordinal number of the level.
-    - **`name`**: String title of the level.
-    - **`path`**: String file path of the level data.
-    - **`type`**: Integer type identifier of the level.
-
-- [lua]`trx.game.Settings`
-
-    Represents global engine settings.
-
-    Properties:
-    - **`lockout_option_ring`**: Whether to disallow the player from using the option ring in-game.
-    - **`load_save_disabled`**: Whether to disable saving and loading the game.
-    - **`play_any_level`**: Whether to show a full list of all levels in place of the New Game passport page.
-    - **`demo_delay`**: The number of seconds to pass in the main menu before playing the demo.
-    - **`cheat_keys`**: Whether to enable original game cheats (the ones where Lara turns around three times).
-
-    Writable properties:
-    - `lockout_option_ring`
-    - `load_save_disabled`
-    - `play_any_level`
-    - `demo_delay`
-    - `cheat_keys`
+    - **`lara_outfit`**: string. The outfit Lara starts the level in. *(read-only)*
+    - **`music_track`**: integer. The track that plays when the level starts. Compare against `trx.catalog.music`. *(read-only)*
+    - **`num`**: integer. The number the level goes by. Not its place in the table: levels the game flow skips do not count, and a gym level has no number at all and reads 0. *(read-only)*
+    - **`path`**: string. Path to the level file. *(read-only)*
+    - **`script_path`**: string. Path to the Lua script that runs when the level loads, or `nil` if it has none. *(read-only)*
+    - **`title`**: string. The level's name, as shown to the player. *(read-only)*
+    - **`type`**: integer. What kind of level it is. Compare against `trx.game.LevelType`. *(read-only)*
+    - **`unobtainable_ally_kills`**: integer. Ally kills the stats screen must not hold against the player. *(read-only)*
+    - **`unobtainable_kills`**: integer. Kills the stats screen must not hold against the player. *(read-only)*
+    - **`unobtainable_pickups`**: integer. Pickups the stats screen must not hold against the player, because they cannot be got. *(read-only)*
+    - **`unobtainable_secrets`**: integer. Secrets the stats screen must not hold against the player. *(read-only)*
+    - **`water_particles`**: boolean. Whether bubbles rise through the level's water. *(read-only)*
 
 ### Functions
 
-- [lua]`trx.game.version`  
-  Returns the current game version integer. This is guessed from the level data.
-- [lua]`trx.game.trx_version`  
-  Returns the current TRX version string.
-
-- [lua]`trx.game.current_level`  
-  Retrieves the [lua]`trx.game.Level` that's currently loaded or `nil`.
-
-- [lua]`#trx.game.settings`  
-  Accesses the global engine settings.
-
-- [lua]`#trx.game.levels`  
-  [lua]`#trx.game.demos`  
-  [lua]`#trx.game.cutscenes`  
-  Returns the number of levels of the specific type.
-
-- [lua]`trx.game.levels[num]`  
-  [lua]`trx.game.demos[num]`  
-  [lua]`trx.game.cutscenes[num]`  
-  Retrieves the [lua]`trx.game.Level` of the specific type at the given index,
-  or `nil` if out of range.
-
 - [lua]`trx.game.play_level(num)`  
-  Plays the specified level via game flow override or errors if invalid.
-  If the Gym level is available, it's the level 1.
+  Starts a level of the game proper.
+
+  Parameters:
+  - **`num`** (integer). The level's number.
+
+  Example:
+  ```lua
+  trx.game.play_level(1)
+  ```
+
 - [lua]`trx.game.play_cutscene(num)`  
-  Plays the specified cutscene via game flow override or errors if invalid.
+  Plays a cutscene.
+
+  Parameters:
+  - **`num`** (integer). The cutscene's number.
+
 - [lua]`trx.game.play_demo(num)`  
-  Plays the specified demo via game flow override or errors if invalid.
+  Plays a demo.
+
+  Parameters:
+  - **`num`** (integer). The demo's number.

--- a/src/meson.build
+++ b/src/meson.build
@@ -276,6 +276,7 @@ common_sources = [
   'trx/game/game/state.c',
   'trx/game/game_buf.c',
   'trx/game/game_flow/common.c',
+  'trx/game/game_flow/fields.c',
   'trx/game/game_flow/inventory.c',
   'trx/game/game_flow/reader.c',
   'trx/game/game_flow/sequencer.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -242,6 +242,18 @@ test('lua_log', test_lua_log_exe, suite: 'unit')
 # trx.lara stands for one C struct, so her fields go through the real reflection
 # layer. Only what is not a field of LARA_INFO is faked.
 # An object is what an item is cut from, so they share a fake engine.
+test_lua_game_exe = executable(
+  'test_lua_game',
+  files('unit/test_lua_game.c', 'unit/fake_engine_game.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/game_flow/fields.c', '../trx/game/lua/game.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_game', test_lua_game_exe, suite: 'unit')
+
 test_lua_objects_exe = executable(
   'test_lua_objects',
   files('unit/test_lua_objects.c', 'unit/fake_engine_items.c') + test_stubs

--- a/src/tests/unit/fake_engine_game.c
+++ b/src/tests/unit/fake_engine_game.c
@@ -1,0 +1,170 @@
+// A game flow of three levels, one cutscene and one demo. The second level is a
+// gym, which is the case worth having: a gym has no number, so the ordinal a
+// script reads is not the level's place in the table.
+
+#include "fake_engine_game.h"
+
+#include <trx/game/game_flow/common.h>
+#include <trx/game/savegame.h>
+
+#include <stdbool.h>
+#include <string.h>
+
+FAKE_GAME_CALLS g_FakeGameCalls;
+
+static GF_LEVEL m_Levels[FAKE_LEVEL_COUNT];
+static GF_LEVEL m_Cutscenes[FAKE_CUTSCENE_COUNT];
+static GF_LEVEL m_Demos[FAKE_DEMO_COUNT];
+static GF_LEVEL_TABLE m_Tables[GFLT_NUMBER_OF];
+static const GF_LEVEL *m_CurrentLevel;
+
+const GF_LEVEL_TABLE *GF_GetLevelTable(const GF_LEVEL_TABLE_TYPE table_type)
+{
+    if (table_type < 0 || table_type >= GFLT_NUMBER_OF) {
+        return nullptr;
+    }
+    return &m_Tables[table_type];
+}
+
+int32_t GF_GetLevelCount(const GF_LEVEL_TABLE_TYPE table_type)
+{
+    const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(table_type);
+    return tbl != nullptr ? tbl->count : 0;
+}
+
+const GF_LEVEL *GF_GetLevel(
+    const GF_LEVEL_TABLE_TYPE table_type, const int32_t num)
+{
+    const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(table_type);
+    if (tbl == nullptr || num < 0 || num >= tbl->count) {
+        return nullptr;
+    }
+    return &tbl->levels[num];
+}
+
+const GF_LEVEL *GF_GetCurrentLevel(void)
+{
+    return m_CurrentLevel;
+}
+
+GF_LEVEL_TABLE_TYPE GF_GetLevelTableType(const GF_LEVEL_TYPE level_type)
+{
+    switch (level_type) {
+    case GFL_TITLE:
+        return GFLT_TITLE;
+    case GFL_CUTSCENE:
+        return GFLT_CUTSCENES;
+    case GFL_DEMO:
+        return GFLT_DEMOS;
+    default:
+        return GFLT_MAIN;
+    }
+}
+
+// A gym has no number, and everything after it still counts up.
+int32_t GF_GetLevelOrdinalNumber(
+    const GF_LEVEL_TABLE_TYPE table_type, const GF_LEVEL *const ref_level)
+{
+    const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(table_type);
+    int32_t ordinal = 1;
+    for (int32_t i = 0; i < tbl->count; i++) {
+        const GF_LEVEL *const level = &tbl->levels[i];
+        if (level == ref_level) {
+            return level->type == GFL_GYM ? 0 : ordinal;
+        }
+        if (level->type != GFL_GYM) {
+            ordinal++;
+        }
+    }
+    return 0;
+}
+
+// The gameflow command the play_* verbs queue, and the savegame bookkeeping
+// they do on the way. Recorded, not performed.
+void GF_OverrideCommand(const GF_COMMAND command)
+{
+    switch (command.action) {
+    case GF_START_GAME:
+        g_FakeGameCalls.play_level++;
+        break;
+    case GF_START_CINE:
+        g_FakeGameCalls.play_cutscene++;
+        break;
+    case GF_START_DEMO:
+        g_FakeGameCalls.play_demo++;
+        break;
+    default:
+        break;
+    }
+    g_FakeGameCalls.last_num = command.param;
+}
+
+void Savegame_PersistGameToCurrentInfo(const GF_LEVEL *const level)
+{
+}
+
+RESUME_INFO *Savegame_GetCurrentInfo(const GF_LEVEL *const level)
+{
+    return nullptr;
+}
+
+int32_t g_TRVersion = 1;
+const char *g_TRXVersion = "TRX-test";
+
+void FakeGame_Reset(void)
+{
+    memset(m_Levels, 0, sizeof(m_Levels));
+    memset(m_Cutscenes, 0, sizeof(m_Cutscenes));
+    memset(m_Demos, 0, sizeof(m_Demos));
+
+    m_Levels[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_GYM,
+        .title = "Lara's Home",
+        .path = "gym.phd",
+        .lara_outfit = "casual",
+        .water_particles = false,
+    };
+    m_Levels[1] = (GF_LEVEL) {
+        .num = 1,
+        .type = GFL_NORMAL,
+        .title = "Caves",
+        .path = "level1.phd",
+        .script_path = "caves.lua",
+        .lara_outfit = "default",
+        .water_particles = true,
+        .unobtainable = { .pickups = 1, .secrets = 2 },
+    };
+    m_Levels[2] = (GF_LEVEL) {
+        .num = 2,
+        .type = GFL_NORMAL,
+        .title = "Vilcabamba",
+        .path = "level2.phd",
+    };
+    m_Cutscenes[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_CUTSCENE,
+        .title = "Cutscene 1",
+    };
+    m_Demos[0] = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_DEMO,
+        .title = "Demo 1",
+    };
+
+    m_Tables[GFLT_MAIN] =
+        (GF_LEVEL_TABLE) { .count = FAKE_LEVEL_COUNT, .levels = m_Levels };
+    m_Tables[GFLT_CUTSCENES] = (GF_LEVEL_TABLE) { .count = FAKE_CUTSCENE_COUNT,
+                                                  .levels = m_Cutscenes };
+    m_Tables[GFLT_DEMOS] =
+        (GF_LEVEL_TABLE) { .count = FAKE_DEMO_COUNT, .levels = m_Demos };
+    m_Tables[GFLT_TITLE] = (GF_LEVEL_TABLE) { .count = 0, .levels = nullptr };
+
+    m_CurrentLevel = nullptr;
+    g_FakeGameCalls = (FAKE_GAME_CALLS) {};
+}
+
+void FakeGame_SetCurrentLevel(const int32_t idx)
+{
+    m_CurrentLevel = idx < 0 ? nullptr : &m_Levels[idx];
+}

--- a/src/tests/unit/fake_engine_game.h
+++ b/src/tests/unit/fake_engine_game.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <trx/game/game_flow/types.h>
+
+#include <stdint.h>
+
+#define FAKE_LEVEL_COUNT 3
+#define FAKE_CUTSCENE_COUNT 1
+#define FAKE_DEMO_COUNT 1
+
+// What the surface asked the engine to do, recorded rather than performed.
+typedef struct {
+    int32_t play_level;
+    int32_t play_cutscene;
+    int32_t play_demo;
+    int32_t last_num;
+} FAKE_GAME_CALLS;
+
+extern FAKE_GAME_CALLS g_FakeGameCalls;
+
+void FakeGame_Reset(void);
+
+// Nothing is being played until something is.
+void FakeGame_SetCurrentLevel(int32_t idx);

--- a/src/tests/unit/lua/game.lua
+++ b/src/tests/unit/lua/game.lua
@@ -1,0 +1,117 @@
+-- The game flow API as a script actually sees it.
+--
+-- The fake flow has three levels - a gym, then two ordinary ones - plus one
+-- cutscene and one demo. The gym is the case worth having: it has no number, so
+-- a level's `num` is not its place in the list.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+test("the level list is a list of Level handles", function()
+  local levels = trx.game.levels
+  assert(#levels == fake.LEVEL_COUNT, "wrong number of levels")
+  assert(levels[2].title == "Caves")
+  assert(levels[3].title == "Vilcabamba")
+end)
+
+test("a level's num is its number, not its place in the list", function()
+  local levels = trx.game.levels
+  -- The gym is first in the table and has no number at all.
+  assert(levels[1].type == trx.game.LevelType.GYM)
+  assert(levels[1].num == 0, "a gym has no number")
+
+  -- And the levels after it are numbered from 1, as the player sees them.
+  assert(levels[2].num == 1)
+  assert(levels[3].num == 2)
+end)
+
+test("a level carries what the game flow said about it", function()
+  local caves = trx.game.levels[2]
+  assert(caves.path == "level1.phd")
+  assert(caves.script_path == "caves.lua")
+  assert(caves.lara_outfit == "default")
+  assert(caves.water_particles == true)
+  assert(caves.unobtainable_pickups == 1)
+  assert(caves.unobtainable_secrets == 2)
+end)
+
+test("a level is read-only", function()
+  raises(function()
+    trx.game.levels[2].title = "Nope"
+  end)
+  raises(function()
+    trx.game.levels[2].num = 99
+  end)
+end)
+
+test("a member of GF_LEVEL nobody declared is not reachable", function()
+  -- The struct has a sequence, injections and item drops. None is declared.
+  local caves = trx.game.levels[2]
+  assert(caves.sequence == nil)
+  assert(caves.injections == nil)
+  assert(caves.item_drops == nil)
+end)
+
+test("cutscenes and demos are their own lists", function()
+  assert(#trx.game.cutscenes == 1)
+  assert(trx.game.cutscenes[1].title == "Cutscene 1")
+  assert(trx.game.cutscenes[1].type == trx.game.LevelType.CUTSCENE)
+
+  assert(#trx.game.demos == 1)
+  assert(trx.game.demos[1].type == trx.game.LevelType.DEMO, "DEMO must exist as a level type")
+end)
+
+test("current_level is nil until a level is playing", function()
+  assert(trx.game.current_level == nil)
+
+  fake.set_current_level(2)
+  assert(trx.game.current_level ~= nil, "no current level")
+  assert(trx.game.current_level.title == "Caves")
+end)
+
+test("the enums come from C", function()
+  assert(trx.game.LevelTable.MAIN ~= nil)
+  assert(trx.game.LevelTable.CUTSCENES ~= nil)
+  assert(trx.game.LevelTable.DEMOS ~= nil)
+  assert(trx.game.LevelTable.TITLE ~= nil)
+
+  assert(trx.game.LevelType.TITLE ~= nil)
+  assert(trx.game.LevelType.DEMO ~= nil)
+  assert(trx.game.LevelType.NORMAL ~= trx.game.LevelType.GYM)
+end)
+
+test("version reads through", function()
+  assert(trx.game.version == 1)
+  assert(trx.game.trx_version == "TRX-test")
+end)
+
+test("play_level queues the level", function()
+  fake.set_current_level(2)
+  trx.game.play_level(3)
+  local calls = fake.calls()
+  assert(calls.play_level == 1, "play_level did not reach the game flow")
+  -- Lua counts from 1, the game flow from 0.
+  assert(calls.last_num == 2)
+end)
+
+test("play_level rejects a level that is not there", function()
+  raises(function()
+    trx.game.play_level(99)
+  end)
+  assert(fake.calls().play_level == 0)
+end)
+
+test("settings is gone", function()
+  -- It was five aliases over trx.config, and it wrote through the destructive
+  -- set. One way to reach a setting is enough.
+  assert(trx.game.settings == nil)
+end)
+
+test("an undeclared name cannot be written onto the module", function()
+  raises(function()
+    trx.game.nonsense = 1
+  end)
+  assert(trx.game.nonsense == nil)
+end)
+
+return h.report()

--- a/src/tests/unit/test_lua_game.c
+++ b/src/tests/unit/test_lua_game.c
@@ -1,0 +1,62 @@
+// The game flow surface. The assertions live in src/tests/unit/lua/game.lua;
+// this stands up the world they run against.
+
+#include "fake_engine_game.h"
+#include "lua_surface.h"
+
+#include <lauxlib.h>
+
+extern void LUA_CreateGame(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateGame(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeGame_Reset();
+    return 0;
+}
+
+static int M_FakeSetCurrentLevel(lua_State *const L)
+{
+    FakeGame_SetCurrentLevel(
+        lua_isnil(L, 1) ? -1 : (int32_t)luaL_checkinteger(L, 1) - 1);
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    lua_pushinteger(L, g_FakeGameCalls.play_level);
+    lua_setfield(L, -2, "play_level");
+    lua_pushinteger(L, g_FakeGameCalls.play_cutscene);
+    lua_setfield(L, -2, "play_cutscene");
+    lua_pushinteger(L, g_FakeGameCalls.play_demo);
+    lua_setfield(L, -2, "play_demo");
+    lua_pushinteger(L, g_FakeGameCalls.last_num);
+    lua_setfield(L, -2, "last_num");
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+    lua_pushcfunction(L, M_FakeSetCurrentLevel);
+    lua_setfield(L, -2, "set_current_level");
+    lua_pushinteger(L, FAKE_LEVEL_COUNT);
+    lua_setfield(L, -2, "LEVEL_COUNT");
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "game",
+        .tests = "game",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/trx/game/enum.c
+++ b/src/trx/game/enum.c
@@ -125,9 +125,15 @@ static __attribute__((constructor)) void M_Init(void)
     ENUM_MAP(
         GF_SEQUENCE_EVENT_TYPE, GFS_ADD_SECRET_REWARD, "add_secret_reward");
 
+    ENUM_MAP(GF_LEVEL_TABLE_TYPE, GFLT_TITLE, "title");
+    ENUM_MAP(GF_LEVEL_TABLE_TYPE, GFLT_MAIN, "main");
+    ENUM_MAP(GF_LEVEL_TABLE_TYPE, GFLT_CUTSCENES, "cutscenes");
+    ENUM_MAP(GF_LEVEL_TABLE_TYPE, GFLT_DEMOS, "demos");
+
     ENUM_MAP(GF_LEVEL_TYPE, GFL_TITLE, "title");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_NORMAL, "normal");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_CUTSCENE, "cutscene");
+    ENUM_MAP(GF_LEVEL_TYPE, GFL_DEMO, "demo");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_GYM, "gym");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_BONUS, "bonus");
     ENUM_MAP(GF_LEVEL_TYPE, GFL_DUMMY, "dummy");

--- a/src/trx/game/game_flow/fields.c
+++ b/src/trx/game/game_flow/fields.c
@@ -1,0 +1,48 @@
+// How to reach the members of GF_LEVEL. Offsets and storage types, nothing
+// else: which of these are public, under what name, and what they mean is
+// declared in data/scripting/game.lua.
+
+#include <trx/core/field.h>
+#include <trx/game/game_flow/common.h>
+#include <trx/game/game_flow/types.h>
+
+// The number the level goes by, which is not the same as its place in the
+// table: skipped levels do not count, and a gym level has no number at all.
+static bool M_GetOrdinal(const void *const self, FIELD_VALUE *const out)
+{
+    const GF_LEVEL *const level = self;
+    *out = (FIELD_VALUE) {
+        .type = FT_INT32,
+        .as_int =
+            GF_GetLevelOrdinalNumber(GF_GetLevelTableType(level->type), level),
+    };
+    return true;
+}
+
+// clang-format off
+static const FIELD_DESC M_GF_LEVEL_FIELDS[] = {
+    // what the level is
+    FIELD_FN("num",        FT_INT32, M_GetOrdinal, nullptr),
+    FIELD_RO(GF_LEVEL, type),
+    FIELD_RO(GF_LEVEL, path),
+    FIELD_RO(GF_LEVEL, title),
+    FIELD_RO(GF_LEVEL, script_path),
+    FIELD_RO(GF_LEVEL, lara_outfit),
+    FIELD_RO(GF_LEVEL, music_track),
+    FIELD_RO(GF_LEVEL, water_particles),
+
+    // what the stats screen must not count against the player
+    FIELD_RO(GF_LEVEL, unobtainable.pickups),
+    FIELD_RO(GF_LEVEL, unobtainable.kills),
+    FIELD_RO(GF_LEVEL, unobtainable.ally_kills),
+    FIELD_RO(GF_LEVEL, unobtainable.secrets),
+
+    // Every member here is read-only, and deliberately: a level is what the game
+    // flow file says it is. The sequence, the injections and the item drops are
+    // not exposed at all - they are the level's program and its load-time data,
+    // and neither is a contract. The sequence in particular is due to be
+    // rewritten as a coroutine, and declaring its shape now would freeze it.
+};
+// clang-format on
+
+TYPE_DEFINE(GF_LEVEL, M_GF_LEVEL_FIELDS)

--- a/src/trx/game/game_flow/fields.c
+++ b/src/trx/game/game_flow/fields.c
@@ -1,13 +1,7 @@
-// How to reach the members of GF_LEVEL. Offsets and storage types, nothing
-// else: which of these are public, under what name, and what they mean is
-// declared in data/scripting/game.lua.
-
 #include <trx/core/field.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/game_flow/types.h>
 
-// The number the level goes by, which is not the same as its place in the
-// table: skipped levels do not count, and a gym level has no number at all.
 static bool M_GetOrdinal(const void *const self, FIELD_VALUE *const out)
 {
     const GF_LEVEL *const level = self;
@@ -21,8 +15,7 @@ static bool M_GetOrdinal(const void *const self, FIELD_VALUE *const out)
 
 // clang-format off
 static const FIELD_DESC M_GF_LEVEL_FIELDS[] = {
-    // what the level is
-    FIELD_FN("num",        FT_INT32, M_GetOrdinal, nullptr),
+    FIELD_FN("num", FT_INT32, M_GetOrdinal, nullptr),
     FIELD_RO(GF_LEVEL, type),
     FIELD_RO(GF_LEVEL, path),
     FIELD_RO(GF_LEVEL, title),
@@ -40,8 +33,7 @@ static const FIELD_DESC M_GF_LEVEL_FIELDS[] = {
     // Every member here is read-only, and deliberately: a level is what the game
     // flow file says it is. The sequence, the injections and the item drops are
     // not exposed at all - they are the level's program and its load-time data,
-    // and neither is a contract. The sequence in particular is due to be
-    // rewritten as a coroutine, and declaring its shape now would freeze it.
+    // and neither is a contract.
 };
 // clang-format on
 

--- a/src/trx/game/lara/fields.c
+++ b/src/trx/game/lara/fields.c
@@ -1,7 +1,3 @@
-// How to reach the members of LARA_INFO. Offsets and storage types, nothing
-// else: which of these are public, under what name, and what they mean is
-// declared in data/scripting/lara.lua.
-//
 // Lara's position, room and hit points are not here. She is an item like any
 // other, and those live on it - see trx.lara.item.
 

--- a/src/trx/game/lua/game.c
+++ b/src/trx/game/lua/game.c
@@ -1,5 +1,6 @@
 #include <trx/game/game_flow.h>
 #include <trx/game/lua/common.h>
+#include <trx/game/lua/struct.h>
 #include <trx/game/savegame.h>
 #include <trx/version.h>
 
@@ -27,68 +28,52 @@ static int M_L_GameCountLevels(lua_State *const L)
     return 1;
 }
 
-// Level property getters
-static int M_L_GameLevelGetNum(lua_State *const L)
+extern const TYPE_DESC TYPE_GF_LEVEL;
+
+// A level lives in the game flow for the whole session, so a handle to one
+// never goes stale. It is addressed by table and index, which the ref carries
+// packed: the table in the high half, the index in the low.
+#define M_PACK(table, idx) (((table) << 16) | ((idx) & 0xffff))
+#define M_TABLE(packed) ((packed) >> 16)
+#define M_IDX(packed) ((packed) & 0xffff)
+
+static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
-    const int32_t idx = luaL_checkinteger(L, 2);
-    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
-    lua_pushinteger(
-        L, lvl != nullptr ? GF_GetLevelOrdinalNumber(table_type, lvl) : 0);
-    return 1;
+    return (void *)GF_GetLevel(M_TABLE(ref->idx), M_IDX(ref->idx));
 }
 
-static int M_L_GameLevelGetName(lua_State *const L)
+static void M_PushLevel(
+    lua_State *const L, const GF_LEVEL_TABLE_TYPE table_type, const int32_t idx)
 {
-    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
-    const int32_t idx = luaL_checkinteger(L, 2);
-    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
-    if (lvl != nullptr && lvl->title != nullptr) {
-        lua_pushstring(L, lvl->title);
-    } else {
+    if (GF_GetLevel(table_type, idx) == nullptr) {
         lua_pushnil(L);
+        return;
     }
+    LUA_Struct_Push(L, &TYPE_GF_LEVEL, M_Resolve, M_PACK(table_type, idx), 0);
+}
+
+// trxc.game.get_level(table_type, idx) -> GF_LEVEL handle or nil
+static int M_L_GameGetLevel(lua_State *const L)
+{
+    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
+    // Lua counts from 1, the table from 0.
+    M_PushLevel(L, table_type, luaL_checkinteger(L, 2) - 1);
     return 1;
 }
 
-static int M_L_GameLevelGetPath(lua_State *const L)
+// trxc.game.get_current_level() -> GF_LEVEL handle or nil
+static int M_L_GameGetCurrentLevel(lua_State *const L)
 {
-    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
-    const int32_t idx = luaL_checkinteger(L, 2);
-    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
-    if (lvl != nullptr && lvl->path != nullptr) {
-        lua_pushstring(L, lvl->path);
-    } else {
+    const GF_LEVEL *const level = GF_GetCurrentLevel();
+    if (level == nullptr) {
         lua_pushnil(L);
+        return 1;
     }
+    const GF_LEVEL_TABLE_TYPE table_type = GF_GetLevelTableType(level->type);
+    M_PushLevel(L, table_type, level - GF_GetLevelTable(table_type)->levels);
     return 1;
 }
 
-static int M_L_GameLevelGetType(lua_State *const L)
-{
-    const GF_LEVEL_TABLE_TYPE table_type = luaL_checkinteger(L, 1);
-    const int32_t idx = luaL_checkinteger(L, 2);
-    const GF_LEVEL *const lvl = GF_GetLevel(table_type, idx - 1);
-    lua_pushinteger(L, lvl != nullptr ? lvl->type : 0);
-    return 1;
-}
-
-static int M_L_GameLevelGetCurrentLevelTable(lua_State *const L)
-{
-    const GF_LEVEL *const lvl = GF_GetCurrentLevel();
-    lua_pushinteger(
-        L, lvl != nullptr ? GF_GetLevelTableType(lvl->type) : GFLT_UNKNOWN);
-    return 1;
-}
-
-static int M_L_GameLevelGetCurrentLevelIndex(lua_State *const L)
-{
-    const GF_LEVEL *const lvl = GF_GetCurrentLevel();
-    lua_pushinteger(L, lvl != nullptr ? lvl->num + 1 : -1);
-    return 1;
-}
-
-// trxc.game.play_level(num) → nil
 static int M_L_GamePlayLevel(lua_State *const L)
 {
     const int32_t level_idx = luaL_checkinteger(L, 1) - 1;
@@ -146,6 +131,9 @@ static int M_L_GamePlayDemo(lua_State *const L)
 
 void LUA_CreateGame(lua_State *const L)
 {
+    LUA_Struct_Register(
+        L, &TYPE_GF_LEVEL, (const luaL_Reg[]) { { nullptr, nullptr } });
+
     lua_getglobal(L, "trxc");
     lua_newtable(L);
 
@@ -155,18 +143,10 @@ void LUA_CreateGame(lua_State *const L)
     lua_setfield(L, -2, "get_trx_version");
     lua_pushcfunction(L, M_L_GameCountLevels);
     lua_setfield(L, -2, "count_levels");
-    lua_pushcfunction(L, M_L_GameLevelGetNum);
-    lua_setfield(L, -2, "get_level_num");
-    lua_pushcfunction(L, M_L_GameLevelGetName);
-    lua_setfield(L, -2, "get_level_name");
-    lua_pushcfunction(L, M_L_GameLevelGetPath);
-    lua_setfield(L, -2, "get_level_path");
-    lua_pushcfunction(L, M_L_GameLevelGetType);
-    lua_setfield(L, -2, "get_level_type");
-    lua_pushcfunction(L, M_L_GameLevelGetCurrentLevelTable);
-    lua_setfield(L, -2, "get_current_level_table");
-    lua_pushcfunction(L, M_L_GameLevelGetCurrentLevelIndex);
-    lua_setfield(L, -2, "get_current_level_idx");
+    lua_pushcfunction(L, M_L_GameGetLevel);
+    lua_setfield(L, -2, "get_level");
+    lua_pushcfunction(L, M_L_GameGetCurrentLevel);
+    lua_setfield(L, -2, "get_current_level");
 
     lua_pushcfunction(L, M_L_GamePlayLevel);
     lua_setfield(L, -2, "play_level");
@@ -174,28 +154,6 @@ void LUA_CreateGame(lua_State *const L)
     lua_setfield(L, -2, "play_cutscene");
     lua_pushcfunction(L, M_L_GamePlayDemo);
     lua_setfield(L, -2, "play_demo");
-
-    lua_newtable(L);
-    lua_pushinteger(L, GFLT_MAIN);
-    lua_setfield(L, -2, "MAIN");
-    lua_pushinteger(L, GFLT_CUTSCENES);
-    lua_setfield(L, -2, "CUTSCENES");
-    lua_pushinteger(L, GFLT_DEMOS);
-    lua_setfield(L, -2, "DEMOS");
-    lua_setfield(L, -2, "LevelTable");
-
-    lua_newtable(L);
-    lua_pushinteger(L, GFL_NORMAL);
-    lua_setfield(L, -2, "NORMAL");
-    lua_pushinteger(L, GFL_CUTSCENE);
-    lua_setfield(L, -2, "CUTSCENE");
-    lua_pushinteger(L, GFL_DEMO);
-    lua_setfield(L, -2, "DEMO");
-    lua_pushinteger(L, GFL_GYM);
-    lua_setfield(L, -2, "GYM");
-    lua_pushinteger(L, GFL_BONUS);
-    lua_setfield(L, -2, "BONUS");
-    lua_setfield(L, -2, "LevelType");
 
     lua_setfield(L, -2, "game");
     lua_pop(L, 1);

--- a/src/trx/game/objects/fields.c
+++ b/src/trx/game/objects/fields.c
@@ -1,7 +1,3 @@
-// How to reach the members of OBJECT. Offsets and storage types, nothing else:
-// which of these are public, under what name, and what they mean is declared in
-// data/scripting/objects.lua.
-//
 // An object is the definition every item of that type is cut from - a wolf's
 // radius, not this wolf's. Per-item state lives on the item; see trx.items.
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This migrates the game LUA API to the new `api` framework and adds tests.
