### PR TITLE
misc: rework ladders and lifts

### DIFF
--- a/src/trx/game/lara/col/vault.c
+++ b/src/trx/game/lara/col/vault.c
@@ -114,7 +114,7 @@ static bool M_IsLowVault(
 static bool M_HasHeadClearance(const M_COLL *const coll)
 {
     const LARA_INFO *const lara = Lara_GetLaraInfo();
-    return (lara->climb_status && coll->front.floor == NO_HEIGHT)
+    return lara->climb_status
         || coll->front.floor - coll->mid.ceiling >= M_MIN_CLEARANCE;
 }
 

--- a/src/trx/game/objects/general/lift.c
+++ b/src/trx/game/objects/general/lift.c
@@ -17,7 +17,7 @@
 #define M_DEFAULT_SPEED       16
 #define M_MAXIMUM_SPEED       64
 #define M_HEIGHT              (STEP_L * 5) // = 1280
-#define M_WALL_WIDTH          (STEP_L / 4) // = 64
+#define M_WALL_WIDTH          (STEP_L / 6) // = 42
 #define M_WALL_COLOR          ((RGBA_8888) { 0, 255, 255, 255 })
 #define M_NUM_FLOOR_SECTORS   4
 #define M_NUM_SECTORS         (M_NUM_FLOOR_SECTORS * 2)
@@ -361,7 +361,9 @@ static void M_InternalCollision(const ITEM *const item, COLL_INFO *const coll)
     for (int32_t i = 0; i < M_NUM_FLOOR_SECTORS; i++) {
         wall.rot.y += DEG_90;
         wall.pos = XYZ_32_OffsetYaw(wall.pos, wall.rot.y, WALL_L);
-        Lara_Col_Push(&wall, coll, false, true);
+        if (i > 0 || p->is_moving) {
+            Lara_Col_Push(&wall, coll, false, true);
+        }
     }
 }
 
@@ -426,11 +428,6 @@ static void M_Collision(
     }
 
     const ITEM *const item = Item_Get(item_num);
-    const M_PRIV *const p = item->priv;
-    if (!p->is_moving) {
-        return;
-    }
-
     const XZ_32 lift_tile = M_GetTile(item->pos);
     const XZ_32 lara_tile = M_GetTile(lara_item->pos);
     const XZ_32 offset = M_GetShaftOffset(item->rot.y);
@@ -441,6 +438,11 @@ static void M_Collision(
     const M_LARA_STATUS lara_status = M_GetLaraStatus(item, lara_item);
     if (lara_status == M_LARA_INSIDE) {
         M_InternalCollision(item, coll);
+        return;
+    }
+
+    const M_PRIV *const p = item->priv;
+    if (!p->is_moving) {
         return;
     }
 
@@ -589,9 +591,6 @@ static bool M_Draw(const ITEM *const item)
     }
 
     const M_PRIV *const p = item->priv;
-    if (!p->is_moving) {
-        return true;
-    }
 
     Matrix_Push();
     Matrix_TranslateAbs32(item->interp.result.pos);
@@ -600,7 +599,9 @@ static bool M_Draw(const ITEM *const item)
     for (int32_t i = 0; i < M_NUM_FLOOR_SECTORS; i++) {
         Matrix_TranslateRel(WALL_L, 0, 0);
         Matrix_RotY(DEG_90);
-        Output_DrawCuboidEx(&p->wall_bounds, M_WALL_COLOR);
+        if (i > 0 || p->is_moving) {
+            Output_DrawCuboidEx(&p->wall_bounds, M_WALL_COLOR);
+        }
     }
 
     Matrix_Pop();


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

427d346 introduced problems with Lara being unable to mount some ladders when using action input only, namely those with a ceiling above but a portal in the wall in front. I have reverted that back to OG.

Lifts will now have internal collision on the side and back walls to prevent Lara interacting with ladders and/or vaulting when she is inside, even when the lift is stationary. When the lift starts moving, the front wall collision will be applied.

Resolves TRX769.