### PR TITLE
gym: allow resetting the best times

### DIFF
--- a/data/trx/ship/cfg/base_strings-de.json5
+++ b/data/trx/ship/cfg/base_strings-de.json5
@@ -224,6 +224,7 @@
             "assault_finish": "Zeit",
             "assault_no_times_set": "Keine Zeiten gesetzt",
             "assault_other_times_fmt": "\\{review}%s",
+            "assault_reset_times": "\\{review}Zurücksetzen",
             "assault_title": "Bestzeiten",
             "basic_fmt": "%d",
             "bonus_statistics": "Bonusstatistiken",

--- a/data/trx/ship/cfg/base_strings-fr.json5
+++ b/data/trx/ship/cfg/base_strings-fr.json5
@@ -224,6 +224,7 @@
             "assault_finish": "\\{review}Fin",
             "assault_no_times_set": "\\{review}Aucun temps défini",
             "assault_other_times_fmt": "\\{review}%s",
+            "assault_reset_times": "\\{review}Réinitialiser",
             "assault_title": "\\{review}MEILLEURS TEMPS",
             "basic_fmt": "%d",
             "bonus_statistics": "Statistiques bonus",

--- a/data/trx/ship/cfg/base_strings-gd.json5
+++ b/data/trx/ship/cfg/base_strings-gd.json5
@@ -224,6 +224,7 @@
             "assault_finish": "Crìochnaich",
             "assault_no_times_set": "Gun Àmanan Fhathast",
             "assault_other_times_fmt": "%s",
+            "assault_reset_times": "\\{review}Ath-shuidhich",
             "assault_title": "NA H-ÀMANAN AS FHEÀRR",
             "basic_fmt": "%d",
             "bonus_statistics": "Staitistig a Bharrachd",

--- a/data/trx/ship/cfg/base_strings-it.json5
+++ b/data/trx/ship/cfg/base_strings-it.json5
@@ -224,6 +224,7 @@
             "assault_finish": "Fine",
             "assault_no_times_set": "Nessun tempo impostato",
             "assault_other_times_fmt": "%s",
+            "assault_reset_times": "\\{review}Ripristina",
             "assault_title": "MIGLIORI TEMPI",
             "basic_fmt": "%d",
             "bonus_statistics": "Statistiche Bonus",

--- a/data/trx/ship/cfg/base_strings-pl.json5
+++ b/data/trx/ship/cfg/base_strings-pl.json5
@@ -224,6 +224,7 @@
             "assault_finish": "Finisz",
             "assault_no_times_set": "Brak czasów",
             "assault_other_times_fmt": "%s",
+            "assault_reset_times": "\\{review}Zresetuj",
             "assault_title": "NAJLEPSZE CZASY",
             "basic_fmt": "%d",
             "bonus_statistics": "Statystyki bonusowe",

--- a/data/trx/ship/cfg/base_strings-ru.json5
+++ b/data/trx/ship/cfg/base_strings-ru.json5
@@ -224,6 +224,7 @@
             "assault_finish": "\\{review}Завершить",
             "assault_no_times_set": "\\{review}Время не установлено",
             "assault_other_times_fmt": "\\{review}%s",
+            "assault_reset_times": "\\{review}Сброс",
             "assault_title": "\\{review}ЛУЧШИЕ ВРЕМЕНА",
             "basic_fmt": "%d",
             "bonus_statistics": "Бонусная статистика",

--- a/data/trx/ship/cfg/base_strings.json5
+++ b/data/trx/ship/cfg/base_strings.json5
@@ -224,6 +224,7 @@
             "assault_finish": "Finish",
             "assault_no_times_set": "No Times Set",
             "assault_other_times_fmt": "%s",
+            "assault_reset_times": "Reset",
             "assault_title": "BEST TIMES",
             "basic_fmt": "%d",
             "bonus_statistics": "Bonus Statistics",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added autocompletion to the developer console (with Tab and Shift+Tab to cycle the matches)
 - added a `/dry` console command, to dry Lara off after a swim
 - added an option for the wobbly geometry of the PlayStation releases (Graphic Options → Rendering → Vertex snapping)
+- added the ability to clear the gym's best times, by holding the key shown below them
 - added internal collision to lifts when they are moving, so that Lara cannot exit through the meshes
 - improved error messages related to bad command invocations
 - changed reflections UV mapping to be more correct

--- a/src/trx/game/game_strings/entries.def
+++ b/src/trx/game/game_strings/entries.def
@@ -689,6 +689,7 @@ GS_DEFINE(general/stats/assault_best_time_fmt,   "%s")
 GS_DEFINE(general/stats/assault_other_times_fmt, "%s")
 GS_DEFINE(general/stats/gym_assault_course,      "Assault Course")
 GS_DEFINE(general/stats/gym_racetrack_course,    "Race Track Course")
+GS_DEFINE(general/stats/assault_reset_times,     "Reset")
 
 // Misc
 GS_DEFINE(general/inventory_ring/heading_inventory,           "INVENTORY")

--- a/src/trx/game/gym.c
+++ b/src/trx/game/gym.c
@@ -291,6 +291,16 @@ const GYM_TRACK_STATS *Gym_TrackManager_GetStats(const GYM_TRACK_TYPE track)
     return Gym_TrackManager_GetMutableStats(track);
 }
 
+void Gym_TrackManager_ClearStats(const GYM_TRACK_TYPE track)
+{
+    GYM_TRACK_STATS *const stats = Gym_TrackManager_GetMutableStats(track);
+    if (stats == nullptr) {
+        return;
+    }
+    *stats = (GYM_TRACK_STATS) {};
+    Config_Update();
+}
+
 bool Gym_TrackManager_IsTimerDisplay(const GYM_TRACK_TYPE track)
 {
     M_PRIV *const p = &m_Priv;

--- a/src/trx/game/gym.h
+++ b/src/trx/game/gym.h
@@ -24,6 +24,10 @@ const GYM_TRACK_STATS *Gym_TrackManager_GetStats(GYM_TRACK_TYPE track);
 // The record table a finished run is filed into. It lives in the player's
 // profile, so a caller that writes it is expected to call Config_Update.
 GYM_TRACK_STATS *Gym_TrackManager_GetMutableStats(GYM_TRACK_TYPE track);
+
+// Discards every recorded time for the track.
+void Gym_TrackManager_ClearStats(GYM_TRACK_TYPE track);
+
 bool Gym_TrackManager_IsTimerDisplay(GYM_TRACK_TYPE track);
 bool Gym_TrackManager_IsTimerActive(GYM_TRACK_TYPE track);
 void Gym_TrackManager_Reset(GYM_TRACK_TYPE track);

--- a/src/trx/game/ui/dialogs/stats.c
+++ b/src/trx/game/ui/dialogs/stats.c
@@ -66,6 +66,7 @@ typedef struct UI_STATS_DIALOG_STATE {
     };
 
     const M_LOOK *look;
+    UI_PROGRESS_BUTTON_STATE *reset_button;
     bool has_floordata_secrets;
     bool has_visible_rows;
 } UI_STATS_DIALOG_STATE;
@@ -652,6 +653,26 @@ static int32_t M_GetAssaultCourseRowCount(const UI_STATS_DIALOG_STATE *const s)
     return MAX(count, M_MIN_ASSAULT_COURSE_ROWS);
 }
 
+static bool M_HasAnyRecordedTime(const UI_STATS_DIALOG_STATE *const s)
+{
+    for (GYM_TRACK_TYPE track = 0; track < GYM_TRACK_NUMBER_OF; track++) {
+        if (s->assault_stats[track]->entries[0].time != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void M_ResetAssaultCourseStats(void *const user_data)
+{
+    UI_STATS_DIALOG_STATE *const s = user_data;
+    for (GYM_TRACK_TYPE track = 0; track < GYM_TRACK_NUMBER_OF; track++) {
+        Gym_TrackManager_ClearStats(track);
+    }
+    UI_Scrollable_SetMaxItems(&s->scrollable, M_GetAssaultCourseRowCount(s));
+    UI_Scrollable_SelectFirstItem(&s->scrollable);
+}
+
 static UI_WINDOW_SETTINGS M_GetWindowSettings(
     const UI_STATS_DIALOG_STATE *const s)
 {
@@ -742,6 +763,10 @@ UI_STATS_DIALOG_STATE *UI_StatsDialog_Init(const UI_STATS_DIALOG_ARGS args)
         }
         s->scrollable.max_items = M_GetAssaultCourseRowCount(s);
         s->has_visible_rows = true;
+        s->reset_button = UI_ProgressButton_Init(
+            g_Config.input.backend, INPUT_ROLE_UNBIND_KEY,
+            GS_ID("general/stats/assault_reset_times"),
+            M_ResetAssaultCourseStats, s);
         break;
     }
 
@@ -750,6 +775,9 @@ UI_STATS_DIALOG_STATE *UI_StatsDialog_Init(const UI_STATS_DIALOG_ARGS args)
 
 void UI_StatsDialog_Free(UI_STATS_DIALOG_STATE *const s)
 {
+    if (s->reset_button != nullptr) {
+        UI_ProgressButton_Free(s->reset_button);
+    }
     Memory_Free(s);
 }
 
@@ -760,6 +788,9 @@ bool UI_StatsDialog_HasVisibleRows(const UI_STATS_DIALOG_STATE *const s)
 
 int32_t UI_StatsDialog_Control(UI_STATS_DIALOG_STATE *const s)
 {
+    if (s->reset_button != nullptr && M_HasAnyRecordedTime(s)) {
+        UI_ProgressButton_Control(s->reset_button);
+    }
     return UI_ScrollableStack_Control(&s->scrollable, UI_STACK_VERTICAL);
 }
 
@@ -789,6 +820,11 @@ void UI_StatsDialog(UI_STATS_DIALOG_STATE *const s)
             });
         M_AssaultCourseStatsRows(s);
         UI_EndScrollableStack();
+        UI_BeginHide(!M_HasAnyRecordedTime(s));
+        UI_BeginAnchor(0.5f, 0.5f);
+        UI_ProgressButton(s->reset_button);
+        UI_EndAnchor();
+        UI_EndHide();
         break;
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

The stats dialog gains a hold-to-confirm button that discards the recorded assault course and race track times.

Resolves TRX246.

Please LMK what you think of the UI – happy to redesign, but I'd need directions.

<img width="3840" height="2160" alt="20260726_173139_Lara&#39;s_Home" src="https://github.com/user-attachments/assets/0a136fa0-eead-4bf9-8b5a-e440554ce9c2" />
<img width="3840" height="2160" alt="20260726_173144_Lara&#39;s_Home" src="https://github.com/user-attachments/assets/53783148-348f-4351-84bf-aed4412e1018" />