### PR TITLE
gun/misc: fix glow lagging behind flash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fixed the `/trigger`, `/untrigger` and `/kill` console commands being usable in demos and cutscenes
 - fixed being unable to drop to the secret ledge in Jungle room 76 from the ledge above (#5818)
 - fixed a crash when drawing an animating object that has no frame data (#5869)
+- fixed the glow around gun and flare flashes lagging behind them (#5920)
 - fixed trains using extreme tilt angles when they come to a stop at a wall (#5886)
 - fixed Lara attempting to climb ladders from inside lifts (#5890)
 - fixed Lara not getting killed by lifts if standing on top of one and the ceiling space becomes too low

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -138,7 +138,8 @@ void Gun_ApplyFlashSemiTransparency(void)
     }
 }
 
-static void M_DrawGunGlow(const WEAPON_INFO *const weapon)
+static void M_DrawGunGlow(
+    const WEAPON_INFO *const weapon, const bool interpolated)
 {
     if (g_TRVersion < 3 && !g_Config.visuals.enable_gun_glow) {
         return;
@@ -151,14 +152,26 @@ static void M_DrawGunGlow(const WEAPON_INFO *const weapon)
         return;
     }
 
-    Matrix_Push();
-    Matrix_TranslateRel32(weapon->glow_pos);
+    // The glow follows a mesh that may be drawn between two game frames, so
+    // the sprite position has to be interpolated the same way.
+    if (interpolated) {
+        Matrix_Push_I();
+        Matrix_TranslateRel32_I(weapon->glow_pos);
+        Matrix_Interpolate();
+    } else {
+        Matrix_Push();
+        Matrix_TranslateRel32(weapon->glow_pos);
+    }
     const XYZ_32 pos = {
         .x = (int32_t)(g_WMatrixPtr->_03 >> W2V_SHIFT),
         .y = (int32_t)(g_WMatrixPtr->_13 >> W2V_SHIFT),
         .z = (int32_t)(g_WMatrixPtr->_23 >> W2V_SHIFT),
     };
-    Matrix_Pop();
+    if (interpolated) {
+        Matrix_Pop_I();
+    } else {
+        Matrix_Pop();
+    }
 
     // The flare's glow pulses as its pyro burns; gunfire glows are steady.
     const int16_t shade =
@@ -398,7 +411,7 @@ void Gun_DrawFlash(
         Object_DrawMesh(flash_obj->mesh_idx, clip, interpolated);
     }
 
-    M_DrawGunGlow(&weapon);
+    M_DrawGunGlow(&weapon, interpolated);
     Output_PopTintOverride();
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The glow sprite position came from the plain matrix stack while the flash mesh is drawn interpolated, leaving the sprite a game frame behind at higher frame rates.

Resolves #5920 / TRX758