### PR TITLE
lara/climb: reset interpolation after corner interaction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 - changed reflections UV mapping to be more correct
 - fixed TR1 and TR2 skyboxes being 2× too bright (regression from 1.9)
 - fixed Lara being unable to use binoculars when fixed cameras or track path flyby sequences are active (regression from 1.9)
+- fixed an interpolation issue when Lara performs inner-corner climbing (regression from 1.9)
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 
 **Lua**

--- a/src/trx/game/interpolation.c
+++ b/src/trx/game/interpolation.c
@@ -293,18 +293,6 @@ static void M_InterpolateBraid(const double ratio, ITEM *const lara_item)
     }
 }
 
-static void M_RememberItem(ITEM *const item)
-{
-    REMEMBER(item, floor);
-    REMEMBER(item, pos.x);
-    REMEMBER(item, pos.y);
-    REMEMBER(item, pos.z);
-    REMEMBER(item, rot.x);
-    REMEMBER(item, rot.y);
-    REMEMBER(item, rot.z);
-    item->prev_frame_num = item->frame_num;
-}
-
 static void M_CommitItem(ITEM *const item)
 {
     COMMIT(item, floor);
@@ -331,12 +319,12 @@ static void M_InterpolateItem(ITEM *const item, const double ratio)
 static void M_RememberItems(void)
 {
     for (int32_t i = 0; i < Item_GetTotalCount(); i++) {
-        M_RememberItem(Item_Get(i));
+        Interpolation_RememberItem(Item_Get(i));
     }
 
     ITEM *const lara_item = Lara_GetItem();
     if (lara_item != nullptr) {
-        M_RememberItem(lara_item);
+        Interpolation_RememberItem(lara_item);
     }
 }
 
@@ -469,6 +457,18 @@ void Interpolation_Remember(void)
     }
     M_RememberItems();
     M_RememberEffects();
+}
+
+void Interpolation_RememberItem(ITEM *const item)
+{
+    REMEMBER(item, floor);
+    REMEMBER(item, pos.x);
+    REMEMBER(item, pos.y);
+    REMEMBER(item, pos.z);
+    REMEMBER(item, rot.x);
+    REMEMBER(item, rot.y);
+    REMEMBER(item, rot.z);
+    item->prev_frame_num = item->frame_num;
 }
 
 void Interpolation_Interpolate(void)

--- a/src/trx/game/interpolation.h
+++ b/src/trx/game/interpolation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/game/items/types.h>
+
 void Interpolation_Enable(void);
 void Interpolation_Disable(void);
 bool Interpolation_IsEnabled(void);
@@ -12,6 +14,7 @@ void Interpolation_SetRate(double rate);
 
 void Interpolation_Interpolate(void);
 void Interpolation_Remember(void);
+void Interpolation_RememberItem(ITEM *item);
 
 // Instantly discard interpolation data
 void Interpolation_CommitLara(void);

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -1,7 +1,6 @@
 #include <trx/config.h>
 #include <trx/game/camera.h>
 #include <trx/game/input.h>
-#include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
 #include <trx/version.h>
@@ -98,7 +97,8 @@ static void M_SetCornerAnim(
     item->pos.x = lara->corner_pos.x;
     item->pos.z = lara->corner_pos.z;
     item->rot.y += rot;
-    Interpolation_CommitLara();
+    item->interp.prev.pos = item->pos;
+    item->interp.prev.rot = item->rot;
 }
 
 static void M_ShimmyCornerOuterLeft(ITEM *const item, COLL_INFO *const coll)

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -1,6 +1,7 @@
 #include <trx/config.h>
 #include <trx/game/camera.h>
 #include <trx/game/input.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
 #include <trx/version.h>
@@ -97,8 +98,7 @@ static void M_SetCornerAnim(
     item->pos.x = lara->corner_pos.x;
     item->pos.z = lara->corner_pos.z;
     item->rot.y += rot;
-    item->interp.prev.pos = item->pos;
-    item->interp.prev.rot = item->rot;
+    Interpolation_RememberItem(item);
 }
 
 static void M_ShimmyCornerOuterLeft(ITEM *const item, COLL_INFO *const coll)

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -2,6 +2,7 @@
 #include <trx/game/camera.h>
 #include <trx/game/collision.h>
 #include <trx/game/game.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/inventory.h>
 #include <trx/game/lara.h>
 #include <trx/game/lara/util.h>
@@ -323,8 +324,7 @@ static void M_JailWakeUp(ITEM *const item, COLL_INFO *const coll)
     Lara_GetMeshPos(LM_HIPS, &pos);
     item->pos.x = pos.x;
     item->pos.z = pos.z;
-    item->interp.prev.pos = item->pos;
-    item->interp.prev.rot = item->rot;
+    Interpolation_RememberItem(item);
 }
 
 // clang-format off

--- a/src/trx/game/objects/creatures/orca.c
+++ b/src/trx/game/objects/creatures/orca.c
@@ -1,5 +1,6 @@
 #include <trx/game/creature.h>
 #include <trx/game/fx.h>
+#include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/objects.h>
 #include <trx/game/output.h>
@@ -111,10 +112,7 @@ static void M_Control(int16_t item_num)
         if (Item_GetRelativeFrame(item) == 59) {
             item->rot.x = -item->rot.x;
             item->rot.y += DEG_180;
-            item->interp.prev.pos = item->pos;
-            item->interp.prev.rot = item->rot;
-            item->interp.result.pos = item->pos;
-            item->interp.result.rot = item->rot;
+            Interpolation_RememberItem(item);
         }
         break;
     }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara's interpolation after climbing around corners. Previously the `prev` values were retained and so even though committing, they would get overwritten when drawing. Maybe we should expose `Interpolation_RememberItem` for re-remembering items in cases like this?

Resolves TRX660.
