### PR TITLE
object/bacon_lara: fix targeting and room number

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fixed Lara attempting to pull up into gaps that would not allow her to stand, resulting in her being pushed out (#5891)
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
 - fixed rain and snow starting over when a save is loaded (#5901)
+- fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fixed shoals of fish and piranhas jumping back to their starting spot when loading a save
 - fixed rain and snow starting over when a save is loaded (#5901)
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
+- fixed Bacon Lara remaining targetable after death
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -141,6 +141,7 @@ static void M_Control(const int16_t item_num)
             if (room_num != item->room_num) {
                 Item_UpdateRoom(item_num, room_num);
             }
+            Item_SetFinished(item, true);
         }
     }
 }

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -138,6 +138,9 @@ static void M_Control(const int16_t item_num)
             item->fall_speed = 0;
             item->goal_anim_state = LS(LS_DEATH);
             item->required_anim_state = LS(LS_DEATH);
+            if (room_num != item->room_num) {
+                Item_UpdateRoom(item_num, room_num);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This prevents Bacon Lara being targetable after death. It also updates her room number for custom levels where the pit she dies in isn't the same room (Atlantis is all the same room).

Resolves TRX764.