### PR TITLE
shell/ui: added support for paste commands in dev console

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - changed outfits to support up to two braids per outfit; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
+- added the possibilty to paste commands in the developer console (with CTRL+V)
 
 **Lua**
 

--- a/src/trx/game/shell/events.c
+++ b/src/trx/game/shell/events.c
@@ -31,6 +31,14 @@ static void M_HandleKeyDown(const SDL_Event *const event)
         // Zero out the next text event so the console-open glyph never
         // shows up.
         m_ConsoleJustOpened = true;
+    } else if (
+        event->key.keysym.sym == SDLK_v
+        && (event->key.keysym.mod & KMOD_CTRL) != 0) {
+        // Ctrl+V: paste clipboard contents into the currently focused
+        // text field (e.g. the console prompt). SDL does not translate
+        // this into a SDL_TEXTINPUT event on its own, so it needs to be
+        // handled explicitly.
+        UI_HandlePaste();
     } else {
         UI_HandleKeyDown(event->key.keysym.sym);
     }

--- a/src/trx/game/ui/common.c
+++ b/src/trx/game/ui/common.c
@@ -204,6 +204,21 @@ void UI_HandleTextEdit(const char *const text)
         .name = "text_edit", .sender = nullptr, .data = (void *)text });
 }
 
+void UI_HandlePaste(void)
+{
+    if (!SDL_HasClipboardText()) {
+        return;
+    }
+
+    char *const text = SDL_GetClipboardText();
+    if (text == nullptr) {
+        return;
+    }
+
+    UI_HandleTextEdit(text);
+    SDL_free(text);
+}
+
 int32_t UI_GetCanvasWidth(void)
 {
     return UI_Scaler_CalcInverse(

--- a/src/trx/game/ui/common.h
+++ b/src/trx/game/ui/common.h
@@ -73,3 +73,7 @@ void UI_ToggleState(bool *config_setting);
 void UI_HandleKeyDown(uint32_t key);
 void UI_HandleKeyUp(uint32_t key);
 void UI_HandleTextEdit(const char *text);
+
+// Inserts the current clipboard contents (if any) into the currently
+// focused text field, as if it had been typed.
+void UI_HandlePaste(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This PR adds the possibility of pasting commands with CTRL+V on the developer console. This could be useful for testing LUA commands
