### PR TITLE
lua: add a watchdog for runaway scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `trx.music.streams`, the soundtrack's streams as `trx.music.Stream` handles, each of which can be paused, resumed, sought and stopped on its own
 - added `trx.sound.samples`, the level's samples as `trx.sound.Sample` handles keyed by id, each with `:play()`, `:stop()` and its `volume`, `range`, `randomness` and `pitch`
 - added `trx.sound.streams`, the sound effects playing now as `trx.sound.Stream` handles, each of which can be paused, resumed and stopped on its own
+- added a script watchdog: a script that runs for over 5 seconds without handing control back is stopped with a script error, where it used to freeze the game
 - changed `trx.items` and `trx.rooms` to hand out opaque handles rather than `{ idx = ... }` tables, so a handle to a killed item now raises instead of silently addressing whatever took its slot
 - changed handles to compare equal when they name the same thing, so `trx.items[0] == trx.items[0]`
 - changed `trx.items` and `trx.rooms` to count from zero, matching the item and room numbers level editors show, and made `pairs()` walk them keyed by that number

--- a/src/meson.build
+++ b/src/meson.build
@@ -445,6 +445,7 @@ common_sources = [
   'trx/game/lua/capi/weather.c',
   'trx/game/lua/common.c',
   'trx/game/lua/field.c',
+  'trx/game/lua/guard.c',
   'trx/game/lua/registry.c',
   'trx/game/lua/sandbox.c',
   'trx/game/lua/utils.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -133,6 +133,17 @@ test_lua_sandbox_exe = executable(
 )
 test('lua_sandbox', test_lua_sandbox_exe, suite: 'unit')
 
+# The guard reads nothing but Lua and the clock, and the test supplies the
+# clock itself, stepped by hand, so the budget runs out deterministically.
+test_lua_guard_exe = executable(
+  'test_lua_guard',
+  files('unit/test_lua_guard.c') + test_stubs + files('../trx/game/lua/guard.c'),
+  include_directories: [src_inc, test_inc],
+  dependencies: [dep_lua],
+  build_by_default: false,
+)
+test('lua_guard', test_lua_guard_exe, suite: 'unit')
+
 # The public Lua surface, driven the way a level script drives it. Everything
 # below the assertions is real - the FIELD_DESC tables, the struct and enum
 # bridges, the trxc modules, and src/lua/api/*.lua read from the tree - and

--- a/src/tests/unit/test_lua_guard.c
+++ b/src/tests/unit/test_lua_guard.c
@@ -1,0 +1,78 @@
+#include "harness.h"
+
+#include <trx/game/lua/guard.h>
+
+#include <lauxlib.h>
+#include <lualib.h>
+
+// The guard reads the clock only from its hook, so a stepping stub stands in
+// for real time: every read moves it one second forward, and a script that
+// loops long enough to be checked a few times runs out of budget.
+
+static double m_Now = 0.0;
+
+double Clock_GetRealTime(void)
+{
+    m_Now += 1.0;
+    return m_Now;
+}
+
+static lua_State *M_Guarded(void)
+{
+    lua_State *const L = luaL_newstate();
+    luaL_openlibs(L);
+    LUA_Guard_Install(L, 3.0);
+    return L;
+}
+
+static bool M_Dies(lua_State *const L, const char *const src)
+{
+    LUA_Guard_Heartbeat();
+    if (luaL_dostring(L, src) == LUA_OK) {
+        return false;
+    }
+    const char *const message = lua_tostring(L, -1);
+    const bool blamed = message != nullptr
+        && strstr(message, "without returning control") != nullptr;
+    lua_pop(L, 1);
+    return blamed;
+}
+
+TEST(guard_aborts_a_runaway_script)
+{
+    lua_State *const L = M_Guarded();
+    CHECK(M_Dies(L, "while true do end"));
+    lua_close(L);
+}
+
+TEST(guard_outlives_a_pcall_that_catches_it)
+{
+    lua_State *const L = M_Guarded();
+    CHECK(
+        M_Dies(L, "while true do pcall(function() while true do end end) end"));
+    lua_close(L);
+}
+
+TEST(guard_covers_coroutines)
+{
+    lua_State *const L = M_Guarded();
+    CHECK(M_Dies(L, "coroutine.wrap(function() while true do end end)()"));
+    CHECK(M_Dies(
+        L,
+        "local co = coroutine.create(function() while true do end end)\n"
+        "local ok, err = coroutine.resume(co)\n"
+        "assert(not ok)\n"
+        "error(err, 0)"));
+    lua_close(L);
+}
+
+TEST(guard_heartbeat_resets_the_budget)
+{
+    lua_State *const L = M_Guarded();
+    CHECK(M_Dies(L, "while true do end"));
+    // The heartbeat in M_Dies starts a fresh budget, so a script that finishes
+    // in time is untouched - even right after a trip.
+    LUA_Guard_Heartbeat();
+    CHECK(luaL_dostring(L, "return 1 + 1") == LUA_OK);
+    lua_close(L);
+}

--- a/src/trx/game/lua/common.c
+++ b/src/trx/game/lua/common.c
@@ -10,6 +10,7 @@
 #include <trx/game/lua/api.h>
 #include <trx/game/lua/embedded_scripts.h>
 #include <trx/game/lua/events.h>
+#include <trx/game/lua/guard.h>
 #include <trx/game/lua/registry.h>
 #include <trx/game/lua/sandbox.h>
 #include <trx/game/lua/utils.h>
@@ -189,6 +190,7 @@ void LUA_Init(void)
     lua_State *const L = luaL_newstate();
     ASSERT(L != nullptr);
     LUA_OpenSafeLibs(L);
+    LUA_Guard_Install(L, LUA_GUARD_BUDGET_SEC);
 
     lua_newtable(L);
     lua_setglobal(L, "trxc");

--- a/src/trx/game/lua/guard.c
+++ b/src/trx/game/lua/guard.c
@@ -1,0 +1,95 @@
+#include <trx/game/lua/guard.h>
+
+#include <trx/debug.h>
+#include <trx/game/clock.h>
+
+#include <lauxlib.h>
+
+// VM instructions between budget checks. Coarse on purpose: a stuck script
+// reaches the next check within microseconds, and every script pays for the
+// clock read.
+#define M_CHECK_INTERVAL 100000
+
+static double m_BudgetSec = 0.0;
+
+// Zero until the first check after a heartbeat. The budget measures
+// continuous Lua execution, not time since the last frame, so a script
+// entered after a long C-side stall is not blamed for it.
+static double m_DeadlineSec = 0.0;
+
+static void M_Hook(lua_State *L, lua_Debug *ar);
+
+// coroutine.create makes a thread with no hook of its own, so both creators
+// route new threads through the guard. wrap keeps its stock behaviour of
+// re-raising a resume error in the caller.
+static const char M_COROUTINE_PATCH[] =
+    "local hook, create, resume = ...\n"
+    "coroutine.create = function(f) return hook(create(f)) end\n"
+    "coroutine.wrap = function(f)\n"
+    "    local co = hook(create(f))\n"
+    "    return function(...)\n"
+    "        local r = table.pack(resume(co, ...))\n"
+    "        if not r[1] then\n"
+    "            error(r[2], 0)\n"
+    "        end\n"
+    "        return table.unpack(r, 2, r.n)\n"
+    "    end\n"
+    "end\n";
+
+static void M_Hook(lua_State *const L, lua_Debug *const ar)
+{
+    const double now = Clock_GetRealTime();
+    if (m_DeadlineSec == 0.0) {
+        m_DeadlineSec = now + m_BudgetSec;
+    }
+    if (now < m_DeadlineSec) {
+        // A trip may have left this thread checking on every instruction.
+        lua_sethook(L, M_Hook, LUA_MASKCOUNT, M_CHECK_INTERVAL);
+        return;
+    }
+    // Check on every instruction until the engine has control again: a script
+    // that catches this error with pcall dies again before it can loop.
+    lua_sethook(L, M_Hook, LUA_MASKCOUNT, 1);
+    // lua_pushfstring's %f prints a lua_Number through "%.14g".
+    luaL_error(
+        L,
+        "script ran for over %f seconds without returning control to the "
+        "engine",
+        m_BudgetSec);
+}
+
+static int M_HookThread(lua_State *const L)
+{
+    lua_State *const co = lua_tothread(L, 1);
+    luaL_argcheck(L, co != nullptr, 1, "thread expected");
+    lua_sethook(co, M_Hook, LUA_MASKCOUNT, M_CHECK_INTERVAL);
+    lua_settop(L, 1);
+    return 1;
+}
+
+static void M_GuardCoroutines(lua_State *const L)
+{
+    const int status = luaL_loadbuffer(
+        L, M_COROUTINE_PATCH, sizeof(M_COROUTINE_PATCH) - 1, "@trx-guard");
+    ASSERT(status == LUA_OK);
+    lua_pushcfunction(L, M_HookThread);
+    lua_getglobal(L, "coroutine");
+    lua_getfield(L, -1, "create");
+    lua_getfield(L, -2, "resume");
+    lua_remove(L, -3);
+    lua_call(L, 3, 0);
+}
+
+void LUA_Guard_Install(lua_State *const L, const double budget_sec)
+{
+    m_BudgetSec = budget_sec;
+    m_DeadlineSec = 0.0;
+    lua_sethook(L, M_Hook, LUA_MASKCOUNT, M_CHECK_INTERVAL);
+    M_GuardCoroutines(L);
+}
+
+// The main loop has control at this moment, so no script is stuck.
+void LUA_Guard_Heartbeat(void)
+{
+    m_DeadlineSec = 0.0;
+}

--- a/src/trx/game/lua/guard.h
+++ b/src/trx/game/lua/guard.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <lua.h>
+
+// Turns a script that never returns - an accidental `while true` - into a
+// script error instead of a frozen game. A debug hook compares the clock
+// against a budget of continuous Lua execution; the heartbeat, called once
+// per frame from the shell, marks that the engine has control. Depends on
+// nothing but Lua and the clock, so a unit test can drive it directly.
+
+// Wall-clock seconds a script may run without handing control back.
+#define LUA_GUARD_BUDGET_SEC 5.0
+
+void LUA_Guard_Install(lua_State *L, double budget_sec);
+void LUA_Guard_Heartbeat(void);

--- a/src/trx/game/shell/events.c
+++ b/src/trx/game/shell/events.c
@@ -3,6 +3,7 @@
 #include <trx/debug.h>
 #include <trx/game/console/common.h>
 #include <trx/game/input/common.h>
+#include <trx/game/lua/guard.h>
 #include <trx/game/replay/test_recorder.h>
 #include <trx/game/replay/test_replay.h>
 #include <trx/game/screenshot.h>
@@ -181,6 +182,8 @@ bool Shell_ProcessEvent(const SDL_Event *const event)
 
 void Shell_ProcessEvents(void)
 {
+    LUA_Guard_Heartbeat();
+
     SDL_Event event;
     if (TestReplay_IsOpened()) {
         TestReplay_RunFrame();


### PR DESCRIPTION

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A debug hook checks a wall-clock budget of continuous Lua execution; the shell's per-frame event pump marks that the engine has control. A script over the budget dies with a script error instead of freezing the game. New coroutine threads are hooked too, and once tripped the hook re-raises on every instruction, so a `pcall` cannot outlast it.