### PR TITLE
objects: guard object lighting against null frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - changed outfits to support up to two braids per outfit; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
+- fixed a crash when drawing an animating object that has no frame data (#5869)
 
 **TR4**
 - added reflections

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -187,7 +187,8 @@ bool Object_DrawAnimatingItemWithSwap(
         return false;
     }
 
-    Output_CalculateObjectLighting(item, &frames[0]->bounds);
+    Output_CalculateObjectLighting(
+        item, frames[0] != nullptr ? &frames[0]->bounds : bounds);
 
     const int16_t *extra_rotation = item->extra_rotations;
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

An animating item whose current animation has no frame data leaves `frames[0]` null, so `&frames[0]->bounds` resolves to a near-null pointer. When the item uses dynamic lighting, `Output_CalculateObjectLighting` dereferences it and crashes. Fall back to the guarded bounds local, as the shadow and clip paths in the same function already do.
