### PR TITLE
objects/train: prevent tilt when stopping at walls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)
+- fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/objects/traps/train.c
+++ b/src/trx/game/objects/traps/train.c
@@ -111,7 +111,9 @@ static void M_Control(const int16_t item_num)
     Room_GetSector(item->pos, &room_num);
     Item_UpdateRoom(item_num, room_num);
 
-    item->rot.x = (mid_height - front_height) << 1;
+    if (mid_height != NO_HEIGHT && front_height != NO_HEIGHT) {
+        item->rot.x = (mid_height - front_height) << 1;
+    }
 
     const XYZ_32 light_pos =
         XYZ_32_OffsetYaw(item->pos, item->rot.y, M_LIGHT_DIST);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This also happens in Aldwych, just wasn't possible to see in the OG given how far away they despawn.

Resolves #5886 / TRX721.
