### PR TITLE
shell: do not show a fatal dialog in batch mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - fixed a brief field of view flicker when exiting photo mode during Lara's special animations, such as turning to gold (regression from 1.5)
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
+- fixed the game displaying a GUI error dialog when it fails to start in headless mode
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/shell/common.c
+++ b/src/trx/game/shell/common.c
@@ -19,13 +19,27 @@
 static bool m_IsExiting = false;
 static bool m_IsFocused = true;
 
+// SDL_ShowSimpleMessageBox blocks until the dialog is dismissed, which never
+// happens in a batch run, so such a run hangs instead of reporting the error
+// and stopping.
+static bool M_IsInteractive(void)
+{
+    const SHELL_ARGS *const args = Shell_GetArgs();
+    if (args == nullptr) {
+        return true;
+    }
+    return !args->headless && !args->startup.dump_lua_api;
+}
+
 static void M_ShowFatalError(
     const char *const log_message, const char *const dialog_message)
 {
     LOG_ERROR("%s", log_message);
-    SDL_Window *const window = Shell_GetWindow();
-    SDL_ShowSimpleMessageBox(
-        SDL_MESSAGEBOX_ERROR, "Tomb Raider Error", dialog_message, window);
+    if (M_IsInteractive()) {
+        SDL_Window *const window = Shell_GetWindow();
+        SDL_ShowSimpleMessageBox(
+            SDL_MESSAGEBOX_ERROR, "Tomb Raider Error", dialog_message, window);
+    }
     Shell_Terminate(1);
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

`SDL_ShowSimpleMessageBox` blocks until the dialog is dismissed, which never happens under `--headless` or `--dump-lua-api`. Instead of reporting the error and stopping, the run hung with the message only in the log.