### PR TITLE
flyby: fix level initialisation and mic pos

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed flyby cameras not working when part of an injection embedded in a level file (regression from 1.9)
+- fixed the microphone's position not updating during flyby sequences (regression from 1.9)
 
 **Lua**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - changed outfits to support up to two braids per outfit; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
+- fixed flyby cameras not working when part of an injection embedded in a level file (regression from 1.9)
 
 **Lua**
 

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -410,6 +410,7 @@ void Camera_FlybyMode_Update(void)
     g_Camera.shift = 0;
     g_Camera.roll = roll;
     Viewport_AlterFOV(fov, FOV_MODE_GAME);
+    Camera_UpdateMicPosition();
 
     M_TestTriggers();
 

--- a/src/trx/game/level/format/format_tr1.c
+++ b/src/trx/game/level/format/format_tr1.c
@@ -145,7 +145,6 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     }
 
     Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);
@@ -168,6 +167,7 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
 
     VFile_SetPos(file, 4);
     Level_Section_ReadTexturePages(ctx, file);
+    Level_Section_PrepareTR123FlybyCameras();
 
     return true;
 }

--- a/src/trx/game/level/format/format_tr2.c
+++ b/src/trx/game/level/format/format_tr2.c
@@ -128,7 +128,6 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     Level_Section_ReadSpriteTextures(ctx, file);
     Level_Section_ReadSpriteSequences(ctx, file);
     Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
     Level_Section_ReadAnimatedTextureRanges(ctx, file);
@@ -144,6 +143,8 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
             file->cur_ptr, file->size - VFile_GetPos(file));
         Inject_AppendInjection(embedded_injection);
     }
+
+    Level_Section_PrepareTR123FlybyCameras();
     return true;
 }
 

--- a/src/trx/game/level/format/format_tr3.c
+++ b/src/trx/game/level/format/format_tr3.c
@@ -127,7 +127,6 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
     Level_Section_ReadSpriteTextures(ctx, file);
     Level_Section_ReadSpriteSequences(ctx, file);
     Level_Section_ReadCamerasAndSinks(ctx, file);
-    Level_Section_ReadFlybyCameras(ctx, file);
     Level_Section_ReadSoundSources(ctx, file);
     Level_Section_ReadPathingData(ctx, file);
 
@@ -145,6 +144,8 @@ static bool M_Load(const LEVEL_FORMAT_LOADER *const loader, VFILE *const file)
             file->cur_ptr, file->size - VFile_GetPos(file));
         Inject_AppendInjection(embedded_injection);
     }
+
+    Level_Section_PrepareTR123FlybyCameras();
     return true;
 }
 

--- a/src/trx/game/level/sections/cinematics.c
+++ b/src/trx/game/level/sections/cinematics.c
@@ -61,20 +61,21 @@ void Level_Section_ReadCamerasAndSinks(
     Benchmark_End(&benchmark, nullptr);
 }
 
-void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *const ctx, VFILE *const file)
+void Level_Section_PrepareTR123FlybyCameras(void)
 {
     const int32_t inject_count = Inject_GetDataCount(IDT_FLYBY_CAMERAS);
-    if (ctx->loader->game_version < 4) {
-        Camera_InitialiseFlybys(inject_count);
-        return;
-    }
+    Camera_InitialiseFlybys(inject_count);
+}
 
+void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *const ctx, VFILE *const file)
+{
     BENCHMARK benchmark = Benchmark_Start();
     const int16_t num_cameras = VFile_ReadS16(file);
     LEVEL_CONTEXT_INFO *const info = &ctx->info;
     info->cameras.flyby_count = num_cameras;
     VFile_Skip(file, sizeof(int16_t)); // reserved padding
-    Camera_InitialiseFlybys(num_cameras + inject_count);
+    Camera_InitialiseFlybys(
+        num_cameras + Inject_GetDataCount(IDT_FLYBY_CAMERAS));
     LOG_INFO("flyby cameras: %d", num_cameras);
     Level_Section_AppendFlybyCameras(0, num_cameras, file);
 

--- a/src/trx/game/level/sections/read.h
+++ b/src/trx/game/level/sections/read.h
@@ -25,6 +25,7 @@ void Level_Section_ReadAnimatedTextureRanges(LEVEL_CONTEXT *ctx, VFILE *file);
 void Level_Section_ReadLightMap(LEVEL_CONTEXT *ctx, VFILE *file);
 void Level_Section_ReadCinematicFrames(LEVEL_CONTEXT *ctx, VFILE *file);
 void Level_Section_ReadCamerasAndSinks(LEVEL_CONTEXT *ctx, VFILE *file);
+void Level_Section_PrepareTR123FlybyCameras(void);
 void Level_Section_ReadFlybyCameras(LEVEL_CONTEXT *ctx, VFILE *file);
 void Level_Section_ReadItems(LEVEL_CONTEXT *ctx, VFILE *file);
 void Level_Section_ReadDemoData(LEVEL_CONTEXT *ctx, VFILE *file);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes initialisation of flyby cameras that are included in embedded injections. The number of cameras will not be known until after the embedded injection is initially read, hence a separate call is required for TR1-3 to initialise the gamebuf before the injection is processed.

Test level from TE available.

Resolves TRX695.