### PR TITLE
lara/col/vault: fix ladders in lifts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
+- fixed Lara attempting to climb ladders from inside lifts (#5890)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/col/vault.c
+++ b/src/trx/game/lara/col/vault.c
@@ -114,7 +114,7 @@ static bool M_IsLowVault(
 static bool M_HasHeadClearance(const M_COLL *const coll)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
-    return lara->climb_status
+    return (lara->climb_status && coll->front.floor == NO_HEIGHT)
         || coll->front.floor - coll->mid.ceiling >= M_MIN_CLEARANCE;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Lara attempting to mount a ladder inside a lift. Ultimately the original vaulting didn't consider ceilings above Lara when a ladder is in place. The check now disregards ceilings only if the ladder is a solid wall.

This can be tested in Opera House. After pulling the switch, sideflip into the lift then hold forward and action.

Resolves #5890 / TRX726.
