### PR TITLE
camera: fix binoculars with fixed cameras

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.1...develop) - ××××-××-××
 - changed reflections UV mapping to be more correct
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
+- fixed Lara being unable to use binoculars when fixed cameras or track path flyby sequences are active (regression from 1.9)
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 
 **Lua**

--- a/src/trx/game/camera/binoculars.c
+++ b/src/trx/game/camera/binoculars.c
@@ -48,8 +48,7 @@ static bool M_CanEnter(void)
         && lara_info->water_status == LWS_ABOVE_WATER
         && Lara_Vehicle_GetItem() == nullptr
         && lara_item->current_anim_state == LS(LS_STOP)
-        && g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_PHOTO_MODE
-        && g_Camera.type != CAM_FLYBY_MODE;
+        && g_Camera.type != CAM_CINEMATIC && g_Camera.type != CAM_PHOTO_MODE;
 }
 
 static void M_Enter(void)

--- a/src/trx/game/camera/environment.c
+++ b/src/trx/game/camera/environment.c
@@ -51,6 +51,10 @@ static inline M_TARGET_STATUS M_HandleCameraTrigger(
         return TARGET_INVALID;
     }
 
+    if (Camera_Binoculars_IsActive()) {
+        return TARGET_INVALID;
+    }
+
     g_Camera.type = CAM_FIXED;
     if (g_Config.visuals.enable_glide_cameras && cam_data->glide != 0) {
         g_Camera.speed = cam_data->glide + 1;

--- a/src/trx/game/flyby_mode.c
+++ b/src/trx/game/flyby_mode.c
@@ -79,8 +79,15 @@ void FlybyMode_PreControl(void)
 
 void FlybyMode_PostControl(void)
 {
-    if (FlybyMode_IsActive()) {
-        g_Camera.type = CAM_FLYBY_MODE;
-        M_RestoreLaraInfo();
+    if (!FlybyMode_IsActive()) {
+        return;
     }
+
+    if (Camera_Binoculars_IsActive()) {
+        FlybyMode_Cancel();
+        return;
+    }
+
+    g_Camera.type = CAM_FLYBY_MODE;
+    M_RestoreLaraInfo();
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows Lara to break out of fixed cameras or flybys (where she is controllable) when binoculars have been requested.

Resolves TRX651.
