### PR TITLE
objects/body_part: draw TR4 exploding deaths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - changed lift collision to force Lara out of her climbing and vaulting animations if one collides with her (#5899, #5911)
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
+- fixed exploding deaths in TR4 showing no flames or explosions
 - fixed some console commands being able to target unintended items
 - fixed the `/trigger` and `/untrigger` console commands crashing or doing nothing on some objects, so they now act on any item exactly as a level trigger would
 - fixed the `/trigger`, `/untrigger` and `/kill` console commands being usable in demos and cutscenes

--- a/src/trx/game/effects/manager.c
+++ b/src/trx/game/effects/manager.c
@@ -119,6 +119,8 @@ int16_t Effect_Create(const int16_t room_num)
     effect->next_active = m_NextEffectActive;
     m_NextEffectActive = effect_num;
     effect->shade = SHADE_NEUTRAL;
+    effect->flag1 = 0;
+    effect->flag2 = 0;
 
     return effect_num;
 }

--- a/src/trx/game/items/utils.c
+++ b/src/trx/game/items/utils.c
@@ -11,6 +11,7 @@
 #include <trx/game/objects/vars.h>
 #include <trx/game/output.h>
 #include <trx/game/random.h>
+#include <trx/game/sparks/spawners.h>
 #include <trx/game/stats.h>
 #include <trx/version.h>
 
@@ -196,6 +197,23 @@ int32_t Item_Shatter(
     Output_CalculateLight(item->pos, item->room_num);
 
     const ANIM_FRAME *const best_frame = Item_GetBestFrame(item);
+
+    // TR4 has no explosion sprite, so an exploding death needs a spark
+    // fireball. OG raises it at the call site rather than inside
+    // ExplodingDeath2; here the damage tells the explosive shatters apart from
+    // the likes of falling blocks, which come apart in silence.
+    if (g_TRVersion == 4 && damage != 0) {
+        const BOUNDS_16 bounds = best_frame->bounds;
+        const XYZ_32 pos = {
+            .x = item->pos.x,
+            .y = item->pos.y + ((bounds.min.y + bounds.max.y) / 2),
+            .z = item->pos.z,
+        };
+        Sparks_TriggerExplosionSparks(pos, 3, -2, 0, item->room_num);
+        for (int32_t i = 0; i < 2; i++) {
+            Sparks_TriggerExplosionSparks(pos, 3, -1, 0, item->room_num);
+        }
+    }
 
     Matrix_PushUnit();
     Matrix_Rot16(item->rot);

--- a/src/trx/game/objects/effects/body_part.c
+++ b/src/trx/game/objects/effects/body_part.c
@@ -170,9 +170,102 @@ static void M_Control_TR3(const int16_t effect_num)
     }
 }
 
+// TR4 has no explosion sprite object, so the burst is made of sparks the way
+// grenades and mines do it (TriggerExplosionSparks in effect2.cpp).
+static void M_SpawnTR4Explosion(const XYZ_32 pos, const int16_t room_num)
+{
+    Sparks_TriggerExplosionSparks(pos, 3, -2, 0, room_num);
+    for (int32_t i = 0; i < 2; i++) {
+        Sparks_TriggerExplosionSparks(pos, 3, -1, 0, room_num);
+    }
+    Sound_Effect(SFX_EXPLOSION_1, &pos, SPM_NORMAL);
+}
+
+// Port of the TR4 ControlBodyPart (missile.cpp). OG only shatters the part
+// into debris on landing; we trail fire sparks and burst instead, since the
+// parts here come from an exploding death.
+static void M_Control_TR4(const int16_t effect_num)
+{
+    EFFECT *const effect = Effect_Get(effect_num);
+    const XYZ_32 old_pos = effect->pos;
+
+    if (effect->speed != 0) {
+        effect->rot.x += effect->fall_speed * 4;
+    }
+    effect->fall_speed += GRAVITY;
+    effect->pos.x += (effect->speed * Math_Sin(effect->rot.y)) >> W2V_SHIFT;
+    effect->pos.y += effect->fall_speed;
+    effect->pos.z += (effect->speed * Math_Cos(effect->rot.y)) >> W2V_SHIFT;
+
+    const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
+    if ((time4 & 0xC) == 0 && (effect->counter & 3) != 0) {
+        Sparks_TriggerFireFlame(effect->pos, effect_num, 0);
+    }
+
+    int16_t room_num = effect->room_num;
+    const SECTOR *const sector = Room_GetSector(effect->pos, &room_num);
+
+    const int32_t ceiling = Room_GetCeiling(sector, effect->pos);
+    if (effect->pos.y < ceiling) {
+        effect->pos.y = ceiling;
+        effect->fall_speed = -effect->fall_speed;
+        effect->speed -= effect->speed >> 3;
+    }
+
+    const int32_t height = Room_GetHeight(sector, effect->pos);
+    if (effect->pos.y >= height) {
+        if ((effect->counter & 3) != 0) {
+            M_SpawnTR4Explosion(
+                (XYZ_32) { effect->pos.x, height, effect->pos.z }, room_num);
+            Effect_Kill(effect_num);
+            return;
+        }
+
+        if (old_pos.y <= height) {
+            if (effect->fall_speed <= 32) {
+                effect->fall_speed = 0;
+            } else {
+                effect->fall_speed = -effect->fall_speed >> 2;
+            }
+        } else {
+            effect->rot.y += DEG_180;
+            effect->pos.x = old_pos.x;
+            effect->pos.z = old_pos.z;
+        }
+
+        effect->speed -= effect->speed >> 2;
+        if (ABS(effect->speed) < 4) {
+            effect->speed = 0;
+        }
+        effect->pos.y = old_pos.y;
+    }
+
+    if (effect->speed == 0) {
+        effect->flag1++;
+        if (effect->flag1 > 32) {
+            Effect_Kill(effect_num);
+            return;
+        }
+    }
+
+    if (room_num != effect->room_num) {
+        Effect_UpdateRoom(effect_num, room_num);
+    }
+}
+
 static void M_Setup(OBJECT *const obj)
 {
-    obj->control_func = g_TRVersion == 3 ? M_Control_TR3 : M_Control_TR12;
+    switch (g_TRVersion) {
+    case 4:
+        obj->control_func = M_Control_TR4;
+        break;
+    case 3:
+        obj->control_func = M_Control_TR3;
+        break;
+    default:
+        obj->control_func = M_Control_TR12;
+        break;
+    }
     obj->loaded = true;
     obj->mesh_count = 0;
 }

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -839,13 +839,18 @@ void Sparks_TriggerExplosionSparks(
     if ((Random_GetControl() & 1) != 0) {
         spark->flags |= SPARK_F_ROTATE;
         spark->rot_angle = (uint16_t)(Random_GetControl() & 0xFFF);
-        const int32_t rot_add = (Random_GetControl() & 0x7F) + 32;
-        spark->rot_add = (int8_t)MIN(rot_add, 127);
+        // TR4 spins either way; TR3 only clockwise and slower.
+        const int32_t rot_add = g_TRVersion == 4
+            ? (Random_GetControl() & 0xFF) + 128
+            : MIN((Random_GetControl() & 0x7F) + 32, 127);
+        spark->rot_add = (int8_t)rot_add;
     }
 
     spark->src_size.width = (uint8_t)((Random_GetControl() & 0xF) + 40);
-    spark->src_size.height =
-        (uint8_t)(spark->src_size.width + (Random_GetControl() & 7) + 8);
+    // TR4 keeps the puff square; TR3 stretches it vertically.
+    spark->src_size.height = g_TRVersion == 4
+        ? spark->src_size.width
+        : (uint8_t)(spark->src_size.width + (Random_GetControl() & 7) + 8);
     spark->dst_size.width = (uint8_t)(spark->src_size.width << 1);
     spark->dst_size.height = (uint8_t)(spark->src_size.height << 1);
     spark->size = spark->src_size;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

TR4 fell into the TR1/2 body part control, which turns each part into an explosion sprite that TR4 does not have, so exploding deaths showed nothing at all. Port `ControlBodyPart` and give the parts trailing flames, a landing burst and a fireball where the shatter happens.

Resolves TRX723.