### PR TITLE
lua: count rooms and items from zero

### DIFF
--- a/data/trx/ship/games/tr3/scripts/antarc.lua
+++ b/data/trx/ship/games/tr3/scripts/antarc.lua
@@ -1,6 +1,5 @@
 trx.events.after_level_state(function()
-  for i = 1, #trx.rooms do
-    local room = trx.rooms[i]
+  for _, room in pairs(trx.rooms) do
     room.damaging = room.underwater
     room.cold = true
   end

--- a/data/trx/ship/games/tr3/scripts/area51.lua
+++ b/data/trx/ship/games/tr3/scripts/area51.lua
@@ -8,7 +8,7 @@ trx.events.before_level_file(function(level)
 end)
 
 trx.events.on_pickup(function(pickup_item)
-  local item = trx.items[pickup_item + 1]
+  local item = trx.items[pickup_item]
   if item.object_id == trx.catalog.objects.quest_item_2 then
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end

--- a/data/trx/ship/games/tr3/scripts/crash.lua
+++ b/data/trx/ship/games/tr3/scripts/crash.lua
@@ -4,5 +4,5 @@ end)
 
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[115].properties.range = { x = 22, y = 6, z = 6 }
+  trx.items[114].properties.range = { x = 22, y = 6, z = 6 }
 end)

--- a/data/trx/ship/games/tr3/scripts/ganges.lua
+++ b/data/trx/ship/games/tr3/scripts/ganges.lua
@@ -6,12 +6,12 @@ trx.events.before_item_setup(function(level)
   props.track_4 = 12
 
   -- Setup shoals
-  trx.items[6].properties.range = { x = 6, y = 1, z = 14 }
-  trx.items[8].properties.range = { x = 2, y = 2, z = 14 }
-  trx.items[29].properties.range = { x = 10, y = 2, z = 6 }
-  trx.items[71].properties.range = { x = 6, y = 1, z = 10 }
-  trx.items[86].properties.range = { x = 6, y = 2, z = 18 }
-  trx.items[87].properties.range = { x = 6, y = 1, z = 26 }
-  trx.items[90].properties.range = { x = 14, y = 1, z = 6 }
-  trx.items[94].properties.range = { x = 18, y = 1, z = 6 }
+  trx.items[5].properties.range = { x = 6, y = 1, z = 14 }
+  trx.items[7].properties.range = { x = 2, y = 2, z = 14 }
+  trx.items[28].properties.range = { x = 10, y = 2, z = 6 }
+  trx.items[70].properties.range = { x = 6, y = 1, z = 10 }
+  trx.items[85].properties.range = { x = 6, y = 2, z = 18 }
+  trx.items[86].properties.range = { x = 6, y = 1, z = 26 }
+  trx.items[89].properties.range = { x = 14, y = 1, z = 6 }
+  trx.items[93].properties.range = { x = 18, y = 1, z = 6 }
 end)

--- a/data/trx/ship/games/tr3/scripts/house.lua
+++ b/data/trx/ship/games/tr3/scripts/house.lua
@@ -1,12 +1,12 @@
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[56].properties.range = { x = 22, y = 2, z = 10 }
-  trx.items[57].properties.range = { x = 18, y = 1, z = 10 }
-  trx.items[58].properties.range = { x = 10, y = 1, z = 14 }
-  trx.items[59].properties.range = { x = 18, y = 2, z = 10 }
-  trx.items[60].properties.range = { x = 26, y = 2, z = 10 }
-  trx.items[78].properties.range = { x = 10, y = 2, z = 18 }
+  trx.items[55].properties.range = { x = 22, y = 2, z = 10 }
+  trx.items[56].properties.range = { x = 18, y = 1, z = 10 }
+  trx.items[57].properties.range = { x = 10, y = 1, z = 14 }
+  trx.items[58].properties.range = { x = 18, y = 2, z = 10 }
+  trx.items[59].properties.range = { x = 26, y = 2, z = 10 }
+  trx.items[77].properties.range = { x = 10, y = 2, z = 18 }
+  trx.items[56].properties.sprite_offset = 1
   trx.items[57].properties.sprite_offset = 1
-  trx.items[58].properties.sprite_offset = 1
-  trx.items[60].properties.sprite_offset = 1
+  trx.items[59].properties.sprite_offset = 1
 end)

--- a/data/trx/ship/games/tr3/scripts/jungle.lua
+++ b/data/trx/ship/games/tr3/scripts/jungle.lua
@@ -4,5 +4,5 @@ end)
 
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[134].properties.range = { x = 10, y = 3, z = 22 }
+  trx.items[133].properties.range = { x = 10, y = 3, z = 22 }
 end)

--- a/data/trx/ship/games/tr3/scripts/mines.lua
+++ b/data/trx/ship/games/tr3/scripts/mines.lua
@@ -3,8 +3,7 @@ trx.events.before_level_file(function(level)
 end)
 
 trx.events.after_level_state(function()
-  for i = 1, #trx.rooms do
-    local room = trx.rooms[i]
+  for _, room in pairs(trx.rooms) do
     room.damaging = room.underwater
     room.cold = true
   end

--- a/data/trx/ship/games/tr3/scripts/office.lua
+++ b/data/trx/ship/games/tr3/scripts/office.lua
@@ -1,5 +1,5 @@
 trx.events.on_pickup(function(pickup_item)
-  local item = trx.items[pickup_item + 1]
+  local item = trx.items[pickup_item]
   if item.object_id == trx.catalog.objects.quest_item_3 then
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end

--- a/data/trx/ship/games/tr3/scripts/rapids.lua
+++ b/data/trx/ship/games/tr3/scripts/rapids.lua
@@ -1,7 +1,7 @@
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[16].properties.range = { x = 6, y = 5, z = 10 }
-  trx.items[52].properties.range = { x = 18, y = 8, z = 18 }
+  trx.items[15].properties.range = { x = 6, y = 5, z = 10 }
+  trx.items[51].properties.range = { x = 18, y = 8, z = 18 }
 
   trx.objects.flame_emitter_side.properties.interval = 4
 end)

--- a/data/trx/ship/games/tr3/scripts/shore.lua
+++ b/data/trx/ship/games/tr3/scripts/shore.lua
@@ -1,8 +1,8 @@
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[9].properties.range = { x = 14, y = 6, z = 22 }
-  trx.items[13].properties.range = { x = 14, y = 6, z = 14 }
-  trx.items[15].properties.range = { x = 22, y = 8, z = 6 }
-  trx.items[13].properties.sprite_offset = 1
-  trx.items[15].properties.sprite_offset = 1
+  trx.items[8].properties.range = { x = 14, y = 6, z = 22 }
+  trx.items[12].properties.range = { x = 14, y = 6, z = 14 }
+  trx.items[14].properties.range = { x = 22, y = 8, z = 6 }
+  trx.items[12].properties.sprite_offset = 1
+  trx.items[14].properties.sprite_offset = 1
 end)

--- a/data/trx/ship/games/tr3/scripts/temple.lua
+++ b/data/trx/ship/games/tr3/scripts/temple.lua
@@ -1,6 +1,6 @@
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[1].properties.range = { x = 6, y = 3, z = 30 }
-  trx.items[20].properties.range = { x = 6, y = 2, z = 18 }
-  trx.items[26].properties.range = { x = 6, y = 2, z = 6 }
+  trx.items[0].properties.range = { x = 6, y = 3, z = 30 }
+  trx.items[19].properties.range = { x = 6, y = 2, z = 18 }
+  trx.items[25].properties.range = { x = 6, y = 2, z = 6 }
 end)

--- a/data/trx/ship/games/tr3/scripts/tonyboss.lua
+++ b/data/trx/ship/games/tr3/scripts/tonyboss.lua
@@ -1,5 +1,5 @@
 trx.events.on_pickup(function(pickup_item)
-  local item = trx.items[pickup_item + 1]
+  local item = trx.items[pickup_item]
   if item.object_id == trx.catalog.objects.quest_item_1 then
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end

--- a/data/trx/ship/games/tr3/scripts/triboss.lua
+++ b/data/trx/ship/games/tr3/scripts/triboss.lua
@@ -1,5 +1,5 @@
 trx.events.on_pickup(function(pickup_item)
-  local item = trx.items[pickup_item + 1]
+  local item = trx.items[pickup_item]
   if item.object_id == trx.catalog.objects.quest_item_4 then
     trx.rooms.flip_effect(trx.catalog.flip_effects.finish_level)
   end

--- a/data/trx/ship/games/tr3/scripts/zoo.lua
+++ b/data/trx/ship/games/tr3/scripts/zoo.lua
@@ -4,6 +4,6 @@ end)
 
 trx.events.before_item_setup(function(level)
   -- Setup shoals
-  trx.items[66].properties.range = { x = 14, y = 6, z = 14 }
-  trx.items[71].properties.range = { x = 14, y = 6, z = 14 }
+  trx.items[65].properties.range = { x = 14, y = 6, z = 14 }
+  trx.items[70].properties.range = { x = 14, y = 6, z = 14 }
 end)

--- a/data/trx/ship/games/tr4/scripts/alexhub.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
+  trx.items[38].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[39].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[40].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[41].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/alexhub2.lua
+++ b/data/trx/ship/games/tr4/scripts/alexhub2.lua
@@ -5,8 +5,8 @@ trx.events.before_item_setup(function(level)
 end)
 
 trx.events.before_item_setup(function(level)
-  trx.items[43].properties.crowbar = true
-  trx.items[80].properties.crowbar = true
+  trx.items[42].properties.crowbar = true
+  trx.items[79].properties.crowbar = true
+  trx.items[82].properties.crowbar = true
   trx.items[83].properties.crowbar = true
-  trx.items[84].properties.crowbar = true
 end)

--- a/data/trx/ship/games/tr4/scripts/bikebit.lua
+++ b/data/trx/ship/games/tr4/scripts/bikebit.lua
@@ -1,3 +1,3 @@
 trx.events.before_item_setup(function(level)
-  trx.items[57].properties.crowbar = true
+  trx.items[56].properties.crowbar = true
 end)

--- a/data/trx/ship/games/tr4/scripts/cortyard.lua
+++ b/data/trx/ship/games/tr4/scripts/cortyard.lua
@@ -1,3 +1,3 @@
 trx.events.before_item_setup(function(level)
-  trx.items[2].properties.lift = true
+  trx.items[1].properties.lift = true
 end)

--- a/data/trx/ship/games/tr4/scripts/csplit1.lua
+++ b/data/trx/ship/games/tr4/scripts/csplit1.lua
@@ -1,8 +1,8 @@
 trx.events.before_item_setup(function(level)
-  trx.items[59].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[93].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[105].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[121].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[58].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[92].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[120].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/karnak1.lua
+++ b/data/trx/ship/games/tr4/scripts/karnak1.lua
@@ -1,6 +1,6 @@
 trx.events.before_item_setup(function(level)
-  trx.items[67].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[69].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[83].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[86].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[66].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[68].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[82].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[85].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/lake.lua
+++ b/data/trx/ship/games/tr4/scripts/lake.lua
@@ -1,10 +1,10 @@
 trx.events.before_item_setup(function(level)
-  trx.items[17].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[16].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[33].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[34].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[35].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[36].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[70].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[71].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[72].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_16.properties.collidable = false
 end)

--- a/data/trx/ship/games/tr4/scripts/libend.lua
+++ b/data/trx/ship/games/tr4/scripts/libend.lua
@@ -1,3 +1,3 @@
 trx.events.before_item_setup(function(level)
-  trx.items[14].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[13].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/library.lua
+++ b/data/trx/ship/games/tr4/scripts/library.lua
@@ -1,4 +1,4 @@
 trx.events.before_item_setup(function(level)
-  trx.items[13].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[136].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[12].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/lowstrt.lua
+++ b/data/trx/ship/games/tr4/scripts/lowstrt.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
-  trx.items[46].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[45].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/palaces.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces.lua
@@ -1,4 +1,4 @@
 trx.events.before_item_setup(function(level)
-  trx.items[64].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[105].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[63].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[104].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/palaces2.lua
+++ b/data/trx/ship/games/tr4/scripts/palaces2.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
   trx.objects.animating_16.properties.collidable = false
-  trx.items[27].properties.crowbar = true
-  trx.items[124].properties.crowbar = true
+  trx.items[26].properties.crowbar = true
+  trx.items[123].properties.crowbar = true
 end)

--- a/data/trx/ship/games/tr4/scripts/semer.lua
+++ b/data/trx/ship/games/tr4/scripts/semer.lua
@@ -1,7 +1,7 @@
 trx.events.before_item_setup(function(level)
-  trx.items[48].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[47].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[235].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[236].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[237].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[238].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[239].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/semer2.lua
+++ b/data/trx/ship/games/tr4/scripts/semer2.lua
@@ -1,10 +1,10 @@
 trx.events.before_item_setup(function(level)
-  trx.items[53].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[52].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[59].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[60].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[61].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[70].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[69].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[95].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[96].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[97].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[98].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[63].properties.lift = true
+  trx.items[62].properties.lift = true
 end)

--- a/data/trx/ship/games/tr4/scripts/settomb1.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb1.lua
@@ -1,5 +1,5 @@
 trx.events.before_item_setup(function(level)
+  trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
   trx.items[4].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[5].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[88].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[87].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 end)

--- a/data/trx/ship/games/tr4/scripts/settomb2.lua
+++ b/data/trx/ship/games/tr4/scripts/settomb2.lua
@@ -1,6 +1,6 @@
 trx.events.before_item_setup(function(level)
-  trx.items[4].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
-  trx.items[136].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[3].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
+  trx.items[135].properties.pickup_mode = trx.items.PickupMode.PLINTH_LOW
 
   trx.objects.animating_13.properties.collidable = false
   trx.objects.animating_14.properties.collidable = false

--- a/data/trx/ship/games/tr4/scripts/train.lua
+++ b/data/trx/ship/games/tr4/scripts/train.lua
@@ -1,4 +1,4 @@
 trx.events.before_item_setup(function(level)
-  trx.items[5].properties.crowbar = true
-  trx.items[58].properties.crowbar = true
+  trx.items[4].properties.crowbar = true
+  trx.items[57].properties.crowbar = true
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added new Lua enums, `trx.items.Status`, `trx.lara.WaterState`, `trx.lara.GunState`, `trx.game.LevelTable`, `trx.catalog.Context` and `trx.rooms.FlipStatus`
 - added `trx.log.generic()` and the `trx.log.LogLevel` enum, to log at a level chosen at runtime
 - added the braid and crowbar constants to `trx.lara.ExtraMesh`, which the engine had but never exposed
-- added indexing and the length operator to `trx.items`, `trx.rooms` and `trx.objects`, so `trx.items[1]` is the first item and `#trx.items` is how many the level has
+- added indexing and the length operator to `trx.items`, `trx.rooms` and `trx.objects`, so `trx.items[0]` is the first item and `#trx.items` is how many the level has
 - added `trx.api.strict()`, which checks a script's arguments against the API's own declarations - worth turning on while writing a level, and leaving off in play
 - added `room:is_valid()`, so a room handle held across a level change can be checked the way an item handle can
 - added the track to the assault course record functions, so the quad bike's records can be read and written at last
@@ -44,7 +44,8 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.sound.samples`, the level's samples as `trx.sound.Sample` handles keyed by id, each with `:play()` and its `volume`, `range`, `randomness` and `pitch`
 - added `trx.sound.streams`, the sound effects playing now as `trx.sound.Stream` handles, each of which can be paused, resumed and stopped on its own
 - changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing whatever took its slot
-- changed handles to compare equal when they name the same thing, so `trx.items[1] == trx.items[1]`
+- changed handles to compare equal when they name the same thing, so `trx.items[0] == trx.items[0]`
+- changed `trx.items` and `trx.rooms` to count from zero, matching the item and room numbers level editors show, and made `pairs()` walk them keyed by that number
 - changed room handles to go stale at a level change rather than quietly naming a different room
 - changed `trx.game.levels` and `trx.game.play_level` to leave out the gym, so numbering no longer shifts and the last level is reachable
 - changed `trx.api` to hold only `strict` and `is_strict` once sealed, and `trx.api.strict()` to check handle method arguments too
@@ -62,7 +63,6 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed Lua enums to answer to a constant's name in any case, so `trx.catalog.objects.wolf` and `trx.catalog.objects.WOLF` are the same constant
 - changed Lua enums to be read-only, including the table `pairs()` used to hand out; writing to one used to break every later lookup
 - changed writes that a field cannot hold to raise rather than truncate, so `item.hit_points = 99999` no longer wraps
-- fixed `trx.events.on_pickup` firing with a 0-based item number, where it is documented to pass a 1-based one
 - fixed a number too large for the engine wrapping into range rather than being refused, so `trx.items[4294967297]` no longer reads as the first item
 - removed `trx.console.log.LogLevel`, a duplicate of `trx.log.LogLevel`
 - removed `trx.events.EventType`

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -12,15 +12,22 @@ order: 3
 1. **Update scripts that use item handles**
    `trx.items` hands out opaque item handles rather than `{ idx = ... }` tables.
    - `trx.items.fn` was removed. Replace `trx.items.fn.get(arg)` with
-     `trx.items.get(arg)`, or index the module directly: `trx.items[17]`,
+     `trx.items.get(arg)`, or index the module directly: `trx.items[16]`,
      `trx.items["lara"]`.
+   - Items count from 0, matching the item numbers level editors show. An item
+     that was `trx.items[13]` under the earlier 1-based numbering is
+     `trx.items[12]` now. `item.room_num` and the item number `on_pickup` passes
+     its handler count from 0 as well.
+   - `pairs(trx.items)` walks the items in order, keyed by that number, so
+     `for i = 1, #trx.items do local item = trx.items[i]` becomes
+     `for num, item in pairs(trx.items) do`.
    - `item.idx` no longer exists, and a handle can no longer carry extra keys of
      your own. Pass the handle itself where you used to pass the index.
    - A handle to a killed or recycled item now raises `stale ITEM handle` when
      read or written, instead of silently addressing whatever item took over the
      slot. Guard handles held across time with `item:is_valid()`.
    - Two handles are equal when they name the same thing, so
-     `trx.items[1] == trx.items[1]` is now true where it used to be false - every
+     `trx.items[0] == trx.items[0]` is now true where it used to be false - every
      lookup handed back a fresh handle. A stale handle does not equal a live one.
    - Writing a value a field cannot hold now raises instead of truncating - e.g.
      `item.hit_points = 99999`, where the field is 16-bit.
@@ -29,9 +36,16 @@ order: 3
 
 2. **Update scripts that use room handles**
    `trx.rooms` hands out opaque room handles rather than `{ idx = ... }` tables.
-   - `room.idx` was replaced by `room.num`. Both count from 1.
+   - `room.idx` was replaced by `room.num`.
+   - Rooms count from 0, matching the room numbers level editors show. A room
+     that was `trx.rooms[15]` under the earlier 1-based numbering is
+     `trx.rooms[14]` now. `camera.room_num`, `camera.target_room_num` and the
+     room argument to `trx.rooms.find_valid_pos` count from 0 as well.
+   - `pairs(trx.rooms)` walks the rooms in order, keyed by that number, so
+     `for i = 1, #trx.rooms do local room = trx.rooms[i]` becomes
+     `for num, room in pairs(trx.rooms) do`.
    - `trx.rooms.fn` was removed. Replace `trx.rooms.fn.get(num)` with
-     `trx.rooms.get(num)`, or index the module directly: `trx.rooms[15]`.
+     `trx.rooms.get(num)`, or index the module directly: `trx.rooms[14]`.
      `trx.rooms.fn.FlipStatus` is now `trx.rooms.FlipStatus`, and
      `trx.rooms.fn.Room`, `trx.rooms.fn.flip` and `trx.rooms.fn.flip_effect`
      became `trx.rooms.Room`, `trx.rooms.flip` and `trx.rooms.flip_effect`.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -24,12 +24,12 @@
   "containers": [
     {
       "countable": true,
-      "description": "Indexing the module reaches an item, and `#trx.items` is how many the level has.",
+      "description": "Indexing the module reaches an item, and `#trx.items` is how many the level has. Items count from zero, matching the item numbers level editors show. `pairs()` walks them in order, keyed by that number.",
       "examples": [
-        "for i = 1, #trx.items do\n  trx.log.info(trx.items[i].object_id)\nend"
+        "for num, item in pairs(trx.items) do\n  trx.log.info(item.object_id)\nend"
       ],
       "key": {
-        "description": "1-based index, or the item's unique name.",
+        "description": "0-based index, or the item's unique name.",
         "type": "any"
       },
       "module": "items",
@@ -40,7 +40,7 @@
     },
     {
       "countable": false,
-      "description": "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.",
+      "description": "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. Keyed by object id or catalog name, not by position.",
       "examples": [
         "trx.objects.wolf.properties.max_hit_points = 30"
       ],
@@ -56,12 +56,12 @@
     },
     {
       "countable": true,
-      "description": "Indexing the module reaches a room, and `#trx.rooms` is how many the level has.",
+      "description": "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them in order, keyed by that number.",
       "examples": [
-        "trx.log.info(#trx.rooms .. \" rooms, first is \" .. trx.rooms[1].num)"
+        "trx.log.info(#trx.rooms .. \" rooms, first is \" .. trx.rooms[0].num)\nfor num, room in pairs(trx.rooms) do\n  room.cold = true\nend"
       ],
       "key": {
-        "description": "1-based room number.",
+        "description": "0-based room number.",
         "type": "integer"
       },
       "module": "rooms",
@@ -2588,7 +2588,7 @@
       ],
       "path": "assault.stats.list_records",
       "returns": {
-        "description": "List of `{ time = seconds, attempt_num = which attempt it was }`.",
+        "description": "List, counted from one, of `{ time = seconds, attempt_num = which attempt it was }`.",
         "type": "table"
       }
     },
@@ -3037,7 +3037,7 @@
           "name": "callback",
           "params": [
             {
-              "description": "1-based index of the item that was picked up.",
+              "description": "0-based index of the item that was picked up.",
               "name": "item_num",
               "type": "integer"
             }
@@ -3152,13 +3152,13 @@
       "path": "game.play_gym"
     },
     {
-      "description": "Retrieves an item by 1-based index or by name.",
+      "description": "Retrieves an item by index or by name. Items count from zero, matching the item numbers level editors show.",
       "examples": [
-        "local item = trx.items[1]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"
+        "local item = trx.items[0]\nitem.name = \"lara\"\nlocal lara = trx.items[\"lara\"]"
       ],
       "params": [
         {
-          "description": "1-based index, or the item's unique name.",
+          "description": "0-based index, or the item's unique name.",
           "name": "key",
           "type": "any"
         }
@@ -3537,13 +3537,13 @@
       "path": "objects.swap_mesh"
     },
     {
-      "description": "Retrieves a room by 1-based index.",
+      "description": "Retrieves a room by number. Rooms count from zero, matching the room numbers level editors show.",
       "examples": [
-        "local room = trx.rooms[15]\nroom.underwater = true"
+        "local room = trx.rooms[14]\nroom.underwater = true"
       ],
       "params": [
         {
-          "description": "1-based room number.",
+          "description": "0-based room number.",
           "name": "num",
           "type": "integer"
         }
@@ -3595,7 +3595,7 @@
           "type": "vec3"
         },
         {
-          "description": "1-based room to search from.",
+          "description": "0-based room to search from.",
           "name": "room_num",
           "type": "integer"
         }
@@ -3608,7 +3608,7 @@
           "type": "vec3"
         },
         {
-          "description": "The 1-based room the position is in.",
+          "description": "The 0-based room the position is in.",
           "type": "integer"
         }
       ]
@@ -3876,7 +3876,7 @@
       "writable": false
     },
     {
-      "description": "1-based number of the room the camera is in, or `nil` if unknown.",
+      "description": "0-based number of the room the camera is in, or `nil` if unknown.",
       "path": "camera.room_num",
       "type": "integer",
       "writable": false
@@ -3894,7 +3894,7 @@
       "writable": false
     },
     {
-      "description": "1-based number of the room the camera is looking at, or `nil` if unknown.",
+      "description": "0-based number of the room the camera is looking at, or `nil` if unknown.",
       "path": "camera.target_room_num",
       "type": "integer",
       "writable": false
@@ -3906,19 +3906,19 @@
       "writable": true
     },
     {
-      "description": "The levels of the game, in order, as a list of `trx.game.Level`.",
+      "description": "The levels of the game, in order, as a list of `trx.game.Level` counted from one.",
       "path": "game.levels",
       "type": "table",
       "writable": false
     },
     {
-      "description": "The cutscenes, as a list of `trx.game.Level`.",
+      "description": "The cutscenes, as a list of `trx.game.Level` counted from one.",
       "path": "game.cutscenes",
       "type": "table",
       "writable": false
     },
     {
-      "description": "The demos, as a list of `trx.game.Level`.",
+      "description": "The demos, as a list of `trx.game.Level` counted from one.",
       "path": "game.demos",
       "type": "table",
       "writable": false
@@ -4240,7 +4240,7 @@
           "writable": true
         },
         {
-          "description": "1-based number of the room containing this item. Set `pos` to move the item between rooms.",
+          "description": "0-based number of the room containing this item. Set `pos` to move the item between rooms.",
           "name": "room_num",
           "type": "integer",
           "writable": false
@@ -4735,7 +4735,7 @@
           "writable": false
         },
         {
-          "description": "1-based room number.",
+          "description": "0-based room number, matching the numbers level editors show.",
           "name": "num",
           "type": "integer",
           "writable": false
@@ -4757,7 +4757,7 @@
         {
           "description": "Whether the handle still refers to a room of the level that is loaded. A level change replaces the rooms, so a handle held across one goes stale rather than naming a different room: reading or writing a field on it raises an error. Check this for a handle held across time.",
           "examples": [
-            "local start_room = trx.rooms[1]\ntrx.events.after_control(function()\n  if start_room:is_valid() then\n    trx.log.info(tostring(start_room.underwater))\n  end\nend)"
+            "local start_room = trx.rooms[0]\ntrx.events.after_control(function()\n  if start_room:is_valid() then\n    trx.log.info(tostring(start_room.underwater))\n  end\nend)"
           ],
           "name": "is_valid",
           "returns": {

--- a/docs/trx/lua/examples/README.md
+++ b/docs/trx/lua/examples/README.md
@@ -15,8 +15,7 @@ section](../../OBJECTS.md) as a reference for original values.
 -- Adjust HP of certain enemies
 trx.events.before_item_setup(function(level)
   -- Randomize bats HP
-  for i = 1, #trx.items do
-    local item = trx.items[i]
+  for _, item in pairs(trx.items) do
     if item.object_id == trx.catalog.objects.bat then
       item.properties.max_hit_points = math.random(5, 10)
     end

--- a/docs/trx/lua/reference/ASSAULT.md
+++ b/docs/trx/lua/reference/ASSAULT.md
@@ -103,7 +103,7 @@ Module for controlling the Assault Course and Quad Bike timers in gym levels.
   Parameters:
   - **`track`** (integer, optional, default `trx.assault.Track.COURSE`). Compare against `trx.assault.Track`.
 
-  Returns: table. List of `{ time = seconds, attempt_num = which attempt it was }`.
+  Returns: table. List, counted from one, of `{ time = seconds, attempt_num = which attempt it was }`.
 
   Example:
   ```lua

--- a/docs/trx/lua/reference/CAMERA.md
+++ b/docs/trx/lua/reference/CAMERA.md
@@ -17,10 +17,10 @@ Module for inspecting the active camera state.
 ### Properties
 
 - **`trx.camera.pos`** (vec3). Current camera position. *(read-only)*
-- **`trx.camera.room_num`** (integer). 1-based number of the room the camera is in, or `nil` if unknown. *(read-only)*
+- **`trx.camera.room_num`** (integer). 0-based number of the room the camera is in, or `nil` if unknown. *(read-only)*
 - **`trx.camera.room`** (Room). The `trx.rooms.Room` the camera is in, or `nil` if unknown. *(read-only)*
 - **`trx.camera.target_pos`** (vec3). Position the camera is looking at. *(read-only)*
-- **`trx.camera.target_room_num`** (integer). 1-based number of the room the camera is looking at, or `nil` if unknown. *(read-only)*
+- **`trx.camera.target_room_num`** (integer). 0-based number of the room the camera is looking at, or `nil` if unknown. *(read-only)*
 
 ### Functions
 

--- a/docs/trx/lua/reference/EVENTS.md
+++ b/docs/trx/lua/reference/EVENTS.md
@@ -99,7 +99,7 @@ A handler attached from a level script is detached automatically when the level 
   Parameters:
   - **`callback`** (function).
     Called with:
-    - **`item_num`** (integer). 1-based index of the item that was picked up.
+    - **`item_num`** (integer). 0-based index of the item that was picked up.
 
   Returns: integer. Listener id. Pass it to `trx.events.detach` to stop listening.
 

--- a/docs/trx/lua/reference/GAME.md
+++ b/docs/trx/lua/reference/GAME.md
@@ -16,9 +16,9 @@ Module for the game flow: which levels there are, and which one is being played.
 
 ### Properties
 
-- **`trx.game.levels`** (table). The levels of the game, in order, as a list of `trx.game.Level`. *(read-only)*
-- **`trx.game.cutscenes`** (table). The cutscenes, as a list of `trx.game.Level`. *(read-only)*
-- **`trx.game.demos`** (table). The demos, as a list of `trx.game.Level`. *(read-only)*
+- **`trx.game.levels`** (table). The levels of the game, in order, as a list of `trx.game.Level` counted from one. *(read-only)*
+- **`trx.game.cutscenes`** (table). The cutscenes, as a list of `trx.game.Level` counted from one. *(read-only)*
+- **`trx.game.demos`** (table). The demos, as a list of `trx.game.Level` counted from one. *(read-only)*
 - **`trx.game.current_level`** (Level). The level being played, or `nil` if none is. *(read-only)*
 - **`trx.game.gym`** (Level). The gym level, or `nil` if this game has no gym. *(read-only)*
 - **`trx.game.version`** (integer). Which Tomb Raider this build is: 1, 2, 3 or 4. *(read-only)*

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -16,15 +16,15 @@ Module for controlling all moveables.
 
 ### Indexing
 
-Indexing the module reaches an item, and `#trx.items` is how many the level has.
+Indexing the module reaches an item, and `#trx.items` is how many the level has. Items count from zero, matching the item numbers level editors show. `pairs()` walks them in order, keyed by that number.
 
-- **`trx.items[key]`** (Item or `nil`). 1-based index, or the item's unique name.
+- **`trx.items[key]`** (Item or `nil`). 0-based index, or the item's unique name.
 - **`#trx.items`** (integer). How many there are.
 
 Example:
 ```lua
-for i = 1, #trx.items do
-  trx.log.info(trx.items[i].object_id)
+for num, item in pairs(trx.items) do
+  trx.log.info(item.object_id)
 end
 ```
 
@@ -83,7 +83,7 @@ end
     - **`name`**: string. Unique item name, or `nil`. Assigning a name already in use raises an error.
     - **`object_id`**: integer. The item's object type. Compare against `trx.catalog.objects`. *(read-only)*
     - **`pos`**: vec3. World position. Updating this also updates `room` and `room_num`.
-    - **`room_num`**: integer. 1-based number of the room containing this item. Set `pos` to move the item between rooms. *(read-only)*
+    - **`room_num`**: integer. 0-based number of the room containing this item. Set `pos` to move the item between rooms. *(read-only)*
     - **`rot`**: vec3. Orientation.
     - **`speed`**: integer. Forward speed.
     - **`status`**: integer. Item status. Use `activate()` and `kill()` to change it, so the item's active-list membership stays in sync. Compare against `trx.items.Status`. *(read-only)*
@@ -152,16 +152,16 @@ end
 ### Functions
 
 - [lua]`trx.items.get(key)`  
-  Retrieves an item by 1-based index or by name.
+  Retrieves an item by index or by name. Items count from zero, matching the item numbers level editors show.
 
   Parameters:
-  - **`key`** (any). 1-based index, or the item's unique name.
+  - **`key`** (any). 0-based index, or the item's unique name.
 
   Returns: Item or `nil`.
 
   Example:
   ```lua
-  local item = trx.items[1]
+  local item = trx.items[0]
   item.name = "lara"
   local lara = trx.items["lara"]
   ```

--- a/docs/trx/lua/reference/OBJECTS.md
+++ b/docs/trx/lua/reference/OBJECTS.md
@@ -18,7 +18,7 @@ An object is the pattern every item of that type is cut from: a wolf's radius, n
 
 ### Indexing
 
-Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.
+Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. Keyed by object id or catalog name, not by position.
 
 - **`trx.objects[key]`** (Object or `nil`). Object id, or its catalog name.
 

--- a/docs/trx/lua/reference/ROOMS.md
+++ b/docs/trx/lua/reference/ROOMS.md
@@ -16,14 +16,17 @@ Module for inspecting and altering the rooms of the current level.
 
 ### Indexing
 
-Indexing the module reaches a room, and `#trx.rooms` is how many the level has.
+Indexing the module reaches a room, and `#trx.rooms` is how many the level has. Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them in order, keyed by that number.
 
-- **`trx.rooms[key]`** (Room or `nil`). 1-based room number.
+- **`trx.rooms[key]`** (Room or `nil`). 0-based room number.
 - **`#trx.rooms`** (integer). How many there are.
 
 Example:
 ```lua
-trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
+trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[0].num)
+for num, room in pairs(trx.rooms) do
+  room.cold = true
+end
 ```
 
 ### Properties
@@ -57,7 +60,7 @@ trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
     - **`cold`**: boolean. Whether Lara's breath is visible in the room.
     - **`damaging`**: boolean. Whether the room drains Lara's exposure meter.
     - **`flip_status`**: integer. Current flip status. Compare against `trx.rooms.FlipStatus`. *(read-only)*
-    - **`num`**: integer. 1-based room number. *(read-only)*
+    - **`num`**: integer. 0-based room number, matching the numbers level editors show. *(read-only)*
     - **`underwater`**: boolean. Whether the room is filled with water.
     - **`wind`**: boolean. Whether the room has a breeze. Requires the player to have breeze enabled.
 
@@ -75,7 +78,7 @@ trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
 
       Example:
       ```lua
-      local start_room = trx.rooms[1]
+      local start_room = trx.rooms[0]
       trx.events.after_control(function()
         if start_room:is_valid() then
           trx.log.info(tostring(start_room.underwater))
@@ -86,16 +89,16 @@ trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
 ### Functions
 
 - [lua]`trx.rooms.get(num)`  
-  Retrieves a room by 1-based index.
+  Retrieves a room by number. Rooms count from zero, matching the room numbers level editors show.
 
   Parameters:
-  - **`num`** (integer). 1-based room number.
+  - **`num`** (integer). 0-based room number.
 
   Returns: Room or `nil`.
 
   Example:
   ```lua
-  local room = trx.rooms[15]
+  local room = trx.rooms[14]
   room.underwater = true
   ```
 
@@ -124,8 +127,8 @@ trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)
 
   Parameters:
   - **`pos`** (vec3). Position to search near.
-  - **`room_num`** (integer). 1-based room to search from.
+  - **`room_num`** (integer). 0-based room to search from.
 
   Returns:
   - vec3 or `nil`. The valid position, or `nil` if none was found nearby.
-  - integer. The 1-based room the position is in.
+  - integer. The 0-based room the position is in.

--- a/src/lua/api/api.lua
+++ b/src/lua/api/api.lua
@@ -209,6 +209,21 @@ local function install_module_meta(module)
     meta.__len = function()
       return container.count()
     end
+    -- pairs() over the module walks the collection, 0-based, one handle at a
+    -- time, so a script iterates without the #..-1 idiom. seal()'s audit reads
+    -- the module's own members instead, and iterates raw to reach them.
+    meta.__pairs = function(t)
+      local n = container.count()
+      return function(_, i)
+        i = i + 1
+        if i >= n then
+          return nil
+        end
+        return i, container.get(i)
+      end,
+        t,
+        -1
+    end
   end
   setmetatable(trx[module], meta)
 end
@@ -412,7 +427,9 @@ function api.seal()
 
   local undeclared = {}
   local function audit(container_path, tbl)
-    for name in pairs(tbl or {}) do
+    -- next, not pairs: a container overrides __pairs to walk its collection, so
+    -- the module's own members are only reachable through a raw iteration.
+    for name in next, tbl or {} do
       if not (declared[container_path] or {})[name] then
         table.insert(undeclared, "trx." .. container_path .. "." .. name)
       end

--- a/src/lua/api/assault.lua
+++ b/src/lua/api/assault.lua
@@ -120,7 +120,8 @@ api.define("assault.stats.list_records", {
   params = { track_param() },
   returns = {
     type = "table",
-    description = "List of `{ time = seconds, attempt_num = which attempt it was }`.",
+    description = "List, counted from one, of `{ time = seconds, attempt_num = which attempt it "
+      .. "was }`.",
   },
   examples = {
     [[for _, record in ipairs(trx.assault.stats.list_records(trx.assault.Track.QUAD)) do

--- a/src/lua/api/camera.lua
+++ b/src/lua/api/camera.lua
@@ -14,7 +14,7 @@ api.property("camera.pos", {
 
 api.property("camera.room_num", {
   type = "integer",
-  description = "1-based number of the room the camera is in, or `nil` if unknown.",
+  description = "0-based number of the room the camera is in, or `nil` if unknown.",
   get = raw.get_room,
 })
 
@@ -35,7 +35,7 @@ api.property("camera.target_pos", {
 
 api.property("camera.target_room_num", {
   type = "integer",
-  description = "1-based number of the room the camera is looking at, or `nil` if unknown.",
+  description = "0-based number of the room the camera is looking at, or `nil` if unknown.",
   get = raw.get_target_room,
 })
 

--- a/src/lua/api/events.lua
+++ b/src/lua/api/events.lua
@@ -141,7 +141,7 @@ api.define("events.on_pickup", {
         {
           name = "item_num",
           type = "integer",
-          description = "1-based index of the item that was picked up.",
+          description = "0-based index of the item that was picked up.",
         },
       },
     },

--- a/src/lua/api/game.lua
+++ b/src/lua/api/game.lua
@@ -127,7 +127,7 @@ end
 
 api.property("game.levels", {
   type = "table",
-  description = "The levels of the game, in order, as a list of `trx.game.Level`.",
+  description = "The levels of the game, in order, as a list of `trx.game.Level` counted from one.",
   get = function()
     return level_list(LevelTable.MAIN)
   end,
@@ -135,7 +135,7 @@ api.property("game.levels", {
 
 api.property("game.cutscenes", {
   type = "table",
-  description = "The cutscenes, as a list of `trx.game.Level`.",
+  description = "The cutscenes, as a list of `trx.game.Level` counted from one.",
   get = function()
     return level_list(LevelTable.CUTSCENES)
   end,
@@ -143,7 +143,7 @@ api.property("game.cutscenes", {
 
 api.property("game.demos", {
   type = "table",
-  description = "The demos, as a list of `trx.game.Level`.",
+  description = "The demos, as a list of `trx.game.Level` counted from one.",
   get = function()
     return level_list(LevelTable.DEMOS)
   end,

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -84,7 +84,7 @@ api.type("items.Item", {
       from = "room_index",
       type = "integer",
       writable = false,
-      description = "1-based number of the room containing this item. Set `pos` to move the item between rooms.",
+      description = "0-based number of the room containing this item. Set `pos` to move the item between rooms.",
     },
     hit_points = {
       from = "hit_points",
@@ -304,7 +304,7 @@ end
 
 local function search(query, first_only)
   local found = {}
-  for i = 1, raw.count() do
+  for i = 0, raw.count() - 1 do
     local item = raw.get(i)
     if item ~= nil and matches(item, query) then
       if first_only then
@@ -320,17 +320,18 @@ local function search(query, first_only)
 end
 
 api.define("items.get", {
-  description = "Retrieves an item by 1-based index or by name.",
+  description = "Retrieves an item by index or by name. Items count from zero, matching the "
+    .. "item numbers level editors show.",
   params = {
     {
       name = "key",
       type = "any",
-      description = "1-based index, or the item's unique name.",
+      description = "0-based index, or the item's unique name.",
     },
   },
   returns = { type = "Item", nullable = true },
   examples = {
-    [==[local item = trx.items[1]
+    [==[local item = trx.items[0]
 item.name = "lara"
 local lara = trx.items["lara"]]==],
   },
@@ -431,15 +432,17 @@ api.define("items.first", {
 })
 
 api.container("items", {
-  description = "Indexing the module reaches an item, and `#trx.items` is how many the level has.",
+  description = "Indexing the module reaches an item, and `#trx.items` is how many the level has. "
+    .. "Items count from zero, matching the item numbers level editors show. `pairs()` walks them "
+    .. "in order, keyed by that number.",
   key = {
     type = "any",
-    description = "1-based index, or the item's unique name.",
+    description = "0-based index, or the item's unique name.",
   },
   value = { type = "Item", nullable = true },
   examples = {
-    [[for i = 1, #trx.items do
-  trx.log.info(trx.items[i].object_id)
+    [[for num, item in pairs(trx.items) do
+  trx.log.info(item.object_id)
 end]],
   },
   get = raw.get,

--- a/src/lua/api/objects.lua
+++ b/src/lua/api/objects.lua
@@ -180,7 +180,8 @@ api.define("objects.swap_mesh", {
 })
 
 api.container("objects", {
-  description = "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf.",
+  description = "Indexing the module reaches an object definition, so `trx.objects.wolf` is the wolf. "
+    .. "Keyed by object id or catalog name, not by position.",
   key = { type = "any", description = "Object id, or its catalog name." },
   value = { type = "Object", nullable = true },
   examples = { [[trx.objects.wolf.properties.max_hit_points = 30]] },

--- a/src/lua/api/rooms.lua
+++ b/src/lua/api/rooms.lua
@@ -27,7 +27,7 @@ api.type("rooms.Room", {
       from = "room_index",
       type = "integer",
       writable = false,
-      description = "1-based room number.",
+      description = "0-based room number, matching the numbers level editors show.",
     },
     underwater = {
       from = "flags.underwater",
@@ -69,7 +69,7 @@ api.type("rooms.Room", {
         .. "different room: reading or writing a field on it raises an error. Check this for a "
         .. "handle held across time.",
       examples = {
-        [[local start_room = trx.rooms[1]
+        [[local start_room = trx.rooms[0]
 trx.events.after_control(function()
   if start_room:is_valid() then
     trx.log.info(tostring(start_room.underwater))
@@ -115,13 +115,14 @@ end)]],
 })
 
 api.define("rooms.get", {
-  description = "Retrieves a room by 1-based index.",
+  description = "Retrieves a room by number. Rooms count from zero, matching the "
+    .. "room numbers level editors show.",
   params = {
-    { name = "num", type = "integer", description = "1-based room number." },
+    { name = "num", type = "integer", description = "0-based room number." },
   },
   returns = { type = "Room", nullable = true },
   examples = {
-    [[local room = trx.rooms[15]
+    [[local room = trx.rooms[14]
 room.underwater = true]],
   },
   impl = raw.get,
@@ -174,7 +175,7 @@ api.define("rooms.find_valid_pos", {
     {
       name = "room_num",
       type = "integer",
-      description = "1-based room to search from.",
+      description = "0-based room to search from.",
     },
   },
   returns = {
@@ -183,17 +184,22 @@ api.define("rooms.find_valid_pos", {
       nullable = true,
       description = "The valid position, or `nil` if none was found nearby.",
     },
-    { type = "integer", description = "The 1-based room the position is in." },
+    { type = "integer", description = "The 0-based room the position is in." },
   },
   impl = raw.find_valid_pos,
 })
 
 api.container("rooms", {
-  description = "Indexing the module reaches a room, and `#trx.rooms` is how many the level has.",
-  key = { type = "integer", description = "1-based room number." },
+  description = "Indexing the module reaches a room, and `#trx.rooms` is how many the level has. "
+    .. "Rooms count from zero, matching the room numbers level editors show. `pairs()` walks them "
+    .. "in order, keyed by that number.",
+  key = { type = "integer", description = "0-based room number." },
   value = { type = "Room", nullable = true },
   examples = {
-    [[trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[1].num)]],
+    [[trx.log.info(#trx.rooms .. " rooms, first is " .. trx.rooms[0].num)
+for num, room in pairs(trx.rooms) do
+  room.cold = true
+end]],
   },
   get = raw.get,
   count = raw.count,

--- a/src/tests/unit/fake_engine_camera.c
+++ b/src/tests/unit/fake_engine_camera.c
@@ -21,12 +21,12 @@ void FakeCamera_Reset(void)
     g_Camera.pos.x = 1024;
     g_Camera.pos.y = 2048;
     g_Camera.pos.z = 3072;
-    // The engine counts rooms from 0 and Lua from 1.
-    g_Camera.pos.room_num = FAKE_CAMERA_ROOM - 1;
+    // The engine and Lua both count rooms from 0.
+    g_Camera.pos.room_num = FAKE_CAMERA_ROOM;
     g_Camera.target.x = 4096;
     g_Camera.target.y = 5120;
     g_Camera.target.z = 6144;
-    g_Camera.target.room_num = FAKE_CAMERA_TARGET_ROOM - 1;
+    g_Camera.target.room_num = FAKE_CAMERA_TARGET_ROOM;
     g_FakeCameraCalls = (FAKE_CAMERA_CALLS) {};
 }
 

--- a/src/tests/unit/lua/api_seal.lua
+++ b/src/tests/unit/lua/api_seal.lua
@@ -13,7 +13,7 @@ local function seal()
 end
 
 test("an undeclared member is unreachable before the seal", function()
-  assert(trx.items[1].box_num == nil, "box_num was never declared")
+  assert(trx.items[0].box_num == nil, "box_num was never declared")
 end)
 
 -- The declaring half of the registry goes the way trxc goes: a script cannot
@@ -42,7 +42,7 @@ test("sealing takes the declaring half off trx.api", function()
     )
   end
 
-  assert(trx.items[1].box_num == nil, "box_num must still be unreachable")
+  assert(trx.items[0].box_num == nil, "box_num must still be unreachable")
 end)
 
 test("what is left of trx.api is strict mode", function()

--- a/src/tests/unit/lua/boot.lua
+++ b/src/tests/unit/lua/boot.lua
@@ -25,10 +25,10 @@ test("strict mode still works once the globals are hardened", function()
   raises(function()
     trx.items.spawn("wolf", { x = 0, y = 0, z = 0 })
   end)
-  assert(trx.items.get(1) ~= nil, "a good call still goes through")
+  assert(trx.items.get(0) ~= nil, "a good call still goes through")
 
   trx.api.strict(false)
-  assert(trx.items.get(1) ~= nil)
+  assert(trx.items.get(0) ~= nil)
 end)
 
 test("the surface cannot be reopened", function()

--- a/src/tests/unit/lua/camera.lua
+++ b/src/tests/unit/lua/camera.lua
@@ -16,8 +16,7 @@ test("position reads through to the engine", function()
   assert(trx.camera.target_pos.z == 6144)
 end)
 
-test("rooms are 1-based, as everywhere else in the API", function()
-  -- The engine counts rooms from 0. A script never sees that.
+test("rooms are 0-based, as everywhere else in the API", function()
   assert(trx.camera.room_num == fake.CAMERA_ROOM)
   assert(trx.camera.target_room_num == fake.CAMERA_TARGET_ROOM)
 end)

--- a/src/tests/unit/lua/items.lua
+++ b/src/tests/unit/lua/items.lua
@@ -12,34 +12,44 @@ local test, raises = h.test, h.raises
 
 local WOLF, VASE, UNLOADED = fake.WOLF, fake.VASE, fake.UNLOADED
 
-test("items are indexed from 1, and by name", function()
+test("items are indexed from 0, and by name", function()
   assert(#trx.items == 2, "length operator")
   assert(trx.items.count() == 2, "count()")
-  assert(trx.items[1] ~= nil and trx.items[2] ~= nil)
-  assert(trx.items[99] == nil, "out of range must be nil")
+  assert(trx.items[0] ~= nil and trx.items[1] ~= nil)
+  assert(trx.items[2] == nil, "out of range must be nil")
 
   -- Narrowed to the engine's index, 2^32 + 1 is 1. It must not come back as
   -- item 1.
   assert(trx.items[4294967297] == nil, "a wide index must not wrap into range")
   assert(trx.items[-1] == nil)
 
-  trx.items[1].name = "wolfie"
+  trx.items[0].name = "wolfie"
   assert(trx.items["wolfie"] ~= nil, "lookup by name")
   assert(trx.items.get("wolfie").name == "wolfie")
   assert(trx.items["nobody"] == nil, "an unknown name must be nil")
 
   -- A name already in use raises rather than silently rebinding.
   raises(function()
-    trx.items[2].name = "wolfie"
+    trx.items[1].name = "wolfie"
   end)
 end)
 
+test("pairs walks the items in order, keyed from 0", function()
+  local seen = {}
+  for num, item in pairs(trx.items) do
+    assert(item == trx.items[num], "the key must be the item index")
+    seen[#seen + 1] = num
+  end
+  assert(#seen == 2, "pairs must yield every item")
+  assert(seen[1] == 0 and seen[2] == 1, "pairs must count from 0, in order")
+end)
+
 test("fields read and write through to the struct", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
 
   it.pos = { x = 512, y = 0, z = 256 }
   assert(it.pos.x == 512 and it.pos.z == 256, "pos did not stick")
-  assert(trx.items[1].pos.x == 512, "not written through to the item")
+  assert(trx.items[0].pos.x == 512, "not written through to the item")
 
   it.rot = { x = 0, y = 16384, z = 0 }
   assert(it.rot.y == 16384)
@@ -47,8 +57,8 @@ test("fields read and write through to the struct", function()
   it.timer = 30
   assert(it.timer == 30)
 
-  -- Rooms are 1-based to scripts; the engine counts from 0.
-  assert(it.room_num == 1)
+  -- Rooms count from 0, matching the engine and the level editor.
+  assert(it.room_num == 0)
 end)
 
 -- These encode an engine invariant. Writing them directly would let a script
@@ -65,25 +75,25 @@ test("read-only fields refuse writes", function()
     "max_hit_points",
   }) do
     raises(function()
-      trx.items[1][name] = 1
+      trx.items[0][name] = 1
     end, "read-only")
   end
 end)
 
 test("a field that does not exist raises rather than being created", function()
   raises(function()
-    trx.items[1].no_such_field = 1
+    trx.items[0].no_such_field = 1
   end, "unknown")
 end)
 
 test("a value the field cannot hold raises instead of truncating", function()
   -- hit_points is 16-bit.
   raises(function()
-    trx.items[1].hit_points = 99999
+    trx.items[0].hit_points = 99999
   end)
 
-  trx.items[1].hit_points = 5
-  assert(trx.items[1].hit_points == 5)
+  trx.items[0].hit_points = 5
+  assert(trx.items[0].hit_points == 5)
 end)
 
 test("the pickup mode enum is reached through trx.items", function()
@@ -123,7 +133,7 @@ test("status matches the enum, and activate() moves it", function()
   assert(trx.items.Status.DEACTIVATED == 2)
   assert(trx.items.Status.INVISIBLE == 3)
 
-  local it = trx.items[1]
+  local it = trx.items[0]
   assert(it.status == trx.items.Status.INACTIVE)
   assert(it.is_active == false)
 
@@ -134,7 +144,7 @@ end)
 -- An index alone would rebind to whatever item recycled the slot; the
 -- generation counter is what makes the handle go stale instead.
 test("a handle to a killed item goes stale", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
   assert(it:is_valid())
 
   it:kill()
@@ -151,26 +161,26 @@ end)
 -- handles point at rather than the userdata itself.
 test("two handles to the same item are equal", function()
   assert(
-    trx.items[1] == trx.items[1],
+    trx.items[0] == trx.items[0],
     "the same item twice must compare equal"
   )
-  assert(trx.items[1] == trx.items.get(1))
-  assert(trx.items[1] ~= trx.items[2], "different items must not")
+  assert(trx.items[0] == trx.items.get(0))
+  assert(trx.items[0] ~= trx.items[1], "different items must not")
 
-  local it = trx.items[1]
+  local it = trx.items[0]
   assert(it ~= 1 and it ~= "wolf" and it ~= nil)
 
   -- The slot is what a stale handle still names, and the generation is what
   -- tells the two occupants apart.
   it:kill()
-  local fresh = trx.items[1]
+  local fresh = trx.items[0]
   assert(it ~= fresh, "a stale handle must not equal a live one")
 end)
 
 -- pairs() hands the iterator to the script, so it is reachable with whatever
 -- the script cares to pass it.
 test("the field iterator refuses a value that is not an item", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
 
   local seen = {}
   for k, v in pairs(it) do
@@ -235,17 +245,17 @@ test("a spawn that raises does not leave an item behind", function()
 end)
 
 test("explode runs the object's death handling; kill does not", function()
-  trx.items[1]:explode()
+  trx.items[0]:explode()
   assert(fake.calls().creature_die == 1, "explode() should reach Creature_Die")
   assert(fake.calls().creature_die_explode, "and it should explode")
 
   fake.reset()
-  trx.items[1]:kill()
+  trx.items[0]:kill()
   assert(fake.calls().creature_die == 0, "kill() just removes the item")
 end)
 
 test("properties overlay the object's defaults", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
 
   -- With no override, a read falls back to the object.
   assert(it.properties.max_hit_points == 20, "the object's default")
@@ -270,14 +280,14 @@ test("properties overlay the object's defaults", function()
 end)
 
 test("computed members and methods are declared", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
 
   assert(it.room.num == it.room_num, "room must be a Room, not a number")
   assert(it:distance_to({ x = 0, y = 0, z = 0 }) == 0)
-  assert(trx.items[2]:distance_to({ x = 0, y = 0, z = 0 }) == 1024)
+  assert(trx.items[1]:distance_to({ x = 0, y = 0, z = 0 }) == 1024)
 
   assert(it.is_alive == true, "a wolf with hit points is alive")
-  assert(trx.items[2].is_alive == false, "a vase is not alive")
+  assert(trx.items[1].is_alive == false, "a vase is not alive")
   assert(it.is_killed == false)
 end)
 
@@ -286,9 +296,9 @@ test("find and first query by object and room", function()
   assert(#wolves == 1, "expected one wolf, got " .. #wolves)
   assert(wolves[1].object_id == WOLF)
 
-  assert(#trx.items.find({ room_num = 2 }) == 1, "by room")
+  assert(#trx.items.find({ room_num = 1 }) == 1, "by room")
   assert(
-    #trx.items.find({ object_id = WOLF, room_num = 2 }) == 0,
+    #trx.items.find({ object_id = WOLF, room_num = 1 }) == 0,
     "both must match"
   )
 
@@ -305,7 +315,7 @@ end)
 -- A method reaches C directly, so strict mode has to put its wrapper in front
 -- of the C function rather than around a Lua one.
 test("strict mode checks a method's arguments", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
   trx.api.strict(true)
 
   local ok = pcall(function()
@@ -326,7 +336,7 @@ end)
 -- The handle is the method's first argument, and a dot where a colon was meant
 -- passes whatever came first instead.
 test("strict mode catches a method called with a dot", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
   trx.api.strict(true)
   local ok = pcall(function()
     return it.distance_to({ x = 0, y = 0, z = 0 })
@@ -337,7 +347,7 @@ end)
 
 -- ITEM has many members the declaration does not name.
 test("undeclared members are unreachable", function()
-  local it = trx.items[1]
+  local it = trx.items[0]
   for _, name in ipairs({
     "box_num",
     "floor",

--- a/src/tests/unit/lua/lara.lua
+++ b/src/tests/unit/lua/lara.lua
@@ -75,7 +75,7 @@ test("properties that are not struct fields still work", function()
 end)
 
 test("lara.item is her Item handle", function()
-  -- She is item 0 in C and item 1 to a script, like every other item.
+  -- She is item 0 to the engine and to a script alike, like every other item.
   assert(trx.lara.item ~= nil, "Lara has no item")
 end)
 

--- a/src/tests/unit/lua/rooms.lua
+++ b/src/tests/unit/lua/rooms.lua
@@ -4,22 +4,22 @@
 -- struct and enum bridges, trxc.rooms, and src/lua/rooms.lua itself. Only the
 -- engine below that is fake (see fake_engine_rooms.c).
 --
--- The fake level has four rooms. Room 1 and room 2 are a flip pair; rooms 3 and
--- 4 are ordinary.
+-- The fake level has four rooms. Room 0 and room 1 are a flip pair; rooms 2 and
+-- 3 are ordinary.
 
 local h = require("harness")
 local test, raises = h.test, h.raises
 
-test("rooms are indexed from 1, and counted", function()
+test("rooms are indexed from 0, and counted", function()
   assert(#trx.rooms == 4, "length operator")
   assert(trx.rooms.count() == 4, "count()")
 
-  assert(trx.rooms[1].num == 1, "the first room is 1, not 0")
-  assert(trx.rooms[4].num == 4)
-  assert(trx.rooms.get(2).num == 2, "get()")
+  assert(trx.rooms[0].num == 0, "the first room is 0")
+  assert(trx.rooms[3].num == 3)
+  assert(trx.rooms.get(1).num == 1, "get()")
 
-  assert(trx.rooms[0] == nil, "room 0 must not resolve")
-  assert(trx.rooms[5] == nil, "out of range must be nil")
+  assert(trx.rooms[-1] == nil, "a negative index must be nil")
+  assert(trx.rooms[4] == nil, "out of range must be nil")
   assert(trx.rooms["2"] == nil, "a numeric string is not a room number")
 
   -- Narrowed to the engine's index, 2^32 + 1 is 1. It must not come back as
@@ -27,8 +27,18 @@ test("rooms are indexed from 1, and counted", function()
   assert(trx.rooms[4294967297] == nil, "a wide index must not wrap into range")
 end)
 
+test("pairs walks the rooms in order, keyed from 0", function()
+  local seen = {}
+  for num, room in pairs(trx.rooms) do
+    assert(room.num == num, "the key must be the room number")
+    seen[#seen + 1] = num
+  end
+  assert(#seen == 4, "pairs must yield every room")
+  assert(seen[1] == 0 and seen[4] == 3, "pairs must count from 0, in order")
+end)
+
 test("room flags read and write as booleans", function()
-  local r = trx.rooms[1]
+  local r = trx.rooms[0]
 
   -- An unset flag reads false, not nil: `if room.underwater == nil` must not be
   -- how a dry room is detected.
@@ -36,8 +46,8 @@ test("room flags read and write as booleans", function()
 
   r.underwater = true
   assert(r.underwater == true, "the flag did not stick")
-  assert(trx.rooms[1].underwater == true, "not written through to the room")
-  assert(trx.rooms[2].underwater == false, "wrote to the wrong room")
+  assert(trx.rooms[0].underwater == true, "not written through to the room")
+  assert(trx.rooms[1].underwater == false, "wrote to the wrong room")
 
   -- flags is a nested struct of plain bools, so this also proves offsetof
   -- reaches through it to the right member.
@@ -47,10 +57,10 @@ end)
 
 test("room flags accept booleans only", function()
   raises(function()
-    trx.rooms[1].wind = 1
+    trx.rooms[0].wind = 1
   end)
   raises(function()
-    trx.rooms[1].cold = nil
+    trx.rooms[0].cold = nil
   end)
 end)
 
@@ -59,12 +69,12 @@ test("flip_status is read-only and matches the enum", function()
   assert(trx.rooms.FlipStatus.UNFLIPPED == 1)
   assert(trx.rooms.FlipStatus.FLIPPED == 2)
 
-  assert(trx.rooms[1].flip_status == trx.rooms.FlipStatus.UNFLIPPED)
-  assert(trx.rooms[2].flip_status == trx.rooms.FlipStatus.FLIPPED)
-  assert(trx.rooms[3].flip_status == trx.rooms.FlipStatus.NONE)
+  assert(trx.rooms[0].flip_status == trx.rooms.FlipStatus.UNFLIPPED)
+  assert(trx.rooms[1].flip_status == trx.rooms.FlipStatus.FLIPPED)
+  assert(trx.rooms[2].flip_status == trx.rooms.FlipStatus.NONE)
 
   raises(function()
-    trx.rooms[1].flip_status = 2
+    trx.rooms[0].flip_status = 2
   end, "read-only")
 end)
 
@@ -75,7 +85,7 @@ test("the fn compat table is gone", function()
 end)
 
 test("computed members are derived in Lua", function()
-  local r = trx.rooms[1]
+  local r = trx.rooms[0]
 
   local b = r.bounds
   assert(b.min_x == 0 and b.max_x == 4096, "bounds")
@@ -87,8 +97,8 @@ test("computed members are derived in Lua", function()
   assert(ib.max_z == b.max_z - 1024)
   assert(ib.min_y == b.min_y and ib.max_y == b.max_y, "y is not inset")
 
-  assert(r.flipped_room.num == 2, "flipped_room must be a Room, not a number")
-  assert(trx.rooms[3].flipped_room == nil, "a room with no pair gives nil")
+  assert(r.flipped_room.num == 1, "flipped_room must be a Room, not a number")
+  assert(trx.rooms[2].flipped_room == nil, "a room with no pair gives nil")
 end)
 
 test("module functions reach the engine", function()
@@ -101,19 +111,19 @@ test("module functions reach the engine", function()
 end)
 
 test("find_valid_pos nudges a position, or gives nil", function()
-  local pos, num = trx.rooms.find_valid_pos({ x = 0, y = 0, z = 0 }, 1)
-  assert(pos ~= nil and num == 1, "expected a valid position")
+  local pos, num = trx.rooms.find_valid_pos({ x = 0, y = 0, z = 0 }, 0)
+  assert(pos ~= nil and num == 0, "expected a valid position")
   assert(pos.y == 16, "the nudged position must come back")
 
-  assert(trx.rooms.find_valid_pos({ x = -1, y = 0, z = 0 }, 1) == nil)
+  assert(trx.rooms.find_valid_pos({ x = -1, y = 0, z = 0 }, 0) == nil)
 end)
 
 -- The rooms of the next level sit where the old ones did, so a bounds check
 -- alone would let a held handle name a different room.
 test("a room handle goes stale at a level change", function()
-  local r = trx.rooms[1]
+  local r = trx.rooms[0]
   assert(r:is_valid())
-  assert(r.num == 1)
+  assert(r.num == 0)
 
   fake.load_next_level()
   assert(not r:is_valid(), "the handle should be stale after a level change")
@@ -126,13 +136,13 @@ test("a room handle goes stale at a level change", function()
   end, "stale")
 
   -- A handle taken from the level that is loaded is fine.
-  assert(trx.rooms[1]:is_valid())
+  assert(trx.rooms[0]:is_valid())
 end)
 
 -- The point of declaring the surface: a member C can reach but nobody names
 -- simply does not exist.
 test("undeclared members are unreachable", function()
-  local r = trx.rooms[1]
+  local r = trx.rooms[0]
   for _, name in ipairs({
     "pos",
     "size",

--- a/src/trx/game/lua/capi/camera.c
+++ b/src/trx/game/lua/capi/camera.c
@@ -13,7 +13,7 @@ static int M_L_CameraGetPos(lua_State *const L)
     return 1;
 }
 
-// trxc.camera.get_room() → int (1-based) or nil
+// trxc.camera.get_room() → int (0-based) or nil
 static int M_L_CameraGetRoom(lua_State *const L)
 {
     LUA_PushOptIndex(L, g_Camera.pos.room_num, NO_ROOM);
@@ -27,7 +27,7 @@ static int M_L_CameraGetTargetPos(lua_State *const L)
     return 1;
 }
 
-// trxc.camera.get_target_room() → int (1-based) or nil
+// trxc.camera.get_target_room() → int (0-based) or nil
 static int M_L_CameraGetTargetRoom(lua_State *const L)
 {
     LUA_PushOptIndex(L, g_Camera.target.room_num, NO_ROOM);

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -70,11 +70,10 @@ static const char *M_SetFrame(void *const self, const FIELD_VALUE *const in)
     return nullptr;
 }
 
-// Scripts count rooms from 1; the engine counts from 0.
 static bool M_GetRoomIndex(const void *const self, FIELD_VALUE *const out)
 {
     const ITEM *const item = self;
-    *out = (FIELD_VALUE) { .type = FT_INT16, .as_int = item->room_num + 1 };
+    *out = (FIELD_VALUE) { .type = FT_INT16, .as_int = item->room_num };
     return true;
 }
 
@@ -280,11 +279,11 @@ static int M_L_ItemsGet(lua_State *const L)
     int32_t idx = -1;
     if (lua_type(L, 1) == LUA_TNUMBER) {
         int32_t num;
-        if (!LUA_CheckBoundedInt(L, 1, 1, Item_GetTotalCount(), &num)) {
+        if (!LUA_CheckBoundedInt(L, 1, 0, Item_GetTotalCount() - 1, &num)) {
             lua_pushnil(L);
             return 1;
         }
-        idx = num - 1;
+        idx = num;
     } else {
         const ITEM *const item = Item_GetByName(luaL_checkstring(L, 1));
         idx = item != nullptr ? Item_GetIndex(item) : -1;

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -8,14 +8,14 @@
 
 #include <lauxlib.h>
 
-// Scripts count rooms from 1; the engine counts from 0. There is no
-// Room_GetIndex, so derive it the way Item_GetIndex does.
+// Scripts and the engine both count rooms from 0. There is no Room_GetIndex, so
+// derive it the way Item_GetIndex does.
 static bool M_GetIndex(const void *const self, FIELD_VALUE *const out)
 {
     const ROOM *const room = self;
     *out = (FIELD_VALUE) {
         .type = FT_INT16,
-        .as_int = (int32_t)(room - Room_Get(0)) + 1,
+        .as_int = (int32_t)(room - Room_Get(0)),
     };
     return true;
 }
@@ -81,11 +81,11 @@ static int M_L_RoomsCount(lua_State *const L)
 static int M_L_RoomsGet(lua_State *const L)
 {
     int32_t num;
-    if (!LUA_CheckBoundedInt(L, 1, 1, Room_GetCount(), &num)) {
+    if (!LUA_CheckBoundedInt(L, 1, 0, Room_GetCount() - 1, &num)) {
         lua_pushnil(L);
         return 1;
     }
-    M_PushRoom(L, num - 1);
+    M_PushRoom(L, num);
     return 1;
 }
 
@@ -116,7 +116,7 @@ static int M_L_RoomsGetBounds(lua_State *const L)
     return 1;
 }
 
-// trxc.rooms.get_flipped_room(room) -> 1-based room number or nil
+// trxc.rooms.get_flipped_room(room) -> 0-based room number or nil
 static int M_L_RoomsGetFlippedRoom(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ROOM);
@@ -168,15 +168,15 @@ static int M_L_RoomsFindValidPos(lua_State *const L)
     // Room_Get gives back nullptr for a room outside the level.
     const lua_Integer room_arg = luaL_checkinteger(L, 2);
     luaL_argcheck(
-        L, room_arg >= 1 && room_arg <= Room_GetCount(), 2, "unknown room");
-    int16_t room_num = (int16_t)(room_arg - 1);
+        L, room_arg >= 0 && room_arg <= Room_GetCount() - 1, 2, "unknown room");
+    int16_t room_num = (int16_t)room_arg;
     if (!Room_FindValidPos(&pos, &room_num)) {
         lua_pushnil(L);
         return 1;
     }
 
     LUA_PushXYZ(L, pos);
-    lua_pushinteger(L, room_num + 1);
+    lua_pushinteger(L, room_num);
     return 2;
 }
 

--- a/src/trx/game/lua/utils.c
+++ b/src/trx/game/lua/utils.c
@@ -126,6 +126,6 @@ void LUA_PushOptIndex(
     if (value == sentinel) {
         lua_pushnil(L);
     } else {
-        lua_pushinteger(L, value + 1);
+        lua_pushinteger(L, value);
     }
 }

--- a/src/trx/game/objects/general/pickup.c
+++ b/src/trx/game/objects/general/pickup.c
@@ -310,7 +310,7 @@ static void M_DoPickup(const int16_t item_num)
     Inv_AddPickup(item);
     Stats_AddPickup();
     // Notify Lua pickup listeners
-    LUA_FireEventInt32(LUA_EVENT_PICKUP, item_num + 1); // LUA uses 1-indexing
+    LUA_FireEventInt32(LUA_EVENT_PICKUP, item_num);
 
     item->status = IS_INVISIBLE;
     Item_Kill(item_num);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`trx.rooms` and `trx.items` now index from zero, matching the room and item numbers level editors show, so an id read from an external tool addresses the same thing in a script. Every derived index moves with them: `item.room_num`, `camera.room_num` and `target_room_num`, `room.flipped_room`, `find_valid_pos`'s `room` argument, and the item number `on_pickup` passes its handler.

`pairs()` over either container walks the collection keyed by that number, one handle at a time, so a loop needs no `#..-1`. The seal audit reads a module's own members through a raw iteration, since the container's `__pairs` now walks the collection instead.

The game-flow tables and assault records stay one-based; they index game-flow order, not external-tool ids.

Firing `on_pickup` with a zero-based number reverts the index change in 2652088c8, which had left the four TR3 boss scripts reading the item after the one picked up.

#### Testing

- [x] Shoals in TR3 are set up correctly
- [x] Plinth pickups in TR4 work correctly
- [x] Crowbar doors in TR4 work correctly
- [x] Picking up meteor artifacts in TR3 ends the level