### PR TITLE
Fix miscellaneous builder-facing LUA bugs

### DIFF
--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -40,6 +40,13 @@ local namespace_order = {}
 -- path -> { fn = what calling the namespace runs }. Held apart from the
 -- metatable so api.strict can swap the wrapper in.
 local namespace_dispatch = {}
+-- Type name -> predicate. Private: reachable, a script could hand strict mode a
+-- checker that accepts anything.
+local checkers
+local containers = {}
+local container_order = {}
+-- module -> { get, count, accepts }. What indexing the module table reaches.
+local module_containers = {}
 -- module -> { name -> spec }. What the module's __index dispatches on.
 local module_properties = {}
 -- module -> function returning the handle it stands for.
@@ -94,16 +101,20 @@ end
 local function install_module_meta(module)
   local props = module_properties[module]
   local instance = module_instances[module]
-  if props == nil and instance == nil then
+  local container = module_containers[module]
+  if props == nil and instance == nil and container == nil then
     return
   end
 
   trx[module] = trx[module] or {}
-  setmetatable(trx[module], {
+  local meta = {
     __index = function(_, key)
       local prop = props ~= nil and props[key] or nil
       if prop ~= nil then
         return prop.get()
+      end
+      if container ~= nil and container.accepts(key) then
+        return container.get(key)
       end
       if instance ~= nil then
         local handle = instance()
@@ -121,7 +132,7 @@ local function install_module_meta(module)
         end
         -- A property is written, not called, so make_checked never sees it.
         -- Strict mode still has to.
-        if strict_enabled and not api.checkers[prop.type](value) then
+        if strict_enabled and not checkers[prop.type](value) then
           error("trx." .. module .. "." .. tostring(key) .. ": expected a " .. tostring(prop.type), 2)
         end
         prop.set(value)
@@ -138,7 +149,13 @@ local function install_module_meta(module)
       end
       error("Cannot set field '" .. tostring(key) .. "' on trx." .. module, 2)
     end,
-  })
+  }
+  if container ~= nil and container.count ~= nil then
+    meta.__len = function()
+      return container.count()
+    end
+  end
+  setmetatable(trx[module], meta)
 end
 
 function api.module(name, spec)
@@ -207,14 +224,12 @@ local function make_checked(fn, path, params)
     table.concat(body, " ")
   )
 
-  local checkers, defaults = {}, {}
+  local param_checkers, defaults = {}, {}
   for i = 1, fixed do
     local p = params[i]
-    -- seal() refuses a parameter whose type nothing can check, so by the time a
-    -- script turns strict mode on there is a checker for every one of them.
-    local check = api.checkers[p.type]
+    local check = checkers[p.type]
     assert(check ~= nil, path .. ": no checker for type '" .. tostring(p.type) .. "'")
-    checkers[i] = check
+    param_checkers[i] = check
     defaults[i] = p.default
   end
 
@@ -222,11 +237,11 @@ local function make_checked(fn, path, params)
     error(("%s: invalid argument '%s'"):format(where, arg), 3)
   end
   -- Named as an API module is, so LUA_GetCallerInfo walks past this frame too.
-  return load(src, "@trx/" .. path .. " (checked)")(fn, checkers, defaults, on_fail)
+  return load(src, "@trx/" .. path .. " (checked)")(fn, param_checkers, defaults, on_fail)
 end
 
--- Type name -> predicate. Doc-facing type names, not Lua type names.
-api.checkers = {
+-- Doc-facing type names, not Lua type names.
+checkers = {
   integer = function(v)
     return math.type(v) == "integer"
   end,
@@ -328,7 +343,7 @@ function api.seal()
   -- value through while strict mode reports a clean run over it.
   local bad = {}
   local function audit_type(where, what, type_name)
-    if api.checkers[type_name] == nil then
+    if checkers[type_name] == nil then
       table.insert(bad, where .. ": " .. what .. " has an unknown type '" .. tostring(type_name) .. "'")
       return false
     end
@@ -340,7 +355,7 @@ function api.seal()
     for _, p in ipairs(params or {}) do
       if p.name ~= "..." then
         if audit_type(where, "'" .. tostring(p.name) .. "'", p.type) and p.default ~= nil then
-          if not api.checkers[p.type](p.default) then
+          if not checkers[p.type](p.default) then
             table.insert(bad, where .. ": the default for '" .. p.name .. "' is not a " .. p.type)
           end
         end
@@ -409,6 +424,39 @@ function api.namespace(path, spec)
   return namespace
 end
 
+-- Declares that a module table can be indexed - trx.items[3], trx.objects.wolf -
+-- and, if it can be counted, that #trx.items is its length.
+--
+-- The registry owns the module's metatable, so a module that set its own would
+-- lose it to the first property declared on it. And pairs() never sees a
+-- metatable, so only a declaration puts the indexing in the reference.
+function api.container(name, spec)
+  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  assert(type(spec) == "table", "api.container: spec must be a table")
+  assert(type(spec.get) == "function", "api.container: get must be a function")
+  assert(spec.count == nil or type(spec.count) == "function", "api.container: count must be a function")
+  assert(type(spec.key) == "table", "api.container: key must describe what the module is indexed by")
+
+  -- A module keyed only by number leaves a string key to the rest of the
+  -- metatable, so trx.rooms.nonsense is nil rather than an error out of C.
+  local by_number_only = spec.key.type == "integer"
+  module_containers[name] = {
+    get = spec.get,
+    count = spec.count,
+    accepts = function(key)
+      local kind = type(key)
+      return kind == "number" or (kind == "string" and not by_number_only)
+    end,
+  }
+
+  if containers[name] == nil then
+    table.insert(container_order, name)
+  end
+  containers[name] = spec
+
+  install_module_meta(name)
+end
+
 function api.define(path, spec)
   assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
   assert(type(spec) == "table", "api.define: spec must be a table")
@@ -459,7 +507,7 @@ function api.type(path, spec)
 
   -- Declaring the type is what makes its name checkable in a params list.
   local _, type_name = split_path(path)
-  api.checkers[type_name] = handle_checker(backing)
+  checkers[type_name] = handle_checker(backing)
 
   local declared = {}
 
@@ -656,7 +704,19 @@ function api.describe()
     constants = {},
     properties = {},
     namespaces = {},
+    containers = {},
   }
+  for _, name in ipairs(container_order) do
+    local spec = containers[name]
+    table.insert(out.containers, {
+      module = name,
+      description = spec.description,
+      key = spec.key,
+      value = spec.value,
+      countable = spec.count ~= nil,
+      examples = spec.examples,
+    })
+  end
   for _, name in ipairs(module_order) do
     table.insert(out.modules, {
       name = name,
@@ -812,6 +872,10 @@ function api.describe()
   by_module(out.constants)
   by_module(out.namespaces)
   by_module(out.properties)
+  -- Keyed by module, not by path, so by_module has nothing to sort on.
+  table.sort(out.containers, function(a, b)
+    return a.module < b.module
+  end)
   table.sort(out.modules, function(a, b)
     return a.name < b.name
   end)

--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -375,6 +375,14 @@ function api.seal()
   for _, path in ipairs(namespace_order) do
     audit_params(path, namespaces[path].params)
   end
+  -- Strict mode checks a method's arguments too, and make_checked needs a
+  -- checker for each. Without this, a type nobody can check would only surface
+  -- the day a builder turned strict mode on.
+  for _, path in ipairs(type_order) do
+    for name, method in pairs(types[path].methods or {}) do
+      audit_params(path .. "." .. name, method.params)
+    end
+  end
   for _, path in ipairs(property_order) do
     audit_type(path, "the property", properties[path].type)
   end
@@ -475,6 +483,38 @@ function api.define(path, spec)
   return spec.impl
 end
 
+-- A method is called with the handle as its first argument, which the
+-- declaration does not name because a script never writes it. Checking it
+-- catches `item.distance_to(pos)` - a dot where a colon was meant.
+local function method_params(spec_params, type_name)
+  local params = { { name = "self", type = type_name } }
+  for i, param in ipairs(spec_params or {}) do
+    params[i + 1] = param
+  end
+  return params
+end
+
+-- A type's methods reach C directly, so make_checked has to go in front of the
+-- C function rather than around a Lua one. Extensions take nothing but the
+-- handle __index hands them, so there is nothing of the script's to check.
+local function bind_type_methods(path)
+  local spec = types[path]
+  local backing = spec.backing
+  local _, type_name = split_path(path)
+  for name, method in pairs(spec.methods or {}) do
+    local from = method.from or name
+    if strict_enabled then
+      struct.expose_method(
+        backing,
+        name,
+        make_checked(struct.method(backing, from), path .. "." .. name, method_params(method.params, type_name))
+      )
+    else
+      struct.expose_method(backing, name, from)
+    end
+  end
+end
+
 -- Rebinds every registered function to (or away from) its checking wrapper.
 function api.strict(enabled)
   strict_enabled = enabled and true or false
@@ -486,6 +526,9 @@ function api.strict(enabled)
   for path, dispatch in pairs(namespace_dispatch) do
     local spec = namespaces[path]
     dispatch.fn = strict_enabled and make_checked(spec.call, path, spec.params) or spec.call
+  end
+  for _, path in ipairs(type_order) do
+    bind_type_methods(path)
   end
 end
 
@@ -518,10 +561,6 @@ function api.type(path, spec)
     declared[from] = true
   end
 
-  for name, method in pairs(spec.methods or {}) do
-    struct.expose_method(backing, name, method.from or name)
-  end
-
   for name, computed in pairs(spec.extensions or {}) do
     assert(type(computed.impl) == "function", "api.type: extension '" .. name .. "' needs an impl")
     struct.expose_computed(backing, name, computed.impl)
@@ -546,6 +585,8 @@ function api.type(path, spec)
     table.insert(type_order, path)
   end
   types[path] = spec
+
+  bind_type_methods(path)
 end
 
 -- Declares an enum: what the constants of a C enum are called in Lua, and what

--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -17,6 +17,7 @@
 -- the trx.* modules have loaded, so builders cannot reach past the public API.
 local struct = trxc.struct
 local enum = trxc.enum
+local capi = trxc.api
 -- Hardening nils this out of the globals, and api.strict runs long after that.
 local load = load
 
@@ -284,6 +285,16 @@ end
 -- Also audits the finished surface: an assignment straight onto a module table
 -- works for scripts, but the docs never see it. Refuse to boot instead.
 function api.seal()
+  -- The declaring half has done its job, and every one of those functions
+  -- raises from here on. It goes the way trxc goes at this same moment: what a
+  -- script cannot successfully call, it should not be able to reach. Done
+  -- before the audit, so the audit sees the surface a script is left with. C
+  -- keeps the two entrypoints it still needs - see lua/capi/api.c.
+  trx.api = {
+    strict = api.strict,
+    is_strict = api.is_strict,
+  }
+
   -- container path ("items", or "console.log") -> set of declared member names.
   local declared = {}
   local function mark(path)
@@ -984,3 +995,32 @@ end
 function api.to_json()
   return table.concat(encode(api.describe(), {}))
 end
+
+-- The registry declares itself, last of all. What is left of it once seal() has
+-- run is what a script can use: strict mode, and the question of whether it is
+-- on. The rest declared the surface and is gone by the time any script runs.
+api.module("api", {
+  order = 20,
+  title = "API registry",
+  description = "Argument checking for the whole of `trx`.",
+})
+
+api.define("api.strict", {
+  description = "Turns argument checking on or off for every function in `trx`, and for the methods "
+    .. "on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler "
+    .. "notices. Turn it on while writing a level, and leave it off in play.",
+  params = { { name = "enabled", type = "boolean" } },
+  examples = { [[trx.api.strict(true)]] },
+  impl = api.strict,
+})
+
+api.define("api.is_strict", {
+  description = "Whether argument checking is on.",
+  returns = { type = "boolean" },
+  impl = api.is_strict,
+})
+
+-- Sealing and dumping the surface stay C's to call, and the dump runs after the
+-- seal has taken them off trx.api. Hand them over while they are still here.
+capi.set_entrypoint("seal", api.seal)
+capi.set_entrypoint("to_json", api.to_json)

--- a/data/scripting/api.lua
+++ b/data/scripting/api.lua
@@ -23,29 +23,45 @@ local load = load
 
 local api = {}
 
--- path -> spec. Ordered separately so docs come out in declaration order.
-local registry = {}
-local order = {}
-local modules = {}
-local module_order = {}
-local types = {}
-local type_order = {}
-local enums = {}
-local enum_order = {}
-local consts = {}
-local const_order = {}
-local properties = {}
-local property_order = {}
-local namespaces = {}
-local namespace_order = {}
+-- A registry keyed by path, keeping the paths in declaration order alongside so
+-- the docs come out the way the files declare, not the way pairs() happens to
+-- iterate. record() is the only writer.
+local function ordered()
+  return { by_path = {}, order = {} }
+end
+
+local function record(reg, path, spec)
+  if reg.by_path[path] == nil then
+    reg.order[#reg.order + 1] = path
+  end
+  reg.by_path[path] = spec
+  return spec
+end
+
+-- Every registry projects to a doc entry the same way: walk it in declaration
+-- order, turn each spec into a plain table. Only the projection differs.
+local function collect(reg, project)
+  local list = {}
+  for _, key in ipairs(reg.order) do
+    list[#list + 1] = project(key, reg.by_path[key])
+  end
+  return list
+end
+
+local registry = ordered()
+local modules = ordered()
+local types = ordered()
+local enums = ordered()
+local consts = ordered()
+local properties = ordered()
+local namespaces = ordered()
 -- path -> { fn = what calling the namespace runs }. Held apart from the
 -- metatable so api.strict can swap the wrapper in.
 local namespace_dispatch = {}
 -- Type name -> predicate. Private: reachable, a script could hand strict mode a
 -- checker that accepts anything.
 local checkers
-local containers = {}
-local container_order = {}
+local containers = ordered()
 -- module -> { get, count, accepts }. What indexing the module table reaches.
 local module_containers = {}
 -- module -> { name -> spec }. What the module's __index dispatches on.
@@ -75,11 +91,27 @@ local function path_parts(path)
   return parts
 end
 
+-- The trx.<module> table, created on first mention. Every declaration hangs its
+-- member off one of these.
+local function module_table(module)
+  trx[module] = trx[module] or {}
+  return trx[module]
+end
+
+-- The guard every declarator opens with: declarations are the engine's to make
+-- at load time, and a spec is a table. `fn` names the caller for the message.
+local function opening(fn, spec)
+  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  if spec ~= nil then
+    assert(type(spec) == "table", fn .. ": spec must be a table")
+  end
+end
+
 -- The module, the table the member hangs off, and the member's own name.
 local function resolve(path)
   local parts = path_parts(path)
   local module = parts[1]
-  trx[module] = trx[module] or {}
+  module_table(module)
   if #parts == 2 then
     return module, trx[module], parts[2]
   end
@@ -107,7 +139,7 @@ local function install_module_meta(module)
     return
   end
 
-  trx[module] = trx[module] or {}
+  module_table(module)
   local meta = {
     __index = function(_, key)
       local prop = props ~= nil and props[key] or nil
@@ -160,18 +192,15 @@ local function install_module_meta(module)
 end
 
 function api.module(name, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
+  opening("api.module")
   assert(type(name) == "string", "api.module: name must be a string")
-  if modules[name] == nil then
-    table.insert(module_order, name)
-  end
-  modules[name] = spec or {}
+  spec = record(modules, name, spec or {})
 
   -- A module that stands for one C struct reads and writes that struct's fields
   -- directly: trx.lara.air is Lara's air. `instance` hands back the handle.
-  if modules[name].instance ~= nil then
-    assert(type(modules[name].instance) == "function", "api.module: instance must be a function")
-    module_instances[name] = modules[name].instance
+  if spec.instance ~= nil then
+    assert(type(spec.instance) == "function", "api.module: instance must be a function")
+    module_instances[name] = spec.instance
     install_module_meta(name)
   end
 end
@@ -241,6 +270,12 @@ local function make_checked(fn, path, params)
   return load(src, "@trx/" .. path .. " (checked)")(fn, param_checkers, defaults, on_fail)
 end
 
+-- The function a caller reaches: the checking wrapper under strict mode, the raw
+-- one otherwise. api.strict flips every binding through here.
+local function bound(fn, path, params)
+  return strict_enabled and make_checked(fn, path, params) or fn
+end
+
 -- Doc-facing type names, not Lua type names.
 checkers = {
   integer = function(v)
@@ -308,17 +343,17 @@ function api.seal()
     declared[container] = declared[container] or {}
     declared[container][name] = true
   end
-  for _, path in ipairs(order) do
+  for _, path in ipairs(registry.order) do
     mark(path)
   end
-  for _, path in ipairs(enum_order) do
+  for _, path in ipairs(enums.order) do
     mark(path)
   end
-  for _, path in ipairs(const_order) do
+  for _, path in ipairs(consts.order) do
     mark(path)
   end
   -- The namespace table itself is a member of its module.
-  for _, path in ipairs(namespace_order) do
+  for _, path in ipairs(namespaces.order) do
     mark(path)
   end
 
@@ -331,12 +366,12 @@ function api.seal()
     end
   end
 
-  for _, module in ipairs(module_order) do
+  for _, module in ipairs(modules.order) do
     audit(module, trx[module])
   end
   -- A namespace hides its members one level down, where the module audit above
   -- cannot see them. Audit it as its own container.
-  for _, path in ipairs(namespace_order) do
+  for _, path in ipairs(namespaces.order) do
     local module, name = split_path(path)
     audit(path, rawget(trx[module] or {}, name))
   end
@@ -380,22 +415,22 @@ function api.seal()
     end
   end
 
-  for _, path in ipairs(order) do
-    audit_params(path, registry[path].params)
+  for _, path in ipairs(registry.order) do
+    audit_params(path, registry.by_path[path].params)
   end
-  for _, path in ipairs(namespace_order) do
-    audit_params(path, namespaces[path].params)
+  for _, path in ipairs(namespaces.order) do
+    audit_params(path, namespaces.by_path[path].params)
   end
   -- Strict mode checks a method's arguments too, and make_checked needs a
   -- checker for each. Without this, a type nobody can check would only surface
   -- the day a builder turned strict mode on.
-  for _, path in ipairs(type_order) do
-    for name, method in pairs(types[path].methods or {}) do
+  for _, path in ipairs(types.order) do
+    for name, method in pairs(types.by_path[path].methods or {}) do
       audit_params(path .. "." .. name, method.params)
     end
   end
-  for _, path in ipairs(property_order) do
-    audit_type(path, "the property", properties[path].type)
+  for _, path in ipairs(properties.order) do
+    audit_type(path, "the property", properties.by_path[path].type)
   end
 
   if #bad > 0 then
@@ -413,8 +448,7 @@ end
 -- A namespace has to be declared before anything inside it: it is the table the
 -- members hang off, and seal() audits its contents just as it audits a module's.
 function api.namespace(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.namespace: spec must be a table")
+  opening("api.namespace", spec)
   local module, name = split_path(path)
 
   local namespace = {}
@@ -422,9 +456,7 @@ function api.namespace(path, spec)
     assert(type(spec.call) == "function", "api.namespace: call must be a function")
     -- Through a holder, so api.strict can swap the wrapper in as it does for the
     -- members.
-    local dispatch = {
-      fn = strict_enabled and make_checked(spec.call, path, spec.params) or spec.call,
-    }
+    local dispatch = { fn = bound(spec.call, path, spec.params) }
     namespace_dispatch[path] = dispatch
     setmetatable(namespace, {
       __call = function(_, ...)
@@ -433,13 +465,9 @@ function api.namespace(path, spec)
     })
   end
 
-  trx[module] = trx[module] or {}
-  rawset(trx[module], name, namespace)
+  rawset(module_table(module), name, namespace)
 
-  if namespaces[path] == nil then
-    table.insert(namespace_order, path)
-  end
-  namespaces[path] = spec
+  record(namespaces, path, spec)
   return namespace
 end
 
@@ -450,8 +478,7 @@ end
 -- lose it to the first property declared on it. And pairs() never sees a
 -- metatable, so only a declaration puts the indexing in the reference.
 function api.container(name, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.container: spec must be a table")
+  opening("api.container", spec)
   assert(type(spec.get) == "function", "api.container: get must be a function")
   assert(spec.count == nil or type(spec.count) == "function", "api.container: count must be a function")
   assert(type(spec.key) == "table", "api.container: key must describe what the module is indexed by")
@@ -468,29 +495,22 @@ function api.container(name, spec)
     end,
   }
 
-  if containers[name] == nil then
-    table.insert(container_order, name)
-  end
-  containers[name] = spec
+  record(containers, name, spec)
 
   install_module_meta(name)
 end
 
 function api.define(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.define: spec must be a table")
+  opening("api.define", spec)
   assert(type(spec.impl) == "function", "api.define: impl must be a function")
   local _, container, name = resolve(path)
 
-  if registry[path] == nil then
-    table.insert(order, path)
-  end
-  registry[path] = spec
+  record(registry, path, spec)
 
   -- The raw implementation is the public function. No wrapper, no overhead.
   -- rawset: some module tables guard __newindex, and a declaration is not a
   -- caller poking at the module.
-  rawset(container, name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+  rawset(container, name, bound(spec.impl, path, spec.params))
   return spec.impl
 end
 
@@ -509,36 +529,34 @@ end
 -- C function rather than around a Lua one. Extensions take nothing but the
 -- handle __index hands them, so there is nothing of the script's to check.
 local function bind_type_methods(path)
-  local spec = types[path]
+  local spec = types.by_path[path]
   local backing = spec.backing
   local _, type_name = split_path(path)
   for name, method in pairs(spec.methods or {}) do
     local from = method.from or name
+    -- The wrapper goes in front of the C function, which struct.method hands
+    -- back; without strict mode the name reaches C to bind directly.
+    local exposed = from
     if strict_enabled then
-      struct.expose_method(
-        backing,
-        name,
-        make_checked(struct.method(backing, from), path .. "." .. name, method_params(method.params, type_name))
-      )
-    else
-      struct.expose_method(backing, name, from)
+      exposed = make_checked(struct.method(backing, from), path .. "." .. name, method_params(method.params, type_name))
     end
+    struct.expose_method(backing, name, exposed)
   end
 end
 
 -- Rebinds every registered function to (or away from) its checking wrapper.
 function api.strict(enabled)
   strict_enabled = enabled and true or false
-  for _, path in ipairs(order) do
+  for _, path in ipairs(registry.order) do
     local _, container, name = resolve(path)
-    local spec = registry[path]
-    rawset(container, name, strict_enabled and make_checked(spec.impl, path, spec.params) or spec.impl)
+    local spec = registry.by_path[path]
+    rawset(container, name, bound(spec.impl, path, spec.params))
   end
   for path, dispatch in pairs(namespace_dispatch) do
-    local spec = namespaces[path]
-    dispatch.fn = strict_enabled and make_checked(spec.call, path, spec.params) or spec.call
+    local spec = namespaces.by_path[path]
+    dispatch.fn = bound(spec.call, path, spec.params)
   end
-  for _, path in ipairs(type_order) do
+  for _, path in ipairs(types.order) do
     bind_type_methods(path)
   end
 end
@@ -554,8 +572,7 @@ end
 -- how to reach a member; this says whether it is part of the API and what it is
 -- called. A member C can reach but nobody declares simply does not exist.
 function api.type(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.type: spec must be a table")
+  opening("api.type", spec)
   assert(type(spec.backing) == "string", "api.type: backing must be a C type name")
   local backing = spec.backing
 
@@ -592,10 +609,7 @@ function api.type(path, spec)
     )
   end
 
-  if types[path] == nil then
-    table.insert(type_order, path)
-  end
-  types[path] = spec
+  record(types, path, spec)
 
   bind_type_methods(path)
 end
@@ -620,8 +634,7 @@ function api.enum_name(spec, reflected_name)
 end
 
 function api.enum(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.enum: spec must be a table")
+  opening("api.enum", spec)
   assert(type(spec.backing) == "string", "api.enum: backing must be a C enum name")
   local module, name = split_path(path)
 
@@ -690,13 +703,9 @@ function api.enum(path, spec)
     end,
   })
 
-  trx[module] = trx[module] or {}
-  rawset(trx[module], name, face)
+  rawset(module_table(module), name, face)
 
-  if enums[path] == nil then
-    table.insert(enum_order, path)
-  end
-  enums[path] = spec
+  record(enums, path, spec)
   return face
 end
 
@@ -704,18 +713,13 @@ end
 -- not a C enum, so api.enum has nothing to reflect. The value still comes from C,
 -- so naming one C does not export fails here rather than quietly being nil.
 function api.const(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.const: spec must be a table")
+  opening("api.const", spec)
   assert(spec.value ~= nil, "api.const: " .. path .. " has no value; is it exported from C?")
   local module, name = split_path(path)
 
-  if consts[path] == nil then
-    table.insert(const_order, path)
-  end
-  consts[path] = spec
+  record(consts, path, spec)
 
-  trx[module] = trx[module] or {}
-  rawset(trx[module], name, spec.value)
+  rawset(module_table(module), name, spec.value)
   return spec.value
 end
 
@@ -724,16 +728,12 @@ end
 -- if there is none. The registry owns the module's metatable - see
 -- install_module_meta - so a hand-rolled getter table would sail past seal().
 function api.property(path, spec)
-  assert(not sealed, "the trx.api registry is sealed; declarations happen at load time")
-  assert(type(spec) == "table", "api.property: spec must be a table")
+  opening("api.property", spec)
   assert(type(spec.get) == "function", "api.property: get must be a function")
   assert(spec.set == nil or type(spec.set) == "function", "api.property: set must be a function")
   local module, name = split_path(path)
 
-  if properties[path] == nil then
-    table.insert(property_order, path)
-  end
-  properties[path] = spec
+  record(properties, path, spec)
 
   local props = module_properties[module]
   if props == nil then
@@ -748,47 +748,36 @@ end
 
 -- The whole surface as plain data: what the docs generator consumes.
 function api.describe()
-  local out = {
-    modules = {},
-    functions = {},
-    types = {},
-    enums = {},
-    constants = {},
-    properties = {},
-    namespaces = {},
-    containers = {},
-  }
-  for _, name in ipairs(container_order) do
-    local spec = containers[name]
-    table.insert(out.containers, {
+  local out = { types = {}, enums = {} }
+  out.containers = collect(containers, function(name, spec)
+    return {
       module = name,
       description = spec.description,
       key = spec.key,
       value = spec.value,
       countable = spec.count ~= nil,
       examples = spec.examples,
-    })
-  end
-  for _, name in ipairs(module_order) do
-    table.insert(out.modules, {
+    }
+  end)
+  out.modules = collect(modules, function(name, spec)
+    return {
       name = name,
-      title = modules[name].title,
-      description = modules[name].description,
-      order = modules[name].order,
-    })
-  end
-  for _, path in ipairs(order) do
-    local spec = registry[path]
-    table.insert(out.functions, {
+      title = spec.title,
+      description = spec.description,
+      order = spec.order,
+    }
+  end)
+  out.functions = collect(registry, function(path, spec)
+    return {
       path = path,
       description = spec.description,
       params = spec.params,
       returns = spec.returns,
       examples = spec.examples,
-    })
-  end
-  for _, path in ipairs(type_order) do
-    local spec = types[path]
+    }
+  end)
+  for _, path in ipairs(types.order) do
+    local spec = types.by_path[path]
     local entry = {
       path = path,
       description = spec.description,
@@ -829,8 +818,8 @@ function api.describe()
     table.sort(entry.extensions, by_name)
     table.insert(out.types, entry)
   end
-  for _, path in ipairs(enum_order) do
-    local spec = enums[path]
+  for _, path in ipairs(enums.order) do
+    local spec = enums.by_path[path]
     local entry = {
       path = path,
       description = spec.description,
@@ -866,35 +855,32 @@ function api.describe()
     end
     table.insert(out.enums, entry)
   end
-  for _, path in ipairs(const_order) do
-    local spec = consts[path]
-    table.insert(out.constants, {
+  out.constants = collect(consts, function(path, spec)
+    return {
       path = path,
       value = spec.value,
       description = spec.description,
-    })
-  end
-  for _, path in ipairs(namespace_order) do
-    local spec = namespaces[path]
-    table.insert(out.namespaces, {
+    }
+  end)
+  out.namespaces = collect(namespaces, function(path, spec)
+    return {
       path = path,
       description = spec.description,
       params = spec.params,
       returns = spec.returns,
       examples = spec.examples,
       callable = spec.call ~= nil,
-    })
-  end
-  for _, path in ipairs(property_order) do
-    local spec = properties[path]
-    table.insert(out.properties, {
+    }
+  end)
+  out.properties = collect(properties, function(path, spec)
+    return {
       path = path,
       type = spec.type,
       description = spec.description,
       enum = spec.enum,
       writable = spec.set ~= nil,
-    })
-  end
+    }
+  end)
 
   -- Which module a declaration lands under is the surface talking; which module
   -- loaded first is not - that is the source list in meson.build, and a module

--- a/data/scripting/assault.lua
+++ b/data/scripting/assault.lua
@@ -75,14 +75,16 @@ api.property("assault.active_track", {
 })
 
 api.namespace("assault.stats", {
-  description = "The Assault Course record table, as shown on the stats screen. The records are "
-    .. "stored in the player's profile, so writing to them outlives the level.",
+  description = "A track's record table, as shown on the stats screen. Each track keeps its own. "
+    .. "The records are stored in the player's profile, so writing to them outlives the level, and "
+    .. "they can be read outside a gym level.",
 })
 
 api.define("assault.stats.add_record", {
   description = "Files a new record, inserting it in time order and bumping the attempt count.",
   params = {
     { name = "time", type = "number", description = "Time in seconds. Must be greater than zero." },
+    track_param(),
   },
   returns = {
     type = "boolean",
@@ -96,6 +98,7 @@ api.define("assault.stats.remove_record", {
   description = "Removes a record, closing the gap behind it.",
   params = {
     { name = "record_id", type = "integer", description = "1-based position in the table." },
+    track_param(),
   },
   returns = { type = "boolean", description = "`false` if there is no record at that position." },
   impl = raw.stats.remove,
@@ -103,12 +106,13 @@ api.define("assault.stats.remove_record", {
 
 api.define("assault.stats.list_records", {
   description = "The records, fastest first.",
+  params = { track_param() },
   returns = {
     type = "table",
     description = "List of `{ time = seconds, attempt_num = which attempt it was }`.",
   },
   examples = {
-    [[for _, record in ipairs(trx.assault.stats.list_records()) do
+    [[for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do
   trx.log.info(("attempt %d: %.2fs"):format(record.attempt_num, record.time))
 end]],
   },

--- a/data/scripting/game.lua
+++ b/data/scripting/game.lua
@@ -172,8 +172,7 @@ api.define("game.play_level", {
     {
       name = "num",
       type = "integer",
-      description = "1-based position in `trx.game.levels`. This is not `Level.num`, which is the "
-        .. "number the level carries.",
+      description = "1-based position in `trx.game.levels`.",
     },
   },
   examples = { [[trx.game.play_level(1)]] },

--- a/data/scripting/game.lua
+++ b/data/scripting/game.lua
@@ -17,7 +17,7 @@ local LevelTable = api.enum("game.LevelTable", {
   },
 })
 
-api.enum("game.LevelType", {
+local LevelType = api.enum("game.LevelType", {
   backing = "GF_LEVEL_TYPE",
   description = "What kind of level it is.",
   values = {
@@ -126,7 +126,7 @@ end
 
 api.property("game.levels", {
   type = "table",
-  description = "The levels of the game proper, in order, as a list of `trx.game.Level`.",
+  description = "The levels of the game, in order, as a list of `trx.game.Level`.",
   get = function()
     return level_list(LevelTable.MAIN)
   end,
@@ -154,6 +154,18 @@ api.property("game.current_level", {
   get = raw.get_current_level,
 })
 
+api.property("game.gym", {
+  type = "Level",
+  description = "The gym level, or `nil` if this game has no gym.",
+  get = function()
+    local level = raw.get_level(LevelTable.MAIN, 0)
+    if level ~= nil and level.type == LevelType.GYM then
+      return level
+    end
+    return nil
+  end,
+})
+
 api.property("game.version", {
   type = "integer",
   description = "Which Tomb Raider this build is: 1, 2, 3 or 4.",
@@ -167,7 +179,7 @@ api.property("game.trx_version", {
 })
 
 api.define("game.play_level", {
-  description = "Starts a level of the game proper.",
+  description = "Starts a level from `trx.game.levels`.",
   params = {
     {
       name = "num",
@@ -193,4 +205,9 @@ api.define("game.play_demo", {
     { name = "num", type = "integer", description = "1-based position in `trx.game.demos`." },
   },
   impl = raw.play_demo,
+})
+
+api.define("game.play_gym", {
+  description = "Starts the gym. Raises if this game has no gym.",
+  impl = raw.play_gym,
 })

--- a/data/scripting/items.lua
+++ b/data/scripting/items.lua
@@ -403,14 +403,15 @@ api.define("items.first", {
   end,
 })
 
--- trx.items holds the registered functions and Status; the metatable adds
--- indexing and the length operator on top.
-setmetatable(trx.items, {
-  __len = raw.count,
-  __index = function(_, key)
-    if type(key) == "number" or type(key) == "string" then
-      return raw.get(key)
-    end
-    return nil
-  end,
+api.container("items", {
+  description = "Indexing the module reaches an item, and `#trx.items` is how many the level has.",
+  key = { type = "any", description = "1-based index, or the item's unique name." },
+  value = { type = "Item", nullable = true },
+  examples = {
+    [[for i = 1, #trx.items do
+  trx.log.info(trx.items[i].object_id)
+end]],
+  },
+  get = raw.get,
+  count = raw.count,
 })

--- a/data/scripting/objects.lua
+++ b/data/scripting/objects.lua
@@ -123,7 +123,7 @@ api.type("objects.Object", {
   },
 })
 
-api.define("objects.get", {
+local get = api.define("objects.get", {
   description = "Retrieves an object definition by id or by name.",
   params = {
     {
@@ -162,10 +162,10 @@ api.define("objects.swap_mesh", {
   impl = raw.swap_mesh,
 })
 
--- trx.objects holds the registered functions; the metatable adds indexing by id
--- and by name on top, so trx.objects.wolf is the wolf.
-setmetatable(trx.objects, {
-  __index = function(_, key)
-    return trx.objects.get(key)
-  end,
+api.container("objects", {
+  description = "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.",
+  key = { type = "any", description = "Object id, or its catalog name." },
+  value = { type = "Object", nullable = true },
+  examples = { [[trx.objects.wolf.properties.max_hit_points = 30]] },
+  get = get,
 })

--- a/data/scripting/rooms.lua
+++ b/data/scripting/rooms.lua
@@ -166,14 +166,11 @@ api.define("rooms.find_valid_pos", {
   impl = raw.find_valid_pos,
 })
 
--- trx.rooms holds the registered functions and FlipStatus; the metatable adds
--- indexing and the length operator on top.
-setmetatable(trx.rooms, {
-  __len = raw.count,
-  __index = function(_, key)
-    if type(key) == "number" then
-      return raw.get(key)
-    end
-    return nil
-  end,
+api.container("rooms", {
+  description = "Indexing the module reaches a room, and `#trx.rooms` is how many the level has.",
+  key = { type = "integer", description = "1-based room number." },
+  value = { type = "Room", nullable = true },
+  examples = { [[trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)]] },
+  get = raw.get,
+  count = raw.count,
 })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - added new Lua enums, `trx.items.Status`, `trx.lara.WaterState`, `trx.lara.GunState`, `trx.game.LevelTable`, `trx.catalog.Context` and `trx.rooms.FlipStatus`
 - added `trx.log.generic()` and the `trx.log.LogLevel` enum, to log at a level chosen at runtime
 - added the braid and crowbar constants to `trx.lara.ExtraMesh`, which the engine had but never exposed
+- added indexing and the length operator to `trx.items`, `trx.rooms` and `trx.objects`, so `trx.items[1]` is the first item and `#trx.items` is how many the level has
 - changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing whatever took its slot; refer to migration notes
 - changed `room.idx` to `room.num`; refer to migration notes
 - changed the Lua level field `name` to `title`; refer to migration notes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
 - added a new Lua module, `trx.locale`, for the text the player reads, looked up by key
 - added `trx.game.LevelType.TITLE`, and a `demo` level type to the game flow, which could not be named before
+- added `trx.game.play_gym()`, to start the gym
 - added `trx.items.spawn()`, to place a new item in the level at runtime
 - added `trx.items.get()`, `trx.items.count()`, `trx.rooms.get()`, `trx.rooms.count()` and `trx.objects.get()`, replacing the `fn` namespaces; refer to migration notes
 - added `trx.rooms.find_valid_pos()`, to nudge a position into valid room geometry

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - added `trx.log.generic()` and the `trx.log.LogLevel` enum, to log at a level chosen at runtime
 - added the braid and crowbar constants to `trx.lara.ExtraMesh`, which the engine had but never exposed
 - added indexing and the length operator to `trx.items`, `trx.rooms` and `trx.objects`, so `trx.items[1]` is the first item and `#trx.items` is how many the level has
+- added `trx.api.strict()`, which checks a script's arguments against the API's own declarations - worth turning on while writing a level, and leaving off in play
 - changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing whatever took its slot; refer to migration notes
 - changed `room.idx` to `room.num`; refer to migration notes
 - changed the Lua level field `name` to `title`; refer to migration notes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - changed Lua enums to be read-only; writing to one used to succeed and silently break every later lookup
 - changed writes that a field cannot hold to raise rather than truncate, so `item.hit_points = 99999` no longer wraps
 - fixed `trx.events.on_pickup` firing with a 0-based item number, where it is documented to pass a 1-based one
+- fixed `trx.game.play_level` numbering shifting every level in a game with a gym
 - removed `trx.console.log.LogLevel`, a duplicate of `trx.log.LogLevel`; refer to migration notes
 - removed `trx.events.EventType`; refer to migration notes
 - removed `trx.game.settings`, which duplicated `trx.config`; refer to migration notes

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -131,7 +131,7 @@ order: 3
 17. **Update scripts that address levels by number**
    `trx.game.play_level` and the `trx.game.levels` list leaves out the gym.
    In a game with a gym `trx.game.levels[1]` used to be the gym; drop any offset
-   that stepped over it.
+   that stepped over it; use `trx.game.play_gym()` and `trx.game.gym`.
 
 18. **Update Lara's outfit definitions**
    The `hair_pos` entries for Lara's braids were changed to `positions`. This

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -128,7 +128,12 @@ order: 3
    It was an undocumented alias of `trx.music.play` and was removed. Use
    `trx.music.play(id[, opts])`.
 
-17. **Update Lara's outfit definitions**
+17. **Update scripts that address levels by number**
+   `trx.game.play_level` and the `trx.game.levels` list leaves out the gym.
+   In a game with a gym `trx.game.levels[1]` used to be the gym; drop any offset
+   that stepped over it.
+
+18. **Update Lara's outfit definitions**
    The `hair_pos` entries for Lara's braids were changed to `positions`. This
    field is now an array (of at most two values) rather than a single position.
    Update `outfits.json5` accordingly.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2967,7 +2967,7 @@
       }
     },
     {
-      "description": "Starts a level of the game proper.",
+      "description": "Starts a level from `trx.game.levels`.",
       "examples": [
         "trx.game.play_level(1)"
       ],
@@ -3001,6 +3001,10 @@
         }
       ],
       "path": "game.play_demo"
+    },
+    {
+      "description": "Starts the gym. Raises if this game has no gym.",
+      "path": "game.play_gym"
     },
     {
       "description": "Retrieves an item by 1-based index or by name.",
@@ -3724,7 +3728,7 @@
       "writable": true
     },
     {
-      "description": "The levels of the game proper, in order, as a list of `trx.game.Level`.",
+      "description": "The levels of the game, in order, as a list of `trx.game.Level`.",
       "path": "game.levels",
       "type": "table",
       "writable": false
@@ -3744,6 +3748,12 @@
     {
       "description": "The level being played, or `nil` if none is.",
       "path": "game.current_level",
+      "type": "Level",
+      "writable": false
+    },
+    {
+      "description": "The gym level, or `nil` if this game has no gym.",
+      "path": "game.gym",
       "type": "Level",
       "writable": false
     },

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2973,7 +2973,7 @@
       ],
       "params": [
         {
-          "description": "1-based position in `trx.game.levels`. This is not `Level.num`, which is the number the level carries.",
+          "description": "1-based position in `trx.game.levels`.",
           "name": "num",
           "type": "integer"
         }

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2447,6 +2447,13 @@
           "description": "Time in seconds. Must be greater than zero.",
           "name": "time",
           "type": "number"
+        },
+        {
+          "default": 1,
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
         }
       ],
       "path": "assault.stats.add_record",
@@ -2462,6 +2469,13 @@
           "description": "1-based position in the table.",
           "name": "record_id",
           "type": "integer"
+        },
+        {
+          "default": 1,
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
         }
       ],
       "path": "assault.stats.remove_record",
@@ -2473,7 +2487,16 @@
     {
       "description": "The records, fastest first.",
       "examples": [
-        "for _, record in ipairs(trx.assault.stats.list_records()) do\n  trx.log.info((\"attempt %d: %.2fs\"):format(record.attempt_num, record.time))\nend"
+        "for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do\n  trx.log.info((\"attempt %d: %.2fs\"):format(record.attempt_num, record.time))\nend"
+      ],
+      "params": [
+        {
+          "default": 1,
+          "enum": "assault.Track",
+          "name": "track",
+          "optional": true,
+          "type": "integer"
+        }
       ],
       "path": "assault.stats.list_records",
       "returns": {
@@ -3665,7 +3688,7 @@
   "namespaces": [
     {
       "callable": false,
-      "description": "The Assault Course record table, as shown on the stats screen. The records are stored in the player's profile, so writing to them outlives the level.",
+      "description": "A track's record table, as shown on the stats screen. Each track keeps its own. The records are stored in the player's profile, so writing to them outlives the level, and they can be read outside a gym level.",
       "path": "assault.stats"
     },
     {

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -2354,6 +2354,26 @@
   ],
   "functions": [
     {
+      "description": "Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.",
+      "examples": [
+        "trx.api.strict(true)"
+      ],
+      "params": [
+        {
+          "name": "enabled",
+          "type": "boolean"
+        }
+      ],
+      "path": "api.strict"
+    },
+    {
+      "description": "Whether argument checking is on.",
+      "path": "api.is_strict",
+      "returns": {
+        "type": "boolean"
+      }
+    },
+    {
       "description": "Starts the timer and clears its state. Raises outside a gym level.",
       "params": [
         {
@@ -3591,6 +3611,12 @@
     }
   ],
   "modules": [
+    {
+      "description": "Argument checking for the whole of `trx`.",
+      "name": "api",
+      "order": 20,
+      "title": "API registry"
+    },
     {
       "description": "Module for controlling the Assault Course and Quad Bike timers in gym levels.",
       "name": "assault",

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -21,6 +21,56 @@
       "value": 1024
     }
   ],
+  "containers": [
+    {
+      "countable": true,
+      "description": "Indexing the module reaches an item, and `#trx.items` is how many the level has.",
+      "examples": [
+        "for i = 1, #trx.items do\n  trx.log.info(trx.items[i].object_id)\nend"
+      ],
+      "key": {
+        "description": "1-based index, or the item's unique name.",
+        "type": "any"
+      },
+      "module": "items",
+      "value": {
+        "nullable": true,
+        "type": "Item"
+      }
+    },
+    {
+      "countable": false,
+      "description": "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.",
+      "examples": [
+        "trx.objects.wolf.properties.max_hit_points = 30"
+      ],
+      "key": {
+        "description": "Object id, or its catalog name.",
+        "type": "any"
+      },
+      "module": "objects",
+      "value": {
+        "nullable": true,
+        "type": "Object"
+      }
+    },
+    {
+      "countable": true,
+      "description": "Indexing the module reaches a room, and `#trx.rooms` is how many the level has.",
+      "examples": [
+        "trx.log.info(#trx.rooms .. \" rooms, first is \" .. trx.rooms[1].num)"
+      ],
+      "key": {
+        "description": "1-based room number.",
+        "type": "integer"
+      },
+      "module": "rooms",
+      "value": {
+        "nullable": true,
+        "type": "Room"
+      }
+    }
+  ],
   "enums": [
     {
       "bulk": false,

--- a/docs/trx/lua/reference/API.md
+++ b/docs/trx/lua/reference/API.md
@@ -1,0 +1,33 @@
+---
+title: API registry
+order: 20
+---
+
+<!--
+  GENERATED FILE - do not edit.
+  Regenerate with: just lua-api-dump
+  The public API is declared next to its implementation, in
+  data/scripting/api.lua. Edit it there.
+-->
+
+## API registry module
+
+Argument checking for the whole of `trx`.
+
+### Functions
+
+- [lua]`trx.api.strict(enabled)`  
+  Turns argument checking on or off for every function in `trx`, and for the methods on its handles. Off by default: checking costs about 100ns a call, which a per-frame handler notices. Turn it on while writing a level, and leave it off in play.
+
+  Parameters:
+  - **`enabled`** (boolean).
+
+  Example:
+  ```lua
+  trx.api.strict(true)
+  ```
+
+- [lua]`trx.api.is_strict()`  
+  Whether argument checking is on.
+
+  Returns: boolean.

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -32,7 +32,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 ### Functions
 
 - [lua]`trx.assault.stats`  
-  The Assault Course record table, as shown on the stats screen. The records are stored in the player's profile, so writing to them outlives the level.
+  A track's record table, as shown on the stats screen. Each track keeps its own. The records are stored in the player's profile, so writing to them outlives the level, and they can be read outside a gym level.
 
 - [lua]`trx.assault.start([track])`  
   Starts the timer and clears its state. Raises outside a gym level.
@@ -74,11 +74,12 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
 
   Returns: boolean.
 
-- [lua]`trx.assault.stats.add_record(time)`  
+- [lua]`trx.assault.stats.add_record(time, [track])`  
   Files a new record, inserting it in time order and bumping the attempt count.
 
   Parameters:
   - **`time`** (number). Time in seconds. Must be greater than zero.
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
   Returns: boolean. `false` if the table is full and the time is slower than every record in it.
 
@@ -87,22 +88,26 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   trx.assault.stats.add_record(30.0)
   ```
 
-- [lua]`trx.assault.stats.remove_record(record_id)`  
+- [lua]`trx.assault.stats.remove_record(record_id, [track])`  
   Removes a record, closing the gap behind it.
 
   Parameters:
   - **`record_id`** (integer). 1-based position in the table.
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
   Returns: boolean. `false` if there is no record at that position.
 
-- [lua]`trx.assault.stats.list_records()`  
+- [lua]`trx.assault.stats.list_records([track])`  
   The records, fastest first.
+
+  Parameters:
+  - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
   Returns: table. List of `{ time = seconds, attempt_num = which attempt it was }`.
 
   Example:
   ```lua
-  for _, record in ipairs(trx.assault.stats.list_records()) do
+  for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do
     trx.log.info(("attempt %d: %.2fs"):format(record.attempt_num, record.time))
   end
   ```

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -16,10 +16,11 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Properties
 
-- **`trx.game.levels`** (table). The levels of the game proper, in order, as a list of `trx.game.Level`. *(read-only)*
+- **`trx.game.levels`** (table). The levels of the game, in order, as a list of `trx.game.Level`. *(read-only)*
 - **`trx.game.cutscenes`** (table). The cutscenes, as a list of `trx.game.Level`. *(read-only)*
 - **`trx.game.demos`** (table). The demos, as a list of `trx.game.Level`. *(read-only)*
 - **`trx.game.current_level`** (Level). The level being played, or `nil` if none is. *(read-only)*
+- **`trx.game.gym`** (Level). The gym level, or `nil` if this game has no gym. *(read-only)*
 - **`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*
 - **`trx.game.trx_version`** (string). The TRX version string. *(read-only)*
 
@@ -86,7 +87,7 @@ Module for the game flow: which levels there are, and which one is being played.
 ### Functions
 
 - [lua]`trx.game.play_level(num)`  
-  Starts a level of the game proper.
+  Starts a level from `trx.game.levels`.
 
   Parameters:
   - **`num`** (integer). 1-based position in `trx.game.levels`.
@@ -107,3 +108,6 @@ Module for the game flow: which levels there are, and which one is being played.
 
   Parameters:
   - **`num`** (integer). 1-based position in `trx.game.demos`.
+
+- [lua]`trx.game.play_gym()`  
+  Starts the gym. Raises if this game has no gym.

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -89,7 +89,7 @@ Module for the game flow: which levels there are, and which one is being played.
   Starts a level of the game proper.
 
   Parameters:
-  - **`num`** (integer). 1-based position in `trx.game.levels`. This is not `Level.num`, which is the number the level carries.
+  - **`num`** (integer). 1-based position in `trx.game.levels`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -14,6 +14,20 @@ order: 4
 
 Module for controlling all moveables.
 
+### Indexing
+
+Indexing the module reaches an item, and `#trx.items` is how many the level has.
+
+- **`trx.items[key]`** (Item or `nil`). 1-based index, or the item's unique name.
+- **`#trx.items`** (integer). How many there are.
+
+Example:
+```lua
+for i = 1, #trx.items do
+  trx.log.info(trx.items[i].object_id)
+end
+```
+
 ### Enums
 
 - [lua]`trx.items.Status`

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -16,6 +16,17 @@ Module for the object definitions a level is built from.
 
 An object is the pattern every item of that type is cut from: a wolf's radius, not this wolf's. Per-item state lives on the item - see `trx.items`.
 
+### Indexing
+
+Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.
+
+- **`trx.objects[key]`** (Object or `nil`). Object id, or its catalog name.
+
+Example:
+```lua
+trx.objects.wolf.properties.max_hit_points = 30
+```
+
 ### Structures
 
 - [lua]`trx.objects.Object`

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -14,6 +14,18 @@ order: 10
 
 Module for inspecting and altering the rooms of the current level.
 
+### Indexing
+
+Indexing the module reaches a room, and `#trx.rooms` is how many the level has.
+
+- **`trx.rooms[key]`** (Room or `nil`). 1-based room number.
+- **`#trx.rooms`** (integer). How many there are.
+
+Example:
+```lua
+trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
+```
+
 ### Enums
 
 - [lua]`trx.rooms.FlipStatus`

--- a/src/meson.build
+++ b/src/meson.build
@@ -411,6 +411,7 @@ common_sources = [
   'trx/game/level/sections/rooms.c',
   'trx/game/level/sections/textures.c',
   'trx/game/level/settings.c',
+  'trx/game/lua/capi/api.c',
   'trx/game/lua/capi/assault.c',
   'trx/game/lua/capi/camera.c',
   'trx/game/lua/capi/catalog.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,29 +35,34 @@ if trx_version == ''
   endif
 endif
 
+# Each file in data/scripting declares part of the trx.* API and is required by
+# name. The list is what the engine ships; test_lua_sources.py holds it to the
+# tree.
+trx_lua_api_sources = files(
+  '../data/scripting/api.lua',
+  '../data/scripting/assault.lua',
+  '../data/scripting/camera.lua',
+  '../data/scripting/catalog.lua',
+  '../data/scripting/config.lua',
+  '../data/scripting/console.lua',
+  '../data/scripting/creatures.lua',
+  '../data/scripting/events.lua',
+  '../data/scripting/game.lua',
+  '../data/scripting/items.lua',
+  '../data/scripting/lara.lua',
+  '../data/scripting/locale.lua',
+  '../data/scripting/log.lua',
+  '../data/scripting/math.lua',
+  '../data/scripting/music.lua',
+  '../data/scripting/objects.lua',
+  '../data/scripting/rooms.lua',
+  '../data/scripting/sound.lua',
+  '../data/scripting/strings.lua',
+)
+
 trx_lua_embed = custom_target(
   'trx_lua_embed',
-  input: [
-    '../data/scripting/api.lua',
-    '../data/scripting/assault.lua',
-    '../data/scripting/camera.lua',
-    '../data/scripting/catalog.lua',
-    '../data/scripting/config.lua',
-    '../data/scripting/console.lua',
-    '../data/scripting/creatures.lua',
-    '../data/scripting/events.lua',
-    '../data/scripting/game.lua',
-    '../data/scripting/items.lua',
-    '../data/scripting/lara.lua',
-    '../data/scripting/locale.lua',
-    '../data/scripting/log.lua',
-    '../data/scripting/math.lua',
-    '../data/scripting/music.lua',
-    '../data/scripting/objects.lua',
-    '../data/scripting/rooms.lua',
-    '../data/scripting/sound.lua',
-    '../data/scripting/strings.lua',
-  ],
+  input: trx_lua_api_sources,
   output: ['trx_embedded_lua.c'],
   command: [
     python3,

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -143,6 +143,7 @@ lua_surface_src = files(
   '../trx/core/memory.c',
   '../trx/core/vector.c',
   '../trx/game/enum.c',
+  '../trx/game/lua/capi/api.c',
   '../trx/game/lua/capi/enum.c',
   '../trx/game/lua/capi/struct.c',
   '../trx/game/lua/field.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -147,6 +147,7 @@ lua_surface_src = files(
   '../trx/game/lua/capi/struct.c',
   '../trx/game/lua/field.c',
   '../trx/game/lua/registry.c',
+  '../trx/game/lua/sandbox.c',
   '../trx/game/lua/utils.c',
 ) + files('unit/lua_surface.c', 'unit/stubs_enum_map.c')
 
@@ -175,6 +176,33 @@ test_lua_items_exe = executable(
   build_by_default: false,
 )
 test('lua_items', test_lua_items_exe, suite: 'unit')
+
+# The same surface, taken through the two boot steps the other suites stop short
+# of: the seal, and hardening the globals.
+test_lua_boot_exe = executable(
+  'test_lua_boot',
+  files('unit/test_lua_boot.c', 'unit/fake_engine_items.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/lua/capi/items.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_boot', test_lua_boot_exe, suite: 'unit')
+
+# No fake engine: the real trig tables are the thing under test.
+test_lua_math_exe = executable(
+  'test_lua_math',
+  files('unit/test_lua_math.c') + test_stubs
+    + lua_surface_src
+    + files('../trx/game/lua/capi/math.c', '../trx/core/math/trig.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua, dep_mathlibrary],
+  c_args: lua_surface_args,
+  build_by_default: false,
+)
+test('lua_math', test_lua_math_exe, suite: 'unit')
 
 test_lua_assault_exe = executable(
   'test_lua_assault',
@@ -413,6 +441,7 @@ endif
 
 python_exe = find_program('python3', required: false)
 if python_exe.found()
+  test('lua_sources', python_exe, args: [files('unit/test_lua_sources.py')], suite: 'unit')
   test('update_lua_docs', python_exe, args: [files('unit/test_update_lua_docs.py')], suite: 'unit')
   test(
     'update_game_strings',

--- a/src/tests/unit/fake_engine_assault.c
+++ b/src/tests/unit/fake_engine_assault.c
@@ -12,6 +12,7 @@ CONFIG g_Config;
 FAKE_ASSAULT_CALLS g_FakeAssaultCalls;
 
 static bool m_InGym;
+static bool m_HasStats[GYM_TRACK_NUMBER_OF];
 static bool m_Running[GYM_TRACK_NUMBER_OF];
 static bool m_Visible[GYM_TRACK_NUMBER_OF];
 static GYM_TRACK_TYPE m_ActiveTrack;
@@ -27,9 +28,23 @@ bool Config_Update(void)
     return true;
 }
 
+// Which game this is decides whether a track has a record table, not which
+// level is up. Both tracks have one here; m_HasStats is what turns one off.
 bool Gym_TrackManager_HasStats(const GYM_TRACK_TYPE track)
 {
-    return m_InGym;
+    return track >= 0 && track < GYM_TRACK_NUMBER_OF && m_HasStats[track];
+}
+
+GYM_TRACK_STATS *Gym_TrackManager_GetMutableStats(const GYM_TRACK_TYPE track)
+{
+    switch (track) {
+    case GYM_TRACK_ASSAULT:
+        return &g_Config.profile.assault_stats;
+    case GYM_TRACK_QUAD:
+        return &g_Config.profile.racetrack_stats;
+    default:
+        return nullptr;
+    }
 }
 
 GYM_TRACK_TYPE Gym_TrackManager_GetActiveTrackType(void)
@@ -78,9 +93,15 @@ void FakeAssault_Reset(void)
     m_InGym = true;
     m_ActiveTrack = GYM_TRACK_NONE;
     for (int32_t i = 0; i < GYM_TRACK_NUMBER_OF; i++) {
+        m_HasStats[i] = true;
         m_Running[i] = false;
         m_Visible[i] = false;
     }
+}
+
+void FakeAssault_SetHasStats(const GYM_TRACK_TYPE track, const bool has_stats)
+{
+    m_HasStats[track] = has_stats;
 }
 
 void FakeAssault_SetInGym(const bool in_gym)

--- a/src/tests/unit/fake_engine_assault.h
+++ b/src/tests/unit/fake_engine_assault.h
@@ -22,6 +22,7 @@ void FakeAssault_Reset(void);
 
 // Outside a gym level the timers do not exist, and every verb raises.
 void FakeAssault_SetInGym(bool in_gym);
+void FakeAssault_SetHasStats(GYM_TRACK_TYPE track, bool has_stats);
 void FakeAssault_SetRunning(GYM_TRACK_TYPE track, bool running);
 void FakeAssault_SetVisible(GYM_TRACK_TYPE track, bool visible);
 void FakeAssault_SetActiveTrack(GYM_TRACK_TYPE track);

--- a/src/tests/unit/fake_engine_game.c
+++ b/src/tests/unit/fake_engine_game.c
@@ -18,6 +18,7 @@ static GF_LEVEL m_Demos[FAKE_DEMO_COUNT];
 static GF_LEVEL m_TitleLevel;
 static GF_LEVEL_TABLE m_Tables[GFLT_NUMBER_OF];
 static const GF_LEVEL *m_CurrentLevel;
+static bool m_HasGym;
 
 const GF_LEVEL_TABLE *GF_GetLevelTable(const GF_LEVEL_TABLE_TYPE table_type)
 {
@@ -57,6 +58,20 @@ const GF_LEVEL *GF_GetLevel(
 const GF_LEVEL *GF_GetTitleLevel(void)
 {
     return &m_TitleLevel;
+}
+
+const GF_LEVEL *GF_GetGymLevel(void)
+{
+    if (!m_HasGym) {
+        return nullptr;
+    }
+    const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(GFLT_MAIN);
+    for (int32_t i = 0; i < tbl->count; i++) {
+        if (tbl->levels[i].type == GFL_GYM) {
+            return &tbl->levels[i];
+        }
+    }
+    return nullptr;
 }
 
 const GF_LEVEL *GF_GetCurrentLevel(void)
@@ -124,6 +139,9 @@ void GF_OverrideCommand(const GF_COMMAND command)
         break;
     case GF_START_DEMO:
         g_FakeGameCalls.play_demo++;
+        break;
+    case GF_SELECT_GAME:
+        g_FakeGameCalls.play_gym++;
         break;
     default:
         break;
@@ -198,7 +216,13 @@ void FakeGame_Reset(void)
     m_Tables[GFLT_TITLE] = (GF_LEVEL_TABLE) { .count = 0, .levels = nullptr };
 
     m_CurrentLevel = nullptr;
+    m_HasGym = true;
     g_FakeGameCalls = (FAKE_GAME_CALLS) {};
+}
+
+void FakeGame_SetGymPresent(const bool present)
+{
+    m_HasGym = present;
 }
 
 void FakeGame_SetCurrentLevel(const int32_t idx)

--- a/src/tests/unit/fake_engine_game.c
+++ b/src/tests/unit/fake_engine_game.c
@@ -15,6 +15,7 @@ FAKE_GAME_CALLS g_FakeGameCalls;
 static GF_LEVEL m_Levels[FAKE_LEVEL_COUNT];
 static GF_LEVEL m_Cutscenes[FAKE_CUTSCENE_COUNT];
 static GF_LEVEL m_Demos[FAKE_DEMO_COUNT];
+static GF_LEVEL m_TitleLevel;
 static GF_LEVEL_TABLE m_Tables[GFLT_NUMBER_OF];
 static const GF_LEVEL *m_CurrentLevel;
 
@@ -26,10 +27,21 @@ const GF_LEVEL_TABLE *GF_GetLevelTable(const GF_LEVEL_TABLE_TYPE table_type)
     return &m_Tables[table_type];
 }
 
+// As the real one: a gym is in the table but is not one of the levels the game
+// numbers, so it is not counted either.
 int32_t GF_GetLevelCount(const GF_LEVEL_TABLE_TYPE table_type)
 {
     const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(table_type);
-    return tbl != nullptr ? tbl->count : 0;
+    if (tbl == nullptr) {
+        return 0;
+    }
+    int32_t count = 0;
+    for (int32_t i = 0; i < tbl->count; i++) {
+        if (tbl->levels[i].type != GFL_GYM) {
+            count++;
+        }
+    }
+    return count;
 }
 
 const GF_LEVEL *GF_GetLevel(
@@ -40,6 +52,11 @@ const GF_LEVEL *GF_GetLevel(
         return nullptr;
     }
     return &tbl->levels[num];
+}
+
+const GF_LEVEL *GF_GetTitleLevel(void)
+{
+    return &m_TitleLevel;
 }
 
 const GF_LEVEL *GF_GetCurrentLevel(void)
@@ -76,6 +93,22 @@ int32_t GF_GetLevelOrdinalNumber(
         }
     }
     return 0;
+}
+
+GF_LEVEL *GF_GetLevelByOrdinalNumber(
+    const GF_LEVEL_TABLE_TYPE table_type, const int32_t level_num)
+{
+    const GF_LEVEL_TABLE *const tbl = GF_GetLevelTable(table_type);
+    if (tbl == nullptr) {
+        return nullptr;
+    }
+    for (int32_t i = 0; i < tbl->count; i++) {
+        GF_LEVEL *const level = &tbl->levels[i];
+        if (GF_GetLevelOrdinalNumber(table_type, level) == level_num) {
+            return level;
+        }
+    }
+    return nullptr;
 }
 
 // The gameflow command the play_* verbs queue, and the savegame bookkeeping
@@ -150,6 +183,11 @@ void FakeGame_Reset(void)
         .type = GFL_DEMO,
         .title = "Demo 1",
     };
+    m_TitleLevel = (GF_LEVEL) {
+        .num = 0,
+        .type = GFL_TITLE,
+        .title = "Title",
+    };
 
     m_Tables[GFLT_MAIN] =
         (GF_LEVEL_TABLE) { .count = FAKE_LEVEL_COUNT, .levels = m_Levels };
@@ -166,4 +204,10 @@ void FakeGame_Reset(void)
 void FakeGame_SetCurrentLevel(const int32_t idx)
 {
     m_CurrentLevel = idx < 0 ? nullptr : &m_Levels[idx];
+}
+
+// The title level, which is not in any table.
+void FakeGame_SetCurrentTitle(void)
+{
+    m_CurrentLevel = &m_TitleLevel;
 }

--- a/src/tests/unit/fake_engine_game.h
+++ b/src/tests/unit/fake_engine_game.h
@@ -13,6 +13,7 @@ typedef struct {
     int32_t play_level;
     int32_t play_cutscene;
     int32_t play_demo;
+    int32_t play_gym;
     int32_t last_num;
 } FAKE_GAME_CALLS;
 
@@ -25,3 +26,6 @@ void FakeGame_SetCurrentLevel(int32_t idx);
 
 // The title level, which is not in any table.
 void FakeGame_SetCurrentTitle(void);
+
+// Whether the flow has a gym. A game without one has nothing to play.
+void FakeGame_SetGymPresent(bool present);

--- a/src/tests/unit/fake_engine_game.h
+++ b/src/tests/unit/fake_engine_game.h
@@ -22,3 +22,6 @@ void FakeGame_Reset(void);
 
 // A negative index leaves the current level unset.
 void FakeGame_SetCurrentLevel(int32_t idx);
+
+// The title level, which is not in any table.
+void FakeGame_SetCurrentTitle(void);

--- a/src/tests/unit/lua/api_seal.lua
+++ b/src/tests/unit/lua/api_seal.lua
@@ -4,35 +4,57 @@
 local h = require("harness")
 local test, raises = h.test, h.raises
 
+-- The cases share one Lua state and may be shuffled, so the seal has to be
+-- something any of them can ask for. It happens once, as it does at boot.
+local function seal()
+  if trx.api.seal ~= nil then
+    trx.api.seal()
+  end
+end
+
 test("an undeclared member is unreachable before the seal", function()
   assert(trx.items[1].box_num == nil, "box_num was never declared")
 end)
 
-test("sealing rejects further declarations", function()
-  trx.api.seal()
+-- The declaring half of the registry goes the way trxc goes: a script cannot
+-- reach api.type to re-expose a member the declarations withheld, because there
+-- is nothing left to reach.
+test("sealing takes the declaring half off trx.api", function()
+  seal()
 
-  raises(function()
-    trx.api.define("items.evil", { impl = function() end })
-  end, "sealed")
+  for _, name in ipairs({
+    "seal",
+    "module",
+    "define",
+    "type",
+    "enum",
+    "enum_name",
+    "const",
+    "property",
+    "namespace",
+    "container",
+    "describe",
+    "to_json",
+  }) do
+    assert(trx.api[name] == nil, "trx.api." .. name .. " must not survive the seal")
+  end
 
-  raises(function()
-    trx.api.type("items.Item", {
-      backing = "ITEM",
-      fields = { box_num = { from = "box_num", type = "integer" } },
-    })
-  end, "sealed")
-
-  -- api.module installs a module's metatable, so it reopens what the seal shut.
-  raises(function()
-    trx.api.module("items", {
-      instance = function()
-        return trx.items[1]
-      end,
-    })
-  end, "sealed")
-
-  -- A rejected declaration must not have bound anything on its way out.
   assert(trx.items[1].box_num == nil, "box_num must still be unreachable")
+end)
+
+test("what is left of trx.api is strict mode", function()
+  seal()
+
+  assert(trx.api.is_strict() == false)
+  trx.api.strict(true)
+  assert(trx.api.is_strict() == true)
+
+  raises(function()
+    trx.items.spawn("wolf", { x = 0, y = 0, z = 0 })
+  end)
+
+  trx.api.strict(false)
+  assert(trx.api.is_strict() == false)
 end)
 
 return h.report()

--- a/src/tests/unit/lua/assault.lua
+++ b/src/tests/unit/lua/assault.lua
@@ -146,6 +146,52 @@ test("a time of zero or less raises", function()
   end)
 end)
 
+-- Every track keeps its own record table. Filing one against the quad bike used
+-- to land in the assault course's.
+test("each track keeps its own records", function()
+  local COURSE, QUAD = trx.assault.Track.COURSE, trx.assault.Track.QUAD
+
+  trx.assault.stats.add_record(30.0)
+  trx.assault.stats.add_record(12.5, QUAD)
+
+  local course = trx.assault.stats.list_records(COURSE)
+  assert(#course == 1 and course[1].time == 30.0, "the course record")
+
+  local quad = trx.assault.stats.list_records(QUAD)
+  assert(#quad == 1 and quad[1].time == 12.5, "the quad record went somewhere else")
+
+  -- Omitting the track still means the course, as it does everywhere else.
+  assert(#trx.assault.stats.list_records() == 1)
+  assert(trx.assault.stats.list_records()[1].time == 30.0)
+
+  assert(trx.assault.stats.remove_record(1, QUAD) == true)
+  assert(#trx.assault.stats.list_records(QUAD) == 0, "the quad record was not removed")
+  assert(#trx.assault.stats.list_records(COURSE) == 1, "the course record went with it")
+end)
+
+-- The records are in the player's profile, not in the level.
+test("records can be read outside a gym level", function()
+  trx.assault.stats.add_record(30.0)
+  fake.set_in_gym(false)
+
+  assert(#trx.assault.stats.list_records() == 1)
+  assert(trx.assault.stats.add_record(10.0) == true)
+end)
+
+-- Which game this is decides whether a track has a record table at all.
+test("a track this game has no records for raises", function()
+  fake.set_has_stats(trx.assault.Track.QUAD, false)
+  raises(function()
+    trx.assault.stats.list_records(trx.assault.Track.QUAD)
+  end, "unavailable")
+  raises(function()
+    trx.assault.stats.add_record(10.0, trx.assault.Track.QUAD)
+  end, "unavailable")
+
+  -- And the course is untouched by it.
+  assert(trx.assault.stats.add_record(10.0) == true)
+end)
+
 test("stats is a table, not a function", function()
   assert(type(trx.assault.stats) == "table")
 end)

--- a/src/tests/unit/lua/boot.lua
+++ b/src/tests/unit/lua/boot.lua
@@ -1,0 +1,40 @@
+-- The surface as a level script meets it: sealed, and with the globals hardened.
+-- No other suite gets that far.
+
+local h = harness
+local test, raises = h.test, h.raises
+
+test("the raw C bridge is gone", function()
+  assert(trxc == nil, "sealing takes trxc off the globals")
+  assert(trx.items.spawn ~= nil, "the public surface is still there")
+end)
+
+test("the loader and the globals it feeds are gone", function()
+  for _, name in ipairs({ "load", "loadfile", "dofile", "require", "package" }) do
+    assert(_G[name] == nil, name .. " must not survive hardening")
+  end
+  assert(string.dump == nil, "string.dump feeds the loader")
+end)
+
+-- Strict mode compiles its wrappers with load(), which api.lua captures at module
+-- scope because hardening nils the global. Every other strict test runs
+-- unhardened and would not notice if that capture went.
+test("strict mode still works once the globals are hardened", function()
+  trx.api.strict(true)
+
+  raises(function()
+    trx.items.spawn("wolf", { x = 0, y = 0, z = 0 })
+  end)
+  assert(trx.items.get(1) ~= nil, "a good call still goes through")
+
+  trx.api.strict(false)
+  assert(trx.items.get(1) ~= nil)
+end)
+
+test("the surface cannot be reopened", function()
+  raises(function()
+    trx.api.define("items.evil", { impl = function() end })
+  end, "sealed")
+end)
+
+return h.report()

--- a/src/tests/unit/lua/boot.lua
+++ b/src/tests/unit/lua/boot.lua
@@ -32,9 +32,9 @@ test("strict mode still works once the globals are hardened", function()
 end)
 
 test("the surface cannot be reopened", function()
-  raises(function()
-    trx.api.define("items.evil", { impl = function() end })
-  end, "sealed")
+  assert(trx.api.define == nil, "the registry's declaring half must not survive the seal")
+  assert(trx.api.type == nil)
+  assert(trx.api.strict ~= nil, "strict mode is a builder's, and stays")
 end)
 
 return h.report()

--- a/src/tests/unit/lua/game.lua
+++ b/src/tests/unit/lua/game.lua
@@ -127,6 +127,24 @@ test("play_level rejects a level that is not there", function()
   assert(fake.calls().play_level == 0)
 end)
 
+-- The gym has no ordinal, so play_level cannot name it; play_gym is the only way
+-- to reach it, and it queues the gym's own num.
+test("play_gym queues the gym", function()
+  trx.game.play_gym()
+  local calls = fake.calls()
+  assert(calls.play_gym == 1, "play_gym did not reach the game flow")
+  assert(calls.last_num == 0, "the gym's own num reaches the game flow")
+  assert(calls.play_level == 0, "the gym is not one of the numbered levels")
+end)
+
+test("play_gym raises when the game has no gym", function()
+  fake.set_gym_present(false)
+  raises(function()
+    trx.game.play_gym()
+  end)
+  assert(fake.calls().play_gym == 0)
+end)
+
 test("a setting is reached through trx.config, and nowhere else", function()
   assert(trx.game.settings == nil)
 end)

--- a/src/tests/unit/lua/game.lua
+++ b/src/tests/unit/lua/game.lua
@@ -7,26 +7,25 @@
 local h = require("harness")
 local test, raises = h.test, h.raises
 
-test("the level list is a list of Level handles", function()
+-- The list holds the levels the game numbers, which is what count_levels counts.
+-- The gym sits in the table ahead of them and is not one of them, so the list
+-- and the table disagree on where every level after it sits.
+test("the level list is the levels the game numbers", function()
   local levels = trx.game.levels
-  assert(#levels == fake.LEVEL_COUNT, "wrong number of levels")
-  assert(levels[2].title == "Caves")
-  assert(levels[3].title == "Vilcabamba")
+  assert(#levels == fake.NUMBERED_LEVEL_COUNT, "wrong number of levels")
+  assert(levels[1].title == "Caves")
+  assert(levels[2].title == "Vilcabamba", "the last level must be reachable")
+  assert(levels[1].type == trx.game.LevelType.NORMAL, "the gym is not in the list")
 end)
 
-test("a level's num is its number, not its place in the list", function()
+test("a level's num is its place in the game flow, not in the list", function()
   local levels = trx.game.levels
-  -- The gym is first in the table and has no number at all.
-  assert(levels[1].type == trx.game.LevelType.GYM)
-  assert(levels[1].num == 0, "a gym has no number")
-
-  -- And the levels after it are numbered from 1, as the player sees them.
-  assert(levels[2].num == 1)
-  assert(levels[3].num == 2)
+  assert(levels[1].num == 1)
+  assert(levels[2].num == 2)
 end)
 
 test("a level carries what the game flow said about it", function()
-  local caves = trx.game.levels[2]
+  local caves = trx.game.levels[1]
   assert(caves.path == "level1.phd")
   assert(caves.script_path == "caves.lua")
   assert(caves.lara_outfit == "default")
@@ -37,16 +36,16 @@ end)
 
 test("a level is read-only", function()
   raises(function()
-    trx.game.levels[2].title = "Nope"
+    trx.game.levels[1].title = "Nope"
   end)
   raises(function()
-    trx.game.levels[2].num = 99
+    trx.game.levels[1].num = 99
   end)
 end)
 
 test("a member of GF_LEVEL nobody declared is not reachable", function()
   -- The struct has a sequence, injections and item drops. None is declared.
-  local caves = trx.game.levels[2]
+  local caves = trx.game.levels[1]
   assert(caves.sequence == nil)
   assert(caves.injections == nil)
   assert(caves.item_drops == nil)
@@ -69,6 +68,22 @@ test("current_level is nil until a level is playing", function()
   assert(trx.game.current_level.title == "Caves")
 end)
 
+-- Neither is in the list the game numbers, and the title level is not even in a
+-- table, so both are only reachable as the level being played.
+test("the gym and the title level still resolve as the current level", function()
+  fake.set_current_level(1)
+  local gym = trx.game.current_level
+  assert(gym ~= nil, "the gym must resolve")
+  assert(gym.type == trx.game.LevelType.GYM)
+  assert(gym.num == 0, "a gym has no number")
+
+  fake.set_current_title()
+  local title = trx.game.current_level
+  assert(title ~= nil, "the title level must resolve")
+  assert(title.type == trx.game.LevelType.TITLE)
+  assert(title.title == "Title")
+end)
+
 test("the enums come from C", function()
   assert(trx.game.LevelTable.MAIN ~= nil)
   assert(trx.game.LevelTable.CUTSCENES ~= nil)
@@ -85,18 +100,29 @@ test("version reads through", function()
   assert(trx.game.trx_version == "TRX-test")
 end)
 
-test("play_level queues the level", function()
+test("play_level queues the level the list named", function()
   fake.set_current_level(2)
-  trx.game.play_level(3)
+
+  -- The second level of the list is the third entry of the table, because the
+  -- gym sits ahead of them. What reaches the game flow is the level's own num.
+  trx.game.play_level(2)
   local calls = fake.calls()
   assert(calls.play_level == 1, "play_level did not reach the game flow")
-  -- Lua counts from 1, the game flow from 0.
+  assert(calls.last_num == trx.game.levels[2].num)
   assert(calls.last_num == 2)
 end)
 
 test("play_level rejects a level that is not there", function()
   raises(function()
     trx.game.play_level(99)
+  end)
+  raises(function()
+    trx.game.play_level(0)
+  end)
+  -- A number too wide for the engine's would otherwise wrap into range and
+  -- start whatever level it landed on.
+  raises(function()
+    trx.game.play_level(4294967297)
   end)
   assert(fake.calls().play_level == 0)
 end)

--- a/src/tests/unit/lua/harness.lua
+++ b/src/tests/unit/lua/harness.lua
@@ -26,6 +26,10 @@ function M.raises(fn, needle)
 end
 
 function M.report()
+  -- A suite that registered nothing reports "0 failed" and the runner takes the
+  -- zero for a pass, which reads exactly like a suite that ran.
+  assert(#M.cases > 0, "the suite registered no cases")
+
   local order = {}
   for i = 1, #M.cases do
     order[i] = i

--- a/src/tests/unit/lua/items.lua
+++ b/src/tests/unit/lua/items.lua
@@ -285,6 +285,39 @@ test("find and first query by object and room", function()
   assert(#trx.items.find() == 0 and trx.items.first() == nil)
 end)
 
+-- A method reaches C directly, so strict mode has to put its wrapper in front of
+-- the C function rather than around a Lua one.
+test("strict mode checks a method's arguments", function()
+  local it = trx.items[1]
+  trx.api.strict(true)
+
+  local ok = pcall(function()
+    -- A colon call with a bad argument.
+    it:distance_to("over there")
+  end)
+  trx.api.strict(false)
+  assert(not ok, "strict mode let a bad argument through to a method")
+
+  -- And it still works with a good one, strict or not.
+  trx.api.strict(true)
+  local distance = it:distance_to({ x = 0, y = 0, z = 0 })
+  trx.api.strict(false)
+  assert(distance == 0)
+  assert(it:distance_to({ x = 0, y = 0, z = 0 }) == 0)
+end)
+
+-- The handle is the method's first argument, and a dot where a colon was meant
+-- passes whatever came first instead.
+test("strict mode catches a method called with a dot", function()
+  local it = trx.items[1]
+  trx.api.strict(true)
+  local ok = pcall(function()
+    return it.distance_to({ x = 0, y = 0, z = 0 })
+  end)
+  trx.api.strict(false)
+  assert(not ok, "strict mode let a method run without its handle")
+end)
+
 -- ITEM has many members the declaration does not name.
 test("undeclared members are unreachable", function()
   local it = trx.items[1]

--- a/src/tests/unit/lua/math.lua
+++ b/src/tests/unit/lua/math.lua
@@ -1,0 +1,49 @@
+-- The fixed-point trigonometry a script places things with. The assertions are on
+-- the engine's own tables: landing where the engine would is the whole point.
+
+local h = require("harness")
+local test = h.test
+
+local DEG_90 = trx.math.DEG_90
+
+test("the angle constants divide a turn the way the engine does", function()
+  assert(DEG_90 * 4 == 0x10000, "four quarter turns make a full turn")
+  assert(trx.math.DEG_45 * 8 == 0x10000)
+  -- 65536/360 is not whole, so a degree is 182 and 360 of them fall 16 short.
+  assert(trx.math.DEG_1 == 182)
+  assert(trx.math.DEG_1 * 360 == 0x10000 - 16)
+  assert(trx.math.WALL_L == 1024)
+end)
+
+test("sin and cos run the circle", function()
+  assert(trx.math.sin(0) == 0.0)
+  assert(trx.math.cos(0) == 1.0)
+  assert(math.abs(trx.math.sin(DEG_90) - 1.0) < 0.001)
+  assert(math.abs(trx.math.cos(DEG_90)) < 0.001)
+  assert(math.abs(trx.math.sin(2 * DEG_90)) < 0.001)
+  assert(math.abs(trx.math.cos(2 * DEG_90) + 1.0) < 0.001)
+end)
+
+test("a full turn wraps to where it started", function()
+  assert(trx.math.sin(4 * DEG_90) == trx.math.sin(0))
+  assert(trx.math.cos(4 * DEG_90) == trx.math.cos(0))
+end)
+
+-- The engine's angles run clockwise from +z, and atan takes z first.
+test("atan takes z before x", function()
+  assert(trx.math.atan(0, 0) == 0)
+  assert(trx.math.atan(1024, 0) == 0, "straight along +z is angle zero")
+  assert(trx.math.atan(0, 1024) == DEG_90, "straight along +x is a quarter turn")
+  assert(trx.math.atan(1024, 1024) == trx.math.DEG_45)
+end)
+
+test("strict mode holds the angle to an integer", function()
+  trx.api.strict(true)
+  h.raises(function()
+    trx.math.sin(1.5)
+  end)
+  trx.api.strict(false)
+  assert(trx.math.sin(0) == 0.0)
+end)
+
+return h.report()

--- a/src/tests/unit/lua_surface.c
+++ b/src/tests/unit/lua_surface.c
@@ -1,6 +1,7 @@
 #include "lua_surface.h"
 
 #include <trx/game/lua/registry.h>
+#include <trx/game/lua/sandbox.h>
 #include <trx/game/lua/utils.h>
 
 #include <stdio.h>
@@ -72,7 +73,9 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
     lua_setfield(L, -2, "reset");
     lua_pushcfunction(L, test->fake_calls);
     lua_setfield(L, -2, "calls");
-    test->push_fake(L);
+    if (test->push_fake != nullptr) {
+        test->push_fake(L);
+    }
     lua_setglobal(L, "fake");
 
     if (luaL_dostring(
@@ -81,7 +84,10 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
             "            warn = function() end, error = function() end }\n"
             "package.preload['trx.log'] = function() return trx.log end\n"
             "package.path = '" REPO_ROOT
-            "/src/tests/unit/lua/?.lua;' .. package.path\n")
+            "/src/tests/unit/lua/?.lua;' .. package.path\n"
+            // Hardening takes require() away, and a hardened suite still needs
+            // the harness.
+            "_G.harness = require('harness')\n")
         != LUA_OK) {
         M_Fail(L, "preamble");
     }
@@ -95,6 +101,19 @@ int LuaSurface_Run(const LUA_SURFACE_TEST *const test)
     }
 
     M_RunModule(L, test->module);
+
+    // From here to the tests, the order is LUA_Init's: seal, then harden.
+    if (test->seal) {
+        if (luaL_dostring(L, "trx.api.seal()") != LUA_OK) {
+            M_Fail(L, "sealing");
+        }
+        lua_pushnil(L);
+        lua_setglobal(L, "trxc");
+    }
+
+    if (test->harden) {
+        LUA_HardenGlobals(L);
+    }
 
     lua_pushfstring(L, REPO_ROOT "/src/tests/unit/lua/%s.lua", test->tests);
     const int32_t base = lua_gettop(L);

--- a/src/tests/unit/lua_surface.h
+++ b/src/tests/unit/lua_surface.h
@@ -18,6 +18,11 @@ typedef struct {
     // Modules loaded before it, for a declaration that reaches into another -
     // trx.camera.room hands back a trx.rooms.Room. NULL-terminated.
     const char *deps[4];
+    // Seal the surface and take trxc off the globals, as the engine does once
+    // the modules have declared.
+    bool seal;
+    // Harden the globals, as the engine does last of all.
+    bool harden;
     // src/tests/unit/lua/<tests>.lua - the assertions.
     const char *tests;
     // Anything the test needs beyond the bridges, which the linked modules

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -435,5 +435,142 @@ test("seal blocks further declarations", function()
   assert(not pcall(api.property, "things.air", { get = function() end }), "property() after seal")
 end)
 
+-- Several bridges read lua_gettop() to tell an omitted argument from a nil one,
+-- so the wrapper must not pass one the caller did not.
+test("strict mode drops an optional argument that carries no default", function()
+  local api = fresh_env()
+  api.define("things.flip", {
+    params = {
+      { name = "id", type = "integer" },
+      { name = "timer", type = "integer", optional = true },
+    },
+    impl = function(...)
+      return select("#", ...)
+    end,
+  })
+
+  api.strict(true)
+  assert(trx.things.flip(1) == 1, "an omitted optional must not arrive as nil")
+  assert(trx.things.flip(1, 5) == 2, "one that was passed must arrive")
+end)
+
+test("strict mode substitutes a default and still checks it", function()
+  local api = fresh_env()
+  api.define("things.track", {
+    params = { { name = "track", type = "integer", optional = true, default = 3 } },
+    impl = function(track)
+      return track
+    end,
+  })
+
+  api.strict(true)
+  assert(trx.things.track() == 3, "the default stands in for the argument")
+  assert(not pcall(trx.things.track, "nope"))
+end)
+
+test("strict mode checks a namespace's call and a property's write", function()
+  local api = fresh_env()
+  local logged, air
+  api.module("things", {})
+  api.namespace("things.log", {
+    description = "Logging.",
+    params = { { name = "message", type = "string" } },
+    call = function(message)
+      logged = message
+    end,
+  })
+  api.property("things.air", {
+    type = "integer",
+    description = "Air.",
+    get = function()
+      return air
+    end,
+    set = function(value)
+      air = value
+    end,
+  })
+
+  api.strict(true)
+  trx.things.log("hello")
+  assert(logged == "hello")
+  assert(not pcall(trx.things.log, 42), "calling the group must be checked")
+
+  trx.things.air = 5
+  assert(air == 5)
+  assert(not pcall(function()
+    trx.things.air = "not an integer"
+  end), "writing a property must be checked")
+end)
+
+test("seal refuses a parameter nothing can check", function()
+  local api = fresh_env()
+  api.define("things.bad", {
+    params = { { name = "a", type = "intger" } },
+    impl = function() end,
+  })
+
+  local ok, err = pcall(api.seal)
+  assert(not ok, "a misspelled type must fail the seal")
+  assert(tostring(err):find("intger", 1, true), "the audit must name it: " .. tostring(err))
+end)
+
+test("seal refuses a default of the wrong type", function()
+  local api = fresh_env()
+  api.define("things.bad", {
+    params = { { name = "a", type = "integer", optional = true, default = "trx.things.A" } },
+    impl = function() end,
+  })
+
+  assert(not pcall(api.seal), "a default that is not of the parameter's type must fail the seal")
+end)
+
+test("seal refuses a required parameter behind an optional one", function()
+  local api = fresh_env()
+  api.define("things.bad", {
+    params = {
+      { name = "a", type = "integer", optional = true },
+      { name = "b", type = "integer" },
+    },
+    impl = function() end,
+  })
+
+  assert(not pcall(api.seal), "a call cannot reach b without passing a")
+end)
+
+test("a container is declared, not hand-rolled onto the module table", function()
+  local api = fresh_env()
+  local things = { "first", "second" }
+  api.module("things", {})
+  api.container("things", {
+    description = "Indexing.",
+    key = { type = "integer", description = "1-based." },
+    value = { type = "string" },
+    get = function(key)
+      return things[key]
+    end,
+    count = function()
+      return #things
+    end,
+  })
+
+  assert(trx.things[1] == "first")
+  assert(#trx.things == 2)
+
+  -- A property declared afterwards must not take the metatable with it.
+  api.property("things.best", {
+    type = "string",
+    description = "Best.",
+    get = function()
+      return things[1]
+    end,
+  })
+  assert(trx.things[2] == "second", "declaring a property must not drop the indexing")
+  assert(trx.things.best == "first")
+end)
+
+-- A suite that registers nothing prints "0 failed" and exits clean, which reads
+-- exactly like a suite that passed.
+assert(passed + failures > 0, "the suite registered no tests")
+
 print(("\n%d passed, %d failed, %d total"):format(passed, failures, passed + failures))
 os.exit(failures == 0 and 0 or 1)

--- a/src/tests/unit/test_api.lua
+++ b/src/tests/unit/test_api.lua
@@ -33,6 +33,10 @@ local function fresh_env()
       expose_computed = function(t, public, fn)
         exposed.computed[public] = fn
       end,
+      -- What strict mode wraps: the C function behind a method.
+      method = function(t, from)
+        return function() end
+      end,
       members = function()
         return {
           { name = "visible", type = "INT32", writable = true },
@@ -66,6 +70,10 @@ local function fresh_env()
           { name = "ON", value = 1 },
         }
       end,
+    },
+    -- Where the registry hands C the entrypoints it keeps after the seal.
+    api = {
+      set_entrypoint = function() end,
     },
   }
   _G.trx = { log = { debug = function() end, warn = function() end } }
@@ -169,7 +177,13 @@ test("describe() reports fields, methods and extensions", function()
   assert(#t.fields == 1, "fields missing")
   assert(#t.methods == 1, "methods missing from describe()")
   assert(#t.extensions == 1, "extensions missing from describe()")
-  assert(#d.functions == 1, "functions missing")
+
+  -- Named rather than counted: the registry declares its own functions too.
+  local declared = {}
+  for _, fn in ipairs(d.functions) do
+    declared[fn.path] = true
+  end
+  assert(declared["things.count"], "functions missing")
 end)
 
 test("enum() reflects the constants out of C", function()

--- a/src/tests/unit/test_lua_assault.c
+++ b/src/tests/unit/test_lua_assault.c
@@ -18,6 +18,13 @@ static int M_FakeSetInGym(lua_State *const L)
     return 0;
 }
 
+static int M_FakeSetHasStats(lua_State *const L)
+{
+    FakeAssault_SetHasStats(
+        (GYM_TRACK_TYPE)luaL_checkinteger(L, 1), lua_toboolean(L, 2));
+    return 0;
+}
+
 static int M_FakeSetRunning(lua_State *const L)
 {
     FakeAssault_SetRunning(
@@ -62,6 +69,8 @@ static void M_PushFake(lua_State *const L)
 {
     lua_pushcfunction(L, M_FakeSetInGym);
     lua_setfield(L, -2, "set_in_gym");
+    lua_pushcfunction(L, M_FakeSetHasStats);
+    lua_setfield(L, -2, "set_has_stats");
     lua_pushcfunction(L, M_FakeSetRunning);
     lua_setfield(L, -2, "set_running");
     lua_pushcfunction(L, M_FakeSetVisible);

--- a/src/tests/unit/test_lua_boot.c
+++ b/src/tests/unit/test_lua_boot.c
@@ -1,0 +1,44 @@
+// The surface after the two boot steps the other suites stop short of: sealing,
+// and hardening the globals. The assertions live in
+// src/tests/unit/lua/boot.lua.
+//
+// It runs against trx.items because a module with checked parameters is what
+// makes strict mode worth turning on after hardening.
+
+#include "fake_engine_items.h"
+#include "lua_surface.h"
+
+static void M_SetUpExtra(lua_State *const L)
+{
+    // As in test_lua_items: the `room` extension hands off to trx.rooms.
+    (void)luaL_dostring(
+        L,
+        "trx.rooms = setmetatable({}, {\n"
+        "  __index = function(_, n) return { num = n } end })\n");
+}
+
+static int M_FakeReset(lua_State *const L)
+{
+    FakeItems_Reset();
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    return 1;
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "items",
+        .tests = "boot",
+        .seal = true,
+        .harden = true,
+        .setup_extra = M_SetUpExtra,
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/tests/unit/test_lua_game.c
+++ b/src/tests/unit/test_lua_game.c
@@ -19,6 +19,12 @@ static int M_FakeSetCurrentLevel(lua_State *const L)
     return 0;
 }
 
+static int M_FakeSetCurrentTitle(lua_State *const L)
+{
+    FakeGame_SetCurrentTitle();
+    return 0;
+}
+
 static int M_FakeCalls(lua_State *const L)
 {
     lua_newtable(L);
@@ -37,8 +43,13 @@ static void M_PushFake(lua_State *const L)
 {
     lua_pushcfunction(L, M_FakeSetCurrentLevel);
     lua_setfield(L, -2, "set_current_level");
+    lua_pushcfunction(L, M_FakeSetCurrentTitle);
+    lua_setfield(L, -2, "set_current_title");
     lua_pushinteger(L, FAKE_LEVEL_COUNT);
     lua_setfield(L, -2, "LEVEL_COUNT");
+    // The levels the game numbers: the gym is in the table but is not one.
+    lua_pushinteger(L, FAKE_LEVEL_COUNT - 1);
+    lua_setfield(L, -2, "NUMBERED_LEVEL_COUNT");
 }
 
 int main(void)

--- a/src/tests/unit/test_lua_game.c
+++ b/src/tests/unit/test_lua_game.c
@@ -25,6 +25,12 @@ static int M_FakeSetCurrentTitle(lua_State *const L)
     return 0;
 }
 
+static int M_FakeSetGymPresent(lua_State *const L)
+{
+    FakeGame_SetGymPresent(lua_toboolean(L, 1));
+    return 0;
+}
+
 static int M_FakeCalls(lua_State *const L)
 {
     lua_newtable(L);
@@ -34,6 +40,8 @@ static int M_FakeCalls(lua_State *const L)
     lua_setfield(L, -2, "play_cutscene");
     lua_pushinteger(L, g_FakeGameCalls.play_demo);
     lua_setfield(L, -2, "play_demo");
+    lua_pushinteger(L, g_FakeGameCalls.play_gym);
+    lua_setfield(L, -2, "play_gym");
     lua_pushinteger(L, g_FakeGameCalls.last_num);
     lua_setfield(L, -2, "last_num");
     return 1;
@@ -45,6 +53,8 @@ static void M_PushFake(lua_State *const L)
     lua_setfield(L, -2, "set_current_level");
     lua_pushcfunction(L, M_FakeSetCurrentTitle);
     lua_setfield(L, -2, "set_current_title");
+    lua_pushcfunction(L, M_FakeSetGymPresent);
+    lua_setfield(L, -2, "set_gym_present");
     lua_pushinteger(L, FAKE_LEVEL_COUNT);
     lua_setfield(L, -2, "LEVEL_COUNT");
     // The levels the game numbers: the gym is in the table but is not one.

--- a/src/tests/unit/test_lua_math.c
+++ b/src/tests/unit/test_lua_math.c
@@ -1,0 +1,29 @@
+// The fixed-point trig surface. The assertions live in
+// src/tests/unit/lua/math.lua.
+//
+// There is no fake engine: the real trig tables are what the module is for, so
+// they are what it is tested against.
+
+#include "lua_surface.h"
+
+static int M_FakeReset(lua_State *const L)
+{
+    return 0;
+}
+
+static int M_FakeCalls(lua_State *const L)
+{
+    lua_newtable(L);
+    return 1;
+}
+
+int main(void)
+{
+    const LUA_SURFACE_TEST test = {
+        .module = "math",
+        .tests = "math",
+        .fake_reset = M_FakeReset,
+        .fake_calls = M_FakeCalls,
+    };
+    return LuaSurface_Run(&test);
+}

--- a/src/tests/unit/test_lua_sources.py
+++ b/src/tests/unit/test_lua_sources.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+"""The embedded Lua source list against the tree it is supposed to mirror.
+
+What the engine embeds is stated in src/meson.build and nowhere else, so nothing
+stops a new file in data/scripting/ from being left out of it.
+
+Left out, the file is still loaded by the surface tests, which read the tree; it
+is simply absent from the binary and from the reference. The suite would be green
+and the module would not exist.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MESON = ROOT / "src/meson.build"
+
+
+def listed(variable: str) -> set[str]:
+    body = re.search(rf"^{variable} = files\((.*?)^\)", MESON.read_text(), re.S | re.M)
+    assert body is not None, f"{variable} is not a files() list in src/meson.build"
+    return {Path(m).name for m in re.findall(r"'([^']+)'", body.group(1))}
+
+
+def main() -> int:
+    failures = []
+
+    for variable, directory in (("trx_lua_api_sources", ROOT / "data/scripting"),):
+        on_disk = {path.name for path in directory.glob("*.lua")}
+        in_meson = listed(variable)
+
+        for name in sorted(on_disk - in_meson):
+            failures.append(
+                f"{directory.relative_to(ROOT)}/{name} is not in {variable}, "
+                f"so the engine would not ship it"
+            )
+        for name in sorted(in_meson - on_disk):
+            failures.append(f"{variable} names {name}, which does not exist")
+
+    for failure in failures:
+        print(f"  FAIL  {failure}", file=sys.stderr)
+    if failures:
+        return 1
+
+    print("  PASS  every Lua source is embedded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tests/unit/test_update_lua_docs.py
+++ b/src/tests/unit/test_update_lua_docs.py
@@ -207,6 +207,57 @@ class TestLuaDocs(unittest.TestCase):
         self.assertIn("things.spawn(id, [angle])", page)
         self.assertIn("default `0`", page)
 
+    def test_an_enum_default_reads_as_the_constant(self):
+        """The default is stored as the constant's value, because that is what
+        the wrapper substitutes. It has to read as the constant."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["params"][1].update(
+            {"default": 1, "enum": "things.State"}
+        )
+        docs.ENUM_CONSTANTS.clear()
+        docs.ENUM_CONSTANTS["things.State"] = {0: "OFF", 1: "ON", 7: "BROKEN"}
+
+        page = docs.render_page(surface["modules"][0], surface)
+        self.assertIn("default `trx.things.State.ON`", page)
+        self.assertNotIn("default `1`", page)
+        docs.ENUM_CONSTANTS.clear()
+
+    def test_several_returns_are_all_rendered(self):
+        """A Lua function is free to hand back more than one value, and the
+        reference has to say what each of them is."""
+        surface = copy.deepcopy(SURFACE)
+        surface["functions"][0]["returns"] = [
+            {"type": "vec3", "nullable": True, "description": "Where."},
+            {"type": "integer", "description": "Which room."},
+        ]
+
+        page = docs.render_page(surface["modules"][0], surface)
+        self.assertIn("vec3 or `nil`. Where.", page)
+        self.assertIn("integer. Which room.", page)
+
+    def test_an_indexable_module_is_described(self):
+        """Indexing lives on a metatable, which pairs() never sees, so the page
+        can only describe it because the container is declared."""
+        surface = copy.deepcopy(SURFACE)
+        surface["containers"] = [
+            {
+                "module": "things",
+                "description": "Indexing reaches a thing.",
+                "key": {"type": "integer", "description": "1-based."},
+                "value": {"type": "Widget", "nullable": True},
+                "countable": True,
+            }
+        ]
+
+        page = docs.render_page(surface["modules"][0], surface)
+        self.assertIn("### Indexing", page)
+        self.assertIn("**`trx.things[key]`** (Widget or `nil`). 1-based.", page)
+        self.assertIn("**`#trx.things`** (integer).", page)
+
+    def test_a_module_with_no_container_gets_no_indexing_section(self):
+        page = docs.render_page(SURFACE["modules"][0], SURFACE)
+        self.assertNotIn("### Indexing", page)
+
     def test_a_callbacks_own_arguments_are_rendered(self):
         """A function-typed parameter renders the arguments it is called with,
         indented under the parameter itself."""

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -275,7 +275,7 @@ bool Gym_TrackManager_HasStats(const GYM_TRACK_TYPE track)
     }
 }
 
-const GYM_TRACK_STATS *Gym_TrackManager_GetStats(const GYM_TRACK_TYPE track)
+GYM_TRACK_STATS *Gym_TrackManager_GetMutableStats(const GYM_TRACK_TYPE track)
 {
     switch (track) {
     case GYM_TRACK_ASSAULT:
@@ -285,6 +285,11 @@ const GYM_TRACK_STATS *Gym_TrackManager_GetStats(const GYM_TRACK_TYPE track)
     default:
         return nullptr;
     }
+}
+
+const GYM_TRACK_STATS *Gym_TrackManager_GetStats(const GYM_TRACK_TYPE track)
+{
+    return Gym_TrackManager_GetMutableStats(track);
 }
 
 bool Gym_TrackManager_IsTimerDisplay(const GYM_TRACK_TYPE track)

--- a/src/trx/game/gym.h
+++ b/src/trx/game/gym.h
@@ -20,6 +20,10 @@ bool Gym_IsInventoryOpenEnabled(void);
 GYM_TRACK_TYPE Gym_TrackManager_GetActiveTrackType(void);
 bool Gym_TrackManager_HasStats(GYM_TRACK_TYPE track);
 const GYM_TRACK_STATS *Gym_TrackManager_GetStats(GYM_TRACK_TYPE track);
+
+// The record table a finished run is filed into. It lives in the player's
+// profile, so a caller that writes it is expected to call Config_Update.
+GYM_TRACK_STATS *Gym_TrackManager_GetMutableStats(GYM_TRACK_TYPE track);
 bool Gym_TrackManager_IsTimerDisplay(GYM_TRACK_TYPE track);
 bool Gym_TrackManager_IsTimerActive(GYM_TRACK_TYPE track);
 void Gym_TrackManager_Reset(GYM_TRACK_TYPE track);

--- a/src/trx/game/lua/api.h
+++ b/src/trx/game/lua/api.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <lua.h>
+
+// Pushes one of the registry's C entrypoints - "seal" or "to_json". They are
+// not on trx.api, so there is no name to reach them by from a script; see
+// lua/capi/api.c. False if it was never handed over, and nothing is pushed.
+bool LUA_API_PushEntrypoint(lua_State *L, const char *name);

--- a/src/trx/game/lua/capi/api.c
+++ b/src/trx/game/lua/capi/api.c
@@ -1,0 +1,59 @@
+#include <trx/game/lua/api.h>
+#include <trx/game/lua/registry.h>
+#include <trx/game/lua/utils.h>
+
+#include <lauxlib.h>
+
+// The registry closes itself once the engine's declarations are in, and takes
+// its declaring half off trx.api as the seal takes trxc off the globals: what a
+// script cannot successfully call, it should not be able to reach.
+//
+// Sealing and dumping the surface are still C's to do, and the dump runs after
+// the seal. So api.lua hands both to C here, and they are held in the Lua
+// registry - reachable by name from nowhere a script can see.
+static const char m_EntrypointsKey[] = "trx.api.entrypoints";
+
+// trxc.api.set_entrypoint(name, fn)
+static int M_L_SetEntrypoint(lua_State *const L)
+{
+    const char *const name = luaL_checkstring(L, 1);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+
+    if (lua_getfield(L, LUA_REGISTRYINDEX, m_EntrypointsKey) != LUA_TTABLE) {
+        lua_pop(L, 1);
+        lua_newtable(L);
+        lua_pushvalue(L, -1);
+        lua_setfield(L, LUA_REGISTRYINDEX, m_EntrypointsKey);
+    }
+    lua_pushvalue(L, 2);
+    lua_setfield(L, -2, name);
+    lua_pop(L, 1);
+    return 0;
+}
+
+bool LUA_API_PushEntrypoint(lua_State *const L, const char *const name)
+{
+    if (lua_getfield(L, LUA_REGISTRYINDEX, m_EntrypointsKey) != LUA_TTABLE) {
+        lua_pop(L, 1);
+        return false;
+    }
+    const int type = lua_getfield(L, -1, name);
+    lua_remove(L, -2);
+    if (type != LUA_TFUNCTION) {
+        lua_pop(L, 1);
+        return false;
+    }
+    return true;
+}
+
+static const luaL_Reg m_Module[] = {
+    { "set_entrypoint", M_L_SetEntrypoint },
+    { nullptr, nullptr },
+};
+
+static void M_Create(lua_State *const L)
+{
+    LUA_RegisterModule(L, "api", m_Module);
+}
+
+REGISTER_LUA_CAPI(.create = M_Create)

--- a/src/trx/game/lua/capi/assault.c
+++ b/src/trx/game/lua/capi/assault.c
@@ -10,15 +10,14 @@
 #include <lauxlib.h>
 #include <stdint.h>
 
-static bool M_StoreAssaultTime(const float time)
+static bool M_StoreTime(GYM_TRACK_STATS *const stats, const float time)
 {
-    GYM_TRACK_STATS *const assault = &g_Config.profile.assault_stats;
     uint32_t logic_time = (uint32_t)(time * LOGIC_FPS);
     int32_t insert_idx = -1;
 
     for (int32_t i = 0; i < MAX_ASSAULT_TIMES; i++) {
-        if (assault->entries[i].time == 0
-            || logic_time < assault->entries[i].time) {
+        if (stats->entries[i].time == 0
+            || logic_time < stats->entries[i].time) {
             insert_idx = i;
             break;
         }
@@ -28,48 +27,52 @@ static bool M_StoreAssaultTime(const float time)
     }
 
     for (int32_t i = MAX_ASSAULT_TIMES - 1; i > insert_idx; i--) {
-        assault->entries[i] = assault->entries[i - 1];
+        stats->entries[i] = stats->entries[i - 1];
     }
 
-    assault->total_attempts++;
-    assault->entries[insert_idx].time = logic_time;
-    assault->entries[insert_idx].attempt_num = assault->total_attempts;
+    stats->total_attempts++;
+    stats->entries[insert_idx].time = logic_time;
+    stats->entries[insert_idx].attempt_num = stats->total_attempts;
     Config_Update();
     return true;
 }
 
-static bool M_RemoveAssaultTimeAtIndex(const int32_t idx)
+static bool M_RemoveTimeAtIndex(GYM_TRACK_STATS *const stats, const int32_t idx)
 {
-    GYM_TRACK_STATS *const assault = &g_Config.profile.assault_stats;
     if (idx < 0 || idx >= MAX_ASSAULT_TIMES) {
         return false;
     }
-    if (assault->entries[idx].time == 0) {
+    if (stats->entries[idx].time == 0) {
         return false;
     }
 
     for (int32_t i = idx; i < MAX_ASSAULT_TIMES - 1; i++) {
-        assault->entries[i] = assault->entries[i + 1];
+        stats->entries[i] = stats->entries[i + 1];
     }
 
-    assault->entries[MAX_ASSAULT_TIMES - 1].time = 0;
-    assault->entries[MAX_ASSAULT_TIMES - 1].attempt_num = 0;
+    stats->entries[MAX_ASSAULT_TIMES - 1].time = 0;
+    stats->entries[MAX_ASSAULT_TIMES - 1].attempt_num = 0;
     Config_Update();
     return true;
 }
 
-static GYM_TRACK_TYPE M_GetTrack(lua_State *const L)
+static GYM_TRACK_TYPE M_GetTrackAt(lua_State *const L, const int arg)
 {
-    const int32_t raw_track = (int32_t)luaL_optinteger(L, 1, GYM_TRACK_ASSAULT);
+    const lua_Integer raw_track = luaL_optinteger(L, arg, GYM_TRACK_ASSAULT);
 
     switch (raw_track) {
     case GYM_TRACK_ASSAULT:
     case GYM_TRACK_QUAD:
         return (GYM_TRACK_TYPE)raw_track;
     default:
-        luaL_error(L, "unknown assault track");
+        luaL_argerror(L, arg, "unknown assault track");
         return GYM_TRACK_ASSAULT;
     }
+}
+
+static GYM_TRACK_TYPE M_GetTrack(lua_State *const L)
+{
+    return M_GetTrackAt(L, 1);
 }
 
 static const char *M_GetTrackName(const GYM_TRACK_TYPE track)
@@ -96,6 +99,19 @@ static void M_CheckTimerAvailable(
     if (!Gym_TrackManager_HasStats(track)) {
         luaL_error(L, "the %s timer is unavailable", M_GetTrackName(track));
     }
+}
+
+// The record table the track keeps. No gym check, unlike the timers: the
+// records live in the player's profile rather than in the level, and it is
+// which game this is that decides whether a track has a table at all.
+static GYM_TRACK_STATS *M_CheckStats(
+    lua_State *const L, const GYM_TRACK_TYPE track)
+{
+    GYM_TRACK_STATS *const stats = Gym_TrackManager_GetMutableStats(track);
+    if (stats == nullptr || !Gym_TrackManager_HasStats(track)) {
+        luaL_error(L, "the %s records are unavailable", M_GetTrackName(track));
+    }
+    return stats;
 }
 
 // trxc.assault.start([track])
@@ -163,32 +179,27 @@ static int M_L_AssaultGetActiveTrack(lua_State *const L)
     return 1;
 }
 
-// trxc.assault.stats.record(time) -> bool
+// trxc.assault.stats.record(time, [track]) -> bool
+//
+// The track comes second here and in remove: a record is about a time, and the
+// time is what a script always says.
 static int M_L_AssaultRecord(lua_State *const L)
 {
-    if (!Gym_TrackManager_HasStats(GYM_TRACK_ASSAULT)) {
-        return luaL_error(L, "assault stats unavailable");
-    }
-
     // Tested for what is allowed: NaN fails every comparison, so `time <= 0`
     // let it through to a cast that cannot hold it.
     const lua_Number time = luaL_checknumber(L, 1);
     if (!(time > 0.0 && time * LOGIC_FPS < (lua_Number)UINT32_MAX)) {
         return luaL_error(L, "time must be a positive number of seconds");
     }
+    GYM_TRACK_STATS *const stats = M_CheckStats(L, M_GetTrackAt(L, 2));
 
-    const bool ok = M_StoreAssaultTime((float)time);
-    lua_pushboolean(L, ok);
+    lua_pushboolean(L, M_StoreTime(stats, (float)time));
     return 1;
 }
 
-// trxc.assault.stats.remove(index) -> bool
+// trxc.assault.stats.remove(record_id, [track]) -> bool
 static int M_L_AssaultRemoveRecord(lua_State *const L)
 {
-    if (!Gym_TrackManager_HasStats(GYM_TRACK_ASSAULT)) {
-        return luaL_error(L, "assault stats unavailable");
-    }
-
     // Lua's formatter has no %lld, and raised over the format rather than the
     // index.
     const lua_Integer index_1 = luaL_checkinteger(L, 1);
@@ -197,33 +208,30 @@ static int M_L_AssaultRemoveRecord(lua_State *const L)
             L, "index out of range: %I (expected 1..%d)", index_1,
             MAX_ASSAULT_TIMES);
     }
+    GYM_TRACK_STATS *const stats = M_CheckStats(L, M_GetTrackAt(L, 2));
 
-    const bool ok = M_RemoveAssaultTimeAtIndex(index_1 - 1);
-    lua_pushboolean(L, ok);
+    lua_pushboolean(L, M_RemoveTimeAtIndex(stats, (int32_t)index_1 - 1));
     return 1;
 }
 
-// trxc.assault.stats.list() -> { { time=, attempt_num= }, ... }
+// trxc.assault.stats.list([track]) -> { { time=, attempt_num= }, ... }
 static int M_L_AssaultListRecords(lua_State *const L)
 {
-    if (!Gym_TrackManager_HasStats(GYM_TRACK_ASSAULT)) {
-        return luaL_error(L, "assault stats unavailable");
-    }
+    const GYM_TRACK_STATS *const stats = M_CheckStats(L, M_GetTrack(L));
 
-    const GYM_TRACK_STATS *const assault = &g_Config.profile.assault_stats;
     lua_newtable(L);
     int32_t out_idx = 1;
 
     for (int32_t i = 0; i < MAX_ASSAULT_TIMES; i++) {
-        if (assault->entries[i].time == 0) {
+        if (stats->entries[i].time == 0) {
             break;
         }
 
         lua_newtable(L);
         lua_pushnumber(
-            L, (lua_Number)((float)assault->entries[i].time / LOGIC_FPS));
+            L, (lua_Number)((float)stats->entries[i].time / LOGIC_FPS));
         lua_setfield(L, -2, "time");
-        lua_pushinteger(L, (lua_Integer)assault->entries[i].attempt_num);
+        lua_pushinteger(L, (lua_Integer)stats->entries[i].attempt_num);
         lua_setfield(L, -2, "attempt_num");
         lua_seti(L, -2, out_idx);
         out_idx++;

--- a/src/trx/game/lua/capi/game.c
+++ b/src/trx/game/lua/capi/game.c
@@ -11,11 +11,11 @@
 #include <lauxlib.h>
 
 // A level lives in the game flow for the whole session, so a handle to one
-// never goes stale. It is addressed by table and index, which the ref carries
-// packed: the table in the high half, the index in the low.
-#define M_PACK(table, idx) (((table) << 16) | ((idx) & 0xffff))
+// never goes stale. It is addressed by table and number, which the ref carries
+// packed: the table in the high half, the number in the low.
+#define M_PACK(table, num) (((table) << 16) | ((num) & 0xffff))
 #define M_TABLE(packed) ((packed) >> 16)
-#define M_IDX(packed) ((packed) & 0xffff)
+#define M_NUM(packed) ((packed) & 0xffff)
 
 static bool M_GetOrdinal(const void *const self, FIELD_VALUE *const out)
 {
@@ -62,19 +62,34 @@ static GF_LEVEL_TABLE_TYPE M_CheckTableType(lua_State *const L, const int arg)
         L, arg, GFLT_NUMBER_OF, "unknown level table");
 }
 
+// The numbering a script counts and addresses levels by is the game flow's own:
+// the one GF_GetLevelCount counts, which leaves out the gym and the levels the
+// flow skips. GF_GetLevel takes a different number - the level's place in the
+// table - so the two must not be handed to one another.
+static const GF_LEVEL *M_GetLevel(
+    const GF_LEVEL_TABLE_TYPE table_type, const int32_t num)
+{
+    // The title level stands on its own rather than sitting in its table, so
+    // there is nothing to look a number up in.
+    if (table_type == GFLT_TITLE) {
+        return num == 1 ? GF_GetTitleLevel() : nullptr;
+    }
+    return GF_GetLevelByOrdinalNumber(table_type, num);
+}
+
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    return (void *)GF_GetLevel(M_TABLE(ref->idx), M_IDX(ref->idx));
+    return (void *)M_GetLevel(M_TABLE(ref->idx), M_NUM(ref->idx));
 }
 
 static void M_PushLevel(
-    lua_State *const L, const GF_LEVEL_TABLE_TYPE table_type, const int32_t idx)
+    lua_State *const L, const GF_LEVEL_TABLE_TYPE table_type, const int32_t num)
 {
-    if (GF_GetLevel(table_type, idx) == nullptr) {
+    if (M_GetLevel(table_type, num) == nullptr) {
         lua_pushnil(L);
         return;
     }
-    LUA_Struct_Push(L, &TYPE_GF_LEVEL, M_Resolve, M_PACK(table_type, idx), 0);
+    LUA_Struct_Push(L, &TYPE_GF_LEVEL, M_Resolve, M_PACK(table_type, num), 0);
 }
 
 // trxc.game.get_version() → int
@@ -99,12 +114,32 @@ static int M_L_GameCountLevels(lua_State *const L)
     return 1;
 }
 
-// trxc.game.get_level(table_type, idx) -> GF_LEVEL handle or nil
+// The level a script named, or an error naming the argument it came in on. Read
+// wide and range-tested before narrowing, so a number too big for the engine's
+// cannot wrap into range.
+static const GF_LEVEL *M_CheckLevel(
+    lua_State *const L, const int arg, const GF_LEVEL_TABLE_TYPE table_type,
+    const char *const what)
+{
+    const lua_Integer num = luaL_checkinteger(L, arg);
+    const GF_LEVEL *const level =
+        num >= 1 && num <= GF_GetLevelCount(table_type)
+        ? M_GetLevel(table_type, (int32_t)num)
+        : nullptr;
+    luaL_argcheck(L, level != nullptr, arg, what);
+    return level;
+}
+
+// trxc.game.get_level(table_type, num) -> GF_LEVEL handle or nil
 static int M_L_GameGetLevel(lua_State *const L)
 {
     const GF_LEVEL_TABLE_TYPE table_type = M_CheckTableType(L, 1);
-    // Lua counts from 1, the table from 0.
-    M_PushLevel(L, table_type, luaL_checkinteger(L, 2) - 1);
+    const lua_Integer num = luaL_checkinteger(L, 2);
+    if (num < 1 || num > INT32_MAX) {
+        lua_pushnil(L);
+        return 1;
+    }
+    M_PushLevel(L, table_type, (int32_t)num);
     return 1;
 }
 
@@ -117,32 +152,33 @@ static int M_L_GameGetCurrentLevel(lua_State *const L)
         return 1;
     }
     const GF_LEVEL_TABLE_TYPE table_type = GF_GetLevelTableType(level->type);
-    M_PushLevel(L, table_type, level - GF_GetLevelTable(table_type)->levels);
+    // A gym has no number and reads 0, which is also the number
+    // GF_GetLevelByOrdinalNumber hands it back on.
+    const int32_t num = table_type == GFLT_TITLE
+        ? 1
+        : GF_GetLevelOrdinalNumber(table_type, level);
+    M_PushLevel(L, table_type, num);
     return 1;
 }
 
 // trxc.game.play_level(num) → nil
+// What the game flow's commands carry is the level's place in its table, which
+// is GF_LEVEL.num - the same number the `play` console command hands them.
 static int M_L_GamePlayLevel(lua_State *const L)
 {
-    const int32_t level_idx = luaL_checkinteger(L, 1) - 1;
-    const int32_t count = GF_GetLevelCount(GFLT_MAIN);
-    if (level_idx < 0 || level_idx >= count) {
-        return luaL_error(L, "invalid level number: %d", level_idx);
-    }
+    const GF_LEVEL *const next_level =
+        M_CheckLevel(L, 1, GFLT_MAIN, "unknown level");
     const GF_LEVEL *const current_level = GF_GetCurrentLevel();
     if (current_level != nullptr) {
-        const GF_LEVEL *const next_level = GF_GetLevel(GFLT_MAIN, level_idx);
-        if (next_level != nullptr) {
-            Savegame_PersistGameToCurrentInfo(next_level);
-            RESUME_INFO *const resume = Savegame_GetCurrentInfo(next_level);
-            if (resume != nullptr) {
-                resume->prev_level = current_level->num;
-            }
+        Savegame_PersistGameToCurrentInfo(next_level);
+        RESUME_INFO *const resume = Savegame_GetCurrentInfo(next_level);
+        if (resume != nullptr) {
+            resume->prev_level = current_level->num;
         }
     }
     GF_OverrideCommand((GF_COMMAND) {
         .action = GF_START_GAME,
-        .param = level_idx,
+        .param = next_level->num,
     });
     return 0;
 }
@@ -150,14 +186,11 @@ static int M_L_GamePlayLevel(lua_State *const L)
 // trxc.game.play_cutscene(num) → nil
 static int M_L_GamePlayCutscene(lua_State *const L)
 {
-    const int32_t idx = luaL_checkinteger(L, 1) - 1;
-    const int32_t count = GF_GetLevelCount(GFLT_CUTSCENES);
-    if (idx < 0 || idx >= count) {
-        return luaL_error(L, "invalid cutscene number: %d", idx);
-    }
+    const GF_LEVEL *const level =
+        M_CheckLevel(L, 1, GFLT_CUTSCENES, "unknown cutscene");
     GF_OverrideCommand((GF_COMMAND) {
         .action = GF_START_CINE,
-        .param = idx,
+        .param = level->num,
     });
     return 0;
 }
@@ -165,14 +198,11 @@ static int M_L_GamePlayCutscene(lua_State *const L)
 // trxc.game.play_demo(num) → nil
 static int M_L_GamePlayDemo(lua_State *const L)
 {
-    const int32_t idx = luaL_checkinteger(L, 1) - 1;
-    const int32_t count = GF_GetLevelCount(GFLT_DEMOS);
-    if (idx < 0 || idx >= count) {
-        return luaL_error(L, "invalid demo number: %d", idx);
-    }
+    const GF_LEVEL *const level =
+        M_CheckLevel(L, 1, GFLT_DEMOS, "unknown demo");
     GF_OverrideCommand((GF_COMMAND) {
         .action = GF_START_DEMO,
-        .param = idx,
+        .param = level->num,
     });
     return 0;
 }

--- a/src/trx/game/lua/capi/game.c
+++ b/src/trx/game/lua/capi/game.c
@@ -114,32 +114,33 @@ static int M_L_GameCountLevels(lua_State *const L)
     return 1;
 }
 
-// The level a script named, or an error naming the argument it came in on. Read
-// wide and range-tested before narrowing, so a number too big for the engine's
-// cannot wrap into range.
+// The level a script named, or an error naming the argument it came in on. The
+// numbered levels start at 1; the gym, which sits at ordinal 0, is not one of
+// them and play_level cannot name it.
 static const GF_LEVEL *M_CheckLevel(
     lua_State *const L, const int arg, const GF_LEVEL_TABLE_TYPE table_type,
     const char *const what)
 {
-    const lua_Integer num = luaL_checkinteger(L, arg);
+    int32_t num;
     const GF_LEVEL *const level =
-        num >= 1 && num <= GF_GetLevelCount(table_type)
-        ? M_GetLevel(table_type, (int32_t)num)
+        LUA_CheckBoundedInt(L, arg, 1, INT32_MAX, &num)
+        ? M_GetLevel(table_type, num)
         : nullptr;
     luaL_argcheck(L, level != nullptr, arg, what);
     return level;
 }
 
 // trxc.game.get_level(table_type, num) -> GF_LEVEL handle or nil
+// Ordinal 0 is the gym, so the range starts there.
 static int M_L_GameGetLevel(lua_State *const L)
 {
     const GF_LEVEL_TABLE_TYPE table_type = M_CheckTableType(L, 1);
-    const lua_Integer num = luaL_checkinteger(L, 2);
-    if (num < 1 || num > INT32_MAX) {
+    int32_t num;
+    if (!LUA_CheckBoundedInt(L, 2, 0, INT32_MAX, &num)) {
         lua_pushnil(L);
         return 1;
     }
-    M_PushLevel(L, table_type, (int32_t)num);
+    M_PushLevel(L, table_type, num);
     return 1;
 }
 
@@ -207,6 +208,23 @@ static int M_L_GamePlayDemo(lua_State *const L)
     return 0;
 }
 
+// trxc.game.play_gym() → nil
+//
+// A gym has no ordinal, so play_level cannot reach it. It is started through
+// GF_SELECT_GAME, as the `gym` console command starts it.
+static int M_L_GamePlayGym(lua_State *const L)
+{
+    const GF_LEVEL *const gym_level = GF_GetGymLevel();
+    if (gym_level == nullptr) {
+        return luaL_error(L, "this game has no gym");
+    }
+    GF_OverrideCommand((GF_COMMAND) {
+        .action = GF_SELECT_GAME,
+        .param = gym_level->num,
+    });
+    return 0;
+}
+
 static const luaL_Reg m_Module[] = {
     { "get_version", M_L_GameVersion },
     { "get_trx_version", M_L_TRXVersion },
@@ -216,6 +234,7 @@ static const luaL_Reg m_Module[] = {
     { "play_level", M_L_GamePlayLevel },
     { "play_cutscene", M_L_GamePlayCutscene },
     { "play_demo", M_L_GamePlayDemo },
+    { "play_gym", M_L_GamePlayGym },
     { nullptr, nullptr },
 };
 

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -536,24 +536,55 @@ static int M_L_StructExposeField(lua_State *const L)
     return 0;
 }
 
-// trxc.struct.expose_method(type, public_name, c_name)
+// One of the C methods the type offers, by its C name.
+static int M_PushRawMethod(
+    lua_State *const L, const TYPE_DESC *const type, const char *const c_name)
+{
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, m_KeyRawMethods);
+    const int found = lua_getfield(L, -1, c_name);
+    lua_remove(L, -2); // raw_methods; the metatable stays below the result
+    return found;
+}
+
+// trxc.struct.method(type, c_name) -> the C function
+//
+// What strict mode wraps. The wrapper goes back through expose_method.
+static int M_L_StructMethod(lua_State *const L)
+{
+    const TYPE_DESC *const type = M_CheckType(L, 1);
+    const char *const c_name = luaL_checkstring(L, 2);
+    if (M_PushRawMethod(L, type, c_name) != LUA_TFUNCTION) {
+        return luaL_error(L, "%s has no method '%s'", type->name, c_name);
+    }
+    return 1;
+}
+
+// trxc.struct.expose_method(type, public_name, c_name | fn)
+//
+// A string names one of the C methods the type offers. A function is exposed as
+// it stands, which is how strict mode puts a checking wrapper in front of one.
 static int M_L_StructExposeMethod(lua_State *const L)
 {
     const TYPE_DESC *const type = M_CheckType(L, 1);
     const char *const public_name = luaL_checkstring(L, 2);
-    const char *const c_name = luaL_checkstring(L, 3);
 
-    luaL_getmetatable(L, type->name);
-    lua_getfield(L, -1, m_KeyRawMethods);
-    if (lua_getfield(L, -1, c_name) != LUA_TFUNCTION) {
-        return luaL_error(
-            L, "%s has no method '%s' (declared as '%s')", type->name, c_name,
-            public_name);
+    if (lua_isfunction(L, 3)) {
+        luaL_getmetatable(L, type->name);
+        lua_pushvalue(L, 3);
+    } else {
+        const char *const c_name = luaL_checkstring(L, 3);
+        if (M_PushRawMethod(L, type, c_name) != LUA_TFUNCTION) {
+            return luaL_error(
+                L, "%s has no method '%s' (declared as '%s')", type->name,
+                c_name, public_name);
+        }
     }
 
-    lua_getfield(L, -3, m_KeyMethods);
+    // stack: metatable, fn
+    lua_getfield(L, -2, m_KeyMethods);
     lua_pushstring(L, public_name);
-    lua_pushvalue(L, -3); // the C function
+    lua_pushvalue(L, -3);
     lua_rawset(L, -3);
     return 0;
 }
@@ -576,6 +607,7 @@ static int M_L_StructExposeComputed(lua_State *const L)
 static const luaL_Reg m_Module[] = {
     { "members", M_L_StructMembers },
     { "expose_field", M_L_StructExposeField },
+    { "method", M_L_StructMethod },
     { "expose_method", M_L_StructExposeMethod },
     { "expose_computed", M_L_StructExposeComputed },
     { nullptr, nullptr },

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -494,6 +494,21 @@ static int M_L_StructMembers(lua_State *const L)
     return 1;
 }
 
+// Puts the value at val_idx under public_name into the type's metatable
+// subtable named `key`. Leaves the stack as it found it.
+static void M_ExposeInto(
+    lua_State *const L, const TYPE_DESC *const type, const char *const key,
+    const char *const public_name, const int val_idx)
+{
+    const int val = lua_absindex(L, val_idx);
+    luaL_getmetatable(L, type->name);
+    lua_getfield(L, -1, key);
+    lua_pushstring(L, public_name);
+    lua_pushvalue(L, val);
+    lua_rawset(L, -3);
+    lua_pop(L, 2); // subtable, metatable
+}
+
 // trxc.struct.expose_field(type, public_name, c_name, writable)
 static int M_L_StructExposeField(lua_State *const L)
 {
@@ -514,25 +529,17 @@ static int M_L_StructExposeField(lua_State *const L)
             type->name, c_name);
     }
 
-    luaL_getmetatable(L, type->name);
-
-    lua_getfield(L, -1, m_KeyFields);
-    lua_pushstring(L, public_name);
     lua_pushlightuserdata(L, (void *)field);
-    lua_rawset(L, -3);
-    lua_pop(L, 1);
+    M_ExposeInto(L, type, m_KeyFields, public_name, -1);
 
     // Read-only is not merely documentation: a field the declaration withholds
     // must be absent from the writable set, or __newindex would let a script
     // set it anyway. FF_READONLY is the hard floor, checked above; this is the
     // declaration narrowing a member C would otherwise write.
     if (writable) {
-        lua_getfield(L, -1, m_KeyWritable);
-        lua_pushstring(L, public_name);
-        lua_pushlightuserdata(L, (void *)field);
-        lua_rawset(L, -3);
-        lua_pop(L, 1);
+        M_ExposeInto(L, type, m_KeyWritable, public_name, -1);
     }
+    lua_pop(L, 1); // field
     return 0;
 }
 
@@ -570,7 +577,6 @@ static int M_L_StructExposeMethod(lua_State *const L)
     const char *const public_name = luaL_checkstring(L, 2);
 
     if (lua_isfunction(L, 3)) {
-        luaL_getmetatable(L, type->name);
         lua_pushvalue(L, 3);
     } else {
         const char *const c_name = luaL_checkstring(L, 3);
@@ -579,13 +585,11 @@ static int M_L_StructExposeMethod(lua_State *const L)
                 L, "%s has no method '%s' (declared as '%s')", type->name,
                 c_name, public_name);
         }
+        lua_remove(L, -2); // the metatable M_PushRawMethod leaves below the fn
     }
 
-    // stack: metatable, fn
-    lua_getfield(L, -2, m_KeyMethods);
-    lua_pushstring(L, public_name);
-    lua_pushvalue(L, -3);
-    lua_rawset(L, -3);
+    M_ExposeInto(L, type, m_KeyMethods, public_name, -1);
+    lua_pop(L, 1); // fn
     return 0;
 }
 
@@ -596,11 +600,7 @@ static int M_L_StructExposeComputed(lua_State *const L)
     const char *const public_name = luaL_checkstring(L, 2);
     luaL_checktype(L, 3, LUA_TFUNCTION);
 
-    luaL_getmetatable(L, type->name);
-    lua_getfield(L, -1, m_KeyExt);
-    lua_pushstring(L, public_name);
-    lua_pushvalue(L, 3);
-    lua_rawset(L, -3);
+    M_ExposeInto(L, type, m_KeyExt, public_name, 3);
     return 0;
 }
 

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -7,6 +7,7 @@
 #include <trx/core/strings.h>
 #include <trx/debug.h>
 #include <trx/game/game_flow/common.h>
+#include <trx/game/lua/api.h>
 #include <trx/game/lua/embedded_scripts.h>
 #include <trx/game/lua/events.h>
 #include <trx/game/lua/registry.h>
@@ -126,7 +127,10 @@ static void M_SealPublicAPI(lua_State *const L)
     // Sealing audits the API too, and only engine scripts declare - so a
     // failure here means our own data is wrong. Fatal, like any other bad
     // engine data.
-    if (luaL_dostring(L, "trx.api.seal()") != LUA_OK) {
+    if (!LUA_API_PushEntrypoint(L, "seal")) {
+        Shell_ExitSystem("the Lua API registry handed over no sealer");
+    }
+    if (lua_pcall(L, 0, 0, 0) != LUA_OK) {
         Shell_ExitSystemFmt(
             "failed to seal the Lua API: %s", lua_tostring(L, -1));
     }
@@ -253,7 +257,12 @@ void LUA_DumpAPI(void)
         LOG_ERROR("--dump-lua-api: Lua is not initialised");
         return;
     }
-    if (luaL_dostring(L, "return trx.api.to_json()") != LUA_OK) {
+    // Sealing has already run by now, so the dumper is no longer on trx.api.
+    if (!LUA_API_PushEntrypoint(L, "to_json")) {
+        LOG_ERROR("--dump-lua-api: the Lua API registry handed over no dumper");
+        return;
+    }
+    if (lua_pcall(L, 0, 1, 0) != LUA_OK) {
         LOG_ERROR("--dump-lua-api failed: %s", lua_tostring(L, -1));
         lua_pop(L, 1);
         return;

--- a/tools/update_lua_docs
+++ b/tools/update_lua_docs
@@ -291,6 +291,21 @@ def render_type(spec: dict) -> list[str]:
     return out
 
 
+def render_container(name: str, spec: dict) -> list[str]:
+    key, value = spec["key"], spec["value"]
+    nullable = " or `nil`" if value.get("nullable") else ""
+    out = ["### Indexing", ""]
+    if spec.get("description"):
+        out.extend(render_prose(spec["description"], ""))
+        out.append("")
+    out.append(f"- **`trx.{name}[key]`** ({value['type']}{nullable}). {describe(key)}")
+    if spec.get("countable"):
+        out.append(f"- **`#trx.{name}`** (integer). How many there are.")
+    out.extend(render_examples(spec.get("examples"), ""))
+    out.append("")
+    return out
+
+
 def render_page(module: dict, api: dict) -> str:
     name = module["name"]
     # Declare a title where capitalizing the module name makes a worse one.
@@ -314,6 +329,12 @@ def render_page(module: dict, api: dict) -> str:
     if module.get("description"):
         out.append(module["description"])
         out.append("")
+
+    container = next(
+        (c for c in api.get("containers", []) if c["module"] == name), None
+    )
+    if container:
+        out.extend(render_container(name, container))
 
     props = [p for p in api.get("properties", []) if p["path"].startswith(f"{name}.")]
     if props:
@@ -372,6 +393,9 @@ def undocumented(api: dict) -> list[str]:
     for space in api.get("namespaces", []):
         if not space.get("description"):
             out.append(space["path"])
+    for container in api.get("containers", []):
+        if not container.get("description"):
+            out.append(f"{container['module']}[]")
     for enum in api.get("enums", []):
         for value in enum.get("values") or []:
             if not value.get("description"):


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR:

- simplifies api.lua and struct.c a bit
- documents iterating on items, rooms, and objects
- documents `trx.api.seal()`
- adds `trx.game.play_gym()` LUA function
- adds `trx.game.gym` LUA property
- fixes `trx.game.play_level()` indexing to work correctly
- fixes `trx.assault.*` functions not honoring `track` argument

These bugs are present in the current stable.