### PR TITLE
objects/bacon_lara: mimic Lara only when in play

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fixed Bacon Lara flickering if she dies in a room different to where she fell from
 - fixed Bacon Lara remaining targetable after death
 - fixed Bacon Lara dying prematurely in some geometry setups
+- fixed Bacon Lara mimicking some of Lara's movements, such as looking or using weapons, before being triggered
 - fixed jittery interpolation on Bacon Lara when falling from great heights
 - fixed the detonator box returning to its original position after loading a save (OG bug)
 - fixed crawler mutants killed by Lara's allies not being included in the stats when the option to include ally kills is enabled (#5691, regression from 1.7)

--- a/src/trx/game/objects/creatures/bacon_lara.c
+++ b/src/trx/game/objects/creatures/bacon_lara.c
@@ -180,7 +180,7 @@ static void M_Control(const int16_t item_num)
 static bool M_Draw(const ITEM *const item)
 {
     M_PRIV *const p = item->priv;
-    if (p->status || item->current_anim_state == LS(LS_DEATH)) {
+    if (p->status || !Item_IsInPlay(item)) {
         return Object_DrawAnimatingItem(item);
     }
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TRX/blob/develop/docs/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change
- [x] I have added a readme entry about my new feature or OG bug fix, or it is a different change

#### Description

This fixes Bacon Lara mimicking some of Lara's movements before she is triggered. She will only be drawn as Lara if she is simulated and not falling to her death.

Resolves TRX783.