### PR TITLE
lara/state/climb: force corner ladder camera update

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 - fixed Lara's braid and pigtails spinning around their own axis (OG bug)
 - fixed a missing texture on Young Lara's left hand
 - fixed a misaligned texture on Young Lara's hips
+- fixed the camera getting stuck when Lara traverses around corner ladders (OG bug)
 
 **Lua**
 

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -92,6 +92,18 @@ static void M_SetCornerAnim(
         item->current_anim_state = LS(LS_HANG);
     }
 
+    if (g_Camera.type == CAM_CHASE
+        && (ladder_end_anim == LA_LADDER_CORNER_RIGHT_OUTER_END
+            || ladder_end_anim == LA_LADDER_CORNER_LEFT_OUTER_END)) {
+        // Some camera strategies will be unable to LOS through the corner from
+        // Lara's old position to her new, so will become stuck. Force a
+        // transitional target update with Lara placed at the corner.
+        // TODO: investigate alternatives to this approach
+        item->pos = XYZ_32_OffsetYaw(item->pos, item->rot.y - rot, STEP_L);
+        g_Camera.speed = 1;
+        Camera_Update();
+    }
+
     const LARA_INFO *const lara = Lara_GetLaraInfo();
     coll->old_pos.x = lara->corner_pos.x;
     coll->old_pos.z = lara->corner_pos.z;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes the TR3/TR4 cameras getting stuck when Lara traverses around an outer ladder corner. Loosening the LOS checks in the camera module results in it being able to go OOB in too many normal gameplay scenarios, so retaining this logic in Lara's control is more preferable as it's the driver behind the "unusual" transition.

Resolves TRX593.