### PR TITLE
console: Remove ability to execute some commands in Demo mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
 - fixed some console commands being able to target unintended items
 - fixed the `/trigger` and `/untrigger` console commands crashing or doing nothing on some objects, so they now act on any item exactly as a level trigger would
-- fixed the `/trigger` and `/untrigger` console commands being usable in demos and cutscenes
+- fixed the `/trigger`, `/untrigger` and `/kill` console commands being usable in demos and cutscenes
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)

--- a/src/trx/game/console/cmd/kill.c
+++ b/src/trx/game/console/cmd/kill.c
@@ -158,7 +158,7 @@ static COMMAND_RESULT M_KillEnemyType(const char *const enemy_name)
 
 static COMMAND_RESULT M_Entrypoint(const COMMAND_CONTEXT *const ctx)
 {
-    if (!Game_IsLoaded()) {
+    if (!Game_IsPlayable()) {
         return CR_UNAVAILABLE;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Remove ability to execute /trigger and /kill commands in demo mode, which could lead to a demo desync. Follows the same pattern as the M_Entrypoint methods in give_item.c & teleport.c
