### PR TITLE
lara/col/climb: test pull up destination heights

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fixed a crash when drawing an animating object that has no frame data (#5869)
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
+- fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -35,6 +35,28 @@ typedef enum {
     // clang-format on
 } M_CLIMB_RESULT;
 
+static int32_t M_GetDestinationClearance(const ITEM *const item)
+{
+    XYZ_32 pos = {
+        .x = 0,
+        .y = -M_CLIMB_HEIGHT,
+        .z = 0,
+    };
+    Lara_GetJointAbsPosition(&pos, LM_HAND_R);
+    int16_t room_num = item->room_num;
+    Room_GetSector(pos, &room_num);
+
+    pos = XYZ_32_OffsetYaw(pos, item->rot.y, LARA_RADIUS * 2);
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, pos);
+    const int32_t ceiling = Room_GetCeiling(sector, pos);
+
+    if (height == NO_HEIGHT || ceiling == NO_HEIGHT) {
+        return NO_HEIGHT;
+    }
+    return ABS(height - ceiling);
+}
+
 static M_CLIMB_RESULT M_TestClimbPos(
     const ITEM *const item, const int32_t front, const int32_t right,
     const int32_t origin, const int32_t item_height, int32_t *const shift)
@@ -841,7 +863,7 @@ static M_CLIMB_RESULT M_TestClimbUpPos(
             return CLIMB_RESULT_POS;
         }
 
-        if (height - ceiling > LARA_HEIGHT) {
+        if (M_GetDestinationClearance(item) > LARA_HEIGHT) {
             *shift = height;
             return CLIMB_RESULT_NEG;
         }
@@ -925,6 +947,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 
     if (g_Input.forward) {
         if (coll->side_front.floor > -850 && coll->side_front.floor < -650
+            && M_GetDestinationClearance(item) > LARA_HEIGHT
             && coll->side_front.floor - coll->side_front.ceiling >= 0
             && coll->side_left2.floor - coll->side_left2.ceiling >= 0
             && coll->side_right2.floor - coll->side_right2.ceiling >= 0


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This tests the height at Lara's destination more accurately when pulling up from a ledge or ladder. It avoids her colliding with the ceiling after being nudged forward following the pull-up. She will either refuse to pull up, or if crawling is enabled, she will pull up into the crawl state. Test level available.

Resolves #5891 / TRX727.
