### PR TITLE
Save weather + refactor FX

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
+- fixed rain and snow starting over when a save is loaded (#5901)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/src/trx/game/fx.h
+++ b/src/trx/game/fx.h
@@ -7,5 +7,4 @@
 #include <trx/game/fx/ring.h>
 #include <trx/game/fx/wake.h>
 #include <trx/game/fx/water.h>
-#include <trx/game/fx/water_particles.h>
 #include <trx/game/fx/weather.h>

--- a/src/trx/game/fx/common.c
+++ b/src/trx/game/fx/common.c
@@ -1,5 +1,7 @@
 #include <trx/game/fx/common.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/debug.h>
 
 #include <stdint.h>
@@ -49,4 +51,36 @@ void FX_Reset(void)
             m_Modules[i]->reset_func();
         }
     }
+}
+
+void FX_Save(JSON_WRITE_IO *const io)
+{
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        const FX_MODULE *const module = m_Modules[i];
+        if (module->save_func == nullptr) {
+            continue;
+        }
+        JSONW_PUSH_OBJECT(io);
+        module->save_func(io);
+        JSONW_POP_AND_SET_NZ(io, module->save_key);
+    }
+}
+
+bool FX_Load(JSON_READ_IO *const io)
+{
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        const FX_MODULE *const module = m_Modules[i];
+        if (module->load_func == nullptr) {
+            continue;
+        }
+        if (module->reset_func != nullptr) {
+            module->reset_func();
+        }
+        if (!JSON_OPTIONAL(JSON_PUSH(io, module->save_key))) {
+            continue;
+        }
+        JSON_MUST(module->load_func(io));
+        JSON_MUST(JSON_POP(io));
+    }
+    JSON_FINISH();
 }

--- a/src/trx/game/fx/common.c
+++ b/src/trx/game/fx/common.c
@@ -1,56 +1,52 @@
 #include <trx/game/fx/common.h>
 
-#include <trx/game/fx/droplets.h>
-#include <trx/game/fx/fire.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/gun_flash.h>
-#include <trx/game/fx/laser.h>
-#include <trx/game/fx/ring.h>
-#include <trx/game/fx/wake.h>
-#include <trx/game/fx/water.h>
-#include <trx/game/fx/water_particles.h>
-#include <trx/game/fx/weather.h>
+#include <trx/debug.h>
+
+#include <stdint.h>
+
+#define M_MAX_MODULES 16
+
+static const FX_MODULE *m_Modules[M_MAX_MODULES];
+static int32_t m_ModuleCount = 0;
+
+void FX_RegisterModule(const FX_MODULE *const module)
+{
+    ASSERT(m_ModuleCount < M_MAX_MODULES);
+    m_Modules[m_ModuleCount++] = module;
+}
 
 void FX_NewFrame(void)
 {
-    FX_Fire_NewFrame();
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        if (m_Modules[i]->new_frame_func != nullptr) {
+            m_Modules[i]->new_frame_func();
+        }
+    }
 }
 
 void FX_Control(void)
 {
-    FX_Fire_Control();
-    FX_Ring_Control();
-    FX_Wake_Control();
-    FX_Water_Control();
-    FX_Weather_Control();
-    FX_WaterParticles_Control();
-    FX_Droplets_Control();
-    FX_Footprint_Control();
-    FX_GunFlash_Control();
-    FX_Laser_Control();
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        if (m_Modules[i]->control_func != nullptr) {
+            m_Modules[i]->control_func();
+        }
+    }
 }
 
 void FX_Draw(void)
 {
-    FX_Fire_Draw();
-    FX_Ring_Draw();
-    FX_Water_Draw();
-    FX_Weather_Draw();
-    FX_WaterParticles_Draw();
-    FX_Droplets_Draw();
-    FX_GunFlash_Draw();
-    FX_Laser_Draw();
-    FX_Footprint_Draw();
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        if (m_Modules[i]->draw_func != nullptr) {
+            m_Modules[i]->draw_func();
+        }
+    }
 }
 
 void FX_Reset(void)
 {
-    FX_Fire_Reset();
-    FX_Water_Reset();
-    FX_Weather_Reset();
-    FX_WaterParticles_Reset();
-    FX_Droplets_Reset();
-    FX_Footprint_Reset();
-    FX_Wake_Reset();
-    FX_Ring_Reset();
+    for (int32_t i = 0; i < m_ModuleCount; i++) {
+        if (m_Modules[i]->reset_func != nullptr) {
+            m_Modules[i]->reset_func();
+        }
+    }
 }

--- a/src/trx/game/fx/common.h
+++ b/src/trx/game/fx/common.h
@@ -1,5 +1,22 @@
 #pragma once
 
+// Lifecycle hooks an effect module takes part in. Every hook is optional.
+typedef struct {
+    void (*new_frame_func)(void);
+    void (*control_func)(void);
+    void (*draw_func)(void);
+    void (*reset_func)(void);
+} FX_MODULE;
+
+void FX_RegisterModule(const FX_MODULE *module);
+
+// One module per translation unit.
+#define REGISTER_FX(module_)                                                   \
+    __attribute__((constructor)) static void M_RegisterFX(void)                \
+    {                                                                          \
+        FX_RegisterModule(&(module_));                                         \
+    }
+
 void FX_Reset(void);
 void FX_NewFrame(void);
 void FX_Control(void);

--- a/src/trx/game/fx/common.h
+++ b/src/trx/game/fx/common.h
@@ -1,11 +1,19 @@
 #pragma once
 
+typedef struct JSON_READ_IO JSON_READ_IO;
+typedef struct JSON_WRITE_IO JSON_WRITE_IO;
+
 // Lifecycle hooks an effect module takes part in. Every hook is optional.
+// A module that persists across saves fills in save_key together with save
+// and load; its state is written as an object under that key.
 typedef struct {
     void (*new_frame_func)(void);
     void (*control_func)(void);
     void (*draw_func)(void);
     void (*reset_func)(void);
+    const char *save_key;
+    void (*save_func)(JSON_WRITE_IO *io);
+    bool (*load_func)(JSON_READ_IO *io);
 } FX_MODULE;
 
 void FX_RegisterModule(const FX_MODULE *module);
@@ -21,3 +29,7 @@ void FX_Reset(void);
 void FX_NewFrame(void);
 void FX_Control(void);
 void FX_Draw(void);
+
+void FX_Save(JSON_WRITE_IO *io);
+// Resets every persisting module before applying what the save holds.
+bool FX_Load(JSON_READ_IO *io);

--- a/src/trx/game/fx/droplets.c
+++ b/src/trx/game/fx/droplets.c
@@ -4,10 +4,9 @@
 // underwater and drained here as droplets spawn. Not to be confused with
 // fx/water_particles.c, which is the TR3 residue drifting around Lara
 // while she is submerged.
-#include <trx/game/fx/droplets.h>
-
 #include <trx/config.h>
 #include <trx/core/math.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
 #include <trx/game/output/sources/poly_fx.h>
@@ -169,7 +168,7 @@ static void M_UpdateDroplet(M_DROPLET *const droplet)
     }
 }
 
-void FX_Droplets_Reset(void)
+static void M_Reset(void)
 {
     memset(m_Droplets, 0, sizeof(m_Droplets));
     memset(m_MeshUnderwater, 0, sizeof(m_MeshUnderwater));
@@ -177,7 +176,7 @@ void FX_Droplets_Reset(void)
     m_Ticks = 0;
 }
 
-void FX_Droplets_Control(void)
+static void M_Control(void)
 {
     if (!M_IsEnabled()) {
         return;
@@ -197,7 +196,7 @@ void FX_Droplets_Control(void)
     }
 }
 
-void FX_Droplets_Draw(void)
+static void M_Draw(void)
 {
     if (!M_IsEnabled()) {
         return;
@@ -239,3 +238,11 @@ void FX_Droplets_Draw(void)
             tail, tail_color, head, head_color, 1.0f, DRAW_BLEND_ADD);
     }
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = M_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/droplets.h
+++ b/src/trx/game/fx/droplets.h
@@ -1,5 +1,0 @@
-#pragma once
-
-void FX_Droplets_Reset(void);
-void FX_Droplets_Control(void);
-void FX_Droplets_Draw(void);

--- a/src/trx/game/fx/fire.c
+++ b/src/trx/game/fx/fire.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/matrix.h>
 #include <trx/game/output/sources/poly_fx.h>
 #include <trx/game/output/state.h>
@@ -328,17 +329,59 @@ static void M_DrawFire(const M_FIRE *const fire)
     }
 }
 
-void FX_Fire_Reset(void)
+static void M_Reset(void)
 {
     memset(m_Sparks, 0, sizeof(m_Sparks));
     memset(m_Fires, 0, sizeof(m_Fires));
     m_NextSpark = 1;
 }
 
-void FX_Fire_NewFrame(void)
+static void M_NewFrame(void)
 {
     for (int32_t i = 0; i < M_MAX_FIRES; i++) {
         m_Fires[i].on = 0;
+    }
+}
+
+static bool M_AnyFireActive(void)
+{
+    for (int32_t i = 0; i < M_MAX_FIRES; i++) {
+        if (m_Fires[i].on) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void M_Control(void)
+{
+    // Spawning draws from the control RNG that demo playback is locked to, so
+    // only run the pool while a fire is registered this frame. Existing sparks
+    // still advance to fade out; that path draws no RNG.
+    if (M_AnyFireActive()) {
+        M_KeepBurning();
+    }
+
+    const int32_t base_sprite = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
+    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
+        SPARK *const spark = &m_Sparks[i];
+        if (spark->on) {
+            M_AdvanceSpark(spark, base_sprite);
+        }
+    }
+}
+
+static void M_Draw(void)
+{
+    if (Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION) == NO_ITEM) {
+        return;
+    }
+
+    for (int32_t i = 0; i < M_MAX_FIRES; i++) {
+        const M_FIRE *const fire = &m_Fires[i];
+        if (fire->on) {
+            M_DrawFire(fire);
+        }
     }
 }
 
@@ -363,44 +406,11 @@ void FX_Fire_Add(
     }
 }
 
-static bool M_AnyFireActive(void)
-{
-    for (int32_t i = 0; i < M_MAX_FIRES; i++) {
-        if (m_Fires[i].on) {
-            return true;
-        }
-    }
-    return false;
-}
+static const FX_MODULE m_Module = {
+    .new_frame_func = M_NewFrame,
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = M_Reset,
+};
 
-void FX_Fire_Control(void)
-{
-    // Spawning draws from the control RNG that demo playback is locked to, so
-    // only run the pool while a fire is registered this frame. Existing sparks
-    // still advance to fade out; that path draws no RNG.
-    if (M_AnyFireActive()) {
-        M_KeepBurning();
-    }
-
-    const int32_t base_sprite = Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION);
-    for (int32_t i = 0; i < M_MAX_SPARKS; i++) {
-        SPARK *const spark = &m_Sparks[i];
-        if (spark->on) {
-            M_AdvanceSpark(spark, base_sprite);
-        }
-    }
-}
-
-void FX_Fire_Draw(void)
-{
-    if (Sparks_GetSpriteIndex(SPARK_TYPE_EXPLOSION) == NO_ITEM) {
-        return;
-    }
-
-    for (int32_t i = 0; i < M_MAX_FIRES; i++) {
-        const M_FIRE *const fire = &m_Fires[i];
-        if (fire->on) {
-            M_DrawFire(fire);
-        }
-    }
-}
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/fire.h
+++ b/src/trx/game/fx/fire.h
@@ -9,11 +9,6 @@
 // registry is rebuilt each tick: FX_Fire_NewFrame clears it before object
 // control runs, emitters re-add through FX_Fire_Add, and the draw only reads.
 
-void FX_Fire_Reset(void);
-void FX_Fire_NewFrame(void);
-void FX_Fire_Control(void);
-void FX_Fire_Draw(void);
-
 // Registers a fire at an absolute world position for this frame. size is 0
 // (small), 1 (medium) or 2 (big); fade dims the fire, 0 meaning full strength.
 void FX_Fire_Add(XYZ_32 pos, int32_t size, int16_t room_num, int32_t fade);

--- a/src/trx/game/fx/footprint.c
+++ b/src/trx/game/fx/footprint.c
@@ -1,6 +1,8 @@
 #include <trx/game/fx/footprint.h>
 
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/collision.h>
@@ -20,7 +22,14 @@
 #define M_FOOTPRINT_Z_DEPTH_ADJUST -0.5f
 
 typedef struct {
-    FX_FOOTPRINT prints[M_MAX_FOOTPRINTS];
+    XYZ_32 pos;
+    int16_t room_num;
+    int16_t y_rot;
+    int16_t life;
+} M_FOOTPRINT;
+
+typedef struct {
+    M_FOOTPRINT prints[M_MAX_FOOTPRINTS];
     int32_t next_idx;
 } M_PRIV;
 
@@ -43,8 +52,7 @@ static const SAMPLE_TRX_ID m_StepSounds[14] = {
 };
 
 static void M_GetWorldPoint(
-    const FX_FOOTPRINT *const print, const XYZ_32 local,
-    XYZ_32 *const out_world)
+    const M_FOOTPRINT *const print, const XYZ_32 local, XYZ_32 *const out_world)
 {
     const int32_t s = Math_Sin(print->y_rot);
     const int32_t c = Math_Cos(print->y_rot);
@@ -56,7 +64,7 @@ static void M_GetWorldPoint(
 }
 
 static int32_t M_GetVertexYOffset(
-    const FX_FOOTPRINT *const print, const XYZ_32 world_pos)
+    const M_FOOTPRINT *const print, const XYZ_32 world_pos)
 {
     int16_t room_num = print->room_num;
     const XYZ_32 pos = { world_pos.x, print->pos.y, world_pos.z };
@@ -77,6 +85,63 @@ static int32_t M_GetVertexYOffset(
     return dy;
 }
 
+static bool M_HasActivePrints(void)
+{
+    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
+        if (m_Priv.prints[i].life != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    if (!M_HasActivePrints()) {
+        return;
+    }
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
+        const M_FOOTPRINT *const print = &m_Priv.prints[i];
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", print->pos);
+        JSONW_WRITE(io, "room_num", print->room_num);
+        JSONW_WRITE(io, "y_rot", print->y_rot);
+        JSONW_WRITE(io, "life", print->life);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET(io, "prints");
+}
+
+static bool M_Load(JSON_READ_IO *const io)
+{
+    if (!JSON_OPTIONAL(JSON_PUSH(io, "prints"))) {
+        return true;
+    }
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_FOOTPRINTS) {
+            LOG_WARNING(
+                "Malformed save: too many footprints. Extra footprints will "
+                "be ignored.");
+            break;
+        }
+
+        M_FOOTPRINT *const print = &m_Priv.prints[i];
+        JSON_MUST(JSON_PUSH_INDEX(io, i));
+        JSON_MUST(JSON_READ(io, "pos", &print->pos));
+        JSON_MUST(JSON_READ(io, "room_num", &print->room_num));
+        JSON_MUST(JSON_READ(io, "y_rot", &print->y_rot));
+        JSON_MUST(JSON_READ(io, "life", &print->life));
+        JSON_MUST(JSON_POP(io));
+    }
+
+    JSON_MUST(JSON_POP(io));
+    JSON_FINISH();
+}
+
 static void M_Control(void)
 {
     if (!g_Config.visuals.enable_footprints) {
@@ -84,7 +149,7 @@ static void M_Control(void)
     }
     M_PRIV *const p = &m_Priv;
     for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        FX_FOOTPRINT *const print = &p->prints[i];
+        M_FOOTPRINT *const print = &p->prints[i];
         if (print->life != 0) {
             print->life--;
         }
@@ -110,7 +175,7 @@ static void M_Draw(void)
     };
 
     for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        const FX_FOOTPRINT *const print = &p->prints[i];
+        const M_FOOTPRINT *const print = &p->prints[i];
         if (print->life == 0) {
             continue;
         }
@@ -135,7 +200,7 @@ static void M_Draw(void)
     }
 }
 
-void FX_Footprint_Reset(void)
+static void M_Reset(void)
 {
     M_PRIV *const p = &m_Priv;
     memset(p, 0, sizeof(*p));
@@ -172,7 +237,7 @@ void FX_Footprint_Add(const ITEM *const lara_item, const bool is_left_foot)
         return;
     }
 
-    FX_FOOTPRINT *const print = &m_Priv.prints[m_Priv.next_idx];
+    M_FOOTPRINT *const print = &m_Priv.prints[m_Priv.next_idx];
     print->pos.x = pos.x;
     print->pos.y = y;
     print->pos.z = pos.z;
@@ -182,28 +247,13 @@ void FX_Footprint_Add(const ITEM *const lara_item, const bool is_left_foot)
     p->next_idx = (p->next_idx + 1) % M_MAX_FOOTPRINTS;
 }
 
-bool FX_Footprint_HasActivePrints(void)
-{
-    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        if (m_Priv.prints[i].life != 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-FX_FOOTPRINT *FX_Footprint_GetPrint(const int32_t idx)
-{
-    if (idx < 0 || idx >= M_MAX_FOOTPRINTS) {
-        return nullptr;
-    }
-    return &m_Priv.prints[idx];
-}
-
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
-    .reset_func = FX_Footprint_Reset,
+    .reset_func = M_Reset,
+    .save_key = "footprints",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/footprint.c
+++ b/src/trx/game/fx/footprint.c
@@ -4,6 +4,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/collision.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/lara.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
@@ -40,6 +41,99 @@ static const SAMPLE_TRX_ID m_StepSounds[14] = {
     SFX_FOOTSTEPS_WOOD,
     SFX_FOOTSTEPS_METAL,
 };
+
+static void M_GetWorldPoint(
+    const FX_FOOTPRINT *const print, const XYZ_32 local,
+    XYZ_32 *const out_world)
+{
+    const int32_t s = Math_Sin(print->y_rot);
+    const int32_t c = Math_Cos(print->y_rot);
+    const int32_t dx = TRIGMULT2(local.x, c) + TRIGMULT2(local.z, s);
+    const int32_t dz = TRIGMULT2(local.z, c) - TRIGMULT2(local.x, s);
+    out_world->x = print->pos.x + dx;
+    out_world->y = print->pos.y + local.y;
+    out_world->z = print->pos.z + dz;
+}
+
+static int32_t M_GetVertexYOffset(
+    const FX_FOOTPRINT *const print, const XYZ_32 world_pos)
+{
+    int16_t room_num = print->room_num;
+    const XYZ_32 pos = { world_pos.x, print->pos.y, world_pos.z };
+    const SECTOR *const sector = Room_GetSector(pos, &room_num);
+    if (sector == nullptr) {
+        return 0;
+    }
+
+    const int32_t height = Room_GetHeight(sector, pos);
+    if (height == NO_HEIGHT) {
+        return 0;
+    }
+
+    int32_t dy = height - print->pos.y;
+    if (ABS(dy) > 128) {
+        dy = 0;
+    }
+    return dy;
+}
+
+static void M_Control(void)
+{
+    if (!g_Config.visuals.enable_footprints) {
+        return;
+    }
+    M_PRIV *const p = &m_Priv;
+    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
+        FX_FOOTPRINT *const print = &p->prints[i];
+        if (print->life != 0) {
+            print->life--;
+        }
+    }
+}
+
+static void M_Draw(void)
+{
+    if (!g_Config.visuals.enable_footprints) {
+        return;
+    }
+
+    const M_PRIV *const p = &m_Priv;
+    const int32_t sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_FOOTPRINT);
+    if (sprite_idx == NO_ITEM) {
+        return;
+    }
+
+    const XYZ_32 corners[3] = {
+        { .x = 0, .y = 0, .z = -64 },
+        { .x = -128, .y = 0, .z = 64 },
+        { .x = 128, .y = 0, .z = 64 },
+    };
+
+    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
+        const FX_FOOTPRINT *const print = &p->prints[i];
+        if (print->life == 0) {
+            continue;
+        }
+
+        XYZ_32 world[3] = {};
+        for (int32_t j = 0; j < 3; j++) {
+            M_GetWorldPoint(print, corners[j], &world[j]);
+            world[j].y += M_GetVertexYOffset(print, world[j]);
+        }
+
+        int32_t c = print->life < 29 ? (print->life << 2) : 112;
+        CLAMP(c, 0, 255);
+
+        const RGBA_8888 color = { c, c, c, 255 };
+        const RGBA_8888 tri_color[3] = { color, color, color };
+
+        for (int32_t j = 0; j < 4; j++) {
+            OutputSource_PolyFX_StageSpriteTriWorldDepth(
+                sprite_idx, world, tri_color, M_FOOTPRINT_Z_DEPTH_ADJUST,
+                DRAW_BLEND_SUB);
+        }
+    }
+}
 
 void FX_Footprint_Reset(void)
 {
@@ -88,99 +182,6 @@ void FX_Footprint_Add(const ITEM *const lara_item, const bool is_left_foot)
     p->next_idx = (p->next_idx + 1) % M_MAX_FOOTPRINTS;
 }
 
-static void M_GetWorldPoint(
-    const FX_FOOTPRINT *const print, const XYZ_32 local,
-    XYZ_32 *const out_world)
-{
-    const int32_t s = Math_Sin(print->y_rot);
-    const int32_t c = Math_Cos(print->y_rot);
-    const int32_t dx = TRIGMULT2(local.x, c) + TRIGMULT2(local.z, s);
-    const int32_t dz = TRIGMULT2(local.z, c) - TRIGMULT2(local.x, s);
-    out_world->x = print->pos.x + dx;
-    out_world->y = print->pos.y + local.y;
-    out_world->z = print->pos.z + dz;
-}
-
-static int32_t M_GetVertexYOffset(
-    const FX_FOOTPRINT *const print, const XYZ_32 world_pos)
-{
-    int16_t room_num = print->room_num;
-    const XYZ_32 pos = { world_pos.x, print->pos.y, world_pos.z };
-    const SECTOR *const sector = Room_GetSector(pos, &room_num);
-    if (sector == nullptr) {
-        return 0;
-    }
-
-    const int32_t height = Room_GetHeight(sector, pos);
-    if (height == NO_HEIGHT) {
-        return 0;
-    }
-
-    int32_t dy = height - print->pos.y;
-    if (ABS(dy) > 128) {
-        dy = 0;
-    }
-    return dy;
-}
-
-void FX_Footprint_Control(void)
-{
-    if (!g_Config.visuals.enable_footprints) {
-        return;
-    }
-    M_PRIV *const p = &m_Priv;
-    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        FX_FOOTPRINT *const print = &p->prints[i];
-        if (print->life != 0) {
-            print->life--;
-        }
-    }
-}
-
-void FX_Footprint_Draw(void)
-{
-    if (!g_Config.visuals.enable_footprints) {
-        return;
-    }
-
-    const M_PRIV *const p = &m_Priv;
-    const int32_t sprite_idx = Sparks_GetSpriteIndex(SPARK_TYPE_FOOTPRINT);
-    if (sprite_idx == NO_ITEM) {
-        return;
-    }
-
-    const XYZ_32 corners[3] = {
-        { .x = 0, .y = 0, .z = -64 },
-        { .x = -128, .y = 0, .z = 64 },
-        { .x = 128, .y = 0, .z = 64 },
-    };
-
-    for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
-        const FX_FOOTPRINT *const print = &p->prints[i];
-        if (print->life == 0) {
-            continue;
-        }
-
-        XYZ_32 world[3] = {};
-        for (int32_t j = 0; j < 3; j++) {
-            M_GetWorldPoint(print, corners[j], &world[j]);
-            world[j].y += M_GetVertexYOffset(print, world[j]);
-        }
-
-        int32_t c = print->life < 29 ? (print->life << 2) : 112;
-        CLAMP(c, 0, 255);
-
-        const RGBA_8888 color = { c, c, c, 255 };
-        const RGBA_8888 tri_color[3] = { color, color, color };
-
-        for (int32_t j = 0; j < 4; j++) {
-            OutputSource_PolyFX_StageSpriteTriWorldDepth(
-                sprite_idx, world, tri_color, M_FOOTPRINT_Z_DEPTH_ADJUST,
-                DRAW_BLEND_SUB);
-        }
-    }
-}
-
 bool FX_Footprint_HasActivePrints(void)
 {
     for (int32_t i = 0; i < M_MAX_FOOTPRINTS; i++) {
@@ -198,3 +199,11 @@ FX_FOOTPRINT *FX_Footprint_GetPrint(const int32_t idx)
     }
     return &m_Priv.prints[idx];
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = FX_Footprint_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/footprint.h
+++ b/src/trx/game/fx/footprint.h
@@ -1,20 +1,5 @@
 #pragma once
 
-#include <trx/core/math/types.h>
 #include <trx/game/items/types.h>
 
-#include <stdint.h>
-
-typedef struct {
-    XYZ_32 pos;
-    int16_t room_num;
-    int16_t y_rot;
-    int16_t life;
-} FX_FOOTPRINT;
-
-void FX_Footprint_Reset(void);
-
 void FX_Footprint_Add(const ITEM *lara_item, bool is_left_foot);
-
-bool FX_Footprint_HasActivePrints(void);
-FX_FOOTPRINT *FX_Footprint_GetPrint(int32_t idx);

--- a/src/trx/game/fx/footprint.h
+++ b/src/trx/game/fx/footprint.h
@@ -16,8 +16,5 @@ void FX_Footprint_Reset(void);
 
 void FX_Footprint_Add(const ITEM *lara_item, bool is_left_foot);
 
-void FX_Footprint_Control(void);
-void FX_Footprint_Draw(void);
-
 bool FX_Footprint_HasActivePrints(void);
 FX_FOOTPRINT *FX_Footprint_GetPrint(int32_t idx);

--- a/src/trx/game/fx/gun_flash.c
+++ b/src/trx/game/fx/gun_flash.c
@@ -4,6 +4,7 @@
 #include <trx/core/colors.h>
 #include <trx/core/math.h>
 #include <trx/game/collision.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/items.h>
 #include <trx/game/matrix.h>
 #include <trx/game/objects.h>
@@ -89,29 +90,7 @@ static void M_GetJointPose(
     out_rot->_23 = 0;
 }
 
-bool FX_GunFlash_Spawn(
-    const ITEM *const owner_item, const CREATURE_GUN *const gun)
-{
-    if (owner_item == nullptr || gun == nullptr || !gun->tr3_enemy_flash) {
-        return false;
-    }
-
-    M_GUN_FLASH *const flash = &m_Priv.flashes[m_Priv.next_idx];
-    flash->active = true;
-    flash->owner_item_num = Item_GetIndex(owner_item);
-    flash->room_num = owner_item->room_num;
-    flash->lifetime = M_LIFETIME;
-    flash->rot = (XZ_16) { .x = gun->tr3_flash_rot_x, .z = M_GetRandomRoll() };
-    flash->bite = gun->tr3_flash;
-    flash->flash_object_id =
-        (gun->tr3_enemy_weapon_flags & 1) != 0 ? O_M16_FLASH : O_GUN_FLASH;
-    flash->light_pos = owner_item->pos;
-
-    m_Priv.next_idx = (m_Priv.next_idx + 1) % M_MAX_FLASHES;
-    return true;
-}
-
-void FX_GunFlash_Control(void)
+static void M_Control(void)
 {
     for (int32_t i = 0; i < M_MAX_FLASHES; i++) {
         M_GUN_FLASH *const flash = &m_Priv.flashes[i];
@@ -150,7 +129,7 @@ void FX_GunFlash_Control(void)
     }
 }
 
-void FX_GunFlash_Draw(void)
+static void M_Draw(void)
 {
     const OBJECT *const glow_obj = Object_Get(O_GLOW);
 
@@ -193,3 +172,32 @@ void FX_GunFlash_Draw(void)
         Matrix_Pop();
     }
 }
+
+bool FX_GunFlash_Spawn(
+    const ITEM *const owner_item, const CREATURE_GUN *const gun)
+{
+    if (owner_item == nullptr || gun == nullptr || !gun->tr3_enemy_flash) {
+        return false;
+    }
+
+    M_GUN_FLASH *const flash = &m_Priv.flashes[m_Priv.next_idx];
+    flash->active = true;
+    flash->owner_item_num = Item_GetIndex(owner_item);
+    flash->room_num = owner_item->room_num;
+    flash->lifetime = M_LIFETIME;
+    flash->rot = (XZ_16) { .x = gun->tr3_flash_rot_x, .z = M_GetRandomRoll() };
+    flash->bite = gun->tr3_flash;
+    flash->flash_object_id =
+        (gun->tr3_enemy_weapon_flags & 1) != 0 ? O_M16_FLASH : O_GUN_FLASH;
+    flash->light_pos = owner_item->pos;
+
+    m_Priv.next_idx = (m_Priv.next_idx + 1) % M_MAX_FLASHES;
+    return true;
+}
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/gun_flash.h
+++ b/src/trx/game/fx/gun_flash.h
@@ -4,5 +4,3 @@
 #include <trx/game/items/types.h>
 
 bool FX_GunFlash_Spawn(const ITEM *owner_item, const CREATURE_GUN *gun);
-void FX_GunFlash_Control(void);
-void FX_GunFlash_Draw(void);

--- a/src/trx/game/fx/laser.c
+++ b/src/trx/game/fx/laser.c
@@ -2,6 +2,7 @@
 
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/los.h>
 #include <trx/game/output/sources/poly_fx.h>
 
@@ -34,25 +35,7 @@ static bool M_GetOwnerItem(const M_LASER *const laser, ITEM **const out_item)
     return *out_item != nullptr;
 }
 
-bool FX_Laser_Spawn(const ITEM *const owner_item, const CREATURE_GUN *const gun)
-{
-    if (owner_item == nullptr || gun == nullptr || !gun->tr3_enemy_flash) {
-        return false;
-    }
-
-    M_LASER *const laser = &m_Priv.lasers[m_Priv.next_idx];
-    laser->active = true;
-    laser->lifetime = M_LIFETIME;
-    laser->owner_item_num = Item_GetIndex(owner_item);
-    laser->bite = gun->tr3_laser.bite;
-    laser->color = gun->tr3_laser.color;
-    laser->width = gun->tr3_laser.width;
-
-    m_Priv.next_idx = (m_Priv.next_idx + 1) % M_MAX_LASERS;
-    return true;
-}
-
-void FX_Laser_Control(void)
+static void M_Control(void)
 {
     for (int32_t i = 0; i < M_MAX_LASERS; i++) {
         M_LASER *const laser = &m_Priv.lasers[i];
@@ -73,7 +56,7 @@ void FX_Laser_Control(void)
     }
 }
 
-void FX_Laser_Draw(void)
+static void M_Draw(void)
 {
     for (int32_t i = 0; i < M_MAX_LASERS; i++) {
         const M_LASER *const laser = &m_Priv.lasers[i];
@@ -129,3 +112,28 @@ void FX_Laser_Draw(void)
         }
     }
 }
+
+bool FX_Laser_Spawn(const ITEM *const owner_item, const CREATURE_GUN *const gun)
+{
+    if (owner_item == nullptr || gun == nullptr || !gun->tr3_enemy_flash) {
+        return false;
+    }
+
+    M_LASER *const laser = &m_Priv.lasers[m_Priv.next_idx];
+    laser->active = true;
+    laser->lifetime = M_LIFETIME;
+    laser->owner_item_num = Item_GetIndex(owner_item);
+    laser->bite = gun->tr3_laser.bite;
+    laser->color = gun->tr3_laser.color;
+    laser->width = gun->tr3_laser.width;
+
+    m_Priv.next_idx = (m_Priv.next_idx + 1) % M_MAX_LASERS;
+    return true;
+}
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/laser.h
+++ b/src/trx/game/fx/laser.h
@@ -4,5 +4,3 @@
 #include <trx/game/items/types.h>
 
 bool FX_Laser_Spawn(const ITEM *owner_item, const CREATURE_GUN *gun);
-void FX_Laser_Control(void);
-void FX_Laser_Draw(void);

--- a/src/trx/game/fx/ring.c
+++ b/src/trx/game/fx/ring.c
@@ -1,5 +1,8 @@
 #include <trx/game/fx/ring.h>
 
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
+#include <trx/core/log.h>
 #include <trx/core/math/func.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
@@ -383,6 +386,95 @@ static void M_DrawKnockBackRings(const int32_t angle_base)
     }
 }
 
+static void M_SaveRings(
+    JSON_WRITE_IO *const io, const FX_RING_TYPE type, const char *const key)
+{
+    if (!m_Active[type]) {
+        return;
+    }
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_RINGS; i++) {
+        const FX_RING *const ring = &m_Rings[type][i];
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "on", ring->on);
+        JSONW_WRITE(io, "life", ring->life);
+        JSONW_WRITE(io, "speed", ring->speed);
+        JSONW_WRITE(io, "radius", ring->radius);
+        JSONW_WRITE(io, "prev_radius", ring->prev_radius);
+        JSONW_WRITE(io, "rot", ((XYZ_16) { ring->rot.x, 0, ring->rot.z }));
+        JSONW_WRITE(
+            io, "prev_rot",
+            ((XYZ_16) { ring->prev_rot.x, 0, ring->prev_rot.z }));
+        JSONW_WRITE(io, "pos", ring->pos);
+        JSONW_WRITE(io, "prev_pos", ring->prev_pos);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, key);
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    M_SaveRings(io, FX_RING_TYPE_BLAST, "blast");
+    M_SaveRings(io, FX_RING_TYPE_KNOCKBACK, "knockback");
+    M_SaveRings(io, FX_RING_TYPE_SUMMON, "summon");
+}
+
+static bool M_LoadRing(JSON_READ_IO *const io, FX_RING *const ring)
+{
+    JSON_MUST(JSON_READ(io, "on", &ring->on));
+    JSON_MUST(JSON_READ(io, "life", &ring->life));
+    JSON_MUST(JSON_READ(io, "speed", &ring->speed));
+    JSON_MUST(JSON_READ(io, "radius", &ring->radius));
+    JSON_MUST(JSON_READ(io, "prev_radius", &ring->prev_radius));
+
+    XYZ_16 rot = {};
+    JSON_MUST(JSON_READ(io, "rot", &rot));
+    ring->rot = (XZ_16) { rot.x, rot.z };
+
+    XYZ_16 prev_rot = {};
+    JSON_MUST(JSON_READ(io, "prev_rot", &prev_rot));
+    ring->prev_rot = (XZ_16) { prev_rot.x, prev_rot.z };
+
+    JSON_MUST(JSON_READ(io, "pos", &ring->pos));
+    JSON_MUST(JSON_READ(io, "prev_pos", &ring->prev_pos));
+    JSON_FINISH();
+}
+
+static bool M_LoadRings(
+    JSON_READ_IO *const io, const FX_RING_TYPE type, const char *const key)
+{
+    if (!JSON_OPTIONAL(JSON_PUSH(io, key))) {
+        return true;
+    }
+
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        JSON_MUST(JSON_PUSH_INDEX(io, i));
+        FX_RING *const ring = FX_Ring_GetRing(type, i);
+        if (ring != nullptr) {
+            JSON_MUST(M_LoadRing(io, ring));
+        } else {
+            LOG_WARNING(
+                "Malformed save: too many %s rings. Extra rings will be "
+                "ignored.",
+                key);
+        }
+        JSON_MUST(JSON_POP(io));
+    }
+
+    JSON_MUST(JSON_POP(io));
+    JSON_FINISH();
+}
+
+static bool M_Load(JSON_READ_IO *const io)
+{
+    JSON_MUST(M_LoadRings(io, FX_RING_TYPE_BLAST, "blast"));
+    JSON_MUST(M_LoadRings(io, FX_RING_TYPE_KNOCKBACK, "knockback"));
+    JSON_MUST(M_LoadRings(io, FX_RING_TYPE_SUMMON, "summon"));
+    JSON_FINISH();
+}
+
 static void M_Control(void)
 {
     if (m_Active[FX_RING_TYPE_BLAST]) {
@@ -398,7 +490,7 @@ static void M_Control(void)
     }
 }
 
-void FX_Ring_Reset(void)
+static void M_Reset(void)
 {
     memset(m_Rings, 0, sizeof(m_Rings));
     memset(m_Active, 0, sizeof(m_Active));
@@ -472,7 +564,10 @@ void FX_Ring_Draw(void)
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = FX_Ring_Draw,
-    .reset_func = FX_Ring_Reset,
+    .reset_func = M_Reset,
+    .save_key = "rings",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/ring.c
+++ b/src/trx/game/fx/ring.c
@@ -3,6 +3,7 @@
 #include <trx/core/math/func.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/objects/common.h>
 #include <trx/game/output.h>
@@ -382,6 +383,21 @@ static void M_DrawKnockBackRings(const int32_t angle_base)
     }
 }
 
+static void M_Control(void)
+{
+    if (m_Active[FX_RING_TYPE_BLAST]) {
+        M_ControlExplosionRings();
+    }
+
+    if (m_Active[FX_RING_TYPE_SUMMON]) {
+        M_ControlSummonRings();
+    }
+
+    if (m_Active[FX_RING_TYPE_KNOCKBACK]) {
+        M_ControlKnockBackRings();
+    }
+}
+
 void FX_Ring_Reset(void)
 {
     memset(m_Rings, 0, sizeof(m_Rings));
@@ -411,21 +427,6 @@ FX_RING *FX_Ring_PeekRing(const FX_RING_TYPE type, const int32_t idx)
         return nullptr;
     }
     return &m_Rings[type][idx];
-}
-
-void FX_Ring_Control(void)
-{
-    if (m_Active[FX_RING_TYPE_BLAST]) {
-        M_ControlExplosionRings();
-    }
-
-    if (m_Active[FX_RING_TYPE_SUMMON]) {
-        M_ControlSummonRings();
-    }
-
-    if (m_Active[FX_RING_TYPE_KNOCKBACK]) {
-        M_ControlKnockBackRings();
-    }
 }
 
 void FX_Ring_SpawnKnockBack(const XYZ_32 pos)
@@ -467,3 +468,11 @@ void FX_Ring_Draw(void)
     M_DrawSummonRings(angle_base);
     M_DrawKnockBackRings(angle_base);
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = FX_Ring_Draw,
+    .reset_func = FX_Ring_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/ring.h
+++ b/src/trx/game/fx/ring.h
@@ -30,8 +30,6 @@ typedef enum {
     FX_RING_TYPE_NUMBER_OF,
 } FX_RING_TYPE;
 
-void FX_Ring_Reset(void);
-
 void FX_Ring_Draw(void);
 void FX_Ring_SpawnKnockBack(XYZ_32 pos);
 void FX_Ring_BounceKnockBack(void);

--- a/src/trx/game/fx/ring.h
+++ b/src/trx/game/fx/ring.h
@@ -32,7 +32,6 @@ typedef enum {
 
 void FX_Ring_Reset(void);
 
-void FX_Ring_Control(void);
 void FX_Ring_Draw(void);
 void FX_Ring_SpawnKnockBack(XYZ_32 pos);
 void FX_Ring_BounceKnockBack(void);

--- a/src/trx/game/fx/wake.c
+++ b/src/trx/game/fx/wake.c
@@ -3,6 +3,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/const.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/output/sources/poly_fx.h>
 
@@ -30,16 +31,7 @@ static XYZ_32 M_GetWakeOrigin(const ITEM *const item, const XZ_32 offset)
     return pos;
 }
 
-void FX_Wake_Reset(void)
-{
-    for (int32_t i = 0; i < M_MAX_POINTS; i++) {
-        m_Points[i][0].life = 0;
-        m_Points[i][1].life = 0;
-    }
-    m_Active = false;
-}
-
-void FX_Wake_Control(void)
+static void M_Control(void)
 {
     if (!m_Active) {
         return;
@@ -66,6 +58,15 @@ void FX_Wake_Control(void)
     if (!any_active) {
         m_Active = false;
     }
+}
+
+void FX_Wake_Reset(void)
+{
+    for (int32_t i = 0; i < M_MAX_POINTS; i++) {
+        m_Points[i][0].life = 0;
+        m_Points[i][1].life = 0;
+    }
+    m_Active = false;
 }
 
 FX_WAKE_POINT *FX_Wake_GetPoint(const int32_t wake_idx, const int32_t side)
@@ -215,3 +216,10 @@ void FX_Wake_Draw(const ITEM *const item)
         }
     }
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .reset_func = FX_Wake_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/wake.h
+++ b/src/trx/game/fx/wake.h
@@ -10,7 +10,6 @@ typedef struct {
 } FX_WAKE_POINT;
 
 void FX_Wake_Reset(void);
-void FX_Wake_Control(void);
 
 FX_WAKE_POINT *FX_Wake_GetPoint(int32_t wake_idx, int32_t side);
 

--- a/src/trx/game/fx/water.c
+++ b/src/trx/game/fx/water.c
@@ -2,6 +2,7 @@
 
 #include <trx/config.h>
 #include <trx/core/utils.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/items.h>
 #include <trx/game/lara/common.h>
@@ -31,7 +32,7 @@ static FX_WATER_SPLASH m_Splashes[4];
 static FX_WATER_RIPPLE m_Ripples[16];
 static int32_t m_SplashCount = 0;
 
-void FX_Water_Reset(void)
+static void M_Reset(void)
 {
     memset(m_Splashes, 0, sizeof(m_Splashes));
     memset(m_Ripples, 0, sizeof(m_Ripples));
@@ -528,7 +529,7 @@ static void M_DrawRipple(const FX_WATER_RIPPLE *r)
         DRAW_BLEND_ADD);
 }
 
-void FX_Water_Draw(void)
+static void M_Draw(void)
 {
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(m_Splashes); i++) {
         const FX_WATER_SPLASH *const splash = &m_Splashes[i];
@@ -547,7 +548,7 @@ void FX_Water_Draw(void)
     }
 }
 
-void FX_Water_Control(void)
+static void M_Control(void)
 {
     if (m_SplashCount > 0) {
         m_SplashCount--;
@@ -627,3 +628,11 @@ void FX_Water_Control(void)
         }
     }
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = M_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/water.h
+++ b/src/trx/game/fx/water.h
@@ -69,10 +69,6 @@ typedef struct {
     int16_t outer_friction;
 } FX_WATER_SPLASH_SETUP;
 
-void FX_Water_Reset(void);
-void FX_Water_Control(void);
-void FX_Water_Draw(void);
-
 FX_WATER_RIPPLE *FX_Water_SetupRipple(
     int32_t x, int32_t y, int32_t z, int32_t size, bool is_still);
 void FX_Water_SetupSplash(const FX_WATER_SPLASH_SETUP *setup);

--- a/src/trx/game/fx/water_particles.c
+++ b/src/trx/game/fx/water_particles.c
@@ -1,11 +1,10 @@
 // TR3 underwater residue: faint specks drifting around Lara while she is
 // submerged. The droplets falling off her once she is out of the water are
 // fx/droplets.c.
-#include <trx/game/fx/water_particles.h>
-
 #include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/game_flow/common.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
@@ -110,12 +109,12 @@ static void M_Spawn(M_WATER_PARTICLE *const particle)
     particle->prev_pos = particle->pos;
 }
 
-void FX_WaterParticles_Reset(void)
+static void M_Reset(void)
 {
     M_Clear();
 }
 
-void FX_WaterParticles_Control(void)
+static void M_Control(void)
 {
     if (!M_IsEnabled()) {
         M_Clear();
@@ -152,7 +151,7 @@ void FX_WaterParticles_Control(void)
     }
 }
 
-void FX_WaterParticles_Draw(void)
+static void M_Draw(void)
 {
     if (!M_IsEnabled()) {
         return;
@@ -246,3 +245,11 @@ void FX_WaterParticles_Draw(void)
             DRAW_BLEND_ADD);
     }
 }
+
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = M_Reset,
+};
+
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/water_particles.h
+++ b/src/trx/game/fx/water_particles.h
@@ -1,5 +1,0 @@
-#pragma once
-
-void FX_WaterParticles_Reset(void);
-void FX_WaterParticles_Control(void);
-void FX_WaterParticles_Draw(void);

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -4,6 +4,7 @@
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/game/state.h>
 #include <trx/game/interpolation.h>
 #include <trx/game/lara.h>
@@ -397,6 +398,36 @@ static void M_DrawSnow(void)
     }
 }
 
+static void M_Control(void)
+{
+    if (!g_Config.visuals.enable_weather) {
+        return;
+    }
+    const WEATHER_TYPE weather_type = m_WeatherType;
+    if (weather_type == WEATHER_RAIN) {
+        M_UpdateRain();
+    } else if (weather_type == WEATHER_SNOW) {
+        M_UpdateSnow();
+    }
+}
+
+static void M_Draw(void)
+{
+    if (!g_Config.visuals.enable_weather) {
+        return;
+    }
+    switch (m_WeatherType) {
+    case WEATHER_RAIN:
+        M_DrawRain();
+        break;
+    case WEATHER_SNOW:
+        M_DrawSnow();
+        break;
+    default:
+        break;
+    }
+}
+
 void FX_Weather_Reset(void)
 {
     M_ClearWeather();
@@ -428,32 +459,10 @@ FX_SNOWFLAKE *FX_Weather_GetSnowflake(const int32_t idx)
     return &m_Snowflakes[idx];
 }
 
-void FX_Weather_Control(void)
-{
-    if (!g_Config.visuals.enable_weather) {
-        return;
-    }
-    const WEATHER_TYPE weather_type = m_WeatherType;
-    if (weather_type == WEATHER_RAIN) {
-        M_UpdateRain();
-    } else if (weather_type == WEATHER_SNOW) {
-        M_UpdateSnow();
-    }
-}
+static const FX_MODULE m_Module = {
+    .control_func = M_Control,
+    .draw_func = M_Draw,
+    .reset_func = FX_Weather_Reset,
+};
 
-void FX_Weather_Draw(void)
-{
-    if (!g_Config.visuals.enable_weather) {
-        return;
-    }
-    switch (m_WeatherType) {
-    case WEATHER_RAIN:
-        M_DrawRain();
-        break;
-    case WEATHER_SNOW:
-        M_DrawSnow();
-        break;
-    default:
-        break;
-    }
-}
+REGISTER_FX(m_Module)

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -34,30 +34,8 @@
 #define M_SNOW_YV_MIN 8
 #define M_SNOW_YV_RANGE 24
 
-typedef struct {
-    XYZ_32 pos;
-    XYZ_32 prev_pos;
-    int32_t prev_yv;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
-    uint8_t life;
-} M_RAINDROP;
-
-typedef struct {
-    XYZ_32 pos;
-    XYZ_32 prev_pos;
-    bool stopped;
-    int32_t prev_yv;
-    int32_t prev_life;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
-    uint8_t life;
-} M_SNOWFLAKE;
-
-static M_RAINDROP m_Raindrops[M_MAX_WEATHER];
-static M_SNOWFLAKE m_Snowflakes[M_MAX_WEATHER];
+static FX_RAINDROP m_Raindrops[M_MAX_WEATHER];
+static FX_SNOWFLAKE m_Snowflakes[M_MAX_WEATHER];
 static WEATHER_TYPE m_WeatherType = WEATHER_NONE;
 
 static void M_ClearWeather(void)
@@ -111,7 +89,7 @@ static bool M_SpawnParticle(XYZ_32 *const pos)
     return true;
 }
 
-static void M_SpawnRainDrop(M_RAINDROP *const drop)
+static void M_SpawnRainDrop(FX_RAINDROP *const drop)
 {
     if (!M_SpawnParticle(&drop->pos)) {
         return;
@@ -132,7 +110,7 @@ static void M_UpdateRain(void)
 
     int32_t num_alive = 0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        M_RAINDROP *const drop = &m_Raindrops[i];
+        FX_RAINDROP *const drop = &m_Raindrops[i];
 
         if (drop->pos.x == 0 && num_alive < M_MAX_WEATHER_ALIVE) {
             num_alive++;
@@ -197,7 +175,7 @@ static void M_DrawRain(void)
         Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
 
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        const M_RAINDROP *const drop = &m_Raindrops[i];
+        const FX_RAINDROP *const drop = &m_Raindrops[i];
         if (drop->pos.x == 0) {
             continue;
         }
@@ -225,7 +203,7 @@ static void M_DrawRain(void)
     }
 }
 
-static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
+static void M_SpawnSnowflake(FX_SNOWFLAKE *const snow)
 {
     if (!M_SpawnParticle(&snow->pos)) {
         return;
@@ -246,7 +224,7 @@ static void M_UpdateSnow(void)
 {
     int32_t num_alive = 0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        M_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        FX_SNOWFLAKE *const snow = &m_Snowflakes[i];
 
         if (snow->pos.x == 0 && num_alive < M_MAX_WEATHER_ALIVE) {
             num_alive++;
@@ -335,7 +313,7 @@ static void M_DrawSnow(void)
     const bool do_interp =
         Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        M_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        FX_SNOWFLAKE *const snow = &m_Snowflakes[i];
         if (snow->pos.x == 0) {
             continue;
         }
@@ -432,6 +410,22 @@ WEATHER_TYPE FX_Weather_GetWeather(void)
 void FX_Weather_SetWeather(const WEATHER_TYPE weather_type)
 {
     m_WeatherType = weather_type;
+}
+
+FX_RAINDROP *FX_Weather_GetRaindrop(const int32_t idx)
+{
+    if (idx < 0 || idx >= M_MAX_WEATHER) {
+        return nullptr;
+    }
+    return &m_Raindrops[idx];
+}
+
+FX_SNOWFLAKE *FX_Weather_GetSnowflake(const int32_t idx)
+{
+    if (idx < 0 || idx >= M_MAX_WEATHER) {
+        return nullptr;
+    }
+    return &m_Snowflakes[idx];
 }
 
 void FX_Weather_Control(void)

--- a/src/trx/game/fx/weather.c
+++ b/src/trx/game/fx/weather.c
@@ -1,6 +1,8 @@
 #include <trx/game/fx/weather.h>
 
 #include <trx/config.h>
+#include <trx/core/json/util/read_io.h>
+#include <trx/core/json/util/write_io.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/camera.h>
@@ -35,8 +37,31 @@
 #define M_SNOW_YV_MIN 8
 #define M_SNOW_YV_RANGE 24
 
-static FX_RAINDROP m_Raindrops[M_MAX_WEATHER];
-static FX_SNOWFLAKE m_Snowflakes[M_MAX_WEATHER];
+typedef struct {
+    XYZ_32 pos;
+    XYZ_32 prev_pos;
+    int32_t prev_yv;
+    int8_t xv;
+    uint8_t yv;
+    int8_t zv;
+    uint8_t life;
+} M_RAINDROP;
+
+typedef struct {
+    XYZ_32 pos;
+    XYZ_32 prev_pos;
+    bool stopped;
+    int32_t prev_yv;
+    int32_t prev_life;
+    int8_t xv;
+    uint8_t yv;
+    int8_t zv;
+    uint8_t life;
+} M_SNOWFLAKE;
+
+// A zero pos.x marks a free slot.
+static M_RAINDROP m_Raindrops[M_MAX_WEATHER];
+static M_SNOWFLAKE m_Snowflakes[M_MAX_WEATHER];
 static WEATHER_TYPE m_WeatherType = WEATHER_NONE;
 
 static void M_ClearWeather(void)
@@ -90,7 +115,7 @@ static bool M_SpawnParticle(XYZ_32 *const pos)
     return true;
 }
 
-static void M_SpawnRainDrop(FX_RAINDROP *const drop)
+static void M_SpawnRainDrop(M_RAINDROP *const drop)
 {
     if (!M_SpawnParticle(&drop->pos)) {
         return;
@@ -111,7 +136,7 @@ static void M_UpdateRain(void)
 
     int32_t num_alive = 0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        FX_RAINDROP *const drop = &m_Raindrops[i];
+        M_RAINDROP *const drop = &m_Raindrops[i];
 
         if (drop->pos.x == 0 && num_alive < M_MAX_WEATHER_ALIVE) {
             num_alive++;
@@ -176,7 +201,7 @@ static void M_DrawRain(void)
         Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
 
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        const FX_RAINDROP *const drop = &m_Raindrops[i];
+        const M_RAINDROP *const drop = &m_Raindrops[i];
         if (drop->pos.x == 0) {
             continue;
         }
@@ -204,7 +229,7 @@ static void M_DrawRain(void)
     }
 }
 
-static void M_SpawnSnowflake(FX_SNOWFLAKE *const snow)
+static void M_SpawnSnowflake(M_SNOWFLAKE *const snow)
 {
     if (!M_SpawnParticle(&snow->pos)) {
         return;
@@ -225,7 +250,7 @@ static void M_UpdateSnow(void)
 {
     int32_t num_alive = 0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        FX_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        M_SNOWFLAKE *const snow = &m_Snowflakes[i];
 
         if (snow->pos.x == 0 && num_alive < M_MAX_WEATHER_ALIVE) {
             num_alive++;
@@ -314,7 +339,7 @@ static void M_DrawSnow(void)
     const bool do_interp =
         Interpolation_IsActive() && ratio > 0.0 && ratio < 1.0;
     for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
-        FX_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        M_SNOWFLAKE *const snow = &m_Snowflakes[i];
         if (snow->pos.x == 0) {
             continue;
         }
@@ -398,6 +423,122 @@ static void M_DrawSnow(void)
     }
 }
 
+static void M_SaveRain(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
+        const M_RAINDROP *const drop = &m_Raindrops[i];
+        if (drop->pos.x == 0) {
+            continue;
+        }
+
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", drop->pos);
+        JSONW_WRITE(io, "xv", drop->xv);
+        JSONW_WRITE(io, "yv", drop->yv);
+        JSONW_WRITE(io, "zv", drop->zv);
+        JSONW_WRITE(io, "life", drop->life);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "rain");
+}
+
+static void M_SaveSnow(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0; i < M_MAX_WEATHER; i++) {
+        const M_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        if (snow->pos.x == 0) {
+            continue;
+        }
+
+        JSONW_PUSH_OBJECT(io);
+        JSONW_WRITE(io, "pos", snow->pos);
+        JSONW_WRITE(io, "xv", snow->xv);
+        JSONW_WRITE(io, "yv", snow->yv);
+        JSONW_WRITE(io, "zv", snow->zv);
+        JSONW_WRITE(io, "life", snow->life);
+        JSONW_WRITE(io, "stopped", snow->stopped);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "snow");
+}
+
+static void M_Save(JSON_WRITE_IO *const io)
+{
+    // Particles of the inactive type are neither updated nor drawn.
+    if (m_WeatherType == WEATHER_RAIN) {
+        M_SaveRain(io);
+    } else if (m_WeatherType == WEATHER_SNOW) {
+        M_SaveSnow(io);
+    }
+}
+
+static bool M_LoadRain(JSON_READ_IO *const io)
+{
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_WEATHER) {
+            LOG_WARNING(
+                "Malformed save: too many raindrops. Extra raindrops will be "
+                "ignored.");
+            break;
+        }
+
+        M_RAINDROP *const drop = &m_Raindrops[i];
+        JSON_MUST(JSON_PUSH_INDEX(io, i));
+        JSON_MUST(JSON_READ(io, "pos", &drop->pos));
+        JSON_MUST(JSON_READ(io, "xv", &drop->xv));
+        JSON_MUST(JSON_READ(io, "yv", &drop->yv));
+        JSON_MUST(JSON_READ(io, "zv", &drop->zv));
+        JSON_MUST(JSON_READ(io, "life", &drop->life));
+        JSON_MUST(JSON_POP(io));
+        drop->prev_pos = drop->pos;
+        drop->prev_yv = drop->yv;
+    }
+    JSON_FINISH();
+}
+
+static bool M_LoadSnow(JSON_READ_IO *const io)
+{
+    const int32_t count = JSON_ARRAY_LEN(io);
+    for (int32_t i = 0; i < count; i++) {
+        if (i >= M_MAX_WEATHER) {
+            LOG_WARNING(
+                "Malformed save: too many snowflakes. Extra snowflakes will "
+                "be ignored.");
+            break;
+        }
+
+        M_SNOWFLAKE *const snow = &m_Snowflakes[i];
+        JSON_MUST(JSON_PUSH_INDEX(io, i));
+        JSON_MUST(JSON_READ(io, "pos", &snow->pos));
+        JSON_MUST(JSON_READ(io, "xv", &snow->xv));
+        JSON_MUST(JSON_READ(io, "yv", &snow->yv));
+        JSON_MUST(JSON_READ(io, "zv", &snow->zv));
+        JSON_MUST(JSON_READ(io, "life", &snow->life));
+        JSON_MUST(JSON_READ(io, "stopped", &snow->stopped));
+        JSON_MUST(JSON_POP(io));
+        snow->prev_pos = snow->pos;
+        snow->prev_yv = snow->yv;
+        snow->prev_life = snow->life;
+    }
+    JSON_FINISH();
+}
+
+static bool M_Load(JSON_READ_IO *const io)
+{
+    if (JSON_OPTIONAL(JSON_PUSH(io, "rain"))) {
+        JSON_MUST(M_LoadRain(io));
+        JSON_MUST(JSON_POP(io));
+    }
+    if (JSON_OPTIONAL(JSON_PUSH(io, "snow"))) {
+        JSON_MUST(M_LoadSnow(io));
+        JSON_MUST(JSON_POP(io));
+    }
+    JSON_FINISH();
+}
+
 static void M_Control(void)
 {
     if (!g_Config.visuals.enable_weather) {
@@ -428,7 +569,7 @@ static void M_Draw(void)
     }
 }
 
-void FX_Weather_Reset(void)
+static void M_Reset(void)
 {
     M_ClearWeather();
 }
@@ -443,26 +584,13 @@ void FX_Weather_SetWeather(const WEATHER_TYPE weather_type)
     m_WeatherType = weather_type;
 }
 
-FX_RAINDROP *FX_Weather_GetRaindrop(const int32_t idx)
-{
-    if (idx < 0 || idx >= M_MAX_WEATHER) {
-        return nullptr;
-    }
-    return &m_Raindrops[idx];
-}
-
-FX_SNOWFLAKE *FX_Weather_GetSnowflake(const int32_t idx)
-{
-    if (idx < 0 || idx >= M_MAX_WEATHER) {
-        return nullptr;
-    }
-    return &m_Snowflakes[idx];
-}
-
 static const FX_MODULE m_Module = {
     .control_func = M_Control,
     .draw_func = M_Draw,
-    .reset_func = FX_Weather_Reset,
+    .reset_func = M_Reset,
+    .save_key = "weather",
+    .save_func = M_Save,
+    .load_func = M_Load,
 };
 
 REGISTER_FX(m_Module)

--- a/src/trx/game/fx/weather.h
+++ b/src/trx/game/fx/weather.h
@@ -1,42 +1,10 @@
 #pragma once
 
-#include <trx/core/math/types.h>
-
-#include <stdint.h>
-
 typedef enum {
     WEATHER_NONE = 0,
     WEATHER_RAIN,
     WEATHER_SNOW,
 } WEATHER_TYPE;
 
-typedef struct {
-    XYZ_32 pos;
-    XYZ_32 prev_pos;
-    int32_t prev_yv;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
-    uint8_t life;
-} FX_RAINDROP;
-
-typedef struct {
-    XYZ_32 pos;
-    XYZ_32 prev_pos;
-    bool stopped;
-    int32_t prev_yv;
-    int32_t prev_life;
-    int8_t xv;
-    uint8_t yv;
-    int8_t zv;
-    uint8_t life;
-} FX_SNOWFLAKE;
-
-void FX_Weather_Reset(void);
 WEATHER_TYPE FX_Weather_GetWeather(void);
 void FX_Weather_SetWeather(WEATHER_TYPE weather_type);
-
-// The particle accessors return nullptr past the end of their pool. A zero
-// pos.x marks a free slot.
-FX_RAINDROP *FX_Weather_GetRaindrop(int32_t idx);
-FX_SNOWFLAKE *FX_Weather_GetSnowflake(int32_t idx);

--- a/src/trx/game/fx/weather.h
+++ b/src/trx/game/fx/weather.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trx/core/math/types.h>
+
 #include <stdint.h>
 
 typedef enum {
@@ -8,8 +10,35 @@ typedef enum {
     WEATHER_SNOW,
 } WEATHER_TYPE;
 
+typedef struct {
+    XYZ_32 pos;
+    XYZ_32 prev_pos;
+    int32_t prev_yv;
+    int8_t xv;
+    uint8_t yv;
+    int8_t zv;
+    uint8_t life;
+} FX_RAINDROP;
+
+typedef struct {
+    XYZ_32 pos;
+    XYZ_32 prev_pos;
+    bool stopped;
+    int32_t prev_yv;
+    int32_t prev_life;
+    int8_t xv;
+    uint8_t yv;
+    int8_t zv;
+    uint8_t life;
+} FX_SNOWFLAKE;
+
 void FX_Weather_Reset(void);
 void FX_Weather_Control(void);
 void FX_Weather_Draw(void);
 WEATHER_TYPE FX_Weather_GetWeather(void);
 void FX_Weather_SetWeather(WEATHER_TYPE weather_type);
+
+// The particle accessors return nullptr past the end of their pool. A zero
+// pos.x marks a free slot.
+FX_RAINDROP *FX_Weather_GetRaindrop(int32_t idx);
+FX_SNOWFLAKE *FX_Weather_GetSnowflake(int32_t idx);

--- a/src/trx/game/fx/weather.h
+++ b/src/trx/game/fx/weather.h
@@ -33,8 +33,6 @@ typedef struct {
 } FX_SNOWFLAKE;
 
 void FX_Weather_Reset(void);
-void FX_Weather_Control(void);
-void FX_Weather_Draw(void);
 WEATHER_TYPE FX_Weather_GetWeather(void);
 void FX_Weather_SetWeather(WEATHER_TYPE weather_type);
 

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -869,6 +869,80 @@ static bool M_ReadFXFootprints(JSON_READ_IO *const io)
     M_FINISH();
 }
 
+static bool M_ReadFXRaindrop(JSON_READ_IO *const io, FX_RAINDROP *const drop)
+{
+    ASSERT(drop != nullptr);
+
+    M_MUST(JSON_READ(io, "pos", &drop->pos));
+    M_MUST(JSON_READ(io, "xv", &drop->xv));
+    M_MUST(JSON_READ(io, "yv", &drop->yv));
+    M_MUST(JSON_READ(io, "zv", &drop->zv));
+    M_MUST(JSON_READ(io, "life", &drop->life));
+    drop->prev_pos = drop->pos;
+    drop->prev_yv = drop->yv;
+    M_FINISH();
+}
+
+static bool M_ReadFXSnowflake(JSON_READ_IO *const io, FX_SNOWFLAKE *const snow)
+{
+    ASSERT(snow != nullptr);
+
+    M_MUST(JSON_READ(io, "pos", &snow->pos));
+    M_MUST(JSON_READ(io, "xv", &snow->xv));
+    M_MUST(JSON_READ(io, "yv", &snow->yv));
+    M_MUST(JSON_READ(io, "zv", &snow->zv));
+    M_MUST(JSON_READ(io, "life", &snow->life));
+    M_MUST(JSON_READ(io, "stopped", &snow->stopped));
+    snow->prev_pos = snow->pos;
+    snow->prev_yv = snow->yv;
+    snow->prev_life = snow->life;
+    M_FINISH();
+}
+
+static bool M_ReadFXWeather(JSON_READ_IO *const io)
+{
+    if (!M_OPTIONAL(JSON_PUSH(io, "weather"))) {
+        return true;
+    }
+
+    if (M_OPTIONAL(JSON_PUSH(io, "rain"))) {
+        const int32_t drop_count = JSON_ARRAY_LEN(io);
+        for (int32_t i = 0; i < drop_count; i++) {
+            M_MUST(JSON_PUSH_INDEX(io, i));
+            FX_RAINDROP *const drop = FX_Weather_GetRaindrop(i);
+            if (drop != nullptr) {
+                M_MUST(M_ReadFXRaindrop(io, drop));
+            } else {
+                LOG_WARNING(
+                    "Malformed save: too many raindrops. Extra raindrops will "
+                    "be ignored.");
+            }
+            M_MUST(JSON_POP(io));
+        }
+        M_MUST(JSON_POP(io));
+    }
+
+    if (M_OPTIONAL(JSON_PUSH(io, "snow"))) {
+        const int32_t snow_count = JSON_ARRAY_LEN(io);
+        for (int32_t i = 0; i < snow_count; i++) {
+            M_MUST(JSON_PUSH_INDEX(io, i));
+            FX_SNOWFLAKE *const snow = FX_Weather_GetSnowflake(i);
+            if (snow != nullptr) {
+                M_MUST(M_ReadFXSnowflake(io, snow));
+            } else {
+                LOG_WARNING(
+                    "Malformed save: too many snowflakes. Extra snowflakes "
+                    "will be ignored.");
+            }
+            M_MUST(JSON_POP(io));
+        }
+        M_MUST(JSON_POP(io));
+    }
+
+    M_MUST(JSON_POP(io));
+    M_FINISH();
+}
+
 static bool M_ShouldLoadMusicTimestamp(
     const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode,
     const MUSIC_ID ambient_track)
@@ -1232,6 +1306,7 @@ bool SG_File_LoadFX(JSON_READ_IO *const io)
 {
     FX_Ring_Reset();
     FX_Footprint_Reset();
+    FX_Weather_Reset();
 
     if (!M_OPTIONAL(JSON_PUSH(io, "vfx"))) {
         return true;

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -4,8 +4,7 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/effects.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/ring.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/fx/weather.h>
 #include <trx/game/game.h>
 #include <trx/game/game_buf.h>
@@ -782,167 +781,6 @@ static bool M_ReadFlare(JSON_READ_IO *const io)
     M_FINISH();
 }
 
-static bool M_ReadFXRing(JSON_READ_IO *const io, FX_RING *const ring)
-{
-    ASSERT(ring != nullptr);
-
-    M_MUST(JSON_READ(io, "on", &ring->on));
-    M_MUST(JSON_READ(io, "life", &ring->life));
-    M_MUST(JSON_READ(io, "speed", &ring->speed));
-    M_MUST(JSON_READ(io, "radius", &ring->radius));
-    M_MUST(JSON_READ(io, "prev_radius", &ring->prev_radius));
-
-    XYZ_16 rot = {};
-    M_MUST(JSON_READ(io, "rot", &rot));
-    ring->rot = (XZ_16) { rot.x, rot.z };
-
-    XYZ_16 prev_rot = {};
-    M_MUST(JSON_READ(io, "prev_rot", &prev_rot));
-    ring->prev_rot = (XZ_16) { prev_rot.x, prev_rot.z };
-
-    M_MUST(JSON_READ(io, "pos", &ring->pos));
-    M_MUST(JSON_READ(io, "prev_pos", &ring->prev_pos));
-    M_FINISH();
-}
-
-static bool M_ReadFXRings(
-    JSON_READ_IO *const io, const FX_RING_TYPE type, const char *const key)
-{
-    if (!M_OPTIONAL(JSON_PUSH(io, key))) {
-        return true;
-    }
-
-    const int32_t ring_count = JSON_ARRAY_LEN(io);
-    for (int32_t i = 0; i < ring_count; i++) {
-        M_MUST(JSON_PUSH_INDEX(io, i));
-        FX_RING *const ring = FX_Ring_GetRing(type, i);
-        if (ring != nullptr) {
-            M_MUST(M_ReadFXRing(io, ring));
-        } else {
-            LOG_WARNING(
-                "Malformed save: too many %s rings. Extra rings will be "
-                "ignored.",
-                key);
-        }
-        M_MUST(JSON_POP(io));
-    }
-
-    M_MUST(JSON_POP(io));
-    M_FINISH();
-}
-
-static bool M_ReadFXFootprint(JSON_READ_IO *const io, FX_FOOTPRINT *const print)
-{
-    ASSERT(print != nullptr);
-
-    M_MUST(JSON_READ(io, "pos", &print->pos));
-    M_MUST(JSON_READ(io, "room_num", &print->room_num));
-    M_MUST(JSON_READ(io, "y_rot", &print->y_rot));
-    M_MUST(JSON_READ(io, "life", &print->life));
-    M_FINISH();
-}
-
-static bool M_ReadFXFootprints(JSON_READ_IO *const io)
-{
-    if (!M_OPTIONAL(JSON_PUSH(io, "footprints"))) {
-        return true;
-    }
-
-    if (M_OPTIONAL(JSON_PUSH(io, "prints"))) {
-        const int32_t print_count = JSON_ARRAY_LEN(io);
-        for (int32_t i = 0; i < print_count; i++) {
-            M_MUST(JSON_PUSH_INDEX(io, i));
-            FX_FOOTPRINT *const print = FX_Footprint_GetPrint(i);
-            if (print != nullptr) {
-                M_MUST(M_ReadFXFootprint(io, print));
-            } else {
-                LOG_WARNING(
-                    "Malformed save: too many footprints. Extra footprints "
-                    "will be ignored.");
-            }
-            M_MUST(JSON_POP(io));
-        }
-        M_MUST(JSON_POP(io));
-    }
-
-    M_MUST(JSON_POP(io));
-    M_FINISH();
-}
-
-static bool M_ReadFXRaindrop(JSON_READ_IO *const io, FX_RAINDROP *const drop)
-{
-    ASSERT(drop != nullptr);
-
-    M_MUST(JSON_READ(io, "pos", &drop->pos));
-    M_MUST(JSON_READ(io, "xv", &drop->xv));
-    M_MUST(JSON_READ(io, "yv", &drop->yv));
-    M_MUST(JSON_READ(io, "zv", &drop->zv));
-    M_MUST(JSON_READ(io, "life", &drop->life));
-    drop->prev_pos = drop->pos;
-    drop->prev_yv = drop->yv;
-    M_FINISH();
-}
-
-static bool M_ReadFXSnowflake(JSON_READ_IO *const io, FX_SNOWFLAKE *const snow)
-{
-    ASSERT(snow != nullptr);
-
-    M_MUST(JSON_READ(io, "pos", &snow->pos));
-    M_MUST(JSON_READ(io, "xv", &snow->xv));
-    M_MUST(JSON_READ(io, "yv", &snow->yv));
-    M_MUST(JSON_READ(io, "zv", &snow->zv));
-    M_MUST(JSON_READ(io, "life", &snow->life));
-    M_MUST(JSON_READ(io, "stopped", &snow->stopped));
-    snow->prev_pos = snow->pos;
-    snow->prev_yv = snow->yv;
-    snow->prev_life = snow->life;
-    M_FINISH();
-}
-
-static bool M_ReadFXWeather(JSON_READ_IO *const io)
-{
-    if (!M_OPTIONAL(JSON_PUSH(io, "weather"))) {
-        return true;
-    }
-
-    if (M_OPTIONAL(JSON_PUSH(io, "rain"))) {
-        const int32_t drop_count = JSON_ARRAY_LEN(io);
-        for (int32_t i = 0; i < drop_count; i++) {
-            M_MUST(JSON_PUSH_INDEX(io, i));
-            FX_RAINDROP *const drop = FX_Weather_GetRaindrop(i);
-            if (drop != nullptr) {
-                M_MUST(M_ReadFXRaindrop(io, drop));
-            } else {
-                LOG_WARNING(
-                    "Malformed save: too many raindrops. Extra raindrops will "
-                    "be ignored.");
-            }
-            M_MUST(JSON_POP(io));
-        }
-        M_MUST(JSON_POP(io));
-    }
-
-    if (M_OPTIONAL(JSON_PUSH(io, "snow"))) {
-        const int32_t snow_count = JSON_ARRAY_LEN(io);
-        for (int32_t i = 0; i < snow_count; i++) {
-            M_MUST(JSON_PUSH_INDEX(io, i));
-            FX_SNOWFLAKE *const snow = FX_Weather_GetSnowflake(i);
-            if (snow != nullptr) {
-                M_MUST(M_ReadFXSnowflake(io, snow));
-            } else {
-                LOG_WARNING(
-                    "Malformed save: too many snowflakes. Extra snowflakes "
-                    "will be ignored.");
-            }
-            M_MUST(JSON_POP(io));
-        }
-        M_MUST(JSON_POP(io));
-    }
-
-    M_MUST(JSON_POP(io));
-    M_FINISH();
-}
-
 static bool M_ShouldLoadMusicTimestamp(
     const MUSIC_ID track_id, const MUSIC_PLAY_MODE mode,
     const MUSIC_ID ambient_track)
@@ -1304,20 +1142,10 @@ bool SG_File_LoadEffects(JSON_READ_IO *const io)
 
 bool SG_File_LoadFX(JSON_READ_IO *const io)
 {
-    FX_Ring_Reset();
-    FX_Footprint_Reset();
-    FX_Weather_Reset();
-
     if (!M_OPTIONAL(JSON_PUSH(io, "vfx"))) {
         return true;
     }
-    if (M_OPTIONAL(JSON_PUSH(io, "rings"))) {
-        M_MUST(M_ReadFXRings(io, FX_RING_TYPE_BLAST, "blast"));
-        M_MUST(M_ReadFXRings(io, FX_RING_TYPE_KNOCKBACK, "knockback"));
-        M_MUST(M_ReadFXRings(io, FX_RING_TYPE_SUMMON, "summon"));
-        M_MUST(JSON_POP(io));
-    }
-    M_MUST(M_ReadFXFootprints(io));
+    M_MUST(FX_Load(io));
     M_MUST(JSON_POP(io));
     M_FINISH();
 }

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -3,8 +3,7 @@
 #include <trx/debug.h>
 #include <trx/game/camera.h>
 #include <trx/game/effects.h>
-#include <trx/game/fx/footprint.h>
-#include <trx/game/fx/ring.h>
+#include <trx/game/fx/common.h>
 #include <trx/game/fx/weather.h>
 #include <trx/game/game.h>
 #include <trx/game/inventory.h>
@@ -399,123 +398,6 @@ static int32_t M_GetMusicTrackFlagsCount(void)
     return last_index + 1;
 }
 
-static void M_WriteFXRings(
-    JSON_WRITE_IO *const io, const FX_RING_TYPE type, const char *const key)
-{
-    if (!FX_Ring_IsRingActive(type)) {
-        return;
-    }
-    JSONW_PUSH_ARRAY(io);
-    for (int32_t i = 0;; i++) {
-        const FX_RING *const ring = FX_Ring_PeekRing(type, i);
-        if (ring == nullptr) {
-            break;
-        }
-
-        JSONW_PUSH_OBJECT(io);
-        JSONW_WRITE(io, "on", ring->on);
-        JSONW_WRITE(io, "life", ring->life);
-        JSONW_WRITE(io, "speed", ring->speed);
-        JSONW_WRITE(io, "radius", ring->radius);
-        JSONW_WRITE(io, "prev_radius", ring->prev_radius);
-        M_WriteXYZ16(io, "rot", (XYZ_16) { ring->rot.x, 0, ring->rot.z });
-        M_WriteXYZ16(
-            io, "prev_rot", (XYZ_16) { ring->prev_rot.x, 0, ring->prev_rot.z });
-        M_WriteXYZ32(io, "pos", ring->pos);
-        M_WriteXYZ32(io, "prev_pos", ring->prev_pos);
-        JSONW_POP_AND_APPEND(io);
-    }
-    JSONW_POP_AND_SET_NZ(io, key);
-}
-
-static void M_WriteFXFootprints(JSON_WRITE_IO *const io)
-{
-    if (!FX_Footprint_HasActivePrints()) {
-        return;
-    }
-
-    JSONW_PUSH_OBJECT(io);
-    JSONW_PUSH_ARRAY(io);
-    for (int32_t i = 0;; i++) {
-        const FX_FOOTPRINT *const print = FX_Footprint_GetPrint(i);
-        if (print == nullptr) {
-            break;
-        }
-
-        JSONW_PUSH_OBJECT(io);
-        M_WriteXYZ32(io, "pos", print->pos);
-        JSONW_WRITE(io, "room_num", print->room_num);
-        JSONW_WRITE(io, "y_rot", print->y_rot);
-        JSONW_WRITE(io, "life", print->life);
-        JSONW_POP_AND_APPEND(io);
-    }
-    JSONW_POP_AND_SET(io, "prints");
-    JSONW_POP_AND_SET_NZ(io, "footprints");
-}
-
-static void M_WriteFXRaindrops(JSON_WRITE_IO *const io)
-{
-    if (FX_Weather_GetWeather() != WEATHER_RAIN) {
-        return;
-    }
-
-    JSONW_PUSH_ARRAY(io);
-    for (int32_t i = 0;; i++) {
-        const FX_RAINDROP *const drop = FX_Weather_GetRaindrop(i);
-        if (drop == nullptr) {
-            break;
-        }
-        if (drop->pos.x == 0) {
-            continue;
-        }
-
-        JSONW_PUSH_OBJECT(io);
-        M_WriteXYZ32(io, "pos", drop->pos);
-        JSONW_WRITE(io, "xv", drop->xv);
-        JSONW_WRITE(io, "yv", drop->yv);
-        JSONW_WRITE(io, "zv", drop->zv);
-        JSONW_WRITE(io, "life", drop->life);
-        JSONW_POP_AND_APPEND(io);
-    }
-    JSONW_POP_AND_SET_NZ(io, "rain");
-}
-
-static void M_WriteFXSnowflakes(JSON_WRITE_IO *const io)
-{
-    if (FX_Weather_GetWeather() != WEATHER_SNOW) {
-        return;
-    }
-
-    JSONW_PUSH_ARRAY(io);
-    for (int32_t i = 0;; i++) {
-        const FX_SNOWFLAKE *const snow = FX_Weather_GetSnowflake(i);
-        if (snow == nullptr) {
-            break;
-        }
-        if (snow->pos.x == 0) {
-            continue;
-        }
-
-        JSONW_PUSH_OBJECT(io);
-        M_WriteXYZ32(io, "pos", snow->pos);
-        JSONW_WRITE(io, "xv", snow->xv);
-        JSONW_WRITE(io, "yv", snow->yv);
-        JSONW_WRITE(io, "zv", snow->zv);
-        JSONW_WRITE(io, "life", snow->life);
-        JSONW_WRITE(io, "stopped", snow->stopped);
-        JSONW_POP_AND_APPEND(io);
-    }
-    JSONW_POP_AND_SET_NZ(io, "snow");
-}
-
-static void M_WriteFXWeather(JSON_WRITE_IO *const io)
-{
-    JSONW_PUSH_OBJECT(io);
-    M_WriteFXRaindrops(io);
-    M_WriteFXSnowflakes(io);
-    JSONW_POP_AND_SET_NZ(io, "weather");
-}
-
 void SG_File_DumpFlares(JSON_WRITE_IO *const io)
 {
     JSONW_PUSH_ARRAY(io);
@@ -572,13 +454,7 @@ void SG_File_DumpEffects(JSON_WRITE_IO *const io)
 void SG_File_DumpFX(JSON_WRITE_IO *const io)
 {
     JSONW_PUSH_OBJECT(io);
-    JSONW_PUSH_OBJECT(io);
-    M_WriteFXRings(io, FX_RING_TYPE_BLAST, "blast");
-    M_WriteFXRings(io, FX_RING_TYPE_KNOCKBACK, "knockback");
-    M_WriteFXRings(io, FX_RING_TYPE_SUMMON, "summon");
-    JSONW_POP_AND_SET_NZ(io, "rings");
-    M_WriteFXFootprints(io);
-    M_WriteFXWeather(io);
+    FX_Save(io);
     JSONW_POP_AND_SET_NZ(io, "vfx");
 }
 

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -453,6 +453,69 @@ static void M_WriteFXFootprints(JSON_WRITE_IO *const io)
     JSONW_POP_AND_SET_NZ(io, "footprints");
 }
 
+static void M_WriteFXRaindrops(JSON_WRITE_IO *const io)
+{
+    if (FX_Weather_GetWeather() != WEATHER_RAIN) {
+        return;
+    }
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0;; i++) {
+        const FX_RAINDROP *const drop = FX_Weather_GetRaindrop(i);
+        if (drop == nullptr) {
+            break;
+        }
+        if (drop->pos.x == 0) {
+            continue;
+        }
+
+        JSONW_PUSH_OBJECT(io);
+        M_WriteXYZ32(io, "pos", drop->pos);
+        JSONW_WRITE(io, "xv", drop->xv);
+        JSONW_WRITE(io, "yv", drop->yv);
+        JSONW_WRITE(io, "zv", drop->zv);
+        JSONW_WRITE(io, "life", drop->life);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "rain");
+}
+
+static void M_WriteFXSnowflakes(JSON_WRITE_IO *const io)
+{
+    if (FX_Weather_GetWeather() != WEATHER_SNOW) {
+        return;
+    }
+
+    JSONW_PUSH_ARRAY(io);
+    for (int32_t i = 0;; i++) {
+        const FX_SNOWFLAKE *const snow = FX_Weather_GetSnowflake(i);
+        if (snow == nullptr) {
+            break;
+        }
+        if (snow->pos.x == 0) {
+            continue;
+        }
+
+        JSONW_PUSH_OBJECT(io);
+        M_WriteXYZ32(io, "pos", snow->pos);
+        JSONW_WRITE(io, "xv", snow->xv);
+        JSONW_WRITE(io, "yv", snow->yv);
+        JSONW_WRITE(io, "zv", snow->zv);
+        JSONW_WRITE(io, "life", snow->life);
+        JSONW_WRITE(io, "stopped", snow->stopped);
+        JSONW_POP_AND_APPEND(io);
+    }
+    JSONW_POP_AND_SET_NZ(io, "snow");
+}
+
+static void M_WriteFXWeather(JSON_WRITE_IO *const io)
+{
+    JSONW_PUSH_OBJECT(io);
+    M_WriteFXRaindrops(io);
+    M_WriteFXSnowflakes(io);
+    JSONW_POP_AND_SET_NZ(io, "weather");
+}
+
 void SG_File_DumpFlares(JSON_WRITE_IO *const io)
 {
     JSONW_PUSH_ARRAY(io);
@@ -515,6 +578,7 @@ void SG_File_DumpFX(JSON_WRITE_IO *const io)
     M_WriteFXRings(io, FX_RING_TYPE_SUMMON, "summon");
     JSONW_POP_AND_SET_NZ(io, "rings");
     M_WriteFXFootprints(io);
+    M_WriteFXWeather(io);
     JSONW_POP_AND_SET_NZ(io, "vfx");
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This saves raindrops and snowflakes positions and transitions, and refactors the FX module to use the `REGISTER` pattern in order to reduce repeated code. Saving/loading bits got moved to individual fx modules to lighten the load on the savegame module; this allowed removing a couple of header files.

#### Testing

Main course

- [x] Load a level with rain (or run /weather rain), stand still until the rain is at full density, save, then load that save
  Expected outcome: rain is at the same density the instant the level appears – no visible ramp-up from nothing, no sudden burst
- [x] Do the same with snow (/weather snow) in an open outdoor area
  Expected outcome: snowfall resumes at full density, and individual flakes continue falling from where they were rather than restarting at the spawn ceiling

Weather edge cases

- [x] Set weather to none (/weather none) in a level that normally has rain, save, load
  Expected outcome: no weather after loading; no leftover particles from before the command
- [x] Turn weather off (Graphic Options → Visuals), save in a level with rain, turn weather back on, load the save
  Expected outcome: no crash; rain appears and behaves normally after the load
- [x] With rain active, run /weather snow, let snow build up, save, load
  Expected outcome: snow is restored; no raindrops appear alongside it
- [x] Save with weather active, load the save, then finish the level normally and enter the next level
  Expected outcome: the next level shows only its own weather; no particles carry over

Effects regressions (registry refactor)

- [x] Set fire to Lara in TR4 and let her burn, then extinguish in water
  Expected outcome: flames render and animate on Lara as before, and stop when she enters water
- [x] Jump into water, swim around, then climb out and walk on dry land
  Expected outcome: splash rings and ripples on entry, underwater specks while submerged, and droplets dripping off Lara for a few seconds after she leaves the water
- [x] Drive a kayak or rib boat across open water, then stop
  Expected outcome: the wake trails behind the vehicle and fades out; no wake left frozen on the surface after stopping
- [x] Walk over sand, snow or mud, then look back at the trail
  Expected outcome: footprints appear behind Lara and fade out over time
- [x] Let an armed enemy shoot at Lara, and fight an enemy that fires a laser
  Expected outcome: muzzle flashes appear on the enemy's weapon, and laser beams render
- [x] Fire a rocket, grenade or explosive ammo at a wall
  Expected outcome: the explosion blast rings render as before
- [x] Restart a level from the pause menu after weather, fire and footprints have been active
  Expected outcome: the level restarts with all effects cleared; nothing carries over from the previous attempt

Save format regressions (serialization move)

- [x] Load a save file made with a released TRX build (1.9.x) that has footprints in it
  Expected outcome: the save loads without errors in TRX.log, and the footprints appear as they did in the old build
- [x] Fight a TR3 boss that spawns rings (Sophia, Willard, Puna, Tony), save mid-fight while rings are on screen, load
  Expected outcome: rings are restored at the same size and position and continue expanding from there
- [x] Walk over sand or snow to lay footprints, save, load, and compare against the trail before saving
  Expected outcome: the same prints in the same places at the same fade level
- [x] Load a save made in an earlier level, then save and load again from the new level
  Expected outcome: no warnings about malformed saves in TRX.log

