### PR TITLE
output: fix TR4 animated texture speed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - fixed a missing texture on Young Lara's left hand
 - fixed a misaligned texture on Young Lara's hips
 - fixed the camera getting stuck when Lara traverses around corner ladders (OG bug)
+- fixed animated textures, such as water surfaces, cycling at half their original speed
 
 **Lua**
 

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -377,7 +377,8 @@ void Output_SetTime(const float time)
 
 void Output_AnimateTextures(int32_t num_frames)
 {
-    const int32_t anim_delta = g_TRVersion == 3 ? 2 : 1;
+    // TR3 and TR4 halve the cycle threshold relative to TR1 and TR2.
+    const int32_t anim_delta = g_TRVersion >= 3 ? 2 : 1;
 
     m_TimeInGame += num_frames;
     m_AnimatedTexturesOffset += num_frames * anim_delta;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

S_AnimateTextures is fed the elapsed 60Hz tick count, so OG advances the accumulator by 2 per game frame against a threshold of 5. TR4 was using the TR1/TR2 step of 1, cycling at half speed.

Resolves TRX557.