### PR TITLE
camera/photo_mode: guard FOV reversion in cinematics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)
 - fixed the camera snapping aggressively to Lara after some flyby sequences (regression from 1.9)
+- fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/camera/photo_mode.c
+++ b/src/trx/game/camera/photo_mode.c
@@ -67,7 +67,11 @@ static void M_ResetCamera(const bool exiting)
     g_Camera = exiting ? m_OriginalCamera : m_StartingCamera;
     // ensure Camera_EnsureEnvironment() picks up the flag change
     g_Camera.underwater = camera.underwater;
-    Viewport_AlterFOV(exiting ? -1 : m_OriginalFOV, m_OriginalFOVMode);
+    // Cinematic cameras control the FOV during their sequences, so avoid
+    // resetting to user FOV on exit to prevent a 1-frame flicker.
+    Viewport_AlterFOV(
+        exiting && m_OriginalCamera.type != CAM_CINEMATIC ? -1 : m_OriginalFOV,
+        m_OriginalFOVMode);
     m_CurrentFOV = m_OriginalFOV / DEG_1;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents user FOV being applied for a frame during cinematic sequences when exiting photo mode. We'll just need to double check #5246 by changing regular FOV through the console during a cinematic sequence, and playing around with photo mode (LGTM, but would appreciate some sanity checks).

Resolves TRX717.
