### PR TITLE
lara/hair: fix braid when wading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,10 +41,12 @@
 **TR1**
 - changed weather to be affected by the breeze
 - changed Bacon Lara's anchor room to be an optional object property rather than a game flow event; refer to migration notes
+- fixed Lara's braid floating or being aligned to the water height when vaulting out of wading depth water (#5900)
 
 **TR2**
 - changed weather to be affected by the breeze
 - fixed Lara being able to use a detonator box or a gong a second time by selecting its key in the inventory
+- fixed Lara's braid floating or being aligned to the water height when vaulting out of wading depth water (#5900)
 
 **TR3**
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)

--- a/src/trx/game/lara/hair.c
+++ b/src/trx/game/lara/hair.c
@@ -401,7 +401,12 @@ static void M_Control(
                 s->pos.z = velocity[0].z;
             }
         } else {
-            switch (lara_info->water_status) {
+            LARA_WATER_STATE water_status = lara_info->water_status;
+            if (water_status == LWS_WADE
+                && (water_height == NO_HEIGHT || s->pos.y <= water_height)) {
+                water_status = LWS_ABOVE_WATER;
+            }
+            switch (water_status) {
             case LWS_ABOVE_WATER:
                 s->pos.y += 10;
                 if (water_height != NO_HEIGHT && s->pos.y > water_height) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This updates Lara's braid to behave as though she is above water when the segments themselves are above the water line. It fixes underwater behavior being applied when Lara is vaulting out of wading-depth water. She remains in wading status until that animation completes, essentially.

This only affects TR2 breeze mode, and TR1 and TR2 in stable.

Resolves #5900 / TRX733.