### PR TITLE
lua/items: fold find and first into the query

### DIFF
--- a/data/trx/ship/games/tr3/scripts/tinnos.lua
+++ b/data/trx/ship/games/tr3/scripts/tinnos.lua
@@ -1,9 +1,6 @@
 trx.events.before_item_setup(function(level)
-  for _, item in
-    ipairs(trx.items.find({
-      object_id = trx.catalog.objects.animating_ext_1,
-    }))
-  do
+  local query = trx.items.query:of_object(trx.catalog.objects.animating_ext_1)
+  for _, item in ipairs(query:matches()) do
     item.properties.kill_on_trigger = true
   end
 end)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - changed Lua enums to be read-only, including the table `pairs()` used to hand out; writing to one used to break every later lookup
 - changed writes that a field cannot hold to raise rather than truncate, so `item.hit_points = 99999` no longer wraps
 - fixed a number too large for the engine wrapping into range rather than being refused, so `trx.items[4294967297]` no longer reads as the first item
+- removed `trx.items.find()` and `trx.items.first()`; `trx.items.query` does both
 - removed `trx.console.log.LogLevel`, a duplicate of `trx.log.LogLevel`
 - removed `trx.events.EventType`
 - removed `trx.game.settings`, which duplicated `trx.config`

--- a/docs/trx/MIGRATING.md
+++ b/docs/trx/MIGRATING.md
@@ -33,6 +33,10 @@ order: 3
      `item.hit_points = 99999`, where the field is 16-bit.
    - `pairs(item)` iterates the item's public fields; it used to yield `idx`
      alone.
+   - `trx.items.find(query)` and `trx.items.first(query)` were removed.
+     `trx.items.query` does both: `trx.items.query:of_object(id):matches()` for
+     the list and `:first()` for one, with `:in_room(num)` in place of the
+     `room_num` key. `of_object` also takes a name, not just an id.
 
 2. **Update scripts that use room handles**
    `trx.rooms` hands out opaque room handles rather than `{ idx = ... }` tables.

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -3539,44 +3539,6 @@
       }
     },
     {
-      "description": "Finds all items matching the query.",
-      "examples": [
-        "local wolves = trx.items.find({ object_id = trx.catalog.objects.wolf })"
-      ],
-      "params": [
-        {
-          "description": "Supported keys: `object_id`, `room_num`. Unknown keys are ignored and logged. Omit it for no matches.",
-          "name": "query",
-          "optional": true,
-          "type": "table"
-        }
-      ],
-      "path": "items.find",
-      "returns": {
-        "description": "List of `Item`.",
-        "type": "table"
-      }
-    },
-    {
-      "description": "Finds the first item matching the query.",
-      "examples": [
-        "local natla = trx.items.first({ object_id = trx.catalog.objects.natla })"
-      ],
-      "params": [
-        {
-          "description": "Supported keys: `object_id`, `room_num`. Omit it for no match.",
-          "name": "query",
-          "optional": true,
-          "type": "table"
-        }
-      ],
-      "path": "items.first",
-      "returns": {
-        "nullable": true,
-        "type": "Item"
-      }
-    },
-    {
       "description": "Hangs an extra mesh on one of Lara's own, replacing whatever is there.",
       "examples": [
         "trx.lara.set_extra_equipment(trx.lara.Mesh.HAND_R, trx.lara.ExtraMesh.OAR)"
@@ -4951,7 +4913,7 @@
         {
           "description": "Whether the handle still refers to a live item. Reading or writing a field on a stale handle raises an error rather than silently operating on an unrelated item, so check this for a handle held across time.",
           "examples": [
-            "local wolf = trx.items.first({ object_id = trx.catalog.objects.wolf })\ntrx.events.after_control(function()\n  if wolf:is_valid() and wolf.hit_points <= 0 then\n    trx.log.info(\"the wolf is down\")\n  end\nend)"
+            "local wolf = trx.items.query:of_object(trx.catalog.objects.wolf):first()\ntrx.events.after_control(function()\n  if wolf:is_valid() and wolf.hit_points <= 0 then\n    trx.log.info(\"the wolf is down\")\n  end\nend)"
           ],
           "name": "is_valid",
           "returns": {

--- a/docs/trx/lua/reference/ITEMS.md
+++ b/docs/trx/lua/reference/ITEMS.md
@@ -143,7 +143,7 @@ Example: `trx.items.query:of_object("wolf"):active():matches()`. *(read-only)*
 
       Example:
       ```lua
-      local wolf = trx.items.first({ object_id = trx.catalog.objects.wolf })
+      local wolf = trx.items.query:of_object(trx.catalog.objects.wolf):first()
       trx.events.after_control(function()
         if wolf:is_valid() and wolf.hit_points <= 0 then
           trx.log.info("the wolf is down")
@@ -205,29 +205,3 @@ Example: `trx.items.query:of_object("wolf"):active():matches()`. *(read-only)*
   Returns the total number of allocated items. Same as `#trx.items`.
 
   Returns: integer.
-
-- [lua]`trx.items.find([query])`  
-  Finds all items matching the query.
-
-  Parameters:
-  - **`query`** (table, optional). Supported keys: `object_id`, `room_num`. Unknown keys are ignored and logged. Omit it for no matches.
-
-  Returns: table. List of `Item`.
-
-  Example:
-  ```lua
-  local wolves = trx.items.find({ object_id = trx.catalog.objects.wolf })
-  ```
-
-- [lua]`trx.items.first([query])`  
-  Finds the first item matching the query.
-
-  Parameters:
-  - **`query`** (table, optional). Supported keys: `object_id`, `room_num`. Omit it for no match.
-
-  Returns: Item or `nil`.
-
-  Example:
-  ```lua
-  local natla = trx.items.first({ object_id = trx.catalog.objects.natla })
-  ```

--- a/src/lua/api/items.lua
+++ b/src/lua/api/items.lua
@@ -243,7 +243,7 @@ api.type("items.Item", {
         .. "stale handle raises an error rather than silently operating on an unrelated item, so "
         .. "check this for a handle held across time.",
       examples = {
-        [[local wolf = trx.items.first({ object_id = trx.catalog.objects.wolf })
+        [[local wolf = trx.items.query:of_object(trx.catalog.objects.wolf):first()
 trx.events.after_control(function()
   if wolf:is_valid() and wolf.hit_points <= 0 then
     trx.log.info("the wolf is down")
@@ -304,51 +304,6 @@ end)]],
     },
   },
 })
-
-local FIND_KEYS = { object_id = true, room_num = true }
-
-local function validate_query(query, fn_name)
-  if type(query) ~= "table" then
-    error("trx.items." .. fn_name .. " query must be a table", 3)
-  end
-  for key, _ in pairs(query) do
-    if not FIND_KEYS[key] then
-      trx.log.warn(
-        "trx.items."
-          .. fn_name
-          .. ": unknown property '"
-          .. tostring(key)
-          .. "'"
-      )
-    end
-  end
-end
-
-local function matches(item, query)
-  for key, _ in pairs(FIND_KEYS) do
-    if query[key] ~= nil and item[key] ~= query[key] then
-      return false
-    end
-  end
-  return true
-end
-
-local function search(query, first_only)
-  local found = {}
-  for i = 0, raw.count() - 1 do
-    local item = raw.get(i)
-    if item ~= nil and matches(item, query) then
-      if first_only then
-        return item
-      end
-      found[#found + 1] = item
-    end
-  end
-  if first_only then
-    return nil
-  end
-  return found
-end
 
 api.define("items.get", {
   description = "Retrieves an item by index or by name. Items count from zero, matching the "
@@ -413,53 +368,6 @@ api.define("items.count", {
   description = "Returns the total number of allocated items. Same as `#trx.items`.",
   returns = { type = "integer" },
   impl = raw.count,
-})
-
-api.define("items.find", {
-  description = "Finds all items matching the query.",
-  params = {
-    {
-      name = "query",
-      type = "table",
-      optional = true,
-      description = "Supported keys: `object_id`, `room_num`. Unknown keys are ignored and logged. "
-        .. "Omit it for no matches.",
-    },
-  },
-  returns = { type = "table", description = "List of `Item`." },
-  examples = {
-    [[local wolves = trx.items.find({ object_id = trx.catalog.objects.wolf })]],
-  },
-  impl = function(query)
-    if query == nil then
-      return {}
-    end
-    validate_query(query, "find")
-    return search(query, false)
-  end,
-})
-
-api.define("items.first", {
-  description = "Finds the first item matching the query.",
-  params = {
-    {
-      name = "query",
-      type = "table",
-      optional = true,
-      description = "Supported keys: `object_id`, `room_num`. Omit it for no match.",
-    },
-  },
-  returns = { type = "Item", nullable = true },
-  examples = {
-    [[local natla = trx.items.first({ object_id = trx.catalog.objects.natla })]],
-  },
-  impl = function(query)
-    if query == nil then
-      return nil
-    end
-    validate_query(query, "first")
-    return search(query, true)
-  end,
 })
 
 -- Every item the level holds, each by its number.

--- a/src/lua/commands/winston.lua
+++ b/src/lua/commands/winston.lua
@@ -5,7 +5,7 @@ local STEP_L = trx.math.WALL_L // 4
 -- Brings an existing Winston to Lara. Returns whether one was found - a dead one
 -- counts, and reports itself.
 local function summon_existing(object_id, target, lara)
-  local items = trx.items.find({ object_id = object_id })
+  local items = trx.items.query:of_object(object_id):matches()
   local winston = items[1]
   if winston == nil then
     return false

--- a/src/tests/unit/lua/items.lua
+++ b/src/tests/unit/lua/items.lua
@@ -325,25 +325,11 @@ test("computed members and methods are declared", function()
   assert(it.is_killed == false)
 end)
 
-test("find and first query by object and room", function()
-  local wolves = trx.items.find({ object_id = WOLF })
-  assert(#wolves == 1, "expected one wolf, got " .. #wolves)
-  assert(wolves[1].object_id == WOLF)
-
-  assert(#trx.items.find({ room_num = 1 }) == 1, "by room")
-  assert(
-    #trx.items.find({ object_id = WOLF, room_num = 1 }) == 0,
-    "both must match"
-  )
-
-  assert(trx.items.first({ object_id = VASE }) ~= nil)
-  -- Nil, not an empty table: a table is truthy, so `if trx.items.first(q) then`
-  -- would take the branch even when nothing matched.
-  assert(trx.items.first({ object_id = 99 }) == nil, "no match must be nil")
-
-  -- An unknown query key is logged and ignored, not fatal.
-  assert(#trx.items.find({ nonsense = 1 }) == 2, "an unknown key is ignored")
-  assert(#trx.items.find() == 0 and trx.items.first() == nil)
+test("query first is a handle or nil, never an empty table", function()
+  assert(trx.items.query:of_object(VASE):first() ~= nil)
+  -- Nil, not an empty table: a table is truthy, so `if q:first() then` would
+  -- take the branch even when nothing matched.
+  assert(trx.items.query:of_object(99):first() == nil, "no match must be nil")
 end)
 
 -- A method reaches C directly, so strict mode has to put its wrapper in front


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

find and first took a { object_id, room_num } table and returned the matching items, or the first. The query does the same and more: trx.items.query:of_object(id):matches() for the list, :first() for one, :in_room(num) for the room, and of_object takes a name as well as an id.

They shipped in 1.3, so this is a breaking change - the changelog and migration notes carry the swap.