### PR TITLE
game_flow/inventory: fix giving flares twice

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
+- fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/game_flow/inventory.c
+++ b/src/trx/game/game_flow/inventory.c
@@ -430,7 +430,9 @@ void GF_InventoryModifier_Apply(
 #define X_PICKUP_NUMBERED(item, option) M_ModifyInventory_Item(type, item);
 #define X_PICKUP_MISC(item, option) M_ModifyInventory_Item(type, item);
 #define X_PICKUP_VARIANT(item, option) M_ModifyInventory_Item(type, item);
+#define X_PICKUP_SUPPLY_VARIANT(item, option)
 #include <trx/game/objects/pickups.def>
+#undef X_PICKUP_SUPPLY_VARIANT
 #undef X_PICKUP_VARIANT
 #undef X_PICKUP_MISC
 #undef X_PICKUP_NUMBERED


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes giving twice the number of flares when defined in the game flow.

Resolves TRX739.
