### PR TITLE
Fix demo desync

### DIFF
--- a/src/trx/game/fx/fire.c
+++ b/src/trx/game/fx/fire.c
@@ -363,10 +363,25 @@ void FX_Fire_Add(
     }
 }
 
+static bool M_AnyFireActive(void)
+{
+    for (int32_t i = 0; i < M_MAX_FIRES; i++) {
+        if (m_Fires[i].on) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void FX_Fire_Control(void)
 {
-    m_Wibble = (m_Wibble + 4) & 0xFC;
-    M_KeepBurning();
+    // Spawning draws from the control RNG that demo playback is locked to, so
+    // only run the pool while a fire is registered this frame. Existing sparks
+    // still advance to fade out; that path draws no RNG.
+    if (M_AnyFireActive()) {
+        m_Wibble = (m_Wibble + 4) & 0xFC;
+        M_KeepBurning();
+    }
 
     const int32_t base_sprite = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
     for (int32_t i = 0; i < M_MAX_SPARKS; i++) {

--- a/src/trx/game/fx/fire.c
+++ b/src/trx/game/fx/fire.c
@@ -4,6 +4,7 @@
 #include <trx/game/const.h>
 #include <trx/game/matrix.h>
 #include <trx/game/output/sources/poly_fx.h>
+#include <trx/game/output/state.h>
 #include <trx/game/random.h>
 #include <trx/game/sparks.h>
 
@@ -28,7 +29,6 @@ typedef struct {
 static SPARK m_Sparks[M_MAX_SPARKS];
 static M_FIRE m_Fires[M_MAX_FIRES];
 static int32_t m_NextSpark = 1;
-static uint8_t m_Wibble = 0;
 
 // Slots 1..19 form a shared pool; slot 0 is reserved for the static flame base.
 static int32_t M_GetFreeSpark(void)
@@ -160,10 +160,11 @@ static void M_TriggerSmoke(void)
 
 static void M_KeepBurning(void)
 {
+    const int32_t time4 = Output_GetTimeInGame() * 4;
     M_TriggerStaticFlame();
-    if ((m_Wibble & 0xF) == 0) {
+    if ((time4 & 0xF) == 0) {
         M_TriggerFireFlame();
-        if ((m_Wibble & 0x1F) == 0) {
+        if ((time4 & 0x1F) == 0) {
             M_TriggerSmoke();
         }
     }
@@ -332,7 +333,6 @@ void FX_Fire_Reset(void)
     memset(m_Sparks, 0, sizeof(m_Sparks));
     memset(m_Fires, 0, sizeof(m_Fires));
     m_NextSpark = 1;
-    m_Wibble = 0;
 }
 
 void FX_Fire_NewFrame(void)
@@ -379,7 +379,6 @@ void FX_Fire_Control(void)
     // only run the pool while a fire is registered this frame. Existing sparks
     // still advance to fade out; that path draws no RNG.
     if (M_AnyFireActive()) {
-        m_Wibble = (m_Wibble + 4) & 0xFC;
         M_KeepBurning();
     }
 

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -7,6 +7,7 @@
 #include <trx/game/lara/common.h>
 #include <trx/game/objects.h>
 #include <trx/game/output/sources/poly_fx.h>
+#include <trx/game/output/state.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
 #include <trx/game/sound.h>
@@ -29,14 +30,12 @@ static const uint8_t m_SplashQuadLinks[32] = {
 static FX_WATER_SPLASH m_Splashes[4];
 static FX_WATER_RIPPLE m_Ripples[16];
 static int32_t m_SplashCount = 0;
-static int32_t m_Wibble = 0;
 
 void FX_Water_Reset(void)
 {
     memset(m_Splashes, 0, sizeof(m_Splashes));
     memset(m_Ripples, 0, sizeof(m_Ripples));
     m_SplashCount = 0;
-    m_Wibble = 0;
 }
 
 static bool M_IsRoomUnderwater(const int16_t room_num)
@@ -318,6 +317,7 @@ void FX_Water_WadeSplash(
         return;
     }
 
+    const int32_t time4 = Output_GetTimeInGame() * 4;
     if (item->fall_speed > 0 && depth < 474 && m_SplashCount == 0) {
         const FX_WATER_SPLASH_SETUP setup = {
             .x = item->pos.x,
@@ -345,7 +345,7 @@ void FX_Water_WadeSplash(
         FX_Water_SetupSplash(&setup);
         m_SplashCount = 16;
     } else if (
-        (m_Wibble & 0xF) == 0
+        (time4 & 0xF) == 0
         && (((Random_GetControl() & 0xF) == 0)
             || item->current_anim_state != LS(LS_STOP))) {
         FX_Water_SetupRipple(
@@ -421,6 +421,7 @@ static void M_DrawSplash(const FX_WATER_SPLASH *s)
     const double ratio = Interpolation_GetWorldRate();
     const bool do_interp =
         Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
+    const int32_t time4 = Output_GetTimeInGame() * 4;
 
     XYZ_32 points[48];
     for (int32_t i = 0; i < 48; i++) {
@@ -441,7 +442,7 @@ static void M_DrawSplash(const FX_WATER_SPLASH *s)
         int32_t sprite_idx = big_splash_idx;
         if (ring == 2 || (ring == 0 && (s->flags & 4U) != 0U)
             || (ring == 1 && (s->flags & 8U) != 0U)) {
-            sprite_idx = small_splash_idx + ((m_Wibble >> 4) & 3);
+            sprite_idx = small_splash_idx + ((time4 >> 4) & 3);
         }
 
         const int32_t life = do_interp
@@ -625,6 +626,4 @@ void FX_Water_Control(void)
             }
         }
     }
-
-    m_Wibble = (m_Wibble + 4) & 0xFC;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the demo desync introduced on develop by porting the TR4 fire emitters in 873e4dc14f65ec05ccd080446d57481a7d7c4563 and, cosmetically, replaces `m_Wibble` with `time4` idiom that we use elsewhere.