### PR TITLE
Corpse fade improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,7 @@
 - fixed Willard being visible outside the hut at the beginning of the cutscene following Antarctica (resolves #5929)
 - fixed Lara, when on fire, not extinguishing at the right water depth compared with OG (regression from 1.1)
 - fixed the waterfall and drowning mist bunching up in one spot instead of spreading out along the water (regression from 1.2)
+- fixed a crash when a level holds fewer raptors than its raptor emitters can send out
 
 **TR4**
 - added dead enemies fading away a few seconds after they fall, as in the original TR4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - fixed mesh debug spheres not rendering after switching mods (regression from 1.5)
 - fixed differing ladder/hanging behavior when Lara comes to a stop from shimmying when corner shimmying is enabled (regression from 1.9)
 - fixed the game displaying a GUI error dialog when it fails to start in headless mode
+- fixed the body bag trigger to also collect Bacon Lara, Qualopec Mummy and Skidoo Driver's corpses
 
 **TR1**
 - changed weather to be affected by the breeze

--- a/src/trx/game/items/manager.c
+++ b/src/trx/game/items/manager.c
@@ -392,6 +392,11 @@ void Item_StartFade(ITEM *const item)
     item->fade = 255;
 }
 
+bool Item_IsFading(const ITEM *const item)
+{
+    return item->fade > 0;
+}
+
 // A body leaves the active list as it dies, so the fade cannot ride on the
 // loop below. The OG counts it off while drawing the room, which leaves a
 // corpse nobody is looking at hanging around; this runs either way.
@@ -602,8 +607,11 @@ void Item_Respawn(const int16_t item_num, const int16_t room_num)
     }
     // The previous occupant died in this slot, leaving it visible and finished.
     // Clear finished so Item_Activate takes the visible item back into play
-    // rather than reading it as a spent corpse.
+    // rather than reading it as a spent corpse. Any fade it had left goes with
+    // it, or the new occupant is drawn part-transparent and destroyed once the
+    // count reaches zero.
     Item_SetFinished(item, false);
+    item->fade = 0;
     // Force the slot back into the room's item chain: a same-room update alone
     // will not relink a slot Item_Destroy left detached, so bounce it through
     // NO_ROOM. Item_Activate then enables the AI with the room settled.

--- a/src/trx/game/items/manager.h
+++ b/src/trx/game/items/manager.h
@@ -39,6 +39,10 @@ void Item_Control(void);
 // Begin fading a body out, if the rules call for bodies to fade at all.
 void Item_StartFade(ITEM *item);
 
+// Whether a body is still on its way out. The item is destroyed once the fade
+// runs out, so anything that reclaims a dead item's slot has to wait for this.
+bool Item_IsFading(const ITEM *item);
+
 // Remove the item from the game; any other handle to it becomes stale. Fires
 // on_destroy during live play, while the item can still be read from the
 // handler.

--- a/src/trx/game/objects/traps/raptor_emitter.c
+++ b/src/trx/game/objects/traps/raptor_emitter.c
@@ -48,13 +48,23 @@ static void M_PopulateSlots(M_PRIV *const p)
     }
 }
 
+// A level with fewer than M_MAX_SLOTS raptors to modify leaves the tail of
+// the slots at NO_ITEM.
+static const ITEM *M_GetRaptorItem(
+    const M_PRIV *const p, const int32_t slot_idx)
+{
+    const int16_t item_num = p->slots[slot_idx];
+    return item_num == NO_ITEM ? nullptr : Item_Get(item_num);
+}
+
 // A dead raptor gives its AI slot up at once, well before the body it leaves
 // has finished fading, so the fade is what says the slot is free to reuse.
 static int32_t M_GetEmptySlot(const M_PRIV *const p)
 {
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
-        const ITEM *const item = Item_Get(p->slots[i]);
-        if (item->creature_data == nullptr && !Item_IsFading(item)) {
+        const ITEM *const item = M_GetRaptorItem(p, i);
+        if (item != nullptr && item->creature_data == nullptr
+            && !Item_IsFading(item)) {
             return i;
         }
     }

--- a/src/trx/game/objects/traps/raptor_emitter.c
+++ b/src/trx/game/objects/traps/raptor_emitter.c
@@ -48,11 +48,13 @@ static void M_PopulateSlots(M_PRIV *const p)
     }
 }
 
+// A dead raptor gives its AI slot up at once, well before the body it leaves
+// has finished fading, so the fade is what says the slot is free to reuse.
 static int32_t M_GetEmptySlot(const M_PRIV *const p)
 {
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
         const ITEM *const item = Item_Get(p->slots[i]);
-        if (item->creature_data == nullptr) {
+        if (item->creature_data == nullptr && !Item_IsFading(item)) {
             return i;
         }
     }

--- a/src/trx/game/objects/traps/wasp_emitter.c
+++ b/src/trx/game/objects/traps/wasp_emitter.c
@@ -75,11 +75,14 @@ static const ITEM *M_GetWaspItem(const M_PRIV *const p, const int32_t slot_idx)
     return item_num == NO_ITEM ? nullptr : Item_Get(item_num);
 }
 
+// A dead wasp gives its AI slot up at once, well before the body it leaves has
+// finished fading, so the fade is what says the slot is free to reuse.
 static int32_t M_GetEmptySlot(const M_PRIV *const p)
 {
     for (int32_t i = 0; i < M_MAX_SLOTS; i++) {
         const ITEM *const item = M_GetWaspItem(p, i);
-        if (item != nullptr && item->creature_data == nullptr) {
+        if (item != nullptr && item->creature_data == nullptr
+            && !Item_IsFading(item)) {
             return i;
         }
     }

--- a/src/trx/game/rooms/triggers/general.c
+++ b/src/trx/game/rooms/triggers/general.c
@@ -6,14 +6,14 @@
 #include <trx/game/rooms.h>
 #include <trx/game/stats.h>
 
-// Remove intelligent items marked to leave a corpse once dead. Part of the OG
+// Remove the bodies of items marked to be cleared once dead. Part of the OG
 // performance work, generously used in Opera House and Barkhang Monastery.
 static void M_DestroyKilledBodies(void)
 {
     for (int32_t i = 0; i < Item_GetLevelCount(); i++) {
         ITEM *const item = Item_Get(i);
         const OBJECT *const obj = Object_Get(item->object_id);
-        if (obj->intelligent && item->clear_body && item->hit_points <= 0
+        if (obj->leaves_corpse && item->clear_body && item->hit_points <= 0
             && !item->is_destroyed) {
             Item_Destroy(i);
         }


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes playing out the fade-out (when it's enabled) on wasp and raptor emitters' recyclable enemies.

Additionally, the clear all bodies trigger now destroys skidoo driver, bacon Lara, and Qualopec mummy's corpses.

Resolves TRX785.
