### PR TITLE
core: share entity handle identity primitive

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -208,6 +208,7 @@ common_sources = [
   'trx/core/enum_map.c',
   'trx/core/event_manager.c',
   'trx/core/filesystem.c',
+  'trx/core/handle.c',
   'trx/core/hash.c',
   'trx/core/json/base.c',
   'trx/core/json/parse.c',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -66,6 +66,14 @@ test_hash_exe = executable(
 )
 test('hash', test_hash_exe, suite: 'unit')
 
+test_handle_exe = executable(
+  'test_handle',
+  files('unit/test_handle.c') + test_stubs + files('../trx/core/handle.c'),
+  include_directories: [src_inc, test_inc],
+  build_by_default: false,
+)
+test('handle', test_handle_exe, suite: 'unit')
+
 test_field_exe = executable(
   'test_field',
   files('unit/test_field.c') + test_stubs + files('../trx/game/lua/field.c'),
@@ -152,6 +160,7 @@ test('lua_guard', test_lua_guard_exe, suite: 'unit')
 # tree is.
 lua_surface_src = files(
   '../trx/core/enum_map.c',
+  '../trx/core/handle.c',
   '../trx/core/memory.c',
   '../trx/core/vector.c',
   '../trx/game/enum.c',
@@ -489,6 +498,7 @@ test_lua_struct_exe = executable(
   'test_lua_struct',
   files('unit/test_lua_struct.c') + test_stubs
     + files(
+      '../trx/core/handle.c',
       '../trx/core/memory.c',
       '../trx/game/lua/capi/struct.c',
       '../trx/game/lua/field.c',

--- a/src/tests/unit/fake_engine_items.c
+++ b/src/tests/unit/fake_engine_items.c
@@ -2,12 +2,13 @@
 // surface with no level loaded.
 //
 // Two behaviours are modelled faithfully because the surface's contract rests
-// on them: Item_Create/Item_Kill bump ITEM.gen, so a handle to a recycled slot
-// goes stale; and Item_SetName refuses a duplicate, which is what makes
-// assigning a name already in use raise.
+// on them: Item_Create/Item_Kill bump the slot's handle generation, so a handle
+// to a recycled slot goes stale; and Item_SetName refuses a duplicate, which is
+// what makes assigning a name already in use raise.
 
 #include "fake_engine_items.h"
 
+#include <trx/core/handle.h>
 #include <trx/game/anims.h>
 #include <trx/game/creature.h>
 #include <trx/game/items.h>
@@ -30,6 +31,8 @@ static ITEM m_Items[FAKE_ITEM_POOL];
 static bool m_Used[FAKE_ITEM_POOL];
 static char m_Names[FAKE_ITEM_POOL][32];
 static int32_t m_Count;
+static uint32_t m_Gens[FAKE_ITEM_POOL];
+static HANDLE_REGISTRY m_Handles;
 
 static OBJECT m_Objects[FAKE_OBJ_COUNT];
 static ANIM m_Anims[FAKE_ANIM_COUNT];
@@ -56,6 +59,13 @@ void FakeItems_Reset(void)
     memset(m_Used, 0, sizeof(m_Used));
     memset(m_Names, 0, sizeof(m_Names));
     memset(m_Props, 0, sizeof(m_Props));
+
+    // A fresh level: the generations persist across the reset, so a handle held
+    // from before it goes stale, as one held across a real level change does.
+    if (m_Handles.gens == nullptr) {
+        Handle_RegistryInit(&m_Handles, m_Gens, FAKE_ITEM_POOL);
+    }
+    Handle_RegistryBumpAll(&m_Handles);
 
     for (int32_t i = 0; i < FAKE_ANIM_COUNT; i++) {
         m_Anims[i] = (ANIM) {
@@ -99,7 +109,6 @@ void FakeItems_Reset(void)
             .hit_points = 20,
             .max_hit_points = 20,
             .status = IS_INACTIVE,
-            .gen = 1,
         };
     }
     m_Items[1].object_id = FAKE_OBJ_VASE;
@@ -131,8 +140,8 @@ int16_t Item_Create(void)
     for (int32_t i = 0; i < FAKE_ITEM_POOL; i++) {
         if (!m_Used[i]) {
             m_Used[i] = true;
-            const uint16_t gen = m_Items[i].gen + 1;
-            m_Items[i] = (ITEM) { .gen = gen };
+            m_Items[i] = (ITEM) {};
+            Handle_RegistryBump(&m_Handles, i);
             if (i >= m_Count) {
                 m_Count = i + 1;
             }
@@ -161,9 +170,22 @@ void Item_Kill(const int16_t item_num)
     item->status = IS_DEACTIVATED;
     item->hit_points = 0;
     item->active = false;
-    item->gen++;
+    Handle_RegistryBump(&m_Handles, item_num);
     m_Used[item_num] = false;
     m_Names[item_num][0] = '\0';
+}
+
+TRX_HANDLE Item_GetHandle(const int16_t item_num)
+{
+    return Handle_RegistryMint(&m_Handles, item_num);
+}
+
+ITEM *Item_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_RegistryIsLive(&m_Handles, handle) || handle.id >= m_Count) {
+        return nullptr;
+    }
+    return Item_Get((int16_t)handle.id);
 }
 
 void Item_AddActive(const int16_t item_num)

--- a/src/tests/unit/fake_engine_rooms.c
+++ b/src/tests/unit/fake_engine_rooms.c
@@ -3,11 +3,12 @@
 
 #include "fake_engine_rooms.h"
 
+#include <trx/core/handle.h>
 #include <trx/game/items/actions/ids.h>
 #include <trx/game/rooms.h>
 
 static ROOM m_Rooms[FAKE_ROOM_COUNT];
-static uint32_t m_RoomGen = 1;
+static HANDLE_EPOCH m_RoomEpoch;
 static bool m_FlipStatus;
 
 FAKE_ROOM_CALLS g_FakeRoomCalls;
@@ -16,13 +17,13 @@ FAKE_ROOM_CALLS g_FakeRoomCalls;
 // so every handle to one of the old ones is stale.
 void FakeRooms_LoadNextLevel(void)
 {
-    m_RoomGen++;
+    Handle_EpochBump(&m_RoomEpoch);
 }
 
 void FakeRooms_Reset(void)
 {
     g_FakeRoomCalls = (FAKE_ROOM_CALLS) { 0 };
-    m_RoomGen++;
+    Handle_EpochBump(&m_RoomEpoch);
     m_FlipStatus = false;
 
     for (int32_t i = 0; i < FAKE_ROOM_COUNT; i++) {
@@ -47,9 +48,17 @@ int32_t Room_GetCount(void)
     return FAKE_ROOM_COUNT;
 }
 
-uint32_t Room_GetGeneration(void)
+TRX_HANDLE Room_GetHandle(const int32_t room_num)
 {
-    return m_RoomGen;
+    return Handle_EpochMint(&m_RoomEpoch, room_num);
+}
+
+ROOM *Room_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_EpochIsLive(&m_RoomEpoch, handle)) {
+        return nullptr;
+    }
+    return Room_Get(handle.id);
 }
 
 ROOM *Room_Get(const int32_t room_num)

--- a/src/tests/unit/fake_engine_sound.c
+++ b/src/tests/unit/fake_engine_sound.c
@@ -2,6 +2,7 @@
 
 #include "fake_engine_sound.h"
 
+#include <trx/core/handle.h>
 #include <trx/core/math/types.h>
 #include <trx/game/sound/common.h>
 #include <trx/game/sound/ids.h>
@@ -17,6 +18,8 @@ typedef struct {
 } FAKE_SLOT;
 
 static FAKE_SLOT m_Slots[FAKE_SOUND_SLOT_COUNT];
+static uint32_t m_SlotGens[FAKE_SOUND_SLOT_COUNT];
+static HANDLE_REGISTRY m_Handles;
 
 bool Sound_IsAvailable_Direct(const SAMPLE_ID sample_id)
 {
@@ -59,6 +62,20 @@ bool Sound_GetActiveSlot(const int32_t slot, SAMPLE_ID *const out_sample_id)
     return true;
 }
 
+TRX_HANDLE Sound_GetActiveSlotHandle(const int32_t slot)
+{
+    return Handle_RegistryMint(&m_Handles, slot);
+}
+
+bool Sound_ResolveActiveSlot(
+    const TRX_HANDLE handle, SAMPLE_ID *const out_sample_id)
+{
+    if (!Handle_RegistryIsLive(&m_Handles, handle)) {
+        return false;
+    }
+    return Sound_GetActiveSlot(handle.id, out_sample_id);
+}
+
 void Sound_StopActiveSlot(const int32_t slot)
 {
     g_FakeSoundCalls.slot_stop_count++;
@@ -99,6 +116,7 @@ int32_t Sound_Effect_Direct(
         if (!m_Slots[slot].active) {
             m_Slots[slot] =
                 (FAKE_SLOT) { .active = true, .sample_id = sfx_num };
+            Handle_RegistryBump(&m_Handles, slot);
             return slot;
         }
     }
@@ -122,6 +140,11 @@ void FakeSound_Reset(void)
     for (int32_t i = 0; i < FAKE_SOUND_SLOT_COUNT; i++) {
         m_Slots[i] = (FAKE_SLOT) {};
     }
+    // The generations persist across the reset, as the engine's do, so a handle
+    // from before it cannot match a slot that a later play reuses.
+    if (m_Handles.gens == nullptr) {
+        Handle_RegistryInit(&m_Handles, m_SlotGens, FAKE_SOUND_SLOT_COUNT);
+    }
 }
 
 void FakeSound_SetStream(const int32_t slot, const int32_t sample_id)
@@ -130,4 +153,5 @@ void FakeSound_SetStream(const int32_t slot, const int32_t sample_id)
         return;
     }
     m_Slots[slot] = (FAKE_SLOT) { .active = true, .sample_id = sample_id };
+    Handle_RegistryBump(&m_Handles, slot);
 }

--- a/src/tests/unit/lua/sound.lua
+++ b/src/tests/unit/lua/sound.lua
@@ -73,6 +73,31 @@ test("streams reaches the playing voices and controls them", function()
   assert(calls.slot_stop_count == 1 and calls.slot_stop_slot == 1)
 end)
 
+-- A finished voice frees its slot, and the next play reuses it. The generation
+-- carried by the handle is what keeps the first voice's handle from addressing
+-- the second.
+test(
+  "a reused voice slot does not answer the previous voice's handle",
+  function()
+    local sample = trx.sound.samples[fake.SAMPLE]
+    local old = sample:play()
+    assert(old:is_valid(), "the voice is playing")
+
+    old:stop()
+    assert(not old:is_valid(), "the stopped voice is gone")
+
+    local new = sample:play()
+    assert(new:is_valid() and new ~= old, "the reused slot is a new voice")
+
+    -- Acting on the stale handle raises rather than reaching the voice that now
+    -- holds its slot.
+    raises(function()
+      old:stop()
+    end, "stale")
+    assert(new:is_valid(), "the new voice must be untouched")
+  end
+)
+
 test("a silent voice is stale, and reading it raises", function()
   local voice = trx.sound.streams[1]
   assert(not voice:is_valid(), "nothing plays on the first slot")

--- a/src/tests/unit/test_handle.c
+++ b/src/tests/unit/test_handle.c
@@ -1,0 +1,81 @@
+#include "harness.h"
+
+#include <trx/core/handle.h>
+
+TEST(equal_handles_agree_on_id_and_generation)
+{
+    CHECK(Handle_Equal((TRX_HANDLE) { 3, 7 }, (TRX_HANDLE) { 3, 7 }));
+    CHECK(!Handle_Equal((TRX_HANDLE) { 3, 7 }, (TRX_HANDLE) { 3, 8 }));
+    CHECK(!Handle_Equal((TRX_HANDLE) { 3, 7 }, (TRX_HANDLE) { 4, 7 }));
+}
+
+TEST(an_epoch_retires_every_handle_at_once)
+{
+    HANDLE_EPOCH epoch = {};
+    const TRX_HANDLE a = Handle_EpochMint(&epoch, 0);
+    const TRX_HANDLE b = Handle_EpochMint(&epoch, 5);
+    CHECK(Handle_EpochIsLive(&epoch, a));
+    CHECK(Handle_EpochIsLive(&epoch, b));
+
+    Handle_EpochBump(&epoch);
+    CHECK(!Handle_EpochIsLive(&epoch, a));
+    CHECK(!Handle_EpochIsLive(&epoch, b));
+
+    // A handle minted in the new epoch is live, regardless of its id.
+    CHECK(Handle_EpochIsLive(&epoch, Handle_EpochMint(&epoch, 0)));
+}
+
+TEST(a_registry_retires_one_slot_without_touching_others)
+{
+    uint32_t gens[4] = {};
+    HANDLE_REGISTRY reg;
+    Handle_RegistryInit(&reg, gens, 4);
+
+    const TRX_HANDLE a = Handle_RegistryMint(&reg, 1);
+    const TRX_HANDLE b = Handle_RegistryMint(&reg, 2);
+
+    Handle_RegistryBump(&reg, 1);
+    CHECK(!Handle_RegistryIsLive(&reg, a));
+    CHECK(Handle_RegistryIsLive(&reg, b));
+
+    // The slot's new occupant has a handle of its own that resolves.
+    CHECK(Handle_RegistryIsLive(&reg, Handle_RegistryMint(&reg, 1)));
+}
+
+TEST(a_recycled_slot_never_matches_its_previous_occupant)
+{
+    uint32_t gens[4] = {};
+    HANDLE_REGISTRY reg;
+    Handle_RegistryInit(&reg, gens, 4);
+
+    const TRX_HANDLE old = Handle_RegistryMint(&reg, 2);
+    Handle_RegistryBump(&reg, 2);
+    const TRX_HANDLE fresh = Handle_RegistryMint(&reg, 2);
+
+    CHECK(old.id == fresh.id);
+    CHECK(!Handle_Equal(old, fresh));
+}
+
+TEST(bump_all_retires_the_whole_pool)
+{
+    uint32_t gens[4] = {};
+    HANDLE_REGISTRY reg;
+    Handle_RegistryInit(&reg, gens, 4);
+
+    const TRX_HANDLE handles[] = {
+        Handle_RegistryMint(&reg, 0),
+        Handle_RegistryMint(&reg, 3),
+    };
+    Handle_RegistryBumpAll(&reg);
+    CHECK(!Handle_RegistryIsLive(&reg, handles[0]));
+    CHECK(!Handle_RegistryIsLive(&reg, handles[1]));
+}
+
+TEST(an_out_of_range_handle_is_never_live)
+{
+    uint32_t gens[2] = {};
+    HANDLE_REGISTRY reg;
+    Handle_RegistryInit(&reg, gens, 2);
+    CHECK(!Handle_RegistryIsLive(&reg, (TRX_HANDLE) { -1, 0 }));
+    CHECK(!Handle_RegistryIsLive(&reg, (TRX_HANDLE) { 2, 0 }));
+}

--- a/src/tests/unit/test_lua_struct.c
+++ b/src/tests/unit/test_lua_struct.c
@@ -38,13 +38,14 @@ static bool m_Dead[M_POOL_SIZE];
 
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    if (ref->idx < 0 || ref->idx >= M_POOL_SIZE || m_Dead[ref->idx]) {
+    const int32_t idx = ref->handle.id;
+    if (idx < 0 || idx >= M_POOL_SIZE || m_Dead[idx]) {
         return nullptr;
     }
-    if (m_Gen[ref->idx] != ref->gen) {
+    if (m_Gen[idx] != ref->handle.gen) {
         return nullptr;
     }
-    return &m_Pool[ref->idx];
+    return &m_Pool[idx];
 }
 
 static int M_L_Reveal(lua_State *const L)
@@ -71,7 +72,9 @@ static const luaL_Reg m_Methods[] = {
 static int M_L_GetWidget(lua_State *const L)
 {
     const int32_t idx = luaL_checkinteger(L, 1);
-    LUA_Struct_Push(L, &TYPE_WIDGET, M_Resolve, idx, m_Gen[idx]);
+    LUA_Struct_Push(
+        L, &TYPE_WIDGET, M_Resolve,
+        (TRX_HANDLE) { .id = idx, .gen = m_Gen[idx] });
     return 1;
 }
 

--- a/src/trx/core/handle.c
+++ b/src/trx/core/handle.c
@@ -1,0 +1,60 @@
+#include <trx/core/handle.h>
+
+bool Handle_Equal(const TRX_HANDLE a, const TRX_HANDLE b)
+{
+    return a.id == b.id && a.gen == b.gen;
+}
+
+void Handle_EpochBump(HANDLE_EPOCH *const epoch)
+{
+    epoch->current++;
+}
+
+TRX_HANDLE Handle_EpochMint(const HANDLE_EPOCH *const epoch, const int32_t id)
+{
+    return (TRX_HANDLE) { .id = id, .gen = epoch->current };
+}
+
+bool Handle_EpochIsLive(
+    const HANDLE_EPOCH *const epoch, const TRX_HANDLE handle)
+{
+    return handle.gen == epoch->current;
+}
+
+void Handle_RegistryInit(
+    HANDLE_REGISTRY *const registry, uint32_t *const gens,
+    const int32_t capacity)
+{
+    registry->gens = gens;
+    registry->capacity = capacity;
+    registry->next = 0;
+}
+
+uint32_t Handle_RegistryBump(HANDLE_REGISTRY *const registry, const int32_t id)
+{
+    // A fresh generation off the shared counter, so no two live handles in the
+    // pool carry the same one even when their slots differ.
+    return registry->gens[id] = ++registry->next;
+}
+
+void Handle_RegistryBumpAll(HANDLE_REGISTRY *const registry)
+{
+    for (int32_t i = 0; i < registry->capacity; i++) {
+        registry->gens[i] = ++registry->next;
+    }
+}
+
+TRX_HANDLE Handle_RegistryMint(
+    const HANDLE_REGISTRY *const registry, const int32_t id)
+{
+    return (TRX_HANDLE) { .id = id, .gen = registry->gens[id] };
+}
+
+bool Handle_RegistryIsLive(
+    const HANDLE_REGISTRY *const registry, const TRX_HANDLE handle)
+{
+    if (handle.id < 0 || handle.id >= registry->capacity) {
+        return false;
+    }
+    return registry->gens[handle.id] == handle.gen;
+}

--- a/src/trx/core/handle.h
+++ b/src/trx/core/handle.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdint.h>
+
+// A weak reference to a game entity, of the kind a script holds across time. It
+// pairs the entity's id - a pool slot, a room number, whatever the owning
+// module keys on - with a generation that says which occupant of that id is
+// meant. The value is self-contained: copied, compared and dropped freely, with
+// nothing to free. Resolving it back to a live pointer stays with the module
+// that owns the entity; core settles only identity and staleness.
+typedef struct {
+    int32_t id;
+    uint32_t gen;
+} TRX_HANDLE;
+
+// Two handles name the same occupant when both the id and the generation agree.
+bool Handle_Equal(TRX_HANDLE a, TRX_HANDLE b);
+
+// A whole-domain epoch, for entities that are all replaced at once and never
+// retired one at a time - rooms, whose table is swapped at each level load. A
+// single bump retires every handle the domain has handed out.
+typedef struct {
+    uint32_t current;
+} HANDLE_EPOCH;
+
+void Handle_EpochBump(HANDLE_EPOCH *epoch);
+TRX_HANDLE Handle_EpochMint(const HANDLE_EPOCH *epoch, int32_t id);
+bool Handle_EpochIsLive(const HANDLE_EPOCH *epoch, TRX_HANDLE handle);
+
+// A per-id generation table, for a bounded pool whose slots are recycled one at
+// a time - the item pool, where a freed slot is handed to the next item.
+// Bumping a slot retires only the handles that named its previous occupant. The
+// generation storage is the caller's, so it can sit wherever the pool already
+// keeps its per-slot state and outlast a level.
+typedef struct {
+    uint32_t *gens;
+    int32_t capacity;
+    uint32_t next;
+} HANDLE_REGISTRY;
+
+// Binds the table to `capacity` slots of caller-owned, zero-initialised
+// storage.
+void Handle_RegistryInit(
+    HANDLE_REGISTRY *registry, uint32_t *gens, int32_t capacity);
+// Retires the slot's outstanding handles and returns its fresh generation.
+uint32_t Handle_RegistryBump(HANDLE_REGISTRY *registry, int32_t id);
+// Retires every slot at once, as when the pool is rebuilt for a new level.
+void Handle_RegistryBumpAll(HANDLE_REGISTRY *registry);
+// A handle for the slot's current occupant.
+TRX_HANDLE Handle_RegistryMint(const HANDLE_REGISTRY *registry, int32_t id);
+// Whether the handle still names the slot's current occupant.
+bool Handle_RegistryIsLive(const HANDLE_REGISTRY *registry, TRX_HANDLE handle);

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -1,5 +1,6 @@
 #include <trx/game/items/manager.h>
 
+#include <trx/core/handle.h>
 #include <trx/core/memory.h>
 #include <trx/core/utils.h>
 #include <trx/game/game.h>
@@ -22,7 +23,10 @@ static int16_t m_MaxUsedItemCount = 0;
 static ITEM *m_Items = nullptr;
 static int16_t m_NextItemActive = NO_ITEM;
 static int16_t m_NextItemFree = NO_ITEM;
-static uint32_t m_ItemGen = 0;
+// One generation per slot, kept apart from the pooled ITEM storage so it
+// outlives a level and a handle held across the change goes stale.
+static uint32_t m_ItemGens[MAX_ITEMS];
+static HANDLE_REGISTRY m_ItemHandles;
 
 static inline bool M_ItemBoundsIntersectsPortal(
     const ITEM *item, const ROOM *room, const PORTAL *const portal)
@@ -67,10 +71,14 @@ void Item_InitialiseItems(const int32_t num_items)
 
     for (int32_t i = 0; i < MAX_ITEMS; i++) {
         m_Items[i].properties = (ITEM_PROPERTY_SET) {};
-        // A handle retained across a level change must not rebind to whatever
-        // now occupies the same slot index, so every slot gets a fresh gen.
-        m_Items[i].gen = ++m_ItemGen;
     }
+
+    // A handle retained across a level change must not rebind to whatever now
+    // occupies the same slot index, so the whole pool is retired at once.
+    if (m_ItemHandles.gens == nullptr) {
+        Handle_RegistryInit(&m_ItemHandles, m_ItemGens, MAX_ITEMS);
+    }
+    Handle_RegistryBumpAll(&m_ItemHandles);
 
     for (int32_t i = m_NextItemFree; i < MAX_ITEMS - 1; i++) {
         ITEM *const item = &m_Items[i];
@@ -104,6 +112,20 @@ ITEM *Item_Get(const int16_t item_num)
 int16_t Item_GetIndex(const ITEM *const item)
 {
     return item - Item_Get(0);
+}
+
+TRX_HANDLE Item_GetHandle(const int16_t item_num)
+{
+    return Handle_RegistryMint(&m_ItemHandles, item_num);
+}
+
+ITEM *Item_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_RegistryIsLive(&m_ItemHandles, handle)
+        || handle.id >= m_MaxUsedItemCount) {
+        return nullptr;
+    }
+    return Item_Get((int16_t)handle.id);
 }
 
 ITEM *Item_Find(const OBJECT_ID obj_id)
@@ -176,7 +198,7 @@ int16_t Item_Create(void)
         m_Items[item_num].flags = 0;
         // A recycled slot must not inherit the previous occupant's name.
         m_Items[item_num].name = nullptr;
-        m_Items[item_num].gen = ++m_ItemGen;
+        Handle_RegistryBump(&m_ItemHandles, item_num);
         ObjectProperty_ResetItem(&m_Items[item_num]);
         m_NextItemFree = m_Items[item_num].next_item;
     }
@@ -338,7 +360,7 @@ void Item_Kill(const int16_t item_num)
     item->flags |= IF_KILLED;
     // Invalidate any script handle to this item, whether or not the slot is
     // recycled below.
-    item->gen = ++m_ItemGen;
+    Handle_RegistryBump(&m_ItemHandles, item_num);
 
     if (item_num >= m_LevelItemCount) {
         item->next_item = m_NextItemFree;

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/handle.h>
 #include <trx/game/anims.h>
 #include <trx/game/items/types.h>
 
@@ -7,6 +8,13 @@ void Item_Reset(void);
 void Item_InitialiseItems(int32_t num_items);
 ITEM *Item_Get(int16_t num);
 int16_t Item_GetIndex(const ITEM *item);
+
+// A handle to the item currently in the slot, and the item a handle still names
+// or nullptr once its slot has been recycled or the level replaced. Scripts
+// hold these across time; the generation is what tells one occupant from the
+// next.
+TRX_HANDLE Item_GetHandle(int16_t item_num);
+ITEM *Item_FromHandle(TRX_HANDLE handle);
 ITEM *Item_Find(OBJECT_ID obj_id);
 
 int32_t Item_GetLevelCount(void);

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -44,11 +44,6 @@ typedef struct ITEM {
     uint16_t flags;
     uint8_t ai_bits;
     int16_t ai_tag;
-    // Bumped on create, on kill, and stamped afresh on every level load.
-    // Scripts hold {index, gen} handles; a mismatch means the slot was recycled
-    // (or the level was reloaded) and the handle is stale. 32-bit so a
-    // high-churn slot cannot wrap back onto a live handle's value.
-    uint32_t gen;
     ITEM_PROPERTY_SET properties;
 
     SHADE shade;

--- a/src/trx/game/lua/capi/game.c
+++ b/src/trx/game/lua/capi/game.c
@@ -84,7 +84,7 @@ static const GF_LEVEL *M_GetLevel(
 
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    return (void *)M_GetLevel(M_TABLE(ref->idx), M_NUM(ref->idx));
+    return (void *)M_GetLevel(M_TABLE(ref->handle.id), M_NUM(ref->handle.id));
 }
 
 static void M_PushLevel(
@@ -94,7 +94,9 @@ static void M_PushLevel(
         lua_pushnil(L);
         return;
     }
-    LUA_Struct_Push(L, &TYPE_GF_LEVEL, M_Resolve, M_PACK(table_type, num), 0);
+    LUA_Struct_Push(
+        L, &TYPE_GF_LEVEL, M_Resolve,
+        (TRX_HANDLE) { .id = M_PACK(table_type, num) });
 }
 
 // trxc.game.get_version() → int

--- a/src/trx/game/lua/capi/items.c
+++ b/src/trx/game/lua/capi/items.c
@@ -210,29 +210,21 @@ static const FIELD_DESC m_Fields[] = {
     FIELD_RO(ITEM, prev_frame_num),
     FIELD_RO(ITEM, next_item),
     FIELD_RO(ITEM, next_active),
-    FIELD_RO(ITEM, gen),
 };
 // clang-format on
 
 TYPE_DEFINE(ITEM, m_Fields)
 
-// Resolve an item handle. This is where the generation counter earns its keep:
-// an index alone would silently rebind to whatever item recycled the slot.
+// The generation carried by the handle is what keeps an index from silently
+// rebinding to whatever item recycled the slot; Item_FromHandle checks it.
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    if (ref->idx < 0 || ref->idx >= Item_GetTotalCount()) {
-        return nullptr;
-    }
-    ITEM *const item = Item_Get(ref->idx);
-    if (item == nullptr || item->gen != ref->gen) {
-        return nullptr;
-    }
-    return item;
+    return Item_FromHandle(ref->handle);
 }
 
 static void M_PushItem(lua_State *const L, const int16_t idx)
 {
-    LUA_Struct_Push(L, &TYPE_ITEM, M_Resolve, idx, Item_Get(idx)->gen);
+    LUA_Struct_Push(L, &TYPE_ITEM, M_Resolve, Item_GetHandle(idx));
 }
 
 // The object property overlay stays a separate namespace: fields address the
@@ -275,7 +267,7 @@ static int M_L_ItemsKill(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
-    Item_Kill(ref->idx);
+    Item_Kill(ref->handle.id);
     return 0;
 }
 
@@ -284,14 +276,14 @@ static int M_L_ItemsActivate(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     ITEM *const item = LUA_Struct_Deref(L, ref);
-    Item_AddActive(ref->idx);
+    Item_AddActive(ref->handle.id);
     item->status = IS_ACTIVE;
     // A creature stays inert without its AI, the way spawn's activate option
     // brings one to life.
     const OBJECT *const obj = Object_Get(item->object_id);
     if (Object_IsType(item->object_id, g_CreatureObjects)
         || Object_IsType(item->object_id, g_LoyalObjects) || obj->intelligent) {
-        LOT_EnableBaddieAI(ref->idx, true);
+        LOT_EnableBaddieAI(ref->handle.id, true);
     }
     return 0;
 }
@@ -396,7 +388,7 @@ static int M_L_ItemsDie(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
-    Creature_Die(ref->idx, lua_toboolean(L, 2));
+    Creature_Die(ref->handle.id, lua_toboolean(L, 2));
     return 0;
 }
 
@@ -405,7 +397,7 @@ static int M_L_ItemsShatter(lua_State *const L)
 {
     LUA_STRUCT_REF *const ref = LUA_Struct_CheckRef(L, 1, &TYPE_ITEM);
     LUA_Struct_Deref(L, ref);
-    Item_Shatter(ref->idx, -1, (int16_t)luaL_optinteger(L, 2, 0));
+    Item_Shatter(ref->handle.id, -1, (int16_t)luaL_optinteger(L, 2, 0));
     return 0;
 }
 

--- a/src/trx/game/lua/capi/lara.c
+++ b/src/trx/game/lua/capi/lara.c
@@ -95,7 +95,7 @@ static LARA_SKIN_EXTRA_MESH M_CheckExtraMesh(lua_State *const L, const int arg)
 // trxc.lara.state() -> LARA_INFO handle
 static int M_L_LaraState(lua_State *const L)
 {
-    LUA_Struct_Push(L, &TYPE_LARA_INFO, M_Resolve, 0, 0);
+    LUA_Struct_Push(L, &TYPE_LARA_INFO, M_Resolve, (TRX_HANDLE) { .id = 0 });
     return 1;
 }
 

--- a/src/trx/game/lua/capi/music.c
+++ b/src/trx/game/lua/capi/music.c
@@ -31,7 +31,7 @@ TYPE_DEFINE(MUSIC_STREAM_VIEW, m_StreamFields)
 
 static void *M_ResolveStream(const LUA_STRUCT_REF *const ref)
 {
-    const int32_t slot = ref->idx;
+    const int32_t slot = ref->handle.id;
     if (slot < 0 || slot >= Music_GetStreamSlotCount()) {
         return nullptr;
     }
@@ -55,7 +55,9 @@ static void M_PushPlayedStream(lua_State *const L, const int32_t slot)
     if (slot < 0) {
         lua_pushnil(L);
     } else {
-        LUA_Struct_Push(L, &TYPE_MUSIC_STREAM_VIEW, M_ResolveStream, slot, 0);
+        LUA_Struct_Push(
+            L, &TYPE_MUSIC_STREAM_VIEW, M_ResolveStream,
+            (TRX_HANDLE) { .id = slot });
     }
 }
 
@@ -65,7 +67,7 @@ static int M_L_MusicStreamStop(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Music_StopStream(ref->idx);
+    Music_StopStream(ref->handle.id);
     return 0;
 }
 
@@ -75,7 +77,7 @@ static int M_L_MusicStreamPause(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Music_PauseStream(ref->idx);
+    Music_PauseStream(ref->handle.id);
     return 0;
 }
 
@@ -85,7 +87,7 @@ static int M_L_MusicStreamUnpause(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Music_UnpauseStream(ref->idx);
+    Music_UnpauseStream(ref->handle.id);
     return 0;
 }
 
@@ -96,7 +98,7 @@ static int M_L_MusicStreamSeek(lua_State *const L)
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
     const double timestamp = luaL_checknumber(L, 2);
-    lua_pushboolean(L, Music_SeekStream(ref->idx, timestamp));
+    lua_pushboolean(L, Music_SeekStream(ref->handle.id, timestamp));
     return 1;
 }
 
@@ -123,7 +125,9 @@ static int M_L_MusicStreamGet(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    LUA_Struct_Push(L, &TYPE_MUSIC_STREAM_VIEW, M_ResolveStream, slot, 0);
+    LUA_Struct_Push(
+        L, &TYPE_MUSIC_STREAM_VIEW, M_ResolveStream,
+        (TRX_HANDLE) { .id = slot });
     return 1;
 }
 
@@ -169,7 +173,7 @@ TYPE_DEFINE(MUSIC_TRACK_VIEW, m_TrackFields)
 
 static void *M_ResolveTrack(const LUA_STRUCT_REF *const ref)
 {
-    const int32_t id = ref->idx;
+    const int32_t id = ref->handle.id;
     if (id < 0 || !Music_IsTrackAvailable_Direct((MUSIC_ID)id)) {
         return nullptr;
     }
@@ -192,7 +196,7 @@ static int M_L_MusicTrackPlay(lua_State *const L)
         }
         lua_pop(L, 1);
     }
-    M_PushPlayedStream(L, Music_Play_Direct((MUSIC_ID)ref->idx, mode));
+    M_PushPlayedStream(L, Music_Play_Direct((MUSIC_ID)ref->handle.id, mode));
     return 1;
 }
 
@@ -202,7 +206,7 @@ static int M_L_MusicTrackPath(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_MUSIC_TRACK_VIEW);
     LUA_Struct_Deref(L, ref);
-    char *path = Music_GetTrackPath((MUSIC_ID)ref->idx);
+    char *path = Music_GetTrackPath((MUSIC_ID)ref->handle.id);
     if (path == nullptr) {
         lua_pushnil(L);
     } else {
@@ -226,7 +230,8 @@ static int M_L_MusicTrackGet(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    LUA_Struct_Push(L, &TYPE_MUSIC_TRACK_VIEW, M_ResolveTrack, id, 0);
+    LUA_Struct_Push(
+        L, &TYPE_MUSIC_TRACK_VIEW, M_ResolveTrack, (TRX_HANDLE) { .id = id });
     return 1;
 }
 

--- a/src/trx/game/lua/capi/objects.c
+++ b/src/trx/game/lua/capi/objects.c
@@ -35,7 +35,7 @@ TYPE_DEFINE(OBJECT, m_Fields)
 // not load still exists as a definition; `loaded` is how a script tells.
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    return Object_TryGet((OBJECT_ID)ref->idx);
+    return Object_TryGet((OBJECT_ID)ref->handle.id);
 }
 
 // The object property overlay stays a separate namespace: fields address the
@@ -72,7 +72,9 @@ static int M_L_ObjectsGet(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    LUA_Struct_Push(L, &TYPE_OBJECT, M_Resolve, (OBJECT_ID)object_id, 0);
+    LUA_Struct_Push(
+        L, &TYPE_OBJECT, M_Resolve,
+        (TRX_HANDLE) { .id = (OBJECT_ID)object_id });
     return 1;
 }
 

--- a/src/trx/game/lua/capi/rooms.c
+++ b/src/trx/game/lua/capi/rooms.c
@@ -54,20 +54,16 @@ static const FIELD_DESC m_Fields[] = {
 
 TYPE_DEFINE(ROOM, m_Fields)
 
-// A room is never recycled within a level, but the table is replaced whole at
-// the next one. A bounds check alone would let a handle held across the change
-// resolve to a different room; the generation is what makes it go stale.
+// A bounds check alone would let a handle held across a level change resolve to
+// a different room; Room_FromHandle checks the epoch that makes it go stale.
 static void *M_Resolve(const LUA_STRUCT_REF *const ref)
 {
-    if (ref->gen != Room_GetGeneration()) {
-        return nullptr;
-    }
-    return Room_Get(ref->idx);
+    return Room_FromHandle(ref->handle);
 }
 
 static void M_PushRoom(lua_State *const L, const int32_t idx)
 {
-    LUA_Struct_Push(L, &TYPE_ROOM, M_Resolve, idx, Room_GetGeneration());
+    LUA_Struct_Push(L, &TYPE_ROOM, M_Resolve, Room_GetHandle(idx));
 }
 
 // trxc.rooms.count() -> int

--- a/src/trx/game/lua/capi/sound.c
+++ b/src/trx/game/lua/capi/sound.c
@@ -48,7 +48,7 @@ TYPE_DEFINE(SOUND_STREAM_VIEW, m_StreamFields)
 
 static void *M_ResolveSample(const LUA_STRUCT_REF *const ref)
 {
-    const int32_t id = ref->idx;
+    const int32_t id = ref->handle.id;
     if (id < 0 || !Sound_IsAvailable_Direct((SAMPLE_ID)id)) {
         return nullptr;
     }
@@ -69,7 +69,7 @@ static void *M_ResolveSample(const LUA_STRUCT_REF *const ref)
 static void *M_ResolveStream(const LUA_STRUCT_REF *const ref)
 {
     SAMPLE_ID sample_id;
-    if (!Sound_GetActiveSlot(ref->idx, &sample_id)) {
+    if (!Sound_GetActiveSlot(ref->handle.id, &sample_id)) {
         return nullptr;
     }
     m_StreamView.sample_id = sample_id;
@@ -83,7 +83,9 @@ static void M_PushPlayedStream(lua_State *const L, const int32_t slot)
     if (slot < 0) {
         lua_pushnil(L);
     } else {
-        LUA_Struct_Push(L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream, slot, 0);
+        LUA_Struct_Push(
+            L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream,
+            (TRX_HANDLE) { .id = slot });
     }
 }
 
@@ -112,7 +114,7 @@ static int M_L_SoundSamplePlay(lua_State *const L)
     M_PushPlayedStream(
         L,
         Sound_Effect_Direct(
-            (SAMPLE_ID)ref->idx, pos_ptr, SPM_ALWAYS | SPM_STATIC_POS));
+            (SAMPLE_ID)ref->handle.id, pos_ptr, SPM_ALWAYS | SPM_STATIC_POS));
     return 1;
 }
 
@@ -122,7 +124,7 @@ static int M_L_SoundSampleStop(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_SOUND_SAMPLE_VIEW);
     LUA_Struct_Deref(L, ref);
-    Sound_StopEffect_Direct((SAMPLE_ID)ref->idx);
+    Sound_StopEffect_Direct((SAMPLE_ID)ref->handle.id);
     return 0;
 }
 
@@ -138,7 +140,7 @@ static int M_L_SoundStreamStop(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_SOUND_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Sound_StopActiveSlot(ref->idx);
+    Sound_StopActiveSlot(ref->handle.id);
     return 0;
 }
 
@@ -148,7 +150,7 @@ static int M_L_SoundStreamPause(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_SOUND_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Sound_PauseActiveSlot(ref->idx);
+    Sound_PauseActiveSlot(ref->handle.id);
     return 0;
 }
 
@@ -158,7 +160,7 @@ static int M_L_SoundStreamUnpause(lua_State *const L)
     LUA_STRUCT_REF *const ref =
         LUA_Struct_CheckRef(L, 1, &TYPE_SOUND_STREAM_VIEW);
     LUA_Struct_Deref(L, ref);
-    Sound_UnpauseActiveSlot(ref->idx);
+    Sound_UnpauseActiveSlot(ref->handle.id);
     return 0;
 }
 
@@ -177,7 +179,8 @@ static int M_L_SoundSampleGet(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    LUA_Struct_Push(L, &TYPE_SOUND_SAMPLE_VIEW, M_ResolveSample, id, 0);
+    LUA_Struct_Push(
+        L, &TYPE_SOUND_SAMPLE_VIEW, M_ResolveSample, (TRX_HANDLE) { .id = id });
     return 1;
 }
 
@@ -217,7 +220,9 @@ static int M_L_SoundStreamGet(lua_State *const L)
         lua_pushnil(L);
         return 1;
     }
-    LUA_Struct_Push(L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream, slot, 0);
+    LUA_Struct_Push(
+        L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream,
+        (TRX_HANDLE) { .id = slot });
     return 1;
 }
 

--- a/src/trx/game/lua/capi/sound.c
+++ b/src/trx/game/lua/capi/sound.c
@@ -69,7 +69,7 @@ static void *M_ResolveSample(const LUA_STRUCT_REF *const ref)
 static void *M_ResolveStream(const LUA_STRUCT_REF *const ref)
 {
     SAMPLE_ID sample_id;
-    if (!Sound_GetActiveSlot(ref->handle.id, &sample_id)) {
+    if (!Sound_ResolveActiveSlot(ref->handle, &sample_id)) {
         return nullptr;
     }
     m_StreamView.sample_id = sample_id;
@@ -85,7 +85,7 @@ static void M_PushPlayedStream(lua_State *const L, const int32_t slot)
     } else {
         LUA_Struct_Push(
             L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream,
-            (TRX_HANDLE) { .id = slot });
+            Sound_GetActiveSlotHandle(slot));
     }
 }
 
@@ -222,7 +222,7 @@ static int M_L_SoundStreamGet(lua_State *const L)
     }
     LUA_Struct_Push(
         L, &TYPE_SOUND_STREAM_VIEW, M_ResolveStream,
-        (TRX_HANDLE) { .id = slot });
+        Sound_GetActiveSlotHandle(slot));
     return 1;
 }
 

--- a/src/trx/game/lua/capi/struct.c
+++ b/src/trx/game/lua/capi/struct.c
@@ -188,7 +188,7 @@ static int M_PairsIter(lua_State *const L)
 
 // LUA_Struct_Push mints a fresh userdata every time, so two handles to the same
 // thing are never the same value. Compare what they point at instead: the type,
-// the slot, and the generation that says which occupant of the slot is meant.
+// and the handle that names the entity and its occupant.
 static int M_Eq(lua_State *const L)
 {
     // Lua takes __eq from the first operand, or from the second when the first
@@ -198,8 +198,7 @@ static int M_Eq(lua_State *const L)
     const LUA_STRUCT_REF *const a = luaL_testudata(L, 1, type->name);
     const LUA_STRUCT_REF *const b = luaL_testudata(L, 2, type->name);
     lua_pushboolean(
-        L,
-        a != nullptr && b != nullptr && a->idx == b->idx && a->gen == b->gen);
+        L, a != nullptr && b != nullptr && Handle_Equal(a->handle, b->handle));
     return 1;
 }
 
@@ -425,15 +424,13 @@ void LUA_Struct_Register(
 
 void LUA_Struct_Push(
     lua_State *const L, const TYPE_DESC *const type,
-    void *(*const resolve)(const LUA_STRUCT_REF *), const int32_t idx,
-    const uint32_t gen)
+    void *(*const resolve)(const LUA_STRUCT_REF *), const TRX_HANDLE handle)
 {
     LUA_STRUCT_REF *const ref = lua_newuserdatauv(L, sizeof(LUA_STRUCT_REF), 0);
     *ref = (LUA_STRUCT_REF) {
         .type = type,
         .resolve = resolve,
-        .idx = idx,
-        .gen = gen,
+        .handle = handle,
     };
     luaL_setmetatable(L, type->name);
 }

--- a/src/trx/game/lua/struct.h
+++ b/src/trx/game/lua/struct.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/handle.h>
 #include <trx/game/lua/field.h>
 #include <trx/game/objects.h>
 
@@ -20,8 +21,9 @@ typedef struct LUA_STRUCT_REF {
     // Resolves the handle to a live pointer, or nullptr if it went stale (the
     // slot was recycled, the level was unloaded, the index went out of range).
     void *(*resolve)(const struct LUA_STRUCT_REF *ref);
-    int32_t idx;
-    uint32_t gen;
+    // Identity: the entity id and the generation that pins its occupant. What
+    // id means, and how staleness is decided, is the owning module's business.
+    TRX_HANDLE handle;
 } LUA_STRUCT_REF;
 
 // Creates the type's metatable. `methods` is the full set of C methods the type
@@ -33,7 +35,7 @@ void LUA_Struct_Register(
 // Push a handle userdata for an instance of a registered type.
 void LUA_Struct_Push(
     lua_State *L, const TYPE_DESC *type,
-    void *(*resolve)(const LUA_STRUCT_REF *), int32_t idx, uint32_t gen);
+    void *(*resolve)(const LUA_STRUCT_REF *), TRX_HANDLE handle);
 
 // Fetch and typecheck a handle at the given stack index.
 LUA_STRUCT_REF *LUA_Struct_CheckRef(

--- a/src/trx/game/rooms/common.c
+++ b/src/trx/game/rooms/common.c
@@ -18,7 +18,7 @@
 
 static int32_t m_RoomCount = 0;
 static ROOM *m_Rooms = nullptr;
-static uint32_t m_RoomGen = 0;
+static HANDLE_EPOCH m_RoomEpoch;
 static bool m_FlipStatus = false;
 static int32_t m_FlipEffect = -1;
 static int32_t m_FlipTimer = 0;
@@ -86,7 +86,7 @@ static void M_GetNewRoom(
 void Room_InitialiseRooms(const int32_t num_rooms)
 {
     m_RoomCount = num_rooms;
-    m_RoomGen++;
+    Handle_EpochBump(&m_RoomEpoch);
     m_Rooms = num_rooms == 0
         ? nullptr
         : GameBuf_Alloc(sizeof(ROOM) * num_rooms, GBUF_ROOMS);
@@ -121,9 +121,17 @@ int32_t Room_GetCount(void)
     return m_RoomCount;
 }
 
-uint32_t Room_GetGeneration(void)
+TRX_HANDLE Room_GetHandle(const int32_t room_num)
 {
-    return m_RoomGen;
+    return Handle_EpochMint(&m_RoomEpoch, room_num);
+}
+
+ROOM *Room_FromHandle(const TRX_HANDLE handle)
+{
+    if (!Handle_EpochIsLive(&m_RoomEpoch, handle)) {
+        return nullptr;
+    }
+    return Room_Get(handle.id);
 }
 
 ROOM *Room_Get(const int32_t room_num)

--- a/src/trx/game/rooms/common.h
+++ b/src/trx/game/rooms/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/handle.h>
 #include <trx/core/math/types.h>
 #include <trx/game/rooms/types.h>
 
@@ -8,10 +9,12 @@ void Room_Shutdown(void);
 int32_t Room_GetCount(void);
 ROOM *Room_Get(int32_t room_num);
 
-// Which level's rooms these are. A room is never recycled within a level, but
-// the table is replaced whole at the next one, so a reference kept across the
-// change names a different room. Bumped by Room_InitialiseRooms.
-uint32_t Room_GetGeneration(void);
+// A handle to the given room, and the room a handle still names or nullptr. A
+// room is never recycled within a level, but the table is replaced whole at the
+// next one; Room_InitialiseRooms starts a new epoch, so a handle kept across
+// the change goes stale rather than naming a different room.
+TRX_HANDLE Room_GetHandle(int32_t room_num);
+ROOM *Room_FromHandle(TRX_HANDLE handle);
 int32_t Room_GetNumber(const ROOM *room);
 
 void Room_InitialiseFlipStatus(void);

--- a/src/trx/game/sound/common.c
+++ b/src/trx/game/sound/common.c
@@ -56,6 +56,10 @@ typedef struct M_SAMPLE_ENTRY {
 } M_SAMPLE_ENTRY;
 
 static M_ACTIVE_SOUND m_ActiveSounds[M_MAX_ACTIVE_SOUNDS] = {};
+// One generation per slot, bumped when a slot is handed to a new voice, so a
+// script handle to a finished voice does not address whatever replaced it.
+static uint32_t m_SlotGens[M_MAX_ACTIVE_SOUNDS];
+static HANDLE_REGISTRY m_SlotHandles;
 static bool m_Initialised = false;
 static float m_MasterVolume = 0.0f;
 static M_SAMPLE_DATA_ENTRY *m_SampleDataMap = nullptr;
@@ -309,6 +313,9 @@ bool Sound_Init(void)
     }
 
     m_Initialised = true;
+    if (m_SlotHandles.gens == nullptr) {
+        Handle_RegistryInit(&m_SlotHandles, m_SlotGens, M_MAX_ACTIVE_SOUNDS);
+    }
     M_ClearAllActiveSounds();
     return true;
 }
@@ -599,7 +606,12 @@ int32_t Sound_Effect_Direct(
         sound->pos_ptr = nullptr;
     }
     M_ClearActiveSoundHandles(sound);
-    return (int32_t)(sound - m_ActiveSounds);
+    // The slot now holds a new voice, so a handle to whatever was here before
+    // must stop resolving. The WAIT and LOOPED early returns above keep an
+    // existing voice, and its handle, alive.
+    const int32_t slot = (int32_t)(sound - m_ActiveSounds);
+    Handle_RegistryBump(&m_SlotHandles, slot);
+    return slot;
 }
 
 int32_t Sound_Effect(
@@ -711,6 +723,20 @@ bool Sound_GetActiveSlot(const int32_t slot, SAMPLE_ID *const out_sample_id)
         *out_sample_id = sound->sample_id;
     }
     return true;
+}
+
+TRX_HANDLE Sound_GetActiveSlotHandle(const int32_t slot)
+{
+    return Handle_RegistryMint(&m_SlotHandles, slot);
+}
+
+bool Sound_ResolveActiveSlot(
+    const TRX_HANDLE handle, SAMPLE_ID *const out_sample_id)
+{
+    if (!Handle_RegistryIsLive(&m_SlotHandles, handle)) {
+        return false;
+    }
+    return Sound_GetActiveSlot(handle.id, out_sample_id);
 }
 
 void Sound_StopActiveSlot(const int32_t slot)

--- a/src/trx/game/sound/common.h
+++ b/src/trx/game/sound/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trx/core/handle.h>
 #include <trx/core/math.h>
 #include <trx/game/sound/enum.h>
 #include <trx/game/sound/ids.h>
@@ -70,6 +71,12 @@ int32_t Sound_GetActiveSlotCount(void);
 
 // Fills the sample id the slot is playing. Returns false when the slot is idle.
 bool Sound_GetActiveSlot(int32_t slot, SAMPLE_ID *out_sample_id);
+
+// A handle to the voice currently in the slot, and the sample a handle still
+// names or false. Each play hands the slot to a new voice; the generation is
+// what keeps a handle from addressing whatever later took its slot.
+TRX_HANDLE Sound_GetActiveSlotHandle(int32_t slot);
+bool Sound_ResolveActiveSlot(TRX_HANDLE handle, SAMPLE_ID *out_sample_id);
 
 // Stops, pauses or resumes the voice in a slot.
 void Sound_StopActiveSlot(int32_t slot);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

A handle a script keeps across time must go stale when the entity it names is replaced, rather than rebind to whatever took the slot. Items carried a per-slot generation, rooms a level-wide one, each open-coded, and every new handle type would add another variant of the same bookkeeping.

Add core/handle: a `TRX_HANDLE` – an id and a generation – with two retirement policies behind it. An epoch retires a whole domain at once, as a level load does to rooms; a registry retires one recycled slot at a time, as the item pool needs. Equality is defined once, so every handle compares the same way.

`LUA_STRUCT_REF` now carries a `TRX_HANDLE`, and every bridge that hands one to a script builds a real one. Items move to a registry and drop their generation field; rooms move to an epoch, replacing `Room_GetGeneration`.

This is essentially adding a separate module to capture logic that was already introduced in develop – just making it more prominent and maintainable.