### PR TITLE
objects: gate spent detonator boxes and gongs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 **TR2**
 - changed weather to be affected by the breeze
+- fixed Lara being able to use a detonator box or a gong a second time by selecting its key in the inventory
 
 **TR4**
 - added reflections

--- a/src/trx/game/objects/general/detonator_box.c
+++ b/src/trx/game/objects/general/detonator_box.c
@@ -118,11 +118,17 @@ normal_collision:
     Object_Collision(item_num, lara_item, coll);
 }
 
+static bool M_IsUsable(const int16_t item_num)
+{
+    return Item_IsInactive(Item_Get(item_num));
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
     obj->control_func = M_Control;
     obj->bounds_func = M_Bounds;
+    obj->is_usable_func = M_IsUsable;
     obj->save_flags = true;
     obj->save_anim = true;
 }

--- a/src/trx/game/objects/general/gong.c
+++ b/src/trx/game/objects/general/gong.c
@@ -61,6 +61,9 @@ static void M_Use(ITEM *const lara_item, ITEM *const receptacle_item)
     }
 
     M_CreateGongBonger(lara_item);
+    // A struck gong is spent. Both the collision path and M_IsUsable, which
+    // gates the key selected from the inventory, read that off this axis.
+    Item_SetFinished(receptacle_item, true);
 
     LARA_INFO *const lara = Lara_GetLaraInfo();
     lara->interact_target.is_moving = false;
@@ -116,10 +119,17 @@ normal_collision:
     Object_Collision(item_num, lara_item, coll);
 }
 
+static bool M_IsUsable(const int16_t item_num)
+{
+    return Item_IsInactive(Item_Get(item_num));
+}
+
 static void M_Setup(OBJECT *const obj)
 {
     obj->collision_func = M_Collision;
     obj->bounds_func = M_Bounds;
+    obj->is_usable_func = M_IsUsable;
+    obj->save_flags = true;
 }
 
 REGISTER_OBJECT(O_GONG, M_Setup)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Selecting the key in the inventory reaches the receptacle through `Object_FindReceptacle`, which only tests the bounds and the object's `is_usable_func`. Neither object had one, so a box that had already gone off, or a gong that had already been struck, stayed a valid target and the use animation played again – the collision path meanwhile refuses it, gating on `Item_IsInactive`.

Both now carry the predicate the keyhole and the puzzle hole use. The gong also had nothing recording that it had been struck, so it marks itself finished and saves its flags.

Resolves TRX750.

#### Testing

- [x] Test that the detonator box cannot be reused with another detonator key.
- [x] Test that the gong cannot be reused with another gong bonger.