### PR TITLE
objects/crawler_mutant: fix stats when killed by allies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
+- fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/objects/creatures/crawler_mutant.c
+++ b/src/trx/game/objects/creatures/crawler_mutant.c
@@ -299,7 +299,7 @@ static void M_ControlCrawler(const int16_t item_num)
 
     M_PRIV *const p = item->priv;
     if (p->burn_timer > M_MAX_BURN_TIME) {
-        item->hit_points = 0;
+        Item_TakeDamage(item, item->hit_points, IDF_NONE, creature->enemy);
     }
 
     if (item->hit_points <= 0) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes crawlers killed by allies not being included in the stats despite the relevant config option being enabled.

Resolves #5691 / TRX740.
