### PR TITLE
lara/col/climb: revert old coll pos after hang test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - fixed the camera snapping aggressively to Lara after some flyby sequences (regression from 1.9)
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
+- fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -376,6 +376,7 @@ static bool M_CanHangSideways(
 {
     LARA_INFO *const lara = Lara_GetLaraInfo();
     const XYZ_32 old_pos = item->pos;
+    const XYZ_32 old_coll_pos = coll->old_pos;
     lara->move_angle = item->rot.y + angle;
 
     int32_t x = item->pos.x;
@@ -401,6 +402,9 @@ static bool M_CanHangSideways(
     item->pos.z = z;
     coll->old_pos.y = item->pos.y;
     const bool blocked = Lara_Col_HangTest(item, coll);
+    if (blocked) {
+        coll->old_pos.y = old_coll_pos.y;
+    }
     item->pos.x = old_pos.x;
     item->pos.z = old_pos.z;
     lara->move_angle = item->rot.y + angle;

--- a/src/trx/game/lara/state/climb.c
+++ b/src/trx/game/lara/state/climb.c
@@ -92,7 +92,7 @@ static void M_SetCornerAnim(
         item->current_anim_state = LS(LS_HANG);
     }
 
-    if (g_Camera.type == CAM_CHASE
+    if (g_Camera.type == CAM_CHASE && on_ladder
         && (ladder_end_anim == LA_LADDER_CORNER_RIGHT_OUTER_END
             || ladder_end_anim == LA_LADDER_CORNER_LEFT_OUTER_END)) {
         // Some camera strategies will be unable to LOS through the corner from


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This restores a particular ladder/hanging snap that is utilised in TR2/3 assault course when Lara approaches the zip line. The old collision position was reset when testing for shimmying, but it wasn't restored on failure.

It also fixes the outer corner ladder camera fix from c183270 wrongly being applied to shimmy corner transitions (unreleased).

Resolves TRX770 / TRX774.
