### PR TITLE
sparks: fix waterfall mist spread

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 **TR3**
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
+- fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 
 **TR4**
 - added reflections

--- a/src/trx/game/lara/state/extra.c
+++ b/src/trx/game/lara/state/extra.c
@@ -8,7 +8,6 @@
 #include <trx/game/lara/util.h>
 #include <trx/game/music.h>
 #include <trx/game/objects/effects/twinkle.h>
-#include <trx/game/output/state.h>
 #include <trx/game/overlay.h>
 #include <trx/game/random.h>
 #include <trx/game/rooms.h>
@@ -228,12 +227,9 @@ static void M_RapidsDrown(ITEM *const item, COLL_INFO *const coll)
 
     item->rot.y += 1024;
 
-    const int32_t time4 = (int32_t)Output_GetTimeInGame() * 4;
-    if ((time4 & 3) == 0) {
-        Sparks_TriggerWaterfallMist(
-            item->pos.x, item->pos.y, item->pos.z,
-            Random_GetControl() & 0x0FFF);
-    }
+    Sparks_TriggerWaterfallMist(
+        item->pos.x, item->pos.y, item->pos.z,
+        (Random_GetControl() & 0x0FFF) << 4);
 }
 
 static void M_PullDagger(ITEM *const item, COLL_INFO *const coll)

--- a/src/trx/game/sparks/spawners.c
+++ b/src/trx/game/sparks/spawners.c
@@ -95,9 +95,12 @@ void Sparks_TriggerWaterfallMist(
     for (int32_t i = 0; i < (int32_t)ARRAY_SIZE(offsets); i++) {
         SPARK *const spark = Sparks_GetFreeSpark();
 
+        // the sparks are spread along the line perpendicular to the flow
         const int32_t offset = (Random_GetControl() & 0x1F) + offsets[i] - 16;
-        const int32_t c = Math_Cos(angle) >> W2V_SHIFT;
-        const int32_t s = Math_Sin(angle) >> W2V_SHIFT;
+        const int32_t spread_x =
+            (offset * Math_Sin(angle + DEG_90)) >> W2V_SHIFT;
+        const int32_t spread_z =
+            (offset * Math_Cos(angle + DEG_90)) >> W2V_SHIFT;
 
         *spark = (SPARK) {
             .on = true,
@@ -111,14 +114,14 @@ void Sparks_TriggerWaterfallMist(
             .dynamic = -1,
             .sprite_idx = sprite_idx,
             .pos = {
-                .x = x + (Random_GetControl() % 16) - 8 + c * offset,
+                .x = x + (Random_GetControl() % 16) - 8 + spread_x,
                 .y = y + (Random_GetControl() % 16) - 8,
-                .z = z + (Random_GetControl() % 16) - 8 + s * offset,
+                .z = z + (Random_GetControl() % 16) - 8 + spread_z,
             },
             .vel = {
-                .x = s,
+                .x = Math_Sin(angle) >> W2V_SHIFT,
                 .y = 0,
-                .z = c,
+                .z = Math_Cos(angle) >> W2V_SHIFT,
             },
             .gravity = 0,
             .max_y_vel = 0,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The angle was reduced to -1/0/1 before scaling the offsets, so all four sparks spawned on top of each other rather than across the flow. The spread also runs perpendicular to the flow, as in OG.

Lara's rapids drown passed a 12-bit angle where a 16-bit one is expected, and gated the mist on a condition that is always true.

Resolves TRX664.