### PR TITLE
objects/lift: prevent vaulting on top of ascending lifts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 - changed the `/music` console command to list the available tracks when given no argument, as `/sfx` does; `/music status` now reports what is playing
 - changed the `/spawn` console command to accept a family such as `pickup` to spawn one of its members
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
-- changed lift collision to force Lara out of her climbing animations if one collides with her (#5899)
+- changed lift collision to force Lara out of her climbing and vaulting animations if one collides with her (#5899, #5911)
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
 - fixed some console commands being able to target unintended items
 - fixed the `/trigger` and `/untrigger` console commands crashing or doing nothing on some objects, so they now act on any item exactly as a level trigger would

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -401,6 +401,23 @@ static void M_PreventClimbing(ITEM *const lara_item)
     Lara_GetLaraInfo()->gun_status = LGS_ARMLESS;
 }
 
+static bool M_ShouldKillLara(
+    const ITEM *const item, const ITEM *const lara_item)
+{
+    int16_t room_num = lara_item->room_num;
+    const SECTOR *const sector = Room_GetSector(lara_item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, lara_item->pos);
+    const int32_t ceiling = Room_GetCeiling(sector, lara_item->pos);
+    if (height == NO_HEIGHT || ceiling == NO_HEIGHT) {
+        return false;
+    }
+
+    const int32_t clearance = ABS(height - ceiling);
+    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(lara_item);
+    const int32_t lara_height = ABS(bounds->max.y - bounds->min.y);
+    return clearance < lara_height;
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -432,18 +449,7 @@ static void M_Collision(
         return;
     }
 
-    int16_t room_num = lara_item->room_num;
-    const SECTOR *const sector = Room_GetSector(lara_item->pos, &room_num);
-    const int32_t height = Room_GetHeight(sector, lara_item->pos);
-    const int32_t ceiling = Room_GetCeiling(sector, lara_item->pos);
-    if (height == NO_HEIGHT || ceiling == NO_HEIGHT) {
-        return;
-    }
-
-    const int32_t clearance = ABS(height - ceiling);
-    const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(lara_item);
-    const int32_t lara_height = ABS(bounds->max.y - bounds->min.y);
-    if (lara_height < clearance) {
+    if (!M_ShouldKillLara(item, lara_item)) {
         return;
     }
 

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -365,6 +365,42 @@ static void M_InternalCollision(const ITEM *const item, COLL_INFO *const coll)
     }
 }
 
+static bool M_ShouldPreventClimbing(
+    const ITEM *const item, const ITEM *const lara_item,
+    const M_LARA_STATUS lara_status)
+{
+    if (!Lara_TestBoundsCollide(item, 0)) {
+        return false;
+    }
+
+    if (Lara_HasState(m_ClimbingStates)) {
+        return true;
+    }
+
+    if (lara_status == M_LARA_BELOW) {
+        return false;
+    }
+
+    // Allow vaulting only if the lift is descending to avoid embedding. This
+    // avoids doing item->pos.y += coll->side_mid.floor in the regular routines
+    // as that would impact vaulting off collapsible tiles and suchlike.
+    if (Item_IsTriggerActiveRO(item)) {
+        return false;
+    }
+
+    return Item_TestAnimEqual(lara_item, LA(LA_CLIMB_2CLICK))
+        || Item_TestAnimEqual(lara_item, LA(LA_CLIMB_3CLICK))
+        || Item_TestAnimEqual(lara_item, LA(LA_STAND_TO_JUMP_UP));
+}
+
+static void M_PreventClimbing(ITEM *const lara_item)
+{
+    lara_item->goal_anim_state = LS(LS_FAST_FALL);
+    lara_item->current_anim_state = LS(LS_FAST_FALL);
+    Item_SwitchToAnim(lara_item, LA(LA_SMASH_JUMP), 0);
+    Lara_GetLaraInfo()->gun_status = LGS_ARMLESS;
+}
+
 static void M_Collision(
     const int16_t item_num, ITEM *const lara_item, COLL_INFO *const coll)
 {
@@ -391,11 +427,8 @@ static void M_Collision(
         return;
     }
 
-    if (Lara_HasState(m_ClimbingStates) && Lara_TestBoundsCollide(item, 0)) {
-        lara_item->goal_anim_state = LS(LS_FAST_FALL);
-        lara_item->current_anim_state = LS(LS_FAST_FALL);
-        Item_SwitchToAnim(lara_item, LA(LA_SMASH_JUMP), 0);
-        Lara_GetLaraInfo()->gun_status = LGS_ARMLESS;
+    if (M_ShouldPreventClimbing(item, lara_item, lara_status)) {
+        M_PreventClimbing(lara_item);
         return;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Lara vaulting on top of ascending lifts to avoid embedding. If the lift is descending, she can proceed given that she'll have left the lift floor anyway. I wanted to avoid touching the regular vaulting collision routines as that would impact cases such as vaulting off collapsible tiles.

Resolves #5911 / TRX745.
