### PR TITLE
objects/flame: fix flame position generation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,9 @@
 - changed weather to be affected by the breeze
 - fixed Lara being able to use a detonator box or a gong a second time by selecting its key in the inventory
 
+**TR3**
+- fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
+
 **TR4**
 - added reflections
 - added TR4 outfits

--- a/src/trx/game/objects/effects/flame.c
+++ b/src/trx/game/objects/effects/flame.c
@@ -172,13 +172,13 @@ static void M_TR3_ControlSmall(
     if (lara->water_status == LWS_CHEAT) {
         effect->counter = 0;
         Effect_Destroy(Effect_GetIndex(effect));
-        lara->burn = 0;
+        lara->burn = false;
         return;
     }
 
     const bool is_green = M_IsGreenAttachedFlame(effect);
     const int32_t flame_type = is_green ? 254 : 255;
-    for (int i = 0; i < LM_NUMBER_OF; i++) {
+    for (int32_t i = LM_NUMBER_OF - 1; i >= 0; i--) {
         if ((time4 & 0xC) == 0) {
             effect->pos.x = 0;
             effect->pos.y = 0;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This corrects the spawning of flames in Lara to iterate through her meshes in reverse, such that the final effect position relates to her hips rather than her head. It resolves Lara having to wade into deeper water compared with OG to extinguish flames.

Resolves TRX741.
