### PR TITLE
inject: add property injection support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TRX/compare/trx-1.9.2...develop) - ××××-××-××
 - added TR4 camera mode, which is similar to TR3 but more responsive to Lara's actions such as picking up items
 - added the ability to paste commands in the developer console (with Ctrl+V)
+- added support to inject object and item properties, for example via TombEditor
 - changed reflections UV mapping to be more correct
 - changed outfits to support up to two braids per outfit; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing

--- a/src/meson.build
+++ b/src/meson.build
@@ -326,6 +326,7 @@ common_sources = [
   'trx/game/inject/editors/items.c',
   'trx/game/inject/editors/meshes.c',
   'trx/game/inject/editors/objects.c',
+  'trx/game/inject/editors/properties.c',
   'trx/game/inject/editors/rooms.c',
   'trx/game/inject/editors/textures.c',
   'trx/game/inject/testers/items.c',

--- a/src/trx/core/virtual_file.c
+++ b/src/trx/core/virtual_file.c
@@ -139,6 +139,20 @@ uint32_t VFile_ReadU32(VFILE *file)
     return result;
 }
 
+float VFile_ReadFloat(VFILE *const file)
+{
+    float result;
+    VFile_Read(file, &result, sizeof(result));
+    return result;
+}
+
+double VFile_ReadDouble(VFILE *const file)
+{
+    double result;
+    VFile_Read(file, &result, sizeof(result));
+    return result;
+}
+
 #define DEFINE_TRY_READ(name, type)                                            \
     bool name(VFILE *const file, type *const dst)                              \
     {                                                                          \

--- a/src/trx/core/virtual_file.h
+++ b/src/trx/core/virtual_file.h
@@ -24,6 +24,8 @@ int32_t VFile_ReadS32(VFILE *file);
 uint8_t VFile_ReadU8(VFILE *file);
 uint16_t VFile_ReadU16(VFILE *file);
 uint32_t VFile_ReadU32(VFILE *file);
+float VFile_ReadFloat(VFILE *file);
+double VFile_ReadDouble(VFILE *file);
 
 bool VFile_TrySkip(VFILE *file, int32_t offset);
 bool VFile_TryRead(VFILE *file, void *target, size_t size);

--- a/src/trx/game/inject/editor.h
+++ b/src/trx/game/inject/editor.h
@@ -5,6 +5,7 @@ void Inject_RegisterEditor(
     void (*handle_func)(
         const INJECTION_CONTEXT *ctx, const INJECTION *injection,
         int32_t element_count));
+void Inject_ApplyProperties(void);
 
 #define REGISTER_INJECT_EDITOR(data_type, handle_func)                         \
     __attribute__((constructor)) static void                                   \

--- a/src/trx/game/inject/editors/properties.c
+++ b/src/trx/game/inject/editors/properties.c
@@ -1,0 +1,224 @@
+#include <trx/core/log.h>
+#include <trx/core/memory.h>
+#include <trx/core/vector.h>
+#include <trx/game/inject.h>
+#include <trx/game/objects.h>
+
+typedef enum {
+    M_TARGET_OBJECT,
+    M_TARGET_ITEM,
+} M_TARGET_TYPE;
+
+typedef struct {
+    const char *name;
+    OBJECT_PROPERTY_VALUE value;
+} M_PROPERTY;
+
+typedef struct {
+    M_TARGET_TYPE target_type;
+    int32_t target_id;
+    VECTOR *properties;
+} M_PROPERTY_BATCH;
+
+static VECTOR *m_Batches = nullptr;
+
+static const char *M_ReadName(const INJECTION *const injection)
+{
+    const int32_t length = VFile_ReadS32(injection->fp);
+    if (length <= 0) {
+        return nullptr;
+    }
+
+    char *const name = Memory_Alloc((size_t)(length + 1));
+    VFile_Read(injection->fp, name, length);
+    name[length] = '\0';
+
+    return name;
+}
+
+static OBJECT_PROPERTY_VALUE M_ReadValue(const INJECTION *const injection)
+{
+    OBJECT_PROPERTY_VALUE value = {};
+    value.type = VFile_ReadS32(injection->fp);
+
+    switch (value.type) {
+    case OBJECT_PROPERTY_TYPE_INT:
+        value.as_int = VFile_ReadS32(injection->fp);
+        break;
+    case OBJECT_PROPERTY_TYPE_FLOAT:
+        value.as_float = VFile_ReadFloat(injection->fp);
+        break;
+    case OBJECT_PROPERTY_TYPE_DOUBLE:
+        value.as_double = VFile_ReadDouble(injection->fp);
+        break;
+    case OBJECT_PROPERTY_TYPE_BOOL:
+        value.as_bool = VFile_ReadS32(injection->fp) != 0;
+        break;
+    case OBJECT_PROPERTY_TYPE_XYZ:
+        value.as_xyz = (XYZ_32) {
+            .x = VFile_ReadS32(injection->fp),
+            .y = VFile_ReadS32(injection->fp),
+            .z = VFile_ReadS32(injection->fp),
+        };
+        break;
+    default:
+        LOG_WARNING("Unknown property type %d", value.type);
+        break;
+    }
+
+    return value;
+}
+
+static void *M_GetBatchTarget(const M_PROPERTY_BATCH *const batch)
+{
+    void *target = nullptr;
+    switch (batch->target_type) {
+    case M_TARGET_OBJECT:
+        OBJECT *const obj = Object_TryGet(batch->target_id);
+        if (obj != nullptr && obj->loaded) {
+            target = (void *)obj;
+        }
+        break;
+
+    case M_TARGET_ITEM:
+        target = (void *)Item_Get(batch->target_id);
+        break;
+
+    default:
+        break;
+    }
+
+    return target;
+}
+
+static void M_ApplyBatch(const M_PROPERTY_BATCH *const batch)
+{
+    void *target = M_GetBatchTarget(batch);
+    if (target == nullptr) {
+        LOG_WARNING(
+            "Invalid property target type %d, id %d", batch->target_type,
+            batch->target_id);
+        return;
+    }
+
+    for (int32_t i = 0; i < batch->properties->count; i++) {
+        const M_PROPERTY *const property = Vector_Get(batch->properties, i);
+
+        bool result;
+        switch (batch->target_type) {
+        case M_TARGET_OBJECT:
+            result = ObjectProperty_SetObjectValueRaw(
+                (OBJECT *)target, property->name, property->value);
+            break;
+
+        case M_TARGET_ITEM:
+            result = ObjectProperty_SetItemValueRaw(
+                (ITEM *)target, property->name, property->value);
+            break;
+
+        default:
+            result = false;
+            break;
+        }
+
+        if (!result) {
+            LOG_WARNING(
+                "Failed to set property %s on target type %d, id %d",
+                property->name, batch->target_type, batch->target_id);
+        }
+    }
+}
+
+static void M_PropertyEdits(
+    const INJECTION_CONTEXT *const ctx, const INJECTION *const injection,
+    const int32_t data_count)
+{
+    if (data_count <= 0) {
+        return;
+    }
+
+    if (m_Batches == nullptr) {
+        m_Batches =
+            Vector_CreateAtCapacity(sizeof(M_PROPERTY_BATCH), data_count);
+    }
+
+    for (int32_t i = 0; i < data_count; i++) {
+        M_PROPERTY_BATCH batch = {};
+        batch.target_type = VFile_ReadS32(injection->fp);
+
+        switch (batch.target_type) {
+        case M_TARGET_OBJECT:
+            const INJECTION_OBJECT_INFO obj_info =
+                Inject_ReadObjectPtr(injection);
+            batch.target_id = obj_info.id;
+            break;
+
+        case M_TARGET_ITEM:
+            batch.target_id = VFile_ReadS32(injection->fp);
+            break;
+
+        default:
+            LOG_WARNING("Unknown property target type %d", batch.target_type);
+            break;
+        }
+
+        const int32_t property_count = VFile_ReadS32(injection->fp);
+        if (property_count > 0) {
+            batch.properties =
+                Vector_CreateAtCapacity(sizeof(M_PROPERTY), property_count);
+            for (int32_t j = 0; j < property_count; j++) {
+                const M_PROPERTY property = {
+                    .name = M_ReadName(injection),
+                    .value = M_ReadValue(injection),
+                };
+                Vector_Add(batch.properties, &property);
+            }
+        }
+
+        Vector_Add(m_Batches, &batch);
+    }
+}
+
+static void M_FreeBatch(M_PROPERTY_BATCH *const batch)
+{
+    if (batch->properties == nullptr) {
+        return;
+    }
+
+    for (int32_t i = 0; i < batch->properties->count; i++) {
+        M_PROPERTY *const property = Vector_Get(batch->properties, i);
+        Memory_FreePointer(&property->name);
+    }
+
+    Vector_Free(batch->properties);
+    batch->properties = nullptr;
+}
+
+static void M_Cleanup(void)
+{
+    if (m_Batches == nullptr) {
+        return;
+    }
+
+    for (int32_t i = 0; i < m_Batches->count; i++) {
+        M_FreeBatch(Vector_Get(m_Batches, i));
+    }
+
+    Vector_Free(m_Batches);
+    m_Batches = nullptr;
+}
+
+void Inject_ApplyProperties(void)
+{
+    if (m_Batches == nullptr) {
+        return;
+    }
+
+    for (int32_t i = 0; i < m_Batches->count; i++) {
+        M_ApplyBatch(Vector_Get(m_Batches, i));
+    }
+
+    M_Cleanup();
+}
+
+REGISTER_INJECT_EDITOR(IDT_PROPERTY_EDITS, M_PropertyEdits)

--- a/src/trx/game/inject/enum.h
+++ b/src/trx/game/inject/enum.h
@@ -94,7 +94,8 @@ typedef enum {
     IDT_OBJ_LINK_EDITS   = 36,
     IDT_ITEM_NAME_EDITS  = 37,
     IDT_FLYBY_CAMERAS    = 38,
-    IDT_NUMBER_OF        = 39,
+    IDT_PROPERTY_EDITS   = 39,
+    IDT_NUMBER_OF        = 40,
 } INJECTION_DATA_TYPE;
 
 typedef enum {

--- a/src/trx/game/level/finalize/gameplay_objects.c
+++ b/src/trx/game/level/finalize/gameplay_objects.c
@@ -1,3 +1,4 @@
+#include <trx/game/inject.h>
 #include <trx/game/items.h>
 #include <trx/game/items/walkable.h>
 #include <trx/game/lara.h>
@@ -160,6 +161,7 @@ void Level_Finalize_LoadObjectsAndItems(LEVEL_CONTEXT *const ctx)
 
     M_PrepareTR4Items(ctx);
 
+    Inject_ApplyProperties();
     LUA_FireEventInt32(LUA_EVENT_BEFORE_ITEM_SETUP, GF_GetCurrentLevel()->num);
 
     const int32_t item_count = Item_GetLevelCount();

--- a/src/trx/game/objects/property.c
+++ b/src/trx/game/objects/property.c
@@ -229,7 +229,7 @@ bool ObjectProperty_SetObjectValueRaw(
     if (!M_CoerceValue(entry->value, value, &coerced_value)) {
         return false;
     }
-    M_ApplyObjectValue(obj, name, &coerced_value);
+    M_ApplyObjectValue(obj, entry->name, &coerced_value);
     return true;
 }
 
@@ -267,7 +267,7 @@ bool ObjectProperty_SetItemValueRaw(
     if (!M_CoerceValue(object_entry->value, value, &coerced_value)) {
         return false;
     }
-    M_ApplyItemValue(item, name, &coerced_value);
+    M_ApplyItemValue(item, object_entry->name, &coerced_value);
     return true;
 }
 

--- a/src/trx/game/stats/init.c
+++ b/src/trx/game/stats/init.c
@@ -348,6 +348,7 @@ void Stats_CalculateMaxStats(void)
                     ObjectProperty_ResetItem(Item_Get(item_num));
                 }
 
+                Inject_ApplyProperties();
                 LUA_FireEventInt32(LUA_EVENT_BEFORE_ITEM_SETUP, level->num);
 
                 const int32_t item_count = Item_GetLevelCount();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds the ability to inject properties for objects and items. Test level available generated from TE.

I initially had an odd bug which turned out to be from freeing the property names from the injection - it was in turn leaving dangling pointers in the main property module. There, we now just reference the definitions' names rather than using the ones passed to it when setting values, otherwise ownership becomes difficult to track. The alternative would be duping and then explicitly freeing, WDYT?

Resolves TRX693.
