### PR TITLE
output/sources/misc: reset vertex count

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)
 - fixed the camera snapping aggressively to Lara after some flyby sequences (regression from 1.9)
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
+- fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/output/sources/misc.c
+++ b/src/trx/game/output/sources/misc.c
@@ -242,6 +242,7 @@ void OutputSource_Misc_Shutdown(void)
     if (p->vertices != nullptr) {
         Vector_Free(p->vertices);
         p->vertices = nullptr;
+        p->vertex_count = 0;
     }
     if (p->scheduled_spheres != nullptr) {
         Vector_Free(p->scheduled_spheres);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This resets the vertex counter for misc output sources on shutdown, to ensure it's accurate after switching mods.

Resolves TRX766.
