### PR TITLE
lara/skin: define offsets for extra equipment

### DIFF
--- a/data/trx/ship/cfg/outfits.json5
+++ b/data/trx/ship/cfg/outfits.json5
@@ -642,6 +642,18 @@
             "extra_outfits": {
                 "LS_EXTRA_MIDAS_KILL": "tr4_young_golden_lara",
             },
+            "extra_mesh_positions": {
+                "EXTRA_MESH_GLASSES_OPAQUE": {
+                    "x": 0,
+                    "y": -4,
+                    "z": 0,
+                },
+                "EXTRA_MESH_GLASSES_TRANSPARENT": {
+                    "x": 0,
+                    "y": -4,
+                    "z": 0,
+                },
+            },
         },
 
         // TR4 Young Golden Lara
@@ -681,6 +693,18 @@
                     ],
                 },
             ],
+            "extra_mesh_positions": {
+                "EXTRA_MESH_GLASSES_OPAQUE": {
+                    "x": 0,
+                    "y": -4,
+                    "z": 0,
+                },
+                "EXTRA_MESH_GLASSES_TRANSPARENT": {
+                    "x": 0,
+                    "y": -4,
+                    "z": 0,
+                },
+            },
         },
 
         // TR4 Classic
@@ -709,6 +733,18 @@
             "extra_outfits": {
                 "LS_EXTRA_MIDAS_KILL": "tr4_golden_lara",
             },
+            "extra_mesh_positions": {
+                "EXTRA_MESH_GLASSES_OPAQUE": {
+                    "x": 0,
+                    "y": -3,
+                    "z": 0,
+                },
+                "EXTRA_MESH_GLASSES_TRANSPARENT": {
+                    "x": 0,
+                    "y": -3,
+                    "z": 0,
+                },
+            },
         },
 
         // TR4 Golden Lara
@@ -735,6 +771,18 @@
                     ],
                 },
             ],
+            "extra_mesh_positions": {
+                "EXTRA_MESH_GLASSES_OPAQUE": {
+                    "x": 0,
+                    "y": -3,
+                    "z": 0,
+                },
+                "EXTRA_MESH_GLASSES_TRANSPARENT": {
+                    "x": 0,
+                    "y": -3,
+                    "z": 0,
+                },
+            },
         },
     },
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 - added the ability to paste commands in the developer console (with Ctrl+V)
 - added a `/dry` console command, to dry Lara off after a swim
 - changed reflections UV mapping to be more correct
-- changed outfits to support joints and up to two braids per outfit; refer to migration notes
+- changed outfits to support joints, up to two braids per outfit, and to allow positional offset adjustments for equipment meshes; refer to migration notes
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)

--- a/docs/trx/OUTFITS.md
+++ b/docs/trx/OUTFITS.md
@@ -242,6 +242,15 @@ behave. The structure of this file is described below.
     <td><code>LS_EXTRA_MIDAS_KILL</code></td>
     <td>When Lara steps on the Midas hand - progressive outfit swap.</td>
   </tr>
+  <tr valign="top">
+    <td><code>extra_mesh_positions</code></td>
+    <td>XYZ map</td>
+    <td colspan="2">
+      Positional offsets for Lara's extra equipment meshes, allowing adjustments
+      to be made per outfit. Used by default in the TR4 outfits to adjust Lara's
+      sunglasses.
+    </td>
+  </tr>
 </table>
 
 ### Braids
@@ -311,7 +320,7 @@ behave. The structure of this file is described below.
   </tr>
   <tr valign="top">
     <td><code>position</code></td>
-    <td>XYZ array</td>
+    <td>XYZ</td>
     <td colspan="2">
       The position relative to Lara's head where the braid will be drawn.
     </td>

--- a/src/trx/game/lara/draw.c
+++ b/src/trx/game/lara/draw.c
@@ -46,8 +46,10 @@ static void M_CacheMatrix(const LARA_MESH mesh)
 }
 
 static void M_DrawEquipmentMesh(
-    const OBJECT_MESH *const mesh, const CLIP clip, const bool interpolated)
+    const LARA_SKIN_EQUIPMENT *const equipment, const CLIP clip,
+    const bool interpolated)
 {
+    const OBJECT_MESH *const mesh = equipment->mesh;
     const GAME_VECTOR pos = {
         .room_num = Lara_GetItem()->room_num,
         .pos = Matrix_MulVec32_M(
@@ -60,9 +62,15 @@ static void M_DrawEquipmentMesh(
     };
     Output_PushTintOverride(Lara_GetMeshTint(pos));
     if (interpolated) {
+        Matrix_Push_I();
+        Matrix_TranslateRel16_I(equipment->offset);
         Output_DrawObjectMesh_I(mesh, clip);
+        Matrix_Pop_I();
     } else {
+        Matrix_Push();
+        Matrix_TranslateRel16(equipment->offset);
         Output_DrawObjectMesh(mesh, clip);
+        Matrix_Pop();
     }
     Output_PopTintOverride();
 }
@@ -145,7 +153,7 @@ static inline void M_DrawEquipment(
         return;
     }
 
-    M_DrawEquipmentMesh(equipment->mesh, clip, interpolated);
+    M_DrawEquipmentMesh(equipment, clip, interpolated);
 }
 
 static bool M_Draw_I(

--- a/src/trx/game/lara/skin/common.c
+++ b/src/trx/game/lara/skin/common.c
@@ -239,13 +239,17 @@ static void M_SetEquipment(
     case EQUIPMENT_TYPE_WEAPON:
         const OBJECT *const gun_swap_obj = Object_Get(O_LARA_SKIN_SWAP_GUNS);
         equipment->mesh = Object_GetMesh(gun_swap_obj->mesh_idx + offset);
+        equipment->offset = (XYZ_16) {};
         break;
     case EQUIPMENT_TYPE_EXTRA:
         const OBJECT *const extra_obj = Object_Get(O_LARA_SKIN_SWAP_EXTRA);
         equipment->mesh = Object_GetMesh(extra_obj->mesh_idx + offset);
+        const LARA_SKIN_OUTFIT *const outfit = M_GetCurrentOutfit();
+        equipment->offset = outfit->extra_mesh_positions[data];
         break;
     default:
         equipment->mesh = nullptr;
+        equipment->offset = (XYZ_16) {};
         break;
     }
 }

--- a/src/trx/game/lara/skin/storage.c
+++ b/src/trx/game/lara/skin/storage.c
@@ -310,6 +310,30 @@ static bool M_LoadExtras(JSON_READ_IO *const io, LARA_SKIN_OUTFIT *const outfit)
         JSON_MUST(JSON_POP(io));
     }
 
+    if (JSON_OPTIONAL(JSON_PUSH(io, "extra_mesh_positions"))) {
+        JSON_OBJECT *const extra_obj = JSON_ReadIO_GetCurrentObject(io);
+        if (extra_obj == nullptr) {
+            JSON_ReadIO_SetError(
+                io, "'extra_mesh_positions' must be an object");
+            JSON_MUST(JSON_POP(io));
+            JSON_FAIL();
+        }
+
+        for (JSON_OBJECT_ELEMENT *elem = extra_obj->start; elem != nullptr;
+             elem = elem->next) {
+            const char *const name = elem->name->string;
+            const int32_t type = ENUM_MAP_GET(LARA_SKIN_EXTRA_MESH, name, -1);
+            if (type < 0 || type >= NUM_EXTRA_MESHES) {
+                JSON_ReadIO_SetError(io, "unknown extra mesh type '%s'", name);
+                JSON_MUST(JSON_POP(io));
+                JSON_FAIL();
+            }
+
+            JSON_MUST(JSON_READ(io, name, &outfit->extra_mesh_positions[type]));
+        }
+        JSON_MUST(JSON_POP(io));
+    }
+
     JSON_FINISH();
 }
 

--- a/src/trx/game/lara/skin/types.h
+++ b/src/trx/game/lara/skin/types.h
@@ -56,6 +56,7 @@ typedef struct {
     int32_t speech_face_offset;
     MESH_PAIR no_holster_offsets;
     int32_t extra_outfits[LS_EXTRA_NUMBER_OF];
+    XYZ_16 extra_mesh_positions[NUM_EXTRA_MESHES];
 } LARA_SKIN_OUTFIT;
 
 typedef struct {
@@ -63,4 +64,5 @@ typedef struct {
     int32_t data;
     bool visible;
     const OBJECT_MESH *mesh;
+    XYZ_16 offset;
 } LARA_SKIN_EQUIPMENT;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This allows defining positional offsets for Lara's extra equipment meshes, and is put to use to place the sunglasses slightly further up on the TR4 outfit models. It avoids having to define separate meshes as a result.

Resolves TRX676.
