### PR TITLE
Add dead entities fading

### DIFF
--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -223,7 +223,7 @@ void main(void) {
 
 uniform sampler2DArray uTexAtlas;
 uniform sampler2D uTexEnvMap;
-uniform vec3 uTint;
+uniform vec4 uTint;
 uniform bool uDiscardAlpha;
 
 #if TR_VERSION >= 4
@@ -389,7 +389,9 @@ void main(void) {
     }
 
     texColor.rgb *= uBrightnessMultiplier;
-    texColor.rgb *= uTint;
+    // All four components: the framebuffer blend is premultiplied alpha, so
+    // fading a fragment out means scaling its coverage along with its color.
+    texColor *= uTint;
 
     outColor = texColor;
 }

--- a/data/trx/ship/cfg/shaders/meshes.glsl
+++ b/data/trx/ship/cfg/shaders/meshes.glsl
@@ -389,9 +389,11 @@ void main(void) {
     }
 
     texColor.rgb *= uBrightnessMultiplier;
-    // All four components: the framebuffer blend is premultiplied alpha, so
-    // fading a fragment out means scaling its coverage along with its color.
+    // The framebuffer blend is premultiplied alpha, so the color carries the
+    // coverage: fading a fragment out scales both, and the color a second time
+    // by the alpha it is premultiplied against.
     texColor *= uTint;
+    texColor.rgb *= uTint.a;
 
     outColor = texColor;
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,7 @@
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
 
 **TR4**
+- added dead enemies fading away a few seconds after they fall, as in the original TR4
 - added reflections
 - added TR4 outfits
 - added seamless body and braid joints to the TR4 outfits, as in the original TR4
@@ -83,7 +84,7 @@ The Lua integration was rewritten and existing scripts will need updating; refer
 - added `p`, a global shorthand for `trx.console.log`, and made the console log functions take any value, pretty-printing a table
 - added a new Lua module, `trx.math`, with the engine's own fixed-point trigonometry and the `DEG_1`, `DEG_45`, `DEG_90` and `WALL_L` constants
 - added a new Lua module, `trx.strings`, with `fuzzy_match()` and `regex_match()`
-- added a new Lua module, `trx.rules`, holding the numbers the game plays by; the first of them are the cold exposure ceiling, rates and damage
+- added a new Lua module, `trx.rules`, holding the numbers the game plays by; the first of them are the cold exposure ceiling, rates and damage, and how fast a dead enemy fades away
 - added a new Lua module, `trx.argparse`, a declarative argument parser inspired by Python's argparse
 - added a new Lua module, `trx.locale`, for the text the player reads, looked up by key
 - added a new Lua module, `trx.weather`, to read and set the runtime weather

--- a/docs/trx/lua/api.json
+++ b/docs/trx/lua/api.json
@@ -4727,6 +4727,11 @@
       "callable": false,
       "implicit": true,
       "path": "rules.exposure"
+    },
+    {
+      "callable": false,
+      "implicit": true,
+      "path": "rules.corpse"
     }
   ],
   "properties": [
@@ -4956,6 +4961,12 @@
     {
       "description": "Hit points lost each frame once the warmth has run out.",
       "path": "rules.exposure.damage",
+      "type": "integer",
+      "writable": true
+    },
+    {
+      "description": "How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.",
+      "path": "rules.corpse.fade_speed",
       "type": "integer",
       "writable": true
     },

--- a/docs/trx/lua/reference/RULES.md
+++ b/docs/trx/lua/reference/RULES.md
@@ -28,6 +28,7 @@ again on every entry, so a level that wants the defaults back asks for them.
 - **`trx.rules.exposure.drain_water`** (integer). Warmth lost each frame in the cold, underwater or at the surface.
 - **`trx.rules.exposure.recovery`** (integer). Warmth regained each frame once out of the cold.
 - **`trx.rules.exposure.damage`** (integer). Hit points lost each frame once the warmth has run out.
+- **`trx.rules.corpse.fade_speed`** (integer). How much of a body's coverage goes each frame, out of 255. It is taken away once nothing is left. `0` leaves it where it lies.
 
 ### Functions
 

--- a/src/lua/api/rules.lua
+++ b/src/lua/api/rules.lua
@@ -56,6 +56,12 @@ rule("exposure.damage", {
   description = "Hit points lost each frame once the warmth has run out.",
 })
 
+rule("corpse.fade_speed", {
+  type = "integer",
+  description = "How much of a body's coverage goes each frame, out of 255. It is taken "
+    .. "away once nothing is left. `0` leaves it where it lies.",
+})
+
 api.define("rules.list", {
   description = "Every rule there is, as dotted `group.field` keys.",
   params = {},

--- a/src/tests/unit/test_lua_cmd_rule.c
+++ b/src/tests/unit/test_lua_cmd_rule.c
@@ -9,6 +9,9 @@
 
 #include <lauxlib.h>
 
+// Rules_Reset reads the version for the rules whose default depends on it.
+int32_t g_TRVersion = 1;
+
 static int M_FakeReset(lua_State *const L)
 {
     FakeConsole_Reset();

--- a/src/trx/core/colors.h
+++ b/src/trx/core/colors.h
@@ -23,6 +23,7 @@ typedef struct {
 #define COLOR_RGB_888_BLACK ((RGB_888) { 0x00, 0x00, 0x00 })
 #define COLOR_RGB_888_WHITE ((RGB_888) { 0xFF, 0xFF, 0xFF })
 #define COLOR_RGB_F_WHITE ((RGB_F) { 1.0f, 1.0f, 1.0f })
+#define COLOR_RGBA_F_WHITE ((RGBA_F) { 1.0f, 1.0f, 1.0f, 1.0f })
 
 RGBA_8888 Color_RGB888ToRGBA8888_Impl(RGB_888 color);
 RGBA_8888 Color_RGB888ToRGBA8888Ex_Impl(RGB_888 color, uint8_t alpha);

--- a/src/trx/game/creature/common.c
+++ b/src/trx/game/creature/common.c
@@ -732,6 +732,14 @@ void Creature_Float(const int16_t item_num)
     const SECTOR *const sector = Room_GetSector(item->pos, &room_num);
     item->floor = Room_GetHeight(sector, item->pos);
     Item_UpdateRoom(item_num, room_num);
+
+    // A drowned body never runs the animation command that starts the fade, so
+    // it begins once the body has risen as far as it is going to. OG also waits
+    // for the death animation to loop back to its first frame, which is how
+    // TR4's rest; the earlier games hold on the last frame instead.
+    if (item->pos.y <= wh) {
+        Item_StartFade(item);
+    }
 }
 
 void Creature_Underwater(ITEM *const item, const int32_t depth)

--- a/src/trx/game/effects/draw.c
+++ b/src/trx/game/effects/draw.c
@@ -25,7 +25,7 @@ void Effect_Draw(const int16_t effect_num)
         Output_DrawSprite(
             effect->interp.result.pos.x, effect->interp.result.pos.y,
             effect->interp.result.pos.z, Object_Get(O_GLOW)->mesh_idx,
-            effect->shade, COLOR_RGB_F_WHITE, DRAW_BLEND, 1.0f);
+            effect->shade, COLOR_RGBA_F_WHITE, DRAW_BLEND, 1.0f);
         return;
     }
 
@@ -36,9 +36,9 @@ void Effect_Draw(const int16_t effect_num)
     }
 
     if (obj->mesh_count < 0) {
-        const RGB_F tint =
+        const RGBA_F tint =
             Object_IsType(effect->object_id, g_WaterSpriteObjects)
-            ? COLOR_RGB_F_WHITE
+            ? COLOR_RGBA_F_WHITE
             : Output_GetTint();
         int16_t shade = effect->shade;
         if (shade == -1) {

--- a/src/trx/game/fx/gun_flash.c
+++ b/src/trx/game/fx/gun_flash.c
@@ -156,8 +156,8 @@ static void M_Draw(void)
         if (glow_obj->loaded) {
             Output_DrawSprite(
                 flash_pos.x, flash_pos.y, flash_pos.z, glow_obj->mesh_idx,
-                SHADE_NEUTRAL, (RGB_F) { 1.0f, 0.89f, 0.13f }, DRAW_BLEND_ADD,
-                1.0f);
+                SHADE_NEUTRAL, (RGBA_F) { 1.0f, 0.89f, 0.13f, 1.0f },
+                DRAW_BLEND_ADD, 1.0f);
         }
 
         Matrix_Push();

--- a/src/trx/game/game_flow/sequencer.c
+++ b/src/trx/game/game_flow/sequencer.c
@@ -223,8 +223,8 @@ GF_COMMAND GF_InterpretSequence(
         } else {
             // console /play level feature
             Inv_RemoveAllItems();
+            Savegame_InitCurrentInfo();
             if (level == GF_GetGymLevel()) {
-                Savegame_InitCurrentInfo();
                 GF_InventoryModifier_Scan(level);
                 GF_InventoryModifier_ApplyToResumeInfo(level);
             } else {

--- a/src/trx/game/gun/misc.c
+++ b/src/trx/game/gun/misc.c
@@ -177,8 +177,9 @@ static void M_DrawGunGlow(
     const int16_t shade =
         weapon->glow_flicker ? (Random_GetDraw() & 0xFFF) + SHADE_NEUTRAL : 0;
     Output_DrawSprite(
-        pos.x, pos.y, pos.z, glow_obj->mesh_idx, shade, weapon->glow_color,
-        DRAW_BLEND_ADD, weapon->glow_scale);
+        pos.x, pos.y, pos.z, glow_obj->mesh_idx, shade,
+        Color_RGBToRGBA(weapon->glow_color), DRAW_BLEND_ADD,
+        weapon->glow_scale);
 }
 
 void Gun_FindTargetPoint(const ITEM *const item, GAME_VECTOR *const target)

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -228,7 +228,7 @@ void Item_Animate(ITEM *const item)
                 const OBJECT *const obj = Object_Get(item->object_id);
                 item->after_death = obj->intelligent ? 1 : 64;
                 Item_SetFinished(item, true);
-                if (obj->intelligent) {
+                if (obj->leaves_corpse) {
                     Item_StartFade(item);
                 }
                 break;

--- a/src/trx/game/items/anim.c
+++ b/src/trx/game/items/anim.c
@@ -228,6 +228,9 @@ void Item_Animate(ITEM *const item)
                 const OBJECT *const obj = Object_Get(item->object_id);
                 item->after_death = obj->intelligent ? 1 : 64;
                 Item_SetFinished(item, true);
+                if (obj->intelligent) {
+                    Item_StartFade(item);
+                }
                 break;
 
             default:

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -15,6 +15,7 @@
 #include <trx/game/output/const.h>
 #include <trx/game/pathing.h>
 #include <trx/game/rooms.h>
+#include <trx/game/rules.h>
 #include <trx/game/sparks.h>
 #include <trx/version.h>
 
@@ -297,6 +298,7 @@ void Item_Initialise(const int16_t item_num)
     item->ai_bits = 0;
     item->ai_tag = 0;
     item->after_death = 0;
+    item->fade = 0;
     item->creature_data = nullptr;
     item->extra_rotations = nullptr;
     item->priv = nullptr;
@@ -382,6 +384,34 @@ void Item_Initialise(const int16_t item_num)
     }
 }
 
+void Item_StartFade(ITEM *const item)
+{
+    if (g_Rules.corpse.fade_speed <= 0 || item->fade > 0) {
+        return;
+    }
+    item->fade = 255;
+}
+
+// A body leaves the active list as it dies, so the fade cannot ride on the
+// loop below. The OG counts it off while drawing the room, which leaves a
+// corpse nobody is looking at hanging around; this runs either way.
+static void M_ControlFades(void)
+{
+    // Read every frame, so changing the rule mid-fade changes the slope from
+    // here on.
+    const int32_t speed = g_Rules.corpse.fade_speed;
+    for (int16_t item_num = 0; item_num < m_MaxUsedItemCount; item_num++) {
+        ITEM *const item = &m_Items[item_num];
+        if (item->fade <= 0) {
+            continue;
+        }
+        item->fade -= speed;
+        if (item->fade <= 0) {
+            Item_Destroy(item_num);
+        }
+    }
+}
+
 void Item_Control(void)
 {
     int16_t item_num = Item_GetNextSimulated();
@@ -395,6 +425,7 @@ void Item_Control(void)
         item_num = next;
     }
 
+    M_ControlFades();
     Carrier_AnimateDrops();
 }
 

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -36,6 +36,9 @@ int16_t Item_Spawn(const ITEM *item, OBJECT_ID obj_id);
 void Item_Initialise(int16_t item_num);
 void Item_Control(void);
 
+// Begin fading a body out, if the rules call for bodies to fade at all.
+void Item_StartFade(ITEM *item);
+
 // Remove the item from the game; any other handle to it becomes stale. Fires
 // on_destroy during live play, while the item can still be read from the
 // handler.

--- a/src/trx/game/items/types.h
+++ b/src/trx/game/items/types.h
@@ -46,6 +46,9 @@ typedef struct ITEM {
     uint32_t touch_bits;
     uint32_t mesh_bits;
     int16_t after_death;
+    // Coverage a fading body has left, out of 255, or 0 when it is not
+    // fading. Kept apart from after_death, which TR3 counts its blood bath by.
+    int16_t fade;
     OBJECT_ID object_id;
     int16_t current_anim_state;
     int16_t goal_anim_state;

--- a/src/trx/game/lara/mesh.c
+++ b/src/trx/game/lara/mesh.c
@@ -144,7 +144,7 @@ OBJECT_MESH *Lara_Mesh_Get(const LARA_MESH mesh)
     return m_Meshes[mesh];
 }
 
-RGB_F Lara_GetMeshTint(const GAME_VECTOR pos)
+RGBA_F Lara_GetMeshTint(const GAME_VECTOR pos)
 {
     if (!g_Config.visuals.enable_responsive_mesh_tint || g_Camera.underwater) {
         return Output_GetTint();
@@ -155,13 +155,13 @@ RGB_F Lara_GetMeshTint(const GAME_VECTOR pos)
     const int32_t water_height = Room_GetWaterHeight(pos.pos, room_num);
 
     if (!Room_Get(room_num)->flags.underwater) {
-        return COLOR_RGB_F_WHITE;
+        return COLOR_RGBA_F_WHITE;
     } else if (water_height == NO_HEIGHT) {
-        return Output_GetWaterColor();
+        return Color_RGBToRGBA(Output_GetWaterColor());
     } else if (pos.y > water_height) {
-        return Output_GetWaterColor();
+        return Color_RGBToRGBA(Output_GetWaterColor());
     } else {
-        return COLOR_RGB_F_WHITE;
+        return COLOR_RGBA_F_WHITE;
     }
 }
 

--- a/src/trx/game/lara/mesh.h
+++ b/src/trx/game/lara/mesh.h
@@ -10,5 +10,5 @@ void Lara_Mesh_SwapSingle(LARA_MESH mesh, OBJECT_ID obj_id);
 void Lara_Mesh_SwapAll(OBJECT_ID obj_id);
 void Lara_Mesh_Set(LARA_MESH mesh, OBJECT_MESH *mesh_ptr);
 OBJECT_MESH *Lara_Mesh_Get(LARA_MESH mesh);
-RGB_F Lara_GetMeshTint(GAME_VECTOR pos);
+RGBA_F Lara_GetMeshTint(GAME_VECTOR pos);
 int32_t Lara_GetMeshIndex(const ITEM *item, int32_t mesh_idx);

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -140,6 +140,7 @@ static void M_FallToDeath(ITEM *const item)
             Item_UpdateRoom(Item_GetIndex(item), room_num);
         }
         Item_SetFinished(item, true);
+        Item_StartFade(item);
     }
 }
 

--- a/src/trx/game/objects/creatures/mummy.c
+++ b/src/trx/game/objects/creatures/mummy.c
@@ -82,6 +82,7 @@ static void M_Setup(OBJECT *const obj)
     obj->collision_func = Object_Collision;
     obj->can_drop_items_func = M_CanDropItems;
 
+    obj->leaves_corpse = true;
     obj->save_flags = true;
     obj->save_hitpoints = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/creatures/skidoo_driver.c
+++ b/src/trx/game/objects/creatures/skidoo_driver.c
@@ -305,6 +305,7 @@ static void M_Setup(OBJECT *const obj)
     obj->priv_size = sizeof(M_PRIV);
     obj->is_targetable_func = M_IsTargetable;
 
+    obj->leaves_corpse = true;
     obj->save_position = true;
     obj->save_flags = true;
     obj->save_anim = true;

--- a/src/trx/game/objects/draw.c
+++ b/src/trx/game/objects/draw.c
@@ -319,7 +319,7 @@ void Object_ApplyExtraRotation(
 
 bool Object_DrawSpriteItem(const ITEM *const item)
 {
-    const RGB_F tint = Output_GetTint();
+    const RGBA_F tint = Output_GetTint();
     SHADE shade = item->shade;
     if (shade.value_1 < 0) {
         shade.value_1 = SHADE_NEUTRAL;

--- a/src/trx/game/objects/setup.c
+++ b/src/trx/game/objects/setup.c
@@ -64,12 +64,14 @@ void Object_SetupAllObjects(void)
         obj->save_anim = false;
         obj->load_floor = false;
         obj->intelligent = false;
+        obj->leaves_corpse = false;
         obj->smartness = -1;
 
         ObjectProperty_ResetObject(obj);
         if (obj->setup_func != nullptr) {
             obj->setup_func(obj);
         }
+        obj->leaves_corpse |= obj->intelligent;
 
         // TODO: this is poor design
         OBJECT_PROPERTIES(

--- a/src/trx/game/objects/types.h
+++ b/src/trx/game/objects/types.h
@@ -117,6 +117,10 @@ typedef struct OBJECT {
     bool enable_interpolation;
     bool loaded;
     bool intelligent;
+    // Whether the object leaves a body behind when it dies, which the rules
+    // may then fade away. Set for every intelligent object; an object that is
+    // not one of those, such as the mummy, says so itself.
+    bool leaves_corpse;
     bool save_position;
     bool save_hitpoints;
     bool save_flags;

--- a/src/trx/game/output/draw.c
+++ b/src/trx/game/output/draw.c
@@ -250,7 +250,7 @@ void Output_DrawRoom(const ROOM *const room, const bool is_outside)
 
 void Output_DrawSprite(
     const int32_t x, const int32_t y, const int32_t z, const int16_t sprite_idx,
-    const int16_t shade, const RGB_F tint, const DRAW_TYPE draw_type,
+    const int16_t shade, const RGBA_F tint, const DRAW_TYPE draw_type,
     const float scale)
 {
     Matrix_Push();

--- a/src/trx/game/output/draw.h
+++ b/src/trx/game/output/draw.h
@@ -11,7 +11,7 @@ void Output_DrawRoom(const ROOM *room, bool is_outside);
 
 // scale multiplies the sprite's own size around its anchor point.
 void Output_DrawSprite(
-    int32_t x, int32_t y, int32_t z, int16_t sprnum, int16_t shade, RGB_F tint,
+    int32_t x, int32_t y, int32_t z, int16_t sprnum, int16_t shade, RGBA_F tint,
     DRAW_TYPE draw_type, float scale);
 void Output_DrawShadow(int16_t size, const BOUNDS_16 *bounds, const ITEM *item);
 void Output_DrawLightningSegment(const LIGHTNING_SEGMENT segment);

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -53,6 +53,9 @@ typedef struct M_MESH_BUF_BINDING {
     UT_hash_handle hh;
 } M_MESH_BUF_BINDING;
 
+// One sorted draw in the transparent pass. A null face means the entry stands
+// for the instance's whole opaque range, which lives in the opaque EBO and is
+// indexed relative to the mesh's first vertex.
 typedef struct {
     int32_t sort_key;
     const MESH_INSTANCE *inst;
@@ -205,6 +208,13 @@ static void M_SortTransparentFaces(const MESH_BATCHER *const batcher)
     M_FACE_SORT *const buf = Vector_GetData(batcher->transparent_sort);
     M_FACE_SORT *bptr = buf;
     for (int32_t i = 0; i < n; i++) {
+        if (bptr->face == nullptr) {
+            // No centroid to work from, so the whole range sorts at the
+            // instance origin.
+            bptr->sort_key = bptr->inst->cwmatrix._23;
+            bptr++;
+            continue;
+        }
         // clang-format off
         bptr->sort_key = (
             bptr->inst->cwmatrix._20 * (int32_t)bptr->face->mesh_centroid.x +
@@ -326,8 +336,24 @@ static void M_OpaquePass(MESH_BATCHER *const batcher)
             M_GetBinding(batcher, inst->mesh);
 
         if (inst->mesh->opaque_vertex_indices->count != 0) {
-            Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
-            M_DrawOpaqueInstance(batcher, inst);
+            if (inst->tint.a < 1.0f) {
+                // An instance drawn at partial coverage cannot write depth:
+                // it would hide whatever the pass draws behind it later. Its
+                // opaque faces go through the sorted pass instead. Face
+                // opacity is fixed when the mesh is built, so the routing has
+                // to happen per instance.
+                Vector_Add(
+                    batcher->transparent_sort,
+                    &(M_FACE_SORT) {
+                        .inst = inst,
+                        .face = nullptr,
+                        .index_start = bind->opaque_index_start,
+                        .index_count = bind->opaque_index_count,
+                    });
+            } else {
+                Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
+                M_DrawOpaqueInstance(batcher, inst);
+            }
         }
 
         // Accumulate transparent polygons and faces.
@@ -374,9 +400,10 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
     }
 
     glBindVertexArray(batcher->vao);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->ebo.transparent);
+    GLuint bound_ebo = 0;
 
     const MESH_INSTANCE *inst = nullptr;
+    const M_MESH_BUF_BINDING *inst_bind = nullptr;
 
     for (int32_t i = 0; i < batcher->transparent_sort->count; i++) {
         const M_FACE_SORT *const sort_ptr =
@@ -386,11 +413,19 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
             continue;
         }
 
+        const GLuint ebo = sort_ptr->face == nullptr ? batcher->ebo.opaque
+                                                     : batcher->ebo.transparent;
+        if (ebo != bound_ebo) {
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
+            bound_ebo = ebo;
+        }
+
         if (sort_ptr->inst != inst) {
             inst = sort_ptr->inst;
             const M_MESH_BUF_BINDING *const bind =
                 M_GetBinding(batcher, inst->mesh);
             ASSERT(bind != nullptr);
+            inst_bind = bind;
             if (bind->needs_object_light) {
                 Output_Lights_UploadCPULight(&inst->light_info);
             } else if (bind->needs_own_light) {
@@ -410,8 +445,15 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
         const void *index_offset =
             (void *)(intptr_t)(sort_ptr->index_start * sizeof(uint32_t));
 
-        glDrawElements(
-            GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT, index_offset);
+        if (sort_ptr->face == nullptr) {
+            glDrawElementsBaseVertex(
+                GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT,
+                index_offset, inst_bind->vertex_start);
+        } else {
+            glDrawElements(
+                GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT,
+                index_offset);
+        }
 
         g_TRX_GL_Metrics.trans_vert_count += sort_ptr->index_count;
     }

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -53,9 +53,11 @@ typedef struct M_MESH_BUF_BINDING {
     UT_hash_handle hh;
 } M_MESH_BUF_BINDING;
 
-// One sorted draw in the transparent pass. A null face means the entry stands
-// for the instance's whole opaque range, which lives in the opaque EBO and is
-// indexed relative to the mesh's first vertex.
+// One sorted draw in the transparent pass. A baked entry draws from the baked
+// buffers with no model matrix of its own; it is either a face, or a whole
+// faded object, which is the one kind that arrives with its depth already
+// worked out. Every other entry names a face of a mesh still sitting in the
+// shared buffers.
 typedef struct {
     // As wide as the matrix it comes from: the camera-space depth carries the
     // W2V_SHIFT scale, so a level deep enough would wrap a 32-bit key and sort
@@ -65,7 +67,27 @@ typedef struct {
     const OUTPUT_MESH_FACE *face;
     int32_t index_start;
     int32_t index_count;
+    // Which faded group the entry stands for, when it stands for one rather
+    // than for a face. See M_IsGroupEntry.
+    int32_t group;
+    bool baked;
 } M_FACE_SORT;
+
+// The solid part of one baked instance, contiguous in the baked buffers so it
+// draws in one go.
+typedef struct {
+    const MESH_INSTANCE *inst;
+    int32_t index_start;
+    int32_t index_count;
+} M_BAKED_RANGE;
+
+// One faded object: a run of solid ranges that lay down their depth together
+// and are blended together, and the depth it all sorts at.
+typedef struct {
+    int32_t range_start;
+    int32_t range_count;
+    int64_t depth_total;
+} M_BAKED_GROUP;
 
 typedef struct MESH_BATCHER {
     SCENE_SOURCE source;
@@ -95,6 +117,28 @@ typedef struct MESH_BATCHER {
     int32_t blend_add_total_indices;
     int32_t transparent_total_indices;
     bool layout_dirty;
+
+    // An instance drawn at partial coverage is baked into world space once a
+    // frame and drawn from here. Sharing one model matrix is what lets the
+    // instances of an object be drawn as an object, and lets what stays
+    // sorted interleave with anything else transparent for free.
+    struct {
+        GLuint vao;
+        GLuint geom;
+        GLuint tex;
+        GLuint shade;
+        GLuint ebo;
+    } baked;
+    VECTOR *baked_geom; // M_MESH_GEOM
+    VECTOR *baked_tex; // M_MESH_TEXTURE
+    VECTOR *baked_shade; // M_MESH_SHADE
+    VECTOR *baked_indices; // uint32_t
+    VECTOR *baked_ranges; // M_BAKED_RANGE
+    VECTOR *baked_groups; // M_BAKED_GROUP
+    // The instance baked last, which is what a new one is joined to: an
+    // object is staged a mesh at a time, so a run of them at one coverage is
+    // one object.
+    const MESH_INSTANCE *bake_tail;
 } MESH_BATCHER;
 
 static M_MESH_BUF_BINDING *M_GetBinding(
@@ -189,6 +233,13 @@ static void M_UpdateMeshGeometry(
         bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
 }
 
+// An entry that names no face is not a face at all: it stands for a whole
+// faded object, which is drawn in one go wherever it sorts.
+static bool M_IsGroupEntry(const M_FACE_SORT *const sort_ptr)
+{
+    return sort_ptr->face == nullptr;
+}
+
 // Order two values as a sign. The differences here are wider than the int the
 // comparator returns, and a truncated difference orders qsort's input
 // inconsistently rather than merely imprecisely.
@@ -207,7 +258,14 @@ static int M_CompareFaceDepth(const void *const a, const void *const b)
     }
     // The instances share one vector, so their addresses stand for the order
     // they were staged in.
-    return M_COMPARE(face_b->inst, face_a->inst);
+    if (face_a->inst != face_b->inst) {
+        return M_COMPARE(face_b->inst, face_a->inst);
+    }
+    // qsort orders entries it is told are equal however it likes, and an
+    // instance can bring many faces at keys that meet. Settle them by where
+    // they sit in the buffer, or the order they are drawn in changes from one
+    // frame to the next.
+    return M_COMPARE(face_b->index_start, face_a->index_start);
 }
 
 // Compute per-face view depth and sort the mesh's transparent ranges
@@ -221,10 +279,8 @@ static void M_SortTransparentFaces(const MESH_BATCHER *const batcher)
     M_FACE_SORT *const buf = Vector_GetData(batcher->transparent_sort);
     M_FACE_SORT *bptr = buf;
     for (int32_t i = 0; i < n; i++) {
-        if (bptr->face == nullptr) {
-            // No centroid to work from, so the whole range sorts at the
-            // instance origin.
-            bptr->sort_key = bptr->inst->cwmatrix._23;
+        if (M_IsGroupEntry(bptr)) {
+            // Not a face: its depth came from the instances it stands for.
             bptr++;
             continue;
         }
@@ -337,6 +393,157 @@ static void M_DrawBlendAddInstance(
     }
 }
 
+// The matrix carries the W2V_SHIFT scale, and the shader divides it out when
+// it uploads. Baking has to land on the same place the shader would have put
+// the vertex, so it divides it out too.
+static XYZ_F M_TransformPoint(
+    const MATRIX *const m, const XYZW_F *const pos, const bool translate)
+{
+    const double x = pos->x;
+    const double y = pos->y;
+    const double z = pos->z;
+    const double w = translate ? 1.0 : 0.0;
+    const double scale = 1.0 / (double)(1 << W2V_SHIFT);
+    return (XYZ_F) {
+        .x = (float)((m->_00 * x + m->_01 * y + m->_02 * z + m->_03 * w)
+                     * scale),
+        .y = (float)((m->_10 * x + m->_11 * y + m->_12 * z + m->_13 * w)
+                     * scale),
+        .z = (float)((m->_20 * x + m->_21 * y + m->_22 * z + m->_23 * w)
+                     * scale),
+    };
+}
+
+static int32_t M_BakeIndices(
+    MESH_BATCHER *const batcher, const int32_t vertex_base,
+    const uint32_t *const indices, const int32_t index_count)
+{
+    const int32_t index_start = batcher->baked_indices->count;
+    for (int32_t i = 0; i < index_count; i++) {
+        const uint32_t index = vertex_base + indices[i];
+        Vector_Add(batcher->baked_indices, &index);
+    }
+    return index_start;
+}
+
+// The object a faded instance belongs to. An object's meshes are staged one
+// after another at the one coverage, so a run of them is an object. Two that
+// happen to run together only share where they sort - each still settles what
+// of itself shows with its own depth.
+static int32_t M_GetBakeGroup(
+    MESH_BATCHER *const batcher, const MESH_INSTANCE *const inst)
+{
+    const MESH_INSTANCE *const tail = batcher->bake_tail;
+    const bool joins = tail != nullptr && batcher->baked_groups->count > 0
+        && tail->room == inst->room && tail->tint.a == inst->tint.a
+        && tail->sort_layer == inst->sort_layer;
+    batcher->bake_tail = inst;
+    if (!joins) {
+        Vector_Add(
+            batcher->baked_groups,
+            &(M_BAKED_GROUP) {
+                .range_start = batcher->baked_ranges->count,
+            });
+    }
+    return batcher->baked_groups->count - 1;
+}
+
+// Put an instance's vertices where the shader would have put them, so that
+// what is drawn from them needs no model matrix of its own.
+static void M_BakeInstance(
+    MESH_BATCHER *const batcher, const M_MESH_BUF_BINDING *const bind,
+    const MESH_INSTANCE *const inst)
+{
+    const int32_t vertex_base = batcher->baked_geom->count;
+    for (int32_t i = 0; i < bind->vertex_count; i++) {
+        M_MESH_GEOM geom = bind->geom_data[i];
+        const XYZ_F pos = M_TransformPoint(&inst->wmatrix, &geom.pos, true);
+        const XYZ_F normal =
+            M_TransformPoint(&inst->wmatrix, &geom.normal, false);
+        geom.pos.x = pos.x;
+        geom.pos.y = pos.y;
+        geom.pos.z = pos.z;
+        geom.normal.x = normal.x;
+        geom.normal.y = normal.y;
+        geom.normal.z = normal.z;
+        Vector_Add(batcher->baked_geom, &geom);
+        Vector_Add(batcher->baked_tex, &bind->tex_data[i]);
+        Vector_Add(batcher->baked_shade, &bind->shade_data[i]);
+    }
+
+    // The solid part goes down whole. Which of it you can see is settled by
+    // the depth buffer, so it needs no order among itself.
+    const int32_t group_idx = M_GetBakeGroup(batcher, inst);
+    M_BAKED_GROUP *const group = Vector_Get(batcher->baked_groups, group_idx);
+    group->depth_total += inst->cwmatrix._23;
+    const int32_t opaque_count = inst->mesh->opaque_vertex_indices->count;
+    if (opaque_count > 0) {
+        const int32_t index_start = M_BakeIndices(
+            batcher, vertex_base,
+            Vector_GetData(inst->mesh->opaque_vertex_indices), opaque_count);
+        Vector_Add(
+            batcher->baked_ranges,
+            &(M_BAKED_RANGE) {
+                .inst = inst,
+                .index_start = index_start,
+                .index_count = opaque_count,
+            });
+        group->range_count++;
+    }
+
+    // The faces that were already transparent stay sorted: they are see
+    // through in their own right, so the solid surface behind them has to
+    // show, and one of them cannot stand in for another.
+    for (int32_t i = 0; i < inst->mesh->transparent_faces->count; i++) {
+        const OUTPUT_MESH_FACE *const face =
+            Vector_Get(inst->mesh->transparent_faces, i);
+        const int32_t index_start = M_BakeIndices(
+            batcher, vertex_base, (const uint32_t *)face->vertex_indices,
+            face->vertex_count);
+        Vector_Add(
+            batcher->transparent_sort,
+            &(M_FACE_SORT) {
+                .inst = inst,
+                .face = face,
+                .index_start = index_start,
+                .index_count = face->vertex_count,
+                .baked = true,
+            });
+    }
+}
+
+static void M_UploadBaked(const MESH_BATCHER *const batcher)
+{
+    if (batcher->baked_geom->count == 0) {
+        return;
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->baked.geom);
+    TRX_GL_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        batcher->baked_geom->count * sizeof(M_MESH_GEOM),
+        Vector_GetData(batcher->baked_geom), GL_STREAM_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->baked.tex);
+    TRX_GL_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        batcher->baked_tex->count * sizeof(M_MESH_TEXTURE),
+        Vector_GetData(batcher->baked_tex), GL_STREAM_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, batcher->baked.shade);
+    TRX_GL_TRACK_DATA(
+        glBufferData, GL_ARRAY_BUFFER,
+        batcher->baked_shade->count * sizeof(M_MESH_SHADE),
+        Vector_GetData(batcher->baked_shade), GL_STREAM_DRAW);
+
+    // The element binding belongs to whichever vertex array is current, so
+    // the baked one goes on first and keeps the change to itself.
+    glBindVertexArray(batcher->baked.vao);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batcher->baked.ebo);
+    TRX_GL_TRACK_DATA(
+        glBufferData, GL_ELEMENT_ARRAY_BUFFER,
+        batcher->baked_indices->count * sizeof(uint32_t),
+        Vector_GetData(batcher->baked_indices), GL_STREAM_DRAW);
+}
+
 static void M_OpaquePass(MESH_BATCHER *const batcher)
 {
     VECTOR *const staged = batcher->staged[SCENE_PASS_OPAQUE];
@@ -348,25 +555,17 @@ static void M_OpaquePass(MESH_BATCHER *const batcher)
         const M_MESH_BUF_BINDING *const bind =
             M_GetBinding(batcher, inst->mesh);
 
+        // Face opacity is fixed when the mesh is built, so the routing has to
+        // happen per instance: at partial coverage the whole instance is
+        // baked, and it leaves this pass entirely.
+        if (inst->tint.a < 1.0f) {
+            M_BakeInstance(batcher, bind, inst);
+            continue;
+        }
+
         if (inst->mesh->opaque_vertex_indices->count != 0) {
-            if (inst->tint.a < 1.0f) {
-                // An instance drawn at partial coverage cannot write depth:
-                // it would hide whatever the pass draws behind it later. Its
-                // opaque faces go through the sorted pass instead. Face
-                // opacity is fixed when the mesh is built, so the routing has
-                // to happen per instance.
-                Vector_Add(
-                    batcher->transparent_sort,
-                    &(M_FACE_SORT) {
-                        .inst = inst,
-                        .face = nullptr,
-                        .index_start = bind->opaque_index_start,
-                        .index_count = bind->opaque_index_count,
-                    });
-            } else {
-                Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
-                M_DrawOpaqueInstance(batcher, inst);
-            }
+            Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
+            M_DrawOpaqueInstance(batcher, inst);
         }
 
         // Accumulate transparent polygons and faces.
@@ -384,6 +583,108 @@ static void M_OpaquePass(MESH_BATCHER *const batcher)
     }
 
     Output_AdjustDepth(0.0f, 0.0f);
+}
+
+// Put an instance's state up. The bake took its matrix away, so an item's
+// instances of one object differ in nothing, and the uploads below drop what
+// they already hold.
+static void M_ApplyBakedState(
+    MESH_BATCHER *const batcher, const MESH_INSTANCE *const inst,
+    const M_MESH_BUF_BINDING *const bind, const MESH_INSTANCE **const prev)
+{
+    if (*prev == nullptr
+        || memcmp(
+               &(*prev)->light_info, &inst->light_info,
+               sizeof(inst->light_info))
+            != 0) {
+        if (bind->needs_object_light) {
+            Output_Lights_UploadCPULight(&inst->light_info);
+        } else if (bind->needs_own_light) {
+            Output_Lights_UploadOwnLight(&inst->light_info);
+        }
+    }
+    if (*prev == nullptr || (*prev)->room != inst->room) {
+        M_SyncRoom(batcher, bind, inst->room);
+    }
+    Output_MeshShader_UploadModelMatrix(batcher->shader, &g_IDMatrix);
+    Output_MeshShader_UploadTint(batcher->shader, inst->tint);
+    Output_MeshShader_UploadWaterEffect(batcher->shader, inst->water_effect);
+    Output_MeshShader_UploadWibbleEffect(batcher->shader, inst->wibble);
+    Output_AdjustDepth(0.0f, inst->depth_adjust * 2.0f / 0.005f);
+    *prev = inst;
+}
+
+static void M_DrawBakedGroupRanges(
+    MESH_BATCHER *const batcher, const M_BAKED_GROUP *const group)
+{
+    const MESH_INSTANCE *prev = nullptr;
+    for (int32_t i = 0; i < group->range_count; i++) {
+        const M_BAKED_RANGE *const range =
+            Vector_Get(batcher->baked_ranges, group->range_start + i);
+        const M_MESH_BUF_BINDING *const bind =
+            M_GetBinding(batcher, range->inst->mesh);
+        ASSERT(bind != nullptr);
+        M_ApplyBakedState(batcher, range->inst, bind, &prev);
+        glDrawElements(
+            GL_TRIANGLES, range->index_count, GL_UNSIGNED_INT,
+            (void *)(intptr_t)(range->index_start * sizeof(uint32_t)));
+        g_TRX_GL_Metrics.trans_vert_count += range->index_count;
+    }
+}
+
+// Geometry at partial coverage is one object at one coverage, not a heap of
+// see-through faces. Sorting its faces cannot order a part against another it
+// is buried in, so the depth buffer does it instead: the solid part lays down
+// its depth, and then only the surface that depth kept is blended, once. It
+// happens where the object sorts, so whatever is in front of it still comes
+// after.
+static void M_DrawBakedGroup(
+    MESH_BATCHER *const batcher, const int32_t group_idx)
+{
+    const M_BAKED_GROUP *const group =
+        Vector_Get(batcher->baked_groups, group_idx);
+    if (group->range_count == 0) {
+        return;
+    }
+
+    Output_MeshShader_UploadAlphaDiscard(batcher->shader, true);
+
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    glDepthMask(GL_TRUE);
+    glDisable(GL_BLEND);
+    M_DrawBakedGroupRanges(batcher, group);
+
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glDepthMask(GL_FALSE);
+    glDepthFunc(GL_EQUAL);
+    glEnable(GL_BLEND);
+    M_DrawBakedGroupRanges(batcher, group);
+
+    glDepthFunc(GL_LESS);
+    Output_MeshShader_UploadAlphaDiscard(batcher->shader, false);
+}
+
+// One entry per object, so it takes its place among the transparent faces the
+// way anything else does.
+static void M_StageBakedGroups(MESH_BATCHER *const batcher)
+{
+    for (int32_t i = 0; i < batcher->baked_groups->count; i++) {
+        const M_BAKED_GROUP *const group = Vector_Get(batcher->baked_groups, i);
+        if (group->range_count == 0) {
+            continue;
+        }
+        const M_BAKED_RANGE *const first =
+            Vector_Get(batcher->baked_ranges, group->range_start);
+        Vector_Add(
+            batcher->transparent_sort,
+            &(M_FACE_SORT) {
+                .sort_key = group->depth_total / group->range_count,
+                .inst = first->inst,
+                .face = nullptr,
+                .group = i,
+                .baked = true,
+            });
+    }
 }
 
 static void M_BlendPass(MESH_BATCHER *const batcher, const SCENE_PASS pass)
@@ -412,25 +713,39 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
         return;
     }
 
-    glBindVertexArray(batcher->vao);
+    M_UploadBaked(batcher);
+
+    GLuint bound_vao = 0;
     GLuint bound_ebo = 0;
 
     const MESH_INSTANCE *inst = nullptr;
-    const M_MESH_BUF_BINDING *inst_bind = nullptr;
 
     for (int32_t i = 0; i < batcher->transparent_sort->count; i++) {
         const M_FACE_SORT *const sort_ptr =
             Vector_Get(batcher->transparent_sort, i);
 
-        if (sort_ptr->index_count == 0) {
+        if (!M_IsGroupEntry(sort_ptr) && sort_ptr->index_count == 0) {
             continue;
         }
 
-        const GLuint ebo = sort_ptr->face == nullptr ? batcher->ebo.opaque
-                                                     : batcher->ebo.transparent;
+        const GLuint vao = sort_ptr->baked ? batcher->baked.vao : batcher->vao;
+        if (vao != bound_vao) {
+            glBindVertexArray(vao);
+            bound_vao = vao;
+            bound_ebo = 0;
+        }
+        const GLuint ebo =
+            sort_ptr->baked ? batcher->baked.ebo : batcher->ebo.transparent;
         if (ebo != bound_ebo) {
             glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
             bound_ebo = ebo;
+        }
+
+        if (M_IsGroupEntry(sort_ptr)) {
+            M_DrawBakedGroup(batcher, sort_ptr->group);
+            // The group put its own state up as it went.
+            inst = nullptr;
+            continue;
         }
 
         if (sort_ptr->inst != inst) {
@@ -438,14 +753,14 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
             const M_MESH_BUF_BINDING *const bind =
                 M_GetBinding(batcher, inst->mesh);
             ASSERT(bind != nullptr);
-            inst_bind = bind;
             if (bind->needs_object_light) {
                 Output_Lights_UploadCPULight(&inst->light_info);
             } else if (bind->needs_own_light) {
                 Output_Lights_UploadOwnLight(&inst->light_info);
             }
             Output_MeshShader_UploadModelMatrix(
-                batcher->shader, &inst->wmatrix);
+                batcher->shader,
+                sort_ptr->baked ? &g_IDMatrix : &inst->wmatrix);
             Output_MeshShader_UploadTint(batcher->shader, inst->tint);
             Output_MeshShader_UploadWaterEffect(
                 batcher->shader, inst->water_effect);
@@ -455,18 +770,9 @@ static void M_TransparentPass(MESH_BATCHER *const batcher)
         }
 
         // indices live in the EBO starting at index_start
-        const void *index_offset =
-            (void *)(intptr_t)(sort_ptr->index_start * sizeof(uint32_t));
-
-        if (sort_ptr->face == nullptr) {
-            glDrawElementsBaseVertex(
-                GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT,
-                index_offset, inst_bind->vertex_start);
-        } else {
-            glDrawElements(
-                GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT,
-                index_offset);
-        }
+        glDrawElements(
+            GL_TRIANGLES, sort_ptr->index_count, GL_UNSIGNED_INT,
+            (void *)(intptr_t)(sort_ptr->index_start * sizeof(uint32_t)));
 
         g_TRX_GL_Metrics.trans_vert_count += sort_ptr->index_count;
     }
@@ -481,6 +787,13 @@ static void M_RenderBegin(const SCENE_SOURCE *const source)
         Vector_Clear(batcher->staged[pass]);
     }
     Vector_Clear(batcher->transparent_sort);
+    Vector_Clear(batcher->baked_geom);
+    Vector_Clear(batcher->baked_tex);
+    Vector_Clear(batcher->baked_shade);
+    Vector_Clear(batcher->baked_indices);
+    Vector_Clear(batcher->baked_ranges);
+    Vector_Clear(batcher->baked_groups);
+    batcher->bake_tail = nullptr;
 }
 
 static void M_RenderPass(
@@ -491,6 +804,7 @@ static void M_RenderPass(
     if (pass == SCENE_PASS_OPAQUE) {
         M_OpaquePass(batcher);
     } else if (pass == SCENE_PASS_TRANSPARENT) {
+        M_StageBakedGroups(batcher);
         M_SortTransparentFaces(batcher);
         M_TransparentPass(batcher);
     } else if (pass == SCENE_PASS_BLEND_SUB) {
@@ -544,29 +858,11 @@ static void M_AnimateTextures(const SCENE_SOURCE *const source)
     }
 }
 
-MESH_BATCHER *MeshBatcher_Create(void)
+static void M_SetupVertexArray(
+    const GLuint vao, const GLuint geom, const GLuint tex, const GLuint shade)
 {
-    MESH_BATCHER *const batcher = Memory_Alloc(sizeof(MESH_BATCHER));
-    batcher->shader = Output_GetMeshShader();
-    batcher->bindings = Vector_Create(sizeof(OUTPUT_MESH *));
-    batcher->binding_map = nullptr;
-    for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
-        batcher->staged[pass] = Vector_Create(sizeof(MESH_INSTANCE));
-    }
-    batcher->source.render_begin = M_RenderBegin;
-    batcher->source.render_pass = M_RenderPass;
-    batcher->source.is_dirty = M_IsDirty;
-    batcher->source.animate_textures = M_AnimateTextures;
-    batcher->source.priv = batcher;
-
-    batcher->transparent_sort = Vector_Create(sizeof(M_FACE_SORT));
-    batcher->layout_dirty = true;
-
-    glGenVertexArrays(1, &batcher->vao);
-    glGenBuffers(3, &batcher->vbo.geom);
-
-    glBindVertexArray(batcher->vao);
-    glBindBuffer(GL_ARRAY_BUFFER, batcher->vbo.geom);
+    glBindVertexArray(vao);
+    glBindBuffer(GL_ARRAY_BUFFER, geom);
 
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_POS);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_NORMAL);
@@ -585,7 +881,7 @@ MESH_BATCHER *MeshBatcher_Create(void)
         OUTPUT_MESH_ATTR_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE,
         sizeof(M_MESH_GEOM), (void *)(intptr_t)offsetof(M_MESH_GEOM, color));
 
-    glBindBuffer(GL_ARRAY_BUFFER, batcher->vbo.tex);
+    glBindBuffer(GL_ARRAY_BUFFER, tex);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_UVW);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TEXTURE_SIZE);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_TRAPEZOID_RATIO);
@@ -606,12 +902,51 @@ MESH_BATCHER *MeshBatcher_Create(void)
         sizeof(M_MESH_TEXTURE),
         (void *)(intptr_t)offsetof(M_MESH_TEXTURE, reflectivity));
 
-    glBindBuffer(GL_ARRAY_BUFFER, batcher->vbo.shade);
+    glBindBuffer(GL_ARRAY_BUFFER, shade);
     glEnableVertexAttribArray(OUTPUT_MESH_ATTR_SHADE);
     glVertexAttribPointer(
         OUTPUT_MESH_ATTR_SHADE, 1, GL_FLOAT, GL_FALSE, sizeof(M_MESH_SHADE), 0);
+}
+
+MESH_BATCHER *MeshBatcher_Create(void)
+{
+    MESH_BATCHER *const batcher = Memory_Alloc(sizeof(MESH_BATCHER));
+    batcher->shader = Output_GetMeshShader();
+    batcher->bindings = Vector_Create(sizeof(OUTPUT_MESH *));
+    batcher->binding_map = nullptr;
+    for (int32_t pass = 0; pass < SCENE_PASS_COUNT; pass++) {
+        batcher->staged[pass] = Vector_Create(sizeof(MESH_INSTANCE));
+    }
+    batcher->source.render_begin = M_RenderBegin;
+    batcher->source.render_pass = M_RenderPass;
+    batcher->source.is_dirty = M_IsDirty;
+    batcher->source.animate_textures = M_AnimateTextures;
+    batcher->source.priv = batcher;
+
+    batcher->transparent_sort = Vector_Create(sizeof(M_FACE_SORT));
+    batcher->layout_dirty = true;
+
+    batcher->baked_geom = Vector_Create(sizeof(M_MESH_GEOM));
+    batcher->baked_tex = Vector_Create(sizeof(M_MESH_TEXTURE));
+    batcher->baked_shade = Vector_Create(sizeof(M_MESH_SHADE));
+    batcher->baked_indices = Vector_Create(sizeof(uint32_t));
+    batcher->baked_ranges = Vector_Create(sizeof(M_BAKED_RANGE));
+    batcher->baked_groups = Vector_Create(sizeof(M_BAKED_GROUP));
+
+    glGenVertexArrays(1, &batcher->vao);
+    glGenBuffers(3, &batcher->vbo.geom);
+
+    M_SetupVertexArray(
+        batcher->vao, batcher->vbo.geom, batcher->vbo.tex, batcher->vbo.shade);
 
     glGenBuffers(3, &batcher->ebo.opaque);
+
+    glGenVertexArrays(1, &batcher->baked.vao);
+    glGenBuffers(3, &batcher->baked.geom);
+    glGenBuffers(1, &batcher->baked.ebo);
+    M_SetupVertexArray(
+        batcher->baked.vao, batcher->baked.geom, batcher->baked.tex,
+        batcher->baked.shade);
 
     return batcher;
 }
@@ -636,6 +971,32 @@ void MeshBatcher_Destroy(MESH_BATCHER *const batcher)
         batcher->ebo.transparent = 0;
         batcher->ebo.blend_add = 0;
     }
+    if (batcher->baked.vao != 0) {
+        glDeleteVertexArrays(1, &batcher->baked.vao);
+        batcher->baked.vao = 0;
+    }
+    if (batcher->baked.geom != 0) {
+        glDeleteBuffers(3, &batcher->baked.geom);
+        batcher->baked.geom = 0;
+        batcher->baked.tex = 0;
+        batcher->baked.shade = 0;
+    }
+    if (batcher->baked.ebo != 0) {
+        glDeleteBuffers(1, &batcher->baked.ebo);
+        batcher->baked.ebo = 0;
+    }
+    Vector_Free(batcher->baked_geom);
+    Vector_Free(batcher->baked_tex);
+    Vector_Free(batcher->baked_shade);
+    Vector_Free(batcher->baked_indices);
+    Vector_Free(batcher->baked_ranges);
+    Vector_Free(batcher->baked_groups);
+    batcher->baked_ranges = nullptr;
+    batcher->baked_groups = nullptr;
+    batcher->baked_geom = nullptr;
+    batcher->baked_tex = nullptr;
+    batcher->baked_shade = nullptr;
+    batcher->baked_indices = nullptr;
     ASSERT(batcher->bindings->count == 0);
     if (batcher->bindings != nullptr) {
         Vector_Free(batcher->bindings);

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -191,6 +191,9 @@ static int M_CompareFaceDepth(const void *const a, const void *const b)
 {
     const M_FACE_SORT *const face_a = a;
     const M_FACE_SORT *const face_b = b;
+    if (face_a->inst->sort_layer != face_b->inst->sort_layer) {
+        return face_a->inst->sort_layer - face_b->inst->sort_layer;
+    }
     if (face_b->sort_key == face_a->sort_key) {
         return face_b->inst - face_a->inst;
     }

--- a/src/trx/game/output/mesh_batcher/batcher.c
+++ b/src/trx/game/output/mesh_batcher/batcher.c
@@ -57,7 +57,10 @@ typedef struct M_MESH_BUF_BINDING {
 // for the instance's whole opaque range, which lives in the opaque EBO and is
 // indexed relative to the mesh's first vertex.
 typedef struct {
-    int32_t sort_key;
+    // As wide as the matrix it comes from: the camera-space depth carries the
+    // W2V_SHIFT scale, so a level deep enough would wrap a 32-bit key and sort
+    // its far geometry as the nearest.
+    int64_t sort_key;
     const MESH_INSTANCE *inst;
     const OUTPUT_MESH_FACE *face;
     int32_t index_start;
@@ -186,18 +189,25 @@ static void M_UpdateMeshGeometry(
         bind->vertex_count * sizeof(M_MESH_GEOM), bind->geom_data);
 }
 
+// Order two values as a sign. The differences here are wider than the int the
+// comparator returns, and a truncated difference orders qsort's input
+// inconsistently rather than merely imprecisely.
+#define M_COMPARE(a_, b_) (((a_) > (b_)) - ((a_) < (b_)))
+
 // Compare two faces by camera-space depth.
 static int M_CompareFaceDepth(const void *const a, const void *const b)
 {
     const M_FACE_SORT *const face_a = a;
     const M_FACE_SORT *const face_b = b;
     if (face_a->inst->sort_layer != face_b->inst->sort_layer) {
-        return face_a->inst->sort_layer - face_b->inst->sort_layer;
+        return M_COMPARE(face_a->inst->sort_layer, face_b->inst->sort_layer);
     }
-    if (face_b->sort_key == face_a->sort_key) {
-        return face_b->inst - face_a->inst;
+    if (face_a->sort_key != face_b->sort_key) {
+        return M_COMPARE(face_b->sort_key, face_a->sort_key);
     }
-    return face_b->sort_key - face_a->sort_key;
+    // The instances share one vector, so their addresses stand for the order
+    // they were staged in.
+    return M_COMPARE(face_b->inst, face_a->inst);
 }
 
 // Compute per-face view depth and sort the mesh's transparent ranges

--- a/src/trx/game/output/mesh_batcher/batcher.h
+++ b/src/trx/game/output/mesh_batcher/batcher.h
@@ -20,6 +20,12 @@ typedef struct MESH_INSTANCE {
     bool wibble;
     int32_t water_effect;
 
+    // Where the instance sits among the sorted pass's layers, drawn low first
+    // and by depth within a layer. A shadow lies flat under the item it
+    // belongs to, so no depth key puts it reliably behind every part of a body
+    // resting on it; it takes a layer of its own instead.
+    int32_t sort_layer;
+
     OUTPUT_LIGHT_INFO light_info;
 
     bool enable_scissor;

--- a/src/trx/game/output/mesh_batcher/batcher.h
+++ b/src/trx/game/output/mesh_batcher/batcher.h
@@ -16,7 +16,7 @@ typedef struct MESH_INSTANCE {
     MATRIX cwmatrix;
     MATRIX wmatrix;
     const ROOM *room;
-    RGB_F tint;
+    RGBA_F tint;
     bool wibble;
     int32_t water_effect;
 

--- a/src/trx/game/output/shaders/mesh.c
+++ b/src/trx/game/output/shaders/mesh.c
@@ -28,7 +28,7 @@ struct OUTPUT_MESH_SHADER {
     float water_effect_params[M_VARIANT_COUNT][3];
     bool is_wibble_effect[M_VARIANT_COUNT];
     bool is_alpha_discard_enabled[M_VARIANT_COUNT];
-    RGB_F tint[M_VARIANT_COUNT];
+    RGBA_F tint[M_VARIANT_COUNT];
     OUTPUT_ATLAS_RECT env_map_rect[M_VARIANT_COUNT];
 };
 
@@ -54,7 +54,7 @@ OUTPUT_MESH_SHADER *Output_MeshShader_Create(void)
         shader->water_effect_params[i][2] = 0.0f;
         shader->is_wibble_effect[i] = false;
         shader->is_alpha_discard_enabled[i] = false;
-        shader->tint[i] = (RGB_F) { 0.0f, 0.0f, 0.0f };
+        shader->tint[i] = (RGBA_F) { 0.0f, 0.0f, 0.0f, 0.0f };
         shader->env_map_rect[i] = (OUTPUT_ATLAS_RECT) { .layer = -1 };
 
         shader->base[i] = Output_Shader_Create(m_VariantPaths[i]);
@@ -207,17 +207,18 @@ void Output_MeshShader_UploadWibbleEffect(
     shader->is_wibble_effect[variant_idx] = is_enabled;
 }
 
-void Output_MeshShader_UploadTint(OUTPUT_MESH_SHADER *const shader, RGB_F tint)
+void Output_MeshShader_UploadTint(OUTPUT_MESH_SHADER *const shader, RGBA_F tint)
 {
     const int32_t variant_idx = M_GetVariantIndex();
     OUTPUT_SHADER *const base = M_GetVariantBase(shader, variant_idx);
     if (tint.r == shader->tint[variant_idx].r
         && tint.g == shader->tint[variant_idx].g
-        && tint.b == shader->tint[variant_idx].b) {
+        && tint.b == shader->tint[variant_idx].b
+        && tint.a == shader->tint[variant_idx].a) {
         return;
     }
     TRX_GL_TRACK_UNIFORM(
-        glUniform3f, Output_Shader_LookupUniform(base, "uTint"), tint.r, tint.g,
-        tint.b);
+        glUniform4f, Output_Shader_LookupUniform(base, "uTint"), tint.r, tint.g,
+        tint.b, tint.a);
     shader->tint[variant_idx] = tint;
 }

--- a/src/trx/game/output/shaders/mesh.h
+++ b/src/trx/game/output/shaders/mesh.h
@@ -50,6 +50,6 @@ void Output_MeshShader_UploadWaterEffect(
     OUTPUT_MESH_SHADER *shader, int32_t water_effect);
 void Output_MeshShader_UploadWibbleEffect(
     OUTPUT_MESH_SHADER *shader, bool is_enabled);
-void Output_MeshShader_UploadTint(OUTPUT_MESH_SHADER *shader, RGB_F tint);
+void Output_MeshShader_UploadTint(OUTPUT_MESH_SHADER *shader, RGBA_F tint);
 void Output_MeshShader_UploadAlphaDiscard(
     OUTPUT_MESH_SHADER *shader, bool is_enabled);

--- a/src/trx/game/output/sources/poly_fx.c
+++ b/src/trx/game/output/sources/poly_fx.c
@@ -40,7 +40,7 @@ typedef struct {
     uint8_t corner_count;
     float z_depth_adjust;
     float shade;
-    RGB_F tint;
+    RGBA_F tint;
     XYZ_32 world_pos[4];
     OUTPUT_UVW uvw[4];
     OUTPUT_TEXTURE_SIZE texture_size[4];
@@ -290,7 +290,7 @@ static bool M_HasMatchingTintState(
     const M_PRIM *const prim_1, const M_PRIM *const prim_2)
 {
     return prim_1->tint.r == prim_2->tint.r && prim_1->tint.g == prim_2->tint.g
-        && prim_1->tint.b == prim_2->tint.b;
+        && prim_1->tint.b == prim_2->tint.b && prim_1->tint.a == prim_2->tint.a;
 }
 
 static bool M_HasMatchingRenderState(

--- a/src/trx/game/output/sources/rooms_debug.c
+++ b/src/trx/game/output/sources/rooms_debug.c
@@ -217,7 +217,7 @@ static void M_RenderPass(
         return;
     }
 
-    Output_MeshShader_UploadTint(p->shader, COLOR_RGB_F_WHITE);
+    Output_MeshShader_UploadTint(p->shader, COLOR_RGBA_F_WHITE);
 
     glBindVertexArray(p->vao);
     glBindBuffer(GL_ARRAY_BUFFER, p->vbo);

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -89,7 +89,7 @@ void OutputSource_Shadows_StageShadow(void)
         .mesh = mesh,
         .cwmatrix = *g_MatrixPtr,
         .wmatrix = *g_WMatrixPtr,
-        .tint = { 1.0f, 1.0f, 1.0f },
+        .tint = COLOR_RGBA_F_WHITE,
         .room = Output_GetCurrentRoom(),
     };
     // XXX: Mesh batcher currently collects the transparent faces for the

--- a/src/trx/game/output/sources/shadows.c
+++ b/src/trx/game/output/sources/shadows.c
@@ -40,7 +40,10 @@ static OUTPUT_MESH *M_GenerateShadow(
         edge.pos.z = z;
         MeshBuilder_AddVertex(builder, &edge);
     }
-    MeshBuilder_AddFan(builder, SCENE_PASS_TRANSPARENT, false, true);
+    // The shadow never writes depth: it lies on the floor and occludes
+    // nothing, and its depth-writing copy would be a second sorted draw for an
+    // instance drawn at partial coverage.
+    MeshBuilder_AddFan(builder, SCENE_PASS_TRANSPARENT, false, false);
     return MeshBuilder_Seal(builder);
 }
 
@@ -89,7 +92,10 @@ void OutputSource_Shadows_StageShadow(void)
         .mesh = mesh,
         .cwmatrix = *g_MatrixPtr,
         .wmatrix = *g_WMatrixPtr,
-        .tint = COLOR_RGBA_F_WHITE,
+        // The shadow is black, so the tint only reaches it through its alpha:
+        // an item drawn at partial coverage takes its shadow along with it.
+        .tint = Output_GetTint(),
+        .sort_layer = -1,
         .room = Output_GetCurrentRoom(),
     };
     // XXX: Mesh batcher currently collects the transparent faces for the

--- a/src/trx/game/output/sources/sky.c
+++ b/src/trx/game/output/sources/sky.c
@@ -113,7 +113,7 @@ static void M_RenderFogGradient(M_PRIV *const p)
         OUTPUT_MESH_ATTR_FLAGS,
         VERT_FLAT_SHADED | VERT_NO_LIGHTING | VERT_NO_WIBBLE
             | VERT_NO_ALPHA_DISCARD);
-    Output_MeshShader_UploadTint(p->shader, COLOR_RGB_F_WHITE);
+    Output_MeshShader_UploadTint(p->shader, COLOR_RGBA_F_WHITE);
     Output_MeshShader_UploadModelMatrix(p->shader, &p->gradient_wmatrix);
     // Like OG, the skybox is drawn without backface culling.
     glDisable(GL_CULL_FACE);
@@ -163,7 +163,7 @@ static void M_RenderPass(
         flags |= VERT_FLAT_SHADED;
     }
     glVertexAttribI1ui(OUTPUT_MESH_ATTR_FLAGS, flags);
-    Output_MeshShader_UploadTint(p->shader, COLOR_RGB_F_WHITE);
+    Output_MeshShader_UploadTint(p->shader, COLOR_RGBA_F_WHITE);
 
     for (int32_t i = 0; i < p->layer_count; i++) {
         const M_LAYER *const layer = &p->layers[i];

--- a/src/trx/game/output/sources/sprites.c
+++ b/src/trx/game/output/sources/sprites.c
@@ -126,7 +126,7 @@ void OutputSource_Sprites_ObserveLevelUnload(void)
 }
 
 void OutputSource_Sprites_Stage(
-    const int32_t sprite_idx, const int16_t shade, const RGB_F tint,
+    const int32_t sprite_idx, const int16_t shade, const RGBA_F tint,
     const DRAW_TYPE draw_type)
 {
     M_PRIV *const p = &m_Priv;

--- a/src/trx/game/output/sources/sprites.h
+++ b/src/trx/game/output/sources/sprites.h
@@ -10,4 +10,4 @@ void OutputSource_Sprites_ObserveLevelLoad(void);
 void OutputSource_Sprites_ObserveLevelUnload(void);
 
 void OutputSource_Sprites_Stage(
-    int32_t sprite_idx, int16_t shade, RGB_F tint, DRAW_TYPE draw_type);
+    int32_t sprite_idx, int16_t shade, RGBA_F tint, DRAW_TYPE draw_type);

--- a/src/trx/game/output/state.c
+++ b/src/trx/game/output/state.c
@@ -53,7 +53,7 @@ static bool m_IsShadeEffect = false;
 static bool m_IsSkyboxEnabled = false;
 
 static int32_t m_TintOverrideDepth = 0;
-static RGB_F m_TintOverrideStack[8] = {};
+static RGBA_F m_TintOverrideStack[8] = {};
 
 float Output_GetTime(void)
 {
@@ -179,18 +179,18 @@ void Output_SetWaterColor(const RGB_888 color)
     m_WaterColor.b = color.b / 255.0f;
 }
 
-RGB_F Output_GetTint(void)
+RGBA_F Output_GetTint(void)
 {
     if (m_TintOverrideDepth != 0) {
         return m_TintOverrideStack[m_TintOverrideDepth - 1];
     }
     if (m_IsShadeEffect) {
-        return m_WaterColor;
+        return Color_RGBToRGBA(m_WaterColor);
     }
-    return COLOR_RGB_F_WHITE;
+    return COLOR_RGBA_F_WHITE;
 }
 
-void Output_PushTintOverride(const RGB_F tint)
+void Output_PushTintOverride(const RGBA_F tint)
 {
     ASSERT(m_TintOverrideDepth < (int32_t)ARRAY_SIZE(m_TintOverrideStack));
     m_TintOverrideStack[m_TintOverrideDepth++] = tint;

--- a/src/trx/game/output/state.h
+++ b/src/trx/game/output/state.h
@@ -25,8 +25,8 @@ void Output_SetupAboveWater(bool is_underwater);
 RGB_F Output_GetWaterColor(void);
 void Output_SetWaterColor(RGB_888 color);
 
-RGB_F Output_GetTint(void);
-void Output_PushTintOverride(RGB_F tint);
+RGBA_F Output_GetTint(void);
+void Output_PushTintOverride(RGBA_F tint);
 void Output_PopTintOverride(void);
 bool Output_GetWaterEffect(void);
 bool Output_GetWibbleEffect(void);

--- a/src/trx/game/rooms/draw.c
+++ b/src/trx/game/rooms/draw.c
@@ -327,7 +327,19 @@ static void M_DrawRoomItem(const int16_t item_num, void *const ud)
     }
 
     M_SetupWaterStatus(Room_Get(item->room_num));
+
+    // A fading body scales down whatever tint is already in force rather than
+    // replacing it, so it keeps the water color it is lying in.
+    const bool is_fading = item->fade > 0;
+    if (is_fading) {
+        RGBA_F tint = Output_GetTint();
+        tint.a *= item->fade / 255.0f;
+        Output_PushTintOverride(tint);
+    }
     bind->drawn |= obj->draw_func(item);
+    if (is_fading) {
+        Output_PopTintOverride();
+    }
 
     if (Output_IsControlFrame()) {
         Item_ControlDraw(item);

--- a/src/trx/game/rules.c
+++ b/src/trx/game/rules.c
@@ -1,16 +1,26 @@
 #include <trx/game/rules.h>
 
+#include <trx/version.h>
+
 #include <string.h>
 
 // The markers only shape the struct, so everything below expands them away.
 #define X_GROUP_BEGIN(group_)
 #define X_GROUP_END(group_)
 
-RULES g_Rules = {
 #define X_RULE(type_, group_, field_, default_) .group_.field_ = default_,
+
+RULES g_Rules = {
 #include <trx/game/rules.def>
-#undef X_RULE
 };
+
+// What a reset puts back. Held apart from g_Rules so a rule whose number
+// depends on the game can have its default written before any reset reads it.
+static RULES m_Defaults = {
+#include <trx/game/rules.def>
+};
+
+#undef X_RULE
 
 // clang-format off
 static const RULE m_Rules[] = {
@@ -18,7 +28,7 @@ static const RULE m_Rules[] = {
     { .name = #group_ "." #field_,                                             \
       .type = Value_TypeOf(g_Rules.group_.field_),                             \
       .target = &g_Rules.group_.field_,                                        \
-      .default_value = &(const type_) { default_ } },
+      .default_value = &m_Defaults.group_.field_ },
 #include <trx/game/rules.def>
 #undef X_RULE
     {}, // sentinel
@@ -48,8 +58,16 @@ void Rules_ResetOne(const RULE *const rule)
     Value_CopyPtr(rule->type, rule->target, rule->default_value);
 }
 
+// A rule can ship with a different number from game to game. Rules_Reset runs
+// once a level is loaded, so the version has settled by the time this does.
+static void M_ApplyGameDefaults(void)
+{
+    m_Defaults.corpse.fade_speed = g_TRVersion >= 4 ? 2 : 0;
+}
+
 void Rules_Reset(void)
 {
+    M_ApplyGameDefaults();
     for (const RULE *rule = m_Rules; rule->name != nullptr; rule++) {
         Rules_ResetOne(rule);
     }

--- a/src/trx/game/rules.def
+++ b/src/trx/game/rules.def
@@ -18,3 +18,10 @@ X_RULE(int16_t, exposure, drain_water, 2)
 X_RULE(int16_t, exposure, recovery,    1)
 X_RULE(int16_t, exposure, damage,      10)
 X_GROUP_END(exposure)
+
+// What becomes of a body once its owner is dead. TR4 fades a body out and
+// takes it away; the other games leave it where it lies, so the shipped 0 is
+// replaced with the game's own default in Rules_Reset.
+X_GROUP_BEGIN(corpse)
+X_RULE(int16_t, corpse, fade_speed, 0)
+X_GROUP_END(corpse)

--- a/src/trx/game/savegame/file_read.c
+++ b/src/trx/game/savegame/file_read.c
@@ -634,6 +634,8 @@ static bool M_ReadItem(JSON_READ_IO *const io, const int16_t read_index)
         // Introduced in TRX 1.2, not written if zero
         M_OPTIONAL(JSON_READ(io, "ai_bits", &item->ai_bits));
         M_OPTIONAL(JSON_READ(io, "ai_tag", &item->ai_tag));
+        // Introduced in TRX 1.10, not written if zero
+        M_OPTIONAL(JSON_READ(io, "fade", &item->fade));
 
         bool intelligent = obj->intelligent;
         // Introduced in TRX 1.2
@@ -1213,9 +1215,11 @@ bool SG_File_LoadResumeInfoList(JSON_READ_IO *const io)
 
 bool SG_File_LoadRules(JSON_READ_IO *const io)
 {
-    // Keyed by name over the rules this build has, so a block that names one
-    // it dropped, omits one it gained, or is absent entirely still loads. What
-    // the save does not carry stays where Savegame_InitCurrentInfo left it.
+    // Introduced in TRX 1.10, only carrying the rules that are off their
+    // defaults. Keyed by name over the rules this build has, so a block that
+    // names one it dropped, omits one it gained, or is absent entirely still
+    // loads. What the save does not carry stays where Savegame_InitCurrentInfo
+    // left it.
     if (!M_OPTIONAL(JSON_PUSH(io, "rules"))) {
         return true;
     }

--- a/src/trx/game/savegame/file_write.c
+++ b/src/trx/game/savegame/file_write.c
@@ -210,6 +210,7 @@ static void M_WriteItem(
         JSONW_WRITE(io, "timer", item->timer);
         JSONW_WRITE_NZ(io, "ai_bits", item->ai_bits);
         JSONW_WRITE_NZ(io, "ai_tag", item->ai_tag);
+        JSONW_WRITE_NZ(io, "fade", item->fade);
         if (intelligent) {
             const CREATURE *const creature = item->creature_data;
             JSONW_WRITE(io, "head_rot", creature->head_rotation);


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This adds dead entities fading-out on death as per TR4; to see it, please use `/rule fade[tab] 2`. There are some problems with z-indexing, but it's the best I could do at this time.

Also, fixes a minor bug with `/play` not resetting the rules engine or Lara's dry status.

Resolves TRX512.