### PR TITLE
camera/flyby_mode: improve snap back to game

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)
+- fixed the camera snapping aggressively to Lara after some flyby sequences (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/camera/common.c
+++ b/src/trx/game/camera/common.c
@@ -114,7 +114,7 @@ void Camera_Reset(void)
 {
     g_Camera.mic_pos.room_num = NO_ROOM;
     g_Camera.pos.room_num = NO_ROOM;
-    Camera_FlybyMode_Deactivate();
+    Camera_FlybyMode_Reset();
 }
 
 void Camera_ApplyBounce(void)

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -322,6 +322,7 @@ void Camera_FlybyMode_Deactivate(void)
         g_Camera.target = m_State.initial.camera_target;
         g_Camera.interp.prev.pos = g_Camera.pos.pos;
         g_Camera.interp.prev.target = g_Camera.target.pos;
+        Camera_Update();
     }
     // TODO: undo fade clip
 }

--- a/src/trx/game/camera/flyby_mode.c
+++ b/src/trx/game/camera/flyby_mode.c
@@ -303,9 +303,14 @@ bool Camera_Flybymode_Cancel(void)
     return true;
 }
 
-void Camera_FlybyMode_Deactivate(void)
+void Camera_FlybyMode_Reset(void)
 {
     m_CurrentSequence = M_NO_SEQUENCE;
+}
+
+void Camera_FlybyMode_Deactivate(void)
+{
+    Camera_FlybyMode_Reset();
     Lara_SetControllable(true);
 
     g_Camera.type = CAM_CHASE;

--- a/src/trx/game/camera/flyby_mode.h
+++ b/src/trx/game/camera/flyby_mode.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 bool Camera_FlybyMode_Activate(int32_t sequence, bool one_shot);
+void Camera_FlybyMode_Reset(void);
 void Camera_FlybyMode_Deactivate(void);
 bool Camera_FlybyMode_IsActive(void);
 bool Camera_Flybymode_Cancel(void);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This improves flybys that snap back to the game to account for Lara having shifted slightly between losing control as the flyby started and coming to a stop. It also brought to light that `Camera_Reset` when called during unloading a level was triggering a full flyby deactivation regardless of whether or not one was active. That is now fixed.

Resolves TRX751.
