### PR TITLE
Add LUA strings utility module

### DIFF
--- a/data/scripting/strings.lua
+++ b/data/scripting/strings.lua
@@ -1,0 +1,47 @@
+local raw = trxc.strings
+local api = trx.api
+
+api.module("strings", {
+  order = 19,
+  description = "Utilities for working with strings.\n\n",
+})
+
+api.define("strings.fuzzy_match", {
+  description = "Matches what someone typed against a list of candidates, forgivingly: `big medi` "
+    .. "finds `large medipack`.\n\n"
+    .. "Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which "
+    .. "comes back untouched on the match - hang an id off it and read it back.",
+  params = {
+    { name = "input", type = "string", description = "What the player typed." },
+    {
+      name = "sources",
+      type = "table",
+      description = "List of `{ key = <the name>, value = <anything>, weight = <integer> }`. "
+        .. "A heavier candidate wins a tie; weight defaults to 1.",
+    },
+  },
+  returns = {
+    type = "table",
+    description = "The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` "
+      .. "means the whole candidate matched, `is_word` that a whole word did.",
+  },
+  examples = {
+    [==[local matches = trx.strings.fuzzy_match("wolf", {
+  { key = "wolf", value = trx.catalog.objects.WOLF },
+  { key = "bear", value = trx.catalog.objects.BEAR },
+})
+local best = matches[1]]==],
+  },
+  impl = raw.fuzzy_match,
+})
+
+api.define("strings.regex_match", {
+  description = "Whether a subject matches a regular expression. Case-insensitive.",
+  params = {
+    { name = "subject", type = "string" },
+    { name = "pattern", type = "string", description = "A PCRE regular expression." },
+  },
+  returns = { type = "boolean" },
+  examples = { [[if trx.strings.regex_match(args, "^%d+$") then ... end]] },
+  impl = raw.regex_match,
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Lua**
 - added a new Lua module, `trx.math`, with the engine's own fixed-point trigonometry and the `DEG_1`, `DEG_45`, `DEG_90` and `WALL_L` constants
+- added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
 - added `trx.game.LevelType.TITLE`, and a `demo` level type to the game flow, which could not be named before
 - added `trx.items.spawn()`, to place a new item in the level at runtime
 - added `trx.items.get()`, `trx.items.count()`, `trx.rooms.get()`, `trx.rooms.count()` and `trx.objects.get()`, replacing the `fn` namespaces; refer to migration notes

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3418,6 +3418,50 @@
     {
       "description": "Stops every sound effect currently playing.",
       "path": "sound.stop_all"
+    },
+    {
+      "description": "Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.\n\nCandidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.",
+      "examples": [
+        "local matches = trx.strings.fuzzy_match(\"wolf\", {\n  { key = \"wolf\", value = trx.catalog.objects.WOLF },\n  { key = \"bear\", value = trx.catalog.objects.BEAR },\n})\nlocal best = matches[1]"
+      ],
+      "params": [
+        {
+          "description": "What the player typed.",
+          "name": "input",
+          "type": "string"
+        },
+        {
+          "description": "List of `{ key = <the name>, value = <anything>, weight = <integer> }`. A heavier candidate wins a tie; weight defaults to 1.",
+          "name": "sources",
+          "type": "table"
+        }
+      ],
+      "path": "strings.fuzzy_match",
+      "returns": {
+        "description": "The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` means the whole candidate matched, `is_word` that a whole word did.",
+        "type": "table"
+      }
+    },
+    {
+      "description": "Whether a subject matches a regular expression. Case-insensitive.",
+      "examples": [
+        "if trx.strings.regex_match(args, \"^%d+$\") then ... end"
+      ],
+      "params": [
+        {
+          "name": "subject",
+          "type": "string"
+        },
+        {
+          "description": "A PCRE regular expression.",
+          "name": "pattern",
+          "type": "string"
+        }
+      ],
+      "path": "strings.regex_match",
+      "returns": {
+        "type": "boolean"
+      }
     }
   ],
   "modules": [
@@ -3503,6 +3547,11 @@
       "description": "Module for playing sound effects.",
       "name": "sound",
       "order": 7
+    },
+    {
+      "description": "Utilities for working with strings.\n\n",
+      "name": "strings",
+      "order": 19
     }
   ],
   "namespaces": [

--- a/docs/trx/lua/reference/STRINGS.md
+++ b/docs/trx/lua/reference/STRINGS.md
@@ -1,0 +1,53 @@
+---
+title: Strings
+order: 19
+---
+
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/strings.lua. Edit it there.
+-->
+
+## Strings module
+
+Utilities for working with strings.
+
+
+
+### Functions
+
+- [lua]`trx.strings.fuzzy_match(input, sources)`  
+  Matches what someone typed against a list of candidates, forgivingly: `big medi` finds `large medipack`.
+
+  Candidates are ranked, best first. Each carries a `value` of the caller's choosing, which comes back untouched on the match - hang an id off it and read it back.
+
+  Parameters:
+  - **`input`** (string). What the player typed.
+  - **`sources`** (table). List of `{ key = <the name>, value = <anything>, weight = <integer> }`. A heavier candidate wins a tie; weight defaults to 1.
+
+  Returns: table. The matches, best first: `{ key, value, score, is_full, is_word }`. `is_full` means the whole candidate matched, `is_word` that a whole word did.
+
+  Example:
+  ```lua
+  local matches = trx.strings.fuzzy_match("wolf", {
+    { key = "wolf", value = trx.catalog.objects.WOLF },
+    { key = "bear", value = trx.catalog.objects.BEAR },
+  })
+  local best = matches[1]
+  ```
+
+- [lua]`trx.strings.regex_match(subject, pattern)`  
+  Whether a subject matches a regular expression. Case-insensitive.
+
+  Parameters:
+  - **`subject`** (string).
+  - **`pattern`** (string). A PCRE regular expression.
+
+  Returns: boolean.
+
+  Example:
+  ```lua
+  if trx.strings.regex_match(args, "^%d+$") then ... end
+  ```

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ trx_lua_embed = custom_target(
     '../data/scripting/objects.lua',
     '../data/scripting/rooms.lua',
     '../data/scripting/sound.lua',
+    '../data/scripting/strings.lua',
   ],
   output: ['trx_embedded_lua.c'],
   command: [
@@ -427,6 +428,7 @@ common_sources = [
   'trx/game/lua/rooms.c',
   'trx/game/lua/sandbox.c',
   'trx/game/lua/sound.c',
+  'trx/game/lua/strings.c',
   'trx/game/lua/struct.c',
   'trx/game/lua/utils.c',
   'trx/game/matrix.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -28,6 +28,9 @@ add_project_arguments(['-Wno-unused', '-Wno-unused-parameter'], language: 'c')
 # project has to find Lua itself, and distributions disagree on the name.
 dep_lua = dependency('lua5.4', 'lua-5.4', 'lua54', 'lua')
 
+# core/strings does its regex with PCRE2.
+dep_pcre2 = dependency('libpcre2-8')
+
 # enum_map.c hashes with uthash, which is headers only.
 c_compiler.check_header('uthash.h', required: true)
 
@@ -208,6 +211,24 @@ test_lua_music_exe = executable(
   build_by_default: false,
 )
 test('lua_music', test_lua_music_exe, suite: 'unit')
+
+# The fuzzy matcher and the regex are the real ones out of trx/core/strings.
+test_lua_strings_exe = executable(
+  'test_lua_strings',
+  files('unit/test_lua_strings.c') + test_stubs
+    + lua_surface_src
+    + files(
+      '../trx/core/strings/common.c',
+      '../trx/core/strings/case_funcs.c',
+      '../trx/core/strings/fuzzy_match.c',
+      '../trx/game/lua/strings.c',
+    ),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua, dep_pcre2],
+  c_args: lua_surface_args + ['-DPCRE2_CODE_UNIT_WIDTH=8'],
+  build_by_default: false,
+)
+test('lua_strings', test_lua_strings_exe, suite: 'unit')
 
 test_lua_sound_exe = executable(
   'test_lua_sound',

--- a/src/tests/unit/lua/strings.lua
+++ b/src/tests/unit/lua/strings.lua
@@ -1,0 +1,68 @@
+-- The string utilities as a script actually sees them.
+--
+-- The matcher is the real one out of trx/core/strings, so what these assert is
+-- what the console does when a player types an object name.
+
+local h = require("harness")
+local test, raises = h.test, h.raises
+
+local function sources()
+  return {
+    { key = "wolf", value = "WOLF" },
+    { key = "bear", value = "BEAR" },
+    { key = "large medipack", value = "MEDI_BIG" },
+    { key = "small medipack", value = "MEDI_SMALL" },
+  }
+end
+
+test("an exact name matches itself", function()
+  local matches = trx.strings.fuzzy_match("wolf", sources())
+  assert(#matches > 0, "the wolf did not match")
+  assert(matches[1].value == "WOLF", "the wolf was not the best match")
+  assert(matches[1].key == "wolf")
+  assert(matches[1].is_full == true, "an exact name is a full match")
+end)
+
+test("the value rides along untouched", function()
+  -- It is the caller's, and the matcher never looks at it. Hang an object id off
+  -- a candidate and read it back.
+  local matches = trx.strings.fuzzy_match("bear", {
+    { key = "bear", value = { id = 8, tag = "anything" } },
+  })
+  assert(matches[1].value.id == 8)
+  assert(matches[1].value.tag == "anything")
+end)
+
+test("a partial name matches, which is the point", function()
+  -- `big medi` is what a player types; `large medipack` is what it is called.
+  local matches = trx.strings.fuzzy_match("medi", sources())
+  assert(#matches > 0, "medi matched nothing")
+  for _, match in ipairs(matches) do
+    assert(match.key:find("medi"), "matched something with no medi in it: " .. match.key)
+  end
+end)
+
+test("a name nobody has matches nothing", function()
+  assert(#trx.strings.fuzzy_match("wombat", sources()) == 0)
+end)
+
+test("weight breaks a tie", function()
+  -- Two candidates spelled the same; the heavier one wins.
+  local matches = trx.strings.fuzzy_match("thing", {
+    { key = "thing", value = "LIGHT", weight = 1 },
+    { key = "thing", value = "HEAVY", weight = 10 },
+  })
+  assert(matches[1].value == "HEAVY", "the heavier candidate must win")
+end)
+
+test("an empty source list matches nothing, rather than raising", function()
+  assert(#trx.strings.fuzzy_match("wolf", {}) == 0)
+end)
+
+test("regex_match answers, and ignores case", function()
+  assert(trx.strings.regex_match("wolf", "^wo") == true)
+  assert(trx.strings.regex_match("WOLF", "^wo") == true, "the match is case-insensitive")
+  assert(trx.strings.regex_match("bear", "^wo") == false)
+end)
+
+return h.report()

--- a/src/tests/unit/stubs_enum_map.c
+++ b/src/tests/unit/stubs_enum_map.c
@@ -15,9 +15,13 @@
 // The real one cycles a ring of growing static buffers, so several results can
 // be live at once; the caller never frees them. enum_map.c only keeps one key
 // alive at a time, but match the contract rather than assume that.
+//
+// Weak, so a test that links core/strings itself - see test_lua_strings - gets
+// the real thing instead of this.
 #define M_BUFFER_COUNT 8
 
-const char *String_FormatStaticV(const char *const fmt, va_list args)
+__attribute__((weak)) const char *String_FormatStaticV(
+    const char *const fmt, va_list args)
 {
     static char *m_Buffers[M_BUFFER_COUNT];
     static size_t m_Capacities[M_BUFFER_COUNT];
@@ -41,7 +45,8 @@ const char *String_FormatStaticV(const char *const fmt, va_list args)
     return *buf;
 }
 
-const char *String_FormatStatic(const char *const fmt, ...)
+__attribute__((weak)) const char *String_FormatStatic(
+    const char *const fmt, ...)
 {
     va_list args;
     va_start(args, fmt);

--- a/src/tests/unit/test_lua_strings.c
+++ b/src/tests/unit/test_lua_strings.c
@@ -1,0 +1,39 @@
+// The string utility surface. The assertions live in
+// src/tests/unit/lua/strings.lua; this stands up the world they run against.
+
+#include "lua_surface.h"
+
+extern void LUA_CreateStrings(lua_State *L);
+
+static void M_SetUpTRXC(lua_State *const L)
+{
+    LUA_CreateStrings(L);
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    return 1;
+}
+
+static void M_PushFake(lua_State *const L)
+{
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "strings",
+        .tests = "strings",
+        .setup_trxc = M_SetUpTRXC,
+        .push_fake = M_PushFake,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -37,6 +37,7 @@ extern void LUA_CreateLara(lua_State *L);
 extern void LUA_CreateLog(lua_State *L);
 extern void LUA_CreateMusic(lua_State *L);
 extern void LUA_CreateMath(lua_State *L);
+extern void LUA_CreateStrings(lua_State *L);
 extern void LUA_CreateStruct(lua_State *L);
 extern void LUA_CreateSound(lua_State *L);
 extern void LUA_CreateConfig(lua_State *L);
@@ -200,6 +201,7 @@ void LUA_Init(void)
     lua_newtable(L);
     lua_setglobal(L, "trx");
 
+    M_LoadTRXCModule(L, LUA_CreateStrings);
     M_LoadTRXCModule(L, LUA_CreateStruct);
     M_LoadTRXCModule(L, LUA_CreateEnum);
     M_LoadTRXCModule(L, LUA_CreateCatalog);

--- a/src/trx/game/lua/strings.c
+++ b/src/trx/game/lua/strings.c
@@ -1,0 +1,95 @@
+#include <trx/core/strings.h>
+#include <trx/core/strings/fuzzy_match.h>
+#include <trx/game/lua/common.h>
+
+#include <lauxlib.h>
+
+// trxc.strings.fuzzy_match(input, sources) -> matches
+//
+// `sources` is a list of { key, value, weight }. The value is the caller's own:
+// it is not read here, and it comes back on the match.
+static int M_L_StringsFuzzyMatch(lua_State *const L)
+{
+    const char *const input = luaL_checkstring(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+
+    VECTOR *const sources = Vector_Create(sizeof(STRING_FUZZY_SOURCE));
+
+    const int32_t count = (int32_t)lua_rawlen(L, 2);
+    for (int32_t i = 1; i <= count; i++) {
+        lua_rawgeti(L, 2, i);
+        if (!lua_istable(L, -1)) {
+            lua_pop(L, 1);
+            continue;
+        }
+
+        lua_getfield(L, -1, "key");
+        const char *const key = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, -1, "weight");
+        const int32_t weight = (int32_t)luaL_optinteger(L, -1, 1);
+        lua_pop(L, 1);
+
+        if (key != nullptr) {
+            // Carry the 1-based index rather than the value itself, so nothing
+            // here holds a reference into the caller's table.
+            const STRING_FUZZY_SOURCE source = {
+                .key = key,
+                .value = (void *)(intptr_t)i,
+                .weight = weight,
+            };
+            Vector_Add(sources, (void *)&source);
+        }
+        lua_pop(L, 1);
+    }
+
+    VECTOR *const matches = String_FuzzyMatch(input, sources);
+
+    lua_newtable(L);
+    for (int32_t i = 0; i < matches->count; i++) {
+        const STRING_FUZZY_MATCH *const match = Vector_Get(matches, i);
+
+        lua_newtable(L);
+        lua_pushstring(L, match->key);
+        lua_setfield(L, -2, "key");
+
+        lua_rawgeti(L, 2, (int32_t)(intptr_t)match->value);
+        lua_getfield(L, -1, "value");
+        lua_remove(L, -2);
+        lua_setfield(L, -2, "value");
+
+        lua_pushinteger(L, match->score.score);
+        lua_setfield(L, -2, "score");
+        lua_pushboolean(L, match->score.is_full);
+        lua_setfield(L, -2, "is_full");
+        lua_pushboolean(L, match->score.is_word);
+        lua_setfield(L, -2, "is_word");
+
+        lua_seti(L, -2, i + 1);
+    }
+
+    Vector_Free(matches);
+    Vector_Free(sources);
+    return 1;
+}
+
+// trxc.strings.regex_match(subject, pattern) -> bool
+static int M_L_StringsRegexMatch(lua_State *const L)
+{
+    lua_pushboolean(
+        L, String_Match(luaL_checkstring(L, 1), luaL_checkstring(L, 2)));
+    return 1;
+}
+
+void LUA_CreateStrings(lua_State *const L)
+{
+    lua_getglobal(L, "trxc");
+    lua_newtable(L);
+    lua_pushcfunction(L, M_L_StringsFuzzyMatch);
+    lua_setfield(L, -2, "fuzzy_match");
+    lua_pushcfunction(L, M_L_StringsRegexMatch);
+    lua_setfield(L, -2, "regex_match");
+    lua_setfield(L, -2, "strings");
+    lua_pop(L, 1);
+}


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds a new `trx.strings` module, which contains `fuzzy_match` and `regex_match` utility functions.