### PR TITLE
objects/shoal: store fish state in savegames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
+- fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/src/trx/game/objects/general/shoal.c
+++ b/src/trx/game/objects/general/shoal.c
@@ -1,8 +1,9 @@
 #include <trx/game/objects/general/shoal.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
-#include <trx/game/game_buf.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara.h>
@@ -52,6 +53,80 @@ typedef struct {
     int32_t sprite_offset;
     GAME_VECTOR anchor;
 } M_PRIV;
+
+static void M_ResetFishInterp(M_FISH *const fish)
+{
+    fish->interp.prev.pos = fish->pos;
+    fish->interp.prev.angle = fish->angle;
+    fish->interp.prev.swim = fish->swim;
+    fish->interp.result.pos = fish->pos;
+    fish->interp.result.angle = fish->angle;
+    fish->interp.result.swim = fish->swim;
+}
+
+static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
+{
+    M_PRIV *const p = item->priv;
+    JSON_OPTIONAL(JSON_READ(io, "piranha_hit_wait", &p->piranha_hit_wait));
+
+    if (JSON_SHOULD(JSON_PUSH(io, "leader"))) {
+        M_LEADER *const leader = &p->leader;
+        JSON_SHOULD(JSON_READ(io, "on", &leader->on));
+        JSON_SHOULD(JSON_READ(io, "angle", &leader->angle));
+        JSON_SHOULD(JSON_READ(io, "speed", &leader->speed));
+        JSON_SHOULD(JSON_READ(io, "angle_time", &leader->angle_time));
+        JSON_SHOULD(JSON_READ(io, "speed_time", &leader->speed_time));
+        JSON_POP(io);
+    }
+
+    if (JSON_SHOULD(JSON_PUSH(io, "fish"))) {
+        const int32_t count = MIN(JSON_ARRAY_LEN(io), M_FISH_PER_SHOAL + 1);
+        for (int32_t i = 0; i < count; i++) {
+            if (!JSON_SHOULD(JSON_PUSH_INDEX(io, i))) {
+                break;
+            }
+            M_FISH *const fish = &p->fish[i];
+            JSON_SHOULD(JSON_READ(io, "pos", &fish->pos));
+            JSON_SHOULD(JSON_READ(io, "angle", &fish->angle));
+            JSON_SHOULD(JSON_READ(io, "dest_y", &fish->dest_y));
+            JSON_SHOULD(JSON_READ(io, "ang_add", &fish->ang_add));
+            JSON_SHOULD(JSON_READ(io, "speed", &fish->speed));
+            JSON_SHOULD(JSON_READ(io, "swim", &fish->swim));
+            M_ResetFishInterp(fish);
+            JSON_POP(io);
+        }
+        JSON_POP(io);
+    }
+}
+
+static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
+{
+    const M_PRIV *const p = item->priv;
+    JSONW_WRITE(io, "piranha_hit_wait", p->piranha_hit_wait);
+
+    const M_LEADER *const leader = &p->leader;
+    JSONW_PUSH_OBJECT(io);
+    JSONW_WRITE(io, "on", leader->on);
+    JSONW_WRITE(io, "angle", leader->angle);
+    JSONW_WRITE(io, "speed", leader->speed);
+    JSONW_WRITE(io, "angle_time", leader->angle_time);
+    JSONW_WRITE(io, "speed_time", leader->speed_time);
+    JSONW_POP_AND_SET(io, "leader");
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_FISH_PER_SHOAL + 1; i++) {
+        const M_FISH *const fish = &p->fish[i];
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", fish->pos);
+        JSONW_WRITE(io, "angle", fish->angle);
+        JSONW_WRITE(io, "dest_y", fish->dest_y);
+        JSONW_WRITE(io, "ang_add", fish->ang_add);
+        JSONW_WRITE(io, "speed", fish->speed);
+        JSONW_WRITE(io, "swim", fish->swim);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET(io, "fish");
+}
 
 static uint16_t M_GetFishAngle12(
     const int32_t x1, const int32_t z1, const int32_t x2, const int32_t z2)
@@ -112,12 +187,7 @@ static void M_SetupFish(M_PRIV *const p, const ITEM *const item)
     fish->angle = 0;
     fish->speed = ((Random_GetControl() & 0x3F) + 8);
     fish->swim = (Random_GetControl() & 0x3F);
-    fish->interp.prev.pos = fish->pos;
-    fish->interp.prev.angle = fish->angle;
-    fish->interp.prev.swim = fish->swim;
-    fish->interp.result.pos = fish->pos;
-    fish->interp.result.angle = fish->angle;
-    fish->interp.result.swim = fish->swim;
+    M_ResetFishInterp(fish);
 
     for (int32_t i = 0; i < M_FISH_PER_SHOAL; i++) {
         fish = &p->fish[i + 1];
@@ -128,12 +198,7 @@ static void M_SetupFish(M_PRIV *const p, const ITEM *const item)
         fish->angle = Random_GetControl() & 0xFFF;
         fish->speed = (Random_GetControl() & 0x1F) + 32;
         fish->swim = Random_GetControl() & 0x3F;
-        fish->interp.prev.pos = fish->pos;
-        fish->interp.prev.angle = fish->angle;
-        fish->interp.prev.swim = fish->swim;
-        fish->interp.result.pos = fish->pos;
-        fish->interp.result.angle = fish->angle;
-        fish->interp.result.swim = fish->swim;
+        M_ResetFishInterp(fish);
     }
 
     leader->on = true;
@@ -605,10 +670,6 @@ static void M_Initialise(const int16_t item_num)
     item->enable_shadow = false;
     item->collidable = false;
 
-    if (item->priv == nullptr) {
-        item->priv = GameBuf_Alloc(sizeof(M_PRIV), GBUF_ITEM_DATA);
-    }
-
     M_PRIV *const p = item->priv;
     p->leader.on = false;
     p->piranha_hit_wait = 0;
@@ -646,6 +707,10 @@ static void M_SetupCommon(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->is_targetable_func = M_IsTargetable;
     obj->draw_func = M_Draw;
+
+    obj->priv_size = sizeof(M_PRIV);
+    obj->priv_load_func = M_LoadPriv;
+    obj->priv_save_func = M_SavePriv;
 
     obj->save_position = true;
     obj->save_hitpoints = true;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This saves the leader and individual fish positions and orientations, so that shoals no longer reset to a fresh random layout when a game is loaded.

Resolves TRX707.

#### Testing

- [x] Load a save made in Coastal on the stable branch
  Expected outcome: save doesn't explode and loads normally, fishies are reset to random positions
- [x] Save in Coastal and save
  Expected outcome: fishies are persisted