### PR TITLE
objects/bacon_lara: fix premature death and interpolation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed Bacon Lara remaining targetable after death
 - fixed Bacon Lara dying prematurely in some geometry setups
+- fixed jittery interpolation on Bacon Lara when falling from great heights
 - fixed the detonator box returning to its original position after loading a save (OG bug)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fixed rain and snow starting over when a save is loaded (#5901)
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed Bacon Lara remaining targetable after death
+- fixed Bacon Lara dying prematurely in some geometry setups
 - fixed the detonator box returning to its original position after loading a save (OG bug)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)
 - fixed Lara receiving twice the number of flares if given via the game flow (regression from 1.9)

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -8,12 +8,14 @@
 #include <trx/game/rooms.h>
 
 #define M_SMASH_JUMP_FRAME 1
+#define M_MAX_DEATH_COUNT 2
 
 typedef struct {
     bool status;
     bool anchored;
     int32_t anchor_x;
     int32_t anchor_z;
+    int32_t death_count;
 } M_PRIV;
 
 static void M_InitialiseAnchor(ITEM *const item)
@@ -43,12 +45,14 @@ static void M_LoadPriv(ITEM *const item, JSON_READ_IO *const io)
 {
     M_PRIV *const p = item->priv;
     JSON_SHOULD(JSON_READ(io, "status", &p->status));
+    JSON_SHOULD(JSON_READ(io, "death_count", &p->death_count));
 }
 
 static void M_SavePriv(const ITEM *const item, JSON_WRITE_IO *const io)
 {
     const M_PRIV *const p = item->priv;
     JSONW_WRITE(io, "status", p->status);
+    JSONW_WRITE(io, "death_count", p->death_count);
 }
 
 static void M_Initialise(const int16_t item_num)
@@ -90,6 +94,15 @@ static void M_SyncToLara(ITEM *const item, const ITEM *const lara_item)
     Item_UpdateRoom(Item_GetIndex(item), lara_item->room_num);
 
     if (floor_height < lara_floor_height + WALL_L || lara_item->gravity) {
+        p->death_count = 0;
+        return;
+    }
+
+    // Bacon Lara runs one frame behind Lara, so the death check must pass twice
+    // in succession. This prevents premature death when Lara is, for example,
+    // pulling out of water.
+    p->death_count++;
+    if (p->death_count < M_MAX_DEATH_COUNT) {
         return;
     }
 

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -9,6 +9,7 @@
 
 #define M_SMASH_JUMP_FRAME 1
 #define M_MAX_DEATH_COUNT 2
+#define M_FALL_RATE 50
 
 typedef struct {
     bool status;
@@ -91,6 +92,7 @@ static void M_SyncToLara(ITEM *const item, const ITEM *const lara_item)
     item->pos = pos;
     item->rot = lara_item->rot;
     item->rot.y -= DEG_180;
+    item->fall_speed = lara_item->fall_speed;
     Item_UpdateRoom(Item_GetIndex(item), lara_item->room_num);
 
     if (floor_height < lara_floor_height + WALL_L || lara_item->gravity) {
@@ -112,7 +114,7 @@ static void M_SyncToLara(ITEM *const item, const ITEM *const lara_item)
     item->speed = 0;
     item->fall_speed = 0;
     item->gravity = true;
-    item->pos.y += 50;
+    item->pos.y += M_FALL_RATE;
     p->status = true;
 }
 

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -63,6 +63,71 @@ static void M_Initialise(const int16_t item_num)
     M_InitialiseAnchor(item);
 }
 
+static void M_SyncToLara(ITEM *const item, const ITEM *const lara_item)
+{
+    M_PRIV *const p = item->priv;
+    const XYZ_32 pos = {
+        .x = 2 * p->anchor_x - lara_item->pos.x,
+        .z = 2 * p->anchor_z - lara_item->pos.z,
+        .y = lara_item->pos.y,
+    };
+
+    int16_t room_num = item->room_num;
+    const SECTOR *sector = Room_GetSector(pos, &room_num);
+    const int32_t floor_height = Room_GetHeight(sector, pos);
+    item->floor = floor_height;
+
+    room_num = lara_item->room_num;
+    sector = Room_GetSector(lara_item->pos, &room_num);
+    const int32_t lara_floor_height = Room_GetHeight(sector, lara_item->pos);
+
+    const int16_t relative_anim = Item_GetRelativeAnim(lara_item);
+    const int16_t relative_frame = Item_GetRelativeFrame(lara_item);
+    Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
+    item->pos = pos;
+    item->rot = lara_item->rot;
+    item->rot.y -= DEG_180;
+    Item_UpdateRoom(Item_GetIndex(item), lara_item->room_num);
+
+    if (floor_height < lara_floor_height + WALL_L || lara_item->gravity) {
+        return;
+    }
+
+    item->current_anim_state = LS(LS_FAST_FALL);
+    item->goal_anim_state = LS(LS_FAST_FALL);
+    Item_SwitchToAnim(item, LA(LA_SMASH_JUMP), M_SMASH_JUMP_FRAME);
+    item->speed = 0;
+    item->fall_speed = 0;
+    item->gravity = true;
+    item->pos.y += 50;
+    p->status = true;
+}
+
+static void M_FallToDeath(ITEM *const item)
+{
+    Item_Animate(item);
+
+    int16_t room_num = item->room_num;
+    const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
+    const int32_t height = Room_GetHeight(sector, item->pos);
+    item->floor = height;
+
+    Room_TestTriggers(item);
+    if (item->pos.y >= height) {
+        item->floor = height;
+        item->pos.y = height;
+        Room_TestTriggers(item);
+        item->gravity = false;
+        item->fall_speed = 0;
+        item->goal_anim_state = LS(LS_DEATH);
+        item->required_anim_state = LS(LS_DEATH);
+        if (room_num != item->room_num) {
+            Item_UpdateRoom(Item_GetIndex(item), room_num);
+        }
+        Item_SetFinished(item, true);
+    }
+}
+
 static void M_Control(const int16_t item_num)
 {
     ITEM *const item = Item_Get(item_num);
@@ -86,63 +151,13 @@ static void M_Control(const int16_t item_num)
     }
 
     if (!p->status) {
-        const XYZ_32 pos = {
-            .x = 2 * p->anchor_x - lara_item->pos.x,
-            .z = 2 * p->anchor_z - lara_item->pos.z,
-            .y = lara_item->pos.y,
-        };
-
-        int16_t room_num = item->room_num;
-        const SECTOR *sector = Room_GetSector(pos, &room_num);
-        const int32_t h = Room_GetHeight(sector, pos);
-        item->floor = h;
-
-        room_num = lara_item->room_num;
-        sector = Room_GetSector(lara_item->pos, &room_num);
-        int32_t lh = Room_GetHeight(sector, lara_item->pos);
-
-        const int16_t relative_anim = Item_GetRelativeAnim(lara_item);
-        const int16_t relative_frame = Item_GetRelativeFrame(lara_item);
-        Item_SwitchToObjAnim(item, relative_anim, relative_frame, O_LARA);
-        item->pos = pos;
-        item->rot = lara_item->rot;
-        item->rot.y -= DEG_180;
-        Item_UpdateRoom(item_num, lara_item->room_num);
-
-        if (h >= lh + WALL_L && !lara_item->gravity) {
-            item->current_anim_state = LS(LS_FAST_FALL);
-            item->goal_anim_state = LS(LS_FAST_FALL);
-            Item_SwitchToAnim(item, LA(LA_SMASH_JUMP), M_SMASH_JUMP_FRAME);
-            item->speed = 0;
-            item->fall_speed = 0;
-            item->gravity = true;
-            item->pos.y += 50;
-            p->status = true;
-        }
+        M_SyncToLara(item, lara_item);
     }
 
+    // Synchronizing with Lara may have invoked Bacon Lara's death, hence check
+    // the flag again on the same frame.
     if (p->status) {
-        Item_Animate(item);
-
-        int16_t room_num = item->room_num;
-        const SECTOR *sector = Room_GetSector(item->pos, &room_num);
-        const int32_t h = Room_GetHeight(sector, item->pos);
-        item->floor = h;
-
-        Room_TestTriggers(item);
-        if (item->pos.y >= h) {
-            item->floor = h;
-            item->pos.y = h;
-            Room_TestTriggers(item);
-            item->gravity = false;
-            item->fall_speed = 0;
-            item->goal_anim_state = LS(LS_DEATH);
-            item->required_anim_state = LS(LS_DEATH);
-            if (room_num != item->room_num) {
-                Item_UpdateRoom(item_num, room_num);
-            }
-            Item_SetFinished(item, true);
-        }
+        M_FallToDeath(item);
     }
 }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes some cases where Bacon Lara can die prematurely because of the one frame delay in her synchronisation with Lara. The death check must now pass twice in succession to validate the floor difference is genuine once caught up with Lara. Her fall speed is also now synchronised with Lara's to avoid jittery interpolation when falling from great heights. Test level available.

Resolves TRX780.