### PR TITLE
camera: guard against invalid flyby updates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
+- fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -338,6 +338,10 @@ void Camera_FlybyMode_Update(void)
 
     const FLYBY_SEQUENCE *const sequence =
         Camera_GetSequence(m_CurrentSequence);
+    if (sequence == nullptr) {
+        return;
+    }
+
     const FLYBY_CAMERA *const first_camera =
         Camera_GetFlybyCamera(sequence->camera_idx);
     const FLYBY_CAMERA *const current_camera =

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -403,6 +403,11 @@ void Camera_PhotoMode_Resume(void)
         // stale pre-step orientation basis.
         M_SyncCameraOrientationFromView();
     } else {
+        if (m_OriginalCamera.type == CAM_FLYBY_MODE) {
+            // The flyby finished between pausing and resuming photo mode.
+            // Resync the original camera to the one generated post-flyby.
+            m_OriginalCamera = g_Camera;
+        }
         g_Camera = m_PreviousState.camera;
     }
     Camera_SetChunky(m_PreviousState.is_chunky);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents attempting to continue a flyby sequence from within photo mode frame advancing after the sequence has finished. Once it has completed, advancing frames will keep the camera at the final position. Exiting photo mode will then return to the chase camera (set by the flyby camera module when it exits).

Resolves TRX752.