### PR TITLE
objects/detonator_box: save the item position

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fixed rain and snow starting over when a save is loaded (#5901)
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed Bacon Lara remaining targetable after death
+- fixed the detonator box returning to its original position after loading a save (OG bug)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)
 - fixed a crash when advancing through a flyby sequence in photo mode and the sequence reaches its end (regression from 1.9)

--- a/src/trx/game/objects/general/detonator_box.c
+++ b/src/trx/game/objects/general/detonator_box.c
@@ -129,6 +129,7 @@ static void M_Setup(OBJECT *const obj)
     obj->control_func = M_Control;
     obj->bounds_func = M_Bounds;
     obj->is_usable_func = M_IsUsable;
+    obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;
 }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

Using the detonator aligns the box to Lara before it animates. Without save_position the item reverts to its level placement on load.

Resolves TRX767.

#### Testing

- [x] Use the box while rotated, save, load: box is rotated
- [x] Use the box while rotated on latest stable, save; switch to PR, load: save loads without problems, box is unrotated