### PR TITLE
objects/vehicles: allow crash survival when immune

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - changed the Breeze option to allow selecting TR2 or TR3 behavior (Graphic Options → Visuals → Breeze)
 - changed lift collision to force Lara out of her climbing and vaulting animations if one collides with her (#5899, #5911)
 - changed lift collision to be optional (Gameplay → Fixes → Fix lift collision)
+- changed skidoo and quad bike crashes to not kill Lara when she is immune
 - fixed exploding deaths in TR4 showing no flames or explosions
 - fixed some console commands being able to target unintended items
 - fixed the `/trigger` and `/untrigger` console commands crashing or doing nothing on some objects, so they now act on any item exactly as a level trigger would

--- a/src/trx/game/objects/vehicles/quad_bike.c
+++ b/src/trx/game/objects/vehicles/quad_bike.c
@@ -1,5 +1,6 @@
 #include <trx/game/objects/vehicles/quad_bike.h>
 
+#include <trx/config.h>
 #include <trx/core/json/util/read_io.h>
 #include <trx/core/json/util/write_io.h>
 #include <trx/game/anims.h>
@@ -1459,9 +1460,15 @@ bool QuadBike_Control(void)
         g_Camera.target_elevation = -5460;
 
         if (quad->flags & 0x40 && item->pos.y == item->floor) {
-            Item_Shatter(lara->item_num, -1, 0);
-            lara_item->hit_points = 0;
-            lara_item->trigger.spent = true;
+            if (g_Config.debug.enable_invulnerability) {
+                lara_item->goal_anim_state = LS(LS_STOP);
+                lara_item->current_anim_state = LS(LS_STOP);
+                Item_SwitchToAnim(lara_item, LA(LA_FREEFALL_LAND), 0);
+            } else {
+                Item_Shatter(lara->item_num, -1, 0);
+                lara_item->hit_points = 0;
+                lara_item->trigger.spent = true;
+            }
             M_Explode(item);
             return false;
         }

--- a/src/trx/game/objects/vehicles/skidoo_common.c
+++ b/src/trx/game/objects/vehicles/skidoo_common.c
@@ -1,5 +1,6 @@
 #include <trx/game/objects/vehicles/skidoo_common.h>
 
+#include <trx/config.h>
 #include <trx/core/math.h>
 #include <trx/core/utils.h>
 #include <trx/game/collision.h>
@@ -741,8 +742,14 @@ bool Skidoo_CheckGetOff(void)
         Item_SwitchToAnim(lara_item, LA(LA_FREEFALL), 0);
         lara_item->current_anim_state = M_STATE_GET_OFF_R;
         if (skidoo->pos.y == skidoo->floor) {
-            lara_item->goal_anim_state = M_STATE_STILL;
-            lara_item->fall_speed = DAMAGE_START + DAMAGE_LENGTH;
+            if (g_Config.debug.enable_invulnerability) {
+                lara_item->goal_anim_state = LS(LS_STOP);
+                lara_item->current_anim_state = LS(LS_STOP);
+                Item_SwitchToAnim(lara_item, LA(LA_FREEFALL_LAND), 0);
+            } else {
+                lara_item->goal_anim_state = M_STATE_STILL;
+                lara_item->fall_speed = DAMAGE_START + DAMAGE_LENGTH;
+            }
             lara_item->speed = 0;
             Skidoo_Explode(skidoo);
         } else {
@@ -750,7 +757,9 @@ bool Skidoo_CheckGetOff(void)
             lara_item->pos.y -= 200;
             lara_item->fall_speed = skidoo->fall_speed;
             lara_item->speed = skidoo->speed;
-            Sound_Effect(SFX_LARA_FALL, &lara_item->pos, SPM_NORMAL);
+            if (!g_Config.debug.enable_invulnerability) {
+                Sound_Effect(SFX_LARA_FALL, &lara_item->pos, SPM_NORMAL);
+            }
         }
         lara_item->rot.x = 0;
         lara_item->rot.z = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This alters the skidoo and quad bike to allow Lara to survive crashes when she is immune. The vehicles themselves continue to explode.

Resolves TRX749.